### PR TITLE
rpc: only allow txs with no calldata when there is value

### DIFF
--- a/.changeset/thirty-radios-sniff.md
+++ b/.changeset/thirty-radios-sniff.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Prevent 0 value transactions with calldata via RPC

--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -320,6 +320,18 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 			if len(signedTx.Data()) > b.MaxCallDataSize {
 				return fmt.Errorf("Calldata cannot be larger than %d, sent %d", b.MaxCallDataSize, len(signedTx.Data()))
 			}
+			// The gas price must be a multiple of a gwei
+			if new(big.Int).Mod(signedTx.GasPrice(), big.NewInt(1e6)).Cmp(common.Big0) != 0 {
+				return errors.New("Gas price must be a multiple of 1,000,000 wei")
+			}
+			// If there is a value field set then reject transactions that
+			// contain calldata. The feature of sending transactions with value
+			// and calldata will be added in the future.
+			if signedTx.Value().Cmp(common.Big0) != 0 {
+				if len(signedTx.Data()) > 0 {
+					return errors.New("Cannot send transactions with value and calldata")
+				}
+			}
 		}
 		return b.eth.syncService.ApplyTransaction(signedTx)
 	}

--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -320,10 +320,6 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 			if len(signedTx.Data()) > b.MaxCallDataSize {
 				return fmt.Errorf("Calldata cannot be larger than %d, sent %d", b.MaxCallDataSize, len(signedTx.Data()))
 			}
-			// The gas price must be a multiple of a gwei
-			if new(big.Int).Mod(signedTx.GasPrice(), big.NewInt(1e6)).Cmp(common.Big0) != 0 {
-				return errors.New("Gas price must be a multiple of 1,000,000 wei")
-			}
 			// If there is a value field set then reject transactions that
 			// contain calldata. The feature of sending transactions with value
 			// and calldata will be added in the future.

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1748,10 +1748,6 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Hash{}, err
 	}
-
-	if new(big.Int).Mod(tx.GasPrice(), big.NewInt(1000000)).Cmp(big.NewInt(0)) != 0 {
-		return common.Hash{}, errors.New("Gas price must be a multiple of 1,000,000 wei")
-	}
 	// L1Timestamp and L1BlockNumber will be set right before execution
 	txMeta := types.NewTransactionMeta(nil, 0, nil, types.SighashEIP155, types.QueueOriginSequencer, nil, nil, encodedTx)
 	tx.SetTransactionMeta(txMeta)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR will prevent transactions via RPC that include a value and calldata. It also moves another Optimism specific check lower into the callstack as to make the diff more controlled
