### PR TITLE
feat[contracts]: ChugSplash tooling to generate complete action bundles from config files

### DIFF
--- a/packages/contracts/src/chugsplash/actions.ts
+++ b/packages/contracts/src/chugsplash/actions.ts
@@ -1,4 +1,4 @@
-/* External Imports */
+/* Imports: External */
 import { fromHexString, toHexString } from '@eth-optimism/core-utils'
 import { ethers } from 'ethers'
 import MerkleTree from 'merkletreejs'

--- a/packages/contracts/src/chugsplash/hardhat-tools.ts
+++ b/packages/contracts/src/chugsplash/hardhat-tools.ts
@@ -1,0 +1,52 @@
+/* Imports: External */
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+
+/* Imports: Internal */
+import { computeStorageSlots, getStorageLayout } from './storage'
+import { ChugSplashConfig, parseChugSplashConfig } from './config'
+import {
+  ChugSplashAction,
+  ChugSplashActionBundle,
+  getChugSplashActionBundle,
+} from './actions'
+
+/**
+ * Generates a ChugSplash action bundle from a config file.
+ * @param hre Hardhat runtime environment, used to load artifacts + storage layouts.
+ * @param config Config file to convert into a bundle.
+ * @param env Environment variables to inject into the config file.
+ * @returns Action bundle generated from the parsed config file.
+ */
+export const makeActionBundleFromConfig = async (
+  hre: HardhatRuntimeEnvironment,
+  config: ChugSplashConfig,
+  env: any = {}
+): Promise<ChugSplashActionBundle> => {
+  const parsed = parseChugSplashConfig(config, env)
+
+  const actions: ChugSplashAction[] = []
+  for (const [contractName, contractConfig] of Object.entries(
+    parsed.contracts
+  )) {
+    const artifact = hre.artifacts.readArtifactSync(contractConfig.source)
+    const storageLayout = await getStorageLayout(hre, contractConfig.source)
+
+    actions.push({
+      target: contractConfig.address,
+      code: artifact.deployedBytecode,
+    })
+
+    for (const slot of computeStorageSlots(
+      storageLayout,
+      contractConfig.variables
+    )) {
+      actions.push({
+        target: contractConfig.address,
+        key: slot.key,
+        value: slot.val,
+      })
+    }
+  }
+
+  return getChugSplashActionBundle(actions)
+}

--- a/packages/contracts/src/chugsplash/index.ts
+++ b/packages/contracts/src/chugsplash/index.ts
@@ -1,3 +1,4 @@
 export * from './actions'
 export * from './config'
 export * from './storage'
+export * from './hardhat-tools'

--- a/packages/contracts/test/chugsplash/hardhat-tools.spec.ts
+++ b/packages/contracts/test/chugsplash/hardhat-tools.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from '../setup'
+
+/* Imports: External */
+import hre from 'hardhat'
+
+/* Imports: Internal */
+import { makeActionBundleFromConfig } from '../../src'
+
+describe('ChugSplash hardhat tooling', () => {
+  describe('makeActionBundleFromConfig', () => {
+    it('should generate an action bundle from a basic config file', async () => {
+      // TODO: What's the best way to test this?
+      await makeActionBundleFromConfig(hre, {
+        contracts: {
+          MyContract: {
+            address: `0x${'11'.repeat(20)}`,
+            source: 'OVM_ExecutionManager',
+            variables: {},
+          },
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a function `makeActionBundleFromConfig` which generates a `ChugSplashActionBundle` given a `ChugSplashConfig` object.

**Additional context**
* Looking for some feedback on how to most effectively test this function.
