### PR TITLE
fix: package contracts with correct paths

### DIFF
--- a/.changeset/hip-mugs-smell.md
+++ b/.changeset/hip-mugs-smell.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+fix contract import paths

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,11 +4,12 @@
   "main": "dist/index",
   "files": [
     "dist/**/*.js",
-    "dist/contracts/*",
-    "dist/dumps/*json",
-    "dist/artifacts/**/*.json",
-    "dist/artifacts-ovm/**/*.json",
-    "dist/types/**/*.ts"
+    "artifacts/**/*.json",
+    "artifacts-ovm/**/*.json",
+    "OVM",
+    "iOVM",
+    "libraries",
+    "mockOVM"
   ],
   "types": "dist/index",
   "license": "MIT",
@@ -21,10 +22,6 @@
     "build:contracts": "hardhat compile --show-stack-traces",
     "build:contracts:ovm": "hardhat compile --network optimism",
     "build:dump": "ts-node \"bin/take-dump.ts\"",
-    "build:copy": "yarn run build:copy:artifacts && yarn build:copy:artifacts:ovm && yarn run build:copy:contracts",
-    "build:copy:artifacts": "copyfiles -u 1 \"artifacts/**/*.json\" \"dist/artifacts\"",
-    "build:copy:artifacts:ovm": "copyfiles -u 1 \"artifacts-ovm/**/*.json\" \"dist/artifacts-ovm\"",
-    "build:copy:contracts": "copyfiles -u 2 \"contracts/optimistic-ethereum/**/*.sol\" \"dist/contracts\"",
     "build:typechain": "hardhat typechain",
     "test": "yarn run test:contracts",
     "test:contracts": "hardhat test --show-stack-traces",
@@ -35,7 +32,11 @@
     "lint:fix:typescript": "prettier --config prettier-config.json --write \"hardhat.config.ts\" \"{src,test}/**/*.ts\"",
     "clean": "rm -rf ./dist ./artifacts ./artifacts-ovm ./cache ./cache-ovm ./tsconfig.build.tsbuildinfo",
     "deploy": "./bin/deploy.ts",
-    "serve": "./bin/serve_dump.sh"
+    "serve": "./bin/serve_dump.sh",
+    "prepublishOnly": "yarn copyfiles -u 2 \"contracts/optimistic-ethereum/**/*\" ./",
+    "postpublish": "rimraf OVM iOVM libraries mockOVM",
+    "prepack": "yarn prepublishOnly",
+    "postpack": "yarn postpublish"
   },
   "dependencies": {
     "@eth-optimism/core-utils": "^0.2.1",

--- a/packages/contracts/scripts/build.sh
+++ b/packages/contracts/scripts/build.sh
@@ -1,3 +1,2 @@
 yarn run build:typescript & yarn run build:contracts
 yarn run build:contracts:ovm
-yarn run build:copy:artifacts & yarn run build:copy:artifacts:ovm & yarn run build:copy:contracts


### PR DESCRIPTION
* Allows importing OVM contract as:

```solidity
import "@eth-optimism/contracts/OVM/accounts/OVM_ECDSAContractAccount.sol";
import "@eth-optimism/contracts/iOVM/...";
import "@eth-optimism/contracts/libraries/...";
```

* Removes the `copyfiles` build steps, these were not required as we can package `artifacts` and `artifacts-ovm` via the `files` field in package.json
* Adds a `prepublish` step which copies over `contracts/optimistic-ethereum/**` to the top level directory