### PR TITLE
feat: let test CI run on all release branches

### DIFF
--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -7,11 +7,13 @@ on:
         - 'l2geth/**'
     branches:
       - master
+      - v*
   pull_request:
     paths:
         - 'l2geth/**'
     branches:
       - master
+      - v*
 
 defaults:
   run:

--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -7,13 +7,13 @@ on:
         - 'l2geth/**'
     branches:
       - master
-      - *rc
+      - '*rc'
   pull_request:
     paths:
         - 'l2geth/**'
     branches:
       - master
-      - *rc
+      - '*rc'
 
 defaults:
   run:

--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -7,13 +7,13 @@ on:
         - 'l2geth/**'
     branches:
       - master
-      - v*
+      - *rc
   pull_request:
     paths:
         - 'l2geth/**'
     branches:
       - master
-      - v*
+      - *rc
 
 defaults:
   run:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - *rc
+      - '*rc'
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v*
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - v*
+      - *rc
   pull_request:
 
 jobs:

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - master
-      - v*
+      - *rc
     paths:
         - 'packages/**/*.sol'
         - 'packages/**/*.ts'
   pull_request:
     branches:
       - master
-      - v*
+      - *rc
     paths:
         - 'packages/**/*.sol'
         - 'packages/**/*.ts'

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - master
+      - v*
     paths:
         - 'packages/**/*.sol'
         - 'packages/**/*.ts'
   pull_request:
     branches:
       - master
+      - v*
     paths:
         - 'packages/**/*.sol'
         - 'packages/**/*.ts'

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - master
-      - *rc
+      - '*rc'
     paths:
         - 'packages/**/*.sol'
         - 'packages/**/*.ts'
   pull_request:
     branches:
       - master
-      - *rc
+      - '*rc'
     paths:
         - 'packages/**/*.sol'
         - 'packages/**/*.ts'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Makes the CI run on all branches which start with `v` indicating that it is a 'version' branch which we can use to prototype breaking changes.

Notes:
- We don't want to publish releases on all `v` branches so I didn't include them `release.yml`
- Example branch that this applies to: https://github.com/ethereum-optimism/optimism/tree/v0.3.0-rlp