### PR TITLE
feat[smock]: add support for overloaded functions

### DIFF
--- a/.changeset/neat-melons-lie.md
+++ b/.changeset/neat-melons-lie.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/smock': patch
+---
+
+Fix a bug where overloaded functions would not be handled correctly

--- a/packages/smock/src/smockit/smockit.ts
+++ b/packages/smock/src/smockit/smockit.ts
@@ -211,7 +211,7 @@ export const smockit = async (
     let mockFn: any
     if (fn !== null) {
       params = this.interface.decodeFunctionData(fn, toHexString(data))
-      mockFn = this.smocked[fn.name]
+      mockFn = this.smocked[fn.name] || this.smocked[fn.format()]
     } else {
       params = toHexString(data)
       mockFn = this.smocked.fallback

--- a/packages/smock/test/contracts/TestHelpers_BasicReturnContract.sol
+++ b/packages/smock/test/contracts/TestHelpers_BasicReturnContract.sol
@@ -131,4 +131,23 @@ contract TestHelpers_BasicReturnContract {
             uint256[] memory _out
         )
     {}
+
+    function overloadedFunction(
+        uint256 _paramA,
+        uint256 _paramB
+    )
+        public
+        returns (
+            uint256
+        )
+    {}
+
+    function overloadedFunction(
+        uint256
+    )
+        public
+        returns (
+            uint256
+        )
+    {}
 }

--- a/packages/smock/test/smockit/function-manipulation.spec.ts
+++ b/packages/smock/test/smockit/function-manipulation.spec.ts
@@ -133,6 +133,23 @@ describe('[smock]: function manipulation tests', () => {
       // TODO
     })
 
+    describe('overloaded functions', () => {
+      it('should be able to modify both versions of an overloaded function', async () => {
+        const expected1 = 1234
+        const expected2 = 5678
+        mock.smocked['overloadedFunction(uint256)'].will.return.with(expected1)
+        mock.smocked['overloadedFunction(uint256,uint256)'].will.return.with(
+          expected2
+        )
+        expect(
+          await mock.callStatic['overloadedFunction(uint256)'](0)
+        ).to.equal(expected1)
+        expect(
+          await mock.callStatic['overloadedFunction(uint256,uint256)'](0, 0)
+        ).to.equal(expected2)
+      })
+    })
+
     describe('returning with data', () => {
       describe('fixed data types', () => {
         describe('default behaviors', () => {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug where smock would not correctly handle overloaded functions. Let's call this a feature. Yay!