### PR TITLE
fix[message-relayer]: avoid getting OOM killed

### DIFF
--- a/.changeset/twelve-peas-compete.md
+++ b/.changeset/twelve-peas-compete.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Fix to avoid getting OOM killed when the relayer runs for a long period of time

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -201,11 +201,11 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
           // Only deal with ~1000 transactions at a time so we can limit the amount of stuff we
           // need to keep in memory. We operate on full batches at a time so the actual amount
           // depends on the size of the batches we're processing.
-          if (
+          const numTransactionsToProcess =
             this.state.nextUnfinalizedTxHeight -
-              this.state.lastFinalizedTxHeight >
-            1000
-          ) {
+            this.state.lastFinalizedTxHeight
+
+          if (numTransactionsToProcess > 1000) {
             break
           }
         }

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -290,9 +290,9 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     const getStateBatchAppendedEventForIndex = (
       txIndex: number
     ): ethers.Event => {
-      return this.state.eventCache.find((event) => {
-        const prevTotalElements = event.args._prevTotalElements
-        const batchSize = event.args._batchSize
+      return this.state.eventCache.find((cachedEvent) => {
+        const prevTotalElements = cachedEvent.args._prevTotalElements.toNumber()
+        const batchSize = cachedEvent.args._batchSize.toNumber()
 
         // Height should be within the bounds of the batch.
         return (


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the `message-relayer` to automatically remove any events from the cache that are no longer necessary. We ended up holding these cached events forever and would eventually get OOM killed.