### PR TITLE
ci: always run all tests

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -54,7 +54,7 @@ jobs:
         run: yarn build
 
       - name: Test
-        run: yarn test:ci
+        run: yarn test
         env:
           FORCE_COLOR: 1
           ENABLE_GAS_REPORT: 1
@@ -89,4 +89,4 @@ jobs:
         run: yarn install
 
       - name: Lint
-        run: yarn lint:ci
+        run: yarn lint

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "clean": "yarn lerna run clean",
     "build": "yarn lerna run build",
     "test": "yarn lerna run test --parallel",
-    "test:ci": "yarn lerna run test --parallel --since origin/master",
     "lint": "yarn lerna run lint",
-    "lint:ci": "yarn lerna run lint  --parallel --since origin/master",
     "lint:fix": "yarn lerna run lint:fix",
     "postinstall": "patch-package",
     "release": "yarn build && yarn changeset publish"


### PR DESCRIPTION
Using the `--since master` flag has been a gigantic footgun. I think it's better to just run all unit tests on CI, they're pretty fast anyway.