### PR TITLE
feat: add proposer & sequencer signers to BS

### DIFF
--- a/.changeset/pink-buttons-hang.md
+++ b/.changeset/pink-buttons-hang.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Add the support for different sequencer & proposer keys in the batch submitter.

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -122,7 +122,8 @@ const GAS_THRESHOLD_IN_GWEI = parseInt(env.GAS_THRESHOLD_IN_GWEI, 10) || 100
 
 // Private keys & mnemonics
 const SEQUENCER_PRIVATE_KEY = env.SEQUENCER_PRIVATE_KEY
-const PROPOSER_PRIVATE_KEY = env.PROPOSER_PRIVATE_KEY || env.SEQUENCER_PRIVATE_KEY // Kept for backwards compatibility
+const PROPOSER_PRIVATE_KEY =
+  env.PROPOSER_PRIVATE_KEY || env.SEQUENCER_PRIVATE_KEY // Kept for backwards compatibility
 const SEQUENCER_MNEMONIC = env.SEQUENCER_MNEMONIC || env.MNEMONIC
 const PROPOSER_MNEMONIC = env.PROPOSER_MNEMONIC || env.MNEMONIC
 const SEQUENCER_HD_PATH = env.SEQUENCER_HD_PATH || env.HD_PATH
@@ -166,18 +167,27 @@ export const run = async () => {
   if (SEQUENCER_PRIVATE_KEY) {
     sequencerSigner = new Wallet(SEQUENCER_PRIVATE_KEY, l1Provider)
   } else if (SEQUENCER_MNEMONIC) {
-    sequencerSigner = Wallet.fromMnemonic(SEQUENCER_MNEMONIC, SEQUENCER_HD_PATH).connect(l1Provider)
+    sequencerSigner = Wallet.fromMnemonic(
+      SEQUENCER_MNEMONIC,
+      SEQUENCER_HD_PATH
+    ).connect(l1Provider)
   } else {
-    throw new Error('Must pass one of SEQUENCER_PRIVATE_KEY, MNEMONIC, or SEQUENCER_MNEMONIC')
+    throw new Error(
+      'Must pass one of SEQUENCER_PRIVATE_KEY, MNEMONIC, or SEQUENCER_MNEMONIC'
+    )
   }
   if (PROPOSER_PRIVATE_KEY) {
     proposerSigner = new Wallet(PROPOSER_PRIVATE_KEY, l1Provider)
   } else if (PROPOSER_MNEMONIC) {
-    proposerSigner = Wallet.fromMnemonic(PROPOSER_MNEMONIC, PROPOSER_HD_PATH).connect(l1Provider)
+    proposerSigner = Wallet.fromMnemonic(
+      PROPOSER_MNEMONIC,
+      PROPOSER_HD_PATH
+    ).connect(l1Provider)
   } else {
-    throw new Error('Must pass one of PROPOSER_PRIVATE_KEY, MNEMONIC, or PROPOSER_MNEMONIC')
+    throw new Error(
+      'Must pass one of PROPOSER_PRIVATE_KEY, MNEMONIC, or PROPOSER_MNEMONIC'
+    )
   }
-
 
   const sequencerAddress = await sequencerSigner.getAddress()
   const proposerAddress = await proposerSigner.getAddress()

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -180,6 +180,7 @@ export const run = async () => {
     throw new Error('Must pass one of PROPOSER_PRIVATE_KEY, MNEMONIC, or PROPOSER_MNEMONIC')
   }
 
+
   const sequencerAddress = await sequencerSigner.getAddress()
   const proposerAddress = await proposerSigner.getAddress()
   const address = await sequencerSigner.getAddress()
@@ -188,6 +189,11 @@ export const run = async () => {
     proposerAddress,
     addressManagerAddress: requiredEnvVars.ADDRESS_MANAGER_ADDRESS,
   })
+
+  // If the sequencer & proposer are the same, use a single wallet
+  if (sequencerAddress === proposerAddress) {
+    proposerSigner = sequencerSigner
+  }
 
   const txBatchSubmitter = new TransactionBatchSubmitter(
     sequencerSigner,

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -111,8 +111,6 @@ const requiredEnvVars: RequiredEnvVars = {
  * PROPOSER_MNEMONIC
  * SEQUENCER_HD_PATH
  * PROPOSER_HD_PATH
- * TX_SUBMITTER_MNEMONIC
- * STATE_SUBMITTER_MNEMONIC
  */
 const env = process.env
 const FRAUD_SUBMISSION_ADDRESS = env.FRAUD_SUBMISSION_ADDRESS || 'no fraud'

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -105,7 +105,14 @@ const requiredEnvVars: RequiredEnvVars = {
  * FRAUD_SUBMISSION_ADDRESS
  * DISABLE_QUEUE_BATCH_APPEND
  * SEQUENCER_PRIVATE_KEY
+ * PROPOSER_PRIVATE_KEY
  * MNEMONIC
+ * SEQUENCER_MNEMONIC
+ * PROPOSER_MNEMONIC
+ * SEQUENCER_HD_PATH
+ * PROPOSER_HD_PATH
+ * TX_SUBMITTER_MNEMONIC
+ * STATE_SUBMITTER_MNEMONIC
  */
 const env = process.env
 const FRAUD_SUBMISSION_ADDRESS = env.FRAUD_SUBMISSION_ADDRESS || 'no fraud'
@@ -114,10 +121,14 @@ const MIN_GAS_PRICE_IN_GWEI = parseInt(env.MIN_GAS_PRICE_IN_GWEI, 10) || 0
 const MAX_GAS_PRICE_IN_GWEI = parseInt(env.MAX_GAS_PRICE_IN_GWEI, 10) || 70
 const GAS_RETRY_INCREMENT = parseInt(env.GAS_RETRY_INCREMENT, 10) || 5
 const GAS_THRESHOLD_IN_GWEI = parseInt(env.GAS_THRESHOLD_IN_GWEI, 10) || 100
-// The private key that will be used to submit tx and state batches.
+
+// Private keys & mnemonics
 const SEQUENCER_PRIVATE_KEY = env.SEQUENCER_PRIVATE_KEY
-const MNEMONIC = env.MNEMONIC
-const HD_PATH = env.HD_PATH
+const PROPOSER_PRIVATE_KEY = env.PROPOSER_PRIVATE_KEY || env.SEQUENCER_PRIVATE_KEY // Kept for backwards compatibility
+const SEQUENCER_MNEMONIC = env.SEQUENCER_MNEMONIC || env.MNEMONIC
+const PROPOSER_MNEMONIC = env.PROPOSER_MNEMONIC || env.MNEMONIC
+const SEQUENCER_HD_PATH = env.SEQUENCER_HD_PATH || env.HD_PATH
+const PROPOSER_HD_PATH = env.PROPOSER_HD_PATH || env.HD_PATH
 // Auto fix batch options -- TODO: Remove this very hacky config
 const AUTO_FIX_BATCH_OPTIONS_CONF = env.AUTO_FIX_BATCH_OPTIONS_CONF
 const autoFixBatchOptions: AutoFixBatchOptions = {
@@ -153,17 +164,28 @@ export const run = async () => {
   )
 
   let sequencerSigner: Signer
+  let proposerSigner: Signer
   if (SEQUENCER_PRIVATE_KEY) {
     sequencerSigner = new Wallet(SEQUENCER_PRIVATE_KEY, l1Provider)
-  } else if (MNEMONIC) {
-    sequencerSigner = Wallet.fromMnemonic(MNEMONIC, HD_PATH).connect(l1Provider)
+  } else if (SEQUENCER_MNEMONIC) {
+    sequencerSigner = Wallet.fromMnemonic(SEQUENCER_MNEMONIC, SEQUENCER_HD_PATH).connect(l1Provider)
   } else {
-    throw new Error('Must pass one of SEQUENCER_PRIVATE_KEY or MNEMONIC')
+    throw new Error('Must pass one of SEQUENCER_PRIVATE_KEY, MNEMONIC, or SEQUENCER_MNEMONIC')
+  }
+  if (PROPOSER_PRIVATE_KEY) {
+    proposerSigner = new Wallet(PROPOSER_PRIVATE_KEY, l1Provider)
+  } else if (PROPOSER_MNEMONIC) {
+    proposerSigner = Wallet.fromMnemonic(PROPOSER_MNEMONIC, PROPOSER_HD_PATH).connect(l1Provider)
+  } else {
+    throw new Error('Must pass one of PROPOSER_PRIVATE_KEY, MNEMONIC, or PROPOSER_MNEMONIC')
   }
 
+  const sequencerAddress = await sequencerSigner.getAddress()
+  const proposerAddress = await proposerSigner.getAddress()
   const address = await sequencerSigner.getAddress()
   logger.info('Configured batch submitter addresses', {
-    batchSubmitterAddress: address,
+    sequencerAddress,
+    proposerAddress,
     addressManagerAddress: requiredEnvVars.ADDRESS_MANAGER_ADDRESS,
   })
 
@@ -192,7 +214,7 @@ export const run = async () => {
   )
 
   const stateBatchSubmitter = new StateBatchSubmitter(
-    sequencerSigner,
+    proposerSigner,
     l2Provider,
     parseInt(requiredEnvVars.MIN_L1_TX_SIZE, 10),
     parseInt(requiredEnvVars.MAX_L1_TX_SIZE, 10),


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Splits up the batch submitter sequencer keys and proposer keys to allow for a different `sequencer account` and `proposer account`. This avoids nonce race conditions when submitting tx batches & state batches