### PR TITLE
docs: Add build step in integration-tests dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ export DOCKER_BUILDKIT=1
 docker-compose build
 docker-compose up -d
 cd ../integration-tests
+yarn build:integration
 yarn test:integration
 ```
 


### PR DESCRIPTION
**Description**

Adds `yarn build:integration` into the set of commands for running integration tests.

An alternative might be to build with Lerna. 
