### PR TITLE
fix[l2geth]: fix a bug where call reverts would not be propagated

### DIFF
--- a/.changeset/cuddly-ravens-smile.md
+++ b/.changeset/cuddly-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fixed a bug where reverts without data would not be correctly propagated for eth_call

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -2,12 +2,7 @@ import { injectL2Context } from '@eth-optimism/core-utils'
 import { Wallet, BigNumber, Contract } from 'ethers'
 import { ethers } from 'hardhat'
 import chai, { expect } from 'chai'
-import {
-  sleep,
-  l2Provider,
-  GWEI,
-  encodeSolidityRevertMessage,
-} from './shared/utils'
+import { sleep, l2Provider, GWEI } from './shared/utils'
 import chaiAsPromised from 'chai-as-promised'
 import { OptimismEnv } from './shared/env'
 import {
@@ -129,12 +124,6 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_call', () => {
-    let expectedReverterRevertData: string
-
-    before(async () => {
-      expectedReverterRevertData = encodeSolidityRevertMessage(revertMessage)
-    })
-
     it('should correctly identify call out-of-gas', async () => {
       await expect(
         provider.call({
@@ -145,9 +134,9 @@ describe('Basic RPC tests', () => {
     })
 
     it('should correctly return solidity revert data from a call', async () => {
-      const revertData = await provider.call(revertingTx)
-      const expectedRevertData = encodeSolidityRevertMessage(revertMessage)
-      expect(revertData).to.eq(expectedRevertData)
+      await expect(await provider.call(revertingTx)).to.be.revertedWith(
+        revertMessage
+      )
     })
 
     it('should produce error when called from ethers', async () => {
@@ -155,9 +144,9 @@ describe('Basic RPC tests', () => {
     })
 
     it('should correctly return revert data from contract creation', async () => {
-      const revertData = await provider.call(revertingDeployTx)
-
-      expect(revertData).to.eq(expectedReverterRevertData)
+      await expect(provider.call(revertingDeployTx)).to.be.revertedWith(
+        revertMessage
+      )
     })
 
     it('should correctly identify contract creation out of gas', async () => {
@@ -172,14 +161,14 @@ describe('Basic RPC tests', () => {
     it('should return the correct error message when attempting to deploy unsafe initcode', async () => {
       // PUSH1 0x00 PUSH1 0x00 SSTORE
       const unsafeCode = '0x6000600055'
-      const tx: TransactionRequest = {
-        data: unsafeCode,
-      }
-      const result = await provider.call(tx)
-      const expected = encodeSolidityRevertMessage(
+
+      await expect(
+        provider.call({
+          data: unsafeCode,
+        })
+      ).to.be.revertedWith(
         'Contract creation code contains unsafe opcodes. Did you use the right compiler or pass an unsafe constructor argument?'
       )
-      expect(result).to.eq(expected)
     })
   })
 

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -134,9 +134,7 @@ describe('Basic RPC tests', () => {
     })
 
     it('should correctly return solidity revert data from a call', async () => {
-      await expect(provider.call(revertingTx)).to.be.revertedWith(
-        revertMessage
-      )
+      await expect(provider.call(revertingTx)).to.be.revertedWith(revertMessage)
     })
 
     it('should produce error when called from ethers', async () => {

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -134,7 +134,7 @@ describe('Basic RPC tests', () => {
     })
 
     it('should correctly return solidity revert data from a call', async () => {
-      await expect(await provider.call(revertingTx)).to.be.revertedWith(
+      await expect(provider.call(revertingTx)).to.be.revertedWith(
         revertMessage
       )
     })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR fixes a bug where reverts would not be correctly propagated during `eth_call`. I based these changes on similar logic performed in upstream geth: https://github.com/ethereum/go-ethereum/blob/3e795881ea6d68c32da5da3c95f0d458a64e35c3/internal/ethapi/api.go#L948-L955.

**Additional context**
Should fix that last issue we were having with uniswap tests.
