### PR TITLE
fix(hh-ovm): Working builds for M1 macs

### DIFF
--- a/.changeset/quiet-cherries-wave.md
+++ b/.changeset/quiet-cherries-wave.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/hardhat-ovm": patch
+---
+
+fix(hh-ovm): Working compilation for M1 macs


### PR DESCRIPTION
**Description**
Fixes the long-elusive https://github.com/ethereum-optimism/optimism/issues/675 where builds were failing on M1 macs.  There is a better fix for this long-term, but we should merge this in now to unblock M1 users.

**Additional context**
We barked up the wrong tree on this one for a while because it looked an awful lot like a caching issue, but turned out to be something else: it seems that on M1s, the hardhat `TASK_COMPILE_SOLIDITY_RUN_SOLC` does not run, probably because it does not see an M1 build, and therefore wants `TASK_COMPILE_SOLIDITY_RUN_SOLCJS` to be run directly.  The fix here routes this task back to `TASK_COMPILE_SOLIDITY_RUN_SOLC` on the first pass, because `hh-ovm` already enforces that we run solcjs, and within that task we do the `//  @unsupported: evm/ovm` filtering.

**Metadata**
- Fixes #675 
