### PR TITLE
test(integration-tests): add reversion RPC coverage

### DIFF
--- a/integration-tests/contracts/ConstructorReverter.sol
+++ b/integration-tests/contracts/ConstructorReverter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0;
+
+import { Reverter } from './Reverter.sol';
+
+contract ConstructorReverter is Reverter {
+   constructor() {
+       doRevert();
+   }
+}

--- a/integration-tests/contracts/Reverter.sol
+++ b/integration-tests/contracts/Reverter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0;
+
+contract Reverter {
+    string constant public revertMessage = "This is a simple reversion.";
+
+    function doRevert() public pure {
+        revert(revertMessage);
+    }
+}

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -4,7 +4,7 @@ import {
   getContractFactory,
   getContractInterface,
 } from '@eth-optimism/contracts'
-import { Watcher } from '@eth-optimism/core-utils'
+import { remove0x, Watcher } from '@eth-optimism/core-utils'
 import {
   Contract,
   Wallet,
@@ -12,6 +12,7 @@ import {
   providers,
   BigNumberish,
   BigNumber,
+  utils,
 } from 'ethers'
 import { cleanEnv, str, num } from 'envalid'
 
@@ -100,3 +101,8 @@ export const fundUser = async (
 }
 
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const abiCoder = new utils.AbiCoder()
+export const encodeSolidityRevertMessage = (_reason: string): string => {
+  return '0x08c379a0' + remove0x(abiCoder.encode(['string'], [_reason]))
+}


### PR DESCRIPTION
**Description**
This PR adds some tests which can now all pass with the ABI-decoded geth output.  This will prevent future regressions in how the node handles exceptions.

- Solves https://github.com/ethereum-optimism/optimism/issues/648