### PR TITLE
dtl: temp syncing bug patch

### DIFF
--- a/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
@@ -56,12 +56,9 @@ export const handleSequencerBlock = {
         data: transaction.input,
       }
 
-      transactionEntry = {
-        ...transactionEntry,
-        gasLimit: `${SEQUENCER_GAS_LIMIT}`, // ?
-        target: SEQUENCER_ENTRYPOINT_ADDRESS,
-        origin: null,
-        data: serialize(
+      let serialized
+      try {
+        serialized = serialize(
           {
             value: transaction.value,
             gasLimit: transaction.gas,
@@ -76,7 +73,34 @@ export const handleSequencerBlock = {
             r: padHexString(transaction.r, 32),
             s: padHexString(transaction.s, 32),
           }
-        ),
+        )
+      } catch (e) {
+        let v = parseSignatureVParam(transaction.v, chainId)
+        v = parseSignatureVParam(v, chainId)
+        serialized = serialize(
+          {
+            value: transaction.value,
+            gasLimit: transaction.gas,
+            gasPrice: transaction.gasPrice,
+            nonce: transaction.nonce,
+            to: transaction.to,
+            data: transaction.input,
+            chainId,
+          },
+          {
+            v,
+            r: padHexString(transaction.r, 32),
+            s: padHexString(transaction.s, 32),
+          }
+        )
+      }
+
+      transactionEntry = {
+        ...transactionEntry,
+        gasLimit: `${SEQUENCER_GAS_LIMIT}`, // ?
+        target: SEQUENCER_ENTRYPOINT_ADDRESS,
+        origin: null,
+        data: serialized,
         decoded: decodedTransaction,
         queueIndex: null,
       }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This fixes the DTL so that it can sync a kovan replica - note that the ideal fix involves serializing the RLP encoded transaction without checking the v param. This PR alters the v param so that it is correctly indexed. I am unsure if this will result in a differing state root, need to sync a kovan replica to check. The transactions that were ingested on kovan with an incorrect v value reverted, they should also revert using this DTL patch but at a slightly different point in their execution.

Note that this should be reverted if merged in the `regenesis/v0.4.0` branch
