### PR TITLE
perf: do not compile contracts on docker-compose

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -32,6 +32,9 @@ services:
         # these keys are hardhat's first 2 accounts, DO NOT use in production
         DEPLOYER_PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
         SEQUENCER_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+        # skip compilation when run in docker-compose, since the contracts
+        # were already compiled in the builder step
+        NO_COMPILE: 1
     ports:
         # expose the service to the host for getting the contract addrs
       - ${DEPLOYER_PORT:-8080}:8081

--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -19,24 +19,20 @@ COPY --from=builder /optimism/packages/hardhat-ovm/dist ./packages/hardhat-ovm/d
 # get the needed built artifacts
 WORKDIR /opt/optimism/packages/contracts
 COPY --from=builder /optimism/packages/contracts/dist ./dist
-COPY --from=builder /optimism/packages/contracts/bin ./bin
 COPY --from=builder /optimism/packages/contracts/*.json ./
 COPY --from=builder /optimism/packages/contracts/node_modules ./node_modules
 COPY --from=builder /optimism/packages/contracts/artifacts ./artifacts
 COPY --from=builder /optimism/packages/contracts/artifacts-ovm ./artifacts-ovm
 
-# copy over the cache so that hardhat-deploy does not recompile
-COPY --from=builder /optimism/packages/contracts/cache ./cache
-COPY --from=builder /optimism/packages/contracts/cache-ovm ./cache-ovm
-
-# get the files for hardhat-deploy
-COPY --from=builder /optimism/packages/contracts/contracts ./contracts
-COPY --from=builder /optimism/packages/contracts/hardhat.config.ts ./
-COPY --from=builder /optimism/packages/contracts/deploy ./deploy
-COPY --from=builder /optimism/packages/contracts/tasks ./tasks
-COPY --from=builder /optimism/packages/contracts/src ./src
-COPY --from=builder /optimism/packages/contracts/test/helpers/constants.ts ./test/helpers/constants.ts
-COPY --from=builder /optimism/packages/contracts/scripts ./scripts
+# get non-build artifacts from the host
+COPY packages/contracts/bin ./bin
+COPY packages/contracts/contracts ./contracts
+COPY packages/contracts/hardhat.config.ts ./
+COPY packages/contracts/deploy ./deploy
+COPY packages/contracts/tasks ./tasks
+COPY packages/contracts/src ./src
+COPY packages/contracts/test/helpers/constants.ts ./test/helpers/constants.ts
+COPY packages/contracts/scripts ./scripts
 
 COPY ./ops/scripts/deployer.sh .
 ENTRYPOINT yarn run deploy

--- a/packages/contracts/bin/deploy.ts
+++ b/packages/contracts/bin/deploy.ts
@@ -36,6 +36,7 @@ const main = async () => {
     ovmProposerAddress: sequencer.address,
     ovmRelayerAddress: sequencer.address,
     ovmAddressManagerOwner: deployer.address,
+    noCompile: process.env.NO_COMPILE ? true : false,
   })
 
   // Stuff below this line is currently required for CI to work properly. We probably want to


### PR DESCRIPTION
As title, disables building via the [`--noCompile`](https://github.com/wighawag/hardhat-deploy/blob/master/src/index.ts#L359-L361) flag, saving us 1m+ of CI time