### PR TITLE
fix: remove type check in rollup client

### DIFF
--- a/.changeset/good-poets-march.md
+++ b/.changeset/good-poets-march.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Ignore the deprecated type field in the API

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -289,18 +289,7 @@ func batchedTransactionToTransaction(res *transaction, signer *types.EIP155Signe
 	} else {
 		return nil, fmt.Errorf("Unknown queue origin: %s", res.QueueOrigin)
 	}
-	// The transaction type must be EIP155 or EthSign. Throughout this
-	// codebase, it is referred to as "sighash type" but it could actually
-	// be generalized to transaction type. Right now the only different
-	// types use a different signature hashing scheme.
-	var sighashType types.SignatureHashType
-	if res.Type == EIP155 {
-		sighashType = types.SighashEIP155
-	} else if res.Type == ETH_SIGN {
-		sighashType = types.SighashEthSign
-	} else {
-		return nil, fmt.Errorf("Unknown transaction type: %s", res.Type)
-	}
+	sighashType := types.SighashEIP155
 	// Transactions that have been decoded are
 	// Queue Origin Sequencer transactions
 	if res.Decoded != nil {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
No longer parse the type field that is returned from the API and just go with the standard type. This feature is deprecated since there is no longer a concept of transaction type
