### PR TITLE
fix: wrong gas estimate in integration tests

### DIFF
--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -355,7 +355,7 @@ describe('Basic RPC tests', () => {
         to: DEFAULT_TRANSACTION.to,
         value: 0,
       })
-      expect(estimate).to.be.eq(0x0dce9004c7)
+      expect(estimate).to.be.eq(59300119727)
     })
 
     it('should return a gas estimate that grows with the size of data', async () => {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Something fishy is going on with CI. Locally this test does appear to fail but somehow it occasionally succeeds in CI. Making this change to see if this will cause CI to fail randomly.