### PR TITLE
fix: send batch-submitter error logs to sentry

### DIFF
--- a/.changeset/long-days-march.md
+++ b/.changeset/long-days-march.md
@@ -3,4 +3,4 @@
 "@eth-optimism/batch-submitter": patch
 ---
 
-directly use DestinationStream in Logger, configure Batch Submitter stream to write errors to Sentry
+initialize Sentry and streams in Logger, remove Sentry from Batch Submitter

--- a/.changeset/long-days-march.md
+++ b/.changeset/long-days-march.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/core-utils": minor
+"@eth-optimism/batch-submitter": patch
+---
+
+directly use DestinationStream in Logger, configure Batch Submitter stream to write errors to Sentry

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -39,8 +39,7 @@
     "bluebird": "^3.7.2",
     "dotenv": "^8.2.0",
     "ethers": "5.0.0",
-    "old-contracts": "npm:@eth-optimism/contracts@^0.0.2-alpha.7",
-    "pino-sentry": "^0.7.0"
+    "old-contracts": "npm:@eth-optimism/contracts@^0.0.2-alpha.7"
   },
   "devDependencies": {
     "@eth-optimism/smock": "^1.0.0",

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -40,7 +40,7 @@
     "dotenv": "^8.2.0",
     "ethers": "5.0.0",
     "old-contracts": "npm:@eth-optimism/contracts@^0.0.2-alpha.7",
-    "pino-sentry": "^0.6.1"
+    "pino-sentry": "^0.7.0"
   },
   "devDependencies": {
     "@eth-optimism/smock": "^1.0.0",

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,5 +1,6 @@
 /* External Imports */
 import { Logger, injectL2Context } from '@eth-optimism/core-utils'
+import * as Sentry from '@sentry/node'
 import { createWriteStream } from 'pino-sentry'
 import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
@@ -20,6 +21,7 @@ import {
 const destination = createWriteStream({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 0.05,
+  level: 'error'
 })
 const log = new Logger({ name: 'oe:batch-submitter:init', destination })
 

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,7 +1,5 @@
 /* External Imports */
 import { Logger, injectL2Context } from '@eth-optimism/core-utils'
-import * as Sentry from '@sentry/node'
-import { createWriteStream } from 'pino-sentry'
 import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
 import { JsonRpcProvider, TransactionReceipt } from '@ethersproject/providers'
@@ -18,12 +16,13 @@ import {
 } from '..'
 
 /* Logger */
-const destination = createWriteStream({
-  dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 0.05,
-  level: 'error'
+const log = new Logger({
+  name: 'oe:batch-submitter:init',
+  sentryOptions: {
+    dsn: process.env.SENTRY_DSN,
+    tracesSampleRate: 0.05,
+  },
 })
-const log = new Logger({ name: 'oe:batch-submitter:init', destination })
 
 interface RequiredEnvVars {
   // The HTTP provider URL for L1.

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -31,9 +31,13 @@
   },
   "dependencies": {
     "@ethersproject/abstract-provider": "^5.0.9",
+    "@sentry/node": "^6.3.0",
+    "@types/pino-multi-stream": "^5.1.1",
     "ethers": "^5.0.31",
     "lodash": "^4.17.21",
     "pino": "^6.11.1",
-    "prom-client": "^13.1.0"
+    "prom-client": "^13.1.0",
+    "pino-multi-stream": "^5.3.0",
+    "pino-sentry": "^0.7.0"
   }
 }

--- a/packages/core-utils/src/common/logger.ts
+++ b/packages/core-utils/src/common/logger.ts
@@ -9,7 +9,7 @@ export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 export interface LoggerOptions {
   name: string
   level?: LogLevel
-  destination?: DestinationObjectOptions | DestinationStream
+  destination?: DestinationStream
 }
 
 /**
@@ -32,7 +32,7 @@ export class Logger {
     }
 
     this.inner = options.destination
-      ? pino(loggerOptions, pino.destination(options.destination))
+      ? pino(loggerOptions, options.destination)
       : pino(loggerOptions)
   }
 

--- a/packages/core-utils/src/common/logger.ts
+++ b/packages/core-utils/src/common/logger.ts
@@ -31,14 +31,14 @@ export class Logger {
       base: null,
     }
 
-    const loggerStreams: Streams = [{ stream: process.stdout }]
+    let loggerStreams: Streams = [{ stream: process.stdout }]
     if (options.sentryOptions) {
       loggerStreams.push({
         level: 'error',
         stream: createWriteStream(options.sentryOptions),
       })
     }
-    if (options.streams) loggerStreams.concat(options.streams)
+    if (options.streams) loggerStreams = loggerStreams.concat(options.streams)
 
     this.inner = pino(loggerOptions, pinoms.multistream(loggerStreams))
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,6 +1744,17 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/core@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.3.0.tgz#3b8db24918a00c0b77f1663fc6d9be925f66bb3e"
+  integrity sha512-voot/lJ9gRXB6bx6tVqbEbD6jOd4Sx6Rfmm6pzfpom9C0q+fjIZTatTLq8GdXj8DzxaH1MBDSwtaq/eC3NqYpA==
+  dependencies:
+    "@sentry/hub" "6.3.0"
+    "@sentry/minimal" "6.3.0"
+    "@sentry/types" "6.3.0"
+    "@sentry/utils" "6.3.0"
+    tslib "^1.9.3"
+
 "@sentry/hub@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.30.0.tgz#2453be9b9cb903404366e198bd30c7ca74cdc100"
@@ -1762,6 +1773,15 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/hub@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.3.0.tgz#4225b3b0f31fe47f24d80753b257a4b57de5d651"
+  integrity sha512-lAnW3Om66t9IR+t1wya1NpOF9lGbvYG6Ca8wxJJGJ1t2PxKwyxpZKzRx0q8M1QFhlZ5cETCzxmM7lBEZ4QVCBg==
+  dependencies:
+    "@sentry/types" "6.3.0"
+    "@sentry/utils" "6.3.0"
+    tslib "^1.9.3"
+
 "@sentry/minimal@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.30.0.tgz#ce3d3a6a273428e0084adcb800bc12e72d34637b"
@@ -1778,6 +1798,15 @@
   dependencies:
     "@sentry/hub" "6.2.5"
     "@sentry/types" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.3.0.tgz#e64d87c92a4676a11168672a96589f46985f2b22"
+  integrity sha512-ZdPUwdPQkaKroy67NkwQRqmnfKyd/C1OyouM9IqYKyBjAInjOijwwc/Rd91PMHalvCOGfp1scNZYbZ+YFs/qQQ==
+  dependencies:
+    "@sentry/hub" "6.3.0"
+    "@sentry/types" "6.3.0"
     tslib "^1.9.3"
 
 "@sentry/node@^5.18.1":
@@ -1810,6 +1839,21 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
+"@sentry/node@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.3.0.tgz#8d55f32930d531b9a2a3b594754392925b1e3816"
+  integrity sha512-n3RemuJsMpSbrIopJ2TxeECwQy/Dvho59SePAVQzK0s6dpG3Ak6YWQSh1XESbFbgLi4KzkbMdeBgznmmEbZPgg==
+  dependencies:
+    "@sentry/core" "6.3.0"
+    "@sentry/hub" "6.3.0"
+    "@sentry/tracing" "6.3.0"
+    "@sentry/types" "6.3.0"
+    "@sentry/utils" "6.3.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
 "@sentry/tracing@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.30.0.tgz#501d21f00c3f3be7f7635d8710da70d9419d4e1f"
@@ -1832,6 +1876,17 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
+"@sentry/tracing@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.3.0.tgz#5da2ce67bb5f9cf4f3aa9b6dff06089478f0c501"
+  integrity sha512-3UNGgQOrDKBoDqLc4vt+0n27Zv3lbNEoCbBydq4IvGfuYq7ozWMsaTcelsotMsd4ckDuOEh8V/nJTqrDjvL76g==
+  dependencies:
+    "@sentry/hub" "6.3.0"
+    "@sentry/minimal" "6.3.0"
+    "@sentry/types" "6.3.0"
+    "@sentry/utils" "6.3.0"
+    tslib "^1.9.3"
+
 "@sentry/types@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.30.0.tgz#19709bbe12a1a0115bc790b8942917da5636f402"
@@ -1841,6 +1896,11 @@
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.5.tgz#34b75285b149e0b9bc5fd54fcc2c445d978c7f2e"
   integrity sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==
+
+"@sentry/types@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.3.0.tgz#919cc1870f34b7126546c77e3c695052795d3add"
+  integrity sha512-xWyCYDmFPjS5ex60kxOOHbHEs4vs00qHbm0iShQfjl4OSg9S2azkcWofDmX8Xbn0FSOUXgdPCjNJW1B0bPVhCA==
 
 "@sentry/utils@5.30.0":
   version "5.30.0"
@@ -1856,6 +1916,14 @@
   integrity sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==
   dependencies:
     "@sentry/types" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/utils@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.3.0.tgz#e28645b6d4acd03a478e58bfe112ea02f81e94a0"
+  integrity sha512-NZzw4oLelgvCsVBG2e+ZtFtaBvgA7rZYtcGFbZTphhAlYoJ6JMCQUzYk0iwJK79yR1quh510x4UE0jynvvToWg==
+  dependencies:
+    "@sentry/types" "6.3.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":
@@ -2138,12 +2206,36 @@
   dependencies:
     "@types/node" "*"
 
+"@types/pino-multi-stream@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/pino-multi-stream/-/pino-multi-stream-5.1.1.tgz#8d5bc607357324621667c8a5613d4a534c075d0f"
+  integrity sha512-juOdSxwfE5TFKJJlq/VzXxTRyO+9yI9RZoyh/CYnof8MvqM+aUSUP1ZXGTuOZe7qgQnGp8xr8NHU2O/rTrYysA==
+  dependencies:
+    "@types/pino" "*"
+
+"@types/pino-pretty@*":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@types/pino-pretty/-/pino-pretty-4.7.0.tgz#e4a18541f8464d1cc48216f5593cc6a0e62dc2c3"
+  integrity sha512-fIZ+VXf9gJoJR4tiiM7G+j/bZkPoZEfFGzA4d8tAWCTpTVyvVaBwnmdLs3wEXYpMjw8eXulrOzNCjmGHT3FgHw==
+  dependencies:
+    "@types/pino" "*"
+
 "@types/pino-std-serializers@*":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz#f8bd52a209c8b3c97d1533b1ba27f57c816382bf"
   integrity sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==
   dependencies:
     "@types/node" "*"
+
+"@types/pino@*":
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/@types/pino/-/pino-6.3.7.tgz#0ccef98a159230cb3fa2589c7e8b00a7550a69f6"
+  integrity sha512-v7FdDXVEL0Zx1zcCf0cJZMojChnF+O0ujDKV1UdocsLuUhENjdtNIaanCZK1zRELp35x//bI2/IHtYUK0vmRvw==
+  dependencies:
+    "@types/node" "*"
+    "@types/pino-pretty" "*"
+    "@types/pino-std-serializers" "*"
+    "@types/sonic-boom" "*"
 
 "@types/pino@^6.3.6":
   version "6.3.6"
@@ -9933,6 +10025,13 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pino-multi-stream@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pino-multi-stream/-/pino-multi-stream-5.3.0.tgz#2816ec4422c7e37e676a210a1705c7155506afd4"
+  integrity sha512-4fAGCRll18I+JmoAbxDvU9zc5sera/3c+VgTtUdoNMOZ/VSHB+HMAYtixKpeRmZTDHDDdE2rtwjVkuwWB8mYQA==
+  dependencies:
+    pino "^6.0.0"
+
 pino-pretty@^4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-4.7.1.tgz#499cf185e110399deae731221c899915c811bd1a"
@@ -9965,6 +10064,18 @@ pino-std-serializers@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz#b56487c402d882eb96cd67c257868016b61ad671"
   integrity sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==
+
+pino@^6.0.0:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.11.3.tgz#0c02eec6029d25e6794fdb6bbea367247d74bc29"
+  integrity sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==
+  dependencies:
+    fast-redact "^3.0.0"
+    fast-safe-stringify "^2.0.7"
+    flatstr "^1.0.12"
+    pino-std-serializers "^3.1.0"
+    quick-format-unescaped "^4.0.3"
+    sonic-boom "^1.0.2"
 
 pino@^6.11.1:
   version "6.11.2"
@@ -10306,6 +10417,11 @@ quick-format-unescaped@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
   integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz#6d6b66b8207aa2b35eef12be1421bb24c428f652"
+  integrity sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg==
 
 quick-lru@^4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,7 +1780,7 @@
     "@sentry/types" "6.2.5"
     tslib "^1.9.3"
 
-"@sentry/node@^5.18.1", "@sentry/node@^5.21.1":
+"@sentry/node@^5.18.1":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.30.0.tgz#4ca479e799b1021285d7fe12ac0858951c11cd48"
   integrity sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==
@@ -9950,12 +9950,12 @@ pino-pretty@^4.7.1:
     split2 "^3.1.1"
     strip-json-comments "^3.1.1"
 
-pino-sentry@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/pino-sentry/-/pino-sentry-0.6.1.tgz#ba3c6b0f904f918a55d99e4fd87cc92da4ba5164"
-  integrity sha512-UWA+rR7ybFFePqMw+hBL93hIureAWw+WfnxTjT3xg7an0lTnZRZ6rSdxIBgNb0pyKx9goHFaQbYU7Y6vSuIIXg==
+pino-sentry@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/pino-sentry/-/pino-sentry-0.7.0.tgz#087717d2787ec437627e97454238ca7ce0562a91"
+  integrity sha512-/rZO1R/oMcMa4mzfIqW6Afap+TGgVHgB8iZfzwjhLdT2PhyuTUNJ3KJT2eIZ0citsQNv26pxRzIPbqgHuQtUAQ==
   dependencies:
-    "@sentry/node" "^5.21.1"
+    "@sentry/node" "^6.2.5"
     commander "^2.20.0"
     pumpify "^2.0.1"
     split2 "^3.1.1"


### PR DESCRIPTION
**Description**
Batch submitter errors weren't being properly sent to Sentry before, due to the way the destination was initialized. This PR adds multi-stream functionality to `Logger`, and has been tested and sends `log.error`s in the Batch Submitter to Sentry.

**Additional context**
This now writes to both Sentry and `stdout`!

<!--- **Metadata**
- Fixes #[Link to Issue] --->
