### PR TITLE
ci: publish npm packages on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,5 +26,8 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@master
+        with:
+          publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "yarn lerna run lint",
     "lint:ci": "yarn lerna run lint  --parallel --since origin/master",
     "lint:fix": "yarn lerna run lint:fix",
-    "post-install": "patch-package"
+    "post-install": "patch-package",
+    "release": "yarn build && yarn changeset publish"
   },
   "dependencies": {
     "@changesets/cli": "^2.16.0"


### PR DESCRIPTION
adds the publish step to the changesets action, so that packages get published to npm alongside everything else