### PR TITLE
Github action to require 2 reviewers

### DIFF
--- a/.github/label-requires-reviews.yml
+++ b/.github/label-requires-reviews.yml
@@ -1,0 +1,3 @@
+---
+  - label: 2-reviewers
+    reviews: 2

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,14 @@
 ---
+2-reviewers:
+  - '.github/**/*'
+  - 'l2geth/**/*'
+  - 'ops/**/*'
+  - 'packages/batch-submitter/**/*'
+  - 'packages/contracts/**/*'
+  - 'packages/data-transport-layer/**/*'
+  - 'packages/message-relayer/**/*'
+  - 'patches/**/*'
+
 A-ci:
   - any: ['.github/**/*']
 
@@ -35,3 +45,4 @@ M-ops:
 
 M-smock:
   - any: ['packages/smock/**/*']
+

--- a/.github/workflows/label-requires-reviews.yml
+++ b/.github/workflows/label-requires-reviews.yml
@@ -1,0 +1,16 @@
+name: Label Reviews
+on:
+  pull_request_review:
+
+jobs:
+  require-reviewers:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: develop
+
+      - name: Require-reviewers
+        uses: travelperk/label-requires-reviews-action@v0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN}}


### PR DESCRIPTION
**Description**
Update the labeler action to add a new label (`2-reviewers`) for sensitive paths.
Add a new action (`require-reviewers`) which fails unless a PR labeled with `2-reviewers` has 2 or more reviews.

**Additional context**
Instead of the inverse match I went this route as this check need to a reviewer count higher then the repo settings.
The `require-reviewers` check needs to be made required on the `develop` branch for this action's intent to be enforced.

