### PR TITLE
contracts: add sequencer and deployer to addresses.json

### DIFF
--- a/.changeset/wild-experts-explode.md
+++ b/.changeset/wild-experts-explode.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Adds OVM_Sequencer and Deployer to the addresses.json output file

--- a/packages/contracts/bin/deploy.ts
+++ b/packages/contracts/bin/deploy.ts
@@ -17,10 +17,10 @@ process.env.CONTRACTS_RPC_URL =
 
 import hre from 'hardhat'
 
-const main = async () => {
-  const sequencer = new Wallet(process.env.SEQUENCER_PRIVATE_KEY)
-  const deployer = new Wallet(process.env.DEPLOYER_PRIVATE_KEY)
+const sequencer = new Wallet(process.env.SEQUENCER_PRIVATE_KEY)
+const deployer = new Wallet(process.env.DEPLOYER_PRIVATE_KEY)
 
+const main = async () => {
   await hre.run('deploy', {
     l1BlockTimeSeconds: process.env.BLOCK_TIME_SECONDS,
     ctcForceInclusionPeriodSeconds: process.env.FORCE_INCLUSION_PERIOD_SECONDS,
@@ -47,7 +47,7 @@ const main = async () => {
     'mockOVM_BondManager': 'OVM_BondManager'
   }
 
-  const contracts = dirtree(
+  const contracts: any = dirtree(
     path.resolve(__dirname, `../deployments/custom`)
   ).children.filter((child) => {
     return child.extension === '.json'
@@ -57,6 +57,9 @@ const main = async () => {
     contracts[nicknames[contractName] || contractName] = artifact.address
     return contracts
   }, {})
+
+  contracts.OVM_Sequencer = await sequencer.getAddress()
+  contracts.Deployer = await deployer.getAddress()
 
   const addresses = JSON.stringify(contracts, null, 2)
   const dumpsPath = path.resolve(__dirname, "../dist/dumps")


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This re-adds the `OVM_Sequencer` and `Deployer` from the previous `deploy.js`, see https://github.com/ethereum-optimism/contracts/blob/55167711ed2658ff22ccba3a5a466c4298049f4c/bin/deploy.js#L114

Users on discord have mentioned they depended on this

