### PR TITLE
feat: add extra logs to DTL

### DIFF
--- a/.changeset/angry-queens-reflect.md
+++ b/.changeset/angry-queens-reflect.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/core-utils": patch
+"@eth-optimism/data-transport-layer": patch
+---
+
+added extra logs to base-service / dtl to improve observability

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -34,9 +34,14 @@ export class BaseService<T> {
       return
     }
 
-    this.logger.info('Service is initializing...')
+    this.logger.info('Service is initializing...', {
+      name: this.name,
+    })
     await this._init()
-    this.logger.info('Service has initialized.')
+    this.logger.info('Service has initialized.', {
+      name: this.name,
+      options: this.options,
+    })
     this.initialized = true
   }
 
@@ -47,13 +52,17 @@ export class BaseService<T> {
     if (this.running) {
       return
     }
-    this.logger.info('Service is starting...')
+    this.logger.info('Service is starting...', {
+      name: this.name,
+    })
     await this.init()
 
     // set the service to running
     this.running = true
     await this._start()
-    this.logger.info('Service has started')
+    this.logger.info('Service has started', {
+      name: this.name,
+    })
   }
 
   /**
@@ -64,9 +73,13 @@ export class BaseService<T> {
       return
     }
 
-    this.logger.info('Service is stopping...')
+    this.logger.info('Service is stopping...', {
+      name: this.name,
+    })
     await this._stop()
-    this.logger.info('Service has stopped')
+    this.logger.info('Service has stopped', {
+      name: this.name,
+    })
     this.running = false
   }
 

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -34,9 +34,7 @@ export class BaseService<T> {
       return
     }
 
-    this.logger.info('Service is initializing...', {
-      name: this.name,
-    })
+    this.logger.info('Service is initializing...')
     await this._init()
     this.logger.info('Service has initialized.', {
       name: this.name,
@@ -52,9 +50,7 @@ export class BaseService<T> {
     if (this.running) {
       return
     }
-    this.logger.info('Service is starting...', {
-      name: this.name,
-    })
+    this.logger.info('Service is starting...')
     await this.init()
 
     // set the service to running

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -56,9 +56,7 @@ export class BaseService<T> {
     // set the service to running
     this.running = true
     await this._start()
-    this.logger.info('Service has started', {
-      name: this.name,
-    })
+    this.logger.info('Service has started')
   }
 
   /**
@@ -69,13 +67,9 @@ export class BaseService<T> {
       return
     }
 
-    this.logger.info('Service is stopping...', {
-      name: this.name,
-    })
+    this.logger.info('Service is stopping...')
     await this._stop()
-    this.logger.info('Service has stopped', {
-      name: this.name,
-    })
+    this.logger.info('Service has stopped')
     this.running = false
   }
 

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -37,7 +37,6 @@ export class BaseService<T> {
     this.logger.info('Service is initializing...')
     await this._init()
     this.logger.info('Service has initialized.', {
-      name: this.name,
       options: this.options,
     })
     this.initialized = true

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -54,8 +54,13 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
   } = {} as any
 
   protected async _init(): Promise<void> {
+    this.logger.info('Initializing L1 Data Transport Service...')
+
     this.state.db = level(this.options.dbPath)
     await this.state.db.open()
+    this.logger.info('Opened db', {
+      dbPath: this.options.dbPath
+    })
 
     this.state.l1TransportServer = new L1TransportServer({
       ...this.options,
@@ -79,13 +84,16 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     }
 
     await this.state.l1TransportServer.init()
+    this.logger.info('Initialized L1 Transport Server')
 
     if (this.options.syncFromL1) {
       await this.state.l1IngestionService.init()
+      this.logger.info('Initialized L1 Ingestion Server')
     }
 
     if (this.options.syncFromL2) {
       await this.state.l2IngestionService.init()
+      this.logger.info('Initialized L2 Ingestion Server')
     }
   }
 
@@ -95,6 +103,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
       this.options.syncFromL1 ? this.state.l1IngestionService.start() : null,
       this.options.syncFromL2 ? this.state.l2IngestionService.start() : null,
     ])
+    this.logger.info('Started L1 Data Transport Service')
   }
 
   protected async _stop(): Promise<void> {
@@ -105,5 +114,6 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     ])
 
     await this.state.db.close()
+    this.logger.info('Stopped L1 Data Transport Service')
   }
 }

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -58,9 +58,6 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
 
     this.state.db = level(this.options.dbPath)
     await this.state.db.open()
-    this.logger.info('Opened db', {
-      dbPath: this.options.dbPath
-    })
 
     this.state.l1TransportServer = new L1TransportServer({
       ...this.options,

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -84,16 +84,13 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     }
 
     await this.state.l1TransportServer.init()
-    this.logger.info('Initialized L1 Transport Server')
 
     if (this.options.syncFromL1) {
       await this.state.l1IngestionService.init()
-      this.logger.info('Initialized L1 Ingestion Server')
     }
 
     if (this.options.syncFromL2) {
       await this.state.l2IngestionService.init()
-      this.logger.info('Initialized L2 Ingestion Server')
     }
   }
 
@@ -103,7 +100,6 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
       this.options.syncFromL1 ? this.state.l1IngestionService.start() : null,
       this.options.syncFromL2 ? this.state.l2IngestionService.start() : null,
     ])
-    this.logger.info('Started L1 Data Transport Service')
   }
 
   protected async _stop(): Promise<void> {
@@ -114,6 +110,5 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     ])
 
     await this.state.db.close()
-    this.logger.info('Stopped L1 Data Transport Service')
   }
 }

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -130,6 +130,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
           url: req.url,
           elapsed,
         })
+        this.logger.debug('Response body', {
+          method: req.method,
+          url: req.url,
+          body: json,
+        })
         return res.json(json)
       } catch (e) {
         const elapsed = Date.now() - start

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -128,7 +128,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         this.logger.info('Served HTTP Request', {
           method: req.method,
           url: req.url,
-          body: req.body,
+          body: json,
           elapsed,
         })
         return res.json(json)
@@ -137,7 +137,6 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         this.logger.info('Failed HTTP Request', {
           method: req.method,
           url: req.url,
-          body: req.body,
           elapsed,
           msg: e.toString(),
         })

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -128,7 +128,6 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         this.logger.info('Served HTTP Request', {
           method: req.method,
           url: req.url,
-          body: json,
           elapsed,
         })
         return res.json(json)


### PR DESCRIPTION
**Description**
Adding extra logs to DTL to improve overall observability. 

**Additional context**
DTL started with better logging than batch submitter, so most of these are on initialization and whenever we respond to API calls. Open to changing these to `.debug` instead! 

**Metadata**
https://github.com/ethereum-optimism/roadmap/issues/860
