### PR TITLE
optimism: syncing dtl with correct contracts

### DIFF
--- a/.changeset/cyan-spiders-listen.md
+++ b/.changeset/cyan-spiders-listen.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/l2geth': patch
+'@eth-optimism/data-transport-layer': patch
+---
+
+Fix bug with replica syncing where contract creations would fail in replicas but pass in the sequencer. This was due to the change from a custom batched tx serialization to the batch serialzation for txs being regular RLP encoding

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -18,8 +18,6 @@ import (
 const (
 	sequencer = "sequencer"
 	l1        = "l1"
-	EIP155    = "EIP155"
-	ETH_SIGN  = "ETH_SIGN"
 )
 
 // errElementNotFound represents the error case of the remote element not being
@@ -104,13 +102,13 @@ type signature struct {
 // When this struct exists in other structs and is set to `nil`,
 // it means that the decoding failed.
 type decoded struct {
-	Signature signature      `json:"sig"`
-	Value     hexutil.Uint64 `json:"value"`
-	GasLimit  uint64         `json:"gasLimit"`
-	GasPrice  uint64         `json:"gasPrice"`
-	Nonce     uint64         `json:"nonce"`
-	Target    common.Address `json:"target"`
-	Data      hexutil.Bytes  `json:"data"`
+	Signature signature       `json:"sig"`
+	Value     hexutil.Uint64  `json:"value"`
+	GasLimit  uint64          `json:"gasLimit"`
+	GasPrice  uint64          `json:"gasPrice"`
+	Nonce     uint64          `json:"nonce"`
+	Target    *common.Address `json:"target"`
+	Data      hexutil.Bytes   `json:"data"`
 }
 
 // RollupClient is able to query for information
@@ -304,10 +302,10 @@ func batchedTransactionToTransaction(res *transaction, signer *types.EIP155Signe
 		data := res.Decoded.Data
 
 		var tx *types.Transaction
-		if to == (common.Address{}) {
+		if to == nil {
 			tx = types.NewContractCreation(nonce, value, gasLimit, gasPrice, data)
 		} else {
-			tx = types.NewTransaction(nonce, to, value, gasLimit, gasPrice, data)
+			tx = types.NewTransaction(nonce, *to, value, gasLimit, gasPrice, data)
 		}
 
 		txMeta := types.NewTransactionMeta(

--- a/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
@@ -51,7 +51,7 @@ export const handleSequencerBlock = {
         gasLimit: BigNumber.from(transaction.gas).toNumber(),
         gasPrice: BigNumber.from(transaction.gasPrice).toNumber(), // ?
         nonce: BigNumber.from(transaction.nonce).toNumber(),
-        target: transaction.to || constants.AddressZero, // ?
+        target: transaction.to,
         data: transaction.input,
       }
 
@@ -66,7 +66,7 @@ export const handleSequencerBlock = {
             gasLimit: transaction.gas,
             gasPrice: transaction.gasPrice,
             nonce: transaction.nonce,
-            to: transaction.to || constants.AddressZero,
+            to: transaction.to,
             data: transaction.input,
             chainId,
           },


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug where there is non-determinism with state roots with replica syncing

The problem was introduced when switching to RLP - previously, sending a transaction to `address(0)` would mean contract creation because we were using a custom serialization. Now that we are using RLP, the target of `RLP(null)` signifies a contract creation. This passes through that information correctly to replicas

Fixes https://github.com/ethereum-optimism/optimism/issues/877
