### PR TITLE
feat(hardhat-ovm): allow overriding the polling interval

### DIFF
--- a/.changeset/chatty-clouds-melt.md
+++ b/.changeset/chatty-clouds-melt.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/hardhat-ovm": minor
+---
+
+allow overriding the ethers polling interval

--- a/packages/hardhat-ovm/package.json
+++ b/packages/hardhat-ovm/package.json
@@ -17,8 +17,11 @@
   "dependencies": {
     "node-fetch": "^2.6.1"
   },
-  "devDependencies": {
-    "@types/mocha": "^8.2.2",
+  "peerDependencies": {
+    "ethers": "^5.1.4",
     "hardhat": "^2.1.2"
+  },
+  "devDependencies": {
+    "@types/mocha": "^8.2.2"
   }
 }

--- a/packages/hardhat-ovm/src/type-extensions.ts
+++ b/packages/hardhat-ovm/src/type-extensions.ts
@@ -26,11 +26,13 @@ declare module 'hardhat/types/config' {
   interface HardhatNetworkConfig {
     ovm: boolean
     ignoreRxList: string[]
+    interval?: number
   }
 
   interface HttpNetworkConfig {
     ovm: boolean
     ignoreRxList: string[]
+    interval?: number
   }
 }
 


### PR DESCRIPTION
Ethers by default uses a polling interval of [4s](https://github.com/ethers-io/ethers.js/blob/3b1d3fcee6bfb5178861e26ff1a1e9daa0663ec9/packages/providers/src.ts/base-provider.ts#L513 for its asynchronous promises runner. This is too long when used with the Optimistic Ethereum stack.

In order to override that setting, we can set the `provider.pollingInterval` to a smaller value, allowing us to reduce the total time wasted when sleeping.

The interval now defaults to 50ms, which should make running the OVM tests smooth. If you want
to run tests against a remote node and do not want to overwhelm it, you can set the parameter in the hardhat config's network, e.g.

```
networks: {
  kovan: {
    ...
   interval: 4000,
  }

}
```