### PR TITLE
feat[contracts]: Restrict tx nonce and gasLimit to uint64

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -458,7 +458,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         override
         public
         returns (
-            uint256 _nonce
+            uint64 _nonce
         )
     {
         return _getAccountNonce(ovmADDRESS());
@@ -473,7 +473,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         notStatic
     {
         address account = ovmADDRESS();
-        uint256 nonce = _getAccountNonce(account);
+        uint64 nonce = _getAccountNonce(account);
 
         // Prevent overflow.
         if (nonce + 1 > nonce) {
@@ -1181,7 +1181,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function _setAccountNonce(
         address _address,
-        uint256 _nonce
+        uint64 _nonce
     )
         internal
     {
@@ -1199,7 +1199,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         internal
         returns (
-            uint256 _nonce
+            uint64 _nonce
         )
     {
         _checkAccountLoad(_address);

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_StateManager.sol
@@ -207,7 +207,7 @@ contract OVM_StateManager is iOVM_StateManager {
      */
     function setAccountNonce(
         address _address,
-        uint256 _nonce
+        uint64 _nonce
     )
         override
         public
@@ -228,7 +228,7 @@ contract OVM_StateManager is iOVM_StateManager {
         public
         view
         returns (
-            uint256
+            uint64
         )
     {
         return accounts[_address].nonce;

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/execution/iOVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/execution/iOVM_ExecutionManager.sol
@@ -117,7 +117,7 @@ interface iOVM_ExecutionManager {
      * Account Abstraction Opcodes *
      ******************************/
 
-    function ovmGETNONCE() external returns (uint256 _nonce);
+    function ovmGETNONCE() external returns (uint64 _nonce);
     function ovmINCREMENTNONCE() external;
     function ovmCREATEEOA(bytes32 _messageHash, uint8 _v, bytes32 _r, bytes32 _s) external;
 

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/execution/iOVM_StateManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/execution/iOVM_StateManager.sol
@@ -45,8 +45,8 @@ interface iOVM_StateManager {
     function getAccount(address _address) external view returns (Lib_OVMCodec.Account memory _account);
     function hasAccount(address _address) external view returns (bool _exists);
     function hasEmptyAccount(address _address) external view returns (bool _exists);
-    function setAccountNonce(address _address, uint256 _nonce) external;
-    function getAccountNonce(address _address) external view returns (uint256 _nonce);
+    function setAccountNonce(address _address, uint64 _nonce) external;
+    function getAccountNonce(address _address) external view returns (uint64 _nonce);
     function getAccountEthAddress(address _address) external view returns (address _ethAddress);
     function getAccountStorageRoot(address _address) external view returns (bytes32 _storageRoot);
     function initPendingAccount(address _address) external;

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/codec/Lib_EIP155Tx.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/codec/Lib_EIP155Tx.sol
@@ -20,9 +20,9 @@ library Lib_EIP155Tx {
     // Struct representing an EIP155 transaction. See EIP link above for more information.
     struct EIP155Tx {
         // These fields correspond to the actual RLP-encoded fields specified by EIP155.
-        uint256 nonce;
+        uint64 nonce;
         uint256 gasPrice;
-        uint256 gasLimit;
+        uint64 gasLimit;
         address to;
         uint256 value;
         bytes data;
@@ -98,9 +98,9 @@ library Lib_EIP155Tx {
         bool isCreate = Lib_RLPReader.readBytes(decoded[3]).length == 0;
 
         return EIP155Tx({
-            nonce: Lib_RLPReader.readUint256(decoded[0]),
+            nonce: Lib_RLPReader.readUint64(decoded[0]),
             gasPrice: Lib_RLPReader.readUint256(decoded[1]),
-            gasLimit: Lib_RLPReader.readUint256(decoded[2]),
+            gasLimit: Lib_RLPReader.readUint64(decoded[2]),
             to: Lib_RLPReader.readAddress(decoded[3]),
             value: Lib_RLPReader.readUint256(decoded[4]),
             data: Lib_RLPReader.readBytes(decoded[5]),

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/codec/Lib_OVMCodec.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/codec/Lib_OVMCodec.sol
@@ -28,7 +28,7 @@ library Lib_OVMCodec {
      ***********/
 
     struct Account {
-        uint256 nonce;
+        uint64 nonce;
         uint256 balance;
         bytes32 storageRoot;
         bytes32 codeHash;
@@ -37,7 +37,7 @@ library Lib_OVMCodec {
     }
 
     struct EVMAccount {
-        uint256 nonce;
+        uint64 nonce;
         uint256 balance;
         bytes32 storageRoot;
         bytes32 codeHash;
@@ -170,7 +170,7 @@ library Lib_OVMCodec {
         // index-by-index circumvents this issue.
         raw[0] = Lib_RLPWriter.writeBytes(
             Lib_Bytes32Utils.removeLeadingZeros(
-                bytes32(_account.nonce)
+                bytes32(uint256(_account.nonce))
             )
         );
         raw[1] = Lib_RLPWriter.writeBytes(
@@ -201,7 +201,7 @@ library Lib_OVMCodec {
         Lib_RLPReader.RLPItem[] memory accountState = Lib_RLPReader.readList(_encoded);
 
         return EVMAccount({
-            nonce: Lib_RLPReader.readUint256(accountState[0]),
+            nonce: Lib_RLPReader.readUint64(accountState[0]),
             balance: Lib_RLPReader.readUint256(accountState[1]),
             storageRoot: Lib_RLPReader.readBytes32(accountState[2]),
             codeHash: Lib_RLPReader.readBytes32(accountState[3])

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/rlp/Lib_RLPReader.sol
@@ -329,6 +329,47 @@ library Lib_RLPReader {
     }
 
     /**
+     * Reads an RLP uint64 value into a uint64.
+     * @param _in RLP uint64 value.
+     * @return Decoded uint64.
+     */
+    function readUint64(
+        RLPItem memory _in
+    )
+        internal
+        pure
+        returns (
+            uint64
+        )
+    {
+        require(
+            _in.length <= 9,
+            "Invalid RLP uint64 value."
+        );
+
+        return uint64(readUint256(_in));
+    }
+
+    /**
+     * Reads an RLP uint64 value into a uint64.
+     * @param _in RLP uint64 value.
+     * @return Decoded uint64.
+     */
+    function readUint64(
+        bytes memory _in
+    )
+        internal
+        pure
+        returns (
+            uint64
+        )
+    {
+        return readUint64(
+            toRLPItem(_in)
+        );
+    }
+
+    /**
      * Reads an RLP bool value into a bool.
      * @param _in RLP bool value.
      * @return Decoded bool.

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -137,7 +137,6 @@ describe('OVM_ECDSAContractAccount', () => {
 
       // The ovmCALL is the 2nd call because the first call transfers the fee.
       const ovmCALL: any = Mock__OVM_ExecutionManager.smocked.ovmCALL.calls[1]
-      expect(ovmCALL._gasLimit).to.equal(DEFAULT_EIP155_TX.gasLimit)
       expect(ovmCALL._address).to.equal(DEFAULT_EIP155_TX.to)
       expect(ovmCALL._calldata).to.equal(DEFAULT_EIP155_TX.data)
     })

--- a/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager/nuisance-gas.spec.ts
+++ b/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager/nuisance-gas.spec.ts
@@ -188,7 +188,7 @@ const test_nuisanceGas: TestDefinition = {
             // This is because there is natural gas consumption between the ovmCALL(GAS/2) and ovmCREATE, which allots nuisance gas via _getNuisanceGasLimit.
             // This means that the ovmCREATE exception, DOES consumes all nuisance gas allotted, but that allotment
             // is less than the full OVM_TX_GAS_LIMIT / 2 which is alloted to the parent ovmCALL.
-            nuisanceGasLeft: 0x3f9e7f,
+            nuisanceGasLeft: 0x3fa2e8,
           },
         },
       },


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Restricts `nonce` and `gasLimit` transaction fields to uint64. Also restricts the `nonce` field within the account struct to uint64.
