### PR TITLE
feat: add default metrics tracking to batch-submitter

### DIFF
--- a/.changeset/red-humans-grin.md
+++ b/.changeset/red-humans-grin.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter": patch
+---
+
+add default metrics to all batch submitters

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -2,7 +2,7 @@
 import { Contract, Signer, utils, providers } from 'ethers'
 import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import * as ynatm from '@eth-optimism/ynatm'
-import { Logger } from '@eth-optimism/core-utils'
+import { Logger, Metrics } from '@eth-optimism/core-utils'
 import { getContractFactory } from 'old-contracts'
 
 export interface RollupInfo {
@@ -51,7 +51,8 @@ export abstract class BatchSubmitter {
     readonly maxGasPriceInGwei: number,
     readonly gasRetryIncrement: number,
     readonly gasThresholdInGwei: number,
-    readonly log: Logger
+    readonly log: Logger,
+    readonly metrics: Metrics
   ) {}
 
   public abstract _submitBatch(

--- a/packages/batch-submitter/src/batch-submitter/index.ts
+++ b/packages/batch-submitter/src/batch-submitter/index.ts
@@ -2,8 +2,8 @@ export * from './batch-submitter'
 export * from './tx-batch-submitter'
 export * from './state-batch-submitter'
 
-export const TX_BATCH_SUBMITTER_LOG_TAG = 'oe:batch-submitter:tx-chain'
-export const STATE_BATCH_SUBMITTER_LOG_TAG = 'oe:batch-submitter:state-chain'
+export const TX_BATCH_SUBMITTER_LOG_TAG = 'oe:batch_submitter:tx_chain'
+export const STATE_BATCH_SUBMITTER_LOG_TAG = 'oe:batch_submitter:state_chain'
 
 // BLOCK_OFFSET is the number of L2 blocks we need to skip for the
 // batch submitter.

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -8,7 +8,7 @@ import {
   Bytes32,
   remove0x,
   toRpcHexString,
-  Metrics
+  Metrics,
 } from '@eth-optimism/core-utils'
 
 /* Internal Imports */

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -8,6 +8,7 @@ import {
   Bytes32,
   remove0x,
   toRpcHexString,
+  Metrics
 } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
@@ -41,6 +42,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
     gasRetryIncrement: number,
     gasThresholdInGwei: number,
     log: Logger,
+    metrics: Metrics,
     fraudSubmissionAddress: string
   ) {
     super(
@@ -59,7 +61,8 @@ export class StateBatchSubmitter extends BatchSubmitter {
       maxGasPriceInGwei,
       gasRetryIncrement,
       gasThresholdInGwei,
-      log
+      log,
+      metrics
     )
     this.fraudSubmissionAddress = fraudSubmissionAddress
   }

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -7,7 +7,7 @@ import {
 } from '@ethersproject/abstract-provider'
 import { getContractInterface, getContractFactory } from 'old-contracts'
 import { getContractInterface as getNewContractInterface } from '@eth-optimism/contracts'
-import { Logger, ctcCoder } from '@eth-optimism/core-utils'
+import { Logger, Metrics, ctcCoder } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
 import {
@@ -48,6 +48,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     gasRetryIncrement: number,
     gasThresholdInGwei: number,
     log: Logger,
+    metrics: Metrics,
     disableQueueBatchAppend: boolean,
     autoFixBatchOptions: AutoFixBatchOptions = {
       fixDoublePlayedDeposits: false,
@@ -70,7 +71,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       maxGasPriceInGwei,
       gasRetryIncrement,
       gasThresholdInGwei,
-      log
+      log,
+      metrics
     )
     this.disableQueueBatchAppend = disableQueueBatchAppend
     this.autoFixBatchOptions = autoFixBatchOptions

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,5 +1,5 @@
 /* External Imports */
-import { Logger, injectL2Context } from '@eth-optimism/core-utils'
+import { Logger, Metrics, injectL2Context } from '@eth-optimism/core-utils'
 import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
 import { JsonRpcProvider, TransactionReceipt } from '@ethersproject/providers'
@@ -16,13 +16,18 @@ import {
 } from '..'
 
 /* Logger */
+const name = 'oe:batch-submitter:init'
 const log = new Logger({
-  name: 'oe:batch-submitter:init',
+  name,
   sentryOptions: {
     release: `@eth-optimism/batch-submitter@${process.env.npm_package_version}`,
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },
+})
+/* Metrics */
+const metrics = new Metrics({
+  prefix: name,
 })
 
 interface RequiredEnvVars {
@@ -159,6 +164,7 @@ export const run = async () => {
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
     new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+    new Metrics({ prefix: TX_BATCH_SUBMITTER_LOG_TAG }),
     DISABLE_QUEUE_BATCH_APPEND,
     autoFixBatchOptions
   )
@@ -180,6 +186,7 @@ export const run = async () => {
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
     new Logger({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
+    new Metrics({ prefix: STATE_BATCH_SUBMITTER_LOG_TAG }),
     FRAUD_SUBMISSION_ADDRESS
   )
 

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -16,7 +16,7 @@ import {
 } from '..'
 
 /* Logger */
-const name = 'oe:batch-submitter:init'
+const name = 'oe:batch_submitter:init'
 const log = new Logger({
   name,
   sentryOptions: {

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -37,6 +37,7 @@ import {
   ctcCoder,
   remove0x,
   Logger,
+  Metrics,
 } from '@eth-optimism/core-utils'
 
 const DECOMPRESSION_ADDRESS = '0x4200000000000000000000000000000000000008'
@@ -78,6 +79,7 @@ class TransactionBatchSubmitter extends RealTransactionBatchSubmitter {
     return true
   }
 }
+const testMetrics = new Metrics({ prefix: 'bs_test' })
 
 describe('BatchSubmitter', () => {
   let signer: Signer
@@ -217,6 +219,7 @@ describe('BatchSubmitter', () => {
       GAS_RETRY_INCREMENT,
       GAS_THRESHOLD_IN_GWEI,
       new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+      testMetrics,
       false
     )
 
@@ -432,6 +435,7 @@ describe('BatchSubmitter', () => {
         GAS_RETRY_INCREMENT,
         GAS_THRESHOLD_IN_GWEI,
         new Logger({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
+        testMetrics,
         '0x' + '01'.repeat(20) // placeholder for fraudSubmissionAddress
       )
     })

--- a/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -33,6 +33,7 @@ import {
   ctcCoder,
   remove0x,
   Logger,
+  Metrics,
 } from '@eth-optimism/core-utils'
 
 const DECOMPRESSION_ADDRESS = '0x4200000000000000000000000000000000000008'
@@ -71,6 +72,7 @@ class TransactionBatchSubmitter extends RealTransactionBatchSubmitter {
     return true
   }
 }
+const testMetrics = new Metrics({ prefix: 'tx_bs_test' })
 
 describe('TransactionBatchSubmitter', () => {
   let signer: Signer
@@ -189,6 +191,7 @@ describe('TransactionBatchSubmitter', () => {
         GAS_RETRY_INCREMENT,
         GAS_THRESHOLD_IN_GWEI,
         new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+        testMetrics,
         false
       )
     })
@@ -309,6 +312,7 @@ describe('TransactionBatchSubmitter', () => {
           GAS_RETRY_INCREMENT,
           GAS_THRESHOLD_IN_GWEI,
           new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+          testMetrics,
           false
         )
 

--- a/packages/core-utils/src/common/index.ts
+++ b/packages/core-utils/src/common/index.ts
@@ -1,5 +1,6 @@
 export * from './addresses'
 export * from './hex-strings'
 export * from './logger'
+export * from './metrics'
 export * from './misc'
 export * from './common'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR adds `Metrics` to each batch submitter, which enables us to start collecting metrics. It does not yet start to track specific metrics (which will be implemented in followup PRs when our prom server is running).

**Additional context**
Here is the list of default metrics being collected: 
https://github.com/siimon/prom-client/blob/96f7495d66b1a21755f745b1367d3e530668a957/lib/defaultMetrics.js#L5-L17

<!--
**Metadata**
- Fixes #[Link to Issue]
-->
