### PR TITLE
ops: publish deployer image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       batch-submitter: ${{ steps.packages.outputs.batch-submitter }}
       message-relayer: ${{ steps.packages.outputs.message-relayer }}
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
+      contracts: ${{ steps.packages.outputs.contracts }}
 
     steps:
       - name: Checkout Repo
@@ -102,6 +103,7 @@ jobs:
       batch-submitter: ${{ needs.release.outputs.batch-submitter }}
       message-relayer: ${{ needs.release.outputs.message-relayer }}
       data-transport-layer: ${{ needs.release.outputs.data-transport-layer }}
+      contracts: ${{ needs.release.outputs.contracts }}
 
     steps:
       - name: Checkout
@@ -200,3 +202,29 @@ jobs:
           file: ./ops/docker/Dockerfile.data-transport-layer
           push: true
           tags: ethereumoptimism/data-transport-layer:${{ needs.builder.outputs.data-transport-layer }}
+
+  contracts:
+    name: Publish Deployer Version ${{ needs.builder.outputs.contracts }}
+    needs: builder
+    if: needs.builder.outputs.contracts != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.deployer
+          push: true
+          tags: ethereumoptimism/deployer:${{ needs.builder.outputs.contracts }}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a Github action for publishing the `deployer` image. This is required for running the system against `kind` for local development
