### PR TITLE
feat: add sentry error context

### DIFF
--- a/.changeset/rich-steaks-train.md
+++ b/.changeset/rich-steaks-train.md
@@ -1,0 +1,6 @@
+---
+"@eth-optimism/batch-submitter": patch
+"@eth-optimism/core-utils": patch
+---
+
+reformat error context for Sentry

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -100,7 +100,7 @@ export abstract class BatchSubmitter {
     })
 
     if (num < this.minBalanceEther) {
-      this.log.warn('Current balance lower than min safe balance', {
+      this.log.fatal('Current balance lower than min safe balance', {
         current: num,
         safeBalance: this.minBalanceEther,
       })

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -25,7 +25,6 @@ const log = new Logger({
     tracesSampleRate: 0.05,
   },
 })
-
 /* Metrics */
 const metrics = new Metrics({
   prefix: name,

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -21,12 +21,11 @@ const log = new Logger({
   name,
   sentryOptions: {
     release: `batch-submitter@${process.env.npm_package_version}`,
-    // @ts-ignore stackAttributeKey belongs to PinoSentryOptions, not exported
-    stackAttributeKey: 'err',
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 0.05,
   },
 })
+
 /* Metrics */
 const metrics = new Metrics({
   prefix: name,

--- a/packages/core-utils/src/common/logger.ts
+++ b/packages/core-utils/src/common/logger.ts
@@ -35,7 +35,10 @@ export class Logger {
     if (options.sentryOptions) {
       loggerStreams.push({
         level: 'error',
-        stream: createWriteStream(options.sentryOptions),
+        stream: createWriteStream({
+          ...options.sentryOptions,
+          stackAttributeKey: 'err',
+        }),
       })
     }
     if (options.streams) loggerStreams = loggerStreams.concat(options.streams)
@@ -104,23 +107,10 @@ export class Logger {
 
   fatal(msg: string, o?: object, ...args: any[]): void {
     if (o) {
-      this.inner.fatal(o, msg, ...args)
-    } else {
-      this.inner.fatal(msg, ...args)
-    }
-  }
-
-  crit(msg: string, o?: object, ...args: any[]): void {
-    if (o) {
-      this.inner.fatal(o, msg, ...args)
-    } else {
-      this.inner.fatal(msg, ...args)
-    }
-  }
-
-  critical(msg: string, o?: object, ...args: any[]): void {
-    if (o) {
-      this.inner.fatal(o, msg, ...args)
+      const context = {
+        extra: { ...o },
+      }
+      this.inner.fatal(context, msg, ...args)
     } else {
       this.inner.fatal(msg, ...args)
     }

--- a/packages/core-utils/src/common/logger.ts
+++ b/packages/core-utils/src/common/logger.ts
@@ -92,7 +92,11 @@ export class Logger {
 
   error(msg: string, o?: object, ...args: any[]): void {
     if (o) {
-      this.inner.error(o, msg, ...args)
+      // Formatting error log for Sentry
+      const context = {
+        extra: { ...o },
+      }
+      this.inner.error(context, msg, ...args)
     } else {
       this.inner.error(msg, ...args)
     }


### PR DESCRIPTION
**Description**
`pino-sentry` only logs context wrapped in the `extra` field. this PR merges our context object into `extra` so we can see the contexts of all errors Sentry catches.

**Additional context**
### test error
```js
log.error('test error v2', {
  err: 'error!!',
  time: 12345,
  isError: true,
})
```
https://sentry.io/organizations/optimismpbc/issues/2359518167/

