### PR TITLE
fix: abi encoded tx

### DIFF
--- a/.changeset/witty-chefs-learn.md
+++ b/.changeset/witty-chefs-learn.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Do not RLP decode the transaction in the OVM_ECDSAContractAccount

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
@@ -19,7 +19,7 @@ import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 /**
  * @title OVM_ECDSAContractAccount
  * @dev The ECDSA Contract Account can be used as the implementation for a ProxyEOA deployed by the
- * ovmCREATEEOA operation. It enables backwards compatibility with Ethereum's Layer 1, by 
+ * ovmCREATEEOA operation. It enables backwards compatibility with Ethereum's Layer 1, by
  * providing EIP155 formatted transaction encodings.
  *
  * Compiler used: optimistic-solc
@@ -49,12 +49,12 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
 
     /**
      * Executes a signed transaction.
-     * @param _encodedTransaction Signed EIP155 transaction.
+     * @param _transaction Signed EIP155 transaction.
      * @return Whether or not the call returned (rather than reverted).
      * @return Data returned by the call.
      */
     function execute(
-        bytes memory _encodedTransaction
+        Lib_EIP155Tx.EIP155Tx memory _transaction
     )
         override
         public
@@ -63,23 +63,22 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
             bytes memory
         )
     {
-        // Attempt to decode the transaction.
-        Lib_EIP155Tx.EIP155Tx memory transaction = Lib_EIP155Tx.decode(
-            _encodedTransaction,
-            Lib_ExecutionManagerWrapper.ovmCHAINID()
-        );
-
         // Address of this contract within the ovm (ovmADDRESS) should be the same as the
         // recovered address of the user who signed this message. This is how we manage to shim
         // account abstraction even though the user isn't a contract.
         require(
-            transaction.sender() == Lib_ExecutionManagerWrapper.ovmADDRESS(),
+            _transaction.sender() == Lib_ExecutionManagerWrapper.ovmADDRESS(),
             "Signature provided for EOA transaction execution is invalid."
+        );
+
+        require(
+            _transaction.chainId == Lib_ExecutionManagerWrapper.ovmCHAINID(),
+            "Transaction signed with wrong chain ID"
         );
 
         // Need to make sure that the transaction nonce is right.
         require(
-            transaction.nonce == Lib_ExecutionManagerWrapper.ovmGETNONCE(),
+            _transaction.nonce == Lib_ExecutionManagerWrapper.ovmGETNONCE(),
             "Transaction nonce does not match the expected nonce."
         );
 
@@ -94,20 +93,20 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
         require(
             OVM_ETH(Lib_PredeployAddresses.OVM_ETH).transfer(
                 Lib_PredeployAddresses.SEQUENCER_FEE_WALLET,
-                SafeMath.mul(transaction.gasLimit, transaction.gasPrice)
+                SafeMath.mul(_transaction.gasLimit, _transaction.gasPrice)
             ),
             "Fee was not transferred to relayer."
         );
 
-        if (transaction.isCreate) {
+        if (_transaction.isCreate) {
             // TEMPORARY: Disable value transfer for contract creations.
             require(
-                transaction.value == 0,
+                _transaction.value == 0,
                 "Value transfer in contract creation not supported."
             );
 
             (address created, bytes memory revertdata) = Lib_ExecutionManagerWrapper.ovmCREATE(
-                transaction.data
+                _transaction.data
             );
 
             // Return true if the contract creation succeeded, false w/ revertdata otherwise.
@@ -123,17 +122,17 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
             Lib_ExecutionManagerWrapper.ovmINCREMENTNONCE();
 
             // Value transfer currently only supported for CALL but not for CREATE.
-            if (transaction.value > 0) {
+            if (_transaction.value > 0) {
                 // TEMPORARY: Block value transfer if the transaction has input data.
                 require(
-                    transaction.data.length == 0,
+                    _transaction.data.length == 0,
                     "Value is nonzero but input data was provided."
                 );
 
                 require(
                     OVM_ETH(Lib_PredeployAddresses.OVM_ETH).transfer(
-                        transaction.to,
-                        transaction.value
+                        _transaction.to,
+                        _transaction.value
                     ),
                     "Value could not be transferred to recipient."
                 );
@@ -144,11 +143,11 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
                 // so that they don't have to pay any fees to the sequencer. Function will remain disabled
                 // until a robust solution is in place.
                 require(
-                    transaction.to != Lib_ExecutionManagerWrapper.ovmADDRESS(),
+                    _transaction.to != Lib_ExecutionManagerWrapper.ovmADDRESS(),
                     "Calls to self are disabled until upgradability is re-enabled."
                 );
 
-                return transaction.to.call(transaction.data);
+                return _transaction.to.call(_transaction.data);
             }
         }
     }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_EIP155Tx } from "../../libraries/codec/Lib_EIP155Tx.sol";
@@ -61,11 +62,12 @@ contract OVM_SequencerEntrypoint {
             );
         }
 
+
         // Forward the transaction over to the EOA.
         (bool success, bytes memory returndata) = target.call(
             abi.encodeWithSignature(
-                "execute(bytes)",
-                encodedTx
+                "execute((uint256,uint256,uint256,address,uint256,bytes,uint8,bytes32,bytes32,uint256,uint8,bool))",
+                transaction
             )
         );
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
@@ -5,7 +5,7 @@ pragma experimental ABIEncoderV2;
 /* Library Imports */
 import { Lib_EIP155Tx } from "../../libraries/codec/Lib_EIP155Tx.sol";
 import { Lib_ExecutionManagerWrapper } from "../../libraries/wrappers/Lib_ExecutionManagerWrapper.sol";
-import { OVM_ECDSAContractAccount } from "../../OVM/accounts/OVM_ECDSAContractAccount.sol";
+import { iOVM_ECDSAContractAccount } from "../../iOVM/accounts/iOVM_ECDSAContractAccount.sol";
 
 /**
  * @title OVM_SequencerEntrypoint
@@ -65,7 +65,7 @@ contract OVM_SequencerEntrypoint {
 
         // Forward the transaction over to the EOA.
         (bool success, bytes memory returndata) = target.call(
-            abi.encodeWithSelector(OVM_ECDSAContractAccount.execute.selector, transaction)
+            abi.encodeWithSelector(iOVM_ECDSAContractAccount.execute.selector, transaction)
         );
 
         if (success) {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
@@ -62,7 +62,6 @@ contract OVM_SequencerEntrypoint {
             );
         }
 
-
         // Forward the transaction over to the EOA.
         (bool success, bytes memory returndata) = target.call(
             abi.encodeWithSignature(

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_SequencerEntrypoint.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 /* Library Imports */
 import { Lib_EIP155Tx } from "../../libraries/codec/Lib_EIP155Tx.sol";
 import { Lib_ExecutionManagerWrapper } from "../../libraries/wrappers/Lib_ExecutionManagerWrapper.sol";
+import { OVM_ECDSAContractAccount } from "../../OVM/accounts/OVM_ECDSAContractAccount.sol";
 
 /**
  * @title OVM_SequencerEntrypoint
@@ -64,10 +65,7 @@ contract OVM_SequencerEntrypoint {
 
         // Forward the transaction over to the EOA.
         (bool success, bytes memory returndata) = target.call(
-            abi.encodeWithSignature(
-                "execute((uint256,uint256,uint256,address,uint256,bytes,uint8,bytes32,bytes32,uint256,uint8,bool))",
-                transaction
-            )
+            abi.encodeWithSelector(OVM_ECDSAContractAccount.execute.selector, transaction)
         );
 
         if (success) {

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/accounts/iOVM_ECDSAContractAccount.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/accounts/iOVM_ECDSAContractAccount.sol
@@ -3,7 +3,7 @@ pragma solidity >0.5.0 <0.8.0;
 pragma experimental ABIEncoderV2;
 
 /* Library Imports */
-import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
+import { Lib_EIP155Tx } from "../../libraries/codec/Lib_EIP155Tx.sol";
 
 /**
  * @title iOVM_ECDSAContractAccount
@@ -15,7 +15,7 @@ interface iOVM_ECDSAContractAccount {
      ********************/
 
     function execute(
-        bytes memory _encodedTransaction
+        Lib_EIP155Tx.EIP155Tx memory _transaction
     )
         external
         returns (

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/codec/Lib_EIP155Tx.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/codec/Lib_EIP155Tx.sol
@@ -48,12 +48,12 @@ library Lib_EIP155Tx {
         // didn't use a uint8, then recovery_parameter would always be a negative number for chain
         // IDs greater than 110 (`255 - 110 * 2 - 35 = 0`). So we need to wrap around to support
         // anything larger.
-        uint8 recoveryParam; 
+        uint8 recoveryParam;
 
         // Whether or not the transaction is a creation. Necessary because we can't make an address
         // "nil". Using the zero address creates a potential conflict if the user did actually
         // intend to send a transaction to the zero address.
-        bool isCreate;       
+        bool isCreate;
     }
 
     // Lets us use nicer syntax.
@@ -152,7 +152,7 @@ library Lib_EIP155Tx {
             raw[8] = Lib_RLPWriter.writeBytes32(_transaction.s);
         } else {
             // Chain ID *is* included in the unsigned transaction.
-            raw[6] = Lib_RLPWriter.writeUint(_transaction.chainId); 
+            raw[6] = Lib_RLPWriter.writeUint(_transaction.chainId);
             raw[7] = Lib_RLPWriter.writeBytes('');
             raw[8] = Lib_RLPWriter.writeBytes('');
         }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -60,6 +60,7 @@
     "@codechecks/client": "0.1.10-beta",
     "@eth-optimism/hardhat-ovm": "^0.2.2",
     "@eth-optimism/smock": "^1.1.3",
+    "@ethersproject/transactions": "^5.0.31",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.3.0",

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -7,10 +7,7 @@ import { MockContract, smockit } from '@eth-optimism/smock'
 import { toPlainObject } from 'lodash'
 
 /* Internal Imports */
-import {
-  LibEIP155TxStruct,
-  DEFAULT_EIP155_TX,
-} from '../../../helpers'
+import { LibEIP155TxStruct, DEFAULT_EIP155_TX } from '../../../helpers'
 import { predeploys } from '../../../../src'
 
 describe('OVM_ECDSAContractAccount', () => {
@@ -57,14 +54,18 @@ describe('OVM_ECDSAContractAccount', () => {
       const transaction = DEFAULT_EIP155_TX
       const encodedTransaction = await wallet.signTransaction(transaction)
 
-      await OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
+      await OVM_ECDSAContractAccount.execute(
+        LibEIP155TxStruct(encodedTransaction)
+      )
     })
 
     it(`should ovmCREATE if EIP155Transaction.to is zero address`, async () => {
       const transaction = { ...DEFAULT_EIP155_TX, to: '' }
       const encodedTransaction = await wallet.signTransaction(transaction)
 
-      await OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
+      await OVM_ECDSAContractAccount.execute(
+        LibEIP155TxStruct(encodedTransaction)
+      )
 
       const ovmCREATE: any =
         Mock__OVM_ExecutionManager.smocked.ovmCREATE.calls[0]
@@ -102,9 +103,7 @@ describe('OVM_ECDSAContractAccount', () => {
 
       await expect(
         OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
-      ).to.be.revertedWith(
-        'Transaction signed with wrong chain ID'
-      )
+      ).to.be.revertedWith('Transaction signed with wrong chain ID')
     })
 
     // TEMPORARY: Skip gas checks for minnet.
@@ -127,16 +126,18 @@ describe('OVM_ECDSAContractAccount', () => {
       Mock__OVM_ETH.smocked.transfer.will.return.with(false)
 
       const tx = LibEIP155TxStruct(encodedTransaction)
-      await expect(
-        OVM_ECDSAContractAccount.execute(tx)
-      ).to.be.revertedWith('Fee was not transferred to relayer.')
+      await expect(OVM_ECDSAContractAccount.execute(tx)).to.be.revertedWith(
+        'Fee was not transferred to relayer.'
+      )
     })
 
     it(`should transfer value if value is greater than 0`, async () => {
       const transaction = { ...DEFAULT_EIP155_TX, value: 1234, data: '0x' }
       const encodedTransaction = await wallet.signTransaction(transaction)
 
-      await OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
+      await OVM_ECDSAContractAccount.execute(
+        LibEIP155TxStruct(encodedTransaction)
+      )
 
       // First call transfers fee, second transfers value (since value > 0).
       expect(

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -7,7 +7,10 @@ import { MockContract, smockit } from '@eth-optimism/smock'
 import { toPlainObject } from 'lodash'
 
 /* Internal Imports */
-import { DEFAULT_EIP155_TX } from '../../../helpers'
+import {
+  LibEIP155TxStruct,
+  DEFAULT_EIP155_TX,
+} from '../../../helpers'
 import { predeploys } from '../../../../src'
 
 describe('OVM_ECDSAContractAccount', () => {
@@ -54,14 +57,14 @@ describe('OVM_ECDSAContractAccount', () => {
       const transaction = DEFAULT_EIP155_TX
       const encodedTransaction = await wallet.signTransaction(transaction)
 
-      await OVM_ECDSAContractAccount.execute(encodedTransaction)
+      await OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
     })
 
     it(`should ovmCREATE if EIP155Transaction.to is zero address`, async () => {
       const transaction = { ...DEFAULT_EIP155_TX, to: '' }
       const encodedTransaction = await wallet.signTransaction(transaction)
 
-      await OVM_ECDSAContractAccount.execute(encodedTransaction)
+      await OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
 
       const ovmCREATE: any =
         Mock__OVM_ExecutionManager.smocked.ovmCREATE.calls[0]
@@ -76,7 +79,7 @@ describe('OVM_ECDSAContractAccount', () => {
       )
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith(
         'Signature provided for EOA transaction execution is invalid.'
       )
@@ -87,7 +90,7 @@ describe('OVM_ECDSAContractAccount', () => {
       const encodedTransaction = await wallet.signTransaction(transaction)
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith(
         'Transaction nonce does not match the expected nonce.'
       )
@@ -98,9 +101,9 @@ describe('OVM_ECDSAContractAccount', () => {
       const encodedTransaction = await wallet.signTransaction(transaction)
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith(
-        'Lib_EIP155Tx: Transaction signed with wrong chain ID'
+        'Transaction signed with wrong chain ID'
       )
     })
 
@@ -109,8 +112,9 @@ describe('OVM_ECDSAContractAccount', () => {
       const transaction = { ...DEFAULT_EIP155_TX, gasLimit: 200000000 }
       const encodedTransaction = await wallet.signTransaction(transaction)
 
+      const tx = LibEIP155TxStruct(encodedTransaction)
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction, {
+        OVM_ECDSAContractAccount.execute(tx, {
           gasLimit: 40000000,
         })
       ).to.be.revertedWith('Gas is not sufficient to execute the transaction.')
@@ -122,8 +126,9 @@ describe('OVM_ECDSAContractAccount', () => {
 
       Mock__OVM_ETH.smocked.transfer.will.return.with(false)
 
+      const tx = LibEIP155TxStruct(encodedTransaction)
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(tx)
       ).to.be.revertedWith('Fee was not transferred to relayer.')
     })
 
@@ -131,7 +136,7 @@ describe('OVM_ECDSAContractAccount', () => {
       const transaction = { ...DEFAULT_EIP155_TX, value: 1234, data: '0x' }
       const encodedTransaction = await wallet.signTransaction(transaction)
 
-      await OVM_ECDSAContractAccount.execute(encodedTransaction)
+      await OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
 
       // First call transfers fee, second transfers value (since value > 0).
       expect(
@@ -155,7 +160,7 @@ describe('OVM_ECDSAContractAccount', () => {
       })
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith('Value could not be transferred to recipient.')
     })
 
@@ -164,7 +169,7 @@ describe('OVM_ECDSAContractAccount', () => {
       const encodedTransaction = await wallet.signTransaction(transaction)
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith('Value transfer in contract creation not supported.')
     })
 
@@ -173,7 +178,7 @@ describe('OVM_ECDSAContractAccount', () => {
       const encodedTransaction = await wallet.signTransaction(transaction)
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith('Value is nonzero but input data was provided.')
     })
 
@@ -184,7 +189,7 @@ describe('OVM_ECDSAContractAccount', () => {
       const encodedTransaction = await wallet.signTransaction(transaction)
 
       await expect(
-        OVM_ECDSAContractAccount.execute(encodedTransaction)
+        OVM_ECDSAContractAccount.execute(LibEIP155TxStruct(encodedTransaction))
       ).to.be.revertedWith(
         'Calls to self are disabled until upgradability is re-enabled.'
       )

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ProxyEOA.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ProxyEOA.spec.ts
@@ -84,7 +84,9 @@ describe('OVM_ProxyEOA', () => {
         data,
       })
 
-      const call = toPlainObject(Mock__OVM_ECDSAContractAccount.smocked.execute.calls[0])
+      const call = toPlainObject(
+        Mock__OVM_ECDSAContractAccount.smocked.execute.calls[0]
+      )
       const _transaction = call._transaction
 
       expect(_transaction[0]).to.deep.equal(transaction.nonce)

--- a/packages/contracts/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/packages/contracts/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -7,8 +7,8 @@ import { smockit, MockContract, unbind } from '@eth-optimism/smock'
 import { toPlainObject } from 'lodash'
 
 /* Internal Imports */
-import { DEFAULT_EIP155_TX } from '../../../helpers'
-import { getContractInterface, predeploys } from '../../../../src'
+import { DEFAULT_EIP155_TX, LibEIP155TxStruct } from '../../../helpers'
+import { getContractInterface, predeploys, getContractFactory } from '../../../../src'
 
 describe('OVM_SequencerEntrypoint', () => {
   const iOVM_ECDSAContractAccount = getContractInterface(
@@ -84,11 +84,17 @@ describe('OVM_SequencerEntrypoint', () => {
         data: encodedTransaction,
       })
 
-      expect(
-        toPlainObject(Mock__wallet.smocked.execute.calls[0])
-      ).to.deep.include({
-        _encodedTransaction: encodedTransaction,
-      })
+
+      const call = toPlainObject(Mock__wallet.smocked.execute.calls[0])
+      const _transaction = call._transaction
+
+      expect(_transaction[0]).to.deep.equal(transaction.nonce)
+      expect(_transaction.nonce).to.deep.equal(transaction.nonce)
+      expect(_transaction.gasPrice).to.deep.equal(transaction.gasPrice)
+      expect(_transaction.gasLimit).to.deep.equal(transaction.gasLimit)
+      expect(_transaction.to).to.deep.equal(transaction.to)
+      expect(_transaction.data).to.deep.equal(transaction.data)
+      expect(_transaction.isCreate).to.deep.equal(false)
     })
 
     it('should send correct calldata if tx is a create', async () => {
@@ -104,11 +110,16 @@ describe('OVM_SequencerEntrypoint', () => {
         data: encodedTransaction,
       })
 
-      expect(
-        toPlainObject(Mock__wallet.smocked.execute.calls[0])
-      ).to.deep.include({
-        _encodedTransaction: encodedTransaction,
-      })
+      const call = toPlainObject(Mock__wallet.smocked.execute.calls[0])
+      const _transaction = call._transaction
+
+      expect(_transaction[0]).to.deep.equal(transaction.nonce)
+      expect(_transaction.nonce).to.deep.equal(transaction.nonce)
+      expect(_transaction.gasPrice).to.deep.equal(transaction.gasPrice)
+      expect(_transaction.gasLimit).to.deep.equal(transaction.gasLimit)
+      expect(_transaction.to).to.deep.equal(ethers.constants.AddressZero)
+      expect(_transaction.data).to.deep.equal(transaction.data)
+      expect(_transaction.isCreate).to.deep.equal(true)
     })
   })
 })

--- a/packages/contracts/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
+++ b/packages/contracts/test/contracts/OVM/precompiles/OVM_SequencerEntrypoint.spec.ts
@@ -8,7 +8,11 @@ import { toPlainObject } from 'lodash'
 
 /* Internal Imports */
 import { DEFAULT_EIP155_TX, LibEIP155TxStruct } from '../../../helpers'
-import { getContractInterface, predeploys, getContractFactory } from '../../../../src'
+import {
+  getContractInterface,
+  predeploys,
+  getContractFactory,
+} from '../../../../src'
 
 describe('OVM_SequencerEntrypoint', () => {
   const iOVM_ECDSAContractAccount = getContractInterface(
@@ -83,7 +87,6 @@ describe('OVM_SequencerEntrypoint', () => {
         to: OVM_SequencerEntrypoint.address,
         data: encodedTransaction,
       })
-
 
       const call = toPlainObject(Mock__wallet.smocked.execute.calls[0])
       const _transaction = call._transaction

--- a/packages/contracts/test/helpers/types/ovm-types.ts
+++ b/packages/contracts/test/helpers/types/ovm-types.ts
@@ -1,5 +1,6 @@
 /* External Imports */
-import { BigNumber } from 'ethers'
+import { BigNumber, constants } from 'ethers'
+import { parse } from '@ethersproject/transactions'
 
 export interface OVMAccount {
   nonce: number | BigNumber
@@ -7,4 +8,26 @@ export interface OVMAccount {
   storageRoot: string
   codeHash: string
   ethAddress: string
+}
+
+
+export function LibEIP155TxStruct(tx) {
+  if (typeof tx === 'string') {
+    tx = parse(tx)
+  }
+  const values = [
+    tx.nonce,
+    tx.gasPrice,
+    tx.gasLimit,
+    tx.to ? tx.to : constants.AddressZero,
+    tx.value,
+    tx.data,
+    tx.v % 256,
+    tx.r,
+    tx.s,
+    tx.chainId,
+    tx.v === 0 ? 0 : tx.v - (2 * tx.chainId) - 35,
+    tx.to === null
+  ]
+  return values
 }

--- a/packages/contracts/test/helpers/types/ovm-types.ts
+++ b/packages/contracts/test/helpers/types/ovm-types.ts
@@ -1,6 +1,6 @@
 /* External Imports */
 import { BigNumber, constants } from 'ethers'
-import { parse } from '@ethersproject/transactions'
+import { parse, Transaction } from '@ethersproject/transactions'
 
 export interface OVMAccount {
   nonce: number | BigNumber
@@ -10,7 +10,7 @@ export interface OVMAccount {
   ethAddress: string
 }
 
-export function LibEIP155TxStruct(tx) {
+export const LibEIP155TxStruct = (tx: Transaction | string): Array<any> => {
   if (typeof tx === 'string') {
     tx = parse(tx)
   }

--- a/packages/contracts/test/helpers/types/ovm-types.ts
+++ b/packages/contracts/test/helpers/types/ovm-types.ts
@@ -10,7 +10,6 @@ export interface OVMAccount {
   ethAddress: string
 }
 
-
 export function LibEIP155TxStruct(tx) {
   if (typeof tx === 'string') {
     tx = parse(tx)
@@ -26,8 +25,8 @@ export function LibEIP155TxStruct(tx) {
     tx.r,
     tx.s,
     tx.chainId,
-    tx.v === 0 ? 0 : tx.v - (2 * tx.chainId) - 35,
-    tx.to === null
+    tx.v === 0 ? 0 : tx.v - 2 * tx.chainId - 35,
+    tx.to === null,
   ]
   return values
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,6 +481,17 @@
     "@ethersproject/logger" "^5.1.0"
     "@ethersproject/rlp" "^5.1.0"
 
+"@ethersproject/address@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.3.0.tgz#e53b69eacebf332e8175de814c5e6507d6932518"
+  integrity sha512-29TgjzEBK+gUEUAOfWCG7s9IxLNLCqvr+oDSk6L9TXD0VLvZJKhJV479tKQqheVA81OeGxfpdxYtUVH8hqlCvA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.3.0"
+    "@ethersproject/bytes" "^5.3.0"
+    "@ethersproject/keccak256" "^5.3.0"
+    "@ethersproject/logger" "^5.3.0"
+    "@ethersproject/rlp" "^5.3.0"
+
 "@ethersproject/base64@5.1.0", "@ethersproject/base64@^5.0.0", "@ethersproject/base64@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.1.0.tgz#27240c174d0a4e13f6eae87416fd876caf7f42b6"
@@ -505,6 +516,15 @@
     "@ethersproject/logger" "^5.1.0"
     bn.js "^4.4.0"
 
+"@ethersproject/bignumber@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.3.0.tgz#74ab2ec9c3bda4e344920565720a6ee9c794e9db"
+  integrity sha512-5xguJ+Q1/zRMgHgDCaqAexx/8DwDVLRemw2i6uR8KyGjwGdXI8f32QZZ1cKGucBN6ekJvpUpHy6XAuQnTv0mPA==
+  dependencies:
+    "@ethersproject/bytes" "^5.3.0"
+    "@ethersproject/logger" "^5.3.0"
+    bn.js "^4.11.9"
+
 "@ethersproject/bytes@5.1.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.0.2", "@ethersproject/bytes@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.1.0.tgz#55dfa9c4c21df1b1b538be3accb50fb76d5facfd"
@@ -512,12 +532,26 @@
   dependencies:
     "@ethersproject/logger" "^5.1.0"
 
+"@ethersproject/bytes@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.3.0.tgz#473e0da7f831d535b2002be05e6f4ca3729a1bc9"
+  integrity sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==
+  dependencies:
+    "@ethersproject/logger" "^5.3.0"
+
 "@ethersproject/constants@5.1.0", "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.0.0", "@ethersproject/constants@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.1.0.tgz#4e7da6367ea0e9be87585d8b09f3fccf384b1452"
   integrity sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==
   dependencies:
     "@ethersproject/bignumber" "^5.1.0"
+
+"@ethersproject/constants@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.3.0.tgz#a5d6d86c0eec2c64c3024479609493b9afb3fc77"
+  integrity sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.3.0"
 
 "@ethersproject/contracts@5.1.0", "@ethersproject/contracts@^5.0.0", "@ethersproject/contracts@^5.0.2", "@ethersproject/contracts@^5.0.5":
   version "5.1.0"
@@ -606,10 +640,23 @@
     "@ethersproject/bytes" "^5.1.0"
     js-sha3 "0.5.7"
 
+"@ethersproject/keccak256@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.3.0.tgz#fb5cd36bdfd6fa02e2ea84964078a9fc6bd731be"
+  integrity sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.3.0"
+    js-sha3 "0.5.7"
+
 "@ethersproject/logger@5.1.0", "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.0.0", "@ethersproject/logger@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.1.0.tgz#4cdeeefac029373349d5818f39c31b82cc6d9bbf"
   integrity sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw==
+
+"@ethersproject/logger@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.3.0.tgz#7a69fa1d4ca0d4b7138da1627eb152f763d84dd0"
+  integrity sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA==
 
 "@ethersproject/networks@5.1.0", "@ethersproject/networks@^5.0.0", "@ethersproject/networks@^5.1.0":
   version "5.1.0"
@@ -632,6 +679,13 @@
   integrity sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==
   dependencies:
     "@ethersproject/logger" "^5.1.0"
+
+"@ethersproject/properties@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.3.0.tgz#feef4c4babeb7c10a6b3449575016f4ad2c092b2"
+  integrity sha512-PaHxJyM5/bfusk6vr3yP//JMnm4UEojpzuWGTmtL5X4uNhNnFNvlYilZLyDr4I9cTkIbipCMsAuIcXWsmdRnEw==
+  dependencies:
+    "@ethersproject/logger" "^5.3.0"
 
 "@ethersproject/providers@5.1.0", "@ethersproject/providers@^5.0.0", "@ethersproject/providers@^5.0.14", "@ethersproject/providers@^5.0.21", "@ethersproject/providers@^5.0.24", "@ethersproject/providers@^5.0.5":
   version "5.1.0"
@@ -674,6 +728,14 @@
     "@ethersproject/bytes" "^5.1.0"
     "@ethersproject/logger" "^5.1.0"
 
+"@ethersproject/rlp@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.3.0.tgz#7cb93a7b5dfa69163894153c9d4b0d936f333188"
+  integrity sha512-oI0joYpsRanl9guDubaW+1NbcpK0vJ3F/6Wpcanzcnqq+oaW9O5E98liwkEDPcb16BUTLIJ+ZF8GPIHYxJ/5Pw==
+  dependencies:
+    "@ethersproject/bytes" "^5.3.0"
+    "@ethersproject/logger" "^5.3.0"
+
 "@ethersproject/sha2@5.1.0", "@ethersproject/sha2@^5.0.0", "@ethersproject/sha2@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.1.0.tgz#6ca42d1a26884b3e32ffa943fe6494af7211506c"
@@ -693,6 +755,18 @@
     "@ethersproject/properties" "^5.1.0"
     bn.js "^4.4.0"
     elliptic "6.5.4"
+
+"@ethersproject/signing-key@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.3.0.tgz#a96c88f8173e1abedfa35de32d3e5db7c48e5259"
+  integrity sha512-+DX/GwHAd0ok1bgedV1cKO0zfK7P/9aEyNoaYiRsGHpCecN7mhLqcdoUiUzE7Uz86LBsxm5ssK0qA1kBB47fbQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.3.0"
+    "@ethersproject/logger" "^5.3.0"
+    "@ethersproject/properties" "^5.3.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
 
 "@ethersproject/solidity@5.1.0", "@ethersproject/solidity@^5.0.0", "@ethersproject/solidity@^5.0.2":
   version "5.1.0"
@@ -743,6 +817,21 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/rlp" "^5.1.0"
     "@ethersproject/signing-key" "^5.1.0"
+
+"@ethersproject/transactions@^5.0.31":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.3.0.tgz#49b86f2bafa4d0bdf8e596578fc795ee47c50458"
+  integrity sha512-cdfK8VVyW2oEBCXhURG0WQ6AICL/r6Gmjh0e4Bvbv6MCn/GBd8FeBH3rtl7ho+AW50csMKeGv3m3K1HSHB2jMQ==
+  dependencies:
+    "@ethersproject/address" "^5.3.0"
+    "@ethersproject/bignumber" "^5.3.0"
+    "@ethersproject/bytes" "^5.3.0"
+    "@ethersproject/constants" "^5.3.0"
+    "@ethersproject/keccak256" "^5.3.0"
+    "@ethersproject/logger" "^5.3.0"
+    "@ethersproject/properties" "^5.3.0"
+    "@ethersproject/rlp" "^5.3.0"
+    "@ethersproject/signing-key" "^5.3.0"
 
 "@ethersproject/units@5.1.0", "@ethersproject/units@^5.0.0":
   version "5.1.0"
@@ -7269,7 +7358,7 @@ hash.js@1.1.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This removes the RLP decoding logic from the `OVM_ECDSAContractAccount` because it is being decoded twice. This will lower gas usage for transactions with a lot of calldata.

**Additional context**
Allows the `EXECUTE_INTRINSIC_GAS` to be much more predictable and smaller due to not needing to RLP decode the transaction inside of the `OVM_ECDSAContractAccount`. 
See https://github.com/ethereum-optimism/optimism/pull/1008


Fixes OP-859