### PR TITLE
fix: proper config parsing for `bin/deploy.ts`

### DIFF
--- a/.changeset/seven-kids-smash.md
+++ b/.changeset/seven-kids-smash.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Adds config parsing to the deploy script for local deployments

--- a/packages/contracts/bin/deploy.ts
+++ b/packages/contracts/bin/deploy.ts
@@ -21,17 +21,19 @@ const main = async () => {
   const sequencer = new Wallet(process.env.SEQUENCER_PRIVATE_KEY)
   const deployer = new Wallet(process.env.DEPLOYER_PRIVATE_KEY)
 
+  const config = parseEnv()
+
   await hre.run('deploy', {
-    l1BlockTimeSeconds: process.env.BLOCK_TIME_SECONDS,
-    ctcForceInclusionPeriodSeconds: process.env.FORCE_INCLUSION_PERIOD_SECONDS,
-    ctcMaxTransactionGasLimit: process.env.MAX_TRANSACTION_GAS_LIMIT,
-    emMinTransactionGasLimit: process.env.MIN_TRANSACTION_GAS_LIMIT,
-    emMaxtransactionGasLimit: process.env.MAX_TRANSACTION_GAS_LIMIT,
-    emMaxGasPerQueuePerEpoch: process.env.MAX_GAS_PER_QUEUE_PER_EPOCH,
-    emSecondsPerEpoch: process.env.SECONDS_PER_EPOCH,
-    emOvmChainId: process.env.CHAIN_ID,
-    sccFraudProofWindow: parseInt(process.env.FRAUD_PROOF_WINDOW_SECONDS, 10),
-    sccSequencerPublishWindow: process.env.SEQUENCER_PUBLISH_WINDOW_SECONDS,
+    l1BlockTimeSeconds: config.l1BlockTimeSeconds,
+    ctcForceInclusionPeriodSeconds: config.ctcForceInclusionPeriodSeconds,
+    ctcMaxTransactionGasLimit: config.ctcMaxTransactionGasLimit,
+    emMinTransactionGasLimit: config.emMinTransactionGasLimit,
+    emMaxtransactionGasLimit: config.emMaxtransactionGasLimit,
+    emMaxGasPerQueuePerEpoch: config.emMaxGasPerQueuePerEpoch,
+    emSecondsPerEpoch: config.emSecondsPerEpoch,
+    emOvmChainId: config.emOvmChainId,
+    sccFraudProofWindow: config.sccFraudProofWindow,
+    sccSequencerPublishWindow: config.sccFraudProofWindow,
     ovmSequencerAddress: sequencer.address,
     ovmProposerAddress: sequencer.address,
     ovmRelayerAddress: sequencer.address,
@@ -75,3 +77,27 @@ main()
     )
     process.exit(1)
   })
+
+function parseEnv() {
+  function ensure(env, type) {
+    if (typeof process.env[env] === 'undefined')
+      return undefined
+    if (type === 'number')
+      return parseInt(process.env[env], 10)
+    return process.env[env]
+  }
+
+  return {
+    l1BlockTimeSeconds: ensure('BLOCK_TIME_SECONDS', 'number'),
+    ctcForceInclusionPeriodSeconds: ensure('FORCE_INCLUSION_PERIOD_SECONDS', 'number'),
+    ctcMaxTransactionGasLimit: ensure('MAX_TRANSACTION_GAS_LIMIT', 'number'),
+    emMinTransactionGasLimit: ensure('MIN_TRANSACTION_GAS_LIMIT', 'number'),
+    emMaxtransactionGasLimit: ensure('MAX_TRANSACTION_GAS_LIMIT', 'number'),
+    emMaxGasPerQueuePerEpoch: ensure('MAX_GAS_PER_QUEUE_PER_EPOCH', 'number'),
+    emSecondsPerEpoch: ensure('ECONDS_PER_EPOCH', 'number'),
+    emOvmChainId: ensure('CHAIN_ID', 'number'),
+    sccFraudProofWindow: ensure('FRAUD_PROOF_WINDOW_SECONDS', 'number'),
+    sccSequencerPublishWindow: ensure('SEQUENCER_PUBLISH_WINDOW_SECONDS', 'number'),
+  }
+}
+


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Previously the types were not being parsed correctly for the deploy script. This parses the config options correctly. Ideally we can remove this by having a wrapper for `hardhat deploy` in the `scripts` directory and then `yarn deploy` calls `./scripts/deploy.sh`
