### PR TITLE
feat[contracts]: Update Lib_AddressManager.AddressSet event to speed up data transport layer

### DIFF
--- a/.changeset/flat-bananas-perform.md
+++ b/.changeset/flat-bananas-perform.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': minor
+'@eth-optimism/data-transport-layer': minor
+---
+
+Update AddressSet event to speed search up a bit. Breaks AddressSet API.

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressManager.sol
@@ -14,8 +14,9 @@ contract Lib_AddressManager is Ownable {
      **********/
 
     event AddressSet(
-        string _name,
-        address _newAddress
+        string indexed _name,
+        address _newAddress,
+        address _oldAddress
     );
 
 
@@ -42,11 +43,13 @@ contract Lib_AddressManager is Ownable {
         public
         onlyOwner
     {
+        address oldAddress = addresses[_getNameHash(_name)];
         addresses[_getNameHash(_name)] = _address;
 
         emit AddressSet(
             _name,
-            _address
+            _address,
+            oldAddress
         );
     }
 

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/resolver/Lib_AddressManager.sol
@@ -43,8 +43,9 @@ contract Lib_AddressManager is Ownable {
         public
         onlyOwner
     {
-        address oldAddress = addresses[_getNameHash(_name)];
-        addresses[_getNameHash(_name)] = _address;
+        bytes32 nameHash = _getNameHash(_name);
+        address oldAddress = addresses[nameHash];
+        addresses[nameHash] = _address;
 
         emit AddressSet(
             _name,

--- a/packages/core-utils/src/events.ts
+++ b/packages/core-utils/src/events.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 export interface EventArgsAddressSet {
   _name: string
   _newAddress: string
+  _oldAddress: string
 }
 
 export interface EventArgsTransactionEnqueued {

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -233,13 +233,11 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
     // We need to figure out how to make this work without Infura. Mark and I think that infura is
     // doing some indexing of events beyond Geth's native capabilities, meaning some event logic
     // will only work on Infura and not on a local geth instance. Not great.
-    const addressSetEvents = ((await this.state.contracts.Lib_AddressManager.queryFilter(
-      this.state.contracts.Lib_AddressManager.filters.AddressSet(),
+    const addressSetEvents = await this.state.contracts.Lib_AddressManager.queryFilter(
+      this.state.contracts.Lib_AddressManager.filters.AddressSet(contractName),
       fromL1Block,
       toL1Block
-    )) as TypedEthersEvent<EventArgsAddressSet>[]).filter((event) => {
-      return event.args._name === contractName
-    })
+    )
 
     // We're going to parse things out in ranges because the address of a given contract may have
     // changed in the range provided by the user.
@@ -317,21 +315,14 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
     contractName: string,
     blockNumber: number
   ): Promise<string> {
-    // TODO: Should be much easier than this. Need to change the params of this event.
-    const relevantAddressSetEvents = (
-      await this.state.contracts.Lib_AddressManager.queryFilter(
-        this.state.contracts.Lib_AddressManager.filters.AddressSet(),
-        this.state.startingL1BlockNumber
-      )
-    ).filter((event) => {
-      return (
-        event.args._name === contractName && event.blockNumber < blockNumber
-      )
-    })
+    const events = await this.state.contracts.Lib_AddressManager.queryFilter(
+      this.state.contracts.Lib_AddressManager.filters.AddressSet(contractName),
+      this.state.startingL1BlockNumber,
+      blockNumber
+    )
 
-    if (relevantAddressSetEvents.length > 0) {
-      return relevantAddressSetEvents[relevantAddressSetEvents.length - 1].args
-        ._newAddress
+    if (events.length > 0) {
+      return events[events.length - 1].args._newAddress
     } else {
       // Address wasn't set before this.
       return constants.AddressZero


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates `AddressSet` so that the `_name` of the changed contract is indexed and that the `_oldAddress` is emitted along with the `_newAddress`. Speeds up some event searching within the `data-transport-layer`. Seems like something quick and useful to sneak into 0.4.0. Would address https://github.com/ethereum-optimism/optimism/issues/625.
