### PR TITLE
fix(hh-ovm): defaults to 0 gasPrice if none provided

### DIFF
--- a/.changeset/dry-bugs-relax.md
+++ b/.changeset/dry-bugs-relax.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-ovm': patch
+---
+
+default to 0 gasPrice if none provided in the network config

--- a/packages/hardhat-ovm/src/index.ts
+++ b/packages/hardhat-ovm/src/index.ts
@@ -222,8 +222,11 @@ extendEnvironment(async (hre) => {
         (hre as any).ethers.provider.url
       )
       provider.pollingInterval = interval
+
+      // the gas price is overriden to the user provided gasPrice or to 0.
       provider.getGasPrice = async () =>
-        ethers.BigNumber.from(hre.network.config.gasPrice)
+        ethers.BigNumber.from(hre.network.config.gasPrice || 0)
+
       ;(hre as any).ethers.provider = provider
 
       // if the node is up, override the getSigners method's signers


### PR DESCRIPTION
As title, to avoid errors like the one specified [here](https://github.com/ethereum-optimism/optimism/issues/664#issuecomment-831433480).