### PR TITLE
docs[message-relayer]: add a README and improve the interface for generating proofs

### DIFF
--- a/.changeset/great-shrimps-rule.md
+++ b/.changeset/great-shrimps-rule.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Adds a README and cleans up the interface for generating messages and proofs

--- a/packages/message-relayer/README.md
+++ b/packages/message-relayer/README.md
@@ -1,0 +1,69 @@
+# @eth-optimism/message-relayer
+
+This package contains:
+
+1. A service for relaying messages from L2 to L1.
+2. Utilities for finding these messages and relaying them.
+
+## Installation
+
+```
+yarn add @eth-optimism/message-relayer
+```
+
+## Relay Utilities
+
+### getMessagesAndProofsForL2Transaction
+
+Finds all L2 => L1 messages sent in a given L2 transaction and generates proof for each.
+
+#### Usage
+
+```typescript
+import { getMessagesAndProofsForL2Transaction } from '@eth-optimism/message-relayer'
+
+const main = async () => {
+  const l1RpcProviderUrl = 'https://layer1.endpoint'
+  const l2RpcProviderUrl = 'https://layer2.endpoint'
+  const l1StateCommitmentChainAddress = 'address of OVM_StateCommitmentChain from deployments page'
+  const l2CrossDomainMessengerAddress = 'address of OVM_L2CrossDomainMessenger from deployments page'
+  const l2TransactionHash = 'hash of the transaction with messages to relay'
+
+  const messagePairs = await getMessagesAndProofsForL2Transaction(
+    l1RpcProviderUrl,
+    l2RpcProviderUrl,
+    l1StateCommitmentChainAddress,
+    l2CrossDomainMessengerAddress,
+    l2TransactionHash
+  )
+
+  console.log(messagePairs)
+  // Will log something along the lines of:
+  // [
+  //   {
+  //     message: {
+  //       target: '0x...',
+  //       sender: '0x...',
+  //       message: '0x...',
+  //       messageNonce: 1234...
+  //     },
+  //     proof: {
+  //       // complicated
+  //     }
+  //   }
+  // ]
+
+  // You can then do something along the lines of:
+  // for (const { message, proof } of messagePairs) {
+  //   await l1CrossDomainMessenger.relayMessage(
+  //     message.target,
+  //     message.sender,
+  //     message.message,
+  //     message.messageNonce,
+  //     proof
+  //   )
+  // }
+} 
+
+main()
+```

--- a/packages/message-relayer/src/relay-tx.ts
+++ b/packages/message-relayer/src/relay-tx.ts
@@ -323,12 +323,19 @@ const getStateTrieProof = async (
  * @returns An array of messages sent in the transaction and a proof of inclusion for each.
  */
 export const getMessagesAndProofsForL2Transaction = async (
-  l1RpcProvider: ethers.providers.JsonRpcProvider,
-  l2RpcProvider: ethers.providers.JsonRpcProvider,
+  l1RpcProvider: ethers.providers.JsonRpcProvider | string,
+  l2RpcProvider: ethers.providers.JsonRpcProvider | string,
   l1StateCommitmentChainAddress: string,
   l2CrossDomainMessengerAddress: string,
   l2TransactionHash: string
 ): Promise<CrossDomainMessagePair[]> => {
+  if (typeof l1RpcProvider === 'string') {
+    l1RpcProvider = new ethers.providers.JsonRpcProvider(l1RpcProvider)
+  }
+  if (typeof l2RpcProvider === 'string') {
+    l2RpcProvider = new ethers.providers.JsonRpcProvider(l2RpcProvider)
+  }
+
   const l2Transaction = await l2RpcProvider.getTransaction(l2TransactionHash)
   if (l2Transaction === null) {
     throw new Error(`unable to find tx with hash: ${l2TransactionHash}`)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a `README.md` and slightly improves on the interface for `getMessagesAndProofsForL2Transaction` for etherscan's sake.