### PR TITLE
feat[contracts]: introduce new L1ChugSplashProxy contract

### DIFF
--- a/.changeset/witty-horses-nail.md
+++ b/.changeset/witty-horses-nail.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Introduce the L1ChugSplashProxy contract

--- a/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
+++ b/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+
+/**
+ * @title L1ChugSplashProxy
+ * @dev Basic ChugSplash proxy contract for L1. Very close to being a normal proxy but has added
+ * functions `setCode` and `setStorage` for changing the code or storage of the contract. Nifty!
+ */
+contract L1ChugSplashProxy {
+
+    /*************
+     * Constants *
+     *************/
+
+    // "Magic" prefix. When prepended to some arbitrary bytecode and used to create a contract, the
+    // appended bytecode will be deployed as given.
+    bytes13 constant internal DEPLOY_CODE_PREFIX = 0x600D380380600D6000396000f3;
+
+    // bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
+    bytes32 constant internal IMPLEMENTATION_KEY = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    // bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1)
+    bytes32 constant internal OWNER_KEY = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+
+    /***************
+     * Constructor *
+     ***************/
+    
+    /**
+     * @param _owner Address of the initial contract owner.
+     */
+    constructor(
+        address _owner
+    ) {
+        _setOwner(_owner);
+    }
+
+
+    /**********************
+     * Function Modifiers *
+     **********************/
+
+    /**
+     * Makes a proxy call instead of triggering the given function when the caller is either the
+     * owner or the zero address. Caller can only ever be the zero address if this function is
+     * being called off-chain via eth_call, which is totally fine and can be convenient for
+     * client-side tooling. Avoids situations where the proxy and implementation share a sighash
+     * and the proxy function ends up being called instead of the implementation one.
+     */
+    modifier proxyCallIfNotOwner() {
+        if (msg.sender == _getOwner() || msg.sender == address(0)) {
+            _;
+        } else {
+            // This WILL halt the call frame on completion.
+            _doProxyCall();
+        }
+    }
+
+
+    /*********************
+     * Fallback Function *
+     *********************/
+
+    fallback()
+        external
+    {
+        // Proxy call by default.
+        _doProxyCall();
+    }
+
+
+    /********************
+     * Public Functions *
+     ********************/
+
+    /**
+     * Sets the code that should be running behind this proxy. Note that this scheme is a bit
+     * different from the standard proxy scheme where one would typically deploy the code
+     * separately and then set the implementation address. We're doing it this way because it gives
+     * us a lot more freedom on the client side. Can only be triggered by the contract owner.
+     * @param _code New contract code to run inside this contract.
+     */
+    function setCode(
+        bytes memory _code
+    )
+        proxyCallIfNotOwner
+        public
+    {
+        // Get the code hash of the current implementation.
+        address implementation = _getImplementation();
+        bytes32 currentCodeHash;
+        assembly {
+            currentCodeHash := extcodehash(implementation)
+        }
+
+        // If the code hash matches the new implementation then we return early.
+        if (keccak256(_code) == currentCodeHash) {
+            return;
+        }
+
+        // Create the deploycode by appending the magic prefix.
+        bytes memory deploycode = abi.encodePacked(
+            DEPLOY_CODE_PREFIX,
+            _code
+        );
+
+        // Deploy the code and set the new implementation address.
+        address newImplementation;
+        assembly {
+            newImplementation := create(0x0, add(deploycode, 0x20), mload(deploycode))
+        }
+        _setImplementation(newImplementation);
+    }
+
+    /**
+     * Modifies some storage slot within the proxy contract. Gives us a lot of power to perform
+     * upgrades in a more transparent way. Only callable by the owner.
+     * @param _key Storage key to modify.
+     * @param _value New value for the storage key.
+     */
+    function setStorage(
+        bytes32 _key,
+        bytes32 _value
+    )
+        proxyCallIfNotOwner
+        public
+    {
+        assembly {
+            sstore(_key, _value)
+        }
+    }
+
+    /**
+     * Changes the owner of the proxy contract. Only callable by the owner.
+     * @param _owner New owner of the proxy contract.
+     */
+    function setOwner(
+        address _owner
+    )
+        proxyCallIfNotOwner
+        public
+    {
+        _setOwner(_owner);
+    }
+
+    /**
+     * Queries the owner of the proxy contract. Can only be called by the owner OR by making an
+     * eth_call and setting the "from" address to address(0).
+     * @return Owner address.
+     */
+    function getOwner()
+        proxyCallIfNotOwner
+        public
+        returns (
+            address
+        )
+    {
+        return _getOwner();
+    }
+
+
+    /**********************
+     * Internal Functions *
+     **********************/
+
+    /**
+     * Sets the implementation address.
+     * @param _implementation New implementation address.
+     */
+    function _setImplementation(
+        address _implementation
+    )
+        internal
+    {
+        assembly {
+            sstore(IMPLEMENTATION_KEY, _implementation)
+        }
+    }
+
+    /**
+     * Queries the implementation address.
+     * @return Implementation address.
+     */
+    function _getImplementation()
+        internal
+        view
+        returns (
+            address
+        )
+    {
+        address implementation;
+        assembly {
+            implementation := sload(IMPLEMENTATION_KEY)
+        }
+        return implementation;
+    }
+
+    /**
+     * Changes the owner of the proxy contract.
+     * @param _owner New owner of the proxy contract.
+     */
+    function _setOwner(
+        address _owner
+    )
+        internal
+    {
+        assembly {
+            sstore(OWNER_KEY, _owner)
+        }
+    }
+
+    /**
+     * Queries the owner of the proxy contract.
+     * @return Owner address.
+     */
+    function _getOwner()
+        internal
+        view 
+        returns (
+            address
+        )
+    {
+        address owner;
+        assembly {
+            owner := sload(OWNER_KEY)
+        }
+        return owner;
+    }
+
+    /**
+     * Performs the proxy call via a delegatecall.
+     */
+    function _doProxyCall()
+        internal
+    {
+        address implementation = _getImplementation();
+
+        assembly {
+            calldatacopy(0x0, 0x0, calldatasize())
+            let result := delegatecall(gas(), implementation, 0x0, calldatasize(), 0x0, 0x0)
+            returndatacopy(0x0, 0x0, returndatasize())
+            switch result
+            case 0x0 {
+                revert(0x0, returndatasize())
+            }
+            default {
+                return (0x0, returndatasize())
+            }
+        }
+    }
+}

--- a/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
+++ b/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
@@ -242,6 +242,11 @@ contract L1ChugSplashProxy {
     {
         address implementation = _getImplementation();
 
+        require(
+            implementation != address(0),
+            "L1ChugSplashProxy: implementation is not set yet"
+        );
+
         assembly {
             // Copy calldata into memory at 0x0....calldatasize.
             calldatacopy(0x0, 0x0, calldatasize())

--- a/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
+++ b/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
@@ -165,6 +165,21 @@ contract L1ChugSplashProxy {
         return _getOwner();
     }
 
+    /**
+     * Queries the implementation address. Can only be called by the owner OR by making an
+     * eth_call and setting the "from" address to address(0).
+     * @return Implementation address.
+     */
+    function getImplementation()
+        proxyCallIfNotOwner
+        public
+        returns (
+            address
+        )
+    {
+        return _getImplementation();
+    }
+
 
     /**********************
      * Internal Functions *

--- a/packages/contracts/contracts/chugsplash/interfaces/iL1ChugSplashDeployer.sol
+++ b/packages/contracts/contracts/chugsplash/interfaces/iL1ChugSplashDeployer.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+
+/**
+ * @title iL1ChugSplashDeployer
+ */
+interface iL1ChugSplashDeployer {
+    function isUpgrading()
+        external
+        view
+        returns (
+            bool
+        );
+}

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -138,7 +138,7 @@ describe('L1ChugSplashProxy', () => {
   })
 
   describe('fallback', () => {
-    it('should pass through to the proxied contract', async () => {
+    it('should revert if implementation is not set', async () => {
       await expect(
         signer1.sendTransaction({
           to: L1ChugSplashProxy.address,

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -120,7 +120,7 @@ describe('L1ChugSplashProxy', () => {
       expect(await hre.ethers.provider.getCode(implementation)).to.equal(code)
     })
 
-    it('should not change the implementation if the code does not change', async () => {
+    it('should not change the implementation address if the code does not change', async () => {
       const code = '0x1234'
 
       await L1ChugSplashProxy.connect(signer1).setCode(code)

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -72,6 +72,16 @@ describe('L1ChugSplashProxy', () => {
       ).to.equal(hre.ethers.constants.AddressZero)
     })
 
+    it('should succeed if called by the zero address in an eth_call', async () => {
+      expect(
+        await L1ChugSplashProxy.connect(
+          hre.ethers.provider
+        ).callStatic.getImplementation({
+          from: hre.ethers.constants.AddressZero,
+        })
+      ).to.equal(hre.ethers.constants.AddressZero)
+    })
+
     it('should otherwise pass through to the proxied contract', async () => {
       await expect(
         L1ChugSplashProxy.connect(signer2).getImplementation()

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -119,6 +119,22 @@ describe('L1ChugSplashProxy', () => {
 
       expect(await hre.ethers.provider.getCode(implementation)).to.equal(code)
     })
+
+    it('should not change the implementation if the code does not change', async () => {
+      const code = '0x1234'
+
+      await L1ChugSplashProxy.connect(signer1).setCode(code)
+
+      const implementation = await L1ChugSplashProxy.connect(
+        signer1
+      ).callStatic.getImplementation()
+
+      await L1ChugSplashProxy.connect(signer1).setCode(code)
+
+      expect(
+        await L1ChugSplashProxy.connect(signer1).callStatic.getImplementation()
+      ).to.equal(implementation)
+    })
   })
 
   describe('fallback', () => {

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from '../../setup'
+
+/* Imports: External */
+import hre, { ethers } from 'hardhat'
+import { Contract, Signer } from 'ethers'
+
+describe('L1ChugSplashProxy', () => {
+  let signer1: Signer
+  let signer2: Signer
+  before(async () => {
+    ;[signer1, signer2] = await hre.ethers.getSigners()
+  })
+
+  let L1ChugSplashProxy: Contract
+  beforeEach(async () => {
+    const Factory__L1ChugSplashProxy = await hre.ethers.getContractFactory(
+      'L1ChugSplashProxy'
+    )
+    L1ChugSplashProxy = await Factory__L1ChugSplashProxy.deploy(
+      await signer1.getAddress()
+    )
+  })
+
+  describe('getOwner', () => {
+    it('should return the owner if called by the owner', async () => {
+      expect(
+        await L1ChugSplashProxy.connect(signer1).callStatic.getOwner()
+      ).to.equal(await signer1.getAddress())
+    })
+
+    it('should return the owner if called by the zero address in an eth_call', async () => {
+      expect(
+        await L1ChugSplashProxy.connect(signer1.provider).callStatic.getOwner({
+          from: hre.ethers.constants.AddressZero,
+        })
+      ).to.equal(await signer1.getAddress())
+    })
+
+    it('should otherwise pass through to the proxied contract', async () => {
+      await expect(
+        L1ChugSplashProxy.connect(signer2).callStatic.getOwner()
+      ).to.be.revertedWith('L1ChugSplashProxy: implementation is not set yet')
+    })
+  })
+
+  describe('setOwner', () => {
+    it('should succeed if called by the owner', async () => {
+      await expect(
+        L1ChugSplashProxy.connect(signer1).setOwner(await signer2.getAddress())
+      ).to.not.be.reverted
+
+      expect(
+        await L1ChugSplashProxy.connect(signer2).callStatic.getOwner()
+      ).to.equal(await signer2.getAddress())
+    })
+
+    it('should otherwise pass through to the proxied contract', async () => {
+      await expect(
+        L1ChugSplashProxy.connect(signer2).setOwner(await signer1.getAddress())
+      ).to.be.revertedWith('L1ChugSplashProxy: implementation is not set yet')
+    })
+  })
+
+  describe('setStorage', () => {})
+})


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Introduces the `L1ChugSplashProxy` contract. Uses some fancy footwork to avoid function signature collisions with the implementation contract, would appreciate a good amount of review on this.

**TODO**
- [x] Add tests
- [x] Add ability to pause the contract

**Metadata**
- Fixes #707 
- Fixes OP-625