### PR TITLE
ci: upload logs for failed integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,3 +93,21 @@ jobs:
           yarn compile
           yarn compile:ovm
           yarn test:integration:ovm
+
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1
+        with:
+          images: 'ethereumoptimism/builder,ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth,ethereumoptimism/integration-tests'
+          dest: './logs'
+
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: logs.tgz
+          path: ./logs.tgz


### PR DESCRIPTION
Adds logs to the `integration` job if a test case fails.

See [this job](https://github.com/ethereum-optimism/optimism/actions/runs/904282429) for an example.

![image](https://user-images.githubusercontent.com/1933029/120717231-0becf700-c47c-11eb-953c-61870aa4b5a6.png)

![image](https://user-images.githubusercontent.com/1933029/120717412-566e7380-c47c-11eb-86e4-4a88ddddb6f4.png)

![image](https://user-images.githubusercontent.com/1933029/120717425-5e2e1800-c47c-11eb-8f9c-c43f204c6a60.png)

![image](https://user-images.githubusercontent.com/1933029/120717432-60907200-c47c-11eb-979c-d1540cebdc2a.png)

Fixes OP-508