### PR TITLE
feat: add node_env to batch submitter

### DIFF
--- a/packages/batch-submitter/.env.example
+++ b/packages/batch-submitter/.env.example
@@ -1,3 +1,5 @@
+# Environment
+NODE_ENV=development
 # Logging & monitoring
 DEBUG=info*,error*,warn*,debug*
 # Leave the SENTRY_DSN variable unset during local development

--- a/packages/batch-submitter/.env.example
+++ b/packages/batch-submitter/.env.example
@@ -1,9 +1,12 @@
 # Environment
 NODE_ENV=development
+# Leave blank during local development
+ETH_NETWORK=
 # Logging & monitoring
 DEBUG=info*,error*,warn*,debug*
 # Leave the SENTRY_DSN variable unset during local development
 SENTRY_DSN=
+SENTRY_TRACE_RATE=
 
 L1_NODE_WEB3_URL=http://localhost:9545
 L2_NODE_WEB3_URL=http://localhost:8545

--- a/packages/batch-submitter/.env.example
+++ b/packages/batch-submitter/.env.example
@@ -1,7 +1,7 @@
 # Environment
 NODE_ENV=development
 # Leave blank during local development
-ETH_NETWORK=
+ETH_NETWORK_NAME=
 # Logging & monitoring
 DEBUG=info*,error*,warn*,debug*
 # Leave the SENTRY_DSN variable unset during local development

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -40,7 +40,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
     maxGasPriceInGwei: number,
     gasRetryIncrement: number,
     gasThresholdInGwei: number,
-    log: Logger,
+    logger: Logger,
     metrics: Metrics,
     fraudSubmissionAddress: string
   ) {
@@ -60,7 +60,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       maxGasPriceInGwei,
       gasRetryIncrement,
       gasThresholdInGwei,
-      log,
+      logger,
       metrics
     )
     this.fraudSubmissionAddress = fraudSubmissionAddress
@@ -73,7 +73,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
   public async _updateChainInfo(): Promise<void> {
     const info: RollupInfo = await this._getRollupInfo()
     if (info.mode === 'verifier') {
-      this.log.error(
+      this.logger.error(
         'Verifier mode enabled! Batch submitter only compatible with sequencer mode'
       )
       process.exit(1)
@@ -88,7 +88,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       sccAddress === this.chainContract.address &&
       ctcAddress === this.ctcContract.address
     ) {
-      this.log.debug('Chain contract already initialized', {
+      this.logger.debug('Chain contract already initialized', {
         sccAddress,
         ctcAddress,
       })
@@ -102,7 +102,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       await getContractFactory('OVM_CanonicalTransactionChain', this.signer)
     ).attach(ctcAddress)
 
-    this.log.info('Connected Optimism contracts', {
+    this.logger.info('Connected Optimism contracts', {
       stateCommitmentChain: this.chainContract.address,
       canonicalTransactionChain: this.ctcContract.address,
     })
@@ -110,23 +110,23 @@ export class StateBatchSubmitter extends BatchSubmitter {
   }
 
   public async _onSync(): Promise<TransactionReceipt> {
-    this.log.info('Syncing mode enabled! Skipping state batch submission...')
+    this.logger.info('Syncing mode enabled! Skipping state batch submission...')
     return
   }
 
   public async _getBatchStartAndEnd(): Promise<Range> {
-    this.log.info('Getting batch start and end for state batch submitter...')
+    this.logger.info('Getting batch start and end for state batch submitter...')
     // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
     const startBlock: number =
       (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET
-    this.log.info('Retrieved start block number from SCC', {
+    this.logger.info('Retrieved start block number from SCC', {
       startBlock,
     })
 
     // We will submit state roots for txs which have been in the tx chain for a while.
     const totalElements: number =
       (await this.ctcContract.getTotalElements()).toNumber() + BLOCK_OFFSET
-    this.log.info('Retrieved total elements from CTC', {
+    this.logger.info('Retrieved total elements from CTC', {
       totalElements,
     })
 
@@ -137,11 +137,11 @@ export class StateBatchSubmitter extends BatchSubmitter {
 
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
-        this.log.error(
+        this.logger.error(
           'State commitment chain is larger than transaction chain. This should never happen!'
         )
       }
-      this.log.info(
+      this.logger.info(
         'No state commitments to submit. Skipping batch submission...'
       )
       return
@@ -162,7 +162,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       [batch, startBlock]
     )
     const batchSizeInBytes = remove0x(tx).length / 2
-    this.log.debug('State batch generated', {
+    this.logger.debug('State batch generated', {
       batchSizeInBytes,
       tx,
     })
@@ -172,7 +172,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
     }
 
     const offsetStartsAtIndex = startBlock - BLOCK_OFFSET // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
-    this.log.debug('Submitting batch.', { tx })
+    this.logger.debug('Submitting batch.', { tx })
 
     const nonce = await this.signer.getTransactionCount()
     const contractFunction = async (gasPrice): Promise<TransactionReceipt> => {
@@ -181,7 +181,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
         offsetStartsAtIndex,
         { nonce, gasPrice }
       )
-      this.log.info('Submitted appendStateBatch transaction', {
+      this.logger.info('Submitted appendStateBatch transaction', {
         nonce,
         txHash: contractTx.hash,
         contractAddr: this.chainContract.address,
@@ -208,13 +208,15 @@ export class StateBatchSubmitter extends BatchSubmitter {
     const batch: Bytes32[] = await bPromise.map(
       [...Array(blockRange).keys()],
       async (i: number) => {
-        this.log.debug('Fetching L2BatchElement', { blockNo: startBlock + i })
+        this.logger.debug('Fetching L2BatchElement', {
+          blockNo: startBlock + i,
+        })
         const block = (await this.l2Provider.getBlockWithTransactions(
           startBlock + i
         )) as L2Block
         const blockTx = block.transactions[0]
         if (blockTx.from === this.fraudSubmissionAddress) {
-          this.log.warn('Found transaction from fraud submission address', {
+          this.logger.warn('Found transaction from fraud submission address', {
             txHash: blockTx.hash,
             fraudSubmissionAddress: this.fraudSubmissionAddress,
           })
@@ -232,7 +234,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
     )
     while (remove0x(tx).length / 2 > this.maxTxSize) {
       batch.splice(Math.ceil((batch.length * 2) / 3)) // Delete 1/3rd of all of the batch elements
-      this.log.debug('Splicing batch...', {
+      this.logger.debug('Splicing batch...', {
         batchSizeInBytes: tx.length / 2,
       })
       tx = this.chainContract.interface.encodeFunctionData('appendStateBatch', [
@@ -241,7 +243,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       ])
     }
 
-    this.log.info('Generated state commitment batch', {
+    this.logger.info('Generated state commitment batch', {
       batch, // list of stateRoots
     })
     return batch

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -186,6 +186,8 @@ export class StateBatchSubmitter extends BatchSubmitter {
         txHash: contractTx.hash,
         contractAddr: this.chainContract.address,
         from: contractTx.from,
+      })
+      this.logger.debug('appendStateBatch transaction data', {
         data: contractTx.data,
       })
       return this.signer.provider.waitForTransaction(

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -148,6 +148,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
             txHash: tx.hash,
             contractAddr: this.chainContract.address,
             from: tx.from,
+          })
+          this.logger.debug('appendQueueBatch transaction data', {
             data: tx.data,
           })
           return this.signer.provider.waitForTransaction(
@@ -252,6 +254,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         txHash: tx.hash,
         contractAddr: this.chainContract.address,
         from: tx.from,
+      })
+      this.logger.debug('appendSequencerBatch transaction data', {
         data: tx.data,
       })
       return this.signer.provider.waitForTransaction(

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -50,7 +50,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     maxGasPriceInGwei: number,
     gasRetryIncrement: number,
     gasThresholdInGwei: number,
-    log: Logger,
+    logger: Logger,
     metrics: Metrics,
     disableQueueBatchAppend: boolean,
     autoFixBatchOptions: AutoFixBatchOptions = {
@@ -74,7 +74,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       maxGasPriceInGwei,
       gasRetryIncrement,
       gasThresholdInGwei,
-      log,
+      logger,
       metrics
     )
     this.disableQueueBatchAppend = disableQueueBatchAppend
@@ -88,7 +88,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   public async _updateChainInfo(): Promise<void> {
     const info: RollupInfo = await this._getRollupInfo()
     if (info.mode === 'verifier') {
-      this.log.error(
+      this.logger.error(
         'Verifier mode enabled! Batch submitter only compatible with sequencer mode'
       )
       process.exit(1)
@@ -101,7 +101,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       typeof this.chainContract !== 'undefined' &&
       ctcAddress === this.chainContract.address
     ) {
-      this.log.debug('Chain contract already initialized', {
+      this.logger.debug('Chain contract already initialized', {
         ctcAddress,
       })
       return
@@ -116,7 +116,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       getContractInterface('OVM_CanonicalTransactionChain'),
       this.signer
     )
-    this.log.info('Initialized new CTC', {
+    this.logger.info('Initialized new CTC', {
       address: this.chainContract.address,
     })
     return
@@ -124,12 +124,12 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   public async _onSync(): Promise<TransactionReceipt> {
     const pendingQueueElements = await this.chainContract.getNumPendingQueueElements()
-    this.log.debug('Got number of pending queue elements', {
+    this.logger.debug('Got number of pending queue elements', {
       pendingQueueElements,
     })
 
     if (pendingQueueElements !== 0) {
-      this.log.info(
+      this.logger.info(
         'Syncing mode enabled! Skipping batch submission and clearing queue elements',
         { pendingQueueElements }
       )
@@ -143,7 +143,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
             nonce,
             gasPrice,
           })
-          this.log.info('Submitted appendQueueBatch transaction', {
+          this.logger.info('Submitted appendQueueBatch transaction', {
             nonce,
             txHash: tx.hash,
             contractAddr: this.chainContract.address,
@@ -160,18 +160,18 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         return this._submitAndLogTx(contractFunction, 'Cleared queue!')
       }
     }
-    this.log.info('Syncing mode enabled but queue is empty. Skipping...')
+    this.logger.info('Syncing mode enabled but queue is empty. Skipping...')
     return
   }
 
   public async _getBatchStartAndEnd(): Promise<Range> {
-    this.log.info(
+    this.logger.info(
       'Getting batch start and end for transaction batch submitter...'
     )
     // TODO: Remove BLOCK_OFFSET by adding a tx to Geth's genesis
     const startBlock =
       (await this.chainContract.getTotalElements()).toNumber() + BLOCK_OFFSET
-    this.log.info('Retrieved start block number from CTC', {
+    this.logger.info('Retrieved start block number from CTC', {
       startBlock,
     })
 
@@ -180,17 +180,17 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         startBlock + this.maxBatchSize,
         await this.l2Provider.getBlockNumber()
       ) + 1 // +1 because the `endBlock` is *exclusive*
-    this.log.info('Retrieved end block number from L2 sequencer', {
+    this.logger.info('Retrieved end block number from L2 sequencer', {
       endBlock,
     })
 
     if (startBlock >= endBlock) {
       if (startBlock > endBlock) {
-        this.log
+        this.logger
           .error(`More chain elements in L1 (${startBlock}) than in the L2 node (${endBlock}).
                    This shouldn't happen because we don't submit batches if the sequencer is syncing.`)
       }
-      this.log.info('No txs to submit. Skipping batch submission...')
+      this.logger.info('No txs to submit. Skipping batch submission...')
       return
     }
     return {
@@ -209,7 +209,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       10
     )
     if (gasPriceInGwei > this.gasThresholdInGwei) {
-      this.log.warn(
+      this.logger.warn(
         'Gas price is higher than gas price threshold; aborting batch submission',
         {
           gasPriceInGwei,
@@ -224,7 +224,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       wasBatchTruncated,
     ] = await this._generateSequencerBatchParams(startBlock, endBlock)
     const batchSizeInBytes = encodeAppendSequencerBatch(batchParams).length / 2
-    this.log.debug('Sequencer batch generated', {
+    this.logger.debug('Sequencer batch generated', {
       batchSizeInBytes,
     })
 
@@ -236,7 +236,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       return
     }
     const l1tipHeight = await this.signer.provider.getBlockNumber()
-    this.log.debug('Submitting batch.', {
+    this.logger.debug('Submitting batch.', {
       calldata: batchParams,
       l1tipHeight,
     })
@@ -247,7 +247,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         nonce,
         gasPrice,
       })
-      this.log.info('Submitted appendSequencerBatch transaction', {
+      this.logger.info('Submitted appendSequencerBatch transaction', {
         nonce,
         txHash: tx.hash,
         contractAddr: this.chainContract.address,
@@ -275,7 +275,9 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     let batch: Batch = await bPromise.map(
       [...Array(blockRange).keys()],
       (i) => {
-        this.log.debug('Fetching L2BatchElement', { blockNo: startBlock + i })
+        this.logger.debug('Fetching L2BatchElement', {
+          blockNo: startBlock + i,
+        })
         return this._getL2BatchElement(startBlock + i)
       },
       { concurrency: 100 }
@@ -284,7 +286,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     // Fix our batches if we are configured to. TODO: Remove this.
     batch = await this._fixBatch(batch)
     if (!(await this._validateBatch(batch))) {
-      this.log.error('Batch is malformed! Cannot submit next batch!')
+      this.logger.error('Batch is malformed! Cannot submit next batch!')
       throw new Error('Batch is malformed! Cannot submit next batch!')
     }
     let sequencerBatchParams = await this._getSequencerBatchParams(
@@ -294,7 +296,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     let wasBatchTruncated = false
     let encoded = encodeAppendSequencerBatch(sequencerBatchParams)
     while (encoded.length / 2 > this.maxTxSize) {
-      this.log.debug('Splicing batch...', {
+      this.logger.debug('Splicing batch...', {
         batchSizeInBytes: encoded.length / 2,
       })
       batch.splice(Math.ceil((batch.length * 2) / 3)) // Delete 1/3rd of all of the batch elements
@@ -309,7 +311,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       wasBatchTruncated = true
     }
 
-    this.log.info('Generated sequencer batch params', {
+    this.logger.info('Generated sequencer batch params', {
       contexts: sequencerBatchParams.contexts,
       transactions: sequencerBatchParams.transactions,
       wasBatchTruncated,
@@ -324,9 +326,9 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     // Verify all of the queue elements are what we expect
     let nextQueueIndex = await this.chainContract.getNextQueueIndex()
     for (const ele of batch) {
-      this.log.debug('Verifying batch element', { ele })
+      this.logger.debug('Verifying batch element', { ele })
       if (!ele.isSequencerTx) {
-        this.log.debug('Checking queue equality against L1 queue index', {
+        this.logger.debug('Checking queue equality against L1 queue index', {
           nextQueueIndex,
         })
         if (!(await this._doesQueueElementMatchL1(nextQueueIndex, ele))) {
@@ -341,11 +343,13 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     let lastBlockNumber: number
     for (const ele of batch) {
       if (ele.timestamp < lastTimestamp) {
-        this.log.error('Timestamp monotonicity violated! Element', { ele })
+        this.logger.error('Timestamp monotonicity violated! Element', { ele })
         return false
       }
       if (ele.blockNumber < lastBlockNumber) {
-        this.log.error('Block Number monotonicity violated! Element', { ele })
+        this.logger.error('Block Number monotonicity violated! Element', {
+          ele,
+        })
         return false
       }
       lastTimestamp = ele.timestamp
@@ -359,7 +363,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     queueElement: BatchElement
   ): Promise<boolean> {
     const logEqualityError = (name, index, expected, got) => {
-      this.log.error('Observed mismatched values', {
+      this.logger.error('Observed mismatched values', {
         index,
         expected,
         got,
@@ -410,7 +414,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       for (const ele of b) {
         if (!ele.isSequencerTx) {
           if (!(await this._doesQueueElementMatchL1(nextQueueIndex, ele))) {
-            this.log.warn('Fixing double played queue element.', {
+            this.logger.warn('Fixing double played queue element.', {
               nextQueueIndex,
             })
             fixedBatch.push(await this._fixQueueElement(nextQueueIndex, ele))
@@ -425,7 +429,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
     // TODO: Remove this super complex logic and rely on Geth to actually supply correct block data.
     const fixMonotonicity = async (b: Batch): Promise<Batch> => {
-      this.log.debug('Fixing monotonicity...')
+      this.logger.debug('Fixing monotonicity...')
       // The earliest allowed timestamp/blockNumber is the last timestamp submitted on chain.
       const {
         lastTimestamp,
@@ -433,7 +437,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       } = await this._getLastTimestampAndBlockNumber()
       let earliestTimestamp = lastTimestamp
       let earliestBlockNumber = lastBlockNumber
-      this.log.debug('Determined earliest timestamp and blockNumber', {
+      this.logger.debug('Determined earliest timestamp and blockNumber', {
         earliestTimestamp,
         earliestBlockNumber,
       })
@@ -466,7 +470,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       }
       // Actually update the latest timestamp and block number
       await updateLatestTimestampAndBlockNumber()
-      this.log.debug('Determined latest timestamp and blockNumber', {
+      this.logger.debug('Determined latest timestamp and blockNumber', {
         latestTimestamp,
         latestBlockNumber,
       })
@@ -488,7 +492,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
           ele.timestamp < earliestTimestamp ||
           ele.blockNumber < earliestBlockNumber
         ) {
-          this.log.error('Fixing timestamp/blockNumber too small', {
+          this.logger.error('Fixing timestamp/blockNumber too small', {
             oldTimestamp: ele.timestamp,
             newTimestamp: earliestTimestamp,
             oldBlockNumber: ele.blockNumber,
@@ -506,7 +510,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
           ele.timestamp > latestTimestamp ||
           ele.blockNumber > latestBlockNumber
         ) {
-          this.log.error('Fixing timestamp/blockNumber too large.', {
+          this.logger.error('Fixing timestamp/blockNumber too large.', {
             oldTimestamp: ele.timestamp,
             newTimestamp: latestTimestamp,
             oldBlockNumber: ele.blockNumber,
@@ -563,7 +567,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     const nextQueueIndex = meta.slice(-20, -10)
     const lastTimestamp = parseInt(meta.slice(-30, -20), 16)
     const lastBlockNumber = parseInt(meta.slice(-40, -30), 16)
-    this.log.debug('Retrieved timestamp and block number from CTC', {
+    this.logger.debug('Retrieved timestamp and block number from CTC', {
       lastTimestamp,
       lastBlockNumber,
     })
@@ -585,7 +589,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       timestamp > queueElement.timestamp &&
       blockNumber > queueElement.blockNumber
     ) {
-      this.log.warn(
+      this.logger.warn(
         'Double deposit detected. Fixing by skipping the deposit & replacing with a dummy tx.',
         {
           timestamp,
@@ -607,7 +611,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       timestamp < queueElement.timestamp &&
       blockNumber < queueElement.blockNumber
     ) {
-      this.log.error('A deposit seems to have been skipped!')
+      this.logger.error('A deposit seems to have been skipped!')
       throw new Error('Skipped deposit?!')
     }
     throw new Error('Unable to fix queue element!')
@@ -691,7 +695,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   private async _getL2BatchElement(blockNumber: number): Promise<BatchElement> {
     const block = await this._getBlock(blockNumber)
-    this.log.debug('Fetched L2 block', {
+    this.logger.debug('Fetched L2 block', {
       block,
     })
 

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -17,7 +17,7 @@ import {
 } from '..'
 
 const environment = process.env.NODE_ENV
-const network = process.env.ETH_NETWORK
+const network = process.env.ETH_NETWORK_NAME
 const release = `batch-submitter@${process.env.npm_package_version}`
 
 /* Logger */

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -236,6 +236,8 @@ export const run = async () => {
               txHash: response.hash,
               to: response.to,
               from: response.from,
+            })
+            logger.debug('empty transaction data', {
               data: response.data,
             })
             await sequencerSigner.provider.waitForTransaction(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Our services currently run without knowing their environment, which adds extra overhead to how we distinguish errors and metrics between mainnet, kovan, and soon goerli. This PR adds `NODE_ENV` and `ETH_NETWORK` to the batch submitter and the related logic for Sentry and prom-client, so we can distinguish between local dev and deployments.

**Additional context**
I plan to make an equivalent PR for the data transport layer, but that requires a bigger refactor related to service-base so want to get this reviewed first.

**Metadata**
- https://github.com/ethereum-optimism/optimism/issues/491
