### PR TITLE
l2geth: fix log error

### DIFF
--- a/.changeset/seven-bulldogs-kneel.md
+++ b/.changeset/seven-bulldogs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Fix logger error

--- a/l2geth/core/vm/ovm_state_manager.go
+++ b/l2geth/core/vm/ovm_state_manager.go
@@ -169,7 +169,7 @@ func testAndSetAccount(evm *EVM, contract *Contract, args map[string]interface{}
 		)
 
 		if err != nil {
-			log.Error("Cannot set account diff", err)
+			log.Error("Cannot set account diff", "err", err)
 		}
 	}
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Simple fix to a logger error where not enough arguments are passed. The logger expects a string followed by key value pairs. This PR adds the second argument to complete the key value pair.