### PR TITLE
Make ts-packages action always run on PRs and master

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -5,16 +5,7 @@ on:
     branches:
       - master
       - '*rc'
-    paths:
-        - 'packages/**/*.sol'
-        - 'packages/**/*.ts'
   pull_request:
-    branches:
-      - master
-      - '*rc'
-    paths:
-        - 'packages/**/*.sol'
-        - 'packages/**/*.ts'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
For establishing the diff in gas costs with previous commits `codechecks` needs to be run on every PR, not just those changing contracts.

Explanation from code maintainter:

>On master you have bunch of commits like (M1) -> (M2) -> (M3) -> (M4) -> (M5) Assume that on (M2) you did a change to smart contract code and codechecks were triggered by your CI and artifacts were recorded.
Now, you create a PR between your branch B  and (M5). In this case codechecks would have to traverse back master branch (M5) -> (M4) -> (M3) to find a commit that has recorded artifacts. And this can be very fragile: how deep should it look? What if artifacts were never recorded at all? 
So the easiest solution is to always record artfacts on master. Then (M5) will simply have all needed data.