### PR TITLE
core-utils: no metrics when in browser environment

### DIFF
--- a/packages/core-utils/src/base-service.ts
+++ b/packages/core-utils/src/base-service.ts
@@ -26,7 +26,10 @@ export class BaseService<T> {
     this.name = name
     this.options = mergeDefaultOptions(options, optionSettings)
     this.logger = new Logger({ name })
-    this.metrics = new Metrics({ prefix: name })
+
+    if (typeof window === 'undefined') {
+      this.metrics = new Metrics({ prefix: name })
+    }
   }
 
   /**


### PR DESCRIPTION
prom-client (prometheus) is a new dependency of core-utils, but it doesn't work in browsers. This should make it so we can use core-utils as a dependency in frontends.