### PR TITLE
feat[contracts]: enable initiating L2 upgrade via L1 to L2 message

### DIFF
--- a/.changeset/fluffy-knives-impress.md
+++ b/.changeset/fluffy-knives-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+enables l2 upgrades to be initiated by an l1 to l2 message


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Pretty straightforward. Makes `L2ChugSplashDeployer` inherit from `OVM_CrossDomainEnabled` and adds a new modifier that allows functions to be called either directly by the owner or via a cross-domain message. Adds tests to cover this new functionality.
