### PR TITLE
Ensure Sentry configuration works via updates to services

### DIFF
--- a/.changeset/breezy-queens-help.md
+++ b/.changeset/breezy-queens-help.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/batch-submitter": patch
+"@eth-optimism/data-transport-layer": patch
+---
+
+Update release tag for Sentry compatability

--- a/ops/docker/Dockerfile.batch-submitter
+++ b/ops/docker/Dockerfile.batch-submitter
@@ -28,4 +28,4 @@ COPY --from=builder /optimism/packages/batch-submitter/node_modules ./node_modul
 
 # copy this over in case you want to run alongside other services
 COPY ./ops/scripts/batches.sh .
-ENTRYPOINT ["node", "exec/run-batch-submitter.js"]
+ENTRYPOINT ["npm", "run", "start"]

--- a/ops/docker/Dockerfile.message-relayer
+++ b/ops/docker/Dockerfile.message-relayer
@@ -29,4 +29,4 @@ COPY --from=builder /optimism/packages/message-relayer/node_modules ./node_modul
 
 # copy this over in case you want to run alongside other services
 COPY ./ops/scripts/relayer.sh .
-ENTRYPOINT ["node", "exec/run-message-relayer.js"]
+ENTRYPOINT ["npm", "run", "start"]

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -165,7 +165,7 @@ export const run = async () => {
     MAX_GAS_PRICE_IN_GWEI,
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
-    new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+    log.child({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
     new Metrics({ prefix: TX_BATCH_SUBMITTER_LOG_TAG }),
     DISABLE_QUEUE_BATCH_APPEND,
     autoFixBatchOptions
@@ -187,7 +187,7 @@ export const run = async () => {
     MAX_GAS_PRICE_IN_GWEI,
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
-    new Logger({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
+    log.child({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
     new Metrics({ prefix: STATE_BATCH_SUBMITTER_LOG_TAG }),
     FRAUD_SUBMISSION_ADDRESS
   )

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -20,7 +20,7 @@ const name = 'oe:batch_submitter:init'
 const log = new Logger({
   name,
   sentryOptions: {
-    release: `@eth-optimism/batch-submitter@${process.env.npm_package_version}`,
+    release: `batch-submitter@${process.env.npm_package_version}`,
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -21,6 +21,8 @@ const log = new Logger({
   name,
   sentryOptions: {
     release: `batch-submitter@${process.env.npm_package_version}`,
+    // @ts-ignore stackAttributeKey belongs to PinoSentryOptions, not exported
+    stackAttributeKey: 'err',
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -107,7 +107,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this.state.app = express()
     Sentry.init({
       dsn: this.options.sentryDsn,
-      release: `@eth-optimism/data-transport-layer@${process.env.npm_package_version}`,
+      release: `data-transport-layer@${process.env.npm_package_version}`,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Express({


### PR DESCRIPTION
There are two issues on Sentry now:

- release: Discarded invalid value
- exception.values.0.stacktrace.frames: Discarded invalid value

These commits address them:
- build: use npm script to start base service based services
- fix: remove invalid slash character from sentry release name
- fix: set stackAttributeKey to conventional 'err' key
