### PR TITLE
feat: fees v3

### DIFF
--- a/.changeset/smooth-ears-pay.md
+++ b/.changeset/smooth-ears-pay.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/l2geth': patch
+'@eth-optimism/core-utils': patch
+---
+
+Implement the latest fee spec such that the L2 gas limit is scaled and the tx.gasPrice/tx.gasLimit show correctly in metamask

--- a/examples/truffle/truffle-config-ovm.js
+++ b/examples/truffle/truffle-config-ovm.js
@@ -17,6 +17,7 @@ module.exports = {
       host: '127.0.0.1',
       port: 8545,
       gasPrice: 0,
+      gas: 54180127,
     }
   },
   compilers: {

--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from 'chai-as-promised'
 chai.use(chaiAsPromised)
 import { BigNumber, utils } from 'ethers'
 import { OptimismEnv } from './shared/env'
-import { TxGasLimit } from '@eth-optimism/core-utils'
+import { TxGasLimit, TxGasPrice } from '@eth-optimism/core-utils'
 
 describe('Fee Payment Integration Tests', async () => {
   let env: OptimismEnv
@@ -13,9 +13,9 @@ describe('Fee Payment Integration Tests', async () => {
     env = await OptimismEnv.new()
   })
 
-  it('Should return a gasPrice of 1500 wei', async () => {
+  it(`Should return a gasPrice of ${TxGasPrice.toString()} wei`, async () => {
     const gasPrice = await env.l2Wallet.getGasPrice()
-    expect(gasPrice).to.deep.eq(BigNumber.from(1500))
+    expect(gasPrice).to.deep.eq(TxGasPrice)
   })
 
   it('Should estimateGas with recoverable L2 gasLimit', async () => {

--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -13,9 +13,9 @@ describe('Fee Payment Integration Tests', async () => {
     env = await OptimismEnv.new()
   })
 
-  it('Should return a gasPrice of 1 wei', async () => {
+  it('Should return a gasPrice of 1500 wei', async () => {
     const gasPrice = await env.l2Wallet.getGasPrice()
-    expect(gasPrice.eq(1))
+    expect(gasPrice).to.deep.eq(BigNumber.from(1500))
   })
 
   it('Should estimateGas with recoverable L2 gasLimit', async () => {
@@ -28,7 +28,7 @@ describe('Fee Payment Integration Tests', async () => {
       utils.parseEther('0.5')
     )
     const executionGas = await (env.ovmEth
-      .provider as any).send('eth_estimateExecutionGas', [tx])
+      .provider as any).send('eth_estimateExecutionGas', [tx, true])
     const decoded = TxGasLimit.decode(gas)
     expect(BigNumber.from(executionGas)).deep.eq(decoded)
   })

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -45,13 +45,13 @@ describe('Native ETH Integration Tests', async () => {
       const amount = utils.parseEther('0.5')
       const addr = '0x' + '1234'.repeat(10)
       const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(0x0ef897216d))
+      expect(gas).to.be.deep.eq(BigNumber.from(64300000020))
     })
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(61400489396))
+      expect(gas).to.be.deep.eq(BigNumber.from(61400000049))
     })
   })
 

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -45,13 +45,13 @@ describe('Native ETH Integration Tests', async () => {
       const amount = utils.parseEther('0.5')
       const addr = '0x' + '1234'.repeat(10)
       const gas = await env.ovmEth.estimateGas.transfer(addr, amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(64300000020))
+      expect(gas).to.be.deep.eq(BigNumber.from(6430020))
     })
 
     it('Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.5')
       const gas = await env.ovmEth.estimateGas.withdraw(amount)
-      expect(gas).to.be.deep.eq(BigNumber.from(61400000049))
+      expect(gas).to.be.deep.eq(BigNumber.from(6140049))
     })
   })
 

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -134,7 +134,7 @@ describe('Basic RPC tests', () => {
         gasPrice: TxGasPrice,
       }
       const fee = tx.gasPrice.mul(tx.gasLimit)
-      const gasLimit = 59300000001
+      const gasLimit = 59200000001
 
       await expect(env.l2Wallet.sendTransaction(tx)).to.be.rejectedWith(
         `fee too low: ${fee}, use at least tx.gasLimit = ${gasLimit} and tx.gasPrice = ${TxGasPrice.toString()}`
@@ -355,7 +355,7 @@ describe('Basic RPC tests', () => {
         to: DEFAULT_TRANSACTION.to,
         value: 0,
       })
-      expect(estimate).to.be.eq(0x0dce9004c7)
+      expect(estimate).to.be.eq(59200000012)
     })
 
     it('should return a gas estimate that grows with the size of data', async () => {
@@ -373,6 +373,7 @@ describe('Basic RPC tests', () => {
         const estimate = await l2Provider.estimateGas(tx)
         const l2Gaslimit = await l2Provider.send('eth_estimateExecutionGas', [
           tx,
+          true,
         ])
 
         const decoded = TxGasLimit.decode(estimate)

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -134,7 +134,7 @@ describe('Basic RPC tests', () => {
         gasPrice: TxGasPrice,
       }
       const fee = tx.gasPrice.mul(tx.gasLimit)
-      const gasLimit = 59200000001
+      const gasLimit = 5920001
 
       await expect(env.l2Wallet.sendTransaction(tx)).to.be.rejectedWith(
         `fee too low: ${fee}, use at least tx.gasLimit = ${gasLimit} and tx.gasPrice = ${TxGasPrice.toString()}`
@@ -213,7 +213,7 @@ describe('Basic RPC tests', () => {
     it('correctly exposes revert data for contract calls', async () => {
       const req: TransactionRequest = {
         ...revertingTx,
-        gasLimit: 59808999999, // override gas estimation
+        gasLimit: 5980899, // override gas estimation
       }
 
       const tx = await wallet.sendTransaction(req)
@@ -236,7 +236,7 @@ describe('Basic RPC tests', () => {
     it('correctly exposes revert data for contract creations', async () => {
       const req: TransactionRequest = {
         ...revertingDeployTx,
-        gasLimit: 177008999999, // override gas estimation
+        gasLimit: 17700899, // override gas estimation
       }
 
       const tx = await wallet.sendTransaction(req)
@@ -355,7 +355,7 @@ describe('Basic RPC tests', () => {
         to: DEFAULT_TRANSACTION.to,
         value: 0,
       })
-      expect(estimate).to.be.eq(59200000012)
+      expect(estimate).to.be.eq(5920012)
     })
 
     it('should return a gas estimate that grows with the size of data', async () => {

--- a/l2geth/core/tx_pool.go
+++ b/l2geth/core/tx_pool.go
@@ -540,10 +540,14 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 
 	// Ensure the transaction doesn't exceed the current block limit gas.
-	// We skip this condition check if the transaction's gasPrice is set to 1gwei,
-	// which indicates a "rollup" transaction that's paying for its data.
-	if pool.currentMaxGas < tx.L2Gas() && tx.GasPrice().Cmp(gwei) != 0 {
-		return ErrGasLimit
+	if vm.UsingOVM {
+		if pool.currentMaxGas < tx.L2Gas() {
+			return ErrGasLimit
+		}
+	} else {
+		if pool.currentMaxGas < tx.Gas() {
+			return ErrGasLimit
+		}
 	}
 
 	// Make sure the transaction is signed properly

--- a/l2geth/core/tx_pool.go
+++ b/l2geth/core/tx_pool.go
@@ -92,9 +92,8 @@ var (
 )
 
 var (
-	evictionInterval    = time.Minute             // Time interval to check for evictable transactions
-	statsReportInterval = 8 * time.Second         // Time interval to report transaction pool stats
-	gwei                = big.NewInt(params.GWei) // 1 gwei, used as a flag for "rollup" transactions
+	evictionInterval    = time.Minute     // Time interval to check for evictable transactions
+	statsReportInterval = 8 * time.Second // Time interval to report transaction pool stats
 )
 
 var (

--- a/l2geth/core/types/transaction.go
+++ b/l2geth/core/types/transaction.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rollup/fees"
 )
 
 //go:generate gencodec -type txdata -field-override txdataMarshaling -out gen_tx_json.go
@@ -225,7 +226,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 
 func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
 func (tx *Transaction) Gas() uint64        { return tx.data.GasLimit }
-func (tx *Transaction) L2Gas() uint64      { return tx.data.GasLimit % 100_000_000 }
+func (tx *Transaction) L2Gas() uint64      { return fees.DecodeL2GasLimitU64(tx.data.GasLimit) }
 func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }
 func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amount) }
 func (tx *Transaction) Nonce() uint64      { return tx.data.AccountNonce }

--- a/l2geth/rollup/fees/rollup_fee_test.go
+++ b/l2geth/rollup/fees/rollup_fee_test.go
@@ -74,7 +74,7 @@ var feeTests = map[string]struct {
 	"max-gaslimit": {
 		dataLen:    10,
 		l1GasPrice: params.GWei,
-		l2GasLimit: 99999999,
+		l2GasLimit: 99_970_000,
 		l2GasPrice: params.GWei,
 	},
 	"larger-divisor": {
@@ -95,7 +95,8 @@ func TestCalculateRollupFee(t *testing.T) {
 
 			fee := EncodeTxGasLimit(data, l1GasPrice, l2GasLimit, l2GasPrice)
 			decodedGasLimit := DecodeL2GasLimit(fee)
-			if l2GasLimit.Cmp(decodedGasLimit) != 0 {
+			roundedL2GasLimit := Ceilmod(l2GasLimit, bigTenThousand)
+			if roundedL2GasLimit.Cmp(decodedGasLimit) != 0 {
 				t.Errorf("rollup fee check failed: expected %d, got %d", l2GasLimit.Uint64(), decodedGasLimit)
 			}
 		})

--- a/l2geth/rollup/fees/rollup_fee_test.go
+++ b/l2geth/rollup/fees/rollup_fee_test.go
@@ -95,7 +95,7 @@ func TestCalculateRollupFee(t *testing.T) {
 
 			fee := EncodeTxGasLimit(data, l1GasPrice, l2GasLimit, l2GasPrice)
 			decodedGasLimit := DecodeL2GasLimit(fee)
-			roundedL2GasLimit := Ceilmod(l2GasLimit, bigTenThousand)
+			roundedL2GasLimit := Ceilmod(l2GasLimit, BigTenThousand)
 			if roundedL2GasLimit.Cmp(decodedGasLimit) != 0 {
 				t.Errorf("rollup fee check failed: expected %d, got %d", l2GasLimit.Uint64(), decodedGasLimit)
 			}

--- a/packages/core-utils/src/fees.ts
+++ b/packages/core-utils/src/fees.ts
@@ -6,7 +6,7 @@ import { BigNumber } from 'ethers'
 import { remove0x } from './common'
 
 const hundredMillion = BigNumber.from(100_000_000)
-const feeScalar = 1000
+const feeScalar = 10_000_000
 export const TxGasPrice = BigNumber.from(feeScalar + feeScalar / 2)
 const txDataZeroGas = 4
 const txDataNonZeroGasEIP2028 = 16
@@ -38,7 +38,7 @@ function encode(input: EncodableL2GasLimit): BigNumber {
   const l2Fee = roundedL2GasLimit.mul(l2GasPrice)
   const sum = l1Fee.add(l2Fee)
   const scaled = sum.div(feeScalar)
-  const rounded = ceilmod(scaled, hundredMillion)
+  const rounded = ceilmod(scaled, tenThousand)
   const roundedScaledL2GasLimit = roundedL2GasLimit.div(tenThousand)
   return rounded.add(roundedScaledL2GasLimit)
 }

--- a/packages/core-utils/src/fees.ts
+++ b/packages/core-utils/src/fees.ts
@@ -11,6 +11,7 @@ export const TxGasPrice = BigNumber.from(feeScalar + feeScalar / 2)
 const txDataZeroGas = 4
 const txDataNonZeroGasEIP2028 = 16
 const overhead = 4200 + 200 * txDataNonZeroGasEIP2028
+const tenThousand = BigNumber.from(10_000)
 
 export interface EncodableL2GasLimit {
   data: Buffer | string
@@ -32,26 +33,43 @@ function encode(input: EncodableL2GasLimit): BigNumber {
     l2GasPrice = BigNumber.from(l2GasPrice)
   }
   const l1GasLimit = calculateL1GasLimit(data)
+  const roundedL2GasLimit = ceilmod(l2GasLimit, tenThousand)
   const l1Fee = l1GasLimit.mul(l1GasPrice)
-  const l2Fee = l2GasLimit.mul(l2GasPrice)
+  const l2Fee = roundedL2GasLimit.mul(l2GasPrice)
   const sum = l1Fee.add(l2Fee)
   const scaled = sum.div(feeScalar)
-  const remainder = scaled.mod(hundredMillion)
-  const scaledSum = scaled.add(hundredMillion)
-  const rounded = scaledSum.sub(remainder)
-  return rounded.add(l2GasLimit)
+  const rounded = ceilmod(scaled, hundredMillion)
+  const roundedScaledL2GasLimit = roundedL2GasLimit.div(tenThousand)
+  return rounded.add(roundedScaledL2GasLimit)
 }
 
 function decode(fee: BigNumber | number): BigNumber {
   if (typeof fee === 'number') {
     fee = BigNumber.from(fee)
   }
-  return fee.mod(hundredMillion)
+  const scaled = fee.mod(tenThousand)
+  return scaled.mul(tenThousand)
 }
 
 export const TxGasLimit = {
   encode,
   decode,
+}
+
+export function ceilmod(a: BigNumber | number, b: BigNumber | number) {
+  if (typeof a === 'number') {
+    a = BigNumber.from(a)
+  }
+  if (typeof b === 'number') {
+    b = BigNumber.from(b)
+  }
+  const remainder = a.mod(b)
+  if (remainder.eq(0)) {
+    return a
+  }
+  const sum = a.add(b)
+  const rounded = sum.sub(remainder)
+  return rounded
 }
 
 export function calculateL1GasLimit(data: string | Buffer): BigNumber {

--- a/packages/core-utils/test/fees/fees.spec.ts
+++ b/packages/core-utils/test/fees/fees.spec.ts
@@ -56,7 +56,7 @@ describe('Fees', () => {
         dataLen: 10,
         l1GasPrice: utils.parseUnits('5', 'ether'),
         l2GasPrice: utils.parseUnits('5', 'ether'),
-        l2GasLimit: 10 ** 8 - 1,
+        l2GasLimit: 99_970_000,
       },
       {
         name: 'zero-l2-gasprice',
@@ -113,7 +113,8 @@ describe('Fees', () => {
         })
 
         const decoded = fees.TxGasLimit.decode(got)
-        expect(decoded).to.deep.eq(BigNumber.from(test.l2GasLimit))
+        const roundedL2GasLimit = fees.ceilmod(test.l2GasLimit, 10_000)
+        expect(decoded).to.deep.eq(roundedL2GasLimit)
       })
     }
   })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the fee calculation to match https://github.com/ethereum-optimism/optimism/issues/823#issuecomment-851760512
This scales down the L2 Gas Limit such that it has the granularity of 10,000. The numbers should now show correctly in metamask

