### PR TITLE
fix: add build files to the published npm package

### DIFF
--- a/.changeset/spotty-sloths-repeat.md
+++ b/.changeset/spotty-sloths-repeat.md
@@ -1,0 +1,8 @@
+---
+"@eth-optimism/contracts": patch
+"@eth-optimism/core-utils": patch
+"@eth-optimism/hardhat-ovm": patch
+"@eth-optimism/smock": patch
+---
+
+adds build files which were not published before to npm

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -3,7 +3,12 @@
   "version": "0.2.2",
   "main": "dist/index",
   "files": [
-    "dist/index"
+    "dist/**/*.js",
+    "dist/contracts/*",
+    "dist/dumps/*json",
+    "dist/artifacts/**/*.json",
+    "dist/artifacts-ovm/**/*.json",
+    "dist/types/**/*.ts"
   ],
   "types": "dist/index",
   "license": "MIT",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "main": "dist/index",
   "files": [
-    "dist/index"
+    "dist/*"
   ],
   "types": "dist/index",
   "repository": "git@github.com:ethereum-optimism/core-utils.git",

--- a/packages/hardhat-ovm/package.json
+++ b/packages/hardhat-ovm/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-      "dist/index"
+      "dist/*"
   ],
   "license": "MIT",
   "scripts": {

--- a/packages/smock/package.json
+++ b/packages/smock/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@eth-optimism/smock",
+   "files": [
+    "dist/src/*"
+  ],
   "version": "1.0.0",
   "main": "dist/src/index",
   "types": "dist/src/index",
-  "files": [
-    "dist/src/index"
-  ],
   "license": "MIT",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
`package.json` was missing the correct `files` tag, in order to publish the entire package to npm