### PR TITLE
l2geth: remove miner panic

### DIFF
--- a/.changeset/little-emus-cover.md
+++ b/.changeset/little-emus-cover.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Don't panic on a monotonicity violation

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -872,12 +872,13 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 		if tx.QueueOrigin().Uint64() == uint64(types.QueueOriginSequencer) {
 			tx.SetL1Timestamp(parent.Time())
 			prev := parent.Transactions()
-			if len(prev) != 1 {
-				panic("Cannot recover L1BlockNumber")
+			if len(prev) == 1 {
+				tx.SetL1BlockNumber(prev[0].L1BlockNumber().Uint64())
+			} else {
+				log.Error("Cannot recover L1 Blocknumber")
 			}
-			tx.SetL1BlockNumber(prev[0].L1BlockNumber().Uint64())
 		} else {
-			panic("Monotonicity violation")
+			log.Error("Cannot recover from monotonicity violation")
 		}
 	}
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes the `panic` from the miner 
