### PR TITLE
fix[smock]: fix broken call assertions for overloaded functions 

### DIFF
--- a/.changeset/cool-baboons-guess.md
+++ b/.changeset/cool-baboons-guess.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/smock': patch
+---
+
+Fixes a bug that would break call assertions for overloaded smocked functions

--- a/packages/smock/src/smockit/smockit.ts
+++ b/packages/smock/src/smockit/smockit.ts
@@ -79,7 +79,10 @@ const smockifyFunction = (
 
           let data: any = toHexString(calldataBuf)
           try {
-            data = contract.interface.decodeFunctionData(fragment.name, data)
+            data = contract.interface.decodeFunctionData(
+              fragment.format(),
+              data
+            )
           } catch (e) {
             console.error(e)
           }

--- a/packages/smock/src/smockit/smockit.ts
+++ b/packages/smock/src/smockit/smockit.ts
@@ -89,11 +89,15 @@ const smockifyFunction = (
 
           return {
             functionName: fragment.name,
+            functionSignature: fragment.format(),
             data,
           }
         })
         .filter((functionResult: any) => {
-          return functionResult.functionName === functionName
+          return (
+            functionResult.functionName === functionName ||
+            functionResult.functionSignature === functionName
+          )
         })
         .map((functionResult: any) => {
           return functionResult.data

--- a/packages/smock/test/contracts/TestHelpers_MockCaller.sol
+++ b/packages/smock/test/contracts/TestHelpers_MockCaller.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+contract TestHelpers_MockCaller {
+    function callMock(address _target, bytes memory _data) public {
+        _target.call(_data);
+    }
+}

--- a/packages/smock/test/smockit/call-assertions.spec.ts
+++ b/packages/smock/test/smockit/call-assertions.spec.ts
@@ -22,8 +22,24 @@ describe('[smock]: call assertion tests', () => {
     mockCaller = await mockCallerFactory.deploy()
   })
 
-  describe('overloaded functions', () => {
-    it('should be able to modify both versions of an overloaded function', async () => {
+  describe('call assertions for functions', () => {
+    it('should be able to make assertions about a non-overloaded function', async () => {
+      mock.smocked.getInputtedUint256.will.return.with(0)
+
+      const expected1 = ethers.BigNumber.from(1234)
+      await mockCaller.callMock(
+        mock.address,
+        mock.interface.encodeFunctionData('getInputtedUint256(uint256)', [
+          expected1,
+        ])
+      )
+
+      expect(mock.smocked.getInputtedUint256.calls[0]).to.deep.equal([
+        expected1,
+      ])
+    })
+
+    it('should be able to make assertions about both versions of an overloaded function', async () => {
       mock.smocked['overloadedFunction(uint256)'].will.return.with(0)
       mock.smocked['overloadedFunction(uint256,uint256)'].will.return.with(0)
 

--- a/packages/smock/test/smockit/call-assertions.spec.ts
+++ b/packages/smock/test/smockit/call-assertions.spec.ts
@@ -1,0 +1,56 @@
+/* Imports: External */
+import hre from 'hardhat'
+import { expect } from 'chai'
+import { Contract } from 'ethers'
+
+/* Imports: Internal */
+import { MockContract, smockit } from '../../src'
+
+describe('[smock]: call assertion tests', () => {
+  const ethers = (hre as any).ethers
+
+  let mock: MockContract
+  beforeEach(async () => {
+    mock = await smockit('TestHelpers_BasicReturnContract')
+  })
+
+  let mockCaller: Contract
+  before(async () => {
+    const mockCallerFactory = await ethers.getContractFactory(
+      'TestHelpers_MockCaller'
+    )
+    mockCaller = await mockCallerFactory.deploy()
+  })
+
+  describe('overloaded functions', () => {
+    it('should be able to modify both versions of an overloaded function', async () => {
+      mock.smocked['overloadedFunction(uint256)'].will.return.with(0)
+      mock.smocked['overloadedFunction(uint256,uint256)'].will.return.with(0)
+
+      const expected1 = ethers.BigNumber.from(1234)
+      await mockCaller.callMock(
+        mock.address,
+        mock.interface.encodeFunctionData('overloadedFunction(uint256)', [
+          expected1,
+        ])
+      )
+
+      expect(
+        mock.smocked['overloadedFunction(uint256)'].calls[0]
+      ).to.deep.equal([expected1])
+
+      const expected2 = ethers.BigNumber.from(5678)
+      await mockCaller.callMock(
+        mock.address,
+        mock.interface.encodeFunctionData(
+          'overloadedFunction(uint256,uint256)',
+          [expected2, expected2]
+        )
+      )
+
+      expect(
+        mock.smocked['overloadedFunction(uint256,uint256)'].calls[0]
+      ).to.deep.equal([expected2, expected2])
+    })
+  })
+})


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug that would cause smock call assertions to fail for overloaded functions. Also starts adding tests for call assertions so we avoid this sort of thing in the future. Necessary for Ben's native ETH work.