### PR TITLE
l2geth: set rlp encoded tx in txmeta in RPC layer

### DIFF
--- a/.changeset/chilly-grapes-greet.md
+++ b/.changeset/chilly-grapes-greet.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Removes the extra setting of the txmeta in the syncservice and instead sets the raw tx in the txmeta at the rpc layer

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1752,8 +1752,8 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	if new(big.Int).Mod(tx.GasPrice(), big.NewInt(1000000)).Cmp(big.NewInt(0)) != 0 {
 		return common.Hash{}, errors.New("Gas price must be a multiple of 1,000,000 wei")
 	}
-	// L1Timestamp and L1BlockNumber will be set by the miner
-	txMeta := types.NewTransactionMeta(nil, 0, nil, types.SighashEIP155, types.QueueOriginSequencer, nil, nil, nil)
+	// L1Timestamp and L1BlockNumber will be set right before execution
+	txMeta := types.NewTransactionMeta(nil, 0, nil, types.SighashEIP155, types.QueueOriginSequencer, nil, nil, encodedTx)
 	tx.SetTransactionMeta(txMeta)
 	return SubmitTransaction(ctx, s.b, tx)
 }

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -743,24 +742,5 @@ func (s *SyncService) ApplyTransaction(tx *types.Transaction) error {
 		tx.SetL1Timestamp(ts)
 		tx.SetL1BlockNumber(bn)
 	}
-
-	// Set the raw transaction data in the meta
-	txRaw, err := rlp.EncodeToBytes(tx)
-	if err != nil {
-		return fmt.Errorf("invalid transaction: %w", err)
-	}
-	meta := tx.GetMeta()
-	newMeta := types.NewTransactionMeta(
-		meta.L1BlockNumber,
-		meta.L1Timestamp,
-		meta.L1MessageSender,
-		meta.SignatureHashType,
-		types.QueueOrigin(meta.QueueOrigin.Uint64()),
-		meta.Index,
-		meta.QueueIndex,
-		txRaw,
-	)
-	tx.SetTransactionMeta(newMeta)
-
 	return s.applyTransaction(tx)
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Sets the raw RLP encoding at the API layer in the `txmeta`
