### PR TITLE
fix: estimate gas when pending tx in mempool

### DIFF
--- a/.changeset/silent-dolphins-hammer.md
+++ b/.changeset/silent-dolphins-hammer.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Fix tx resubmission estimateGas bug in batch submitter

--- a/packages/batch-submitter/src/index.ts
+++ b/packages/batch-submitter/src/index.ts
@@ -1,2 +1,3 @@
 export * from './batch-submitter'
+export * from './utils'
 export * from './transaction-chain-contract'

--- a/packages/batch-submitter/src/transaction-chain-contract.ts
+++ b/packages/batch-submitter/src/transaction-chain-contract.ts
@@ -1,16 +1,14 @@
 /* External Imports */
-import { Contract, BigNumber, ethers } from 'ethers'
+import { Contract, ethers } from 'ethers'
 import {
   TransactionResponse,
   TransactionRequest,
 } from '@ethersproject/abstract-provider'
-import { JsonRpcProvider } from '@ethersproject/providers'
 import { keccak256 } from 'ethers/lib/utils'
 import {
   AppendSequencerBatchParams,
   BatchContext,
   encodeAppendSequencerBatch,
-  encodeHex,
   remove0x,
 } from '@eth-optimism/core-utils'
 
@@ -33,7 +31,6 @@ export class CanonicalTransactionChainContract extends Contract {
         from: await this.signer.getAddress(),
         data,
       })
-      const value = 0
 
       return {
         nonce,
@@ -55,7 +52,9 @@ export class CanonicalTransactionChainContract extends Contract {
  * Internal Functions *
  *********************/
 
-const APPEND_SEQUENCER_BATCH_METHOD_ID = 'appendSequencerBatch()'
+const APPEND_SEQUENCER_BATCH_METHOD_ID = keccak256(
+  Buffer.from('appendSequencerBatch()')
+).slice(2, 10)
 
 const appendSequencerBatch = async (
   OVM_CanonicalTransactionChain: Contract,
@@ -70,18 +69,7 @@ const appendSequencerBatch = async (
 }
 
 const getEncodedCalldata = (batch: AppendSequencerBatchParams): string => {
-  const methodId = keccak256(
-    Buffer.from(APPEND_SEQUENCER_BATCH_METHOD_ID)
-  ).slice(2, 10)
+  const methodId = APPEND_SEQUENCER_BATCH_METHOD_ID
   const calldata = encodeAppendSequencerBatch(batch)
   return '0x' + remove0x(methodId) + remove0x(calldata)
-}
-
-const encodeBatchContext = (context: BatchContext): string => {
-  return (
-    encodeHex(context.numSequencedTransactions, 6) +
-    encodeHex(context.numSubsequentQueueTransactions, 6) +
-    encodeHex(context.timestamp, 10) +
-    encodeHex(context.blockNumber, 10)
-  )
 }

--- a/packages/batch-submitter/src/transaction-chain-contract.ts
+++ b/packages/batch-submitter/src/transaction-chain-contract.ts
@@ -1,15 +1,17 @@
 /* External Imports */
-import { Contract, BigNumber } from 'ethers'
+import { Contract, BigNumber, ethers } from 'ethers'
 import {
   TransactionResponse,
   TransactionRequest,
 } from '@ethersproject/abstract-provider'
+import { JsonRpcProvider } from '@ethersproject/providers'
 import { keccak256 } from 'ethers/lib/utils'
 import {
   AppendSequencerBatchParams,
   BatchContext,
   encodeAppendSequencerBatch,
   encodeHex,
+  remove0x,
 } from '@eth-optimism/core-utils'
 
 export { encodeAppendSequencerBatch, BatchContext, AppendSequencerBatchParams }
@@ -19,6 +21,28 @@ export { encodeAppendSequencerBatch, BatchContext, AppendSequencerBatchParams }
  * where the `appendSequencerBatch(...)` function uses a specialized encoding for improved efficiency.
  */
 export class CanonicalTransactionChainContract extends Contract {
+  public customPopulateTransaction = {
+    appendSequencerBatch: async (
+      batch: AppendSequencerBatchParams
+    ): Promise<ethers.PopulatedTransaction> => {
+      const nonce = await this.signer.getTransactionCount()
+      const to = this.address
+      const data = getEncodedCalldata(batch)
+      const gasLimit = await this.signer.provider.estimateGas({
+        to,
+        from: await this.signer.getAddress(),
+        data,
+      })
+      const value = 0
+
+      return {
+        nonce,
+        to,
+        data,
+        gasLimit,
+      }
+    },
+  }
   public async appendSequencerBatch(
     batch: AppendSequencerBatchParams,
     options?: TransactionRequest
@@ -38,15 +62,19 @@ const appendSequencerBatch = async (
   batch: AppendSequencerBatchParams,
   options?: TransactionRequest
 ): Promise<TransactionResponse> => {
+  return OVM_CanonicalTransactionChain.signer.sendTransaction({
+    to: OVM_CanonicalTransactionChain.address,
+    data: getEncodedCalldata(batch),
+    ...options,
+  })
+}
+
+const getEncodedCalldata = (batch: AppendSequencerBatchParams): string => {
   const methodId = keccak256(
     Buffer.from(APPEND_SEQUENCER_BATCH_METHOD_ID)
   ).slice(2, 10)
   const calldata = encodeAppendSequencerBatch(batch)
-  return OVM_CanonicalTransactionChain.signer.sendTransaction({
-    to: OVM_CanonicalTransactionChain.address,
-    data: '0x' + methodId + calldata,
-    ...options,
-  })
+  return '0x' + remove0x(methodId) + remove0x(calldata)
 }
 
 const encodeBatchContext = (context: BatchContext): string => {

--- a/packages/batch-submitter/src/utils/index.ts
+++ b/packages/batch-submitter/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './tx-submission'

--- a/packages/batch-submitter/src/utils/tx-submission.ts
+++ b/packages/batch-submitter/src/utils/tx-submission.ts
@@ -1,0 +1,94 @@
+import { Signer, utils, ethers, PopulatedTransaction } from 'ethers'
+import {
+  TransactionReceipt,
+  TransactionResponse,
+} from '@ethersproject/abstract-provider'
+import * as ynatm from '@eth-optimism/ynatm'
+
+interface ResubmissionConfig {
+  resubmissionTimeout: number
+  minGasPriceInGwei: number
+  maxGasPriceInGwei: number
+  gasRetryIncrement: number
+}
+
+export type SubmitTransactionFn = (
+  tx: PopulatedTransaction
+) => Promise<TransactionReceipt>
+
+export interface TxSubmissionHooks {
+  beforeSendTransaction: (tx: PopulatedTransaction) => void
+  onTransactionResponse: (txResponse: TransactionResponse) => void
+}
+
+const getGasPriceInGwei = async (signer: Signer): Promise<number> => {
+  return parseInt(
+    ethers.utils.formatUnits(await signer.getGasPrice(), 'gwei'),
+    10
+  )
+}
+
+export const submitTransactionWithYNATM = async (
+  tx: PopulatedTransaction,
+  signer: Signer,
+  config: ResubmissionConfig,
+  numConfirmations: number,
+  hooks: TxSubmissionHooks
+): Promise<TransactionReceipt> => {
+  const sendTxAndWaitForReceipt = async (
+    gasPrice
+  ): Promise<TransactionReceipt> => {
+    const fullTx = {
+      ...tx,
+      gasPrice,
+    }
+    hooks.beforeSendTransaction(fullTx)
+    const txResponse = await signer.sendTransaction(fullTx)
+    hooks.onTransactionResponse(txResponse)
+    return signer.provider.waitForTransaction(txResponse.hash, numConfirmations)
+  }
+
+  const minGasPrice = await getGasPriceInGwei(signer)
+  const receipt = await ynatm.send({
+    sendTransactionFunction: sendTxAndWaitForReceipt,
+    minGasPrice: ynatm.toGwei(minGasPrice),
+    maxGasPrice: ynatm.toGwei(config.maxGasPriceInGwei),
+    gasPriceScalingFunction: ynatm.LINEAR(config.gasRetryIncrement),
+    delay: config.resubmissionTimeout,
+  })
+  return receipt
+}
+
+export interface TransactionSubmitter {
+  submitTransaction(
+    tx: PopulatedTransaction,
+    hooks?: TxSubmissionHooks
+  ): Promise<TransactionReceipt>
+}
+
+export class YnatmTransactionSubmitter implements TransactionSubmitter {
+  constructor(
+    readonly signer: Signer,
+    readonly ynatmConfig: ResubmissionConfig,
+    readonly numConfirmations: number
+  ) {}
+
+  public async submitTransaction(
+    tx: PopulatedTransaction,
+    hooks?: TxSubmissionHooks
+  ): Promise<TransactionReceipt> {
+    if (!hooks) {
+      hooks = {
+        beforeSendTransaction: () => undefined,
+        onTransactionResponse: () => undefined,
+      }
+    }
+    return submitTransactionWithYNATM(
+      tx,
+      this.signer,
+      this.ynatmConfig,
+      this.numConfirmations,
+      hooks
+    )
+  }
+}

--- a/packages/batch-submitter/src/utils/tx-submission.ts
+++ b/packages/batch-submitter/src/utils/tx-submission.ts
@@ -5,7 +5,7 @@ import {
 } from '@ethersproject/abstract-provider'
 import * as ynatm from '@eth-optimism/ynatm'
 
-interface ResubmissionConfig {
+export interface ResubmissionConfig {
   resubmissionTimeout: number
   minGasPriceInGwei: number
   maxGasPriceInGwei: number

--- a/packages/batch-submitter/test/utils/tx-submission.spec.ts
+++ b/packages/batch-submitter/test/utils/tx-submission.spec.ts
@@ -1,0 +1,131 @@
+import { expect } from '../setup'
+import { ethers, BigNumber, Signer } from 'ethers'
+import { submitTransactionWithYNATM } from '../../src/utils/tx-submission'
+import { ResubmissionConfig } from '../../src'
+import {
+  TransactionReceipt,
+  TransactionResponse,
+} from '@ethersproject/abstract-provider'
+
+const nullFunction = () => undefined
+const nullHooks = {
+  beforeSendTransaction: nullFunction,
+  onTransactionResponse: nullFunction,
+}
+
+describe('submitTransactionWithYNATM', async () => {
+  it('calls sendTransaction, waitForTransaction, and hooks with correct inputs', async () => {
+    const called = {
+      sendTransaction: false,
+      waitForTransaction: false,
+      beforeSendTransaction: false,
+      onTransactionResponse: false,
+    }
+    const dummyHash = 'dummy hash'
+    const numConfirmations = 3
+    const tx = {
+      data: 'we here though',
+    } as ethers.PopulatedTransaction
+    const sendTransaction = async (
+      _tx: ethers.PopulatedTransaction
+    ): Promise<TransactionResponse> => {
+      called.sendTransaction = true
+      expect(_tx.data).to.equal(tx.data)
+      return {
+        hash: dummyHash,
+      } as TransactionResponse
+    }
+    const waitForTransaction = async (
+      hash: string,
+      _numConfirmations: number
+    ): Promise<TransactionReceipt> => {
+      called.waitForTransaction = true
+      expect(hash).to.equal(dummyHash)
+      expect(_numConfirmations).to.equal(numConfirmations)
+      return {
+        to: '',
+        from: '',
+        status: 1,
+      } as TransactionReceipt
+    }
+    const signer = {
+      getGasPrice: async () => ethers.BigNumber.from(0),
+      sendTransaction,
+      provider: {
+        waitForTransaction,
+      },
+    } as Signer
+    const hooks = {
+      beforeSendTransaction: (submittingTx: ethers.PopulatedTransaction) => {
+        called.beforeSendTransaction = true
+        expect(submittingTx.data).to.equal(tx.data)
+      },
+      onTransactionResponse: (txResponse: TransactionResponse) => {
+        called.onTransactionResponse = true
+        expect(txResponse.hash).to.equal(dummyHash)
+      },
+    }
+    const config: ResubmissionConfig = {
+      resubmissionTimeout: 1000,
+      minGasPriceInGwei: 0,
+      maxGasPriceInGwei: 0,
+      gasRetryIncrement: 1,
+    }
+    await submitTransactionWithYNATM(
+      tx,
+      signer,
+      config,
+      numConfirmations,
+      hooks
+    )
+    expect(called.sendTransaction).to.be.true
+    expect(called.waitForTransaction).to.be.true
+    expect(called.beforeSendTransaction).to.be.true
+    expect(called.onTransactionResponse).to.be.true
+  })
+
+  it('repeatedly increases the gas limit of the transaction when wait takes too long', async () => {
+    // Make transactions take longer to be included
+    // than our resubmission timeout
+    const resubmissionTimeout = 100
+    const txReceiptDelay = resubmissionTimeout * 3
+    const numConfirmations = 3
+    let lastGasPrice = BigNumber.from(0)
+    // Create a transaction which has a gas price that we will watch increment
+    const tx = {
+      gasPrice: lastGasPrice.add(1),
+      data: 'hello world!',
+    } as ethers.PopulatedTransaction
+    const sendTransaction = async (
+      _tx: ethers.PopulatedTransaction
+    ): Promise<TransactionResponse> => {
+      // Ensure the gas price is always increasing
+      expect(_tx.gasPrice > lastGasPrice).to.be.true
+      lastGasPrice = _tx.gasPrice
+      return {
+        hash: 'dummy hash',
+      } as TransactionResponse
+    }
+    const waitForTransaction = async (
+      hash: string,
+      _numConfirmations: number
+    ): Promise<TransactionReceipt> => {
+      await new Promise((r) => setTimeout(r, txReceiptDelay))
+      return {} as TransactionReceipt
+    }
+    const signer = {
+      getGasPrice: async () => ethers.BigNumber.from(0),
+      sendTransaction,
+      provider: {
+        waitForTransaction,
+      },
+    } as Signer
+    const config: ResubmissionConfig = {
+      resubmissionTimeout,
+      minGasPriceInGwei: 0,
+      maxGasPriceInGwei: 1000,
+      gasRetryIncrement: 1,
+    }
+    await submitTransactionWithYNATM(tx, signer, config, 0, nullHooks)
+  })
+})


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
We have observed that when a transaction is stuck in the mempool, the replacement transactions fail to be applied and would return `UNPREDICTABLE_GAS_LIMIT` with the error that the starting index in the batch is incorrect.

The reason the starting index was seemingly incorrect was because `eth_estimateGas` has `blockTag=pending` by default. 
That meant that when we attempted to resubmit our transaction, while estimating gas, it would attempt to reapply the same batch on top of the pending transaction. We explicitly **do not** want this behavior.

This PR changes the batch submitter submission logic in such a way that before submitting the transaction it populates the transaction fields **including** the `gasLimit`. This way we explicitly specify a `gasLimit`, we don't call `estimateGas`, and the transaction resubmission can occur.

Fixes OP-834