### PR TITLE
feat[contracts]: temporarily disable EOA upgrades

### DIFF
--- a/.changeset/chatty-walls-rescue.md
+++ b/.changeset/chatty-walls-rescue.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': minor
+---
+
+Disables EOA contract upgrades until further notice

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -20,9 +20,10 @@ contract OVM_ProxyEOA {
      * Events *
      **********/
     
-    event Upgraded(
-        address indexed implementation
-    );
+    // NOTE: See comment below w/r/t/ upgrade() to understand why we've commented this out.
+    // event Upgraded(
+    //    address indexed implementation
+    // );
 
 
     /*************

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -62,23 +62,27 @@ contract OVM_ProxyEOA {
      * Public Functions *
      ********************/
 
-    /**
-     * Changes the implementation address.
-     * @param _implementation New implementation address.
-     */
-    function upgrade(
-        address _implementation
-    )
-        external
-    {
-        require(
-            msg.sender == Lib_ExecutionManagerWrapper.ovmADDRESS(),
-            "EOAs can only upgrade their own EOA implementation"
-        );
-
-        _setImplementation(_implementation);
-        emit Upgraded(_implementation);
-    }
+    // NOTE: Upgrades are temporarily disabled while we construct a whitelist-based system of
+    // contract accounts that users can use. Without such a system, users could upgrade their
+    // accounts to a contract that completely avoids paying fees.
+    //
+    // /**
+    //  * Changes the implementation address.
+    //  * @param _implementation New implementation address.
+    //  */
+    // function upgrade(
+    //     address _implementation
+    // )
+    //     external
+    // {
+    //     require(
+    //         msg.sender == Lib_ExecutionManagerWrapper.ovmADDRESS(),
+    //         "EOAs can only upgrade their own EOA implementation"
+    //     );
+    //
+    //     _setImplementation(_implementation);
+    //     emit Upgraded(_implementation);
+    // }
 
     /**
      * Gets the address of the current implementation.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -19,11 +19,10 @@ contract OVM_ProxyEOA {
     /**********
      * Events *
      **********/
-    
-    // NOTE: See comment below w/r/t/ upgrade() to understand why we've commented this out.
-    // event Upgraded(
-    //    address indexed implementation
-    // );
+
+    event Upgraded(
+       address indexed implementation
+    );
 
 
     /*************
@@ -63,27 +62,27 @@ contract OVM_ProxyEOA {
      * Public Functions *
      ********************/
 
-    // NOTE: Upgrades are temporarily disabled while we construct a whitelist-based system of
-    // contract accounts that users can use. Without such a system, users could upgrade their
-    // accounts to a contract that completely avoids paying fees.
-    //
-    // /**
-    //  * Changes the implementation address.
-    //  * @param _implementation New implementation address.
-    //  */
-    // function upgrade(
-    //     address _implementation
-    // )
-    //     external
-    // {
-    //     require(
-    //         msg.sender == Lib_ExecutionManagerWrapper.ovmADDRESS(),
-    //         "EOAs can only upgrade their own EOA implementation"
-    //     );
-    //
-    //     _setImplementation(_implementation);
-    //     emit Upgraded(_implementation);
-    // }
+    /**
+     * Changes the implementation address.
+     * @param _implementation New implementation address.
+     */
+    function upgrade(
+        address _implementation
+    )
+        external
+    {
+        // NOTE: Upgrades are temporarily disabled because users can, in theory, modify their EOA
+        // so that they don't have to pay any fees to the sequencer. Function will remain disabled
+        // until a robust solution is in place.
+
+        // require(
+        //     msg.sender == Lib_ExecutionManagerWrapper.ovmADDRESS(),
+        //     "EOAs can only upgrade their own EOA implementation"
+        // );
+
+        // _setImplementation(_implementation);
+        // emit Upgraded(_implementation);
+    }
 
     /**
      * Gets the address of the current implementation.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ProxyEOA.sol
@@ -21,7 +21,7 @@ contract OVM_ProxyEOA {
      **********/
 
     event Upgraded(
-       address indexed implementation
+        address indexed implementation
     );
 
 

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ProxyEOA.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ProxyEOA.spec.ts
@@ -44,7 +44,9 @@ describe('OVM_ProxyEOA', () => {
     })
   })
 
-  describe('upgrade()', () => {
+  // NOTE: Upgrades are disabled for now but will be re-enabled at a later point in time. See
+  // comment in OVM_ProxyEOA.sol for additional information.
+  describe.skip('upgrade()', () => {
     it(`should upgrade the proxy implementation`, async () => {
       const newImpl = `0x${'81'.repeat(20)}`
       Mock__OVM_ExecutionManager.smocked.ovmADDRESS.will.return.with(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Temporarily disables upgrades within `OVM_ProxyEOA` to prevent users from changing their EOA to a contract that doesn't pay fees. Will be re-enabled once we have a whitelisting system for contracts that are guaranteed to pay fees correctly (or figure out some alternative mechanism entirely).
