### PR TITLE
build: data-transport-layer leveldb file is gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ cache-ovm
 l2geth/build/bin
 packages/contracts/deployments/custom
 
+packages/contracts/data-transport-layer/db
+
 .env


### PR DESCRIPTION
Noticed this from discussion: https://github.com/ethereum-optimism/optimism/pull/480#discussion_r615918652