### PR TITLE
fix[contracts]: Remove verifyExclusionProof

### DIFF
--- a/.changeset/thin-horses-change.md
+++ b/.changeset/thin-horses-change.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Removed verifyExclusionProof function from MerkleTrie library.

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol
@@ -93,34 +93,6 @@ library Lib_MerkleTrie {
     }
 
     /**
-     * @notice Verifies a proof that a given key is *not* present in
-     * the Merkle trie.
-     * @param _key Key of the node to search for, as a hex string.
-     * @param _proof Merkle trie inclusion proof for the node *nearest* the
-     * target node.
-     * @param _root Known root of the Merkle trie. Used to verify that the
-     * included proof is correctly constructed.
-     * @return _verified `true` if the key is absent in the trie, `false` otherwise.
-     */
-    function verifyExclusionProof(
-        bytes memory _key,
-        bytes memory _proof,
-        bytes32 _root
-    )
-        internal
-        pure
-        returns (
-            bool _verified
-        )
-    {
-        (
-            bool exists,
-        ) = get(_key, _proof, _root);
-
-        return exists == false;
-    }
-
-    /**
      * @notice Updates a Merkle trie and returns a new root hash.
      * @param _key Key of the node to update, as a hex string.
      * @param _value Value of the node to update, as a hex string.

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_SecureMerkleTrie.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_SecureMerkleTrie.sol
@@ -43,31 +43,6 @@ library Lib_SecureMerkleTrie {
     }
 
     /**
-     * @notice Verifies a proof that a given key is *not* present in
-     * the Merkle trie.
-     * @param _key Key of the node to search for, as a hex string.
-     * @param _proof Merkle trie inclusion proof for the node *nearest* the
-     * target node.
-     * @param _root Known root of the Merkle trie. Used to verify that the
-     * included proof is correctly constructed.
-     * @return _verified `true` if the key is not present in the trie, `false` otherwise.
-     */
-    function verifyExclusionProof(
-        bytes memory _key,
-        bytes memory _proof,
-        bytes32 _root
-    )
-        internal
-        pure
-        returns (
-            bool _verified
-        )
-    {
-        bytes memory key = _getSecureKey(_key);
-        return Lib_MerkleTrie.verifyExclusionProof(key, _proof, _root);
-    }
-
-    /**
      * @notice Updates a Merkle trie and returns a new root hash.
      * @param _key Key of the node to update, as a hex string.
      * @param _value Value of the node to update, as a hex string.

--- a/packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
+++ b/packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
@@ -29,24 +29,6 @@ contract TestLib_MerkleTrie {
         );
     }
 
-    function verifyExclusionProof(
-        bytes memory _key,
-        bytes memory _proof,
-        bytes32 _root
-    )
-        public
-        pure
-        returns (
-            bool
-        )
-    {
-        return Lib_MerkleTrie.verifyExclusionProof(
-            _key,
-            _proof,
-            _root
-        );
-    }
-
     function update(
         bytes memory _key,
         bytes memory _value,

--- a/packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
+++ b/packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
@@ -30,24 +30,6 @@ contract TestLib_SecureMerkleTrie {
         );
     }
 
-    function verifyExclusionProof(
-        bytes memory _key,
-        bytes memory _proof,
-        bytes32 _root
-    )
-        public
-        pure
-        returns (
-            bool
-        )
-    {
-        return Lib_SecureMerkleTrie.verifyExclusionProof(
-            _key,
-            _proof,
-            _root
-        );
-    }
-
     function update(
         bytes memory _key,
         bytes memory _value,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes `Lib_MerkleTrie.verifyExclusionProof` and the various references to it. We haven't been using this method at all, I don't see why it needs to remain in the codebase. 

**Metadata**
- Fixes #770 
