### PR TITLE
fix[dtl]: represent gas limit as a string to avoid issues with large gas limits

### DIFF
--- a/.changeset/chilled-books-grab.md
+++ b/.changeset/chilled-books-grab.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fixes incorrect type parsing in the RollupClient. The gasLimit became greater than the largest safe JS number so it needs to be represented as a string

--- a/.changeset/dull-fishes-type.md
+++ b/.changeset/dull-fishes-type.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Represent gaslimit as a string to avoid an overflow

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -104,7 +104,7 @@ type signature struct {
 type decoded struct {
 	Signature signature       `json:"sig"`
 	Value     hexutil.Uint64  `json:"value"`
-	GasLimit  uint64          `json:"gasLimit"`
+	GasLimit  uint64          `json:"gasLimit,string"`
 	GasPrice  uint64          `json:"gasPrice"`
 	Nonce     uint64          `json:"nonce"`
 	Target    *common.Address `json:"target"`

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -244,7 +244,7 @@ const maybeDecodeSequencerBatchTransaction = (
     return {
       nonce: BigNumber.from(decodedTx.nonce).toNumber(),
       gasPrice: BigNumber.from(decodedTx.gasPrice).toNumber(),
-      gasLimit: BigNumber.from(decodedTx.gasLimit).toNumber(),
+      gasLimit: BigNumber.from(decodedTx.gasLimit).toString(),
       value: toRpcHexString(decodedTx.value),
       target: toHexString(decodedTx.to), // Maybe null this out for creations?
       data: toHexString(decodedTx.data),

--- a/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
@@ -48,7 +48,7 @@ export const handleSequencerBlock = {
           s: padHexString(transaction.s, 32),
         },
         value: transaction.value,
-        gasLimit: BigNumber.from(transaction.gas).toNumber(),
+        gasLimit: BigNumber.from(transaction.gas).toString(),
         gasPrice: BigNumber.from(transaction.gasPrice).toNumber(), // ?
         nonce: BigNumber.from(transaction.nonce).toNumber(),
         target: transaction.to,

--- a/packages/data-transport-layer/src/types/database-types.ts
+++ b/packages/data-transport-layer/src/types/database-types.ts
@@ -5,7 +5,7 @@ export interface DecodedSequencerBatchTransaction {
     v: number
   }
   value: string
-  gasLimit: number
+  gasLimit: string
   gasPrice: number
   nonce: number
   target: string


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Represents gas limit as a string within `DecodedSequencerBatchTransaction`s in order to avoid issues where particularly large gas limits would crash the DTL.