### PR TITLE
fix: no gas refund

### DIFF
--- a/.changeset/sharp-dragons-check.md
+++ b/.changeset/sharp-dragons-check.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Removes the gas refund for unused gas in geth since it is instead managed in the smart contracts

--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -280,6 +280,9 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 }
 
 func (st *StateTransition) refundGas() {
+	if vm.UsingOVM {
+		return
+	}
 	// Apply refund counter, capped to half of the used gas.
 	refund := st.gasUsed() / 2
 	if refund > st.state.GetRefund() {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
We previously have observed account values being set when they shouldn't ever be and it is likely due to this line in the state transition. The unused gas was being refunded to the account. The optimism smart contracts should handle gas accounting instead of geth itself.

This PR simply ends the `refundGas` function early when running the OVM so that the account's balance is not modified