### PR TITLE
test[integration-tests]: add an integration test for contract deployments that run out of gas

### DIFF
--- a/.changeset/rotten-pillows-change.md
+++ b/.changeset/rotten-pillows-change.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/l2geth': patch
+---
+
+Adds a test for contract deployments that run out of gas

--- a/integration-tests/contracts/TestOOG.sol
+++ b/integration-tests/contracts/TestOOG.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0;
+
+contract TestOOG {
+    constructor() {
+        bytes32 h;
+        for (uint256 i = 0; i < 100000; i++) {
+            h = keccak256(abi.encodePacked(h));
+        }
+    }
+}

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -121,6 +121,14 @@ describe('Basic RPC tests', () => {
         'invalid transaction: insufficient funds for gas * price + value'
       )
     })
+
+    it('should correctly report OOG for contract creations', async () => {
+      const factory = await ethers.getContractFactory('TestOOG')
+
+      await expect(factory.connect(wallet).deploy()).to.be.rejectedWith(
+        'gas required exceeds allowance'
+      )
+    })
   })
 
   describe('eth_call', () => {

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1131,7 +1131,7 @@ func legacyDoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrO
 				}
 				return 0, err
 			}
-			return 0, fmt.Errorf("gas required exceeds allowance (%d) or always failing transaction", cap)
+			return 0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
 		}
 	}
 	return hexutil.Uint64(hi), nil


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds an integration test for contract deployments that run out of gas. Also updates the returned error message to be more clear, following the same pattern that upstream geth uses: https://github.com/ethereum/go-ethereum/blob/154ca32a8ade0a7d2461d0eb432361261a51a395/internal/ethapi/api.go#L1061

**Metadata**
- Fixes #761
