### PR TITLE
message-relayer: add in address check for better error alerting

### DIFF
--- a/.changeset/nasty-bees-remain.md
+++ b/.changeset/nasty-bees-remain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Add a check for `OVM_L2MessageRelayer` in the AddressManager before attempting to relay messages to help surface errors more quickly

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -496,11 +496,19 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
         }
       )
 
+      this.logger.info('Relay message transaction sent', {
+        transactionHash: result,
+      })
+
       try {
         const receipt = await result.wait()
 
-        this.logger.info('Relay message transaction sent', {
+        this.logger.info('Relay message included in block', {
           transactionHash: receipt.transactionHash,
+          blockNumber: receipt.blockNumber,
+          gasUsed: receipt.gasUsed.toString(),
+          confirmations: receipt.confirmations,
+          status: receipt.status,
         })
       } catch (err) {
         this.logger.error('Real relay attempt failed, skipping.', { err })

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -151,6 +151,16 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       await sleep(this.options.pollingInterval)
 
       try {
+        // Check that the correct address is set in the address manager
+        const relayer = await this.state.Lib_AddressManager.getAddress('OVM_L2MessageRelayer')
+        // If it is address(0), then message relaying is not authenticated
+        if (relayer !== ethers.constants.AddressZero) {
+          const address = await this.options.l1Wallet.getAddress()
+          if (relayer !== address) {
+            throw new Error(`OVM_L2MessageRelayer (${relayer}) is not set to message-passer EOA ${address}`)
+          }
+        }
+
         this.logger.info('Checking for newly finalized transactions...')
         if (
           !(await this._isTransactionFinalized(

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -152,12 +152,16 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
 
       try {
         // Check that the correct address is set in the address manager
-        const relayer = await this.state.Lib_AddressManager.getAddress('OVM_L2MessageRelayer')
+        const relayer = await this.state.Lib_AddressManager.getAddress(
+          'OVM_L2MessageRelayer'
+        )
         // If it is address(0), then message relaying is not authenticated
         if (relayer !== ethers.constants.AddressZero) {
           const address = await this.options.l1Wallet.getAddress()
           if (relayer !== address) {
-            throw new Error(`OVM_L2MessageRelayer (${relayer}) is not set to message-passer EOA ${address}`)
+            throw new Error(
+              `OVM_L2MessageRelayer (${relayer}) is not set to message-passer EOA ${address}`
+            )
           }
         }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR will have the message relayer check the address manager and compare its address against the address in the message relayer if there is an address set at `OVM_L2MessageRelayer`

**Additional context**
This will help to surface misconfigurations in the future more quickly

