### PR TITLE
config: message relayer

### DIFF
--- a/.changeset/cuddly-beans-brake.md
+++ b/.changeset/cuddly-beans-brake.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Add updated config parsing in a backwards compatible way

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -1,30 +1,47 @@
 import { Wallet, providers } from 'ethers'
 import { MessageRelayerService } from '../service'
 import SpreadSheet from '../spreadsheet'
-import { config } from 'dotenv'
-config()
+import * as dotenv from 'dotenv'
+import Config from 'bcfg'
 
-const env = process.env
-const L2_NODE_WEB3_URL = env.L2_NODE_WEB3_URL
-const L1_NODE_WEB3_URL = env.L1_NODE_WEB3_URL
-const ADDRESS_MANAGER_ADDRESS = env.ADDRESS_MANAGER_ADDRESS
-const L1_WALLET_KEY = env.L1_WALLET_KEY
-const MNEMONIC = env.MNEMONIC
-const HD_PATH = env.HD_PATH
-const RELAY_GAS_LIMIT = env.RELAY_GAS_LIMIT || '4000000'
-const POLLING_INTERVAL = env.POLLING_INTERVAL || '5000'
-const GET_LOGS_INTERVAL = env.GET_LOGS_INTERVAL || '2000'
-const L2_BLOCK_OFFSET = env.L2_BLOCK_OFFSET || '1'
-const L1_START_OFFSET = env.L1_BLOCK_OFFSET || '1'
-const FROM_L2_TRANSACTION_INDEX = env.FROM_L2_TRANSACTION_INDEX || '0'
+interface Bcfg {
+  load: (options: { env?: boolean; argv?: boolean }) => void
+  str: (name: string, defaultValue?: string) => string
+  uint: (name: string, defaultValue?: number) => number
+  bool: (name: string, defaultValue?: boolean) => boolean
+  ufloat: (name: string, defaultValue?: number) => number
+}
 
-// Spreadsheet configuration
-const SPREADSHEET_MODE = env.SPREADSHEET_MODE || ''
-const SHEET_ID = env.SHEET_ID || ''
-const CLIENT_EMAIL = env.CLIENT_EMAIL || ''
-const CLIENT_PRIVATE_KEY = env.CLIENT_PRIVATE_KEY || ''
+dotenv.config()
 
 const main = async () => {
+  const config: Bcfg = new Config('message-relayer')
+  config.load({
+    env: true,
+    argv: true,
+  })
+
+  const env = process.env
+  const L2_NODE_WEB3_URL = env.L2_NODE_WEB3_URL || config.str('l2-node-web3-url')
+  const L1_NODE_WEB3_URL = env.L1_NODE_WEB3_URL || config.str('l1-node-web3-url')
+  const ADDRESS_MANAGER_ADDRESS = env.ADDRESS_MANAGER_ADDRESS || config.str('address-manager-address')
+  const L1_WALLET_KEY = env.L1_WALLET_KEY || config.str('l1-wallet-key')
+  const MNEMONIC = env.MNEMONIC || config.str('mnemonic')
+  const HD_PATH = env.HD_PATH || config.str('hd-path')
+  const RELAY_GAS_LIMIT = env.RELAY_GAS_LIMIT || config.uint('relay-gas-limit', 4000000)
+  const POLLING_INTERVAL = env.POLLING_INTERVAL || config.uint('polling-interval', 5000)
+  const GET_LOGS_INTERVAL = env.GET_LOGS_INTERVAL || config.uint('get-logs-interval', 2000)
+  const L2_BLOCK_OFFSET = env.L2_BLOCK_OFFSET || config.uint('l2-block-offset', 1)
+  const L1_START_OFFSET = env.L1_BLOCK_OFFSET || config.uint('l1-block-offset', 1)
+  const FROM_L2_TRANSACTION_INDEX = env.FROM_L2_TRANSACTION_INDEX || config.uint('from-l2-transaction-index', 0)
+
+  // Spreadsheet configuration
+  const SPREADSHEET_MODE = env.SPREADSHEET_MODE || config.bool('spreadsheet-mode', false)
+  const SHEET_ID = env.SHEET_ID || config.str('sheet-id', '')
+  const CLIENT_EMAIL = env.CLIENT_EMAIL || config.str('client-email', '')
+  const CLIENT_PRIVATE_KEY = env.CLIENT_PRIVATE_KEY || config.str('client-private-key', '')
+
+
   if (!ADDRESS_MANAGER_ADDRESS) {
     throw new Error('Must pass ADDRESS_MANAGER_ADDRESS')
   }
@@ -69,11 +86,17 @@ const main = async () => {
     l2RpcProvider: l2Provider,
     addressManagerAddress: ADDRESS_MANAGER_ADDRESS,
     l1Wallet: wallet,
+    // @ts-ignore: Type error that isn't erroneous
     relayGasLimit: parseInt(RELAY_GAS_LIMIT, 10),
+    // @ts-ignore: Type error that isn't erroneous
     fromL2TransactionIndex: parseInt(FROM_L2_TRANSACTION_INDEX, 10),
+    // @ts-ignore: Type error that isn't erroneous
     pollingInterval: parseInt(POLLING_INTERVAL, 10),
+    // @ts-ignore: Type error that isn't erroneous
     l2BlockOffset: parseInt(L2_BLOCK_OFFSET, 10),
+    // @ts-ignore: Type error that isn't erroneous
     l1StartOffset: parseInt(L1_START_OFFSET, 10),
+    // @ts-ignore: Type error that isn't erroneous
     getLogsInterval: parseInt(GET_LOGS_INTERVAL, 10),
     spreadsheetMode: !!SPREADSHEET_MODE,
     spreadsheet,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This updates the config parsing for the message relayer in a backwards compatible way. `bcfg` is used which parses both from the command line (argv) and from environment variables. The env vars it looks for are based on the prefix `MESSAGE_RELAYER_<name of variable`. This PR is intentionally backwards compatible until we can update all config throughout the repo
