### PR TITLE
dtl: log error stack for failed http request

### DIFF
--- a/.changeset/slimy-rivers-promise.md
+++ b/.changeset/slimy-rivers-promise.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Logs the error stacktrace for a failed HTTP request

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -198,6 +198,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
           url: req.url,
           elapsed,
           msg: e.toString(),
+          stack: e.stack,
         })
         return res.status(400).json({
           error: e.toString(),


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR adds in logging of the error stack when there is a failed HTTP request to the DTL

**Additional context**
This will be nice for debugging purposes

