### PR TITLE
chore: add a basic .editorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+# defaults
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.sol]
+indent_size = 4


### PR DESCRIPTION
**Description**

Adds a basic `.editorConfig`. This will pretty much eliminate any issues with extra whitespace creeping in at EOL, resulting in 'dirty' commits. 

Many editors will inherit settings from this file, but VSCode requires an [extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) to support it. 

Learn more: https://editorconfig.org/.

**Metadata**
- Fixes None
