### PR TITLE
build: fix wrongly named prettier config file in integration-tests

### DIFF
--- a/integration-tests/.prettierrc.json
+++ b/integration-tests/.prettierrc.json
@@ -1,0 +1,1 @@
+../.prettierrc.json

--- a/integration-tests/prettier-config.json
+++ b/integration-tests/prettier-config.json
@@ -1,1 +1,0 @@
-../prettier-config.json


### PR DESCRIPTION
Seems to have been missed in #649
