### PR TITLE
fix(dtl): incorrect parsing of eth_getBlockRange result

### DIFF
--- a/.changeset/spotty-drinks-bathe.md
+++ b/.changeset/spotty-drinks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+incorrect parsing of eth_getBlockRange result

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -194,7 +194,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
       const respJson = await bfj.parse(resp.data, {
         yieldRate: 4096, // this yields abit more often than the default of 16384
       })
-      blocks = respJson.data
+      blocks = respJson.result
     }
 
     for (const block of blocks) {


### PR DESCRIPTION
Parsing of the `eth_getBlockRange` result was incorrect. This was a bug due to a variable shadowing not realized until a lint error was fixed.