### PR TITLE
feat: add Sentry release automation

### DIFF
--- a/.changeset/big-parents-glow.md
+++ b/.changeset/big-parents-glow.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/batch-submitter": patch
+"@eth-optimism/data-transport-layer": patch
+---
+
+Adds a release version to batch-submitter and data-transport-layer usage of Sentry

--- a/packages/batch-submitter/exec/run-batch-submitter.js
+++ b/packages/batch-submitter/exec/run-batch-submitter.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+console.log(process.env.npm_package_version);
+process.exit(1)
+
 const batchSubmitter = require("../dist/src/exec/run-batch-submitter")
 
 batchSubmitter.run()

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -19,6 +19,7 @@ import {
 const log = new Logger({
   name: 'oe:batch-submitter:init',
   sentryOptions: {
+    release: `@eth-optimism/batch-submitter@${process.env.npm_package_version}`,
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -105,6 +105,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this.state.app = express()
     Sentry.init({
       dsn: this.options.sentryDsn,
+      release: `@eth-optimism/data-transport-layer@${process.env.npm_package_version}`,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Express({


### PR DESCRIPTION
[Binding the version](https://docs.sentry.io/platforms/node/configuration/releases/#bind-the-version) enables releases to be tagged on Sentry, allowing us to identify errors being resolved by new releases.
