### PR TITLE
fix(sync-service): prevent underflows

### DIFF
--- a/.changeset/kind-houses-rush.md
+++ b/.changeset/kind-houses-rush.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+fix potential underflow when launching the chain when the last verified index is 0

--- a/l2geth/rollup/config.go
+++ b/l2geth/rollup/config.go
@@ -10,8 +10,6 @@ import (
 type Config struct {
 	// Maximum calldata size for a Queue Origin Sequencer Tx
 	MaxCallDataSize int
-	// Number of confs before applying a L1 to L2 tx
-	Eth1ConfirmationDepth uint64
 	// Verifier mode
 	IsVerifier bool
 	// Enable the sync service

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -53,7 +53,6 @@ type SyncService struct {
 	syncing                   atomic.Value
 	chainHeadSub              event.Subscription
 	OVMContext                OVMContext
-	confirmationDepth         uint64
 	pollInterval              time.Duration
 	timestampRefreshThreshold time.Duration
 	chainHeadCh               chan core.ChainHeadEvent
@@ -103,7 +102,6 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 		cancel:                    cancel,
 		verifier:                  cfg.IsVerifier,
 		enable:                    cfg.Eth1SyncServiceEnable,
-		confirmationDepth:         cfg.Eth1ConfirmationDepth,
 		syncing:                   atomic.Value{},
 		bc:                        bc,
 		txpool:                    txpool,


### PR DESCRIPTION
Prevents potential underflow when initializing the sync service with a latest index = 0.

Also removes dead code.