### PR TITLE
ci: break up into multiple jobs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,6 +68,8 @@ jobs:
         working-directory: ./examples/hardhat
         run: |
           yarn
+          yarn compile
+          yarn compile:ovm
 
       - name: Test & deploy hardhat-example on hardhat (regression)
         working-directory: ./examples/hardhat
@@ -85,15 +87,15 @@ jobs:
         working-directory: ./examples/waffle
         run: |
           yarn
+          yarn compile
+          yarn compile:ovm
 
       - name: Test & deploy waffle-example on waffle (regression)
         working-directory: ./examples/waffle
         run: |
-          yarn compile
           yarn test:integration
 
       - name: Test & deploy waffle-example on Optimism
         working-directory: ./examples/waffle
         run: |
-          yarn compile:ovm
           yarn test:integration:ovm

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,7 @@ jobs:
     needs: build
     steps:
       # Monorepo tests
+      - uses: actions/checkout@v2
       - name: Bring the stack up and wait for the sequencer to be ready
         working-directory: ./ops
         run: docker-compose up -d && ./scripts/wait-for-sequencer.sh
@@ -60,6 +61,7 @@ jobs:
     needs: build
     steps:
       # Examples Tests
+      - uses: actions/checkout@v2
       - name: Test & deploy hardhat-example on hardhat (regression)
         working-directory: ./examples/hardhat
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,13 +9,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  integration:
+  build:
     runs-on: ubuntu-latest
     env:
         DOCKER_BUILDKIT: 1
         COMPOSE_DOCKER_CLI_BUILD: 1
     steps:
-      # Monorepo tests
       - uses: actions/checkout@v2
 
       - name: Get yarn cache directory path
@@ -34,6 +33,11 @@ jobs:
         working-directory: ./ops
         run: ./scripts/build-ci.sh
 
+  integration:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Monorepo tests
       - name: Bring the stack up and wait for the sequencer to be ready
         working-directory: ./ops
         run: docker-compose up -d && ./scripts/wait-for-sequencer.sh
@@ -51,6 +55,10 @@ jobs:
       - name: Print gas report
         run: cat integration-tests/gas-report.txt
 
+  examples:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       # Examples Tests
       - name: Test & deploy hardhat-example on hardhat (regression)
         working-directory: ./examples/hardhat

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+
       - name: Build the services
         working-directory: ./ops
         run: ./scripts/build-ci.sh
@@ -62,6 +63,12 @@ jobs:
     steps:
       # Examples Tests
       - uses: actions/checkout@v2
+
+      - name: Install and build hardhat example
+        working-directory: ./examples/hardhat
+        run: |
+          yarn
+
       - name: Test & deploy hardhat-example on hardhat (regression)
         working-directory: ./examples/hardhat
         run: |
@@ -74,11 +81,17 @@ jobs:
           yarn deploy:ovm
           yarn test:integration:ovm
 
+      - name: Install and build hardhat example
+        working-directory: ./examples/waffle
+        run: |
+          yarn
+
       - name: Test & deploy waffle-example on waffle (regression)
         working-directory: ./examples/waffle
         run: |
           yarn compile
           yarn test:integration
+
       - name: Test & deploy waffle-example on Optimism
         working-directory: ./examples/waffle
         run: |


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR breaks the system tests up into multiple Github actions jobs so that they can run in parallel. The build happens first and then the other jobs can start that depend on the build.
