### PR TITLE
feat[contracts]: add ability to pause EM during upgrades

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -205,7 +205,12 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
         // uint256 gasProvided = gasleft();
 
         bytes memory returndata;
-        if (_isUpgrading()) {
+        if (_isUpgrading() == true) {
+            // When we’re in the middle of an upgrade we completely ignore
+            // `transaction._entrypoint` and direct *all* transactions to the L2ChugSplashDeployer
+            // located at 0x42...0D. L1 => L2 messages executed during the middle of an upgrade
+            // will fail. Any transactions *not* intended to be sent to the L2ChugSplashDeployer
+            // will also fail and must be submitted again.
             (bool success, bytes memory ret) = ovmCALL(
                 _transaction.gasLimit - gasMeterConfig.minTransactionGasLimit,
                 0x420000000000000000000000000000000000000D,

--- a/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager.gas-spec.ts
+++ b/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager.gas-spec.ts
@@ -81,6 +81,8 @@ describe('OVM_ExecutionManager gas consumption', () => {
     MOCK__STATE_MANAGER.smocked.hasAccount.will.return.with(true)
     MOCK__STATE_MANAGER.smocked.testAndSetAccountLoaded.will.return.with(true)
 
+    MOCK__STATE_MANAGER.smocked.hasContractStorage.will.return.with(true)
+
     await AddressManager.setAddress(
       'OVM_StateManagerFactory',
       MOCK__STATE_MANAGER.address
@@ -110,7 +112,7 @@ describe('OVM_ExecutionManager gas consumption', () => {
       )
       console.log(`calculated gas cost of ${gasCost}`)
 
-      const benchmark: number = 106_000
+      const benchmark: number = 117_000
       expect(gasCost).to.be.lte(benchmark)
       expect(gasCost).to.be.gte(
         benchmark - 1_000,

--- a/packages/contracts/test/contracts/chugsplash/L2ChugSplashDeployer.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L2ChugSplashDeployer.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '../../setup'
 
 /* Imports: External */
 import hre from 'hardhat'
-import { ethers, Contract, Signer, ContractFactory } from 'ethers'
+import { ethers, Contract, Signer, ContractFactory, Wallet } from 'ethers'
 import { MockContract, smockit } from '@eth-optimism/smock'
 
 /* Imports: Internal */
@@ -15,6 +15,11 @@ import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../helpers'
 import { toPlainObject } from 'lodash'
 
 describe('L2ChugSplashDeployer', () => {
+  let wallet: Wallet
+  before(async () => {
+    ;[wallet] = hre.waffle.provider.getWallets()
+  })
+
   let signer1: Signer
   let signer2: Signer
   before(async () => {
@@ -26,6 +31,8 @@ describe('L2ChugSplashDeployer', () => {
     Mock__OVM_ExecutionManager = await smockit('OVM_ExecutionManager', {
       address: predeploys.OVM_ExecutionManagerWrapper,
     })
+
+    Mock__OVM_ExecutionManager.smocked.ovmCHAINID.will.return.with(420)
   })
 
   let Factory__L2ChugSplashDeployer: ContractFactory
@@ -257,6 +264,74 @@ describe('L2ChugSplashDeployer', () => {
           )
         ).to.not.be.reverted
       })
+    })
+  })
+
+  describe('fallback', () => {
+    it('should revert if not provided a valid EIP155 tx', async () => {
+      await expect(
+        signer1.sendTransaction({
+          to: L2ChugSplashDeployer.address,
+          data: '0x',
+        })
+      ).to.be.reverted
+    })
+
+    it('should revert if the target is not the L2ChugSplashDeployer', async () => {
+      await expect(
+        signer1.sendTransaction({
+          to: L2ChugSplashDeployer.address,
+          data: await wallet.signTransaction({
+            chainId: 420,
+            to: await signer1.getAddress(),
+            data: '0x',
+          }),
+        })
+      ).to.be.reverted
+    })
+
+    it('should revert if trying to call approveTransactionBundle', async () => {
+      await expect(
+        signer1.sendTransaction({
+          to: L2ChugSplashDeployer.address,
+          data: await wallet.signTransaction({
+            chainId: 420,
+            to: L2ChugSplashDeployer.address,
+            data: L2ChugSplashDeployer.interface.encodeFunctionData(
+              'approveTransactionBundle',
+              [ethers.constants.HashZero, 1234]
+            ),
+          }),
+        })
+      ).to.be.reverted
+    })
+
+    it('should be able to trigger executeAction', async () => {
+      const bundle: ChugSplashActionBundle = getChugSplashActionBundle([
+        {
+          target: NON_ZERO_ADDRESS,
+          code: '0x1234',
+        },
+      ])
+
+      await L2ChugSplashDeployer.connect(signer1).approveTransactionBundle(
+        bundle.root,
+        bundle.actions.length
+      )
+
+      await expect(
+        signer1.sendTransaction({
+          to: L2ChugSplashDeployer.address,
+          data: await wallet.signTransaction({
+            chainId: 420,
+            to: L2ChugSplashDeployer.address,
+            data: L2ChugSplashDeployer.interface.encodeFunctionData(
+              'executeAction',
+              [bundle.actions[0].action, bundle.actions[0].proof]
+            ),
+          }),
+        })
+      ).to.not.be.reverted
     })
   })
 })

--- a/packages/contracts/test/contracts/chugsplash/L2ChugSplashDeployer.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L2ChugSplashDeployer.spec.ts
@@ -236,13 +236,13 @@ describe('L2ChugSplashDeployer', () => {
       })
 
       it('should change the upgrade status when the bundle is complete', async () => {
-        expect(await L2ChugSplashDeployer.hasActiveBundle()).to.equal(true)
+        expect(await L2ChugSplashDeployer.isUpgrading()).to.equal(true)
 
         for (const action of bundle.actions) {
           await L2ChugSplashDeployer.executeAction(action.action, action.proof)
         }
 
-        expect(await L2ChugSplashDeployer.hasActiveBundle()).to.equal(false)
+        expect(await L2ChugSplashDeployer.isUpgrading()).to.equal(false)
       })
 
       it('should allow the upgrader to submit a new bundle when the previous bundle is complete', async () => {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a flag that will cause the EM to redirect all transactions to the `L2ChugSplashDeployer` while an upgrade is active. Makes sure that we won't have any weird behavior while an upgrade is in progress.
