### PR TITLE
ci: add 90s timeout when waiting for sequencer to be up

### DIFF
--- a/ops/scripts/wait-for-sequencer.sh
+++ b/ops/scripts/wait-for-sequencer.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 CONTAINER=l2geth
 
+RETRIES=30
+i=0
 until docker-compose logs l2geth | grep -q "Starting Sequencer Loop";
 do
     sleep 3
+    if [ $i -eq $RETRIES ]; then
+        echo 'Timed out waiting for sequencer'
+        break
+    fi
     echo 'Waiting for sequencer...'
+    ((i=i+1))
 done


### PR DESCRIPTION
As title, to prevent PRs from running for hours if there's an issue when bringing up the stack.