### PR TITLE
ops: cleaner docker-compose startup logs

### DIFF
--- a/ops/scripts/batches.sh
+++ b/ops/scripts/batches.sh
@@ -2,12 +2,17 @@
 RETRIES=${RETRIES:-40}
 
 # get the addrs from the URL provided
-ADDRESSES=$(curl --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 # set the env
 export ADDRESS_MANAGER_ADDRESS=$(echo $ADDRESSES | jq -r '.AddressManager')
 
 # waits for l2geth to be up
-curl --retry-connrefused --retry $RETRIES --retry-delay 1 $L2_NODE_WEB3_URL
+curl --silent \
+    --retry-connrefused \
+    --retry $RETRIES \
+    --retry-delay 1 \
+    --output /dev/null \
+    $L2_NODE_WEB3_URL
 
 # go
 exec node ./exec/run-batch-submitter.js

--- a/ops/scripts/deployer.sh
+++ b/ops/scripts/deployer.sh
@@ -4,7 +4,14 @@ RETRIES=${RETRIES:-20}
 JSON='{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}'
 
 # wait for the base layer to be up
-curl -H "Content-Type: application/json" --retry-connrefused --retry $RETRIES --retry-delay 1 -d $JSON $L1_NODE_WEB3_URL
+curl \
+    --silent \
+    -H "Content-Type: application/json" \
+    --retry-connrefused \
+    --retry $RETRIES \
+    --retry-delay 1 \
+    -d $JSON \
+    $L1_NODE_WEB3_URL
 
 yarn run deploy
 

--- a/ops/scripts/dtl.sh
+++ b/ops/scripts/dtl.sh
@@ -2,7 +2,7 @@
 RETRIES=${RETRIES:-60}
 
 # get the addrs from the URL provided
-ADDRESSES=$(curl --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 # set the env
 export DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$(echo $ADDRESSES | jq -r '.AddressManager')
 

--- a/ops/scripts/geth.sh
+++ b/ops/scripts/geth.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 RETRIES=${RETRIES:-40}
 # get the addrs from the URL provided
-ADDRESSES=$(curl --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 
 function envSet() {
     VAR=$1
@@ -20,6 +20,12 @@ if [ $ETH1_L1_ETH_GATEWAY_ADDRESS == null ]; then
 fi
 
 # wait for the dtl to be up, else geth will crash if it cannot connect
-curl --retry-connrefused --retry $RETRIES --retry-delay 2 $ROLLUP_CLIENT_HTTP
+curl \
+    --silent \
+    --output /dev/null \
+    --retry-connrefused \
+    --retry $RETRIES \
+    --retry-delay 1 \
+    $ROLLUP_CLIENT_HTTP
 
 exec geth --verbosity=6

--- a/ops/scripts/relayer.sh
+++ b/ops/scripts/relayer.sh
@@ -2,12 +2,18 @@
 RETRIES=${RETRIES:-60}
 
 # get the addrs from the URL provided
-ADDRESSES=$(curl --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 # set the env
 export ADDRESS_MANAGER_ADDRESS=$(echo $ADDRESSES | jq -r '.AddressManager')
 
 # waits for l2geth to be up
-curl --retry-connrefused --retry $RETRIES --retry-delay 1 $L2_NODE_WEB3_URL
+curl \
+    --silent \
+    --output /dev/null \
+    --retry-connrefused \
+    --retry $RETRIES \
+    --retry-delay 1 \
+    $L2_NODE_WEB3_URL
 
 # go
 exec node ./exec/run-message-relayer.js


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Cleans up the error logs in the `docker-compose` entrypoint files by using `curl --silent --output /dev/null`. It reduces the spam at the beginning of the local network coming online.

