### PR TITLE
dtl: prevent null reference in L1 handler

### DIFF
--- a/.changeset/violet-comics-reflect.md
+++ b/.changeset/violet-comics-reflect.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Prevent access of null value in L1 transaction deserialization

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -121,7 +121,7 @@ export const handleEventsSequencerBatchAppended: EventHandlerSet<
           data: toHexString(sequencerTransaction),
           queueOrigin: 'sequencer',
           type,
-          value: decoded.value,
+          value: decoded ? decoded.value : '0x0',
           queueIndex: null,
           decoded,
           confirmed: true,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Checks to make sure that the `decoded` transaction is not null before attempting to reference its `value`