### PR TITLE
Fix bridge contracts upgradeability

### DIFF
--- a/.changeset/curly-tables-behave.md
+++ b/.changeset/curly-tables-behave.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Fix bridge contracts upgradeability by changing `Abs_L1TokenGateway.DEFAULT_FINALIZE_DEPOSIT_L2_GAS` from a storage var to an internal constant.
+Additionally, make some bridge functions virtual so they could be overriden in child contracts.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// @unsupported: ovm 
+// @unsupported: ovm
 pragma solidity >0.5.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
@@ -16,7 +16,7 @@ import { OVM_CrossDomainEnabled } from "../../../libraries/bridge/OVM_CrossDomai
  * It synchronizes a corresponding L2 representation of the "deposited token", informing it
  * of new deposits and releasing L1 funds when there are newly finalized withdrawals.
  *
- * NOTE: This abstract contract gives all the core functionality of an L1 token gateway, 
+ * NOTE: This abstract contract gives all the core functionality of an L1 token gateway,
  * but provides easy hooks in case developers need extensions in child contracts.
  * In many cases, the default OVM_L1ERC20Gateway will suffice.
  *
@@ -41,7 +41,7 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      */
     constructor(
         address _l2DepositedToken,
-        address _l1messenger 
+        address _l1messenger
     )
         OVM_CrossDomainEnabled(_l1messenger)
     {
@@ -53,7 +53,7 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      ********************************/
 
     // Default gas value which can be overridden if more complex logic runs on L2.
-    uint32 public DEFAULT_FINALIZE_DEPOSIT_L2_GAS = 1200000;
+    uint32 internal constant DEFAULT_FINALIZE_DEPOSIT_L2_GAS = 1200000;
 
     /**
      * @dev Core logic to be performed when a withdrawal is finalized on L1.
@@ -96,10 +96,10 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * dynamic, and the above public constant does not suffice.
      *
      */
-
     function getFinalizeDepositL2Gas()
         public
         view
+        virtual
         returns(
             uint32
         )
@@ -118,8 +118,9 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     function deposit(
         uint _amount
     )
-        public
+        external
         override
+        virtual
     {
         _initiateDeposit(msg.sender, msg.sender, _amount);
     }
@@ -133,8 +134,9 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
         address _to,
         uint _amount
     )
-        public
+        external
         override
+        virtual
     {
         _initiateDeposit(msg.sender, _to, _amount);
     }
@@ -183,9 +185,9 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      *************************/
 
     /**
-     * @dev Complete a withdrawal from L2 to L1, and credit funds to the recipient's balance of the 
-     * L1 ERC20 token. 
-     * This call will fail if the initialized withdrawal from L2 has not been finalized. 
+     * @dev Complete a withdrawal from L2 to L1, and credit funds to the recipient's balance of the
+     * L1 ERC20 token.
+     * This call will fail if the initialized withdrawal from L2 has not been finalized.
      *
      * @param _to L1 address to credit the withdrawal to
      * @param _amount Amount of the ERC20 to withdraw
@@ -195,7 +197,8 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
         uint _amount
     )
         external
-        override 
+        override
+        virtual
         onlyFromCrossDomainAccount(l2DepositedToken)
     {
         // Call our withdrawal accounting handler implemented by child contracts.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -55,7 +55,6 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      *
      * @param _l1TokenGateway Address of the corresponding L1 gateway deployed to the main chain
      */
-
     function init(
         iOVM_L1TokenGateway _l1TokenGateway
     )
@@ -64,7 +63,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         require(address(l1TokenGateway) == address(0), "Contract has already been initialized");
 
         l1TokenGateway = _l1TokenGateway;
-        
+
         emit Initialized(l1TokenGateway);
     }
 
@@ -81,8 +80,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * Overridable Accounting logic *
      ********************************/
 
-    // Default gas value which can be overridden if more complex logic runs on L2.
-    uint32 constant DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS = 100000;
+    // Default gas value which can be overridden if more complex logic runs on L1.
+    uint32 internal constant DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS = 100000;
 
     /**
      * @dev Core logic to be performed when a withdrawal from L2 is initialized.
@@ -91,7 +90,6 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * param _to Address being withdrawn to
      * param _amount Amount being withdrawn
      */
-
     function _handleInitiateWithdrawal(
         address, // _to,
         uint // _amount
@@ -122,9 +120,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     /**
      * @dev Overridable getter for the *L1* gas limit of settling the withdrawal, in the case it may be
      * dynamic, and the above public constant does not suffice.
-     *
      */
-
     function getFinalizeWithdrawalL1Gas()
         public
         view
@@ -150,6 +146,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     )
         external
         override
+        virtual
         onlyInitialized()
     {
         _initiateWithdrawal(msg.sender, _amount);
@@ -166,6 +163,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     )
         external
         override
+        virtual
         onlyInitialized()
     {
         _initiateWithdrawal(_to, _amount);
@@ -208,9 +206,9 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      ************************************/
 
     /**
-     * @dev Complete a deposit from L1 to L2, and credits funds to the recipient's balance of this 
-     * L2 token. 
-     * This call will fail if it did not originate from a corresponding deposit in OVM_l1TokenGateway. 
+     * @dev Complete a deposit from L1 to L2, and credits funds to the recipient's balance of this
+     * L2 token.
+     * This call will fail if it did not originate from a corresponding deposit in OVM_l1TokenGateway.
      *
      * @param _to Address to receive the withdrawal at
      * @param _amount Amount of the token to withdraw
@@ -220,7 +218,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         uint _amount
     )
         external
-        override 
+        override
+        virtual
         onlyInitialized()
         onlyFromCrossDomainAccount(address(l1TokenGateway))
     {

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
@@ -66,7 +66,7 @@ describe('OVM_L1ERC20Gateway', () => {
       Mock__OVM_L1CrossDomainMessenger.address
     )
 
-    finalizeDepositGasLimit = await OVM_L1ERC20Gateway.DEFAULT_FINALIZE_DEPOSIT_L2_GAS()
+    finalizeDepositGasLimit = await OVM_L1ERC20Gateway.getFinalizeDepositL2Gas()
   })
 
   describe('finalizeWithdrawal', () => {


### PR DESCRIPTION
Hello World, I've made a few tweaks.

**Summary**

This PR fixes an issue that manifests when deploying `Abs_L1TokenGateway.sol` contract behind a delegate proxy. This was probably missed as your proxied `OVM_L1ETHGateway.sol` is not using `Abs_L1TokenGateway.sol` directly, and [the re-implementation avoids the bug](https://github.com/ethereum-optimism/optimism/blob/1743a6d179d4449586c133f5aed18779761093b1/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol#L28).

Additionally it makes L1 `deposit/depositTo` & L2 `withdraw/withdrawTo` gateway functions virtual and external.

**Description**

While implementing LINK Optimism bridge contracts, a bug manifested with proxy deployments. The  `Abs_L1TokenGateway.DEFAULT_FINALIZE_DEPOSIT_L2_GAS` was actually a storage var, not a constant (which could be confusing because of the uppercase naming style). Because it's a storage var, it was not initialized by default in the proxy delegate call context. So the L1 deposits failed with an error `"VM Exception while processing transaction: revert Transaction gas limit too low to enqueue."`.

The assumingly virtual, `getFinalizeDepositL2Gas` was also not marked as virtual so we needed to [initialize the gas config like this](https://github.com/smartcontractkit/LinkToken/blob/791916d5c61d7fa0f6c67bcdd43deca7aa885fd2/contracts/v0.7/bridge/optimism/OVM_L1ERC20Gateway.sol#L85).

The PR changes `Abs_L1TokenGateway.DEFAULT_FINALIZE_DEPOSIT_L2_GAS` and `Abs_L2DepositedToken.DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS` to internal constants, also adds virtual declaration to `Abs_L1TokenGateway.getFinalizeDepositL2Gas` as the comment above the function suggests it should be.

The PR also makes L1 `deposit/depositTo` & L2 `withdraw/withdrawTo` gateway functions virtual and external. The virtual declaration enables extending contracts to differentiate between two methods, which can be helpful in certain situations. At Chainlink, to avoid accidentally lost tokens we would like to block deposits and withdrawals to contracts, unless explicit in intention by using `depositToUsafe/withdrawToUnsafe`. This change enables us to have a [more polished and straightforward implementation.](https://github.com/smartcontractkit/LinkToken/pull/31).