### PR TITLE
fix[contracts]: Remove some old ovmEXTCODECOPY logic

### DIFF
--- a/.changeset/twelve-items-sing.md
+++ b/.changeset/twelve-items-sing.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Remove unused logic in ovmEXTCODECOPY

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -750,7 +750,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         return Lib_EthUtils.getCode(
             _getAccountEthAddress(_contract),
             _offset,
-            length
+            _length
         );
     }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -747,13 +747,6 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
             bytes memory _code
         )
     {
-        // `ovmEXTCODECOPY` is the only overridden opcode capable of producing exactly one byte of
-        // return data. By blocking reads of one byte, we're able to use the condition that an
-        // OVM_ExecutionManager function return value having a length of exactly one byte indicates
-        // an error without an explicit revert. If users were able to read a single byte, they
-        // could forcibly trigger behavior that should only be available to this contract.
-        uint256 length = _length == 1 ? 2 : _length;
-
         return Lib_EthUtils.getCode(
             _getAccountEthAddress(_contract),
             _offset,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes a single line of logic in `ovmEXTCODECOPY` that we don't make use of anymore.