### PR TITLE
fix(contracts): import predeploys

### DIFF
--- a/packages/contracts/src/contract-deployment/config.ts
+++ b/packages/contracts/src/contract-deployment/config.ts
@@ -5,6 +5,8 @@ import { Overrides } from '@ethersproject/contracts'
 
 /* Internal Imports */
 import { getContractFactory } from '../contract-defs'
+import { predeploys } from '../predeploys'
+
 
 export interface RollupDeployConfig {
   deploymentSigner: Signer

--- a/packages/contracts/src/contract-deployment/config.ts
+++ b/packages/contracts/src/contract-deployment/config.ts
@@ -7,7 +7,6 @@ import { Overrides } from '@ethersproject/contracts'
 import { getContractFactory } from '../contract-defs'
 import { predeploys } from '../predeploys'
 
-
 export interface RollupDeployConfig {
   deploymentSigner: Signer
   ovmGasMeteringConfig: {


### PR DESCRIPTION
Adds an import that was removed when splitting apart 0.4.0 and 0.50.