### PR TITLE
l2geth + contracts:  standard interface for systems contracts and userland contracts

### DIFF
--- a/.changeset/great-clouds-call.md
+++ b/.changeset/great-clouds-call.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/l2geth": patch
+---
+
+Return bytes from both ExecutionManager.run and ExecutionManager.simulateMessage and be sure to properly ABI decode the return values and the nested (bool, returndata)

--- a/.changeset/weak-suits-burn.md
+++ b/.changeset/weak-suits-burn.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/contracts": patch
+---
+
+Update ABI of simulateMessage to match run

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -163,7 +163,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         override
         public
         returns (
-            bytes memory
+            bytes memory _returndata
         )
     {
         // Make sure that run() is not re-enterable.  This condition should always be satisfied
@@ -1882,8 +1882,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         external
         returns (
-            bool,
-            bytes memory
+            bytes memory _returndata
         )
     {
         // Prevent this call from having any effect unless in a custom-set VM frame
@@ -1899,18 +1898,19 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         if (isCreate) {
             (address created, bytes memory revertData) = ovmCREATE(_transaction.data);
             if (created == address(0)) {
-                return (false, revertData);
+                return abi.encode(false, revertData);
             } else {
                 // The eth_call RPC endpoint for to = undefined will return the deployed bytecode
                 // in the success case, differing from standard create messages.
-                return (true, Lib_EthUtils.getCode(created));
+                return abi.encode(true, Lib_EthUtils.getCode(created));
             }
         } else {
-            return ovmCALL(
+            (bool success, bytes memory returndata) = ovmCALL(
                 _transaction.gasLimit,
                 _transaction.entrypoint,
                 _transaction.data
             );
+            return abi.encode(success, returndata);
         }
     }
 }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -163,7 +163,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         override
         public
         returns (
-            bytes memory _returndata
+            bytes memory
         )
     {
         // Make sure that run() is not re-enterable.  This condition should always be satisfied
@@ -1882,7 +1882,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     )
         external
         returns (
-            bytes memory _returndata
+            bytes memory
         )
     {
         // Prevent this call from having any effect unless in a custom-set VM frame


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR ABI decodes the results from the EVM execution. Previously we were just slicing bytes, which worked in some cases. Once we started to return different ABIs, the slicing no longer worked. I observed some pretty unexpected results being assigned to `ret` and `success` with just the slicing.

**Additional context**
There have been problems around `eth_estimateGas` failing - I believe this is due to the fact that `simulateMessage()` and `run()` return different ABI encoded types and the parsing was the same for both. This is an attempt to solve the problem once and for all, so that `eth_call` and `eth_estimateGas` are stable and work the same as `eth_sendRawTransaction`

