### PR TITLE
maintenance[contracts]: move various deps to dev deps

### DIFF
--- a/.changeset/kind-bears-think.md
+++ b/.changeset/kind-bears-think.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Move various dependencies from primary deps to dev deps

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -48,12 +48,7 @@
     "@eth-optimism/core-utils": "^0.4.1",
     "@ethersproject/abstract-provider": "^5.0.8",
     "@ethersproject/contracts": "^5.0.5",
-    "@openzeppelin/contracts": "^3.3.0",
-    "@openzeppelin/contracts-upgradeable": "^3.3.0",
-    "@typechain/hardhat": "^1.0.1",
-    "ganache-core": "^2.13.2",
-    "glob": "^7.1.6",
-    "solidity-coverage": "^0.7.16"
+    "glob": "^7.1.6"
   },
   "devDependencies": {
     "@codechecks/client": "0.1.10-beta",
@@ -63,6 +58,9 @@
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@typechain/ethers-v5": "1.0.0",
     "@types/buffer-xor": "^2.0.0",
+    "@typechain/hardhat": "^1.0.1",
+    "@openzeppelin/contracts": "^3.3.0",
+    "@openzeppelin/contracts-upgradeable": "^3.3.0",
     "@types/chai": "^4.2.17",
     "@types/copyfiles": "^2.4.0",
     "@types/glob": "^7.1.3",
@@ -71,6 +69,7 @@
     "@types/mocha": "^8.2.2",
     "@types/yargs": "^16.0.1",
     "buffer-xor": "^2.0.2",
+    "ganache-core": "^2.13.2",
     "chai": "^4.3.1",
     "copyfiles": "^2.3.0",
     "directory-tree": "^2.2.7",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Moves the following dependencies within `@eth-optimism/contracts` to `devDependencies`:

- @openzeppelin/contracts
- @openzeppelin/contracts-upgradeable
- @typechain/hardhat
- ganache-core

Also removes a duplicated `solidity-coverage` dependency. 

I don't think any of these packages are needed in the main dependencies. `ganache-core` is the primary one I'm skeptical of, but it's only used within `bin/take-dump.ts`. I'm hoping that this will make the whole package browser compatible.