### PR TITLE
build: make erc20 example private

### DIFF
--- a/examples/waffle/package.json
+++ b/examples/waffle/package.json
@@ -20,6 +20,7 @@
     "ERC20",
     "waffle"
   ],
+  "private": true,
   "homepage": "https://github.com/ethereum-optimism/ERC20-Example#readme",
   "license": "MIT",
   "author": "Optimism PBC",


### PR DESCRIPTION
Prevents unnecessary publishing from accidentally happening.
