### PR TITLE
ci: tag docker image for canary with abbreviated GITHUB_SHA

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -155,7 +155,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.message-relayer
           push: true
-          tags: ethereumoptimism/message-relayer:${{ GITHUB_SHA::6 }}
+          tags: ethereumoptimism/message-relayer:${{ GITHUB_SHA::8 }}
 
   batch-submitter:
     name: Publish Batch Submitter Version ${{ needs.builder.outputs.batch-submitter }}
@@ -181,7 +181,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.batch-submitter
           push: true
-          tags: ethereumoptimism/batch-submitter:${{ GITHUB_SHA::6 }}
+          tags: ethereumoptimism/batch-submitter:${{ GITHUB_SHA::8 }}
 
   data-transport-layer:
     name: Publish Data Transport Layer Version ${{ needs.builder.outputs.data-transport-layer }}
@@ -207,7 +207,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.data-transport-layer
           push: true
-          tags: ethereumoptimism/data-transport-layer:${{ GITHUB_SHA::6 }}
+          tags: ethereumoptimism/data-transport-layer:${{ GITHUB_SHA::8 }}
 
   contracts:
     name: Publish Deployer Version ${{ needs.builder.outputs.contracts }}
@@ -233,7 +233,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.deployer
           push: true
-          tags: ethereumoptimism/deployer:${{ GITHUB_SHA::6 }}
+          tags: ethereumoptimism/deployer:${{ GITHUB_SHA::8 }}
 
   integration_tests:
     name: Publish Integration tests ${{ needs.builder.outputs.integration-tests }}
@@ -259,4 +259,4 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.integration-tests
           push: true
-          tags: ethereumoptimism/integration-tests:${{ GITHUB_SHA::6 }}
+          tags: ethereumoptimism/integration-tests:${{ GITHUB_SHA::8 }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -155,7 +155,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.message-relayer
           push: true
-          tags: ethereumoptimism/message-relayer:${{ needs.builder.outputs.message-relayer }}
+          tags: ethereumoptimism/message-relayer:${{ GITHUB_SHA::6 }}
 
   batch-submitter:
     name: Publish Batch Submitter Version ${{ needs.builder.outputs.batch-submitter }}
@@ -181,7 +181,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.batch-submitter
           push: true
-          tags: ethereumoptimism/batch-submitter:${{ needs.builder.outputs.batch-submitter }}
+          tags: ethereumoptimism/batch-submitter:${{ GITHUB_SHA::6 }}
 
   data-transport-layer:
     name: Publish Data Transport Layer Version ${{ needs.builder.outputs.data-transport-layer }}
@@ -207,7 +207,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.data-transport-layer
           push: true
-          tags: ethereumoptimism/data-transport-layer:${{ needs.builder.outputs.data-transport-layer }}
+          tags: ethereumoptimism/data-transport-layer:${{ GITHUB_SHA::6 }}
 
   contracts:
     name: Publish Deployer Version ${{ needs.builder.outputs.contracts }}
@@ -233,7 +233,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.deployer
           push: true
-          tags: ethereumoptimism/deployer:${{ needs.builder.outputs.contracts }}
+          tags: ethereumoptimism/deployer:${{ GITHUB_SHA::6 }}
 
   integration_tests:
     name: Publish Integration tests ${{ needs.builder.outputs.integration-tests }}
@@ -259,4 +259,4 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.integration-tests
           push: true
-          tags: ethereumoptimism/integration-tests:${{ needs.builder.outputs.integration-tests }}
+          tags: ethereumoptimism/integration-tests:${{ GITHUB_SHA::6 }}


### PR DESCRIPTION
This tags Canary build Docker images with the SHA of the commit hash it is being built for.
