### PR TITLE
docker: have geth wait for dtl to be up before starting

### DIFF
--- a/ops/scripts/geth.sh
+++ b/ops/scripts/geth.sh
@@ -19,6 +19,7 @@ if [ $ETH1_L1_ETH_GATEWAY_ADDRESS == null ]; then
     envSet ETH1_L1_ETH_GATEWAY_ADDRESS OVM_L1ETHGateway
 fi
 
-curl --retry-connrefused --retry $RETRIES --retry-delay 1 $ROLLUP_CLIENT_HTTP
+# wait for the dtl to be up, else geth will crash if it cannot connect
+curl --retry-connrefused --retry $RETRIES --retry-delay 2 $ROLLUP_CLIENT_HTTP
 
 exec geth --verbosity=6

--- a/ops/scripts/geth.sh
+++ b/ops/scripts/geth.sh
@@ -19,4 +19,6 @@ if [ $ETH1_L1_ETH_GATEWAY_ADDRESS == null ]; then
     envSet ETH1_L1_ETH_GATEWAY_ADDRESS OVM_L1ETHGateway
 fi
 
+curl --retry-connrefused --retry $RETRIES --retry-delay 1 $ROLLUP_CLIENT_HTTP
+
 exec geth --verbosity=6


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
`docker-compose up` wasn't working on my machine due to a race condition between geth and the DTL starting. This adds the required coordination to the geth dockerfile entrypoint so that it waits for the DTL
