### PR TITLE
test: estimate gas for wETH transfer

### DIFF
--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -12,12 +12,6 @@ describe('Fee Payment Integration Tests', async () => {
     env = await OptimismEnv.new()
   })
 
-  it('Should estimate gas for wETH transfer', async () => {
-    const amount = utils.parseEther('0.5')
-    const gas = await env.ovmEth.estimateGas.transfer(other, amount)
-    expect(gas).is.instanceof(BigNumber)
-  })
-
   it('Paying a nonzero but acceptable gasPrice fee', async () => {
     const amount = utils.parseEther('0.5')
 

--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -12,6 +12,12 @@ describe('Fee Payment Integration Tests', async () => {
     env = await OptimismEnv.new()
   })
 
+  it('Should estimate gas for wETH transfer', async () => {
+    const amount = utils.parseEther('0.5')
+    const gas = await env.ovmEth.estimateGas.transfer(other, amount)
+    expect(gas).is.instanceof(BigNumber)
+  })
+
   it('Paying a nonzero but acceptable gasPrice fee', async () => {
     const amount = utils.parseEther('0.5')
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -40,6 +40,21 @@ describe('Native ETH Integration Tests', async () => {
     l2Bob = l1Bob.connect(env.l2Wallet.provider)
   })
 
+  describe('estimateGas', () => {
+    it('Should estimate gas for ETH transfer', async () => {
+      const amount = utils.parseEther('0.5')
+      const addr = await l2Bob.getAddress()
+      const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
+      expect(gas).is.instanceof(BigNumber)
+    })
+
+    it('Should estimate gas for ETH withdraw', async () => {
+      const amount = utils.parseEther('0.5')
+      const gas = await env.ovmEth.estimateGas.withdraw(amount)
+      expect(gas).is.instanceof(BigNumber)
+    })
+  })
+
   it('deposit', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a test that runs an `estimateGas` for `weth.transfer`. This is an attempt to reproduce the "used too much gas" problem with estimate gas. The call to `eth_estimateGas` fails but the transaction actually is not out of gas
