### PR TITLE
fix: bring the batch submitter last to avoid CI flakiness

### DIFF
--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -129,6 +129,7 @@ describe('Basic RPC tests', () => {
         const estimate = await l2Provider.estimateGas({
           ...DEFAULT_TRANSACTION,
           data: '0x' + '00'.repeat(len),
+          from: '0x' + '1234'.repeat(10),
         })
 
         expect(estimate.gt(last)).to.be.true

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -57,20 +57,6 @@ services:
     ports:
       - ${DTL_PORT:-7878}:7878
 
-  batch_submitter:
-    image: ethereumoptimism:batch-submitter
-    build:
-      context: ..
-      dockerfile: ./ops/docker/Dockerfile.batches
-    entrypoint: ./batches.sh
-    env_file:
-        ./envs/batches.env
-    environment:
-        L1_NODE_WEB3_URL: http://l1_chain:8545
-        L2_NODE_WEB3_URL: http://l2geth:8545
-        URL: http://deployer:8081/addresses.json
-        SEQUENCER_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
-
   l2geth:
     image: ethereumoptimism:l2geth
     build:
@@ -108,3 +94,17 @@ services:
         RETRIES: 60
         POLLING_INTERVAL: 500
         GET_LOGS_INTERVAL: 500
+
+  batch_submitter:
+    image: ethereumoptimism:batch-submitter
+    build:
+      context: ..
+      dockerfile: ./ops/docker/Dockerfile.batches
+    entrypoint: ./batches.sh
+    env_file:
+        ./envs/batches.env
+    environment:
+        L1_NODE_WEB3_URL: http://l1_chain:8545
+        L2_NODE_WEB3_URL: http://l2geth:8545
+        URL: http://deployer:8081/addresses.json
+        SEQUENCER_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"


### PR DESCRIPTION
fixes #430 

* It seems like the batch submitter sometimes does not submit L2 batches. Locally, this is fixable by stopping and re-starting it. I diff'ed the logs between a "good" test run and a flaky run and found out
* the rpc-spec was also flaky sometimes due to trying to use an already used nonce, we fix this by using an address whose nonce does not depend in the tests