### PR TITLE
fix[contracts]: Update contracts package.json to export typechain artifacts

### DIFF
--- a/.changeset/smooth-beds-rhyme.md
+++ b/.changeset/smooth-beds-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Minor update to package.json to correctly export typechain artifacts"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index",
   "files": [
     "dist/**/*.js",
+    "dist/types/*.ts",
     "artifacts/**/*.json",
     "artifacts-ovm/**/*.json",
     "OVM",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
`package.json` wasn't correctly exporting our typechain artifacts. This should fix it. Requires a new release for people to use this, though. Fixes #505 
