### PR TITLE
ops: configurable l2geth verbosity

### DIFF
--- a/ops/scripts/geth.sh
+++ b/ops/scripts/geth.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 RETRIES=${RETRIES:-40}
+VERBOSITY=${VERBOSITY:-6}
 # get the addrs from the URL provided
 ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 
@@ -28,4 +29,4 @@ curl \
     --retry-delay 1 \
     $ROLLUP_CLIENT_HTTP
 
-exec geth --verbosity=6
+exec geth --verbosity="$VERBOSITY"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Allows for a configurable L2Geth verbosity. This is nice for being able to modify the loglevel dynamically in the integration tests. There is a bit of a security concern re: arbitrary code execution so I made sure to quote the value. This only runs in the integration tests so I don't think its that big of a concern.
