### PR TITLE
feat[dtl]: add endpoint metrics

### DIFF
--- a/.changeset/famous-dragons-eat.md
+++ b/.changeset/famous-dragons-eat.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+add metrics to measure http endpoint latency

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -19,9 +19,9 @@
     "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
+    "@eth-optimism/common-ts": "^0.0.1",
     "@eth-optimism/contracts": "^0.2.8",
     "@eth-optimism/core-utils": "^0.3.2",
-    "@eth-optimism/common-ts": "^0.0.1",
     "@ethersproject/providers": "^5.0.21",
     "@sentry/node": "^6.3.1",
     "@sentry/tracing": "^6.3.1",
@@ -32,6 +32,7 @@
     "dotenv": "^8.2.0",
     "ethers": "^5.0.26",
     "express": "^4.17.1",
+    "express-prom-bundle": "^6.3.6",
     "level": "^6.0.1",
     "levelup": "^4.4.0",
     "node-fetch": "^2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6068,6 +6068,14 @@ expand-template@^2.0.3:
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
+express-prom-bundle@^6.3.6:
+  version "6.3.6"
+  resolved "https://registry.yarnpkg.com/express-prom-bundle/-/express-prom-bundle-6.3.6.tgz#c8da1c1024edfcc54953c365991aca57ffd0cfda"
+  integrity sha512-IRsTRCEKCVCHEriQlZ1FuutjEFc89KASsveXh+1HcGEnuZKiAC4LugxrsGEIdySqYvqOYSr2SWHJ6L8/BK2SHA==
+  dependencies:
+    on-finished "^2.3.0"
+    url-value-parser "^2.0.0"
+
 express@^4.14.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -9933,7 +9941,7 @@ oboe@2.1.4:
     ethers "5.0.0"
     ganache-core "^2.12.1"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
@@ -13081,6 +13089,11 @@ url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
   integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
+
+url-value-parser@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/url-value-parser/-/url-value-parser-2.0.3.tgz#cd4b8d6754e458d65e8125260c09718d926e6e21"
+  integrity sha512-FjIX+Q9lYmDM9uYIGdMYfQW0uLbWVwN2NrL2ayAI7BTOvEwzH+VoDdNquwB9h4dFAx+u6mb0ONLa3sHD5DvyvA==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Add prom bundle to measure http endpoint latency metrics in the DTL. 

**Additional context**
The issue originally also planned to add a counter to a legacy endpoint, but that PR has been closed: https://github.com/ethereum-optimism/optimism/pull/567#discussion_r618905970 I can patch this up if this will be in the release candidate.

**Metadata**
https://github.com/ethereum-optimism/optimism/issues/636
