### PR TITLE
l2geth: replica gas estimation fix

### DIFF
--- a/.changeset/tough-bugs-invent.md
+++ b/.changeset/tough-bugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Allow gas estimation for replicas

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -347,13 +347,11 @@ func (s *SyncService) verify() error {
 func (s *SyncService) SequencerLoop() {
 	log.Info("Starting Sequencer Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	for {
-		err := s.updateL1GasPrice()
-		if err != nil {
+		if err := s.updateL1GasPrice(); err != nil {
 			log.Error("Cannot update L1 gas price", "msg", err)
-			continue
 		}
 		s.txLock.Lock()
-		err = s.sequence()
+		err := s.sequence()
 		if err != nil {
 			log.Error("Could not sequence", "error", err)
 		}

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -443,8 +443,10 @@ func (s *SyncService) sequence() error {
 	return nil
 }
 
+// updateL1GasPrice queries for the current L1 gas price and then stores it
+// in the L1 Gas Price Oracle. This must be called over time to properly
+// estimate the transaction fees that the sequencer should charge.
 func (s *SyncService) updateL1GasPrice() error {
-	// Update to the latest L1 gas price
 	l1GasPrice, err := s.client.GetL1GasPrice()
 	if err != nil {
 		return err

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -296,6 +296,9 @@ func (s *SyncService) Stop() error {
 func (s *SyncService) VerifierLoop() {
 	log.Info("Starting Verifier Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	for {
+		if err := s.updateL1GasPrice(); err != nil {
+			log.Error("Cannot update L1 gas price", "msg", err)
+		}
 		if err := s.verify(); err != nil {
 			log.Error("Could not verify", "error", err)
 		}
@@ -344,8 +347,13 @@ func (s *SyncService) verify() error {
 func (s *SyncService) SequencerLoop() {
 	log.Info("Starting Sequencer Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	for {
+		err := s.updateL1GasPrice()
+		if err != nil {
+			log.Error("Cannot update L1 gas price", "msg", err)
+			continue
+		}
 		s.txLock.Lock()
-		err := s.sequence()
+		err = s.sequence()
 		if err != nil {
 			log.Error("Could not sequence", "error", err)
 		}
@@ -360,14 +368,6 @@ func (s *SyncService) SequencerLoop() {
 }
 
 func (s *SyncService) sequence() error {
-	// Update to the latest L1 gas price
-	l1GasPrice, err := s.client.GetL1GasPrice()
-	if err != nil {
-		return err
-	}
-	s.L1gpo.SetL1GasPrice(l1GasPrice)
-	log.Info("Adjusted L1 Gas Price", "gasprice", l1GasPrice)
-
 	// Only the sequencer needs to poll for enqueue transactions
 	// and then can choose when to apply them. We choose to apply
 	// transactions such that it makes for efficient batch submitting.
@@ -442,6 +442,17 @@ func (s *SyncService) sequence() error {
 		}
 	}
 
+	return nil
+}
+
+func (s *SyncService) updateL1GasPrice() error {
+	// Update to the latest L1 gas price
+	l1GasPrice, err := s.client.GetL1GasPrice()
+	if err != nil {
+		return err
+	}
+	s.L1gpo.SetL1GasPrice(l1GasPrice)
+	log.Info("Adjusted L1 Gas Price", "gasprice", l1GasPrice)
 	return nil
 }
 

--- a/l2geth/rollup/sync_service_test.go
+++ b/l2geth/rollup/sync_service_test.go
@@ -169,8 +169,8 @@ func TestSyncServiceL1GasPrice(t *testing.T) {
 		t.Fatal("expected 0 gas price, got", gasBefore)
 	}
 
-	// run 1 iteration of the eloop
-	service.sequence()
+	// Update the gas price
+	service.updateL1GasPrice()
 
 	gasAfter, err := service.L1gpo.SuggestDataPrice(context.Background())
 	if err != nil {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR fixes a problem with the verifier/replica where it does not keep track of the current gas price. This is bad because it would make them not usable for `eth_estimateGas`. For `eth_estimateGas` to work, the node must know the current L1 gas price.

It abstracts the update L1 gas price logic into its own function and then adds it to the verifier codepath so both the verifier and the sequencer keep track of the L1 gas price.

It builds off of:
- https://github.com/ethereum-optimism/optimism/pull/438/commits/2f6b0ecb78a423315a9c6a83958153255b3295e5
- Small change from #477 - testing the `SyncService.updateL1GasPrice` directly

Related:
- https://github.com/ethereum-optimism/optimism/issues/515
