### PR TITLE
feat[contracts]: have hardhat-deploy register L1MultiMessageRelayer on mainnet

### DIFF
--- a/packages/contracts/deploy/014-OVM_L1MultiMessageRelayer.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1MultiMessageRelayer.deploy.ts
@@ -5,6 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndRegister,
   getDeployedContract,
+  registerAddress,
 } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -13,11 +14,20 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndRegister({
+  const OVM_L1MultiMessageRelayer = await deployAndRegister({
     hre,
     name: 'OVM_L1MultiMessageRelayer',
     args: [Lib_AddressManager.address],
   })
+
+  // OVM_L2MessageRelayer *must* be set to multi message relayer address on L1.
+  if (hre.network.name.includes('mainnet')) {
+    await registerAddress({
+      hre,
+      name: 'OVM_L2MessageRelayer',
+      address: OVM_L1MultiMessageRelayer.address
+    })
+  }
 }
 
 deployFn.dependencies = ['Lib_AddressManager']

--- a/packages/contracts/src/hardhat-deploy-ethers.ts
+++ b/packages/contracts/src/hardhat-deploy-ethers.ts
@@ -54,7 +54,7 @@ export const deployAndRegister = async ({
   name: string
   args: any[]
   contract?: string
-}) => {
+}): Promise<Contract> => {
   const { deploy } = hre.deployments
   const { deployer } = await hre.getNamedAccounts()
 
@@ -74,6 +74,8 @@ export const deployAndRegister = async ({
       address: result.address,
     })
   }
+
+  return getDeployedContract(hre, contract || name)
 }
 
 export const getDeployedContract = async (


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Slightly modifies our deployment so that we'll set `OVM_L2MessageRelayer = L1MultiMessageRelayer.address` on mainnet.
