### PR TITLE
fix[hardhat-ovm]: use correct url when creating ethers object

### DIFF
--- a/.changeset/witty-houses-happen.md
+++ b/.changeset/witty-houses-happen.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-ovm': patch
+---
+
+Fix a bug that broke hardhat-ethers

--- a/.changeset/witty-houses-happen.md
+++ b/.changeset/witty-houses-happen.md
@@ -2,4 +2,4 @@
 '@eth-optimism/hardhat-ovm': patch
 ---
 
-Fix a bug that broke hardhat-ethers
+Instantiate the harhat ethers provider using the Hardhat network config if no provider URL is set, and set the provider at the end, so that the overridden `getSigner` method is used. 

--- a/packages/hardhat-ovm/src/index.ts
+++ b/packages/hardhat-ovm/src/index.ts
@@ -248,14 +248,13 @@ extendEnvironment(async (hre) => {
 
       // override the provider polling interval
       const provider = new ethers.providers.JsonRpcProvider(
-        (hre as any).ethers.provider.url
+        (hre as any).ethers.provider.url || (hre as any).network.config.url
       )
       provider.pollingInterval = interval
 
       // the gas price is overriden to the user provided gasPrice or to 0.
       provider.getGasPrice = async () =>
         ethers.BigNumber.from(hre.network.config.gasPrice || 0)
-      ;(hre as any).ethers.provider = provider
 
       // if the node is up, override the getSigners method's signers
       try {
@@ -281,6 +280,9 @@ extendEnvironment(async (hre) => {
         ;(hre as any).ethers.getSigners = () => signers
         /* tslint:disable:no-empty */
       } catch (e) {}
+
+      // Update the provider at the very end to avoid any weird issues.
+      ;(hre as any).ethers.provider = provider
     }
   }
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
For some reason we were using the completely incorrect URL when modifying the `hardhat-ethers` object. I don't know if this was an error on our part or some sort of dependency that broke, so using `||` to remain backwards compatible if it indeed was an updated dependency. Also moves the step where we update the provider to the very end of the modification code so we can avoid weird issues when overriding `getSigners`.

**Metadata**
- Fixes #935
