### PR TITLE
Move the metric prefix string to a label

### DIFF
--- a/.changeset/sour-adults-worry.md
+++ b/.changeset/sour-adults-worry.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/batch-submitter': patch
+'@eth-optimism/common-ts': patch
+'@eth-optimism/data-transport-layer': patch
+---
+
+Move the metric prefix string to a label #1047

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -84,6 +84,7 @@ export const run = async () => {
   const env = process.env
   const environment = config.str('node-env', env.NODE_ENV)
   const network = config.str('eth-network-name', env.ETH_NETWORK_NAME)
+  const service = `batch-submitter`
   const release = `batch-submitter@${env.npm_package_version}`
   const sentryDsn = config.str('sentry-dsn', env.SENTRY_DSN)
   const sentryTraceRate = config.ufloat(
@@ -181,8 +182,7 @@ export const run = async () => {
 
   /* Metrics */
   const metrics = new Metrics({
-    prefix: name,
-    labels: { environment, release, network },
+    labels: { environment, release, network, service },
   })
 
   const FRAUD_SUBMISSION_ADDRESS = config.str(

--- a/packages/common-ts/src/common/metrics.ts
+++ b/packages/common-ts/src/common/metrics.ts
@@ -9,7 +9,7 @@ import { Server } from 'net'
 import { Logger } from './logger'
 
 export interface MetricsOptions {
-  prefix: string
+  prefix?: string
   labels?: Object
 }
 

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -153,11 +153,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
    */
   private _initMetrics() {
     this.metrics = new Metrics({
-      prefix: this.name,
       labels: {
         environment: this.options.nodeEnv,
         network: this.options.ethNetworkName,
         release: this.options.release,
+        service: this.name,
       },
     })
     const metricsMiddleware = promBundle({


### PR DESCRIPTION
**Description**
Move the metric prefix string to a label

**Additional context**
Changing metric names with a prefix or suffix affects the ability to reuse metric queries. It would be better to keep consistent metric names for the same metrics and use labels to identify specific services.
