### PR TITLE
contracts: fix build script

### DIFF
--- a/.changeset/two-houses-work.md
+++ b/.changeset/two-houses-work.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Updates the `yarn build` command to not error

--- a/packages/contracts/scripts/build.sh
+++ b/packages/contracts/scripts/build.sh
@@ -1,2 +1,7 @@
-yarn run build:typescript & yarn run build:contracts
-yarn run build:typescript:ovm & yarn run build:contracts:ovm
+#!/bin/bash
+
+set -e
+
+yarn run build:typescript
+yarn run build:contracts
+yarn run build:contracts:ovm

--- a/packages/contracts/scripts/build.sh
+++ b/packages/contracts/scripts/build.sh
@@ -2,6 +2,7 @@
 
 set -e
 
-yarn run build:typescript &
-yarn run build:contracts
-yarn run build:contracts:ovm
+yarn run build:typescript&
+yarn run build:contracts&
+yarn run build:contracts:ovm&
+wait

--- a/packages/contracts/scripts/build.sh
+++ b/packages/contracts/scripts/build.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-yarn run build:typescript
+yarn run build:typescript &
 yarn run build:contracts
 yarn run build:contracts:ovm


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR fixes the script that is called during `yarn build`
- Remove call to `yarn run build:typescript:ovm` which does not exist
- Adds shebang to top of file
- Builds the typescript, contracts and ovm contracts
- Uses `set -e` to fail script execution if any commands exit with non-zero exit code

