### PR TITLE
fix: geth miner timestamp bug

### DIFF
--- a/.changeset/gorgeous-countries-listen.md
+++ b/.changeset/gorgeous-countries-listen.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Prevent montonicity errors in the miner

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -863,12 +863,11 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 	tstart := time.Now()
 
 	parent := w.chain.CurrentBlock()
-	timestamp := tx.L1Timestamp()
 	num := parent.Number()
 
 	// Preserve liveliness as best as possible. Must panic on L1 to L2
 	// transactions as the timestamp cannot be malleated
-	if parent.Time() > timestamp {
+	if parent.Time() > tx.L1Timestamp() {
 		log.Error("Monotonicity violation", "index", num)
 		if tx.QueueOrigin().Uint64() == uint64(types.QueueOriginSequencer) {
 			tx.SetL1Timestamp(parent.Time())
@@ -898,7 +897,7 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 		Number:     num.Add(num, common.Big1),
 		GasLimit:   w.config.GasFloor,
 		Extra:      w.extra,
-		Time:       timestamp,
+		Time:       tx.L1Timestamp(),
 	}
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		return fmt.Errorf("Failed to prepare header for mining: %w", err)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug in the prevent monotonicity logic where the updated timestamp is not used. The old code updated the `L1Timestamp` on the transaction struct but didn't pass it along to the block header. The timestamp for evm execution is pulled from the block timestamp. This will prevent the same bug from happening again
