### PR TITLE
fix(l2geth): add an env var METRICS_ENABLE for MetricsEnabledFlag

### DIFF
--- a/.changeset/two-suits-care.md
+++ b/.changeset/two-suits-care.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+add an env var METRICS_ENABLE for MetricsEnabledFlag

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -755,6 +755,8 @@ var (
 	MetricsEnabledFlag = cli.BoolFlag{
 		Name:  "metrics",
 		Usage: "Enable metrics collection and reporting",
+
+		EnvVar: "METRICS_ENABLE",
 	}
 	MetricsEnabledExpensiveFlag = cli.BoolFlag{
 		Name:  "metrics.expensive",


### PR DESCRIPTION
**Description**
Adds an env var `METRICS_ENABLE` for the `MetricsEnabledFlag` CLI arg.

