### PR TITLE
Restrict visibilities to external

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -161,7 +161,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         address _ovmStateManager
     )
         override
-        public
+        external
     {
         // Make sure that run() is not re-enterable.  This condition should always be satisfied
         // Once run has been called once, due to the behavior of _isValidInput().
@@ -228,7 +228,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmCALLER()
         override
-        public
+        external
         view
         returns (
             address _CALLER
@@ -258,7 +258,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmTIMESTAMP()
         override
-        public
+        external
         view
         returns (
             uint256 _TIMESTAMP
@@ -273,7 +273,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmNUMBER()
         override
-        public
+        external
         view
         returns (
             uint256 _NUMBER
@@ -288,7 +288,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmGASLIMIT()
         override
-        public
+        external
         view
         returns (
             uint256 _GASLIMIT
@@ -303,7 +303,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmCHAINID()
         override
-        public
+        external
         view
         returns (
             uint256 _CHAINID
@@ -322,7 +322,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmL1QUEUEORIGIN()
         override
-        public
+        external
         view
         returns (
             Lib_OVMCodec.QueueOrigin _queueOrigin
@@ -337,7 +337,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmL1TXORIGIN()
         override
-        public
+        external
         view
         returns (
             address _l1TxOrigin
@@ -417,7 +417,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         bytes32 _salt
     )
         override
-        public
+        external
         notStatic
         fixedGasDiscount(40000)
         returns (
@@ -456,7 +456,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmGETNONCE()
         override
-        public
+        external
         returns (
             uint256 _nonce
         )
@@ -469,7 +469,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
      */
     function ovmINCREMENTNONCE()
         override
-        public
+        external
         notStatic
     {
         address account = ovmADDRESS();
@@ -618,7 +618,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         bytes memory _calldata
     )
         override
-        public
+        external
         fixedGasDiscount(80000)
         returns (
             bool _success,
@@ -653,7 +653,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         bytes memory _calldata
     )
         override
-        public
+        external
         fixedGasDiscount(40000)
         returns (
             bool _success,
@@ -685,7 +685,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         bytes32 _key
     )
         override
-        public
+        external
         netGasCost(40000)
         returns (
             bytes32 _value
@@ -710,7 +710,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         bytes32 _value
     )
         override
-        public
+        external
         notStatic
         netGasCost(60000)
     {
@@ -782,7 +782,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         address _contract
     )
         override
-        public
+        external
         returns (
             bytes32 _EXTCODEHASH
         )

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_DeployerWhitelist.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_DeployerWhitelist.sol
@@ -56,7 +56,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
         bool _allowArbitraryDeployment
     )
         override
-        public
+        external
     {
         if (initialized == true) {
             return;
@@ -77,7 +77,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
         bool _isWhitelisted
     )
         override
-        public
+        external
         onlyOwner
     {
         whitelist[_deployer] = _isWhitelisted;
@@ -116,7 +116,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
      */
     function enableArbitraryContractDeployment()
         override
-        public
+        external
         onlyOwner
     {
         setAllowArbitraryDeployment(true);
@@ -132,7 +132,7 @@ contract OVM_DeployerWhitelist is iOVM_DeployerWhitelist {
         address _deployer
     )
         override
-        public
+        external
         returns (
             bool
         )

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
@@ -132,7 +132,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
      */
     function getPreStateRoot()
         override
-        public
+        external
         view
         returns (
             bytes32 _preStateRoot
@@ -147,7 +147,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
      */
     function getPostStateRoot()
         override
-        public
+        external
         view
         returns (
             bytes32 _postStateRoot
@@ -162,7 +162,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
      */
     function isComplete()
         override
-        public
+        external
         view
         returns (
             bool _complete
@@ -188,7 +188,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
         bytes memory _stateTrieWitness
     )
         override
-        public
+        external
         onlyDuringPhase(TransitionPhase.PRE_EXECUTION)
         contributesToFraudProof(preStateRoot, transactionHash)
     {
@@ -260,7 +260,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
         bytes memory _storageTrieWitness
     )
         override
-        public
+        external
         onlyDuringPhase(TransitionPhase.PRE_EXECUTION)
         contributesToFraudProof(preStateRoot, transactionHash)
     {
@@ -324,7 +324,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
         Lib_OVMCodec.Transaction memory _transaction
     )
         override
-        public
+        external
         onlyDuringPhase(TransitionPhase.PRE_EXECUTION)
         contributesToFraudProof(preStateRoot, transactionHash)
     {
@@ -374,7 +374,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
         bytes memory _stateTrieWitness
     )
         override
-        public
+        external
         onlyDuringPhase(TransitionPhase.POST_EXECUTION)
         contributesToFraudProof(preStateRoot, transactionHash)
     {
@@ -417,7 +417,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
         bytes memory _storageTrieWitness
     )
         override
-        public
+        external
         onlyDuringPhase(TransitionPhase.POST_EXECUTION)
         contributesToFraudProof(preStateRoot, transactionHash)
     {
@@ -457,7 +457,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
      */
     function completeTransition()
         override
-        public
+        external
         onlyDuringPhase(TransitionPhase.POST_EXECUTION)
     {
         require(

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressManager.sol
@@ -39,7 +39,7 @@ contract Lib_AddressManager is Ownable {
         string memory _name,
         address _address
     )
-        public
+        external
         onlyOwner
     {
         addresses[_getNameHash(_name)] = _address;
@@ -58,7 +58,7 @@ contract Lib_AddressManager is Ownable {
     function getAddress(
         string memory _name
     )
-        public
+        external
         view
         returns (
             address

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol
@@ -314,8 +314,8 @@ library Lib_MerkleTrie {
                     currentNodeID = bytes32(RLP_NULL);
                     break;
                 } else if (prefix == PREFIX_EXTENSION_EVEN || prefix == PREFIX_EXTENSION_ODD) {
-                    if (sharedNibbleLength == 0) {
-                        // Our extension node doesn't share any part of our key.
+                    if (sharedNibbleLength != pathRemainder.length) {
+                        // Our extension node is not identical to the remainder.
                         // We've hit the end of this path, updates will need to modify this extension.
                         currentNodeID = bytes32(RLP_NULL);
                         break;


### PR DESCRIPTION
If a function does not need to be accessed from within the contract, it should be labelled external because: 
1. The use of the function is made semantically clearer to reviewers
2. It should save gas, though the optimizer may address that (but fewer optimizer changes is also a benefit).