### PR TITLE
fix: add changeset to PR 1037

### DIFF
--- a/.changeset/brown-penguins-join.md
+++ b/.changeset/brown-penguins-join.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': minor
+---
+
+Fix L2 block streaming bug


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Release 0.3.4 of the DTL currently cannot sync from L2 due to a bug that's only fixed in https://github.com/ethereum-optimism/optimism/pull/1037. This PR adds a changeset to give infrastructure providers a new version to unblock them.

**Additional context**

**Metadata**
- 
