### PR TITLE
chore: log errors on monotonicity fixes

### DIFF
--- a/.changeset/selfish-ladybugs-pull.md
+++ b/.changeset/selfish-ladybugs-pull.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter": patch
+---
+
+log errors for monotonicity violations

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -496,7 +496,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
           ele.timestamp < earliestTimestamp ||
           ele.blockNumber < earliestBlockNumber
         ) {
-          this.log.warn('Fixing timestamp/blockNumber too small', {
+          this.log.error('Fixing timestamp/blockNumber too small', {
             oldTimestamp: ele.timestamp,
             newTimestamp: earliestTimestamp,
             oldBlockNumber: ele.blockNumber,
@@ -514,7 +514,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
           ele.timestamp > latestTimestamp ||
           ele.blockNumber > latestBlockNumber
         ) {
-          this.log.warn('Fixing timestamp/blockNumber too large.', {
+          this.log.error('Fixing timestamp/blockNumber too large.', {
             oldTimestamp: ele.timestamp,
             newTimestamp: latestTimestamp,
             oldBlockNumber: ele.blockNumber,


### PR DESCRIPTION
**Description**
While discussing metrics, @K-Ho raised that batch submitter should not be fixing monotonicity errors (which should now be fully handled by geth). We want to be notified if it is, because that means there is a monotonicity violation and we need to debug geth. This PR logs an error when we fix monotonicity errors in batch submitter, which will then notify us through Sentry.

**Additional context**
`log.error`s are piped to sentry which notifies us.
