### PR TITLE
l2geth: shorter default timestamp refresh

### DIFF
--- a/.changeset/slimy-rocks-exist.md
+++ b/.changeset/slimy-rocks-exist.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Set default timestamp refresh threshold to 3 minutes

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -846,7 +846,7 @@ var (
 	RollupTimstampRefreshFlag = cli.DurationFlag{
 		Name:   "rollup.timestamprefresh",
 		Usage:  "Interval for refreshing the timestamp",
-		Value:  time.Minute * 15,
+		Value:  time.Minute * 3,
 		EnvVar: "ROLLUP_TIMESTAMP_REFRESH",
 	}
 	// Flag to enable verifier mode

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -75,8 +75,8 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 	}
 	timestampRefreshThreshold := cfg.TimestampRefreshThreshold
 	if timestampRefreshThreshold == 0 {
-		log.Info("Sanitizing timestamp refresh threshold to 15 minutes")
-		timestampRefreshThreshold = time.Minute * 15
+		log.Info("Sanitizing timestamp refresh threshold to 3 minutes")
+		timestampRefreshThreshold = time.Minute * 3
 	}
 
 	// Layer 2 chainid


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The timestamp and blocknumber in the OVM context must be updated on a L1 to L2 transaction (`enqueue`) or can be updated at anytime by the sequencer. It is currently cheaper to submit batches when the timestamp changes less often, but that results in degraded user experience. This lowers the default timestamp refresh from 15 minutes to 3 minutes. This means that if an `enqueue` transaction does not occur for 3 minutes, then the sequencer will query the tip of L1 and set the OVM context based on the current L1 timestamp and blocknumber. Note that in practice, the "tip" trails L1 by a configurable number of blocks

