### PR TITLE
ops: expose debug namespace

### DIFF
--- a/ops/envs/geth.env
+++ b/ops/envs/geth.env
@@ -12,7 +12,7 @@ ROLLUP_ENABLE_L2_GAS_POLLING=true
 RPC_ENABLE=true
 RPC_ADDR=0.0.0.0
 RPC_PORT=8545
-RPC_API=eth,net,rollup,web3
+RPC_API=eth,net,rollup,web3,debug
 RPC_CORS_DOMAIN=*
 RPC_VHOSTS=*
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Exposes the `debug` namespace for the integration tests so that these methods can have integration tests written for them. Right now there is a known issue with L1 to L2 transactions that cause methods in the `debug` namespace to fail. The error observed is "incorrect nonce" - the L1 to L2 messages technically don't have a "from" and the nonce is set to be the queue index as to prevent hash collisions between L1 to L2 messages. Since they do not have a "from", the nonce should be set to 0 when converting from a `types.Transaction` to a `types.Message` if the queue origin is L1 to L2
