### PR TITLE
l2geth: gaslimit encoding state polling

### DIFF
--- a/l2geth/cmd/geth/main.go
+++ b/l2geth/cmd/geth/main.go
@@ -156,7 +156,6 @@ var (
 		utils.Eth1ETHGatewayAddressFlag,
 		utils.Eth1ChainIdFlag,
 		utils.RollupClientHttpFlag,
-		// Enable verifier mode
 		utils.RollupEnableVerifierFlag,
 		utils.RollupAddressManagerOwnerAddressFlag,
 		utils.RollupTimstampRefreshFlag,
@@ -166,6 +165,8 @@ var (
 		utils.RollupMaxCalldataSizeFlag,
 		utils.RollupDataPriceFlag,
 		utils.RollupExecutionPriceFlag,
+		utils.RollupEnableL2GasPollingFlag,
+		utils.RollupGasPriceOracleAddressFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/l2geth/cmd/geth/usage.go
+++ b/l2geth/cmd/geth/usage.go
@@ -80,6 +80,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupMaxCalldataSizeFlag,
 			utils.RollupDataPriceFlag,
 			utils.RollupExecutionPriceFlag,
+			utils.RollupEnableL2GasPollingFlag,
+			utils.RollupGasPriceOracleAddressFlag,
 		},
 	},
 	{

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -891,6 +891,17 @@ var (
 		Value:  eth.DefaultConfig.Rollup.ExecutionPrice,
 		EnvVar: "ROLLUP_EXECUTIONPRICE",
 	}
+	RollupGasPriceOracleAddressFlag = cli.StringFlag{
+		Name:   "rollup.gaspriceoracleaddress",
+		Usage:  "Address of the rollup gas price oracle",
+		Value:  "0x",
+		EnvVar: "ROLLUP_GAS_PRICE_ORACLE_ADDRESS",
+	}
+	RollupEnableL2GasPollingFlag = cli.BoolFlag{
+		Name:   "rollup.enablel2gaspolling",
+		Usage:  "",
+		EnvVar: "ROLLUP_ENABLE_L2_GAS_POLLING",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1169,6 +1180,13 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 	}
 	if ctx.GlobalIsSet(RollupExecutionPriceFlag.Name) {
 		cfg.ExecutionPrice = GlobalBig(ctx, RollupExecutionPriceFlag.Name)
+	}
+	if ctx.GlobalIsSet(RollupGasPriceOracleAddressFlag.Name) {
+		addr := ctx.GlobalString(RollupGasPriceOracleAddressFlag.Name)
+		cfg.GasPriceOracleAddress = common.HexToAddress(addr)
+	}
+	if ctx.GlobalIsSet(RollupEnableL2GasPollingFlag.Name) {
+		cfg.EnableL2GasPolling = true
 	}
 }
 

--- a/l2geth/rollup/config.go
+++ b/l2geth/rollup/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	L1CrossDomainMessengerAddress common.Address
 	AddressManagerOwnerAddress    common.Address
 	L1ETHGatewayAddress           common.Address
+	GasPriceOracleAddress         common.Address
+	// Turns on checking of state for L2 gas price
+	EnableL2GasPolling bool
 	// Deployment Height of the canonical transaction chain
 	CanonicalTransactionChainDeployHeight *big.Int
 	// Path to the state dump

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -471,6 +471,8 @@ func (s *SyncService) updateL1GasPrice() error {
 // It must be enabled to function until all nodes are running with the correct
 // contract deployed.
 func (s *SyncService) updateL2GasPrice(hash *common.Hash) error {
+	// TOOD(mark): this is temporary and will be able to be rmoved when the
+	// OVM_GasPriceOracle is moved into the predeploy contracts
 	if !s.enableL2GasPolling {
 		return nil
 	}

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -312,7 +312,7 @@ func (s *SyncService) VerifierLoop() {
 		if err := s.verify(); err != nil {
 			log.Error("Could not verify", "error", err)
 		}
-		if err := s.updateL2GasPrice(); err != nil {
+		if err := s.updateL2GasPrice(nil); err != nil {
 			log.Error("Cannot update L2 gas price", "msg", err)
 		}
 		time.Sleep(s.pollInterval)
@@ -369,7 +369,7 @@ func (s *SyncService) SequencerLoop() {
 		}
 		s.txLock.Unlock()
 
-		if err := s.updateL2GasPrice(); err != nil {
+		if err := s.updateL2GasPrice(nil); err != nil {
 			log.Error("Cannot update L2 gas price", "msg", err)
 		}
 		if s.updateContext() != nil {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This adds in L2 state polling in the `sequence` and `verify` loops to pull out the L2 gas price that is set inside of the `OVM_GasPriceOracle` being worked on here: https://github.com/ethereum-optimism/optimism/pull/912

This is fully backwards compatible with the config option `EnableL2GasPolling` as it defaults to false. The config option `GasPriceOracleAddress` will set the address that it reads from, this should default to the `0x42..` address that the contract lives at. Having this address be configurable will let us deploy it to L2 and then update the network with the correct address configured and have it start working. Note that infrastructure providers will also need to reconfigure with the address that the contract ends up being deployed to.

**Additional context**
This is opened up as a PR to https://github.com/ethereum-optimism/optimism/pull/906 to prevent it from growing too large without review

This still needs config parsing and to pass through the config options to the `rollup.Config`