### PR TITLE
fix: prevent eth sendtransaction

### DIFF
--- a/.changeset/curly-pumas-wait.md
+++ b/.changeset/curly-pumas-wait.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fill in the raw transaction into the txmeta in the `eth_sendTransaction` codepath

--- a/.changeset/kind-plants-tickle.md
+++ b/.changeset/kind-plants-tickle.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Block access to RPCs related to signing transactions

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1654,12 +1654,14 @@ func (args *SendTxArgs) toTransaction() *types.Transaction {
 	}
 	if args.To == nil {
 		tx := types.NewContractCreation(uint64(*args.Nonce), (*big.Int)(args.Value), uint64(*args.Gas), (*big.Int)(args.GasPrice), input)
-		txMeta := types.NewTransactionMeta(args.L1BlockNumber, 0, nil, types.SighashEIP155, types.QueueOriginSequencer, nil, nil, nil)
+		raw, _ := rlp.EncodeToBytes(tx)
+		txMeta := types.NewTransactionMeta(args.L1BlockNumber, 0, nil, types.SighashEIP155, types.QueueOriginSequencer, nil, nil, raw)
 		tx.SetTransactionMeta(txMeta)
 		return tx
 	}
 	tx := types.NewTransaction(uint64(*args.Nonce), *args.To, (*big.Int)(args.Value), uint64(*args.Gas), (*big.Int)(args.GasPrice), input)
-	txMeta := types.NewTransactionMeta(args.L1BlockNumber, 0, args.L1MessageSender, args.SignatureHashType, types.QueueOriginSequencer, nil, nil, nil)
+	raw, _ := rlp.EncodeToBytes(tx)
+	txMeta := types.NewTransactionMeta(args.L1BlockNumber, 0, args.L1MessageSender, args.SignatureHashType, types.QueueOriginSequencer, nil, nil, raw)
 	tx.SetTransactionMeta(txMeta)
 	return tx
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR blocks certain endpoints from being available for users based on the environment variable `USING_OVM`. We need to turn this env var into an actual flag and have it select a `consensus.Engine`, but will leave that for future work. The blocked endpoints are:
- `eth_fillTransaction`
- `eth_sign`
- `eth_sendTransaction`
- `eth_signTransaction`

It also adds in the `txmeta.rawTransaction` field in an additional place where transactions are serialized based on user input. This code path should no longer be reachable because it is behind `eth_sendTransaction`.
