### PR TITLE
ci: use correct service name when building integration tests

### DIFF
--- a/ops/scripts/build-ci.sh
+++ b/ops/scripts/build-ci.sh
@@ -1,7 +1,7 @@
 # build in 2 steps
 function build_images() {
     docker-compose build --parallel -- builder l2geth l1_chain
-    docker-compose build --parallel -- deployer dtl batch_submitter relayer integration_test
+    docker-compose build --parallel -- deployer dtl batch_submitter relayer integration_tests
 }
 
 function build_dependencies() {


### PR DESCRIPTION
Fixes typo introduced in #670 