### PR TITLE
contracts: remove all trailing whitespace

### DIFF
--- a/.changeset/tiny-bats-wave.md
+++ b/.changeset/tiny-bats-wave.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Remove trailing whitespace from many files

--- a/packages/contracts/bin/gen_safety_checker_constants.py
+++ b/packages/contracts/bin/gen_safety_checker_constants.py
@@ -52,7 +52,7 @@ for i in range(0, 0x100, 0x20):
   for j in range(i, i+0x20, 1):
     ret += ("%02X" % stoplist[j])
   rr += ret+"),\n"
-  
+
 rr = rr[:-2] + "];"
 
 print(rr)

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
@@ -20,7 +20,7 @@ import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 /**
  * @title OVM_ECDSAContractAccount
  * @dev The ECDSA Contract Account can be used as the implementation for a ProxyEOA deployed by the
- * ovmCREATEEOA operation. It enables backwards compatibility with Ethereum's Layer 1, by 
+ * ovmCREATEEOA operation. It enables backwards compatibility with Ethereum's Layer 1, by
  * providing eth_sign and EIP155 formatted transaction encodings.
  *
  * Compiler used: optimistic-solc

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -8,9 +8,9 @@ import { Lib_Bytes32Utils } from "../../libraries/utils/Lib_Bytes32Utils.sol";
 /**
  * @title OVM_ProxyEOA
  * @dev The Proxy EOA contract uses a delegate call to execute the logic in an implementation contract.
- * In combination with the logic implemented in the ECDSA Contract Account, this enables a form of upgradable 
- * 'account abstraction' on layer 2. 
- * 
+ * In combination with the logic implemented in the ECDSA Contract Account, this enables a form of upgradable
+ * 'account abstraction' on layer 2.
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1MultiMessageRelayer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1MultiMessageRelayer.sol
@@ -12,7 +12,7 @@ import { Lib_AddressResolver } from "../../../libraries/resolver/Lib_AddressReso
 
 /**
  * @title OVM_L1MultiMessageRelayer
- * @dev The L1 Multi-Message Relayer contract is a gas efficiency optimization which enables the 
+ * @dev The L1 Multi-Message Relayer contract is a gas efficiency optimization which enables the
  * relayer to submit multiple messages in a single transaction to be relayed by the L1 Cross Domain
  * Message Sender.
  *
@@ -26,7 +26,7 @@ contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressRes
      ***************/
     constructor(
         address _libAddressManager
-    ) 
+    )
         Lib_AddressResolver(_libAddressManager)
     {}
 
@@ -50,10 +50,10 @@ contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressRes
      * @notice Forwards multiple cross domain messages to the L1 Cross Domain Messenger for relaying
      * @param _messages An array of L2 to L1 messages
      */
-    function batchRelayMessages(L2ToL1Message[] calldata _messages) 
+    function batchRelayMessages(L2ToL1Message[] calldata _messages)
         override
         external
-        onlyBatchRelayer 
+        onlyBatchRelayer
     {
         iOVM_L1CrossDomainMessenger messenger = iOVM_L1CrossDomainMessenger(resolve("Proxy__OVM_L1CrossDomainMessenger"));
         for (uint256 i = 0; i < _messages.length; i++) {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// @unsupported: ovm 
+// @unsupported: ovm
 pragma solidity >0.5.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
@@ -27,7 +27,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
     /********************************
      * External Contract References *
      ********************************/
-    
+
     iOVM_ERC20 public l1ERC20;
 
     /***************
@@ -41,7 +41,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
     constructor(
         iOVM_ERC20 _l1ERC20,
         address _l2DepositedERC20,
-        address _l1messenger 
+        address _l1messenger
     )
         Abs_L1TokenGateway(
             _l2DepositedERC20,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -78,7 +78,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev deposit an amount of the ETH to the caller's balance on L2
      */
-    function deposit() 
+    function deposit()
         external
         override
         payable
@@ -137,7 +137,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev Complete a withdrawal from L2 to L1, and credit funds to the recipient's balance of the
      * L1 ETH token.
-     * Since only the xDomainMessenger can call this function, it will never be called before the withdrawal is finalized. 
+     * Since only the xDomainMessenger can call this function, it will never be called before the withdrawal is finalized.
      *
      * @param _to L1 address to credit the withdrawal to
      * @param _amount Amount of the ETH to withdraw

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -157,7 +157,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     {
         return buffer.get(uint40(_index));
     }
-    
+
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -536,7 +536,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         // "magic" prefix to deploy an exact copy of the code:
         // PUSH1 0x0D   # size of this prefix in bytes
         // CODESIZE
-        // SUB          # subtract prefix size from codesize 
+        // SUB          # subtract prefix size from codesize
         // DUP1
         // PUSH1 0x0D
         // PUSH1 0x00
@@ -1064,9 +1064,9 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      * This function sanitizes the return types for creation messages to match calls (bool, bytes),
      * by being an external function which the EM can call, that mimics the success/fail case of the CREATE.
      * This allows for consistent handling of both types of messages in _handleExternalMessage().
-     * Having this step occur as a separate call frame also allows us to easily revert the 
+     * Having this step occur as a separate call frame also allows us to easily revert the
      * contract deployment in the event that the code is unsafe.
-     * 
+     *
      * @param _gasLimit Amount of gas to be passed into this creation.
      * @param _creationCode Code to pass into CREATE for deployment.
      * @param _address OVM address being deployed to.
@@ -1111,7 +1111,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         if (ethAddress == address(0)) {
             // If the creation fails, the EVM lets us grab its revert data. This may contain a revert flag
             // to be used above in _handleExternalMessage, so we pass the revert data back up unmodified.
-            assembly { 
+            assembly {
                 returndatacopy(0,0,returndatasize())
                 revert(0, returndatasize())
             }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
@@ -9,7 +9,7 @@ import { iOVM_SafetyChecker } from "../../iOVM/execution/iOVM_SafetyChecker.sol"
  * @dev  The Safety Checker verifies that contracts deployed on L2 do not contain any
  * "unsafe" operations. An operation is considered unsafe if it would access state variables which
  * are specific to the environment (ie. L1 or L2) in which it is executed, as this could be used
- * to "escape the sandbox" of the OVM, resulting in non-deterministic fraud proofs. 
+ * to "escape the sandbox" of the OVM, resulting in non-deterministic fraud proofs.
  * That is, an attacker would be able to "prove fraud" on an honestly applied transaction.
  * Note that a "safe" contract requires opcodes to appear in a particular pattern;
  * omission of "unsafe" opcodes is necessary, but not sufficient.
@@ -129,7 +129,7 @@ contract OVM_SafetyChecker is iOVM_SafetyChecker {
                     if ((firstOps >> 192) == 0x3350600060045af1) {
                         _pc += 8;
                     // Call EM and abort execution if instructed
-                    // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x0E ADD JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x00 REVERT JUMPDEST RETURNDATASIZE PUSH1 0x01 EQ ISZERO PC PUSH1 0x0a ADD JUMPI PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST 
+                    // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x0E ADD JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x00 REVERT JUMPDEST RETURNDATASIZE PUSH1 0x01 EQ ISZERO PC PUSH1 0x0a ADD JUMPI PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST
                     } else if (firstOps == 0x336000905af158600e01573d6000803e3d6000fd5b3d6001141558600a015760 && secondOps == 0x016000f35b) {
                         _pc += 37;
                     } else {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
@@ -14,7 +14,7 @@ import { iOVM_StateManager } from "../../iOVM/execution/iOVM_StateManager.sol";
  * the Execution Manager and State Transitioner. It runs on L1 during the setup and execution of a fraud proof.
  * The same logic runs on L2, but has been implemented as a precompile in the L2 go-ethereum client
  * (see https://github.com/ethereum-optimism/go-ethereum/blob/master/core/vm/ovm_state_manager.go).
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -63,7 +63,7 @@ contract OVM_StateManager is iOVM_StateManager {
      **********************/
 
     /**
-     * Simple authentication, this contract should only be accessible to the owner (which is expected to be the State Transitioner during `PRE_EXECUTION` 
+     * Simple authentication, this contract should only be accessible to the owner (which is expected to be the State Transitioner during `PRE_EXECUTION`
      * or the OVM_ExecutionManager during transaction execution.
      */
     modifier authenticated() {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManagerFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManagerFactory.sol
@@ -12,7 +12,7 @@ import { OVM_StateManager } from "./OVM_StateManager.sol";
  * @title OVM_StateManagerFactory
  * @dev The State Manager Factory is called by a State Transitioner's init code, to create a new
  * State Manager for use in the Fraud Verification process.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol
@@ -26,7 +26,7 @@ interface ERC1820ImplementerInterface {
 /**
  * @title ERC1820 Pseudo-introspection Registry Contract
  * @author Jordi Baylina and Jacques Dafflon
- * @dev This contract is the official implementation of the ERC1820 Registry 
+ * @dev This contract is the official implementation of the ERC1820 Registry
  * For more details, see https://eips.ethereum.org/EIPS/eip-1820
  *
  * Compiler used: optimistic-solc

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_DeployerWhitelist.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_DeployerWhitelist.sol
@@ -8,9 +8,9 @@ import { iOVM_DeployerWhitelist } from "../../iOVM/predeploys/iOVM_DeployerWhite
  * @title OVM_DeployerWhitelist
  * @dev The Deployer Whitelist is a temporary predeploy used to provide additional safety during the
  * initial phases of our mainnet roll out. It is owned by the Optimism team, and defines accounts
- * which are allowed to deploy contracts on Layer2. The Execution Manager will only allow an 
+ * which are allowed to deploy contracts on Layer2. The Execution Manager will only allow an
  * ovmCREATE or ovmCREATE2 operation to proceed if the deployer's address whitelisted.
- * 
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
@@ -19,7 +19,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
     /**********************
      * Contract Constants *
      **********************/
-    
+
     bool public initialized;
     bool public allowArbitraryDeployment;
     address override public owner;
@@ -29,7 +29,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
     /**********************
      * Function Modifiers *
      **********************/
-    
+
     /**
      * Blocks functions to anyone except the contract owner.
      */
@@ -45,7 +45,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
     /********************
      * Public Functions *
      ********************/
-    
+
     /**
      * Initializes the whitelist.
      * @param _owner Address of the owner for this contract.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ETH.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ETH.sol
@@ -12,9 +12,9 @@ import { OVM_L2DepositedERC20 } from "../bridge/tokens/OVM_L2DepositedERC20.sol"
 
 /**
  * @title OVM_ETH
- * @dev The ETH predeploy provides an ERC20 interface for ETH deposited to Layer 2. Note that 
+ * @dev The ETH predeploy provides an ERC20 interface for ETH deposited to Layer 2. Note that
  * unlike on Layer 1, Layer 2 accounts do not have a balance field.
- * 
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
@@ -22,7 +22,7 @@ contract OVM_ETH is OVM_L2DepositedERC20 {
     constructor(
         address _l2CrossDomainMessenger,
         address _l1ETHGateway
-    ) 
+    )
         OVM_L2DepositedERC20(
             _l2CrossDomainMessenger,
             "Ether",

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L1MessageSender.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L1MessageSender.sol
@@ -7,16 +7,16 @@ import { iOVM_ExecutionManager } from "../../iOVM/execution/iOVM_ExecutionManage
 
 /**
  * @title OVM_L1MessageSender
- * @dev The L1MessageSender is a predeploy contract running on L2. During the execution of cross 
+ * @dev The L1MessageSender is a predeploy contract running on L2. During the execution of cross
  * domain transaction from L1 to L2, it returns the address of the L1 account (either an EOA or
- * contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()` 
+ * contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()`
  * function.
- * 
- * This contract exclusively serves as a getter for the ovmL1TXORIGIN operation. This is necessary 
- * because there is no corresponding operation in the EVM which the the optimistic solidity compiler 
+ *
+ * This contract exclusively serves as a getter for the ovmL1TXORIGIN operation. This is necessary
+ * because there is no corresponding operation in the EVM which the the optimistic solidity compiler
  * can be replaced with a call to the ExecutionManager's ovmL1TXORIGIN() function.
  *
- * 
+ *
  * Compiler used: solc
  * Runtime target: OVM
  */
@@ -37,7 +37,7 @@ contract OVM_L1MessageSender is iOVM_L1MessageSender {
             address _l1MessageSender
         )
     {
-        // Note that on L2 msg.sender (ie. evmCALLER) will always be the Execution Manager 
+        // Note that on L2 msg.sender (ie. evmCALLER) will always be the Execution Manager
         return iOVM_ExecutionManager(msg.sender).ovmL1TXORIGIN();
     }
 }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L2ToL1MessagePasser.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L2ToL1MessagePasser.sol
@@ -6,11 +6,11 @@ import { iOVM_L2ToL1MessagePasser } from "../../iOVM/predeploys/iOVM_L2ToL1Messa
 
 /**
  * @title OVM_L2ToL1MessagePasser
- * @dev The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof of the 
+ * @dev The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof of the
  * of a message on L2. The L1 Cross Domain Messenger performs this proof in its
- * _verifyStorageProof function, which verifies the existence of the transaction hash in this 
+ * _verifyStorageProof function, which verifies the existence of the transaction hash in this
  * contract's `sentMessages` mapping.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -37,8 +37,8 @@ contract OVM_L2ToL1MessagePasser is iOVM_L2ToL1MessagePasser {
         override
         public
     {
-        // Note: although this function is public, only messages sent from the OVM_L2CrossDomainMessenger 
-        // will be relayed by the OVM_L1CrossDomainMessenger. This is enforced by a check in 
+        // Note: although this function is public, only messages sent from the OVM_L2CrossDomainMessenger
+        // will be relayed by the OVM_L1CrossDomainMessenger. This is enforced by a check in
         // OVM_L1CrossDomainMessenger._verifyStorageProof().
         sentMessages[keccak256(
             abi.encodePacked(

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
@@ -13,12 +13,12 @@ import { Lib_ExecutionManagerWrapper } from "../../libraries/wrappers/Lib_Execut
 
 /**
  * @title OVM_SequencerEntrypoint
- * @dev The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by 
- * any account. It accepts a more efficient compressed calldata format, which it decompresses and 
+ * @dev The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by
+ * any account. It accepts a more efficient compressed calldata format, which it decompresses and
  * encodes to the standard EIP155 transaction format.
  * This contract is the implementation referenced by the Proxy Sequencer Entrypoint, thus enabling
  * the Optimism team to upgrade the decompression of calldata from the Sequencer.
- * 
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
@@ -27,7 +27,7 @@ contract OVM_SequencerEntrypoint {
     /*********
      * Enums *
      *********/
-    
+
     enum TransactionType {
         NATIVE_ETH_TRANSACTION,
         ETH_SIGNED_MESSAGE

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_BondManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_BondManager.sol
@@ -10,11 +10,11 @@ import { iOVM_FraudVerifier } from "../../iOVM/verification/iOVM_FraudVerifier.s
 
 /**
  * @title OVM_BondManager
- * @dev The Bond Manager contract handles deposits in the form of an ERC20 token from bonded 
+ * @dev The Bond Manager contract handles deposits in the form of an ERC20 token from bonded
  * Proposers. It also handles the accounting of gas costs spent by a Verifier during the course of a
- * fraud proof. In the event of a successful fraud proof, the fraudulent Proposer's bond is slashed, 
+ * fraud proof. In the event of a successful fraud proof, the fraudulent Proposer's bond is slashed,
  * and the Verifier's gas costs are refunded.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -109,14 +109,14 @@ contract OVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
             bond.earliestTimestamp = timestamp;
         }
 
-        // if the fraud proof's dispute period does not intersect with the 
+        // if the fraud proof's dispute period does not intersect with the
         // withdrawal's timestamp, then the user should not be slashed
         // e.g if a user at day 10 submits a withdrawal, and a fraud proof
         // from day 1 gets published, the user won't be slashed since day 8 (1d + 7d)
         // is before the user started their withdrawal. on the contrary, if the user
         // had started their withdrawal at, say, day 6, they would be slashed
         if (
-            bond.withdrawalTimestamp != 0 && 
+            bond.withdrawalTimestamp != 0 &&
             uint256(bond.withdrawalTimestamp) > timestamp + disputePeriodSeconds &&
             bond.state == State.WITHDRAWING
         ) {
@@ -154,15 +154,15 @@ contract OVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
         Bond storage bond = bonds[msg.sender];
 
         require(
-            block.timestamp >= uint256(bond.withdrawalTimestamp) + disputePeriodSeconds, 
+            block.timestamp >= uint256(bond.withdrawalTimestamp) + disputePeriodSeconds,
             Errors.TOO_EARLY
         );
         require(bond.state == State.WITHDRAWING, Errors.SLASHED);
-        
+
         // refunds!
         bond.state = State.NOT_COLLATERALIZED;
         bond.withdrawalTimestamp = 0;
-        
+
         require(
             token.transfer(msg.sender, requiredCollateral),
             Errors.ERC20_ERR

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_FraudVerifier.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_FraudVerifier.sol
@@ -21,10 +21,10 @@ import { Abs_FraudContributor } from "./Abs_FraudContributor.sol";
 
 /**
  * @title OVM_FraudVerifier
- * @dev The Fraud Verifier contract coordinates the entire fraud proof verification process. 
+ * @dev The Fraud Verifier contract coordinates the entire fraud proof verification process.
  * If the fraud proof was successful it prunes any state batches from State Commitment Chain
  * which were published after the fraudulent state root.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -204,7 +204,7 @@ contract OVM_FraudVerifier is Lib_AddressResolver, Abs_FraudContributor, iOVM_Fr
             _postStateRoot != transitioner.getPostStateRoot(),
             "State transition has not been proven fraudulent."
         );
-        
+
         _cancelStateTransition(_postStateRootBatchHeader, _preStateRoot);
 
         // TEMPORARY: Remove the transitioner; for minnet.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitionerFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitionerFactory.sol
@@ -15,9 +15,9 @@ import { OVM_StateTransitioner } from "./OVM_StateTransitioner.sol";
 
 /**
  * @title OVM_StateTransitionerFactory
- * @dev The State Transitioner Factory is used by the Fraud Verifier to create a new State 
+ * @dev The State Transitioner Factory is used by the Fraud Verifier to create a new State
  * Transitioner during the initialization of a fraud proof.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1MultiMessageRelayer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1MultiMessageRelayer.sol
@@ -14,5 +14,5 @@ interface iOVM_L1MultiMessageRelayer {
         iOVM_L1CrossDomainMessenger.L2MessageInclusionProof proof;
     }
 
-    function batchRelayMessages(L2ToL1Message[] calldata _messages) external; 
+    function batchRelayMessages(L2ToL1Message[] calldata _messages) external;
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -16,7 +16,7 @@ interface iOVM_L1TokenGateway {
         address _to,
         uint256 _amount
     );
-  
+
     event WithdrawalFinalized(
         address indexed _to,
         uint256 _amount

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -20,7 +20,7 @@ interface iOVM_L2DepositedToken {
     event DepositFinalized(
         address indexed _to,
         uint256 _amount
-    );    
+    );
 
 
     /********************

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
@@ -16,7 +16,7 @@ contract OVM_CrossDomainEnabled {
 
     /***************
      * Constructor *
-     ***************/    
+     ***************/
     constructor(
         address _messenger
     ) {
@@ -46,14 +46,14 @@ contract OVM_CrossDomainEnabled {
 
         _;
     }
-    
+
     /**********************
      * Internal Functions *
      **********************/
 
     /**
      * @notice Gets the messenger, usually from storage.  This function is exposed in case a child contract needs to override.
-     * @return The address of the cross-domain messenger contract which should be used. 
+     * @return The address of the cross-domain messenger contract which should be used.
      */
     function getCrossDomainMessenger()
         internal

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_ResolvedDelegateProxy.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_ResolvedDelegateProxy.sol
@@ -17,10 +17,10 @@ contract Lib_ResolvedDelegateProxy {
     // implementation contract. For example, instead of storing these fields at
     // storage slot `0` & `1`, they are stored at `keccak256(key + slot)`.
     // See: https://solidity.readthedocs.io/en/v0.7.0/internals/layout_in_storage.html
-    // NOTE: Do not use this code in your own contract system. 
+    // NOTE: Do not use this code in your own contract system.
     //      There is a known flaw in this contract, and we will remove it from the repository
     //      in the near future. Due to the very limited way that we are using it, this flaw is
-    //      not an issue in our system. 
+    //      not an issue in our system.
     mapping (address => string) private implementationName;
     mapping (address => Lib_AddressManager) private addressManager;
 

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
@@ -23,7 +23,7 @@ library Lib_RLPReader {
         LIST_ITEM
     }
 
-    
+
     /***********
      * Structs *
      ***********/
@@ -32,12 +32,12 @@ library Lib_RLPReader {
         uint256 length;
         uint256 ptr;
     }
-    
+
 
     /**********************
      * Internal Functions *
      **********************/
-    
+
     /**
      * Converts bytes to a reference to memory position and length.
      * @param _in Input bytes to convert.
@@ -484,7 +484,7 @@ library Lib_RLPReader {
             // Short string.
 
             uint256 strLen = prefix - 0x80;
-            
+
             require(
                 _in.length > strLen,
                 "Invalid RLP short string."

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -104,7 +104,7 @@ library Lib_RingBuffer {
         internal
     {
         RingBufferContext memory ctx = _self.getContext();
-        
+
         _self.push(
             _value,
             ctx.extraData
@@ -124,7 +124,7 @@ library Lib_RingBuffer {
         internal
         view
         returns (
-            bytes32    
+            bytes32
         )
     {
         RingBufferContext memory ctx = _self.getContext();

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/wrappers/Lib_ExecutionManagerWrapper.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/wrappers/Lib_ExecutionManagerWrapper.sol
@@ -7,7 +7,7 @@ import { Lib_ErrorUtils } from "../utils/Lib_ErrorUtils.sol";
 
 /**
  * @title Lib_ExecutionManagerWrapper
- * 
+ *
  * Compiler used: solc
  * Runtime target: OVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
@@ -78,7 +78,7 @@ contract mockOVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
     )
         override
         public
-        pure 
+        pure
         returns (
             uint256
         )

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol
@@ -14,7 +14,7 @@ contract TestLib_MerkleTree {
         bytes32[] memory _elements
     )
         public
-       pure 
+       pure
         returns (
             bytes32
         )

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_RingBuffer.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_RingBuffer.sol
@@ -10,7 +10,7 @@ import { Lib_RingBuffer } from "../../optimistic-ethereum/libraries/utils/Lib_Ri
  */
 contract TestLib_RingBuffer {
     using Lib_RingBuffer for Lib_RingBuffer.RingBuffer;
-    
+
     Lib_RingBuffer.RingBuffer internal buf;
 
     function push(
@@ -31,7 +31,7 @@ contract TestLib_RingBuffer {
         public
         view
         returns (
-            bytes32    
+            bytes32
         )
     {
         return buf.get(_index);


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR removes all trailing whitespaces found in the contracts. This is important because removal of whitespace in random files during PR review adds overhead. We should try to not introduce any more.

From the `contracts` directory, generated with the command:

```bash
$ find . -type f -print0 | xargs -0 perl -pi -e 's/ +$//'
```