### PR TITLE
l2geth: remove eth_sendRawEthSignTransaction endpoint

### DIFF
--- a/.changeset/breezy-queens-help.md
+++ b/.changeset/breezy-queens-help.md
@@ -1,6 +1,0 @@
----
-"@eth-optimism/batch-submitter": patch
-"@eth-optimism/data-transport-layer": patch
----
-
-Update release tag for Sentry compatability

--- a/.changeset/breezy-queens-help.md
+++ b/.changeset/breezy-queens-help.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/batch-submitter": patch
+"@eth-optimism/data-transport-layer": patch
+---
+
+Update release tag for Sentry compatability

--- a/.changeset/eight-dancers-learn.md
+++ b/.changeset/eight-dancers-learn.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/smock": minor
+---
+
+Adds support for hardhat ^2.2.0, required because of move to ethereumjs-vm v5.

--- a/.changeset/eight-dancers-learn.md
+++ b/.changeset/eight-dancers-learn.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/smock": minor
----
-
-Adds support for hardhat ^2.2.0, required because of move to ethereumjs-vm v5.

--- a/.changeset/many-wombats-hear.md
+++ b/.changeset/many-wombats-hear.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/batch-submitter": patch
----
-
-properly start the batch submitter instead of instantly exiting

--- a/.changeset/red-humans-grin.md
+++ b/.changeset/red-humans-grin.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/batch-submitter": patch
----
-
-add default metrics to all batch submitters

--- a/.changeset/red-humans-grin.md
+++ b/.changeset/red-humans-grin.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter": patch
+---
+
+add default metrics to all batch submitters

--- a/.changeset/slimy-tomatoes-report.md
+++ b/.changeset/slimy-tomatoes-report.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/specs": minor
----
-
-Add a new package to contain specs

--- a/.changeset/tiny-bats-wave.md
+++ b/.changeset/tiny-bats-wave.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/contracts": patch
----
-
-Remove trailing whitespace from many files

--- a/.changeset/tiny-bats-wave.md
+++ b/.changeset/tiny-bats-wave.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Remove trailing whitespace from many files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       batch-submitter: ${{ steps.packages.outputs.batch-submitter }}
       message-relayer: ${{ steps.packages.outputs.message-relayer }}
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
+      contracts: ${{ steps.packages.outputs.contracts }}
 
     steps:
       - name: Checkout Repo
@@ -102,6 +103,7 @@ jobs:
       batch-submitter: ${{ needs.release.outputs.batch-submitter }}
       message-relayer: ${{ needs.release.outputs.message-relayer }}
       data-transport-layer: ${{ needs.release.outputs.data-transport-layer }}
+      contracts: ${{ needs.release.outputs.contracts }}
 
     steps:
       - name: Checkout
@@ -200,3 +202,29 @@ jobs:
           file: ./ops/docker/Dockerfile.data-transport-layer
           push: true
           tags: ethereumoptimism/data-transport-layer:${{ needs.builder.outputs.data-transport-layer }}
+
+  contracts:
+    name: Publish Deployer Version ${{ needs.builder.outputs.contracts }}
+    needs: builder
+    if: needs.builder.outputs.contracts != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.deployer
+          push: true
+          tags: ethereumoptimism/deployer:${{ needs.builder.outputs.contracts }}

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1740,33 +1740,6 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	return SubmitTransaction(ctx, s.b, tx)
 }
 
-// SendRawEthSignTransaction will add the signed transaction to the mempool.
-// The signature hash was computed with `eth_sign`, meaning that the
-// `abi.encodedPacked` transaction was prefixed with the string
-// "Ethereum Signed Message".
-func (s *PublicTransactionPoolAPI) SendRawEthSignTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
-	if s.b.IsVerifier() {
-		return common.Hash{}, errors.New("Cannot send raw ethsign transaction in verifier mode")
-	}
-
-	if s.b.IsSyncing() {
-		return common.Hash{}, errors.New("Cannot send raw transaction while syncing")
-	}
-
-	tx := new(types.Transaction)
-	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
-		return common.Hash{}, err
-	}
-
-	if new(big.Int).Mod(tx.GasPrice(), big.NewInt(1000000)).Cmp(big.NewInt(0)) != 0 {
-		return common.Hash{}, errors.New("Gas price must be a multiple of 1,000,000 wei")
-	}
-	// L1Timestamp and L1BlockNumber will be set by the miner
-	txMeta := types.NewTransactionMeta(nil, 0, nil, types.SighashEthSign, types.QueueOriginSequencer, nil, nil, nil)
-	tx.SetTransactionMeta(txMeta)
-	return SubmitTransaction(ctx, s.b, tx)
-}
-
 // Sign calculates an ECDSA signature for:
 // keccack256("\x19Ethereum Signed Message:\n" + len(message) + message).
 //

--- a/ops/docker/Dockerfile.batch-submitter
+++ b/ops/docker/Dockerfile.batch-submitter
@@ -28,4 +28,4 @@ COPY --from=builder /optimism/packages/batch-submitter/node_modules ./node_modul
 
 # copy this over in case you want to run alongside other services
 COPY ./ops/scripts/batches.sh .
-ENTRYPOINT ["node", "exec/run-batch-submitter.js"]
+ENTRYPOINT ["npm", "run", "start"]

--- a/ops/docker/Dockerfile.message-relayer
+++ b/ops/docker/Dockerfile.message-relayer
@@ -29,4 +29,4 @@ COPY --from=builder /optimism/packages/message-relayer/node_modules ./node_modul
 
 # copy this over in case you want to run alongside other services
 COPY ./ops/scripts/relayer.sh .
-ENTRYPOINT ["node", "exec/run-message-relayer.js"]
+ENTRYPOINT ["npm", "run", "start"]

--- a/packages/batch-submitter/CHANGELOG.md
+++ b/packages/batch-submitter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.1
+
+### Patch Changes
+
+- ab285e4: properly start the batch submitter instead of instantly exiting
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/batch-submitter/CHANGELOG.md
+++ b/packages/batch-submitter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.2
+
+### Patch Changes
+
+- 6d31324: Update release tag for Sentry compatability
+- a2f6e83: add default metrics to all batch submitters
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/batch-submitter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "[Optimism] Batch submission for sequencer & aggregators",
   "main": "dist/index",

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/batch-submitter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "[Optimism] Batch submission for sequencer & aggregators",
   "main": "dist/index",

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -2,7 +2,7 @@
 import { Contract, Signer, utils, providers } from 'ethers'
 import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import * as ynatm from '@eth-optimism/ynatm'
-import { Logger } from '@eth-optimism/core-utils'
+import { Logger, Metrics } from '@eth-optimism/core-utils'
 import { getContractFactory } from 'old-contracts'
 
 export interface RollupInfo {
@@ -51,7 +51,8 @@ export abstract class BatchSubmitter {
     readonly maxGasPriceInGwei: number,
     readonly gasRetryIncrement: number,
     readonly gasThresholdInGwei: number,
-    readonly log: Logger
+    readonly log: Logger,
+    readonly metrics: Metrics
   ) {}
 
   public abstract _submitBatch(

--- a/packages/batch-submitter/src/batch-submitter/index.ts
+++ b/packages/batch-submitter/src/batch-submitter/index.ts
@@ -2,8 +2,8 @@ export * from './batch-submitter'
 export * from './tx-batch-submitter'
 export * from './state-batch-submitter'
 
-export const TX_BATCH_SUBMITTER_LOG_TAG = 'oe:batch-submitter:tx-chain'
-export const STATE_BATCH_SUBMITTER_LOG_TAG = 'oe:batch-submitter:state-chain'
+export const TX_BATCH_SUBMITTER_LOG_TAG = 'oe:batch_submitter:tx_chain'
+export const STATE_BATCH_SUBMITTER_LOG_TAG = 'oe:batch_submitter:state_chain'
 
 // BLOCK_OFFSET is the number of L2 blocks we need to skip for the
 // batch submitter.

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -8,6 +8,7 @@ import {
   Bytes32,
   remove0x,
   toRpcHexString,
+  Metrics,
 } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
@@ -41,6 +42,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
     gasRetryIncrement: number,
     gasThresholdInGwei: number,
     log: Logger,
+    metrics: Metrics,
     fraudSubmissionAddress: string
   ) {
     super(
@@ -59,7 +61,8 @@ export class StateBatchSubmitter extends BatchSubmitter {
       maxGasPriceInGwei,
       gasRetryIncrement,
       gasThresholdInGwei,
-      log
+      log,
+      metrics
     )
     this.fraudSubmissionAddress = fraudSubmissionAddress
   }

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -7,7 +7,7 @@ import {
 } from '@ethersproject/abstract-provider'
 import { getContractInterface, getContractFactory } from 'old-contracts'
 import { getContractInterface as getNewContractInterface } from '@eth-optimism/contracts'
-import { Logger, ctcCoder } from '@eth-optimism/core-utils'
+import { Logger, Metrics, ctcCoder } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
 import {
@@ -48,6 +48,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     gasRetryIncrement: number,
     gasThresholdInGwei: number,
     log: Logger,
+    metrics: Metrics,
     disableQueueBatchAppend: boolean,
     autoFixBatchOptions: AutoFixBatchOptions = {
       fixDoublePlayedDeposits: false,
@@ -70,7 +71,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       maxGasPriceInGwei,
       gasRetryIncrement,
       gasThresholdInGwei,
-      log
+      log,
+      metrics
     )
     this.disableQueueBatchAppend = disableQueueBatchAppend
     this.autoFixBatchOptions = autoFixBatchOptions

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -165,7 +165,7 @@ export const run = async () => {
     MAX_GAS_PRICE_IN_GWEI,
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
-    new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+    log.child({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
     new Metrics({ prefix: TX_BATCH_SUBMITTER_LOG_TAG }),
     DISABLE_QUEUE_BATCH_APPEND,
     autoFixBatchOptions
@@ -187,7 +187,7 @@ export const run = async () => {
     MAX_GAS_PRICE_IN_GWEI,
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
-    new Logger({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
+    log.child({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
     new Metrics({ prefix: STATE_BATCH_SUBMITTER_LOG_TAG }),
     FRAUD_SUBMISSION_ADDRESS
   )

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -20,7 +20,7 @@ const name = 'oe:batch_submitter:init'
 const log = new Logger({
   name,
   sentryOptions: {
-    release: `@eth-optimism/batch-submitter@${process.env.npm_package_version}`,
+    release: `batch-submitter@${process.env.npm_package_version}`,
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -21,6 +21,8 @@ const log = new Logger({
   name,
   sentryOptions: {
     release: `batch-submitter@${process.env.npm_package_version}`,
+    // @ts-ignore stackAttributeKey belongs to PinoSentryOptions, not exported
+    stackAttributeKey: 'err',
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,5 +1,5 @@
 /* External Imports */
-import { Logger, injectL2Context } from '@eth-optimism/core-utils'
+import { Logger, Metrics, injectL2Context } from '@eth-optimism/core-utils'
 import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
 import { JsonRpcProvider, TransactionReceipt } from '@ethersproject/providers'
@@ -16,13 +16,18 @@ import {
 } from '..'
 
 /* Logger */
+const name = 'oe:batch_submitter:init'
 const log = new Logger({
-  name: 'oe:batch-submitter:init',
+  name,
   sentryOptions: {
     release: `@eth-optimism/batch-submitter@${process.env.npm_package_version}`,
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },
+})
+/* Metrics */
+const metrics = new Metrics({
+  prefix: name,
 })
 
 interface RequiredEnvVars {
@@ -159,6 +164,7 @@ export const run = async () => {
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
     new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+    new Metrics({ prefix: TX_BATCH_SUBMITTER_LOG_TAG }),
     DISABLE_QUEUE_BATCH_APPEND,
     autoFixBatchOptions
   )
@@ -180,6 +186,7 @@ export const run = async () => {
     GAS_RETRY_INCREMENT,
     GAS_THRESHOLD_IN_GWEI,
     new Logger({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
+    new Metrics({ prefix: STATE_BATCH_SUBMITTER_LOG_TAG }),
     FRAUD_SUBMISSION_ADDRESS
   )
 

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -37,6 +37,7 @@ import {
   ctcCoder,
   remove0x,
   Logger,
+  Metrics,
 } from '@eth-optimism/core-utils'
 
 const DECOMPRESSION_ADDRESS = '0x4200000000000000000000000000000000000008'
@@ -78,6 +79,7 @@ class TransactionBatchSubmitter extends RealTransactionBatchSubmitter {
     return true
   }
 }
+const testMetrics = new Metrics({ prefix: 'bs_test' })
 
 describe('BatchSubmitter', () => {
   let signer: Signer
@@ -217,6 +219,7 @@ describe('BatchSubmitter', () => {
       GAS_RETRY_INCREMENT,
       GAS_THRESHOLD_IN_GWEI,
       new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+      testMetrics,
       false
     )
 
@@ -432,6 +435,7 @@ describe('BatchSubmitter', () => {
         GAS_RETRY_INCREMENT,
         GAS_THRESHOLD_IN_GWEI,
         new Logger({ name: STATE_BATCH_SUBMITTER_LOG_TAG }),
+        testMetrics,
         '0x' + '01'.repeat(20) // placeholder for fraudSubmissionAddress
       )
     })

--- a/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/transaction-batch-submitter.spec.ts
@@ -33,6 +33,7 @@ import {
   ctcCoder,
   remove0x,
   Logger,
+  Metrics,
 } from '@eth-optimism/core-utils'
 
 const DECOMPRESSION_ADDRESS = '0x4200000000000000000000000000000000000008'
@@ -71,6 +72,7 @@ class TransactionBatchSubmitter extends RealTransactionBatchSubmitter {
     return true
   }
 }
+const testMetrics = new Metrics({ prefix: 'tx_bs_test' })
 
 describe('TransactionBatchSubmitter', () => {
   let signer: Signer
@@ -189,6 +191,7 @@ describe('TransactionBatchSubmitter', () => {
         GAS_RETRY_INCREMENT,
         GAS_THRESHOLD_IN_GWEI,
         new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+        testMetrics,
         false
       )
     })
@@ -309,6 +312,7 @@ describe('TransactionBatchSubmitter', () => {
           GAS_RETRY_INCREMENT,
           GAS_THRESHOLD_IN_GWEI,
           new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
+          testMetrics,
           false
         )
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.7
+
+### Patch Changes
+
+- e3f55ad: Remove trailing whitespace from many files
+
 ## 0.2.6
 
 ### Patch Changes

--- a/packages/contracts/bin/gen_safety_checker_constants.py
+++ b/packages/contracts/bin/gen_safety_checker_constants.py
@@ -52,7 +52,7 @@ for i in range(0, 0x100, 0x20):
   for j in range(i, i+0x20, 1):
     ret += ("%02X" % stoplist[j])
   rr += ret+"),\n"
-  
+
 rr = rr[:-2] + "];"
 
 print(rr)

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
@@ -20,7 +20,7 @@ import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 /**
  * @title OVM_ECDSAContractAccount
  * @dev The ECDSA Contract Account can be used as the implementation for a ProxyEOA deployed by the
- * ovmCREATEEOA operation. It enables backwards compatibility with Ethereum's Layer 1, by 
+ * ovmCREATEEOA operation. It enables backwards compatibility with Ethereum's Layer 1, by
  * providing eth_sign and EIP155 formatted transaction encodings.
  *
  * Compiler used: optimistic-solc

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -8,9 +8,9 @@ import { Lib_Bytes32Utils } from "../../libraries/utils/Lib_Bytes32Utils.sol";
 /**
  * @title OVM_ProxyEOA
  * @dev The Proxy EOA contract uses a delegate call to execute the logic in an implementation contract.
- * In combination with the logic implemented in the ECDSA Contract Account, this enables a form of upgradable 
- * 'account abstraction' on layer 2. 
- * 
+ * In combination with the logic implemented in the ECDSA Contract Account, this enables a form of upgradable
+ * 'account abstraction' on layer 2.
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/Abs_BaseCrossDomainMessenger.sol
@@ -11,7 +11,7 @@ import { Lib_ReentrancyGuard } from "../../../libraries/utils/Lib_ReentrancyGuar
 /**
  * @title Abs_BaseCrossDomainMessenger
  * @dev The Base Cross Domain Messenger is an abstract contract providing the interface and common functionality used in the
- * L1 and L2 Cross Domain Messengers. It can also serve as a template for developers wishing to implement a custom bridge 
+ * L1 and L2 Cross Domain Messengers. It can also serve as a template for developers wishing to implement a custom bridge
  * contract to suit their needs.
  *
  * Compiler used: defined by child contract

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1MultiMessageRelayer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1MultiMessageRelayer.sol
@@ -12,7 +12,7 @@ import { Lib_AddressResolver } from "../../../libraries/resolver/Lib_AddressReso
 
 /**
  * @title OVM_L1MultiMessageRelayer
- * @dev The L1 Multi-Message Relayer contract is a gas efficiency optimization which enables the 
+ * @dev The L1 Multi-Message Relayer contract is a gas efficiency optimization which enables the
  * relayer to submit multiple messages in a single transaction to be relayed by the L1 Cross Domain
  * Message Sender.
  *
@@ -26,7 +26,7 @@ contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressRes
      ***************/
     constructor(
         address _libAddressManager
-    ) 
+    )
         Lib_AddressResolver(_libAddressManager)
     {}
 
@@ -50,10 +50,10 @@ contract OVM_L1MultiMessageRelayer is iOVM_L1MultiMessageRelayer, Lib_AddressRes
      * @notice Forwards multiple cross domain messages to the L1 Cross Domain Messenger for relaying
      * @param _messages An array of L2 to L1 messages
      */
-    function batchRelayMessages(L2ToL1Message[] calldata _messages) 
+    function batchRelayMessages(L2ToL1Message[] calldata _messages)
         override
         external
-        onlyBatchRelayer 
+        onlyBatchRelayer
     {
         iOVM_L1CrossDomainMessenger messenger = iOVM_L1CrossDomainMessenger(resolve("Proxy__OVM_L1CrossDomainMessenger"));
         for (uint256 i = 0; i < _messages.length; i++) {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
@@ -14,6 +14,7 @@ import { iOVM_L2ToL1MessagePasser } from "../../../iOVM/predeploys/iOVM_L2ToL1Me
 /* Contract Imports */
 import { Abs_BaseCrossDomainMessenger } from "./Abs_BaseCrossDomainMessenger.sol";
 
+
 /**
  * @title OVM_L2CrossDomainMessenger
  * @dev The L2 Cross Domain Messenger contract sends messages from L2 to L1, and is the entry point
@@ -104,6 +105,7 @@ contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, Abs_BaseCros
                 block.number
             )
         );
+
         relayedMessages[relayId] = true;
     }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// @unsupported: ovm 
+// @unsupported: ovm
 pragma solidity >0.5.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
@@ -27,7 +27,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
     /********************************
      * External Contract References *
      ********************************/
-    
+
     iOVM_ERC20 public l1ERC20;
 
     /***************
@@ -41,7 +41,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
     constructor(
         iOVM_ERC20 _l1ERC20,
         address _l2DepositedERC20,
-        address _l1messenger 
+        address _l1messenger
     )
         Abs_L1TokenGateway(
             _l2DepositedERC20,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -78,7 +78,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev deposit an amount of the ETH to the caller's balance on L2
      */
-    function deposit() 
+    function deposit()
         external
         override
         payable
@@ -137,7 +137,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev Complete a withdrawal from L2 to L1, and credit funds to the recipient's balance of the
      * L1 ETH token.
-     * Since only the xDomainMessenger can call this function, it will never be called before the withdrawal is finalized. 
+     * Since only the xDomainMessenger can call this function, it will never be called before the withdrawal is finalized.
      *
      * @param _to L1 address to credit the withdrawal to
      * @param _amount Amount of the ETH to withdraw

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_ChainStorageContainer.sol
@@ -157,7 +157,7 @@ contract OVM_ChainStorageContainer is iOVM_ChainStorageContainer, Lib_AddressRes
     {
         return buffer.get(uint40(_index));
     }
-    
+
     /**
      * @inheritdoc iOVM_ChainStorageContainer
      */

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -536,7 +536,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         // "magic" prefix to deploy an exact copy of the code:
         // PUSH1 0x0D   # size of this prefix in bytes
         // CODESIZE
-        // SUB          # subtract prefix size from codesize 
+        // SUB          # subtract prefix size from codesize
         // DUP1
         // PUSH1 0x0D
         // PUSH1 0x00
@@ -1064,9 +1064,9 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      * This function sanitizes the return types for creation messages to match calls (bool, bytes),
      * by being an external function which the EM can call, that mimics the success/fail case of the CREATE.
      * This allows for consistent handling of both types of messages in _handleExternalMessage().
-     * Having this step occur as a separate call frame also allows us to easily revert the 
+     * Having this step occur as a separate call frame also allows us to easily revert the
      * contract deployment in the event that the code is unsafe.
-     * 
+     *
      * @param _gasLimit Amount of gas to be passed into this creation.
      * @param _creationCode Code to pass into CREATE for deployment.
      * @param _address OVM address being deployed to.
@@ -1111,7 +1111,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         if (ethAddress == address(0)) {
             // If the creation fails, the EVM lets us grab its revert data. This may contain a revert flag
             // to be used above in _handleExternalMessage, so we pass the revert data back up unmodified.
-            assembly { 
+            assembly {
                 returndatacopy(0,0,returndatasize())
                 revert(0, returndatasize())
             }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_SafetyChecker.sol
@@ -9,7 +9,7 @@ import { iOVM_SafetyChecker } from "../../iOVM/execution/iOVM_SafetyChecker.sol"
  * @dev  The Safety Checker verifies that contracts deployed on L2 do not contain any
  * "unsafe" operations. An operation is considered unsafe if it would access state variables which
  * are specific to the environment (ie. L1 or L2) in which it is executed, as this could be used
- * to "escape the sandbox" of the OVM, resulting in non-deterministic fraud proofs. 
+ * to "escape the sandbox" of the OVM, resulting in non-deterministic fraud proofs.
  * That is, an attacker would be able to "prove fraud" on an honestly applied transaction.
  * Note that a "safe" contract requires opcodes to appear in a particular pattern;
  * omission of "unsafe" opcodes is necessary, but not sufficient.
@@ -129,7 +129,7 @@ contract OVM_SafetyChecker is iOVM_SafetyChecker {
                     if ((firstOps >> 192) == 0x3350600060045af1) {
                         _pc += 8;
                     // Call EM and abort execution if instructed
-                    // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x0E ADD JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x00 REVERT JUMPDEST RETURNDATASIZE PUSH1 0x01 EQ ISZERO PC PUSH1 0x0a ADD JUMPI PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST 
+                    // CALLER PUSH1 0x00 SWAP1 GAS CALL PC PUSH1 0x0E ADD JUMPI RETURNDATASIZE PUSH1 0x00 DUP1 RETURNDATACOPY RETURNDATASIZE PUSH1 0x00 REVERT JUMPDEST RETURNDATASIZE PUSH1 0x01 EQ ISZERO PC PUSH1 0x0a ADD JUMPI PUSH1 0x01 PUSH1 0x00 RETURN JUMPDEST
                     } else if (firstOps == 0x336000905af158600e01573d6000803e3d6000fd5b3d6001141558600a015760 && secondOps == 0x016000f35b) {
                         _pc += 37;
                     } else {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
@@ -14,7 +14,7 @@ import { iOVM_StateManager } from "../../iOVM/execution/iOVM_StateManager.sol";
  * the Execution Manager and State Transitioner. It runs on L1 during the setup and execution of a fraud proof.
  * The same logic runs on L2, but has been implemented as a precompile in the L2 go-ethereum client
  * (see https://github.com/ethereum-optimism/go-ethereum/blob/master/core/vm/ovm_state_manager.go).
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -63,7 +63,7 @@ contract OVM_StateManager is iOVM_StateManager {
      **********************/
 
     /**
-     * Simple authentication, this contract should only be accessible to the owner (which is expected to be the State Transitioner during `PRE_EXECUTION` 
+     * Simple authentication, this contract should only be accessible to the owner (which is expected to be the State Transitioner during `PRE_EXECUTION`
      * or the OVM_ExecutionManager during transaction execution.
      */
     modifier authenticated() {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManagerFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManagerFactory.sol
@@ -12,7 +12,7 @@ import { OVM_StateManager } from "./OVM_StateManager.sol";
  * @title OVM_StateManagerFactory
  * @dev The State Manager Factory is called by a State Transitioner's init code, to create a new
  * State Manager for use in the Fraud Verification process.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/ERC1820Registry.sol
@@ -26,7 +26,7 @@ interface ERC1820ImplementerInterface {
 /**
  * @title ERC1820 Pseudo-introspection Registry Contract
  * @author Jordi Baylina and Jacques Dafflon
- * @dev This contract is the official implementation of the ERC1820 Registry 
+ * @dev This contract is the official implementation of the ERC1820 Registry
  * For more details, see https://eips.ethereum.org/EIPS/eip-1820
  *
  * Compiler used: optimistic-solc

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_DeployerWhitelist.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_DeployerWhitelist.sol
@@ -8,9 +8,9 @@ import { iOVM_DeployerWhitelist } from "../../iOVM/predeploys/iOVM_DeployerWhite
  * @title OVM_DeployerWhitelist
  * @dev The Deployer Whitelist is a temporary predeploy used to provide additional safety during the
  * initial phases of our mainnet roll out. It is owned by the Optimism team, and defines accounts
- * which are allowed to deploy contracts on Layer2. The Execution Manager will only allow an 
+ * which are allowed to deploy contracts on Layer2. The Execution Manager will only allow an
  * ovmCREATE or ovmCREATE2 operation to proceed if the deployer's address whitelisted.
- * 
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
@@ -19,7 +19,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
     /**********************
      * Contract Constants *
      **********************/
-    
+
     bool public initialized;
     bool public allowArbitraryDeployment;
     address override public owner;
@@ -29,7 +29,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
     /**********************
      * Function Modifiers *
      **********************/
-    
+
     /**
      * Blocks functions to anyone except the contract owner.
      */
@@ -45,7 +45,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
     /********************
      * Public Functions *
      ********************/
-    
+
     /**
      * Initializes the whitelist.
      * @param _owner Address of the owner for this contract.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ETH.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_ETH.sol
@@ -12,9 +12,9 @@ import { OVM_L2DepositedERC20 } from "../bridge/tokens/OVM_L2DepositedERC20.sol"
 
 /**
  * @title OVM_ETH
- * @dev The ETH predeploy provides an ERC20 interface for ETH deposited to Layer 2. Note that 
+ * @dev The ETH predeploy provides an ERC20 interface for ETH deposited to Layer 2. Note that
  * unlike on Layer 1, Layer 2 accounts do not have a balance field.
- * 
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
@@ -22,7 +22,7 @@ contract OVM_ETH is OVM_L2DepositedERC20 {
     constructor(
         address _l2CrossDomainMessenger,
         address _l1ETHGateway
-    ) 
+    )
         OVM_L2DepositedERC20(
             _l2CrossDomainMessenger,
             "Ether",

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L1MessageSender.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L1MessageSender.sol
@@ -7,16 +7,16 @@ import { iOVM_ExecutionManager } from "../../iOVM/execution/iOVM_ExecutionManage
 
 /**
  * @title OVM_L1MessageSender
- * @dev The L1MessageSender is a predeploy contract running on L2. During the execution of cross 
+ * @dev The L1MessageSender is a predeploy contract running on L2. During the execution of cross
  * domain transaction from L1 to L2, it returns the address of the L1 account (either an EOA or
- * contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()` 
+ * contract) which sent the message to L2 via the Canonical Transaction Chain's `enqueue()`
  * function.
- * 
- * This contract exclusively serves as a getter for the ovmL1TXORIGIN operation. This is necessary 
- * because there is no corresponding operation in the EVM which the the optimistic solidity compiler 
+ *
+ * This contract exclusively serves as a getter for the ovmL1TXORIGIN operation. This is necessary
+ * because there is no corresponding operation in the EVM which the the optimistic solidity compiler
  * can be replaced with a call to the ExecutionManager's ovmL1TXORIGIN() function.
  *
- * 
+ *
  * Compiler used: solc
  * Runtime target: OVM
  */
@@ -37,7 +37,7 @@ contract OVM_L1MessageSender is iOVM_L1MessageSender {
             address _l1MessageSender
         )
     {
-        // Note that on L2 msg.sender (ie. evmCALLER) will always be the Execution Manager 
+        // Note that on L2 msg.sender (ie. evmCALLER) will always be the Execution Manager
         return iOVM_ExecutionManager(msg.sender).ovmL1TXORIGIN();
     }
 }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L2ToL1MessagePasser.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L2ToL1MessagePasser.sol
@@ -6,11 +6,11 @@ import { iOVM_L2ToL1MessagePasser } from "../../iOVM/predeploys/iOVM_L2ToL1Messa
 
 /**
  * @title OVM_L2ToL1MessagePasser
- * @dev The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof of the 
+ * @dev The L2 to L1 Message Passer is a utility contract which facilitate an L1 proof of the
  * of a message on L2. The L1 Cross Domain Messenger performs this proof in its
- * _verifyStorageProof function, which verifies the existence of the transaction hash in this 
+ * _verifyStorageProof function, which verifies the existence of the transaction hash in this
  * contract's `sentMessages` mapping.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -37,8 +37,8 @@ contract OVM_L2ToL1MessagePasser is iOVM_L2ToL1MessagePasser {
         override
         public
     {
-        // Note: although this function is public, only messages sent from the OVM_L2CrossDomainMessenger 
-        // will be relayed by the OVM_L1CrossDomainMessenger. This is enforced by a check in 
+        // Note: although this function is public, only messages sent from the OVM_L2CrossDomainMessenger
+        // will be relayed by the OVM_L1CrossDomainMessenger. This is enforced by a check in
         // OVM_L1CrossDomainMessenger._verifyStorageProof().
         sentMessages[keccak256(
             abi.encodePacked(

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
@@ -13,12 +13,12 @@ import { Lib_ExecutionManagerWrapper } from "../../libraries/wrappers/Lib_Execut
 
 /**
  * @title OVM_SequencerEntrypoint
- * @dev The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by 
- * any account. It accepts a more efficient compressed calldata format, which it decompresses and 
+ * @dev The Sequencer Entrypoint is a predeploy which, despite its name, can in fact be called by
+ * any account. It accepts a more efficient compressed calldata format, which it decompresses and
  * encodes to the standard EIP155 transaction format.
  * This contract is the implementation referenced by the Proxy Sequencer Entrypoint, thus enabling
  * the Optimism team to upgrade the decompression of calldata from the Sequencer.
- * 
+ *
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
@@ -27,7 +27,7 @@ contract OVM_SequencerEntrypoint {
     /*********
      * Enums *
      *********/
-    
+
     enum TransactionType {
         NATIVE_ETH_TRANSACTION,
         ETH_SIGNED_MESSAGE

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_BondManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_BondManager.sol
@@ -10,11 +10,11 @@ import { iOVM_FraudVerifier } from "../../iOVM/verification/iOVM_FraudVerifier.s
 
 /**
  * @title OVM_BondManager
- * @dev The Bond Manager contract handles deposits in the form of an ERC20 token from bonded 
+ * @dev The Bond Manager contract handles deposits in the form of an ERC20 token from bonded
  * Proposers. It also handles the accounting of gas costs spent by a Verifier during the course of a
- * fraud proof. In the event of a successful fraud proof, the fraudulent Proposer's bond is slashed, 
+ * fraud proof. In the event of a successful fraud proof, the fraudulent Proposer's bond is slashed,
  * and the Verifier's gas costs are refunded.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -109,14 +109,14 @@ contract OVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
             bond.earliestTimestamp = timestamp;
         }
 
-        // if the fraud proof's dispute period does not intersect with the 
+        // if the fraud proof's dispute period does not intersect with the
         // withdrawal's timestamp, then the user should not be slashed
         // e.g if a user at day 10 submits a withdrawal, and a fraud proof
         // from day 1 gets published, the user won't be slashed since day 8 (1d + 7d)
         // is before the user started their withdrawal. on the contrary, if the user
         // had started their withdrawal at, say, day 6, they would be slashed
         if (
-            bond.withdrawalTimestamp != 0 && 
+            bond.withdrawalTimestamp != 0 &&
             uint256(bond.withdrawalTimestamp) > timestamp + disputePeriodSeconds &&
             bond.state == State.WITHDRAWING
         ) {
@@ -154,15 +154,15 @@ contract OVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
         Bond storage bond = bonds[msg.sender];
 
         require(
-            block.timestamp >= uint256(bond.withdrawalTimestamp) + disputePeriodSeconds, 
+            block.timestamp >= uint256(bond.withdrawalTimestamp) + disputePeriodSeconds,
             Errors.TOO_EARLY
         );
         require(bond.state == State.WITHDRAWING, Errors.SLASHED);
-        
+
         // refunds!
         bond.state = State.NOT_COLLATERALIZED;
         bond.withdrawalTimestamp = 0;
-        
+
         require(
             token.transfer(msg.sender, requiredCollateral),
             Errors.ERC20_ERR

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_FraudVerifier.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_FraudVerifier.sol
@@ -21,10 +21,10 @@ import { Abs_FraudContributor } from "./Abs_FraudContributor.sol";
 
 /**
  * @title OVM_FraudVerifier
- * @dev The Fraud Verifier contract coordinates the entire fraud proof verification process. 
+ * @dev The Fraud Verifier contract coordinates the entire fraud proof verification process.
  * If the fraud proof was successful it prunes any state batches from State Commitment Chain
  * which were published after the fraudulent state root.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */
@@ -204,7 +204,7 @@ contract OVM_FraudVerifier is Lib_AddressResolver, Abs_FraudContributor, iOVM_Fr
             _postStateRoot != transitioner.getPostStateRoot(),
             "State transition has not been proven fraudulent."
         );
-        
+
         _cancelStateTransition(_postStateRootBatchHeader, _preStateRoot);
 
         // TEMPORARY: Remove the transitioner; for minnet.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitionerFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitionerFactory.sol
@@ -15,9 +15,9 @@ import { OVM_StateTransitioner } from "./OVM_StateTransitioner.sol";
 
 /**
  * @title OVM_StateTransitionerFactory
- * @dev The State Transitioner Factory is used by the Fraud Verifier to create a new State 
+ * @dev The State Transitioner Factory is used by the Fraud Verifier to create a new State
  * Transitioner during the initialization of a fraud proof.
- * 
+ *
  * Compiler used: solc
  * Runtime target: EVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1MultiMessageRelayer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1MultiMessageRelayer.sol
@@ -14,5 +14,5 @@ interface iOVM_L1MultiMessageRelayer {
         iOVM_L1CrossDomainMessenger.L2MessageInclusionProof proof;
     }
 
-    function batchRelayMessages(L2ToL1Message[] calldata _messages) external; 
+    function batchRelayMessages(L2ToL1Message[] calldata _messages) external;
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -16,7 +16,7 @@ interface iOVM_L1TokenGateway {
         address _to,
         uint256 _amount
     );
-  
+
     event WithdrawalFinalized(
         address indexed _to,
         uint256 _amount

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -20,7 +20,7 @@ interface iOVM_L2DepositedToken {
     event DepositFinalized(
         address indexed _to,
         uint256 _amount
-    );    
+    );
 
 
     /********************

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
@@ -16,7 +16,7 @@ contract OVM_CrossDomainEnabled {
 
     /***************
      * Constructor *
-     ***************/    
+     ***************/
     constructor(
         address _messenger
     ) {
@@ -46,14 +46,14 @@ contract OVM_CrossDomainEnabled {
 
         _;
     }
-    
+
     /**********************
      * Internal Functions *
      **********************/
 
     /**
      * @notice Gets the messenger, usually from storage.  This function is exposed in case a child contract needs to override.
-     * @return The address of the cross-domain messenger contract which should be used. 
+     * @return The address of the cross-domain messenger contract which should be used.
      */
     function getCrossDomainMessenger()
         internal

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_ResolvedDelegateProxy.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_ResolvedDelegateProxy.sol
@@ -17,10 +17,10 @@ contract Lib_ResolvedDelegateProxy {
     // implementation contract. For example, instead of storing these fields at
     // storage slot `0` & `1`, they are stored at `keccak256(key + slot)`.
     // See: https://solidity.readthedocs.io/en/v0.7.0/internals/layout_in_storage.html
-    // NOTE: Do not use this code in your own contract system. 
+    // NOTE: Do not use this code in your own contract system.
     //      There is a known flaw in this contract, and we will remove it from the repository
     //      in the near future. Due to the very limited way that we are using it, this flaw is
-    //      not an issue in our system. 
+    //      not an issue in our system.
     mapping (address => string) private implementationName;
     mapping (address => Lib_AddressManager) private addressManager;
 

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
@@ -23,7 +23,7 @@ library Lib_RLPReader {
         LIST_ITEM
     }
 
-    
+
     /***********
      * Structs *
      ***********/
@@ -32,12 +32,12 @@ library Lib_RLPReader {
         uint256 length;
         uint256 ptr;
     }
-    
+
 
     /**********************
      * Internal Functions *
      **********************/
-    
+
     /**
      * Converts bytes to a reference to memory position and length.
      * @param _in Input bytes to convert.
@@ -484,7 +484,7 @@ library Lib_RLPReader {
             // Short string.
 
             uint256 strLen = prefix - 0x80;
-            
+
             require(
                 _in.length > strLen,
                 "Invalid RLP short string."

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/utils/Lib_RingBuffer.sol
@@ -104,7 +104,7 @@ library Lib_RingBuffer {
         internal
     {
         RingBufferContext memory ctx = _self.getContext();
-        
+
         _self.push(
             _value,
             ctx.extraData
@@ -124,7 +124,7 @@ library Lib_RingBuffer {
         internal
         view
         returns (
-            bytes32    
+            bytes32
         )
     {
         RingBufferContext memory ctx = _self.getContext();

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/wrappers/Lib_ExecutionManagerWrapper.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/wrappers/Lib_ExecutionManagerWrapper.sol
@@ -7,7 +7,7 @@ import { Lib_ErrorUtils } from "../utils/Lib_ErrorUtils.sol";
 
 /**
  * @title Lib_ExecutionManagerWrapper
- * 
+ *
  * Compiler used: solc
  * Runtime target: OVM
  */

--- a/packages/contracts/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/mockOVM/verification/mockOVM_BondManager.sol
@@ -78,7 +78,7 @@ contract mockOVM_BondManager is iOVM_BondManager, Lib_AddressResolver {
     )
         override
         public
-        pure 
+        pure
         returns (
             uint256
         )

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol
@@ -14,7 +14,7 @@ contract TestLib_MerkleTree {
         bytes32[] memory _elements
     )
         public
-       pure 
+       pure
         returns (
             bytes32
         )

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_RingBuffer.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_RingBuffer.sol
@@ -10,7 +10,7 @@ import { Lib_RingBuffer } from "../../optimistic-ethereum/libraries/utils/Lib_Ri
  */
 contract TestLib_RingBuffer {
     using Lib_RingBuffer for Lib_RingBuffer.RingBuffer;
-    
+
     Lib_RingBuffer.RingBuffer internal buf;
 
     function push(
@@ -31,7 +31,7 @@ contract TestLib_RingBuffer {
         public
         view
         returns (
-            bytes32    
+            bytes32
         )
     {
         return buf.get(_index);

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "dist/index",
   "files": [
     "dist/**/*.js",
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@eth-optimism/hardhat-ovm": "^0.0.3",
-    "@eth-optimism/smock": "^1.0.2",
+    "@eth-optimism/smock": "^1.1.0",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@typechain/ethers-v5": "1.0.0",

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
@@ -113,7 +113,7 @@ describe('OVM_L1CrossDomainMessenger', () => {
       ).to.deep.equal([
         Mock__OVM_L2CrossDomainMessenger.address,
         BigNumber.from(gasLimit),
-        getXDomainCalldata(await signer.getAddress(), target, message, 0),
+        getXDomainCalldata(target, await signer.getAddress(), message, 0),
       ])
     })
 
@@ -171,7 +171,7 @@ describe('OVM_L1CrossDomainMessenger', () => {
       ])
       sender = await signer.getAddress()
 
-      calldata = getXDomainCalldata(sender, target, message, 0)
+      calldata = getXDomainCalldata(target, sender, message, 0)
 
       const precompile = '0x4200000000000000000000000000000000000000'
 

--- a/packages/contracts/test/helpers/codec/bridge.ts
+++ b/packages/contracts/test/helpers/codec/bridge.ts
@@ -1,8 +1,8 @@
 import { getContractInterface } from '../../../src/contract-defs'
 
 export const getXDomainCalldata = (
-  sender: string,
   target: string,
+  sender: string,
   message: string,
   messageNonce: number
 ): string => {

--- a/packages/core-utils/src/common/index.ts
+++ b/packages/core-utils/src/common/index.ts
@@ -1,5 +1,6 @@
 export * from './addresses'
 export * from './hex-strings'
 export * from './logger'
+export * from './metrics'
 export * from './misc'
 export * from './common'

--- a/packages/data-transport-layer/CHANGELOG.md
+++ b/packages/data-transport-layer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # data transport layer
 
+## 0.2.2
+
+### Patch Changes
+
+- 6d31324: Update release tag for Sentry compatability
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/data-transport-layer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "main": "dist/index",
   "files": [

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -107,7 +107,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this.state.app = express()
     Sentry.init({
       dsn: this.options.sentryDsn,
-      release: `@eth-optimism/data-transport-layer@${process.env.npm_package_version}`,
+      release: `data-transport-layer@${process.env.npm_package_version}`,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Express({

--- a/packages/smock/CHANGELOG.md
+++ b/packages/smock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/smock
 
+## 1.1.0
+
+### Minor Changes
+
+- 79f812d: Adds support for hardhat ^2.2.0, required because of move to ethereumjs-vm v5.
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/smock/package.json
+++ b/packages/smock/package.json
@@ -3,7 +3,7 @@
   "files": [
     "dist/src/*"
   ],
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "dist/src/index",
   "types": "dist/src/index",
   "license": "MIT",

--- a/packages/smock/package.json
+++ b/packages/smock/package.json
@@ -28,15 +28,15 @@
     "bn.js": "^5.2.0"
   },
   "devDependencies": {
-    "@nomiclabs/ethereumjs-vm": "4.2.2",
+    "@nomiclabs/ethereumjs-vm": "^4.2.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/lodash": "^4.14.161",
     "chai": "^4.3.0",
     "ethereum-waffle": "^3.3.0",
-    "ethers": "^5.0.32",
+    "ethers": "^5.0.31",
     "glob": "^7.1.6",
-    "hardhat": "^2.1.1",
+    "hardhat": "^2.2.1",
     "lodash": "^4.17.20",
     "prettier": "^2.2.1"
   }

--- a/packages/smock/src/common/hardhat-common.ts
+++ b/packages/smock/src/common/hardhat-common.ts
@@ -1,6 +1,7 @@
 /* Imports: External */
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { HardhatNetworkProvider } from 'hardhat/internal/hardhat-network/provider/provider'
+import { fromHexString, toHexString } from '@eth-optimism/core-utils'
 
 /**
  * Finds the "base" Ethereum provider of the current hardhat environment.
@@ -43,4 +44,36 @@ export const findBaseHardhatProvider = (
   // TODO: Figure out a reliable way to do a type check here. Source for inspiration:
   // https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
   return provider as any
+}
+
+/**
+ * Converts a string into the fancy new address thing that ethereumjs-vm v5 expects while also
+ * maintaining backwards compatibility with ethereumjs-vm v4.
+ * @param address String address to convert into the fancy new address type.
+ * @returns Fancified address.
+ */
+export const toFancyAddress = (address: string): any => {
+  const fancyAddress = fromHexString(address)
+  ;(fancyAddress as any).buf = fromHexString(address)
+  ;(fancyAddress as any).toString = (encoding?: any) => {
+    if (encoding === undefined) {
+      return address.toLowerCase()
+    } else {
+      return fromHexString(address).toString(encoding)
+    }
+  }
+  return fancyAddress
+}
+
+/**
+ * Same as toFancyAddress but in the opposite direction.
+ * @param fancyAddress Fancy address to turn into a string.
+ * @returns Way more boring address.
+ */
+export const fromFancyAddress = (fancyAddress: any): string => {
+  if (fancyAddress.buf) {
+    return toHexString(fancyAddress.buf)
+  } else {
+    return toHexString(fancyAddress)
+  }
 }

--- a/packages/smock/src/smockit/smockit.ts
+++ b/packages/smock/src/smockit/smockit.ts
@@ -6,6 +6,9 @@ import { toHexString, fromHexString } from '@eth-optimism/core-utils'
 /* Imports: Internal */
 import {
   isArtifact,
+  isContract,
+  isContractFactory,
+  isInterface,
   MockContract,
   MockContractFunction,
   MockReturnValue,
@@ -33,13 +36,19 @@ const makeContractInterfaceFromSpec = async (
     return spec.interface
   } else if (spec instanceof ethers.utils.Interface) {
     return spec
+  } else if (isInterface(spec)) {
+    return spec as any
+  } else if (isContractFactory(spec)) {
+    return (spec as any).interface
+  } else if (isContract(spec)) {
+    return (spec as any).interface
   } else if (isArtifact(spec)) {
     return new ethers.utils.Interface(spec.abi)
   } else if (typeof spec === 'string') {
     try {
       return new ethers.utils.Interface(spec)
     } catch (err) {
-      return (await hre.ethers.getContractFactory(spec)).interface
+      return (await (hre as any).ethers.getContractFactory(spec)).interface
     }
   } else {
     return new ethers.utils.Interface(spec)
@@ -150,7 +159,7 @@ export const smockit = async (
   const contract = new ethers.Contract(
     opts.address || makeRandomAddress(),
     await makeContractInterfaceFromSpec(spec),
-    opts.provider || hre.ethers.provider // TODO: Probably check that this exists.
+    opts.provider || (hre as any).ethers.provider // TODO: Probably check that this exists.
   ) as MockContract
 
   // Start by smocking the fallback.

--- a/packages/smock/src/smockit/types.ts
+++ b/packages/smock/src/smockit/types.ts
@@ -62,7 +62,11 @@ export interface SmockedVM {
 
   on: (event: string, callback: Function) => void
 
-  pStateManager: {
+  stateManager?: {
+    putContractCode: (address: Buffer, code: Buffer) => Promise<void>
+  }
+
+  pStateManager?: {
     putContractCode: (address: Buffer, code: Buffer) => Promise<void>
   }
 }
@@ -88,6 +92,30 @@ export const isMockContract = (obj: any): obj is MockContract => {
       return isMockFunction(smockFunction)
     })
   )
+}
+
+export const isInterface = (obj: any): boolean => {
+  return (
+    obj &&
+    obj.functions !== undefined &&
+    obj.errors !== undefined &&
+    obj.structs !== undefined &&
+    obj.events !== undefined &&
+    Array.isArray(obj.fragments)
+  )
+}
+
+export const isContract = (obj: any): boolean => {
+  return (
+    obj &&
+    obj.functions !== undefined &&
+    obj.estimateGas !== undefined &&
+    obj.callStatic !== undefined
+  )
+}
+
+export const isContractFactory = (obj: any): boolean => {
+  return obj && obj.interface !== undefined && obj.deploy !== undefined
 }
 
 export const isArtifact = (obj: any): obj is Artifact => {

--- a/packages/smock/test/smockit/function-manipulation.spec.ts
+++ b/packages/smock/test/smockit/function-manipulation.spec.ts
@@ -1,5 +1,5 @@
 /* Imports: External */
-import { ethers } from 'hardhat'
+import hre from 'hardhat'
 import { expect } from 'chai'
 import { toPlainObject } from 'lodash'
 import { BigNumber } from 'ethers'
@@ -8,6 +8,8 @@ import { BigNumber } from 'ethers'
 import { MockContract, smockit } from '../../src'
 
 describe('[smock]: function manipulation tests', () => {
+  const ethers = (hre as any).ethers
+
   let mock: MockContract
   beforeEach(async () => {
     mock = await smockit('TestHelpers_BasicReturnContract')

--- a/packages/smock/test/smockit/smock-initialization.spec.ts
+++ b/packages/smock/test/smockit/smock-initialization.spec.ts
@@ -1,11 +1,13 @@
 /* Imports: External */
-import { ethers, artifacts } from 'hardhat'
+import hre from 'hardhat'
 import { expect } from 'chai'
 
 /* Imports: Internal */
 import { smockit, isMockContract } from '../../src'
 
 describe('[smock]: initialization tests', () => {
+  const ethers = (hre as any).ethers
+
   describe('initialization: ethers objects', () => {
     it('should be able to create a SmockContract from an ethers ContractFactory', async () => {
       const spec = await ethers.getContractFactory('TestHelpers_EmptyContract')
@@ -46,7 +48,7 @@ describe('[smock]: initialization tests', () => {
     })
 
     it('should be able to create a SmockContract from a JSON contract artifact object', async () => {
-      const artifact = await artifacts.readArtifact(
+      const artifact = await hre.artifacts.readArtifact(
         'TestHelpers_BasicReturnContract'
       )
       const spec = artifact
@@ -56,7 +58,7 @@ describe('[smock]: initialization tests', () => {
     })
 
     it('should be able to create a SmockContract from a JSON contract ABI object', async () => {
-      const artifact = await artifacts.readArtifact(
+      const artifact = await hre.artifacts.readArtifact(
         'TestHelpers_BasicReturnContract'
       )
       const spec = artifact.abi
@@ -66,7 +68,7 @@ describe('[smock]: initialization tests', () => {
     })
 
     it('should be able to create a SmockContract from a JSON contract ABI string', async () => {
-      const artifact = await artifacts.readArtifact(
+      const artifact = await hre.artifacts.readArtifact(
         'TestHelpers_BasicReturnContract'
       )
       const spec = JSON.stringify(artifact.abi)

--- a/specs/CHANGELOG.md
+++ b/specs/CHANGELOG.md
@@ -1,0 +1,6 @@
+# @eth-optimism/specs
+
+## 0.2.0
+### Minor Changes
+
+- 318857e: Add a new package to contain specs

--- a/specs/package.json
+++ b/specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/specs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "private": true,
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,6 +305,76 @@
     patch-package "^6.2.2"
     postinstall-postinstall "^2.1.0"
 
+"@ethereumjs/block@^3.2.0", "@ethereumjs/block@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.2.1.tgz#c24c345e6dd6299efa4bed40979280b7dda96d3a"
+  integrity sha512-FCxo5KwwULne2A2Yuae4iaGGqSsRjwzXOlDhGalOFiBbLfP3hE04RHaHGw4c8vh1PfOrLauwi0dQNUBkOG3zIA==
+  dependencies:
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/tx" "^3.1.3"
+    ethereumjs-util "^7.0.10"
+    merkle-patricia-tree "^4.1.0"
+
+"@ethereumjs/blockchain@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.2.1.tgz#83ed83647667265f1666f111caf065ef9d1e82b5"
+  integrity sha512-+hshP2qSOOFsiYvZCbaDQFG7jYTWafE8sfBi+pAsdhAHfP7BN7VLyob7qoQISgwS1s7NTR4c4+2t/woU9ahItw==
+  dependencies:
+    "@ethereumjs/block" "^3.2.0"
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/ethash" "^1.0.0"
+    debug "^2.2.0"
+    ethereumjs-util "^7.0.9"
+    level-mem "^5.0.1"
+    lru-cache "^5.1.1"
+    rlp "^2.2.4"
+    semaphore-async-await "^1.5.1"
+
+"@ethereumjs/common@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.2.0.tgz#850a3e3e594ee707ad8d44a11e8152fb62450535"
+  integrity sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.0.9"
+
+"@ethereumjs/ethash@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/ethash/-/ethash-1.0.0.tgz#4e77f85b37be1ade5393e8719bdabac3e796ddaa"
+  integrity sha512-iIqnGG6NMKesyOxv2YctB2guOVX18qMAWlj3QlZyrc+GqfzLqoihti+cVNQnyNxr7eYuPdqwLQOFuPe6g/uKjw==
+  dependencies:
+    "@types/levelup" "^4.3.0"
+    buffer-xor "^2.0.1"
+    ethereumjs-util "^7.0.7"
+    miller-rabin "^4.0.0"
+
+"@ethereumjs/tx@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.3.tgz#0e4b0ccec2f12b1f0bbbb0e7542dd79d9ec25d87"
+  integrity sha512-DJBu6cbwYtiPTFeCUR8DF5p+PF0jxs+0rALJZiEcTz2tiRPIEkM72GEbrkGuqzENLCzBrJHT43O0DxSYTqeo+g==
+  dependencies:
+    "@ethereumjs/common" "^2.2.0"
+    ethereumjs-util "^7.0.10"
+
+"@ethereumjs/vm@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.3.2.tgz#b4d83a3d50a7ad22d6d412cc21bbde221b3e2871"
+  integrity sha512-QmCUQrW6xbhgEbQh9njue4kAJdM056C+ytBFUTF/kDYa3kNDm4Qxp9HUyTlt1OCSXvDhws0qqlh8+q+pmXpN7g==
+  dependencies:
+    "@ethereumjs/block" "^3.2.1"
+    "@ethereumjs/blockchain" "^5.2.1"
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/tx" "^3.1.3"
+    async-eventemitter "^0.2.4"
+    core-js-pure "^3.0.1"
+    debug "^2.2.0"
+    ethereumjs-util "^7.0.10"
+    functional-red-black-tree "^1.0.1"
+    mcl-wasm "^0.7.1"
+    merkle-patricia-tree "^4.1.0"
+    rustbn.js "~0.2.0"
+    util.promisify "^1.0.1"
+
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"
@@ -1479,7 +1549,7 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@nomiclabs/ethereumjs-vm@4.2.2":
+"@nomiclabs/ethereumjs-vm@4.2.2", "@nomiclabs/ethereumjs-vm@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@nomiclabs/ethereumjs-vm/-/ethereumjs-vm-4.2.2.tgz#2f8817113ca0fb6c44c1b870d0a809f0e026a6cc"
   integrity sha512-8WmX94mMcJaZ7/m7yBbyuS6B+wuOul+eF+RY9fBpGhNaUpyMR/vFIcDojqcWQ4Yafe1tMKY5LDu2yfT4NZgV4Q==
@@ -2720,7 +2790,7 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-async-eventemitter@^0.2.2:
+async-eventemitter@^0.2.2, async-eventemitter@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/async-eventemitter/-/async-eventemitter-0.2.4.tgz#f5e7c8ca7d3e46aab9ec40a292baf686a0bafaca"
   integrity sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==
@@ -4382,6 +4452,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -5485,7 +5563,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.8:
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.7, ethereumjs-util@^7.0.8, ethereumjs-util@^7.0.9:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
   integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
@@ -5726,6 +5804,11 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -6720,6 +6803,57 @@ hardhat@^2.0.8, hardhat@^2.0.9, hardhat@^2.1.1, hardhat@^2.1.2:
     io-ts "1.10.4"
     lodash "^4.17.11"
     merkle-patricia-tree "3.0.0"
+    mnemonist "^0.38.0"
+    mocha "^7.1.2"
+    node-fetch "^2.6.0"
+    qs "^6.7.0"
+    raw-body "^2.4.1"
+    resolve "1.17.0"
+    semver "^6.3.0"
+    slash "^3.0.0"
+    solc "0.7.3"
+    source-map-support "^0.5.13"
+    stacktrace-parser "^0.1.10"
+    "true-case-path" "^2.2.1"
+    tsort "0.0.1"
+    uuid "^3.3.2"
+    ws "^7.2.1"
+
+hardhat@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.2.1.tgz#bef0031b994e3f60a88d428f2097195c58cf9ed2"
+  integrity sha512-8s7MtGXdh0NDwQKdlA8m8QdloVIN1+hv5aFpn0G5Ljj9vfNY9kUoc0a9pMboeGbd9WrS+XrZs5YlsPgQjaW/Tg==
+  dependencies:
+    "@ethereumjs/block" "^3.2.1"
+    "@ethereumjs/blockchain" "^5.2.1"
+    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/tx" "^3.1.3"
+    "@ethereumjs/vm" "^5.3.2"
+    "@sentry/node" "^5.18.1"
+    "@solidity-parser/parser" "^0.11.0"
+    "@types/bn.js" "^5.1.0"
+    "@types/lru-cache" "^5.1.0"
+    abort-controller "^3.0.0"
+    adm-zip "^0.4.16"
+    ansi-escapes "^4.3.0"
+    chalk "^2.4.2"
+    chokidar "^3.4.0"
+    ci-info "^2.0.0"
+    debug "^4.1.1"
+    enquirer "^2.3.0"
+    env-paths "^2.2.0"
+    eth-sig-util "^2.5.2"
+    ethereum-cryptography "^0.1.2"
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^7.0.10"
+    find-up "^2.1.0"
+    fp-ts "1.19.3"
+    fs-extra "^7.0.1"
+    glob "^7.1.3"
+    immutable "^4.0.0-rc.12"
+    io-ts "1.10.4"
+    lodash "^4.17.11"
+    merkle-patricia-tree "^4.1.0"
     mnemonist "^0.38.0"
     mocha "^7.1.2"
     node-fetch "^2.6.0"
@@ -8398,6 +8532,11 @@ match-all@^1.2.6:
   resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
   integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
+mcl-wasm@^0.7.1:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.6.tgz#c1789ebda5565d49b77d2ee195ff3e4d282f1554"
+  integrity sha512-cbRl3sUOkBeRY2hsM4t1EIln2TIdQBkSiTOqNTv/4Hu5KOECnMWCgjIf+a9Ebunyn22VKqkMF3zj6ejRzz7YBw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8554,7 +8693,7 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     rlp "^2.0.0"
     semaphore ">=1.0.1"
 
-merkle-patricia-tree@^4.0.0:
+merkle-patricia-tree@^4.0.0, merkle-patricia-tree@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-4.1.0.tgz#010636c4cfd68682df33a2e3186b7d0be7b98b9d"
   integrity sha512-vmP1J7FwIpprFMVjjSMM1JAwFce85Q+tp0TYIedYv8qaMh2oLUZ3ETXn9wbgi9S6elySzKzGa+Ai6VNKGEwSlg==
@@ -10186,6 +10325,11 @@ prettier@^1.14.2, prettier@^1.16.4, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -12605,7 +12749,7 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
-util.promisify@^1.0.0:
+util.promisify@^1.0.0, util.promisify@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.1.tgz#77832f57ced2c9478174149cae9b96e9918cd54b"
   integrity sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Description
Removes the `eth_sendRawEthSignTransaction` RPC endpoint. This is required for the RLP regenesis and we should make sure that Synthetix no longer uses the OptimismProvider before going to production with this.
