### PR TITLE
Test execution cost of ExecutionManager ovmCALL

### DIFF
--- a/packages/contracts/contracts/test-helpers/Helper_ExecutionManager.sol
+++ b/packages/contracts/contracts/test-helpers/Helper_ExecutionManager.sol
@@ -19,6 +19,13 @@ contract Helper_ExecutionManager is OVM_ExecutionManager {
         return ovmCALL(_gasLimit, _address, _calldata);
     }
 
+    function ovmDELEGATECALLHelper(uint256 _gasLimit, address _address, bytes memory _calldata, iOVM_StateManager _ovmStateManager)
+    external returns (bool _success, bytes memory _returndata)
+    {
+        ovmStateManager = _ovmStateManager;
+        return this.ovmDELEGATECALL(_gasLimit, _address, _calldata);
+    }
+
     function returnData(bytes memory _returnData) public pure returns (bytes memory) {
         return _returnData;
     }

--- a/packages/contracts/contracts/test-helpers/Helper_ExecutionManager.sol
+++ b/packages/contracts/contracts/test-helpers/Helper_ExecutionManager.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// @unsupported: ovm
+pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+import { iOVM_StateManager} from "../optimistic-ethereum/iOVM/execution/iOVM_StateManager.sol";
+import { OVM_ExecutionManager} from "../optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol";
+
+contract Helper_ExecutionManager is OVM_ExecutionManager {
+    constructor(address _libAddressManager, GasMeterConfig memory _gasMeterConfig, GlobalContext memory _globalContext)
+    OVM_ExecutionManager(_libAddressManager, _gasMeterConfig, _globalContext)
+    {
+    }
+
+    function ovmCALLHelper(uint256 _gasLimit, address _address, bytes memory _calldata, iOVM_StateManager _ovmStateManager)
+    external returns (bool _success, bytes memory _returndata)
+    {
+        ovmStateManager = _ovmStateManager;
+        return ovmCALL(_gasLimit, _address, _calldata);
+    }
+
+    function returnData(bytes memory _returnData) public pure returns (bytes memory) {
+        return _returnData;
+    }
+}

--- a/packages/contracts/contracts/test-helpers/Helper_TestRunner.sol
+++ b/packages/contracts/contracts/test-helpers/Helper_TestRunner.sol
@@ -17,10 +17,7 @@ contract Helper_TestRunner {
         bool onlyValidateFlag;
     }
 
-    function runSingleTestStep(
-        TestStep memory _step
-    )
-        public
+    function runSingleTestStep(TestStep memory _step) public
     {
         bytes32 namehash = keccak256(abi.encodePacked(_step.functionName));
         if (namehash == keccak256("evmRETURN")) {
@@ -135,19 +132,15 @@ contract Helper_TestRunner {
         }
     }
 
-    function runMultipleTestSteps(
-        TestStep[] memory _steps
-    )
-        public
+    function runMultipleTestSteps(TestStep[] memory _steps)
+    public
     {
         for (uint256 i = 0; i < _steps.length; i++) {
             runSingleTestStep(_steps[i]);
         }
     }
 
-    function _decodeRevertData(
-        bytes memory _revertdata
-    )
+    function _decodeRevertData(bytes memory _revertdata)
         internal
         pure
         returns (

--- a/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager.gas-spec.ts
+++ b/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager.gas-spec.ts
@@ -14,10 +14,7 @@ import {
   GasMeasurement,
 } from '../../../helpers'
 
-import {
-  OVM_TX_GAS_LIMIT,
-  RUN_OVM_TEST_GAS,
-} from '../../../helpers/constants'
+import { OVM_TX_GAS_LIMIT, RUN_OVM_TEST_GAS } from '../../../helpers/constants'
 
 const DUMMY_GASMETERCONFIG = {
   minTransactionGasLimit: 0,
@@ -112,13 +109,15 @@ describe('OVM_ExecutionManager gas consumption', () => {
     ).connect(wallet)
 
     await OVM_StateManager.connect(wallet).putAccount(
-      Helper_TestRunner.address, {
+      Helper_TestRunner.address,
+      {
         nonce: BigNumber.from(123),
         balance: BigNumber.from(456),
         storageRoot: NON_NULL_BYTES32,
         codeHash: NON_NULL_BYTES32,
         ethAddress: Helper_TestRunner.address,
-    })
+      }
+    )
 
     Helper_ExecutionManager = (
       await Factory__OVM_ExecutionManager.deploy(
@@ -152,64 +151,120 @@ describe('OVM_ExecutionManager gas consumption', () => {
 
     const dataVariants = [
       {
-        inputData: "0x11",
-        returnData: "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000011100000000000000000000000000000000000000000000000000000000000000"
+        inputData: '0x11',
+        returnData:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000011100000000000000000000000000000000000000000000000000000000000000',
       },
       {
-        inputData: "0x1111111111111111111111111111111111111111111111111111111111111111",
-        returnData: "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000201111111111111111111111111111111111111111111111111111111111111111"
+        inputData:
+          '0x1111111111111111111111111111111111111111111111111111111111111111',
+        returnData:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000201111111111111111111111111111111111111111111111111111111111111111',
       },
       {
-        inputData: "0x11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-        returnData: "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+        inputData:
+          '0x11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+        returnData:
+          '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
       },
       {
-        inputData: "0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-        returnData: "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+        inputData:
+          '0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+        returnData:
+          '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000060111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
       },
       {
-        inputData: "0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
-        returnData: "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000801111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-      }
+        inputData:
+          '0x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+        returnData:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000801111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+      },
     ]
 
-    dataVariants.forEach(
-      async (dataVariant) => {
-        it('Gas cost of ovmCALL', async () => {
-          const ovmCallData = Helper_ExecutionManager.interface.encodeFunctionData(
-            'returnData', [dataVariant.inputData]
-          )
+    dataVariants.forEach(async (dataVariant) => {
+      it('Gas cost of ovmCALL', async () => {
+        const ovmCallData = Helper_ExecutionManager.interface.encodeFunctionData(
+          'returnData',
+          [dataVariant.inputData]
+        )
 
-          const encodedStep = Helper_TestRunner.interface.encodeFunctionData(
-            'runSingleTestStep',
-            [
-              {
-                functionName: "ovmCALL",
-                functionData: ovmCallData,
-                expectedReturnStatus: true,
-                expectedReturnData: dataVariant.returnData,
-                onlyValidateFlag: false
-              }
-            ]
-          )
+        const encodedStep = Helper_TestRunner.interface.encodeFunctionData(
+          'runSingleTestStep',
+          [
+            {
+              functionName: 'ovmCALL',
+              functionData: ovmCallData,
+              expectedReturnStatus: true,
+              expectedReturnData: dataVariant.returnData,
+              onlyValidateFlag: false,
+            },
+          ]
+        )
 
-          const tx = await Helper_ExecutionManager.ovmCALLHelper(
-            OVM_TX_GAS_LIMIT,
-            Helper_TestRunner.address,
-            encodedStep,
-            OVM_StateManager.address,
-            { gasLimit: RUN_OVM_TEST_GAS }
-          )
+        const tx = await Helper_ExecutionManager.ovmCALLHelper(
+          OVM_TX_GAS_LIMIT,
+          Helper_TestRunner.address,
+          encodedStep,
+          OVM_StateManager.address,
+          { gasLimit: RUN_OVM_TEST_GAS }
+        )
 
-          const gasUsed = (
-            await Helper_ExecutionManager.provider.getTransactionReceipt(tx.hash)
-          ).gasUsed
+        const gasUsed = (
+          await Helper_ExecutionManager.provider.getTransactionReceipt(tx.hash)
+        ).gasUsed
 
-          console.log("inputData bytes size", ethers.utils.hexDataLength(dataVariant.inputData))
-          console.log("returnData bytes size", ethers.utils.hexDataLength(dataVariant.returnData))
-          console.log("gasUsed", gasUsed.toString())
-        })
-      }
-    )
+        console.log(
+          'inputData bytes size',
+          ethers.utils.hexDataLength(dataVariant.inputData)
+        )
+        console.log(
+          'returnData bytes size',
+          ethers.utils.hexDataLength(dataVariant.returnData)
+        )
+        console.log('gasUsed', gasUsed.toString())
+      })
+
+      it('Gas cost of ovmDELEGATECALL', async () => {
+        const ovmCallData = Helper_ExecutionManager.interface.encodeFunctionData(
+          'returnData',
+          [dataVariant.inputData]
+        )
+
+        const encodedStep = Helper_TestRunner.interface.encodeFunctionData(
+          'runSingleTestStep',
+          [
+            {
+              functionName: 'ovmDELEGATECALL',
+              functionData: ovmCallData,
+              expectedReturnStatus: true,
+              expectedReturnData: dataVariant.returnData,
+              onlyValidateFlag: false,
+            },
+          ]
+        )
+
+        const tx = await Helper_ExecutionManager.ovmDELEGATECALLHelper(
+          OVM_TX_GAS_LIMIT,
+          Helper_TestRunner.address,
+          encodedStep,
+          OVM_StateManager.address,
+          { gasLimit: RUN_OVM_TEST_GAS }
+        )
+
+        const gasUsed = (
+          await Helper_ExecutionManager.provider.getTransactionReceipt(tx.hash)
+        ).gasUsed
+
+        console.log(
+          'inputData bytes size',
+          ethers.utils.hexDataLength(dataVariant.inputData)
+        )
+        console.log(
+          'returnData bytes size',
+          ethers.utils.hexDataLength(dataVariant.returnData)
+        )
+        console.log('gasUsed', gasUsed.toString())
+      })
+    })
   })
 })


### PR DESCRIPTION
**Description**
Here we add a set of unit tests measuring the gas consumption of `ExecutionManager.ovmCALL` function. For the purposes of getting the costs for that, relative to the size of the input and return data arguments only (excluding the inner `.call` logic cost) we measure with a simple pure function with no logic that just returns the bytes data it was given, that is the `Helper_ExecutionManager.returnData` function. 

The following are the results from the various input/output byte pairs:

| inputData bytes size | returnData bytes size | ovmCALL gasUsed | ovmDELEGATECALL gasUsed |
|----------------------|-----------------------|---------|---------|
| 32                   | 96                    | 66,238   | 69,026|
| 64                   | 128                   | 67,587   | 70,527 |
| 96                   | 160                   | 68,938   | 72,031 |
| 128                  | 193                   | 70,288   | 73,534 |

In summary for every additional 32 bytes input and 32 bytes of output data `ovmCALL` spends ~1,350 additional gas on top of the base gas (64,888 gas) and `ovmDELEGATECALL` spends ~1,500 additional gas on top of the base gas (67,526 gas).

**Additional context**
We would like to get a better understanding of the gas overhead which the `OVM_ExecutionManager` consumes performing the virtualized ovm OPCODES.  Most importantly, we are interested in the dynamic ones, such as `ovmCALL` and `ovmDELEGATECALL`.
Note that we do memory checks/manipulation on both of these fields within ovmCALL, so it should not just be the raw internal call costs that we end up measuring.

**Metadata**
- Resolves https://linear.app/optimism/issue/OP-565/gas-meter-ovm-execution-in-l2
