### PR TITLE
feat[contracts]: optimize MerkleTrie by skipping an RLP decoding step

### DIFF
--- a/.changeset/rude-chefs-sniff.md
+++ b/.changeset/rude-chefs-sniff.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': minor
+'@eth-optimism/message-relayer': minor
+---
+
+Optimizes Lib_MerkleTrie by accepting an ABI encoded array of proof elements instead of an RLP encoded list

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
@@ -185,7 +185,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
     function proveContractState(
         address _ovmContractAddress,
         address _ethContractAddress,
-        bytes memory _stateTrieWitness
+        bytes[] memory _stateTrieWitness
     )
         override
         external
@@ -257,7 +257,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
     function proveStorageSlot(
         address _ovmContractAddress,
         bytes32 _key,
-        bytes memory _storageTrieWitness
+        bytes[] memory _storageTrieWitness
     )
         override
         external
@@ -371,7 +371,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
      */
     function commitContractState(
         address _ovmContractAddress,
-        bytes memory _stateTrieWitness
+        bytes[] memory _stateTrieWitness
     )
         override
         external
@@ -414,7 +414,7 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
     function commitStorageSlot(
         address _ovmContractAddress,
         bytes32 _key,
-        bytes memory _storageTrieWitness
+        bytes[] memory _storageTrieWitness
     )
         override
         external

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1CrossDomainMessenger.sol
@@ -21,8 +21,8 @@ interface iOVM_L1CrossDomainMessenger is iAbs_BaseCrossDomainMessenger {
         bytes32 stateRoot;
         Lib_OVMCodec.ChainBatchHeader stateRootBatchHeader;
         Lib_OVMCodec.ChainInclusionProof stateRootProof;
-        bytes stateTrieWitness;
-        bytes storageTrieWitness;
+        bytes[] stateTrieWitness;
+        bytes[] storageTrieWitness;
     }
 
 

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/verification/iOVM_StateTransitioner.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/verification/iOVM_StateTransitioner.sol
@@ -40,13 +40,13 @@ interface iOVM_StateTransitioner {
     function proveContractState(
         address _ovmContractAddress,
         address _ethContractAddress,
-        bytes calldata _stateTrieWitness
+        bytes[] calldata _stateTrieWitness
     ) external;
 
     function proveStorageSlot(
         address _ovmContractAddress,
         bytes32 _key,
-        bytes calldata _storageTrieWitness
+        bytes[] calldata _storageTrieWitness
     ) external;
 
 
@@ -65,13 +65,13 @@ interface iOVM_StateTransitioner {
 
     function commitContractState(
         address _ovmContractAddress,
-        bytes calldata _stateTrieWitness
+        bytes[] calldata _stateTrieWitness
     ) external;
 
     function commitStorageSlot(
         address _ovmContractAddress,
         bytes32 _key,
-        bytes calldata _storageTrieWitness
+        bytes[] calldata _storageTrieWitness
     ) external;
 
 

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_BytesUtils } from "../utils/Lib_BytesUtils.sol";
@@ -73,7 +74,7 @@ library Lib_MerkleTrie {
     function verifyInclusionProof(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         internal
@@ -106,7 +107,7 @@ library Lib_MerkleTrie {
     function update(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         internal
@@ -137,7 +138,7 @@ library Lib_MerkleTrie {
      */
     function get(
         bytes memory _key,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         internal
@@ -536,27 +537,25 @@ library Lib_MerkleTrie {
     }
 
     /**
-     * @notice Parses an RLP-encoded proof into something more useful.
-     * @param _proof RLP-encoded proof to parse.
-     * @return _parsed Proof parsed into easily accessible structs.
+     * @notice Parses RLP-encoded proof elements into more useful structs.
+     * @param _proof RLP-encoded proof elements to parse.
+     * @return Parsed proof elements.
      */
     function _parseProof(
-        bytes memory _proof
+        bytes[] memory _proof
     )
         private
         pure
         returns (
-            TrieNode[] memory _parsed
+            TrieNode[] memory
         )
     {
-        Lib_RLPReader.RLPItem[] memory nodes = Lib_RLPReader.readList(_proof);
-        TrieNode[] memory proof = new TrieNode[](nodes.length);
+        TrieNode[] memory proof = new TrieNode[](_proof.length);
 
-        for (uint256 i = 0; i < nodes.length; i++) {
-            bytes memory encoded = Lib_RLPReader.readBytes(nodes[i]);
+        for (uint256 i = 0; i < _proof.length; i++) {
             proof[i] = TrieNode({
-                encoded: encoded,
-                decoded: Lib_RLPReader.readList(encoded)
+                encoded: _proof[i],
+                decoded: Lib_RLPReader.readList(_proof[i])
             });
         }
 

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_SecureMerkleTrie.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/trie/Lib_SecureMerkleTrie.sol
@@ -29,7 +29,7 @@ library Lib_SecureMerkleTrie {
     function verifyInclusionProof(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         internal
@@ -56,7 +56,7 @@ library Lib_SecureMerkleTrie {
     function update(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         internal
@@ -79,7 +79,7 @@ library Lib_SecureMerkleTrie {
      */
     function get(
         bytes memory _key,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         internal

--- a/packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
+++ b/packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_MerkleTrie } from "../../optimistic-ethereum/libraries/trie/Lib_MerkleTrie.sol";
@@ -12,7 +13,7 @@ contract TestLib_MerkleTrie {
     function verifyInclusionProof(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         public
@@ -32,7 +33,7 @@ contract TestLib_MerkleTrie {
     function update(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         public
@@ -51,7 +52,7 @@ contract TestLib_MerkleTrie {
 
     function get(
         bytes memory _key,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         public

--- a/packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
+++ b/packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
@@ -13,7 +13,7 @@ contract TestLib_SecureMerkleTrie {
     function verifyInclusionProof(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         public
@@ -33,7 +33,7 @@ contract TestLib_SecureMerkleTrie {
     function update(
         bytes memory _key,
         bytes memory _value,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         public
@@ -52,7 +52,7 @@ contract TestLib_SecureMerkleTrie {
 
     function get(
         bytes memory _key,
-        bytes memory _proof,
+        bytes[] memory _proof,
         bytes32 _root
     )
         public

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
@@ -329,8 +329,8 @@ describe('OVM_L1CrossDomainMessenger', () => {
         stateRoot: ethers.constants.HashZero,
         stateRootBatchHeader: DUMMY_BATCH_HEADERS[0],
         stateRootProof: DUMMY_BATCH_PROOFS[0],
-        stateTrieWitness: '0x',
-        storageTrieWitness: '0x',
+        stateTrieWitness: [],
+        storageTrieWitness: [],
       }
 
       await expect(
@@ -353,8 +353,8 @@ describe('OVM_L1CrossDomainMessenger', () => {
         stateRoot: ethers.constants.HashZero,
         stateRootBatchHeader: DUMMY_BATCH_HEADERS[0],
         stateRootProof: DUMMY_BATCH_PROOFS[0],
-        stateTrieWitness: '0x',
-        storageTrieWitness: '0x',
+        stateTrieWitness: [],
+        storageTrieWitness: [],
       }
 
       await expect(
@@ -372,7 +372,7 @@ describe('OVM_L1CrossDomainMessenger', () => {
       await expect(
         OVM_L1CrossDomainMessenger.relayMessage(target, sender, message, 0, {
           ...proof,
-          storageTrieWitness: '0x',
+          storageTrieWitness: [],
         })
       ).to.be.reverted
     })
@@ -381,7 +381,7 @@ describe('OVM_L1CrossDomainMessenger', () => {
       await expect(
         OVM_L1CrossDomainMessenger.relayMessage(target, sender, message, 0, {
           ...proof,
-          stateTrieWitness: '0x',
+          stateTrieWitness: [],
         })
       ).to.be.reverted
     })

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1MultiMessageRelayer.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1MultiMessageRelayer.spec.ts
@@ -57,8 +57,8 @@ describe('OVM_L1MultiMessageRelayer', () => {
       stateRoot: NON_NULL_BYTES32,
       stateRootBatchHeader: DUMMY_BATCH_HEADERS[0],
       stateRootProof: DUMMY_BATCH_PROOFS[0],
-      stateTrieWitness: toHexString('some bytes'),
-      storageTrieWitness: toHexString('some more bytes'),
+      stateTrieWitness: [],
+      storageTrieWitness: [],
     }
 
     // create a few dummy messages to relay

--- a/packages/contracts/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
+++ b/packages/contracts/test/contracts/OVM/verification/OVM_StateTransitioner.spec.ts
@@ -112,7 +112,7 @@ describe('OVM_StateTransitioner', () => {
       })
 
       describe('when provided an invalid account inclusion proof', () => {
-        const proof = '0x'
+        const proof = []
 
         it('should revert', async () => {
           await expect(
@@ -190,7 +190,7 @@ describe('OVM_StateTransitioner', () => {
           OVM_StateTransitioner.proveStorageSlot(
             NON_ZERO_ADDRESS,
             NON_NULL_BYTES32,
-            '0x'
+            []
           )
         ).to.be.revertedWith(
           'Contract must be verified before proving a storage slot.'
@@ -206,7 +206,7 @@ describe('OVM_StateTransitioner', () => {
       describe('when provided an invalid slot inclusion proof', () => {
         const key = ethers.utils.keccak256('0x1234')
         const val = ethers.utils.keccak256('0x5678')
-        const proof = '0x'
+        const proof = []
         beforeEach(async () => {
           const generator = await TrieTestGenerator.fromNodes({
             nodes: [
@@ -239,7 +239,7 @@ describe('OVM_StateTransitioner', () => {
       describe('when provided a valid slot inclusion proof', () => {
         const key = ethers.utils.keccak256('0x1234')
         const val = ethers.utils.keccak256('0x5678')
-        let proof: string
+        let proof: string[]
         beforeEach(async () => {
           const generator = await TrieTestGenerator.fromNodes({
             nodes: [
@@ -359,7 +359,7 @@ describe('OVM_StateTransitioner', () => {
 
       it('should revert', async () => {
         await expect(
-          OVM_StateTransitioner.commitContractState(ovmContractAddress, '0x')
+          OVM_StateTransitioner.commitContractState(ovmContractAddress, [])
         ).to.be.revertedWith(
           `Account state wasn't changed or has already been committed`
         )
@@ -450,7 +450,7 @@ describe('OVM_StateTransitioner', () => {
 
       it('should revert', async () => {
         await expect(
-          OVM_StateTransitioner.commitStorageSlot(ovmContractAddress, key, '0x')
+          OVM_StateTransitioner.commitStorageSlot(ovmContractAddress, key, [])
         ).to.be.revertedWith(
           `Storage slot value wasn't changed or has already been committed.`
         )
@@ -465,7 +465,7 @@ describe('OVM_StateTransitioner', () => {
       })
 
       describe('with a valid proof', () => {
-        let storageTrieProof: string
+        let storageTrieProof: string[]
         beforeEach(async () => {
           const storageGenerator = await TrieTestGenerator.fromNodes({
             nodes: [

--- a/packages/contracts/test/helpers/trie/trie-test-generator.ts
+++ b/packages/contracts/test/helpers/trie/trie-test-generator.ts
@@ -13,7 +13,7 @@ export interface TrieNode {
 export interface InclusionProofTest {
   key: string
   val: string
-  proof: string
+  proof: string[]
   root: string
 }
 
@@ -167,7 +167,7 @@ export class TrieTestGenerator {
     const val = await trie.get(fromHexString(key))
 
     return {
-      proof: toHexString(rlp.encode(proof)),
+      proof: proof.map(toHexString),
       key: toHexString(key),
       val: toHexString(val),
       root: toHexString(trie.root),
@@ -199,7 +199,7 @@ export class TrieTestGenerator {
     const newRoot = trie.root
 
     return {
-      proof: toHexString(rlp.encode(proof)),
+      proof: proof.map(toHexString),
       key: toHexString(key),
       val: toHexString(val),
       root: toHexString(oldRoot),
@@ -222,7 +222,7 @@ export class TrieTestGenerator {
     return {
       address,
       account: rlpDecodeAccount(toHexString(account)),
-      accountTrieWitness: toHexString(rlp.encode(proof)),
+      accountTrieWitness: proof.map(toHexString),
       accountTrieRoot: toHexString(trie.root),
     }
   }
@@ -249,7 +249,7 @@ export class TrieTestGenerator {
     return {
       address,
       account,
-      accountTrieWitness: toHexString(rlp.encode(proof)),
+      accountTrieWitness: proof.map(toHexString),
       accountTrieRoot: toHexString(oldRoot),
       newAccountTrieRoot: toHexString(newRoot),
     }

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -30,14 +30,13 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "^0.1.2",
-    "bcfg": "^0.1.6",
     "@eth-optimism/contracts": "^0.3.1",
     "@eth-optimism/core-utils": "^0.4.3",
+    "bcfg": "^0.1.6",
     "dotenv": "^8.2.0",
     "ethers": "^5.1.0",
     "google-spreadsheet": "^3.1.15",
-    "merkletreejs": "^0.2.18",
-    "rlp": "^2.2.6"
+    "merkletreejs": "^0.2.18"
   },
   "devDependencies": {
     "prettier": "^2.2.1",

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -1,10 +1,9 @@
 /* Imports: External */
 import { Contract, ethers, Wallet, BigNumber, providers } from 'ethers'
-import * as rlp from 'rlp'
 import { MerkleTree } from 'merkletreejs'
 
 /* Imports: Internal */
-import { fromHexString, sleep } from '@eth-optimism/core-utils'
+import { fromHexString, sleep, toHexString } from '@eth-optimism/core-utils'
 import { BaseService } from '@eth-optimism/common-ts'
 import SpreadSheet from './spreadsheet'
 
@@ -435,8 +434,8 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
         index,
         siblings: treeProof,
       },
-      stateTrieWitness: rlp.encode(proof.accountProof),
-      storageTrieWitness: rlp.encode(proof.storageProof[0].proof),
+      stateTrieWitness: proof.accountProof.map(toHexString),
+      storageTrieWitness: proof.storageProof[0].proof.map(toHexString),
     }
   }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Optimizes `Lib_MerkleTrie` functions by skipping an unnecessary RLP decoding step. I'm really not sure *why* I originally implemented this step, but this alternative is totally fine and should save a bunch of gas.