### PR TITLE
Update Github Actions for the develop branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "develop",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches:
+      - develop
       - master
 
 jobs:


### PR DESCRIPTION
**Description**
Now that `develop` is the default branch, we should generate packages from the branch for testing deployments.

**Additional context**
Added the `develop` branch to the workflows:
- geth unit tests
- integration
- Release
- typescript / contracts
