### PR TITLE
maintenance: use dashes in chain container names

### DIFF
--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -105,16 +105,21 @@ describe('OVM Context: Layer 2 EVM Context', () => {
 
     for (let i = start; i < tip.number; i++) {
       const block = await L2Provider.getBlockWithTransactions(i)
-      const [, returnData] = await OVMMulticall.callStatic.aggregate([
+      const [, returnData] = await OVMMulticall.callStatic.aggregate(
         [
-          OVMMulticall.address,
-          OVMMulticall.interface.encodeFunctionData('getCurrentBlockTimestamp'),
+          [
+            OVMMulticall.address,
+            OVMMulticall.interface.encodeFunctionData(
+              'getCurrentBlockTimestamp'
+            ),
+          ],
+          [
+            OVMMulticall.address,
+            OVMMulticall.interface.encodeFunctionData('getCurrentBlockNumber'),
+          ],
         ],
-        [
-          OVMMulticall.address,
-          OVMMulticall.interface.encodeFunctionData('getCurrentBlockNumber'),
-        ],
-      ], {blockTag: i})
+        { blockTag: i }
+      )
 
       const timestamp = BigNumber.from(returnData[0])
       const blockNumber = BigNumber.from(returnData[1])

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -174,8 +174,8 @@ describe('Basic RPC tests', () => {
       // 96 bytes * 16 per non zero byte
       const onesCost = BigNumber.from(96).mul(16)
       const expectedCost = dataLen
-        .map(len => BigNumber.from(len).mul(4))
-        .map(zerosCost => zerosCost.add(onesCost))
+        .map((len) => BigNumber.from(len).mul(4))
+        .map((zerosCost) => zerosCost.add(onesCost))
 
       // Repeat this test for a series of possible transaction sizes.
       for (let i = 0; i < dataLen.length; i++) {

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -18,12 +18,17 @@ import { cleanEnv, str, num } from 'envalid'
 export const GWEI = BigNumber.from(1e9)
 
 const env = cleanEnv(process.env, {
-  L1_URL:            str({ default: "http://localhost:9545" }),
-  L2_URL:            str({ default: "http://localhost:8545" }),
+  L1_URL: str({ default: 'http://localhost:9545' }),
+  L2_URL: str({ default: 'http://localhost:8545' }),
   L1_POLLING_INTERVAL: num({ default: 10 }),
   L2_POLLING_INTERVAL: num({ default: 10 }),
-  PRIVATE_KEY:         str({ default: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' }),
-  ADDRESS_MANAGER: str({ default: '0x5FbDB2315678afecb367f032d93F642f64180aa3' })
+  PRIVATE_KEY: str({
+    default:
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+  }),
+  ADDRESS_MANAGER: str({
+    default: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+  }),
 })
 
 // The hardhat instance

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -545,7 +545,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     )
 
     const addr = await manager.getAddress(
-      'OVM_ChainStorageContainer:CTC:batches'
+      'OVM_ChainStorageContainer-CTC-batches'
     )
     const container = new Contract(
       addr,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -94,7 +94,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         )
     {
         return iOVM_ChainStorageContainer(
-            resolve("OVM_ChainStorageContainer:CTC:batches")
+            resolve("OVM_ChainStorageContainer-CTC-batches")
         );
     }
 
@@ -111,7 +111,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         )
     {
         return iOVM_ChainStorageContainer(
-            resolve("OVM_ChainStorageContainer:CTC:queue")
+            resolve("OVM_ChainStorageContainer-CTC-queue")
         );
     }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_StateCommitmentChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_StateCommitmentChain.sol
@@ -72,7 +72,7 @@ contract OVM_StateCommitmentChain is iOVM_StateCommitmentChain, Lib_AddressResol
         )
     {
         return iOVM_ChainStorageContainer(
-            resolve("OVM_ChainStorageContainer:SCC:batches")
+            resolve("OVM_ChainStorageContainer-SCC-batches")
         );
     }
 

--- a/packages/contracts/deploy/001-OVM_ChainStorageContainer_ctc_batches.deploy.ts
+++ b/packages/contracts/deploy/001-OVM_ChainStorageContainer_ctc_batches.deploy.ts
@@ -15,7 +15,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   await deployAndRegister({
     hre,
-    name: 'OVM_ChainStorageContainer:CTC:batches',
+    name: 'OVM_ChainStorageContainer-CTC-batches',
     contract: 'OVM_ChainStorageContainer',
     args: [Lib_AddressManager.address, 'OVM_CanonicalTransactionChain'],
   })

--- a/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_queue.deploy.ts
+++ b/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_queue.deploy.ts
@@ -15,7 +15,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   await deployAndRegister({
     hre,
-    name: 'OVM_ChainStorageContainer:CTC:queue',
+    name: 'OVM_ChainStorageContainer-CTC-queue',
     contract: 'OVM_ChainStorageContainer',
     args: [Lib_AddressManager.address, 'OVM_CanonicalTransactionChain'],
   })

--- a/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
+++ b/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
@@ -15,7 +15,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   await deployAndRegister({
     hre,
-    name: 'OVM_ChainStorageContainer:SCC:batches',
+    name: 'OVM_ChainStorageContainer-SCC-batches',
     contract: 'OVM_ChainStorageContainer',
     args: [Lib_AddressManager.address, 'OVM_StateCommitmentChain'],
   })

--- a/packages/contracts/src/contract-deployment/config.ts
+++ b/packages/contracts/src/contract-deployment/config.ts
@@ -233,15 +233,15 @@ export const makeContractDeployConfig = async (
         '0x0000000000000000000000000000000000000000', // will be overridden by geth when state dump is ingested.  Storage key: 0x0000000000000000000000000000000000000000000000000000000000000008
       ],
     },
-    'OVM_ChainStorageContainer:CTC:batches': {
+    'OVM_ChainStorageContainer-CTC-batches': {
       factory: getContractFactory('OVM_ChainStorageContainer'),
       params: [AddressManager.address, 'OVM_CanonicalTransactionChain'],
     },
-    'OVM_ChainStorageContainer:CTC:queue': {
+    'OVM_ChainStorageContainer-CTC-queue': {
       factory: getContractFactory('OVM_ChainStorageContainer'),
       params: [AddressManager.address, 'OVM_CanonicalTransactionChain'],
     },
-    'OVM_ChainStorageContainer:SCC:batches': {
+    'OVM_ChainStorageContainer-SCC-batches': {
       factory: getContractFactory('OVM_ChainStorageContainer'),
       params: [AddressManager.address, 'OVM_StateCommitmentChain'],
     },

--- a/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.gas.spec.ts
@@ -114,12 +114,12 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
     )
 
     await AddressManager.setAddress(
-      'OVM_ChainStorageContainer:CTC:batches',
+      'OVM_ChainStorageContainer-CTC-batches',
       batches.address
     )
 
     await AddressManager.setAddress(
-      'OVM_ChainStorageContainer:CTC:queue',
+      'OVM_ChainStorageContainer-CTC-queue',
       queue.address
     )
 

--- a/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -164,12 +164,12 @@ describe('OVM_CanonicalTransactionChain', () => {
     )
 
     await AddressManager.setAddress(
-      'OVM_ChainStorageContainer:CTC:batches',
+      'OVM_ChainStorageContainer-CTC-batches',
       batches.address
     )
 
     await AddressManager.setAddress(
-      'OVM_ChainStorageContainer:CTC:queue',
+      'OVM_ChainStorageContainer-CTC-queue',
       queue.address
     )
 

--- a/packages/contracts/test/contracts/OVM/chain/OVM_StateCommitmentChain.spec.ts
+++ b/packages/contracts/test/contracts/OVM/chain/OVM_StateCommitmentChain.spec.ts
@@ -83,7 +83,7 @@ describe('OVM_StateCommitmentChain', () => {
     )
 
     await AddressManager.setAddress(
-      'OVM_ChainStorageContainer:SCC:batches',
+      'OVM_ChainStorageContainer-SCC-batches',
       batches.address
     )
 

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -197,7 +197,8 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
             break
           case 'l2':
             currentL2Block = await this.state.db.getLatestUnconfirmedTransaction()
-            highestL2BlockNumber = (await this.state.db.getHighestSyncedUnconfirmedBlock()) - 1
+            highestL2BlockNumber =
+              (await this.state.db.getHighestSyncedUnconfirmedBlock()) - 1
             break
           default:
             throw new Error(`Unknown transaction backend ${backend}`)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Changes the names of the various chain storage container contracts to use dashes instead of colons.

Would address #663 
