### PR TITLE
geth: only accept txs with a 0 value

### DIFF
--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -51,6 +51,17 @@ describe('Basic RPC tests', () => {
         provider.sendTransaction(await wallet.signTransaction(tx))
       ).to.be.rejectedWith('Cannot submit unprotected transaction')
     })
+
+    it('should not accept a transaction with a value', async () => {
+      const tx = {
+        ...DEFAULT_TRANSACTION,
+        chainId: (await wallet.getChainId()),
+        value: 100,
+      }
+      await expect(
+        provider.sendTransaction(await wallet.signTransaction(tx))
+      ).to.be.rejectedWith('Cannot send transaction with non-zero value. Use WETH.transfer()')
+    })
   })
 
   describe('eth_getTransactionByHash', () => {

--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -294,6 +294,11 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 // a lock can be used around the remotes for when the sequencer is reorganizing.
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	if b.UsingOVM {
+		// The value field is not rolled up so it must be set to 0
+		if signedTx.Value().Cmp(new(big.Int)) != 0 {
+			return fmt.Errorf("Cannot send transaction with non-zero value. Use WETH.transfer()")
+		}
+
 		to := signedTx.To()
 		if to != nil {
 			if *to == (common.Address{}) {


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Until https://github.com/ethereum-optimism/contracts/pull/300 is merged, we cannot accept transactions with an ETH value set. This PR prevents the sequencer from accepting transactions with a value set as well as adds an RPC level integration test for the functionality.

