### PR TITLE
fix[message-relayer]: fix failing test because of merge with develop

### DIFF
--- a/packages/message-relayer/test/unit-tests/relay-tx.spec.ts
+++ b/packages/message-relayer/test/unit-tests/relay-tx.spec.ts
@@ -58,7 +58,7 @@ describe('relay transaction generation functions', () => {
       .deploy(AddressManager.address, 0, 0)
 
     await AddressManager.setAddress(
-      'OVM_ChainStorageContainer:SCC:batches',
+      'OVM_ChainStorageContainer-SCC-batches',
       ChainStorageContainer.address
     )
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a failing test that was referring to an outdated contract name.
