### PR TITLE
fix[integration-tests]: Use fixed address in gas estimation test

### DIFF
--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -43,7 +43,7 @@ describe('Native ETH Integration Tests', async () => {
   describe('estimateGas', () => {
     it('Should estimate gas for ETH transfer', async () => {
       const amount = utils.parseEther('0.5')
-      const addr = await l2Bob.getAddress()
+      const addr = '0x' + '1234'.repeat(10)
       const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
       expect(gas).to.be.deep.eq(BigNumber.from(213546))
     })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Trying to see if using a fixed address will solve the flickering integration test.
