### PR TITLE
Pass additional information across domains via token gateways

### DIFF
--- a/.changeset/wild-months-matter.md
+++ b/.changeset/wild-months-matter.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Token gateways pass additional information: sender and arbitrary data.

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -131,24 +131,13 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
 
-    const data = `0x` + 'ab'.repeat(50_000)
+    const data = `0x` + 'ab'.repeat(40_001)
     const { tx, receipt } = await env.waitForXDomainTransaction(
       env.gateway.deposit(9_000_000, data, { value: depositAmount }),
       Direction.L1ToL2
     )
 
-    const l1FeePaid = receipt.gasUsed.mul(tx.gasPrice)
-    const postBalances = await getBalances(env)
-
-    expect(postBalances.l1GatewayBalance).to.deep.eq(
-      preBalances.l1GatewayBalance.add(depositAmount)
-    )
-    expect(postBalances.l2UserBalance).to.deep.eq(
-      preBalances.l2UserBalance.add(depositAmount)
-    )
-    expect(postBalances.l1UserBalance).to.deep.eq(
-      preBalances.l1UserBalance.sub(l1FeePaid.add(depositAmount))
-    )
+    expect(receipt.status).to.be.equal(0)
   })
 
   it('withdraw', async () => {

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -103,9 +103,12 @@ describe('Native ETH Integration Tests', async () => {
   })
 
   it('deposit with a large data argument', async () => {
+    const MAX_L2_DATA_LENGTH = 40_000
     const depositAmount = 10
     const preBalances = await getBalances(env)
-    const data = `0x` + 'ab'.repeat(32000)
+
+    // Assume 9 MM gas, and add 10% safety factor to hardcoded max length.
+    const data = `0x` + 'ab'.repeat(MAX_L2_DATA_LENGTH * 1.1)
     const { tx, receipt } = await env.waitForXDomainTransaction(
       env.gateway.deposit(9_000_000, data, { value: depositAmount }),
       Direction.L1ToL2

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -102,6 +102,29 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
+  it('deposit with a large data argument', async () => {
+    const depositAmount = 10
+    const preBalances = await getBalances(env)
+    const data = `0x` + 'ab'.repeat(32000)
+    const { tx, receipt } = await env.waitForXDomainTransaction(
+      env.gateway.deposit(data, 9_000_000, { value: depositAmount }),
+      Direction.L1ToL2
+    )
+
+    const l1FeePaid = receipt.gasUsed.mul(tx.gasPrice)
+    const postBalances = await getBalances(env)
+
+    expect(postBalances.l1GatewayBalance).to.deep.eq(
+      preBalances.l1GatewayBalance.add(depositAmount)
+    )
+    expect(postBalances.l2UserBalance).to.deep.eq(
+      preBalances.l2UserBalance.add(depositAmount)
+    )
+    expect(postBalances.l1UserBalance).to.deep.eq(
+      preBalances.l1UserBalance.sub(l1FeePaid.add(depositAmount))
+    )
+  })
+
   it('withdraw', async () => {
     const withdrawAmount = BigNumber.from(3)
     const preBalances = await getBalances(env)

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -59,7 +59,7 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const { tx, receipt } = await env.waitForXDomainTransaction(
-      env.gateway.deposit("0xFFFF", { value: depositAmount }),
+      env.gateway.deposit('0xFFFF', 0, { value: depositAmount }),
       Direction.L1ToL2
     )
 
@@ -81,7 +81,7 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const depositReceipts = await env.waitForXDomainTransaction(
-      env.gateway.depositTo(l2Bob.address, "0xFFFF", {
+      env.gateway.depositTo(l2Bob.address, '0xFFFF', 0, {
         value: depositAmount,
       }),
       Direction.L1ToL2
@@ -111,7 +111,7 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdraw(withdrawAmount, "0xFFFF"),
+      env.ovmEth.withdraw(withdrawAmount, '0xFFFF', 0),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -140,7 +140,7 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount, "0xFFFF"),
+      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount, '0xFFFF', 0),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -162,7 +162,7 @@ describe('Native ETH Integration Tests', async () => {
     // 1. deposit
     const amount = utils.parseEther('1')
     await env.waitForXDomainTransaction(
-      env.gateway.deposit("0xFFFF", {
+      env.gateway.deposit('0xFFFF', 0, {
         value: amount,
       }),
       Direction.L1ToL2
@@ -180,7 +180,7 @@ describe('Native ETH Integration Tests', async () => {
     // 3. do withdrawal
     const withdrawnAmount = utils.parseEther('0.95')
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.connect(other).withdraw(withdrawnAmount, "0xFFFF"),
+      env.ovmEth.connect(other).withdraw(withdrawnAmount, '0xFFFF', 0),
       Direction.L2ToL1
     )
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -5,7 +5,7 @@ import { Direction } from './shared/watcher-utils'
 import { PROXY_SEQUENCER_ENTRYPOINT_ADDRESS } from './shared/utils'
 import { OptimismEnv } from './shared/env'
 
-const DEFAULT_TEST_GAS_L1 = 250_000
+const DEFAULT_TEST_GAS_L1 = 230_000
 const DEFAULT_TEST_GAS_L2 = 825_000
 // TX size enforced by CTC:
 const MAX_ROLLUP_TX_SIZE = 50_000

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -118,11 +118,11 @@ describe('Native ETH Integration Tests', async () => {
 
     // Set data length slightly less than MAX_ROLLUP_TX_SIZE
     // to allow for encoding and other arguments
-    const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE - 100)
+    const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE - 500)
     const { tx, receipt } = await env.waitForXDomainTransaction(
       env.gateway.deposit(ASSUMED_L2_GAS_LIMIT, data, {
         value: depositAmount,
-        // gasLimit: 5_000_000
+        gasLimit: 4_000_000,
       }),
       Direction.L1ToL2
     )
@@ -143,7 +143,6 @@ describe('Native ETH Integration Tests', async () => {
 
   it('deposit fails with a TOO large data argument', async () => {
     const depositAmount = 10
-    const preBalances = await getBalances(env)
 
     const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE + 1)
     await expect(
@@ -151,7 +150,9 @@ describe('Native ETH Integration Tests', async () => {
         value: depositAmount,
         gasLimit: 4_000_000,
       })
-    ).to.be.revertedWith('Data is too long to safely forward to L2')
+    ).to.be.revertedWith(
+      'Transaction data size exceeds maximum for rollup transaction.'
+    )
   })
 
   it('withdraw', async () => {

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -111,7 +111,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it.only('deposit passes with a large data argument', async () => {;
+  it('deposit passes with a large data argument', async () => {
     const ASSUMED_L2_GAS_LIMIT = 8_000_000
     const depositAmount = 10
     const preBalances = await getBalances(env)
@@ -121,7 +121,7 @@ describe('Native ETH Integration Tests', async () => {
     const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE - 100)
     const { tx, receipt } = await env.waitForXDomainTransaction(
       env.gateway.deposit(ASSUMED_L2_GAS_LIMIT, data, {
-        value: depositAmount
+        value: depositAmount,
         // gasLimit: 5_000_000
       }),
       Direction.L1ToL2
@@ -141,11 +141,11 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it.only('deposit fails with a TOO large data argument', async () => {
+  it('deposit fails with a TOO large data argument', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
 
-    const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE+1)
+    const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE + 1)
     await expect(
       env.gateway.deposit(DEFAULT_TEST_GAS_L2, data, {
         value: depositAmount,
@@ -192,7 +192,12 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount, DEFAULT_TEST_GAS_L1, '0xFFFF'),
+      env.ovmEth.withdrawTo(
+        l1Bob.address,
+        withdrawAmount,
+        DEFAULT_TEST_GAS_L1,
+        '0xFFFF'
+      ),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -233,7 +238,9 @@ describe('Native ETH Integration Tests', async () => {
     // 3. do withdrawal
     const withdrawnAmount = utils.parseEther('0.95')
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.connect(other).withdraw(withdrawnAmount, DEFAULT_TEST_GAS_L1, '0xFFFF'),
+      env.ovmEth
+        .connect(other)
+        .withdraw(withdrawnAmount, DEFAULT_TEST_GAS_L1, '0xFFFF'),
       Direction.L2ToL1
     )
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -56,7 +56,7 @@ describe('Native ETH Integration Tests', async () => {
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount, 0, '0xFFFF')
-      expect(gas).to.be.deep.eq(BigNumber.from(0x248dede997bf))
+      expect(gas).to.be.deep.eq(BigNumber.from(21000))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -56,7 +56,7 @@ describe('Native ETH Integration Tests', async () => {
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount, 0, '0xFFFF')
-      expect(gas).to.be.deep.eq(BigNumber.from(21000))
+      expect(gas).to.be.deep.eq(BigNumber.from(0x248dede997bf))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -50,7 +50,7 @@ describe('Native ETH Integration Tests', async () => {
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
-      const gas = await env.ovmEth.estimateGas.withdraw(amount, '0xFFFF')
+      const gas = await env.ovmEth.estimateGas.withdraw(amount, '0xFFFF', 0)
       expect(gas).to.be.deep.eq(BigNumber.from(0x207ad91a77b4))
     })
   })

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -50,8 +50,8 @@ describe('Native ETH Integration Tests', async () => {
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
-      const gas = await env.ovmEth.estimateGas.withdraw(amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(61400489396))
+      const gas = await env.ovmEth.estimateGas.withdraw(amount, '0xFFFF')
+      expect(gas).to.be.deep.eq(BigNumber.from(0x207ad91a77b4))
     })
   })
 
@@ -59,7 +59,7 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const { tx, receipt } = await env.waitForXDomainTransaction(
-      env.gateway.deposit({ value: depositAmount }),
+      env.gateway.deposit("0xFFFF", { value: depositAmount }),
       Direction.L1ToL2
     )
 
@@ -81,7 +81,7 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const depositReceipts = await env.waitForXDomainTransaction(
-      env.gateway.depositTo(l2Bob.address, {
+      env.gateway.depositTo(l2Bob.address, "0xFFFF", {
         value: depositAmount,
       }),
       Direction.L1ToL2
@@ -111,7 +111,7 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdraw(withdrawAmount),
+      env.ovmEth.withdraw(withdrawAmount, "0xFFFF"),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -140,7 +140,7 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount),
+      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount, "0xFFFF"),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -162,7 +162,7 @@ describe('Native ETH Integration Tests', async () => {
     // 1. deposit
     const amount = utils.parseEther('1')
     await env.waitForXDomainTransaction(
-      env.gateway.deposit({
+      env.gateway.deposit("0xFFFF", {
         value: amount,
       }),
       Direction.L1ToL2
@@ -180,7 +180,7 @@ describe('Native ETH Integration Tests', async () => {
     // 3. do withdrawal
     const withdrawnAmount = utils.parseEther('0.95')
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.connect(other).withdraw(withdrawnAmount),
+      env.ovmEth.connect(other).withdraw(withdrawnAmount, "0xFFFF"),
       Direction.L2ToL1
     )
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -56,7 +56,7 @@ describe('Native ETH Integration Tests', async () => {
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount, 0, '0xFFFF')
-      expect(gas).to.be.deep.eq(BigNumber.from(0x207ad91a77b4))
+      expect(gas).to.be.deep.eq(BigNumber.from(0x248dede997bf))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -56,7 +56,7 @@ describe('Native ETH Integration Tests', async () => {
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount, 0, '0xFFFF')
-      expect(gas).to.be.deep.eq(BigNumber.from(0x248dede997bf))
+      expect(gas).to.be.deep.eq(BigNumber.from(0x0f5203e9bf))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -50,7 +50,7 @@ describe('Native ETH Integration Tests', async () => {
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
-      const gas = await env.ovmEth.estimateGas.withdraw(amount, '0xFFFF', 0)
+      const gas = await env.ovmEth.estimateGas.withdraw(amount, 0, '0xFFFF')
       expect(gas).to.be.deep.eq(BigNumber.from(0x207ad91a77b4))
     })
   })
@@ -59,7 +59,7 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const { tx, receipt } = await env.waitForXDomainTransaction(
-      env.gateway.deposit('0xFFFF', 0, { value: depositAmount }),
+      env.gateway.deposit(0, '0xFFFF', { value: depositAmount }),
       Direction.L1ToL2
     )
 
@@ -81,7 +81,7 @@ describe('Native ETH Integration Tests', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const depositReceipts = await env.waitForXDomainTransaction(
-      env.gateway.depositTo(l2Bob.address, '0xFFFF', 0, {
+      env.gateway.depositTo(l2Bob.address, 0, '0xFFFF', {
         value: depositAmount,
       }),
       Direction.L1ToL2
@@ -107,7 +107,7 @@ describe('Native ETH Integration Tests', async () => {
     const preBalances = await getBalances(env)
     const data = `0x` + 'ab'.repeat(32000)
     const { tx, receipt } = await env.waitForXDomainTransaction(
-      env.gateway.deposit(data, 9_000_000, { value: depositAmount }),
+      env.gateway.deposit(9_000_000, data, { value: depositAmount }),
       Direction.L1ToL2
     )
 
@@ -134,7 +134,7 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdraw(withdrawAmount, '0xFFFF', 0),
+      env.ovmEth.withdraw(withdrawAmount, 0, '0xFFFF'),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -163,7 +163,7 @@ describe('Native ETH Integration Tests', async () => {
     )
 
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount, '0xFFFF', 0),
+      env.ovmEth.withdrawTo(l1Bob.address, withdrawAmount, 0, '0xFFFF'),
       Direction.L2ToL1
     )
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
@@ -185,7 +185,7 @@ describe('Native ETH Integration Tests', async () => {
     // 1. deposit
     const amount = utils.parseEther('1')
     await env.waitForXDomainTransaction(
-      env.gateway.deposit('0xFFFF', 0, {
+      env.gateway.deposit(0, '0xFFFF', {
         value: amount,
       }),
       Direction.L1ToL2
@@ -203,7 +203,7 @@ describe('Native ETH Integration Tests', async () => {
     // 3. do withdrawal
     const withdrawnAmount = utils.parseEther('0.95')
     const receipts = await env.waitForXDomainTransaction(
-      env.ovmEth.connect(other).withdraw(withdrawnAmount, '0xFFFF', 0),
+      env.ovmEth.connect(other).withdraw(withdrawnAmount, 0, '0xFFFF'),
       Direction.L2ToL1
     )
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,9 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, 0, '0xFFFF', { value, gasLimit: 9_000_000 })
-    : gateway.deposit(0, '0xFFFF', { value, 9_000_000})
+    ? gateway.depositTo(recipient, 150_000, '0xFFFF', { value, gasLimit: 150_000 })
+    : gateway.deposit(150_000, '0xFFFF', { value, gasLimit: 150_000 })
+
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,8 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, { value })
-    : gateway.deposit({ value })
+    ? gateway.depositTo(recipient, "0x", { value, gasLimit: 2_000_000 })
+    : gateway.deposit("0x", { value, gasLimit: 2_000_000 })
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,8 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, 150_000, '0xFFFF', { value, gasLimit: 150_000 })
-    : gateway.deposit(150_000, '0xFFFF', { value, gasLimit: 150_000 })
+    ? gateway.depositTo(recipient, 1_000_000, '0xFFFF', { value })
+    : gateway.deposit(1_000_000, '0xFFFF', { value })
 
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,8 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, '0x', 0, { value })
-    : gateway.deposit('0x', 0, { value })
+    ? gateway.depositTo(recipient, 0, '0xFFFF', { value })
+    : gateway.deposit(0, '0xFFFF', { value })
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,8 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, 0, '0xFFFF', { value })
-    : gateway.deposit(0, '0xFFFF', { value })
+    ? gateway.depositTo(recipient, 0, '0xFFFF', { value, gasLimit: 9_000_000 })
+    : gateway.deposit(0, '0xFFFF', { value, 9_000_000})
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,8 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, '0x', 0, { value, gasLimit: 500_000 })
-    : gateway.deposit('0x', 0, { value, gasLimit: 500_000 })
+    ? gateway.depositTo(recipient, '0x', 0, { value })
+    : gateway.deposit('0x', 0, { value })
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -101,8 +101,8 @@ export const fundUser = async (
 ) => {
   const value = BigNumber.from(amount)
   const tx = recipient
-    ? gateway.depositTo(recipient, "0x", { value, gasLimit: 2_000_000 })
-    : gateway.deposit("0x", { value, gasLimit: 2_000_000 })
+    ? gateway.depositTo(recipient, '0x', 0, { value, gasLimit: 500_000 })
+    : gateway.deposit('0x', 0, { value, gasLimit: 500_000 })
   await waitForXDomainTransaction(watcher, tx, Direction.L1ToL2)
 }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -98,7 +98,7 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      */
     function getFinalizeDepositL2Gas()
         public
-        view
+        pure
         virtual
         returns(
             uint32
@@ -116,13 +116,14 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @param _amount Amount of the ERC20 to deposit
      */
     function deposit(
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external
         override
         virtual
     {
-        _initiateDeposit(msg.sender, msg.sender, _amount);
+        _initiateDeposit(msg.sender, msg.sender, _amount, _data);
     }
 
     /**
@@ -132,13 +133,14 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      */
     function depositTo(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external
         override
         virtual
     {
-        _initiateDeposit(msg.sender, _to, _amount);
+        _initiateDeposit(msg.sender, _to, _amount, _data);
     }
 
     /**
@@ -152,7 +154,8 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     function _initiateDeposit(
         address _from,
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         internal
     {
@@ -164,20 +167,23 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
         );
 
         // Construct calldata for l2DepositedToken.finalizeDeposit(_to, _amount)
-        bytes memory data = abi.encodeWithSelector(
+        bytes memory message = abi.encodeWithSelector(
             iOVM_L2DepositedToken.finalizeDeposit.selector,
+            _from,
             _to,
-            _amount
+            _amount,
+            _data
         );
 
         // Send calldata into L2
         sendCrossDomainMessage(
             l2DepositedToken,
-            data,
+            message,
             getFinalizeDepositL2Gas()
         );
 
-        emit DepositInitiated(_from, _to, _amount);
+        // We omit _data here because events only support bytes32 types.
+        emit DepositInitiated(_from, _to, _amount, _data);
     }
 
     /*************************
@@ -189,24 +195,27 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * L1 ERC20 token.
      * This call will fail if the initialized withdrawal from L2 has not been finalized.
      *
+     * @param _from L2 address initiating the transfer
      * @param _to L1 address to credit the withdrawal to
-     * @param _amount Amount of the ERC20 to withdraw
+     * @param _data Data provided by the sender on L2.
      */
     function finalizeWithdrawal(
+        address _from,
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external
         override
         virtual
         onlyFromCrossDomainAccount(l2DepositedToken)
     {
+        // todo: add verification check on _from and _data
         // Call our withdrawal accounting handler implemented by child contracts.
         _handleFinalizeWithdrawal(
             _to,
             _amount
         );
-
-        emit WithdrawalFinalized(_to, _amount);
+        emit WithdrawalFinalized(_from, _to, _amount, _data);
     }
 }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -58,7 +58,6 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     /**
      * @dev Core logic to be performed when a withdrawal is finalized on L1.
      * In most cases, this will simply send locked funds to the withdrawer.
-     *
      * param _to Address being withdrawn to.
      * param _amount Amount being withdrawn.
      */
@@ -75,7 +74,6 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     /**
      * @dev Core logic to be performed when a deposit is initiated on L1.
      * In most cases, this will simply send locked funds to the withdrawer.
-     *
      * param _from Address being deposited from on L1.
      * param _to Address being deposited into on L2.
      * param _amount Amount being deposited.
@@ -115,10 +113,11 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @dev deposit an amount of the ERC20 to the caller's balance on L2
      * @param _amount Amount of the ERC20 to deposit
      * @param _l2Gas Optional gas limit to complete the deposit on l2.
-     *  If not provided, the default amount is passed.
+     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
+     *        to the default amount.
      * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function deposit(
         uint256 _amount,
@@ -137,10 +136,11 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @param _to L2 address to credit the withdrawal to.
      * @param _amount Amount of the ERC20 to deposit.
      * @param _l2Gas Optional gas limit to complete the deposit on l2.
-     *  If not provided, the default amount is passed.
+     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
+     *        to the default amount.
      * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function depositTo(
         address _to,
@@ -162,11 +162,12 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @param _from Account to pull the deposit from on L1
      * @param _to Account to give the deposit to on L2
      * @param _amount Amount of the ERC20 to deposit.
-     * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
      * @param _l2Gas Optional gas limit to complete the deposit on l2.
-     *  If not provided, the default amount is passed.
+     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
+     *        to the default amount.
+     * @param _data Optional data to forward to L2. This data is provided
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function _initiateDeposit(
         address _from,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -114,39 +114,45 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     /**
      * @dev deposit an amount of the ERC20 to the caller's balance on L2
      * @param _amount Amount of the ERC20 to deposit
-     * @param _data Data to forward to L2.
-     * @param _l2Gas Gas limit for the provided message.
+     * @param _l2Gas Optional gas limit to complete the deposit on l2.
+     *  If not provided, the default amount is passed.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
      */
     function deposit(
-        uint _amount,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint256 _amount,
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external
         override
         virtual
     {
-        _initiateDeposit(msg.sender, msg.sender, _amount, _data, _l2Gas);
+        _initiateDeposit(msg.sender, msg.sender, _amount, _l2Gas, _data);
     }
 
     /**
      * @dev deposit an amount of ERC20 to a recipient's balance on L2
      * @param _to L2 address to credit the withdrawal to.
      * @param _amount Amount of the ERC20 to deposit.
-     * @param _data Data to forward to L2.
-     * @param _l2Gas Gas limit for the provided message.
+     * @param _l2Gas Optional gas limit to complete the deposit on l2.
+     *  If not provided, the default amount is passed.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
      */
     function depositTo(
         address _to,
-        uint _amount,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint256 _amount,
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external
         override
         virtual
     {
-        _initiateDeposit(msg.sender, _to, _amount, _data, _l2Gas);
+        _initiateDeposit(msg.sender, _to, _amount, _l2Gas, _data);
     }
 
     /**
@@ -156,15 +162,18 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @param _from Account to pull the deposit from on L1
      * @param _to Account to give the deposit to on L2
      * @param _amount Amount of the ERC20 to deposit.
-     * @param _data Data to forward to L2.
-     * @param _l2Gas Gas limit for the provided message.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
+     * @param _l2Gas Optional gas limit to complete the deposit on l2.
+     *  If not provided, the default amount is passed.
      */
     function _initiateDeposit(
         address _from,
         address _to,
-        uint _amount,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint256 _amount,
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         internal
     {
@@ -212,12 +221,14 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
      * @param _from L2 address initiating the transfer.
      * @param _to L1 address to credit the withdrawal to.
      * @param _amount Amount of the ERC20 to deposit.
-     * @param _data Data provided by the sender on L2.
+     * @param _data Data provided by the sender on L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
      */
     function finalizeWithdrawal(
         address _from,
         address _to,
-        uint _amount,
+        uint256 _amount,
         bytes calldata _data
     )
         external

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -153,6 +153,9 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     )
         internal
     {
+
+        require(_data.length < 40_000, "Data is too long to safely forward to L2");
+
         // Call our deposit accounting handler implemented by child contracts.
         _handleInitiateDeposit(
             _from,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -153,9 +153,6 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
     )
         internal
     {
-
-        require(_data.length < 40_000, "Data is too long to safely forward to L2");
-
         // Call our deposit accounting handler implemented by child contracts.
         _handleInitiateDeposit(
             _from,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L1TokenGateway.sol
@@ -172,8 +172,8 @@ abstract contract Abs_L1TokenGateway is iOVM_L1TokenGateway, OVM_CrossDomainEnab
         // Send calldata into L2
         sendCrossDomainMessage(
             l2DepositedToken,
-            message,
-            _l2Gas
+            _l2Gas,
+            message
         );
 
         // We omit _data here because events only support bytes32 types.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -81,7 +81,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      ********************************/
 
     // Default gas value which can be overridden if more complex logic runs on L1.
-    uint32 internal constant DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS = 100000;
+    uint32 internal constant DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS = 100_000;
 
     /**
      * @dev Core logic to be performed when a withdrawal from L2 is initialized.
@@ -124,6 +124,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     function getFinalizeWithdrawalL1Gas()
         public
         pure
+        override
         virtual
         returns(
             uint32
@@ -139,11 +140,14 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
 
     /**
      * @dev initiate a withdraw of some tokens to the caller's account on L1
-     * @param _amount Amount of the token to withdraw
+     * @param _amount Amount of the token to withdraw.
+     * @param _data Data to forward to L1.
+     * @param _l1Gas Gas limit for the provided message.
      */
     function withdraw(
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l1Gas
     )
         external
         override
@@ -154,19 +158,23 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             msg.sender,
             msg.sender,
             _amount,
-            _data
+            _data,
+            _l1Gas
         );
     }
 
     /**
-     * @dev initiate a withdraw of some token to a recipient's account on L1
-     * @param _to L1 adress to credit the withdrawal to
-     * @param _amount Amount of the token to withdraw
+     * @dev initiate a withdraw of some token to a recipient's account on L1.
+     * @param _to L1 adress to credit the withdrawal to.
+     * @param _amount Amount of the token to withdraw.
+     * @param _data Data to forward to L1.
+     * @param _l1Gas Gas limit for the provided message.
      */
     function withdrawTo(
         address _to,
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l1Gas
     )
         external
         override
@@ -177,22 +185,26 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             msg.sender,
             _to,
             _amount,
-            _data);
+            _data,
+            _l1Gas
+        );
     }
 
     /**
      * @dev Performs the logic for deposits by storing the token and informing the L2 token Gateway of the deposit.
      *
-     * @param _to Account to give the withdrawal to on L1
-     * @param _to Account to give the withdrawal to on L1
-     * @param _amount Amount of the token to withdraw
-     * @param _amount Amount of the token to withdraw
+     * @param _from Account to pull the deposit from on L2.
+     * @param _to Account to give the withdrawal to on L1.
+     * @param _amount Amount of the token to withdraw.
+     * @param _data Data to forward to L1.
+     * @param _l1Gas Gas limit for the provided message on L1.
      */
     function _initiateWithdrawal(
         address _from,
         address _to,
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l1Gas
     )
         internal
     {
@@ -208,11 +220,15 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             _data
         );
 
+        // Prevent tokens stranded on other side by taking
+        // the max of the user provided gas and DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS
+        uint32 defaultGas = getFinalizeWithdrawalL1Gas();
+        uint32 l1Gas = _l1Gas > defaultGas ? _l1Gas : defaultGas;
         // Send message up to L1 gateway
         sendCrossDomainMessage(
             address(l1TokenGateway),
             message,
-            getFinalizeWithdrawalL1Gas()
+            l1Gas
         );
 
         emit WithdrawalInitiated(msg.sender, _to, _amount, _data);
@@ -227,6 +243,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * L2 token.
      * This call will fail if it did not originate from a corresponding deposit in OVM_l1TokenGateway.
      *
+     * @param _from Account to pull the deposit from on L2.
      * @param _to Address to receive the withdrawal at
      * @param _amount Amount of the token to withdraw
      * @param _data Data provided by the sender on L1.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -40,7 +40,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      ********************************/
 
     /**
-     * @param _l2CrossDomainMessenger L1 Messenger address being used for cross-chain communications.
+     * @param _l2CrossDomainMessenger L2 Messenger address being used for cross-chain communications.
      */
     constructor(
         address _l2CrossDomainMessenger
@@ -50,9 +50,10 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
 
     /**
      * @dev Initialize this contract with the L1 token gateway address.
-     * The flow: 1) this contract gets deployed on L2, 2) the L1
-     * gateway is deployed with addr from (1), 3) L1 gateway address passed here.
-     *
+     *      The flow:
+     *          1) this contract is deployed on L2,
+     *          2) the L1 gateway is deployed with addr from (1),
+     *          3) L1 gateway address passed here.
      * @param _l1TokenGateway Address of the corresponding L1 gateway deployed to the main chain
      */
     function init(
@@ -86,9 +87,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     /**
      * @dev Core logic to be performed when a withdrawal from L2 is initialized.
      * In most cases, this will simply burn the withdrawn L2 funds.
-     *
-     * param _to Address being withdrawn to
-     * param _amount Amount being withdrawn
+     * param _to Address being withdrawn to.
+     * param _amount Amount being withdrawn.
      */
     function _handleInitiateWithdrawal(
         address, // _to,
@@ -103,9 +103,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     /**
      * @dev Core logic to be performed when a deposit from L2 is finalized on L2.
      * In most cases, this will simply _mint() to credit L2 funds to the recipient.
-     *
-     * param _to Address being deposited to on L2
-     * param _amount Amount which was deposited on L1
+     * param _to Address being deposited to on L2.
+     * param _amount Amount which was deposited on L1.
      */
     function _handleFinalizeDeposit(
         address, // _to
@@ -141,8 +140,12 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     /**
      * @dev initiate a withdraw of some tokens to the caller's account on L1
      * @param _amount Amount of the token to withdraw.
-     * @param _data Data to forward to L1.
-     * @param _l1Gas Gas limit for the provided message.
+     * @param _l1Gas Optional gas limit to complete the deposit on L1.
+     *        If the default amount is greater than the value provided, the L1 gasLimit will be set
+     *        to the default amount.
+     * @param _data Optional data to forward to L1. This data is provided
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function withdraw(
         uint256 _amount,
@@ -167,8 +170,12 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @dev initiate a withdraw of some token to a recipient's account on L1.
      * @param _to L1 adress to credit the withdrawal to.
      * @param _amount Amount of the token to withdraw.
-     * @param _data Data to forward to L1.
-     * @param _l1Gas Gas limit for the provided message.
+     * @param _l1Gas Optional gas limit to complete the deposit on L2.
+     *        If the default amount is greater than the value provided, the L1 gasLimit will be set
+     *        to the default amount.
+     * @param _data Optional data to forward to L1. This data is provided
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function withdrawTo(
         address _to,
@@ -192,15 +199,15 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
 
     /**
      * @dev Performs the logic for deposits by storing the token and informing the L2 token Gateway of the deposit.
-     *
      * @param _from Account to pull the deposit from on L2.
      * @param _to Account to give the withdrawal to on L1.
      * @param _amount Amount of the token to withdraw.
-     * @param _l1Gas Optional gas limit to complete the deposit on l2.
-     *  If not provided, the default amount is passed.
-     * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
+     * @param _l1Gas Optional gas limit to complete the deposit on L2.
+     *        If the default amount is greater than the value provided, the L1 gasLimit will be set
+     *        to the default amount.
+     * @param _data Optional data to forward to L1. This data is provided
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function _initiateWithdrawal(
         address _from,
@@ -245,13 +252,12 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @dev Complete a deposit from L1 to L2, and credits funds to the recipient's balance of this
      * L2 token.
      * This call will fail if it did not originate from a corresponding deposit in OVM_l1TokenGateway.
-     *
      * @param _from Account to pull the deposit from on L2.
      * @param _to Address to receive the withdrawal at
      * @param _amount Amount of the token to withdraw
      * @param _data Data provider by the sender on L1. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function finalizeDeposit(
         address _from,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -92,7 +92,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      */
     function _handleInitiateWithdrawal(
         address, // _to,
-        uint // _amount
+        uint256 // _amount
     )
         internal
         virtual
@@ -109,7 +109,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      */
     function _handleFinalizeDeposit(
         address, // _to
-        uint // _amount
+        uint256 // _amount
     )
         internal
         virtual
@@ -145,9 +145,9 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _l1Gas Gas limit for the provided message.
      */
     function withdraw(
-        uint _amount,
-        bytes calldata _data,
-        uint32 _l1Gas
+        uint256 _amount,
+        uint32 _l1Gas,
+        bytes calldata _data
     )
         external
         override
@@ -158,8 +158,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             msg.sender,
             msg.sender,
             _amount,
-            _data,
-            _l1Gas
+            _l1Gas,
+            _data
         );
     }
 
@@ -172,9 +172,9 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      */
     function withdrawTo(
         address _to,
-        uint _amount,
-        bytes calldata _data,
-        uint32 _l1Gas
+        uint256 _amount,
+        uint32 _l1Gas,
+        bytes calldata _data
     )
         external
         override
@@ -185,8 +185,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             msg.sender,
             _to,
             _amount,
-            _data,
-            _l1Gas
+            _l1Gas,
+            _data
         );
     }
 
@@ -196,15 +196,18 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _from Account to pull the deposit from on L2.
      * @param _to Account to give the withdrawal to on L1.
      * @param _amount Amount of the token to withdraw.
-     * @param _data Data to forward to L1.
-     * @param _l1Gas Gas limit for the provided message on L1.
+     * @param _l1Gas Optional gas limit to complete the deposit on l2.
+     *  If not provided, the default amount is passed.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
      */
     function _initiateWithdrawal(
         address _from,
         address _to,
-        uint _amount,
-        bytes calldata _data,
-        uint32 _l1Gas
+        uint256 _amount,
+        uint32 _l1Gas,
+        bytes calldata _data
     )
         internal
     {
@@ -246,12 +249,14 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _from Account to pull the deposit from on L2.
      * @param _to Address to receive the withdrawal at
      * @param _amount Amount of the token to withdraw
-     * @param _data Data provided by the sender on L1.
+     * @param _data Data provider by the sender on L1. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
      */
     function finalizeDeposit(
         address _from,
         address _to,
-        uint _amount,
+        uint256 _amount,
         bytes calldata _data
     )
         external

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -116,23 +116,6 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         revert("Accounting must be implemented by child contract.");
     }
 
-    /**
-     * @dev Overridable getter for the *L1* gas limit of settling the withdrawal, in the case it may be
-     * dynamic, and the above public constant does not suffice.
-     */
-    function getFinalizeWithdrawalL1Gas()
-        public
-        pure
-        override
-        virtual
-        returns(
-            uint32
-        )
-    {
-        return DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS;
-    }
-
-
     /***************
      * Withdrawing *
      ***************/
@@ -140,16 +123,14 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
     /**
      * @dev initiate a withdraw of some tokens to the caller's account on L1
      * @param _amount Amount of the token to withdraw.
-     * @param _l1Gas Optional gas limit to complete the deposit on L1.
-     *        If the default amount is greater than the value provided, the L1 gasLimit will be set
-     *        to the default amount.
+     * param _l1Gas Unused, but included for potential forward compatibility considerations.
      * @param _data Optional data to forward to L1. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function withdraw(
         uint256 _amount,
-        uint32 _l1Gas,
+        uint32, // _l1Gas,
         bytes calldata _data
     )
         external
@@ -161,7 +142,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             msg.sender,
             msg.sender,
             _amount,
-            _l1Gas,
+            0,
             _data
         );
     }
@@ -170,17 +151,15 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @dev initiate a withdraw of some token to a recipient's account on L1.
      * @param _to L1 adress to credit the withdrawal to.
      * @param _amount Amount of the token to withdraw.
-     * @param _l1Gas Optional gas limit to complete the deposit on L2.
-     *        If the default amount is greater than the value provided, the L1 gasLimit will be set
-     *        to the default amount.
+     * param _l1Gas Unused, but included for potential forward compatibility considerations.
      * @param _data Optional data to forward to L1. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function withdrawTo(
         address _to,
         uint256 _amount,
-        uint32 _l1Gas,
+        uint32, // _l1Gas,
         bytes calldata _data
     )
         external
@@ -192,7 +171,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             msg.sender,
             _to,
             _amount,
-            _l1Gas,
+            0,
             _data
         );
     }
@@ -202,18 +181,16 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _from Account to pull the deposit from on L2.
      * @param _to Account to give the withdrawal to on L1.
      * @param _amount Amount of the token to withdraw.
-     * @param _l1Gas Optional gas limit to complete the deposit on L2.
-     *        If the default amount is greater than the value provided, the L1 gasLimit will be set
-     *        to the default amount.
+     * param _l1Gas Unused, but included for potential forward compatibility considerations.
      * @param _data Optional data to forward to L1. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function _initiateWithdrawal(
         address _from,
         address _to,
         uint256 _amount,
-        uint32 _l1Gas,
+        uint32, // _l1Gas,
         bytes calldata _data
     )
         internal
@@ -230,15 +207,11 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
             _data
         );
 
-        // Prevent tokens stranded on other side by taking
-        // the max of the user provided gas and DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS
-        uint32 defaultGas = getFinalizeWithdrawalL1Gas();
-        uint32 l1Gas = _l1Gas > defaultGas ? _l1Gas : defaultGas;
         // Send message up to L1 gateway
         sendCrossDomainMessage(
             address(l1TokenGateway),
             message,
-            l1Gas
+            0
         );
 
         emit WithdrawalInitiated(msg.sender, _to, _amount, _data);
@@ -257,7 +230,7 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * @param _amount Amount of the token to withdraw
      * @param _data Data provider by the sender on L1. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function finalizeDeposit(
         address _from,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -81,9 +81,6 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
      * Overridable Accounting logic *
      ********************************/
 
-    // Default gas value which can be overridden if more complex logic runs on L1.
-    uint32 internal constant DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS = 100_000;
-
     /**
      * @dev Core logic to be performed when a withdrawal from L2 is initialized.
      * In most cases, this will simply burn the withdrawn L2 funds.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/Abs_L2DepositedToken.sol
@@ -207,8 +207,8 @@ abstract contract Abs_L2DepositedToken is iOVM_L2DepositedToken, OVM_CrossDomain
         // Send message up to L1 gateway
         sendCrossDomainMessage(
             address(l1TokenGateway),
-            message,
-            0
+            0,
+            message
         );
 
         emit WithdrawalInitiated(msg.sender, _to, _amount, _data);

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -89,7 +89,7 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
      */
     function _handleFinalizeWithdrawal(
         address _to,
-        uint _amount
+        uint256 _amount
     )
         internal
         override

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -35,8 +35,8 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
      ***************/
 
     /**
-     * @param _l1ERC20 L1 ERC20 address this contract stores deposits for
-     * @param _l2DepositedERC20 L2 Gateway address on the chain being deposited into
+     * @param _l1ERC20 L1 ERC20 address this contract stores deposits for.
+     * @param _l2DepositedERC20 L2 Gateway address on the chain being deposited into.
      */
     constructor(
         iOVM_ERC20 _l1ERC20,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ERC20Gateway.sol
@@ -58,11 +58,11 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
 
     /**
      * @dev When a deposit is initiated on L1, the L1 Gateway
-     * transfers the funds to itself for future withdrawals
+     * transfers the funds to itself for future withdrawals.
      *
-     * @param _from L1 address ETH is being deposited from
-     * param _to L2 address that the ETH is being deposited to
-     * @param _amount Amount of ERC20 to send
+     * @param _from L1 address ETH is being deposited from.
+     * param _to L2 address that the ETH is being deposited to.
+     * @param _amount Amount of ERC20 to send.
      */
     function _handleInitiateDeposit(
         address _from,
@@ -82,10 +82,10 @@ contract OVM_L1ERC20Gateway is Abs_L1TokenGateway {
 
     /**
      * @dev When a withdrawal is finalized on L1, the L1 Gateway
-     * transfers the funds to the withdrawer
+     * transfers the funds to the withdrawer.
      *
-     * @param _to L1 address that the ERC20 is being withdrawn to
-     * @param _amount Amount of ERC20 to send
+     * @param _to L1 address that the ERC20 is being withdrawn to.
+     * @param _amount Amount of ERC20 to send.
      */
     function _handleFinalizeWithdrawal(
         address _to,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -80,12 +80,15 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
 
     /**
      * @dev Deposit an amount of the ETH to the caller's balance on L2.
-     * @param _data Data to forward to L2.
-     * @param _l2Gas Gas limit for the provided message.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
+     * @param _l2Gas Optional gas limit to complete the deposit on l2.
+       If not provided, the default amount is passed.
      */
     function deposit(
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external
         override
@@ -102,13 +105,16 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev Deposit an amount of ETH to a recipient's balance on L2.
      * @param _to L2 address to credit the withdrawal to.
-     * @param _data Data to forward to L2.
-     * @param _l2Gas Gas limit for the provided message.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
+     * @param _l2Gas Optional gas limit to complete the deposit on l2.
+       If not provided, the default amount is passed.
      */
     function depositTo(
         address _to,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external
         override
@@ -127,14 +133,17 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
      *
      * @param _from Account to pull the deposit from on L1
      * @param _to Account to give the deposit to on L2
-     * @param _data Data to forward to L2.
-     * @param _l2Gas Gas limit for the provided message.
+     * @param _data Optional data to forward to L2. This data is provided
+     *   solely as a convenience for external contracts. Aside from enforcing a maximum
+     *   length, these contracts provide no guarantees about it's content.
+     * @param _l2Gas Optional gas limit to complete the deposit on l2.
+       If not provided, the default amount is passed.
      */
     function _initiateDeposit(
         address _from,
         address _to,
-        bytes memory _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes memory _data
     )
         internal
     {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -75,16 +75,17 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
         external
         payable
     {
-        _initiateDeposit(msg.sender, msg.sender, bytes(""), 0);
+        _initiateDeposit(msg.sender, msg.sender, 0, bytes(""));
     }
 
     /**
      * @dev Deposit an amount of the ETH to the caller's balance on L2.
+     * @param _l2Gas Optional gas limit to complete the deposit on L2
+     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
+     *        to the default amount.
      * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
-     * @param _l2Gas Optional gas limit to complete the deposit on l2.
-       If not provided, the default amount is passed.
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function deposit(
         uint32 _l2Gas,
@@ -97,19 +98,20 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
         _initiateDeposit(
             msg.sender,
             msg.sender,
-            _data,
-            _l2Gas
+            _l2Gas,
+            _data
         );
     }
 
     /**
      * @dev Deposit an amount of ETH to a recipient's balance on L2.
      * @param _to L2 address to credit the withdrawal to.
+     * @param _l2Gas Optional gas limit to complete the deposit on L2.
+     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
+     *        to the default amount.
      * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
-     * @param _l2Gas Optional gas limit to complete the deposit on l2.
-       If not provided, the default amount is passed.
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function depositTo(
         address _to,
@@ -123,21 +125,21 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
         _initiateDeposit(
             msg.sender,
             _to,
-            _data,
-            _l2Gas
+            _l2Gas,
+            _data
         );
     }
 
     /**
      * @dev Performs the logic for deposits by storing the ETH and informing the L2 ETH Gateway of the deposit.
-     *
-     * @param _from Account to pull the deposit from on L1
-     * @param _to Account to give the deposit to on L2
+     * @param _from Account to pull the deposit from on L1.
+     * @param _to Account to give the deposit to on L2.
+     * @param _l2Gas Optional gas limit to complete the deposit on L2.
+     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
+     *        to the default amount.
      * @param _data Optional data to forward to L2. This data is provided
-     *   solely as a convenience for external contracts. Aside from enforcing a maximum
-     *   length, these contracts provide no guarantees about it's content.
-     * @param _l2Gas Optional gas limit to complete the deposit on l2.
-       If not provided, the default amount is passed.
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function _initiateDeposit(
         address _from,
@@ -158,7 +160,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
             );
 
         // Prevent tokens stranded on other side by taking
-        // the max of the user provided gas and DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS
+        // the max of the user provided gas and DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS.
         uint32 defaultGas = getFinalizeDepositL2Gas();
         uint32 l2Gas = _l2Gas > defaultGas ? _l2Gas : defaultGas;
 
@@ -180,11 +182,12 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
      * @dev Complete a withdrawal from L2 to L1, and credit funds to the recipient's balance of the
      * L1 ETH token.
      * Since only the xDomainMessenger can call this function, it will never be called before the withdrawal is finalized.
-     *
      * @param _from L2 address initiating the transfer.
      * @param _to L1 address to credit the withdrawal to.
      * @param _amount Amount of the ERC20 to deposit.
-     * @param _data Data provided by the sender on L2.
+     * @param _data Optional data to forward to L2. This data is provided
+     *        solely as a convenience for external contracts. Aside from enforcing a maximum
+     *        length, these contracts provide no guarantees about it's content.
      */
     function finalizeWithdrawal(
         address _from,
@@ -222,8 +225,8 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev Internal accounting function for moving around L1 ETH.
      *
-     * @param _to L1 address to transfer ETH to
-     * @param _value Amount of ETH to send to
+     * @param _to L1 address to transfer ETH to.
+     * @param _value Amount of ETH to transfer.
      */
     function _safeTransferETH(
         address _to,
@@ -240,8 +243,8 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
      *****************************/
 
     /**
-     * @dev Migrates entire ETH balance to another gateway
-     * @param _to Gateway Proxy address to migrate ETH to
+     * @dev Migrates entire ETH balance to another gateway.
+     * @param _to Gateway Proxy address to migrate ETH to.
      */
     function migrateEth(address payable _to) external {
         address owner = Lib_AddressManager(libAddressManager).owner();
@@ -252,7 +255,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
 
     /**
      * @dev Adds ETH balance to the account. This is meant to allow for ETH
-     * to be migrated from an old gateway to a new gateway
+     * to be migrated from an old gateway to a new gateway.
      */
     function donateETH() external payable {}
 }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -80,12 +80,10 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
 
     /**
      * @dev Deposit an amount of the ETH to the caller's balance on L2.
-     * @param _l2Gas Optional gas limit to complete the deposit on L2
-     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
-     *        to the default amount.
+     * @param _l2Gas Gas limit required to complete the deposit on L2.
      * @param _data Optional data to forward to L2. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function deposit(
         uint32 _l2Gas,
@@ -106,12 +104,10 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev Deposit an amount of ETH to a recipient's balance on L2.
      * @param _to L2 address to credit the withdrawal to.
-     * @param _l2Gas Optional gas limit to complete the deposit on L2.
-     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
-     *        to the default amount.
+     * @param _l2Gas Gas limit required to complete the deposit on L2.
      * @param _data Optional data to forward to L2. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function depositTo(
         address _to,
@@ -134,12 +130,10 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
      * @dev Performs the logic for deposits by storing the ETH and informing the L2 ETH Gateway of the deposit.
      * @param _from Account to pull the deposit from on L1.
      * @param _to Account to give the deposit to on L2.
-     * @param _l2Gas Optional gas limit to complete the deposit on L2.
-     *        If the default amount is greater than the value provided, the L2 gasLimit will be set
-     *        to the default amount.
+     * @param _l2Gas Gas limit required to complete the deposit on L2.
      * @param _data Optional data to forward to L2. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function _initiateDeposit(
         address _from,
@@ -159,16 +153,11 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
                 _data
             );
 
-        // Prevent tokens stranded on other side by taking
-        // the max of the user provided gas and DEFAULT_FINALIZE_WITHDRAWAL_L1_GAS.
-        uint32 defaultGas = getFinalizeDepositL2Gas();
-        uint32 l2Gas = _l2Gas > defaultGas ? _l2Gas : defaultGas;
-
         // Send calldata into L2
         sendCrossDomainMessage(
             ovmEth,
             message,
-            l2Gas
+            _l2Gas
         );
 
         emit DepositInitiated(_from, _to, msg.value, _data);
@@ -187,7 +176,7 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
      * @param _amount Amount of the ERC20 to deposit.
      * @param _data Optional data to forward to L2. This data is provided
      *        solely as a convenience for external contracts. Aside from enforcing a maximum
-     *        length, these contracts provide no guarantees about it's content.
+     *        length, these contracts provide no guarantees about its content.
      */
     function finalizeWithdrawal(
         address _from,
@@ -202,20 +191,6 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
         _safeTransferETH(_to, _amount);
 
         emit WithdrawalFinalized(_from, _to, _amount, _data);
-    }
-
-    /**
-     * @dev Getter for the L2 gas limit.
-     */
-    function getFinalizeDepositL2Gas()
-        public
-        pure
-        override
-        returns(
-            uint32
-        )
-    {
-        return ETH_FINALIZE_L2_GAS;
     }
 
     /**********************************

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -143,6 +143,9 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     )
         internal
     {
+
+        require(_data.length < 40_000, "Data is too long to safely forward to L2");
+
         // Construct calldata for l2ETHGateway.finalizeDeposit(_to, _amount)
         bytes memory message =
             abi.encodeWithSelector(

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -143,9 +143,6 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     )
         internal
     {
-
-        require(_data.length < 40_000, "Data is too long to safely forward to L2");
-
         // Construct calldata for l2ETHGateway.finalizeDeposit(_to, _amount)
         bytes memory message =
             abi.encodeWithSelector(

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -152,8 +152,8 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
         // Send calldata into L2
         sendCrossDomainMessage(
             ovmEth,
-            message,
-            _l2Gas
+            _l2Gas,
+            message
         );
 
         emit DepositInitiated(_from, _to, msg.value, _data);

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1ETHGateway.sol
@@ -21,12 +21,6 @@ import { Lib_AddressManager } from "../../../libraries/resolver/Lib_AddressManag
  */
 contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_AddressResolver {
 
-    /*************
-     * Constants *
-     ************/
-
-    uint32 constant ETH_FINALIZE_L2_GAS = 1_200_000;
-
     /********************************
      * External Contract References *
      ********************************/
@@ -70,12 +64,14 @@ contract OVM_L1ETHGateway is iOVM_L1ETHGateway, OVM_CrossDomainEnabled, Lib_Addr
     /**
      * @dev This function can be called with no data
      * to deposit an amount of ETH to the caller's balance on L2.
+     * Since the receive function doesn't take data, a conservative
+     * default of 1.2 Million gas is forwarded to L2.
      */
     receive()
         external
         payable
     {
-        _initiateDeposit(msg.sender, msg.sender, 0, bytes(""));
+        _initiateDeposit(msg.sender, msg.sender, 1_200_000, bytes(""));
     }
 
     /**

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2DepositedERC20.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2DepositedERC20.sol
@@ -31,8 +31,8 @@ contract OVM_L2DepositedERC20 is Abs_L2DepositedToken, UniswapV2ERC20 {
 
     /**
      * @param _l2CrossDomainMessenger Cross-domain messenger used by this contract.
-     * @param _name ERC20 name
-     * @param _symbol ERC20 symbol
+     * @param _name ERC20 name.
+     * @param _symbol ERC20 symbol.
      */
     constructor(
         address _l2CrossDomainMessenger,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2DepositedERC20.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2DepositedERC20.sol
@@ -46,7 +46,7 @@ contract OVM_L2DepositedERC20 is Abs_L2DepositedToken, UniswapV2ERC20 {
     // When a withdrawal is initiated, we burn the withdrawer's funds to prevent subsequent L2 usage.
     function _handleInitiateWithdrawal(
         address, // _to,
-        uint _amount
+        uint256 _amount
     )
         internal
         override
@@ -57,7 +57,7 @@ contract OVM_L2DepositedERC20 is Abs_L2DepositedToken, UniswapV2ERC20 {
     // When a deposit is finalized, we credit the account on L2 with the same amount of tokens.
     function _handleFinalizeDeposit(
         address _to,
-        uint _amount
+        uint256 _amount
     )
         internal
         override

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
@@ -30,14 +30,16 @@ interface iOVM_L1ETHGateway {
      ********************/
 
     function deposit(
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l2Gas
     )
         external
         payable;
 
     function depositTo(
         address _to,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l2Gas
     )
         external
         payable;
@@ -51,7 +53,6 @@ interface iOVM_L1ETHGateway {
         address _to,
         uint _amount,
         bytes calldata _data
-
     )
         external;
 

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
@@ -30,16 +30,16 @@ interface iOVM_L1ETHGateway {
      ********************/
 
     function deposit(
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external
         payable;
 
     function depositTo(
         address _to,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external
         payable;

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
@@ -13,25 +13,31 @@ interface iOVM_L1ETHGateway {
 
     event DepositInitiated(
         address indexed _from,
-        address _to,
-        uint256 _amount
+        address indexed _to,
+        uint256 _amount,
+        bytes _data
     );
 
     event WithdrawalFinalized(
+        address indexed _from,
         address indexed _to,
-        uint256 _amount
+        uint256 _amount,
+        bytes _data
     );
 
     /********************
      * Public Functions *
      ********************/
 
-    function deposit()
+    function deposit(
+        bytes calldata _data
+    )
         external
         payable;
 
     function depositTo(
-        address _to
+        address _to,
+        bytes calldata _data
     )
         external
         payable;
@@ -41,8 +47,11 @@ interface iOVM_L1ETHGateway {
      *************************/
 
     function finalizeWithdrawal(
+        address _from,
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
+
     )
         external;
 

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ETHGateway.sol
@@ -56,10 +56,4 @@ interface iOVM_L1ETHGateway {
     )
         external;
 
-    function getFinalizeDepositL2Gas()
-        external
-        view
-        returns(
-            uint32
-        );
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -32,16 +32,16 @@ interface iOVM_L1TokenGateway {
 
     function deposit(
         uint _amount,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external;
 
     function depositTo(
         address _to,
         uint _amount,
-        bytes calldata _data,
-        uint32 _l2Gas
+        uint32 _l2Gas,
+        bytes calldata _data
     )
         external;
 

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -13,13 +13,16 @@ interface iOVM_L1TokenGateway {
 
     event DepositInitiated(
         address indexed _from,
-        address _to,
-        uint256 _amount
+        address indexed _to,
+        uint256 _amount,
+        bytes _data
     );
 
     event WithdrawalFinalized(
+        address indexed _from,
         address indexed _to,
-        uint256 _amount
+        uint256 _amount,
+        bytes _data
     );
 
 
@@ -28,13 +31,15 @@ interface iOVM_L1TokenGateway {
      ********************/
 
     function deposit(
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external;
 
     function depositTo(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external;
 
@@ -44,8 +49,10 @@ interface iOVM_L1TokenGateway {
      *************************/
 
     function finalizeWithdrawal(
+        address _from,
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external;
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -58,10 +58,4 @@ interface iOVM_L1TokenGateway {
     )
         external;
 
-    function getFinalizeDepositL2Gas()
-        external
-        view
-        returns(
-            uint32
-        );
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol
@@ -32,14 +32,16 @@ interface iOVM_L1TokenGateway {
 
     function deposit(
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l2Gas
     )
         external;
 
     function depositTo(
         address _to,
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l2Gas
     )
         external;
 
@@ -55,4 +57,11 @@ interface iOVM_L1TokenGateway {
         bytes calldata _data
     )
         external;
+
+    function getFinalizeDepositL2Gas()
+        external
+        view
+        returns(
+            uint32
+        );
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -32,16 +32,16 @@ interface iOVM_L2DepositedToken {
 
     function withdraw(
         uint _amount,
-        bytes calldata _data,
-        uint32 _l1Gas
+        uint32 _l1Gas,
+        bytes calldata _data
     )
         external;
 
     function withdrawTo(
         address _to,
         uint _amount,
-        bytes calldata _data,
-        uint32 _l1Gas
+        uint32 _l1Gas,
+        bytes calldata _data
     )
         external;
 

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -13,13 +13,16 @@ interface iOVM_L2DepositedToken {
 
     event WithdrawalInitiated(
         address indexed _from,
-        address _to,
-        uint256 _amount
+        address indexed _to,
+        uint256 _amount,
+        bytes _data
     );
 
     event DepositFinalized(
+        address indexed _from,
         address indexed _to,
-        uint256 _amount
+        uint256 _amount,
+        bytes _data
     );
 
 
@@ -28,13 +31,15 @@ interface iOVM_L2DepositedToken {
      ********************/
 
     function withdraw(
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external;
 
     function withdrawTo(
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external;
 
@@ -44,8 +49,10 @@ interface iOVM_L2DepositedToken {
      *************************/
 
     function finalizeDeposit(
+        address _from,
         address _to,
-        uint _amount
+        uint _amount,
+        bytes calldata _data
     )
         external;
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -32,14 +32,16 @@ interface iOVM_L2DepositedToken {
 
     function withdraw(
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l1Gas
     )
         external;
 
     function withdrawTo(
         address _to,
         uint _amount,
-        bytes calldata _data
+        bytes calldata _data,
+        uint32 _l1Gas
     )
         external;
 
@@ -55,4 +57,13 @@ interface iOVM_L2DepositedToken {
         bytes calldata _data
     )
         external;
+
+    function getFinalizeWithdrawalL1Gas()
+        external
+        pure
+        virtual
+        returns(
+            uint32
+        );
+
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2DepositedToken.sol
@@ -58,12 +58,4 @@ interface iOVM_L2DepositedToken {
     )
         external;
 
-    function getFinalizeWithdrawalL1Gas()
-        external
-        pure
-        virtual
-        returns(
-            uint32
-        );
-
 }

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
@@ -23,7 +23,7 @@ contract OVM_CrossDomainEnabled {
 
     /***************
      * Constructor *
-     ***************/    
+     ***************/
 
     /**
      * @param _messenger Address of the CrossDomainMessenger on the current layer.
@@ -68,7 +68,7 @@ contract OVM_CrossDomainEnabled {
     /**
      * Gets the messenger, usually from storage. This function is exposed in case a child contract
      * needs to override.
-     * @return The address of the cross-domain messenger contract which should be used. 
+     * @return The address of the cross-domain messenger contract which should be used.
      */
     function getCrossDomainMessenger()
         internal
@@ -83,17 +83,17 @@ contract OVM_CrossDomainEnabled {
     /**
      * Sends a message to an account on another domain
      * @param _crossDomainTarget The intended recipient on the destination domain
-     * @param _data The data to send to the target (usually calldata to a function with
+     * @param _message The data to send to the target (usually calldata to a function with
      *  `onlyFromCrossDomainAccount()`)
      * @param _gasLimit The gasLimit for the receipt of the message on the target domain.
      */
     function sendCrossDomainMessage(
         address _crossDomainTarget,
-        bytes memory _data,
+        bytes memory _message,
         uint32 _gasLimit
     )
         internal
     {
-        getCrossDomainMessenger().sendMessage(_crossDomainTarget, _data, _gasLimit);
+        getCrossDomainMessenger().sendMessage(_crossDomainTarget, _message, _gasLimit);
     }
 }

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/bridge/OVM_CrossDomainEnabled.sol
@@ -89,8 +89,8 @@ contract OVM_CrossDomainEnabled {
      */
     function sendCrossDomainMessage(
         address _crossDomainTarget,
-        bytes memory _message,
-        uint32 _gasLimit
+        uint32 _gasLimit,
+        bytes memory _message
     )
         internal
     {

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
@@ -184,7 +184,7 @@ describe('OVM_L1ERC20Gateway', () => {
 
     it('deposit() escrows the deposit amount and sends the correct deposit message', async () => {
       // alice calls deposit on the gateway and the L1 gateway calls transferFrom on the token
-      await OVM_L1ERC20Gateway.deposit(depositAmount, NON_NULL_BYTES32)
+      await OVM_L1ERC20Gateway.deposit(depositAmount, NON_NULL_BYTES32, 0)
       const depositCallToMessenger =
         Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -214,13 +214,27 @@ describe('OVM_L1ERC20Gateway', () => {
       expect(depositCallToMessenger._gasLimit).to.equal(finalizeDepositGasLimit)
     })
 
+    it('deposit() uses the user provided gas limit if it is larger than the default value', async () => {
+      const customGasLimit = 10_000_000
+      await OVM_L1ERC20Gateway.deposit(
+        depositAmount,
+        NON_NULL_BYTES32,
+        customGasLimit
+      )
+
+      const depositCallToMessenger =
+        Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
+      expect(depositCallToMessenger._gasLimit).to.equal(customGasLimit)
+    })
+
     it('depositTo() escrows the deposit amount and sends the correct deposit message', async () => {
       // depositor calls deposit on the gateway and the L1 gateway calls transferFrom on the token
       const bobsAddress = await bob.getAddress()
       await OVM_L1ERC20Gateway.depositTo(
         bobsAddress,
         depositAmount,
-        NON_NULL_BYTES32
+        NON_NULL_BYTES32,
+        0
       )
       const depositCallToMessenger =
         Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
@@ -249,6 +263,21 @@ describe('OVM_L1ERC20Gateway', () => {
         )
       )
       expect(depositCallToMessenger._gasLimit).to.equal(finalizeDepositGasLimit)
+    })
+
+    it('depositTo() uses the user provided gas limit if it is larger than the default value', async () => {
+      const bobsAddress = await bob.getAddress()
+      const customGasLimit = 10_000_000
+      await OVM_L1ERC20Gateway.depositTo(
+        bobsAddress,
+        depositAmount,
+        NON_NULL_BYTES32,
+        customGasLimit
+      )
+
+      const depositCallToMessenger =
+        Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
+      expect(depositCallToMessenger._gasLimit).to.equal(customGasLimit)
     })
   })
 })

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
@@ -6,7 +6,7 @@ import { Signer, ContractFactory, Contract, constants } from 'ethers'
 import { smockit, MockContract, smoddit } from '@eth-optimism/smock'
 
 /* Internal Imports */
-import { NON_ZERO_ADDRESS } from '../../../../helpers'
+import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../../../helpers'
 
 const INITIAL_TOTAL_L1_SUPPLY = 3000
 
@@ -81,7 +81,12 @@ describe('OVM_L1ERC20Gateway', () => {
       )
 
       await expect(
-        OVM_L1ERC20Gateway.finalizeWithdrawal(constants.AddressZero, 1)
+        OVM_L1ERC20Gateway.finalizeWithdrawal(
+          constants.AddressZero,
+          constants.AddressZero,
+          1,
+          NON_NULL_BYTES32
+        )
       ).to.be.revertedWith(ERR_INVALID_MESSENGER)
     })
 
@@ -91,9 +96,15 @@ describe('OVM_L1ERC20Gateway', () => {
       )
 
       await expect(
-        OVM_L1ERC20Gateway.finalizeWithdrawal(constants.AddressZero, 1, {
-          from: Mock__OVM_L1CrossDomainMessenger.address,
-        })
+        OVM_L1ERC20Gateway.finalizeWithdrawal(
+          constants.AddressZero,
+          constants.AddressZero,
+          1,
+          NON_NULL_BYTES32,
+          {
+            from: Mock__OVM_L1CrossDomainMessenger.address,
+          }
+        )
       ).to.be.revertedWith(ERR_INVALID_X_DOMAIN_MSG_SENDER)
     })
 
@@ -110,7 +121,9 @@ describe('OVM_L1ERC20Gateway', () => {
 
       const res = await OVM_L1ERC20Gateway.finalizeWithdrawal(
         NON_ZERO_ADDRESS,
+        NON_ZERO_ADDRESS,
         withdrawalAmount,
+        NON_NULL_BYTES32,
         { from: Mock__OVM_L1CrossDomainMessenger.address }
       )
 
@@ -171,7 +184,7 @@ describe('OVM_L1ERC20Gateway', () => {
 
     it('deposit() escrows the deposit amount and sends the correct deposit message', async () => {
       // alice calls deposit on the gateway and the L1 gateway calls transferFrom on the token
-      await OVM_L1ERC20Gateway.deposit(depositAmount)
+      await OVM_L1ERC20Gateway.deposit(depositAmount, NON_NULL_BYTES32)
       const depositCallToMessenger =
         Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -195,7 +208,7 @@ describe('OVM_L1ERC20Gateway', () => {
       expect(depositCallToMessenger._message).to.equal(
         await Mock__OVM_L2DepositedERC20.interface.encodeFunctionData(
           'finalizeDeposit',
-          [depositer, depositAmount]
+          [depositer, depositer, depositAmount, NON_NULL_BYTES32]
         )
       )
       expect(depositCallToMessenger._gasLimit).to.equal(finalizeDepositGasLimit)
@@ -204,7 +217,11 @@ describe('OVM_L1ERC20Gateway', () => {
     it('depositTo() escrows the deposit amount and sends the correct deposit message', async () => {
       // depositor calls deposit on the gateway and the L1 gateway calls transferFrom on the token
       const bobsAddress = await bob.getAddress()
-      await OVM_L1ERC20Gateway.depositTo(bobsAddress, depositAmount)
+      await OVM_L1ERC20Gateway.depositTo(
+        bobsAddress,
+        depositAmount,
+        NON_NULL_BYTES32
+      )
       const depositCallToMessenger =
         Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -228,7 +245,7 @@ describe('OVM_L1ERC20Gateway', () => {
       expect(depositCallToMessenger._message).to.equal(
         await Mock__OVM_L2DepositedERC20.interface.encodeFunctionData(
           'finalizeDeposit',
-          [bobsAddress, depositAmount]
+          [depositer, bobsAddress, depositAmount, NON_NULL_BYTES32]
         )
       )
       expect(depositCallToMessenger._gasLimit).to.equal(finalizeDepositGasLimit)

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ERC20Gateway.spec.ts
@@ -184,7 +184,7 @@ describe('OVM_L1ERC20Gateway', () => {
 
     it('deposit() escrows the deposit amount and sends the correct deposit message', async () => {
       // alice calls deposit on the gateway and the L1 gateway calls transferFrom on the token
-      await OVM_L1ERC20Gateway.deposit(depositAmount, NON_NULL_BYTES32, 0)
+      await OVM_L1ERC20Gateway.deposit(depositAmount, 0, NON_NULL_BYTES32)
       const depositCallToMessenger =
         Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -218,8 +218,8 @@ describe('OVM_L1ERC20Gateway', () => {
       const customGasLimit = 10_000_000
       await OVM_L1ERC20Gateway.deposit(
         depositAmount,
+        customGasLimit,
         NON_NULL_BYTES32,
-        customGasLimit
       )
 
       const depositCallToMessenger =
@@ -233,8 +233,8 @@ describe('OVM_L1ERC20Gateway', () => {
       await OVM_L1ERC20Gateway.depositTo(
         bobsAddress,
         depositAmount,
+        0,
         NON_NULL_BYTES32,
-        0
       )
       const depositCallToMessenger =
         Mock__OVM_L1CrossDomainMessenger.smocked.sendMessage.calls[0]
@@ -271,8 +271,8 @@ describe('OVM_L1ERC20Gateway', () => {
       await OVM_L1ERC20Gateway.depositTo(
         bobsAddress,
         depositAmount,
-        NON_NULL_BYTES32,
-        customGasLimit
+        customGasLimit,
+        NON_NULL_BYTES32
       )
 
       const depositCallToMessenger =

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ETHGateway.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L1ETHGateway.spec.ts
@@ -126,7 +126,7 @@ describe('OVM_L1ETHGateway', () => {
       )
 
       // thanks Alice
-      await OVM_L1ETHGateway.connect(alice).deposit(NON_NULL_BYTES32, 0, {
+      await OVM_L1ETHGateway.connect(alice).deposit(0, NON_NULL_BYTES32, {
         value: ethers.utils.parseEther('1.0'),
         gasPrice: 0,
       })
@@ -195,7 +195,7 @@ describe('OVM_L1ETHGateway', () => {
       const initialBalance = await ethers.provider.getBalance(depositer)
 
       // alice calls deposit on the gateway and the L1 gateway calls transferFrom on the token
-      await OVM_L1ETHGateway.connect(alice).deposit(NON_NULL_BYTES32, 0, {
+      await OVM_L1ETHGateway.connect(alice).deposit(0, NON_NULL_BYTES32, {
         value: depositAmount,
         gasPrice: 0,
       })
@@ -236,8 +236,8 @@ describe('OVM_L1ETHGateway', () => {
       const customGasLimit = 10_000_000
       // alice calls deposit on the gateway and the L1 gateway calls transferFrom on the token
       await OVM_L1ETHGateway.connect(alice).deposit(
-        NON_NULL_BYTES32,
         customGasLimit,
+        NON_NULL_BYTES32,
         {
           value: depositAmount,
           gasPrice: 0,
@@ -257,8 +257,8 @@ describe('OVM_L1ETHGateway', () => {
 
       await OVM_L1ETHGateway.connect(alice).depositTo(
         bobsAddress,
-        NON_NULL_BYTES32,
         0,
+        NON_NULL_BYTES32,
         {
           value: depositAmount,
           gasPrice: 0,
@@ -301,8 +301,8 @@ describe('OVM_L1ETHGateway', () => {
       // alice calls deposit on the gateway and the L1 gateway calls transferFrom on the token
       await OVM_L1ETHGateway.connect(alice).depositTo(
         bobsAddress,
-        NON_NULL_BYTES32,
         customGasLimit,
+        NON_NULL_BYTES32,
         {
           value: depositAmount,
           gasPrice: 0,

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '@eth-optimism/smock'
 
 /* Internal Imports */
-import { NON_ZERO_ADDRESS } from '../../../../helpers'
+import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../../../helpers'
 
 const ERR_INVALID_MESSENGER = 'OVM_XCHAIN: messenger contract unauthenticated'
 const ERR_INVALID_X_DOMAIN_MSG_SENDER =
@@ -66,7 +66,12 @@ describe('OVM_L2DepositedERC20', () => {
       await OVM_L2DepositedERC20.init(NON_ZERO_ADDRESS)
 
       await expect(
-        OVM_L2DepositedERC20.finalizeDeposit(constants.AddressZero, 0)
+        OVM_L2DepositedERC20.finalizeDeposit(
+          constants.AddressZero,
+          constants.AddressZero,
+          0,
+          NON_NULL_BYTES32
+        )
       ).to.be.revertedWith(ERR_INVALID_MESSENGER)
     })
 
@@ -76,9 +81,15 @@ describe('OVM_L2DepositedERC20', () => {
       )
 
       await expect(
-        OVM_L2DepositedERC20.finalizeDeposit(constants.AddressZero, 0, {
-          from: Mock__OVM_L2CrossDomainMessenger.address,
-        })
+        OVM_L2DepositedERC20.finalizeDeposit(
+          constants.AddressZero,
+          constants.AddressZero,
+          0,
+          NON_NULL_BYTES32,
+          {
+            from: Mock__OVM_L2CrossDomainMessenger.address,
+          }
+        )
       ).to.be.revertedWith(ERR_INVALID_X_DOMAIN_MSG_SENDER)
     })
 
@@ -89,8 +100,10 @@ describe('OVM_L2DepositedERC20', () => {
       )
 
       await OVM_L2DepositedERC20.finalizeDeposit(
+        NON_ZERO_ADDRESS,
         await alice.getAddress(),
         depositAmount,
+        NON_NULL_BYTES32,
         { from: Mock__OVM_L2CrossDomainMessenger.address }
       )
 
@@ -124,7 +137,7 @@ describe('OVM_L2DepositedERC20', () => {
     })
 
     it('withdraw() burns and sends the correct withdrawal message', async () => {
-      await SmoddedL2Gateway.withdraw(withdrawAmount)
+      await SmoddedL2Gateway.withdraw(withdrawAmount, NON_NULL_BYTES32)
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -149,7 +162,12 @@ describe('OVM_L2DepositedERC20', () => {
       expect(withdrawalCallToMessenger._message).to.equal(
         await Factory__OVM_L1ERC20Gateway.interface.encodeFunctionData(
           'finalizeWithdrawal',
-          [await alice.getAddress(), withdrawAmount]
+          [
+            await alice.getAddress(),
+            await alice.getAddress(),
+            withdrawAmount,
+            NON_NULL_BYTES32,
+          ]
         )
       )
       // Hardcoded gaslimit should be correct
@@ -159,7 +177,11 @@ describe('OVM_L2DepositedERC20', () => {
     })
 
     it('withdrawTo() burns and sends the correct withdrawal message', async () => {
-      await SmoddedL2Gateway.withdrawTo(await bob.getAddress(), withdrawAmount)
+      await SmoddedL2Gateway.withdrawTo(
+        await bob.getAddress(),
+        withdrawAmount,
+        NON_NULL_BYTES32
+      )
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -184,7 +206,12 @@ describe('OVM_L2DepositedERC20', () => {
       expect(withdrawalCallToMessenger._message).to.equal(
         await Factory__OVM_L1ERC20Gateway.interface.encodeFunctionData(
           'finalizeWithdrawal',
-          [await bob.getAddress(), withdrawAmount]
+          [
+            await alice.getAddress(),
+            await bob.getAddress(),
+            withdrawAmount,
+            NON_NULL_BYTES32,
+          ]
         )
       )
       // Hardcoded gaslimit should be correct

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
@@ -137,7 +137,7 @@ describe('OVM_L2DepositedERC20', () => {
     })
 
     it('withdraw() burns and sends the correct withdrawal message', async () => {
-      await SmoddedL2Gateway.withdraw(withdrawAmount, NON_NULL_BYTES32, 0)
+      await SmoddedL2Gateway.withdraw(withdrawAmount, 0, NON_NULL_BYTES32)
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -180,8 +180,8 @@ describe('OVM_L2DepositedERC20', () => {
       const customGasLimit = 10_000_000
       await SmoddedL2Gateway.withdraw(
         withdrawAmount,
+        customGasLimit,
         NON_NULL_BYTES32,
-        customGasLimit
       )
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
@@ -192,8 +192,8 @@ describe('OVM_L2DepositedERC20', () => {
       await SmoddedL2Gateway.withdrawTo(
         await bob.getAddress(),
         withdrawAmount,
+        0,
         NON_NULL_BYTES32,
-        0
       )
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
@@ -238,8 +238,8 @@ describe('OVM_L2DepositedERC20', () => {
       await SmoddedL2Gateway.withdrawTo(
         await bob.getAddress(),
         withdrawAmount,
-        NON_NULL_BYTES32,
-        customGasLimit
+        customGasLimit,
+        NON_NULL_BYTES32
       )
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2DepositedERC20.spec.ts
@@ -137,7 +137,7 @@ describe('OVM_L2DepositedERC20', () => {
     })
 
     it('withdraw() burns and sends the correct withdrawal message', async () => {
-      await SmoddedL2Gateway.withdraw(withdrawAmount, NON_NULL_BYTES32)
+      await SmoddedL2Gateway.withdraw(withdrawAmount, NON_NULL_BYTES32, 0)
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
 
@@ -176,11 +176,24 @@ describe('OVM_L2DepositedERC20', () => {
       )
     })
 
+    it('withdraw() uses the user provided gas limit if it is larger than the default value ', async () => {
+      const customGasLimit = 10_000_000
+      await SmoddedL2Gateway.withdraw(
+        withdrawAmount,
+        NON_NULL_BYTES32,
+        customGasLimit
+      )
+      const withdrawalCallToMessenger =
+        Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
+      expect(withdrawalCallToMessenger._gasLimit).to.equal(customGasLimit)
+    })
+
     it('withdrawTo() burns and sends the correct withdrawal message', async () => {
       await SmoddedL2Gateway.withdrawTo(
         await bob.getAddress(),
         withdrawAmount,
-        NON_NULL_BYTES32
+        NON_NULL_BYTES32,
+        0
       )
       const withdrawalCallToMessenger =
         Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
@@ -218,6 +231,19 @@ describe('OVM_L2DepositedERC20', () => {
       expect(withdrawalCallToMessenger._gasLimit).to.equal(
         finalizeWithdrawalGasLimit
       )
+    })
+
+    it('withdrawTo() uses the user provided gas limit if it is larger than the default value ', async () => {
+      const customGasLimit = 10_000_000
+      await SmoddedL2Gateway.withdrawTo(
+        await bob.getAddress(),
+        withdrawAmount,
+        NON_NULL_BYTES32,
+        customGasLimit
+      )
+      const withdrawalCallToMessenger =
+        Mock__OVM_L2CrossDomainMessenger.smocked.sendMessage.calls[0]
+      expect(withdrawalCallToMessenger._gasLimit).to.equal(customGasLimit)
     })
   })
 


### PR DESCRIPTION
## Description 

Enables passing additional information across domains, by adding 3 new arguments to the initiating deposit/withdraw functions: 
- `address _from`: address of the sender on the originating domain
- `bytes _data`: arbitrary data to pass to the receiving domain
- `uint32 gas`: an optional argument allowing the sender to specify the gas amount required to relay the message on the receiving domain (necessary because the `_data` field makes the cost unbounded.

**NOTE:**
This PR replaces #733 which also include changing the function names to us the `inbound`/`outbound` terminology in the [draft EIP](https://ethereum-magicians.org/t/outlining-a-standard-interface-for-cross-domain-erc20-transfers/6151). I cut the scope of the PR down to make it easier to review. Whether or not the terminology change is introduced will depend on the ongoing work address community and partner input on the gateway design. 

