### PR TITLE
l2geth: optimize loops

### DIFF
--- a/.changeset/angry-numbers-swim.md
+++ b/.changeset/angry-numbers-swim.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Optimize main polling loops

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -146,6 +146,7 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 				continue
 			}
 			if !status.Syncing {
+				t.Stop()
 				break
 			}
 			log.Info("Still syncing", "index", status.CurrentTransactionIndex, "tip", status.HighestKnownTransactionIndex)

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -139,7 +139,7 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 
 		// Wait until the remote service is done syncing
 		t := time.NewTicker(10 * time.Second)
-		for range t.C {
+		for ; true; <-t.C {
 			status, err := service.client.SyncStatus(service.backend)
 			if err != nil {
 				log.Error("Cannot get sync status")
@@ -322,7 +322,7 @@ func (s *SyncService) Stop() error {
 func (s *SyncService) VerifierLoop() {
 	log.Info("Starting Verifier Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	t := time.NewTicker(s.pollInterval)
-	for range t.C {
+	for ; true; <-t.C {
 		if err := s.updateL1GasPrice(); err != nil {
 			log.Error("Cannot update L1 gas price", "msg", err)
 		}
@@ -356,7 +356,7 @@ func (s *SyncService) verify() error {
 func (s *SyncService) SequencerLoop() {
 	log.Info("Starting Sequencer Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	t := time.NewTicker(s.pollInterval)
-	for range t.C {
+	for ; true; <-t.C {
 		if err := s.updateL1GasPrice(); err != nil {
 			log.Error("Cannot update L1 gas price", "msg", err)
 		}

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -138,7 +138,8 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 		}
 
 		// Wait until the remote service is done syncing
-		for {
+		t := time.NewTicker(10 * time.Second)
+		for range t.C {
 			status, err := service.client.SyncStatus(service.backend)
 			if err != nil {
 				log.Error("Cannot get sync status")
@@ -148,7 +149,6 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 				break
 			}
 			log.Info("Still syncing", "index", status.CurrentTransactionIndex, "tip", status.HighestKnownTransactionIndex)
-			time.Sleep(10 * time.Second)
 		}
 
 		// Initialize the latest L1 data here to make sure that
@@ -320,7 +320,8 @@ func (s *SyncService) Stop() error {
 // VerifierLoop is the main loop for Verifier mode
 func (s *SyncService) VerifierLoop() {
 	log.Info("Starting Verifier Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
-	for {
+	t := time.NewTicker(s.pollInterval)
+	for range t.C {
 		if err := s.updateL1GasPrice(); err != nil {
 			log.Error("Cannot update L1 gas price", "msg", err)
 		}
@@ -330,7 +331,6 @@ func (s *SyncService) VerifierLoop() {
 		if err := s.updateL2GasPrice(nil); err != nil {
 			log.Error("Cannot update L2 gas price", "msg", err)
 		}
-		time.Sleep(s.pollInterval)
 	}
 }
 
@@ -354,7 +354,8 @@ func (s *SyncService) verify() error {
 // transactions and then updates the EthContext.
 func (s *SyncService) SequencerLoop() {
 	log.Info("Starting Sequencer Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
-	for {
+	t := time.NewTicker(s.pollInterval)
+	for range t.C {
 		if err := s.updateL1GasPrice(); err != nil {
 			log.Error("Cannot update L1 gas price", "msg", err)
 		}
@@ -370,7 +371,6 @@ func (s *SyncService) SequencerLoop() {
 		if err := s.updateContext(); err != nil {
 			log.Error("Could not update execution context", "error", err)
 		}
-		time.Sleep(s.pollInterval)
 	}
 }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replaces `time.Sleep` for loops with ranging over a `time.Ticker`. This pattern is easier for the scheduler to manage

Shoutout @fxfactorial