### PR TITLE
fix: typo in USE_HARDHAT config

### DIFF
--- a/.changeset/popular-feet-suffer.md
+++ b/.changeset/popular-feet-suffer.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Fix typo in USE_HARDHAT config

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -116,7 +116,7 @@ export const run = async () => {
     logger = new Logger({ name })
   }
 
-  const useHardhat = config.bool('use-hardhat', !!env.USE_HARDAT)
+  const useHardhat = config.bool('use-hardhat', !!env.USE_HARDHAT)
   const DEBUG_IMPERSONATE_SEQUENCER_ADDRESS = config.str(
     'debug-impersonate-sequencer-address',
     env.DEBUG_IMPERSONATE_SEQUENCER_ADDRESS


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Quickly fixing a typo in the `USE_HARDHAT` config