### PR TITLE
docker: correctly tag and fix entrypoints

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -5,14 +5,14 @@ version: "3"
 services:
   # base service builder
   builder:
-    image: ethereumoptimism:builder
+    image: ethereumoptimism/builder
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.monorepo
 
   # this is a helper service used because there's no official hardhat image
   l1_chain:
-    image: ethereumoptimism:hardhat
+    image: ethereumoptimism/hardhat
     build:
       context: ./docker/hardhat
       dockerfile: Dockerfile
@@ -21,7 +21,7 @@ services:
       - ${L1_CHAIN_PORT:-9545}:8545
 
   deployer:
-    image: ethereumoptimism:deployer
+    image: ethereumoptimism/deployer
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.deployer
@@ -37,7 +37,7 @@ services:
       - ${DEPLOYER_PORT:-8080}:8081
 
   dtl:
-    image: ethereumoptimism:data-transport-layer
+    image: ethereumoptimism/data-transport-layer
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.dtl
@@ -58,7 +58,7 @@ services:
       - ${DTL_PORT:-7878}:7878
 
   l2geth:
-    image: ethereumoptimism:l2geth
+    image: ethereumoptimism/l2geth
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.geth
@@ -80,7 +80,7 @@ services:
       - ${L2GETH_WS_PORT:-8546}:8546
 
   relayer:
-    image: ethereumoptimism:relayer
+    image: ethereumoptimism/relayer
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.relayer
@@ -96,7 +96,7 @@ services:
         GET_LOGS_INTERVAL: 500
 
   batch_submitter:
-    image: ethereumoptimism:batch-submitter
+    image: ethereumoptimism/batch-submitter
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.batches

--- a/ops/docker/Dockerfile.batches
+++ b/ops/docker/Dockerfile.batches
@@ -1,4 +1,4 @@
-FROM ethereumoptimism:builder AS builder
+FROM ethereumoptimism/builder AS builder
 
 FROM node:14-alpine
 

--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -1,4 +1,4 @@
-FROM ethereumoptimism:builder AS builder
+FROM ethereumoptimism/builder AS builder
 
 FROM node:14-alpine
 

--- a/ops/docker/Dockerfile.dtl
+++ b/ops/docker/Dockerfile.dtl
@@ -1,4 +1,4 @@
-FROM ethereumoptimism:builder AS builder
+FROM ethereumoptimism/builder AS builder
 
 FROM node:14-alpine
 

--- a/ops/docker/Dockerfile.monorepo
+++ b/ops/docker/Dockerfile.monorepo
@@ -36,7 +36,7 @@ RUN yarn install --frozen-lockfile
 
 ### BUILDER: Builds the typescript
 FROM node
- 
+
 WORKDIR /optimism
 
 # cache the node_modules copying step since it's expensive

--- a/ops/docker/Dockerfile.relayer
+++ b/ops/docker/Dockerfile.relayer
@@ -1,4 +1,4 @@
-FROM ethereumoptimism:builder AS builder
+FROM ethereumoptimism/builder AS builder
 
 FROM node:14-alpine
 

--- a/ops/scripts/batches.sh
+++ b/ops/scripts/batches.sh
@@ -10,4 +10,4 @@ export ADDRESS_MANAGER_ADDRESS=$(echo $ADDRESSES | jq -r '.AddressManager')
 curl --retry-connrefused --retry $RETRIES --retry-delay 1 $L2_NODE_WEB3_URL
 
 # go
-node ./exec/run-batch-submitter.js
+exec node ./exec/run-batch-submitter.js

--- a/ops/scripts/deployer.sh
+++ b/ops/scripts/deployer.sh
@@ -9,4 +9,4 @@ curl -H "Content-Type: application/json" --retry-connrefused --retry $RETRIES --
 yarn run deploy
 
 # serve the addrs and the state dump
-./bin/serve_dump.sh
+exec ./bin/serve_dump.sh

--- a/ops/scripts/dtl.sh
+++ b/ops/scripts/dtl.sh
@@ -7,4 +7,4 @@ ADDRESSES=$(curl --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 export DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$(echo $ADDRESSES | jq -r '.AddressManager')
 
 # go
-node dist/src/services/run.js
+exec node dist/src/services/run.js

--- a/ops/scripts/geth.sh
+++ b/ops/scripts/geth.sh
@@ -19,4 +19,4 @@ if [ $ETH1_L1_ETH_GATEWAY_ADDRESS == null ]; then
     envSet ETH1_L1_ETH_GATEWAY_ADDRESS OVM_L1ETHGateway
 fi
 
-geth --verbosity=6
+exec geth --verbosity=6

--- a/ops/scripts/relayer.sh
+++ b/ops/scripts/relayer.sh
@@ -10,4 +10,4 @@ export ADDRESS_MANAGER_ADDRESS=$(echo $ADDRESSES | jq -r '.AddressManager')
 curl --retry-connrefused --retry $RETRIES --retry-delay 1 $L2_NODE_WEB3_URL
 
 # go
-node ./exec/run-message-relayer.js
+exec node ./exec/run-message-relayer.js


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR fixes the docker image names as the schema is `repository/org/image:tag`, this was previously naming things `image:tag` (`ethereumoptimism:builder`) which implies that they are the same service. This would make it impossible to do versions as the tag is meant to specify the version. This updates the schema to be `org/image:tag` (`ethereumoptimism/builder:latest`) where `latest` is used as the tag and what was previously the tag is now the image.

It also adds `exec` to the docker entry scripts per https://cloud.google.com/solutions/best-practices-for-building-containers. This will make PID1 inherited by the command that is ran at the end of the entry script meaning that it will receive signals from docker/k8s correctly