### PR TITLE
Add erc1271 support to contract account

### DIFF
--- a/.changeset/blue-cooks-join.md
+++ b/.changeset/blue-cooks-join.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/contracts': patch
+---
+
+Adds ERC1271 support to default contract account

--- a/integration-tests/test/predeploys.spec.ts
+++ b/integration-tests/test/predeploys.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+
+/* Imports: External */
+import { Contract, Wallet } from 'ethers'
+import { OptimismEnv } from './shared/env'
+import { getContractInterface } from '@eth-optimism/contracts'
+
+describe('ECDSAContractAccount', () => {
+  let l2Wallet: Wallet
+
+  const DEFAULT_TRANSACTION = {
+    to: '0x' + '1234'.repeat(10),
+    gasLimit: 33600000000001,
+    gasPrice: 0,
+    data: '0x',
+    value: 0,
+  }
+  before(async () => {
+    const env = await OptimismEnv.new()
+    l2Wallet = env.l2Wallet
+  })
+
+  let ProxyEOA: Contract
+
+  beforeEach(async () => {
+    // Send a transaction to ensure there is a ProxyEOA deployed at l2Wallet.address
+    const result = await l2Wallet.sendTransaction(DEFAULT_TRANSACTION)
+    await result.wait()
+  })
+
+  it('should correctly evaluate isValidSignature', async () => {
+    ProxyEOA = new Contract(
+      l2Wallet.address,
+      getContractInterface('OVM_ECDSAContractAccount'),
+      l2Wallet
+    )
+    const message = '0x42'
+    const messageHash = ethers.utils.hashMessage(message)
+    const signature = await l2Wallet.signMessage(message)
+    const isValid = await ProxyEOA.isValidSignature(messageHash, signature)
+    expect(isValid).to.equal('0x1626ba7e')
+  })
+})

--- a/integration-tests/test/predeploys.spec.ts
+++ b/integration-tests/test/predeploys.spec.ts
@@ -4,41 +4,46 @@ import { ethers } from 'hardhat'
 /* Imports: External */
 import { Contract, Wallet } from 'ethers'
 import { OptimismEnv } from './shared/env'
+import { DEFAULT_TRANSACTION } from './shared/utils'
 import { getContractInterface } from '@eth-optimism/contracts'
 
 describe('ECDSAContractAccount', () => {
   let l2Wallet: Wallet
 
-  const DEFAULT_TRANSACTION = {
-    to: '0x' + '1234'.repeat(10),
-    gasLimit: 33600000000001,
-    gasPrice: 0,
-    data: '0x',
-    value: 0,
-  }
   before(async () => {
     const env = await OptimismEnv.new()
     l2Wallet = env.l2Wallet
   })
 
   let ProxyEOA: Contract
+  let messageHash: string
+  let signature: string
 
-  beforeEach(async () => {
+  before(async () => {
     // Send a transaction to ensure there is a ProxyEOA deployed at l2Wallet.address
     const result = await l2Wallet.sendTransaction(DEFAULT_TRANSACTION)
     await result.wait()
-  })
-
-  it('should correctly evaluate isValidSignature', async () => {
     ProxyEOA = new Contract(
       l2Wallet.address,
       getContractInterface('OVM_ECDSAContractAccount'),
       l2Wallet
     )
     const message = '0x42'
-    const messageHash = ethers.utils.hashMessage(message)
-    const signature = await l2Wallet.signMessage(message)
+    messageHash = ethers.utils.hashMessage(message)
+    signature = await l2Wallet.signMessage(message)
+  })
+
+  it('should correctly evaluate isValidSignature from this wallet', async () => {
     const isValid = await ProxyEOA.isValidSignature(messageHash, signature)
+    expect(isValid).to.equal('0x1626ba7e')
+  })
+
+  it('should correctly evaluate isValidSignature from other wallet', async () => {
+    const otherWallet = Wallet.createRandom().connect(l2Wallet.provider)
+    const isValid = await ProxyEOA.connect(otherWallet).isValidSignature(
+      messageHash,
+      signature
+    )
     expect(isValid).to.equal('0x1626ba7e')
   })
 })

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -7,7 +7,12 @@ import {
 import { Wallet, BigNumber, Contract, ContractFactory } from 'ethers'
 import { ethers } from 'hardhat'
 import chai, { expect } from 'chai'
-import { sleep, l2Provider, DEFAULT_TRANSACTION } from './shared/utils'
+import {
+  sleep,
+  l2Provider,
+  DEFAULT_TRANSACTION,
+  fundUser,
+} from './shared/utils'
 import chaiAsPromised from 'chai-as-promised'
 import { OptimismEnv } from './shared/env'
 import {

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -7,7 +7,7 @@ import {
 import { Wallet, BigNumber, Contract, ContractFactory } from 'ethers'
 import { ethers } from 'hardhat'
 import chai, { expect } from 'chai'
-import { sleep, l2Provider, l1Provider, fundUser } from './shared/utils'
+import { sleep, l2Provider, DEFAULT_TRANSACTION } from './shared/utils'
 import chaiAsPromised from 'chai-as-promised'
 import { OptimismEnv } from './shared/env'
 import {
@@ -21,14 +21,6 @@ chai.use(solidity)
 describe('Basic RPC tests', () => {
   let env: OptimismEnv
   let wallet: Wallet
-
-  const DEFAULT_TRANSACTION = {
-    to: '0x' + '1234'.repeat(10),
-    gasLimit: 33600000000001,
-    gasPrice: 0,
-    data: '0x',
-    value: 0,
-  }
 
   const provider = injectL2Context(l2Provider)
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -113,3 +113,11 @@ const abiCoder = new utils.AbiCoder()
 export const encodeSolidityRevertMessage = (_reason: string): string => {
   return '0x08c379a0' + remove0x(abiCoder.encode(['string'], [_reason]))
 }
+
+export const DEFAULT_TRANSACTION = {
+  to: '0x' + '1234'.repeat(10),
+  gasLimit: 33600000000001,
+  gasPrice: 0,
+  data: '0x',
+  value: 0,
+}

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
@@ -73,7 +73,7 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
             bytes4 magicValue
         )
     {
-        return ECDSA.recover(hash, signature) == msg.sender ?
+        return ECDSA.recover(hash, signature) == address(this) ?
             this.isValidSignature.selector :
             bytes4(0);
     }

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/accounts/OVM_ECDSAContractAccount.sol
@@ -15,6 +15,7 @@ import { OVM_ETH } from "../predeploys/OVM_ETH.sol";
 
 /* External Imports */
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { ECDSA } from "@openzeppelin/contracts/cryptography/ECDSA.sol";
 
 /**
  * @title OVM_ECDSAContractAccount
@@ -55,6 +56,26 @@ contract OVM_ECDSAContractAccount is iOVM_ECDSAContractAccount {
         payable
     {
         return;
+    }
+
+   /**
+    * @dev Should return whether the signature provided is valid for the provided data
+    * @param hash      Hash of the data to be signed
+    * @param signature Signature byte array associated with _data
+    */
+    function isValidSignature(
+        bytes32 hash,
+        bytes memory signature
+    )
+        public
+        view
+        returns (
+            bytes4 magicValue
+        )
+    {
+        return ECDSA.recover(hash, signature) == msg.sender ?
+            this.isValidSignature.selector :
+            bytes4(0);
     }
 
     /**

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -200,7 +200,7 @@ describe('OVM_ECDSAContractAccount', () => {
       )
     })
   })
-  
+
   describe('isValidSignature()', () => {
     const message = '0x42'
     const messageHash = ethers.utils.hashMessage(message)

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '../../../setup'
 
 /* External Imports */
 import { ethers, waffle } from 'hardhat'
-import { ContractFactory, Contract, Signer, BigNumber, utils } from 'ethers'
+import { ContractFactory, Contract, Wallet, BigNumber, utils } from 'ethers'
 import { MockContract, smockit } from '@eth-optimism/smock'
 import { toPlainObject } from 'lodash'
 
@@ -11,9 +11,10 @@ import { LibEIP155TxStruct, DEFAULT_EIP155_TX } from '../../../helpers'
 import { predeploys } from '../../../../src'
 
 describe('OVM_ECDSAContractAccount', () => {
-  let wallet: Signer
+  let wallet: Wallet
   before(async () => {
-    ;[wallet] = await ethers.getSigners()
+    const provider = waffle.provider
+    ;[wallet] = provider.getWallets()
   })
 
   let Mock__OVM_ExecutionManager: MockContract
@@ -188,7 +189,7 @@ describe('OVM_ECDSAContractAccount', () => {
     it(`should revert if trying call itself`, async () => {
       const transaction = {
         ...DEFAULT_EIP155_TX,
-        to: await wallet.getAddress(),
+        to: wallet.address,
       }
       const encodedTransaction = await wallet.signTransaction(transaction)
 

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -2,14 +2,13 @@ import { expect } from '../../../setup'
 
 /* External Imports */
 import { ethers, waffle } from 'hardhat'
-import { ContractFactory, Contract, Wallet, BigNumber } from 'ethers'
+import { ContractFactory, Contract, Wallet, BigNumber, utils } from 'ethers'
 import { MockContract, smockit } from '@eth-optimism/smock'
 import { toPlainObject } from 'lodash'
 
 /* Internal Imports */
 import { LibEIP155TxStruct, DEFAULT_EIP155_TX } from '../../../helpers'
 import { predeploys } from '../../../../src'
-import { keccak256 } from '@ethersproject/keccak256'
 
 describe('OVM_ECDSAContractAccount', () => {
   let wallet: Wallet
@@ -204,23 +203,20 @@ describe('OVM_ECDSAContractAccount', () => {
     // An integration test exists testing this instead
 
     it(`should revert for a malformed signature`, async () => {
-      const messageHash = keccak256('0x42')
-      let messageHashBinary = ethers.utils.arrayify(messageHash);
+      const messageHash = utils.keccak256('0x42')
       await expect(
-        OVM_ECDSAContractAccount.isValidSignature(messageHashBinary, '0xdeadbeef')
-      ).to.be.revertedWith(
-        'ECDSA: invalid signature length'
-      )
+        OVM_ECDSAContractAccount.isValidSignature(messageHash, '0xdeadbeef')
+      ).to.be.revertedWith('ECDSA: invalid signature length')
     })
 
     it(`should return 0 for an invalid signature`, async () => {
-      const messageHash = keccak256('0x42')
-      let messageHashBinary = ethers.utils.arrayify(messageHash);
-      const signature = await wallet.signMessage(messageHashBinary)
-      const bytes = await OVM_ECDSAContractAccount.isValidSignature(messageHashBinary, signature)
+      const messageHash = utils.keccak256('0x42')
+      const signature = await wallet.signMessage('0x42')
+      const bytes = await OVM_ECDSAContractAccount.isValidSignature(
+        messageHash,
+        signature
+      )
       expect(bytes).to.equal('0x00000000')
     })
   })
-
-
 })

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -198,11 +198,11 @@ describe('OVM_ECDSAContractAccount', () => {
       )
     })
   })
-
+  
   describe('isValidSignature()', () => {
     // NOTE: There is no good way to unit test verifying a valid signature
     // An integration test exists testing this instead
-    
+
     it(`should revert for a malformed signature`, async () => {
       const messageHash = keccak256('0x42')
       let messageHashBinary = ethers.utils.arrayify(messageHash);

--- a/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
+++ b/packages/contracts/test/contracts/OVM/accounts/OVM_ECDSAContractAccount.spec.ts
@@ -9,6 +9,7 @@ import { toPlainObject } from 'lodash'
 /* Internal Imports */
 import { LibEIP155TxStruct, DEFAULT_EIP155_TX } from '../../../helpers'
 import { predeploys } from '../../../../src'
+import { keccak256 } from '@ethersproject/keccak256'
 
 describe('OVM_ECDSAContractAccount', () => {
   let wallet: Wallet
@@ -197,4 +198,29 @@ describe('OVM_ECDSAContractAccount', () => {
       )
     })
   })
+
+  describe('isValidSignature()', () => {
+    // NOTE: There is no good way to unit test verifying a valid signature
+    // An integration test exists testing this instead
+    
+    it(`should revert for a malformed signature`, async () => {
+      const messageHash = keccak256('0x42')
+      let messageHashBinary = ethers.utils.arrayify(messageHash);
+      await expect(
+        OVM_ECDSAContractAccount.isValidSignature(messageHashBinary, '0xdeadbeef')
+      ).to.be.revertedWith(
+        'ECDSA: invalid signature length'
+      )
+    })
+
+    it(`should return 0 for an invalid signature`, async () => {
+      const messageHash = keccak256('0x42')
+      let messageHashBinary = ethers.utils.arrayify(messageHash);
+      const signature = await wallet.signMessage(messageHashBinary)
+      const bytes = await OVM_ECDSAContractAccount.isValidSignature(messageHashBinary, signature)
+      expect(bytes).to.equal('0x00000000')
+    })
+  })
+
+
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds ERC1271 support to default contract account implementation. Needed for Uniswap `permit` functionality

Fixes OP-839