### PR TITLE
Revert "ops: docker-compose builder scale 0"

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -6,7 +6,6 @@ services:
   # base service builder
   builder:
     image: ethereumoptimism/builder
-    scale: 0
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.monorepo


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#680 since it is not supported in `docker-compose` v3 #692 