### PR TITLE
Test the reentrancy modifier on OVM_L1CrossDomainMessenger.relayMessage()

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
@@ -11,7 +11,7 @@ import { Lib_ReentrancyGuard } from "../../../libraries/utils/Lib_ReentrancyGuar
 /**
  * @title Abs_BaseCrossDomainMessenger
  * @dev The Base Cross Domain Messenger is an abstract contract providing the interface and common functionality used in the
- * L1 and L2 Cross Domain Messengers. It can also serve as a template for developers wishing to implement a custom bridge 
+ * L1 and L2 Cross Domain Messengers. It can also serve as a template for developers wishing to implement a custom bridge
  * contract to suit their needs.
  *
  * Compiler used: defined by child contract

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
@@ -14,6 +14,7 @@ import { iOVM_L2ToL1MessagePasser } from "../../../iOVM/predeploys/iOVM_L2ToL1Me
 /* Contract Imports */
 import { Abs_BaseCrossDomainMessenger } from "./Abs_BaseCrossDomainMessenger.sol";
 
+
 /**
  * @title OVM_L2CrossDomainMessenger
  * @dev The L2 Cross Domain Messenger contract sends messages from L2 to L1, and is the entry point
@@ -104,6 +105,7 @@ contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, Abs_BaseCros
                 block.number
             )
         );
+
         relayedMessages[relayId] = true;
     }
 

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
@@ -113,7 +113,7 @@ describe('OVM_L1CrossDomainMessenger', () => {
       ).to.deep.equal([
         Mock__OVM_L2CrossDomainMessenger.address,
         BigNumber.from(gasLimit),
-        getXDomainCalldata(await signer.getAddress(), target, message, 0),
+        getXDomainCalldata(target, await signer.getAddress(), message, 0),
       ])
     })
 
@@ -171,7 +171,7 @@ describe('OVM_L1CrossDomainMessenger', () => {
       ])
       sender = await signer.getAddress()
 
-      calldata = getXDomainCalldata(sender, target, message, 0)
+      calldata = getXDomainCalldata(target, sender, message, 0)
 
       const precompile = '0x4200000000000000000000000000000000000000'
 

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L2CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L2CrossDomainMessenger.spec.ts
@@ -197,5 +197,27 @@ describe('OVM_L2CrossDomainMessenger', () => {
         )
       ).to.be.true
     })
+
+    it('should revert if trying reenter `relayMessage`', async () => {
+      // What if reentering to `sendMessage`?
+      Mock__OVM_L1MessageSender.smocked.getL1MessageSender.will.return.with(
+        Mock__OVM_L1CrossDomainMessenger.address
+      )
+
+    const reentrantMessage = OVM_L2CrossDomainMessenger.interface.encodeFunctionData('relayMessage', [
+      OVM_L2CrossDomainMessenger.address,
+      sender,
+      message,
+      1
+    ])
+    sender = await signer.getAddress()
+
+      await OVM_L2CrossDomainMessenger.relayMessage(relayer, sender, reentrantMessage, 0)
+
+      await expect(
+        OVM_L2CrossDomainMessenger.relayMessage(target, sender, message, 0)
+      ).to.be.revertedWith('Provided message has already been received.')
+    })
+
   })
 })

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L2CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L2CrossDomainMessenger.spec.ts
@@ -204,10 +204,9 @@ describe('OVM_L2CrossDomainMessenger', () => {
         Mock__OVM_L1CrossDomainMessenger.address
       )
 
-      const reentrantMessageArgs = [target, sender, message, 1]
       const reentrantMessage = OVM_L2CrossDomainMessenger.interface.encodeFunctionData(
         'relayMessage',
-        reentrantMessageArgs
+        [target, sender, message, 1]
       )
 
       // Calculate xDomainCallData used for indexing
@@ -219,10 +218,8 @@ describe('OVM_L2CrossDomainMessenger', () => {
         0
       )
 
-      const blockNumber = await getNextBlockNumber(ethers.provider)
-
       // Make the call.
-      const res = await OVM_L2CrossDomainMessenger.relayMessage(
+      await OVM_L2CrossDomainMessenger.relayMessage(
         OVM_L2CrossDomainMessenger.address,
         sender,
         reentrantMessage,
@@ -239,6 +236,9 @@ describe('OVM_L2CrossDomainMessenger', () => {
         )
       ).to.be.false
 
+      // Criteria 2: the relayID of the reentrant message is recorded.
+      // Get blockNumber at time of the call.
+      const blockNumber = (await getNextBlockNumber(ethers.provider)) - 1
       const relayId = solidityKeccak256(
         ['bytes'],
         [
@@ -248,17 +248,12 @@ describe('OVM_L2CrossDomainMessenger', () => {
           ),
         ]
       )
-      // Criteria 2: the reentrant message is listed with a relayID.
-      expect(
-        await OVM_L2CrossDomainMessenger.relayedMessages(
-          relayId
-        )
-      ).to.be.true
+
+      expect(await OVM_L2CrossDomainMessenger.relayedMessages(relayId)).to.be
+        .true
 
       // Criteria 3: the target contract did not receive a call.
-      expect(Mock__TargetContract.smocked.setTarget.calls[0].length).to.deep.equal(
-        0
-      )
+      expect(Mock__TargetContract.smocked.setTarget.calls[0]).to.be.undefined
     })
   })
 })

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L2CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L2CrossDomainMessenger.spec.ts
@@ -88,7 +88,7 @@ describe('OVM_L2CrossDomainMessenger', () => {
       expect(
         Mock__OVM_L2ToL1MessagePasser.smocked.passMessageToL1.calls[0]
       ).to.deep.equal([
-        getXDomainCalldata(await signer.getAddress(), target, message, 0),
+        getXDomainCalldata(target, await signer.getAddress(), message, 0),
       ])
     })
 
@@ -192,7 +192,7 @@ describe('OVM_L2CrossDomainMessenger', () => {
         await OVM_L2CrossDomainMessenger.successfulMessages(
           solidityKeccak256(
             ['bytes'],
-            [getXDomainCalldata(await signer.getAddress(), target, message, 0)]
+            [getXDomainCalldata(target, sender, message, 0)]
           )
         )
       ).to.be.true

--- a/packages/contracts/test/helpers/codec/bridge.ts
+++ b/packages/contracts/test/helpers/codec/bridge.ts
@@ -1,8 +1,8 @@
 import { getContractInterface } from '../../../src/contract-defs'
 
 export const getXDomainCalldata = (
-  sender: string,
   target: string,
+  sender: string,
   message: string,
   messageNonce: number
 ): string => {


### PR DESCRIPTION
**Description**

Adds a test for the reentrancy modifier on `OVM_L1CrossDomainMessenger.relayMessage()`

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
