### PR TITLE
Revert "docs: add docker-compose up step to README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ cd ops
 export COMPOSE_DOCKER_CLI_BUILD=1
 export DOCKER_BUILDKIT=1
 docker-compose build
-docker-compose up
 cd ../integration-tests
 yarn build:integration
 yarn test:integration


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#914, per @gakonst comment there:

> This was not missing because integration tests bring the network up #699. This PR should be reverted, or an additional change should be made in the readme that runs the integration tests like `NO_NETWORK=1 yarn test:integration`, so that the network doesn't get brought up via this [flag](https://github.com/ethereum-optimism/optimism/blob/develop/integration-tests/test/setup-docker-compose-network.js#L5)

