### PR TITLE
fix[batch-submitter]: read metrics env vars correctly

### DIFF
--- a/packages/batch-submitter/.env.example
+++ b/packages/batch-submitter/.env.example
@@ -4,9 +4,9 @@ NODE_ENV=development
 ETH_NETWORK_NAME=
 # Logging & monitoring
 DEBUG=info*,error*,warn*,debug*
-RUN_PROMETHEUS_SERVER=
-PROMETHEUS_PORT=
-PROMETHEUS_HOSTNAME=
+RUN_METRICS_SERVER=
+METRICS_PORT=
+METRICS_HOSTNAME=
 # Leave the SENTRY_DSN variable unset during local development
 SENTRY_DSN=
 SENTRY_TRACE_RATE=

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -465,8 +465,14 @@ export const run = async () => {
     await createMetricsServer({
       logger,
       registry: metrics.registry,
-      port: config.uint('prometheus-port', 7300),
-      hostname: config.str('prometheus-hostname', '127.0.0.1'),
+      port: config.uint(
+        'prometheus-port',
+        parseInt(env.PROMETHEUS_PORT, 10) || 7300
+      ),
+      hostname: config.str(
+        'prometheus-hostname',
+        env.PROMETHEUS_HOSTNAME || '127.0.0.1'
+      ),
     })
   }
 }

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -67,7 +67,7 @@ interface RequiredEnvVars {
  * USE_HARDHAT
  * DEBUG_IMPERSONATE_SEQUENCER_ADDRESS
  * DEBUG_IMPERSONATE_PROPOSER_ADDRESS
- * RUN_PROMETHEUS_SERVER
+ * RUN_METRICS_SERVER
  */
 
 export const run = async () => {
@@ -458,20 +458,15 @@ export const run = async () => {
     loop(() => stateBatchSubmitter.submitNextBatch())
   }
 
-  if (
-    config.bool('run-prometheus-server', env.RUN_PROMETHEUS_SERVER === 'true')
-  ) {
+  if (config.bool('run-metrics-server', env.RUN_METRICS_SERVER === 'true')) {
     // Initialize metrics server
     await createMetricsServer({
       logger,
       registry: metrics.registry,
-      port: config.uint(
-        'prometheus-port',
-        parseInt(env.PROMETHEUS_PORT, 10) || 7300
-      ),
+      port: config.uint('metrics-port', parseInt(env.METRICS_PORT, 10) || 7300),
       hostname: config.str(
-        'prometheus-hostname',
-        env.PROMETHEUS_HOSTNAME || '127.0.0.1'
+        'metrics-hostname',
+        env.METRICS_HOSTNAME || '127.0.0.1'
       ),
     })
   }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes reading the default prom server env vars before we switch over to fully using bcfg.

**Additional context**
unblocks @optimisticben !

**Metadata**
- Fixes #[Link to Issue]
