### PR TITLE
Calculate fees correctly based on zero/non-zero bytes

### DIFF
--- a/.changeset/violet-beers-unite.md
+++ b/.changeset/violet-beers-unite.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Calculate data fees based on if a byte was zero or non-zero

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -45,13 +45,13 @@ describe('Native ETH Integration Tests', async () => {
       const amount = utils.parseEther('0.5')
       const addr = await l2Bob.getAddress()
       const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(214314))
+      expect(gas).to.be.deep.eq(BigNumber.from(213546))
     })
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(505285))
+      expect(gas).to.be.deep.eq(BigNumber.from(503749))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -45,13 +45,13 @@ describe('Native ETH Integration Tests', async () => {
       const amount = utils.parseEther('0.5')
       const addr = await l2Bob.getAddress()
       const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(197514))
+      expect(gas).to.be.deep.eq(BigNumber.from(214314))
     })
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(490405))
+      expect(gas).to.be.deep.eq(BigNumber.from(505285))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -45,13 +45,13 @@ describe('Native ETH Integration Tests', async () => {
       const amount = utils.parseEther('0.5')
       const addr = await l2Bob.getAddress()
       const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
-      expect(gas).is.instanceof(BigNumber)
+      expect(gas).to.be.deep.eq(BigNumber.from(197514))
     })
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount)
-      expect(gas).is.instanceof(BigNumber)
+      expect(gas).to.be.deep.eq(BigNumber.from(490405))
     })
   })
 

--- a/l2geth/core/rollup_fee.go
+++ b/l2geth/core/rollup_fee.go
@@ -2,20 +2,33 @@ package core
 
 import (
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // RollupBaseTxSize is the encoded rollup transaction's compressed size excluding
 // the variable length data.
 // Ref: https://github.com/ethereum-optimism/optimism/blob/91a9a3dcddf534ae1c906133b6d8e015a23c463b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol#L47
-const RollupBaseTxSize int = 96
+const RollupBaseTxSize uint64 = 96
 
 // CalculateFee calculates the fee that must be paid to the Rollup sequencer, taking into
 // account the cost of publishing data to L1.
-// Returns: (RollupBaseTxSize + len(data)) * dataPrice + executionPrice * gasUsed
+// Returns: (4 * zeroDataBytes + 16 * (nonZeroDataBytes + RollupBaseTxSize)) * dataPrice + executionPrice * gasUsed
 func CalculateRollupFee(data []byte, gasUsed uint64, dataPrice, executionPrice *big.Int) *big.Int {
-	dataLen := int64(RollupBaseTxSize + len(data))
+    var zeros uint64
+    for _, byt := range data {
+        if byt != 0 {
+            zeros++
+        }
+    }
+    ones := uint64(len(data)) - zeros
+
+    zerosCost := big.NewInt(int64(zeros * params.TxDataZeroGas))
+    onesCost := big.NewInt(int64((RollupBaseTxSize + ones) * params.TxDataNonZeroGasEIP2028))
+    dataCost := new(big.Int).Add(zerosCost, onesCost)
+
 	// get the data fee
-	dataFee := new(big.Int).Mul(dataPrice, big.NewInt(dataLen))
+	dataFee := new(big.Int).Mul(dataPrice, dataCost)
 	executionFee := new(big.Int).Mul(executionPrice, new(big.Int).SetUint64(gasUsed))
 	fee := new(big.Int).Add(dataFee, executionFee)
 	return fee

--- a/l2geth/core/rollup_fee.go
+++ b/l2geth/core/rollup_fee.go
@@ -15,17 +15,17 @@ const RollupBaseTxSize uint64 = 96
 // account the cost of publishing data to L1.
 // Returns: (4 * zeroDataBytes + 16 * (nonZeroDataBytes + RollupBaseTxSize)) * dataPrice + executionPrice * gasUsed
 func CalculateRollupFee(data []byte, gasUsed uint64, dataPrice, executionPrice *big.Int) *big.Int {
-    var zeros uint64
-    for _, byt := range data {
-        if byt != 0 {
-            zeros++
-        }
-    }
-    ones := uint64(len(data)) - zeros
+	var zeros uint64
+	for _, byt := range data {
+		if byt != 0 {
+			zeros++
+		}
+	}
+	ones := uint64(len(data)) - zeros
 
-    zerosCost := big.NewInt(int64(zeros * params.TxDataZeroGas))
-    onesCost := big.NewInt(int64((RollupBaseTxSize + ones) * params.TxDataNonZeroGasEIP2028))
-    dataCost := new(big.Int).Add(zerosCost, onesCost)
+	zerosCost := big.NewInt(int64(zeros * params.TxDataZeroGas))
+	onesCost := big.NewInt(int64((RollupBaseTxSize + ones) * params.TxDataNonZeroGasEIP2028))
+	dataCost := new(big.Int).Add(zerosCost, onesCost)
 
 	// get the data fee
 	dataFee := new(big.Int).Mul(dataPrice, dataCost)

--- a/l2geth/core/rollup_fee_test.go
+++ b/l2geth/core/rollup_fee_test.go
@@ -23,17 +23,10 @@ func TestCalculateRollupFee(t *testing.T) {
 			data := make([]byte, 0, tt.dataLen)
 			fee := CalculateRollupFee(data, tt.gasUsed, big.NewInt(tt.dataPrice), big.NewInt(tt.executionPrice))
 
-			var zeros uint64
-			for _, byt := range data {
-				if byt != 0 {
-					zeros++
-				}
-			}
-			ones := uint64(len(data)) - zeros
-
-			zerosCost := zeros * 4
+			zeroes, ones := zeroesAndOnes(data)
+			zeroesCost := zeroes * 4
 			onesCost := (96 + ones) * 16
-			dataCost := zerosCost + onesCost
+			dataCost := zeroesCost + onesCost
 			dataFee := int64(dataCost) * tt.dataPrice
 
 			executionFee := uint64(tt.executionPrice) * tt.gasUsed

--- a/l2geth/core/rollup_fee_test.go
+++ b/l2geth/core/rollup_fee_test.go
@@ -23,9 +23,21 @@ func TestCalculateRollupFee(t *testing.T) {
 			data := make([]byte, 0, tt.dataLen)
 			fee := CalculateRollupFee(data, tt.gasUsed, big.NewInt(tt.dataPrice), big.NewInt(tt.executionPrice))
 
-			dataFee := uint64((RollupBaseTxSize + len(data)) * int(tt.dataPrice))
+            var zeros uint64
+            for _, byt := range data {
+                if byt != 0 {
+                    zeros++
+                }
+            }
+            ones := uint64(len(data)) - zeros
+
+            zerosCost := zeros * 4
+            onesCost := (96 + ones) * 16
+            dataCost := zerosCost + onesCost
+            dataFee := int64(dataCost) * tt.dataPrice
+
 			executionFee := uint64(tt.executionPrice) * tt.gasUsed
-			expectedFee := dataFee + executionFee
+			expectedFee := uint64(dataFee) + executionFee
 			if fee.Cmp(big.NewInt(int64(expectedFee))) != 0 {
 				t.Errorf("rollup fee check failed: expected %d, got %s", expectedFee, fee.String())
 			}

--- a/l2geth/core/rollup_fee_test.go
+++ b/l2geth/core/rollup_fee_test.go
@@ -23,18 +23,18 @@ func TestCalculateRollupFee(t *testing.T) {
 			data := make([]byte, 0, tt.dataLen)
 			fee := CalculateRollupFee(data, tt.gasUsed, big.NewInt(tt.dataPrice), big.NewInt(tt.executionPrice))
 
-            var zeros uint64
-            for _, byt := range data {
-                if byt != 0 {
-                    zeros++
-                }
-            }
-            ones := uint64(len(data)) - zeros
+			var zeros uint64
+			for _, byt := range data {
+				if byt != 0 {
+					zeros++
+				}
+			}
+			ones := uint64(len(data)) - zeros
 
-            zerosCost := zeros * 4
-            onesCost := (96 + ones) * 16
-            dataCost := zerosCost + onesCost
-            dataFee := int64(dataCost) * tt.dataPrice
+			zerosCost := zeros * 4
+			onesCost := (96 + ones) * 16
+			dataCost := zerosCost + onesCost
+			dataFee := int64(dataCost) * tt.dataPrice
 
 			executionFee := uint64(tt.executionPrice) * tt.gasUsed
 			expectedFee := uint64(dataFee) + executionFee


### PR DESCRIPTION
Fixes https://github.com/ethereum-optimism/optimism/issues/515. 

Does *not* introduce `nonCallDataL1GasOverhead` since we do not have a standard way to estimate / calculate it yet and seems to be a micro optimization.