### PR TITLE
chore: reduce hardhat timeout to 20 seconds

### DIFF
--- a/.changeset/cold-cows-cross.md
+++ b/.changeset/cold-cows-cross.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Reduce test timeout from 100 to 20 seconds

--- a/integration-tests/hardhat.config.ts
+++ b/integration-tests/hardhat.config.ts
@@ -10,7 +10,7 @@ const enableGasReport = !!process.env.ENABLE_GAS_REPORT
 
 const config: HardhatUserConfig = {
   mocha: {
-    timeout: 100000,
+    timeout: 20000,
   },
   networks: {
     optimism: {


### PR DESCRIPTION
## **Description**

Reduces the timeout on integration tests from 100 to 20 seconds. I think this is a reasonable compromise between the developer experience of running and testing on a laptop (possibly requiring more time), and the time required to run a test in CI (average is about 4 seconds).

The current timeout of 100 seconds is much more than necessary.  I suspect it’s probably a relic from before running yarn test:integration properly handled waiting for the sequencer to come up.