### PR TITLE
build: add --fail and --show-error to usage of curl for awaiting service readiness

### DIFF
--- a/ops/scripts/batches.sh
+++ b/ops/scripts/batches.sh
@@ -3,13 +3,15 @@ RETRIES=${RETRIES:-40}
 
 if [[ ! -z "$URL" ]]; then
     # get the addrs from the URL provided
-    ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+    ADDRESSES=$(curl --fail --show-error --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
     # set the env
     export ADDRESS_MANAGER_ADDRESS=$(echo $ADDRESSES | jq -r '.AddressManager')
 fi
 
 # waits for l2geth to be up
-curl --silent \
+curl --fail \
+    --show-error \
+    --silent \
     --retry-connrefused \
     --retry $RETRIES \
     --retry-delay 1 \

--- a/ops/scripts/deployer.sh
+++ b/ops/scripts/deployer.sh
@@ -6,6 +6,8 @@ JSON='{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}'
 
 # wait for the base layer to be up
 curl \
+    --fail \
+    --show-error \
     --silent \
     -H "Content-Type: application/json" \
     --retry-connrefused \

--- a/ops/scripts/dtl.sh
+++ b/ops/scripts/dtl.sh
@@ -3,7 +3,7 @@ RETRIES=${RETRIES:-60}
 
 if [[ ! -z "$URL" ]]; then
     # get the addrs from the URL provided
-    ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+    ADDRESSES=$(curl --fail --show-error --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
     # set the env
     export DATA_TRANSPORT_LAYER__ADDRESS_MANAGER=$(echo $ADDRESSES | jq -r '.AddressManager')
 fi

--- a/ops/scripts/geth.sh
+++ b/ops/scripts/geth.sh
@@ -4,7 +4,7 @@ VERBOSITY=${VERBOSITY:-6}
 
 if [[ ! -z "$URL" ]]; then
     # get the addrs from the URL provided
-    ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+    ADDRESSES=$(curl --fail --show-error --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
 
     function envSet() {
         VAR=$1
@@ -25,6 +25,8 @@ fi
 
 # wait for the dtl to be up, else geth will crash if it cannot connect
 curl \
+    --fail \
+    --show-error \
     --silent \
     --output /dev/null \
     --retry-connrefused \

--- a/ops/scripts/relayer.sh
+++ b/ops/scripts/relayer.sh
@@ -3,13 +3,15 @@ RETRIES=${RETRIES:-60}
 
 if [[ ! -z "$URL" ]]; then
     # get the addrs from the URL provided
-    ADDRESSES=$(curl --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
+    ADDRESSES=$(curl --fail --show-error --silent --retry-connrefused --retry $RETRIES --retry-delay 5 $URL)
     # set the env
     export ADDRESS_MANAGER_ADDRESS=$(echo $ADDRESSES | jq -r '.AddressManager')
 fi
 
 # waits for l2geth to be up
 curl \
+    --fail \
+    --show-error \
     --silent \
     --output /dev/null \
     --retry-connrefused \


### PR DESCRIPTION
This will help us debug any local issues with Docker failing to correctly wait for the right services and with passing addresses around during local development
