### PR TITLE
l2geth: docall protect nil block

### DIFF
--- a/.changeset/forty-hotels-brake.md
+++ b/.changeset/forty-hotels-brake.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Protect a possible `nil` reference in `eth_call` when the blockchain is empty

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -937,14 +937,16 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		if err != nil {
 			return nil, 0, false, err
 		}
-		txs := block.Transactions()
-		if header.Number.Uint64() != 0 {
-			if len(txs) != 1 {
-				return nil, 0, false, fmt.Errorf("block %d has more than 1 transaction", header.Number.Uint64())
+		if block != nil {
+			txs := block.Transactions()
+			if header.Number.Uint64() != 0 {
+				if len(txs) != 1 {
+					return nil, 0, false, fmt.Errorf("block %d has more than 1 transaction", header.Number.Uint64())
+				}
+				tx := txs[0]
+				blockNumber = tx.L1BlockNumber()
+				timestamp = new(big.Int).SetUint64(tx.L1Timestamp())
 			}
-			tx := txs[0]
-			blockNumber = tx.L1BlockNumber()
-			timestamp = new(big.Int).SetUint64(tx.L1Timestamp())
 		}
 		msg, err = core.EncodeSimulatedMessage(msg, timestamp, blockNumber, executionManager, stateManager)
 		if err != nil {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Protects a `nil` reference of the block during `eth_call`. This is a problem because some of the L2 EVM context is based on L1 values. In particular the block number and timestamp are not the L2 values but instead are the L1 values. During `eth_call`, the correct block number and timestamp must be set. The current approach reads a historical block from the db and pulls out the timestamp and blocknumber from that block. The L1 timestamp and L1 blocknumber are serialized as part of the `TransactionMeta` in the db.
