### PR TITLE
fix: force LF line endings for scripts to avoid docker problems on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/packages/contracts/bin/deploy.ts
+++ b/packages/contracts/bin/deploy.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env ts-node-script
-
 import { Wallet } from 'ethers'
 import path from 'path'
 import dirtree from 'directory-tree'

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -38,13 +38,13 @@
     "lint:check": "yarn run lint:typescript",
     "lint:typescript": "tslint --format stylish --project .",
     "clean": "rm -rf ./dist ./artifacts ./artifacts-ovm ./cache ./cache-ovm ./tsconfig.build.tsbuildinfo",
-    "deploy": "./bin/deploy.ts && yarn generate-markdown",
+    "deploy": "ts-node \"./bin/deploy.ts\" && yarn generate-markdown",
     "serve": "./bin/serve_dump.sh",
     "prepublishOnly": "yarn copyfiles -u 2 \"contracts/optimistic-ethereum/**/*\" ./",
     "postpublish": "rimraf OVM iOVM libraries mockOVM",
     "prepack": "yarn prepublishOnly",
     "postpack": "yarn postpublish",
-    "generate-markdown": "node scripts/generate-markdown.js"
+    "generate-markdown": "node \"./scripts/generate-markdown.js\""
   },
   "dependencies": {
     "@eth-optimism/core-utils": "^0.4.4",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Our scripts had CRLF endings (Windows EOL format) which seems to conflict with docker on windows. Adding this `.gitattributes` file will automatically update all `*.sh` files to use the LF format on checkout, solving the issue. There was one additional problem with a typescript file (`contracts/bin/deploy.ts`) along the same lines. It was easier to modify how we were executing the script than to figure out how to properly add *only* executable typescript files to the `.gitattributes`.

**Metadata**
- Fixes #960 
