### PR TITLE
Remove unnecessary tsconfig arguments

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,8 +12,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "typeRoots": [
-            "node_modules/@types"
-      ]
+      "node_modules/@types"
+    ]
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,3 @@
 {
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@eth-optimism/*": ["packages/*/src", "integration-tests/*/test"]
-    },
-    "skipLibCheck": true
-  }
+  "extends": "./tsconfig.build.json"
 }


### PR DESCRIPTION
Removes skipLibCheck, paths, and baseUrl from base typescript config. It's not clear from the commit history why these were added, and the integration tests have passed for me locally on a fresh build with these changes added. 
