### PR TITLE
optimization: add back in the abi caching

### DIFF
--- a/.changeset/rude-moons-kiss.md
+++ b/.changeset/rude-moons-kiss.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+CPU Optimization by caching ABI methods

--- a/l2geth/accounts/abi/abi.go
+++ b/l2geth/accounts/abi/abi.go
@@ -32,6 +32,7 @@ type ABI struct {
 	Constructor Method
 	Methods     map[string]Method
 	Events      map[string]Event
+	MethodsById map[[4]byte]*Method
 }
 
 // JSON returns a parsed ABI interface and error if it failed.
@@ -120,6 +121,7 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	abi.Methods = make(map[string]Method)
+	abi.MethodsById = make(map[[4]byte]*Method)
 	abi.Events = make(map[string]Event)
 	for _, field := range fields {
 		switch field.Type {
@@ -136,13 +138,17 @@ func (abi *ABI) UnmarshalJSON(data []byte) error {
 				_, ok = abi.Methods[name]
 			}
 			isConst := field.Constant || field.StateMutability == "pure" || field.StateMutability == "view"
-			abi.Methods[name] = Method{
+			method := Method{
 				Name:    name,
 				RawName: field.Name,
 				Const:   isConst,
 				Inputs:  field.Inputs,
 				Outputs: field.Outputs,
 			}
+			abi.Methods[name] = method
+			// add method to the id cache
+			sigdata := method.ID()
+			abi.MethodsById[[4]byte{sigdata[0], sigdata[1], sigdata[2], sigdata[3]}] = &method
 		case "event":
 			name := field.Name
 			_, ok := abi.Events[name]
@@ -168,12 +174,12 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 	if len(sigdata) < 4 {
 		return nil, fmt.Errorf("data too short (%d bytes) for abi method lookup", len(sigdata))
 	}
-	for _, method := range abi.Methods {
-		if bytes.Equal(method.ID(), sigdata[:4]) {
-			return &method, nil
-		}
+
+	method, exist := abi.MethodsById[[4]byte{sigdata[0], sigdata[1], sigdata[2], sigdata[3]}]
+	if !exist {
+		return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
 	}
-	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
+	return method, nil
 }
 
 // EventByID looks an event up by its topic hash in the


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This adds back in geohot's optimization:  https://github.com/ethereum-optimism/go-ethereum/commit/8d13a77e4916393b87ea3601590eea9f004ce09e
It was recently [removed]( https://github.com/ethereum-optimism/go-ethereum/commit/9e1ca7e30a927df064ed9f0469a29f316c91a731) but is still useful as it is still in the [hot code path](https://github.com/ethereum-optimism/optimism/blob/c4266faf369c929bf555951df5810b6522c7a248/l2geth/core/vm/ovm_state_manager.go#L40).

Below is a picture from the `pprof` CPU profiling before these changes

<img width="811" alt="Screen Shot 2021-04-19 at 10 49 48 AM" src="https://user-images.githubusercontent.com/6626818/115280676-0a01eb00-a0fd-11eb-99f7-afdf0656d4ba.png">

This PR adds a cache to `abi.Method.ID` so that each call doesn't result in a bunch of hashing and reduces the amount of time that is spent in that method significantly.

It was generated with the following script on top of https://github.com/ethereum-optimism/optimism/pull/477 so be sure to checkout that branch and `make geth` before running it:
```bash
#!/bin/bash

USING_OVM=true ./build/bin/geth \
    --datadir $HOME/.ethereum \
    --eth1.syncservice \
    --rollup.synctype sequenced \
    --eth1.l1crossdomainmessengeraddress 0xD1EC7d40CCd01EB7A305b94cBa8AB6D17f6a9eFE \
    --eth1.l1ethgatewayaddress 0xF20C38fCdDF0C790319Fd7431d17ea0c2bC9959c \
    --rollup.addressmanagerowneraddress 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A \
    --rollup.statedumppath https://storage.googleapis.com/optimism/mainnet/3.json \
    --eth1.ctcdeploymentheight 12207792 \
    --rollup.clienthttp http://localhost:7878 \
    --rollup.verifier \
    --rpc \
    --dev \
    --chainid 10 \
    --rpcaddr 0.0.0.0 \
    --rpcport 8545 \
    --rpcvhosts '*' \
    --rpccorsdomain '*' \
    --ws \
    --wsaddr 0.0.0.0 \
    --wsport 8546 \
    --wsorigins '*' \
    --rpcapi 'eth,net,rollup,web3' \
    --gasprice 0 \
    --miner.gastarget 9000000 \
    --miner.gaslimit 9000000 \
    --nousb \
    --gcmode=archive \
    --ipcdisable \
    --verbosity=3 \
    --pprof \
    --cpuprofile cpu.prof
```

Run the above script and let `geth` run for some time and then `SIGINT` the process. This will result in the generation of the file `cpu.prof`.
Use `pprof` to create an SVG that can be viewed in the browser. The following command will drop you into the interactive `pprof` CLI, once you are in it use the `svg` command to generate an SVG
```bash
$ go tool pprof -lines cpu.prof
```

Once the SVG has been created, `python3` can be used to serve it to the browser

```bash
$ python -m http.server --bind 0.0.0.0 8080 --directory .
```

**Additional context**
Need to do additional profiling to determine where the actual bottlenecks are but this was low hanging fruit