### PR TITLE
feat[contracts]: Make ProxyEOA compatible with eip1967

### DIFF
--- a/.changeset/old-cycles-invite.md
+++ b/.changeset/old-cycles-invite.md
@@ -2,4 +2,4 @@
 "@eth-optimism/contracts": patch
 ---
 
-Makes ProxyEOA compatible with EIP1967
+Makes ProxyEOA compatible with EIP1967, not backwards compatible since the storage slot changes.

--- a/.changeset/old-cycles-invite.md
+++ b/.changeset/old-cycles-invite.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Makes ProxyEOA compatible with EIP1967

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -16,12 +16,21 @@ import { Lib_Bytes32Utils } from "../../libraries/utils/Lib_Bytes32Utils.sol";
  */
 contract OVM_ProxyEOA {
 
+    /**********
+     * Events *
+     **********/
+    
+    event Upgraded(
+        address indexed implementation
+    );
+
+
     /*************
      * Constants *
      *************/
 
     address constant DEFAULT_IMPLEMENTATION = 0x4200000000000000000000000000000000000003;
-    bytes32 constant IMPLEMENTATION_KEY = 0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead;
+    bytes32 constant IMPLEMENTATION_KEY = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1);
 
 
     /*********************
@@ -68,6 +77,7 @@ contract OVM_ProxyEOA {
         );
 
         _setImplementation(_implementation);
+        emit Upgraded(_implementation);
     }
 
     /**

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -30,7 +30,7 @@ contract OVM_ProxyEOA {
      *************/
 
     address constant DEFAULT_IMPLEMENTATION = 0x4200000000000000000000000000000000000003;
-    bytes32 constant IMPLEMENTATION_KEY = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1);
+    bytes32 constant IMPLEMENTATION_KEY = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc; //bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1);
 
 
     /*********************

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ProxyEOA.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ProxyEOA.spec.ts
@@ -94,7 +94,7 @@ describe('OVM_ProxyEOA', () => {
   })
   describe('upgrade()', () => {
     const implSlotKey =
-      '0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead'
+      '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc' //bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
     it(`should upgrade the proxy implementation`, async () => {
       const newImpl = `0x${'81'.repeat(20)}`
       const newImplBytes32 = addrToBytes32(newImpl)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes #550. Very simple change, ensures that our implementation storage slot is correct. Also emits the right event whenever the contract is upgraded.
