### PR TITLE
Add PR labeler to Github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,37 @@
+---
+A-ci:
+  - any: ['.github/**/*']
+
+A-contracts:
+  - any: ['packages/contracts/**/*']
+
+A-geth:
+  - any: ['l2geth/**/*']
+
+A-integration-tests:
+  - any: ['integration-tests/**/*']
+
+A-ts-packages:
+  - any: ['packages/**/*']
+    all: ['!packages/contracts/**/*']
+
+M-batch-submitter:
+  - any: ['packages/batch-submitter/**/*']
+
+M-contracts:
+  - any: ['packages/contracts/**/*']
+
+M-core-utils:
+  - any: ['packages/core-utils/**/*']
+
+M-dtl:
+  - any: ['packages/data-transport-layer/**/*']
+
+M-hardhat-ovm:
+  - any: ['packages/hardhat-ovm/**/*']
+
+M-ops:
+  - any: ['ops/**/*']
+
+M-smock:
+  - any: ['packages/smock/**/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+---
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
**Description**
Add a new Github action to the repository which will apply labels to new PRs.

**Additional context**
The action added https://github.com/actions/labeler

Initiated on the [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event on the repository. 

**Metadata**
https://optimism-workspace.slack.com/archives/C01TQ2ZEPAN/p1620430712083000
