### PR TITLE
ops: docker-compose builder scale 0

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -6,6 +6,7 @@ services:
   # base service builder
   builder:
     image: ethereumoptimism/builder
+    scale: 0
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.monorepo


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR sets `builder.scale` to `0` so that it doesn't start with `docker-compose up`. This is useful for the command:

```bash
$ docker-compose up --abort-on-container-exit
```

This will allow for quicker debugging when it comes to https://github.com/ethereum-optimism/optimism/issues/570. As soon as one of the containers fails, it will exit the entire command
