### PR TITLE
choretag private packages w/o publishing them to NPM

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -2,6 +2,7 @@
   "name": "@eth-optimism/integration-tests",
   "version": "0.0.1",
   "description": "[Optimism] Integration Tests",
+  "private": true,
   "author": "Optimism PBC",
   "license": "MIT",
   "scripts": {

--- a/l2geth/package.json
+++ b/l2geth/package.json
@@ -1,4 +1,5 @@
 {
   "name": "@eth-optimism/l2geth",
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "private": true,
   "devDependencies": {
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "patch-package": "^6.4.7"
   },
   "scripts": {
     "clean": "yarn lerna run clean",
@@ -18,7 +19,8 @@
     "test:ci": "yarn lerna run test --parallel --since origin/master",
     "lint": "yarn lerna run lint",
     "lint:ci": "yarn lerna run lint  --parallel --since origin/master",
-    "lint:fix": "yarn lerna run lint:fix"
+    "lint:fix": "yarn lerna run lint:fix",
+    "post-install": "patch-package"
   },
   "dependencies": {
     "@changesets/cli": "^2.16.0"

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/batch-submitter",
   "version": "0.1.7",
+  "private": true,
   "description": "[Optimism] Batch submission for sequencer & aggregators",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/data-transport-layer",
   "version": "0.1.2",
+  "private": true,
   "main": "dist/index",
   "files": [
     "dist/index"

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/message-relayer",
   "version": "0.0.1",
+  "private": true,
   "description": "[Optimism] Cross Domain Message Relayer service",
   "main": "dist/index",
   "types": "dist/index",

--- a/patches/@changesets+cli+2.16.0.patch
+++ b/patches/@changesets+cli+2.16.0.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/@changesets/cli/dist/cli.cjs.dev.js b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
+index f771824..662990f 100644
+--- a/node_modules/@changesets/cli/dist/cli.cjs.dev.js
++++ b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
+@@ -786,6 +786,7 @@ async function publishPackages({
+ }) {
+   const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]));
+   const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
++  const privatePackages = packages.filter(pkg => pkg.packageJson.private);
+   let twoFactorState = otp === undefined ? {
+     token: null,
+     isRequired: isCI || publicPackages.some(x => x.packageJson.publishConfig && x.packageJson.publishConfig.registry && x.packageJson.publishConfig.registry !== "https://registry.npmjs.org" && x.packageJson.publishConfig.registry !== "https://registry.yarnpkg.com") || process.env.npm_config_registry !== undefined && process.env.npm_config_registry !== "https://registry.npmjs.org" && process.env.npm_config_registry !== "https://registry.yarnpkg.com" ? Promise.resolve(false) : // note: we're not awaiting this here, we want this request to happen in parallel with getUnpublishedPackages
+@@ -800,10 +801,26 @@ async function publishPackages({
+     logger.warn("No unpublished packages to publish");
+   }
+ 
+-  return Promise.all(unpublishedPackagesInfo.map(pkgInfo => {
+-    let pkg = packagesByName.get(pkgInfo.name);
+-    return publishAPackage(pkg, access, twoFactorState, getReleaseTag(pkgInfo, preState, tag));
+-  }));
++  const privatePromises = privatePackages.filter(privatePackage => {
++      const tagName = `${privatePackage.packageJson.name}@${privatePackage.packageJson.version}`
++      return !tagExists(tagName)
++  }).map(privatePackage => {
++    return Promise.resolve({
++        name: privatePackage.packageJson.name,
++        newVersion: privatePackage.packageJson.version,
++        // Private packages do not need to be published
++        published: true
++      });
++  });
++
++
++  const publicPromises = unpublishedPackagesInfo.map(pkgInfo => {
++      let pkg = packagesByName.get(pkgInfo.name);
++      return publishAPackage(pkg, access, twoFactorState, getReleaseTag(pkgInfo, preState, tag));
++  })
++
++  const promises = [...privatePromises, ...publicPromises]
++  return Promise.all(promises);
+ }
+ 
+ async function publishAPackage(pkg, access, twoFactorState, tag) {
+@@ -1357,3 +1374,8 @@ ${util.format("", err).replace(process.cwd(), "<cwd>")}
+   logger.error(err);
+   process.exit(1);
+ });
++
++async function tagExists(tagStr) {
++  const gitCmd = await spawn("git", ["tag", "-l", tagStr]);
++  return !!gitCmd.stdout.toString().trim();
++}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9698,7 +9698,7 @@ patch-package@6.2.2:
     slash "^2.0.0"
     tmp "^0.0.33"
 
-patch-package@^6.2.2:
+patch-package@^6.2.2, patch-package@^6.4.7:
   version "6.4.7"
   resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
   integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==


### PR DESCRIPTION
Adds a patch from a [discussion in Changesets](https://github.com/atlassian/changesets/issues/399) which allows a package to be automatically tagged, even though it is marked as private. This will allow us to use changesets' publish flow to publish NPM packages automatically, and then we'll only need to add an additional job for publishing docker images.