### PR TITLE
Add funding L2 ETH step to deploy script on local networks

### DIFF
--- a/.changeset/kind-houses-rush.md
+++ b/.changeset/kind-houses-rush.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+fix potential underflow when launching the chain when the last verified index is 0

--- a/l2geth/rollup/config.go
+++ b/l2geth/rollup/config.go
@@ -10,8 +10,6 @@ import (
 type Config struct {
 	// Maximum calldata size for a Queue Origin Sequencer Tx
 	MaxCallDataSize int
-	// Number of confs before applying a L1 to L2 tx
-	Eth1ConfirmationDepth uint64
 	// Verifier mode
 	IsVerifier bool
 	// Enable the sync service

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -53,7 +53,6 @@ type SyncService struct {
 	syncing                   atomic.Value
 	chainHeadSub              event.Subscription
 	OVMContext                OVMContext
-	confirmationDepth         uint64
 	pollInterval              time.Duration
 	timestampRefreshThreshold time.Duration
 	chainHeadCh               chan core.ChainHeadEvent
@@ -103,7 +102,6 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 		cancel:                    cancel,
 		verifier:                  cfg.IsVerifier,
 		enable:                    cfg.Eth1SyncServiceEnable,
-		confirmationDepth:         cfg.Eth1ConfirmationDepth,
 		syncing:                   atomic.Value{},
 		bc:                        bc,
 		txpool:                    txpool,
@@ -244,8 +242,12 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 		s.SetLatestL1Timestamp(context.Timestamp)
 		s.SetLatestL1BlockNumber(context.BlockNumber)
 	} else {
+		// Prevent underflows
+		if *index != 0 {
+			*index = *index - 1
+		}
 		log.Info("Found latest index", "index", *index)
-		block := s.bc.GetBlockByNumber(*index - 1)
+		block := s.bc.GetBlockByNumber(*index)
 		if block == nil {
 			block = s.bc.CurrentBlock()
 			idx := block.Number().Uint64()
@@ -254,11 +256,12 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 				return fmt.Errorf("Current block height greater than index")
 			}
 			s.SetLatestIndex(&idx)
-			log.Info("Block not found, resetting index", "new", idx, "old", *index-1)
+			log.Info("Block not found, resetting index", "new", idx, "old", *index)
 		}
 		txs := block.Transactions()
 		if len(txs) != 1 {
-			log.Error("Unexpected number of transactions in block: %d", len(txs))
+			log.Error("Unexpected number of transactions in block", "count", len(txs))
+			panic("Cannot recover OVM Context")
 		}
 		tx := txs[0]
 		s.SetLatestL1Timestamp(tx.L1Timestamp())

--- a/ops/envs/geth.env
+++ b/ops/envs/geth.env
@@ -12,7 +12,7 @@ ROLLUP_ENABLE_L2_GAS_POLLING=true
 RPC_ENABLE=true
 RPC_ADDR=0.0.0.0
 RPC_PORT=8545
-RPC_API=eth,net,rollup,web3
+RPC_API=eth,net,rollup,web3,debug
 RPC_CORS_DOMAIN=*
 RPC_VHOSTS=*
 

--- a/packages/contracts/deploy/018-fund-accounts.ts
+++ b/packages/contracts/deploy/018-fund-accounts.ts
@@ -1,0 +1,36 @@
+/* Imports: External */
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+
+/* Imports: Internal */
+import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+import { ethers } from 'hardhat'
+
+const deployFn: DeployFunction = async (hre) => {
+  const { deployer } = await hre.getNamedAccounts()
+
+   // Fund all default hardhat signers  with ETH if deploying on a local hardhat network
+   const { chainId } = await ethers.provider.getNetwork()
+   if (chainId === 31337) {
+     const Proxy__OVM_L1ETHGateway = await getDeployedContract(
+       hre,
+       'Proxy__OVM_L1ETHGateway',
+       {
+         signerOrProvider: deployer,
+         iface: 'OVM_L1ETHGateway',
+       }
+     )
+     const signers = await ethers.getSigners()
+     for (const signer of signers) {
+       const to = await signer.getAddress()
+       const amount = '100'
+       const value = ethers.utils.parseEther(amount)
+       await Proxy__OVM_L1ETHGateway.depositTo(to, { value })
+       console.log(`✓ Funded ${to} on L2 with ${amount} ETH`)
+     }
+   }
+}
+
+deployFn.dependencies = ['Proxy__OVM_L1ETHGateway']
+deployFn.tags = ['fund-accounts']
+
+export default deployFn

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -82,7 +82,6 @@ if (
   process.env.CONTRACTS_RPC_URL
 ) {
   config.networks[process.env.CONTRACTS_TARGET_NETWORK] = {
-    accounts: [process.env.CONTRACTS_DEPLOYER_KEY],
     url: process.env.CONTRACTS_RPC_URL,
     live: true,
     saveDeployments: true,

--- a/packages/contracts/test/helpers/test-runner/test.types.ts
+++ b/packages/contracts/test/helpers/test-runner/test.types.ts
@@ -213,7 +213,6 @@ export const isTestStep_Context = (
     'ovmCALLER',
     'ovmNUMBER',
     'ovmADDRESS',
-    'ovmNUMBER',
     'ovmL1TXORIGIN',
     'ovmTIMESTAMP',
     'ovmGASLIMIT',


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a step to the deploy script that deposits ETH into L2 for each of the 20 default hardhat signer accounts. This step will only be run if the chainId of the L1 network is `31337`.
