### PR TITLE
l2geth: rollup client batch api

### DIFF
--- a/.changeset/empty-boxes-repair.md
+++ b/.changeset/empty-boxes-repair.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Add batch API to rollup client

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -13,12 +13,17 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-/**
- * GET /enqueue/index/{index}
- * GET /transaction/index/{index}
- * GET /eth/context/latest
- */
+// Constants that are used to compare against values in the deserialized JSON
+// fetched by the RollupClient
+const (
+	sequencer = "sequencer"
+	l1        = "l1"
+	EIP155    = "EIP155"
+	ETH_SIGN  = "ETH_SIGN"
+)
 
+// Batch represents the data structure that is submitted with
+// a series of transactions to layer one
 type Batch struct {
 	Index             uint64         `json:"index"`
 	Root              common.Hash    `json:"root,omitempty"`
@@ -90,11 +95,13 @@ type decoded struct {
 type RollupClient interface {
 	GetEnqueue(index uint64) (*types.Transaction, error)
 	GetLatestEnqueue() (*types.Transaction, error)
-	GetTransaction(index uint64) (*types.Transaction, error)
+	GetTransaction(uint64) (*types.Transaction, error)
 	GetLatestTransaction() (*types.Transaction, error)
-	GetEthContext(index uint64) (*EthContext, error)
+	GetEthContext(uint64) (*EthContext, error)
 	GetLatestEthContext() (*EthContext, error)
 	GetLastConfirmedEnqueue() (*types.Transaction, error)
+	GetLatestTransactionBatch() (*Batch, []*types.Transaction, error)
+	GetTransactionBatch(uint64) (*Batch, []*types.Transaction, error)
 	SyncStatus() (*SyncStatus, error)
 	GetL1GasPrice() (*big.Int, error)
 }
@@ -109,9 +116,15 @@ type TransactionResponse struct {
 	Batch       *Batch       `json:"batch"`
 }
 
+type TransactionBatchResponse struct {
+	Batch        *Batch         `json:"batch"`
+	Transactions []*transaction `json:"transactions"`
+}
+
 func NewClient(url string, chainID *big.Int) *Client {
 	client := resty.New()
 	client.SetHostURL(url)
+	client.SetHeader("User-Agent", "sequencer")
 	signer := types.NewOVMSigner(chainID)
 
 	return &Client{
@@ -120,7 +133,6 @@ func NewClient(url string, chainID *big.Int) *Client {
 	}
 }
 
-// This needs to return a transaction instead
 func (c *Client) GetEnqueue(index uint64) (*types.Transaction, error) {
 	str := strconv.FormatUint(index, 10)
 	response, err := c.client.R().
@@ -222,45 +234,45 @@ func (c *Client) GetLatestEnqueue() (*types.Transaction, error) {
 	return tx, nil
 }
 
-func transactionResponseToTransaction(res *TransactionResponse, signer *types.OVMSigner) (*types.Transaction, error) {
+func batchedTransactionToTransaction(res *transaction, signer *types.OVMSigner) (*types.Transaction, error) {
 	// `nil` transactions are not found
-	if res.Transaction == nil {
+	if res == nil {
 		return nil, nil
 	}
 	// The queue origin must be either sequencer of l1, otherwise
 	// it is considered an unknown queue origin and will not be processed
 	var queueOrigin types.QueueOrigin
-	if res.Transaction.QueueOrigin == "sequencer" {
+	if res.QueueOrigin == sequencer {
 		queueOrigin = types.QueueOriginSequencer
-	} else if res.Transaction.QueueOrigin == "l1" {
+	} else if res.QueueOrigin == l1 {
 		queueOrigin = types.QueueOriginL1ToL2
 	} else {
-		return nil, fmt.Errorf("Unknown queue origin: %s", res.Transaction.QueueOrigin)
+		return nil, fmt.Errorf("Unknown queue origin: %s", res.QueueOrigin)
 	}
 	// The transaction type must be EIP155 or EthSign. Throughout this
 	// codebase, it is referred to as "sighash type" but it could actually
 	// be generalized to transaction type. Right now the only different
 	// types use a different signature hashing scheme.
 	var sighashType types.SignatureHashType
-	if res.Transaction.Type == "EIP155" {
+	if res.Type == EIP155 {
 		sighashType = types.SighashEIP155
-	} else if res.Transaction.Type == "ETH_SIGN" {
+	} else if res.Type == ETH_SIGN {
 		sighashType = types.SighashEthSign
 	} else {
-		return nil, fmt.Errorf("Unknown transaction type: %s", res.Transaction.Type)
+		return nil, fmt.Errorf("Unknown transaction type: %s", res.Type)
 	}
 	// Transactions that have been decoded are
 	// Queue Origin Sequencer transactions
-	if res.Transaction.Decoded != nil {
-		nonce := res.Transaction.Decoded.Nonce
-		to := res.Transaction.Decoded.Target
+	if res.Decoded != nil {
+		nonce := res.Decoded.Nonce
+		to := res.Decoded.Target
 		value := new(big.Int)
 		// Note: there are two gas limits, one top level and
 		// another on the raw transaction itself. Maybe maxGasLimit
 		// for the top level?
-		gasLimit := res.Transaction.Decoded.GasLimit
-		gasPrice := new(big.Int).SetUint64(res.Transaction.Decoded.GasPrice)
-		data := res.Transaction.Decoded.Data
+		gasLimit := res.Decoded.GasLimit
+		gasPrice := new(big.Int).SetUint64(res.Decoded.GasPrice)
+		data := res.Decoded.Data
 
 		var tx *types.Transaction
 		if to == (common.Address{}) {
@@ -270,22 +282,22 @@ func transactionResponseToTransaction(res *TransactionResponse, signer *types.OV
 		}
 
 		txMeta := types.NewTransactionMeta(
-			new(big.Int).SetUint64(res.Transaction.BlockNumber),
-			res.Transaction.Timestamp,
-			res.Transaction.Origin,
+			new(big.Int).SetUint64(res.BlockNumber),
+			res.Timestamp,
+			res.Origin,
 			sighashType,
 			queueOrigin,
-			&res.Transaction.Index,
-			res.Transaction.QueueIndex,
-			res.Transaction.Data,
+			&res.Index,
+			res.QueueIndex,
+			res.Data,
 		)
 		tx.SetTransactionMeta(txMeta)
 
-		r, s := res.Transaction.Decoded.Signature.R, res.Transaction.Decoded.Signature.S
+		r, s := res.Decoded.Signature.R, res.Decoded.Signature.S
 		sig := make([]byte, crypto.SignatureLength)
 		copy(sig[32-len(r):32], r)
 		copy(sig[64-len(s):64], s)
-		sig[64] = byte(res.Transaction.Decoded.Signature.V)
+		sig[64] = byte(res.Decoded.Signature.V)
 
 		tx, err := tx.WithSignature(signer, sig[:])
 		if err != nil {
@@ -298,26 +310,26 @@ func transactionResponseToTransaction(res *TransactionResponse, signer *types.OV
 	// The transaction is  either an L1 to L2 transaction or it does not have a
 	// known deserialization
 	nonce := uint64(0)
-	if res.Transaction.QueueOrigin == "l1" {
-		if res.Transaction.QueueIndex == nil {
+	if res.QueueOrigin == l1 {
+		if res.QueueIndex == nil {
 			return nil, errors.New("Queue origin L1 to L2 without a queue index")
 		}
-		nonce = *res.Transaction.QueueIndex
+		nonce = *res.QueueIndex
 	}
-	target := res.Transaction.Target
-	gasLimit := res.Transaction.GasLimit
-	data := res.Transaction.Data
-	origin := res.Transaction.Origin
+	target := res.Target
+	gasLimit := res.GasLimit
+	data := res.Data
+	origin := res.Origin
 	tx := types.NewTransaction(nonce, target, big.NewInt(0), gasLimit, big.NewInt(0), data)
 	txMeta := types.NewTransactionMeta(
-		new(big.Int).SetUint64(res.Transaction.BlockNumber),
-		res.Transaction.Timestamp,
+		new(big.Int).SetUint64(res.BlockNumber),
+		res.Timestamp,
 		origin,
 		sighashType,
 		queueOrigin,
-		&res.Transaction.Index,
-		res.Transaction.QueueIndex,
-		res.Transaction.Data,
+		&res.Index,
+		res.QueueIndex,
+		res.Data,
 	)
 	tx.SetTransactionMeta(txMeta)
 	return tx, nil
@@ -339,8 +351,7 @@ func (c *Client) GetTransaction(index uint64) (*types.Transaction, error) {
 	if !ok {
 		return nil, fmt.Errorf("could not get tx with index %d", index)
 	}
-
-	return transactionResponseToTransaction(res, c.signer)
+	return batchedTransactionToTransaction(res.Transaction, c.signer)
 }
 
 func (c *Client) GetLatestTransaction() (*types.Transaction, error) {
@@ -353,10 +364,10 @@ func (c *Client) GetLatestTransaction() (*types.Transaction, error) {
 	}
 	res, ok := response.Result().(*TransactionResponse)
 	if !ok {
-		return nil, errors.New("")
+		return nil, errors.New("Cannot get latest transaction")
 	}
 
-	return transactionResponseToTransaction(res, c.signer)
+	return batchedTransactionToTransaction(res.Transaction, c.signer)
 }
 
 func (c *Client) GetEthContext(blockNumber uint64) (*EthContext, error) {
@@ -376,7 +387,6 @@ func (c *Client) GetEthContext(blockNumber uint64) (*EthContext, error) {
 	if !ok {
 		return nil, errors.New("Cannot parse EthContext")
 	}
-
 	return context, nil
 }
 
@@ -443,6 +453,56 @@ func (c *Client) SyncStatus() (*SyncStatus, error) {
 	}
 
 	return status, nil
+}
+
+func (c *Client) GetLatestTransactionBatch() (*Batch, []*types.Transaction, error) {
+	response, err := c.client.R().
+		SetResult(&TransactionBatchResponse{}).
+		Get("/batch/transaction/latest")
+
+	if err != nil {
+		return nil, nil, errors.New("Cannot get latest transaction batch")
+	}
+	txBatch, ok := response.Result().(*TransactionBatchResponse)
+	if !ok {
+		return nil, nil, fmt.Errorf("Cannot parse transaction batch response")
+	}
+	return parseTransactionBatchResponse(txBatch, c.signer)
+}
+
+func (c *Client) GetTransactionBatch(index uint64) (*Batch, []*types.Transaction, error) {
+	str := strconv.FormatUint(index, 10)
+	response, err := c.client.R().
+		SetResult(&TransactionBatchResponse{}).
+		SetPathParams(map[string]string{
+			"index": str,
+		}).
+		Get("/batch/transaction/index/{index}")
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Cannot get transaction batch %d", index)
+	}
+	txBatch, ok := response.Result().(*TransactionBatchResponse)
+	if !ok {
+		return nil, nil, fmt.Errorf("Cannot parse transaction batch response")
+	}
+	return parseTransactionBatchResponse(txBatch, c.signer)
+}
+
+func parseTransactionBatchResponse(txBatch *TransactionBatchResponse, signer *types.OVMSigner) (*Batch, []*types.Transaction, error) {
+	if txBatch == nil {
+		return nil, nil, nil
+	}
+	batch := txBatch.Batch
+	txs := make([]*types.Transaction, len(txBatch.Transactions))
+	for i, tx := range txBatch.Transactions {
+		transaction, err := batchedTransactionToTransaction(tx, signer)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Cannot parse transaction batch: %w", err)
+		}
+		txs[i] = transaction
+	}
+	return batch, txs, nil
 }
 
 func (c *Client) GetL1GasPrice() (*big.Int, error) {

--- a/l2geth/rollup/sync_service_test.go
+++ b/l2geth/rollup/sync_service_test.go
@@ -428,6 +428,14 @@ func (m *mockClient) GetLastConfirmedEnqueue() (*types.Transaction, error) {
 	return nil, nil
 }
 
+func (m *mockClient) GetLatestTransactionBatch() (*Batch, []*types.Transaction, error) {
+	return nil, nil, nil
+}
+
+func (m *mockClient) GetTransactionBatch(index uint64) (*Batch, []*types.Transaction, error) {
+	return nil, nil, nil
+}
+
 func (m *mockClient) SyncStatus() (*SyncStatus, error) {
 	return &SyncStatus{
 		Syncing: false,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds the batch fetching API to the `RollupClient` so that it can be used to fetch batches from the DTL. Follow up PRs will use this code to sync as the verifier and also to ensure that the L2 transactions match what has been batch submitted as the sequencer.

**Additional context**
This is required for https://github.com/ethereum-optimism/optimism/pull/477

