### PR TITLE
dtlL fix syncing off by one

### DIFF
--- a/.changeset/blue-needles-clap.md
+++ b/.changeset/blue-needles-clap.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/data-transport-layer": patch
+---
+
+Account for the off by one with regards to the l2geth block number and the CTC index

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -189,7 +189,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
             break
           case 'l2':
             currentL2Block = await this.state.db.getLatestUnconfirmedTransaction()
-            highestL2BlockNumber = await this.state.db.getHighestSyncedUnconfirmedBlock()
+            highestL2BlockNumber = (await this.state.db.getHighestSyncedUnconfirmedBlock()) - 1
             break
           default:
             throw new Error(`Unknown transaction backend ${backend}`)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes an off by one error in the DTL that prevents a replica from syncing. The replica will always think that the DTL is syncing due to an off by one with the block number that the transaction is in when indexed in L2geth vs the index of the transaction in the canonical transaction chain. The genesis block is not batch submitted which makes the CTC index 1 less than the corresponding index in L2geth. There is a single transaction per block in L2geth meaning that the blocknumber can reliably correspond to the CTC index if the off by one is taken into account

