### PR TITLE
build: change test script name to avoid wrongly considered unit tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,21 +56,21 @@ jobs:
         working-directory: ./examples/hardhat
         run: |
           yarn deploy
-          yarn test
+          yarn test:integration
 
       - name: Test & deploy hardhat-example on Optimism
         working-directory: ./examples/hardhat
         run: |
           yarn deploy:ovm
-          yarn test:ovm
+          yarn test:integration:ovm
 
       - name: Test & deploy waffle-example on waffle (regression)
         working-directory: ./examples/waffle
         run: |
           yarn compile
-          yarn test
+          yarn test:integration
       - name: Test & deploy waffle-example on Optimism
         working-directory: ./examples/waffle
         run: |
           yarn compile:ovm
-          yarn test:ovm
+          yarn test:integration:ovm

--- a/examples/hardhat/package.json
+++ b/examples/hardhat/package.json
@@ -9,8 +9,8 @@
     "deploy:ovm": "hardhat deploy --network optimism",
     "compile": "hardhat compile",
     "compile:ovm": "hardhat compile --network optimism",
-    "test": "hardhat test",
-    "test:ovm": "hardhat test --network optimism",
+    "test:integration": "hardhat test",
+    "test:integration:ovm": "hardhat test --network optimism",
     "clean": "rimraf ./cache-ovm ./cache ./artifacts-ovm ./artifacts ./deployments"
   },
   "devDependencies": {

--- a/examples/waffle/package.json
+++ b/examples/waffle/package.json
@@ -6,8 +6,8 @@
     "clean": "rimraf build",
     "compile": "waffle",
     "compile:ovm": "waffle waffle-ovm.json",
-    "test": "mocha 'test/*.spec.js' --timeout 10000",
-    "test:ovm": "TARGET=OVM mocha 'test/*.spec.js' --timeout 50000"
+    "test:integration": "mocha 'test/*.spec.js' --timeout 10000",
+    "test:integration:ovm": "TARGET=OVM mocha 'test/*.spec.js' --timeout 50000"
   },
   "keywords": [
     "optimism",


### PR DESCRIPTION
Annoying an entire folder without removing it from the workspace is frustrating if the names of the `package.json` packages do not equal the name of packages. We could do something like [what is proposed in this thread](https://github.com/lerna/lerna/issues/1370) i.e.,

```bash
lerna run yarn --scope={$(ls ./packages | xargs echo | sed 's/ /,/g')}
```

But `ls` doesn't work.

A short-term fix is to rename the `test` command. This makes it more explicit what the test is (i.e., integration) and is a simple fix.

Fixes https://github.com/ethereum-optimism/optimism/issues/702
