### PR TITLE
ops: set e in deployer entrypoint script

### DIFF
--- a/ops/scripts/deployer.sh
+++ b/ops/scripts/deployer.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-RETRIES=${RETRIES:-20}
+set -e
 
+RETRIES=${RETRIES:-20}
 JSON='{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}'
 
 # wait for the base layer to be up


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Set some flags in `deployer.sh` that will cause the script to end early if any commands exit with a non 0 exit code. This prevents `yarn deploy` from failing and then the dump being served without the `addresses.json`

Updated to just `set -e`

See the linux man page for set: https://ss64.com/bash/set.html

```
   -e  Exit immediately if a simple command exits with a non-zero status, unless
       the command that fails is part of an until or  while loop, part of an
       if statement, part of a && or || list, or if the command's return status
       is being inverted using !.  -o errexit
```
This means that if `yarn deploy` fails, then the entire script will fail