### PR TITLE
feat[smock]: Add support for hardhat 2.2.0

### DIFF
--- a/.changeset/eight-dancers-learn.md
+++ b/.changeset/eight-dancers-learn.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/smock": minor
+---
+
+Adds support for hardhat ^2.2.0, required because of move to ethereumjs-vm v5.

--- a/packages/smock/package.json
+++ b/packages/smock/package.json
@@ -34,7 +34,7 @@
     "@types/lodash": "^4.14.161",
     "chai": "^4.3.0",
     "ethereum-waffle": "^3.3.0",
-    "ethers": "^5.1.3",
+    "ethers": "^5.0.31",
     "glob": "^7.1.6",
     "hardhat": "^2.2.1",
     "lodash": "^4.17.20",

--- a/packages/smock/package.json
+++ b/packages/smock/package.json
@@ -28,15 +28,15 @@
     "bn.js": "^5.2.0"
   },
   "devDependencies": {
-    "@nomiclabs/ethereumjs-vm": "4.2.2",
+    "@nomiclabs/ethereumjs-vm": "^4.2.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/lodash": "^4.14.161",
     "chai": "^4.3.0",
     "ethereum-waffle": "^3.3.0",
-    "ethers": "^5.0.32",
+    "ethers": "^5.1.3",
     "glob": "^7.1.6",
-    "hardhat": "^2.1.1",
+    "hardhat": "^2.2.1",
     "lodash": "^4.17.20",
     "prettier": "^2.2.1"
   }

--- a/packages/smock/src/common/hardhat-common.ts
+++ b/packages/smock/src/common/hardhat-common.ts
@@ -1,7 +1,7 @@
 /* Imports: External */
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { HardhatNetworkProvider } from 'hardhat/internal/hardhat-network/provider/provider'
-import { fromHexString } from '@eth-optimism/core-utils'
+import { fromHexString, toHexString } from '@eth-optimism/core-utils'
 
 /**
  * Finds the "base" Ethereum provider of the current hardhat environment.
@@ -53,10 +53,23 @@ export const findBaseHardhatProvider = (
  * @returns Fancified address.
  */
 export const toFancyAddress = (address: string): any => {
-  const addressBuf = fromHexString(address)
-  ;(addressBuf as any).buf = fromHexString(address)
-  ;(addressBuf as any).toString = () => {
+  const fancyAddress = fromHexString(address)
+  ;(fancyAddress as any).buf = fromHexString(address)
+  ;(fancyAddress as any).toString = () => {
     return address.toLowerCase()
   }
-  return addressBuf
+  return fancyAddress
+}
+
+/**
+ * Same as toFancyAddress but in the opposite direction.
+ * @param fancyAddress Fancy address to turn into a string.
+ * @returns Way more boring address.
+ */
+export const fromFancyAddress = (fancyAddress: any): string => {
+  if (fancyAddress.buf) {
+    return toHexString(fancyAddress.buf)
+  } else {
+    return toHexString(fancyAddress)
+  }
 }

--- a/packages/smock/src/common/hardhat-common.ts
+++ b/packages/smock/src/common/hardhat-common.ts
@@ -55,8 +55,12 @@ export const findBaseHardhatProvider = (
 export const toFancyAddress = (address: string): any => {
   const fancyAddress = fromHexString(address)
   ;(fancyAddress as any).buf = fromHexString(address)
-  ;(fancyAddress as any).toString = () => {
-    return address.toLowerCase()
+  ;(fancyAddress as any).toString = (encoding?: any) => {
+    if (encoding === undefined) {
+      return address.toLowerCase()
+    } else {
+      return fromHexString(address).toString(encoding)
+    }
   }
   return fancyAddress
 }

--- a/packages/smock/src/common/hardhat-common.ts
+++ b/packages/smock/src/common/hardhat-common.ts
@@ -1,6 +1,7 @@
 /* Imports: External */
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { HardhatNetworkProvider } from 'hardhat/internal/hardhat-network/provider/provider'
+import { fromHexString } from '@eth-optimism/core-utils'
 
 /**
  * Finds the "base" Ethereum provider of the current hardhat environment.
@@ -43,4 +44,19 @@ export const findBaseHardhatProvider = (
   // TODO: Figure out a reliable way to do a type check here. Source for inspiration:
   // https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
   return provider as any
+}
+
+/**
+ * Converts a string into the fancy new address thing that ethereumjs-vm v5 expects while also
+ * maintaining backwards compatibility with ethereumjs-vm v4.
+ * @param address String address to convert into the fancy new address type.
+ * @returns Fancified address.
+ */
+export const toFancyAddress = (address: string): any => {
+  const addressBuf = fromHexString(address)
+  ;(addressBuf as any).buf = fromHexString(address)
+  ;(addressBuf as any).toString = () => {
+    return address.toLowerCase()
+  }
+  return addressBuf
 }

--- a/packages/smock/src/smockit/binding.ts
+++ b/packages/smock/src/smockit/binding.ts
@@ -8,6 +8,7 @@ import BN from 'bn.js'
 
 /* Imports: Internal */
 import { MockContract, SmockedVM } from './types'
+import { toFancyAddress } from '../common'
 
 /**
  * Checks to see if smock has been initialized already. Basically just checking to see if we've
@@ -52,7 +53,12 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
       return
     }
 
-    const target = toHexString(message.to).toLowerCase()
+    let target: string
+    if (message.to.buf) {
+      target = toHexString(message.to.buf).toLowerCase()
+    } else {
+      target = toHexString(message.to).toLowerCase()
+    }
 
     // Check if the target address is a smocked contract.
     if (!(target in vm._smockState.mocks)) {
@@ -77,7 +83,13 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
     // later creates a contract at that address. Not sure how to handle this case. Very open to
     // ideas.
     if (result.createdAddress) {
-      const created = toHexString(result.createdAddress).toLowerCase()
+      let created: string
+      if (result.createdAddress.buf) {
+        created = toHexString(result.createdAddress.buf).toLowerCase()
+      } else {
+        created = toHexString(result.createdAddress).toLowerCase()
+      }
+
       if (created in vm._smockState.mocks) {
         delete vm._smockState.mocks[created]
       }
@@ -92,7 +104,13 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
     // contracts never create new sub-calls (meaning this `afterMessage` event corresponds directly
     // to a `beforeMessage` event emitted during a call to a smock contract).
     const message = vm._smockState.messages.pop()
-    const target = toHexString(message.to).toLowerCase()
+
+    let target: string
+    if (message.to.buf) {
+      target = toHexString(message.to.buf).toLowerCase()
+    } else {
+      target = toHexString(message.to).toLowerCase()
+    }
 
     // Not sure if this can ever actually happen? Just being safe.
     if (!(target in vm._smockState.mocks)) {
@@ -157,7 +175,7 @@ export const bindSmock = async (
   }
 
   const vm: SmockedVM = (provider as any)._node._vm
-  const pStateManager = vm.pStateManager
+  const pStateManager = vm.pStateManager || vm.stateManager
 
   // Add mock to our list of mocks currently attached to the VM.
   vm._smockState.mocks[mock.address.toLowerCase()] = mock
@@ -166,7 +184,7 @@ export const bindSmock = async (
   // Solidity will sometimes throw if it's calling something without code (I forget the exact
   // scenario that causes this throw).
   await pStateManager.putContractCode(
-    fromHexString(mock.address),
+    toFancyAddress(mock.address),
     Buffer.from('00', 'hex')
   )
 }

--- a/packages/smock/src/smockit/binding.ts
+++ b/packages/smock/src/smockit/binding.ts
@@ -7,9 +7,11 @@ import BN from 'bn.js'
 // Handle hardhat ^2.2.0
 let TransactionExecutionError: any
 try {
+  // tslint:disable-next-line
   TransactionExecutionError = require('hardhat/internal/hardhat-network/provider/errors')
     .TransactionExecutionError
 } catch (err) {
+  // tslint:disable-next-line
   TransactionExecutionError = require('hardhat/internal/core/providers/errors')
     .TransactionExecutionError
 }

--- a/packages/smock/src/smockit/binding.ts
+++ b/packages/smock/src/smockit/binding.ts
@@ -1,10 +1,18 @@
 /* Imports: External */
-import { TransactionExecutionError } from 'hardhat/internal/hardhat-network/provider/errors'
 import { HardhatNetworkProvider } from 'hardhat/internal/hardhat-network/provider/provider'
 import { decodeRevertReason } from 'hardhat/internal/hardhat-network/stack-traces/revert-reasons'
 import { VmError } from '@nomiclabs/ethereumjs-vm/dist/exceptions'
-import { toHexString, fromHexString } from '@eth-optimism/core-utils'
 import BN from 'bn.js'
+
+// Handle hardhat ^2.2.0
+let TransactionExecutionError: any
+try {
+  TransactionExecutionError = require('hardhat/internal/hardhat-network/provider/errors')
+    .TransactionExecutionError
+} catch (err) {
+  TransactionExecutionError = require('hardhat/internal/core/providers/errors')
+    .TransactionExecutionError
+}
 
 /* Imports: Internal */
 import { MockContract, SmockedVM } from './types'

--- a/packages/smock/src/smockit/binding.ts
+++ b/packages/smock/src/smockit/binding.ts
@@ -8,7 +8,7 @@ import BN from 'bn.js'
 
 /* Imports: Internal */
 import { MockContract, SmockedVM } from './types'
-import { toFancyAddress } from '../common'
+import { fromFancyAddress, toFancyAddress } from '../common'
 
 /**
  * Checks to see if smock has been initialized already. Basically just checking to see if we've
@@ -53,12 +53,7 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
       return
     }
 
-    let target: string
-    if (message.to.buf) {
-      target = toHexString(message.to.buf).toLowerCase()
-    } else {
-      target = toHexString(message.to).toLowerCase()
-    }
+    const target = fromFancyAddress(message.to)
 
     // Check if the target address is a smocked contract.
     if (!(target in vm._smockState.mocks)) {
@@ -83,13 +78,7 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
     // later creates a contract at that address. Not sure how to handle this case. Very open to
     // ideas.
     if (result.createdAddress) {
-      let created: string
-      if (result.createdAddress.buf) {
-        created = toHexString(result.createdAddress.buf).toLowerCase()
-      } else {
-        created = toHexString(result.createdAddress).toLowerCase()
-      }
-
+      const created = fromFancyAddress(result.createdAddress)
       if (created in vm._smockState.mocks) {
         delete vm._smockState.mocks[created]
       }
@@ -104,13 +93,7 @@ const initializeSmock = (provider: HardhatNetworkProvider): void => {
     // contracts never create new sub-calls (meaning this `afterMessage` event corresponds directly
     // to a `beforeMessage` event emitted during a call to a smock contract).
     const message = vm._smockState.messages.pop()
-
-    let target: string
-    if (message.to.buf) {
-      target = toHexString(message.to.buf).toLowerCase()
-    } else {
-      target = toHexString(message.to).toLowerCase()
-    }
+    const target = fromFancyAddress(message.to)
 
     // Not sure if this can ever actually happen? Just being safe.
     if (!(target in vm._smockState.mocks)) {

--- a/packages/smock/src/smockit/smockit.ts
+++ b/packages/smock/src/smockit/smockit.ts
@@ -6,6 +6,9 @@ import { toHexString, fromHexString } from '@eth-optimism/core-utils'
 /* Imports: Internal */
 import {
   isArtifact,
+  isContract,
+  isContractFactory,
+  isInterface,
   MockContract,
   MockContractFunction,
   MockReturnValue,
@@ -33,13 +36,19 @@ const makeContractInterfaceFromSpec = async (
     return spec.interface
   } else if (spec instanceof ethers.utils.Interface) {
     return spec
+  } else if (isInterface(spec)) {
+    return spec as any
+  } else if (isContractFactory(spec)) {
+    return (spec as any).interface
+  } else if (isContract(spec)) {
+    return (spec as any).interface
   } else if (isArtifact(spec)) {
     return new ethers.utils.Interface(spec.abi)
   } else if (typeof spec === 'string') {
     try {
       return new ethers.utils.Interface(spec)
     } catch (err) {
-      return (await hre.ethers.getContractFactory(spec)).interface
+      return (await (hre as any).ethers.getContractFactory(spec)).interface
     }
   } else {
     return new ethers.utils.Interface(spec)
@@ -150,7 +159,7 @@ export const smockit = async (
   const contract = new ethers.Contract(
     opts.address || makeRandomAddress(),
     await makeContractInterfaceFromSpec(spec),
-    opts.provider || hre.ethers.provider // TODO: Probably check that this exists.
+    opts.provider || (hre as any).ethers.provider // TODO: Probably check that this exists.
   ) as MockContract
 
   // Start by smocking the fallback.

--- a/packages/smock/src/smockit/types.ts
+++ b/packages/smock/src/smockit/types.ts
@@ -62,7 +62,11 @@ export interface SmockedVM {
 
   on: (event: string, callback: Function) => void
 
-  pStateManager: {
+  stateManager?: {
+    putContractCode: (address: Buffer, code: Buffer) => Promise<void>
+  }
+
+  pStateManager?: {
     putContractCode: (address: Buffer, code: Buffer) => Promise<void>
   }
 }
@@ -88,6 +92,30 @@ export const isMockContract = (obj: any): obj is MockContract => {
       return isMockFunction(smockFunction)
     })
   )
+}
+
+export const isInterface = (obj: any): boolean => {
+  return (
+    obj &&
+    obj.functions !== undefined &&
+    obj.errors !== undefined &&
+    obj.structs !== undefined &&
+    obj.events !== undefined &&
+    Array.isArray(obj.fragments)
+  )
+}
+
+export const isContract = (obj: any): boolean => {
+  return (
+    obj &&
+    obj.functions !== undefined &&
+    obj.estimateGas !== undefined &&
+    obj.callStatic !== undefined
+  )
+}
+
+export const isContractFactory = (obj: any): boolean => {
+  return obj && obj.interface !== undefined && obj.deploy !== undefined
 }
 
 export const isArtifact = (obj: any): obj is Artifact => {

--- a/packages/smock/test/smockit/function-manipulation.spec.ts
+++ b/packages/smock/test/smockit/function-manipulation.spec.ts
@@ -1,5 +1,5 @@
 /* Imports: External */
-import { ethers } from 'hardhat'
+import hre from 'hardhat'
 import { expect } from 'chai'
 import { toPlainObject } from 'lodash'
 import { BigNumber } from 'ethers'
@@ -8,6 +8,8 @@ import { BigNumber } from 'ethers'
 import { MockContract, smockit } from '../../src'
 
 describe('[smock]: function manipulation tests', () => {
+  const ethers = (hre as any).ethers
+
   let mock: MockContract
   beforeEach(async () => {
     mock = await smockit('TestHelpers_BasicReturnContract')

--- a/packages/smock/test/smockit/smock-initialization.spec.ts
+++ b/packages/smock/test/smockit/smock-initialization.spec.ts
@@ -1,11 +1,13 @@
 /* Imports: External */
-import { ethers, artifacts } from 'hardhat'
+import hre from 'hardhat'
 import { expect } from 'chai'
 
 /* Imports: Internal */
 import { smockit, isMockContract } from '../../src'
 
 describe('[smock]: initialization tests', () => {
+  const ethers = (hre as any).ethers
+
   describe('initialization: ethers objects', () => {
     it('should be able to create a SmockContract from an ethers ContractFactory', async () => {
       const spec = await ethers.getContractFactory('TestHelpers_EmptyContract')
@@ -46,7 +48,7 @@ describe('[smock]: initialization tests', () => {
     })
 
     it('should be able to create a SmockContract from a JSON contract artifact object', async () => {
-      const artifact = await artifacts.readArtifact(
+      const artifact = await hre.artifacts.readArtifact(
         'TestHelpers_BasicReturnContract'
       )
       const spec = artifact
@@ -56,7 +58,7 @@ describe('[smock]: initialization tests', () => {
     })
 
     it('should be able to create a SmockContract from a JSON contract ABI object', async () => {
-      const artifact = await artifacts.readArtifact(
+      const artifact = await hre.artifacts.readArtifact(
         'TestHelpers_BasicReturnContract'
       )
       const spec = artifact.abi
@@ -66,7 +68,7 @@ describe('[smock]: initialization tests', () => {
     })
 
     it('should be able to create a SmockContract from a JSON contract ABI string', async () => {
-      const artifact = await artifacts.readArtifact(
+      const artifact = await hre.artifacts.readArtifact(
         'TestHelpers_BasicReturnContract'
       )
       const spec = JSON.stringify(artifact.abi)

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,21 +405,6 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/strings" "^5.1.0"
 
-"@ethersproject/abi@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.1.1.tgz#79525f582338d98660ac709c65b44c3c081ed2fc"
-  integrity sha512-UNmhRL4ngm1nCWvhJWRd55PvP1JWojGD4BR63JxyiiWZQAszYzaHHeYdRcj+NY3S0kV6SmAS2dZWSBOZPnXbSw==
-  dependencies:
-    "@ethersproject/address" "^5.1.0"
-    "@ethersproject/bignumber" "^5.1.0"
-    "@ethersproject/bytes" "^5.1.0"
-    "@ethersproject/constants" "^5.1.0"
-    "@ethersproject/hash" "^5.1.0"
-    "@ethersproject/keccak256" "^5.1.0"
-    "@ethersproject/logger" "^5.1.0"
-    "@ethersproject/properties" "^5.1.0"
-    "@ethersproject/strings" "^5.1.0"
-
 "@ethersproject/abstract-provider@5.1.0", "@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.0.10", "@ethersproject/abstract-provider@^5.0.5", "@ethersproject/abstract-provider@^5.0.8", "@ethersproject/abstract-provider@^5.0.9", "@ethersproject/abstract-provider@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.1.0.tgz#1f24c56cda5524ef4ed3cfc562a01d6b6f8eeb0b"
@@ -479,15 +464,6 @@
     "@ethersproject/logger" "^5.1.0"
     bn.js "^4.4.0"
 
-"@ethersproject/bignumber@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.1.1.tgz#84812695253ccbc639117f7ac49ee1529b68e637"
-  integrity sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==
-  dependencies:
-    "@ethersproject/bytes" "^5.1.0"
-    "@ethersproject/logger" "^5.1.0"
-    bn.js "^4.4.0"
-
 "@ethersproject/bytes@5.1.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.0.2", "@ethersproject/bytes@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.1.0.tgz#55dfa9c4c21df1b1b538be3accb50fb76d5facfd"
@@ -506,22 +482,6 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.1.0.tgz#f7c3451f1af77e029005733ccab3419d07d23f6b"
   integrity sha512-dvTMs/4XGSc57cYOW0KjgX1NdTujUu7mNb6PQdJWg08m9ULzPyGZuBkFJnijBcp6vTOCQ59RwjboWgNWw393og==
-  dependencies:
-    "@ethersproject/abi" "^5.1.0"
-    "@ethersproject/abstract-provider" "^5.1.0"
-    "@ethersproject/abstract-signer" "^5.1.0"
-    "@ethersproject/address" "^5.1.0"
-    "@ethersproject/bignumber" "^5.1.0"
-    "@ethersproject/bytes" "^5.1.0"
-    "@ethersproject/constants" "^5.1.0"
-    "@ethersproject/logger" "^5.1.0"
-    "@ethersproject/properties" "^5.1.0"
-    "@ethersproject/transactions" "^5.1.0"
-
-"@ethersproject/contracts@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.1.1.tgz#c66cb6d618fcbd73e20a6b808e8f768b2b781d0b"
-  integrity sha512-6WwktLJ0DFWU8pDkgH4IGttQHhQN4SnwKFu9h+QYVe48VGWtbDu4W8/q/7QA1u/HWlWMrKxqawPiZUJj0UMvOw==
   dependencies:
     "@ethersproject/abi" "^5.1.0"
     "@ethersproject/abstract-provider" "^5.1.0"
@@ -657,31 +617,6 @@
     bech32 "1.1.4"
     ws "7.2.3"
 
-"@ethersproject/providers@5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.1.2.tgz#4e4459698903f911402fe91aa7544eb07f3921ed"
-  integrity sha512-GqsS8rd+eyd4eNkcNgzZ4l9IRULBPUZa7JPnv22k4MHflMobUseyhfbVnmoN5bVNNkOxjV1IPTw9i0sV1hwdpg==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.1.0"
-    "@ethersproject/abstract-signer" "^5.1.0"
-    "@ethersproject/address" "^5.1.0"
-    "@ethersproject/basex" "^5.1.0"
-    "@ethersproject/bignumber" "^5.1.0"
-    "@ethersproject/bytes" "^5.1.0"
-    "@ethersproject/constants" "^5.1.0"
-    "@ethersproject/hash" "^5.1.0"
-    "@ethersproject/logger" "^5.1.0"
-    "@ethersproject/networks" "^5.1.0"
-    "@ethersproject/properties" "^5.1.0"
-    "@ethersproject/random" "^5.1.0"
-    "@ethersproject/rlp" "^5.1.0"
-    "@ethersproject/sha2" "^5.1.0"
-    "@ethersproject/strings" "^5.1.0"
-    "@ethersproject/transactions" "^5.1.0"
-    "@ethersproject/web" "^5.1.0"
-    bech32 "1.1.4"
-    ws "7.2.3"
-
 "@ethersproject/random@5.1.0", "@ethersproject/random@^5.0.0", "@ethersproject/random@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.1.0.tgz#0bdff2554df03ebc5f75689614f2d58ea0d9a71f"
@@ -742,21 +677,6 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.1.0.tgz#da7fcd7e77e23dcfcca317a945f60bc228c61b36"
   integrity sha512-s10crRLZEA0Bgv6FGEl/AKkTw9f+RVUrlWDX1rHnD4ZncPFeiV2AJr4nT7QSUhxJdFPvjyKRDb3nEH27dIqcPQ==
-  dependencies:
-    "@ethersproject/address" "^5.1.0"
-    "@ethersproject/bignumber" "^5.1.0"
-    "@ethersproject/bytes" "^5.1.0"
-    "@ethersproject/constants" "^5.1.0"
-    "@ethersproject/keccak256" "^5.1.0"
-    "@ethersproject/logger" "^5.1.0"
-    "@ethersproject/properties" "^5.1.0"
-    "@ethersproject/rlp" "^5.1.0"
-    "@ethersproject/signing-key" "^5.1.0"
-
-"@ethersproject/transactions@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.1.1.tgz#5a6bbb25fb062c3cc75eb0db12faefcdd3870813"
-  integrity sha512-Nwgbp09ttIVN0OoUBatCXaHxR7grWPHbozJN8v7AXDLrl6nnOIBEMDh+yJTnosSQlFhcyjfTGGN+Mx6R8HdvMw==
   dependencies:
     "@ethersproject/address" "^5.1.0"
     "@ethersproject/bignumber" "^5.1.0"
@@ -5790,42 +5710,6 @@ ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.26, ethers@^5.0.31, eth
     "@ethersproject/solidity" "5.1.0"
     "@ethersproject/strings" "5.1.0"
     "@ethersproject/transactions" "5.1.0"
-    "@ethersproject/units" "5.1.0"
-    "@ethersproject/wallet" "5.1.0"
-    "@ethersproject/web" "5.1.0"
-    "@ethersproject/wordlists" "5.1.0"
-
-ethers@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.1.3.tgz#68eb48742b8a8ca53480bca2e53fb314c23fea7f"
-  integrity sha512-QAj+LG3z5HsK6UDAOdCjDEthWioZ7sTzAcMWyVrQF+ACioalQ99NrrSxIq5qS0c+hoy3TAIjqpYteHgC2Iqy+w==
-  dependencies:
-    "@ethersproject/abi" "5.1.1"
-    "@ethersproject/abstract-provider" "5.1.0"
-    "@ethersproject/abstract-signer" "5.1.0"
-    "@ethersproject/address" "5.1.0"
-    "@ethersproject/base64" "5.1.0"
-    "@ethersproject/basex" "5.1.0"
-    "@ethersproject/bignumber" "5.1.1"
-    "@ethersproject/bytes" "5.1.0"
-    "@ethersproject/constants" "5.1.0"
-    "@ethersproject/contracts" "5.1.1"
-    "@ethersproject/hash" "5.1.0"
-    "@ethersproject/hdnode" "5.1.0"
-    "@ethersproject/json-wallets" "5.1.0"
-    "@ethersproject/keccak256" "5.1.0"
-    "@ethersproject/logger" "5.1.0"
-    "@ethersproject/networks" "5.1.0"
-    "@ethersproject/pbkdf2" "5.1.0"
-    "@ethersproject/properties" "5.1.0"
-    "@ethersproject/providers" "5.1.2"
-    "@ethersproject/random" "5.1.0"
-    "@ethersproject/rlp" "5.1.0"
-    "@ethersproject/sha2" "5.1.0"
-    "@ethersproject/signing-key" "5.1.0"
-    "@ethersproject/solidity" "5.1.0"
-    "@ethersproject/strings" "5.1.0"
-    "@ethersproject/transactions" "5.1.1"
     "@ethersproject/units" "5.1.0"
     "@ethersproject/wallet" "5.1.0"
     "@ethersproject/web" "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,6 +305,76 @@
     patch-package "^6.2.2"
     postinstall-postinstall "^2.1.0"
 
+"@ethereumjs/block@^3.2.0", "@ethereumjs/block@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.2.1.tgz#c24c345e6dd6299efa4bed40979280b7dda96d3a"
+  integrity sha512-FCxo5KwwULne2A2Yuae4iaGGqSsRjwzXOlDhGalOFiBbLfP3hE04RHaHGw4c8vh1PfOrLauwi0dQNUBkOG3zIA==
+  dependencies:
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/tx" "^3.1.3"
+    ethereumjs-util "^7.0.10"
+    merkle-patricia-tree "^4.1.0"
+
+"@ethereumjs/blockchain@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.2.1.tgz#83ed83647667265f1666f111caf065ef9d1e82b5"
+  integrity sha512-+hshP2qSOOFsiYvZCbaDQFG7jYTWafE8sfBi+pAsdhAHfP7BN7VLyob7qoQISgwS1s7NTR4c4+2t/woU9ahItw==
+  dependencies:
+    "@ethereumjs/block" "^3.2.0"
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/ethash" "^1.0.0"
+    debug "^2.2.0"
+    ethereumjs-util "^7.0.9"
+    level-mem "^5.0.1"
+    lru-cache "^5.1.1"
+    rlp "^2.2.4"
+    semaphore-async-await "^1.5.1"
+
+"@ethereumjs/common@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.2.0.tgz#850a3e3e594ee707ad8d44a11e8152fb62450535"
+  integrity sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.0.9"
+
+"@ethereumjs/ethash@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/ethash/-/ethash-1.0.0.tgz#4e77f85b37be1ade5393e8719bdabac3e796ddaa"
+  integrity sha512-iIqnGG6NMKesyOxv2YctB2guOVX18qMAWlj3QlZyrc+GqfzLqoihti+cVNQnyNxr7eYuPdqwLQOFuPe6g/uKjw==
+  dependencies:
+    "@types/levelup" "^4.3.0"
+    buffer-xor "^2.0.1"
+    ethereumjs-util "^7.0.7"
+    miller-rabin "^4.0.0"
+
+"@ethereumjs/tx@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.3.tgz#0e4b0ccec2f12b1f0bbbb0e7542dd79d9ec25d87"
+  integrity sha512-DJBu6cbwYtiPTFeCUR8DF5p+PF0jxs+0rALJZiEcTz2tiRPIEkM72GEbrkGuqzENLCzBrJHT43O0DxSYTqeo+g==
+  dependencies:
+    "@ethereumjs/common" "^2.2.0"
+    ethereumjs-util "^7.0.10"
+
+"@ethereumjs/vm@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.3.2.tgz#b4d83a3d50a7ad22d6d412cc21bbde221b3e2871"
+  integrity sha512-QmCUQrW6xbhgEbQh9njue4kAJdM056C+ytBFUTF/kDYa3kNDm4Qxp9HUyTlt1OCSXvDhws0qqlh8+q+pmXpN7g==
+  dependencies:
+    "@ethereumjs/block" "^3.2.1"
+    "@ethereumjs/blockchain" "^5.2.1"
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/tx" "^3.1.3"
+    async-eventemitter "^0.2.4"
+    core-js-pure "^3.0.1"
+    debug "^2.2.0"
+    ethereumjs-util "^7.0.10"
+    functional-red-black-tree "^1.0.1"
+    mcl-wasm "^0.7.1"
+    merkle-patricia-tree "^4.1.0"
+    rustbn.js "~0.2.0"
+    util.promisify "^1.0.1"
+
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"
@@ -324,6 +394,21 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.1.0.tgz#d582c9f6a8e8192778b5f2c991ce19d7b336b0c5"
   integrity sha512-N/W9Sbn1/C6Kh2kuHRjf/hX6euMK4+9zdJRBB8sDWmihVntjUAfxbusGZKzDQD8i3szAHhTz8K7XADV5iFNfJw==
+  dependencies:
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/hash" "^5.1.0"
+    "@ethersproject/keccak256" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
+
+"@ethersproject/abi@5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.1.1.tgz#79525f582338d98660ac709c65b44c3c081ed2fc"
+  integrity sha512-UNmhRL4ngm1nCWvhJWRd55PvP1JWojGD4BR63JxyiiWZQAszYzaHHeYdRcj+NY3S0kV6SmAS2dZWSBOZPnXbSw==
   dependencies:
     "@ethersproject/address" "^5.1.0"
     "@ethersproject/bignumber" "^5.1.0"
@@ -394,6 +479,15 @@
     "@ethersproject/logger" "^5.1.0"
     bn.js "^4.4.0"
 
+"@ethersproject/bignumber@5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.1.1.tgz#84812695253ccbc639117f7ac49ee1529b68e637"
+  integrity sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==
+  dependencies:
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    bn.js "^4.4.0"
+
 "@ethersproject/bytes@5.1.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.0.2", "@ethersproject/bytes@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.1.0.tgz#55dfa9c4c21df1b1b538be3accb50fb76d5facfd"
@@ -412,6 +506,22 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.1.0.tgz#f7c3451f1af77e029005733ccab3419d07d23f6b"
   integrity sha512-dvTMs/4XGSc57cYOW0KjgX1NdTujUu7mNb6PQdJWg08m9ULzPyGZuBkFJnijBcp6vTOCQ59RwjboWgNWw393og==
+  dependencies:
+    "@ethersproject/abi" "^5.1.0"
+    "@ethersproject/abstract-provider" "^5.1.0"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
+
+"@ethersproject/contracts@5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.1.1.tgz#c66cb6d618fcbd73e20a6b808e8f768b2b781d0b"
+  integrity sha512-6WwktLJ0DFWU8pDkgH4IGttQHhQN4SnwKFu9h+QYVe48VGWtbDu4W8/q/7QA1u/HWlWMrKxqawPiZUJj0UMvOw==
   dependencies:
     "@ethersproject/abi" "^5.1.0"
     "@ethersproject/abstract-provider" "^5.1.0"
@@ -547,6 +657,31 @@
     bech32 "1.1.4"
     ws "7.2.3"
 
+"@ethersproject/providers@5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.1.2.tgz#4e4459698903f911402fe91aa7544eb07f3921ed"
+  integrity sha512-GqsS8rd+eyd4eNkcNgzZ4l9IRULBPUZa7JPnv22k4MHflMobUseyhfbVnmoN5bVNNkOxjV1IPTw9i0sV1hwdpg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.1.0"
+    "@ethersproject/abstract-signer" "^5.1.0"
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/basex" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/hash" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/networks" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/random" "^5.1.0"
+    "@ethersproject/rlp" "^5.1.0"
+    "@ethersproject/sha2" "^5.1.0"
+    "@ethersproject/strings" "^5.1.0"
+    "@ethersproject/transactions" "^5.1.0"
+    "@ethersproject/web" "^5.1.0"
+    bech32 "1.1.4"
+    ws "7.2.3"
+
 "@ethersproject/random@5.1.0", "@ethersproject/random@^5.0.0", "@ethersproject/random@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.1.0.tgz#0bdff2554df03ebc5f75689614f2d58ea0d9a71f"
@@ -607,6 +742,21 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.1.0.tgz#da7fcd7e77e23dcfcca317a945f60bc228c61b36"
   integrity sha512-s10crRLZEA0Bgv6FGEl/AKkTw9f+RVUrlWDX1rHnD4ZncPFeiV2AJr4nT7QSUhxJdFPvjyKRDb3nEH27dIqcPQ==
+  dependencies:
+    "@ethersproject/address" "^5.1.0"
+    "@ethersproject/bignumber" "^5.1.0"
+    "@ethersproject/bytes" "^5.1.0"
+    "@ethersproject/constants" "^5.1.0"
+    "@ethersproject/keccak256" "^5.1.0"
+    "@ethersproject/logger" "^5.1.0"
+    "@ethersproject/properties" "^5.1.0"
+    "@ethersproject/rlp" "^5.1.0"
+    "@ethersproject/signing-key" "^5.1.0"
+
+"@ethersproject/transactions@5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.1.1.tgz#5a6bbb25fb062c3cc75eb0db12faefcdd3870813"
+  integrity sha512-Nwgbp09ttIVN0OoUBatCXaHxR7grWPHbozJN8v7AXDLrl6nnOIBEMDh+yJTnosSQlFhcyjfTGGN+Mx6R8HdvMw==
   dependencies:
     "@ethersproject/address" "^5.1.0"
     "@ethersproject/bignumber" "^5.1.0"
@@ -1479,7 +1629,7 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@nomiclabs/ethereumjs-vm@4.2.2":
+"@nomiclabs/ethereumjs-vm@4.2.2", "@nomiclabs/ethereumjs-vm@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.2.tgz#2f8817113ca0fb6c44c1b870d0a809f0e026a6cc"
   integrity sha512-8WmX94mMcJaZ7/m7yBbyuS6B+wuOul+eF+RY9fBpGhNaUpyMR/vFIcDojqcWQ4Yafe1tMKY5LDu2yfT4NZgV4Q==
@@ -2720,7 +2870,7 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-async-eventemitter@^0.2.2:
+async-eventemitter@^0.2.2, async-eventemitter@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/async-eventemitter/-/async-eventemitter-0.2.4.tgz#f5e7c8ca7d3e46aab9ec40a292baf686a0bafaca"
   integrity sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==
@@ -4382,6 +4532,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -5485,7 +5643,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.8:
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.7, ethereumjs-util@^7.0.8, ethereumjs-util@^7.0.9:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
   integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
@@ -5637,6 +5795,42 @@ ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.26, ethers@^5.0.31, eth
     "@ethersproject/web" "5.1.0"
     "@ethersproject/wordlists" "5.1.0"
 
+ethers@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.1.3.tgz#68eb48742b8a8ca53480bca2e53fb314c23fea7f"
+  integrity sha512-QAj+LG3z5HsK6UDAOdCjDEthWioZ7sTzAcMWyVrQF+ACioalQ99NrrSxIq5qS0c+hoy3TAIjqpYteHgC2Iqy+w==
+  dependencies:
+    "@ethersproject/abi" "5.1.1"
+    "@ethersproject/abstract-provider" "5.1.0"
+    "@ethersproject/abstract-signer" "5.1.0"
+    "@ethersproject/address" "5.1.0"
+    "@ethersproject/base64" "5.1.0"
+    "@ethersproject/basex" "5.1.0"
+    "@ethersproject/bignumber" "5.1.1"
+    "@ethersproject/bytes" "5.1.0"
+    "@ethersproject/constants" "5.1.0"
+    "@ethersproject/contracts" "5.1.1"
+    "@ethersproject/hash" "5.1.0"
+    "@ethersproject/hdnode" "5.1.0"
+    "@ethersproject/json-wallets" "5.1.0"
+    "@ethersproject/keccak256" "5.1.0"
+    "@ethersproject/logger" "5.1.0"
+    "@ethersproject/networks" "5.1.0"
+    "@ethersproject/pbkdf2" "5.1.0"
+    "@ethersproject/properties" "5.1.0"
+    "@ethersproject/providers" "5.1.2"
+    "@ethersproject/random" "5.1.0"
+    "@ethersproject/rlp" "5.1.0"
+    "@ethersproject/sha2" "5.1.0"
+    "@ethersproject/signing-key" "5.1.0"
+    "@ethersproject/solidity" "5.1.0"
+    "@ethersproject/strings" "5.1.0"
+    "@ethersproject/transactions" "5.1.1"
+    "@ethersproject/units" "5.1.0"
+    "@ethersproject/wallet" "5.1.0"
+    "@ethersproject/web" "5.1.0"
+    "@ethersproject/wordlists" "5.1.0"
+
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
@@ -5726,6 +5920,11 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -6720,6 +6919,57 @@ hardhat@^2.0.8, hardhat@^2.0.9, hardhat@^2.1.1, hardhat@^2.1.2:
     io-ts "1.10.4"
     lodash "^4.17.11"
     merkle-patricia-tree "3.0.0"
+    mnemonist "^0.38.0"
+    mocha "^7.1.2"
+    node-fetch "^2.6.0"
+    qs "^6.7.0"
+    raw-body "^2.4.1"
+    resolve "1.17.0"
+    semver "^6.3.0"
+    slash "^3.0.0"
+    solc "0.7.3"
+    source-map-support "^0.5.13"
+    stacktrace-parser "^0.1.10"
+    "true-case-path" "^2.2.1"
+    tsort "0.0.1"
+    uuid "^3.3.2"
+    ws "^7.2.1"
+
+hardhat@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.2.1.tgz#bef0031b994e3f60a88d428f2097195c58cf9ed2"
+  integrity sha512-8s7MtGXdh0NDwQKdlA8m8QdloVIN1+hv5aFpn0G5Ljj9vfNY9kUoc0a9pMboeGbd9WrS+XrZs5YlsPgQjaW/Tg==
+  dependencies:
+    "@ethereumjs/block" "^3.2.1"
+    "@ethereumjs/blockchain" "^5.2.1"
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/tx" "^3.1.3"
+    "@ethereumjs/vm" "^5.3.2"
+    "@sentry/node" "^5.18.1"
+    "@solidity-parser/parser" "^0.11.0"
+    "@types/bn.js" "^5.1.0"
+    "@types/lru-cache" "^5.1.0"
+    abort-controller "^3.0.0"
+    adm-zip "^0.4.16"
+    ansi-escapes "^4.3.0"
+    chalk "^2.4.2"
+    chokidar "^3.4.0"
+    ci-info "^2.0.0"
+    debug "^4.1.1"
+    enquirer "^2.3.0"
+    env-paths "^2.2.0"
+    eth-sig-util "^2.5.2"
+    ethereum-cryptography "^0.1.2"
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^7.0.10"
+    find-up "^2.1.0"
+    fp-ts "1.19.3"
+    fs-extra "^7.0.1"
+    glob "^7.1.3"
+    immutable "^4.0.0-rc.12"
+    io-ts "1.10.4"
+    lodash "^4.17.11"
+    merkle-patricia-tree "^4.1.0"
     mnemonist "^0.38.0"
     mocha "^7.1.2"
     node-fetch "^2.6.0"
@@ -8398,6 +8648,11 @@ match-all@^1.2.6:
   resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
   integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
+mcl-wasm@^0.7.1:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.6.tgz#c1789ebda5565d49b77d2ee195ff3e4d282f1554"
+  integrity sha512-cbRl3sUOkBeRY2hsM4t1EIln2TIdQBkSiTOqNTv/4Hu5KOECnMWCgjIf+a9Ebunyn22VKqkMF3zj6ejRzz7YBw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8554,7 +8809,7 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     rlp "^2.0.0"
     semaphore ">=1.0.1"
 
-merkle-patricia-tree@^4.0.0:
+merkle-patricia-tree@^4.0.0, merkle-patricia-tree@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-4.1.0.tgz#010636c4cfd68682df33a2e3186b7d0be7b98b9d"
   integrity sha512-vmP1J7FwIpprFMVjjSMM1JAwFce85Q+tp0TYIedYv8qaMh2oLUZ3ETXn9wbgi9S6elySzKzGa+Ai6VNKGEwSlg==
@@ -10186,6 +10441,11 @@ prettier@^1.14.2, prettier@^1.16.4, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -12605,7 +12865,7 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
-util.promisify@^1.0.0:
+util.promisify@^1.0.0, util.promisify@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.1.tgz#77832f57ced2c9478174149cae9b96e9918cd54b"
   integrity sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Hardhat ^2.2.0 introduces breaking changes because they've moved over from `ethereumjs-vm@^4` to `ethereumjs-vm@^5`. This PR should make `smock` compatible with ^2.2.0 while also maintaining backwards compatibility.
