### PR TITLE
fix: ensure hardhat does not fail if no input sources provided

### DIFF
--- a/.changeset/olive-fishes-share.md
+++ b/.changeset/olive-fishes-share.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-ovm': patch
+---
+
+Ensure hardhat does not fail if no input sources provided

--- a/packages/hardhat-ovm/src/index.ts
+++ b/packages/hardhat-ovm/src/index.ts
@@ -161,6 +161,8 @@ subtask(
       }
     }
 
+    if (Object.keys(ovmInput.sources).length === 0) return {};
+
     // Build both inputs separately.
     const ovmOutput = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {
       input: ovmInput,

--- a/packages/hardhat-ovm/src/index.ts
+++ b/packages/hardhat-ovm/src/index.ts
@@ -161,7 +161,7 @@ subtask(
       }
     }
 
-    if (Object.keys(ovmInput.sources).length === 0) return {};
+    if (Object.keys(ovmInput.sources).length === 0) return {}
 
     // Build both inputs separately.
     const ovmOutput = await hre.run(TASK_COMPILE_SOLIDITY_RUN_SOLCJS, {


### PR DESCRIPTION
Implementing proposed fix from https://github.com/ethereum-optimism/optimism/issues/674.
