### PR TITLE
dtl: remove stringify from db logic + more overflow protection

### DIFF
--- a/.changeset/cold-ways-grow.md
+++ b/.changeset/cold-ways-grow.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/l2geth': patch
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add extra overflow protection for the DTL types

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -104,8 +104,8 @@ type decoded struct {
 	Signature signature       `json:"sig"`
 	Value     hexutil.Uint64  `json:"value"`
 	GasLimit  uint64          `json:"gasLimit,string"`
-	GasPrice  uint64          `json:"gasPrice"`
-	Nonce     uint64          `json:"nonce"`
+	GasPrice  uint64          `json:"gasPrice,string"`
+	Nonce     uint64          `json:"nonce,string"`
 	Target    *common.Address `json:"target"`
 	Data      hexutil.Bytes   `json:"data"`
 }

--- a/packages/data-transport-layer/src/db/transport-db.ts
+++ b/packages/data-transport-layer/src/db/transport-db.ts
@@ -379,9 +379,7 @@ export class TransportDB {
     if (index === null) {
       return null
     }
-    let entry = await this.db.get<TEntry>(`${key}:index`, index)
-    entry = stringify(entry)
-    return entry
+    return this.db.get<TEntry>(`${key}:index`, index)
   }
 
   private async _getEntries<TEntry extends Indexed>(
@@ -389,28 +387,6 @@ export class TransportDB {
     startIndex: number,
     endIndex: number
   ): Promise<TEntry[] | []> {
-    const entries = await this.db.range<TEntry>(
-      `${key}:index`,
-      startIndex,
-      endIndex
-    )
-    const results = []
-    for (const entry of entries) {
-      results.push(stringify(entry))
-    }
-    return results
+    return this.db.range<TEntry>(`${key}:index`, startIndex, endIndex)
   }
-}
-
-function stringify(entry) {
-  if (entry === null || entry === undefined) {
-    return entry
-  }
-  if (entry.gasLimit) {
-    entry.gasLimit = BigNumber.from(entry.gasLimit).toString()
-  }
-  if (entry.decoded) {
-    entry.decoded.gasLimit = BigNumber.from(entry.decoded.gasLimit).toString()
-  }
-  return entry
 }

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -240,8 +240,8 @@ const maybeDecodeSequencerBatchTransaction = (
     const decodedTx = ethers.utils.parseTransaction(transaction)
 
     return {
-      nonce: BigNumber.from(decodedTx.nonce).toNumber(),
-      gasPrice: BigNumber.from(decodedTx.gasPrice).toNumber(),
+      nonce: BigNumber.from(decodedTx.nonce).toString(),
+      gasPrice: BigNumber.from(decodedTx.gasPrice).toString(),
       gasLimit: BigNumber.from(decodedTx.gasLimit).toString(),
       value: toRpcHexString(decodedTx.value),
       target: toHexString(decodedTx.to), // Maybe null this out for creations?

--- a/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
@@ -49,8 +49,8 @@ export const handleSequencerBlock = {
         },
         value: transaction.value,
         gasLimit: BigNumber.from(transaction.gas).toString(),
-        gasPrice: BigNumber.from(transaction.gasPrice).toNumber(), // ?
-        nonce: BigNumber.from(transaction.nonce).toNumber(),
+        gasPrice: BigNumber.from(transaction.gasPrice).toString(),
+        nonce: BigNumber.from(transaction.nonce).toString(),
         target: transaction.to,
         data: transaction.input,
       }

--- a/packages/data-transport-layer/src/types/database-types.ts
+++ b/packages/data-transport-layer/src/types/database-types.ts
@@ -6,8 +6,8 @@ export interface DecodedSequencerBatchTransaction {
   }
   value: string
   gasLimit: string
-  gasPrice: number
-  nonce: number
+  gasPrice: string
+  nonce: string
   target: string
   data: string
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This removes the backwards compatible db fix that prevents overflows in `tx.gasLimit`
It also adds in more overflows checks by storing things as strings.
JSON is stored directly in the db, there is no longer a need to type cast it to a string to prevent overflows for JS numbers. The backwards compatibility allowed for a database with a combo of strings and numbers in it. Post regenesis, there will only be strings.

The DTL is very prone to overflows and we need to do a full pass over it to make sure that it is safe.