### PR TITLE
fix: fix incorrectly provided error object to pino

### DIFF
--- a/.changeset/wise-onions-type.md
+++ b/.changeset/wise-onions-type.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter": patch
+---
+
+Correctly formatted error object to log exceptions

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -213,7 +213,7 @@ export const run = async () => {
           }
         }
       } catch (err) {
-        log.error('Cannot clear transactions', err)
+        log.error('Cannot clear transactions', { err })
         process.exit(1)
       }
     }
@@ -222,7 +222,7 @@ export const run = async () => {
       try {
         await func()
       } catch (err) {
-        log.error('Error submitting batch', err)
+        log.error('Error submitting batch', { err })
         log.info('Retrying...')
       }
       // Sleep


### PR DESCRIPTION
Error must be provided inside of an `err` object.
