### PR TITLE
dtl: add query param based querying for txs

### DIFF
--- a/.changeset/calm-books-hope.md
+++ b/.changeset/calm-books-hope.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/data-transport-layer": patch
+---
+
+Add backwards compatible query params to REST API

--- a/.changeset/calm-books-hope.md
+++ b/.changeset/calm-books-hope.md
@@ -2,4 +2,7 @@
 "@eth-optimism/data-transport-layer": patch
 ---
 
-Add backwards compatible query params to REST API
+Allow the DTL to provide data from either L1 or L2, configurable via a query param sent by the client.
+The config option `default-backend` can be used to specify the backend to be
+used if the query param is not specified. This allows it to be backwards
+compatible with how the DTL was previously used.

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -43,10 +43,6 @@ const optionSettings = {
     default: false,
     validate: validators.isBoolean,
   },
-  stopL2SyncAtBlock: {
-    default: Infinity,
-    validate: validators.isInteger,
-  },
 }
 
 export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
@@ -80,30 +76,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
         const highestSyncedL2BlockNumber =
           (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 1
 
-        // Shut down if we're at the stop block.
-        if (
-          this.options.stopL2SyncAtBlock !== undefined &&
-          this.options.stopL2SyncAtBlock !== null &&
-          highestSyncedL2BlockNumber >= this.options.stopL2SyncAtBlock
-        ) {
-          this.logger.info(
-            "L2 sync is shutting down because we've reached your target block. Goodbye!"
-          )
-          return
-        }
-
-        let currentL2Block = await this.state.l2RpcProvider.getBlockNumber()
-
-        // Make sure we can't exceed the stop block.
-        if (
-          this.options.stopL2SyncAtBlock !== undefined &&
-          this.options.stopL2SyncAtBlock !== null
-        ) {
-          currentL2Block = Math.min(
-            currentL2Block,
-            this.options.stopL2SyncAtBlock
-          )
-        }
+        const currentL2Block = await this.state.l2RpcProvider.getBlockNumber()
 
         // Make sure we don't exceed the tip.
         const targetL2Block = Math.min(

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -21,12 +21,12 @@ export interface L1DataTransportServiceOptions {
   logsPerPollingInterval: number
   pollingInterval: number
   port: number
-  showUnconfirmedTransactions: boolean
   syncFromL1?: boolean
   syncFromL2?: boolean
   transactionsPerPollingInterval: number
   legacySequencerCompatibility: boolean
   sentryDsn?: string
+  defaultSource: string
 }
 
 const optionSettings = {

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -26,7 +26,7 @@ export interface L1DataTransportServiceOptions {
   transactionsPerPollingInterval: number
   legacySequencerCompatibility: boolean
   sentryDsn?: string
-  defaultSource: string
+  defaultBackend: string
 }
 
 const optionSettings = {

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -26,7 +26,6 @@ export interface L1DataTransportServiceOptions {
   syncFromL2?: boolean
   transactionsPerPollingInterval: number
   legacySequencerCompatibility: boolean
-  stopL2SyncAtBlock?: number
   sentryDsn?: string
 }
 

--- a/packages/data-transport-layer/src/services/run.ts
+++ b/packages/data-transport-layer/src/services/run.ts
@@ -39,7 +39,6 @@ interface Bcfg {
       l2ChainId: config.uint('l2ChainId'),
       syncFromL1: config.bool('syncFromL1', true),
       syncFromL2: config.bool('syncFromL2', false),
-      showUnconfirmedTransactions: config.bool('syncFromL2', false),
       transactionsPerPollingInterval: config.uint(
         'transactionsPerPollingInterval',
         1000
@@ -49,6 +48,7 @@ interface Bcfg {
         false
       ),
       sentryDsn: config.str('sentryDsn'),
+      defaultSource: config.str('defaultSource', 'batched'),
     })
 
     await service.start()

--- a/packages/data-transport-layer/src/services/run.ts
+++ b/packages/data-transport-layer/src/services/run.ts
@@ -48,7 +48,7 @@ interface Bcfg {
         false
       ),
       sentryDsn: config.str('sentryDsn'),
-      defaultSource: config.str('defaultSource', 'batched'),
+      defaultBackend: config.str('defaultBackend', 'l1'),
     })
 
     await service.start()

--- a/packages/data-transport-layer/src/services/run.ts
+++ b/packages/data-transport-layer/src/services/run.ts
@@ -48,7 +48,6 @@ interface Bcfg {
         'legacySequencerCompatibility',
         false
       ),
-      stopL2SyncAtBlock: config.uint('stopL2SyncAtBlock'),
       sentryDsn: config.str('sentryDsn'),
     })
 

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -48,6 +48,12 @@ const optionSettings = {
       return validators.isUrl(val) || validators.isJsonRpcProvider(val)
     },
   },
+  defaultSource: {
+    default: 'batched',
+    validate: (val: string) => {
+      return val === 'batched' || val === 'sequenced'
+    }
+  }
 }
 
 export class L1TransportServer extends BaseService<L1TransportServerOptions> {
@@ -63,7 +69,6 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
   } = {} as any
 
   protected async _init(): Promise<void> {
-    // TODO: I don't know if this is strictly necessary, but it's probably a good thing to do.
     if (!this.options.db.isOpen()) {
       await this.options.db.open()
     }
@@ -168,14 +173,27 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
    * TODO: Link to our API spec.
    */
   private _registerAllRoutes(): void {
-    // TODO: Maybe add doc-like comments to each of these routes?
-
+    // TODO: this needs a source argument
     this._registerRoute(
       'get',
       '/eth/syncing',
-      async (): Promise<SyncingResponse> => {
-        const highestL2BlockNumber = await this.state.db.getHighestL2BlockNumber()
-        const currentL2Block = await this.state.db.getLatestTransaction()
+      async (req): Promise<SyncingResponse> => {
+        const source = req.query.source || this.options.defaultSource
+
+        let currentL2Block
+        let highestL2BlockNumber
+        switch (source) {
+          case 'batched':
+            currentL2Block = await this.state.db.getLatestTransaction()
+            highestL2BlockNumber = await this.state.db.getHighestL2BlockNumber()
+            break
+          case 'sequenced':
+            currentL2Block = await this.state.db.getLatestUnconfirmedTransaction()
+            highestL2BlockNumber = await this.state.db.getHighestSyncedUnconfirmedBlock()
+            break
+          default:
+            throw new Error(`Unknown transaction source ${source}`)
+        }
 
         if (currentL2Block === null) {
           if (highestL2BlockNumber === null) {
@@ -326,21 +344,19 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this._registerRoute(
       'get',
       '/transaction/latest',
-      async (): Promise<TransactionResponse> => {
-        let transaction = await this.state.db.getLatestFullTransaction()
-        if (this.options.showUnconfirmedTransactions) {
-          const latestUnconfirmedTx = await this.state.db.getLatestUnconfirmedTransaction()
-          if (
-            transaction === null ||
-            transaction === undefined ||
-            latestUnconfirmedTx.index >= transaction.index
-          ) {
-            transaction = latestUnconfirmedTx
-          }
-        }
+      async (req): Promise<TransactionResponse> => {
+        const source = req.query.source || this.options.defaultSource
+        let transaction = null
 
-        if (transaction === null) {
-          transaction = await this.state.db.getLatestFullTransaction()
+        switch (source) {
+          case 'batched':
+            transaction = await this.state.db.getLatestFullTransaction()
+            break
+          case 'sequenced':
+            transaction = await this.state.db.getLatestUnconfirmedTransaction()
+            break
+          default:
+            throw new Error(`Unknown transaction source ${source}`)
         }
 
         if (transaction === null) {
@@ -365,17 +381,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/transaction/index/:index',
       async (req): Promise<TransactionResponse> => {
+        const source = req.query.source || this.options.defaultSource
         let transaction = null
-        if (this.options.showUnconfirmedTransactions) {
-          transaction = await this.state.db.getUnconfirmedTransactionByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
-        }
 
-        if (transaction === null) {
-          transaction = await this.state.db.getFullTransactionByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
+        switch (source) {
+          case 'batched':
+            transaction = await this.state.db.getFullTransactionByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          case 'sequenced':
+            transaction = await this.state.db.getUnconfirmedTransactionByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          default:
+            throw new Error(`Unknown transaction source ${source}`)
         }
 
         if (transaction === null) {
@@ -453,21 +474,19 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this._registerRoute(
       'get',
       '/stateroot/latest',
-      async (): Promise<StateRootResponse> => {
-        let stateRoot = await this.state.db.getLatestStateRoot()
-        if (this.options.showUnconfirmedTransactions) {
-          const latestUnconfirmedStateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
-          if (
-            stateRoot === null ||
-            stateRoot === undefined ||
-            latestUnconfirmedStateRoot.index >= stateRoot.index
-          ) {
-            stateRoot = latestUnconfirmedStateRoot
-          }
-        }
+      async (req): Promise<StateRootResponse> => {
+        const source = req.query.source || this.options.defaultSource
+        let stateRoot = null
 
-        if (stateRoot === null) {
-          stateRoot = await this.state.db.getLatestStateRoot()
+        switch (source) {
+          case 'batched':
+            stateRoot = await this.state.db.getLatestStateRoot()
+            break
+          case 'sequenced':
+            stateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
+            break
+          default:
+            throw new Error(`Unknown transaction source ${source}`)
         }
 
         if (stateRoot === null) {
@@ -492,17 +511,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/stateroot/index/:index',
       async (req): Promise<StateRootResponse> => {
+        const source = req.query.source || this.options.defaultSource
         let stateRoot = null
-        if (this.options.showUnconfirmedTransactions) {
-          stateRoot = await this.state.db.getUnconfirmedStateRootByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
-        }
 
-        if (stateRoot === null) {
-          stateRoot = await this.state.db.getStateRootByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
+        switch (source) {
+          case 'batched':
+            stateRoot = await this.state.db.getStateRootByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          case 'sequenced':
+            stateRoot = await this.state.db.getUnconfirmedStateRootByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          default:
+            throw new Error(`Unknown transaction source ${source}`)
         }
 
         if (stateRoot === null) {

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -173,7 +173,6 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
    * TODO: Link to our API spec.
    */
   private _registerAllRoutes(): void {
-    // TODO: this needs a source argument
     this._registerRoute(
       'get',
       '/eth/syncing',

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -48,10 +48,10 @@ const optionSettings = {
       return validators.isUrl(val) || validators.isJsonRpcProvider(val)
     },
   },
-  defaultSource: {
-    default: 'batched',
+  defaultBackend: {
+    default: 'l1',
     validate: (val: string) => {
-      return val === 'batched' || val === 'sequenced'
+      return val === 'l1' || val === 'l2'
     }
   }
 }
@@ -177,21 +177,21 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/eth/syncing',
       async (req): Promise<SyncingResponse> => {
-        const source = req.query.source || this.options.defaultSource
+        const backend = req.query.backend || this.options.defaultBackend
 
         let currentL2Block
         let highestL2BlockNumber
-        switch (source) {
-          case 'batched':
+        switch (backend) {
+          case 'l1':
             currentL2Block = await this.state.db.getLatestTransaction()
             highestL2BlockNumber = await this.state.db.getHighestL2BlockNumber()
             break
-          case 'sequenced':
+          case 'l2':
             currentL2Block = await this.state.db.getLatestUnconfirmedTransaction()
             highestL2BlockNumber = await this.state.db.getHighestSyncedUnconfirmedBlock()
             break
           default:
-            throw new Error(`Unknown transaction source ${source}`)
+            throw new Error(`Unknown transaction backend ${backend}`)
         }
 
         if (currentL2Block === null) {
@@ -344,18 +344,18 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/transaction/latest',
       async (req): Promise<TransactionResponse> => {
-        const source = req.query.source || this.options.defaultSource
+        const backend = req.query.backend || this.options.defaultBackend
         let transaction = null
 
-        switch (source) {
-          case 'batched':
+        switch (backend) {
+          case 'l1':
             transaction = await this.state.db.getLatestFullTransaction()
             break
-          case 'sequenced':
+          case 'l2':
             transaction = await this.state.db.getLatestUnconfirmedTransaction()
             break
           default:
-            throw new Error(`Unknown transaction source ${source}`)
+            throw new Error(`Unknown transaction backend ${backend}`)
         }
 
         if (transaction === null) {
@@ -380,22 +380,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/transaction/index/:index',
       async (req): Promise<TransactionResponse> => {
-        const source = req.query.source || this.options.defaultSource
+        const backend = req.query.backend || this.options.defaultBackend
         let transaction = null
 
-        switch (source) {
-          case 'batched':
+        switch (backend ) {
+          case 'l1':
             transaction = await this.state.db.getFullTransactionByIndex(
               BigNumber.from(req.params.index).toNumber()
             )
             break
-          case 'sequenced':
+          case 'l2':
             transaction = await this.state.db.getUnconfirmedTransactionByIndex(
               BigNumber.from(req.params.index).toNumber()
             )
             break
           default:
-            throw new Error(`Unknown transaction source ${source}`)
+            throw new Error(`Unknown transaction backend ${backend}`)
         }
 
         if (transaction === null) {
@@ -474,18 +474,18 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/stateroot/latest',
       async (req): Promise<StateRootResponse> => {
-        const source = req.query.source || this.options.defaultSource
+        const backend = req.query.backend || this.options.defaultBackend
         let stateRoot = null
 
-        switch (source) {
-          case 'batched':
+        switch (backend) {
+          case 'l1':
             stateRoot = await this.state.db.getLatestStateRoot()
             break
-          case 'sequenced':
+          case 'l2':
             stateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
             break
           default:
-            throw new Error(`Unknown transaction source ${source}`)
+            throw new Error(`Unknown transaction backend ${backend}`)
         }
 
         if (stateRoot === null) {
@@ -510,22 +510,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/stateroot/index/:index',
       async (req): Promise<StateRootResponse> => {
-        const source = req.query.source || this.options.defaultSource
+        const backend = req.query.backend || this.options.defaultBackend
         let stateRoot = null
 
-        switch (source) {
-          case 'batched':
+        switch (backend) {
+          case 'l1':
             stateRoot = await this.state.db.getStateRootByIndex(
               BigNumber.from(req.params.index).toNumber()
             )
             break
-          case 'sequenced':
+          case 'l2':
             stateRoot = await this.state.db.getUnconfirmedStateRootByIndex(
               BigNumber.from(req.params.index).toNumber()
             )
             break
           default:
-            throw new Error(`Unknown transaction source ${source}`)
+            throw new Error(`Unknown transaction backend ${backend}`)
         }
 
         if (stateRoot === null) {

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -48,9 +48,6 @@ const optionSettings = {
       return validators.isUrl(val) || validators.isJsonRpcProvider(val)
     },
   },
-  showUnconfirmedTransactions: {
-    validate: validators.isBoolean,
-  },
 }
 
 export class L1TransportServer extends BaseService<L1TransportServerOptions> {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The DTL currently prioritizes transactions sourced from L2 instead of transactions sourced from L1. This was a quick patch required for sequencer maintenance, the source of truth should generally be L1. This allows the client to specify a query param that says to source the transaction from L1 or from L2 

**Additional context**
Related to https://github.com/ethereum-optimism/optimism/pull/477
Previously query params had no impact on the DTL. The DTL has a backing index for both transactions ingested from the L1 contracts (CTC + SCC) and an index for transactions pulled from a sequencer (`eth_getBlockByNumber`). The DTL has preferred different data sources over time. Before this PR, the config option `showUnconfirmedTransactions` being set to true would prefer the L2 sourced transactions but then fall back to L1 sourced transactions. After this PR, the client will specify the data source and then the server will only return that transaction sourced from that datasource.