### PR TITLE
Enable custom tagging of release docker image

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -2,7 +2,12 @@ name: Publish Packages (canary)
 
 on:
   # enable users to manually trigger with workflow_dispatch
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+    canaryImageName:
+      description: 'Docker Image Tag (keep empty for git hash) — DANGER: This can override public images, be careful!'
+      required: false
+      default: '0.0.0-rc-0'
 
 jobs:
   canary-publish:
@@ -155,7 +160,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.message-relayer
           push: true
-          tags: ethereumoptimism/message-relayer:${{ GITHUB_SHA::8 }}
+          tags: ethereumoptimism/message-relayer:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
 
   batch-submitter:
     name: Publish Batch Submitter Version ${{ needs.builder.outputs.batch-submitter }}
@@ -181,7 +186,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.batch-submitter
           push: true
-          tags: ethereumoptimism/batch-submitter:${{ GITHUB_SHA::8 }}
+          tags: ethereumoptimism/batch-submitter:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
 
   data-transport-layer:
     name: Publish Data Transport Layer Version ${{ needs.builder.outputs.data-transport-layer }}
@@ -207,7 +212,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.data-transport-layer
           push: true
-          tags: ethereumoptimism/data-transport-layer:${{ GITHUB_SHA::8 }}
+          tags: ethereumoptimism/data-transport-layer:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
 
   contracts:
     name: Publish Deployer Version ${{ needs.builder.outputs.contracts }}
@@ -233,7 +238,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.deployer
           push: true
-          tags: ethereumoptimism/deployer:${{ GITHUB_SHA::8 }}
+          tags: ethereumoptimism/deployer:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
 
   integration_tests:
     name: Publish Integration tests ${{ needs.builder.outputs.integration-tests }}
@@ -259,4 +264,4 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.integration-tests
           push: true
-          tags: ethereumoptimism/integration-tests:${{ GITHUB_SHA::8 }}
+          tags: ethereumoptimism/integration-tests:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -4,8 +4,8 @@ on:
   # enable users to manually trigger with workflow_dispatch
   workflow_dispatch:
     inputs:
-    canaryImageName:
-      description: 'Docker Image Tag (keep empty for git hash) — DANGER: This can override public images, be careful!'
+    customImageName:
+      description: 'Cusotm Docker Image Tag (keep empty for git hash)'
       required: false
       default: '0.0.0-rc-0'
 
@@ -70,6 +70,19 @@ jobs:
         id: packages
         run: |
           node ops/scripts/ci-versions.js ${{ toJSON(steps.changesets.outputs.publishedPackages) }}
+
+      - name: Docker Image Name
+        id: docker_image_name
+        run: |
+          if [ $CUSTOM_IMAGE_NAME == '' ]
+          then
+              echo "::set-output name=canary-docker-tag::$GITHUB_SHA_PREFIX"
+          else
+              echo "::set-output name=canary-docker-tag::prerelease-$CUSTOM_IMAGE_NAME"
+          fi
+        env:
+          GITHUB_SHA_PREFIX: ${{ GITHUB_SHA::8 }}
+          CUSTOM_IMAGE_NAME: ${{ github.event.inputs.customImageName }}
 
 
   # The below code is duplicated, would be ideal if we could use a matrix with a
@@ -160,7 +173,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.message-relayer
           push: true
-          tags: ethereumoptimism/message-relayer:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
+          tags: ethereumoptimism/message-relayer:${{ steps.docker_image_name.outputs.canary-docker-tag }}
 
   batch-submitter:
     name: Publish Batch Submitter Version ${{ needs.builder.outputs.batch-submitter }}
@@ -186,7 +199,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.batch-submitter
           push: true
-          tags: ethereumoptimism/batch-submitter:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
+          tags: ethereumoptimism/batch-submitter:${{ steps.docker_image_name.outputs.canary-docker-tag }}
 
   data-transport-layer:
     name: Publish Data Transport Layer Version ${{ needs.builder.outputs.data-transport-layer }}
@@ -212,7 +225,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.data-transport-layer
           push: true
-          tags: ethereumoptimism/data-transport-layer:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
+          tags: ethereumoptimism/data-transport-layer:${{ steps.docker_image_name.outputs.canary-docker-tag }}
 
   contracts:
     name: Publish Deployer Version ${{ needs.builder.outputs.contracts }}
@@ -238,7 +251,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.deployer
           push: true
-          tags: ethereumoptimism/deployer:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
+          tags: ethereumoptimism/deployer:${{ steps.docker_image_name.outputs.canary-docker-tag }}
 
   integration_tests:
     name: Publish Integration tests ${{ needs.builder.outputs.integration-tests }}
@@ -264,4 +277,4 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.integration-tests
           push: true
-          tags: ethereumoptimism/integration-tests:${{ github.event.inputs.canaryImageName == '' && GITHUB_SHA::8 || github.event.inputs.canaryImageName }}
+          tags: ethereumoptimism/integration-tests:${{ steps.docker_image_name.outputs.canary-docker-tag }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
     customImageName:
-      description: 'Cusotm Docker Image Tag (keep empty for git hash)'
+      description: 'Custom Docker Image Tag (keep empty for git hash)'
       required: false
       default: '0.0.0-rc-0'
 


### PR DESCRIPTION
Enables Github user to trigger a deployment with a custom Docker image name