### PR TITLE
feat[contracts]: Have Messenger contracts emit an event on failed relay

### DIFF
--- a/.changeset/violet-falcons-hunt.md
+++ b/.changeset/violet-falcons-hunt.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Add an extra event to messenger contracts to emit when a message is unsuccessfully relayed

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
@@ -128,6 +128,8 @@ contract OVM_L1CrossDomainMessenger is iOVM_L1CrossDomainMessenger, Abs_BaseCros
         if (success == true) {
             successfulMessages[xDomainCalldataHash] = true;
             emit RelayedMessage(xDomainCalldataHash);
+        } else {
+            emit FailedRelayedMessage(xDomainCalldataHash);
         }
 
         // Store an identifier that can be used to prove that the given message was relayed by some

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L2CrossDomainMessenger.sol
@@ -93,6 +93,8 @@ contract OVM_L2CrossDomainMessenger is iOVM_L2CrossDomainMessenger, Abs_BaseCros
         if (success == true) {
             successfulMessages[xDomainCalldataHash] = true;
             emit RelayedMessage(xDomainCalldataHash);
+        } else {
+            emit FailedRelayedMessage(xDomainCalldataHash);
         }
 
         // Store an identifier that can be used to prove that the given message was relayed by some

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iAbs_BaseCrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iAbs_BaseCrossDomainMessenger.sol
@@ -10,13 +10,18 @@ interface iAbs_BaseCrossDomainMessenger {
     /**********
      * Events *
      **********/
+
     event SentMessage(bytes message);
     event RelayedMessage(bytes32 msgHash);
+    event FailedRelayedMessage(bytes32 msgHash);
 
-    /**********************
-     * Contract Variables *
-     **********************/
+
+    /*************
+     * Variables *
+     *************/
+
     function xDomainMessageSender() external view returns (address);
+
 
     /********************
      * Public Functions *


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a new event `FailedRelayedMessage` to `L1CrossDomainMessenger` and `L2CrossDomainMessenger`, to be emitted in the case that a relay failed. Alternative described in #587 was simply to add a `success` boolean to `RelayedMessage`, but some of our services rely on the current `RelayedMessage` event and I didn't want to break anything. I think this is good enough.

**Metadata**
- Fixes #587 
