### PR TITLE
fix: tx enums

### DIFF
--- a/.changeset/fluffy-mangos-rest.md
+++ b/.changeset/fluffy-mangos-rest.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/core-utils': patch
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add an additional enum for EthSign transactions as they now are batch submitted with 2 different enum values

--- a/packages/core-utils/src/coders/ecdsa-coder.ts
+++ b/packages/core-utils/src/coders/ecdsa-coder.ts
@@ -9,11 +9,13 @@ import { Coder, Signature, Uint16, Uint8, Uint24, Address } from './types'
 export enum TxType {
   EIP155 = 0,
   EthSign = 1,
+  EthSign2 = 2,
 }
 
 export const txTypePlainText = {
   0: TxType.EIP155,
   1: TxType.EthSign,
+  2: TxType.EthSign2,
   EIP155: TxType.EIP155,
   EthSign: TxType.EthSign,
 }
@@ -169,6 +171,20 @@ class EthSignTxCoder extends DefaultEcdsaTxCoder {
   }
 }
 
+class EthSign2TxCoder extends DefaultEcdsaTxCoder {
+  constructor() {
+    super(TxType.EthSign2)
+  }
+
+  public encode(txData: EthSignTxData): string {
+    return super.encode(txData)
+  }
+
+  public decode(txData: string): EthSignTxData {
+    return super.decode(txData)
+  }
+}
+
 class Eip155TxCoder extends DefaultEcdsaTxCoder {
   constructor() {
     super(TxType.EIP155)
@@ -209,6 +225,9 @@ function decode(data: string | Buffer): EIP155TxData {
   if (type === TxType.EthSign) {
     return new EthSignTxCoder().decode(data)
   }
+  if (type === TxType.EthSign2) {
+    return new EthSign2TxCoder().decode(data)
+  }
   return null
 }
 
@@ -218,6 +237,7 @@ function decode(data: string | Buffer): EIP155TxData {
 export const ctcCoder = {
   eip155TxData: new Eip155TxCoder(),
   ethSignTxData: new EthSignTxCoder(),
+  ethSign2TxData: new EthSign2TxCoder(),
   encode,
   decode,
 }

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -254,6 +254,9 @@ const maybeDecodeSequencerBatchTransaction = (
     } else if (txType === TxType.EthSign) {
       type = 'ETH_SIGN'
       decoded = ctcCoder.ethSignTxData.decode(transaction.toString('hex'))
+    } else if (txType === TxType.EthSign2) {
+      type = 'ETH_SIGN'
+      decoded = ctcCoder.ethSign2TxData.decode(transaction.toString('hex'))
     } else {
       throw new Error(`Unknown sequencer transaction type.`)
     }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The bug in the enums has returned with recent changes to the batch submitter and l2geth. The enum scheme is being deprecated very shortly in `v0.3.0`, this patch is meant to fix verifiers that sync from L1 because `ETH_SIGN` transactions were submitted starting in batch 338 with a 2 enum instead of a 1 enum. This is due to the raw transaction bytes being used for batch submission because l2geth would mutate the first byte previously to fit what the contracts needed.

This code will be deleted in `v0.3.0`
