### PR TITLE
fix: l1 block number logic debug and logging

### DIFF
--- a/.changeset/four-humans-draw.md
+++ b/.changeset/four-humans-draw.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter": patch
+---
+
+removed unused l1 block number logic, added debug logging to batch submitter


### PR DESCRIPTION
**Description**
Our batch submitter has been reverting with error logs we haven't encountered in the past (see linked issue). This PR deletes the related codepaths that should not be active and adds logs that may help us debug the issue.

**Additional context**
See linked issue.

**Metadata**
- Attempts to debug https://github.com/ethereum-optimism/optimism/issues/455
