### PR TITLE
dtl: error logging with message, stack and code

### DIFF
--- a/.changeset/cyan-days-act.md
+++ b/.changeset/cyan-days-act.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Better error logging in the DTL

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -201,10 +201,13 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         }
       } catch (err) {
         if (!this.running || this.options.dangerouslyCatchAllErrors) {
-          this.logger.error('Caught an unhandled error', { err })
+          this.logger.error('Caught an unhandled error', {
+            message: err.toString(),
+            stack: err.stack,
+            code: err.code,
+          })
           await sleep(this.options.pollingInterval)
         } else {
-          // TODO: Is this the best thing to do here?
           throw err
         }
       }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds better error logging to the DTL. Previously it would log an empty object for the error and now it logs the stack as well as the error message 
