### PR TITLE
contracts: remove only relayer

### DIFF
--- a/.changeset/flat-camels-cross.md
+++ b/.changeset/flat-camels-cross.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Remove the `onlyRelayer` modifier for self withdrawals

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
@@ -70,26 +70,6 @@ contract OVM_L1CrossDomainMessenger is
         Lib_AddressResolver(address(0))
     {}
 
-    /**********************
-     * Function Modifiers *
-     **********************/
-
-    /**
-     * Modifier to enforce that, if configured, only the OVM_L2MessageRelayer contract may
-     * successfully call a method.
-     */
-    modifier onlyRelayer() {
-        address relayer = resolve("OVM_L2MessageRelayer");
-        if (relayer != address(0)) {
-            require(
-                msg.sender == relayer,
-                "Only OVM_L2MessageRelayer can relay L2-to-L1 messages."
-            );
-        }
-        _;
-    }
-
-
     /********************
      * Public Functions *
      ********************/
@@ -169,7 +149,6 @@ contract OVM_L1CrossDomainMessenger is
         override
         public
         nonReentrant
-        onlyRelayer
         whenNotPaused
     {
         bytes memory xDomainCalldata = _getXDomainCalldata(

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
@@ -442,27 +442,5 @@ describe('OVM_L1CrossDomainMessenger', () => {
         ).to.not.be.reverted
       })
     })
-
-    describe('onlyRelayer', () => {
-      it('when the OVM_L2MessageRelayer address is set, should revert if called by a different account', async () => {
-        // set to a random NON-ZERO address
-        await AddressManager.setAddress(
-          'OVM_L2MessageRelayer',
-          '0x1234123412341234123412341234123412341234'
-        )
-
-        await expect(
-          OVM_L1CrossDomainMessenger.relayMessage(
-            target,
-            sender,
-            message,
-            0,
-            proof
-          )
-        ).to.be.revertedWith(
-          'Only OVM_L2MessageRelayer can relay L2-to-L1 messages.'
-        )
-      })
-    })
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes the `onlyRelayer` modifier from the `OVM_L1CrossDomainMessenger` so that self withdrawals are guaranteed. Note that if `OVM_L2MessageRelayer` is set to `address(0)` it turns on self withdrawals so this is not required right now


