### PR TITLE
feat: add metrics to core-utils 

### DIFF
--- a/.changeset/calm-days-sleep.md
+++ b/.changeset/calm-days-sleep.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/core-utils": minor
----
-
-add Metrics and use in base-service

--- a/.changeset/calm-days-sleep.md
+++ b/.changeset/calm-days-sleep.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/core-utils": minor
+---
+
+add Metrics and use in base-service

--- a/.changeset/few-bags-roll.md
+++ b/.changeset/few-bags-roll.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/core-utils": minor
+"@eth-optimism/data-transport-layer": minor
+---
+
+add Metrics and use in base-service, rename DTL services to avoid spaces

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -33,6 +33,7 @@
     "@ethersproject/abstract-provider": "^5.0.9",
     "ethers": "^5.0.31",
     "lodash": "^4.17.21",
-    "pino": "^6.11.1"
+    "pino": "^6.11.1",
+    "prom-client": "^13.1.0"
   }
 }

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -1,5 +1,6 @@
 /* Imports: Internal */
 import { Logger } from './common/logger'
+import { Metrics } from './common/metrics'
 
 type OptionSettings<TOptions> = {
   [P in keyof TOptions]?: {
@@ -16,6 +17,7 @@ export class BaseService<T> {
   protected name: string
   protected options: T
   protected logger: Logger
+  protected metrics: Metrics
   protected initialized: boolean = false
   protected running: boolean = false
 
@@ -24,6 +26,7 @@ export class BaseService<T> {
     this.name = name
     this.options = mergeDefaultOptions(options, optionSettings)
     this.logger = new Logger({ name })
+    this.metrics = new Metrics({ prefix: name })
   }
 
   /**

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -26,7 +26,7 @@ export class BaseService<T> {
     this.name = name
     this.options = mergeDefaultOptions(options, optionSettings)
     this.logger = new Logger({ name })
-    this.metrics = new Metrics({ prefix: name.split(' ').join('_') })
+    this.metrics = new Metrics({ prefix: name })
   }
 
   /**

--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -26,7 +26,7 @@ export class BaseService<T> {
     this.name = name
     this.options = mergeDefaultOptions(options, optionSettings)
     this.logger = new Logger({ name })
-    this.metrics = new Metrics({ prefix: name })
+    this.metrics = new Metrics({ prefix: name.split(' ').join('_') })
   }
 
   /**

--- a/packages/core-utils/src/common/metrics.ts
+++ b/packages/core-utils/src/common/metrics.ts
@@ -1,0 +1,31 @@
+import prometheus, {
+  collectDefaultMetrics,
+  DefaultMetricsCollectorConfiguration,
+  Registry,
+} from 'prom-client'
+
+export interface MetricsOptions {
+  prefix: string
+  labels?: Object
+}
+
+export class Metrics {
+  options: MetricsOptions
+  client: typeof prometheus
+  registry: Registry
+
+  constructor(options: MetricsOptions) {
+    this.options = options
+
+    const metricsOptions: DefaultMetricsCollectorConfiguration = {
+      prefix: options.prefix,
+      labels: options.labels,
+    }
+
+    this.client = prometheus
+    this.registry = prometheus.register
+
+    // Collect default metrics (event loop lag, memory, file descriptors etc.)
+    collectDefaultMetrics(metricsOptions)
+  }
+}

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -60,7 +60,7 @@ const optionSettings = {
 
 export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
   constructor(options: L1IngestionServiceOptions) {
-    super('L1 Ingestion Service', options, optionSettings)
+    super('L1_Ingestion_Service', options, optionSettings)
   }
 
   private state: {

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -51,7 +51,7 @@ const optionSettings = {
 
 export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
   constructor(options: L2IngestionServiceOptions) {
-    super('L2 Ingestion Service', options, optionSettings)
+    super('L2_Ingestion_Service', options, optionSettings)
   }
 
   private state: {

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -44,7 +44,7 @@ const optionSettings = {
 // prettier-ignore
 export class L1DataTransportService extends BaseService<L1DataTransportServiceOptions> {
   constructor(options: L1DataTransportServiceOptions) {
-    super('L1 Data Transport Service', options, optionSettings)
+    super('L1_Data_Transport_Service', options, optionSettings)
   }
 
   private state: {

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -55,7 +55,7 @@ const optionSettings = {
 
 export class L1TransportServer extends BaseService<L1TransportServerOptions> {
   constructor(options: L1TransportServerOptions) {
-    super('L1 Transport Server', options, optionSettings)
+    super('L1_Transport_Server', options, optionSettings)
   }
 
   private state: {

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -57,10 +57,8 @@ const optionSettings = {
 }
 
 export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
-  protected name = 'Message Relayer'
-
   constructor(options: MessageRelayerOptions) {
-    super('Message Relayer', options, optionSettings)
+    super('Message_Relayer', options, optionSettings)
   }
 
   protected spreadsheetMode: boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -3300,6 +3300,11 @@ bindings@^1.4.0, bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 bip39@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.5.0.tgz#51cbd5179460504a63ea3c000db3f787ca051235"
@@ -10086,6 +10091,13 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+prom-client@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-13.1.0.tgz#1185caffd8691e28d32e373972e662964e3dba45"
+  integrity sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -11780,6 +11792,13 @@ tar@^6.0.2, tar@^6.1.0:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Description**
We want to be collecting metrics in our TypeScript services. This PR adds a Metrics class to core-utils and uses it in base-service. 

**Additional context**
The metrics class will be used to collect metrics in batch-submitter and data-transport-layer.