### PR TITLE
fix[hardhat-ovm]: Allow for private key config option for signers

### DIFF
--- a/.changeset/tame-stingrays-retire.md
+++ b/.changeset/tame-stingrays-retire.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-ovm': patch
+---
+
+Allow for private key config option for signers

--- a/packages/hardhat-ovm/src/index.ts
+++ b/packages/hardhat-ovm/src/index.ts
@@ -4,7 +4,10 @@ import * as path from 'path'
 import fetch from 'node-fetch'
 import { ethers } from 'ethers'
 import { subtask, extendEnvironment } from 'hardhat/config'
-import { HardhatNetworkHDAccountsConfig } from 'hardhat/types/config'
+import {
+  HardhatNetworkHDAccountsConfig,
+  HardhatNetworkAccountUserConfig,
+} from 'hardhat/types/config'
 import { getCompilersDir } from 'hardhat/internal/util/global-dir'
 import { Artifacts } from 'hardhat/internal/artifacts'
 import {
@@ -259,9 +262,17 @@ extendEnvironment(async (hre) => {
       // if the node is up, override the getSigners method's signers
       try {
         let signers: ethers.Signer[]
-        const accounts = hre.network.config
-          .accounts as HardhatNetworkHDAccountsConfig
-        if (accounts) {
+        const accounts = hre.network.config.accounts as
+          | HardhatNetworkHDAccountsConfig
+          | HardhatNetworkAccountUserConfig[]
+        if (Array.isArray(accounts)) {
+          signers = (accounts as HardhatNetworkAccountUserConfig[]).map(
+            (account) =>
+              new ethers.Wallet(
+                typeof account === 'string' ? account : account.privateKey
+              ).connect(provider)
+          )
+        } else if (accounts) {
           const indices = Array.from(Array(20).keys()) // generates array of [0, 1, 2, ..., 18, 19]
           signers = indices.map((i) =>
             ethers.Wallet.fromMnemonic(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Currently the hardhat-ovm plugin isn't allowing for private keys for accounts from hardhat.config.js (it's always looking for mnemonic). This PR adds support for private key account config option as allowed by [hardhat config](https://hardhat.org/config/).

**Additional context**


**Metadata**

