### PR TITLE
fix[l2geth]: fix accidental merge conflict

### DIFF
--- a/l2geth/rollup/sync_service_test.go
+++ b/l2geth/rollup/sync_service_test.go
@@ -177,7 +177,6 @@ func TestTransactionToTipNoIndex(t *testing.T) {
 		l1BlockNumber,
 		timestamp,
 		&l1TxOrigin,
-		types.SighashEIP155,
 		types.QueueOriginL1ToL2,
 		nil, // The index is `nil`, expect it to be set afterwards
 		nil,
@@ -868,7 +867,6 @@ func mockTx() *types.Transaction {
 		l1BlockNumber,
 		timestamp,
 		&l1TxOrigin,
-		types.SighashEIP155,
 		types.QueueOriginSequencer,
 		nil,
 		nil,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes an accidental merge conflict introduced in `regenesis/0.4.0`.