### PR TITLE
fix(contracts): do not build ovm and contracts concurrently

### DIFF
--- a/packages/contracts/scripts/build.sh
+++ b/packages/contracts/scripts/build.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-yarn run build:typescript&
-yarn run build:contracts&
-yarn run build:contracts:ovm&
+yarn build:typescript &
+yarn build:contracts &
+yarn build:contracts:ovm
+
 wait


### PR DESCRIPTION
there's a race condition somewhere in hardhat which does not generate the artifacts
in the correct directory sometimes, causing our tests to fail with 'artifact not found'

This issue was introduced in https://github.com/ethereum-optimism/optimism/pull/642