### PR TITLE
chore: use primary ovm-solc

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -53,7 +53,7 @@ const config: HardhatUserConfig = {
     },
   },
   ovm: {
-    solcVersion: '0.7.6-allow_kall_2', // temporary until we fix the build for 0.7.6
+    solcVersion: '0.7.6',
   },
   typechain: {
     outDir: 'dist/types',


### PR DESCRIPTION
**Description**

Now that we have [merged `kall` support into the mainline compiler](https://github.com/ethereum-optimism/solc-bin/commit/11123332d88c823e8831c5e5ed042f9abc6accab), we can update the funky import.

**Additional context**
I believe that the root cause of all of this was a caching layer in the `builder`.

**Metadata**
- Fixes https://github.com/ethereum-optimism/optimism/issues/675