### PR TITLE
fix: revert hardhat type usage

### DIFF
--- a/packages/contracts/src/hardhat-deploy-ethers.ts
+++ b/packages/contracts/src/hardhat-deploy-ethers.ts
@@ -2,7 +2,6 @@
 import { Contract } from 'ethers'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
-import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
 export const registerAddress = async ({
   hre,
@@ -51,7 +50,7 @@ export const deployAndRegister = async ({
   args,
   contract,
 }: {
-  hre: HardhatRuntimeEnvironment
+  hre: any
   name: string
   args: any[]
   contract?: string
@@ -78,7 +77,7 @@ export const deployAndRegister = async ({
 }
 
 export const getDeployedContract = async (
-  hre: HardhatRuntimeEnvironment,
+  hre: any,
   name: string,
   options: {
     iface?: string


### PR DESCRIPTION
Unfortunately there is a build error that does not show on CI.

```
$ hardhat compile --show-stack-traces
Error: src/hardhat-deploy-ethers.ts(59,26): error TS2339: Property 'deployments' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(60,34): error TS2339: Property 'getNamedAccounts' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(69,13): error TS2339: Property 'ethers' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(88,30): error TS2339: Property 'deployments' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(90,13): error TS2339: Property 'ethers' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(93,23): error TS2339: Property 'ethers' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(95,31): error TS2339: Property 'ethers' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(99,49): error TS2339: Property 'ethers' does not exist on type 'HardhatRuntimeEnvironment'.
Error: src/hardhat-deploy-ethers.ts(102,30): error TS2339: Property 'ethers' does not exist on type 'HardhatRuntimeEnvironment'.
```
