### PR TITLE
fix: delete extraneous CODEOWNERS file

### DIFF
--- a/packages/smock/.github/CODEOWNERS
+++ b/packages/smock/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @smartcontracts


### PR DESCRIPTION
**Description**

Removing `packages/smock/CODEOWNERS` because it duplicates (likely overrides) the file in root.