### PR TITLE
Ensure Sentry is correctly set up for DTL and MR

### DIFF
--- a/.changeset/modern-chicken-listen.md
+++ b/.changeset/modern-chicken-listen.md
@@ -1,0 +1,8 @@
+---
+'@eth-optimism/batch-submitter': patch
+'@eth-optimism/common-ts': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Improve Sentry support, initializing as needed and ensuring ERROR logs route to Sentry

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -37,6 +37,7 @@
     "@eth-optimism/ynatm": "^0.2.2",
     "@ethersproject/abstract-provider": "^5.0.5",
     "@ethersproject/providers": "^5.0.14",
+    "@sentry/node": "^6.2.5",
     "bcfg": "^0.1.6",
     "bluebird": "^3.7.2",
     "dotenv": "^8.2.0",

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,5 +1,6 @@
 /* External Imports */
 import { injectL2Context, Bcfg } from '@eth-optimism/core-utils'
+import * as Sentry from '@sentry/node'
 import { Logger, Metrics, createMetricsServer } from '@eth-optimism/common-ts'
 import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
@@ -101,15 +102,17 @@ export const run = async () => {
   let logger
 
   if (config.bool('use-sentry', env.USE_SENTRY === 'true')) {
+    const sentryOptions = {
+      release,
+      dsn: sentryDsn,
+      tracesSampleRate: sentryTraceRate,
+      environment: network,
+    }
+    Sentry.init(sentryOptions)
     // Initialize Sentry for Batch Submitter deployed to a network
     logger = new Logger({
       name,
-      sentryOptions: {
-        release,
-        dsn: sentryDsn,
-        tracesSampleRate: sentryTraceRate,
-        environment: network,
-      },
+      sentryOptions,
     })
   } else {
     // Skip initializing Sentry

--- a/packages/common-ts/src/base-service.ts
+++ b/packages/common-ts/src/base-service.ts
@@ -26,12 +26,18 @@ export class BaseService<T> {
   protected initialized: boolean = false
   protected running: boolean = false
 
-  constructor(name: string, options: BaseServiceOptions<T>, optionSettings: OptionSettings<T>) {
+  constructor(
+    name: string,
+    options: BaseServiceOptions<T>,
+    optionSettings: OptionSettings<T>
+  ) {
     validateOptions(options, optionSettings)
     this.name = name
     this.options = mergeDefaultOptions(options, optionSettings)
     this.logger = options.logger || new Logger({ name })
-    if (options.metrics) this.metrics = options.metrics
+    if (options.metrics) {
+      this.metrics = options.metrics
+    }
   }
 
   /**

--- a/packages/common-ts/src/base-service.ts
+++ b/packages/common-ts/src/base-service.ts
@@ -9,6 +9,11 @@ type OptionSettings<TOptions> = {
   }
 }
 
+type BaseServiceOptions<T> = T & {
+  logger?: Logger
+  metrics?: Metrics
+}
+
 /**
  * Base for other "Service" objects. Handles your standard initialization process, can dynamically
  * start and stop.
@@ -21,11 +26,12 @@ export class BaseService<T> {
   protected initialized: boolean = false
   protected running: boolean = false
 
-  constructor(name: string, options: T, optionSettings: OptionSettings<T>) {
+  constructor(name: string, options: BaseServiceOptions<T>, optionSettings: OptionSettings<T>) {
     validateOptions(options, optionSettings)
     this.name = name
     this.options = mergeDefaultOptions(options, optionSettings)
-    this.logger = new Logger({ name })
+    this.logger = options.logger || new Logger({ name })
+    if (options.metrics) this.metrics = options.metrics
   }
 
   /**

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -1,5 +1,5 @@
 /* Imports: External */
-import { BaseService } from '@eth-optimism/common-ts'
+import { BaseService, Logger } from '@eth-optimism/common-ts'
 import { LevelUp } from 'levelup'
 import level from 'level'
 

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -1,5 +1,5 @@
 /* Imports: External */
-import { BaseService, Metrics } from '@eth-optimism/common-ts'
+import { BaseService, Logger, Metrics } from '@eth-optimism/common-ts'
 import express, { Request, Response } from 'express'
 import promBundle from 'express-prom-bundle'
 import cors from 'cors'
@@ -125,10 +125,17 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
    * Initialize Sentry and related middleware
    */
   private _initSentry() {
-    Sentry.init({
+    const sentryOptions = {
       dsn: this.options.sentryDsn,
       release: this.options.release,
       environment: this.options.ethNetworkName,
+    }
+    this.logger = new Logger({
+      name: this.name,
+      sentryOptions,
+    })
+    Sentry.init({
+      ...sentryOptions,
       integrations: [
         new Sentry.Integrations.Http({ tracing: true }),
         new Tracing.Integrations.Express({

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -32,6 +32,7 @@
     "@eth-optimism/common-ts": "^0.1.2",
     "@eth-optimism/contracts": "^0.3.5",
     "@eth-optimism/core-utils": "^0.4.5",
+    "@sentry/node": "6.2.5",
     "bcfg": "^0.1.6",
     "dotenv": "^8.2.0",
     "ethers": "^5.1.0",

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -17,8 +17,8 @@ const main = async () => {
 
   const env = process.env
 
-  const SENTRY_DSN = config.str('use-sentry', env.SENTRY_DSN)
-  const USE_SENTRY = config.str('sentry-dsn', env.USE_SENTRY)
+  const SENTRY_DSN = config.str('sentry-dsn', env.SENTRY_DSN)
+  const USE_SENTRY = config.bool('use-sentry', env.USE_SENTRY === 'true')
   const ETH_NETWORK_NAME = config.str('eth-network-name', env.ETH_NETWORK_NAME)
 
   let loggerOptions = {

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -2,6 +2,7 @@ import { Wallet, providers } from 'ethers'
 import { MessageRelayerService } from '../service'
 import { Bcfg } from '@eth-optimism/core-utils'
 import { Logger } from '@eth-optimism/common-ts'
+import * as Sentry from '@sentry/node'
 import * as dotenv from 'dotenv'
 import Config from 'bcfg'
 
@@ -19,6 +20,16 @@ const main = async () => {
   const SENTRY_DSN = config.str('use-sentry', env.SENTRY_DSN)
   const USE_SENTRY = config.str('sentry-dsn', env.USE_SENTRY)
   const ETH_NETWORK_NAME = config.str('eth-network-name', env.ETH_NETWORK_NAME)
+
+  const sentryOptions = {
+    release: `message-relayer@${process.env.npm_package_version}`,
+    dsn: SENTRY_DSN,
+    environment: ETH_NETWORK_NAME,
+  }
+
+  if (USE_SENTRY) {
+    Sentry.init(sentryOptions)
+  }
 
   const L2_NODE_WEB3_URL = config.str('l2-node-web3-url', env.L2_NODE_WEB3_URL)
   const L1_NODE_WEB3_URL = config.str('l1-node-web3-url', env.L1_NODE_WEB3_URL)
@@ -89,14 +100,7 @@ const main = async () => {
     l1StartOffset: L1_START_OFFSET,
     getLogsInterval: GET_LOGS_INTERVAL,
     logger: USE_SENTRY
-      ? new Logger({
-          name: 'Message_Relayer',
-          sentryOptions: {
-            release: `message-relayer@${process.env.npm_package_version}`,
-            dsn: SENTRY_DSN,
-            environment: ETH_NETWORK_NAME,
-          },
-        })
+      ? new Logger({ name: 'Message_Relayer', sentryOptions })
       : undefined,
   })
 

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -21,15 +21,21 @@ const main = async () => {
   const USE_SENTRY = config.str('sentry-dsn', env.USE_SENTRY)
   const ETH_NETWORK_NAME = config.str('eth-network-name', env.ETH_NETWORK_NAME)
 
-  const sentryOptions = {
-    release: `message-relayer@${process.env.npm_package_version}`,
-    dsn: SENTRY_DSN,
-    environment: ETH_NETWORK_NAME,
+  let loggerOptions = {
+    name: 'Message_Relayer',
   }
 
   if (USE_SENTRY) {
+    const sentryOptions = {
+      release: `message-relayer@${process.env.npm_package_version}`,
+      dsn: SENTRY_DSN,
+      environment: ETH_NETWORK_NAME,
+    }
+    loggerOptions['sentryOptions'] = sentryOptions
     Sentry.init(sentryOptions)
   }
+
+  const logger = new Logger(loggerOptions)
 
   const L2_NODE_WEB3_URL = config.str('l2-node-web3-url', env.L2_NODE_WEB3_URL)
   const L1_NODE_WEB3_URL = config.str('l1-node-web3-url', env.L1_NODE_WEB3_URL)
@@ -99,9 +105,7 @@ const main = async () => {
     l2BlockOffset: L2_BLOCK_OFFSET,
     l1StartOffset: L1_START_OFFSET,
     getLogsInterval: GET_LOGS_INTERVAL,
-    logger: USE_SENTRY
-      ? new Logger({ name: 'Message_Relayer', sentryOptions })
-      : undefined,
+    logger,
   })
 
   await service.start()

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -1,7 +1,7 @@
 import { Wallet, providers } from 'ethers'
 import { MessageRelayerService } from '../service'
 import { Bcfg } from '@eth-optimism/core-utils'
-import { Logger } from '@eth-optimism/common-ts'
+import { Logger, LoggerOptions } from '@eth-optimism/common-ts'
 import * as Sentry from '@sentry/node'
 import * as dotenv from 'dotenv'
 import Config from 'bcfg'
@@ -21,7 +21,7 @@ const main = async () => {
   const USE_SENTRY = config.bool('use-sentry', env.USE_SENTRY === 'true')
   const ETH_NETWORK_NAME = config.str('eth-network-name', env.ETH_NETWORK_NAME)
 
-  let loggerOptions = {
+  let loggerOptions: LoggerOptions = {
     name: 'Message_Relayer',
   }
 
@@ -31,7 +31,7 @@ const main = async () => {
       dsn: SENTRY_DSN,
       environment: ETH_NETWORK_NAME,
     }
-    loggerOptions['sentryOptions'] = sentryOptions
+    loggerOptions.sentryOptions = sentryOptions
     Sentry.init(sentryOptions)
   }
 

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -1,6 +1,7 @@
 import { Wallet, providers } from 'ethers'
 import { MessageRelayerService } from '../service'
 import { Bcfg } from '@eth-optimism/core-utils'
+import { Logger } from '@eth-optimism/common-ts'
 import * as dotenv from 'dotenv'
 import Config from 'bcfg'
 
@@ -14,6 +15,11 @@ const main = async () => {
   })
 
   const env = process.env
+
+  const SENTRY_DSN = config.str('use-sentry', env.SENTRY_DSN)
+  const USE_SENTRY = config.str('sentry-dsn', env.USE_SENTRY)
+  const ETH_NETWORK_NAME = config.str('eth-network-name', env.ETH_NETWORK_NAME)
+
   const L2_NODE_WEB3_URL = config.str('l2-node-web3-url', env.L2_NODE_WEB3_URL)
   const L1_NODE_WEB3_URL = config.str('l1-node-web3-url', env.L1_NODE_WEB3_URL)
   const ADDRESS_MANAGER_ADDRESS = config.str(
@@ -82,6 +88,16 @@ const main = async () => {
     l2BlockOffset: L2_BLOCK_OFFSET,
     l1StartOffset: L1_START_OFFSET,
     getLogsInterval: GET_LOGS_INTERVAL,
+    logger: USE_SENTRY
+      ? new Logger({
+          name: 'Message_Relayer',
+          sentryOptions: {
+            release: `message-relayer@${process.env.npm_package_version}`,
+            dsn: SENTRY_DSN,
+            environment: ETH_NETWORK_NAME,
+          },
+        })
+      : undefined,
   })
 
   await service.start()

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -21,7 +21,7 @@ const main = async () => {
   const USE_SENTRY = config.bool('use-sentry', env.USE_SENTRY === 'true')
   const ETH_NETWORK_NAME = config.str('eth-network-name', env.ETH_NETWORK_NAME)
 
-  let loggerOptions: LoggerOptions = {
+  const loggerOptions: LoggerOptions = {
     name: 'Message_Relayer',
   }
 

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -5,7 +5,7 @@ import { MerkleTree } from 'merkletreejs'
 
 /* Imports: Internal */
 import { fromHexString, sleep } from '@eth-optimism/core-utils'
-import { BaseService } from '@eth-optimism/common-ts'
+import { Logger, BaseService, Metrics } from '@eth-optimism/common-ts'
 
 import { loadContract, loadContractFromManager } from '@eth-optimism/contracts'
 import { StateRootBatchHeader, SentMessage, SentMessageProof } from './types'
@@ -40,6 +40,12 @@ interface MessageRelayerOptions {
 
   // Number of blocks within each getLogs query - max is 2000
   getLogsInterval?: number
+
+  // A custom logger to transport logs via; default STDOUT
+  logger?: Logger
+
+  // A custom metrics tracker to manage metrics; default undefined
+  metrics?: Metrics
 }
 
 const optionSettings = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,6 +1958,21 @@
     "@sentry/types" "6.6.0"
     tslib "^1.9.3"
 
+"@sentry/node@6.2.5", "@sentry/node@^6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.2.5.tgz#6e6694c0c3ce6ca231710f40da0cac7fd5c645ef"
+  integrity sha512-/iM3khzGnUH713VFhZBAEYJhb/saEQSVz7Udogml+O7mFQ4rutnwJhgoGcB9YYrwMv2m7qOSszkdZbemDV6k2g==
+  dependencies:
+    "@sentry/core" "6.2.5"
+    "@sentry/hub" "6.2.5"
+    "@sentry/tracing" "6.2.5"
+    "@sentry/types" "6.2.5"
+    "@sentry/utils" "6.2.5"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
 "@sentry/node@^5.18.1":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.30.0.tgz#4ca479e799b1021285d7fe12ac0858951c11cd48"
@@ -1968,21 +1983,6 @@
     "@sentry/tracing" "5.30.0"
     "@sentry/types" "5.30.0"
     "@sentry/utils" "5.30.0"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^1.9.3"
-
-"@sentry/node@^6.2.5":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.2.5.tgz#6e6694c0c3ce6ca231710f40da0cac7fd5c645ef"
-  integrity sha512-/iM3khzGnUH713VFhZBAEYJhb/saEQSVz7Udogml+O7mFQ4rutnwJhgoGcB9YYrwMv2m7qOSszkdZbemDV6k2g==
-  dependencies:
-    "@sentry/core" "6.2.5"
-    "@sentry/hub" "6.2.5"
-    "@sentry/tracing" "6.2.5"
-    "@sentry/types" "6.2.5"
-    "@sentry/utils" "6.2.5"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,15 +1875,15 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
-"@sentry/core@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.3.5.tgz#6b73de736eb9d0040be94cdbb06a744cd6b9172e"
-  integrity sha512-VR2ibDy33mryD0mT6d9fGhKjdNzS2FSwwZPe9GvmNOjkyjly/oV91BKVoYJneCqOeq8fyj2lvkJGKuupdJNDqg==
+"@sentry/core@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.6.0.tgz#51661d2dd5023d6cd07467422de1854282ced7e5"
+  integrity sha512-EjdeT6paAdxAZgfsVCB8wneahQF3nAUt9GxOJxaOBUv8BSc3HQ/svcTU3RU7k8YsP26PseEOIsedaxsEVZ+7og==
   dependencies:
-    "@sentry/hub" "6.3.5"
-    "@sentry/minimal" "6.3.5"
-    "@sentry/types" "6.3.5"
-    "@sentry/utils" "6.3.5"
+    "@sentry/hub" "6.6.0"
+    "@sentry/minimal" "6.6.0"
+    "@sentry/types" "6.6.0"
+    "@sentry/utils" "6.6.0"
     tslib "^1.9.3"
 
 "@sentry/hub@5.30.0":
@@ -1913,13 +1913,13 @@
     "@sentry/utils" "6.3.1"
     tslib "^1.9.3"
 
-"@sentry/hub@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.3.5.tgz#c5bc6760f7e4e53e87149703b106804299060389"
-  integrity sha512-ZYFo7VYKwdPVjuV9BDFiYn+MpANn6eZMz5QDBfZ2dugIvIVbuOyOOLx8PSa3ZXJoVTZZ7s2wD2fi/ZxKjNjZOQ==
+"@sentry/hub@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.6.0.tgz#1b9fa22ee104b7d6afd2dc4c40a1459fda259366"
+  integrity sha512-1Yw0kbxcvO7njZUDGvCKB6DxU5jQio7Be3Kx5qxwcx8ojpT9lo9p+IYZajgl6zQqkjjbVm/4SoYqU24ozu5vxw==
   dependencies:
-    "@sentry/types" "6.3.5"
-    "@sentry/utils" "6.3.5"
+    "@sentry/types" "6.6.0"
+    "@sentry/utils" "6.6.0"
     tslib "^1.9.3"
 
 "@sentry/minimal@5.30.0":
@@ -1949,13 +1949,13 @@
     "@sentry/types" "6.3.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.3.5.tgz#ef4894771243d01d81e91819400d2ecdcb34b411"
-  integrity sha512-4RqIGAU0+8iI/1sw0GYPTr4SUA88/i2+JPjFJ+qloh5ANVaNwhFPRChw+Ys9xpre8LV9JZrEsEf8AvQr4fkNbA==
+"@sentry/minimal@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.6.0.tgz#48684734e3c380e5e63a9357d05f0c18bae84419"
+  integrity sha512-xVBlZIDxSvHvNdvD5KmjTf8Xgi78vLpT4xqJaDUkW7B+DqWMVJZe5aUdQmcp7X/zWxctBwyMKsdHO7oiHkpS+Q==
   dependencies:
-    "@sentry/hub" "6.3.5"
-    "@sentry/types" "6.3.5"
+    "@sentry/hub" "6.6.0"
+    "@sentry/types" "6.6.0"
     tslib "^1.9.3"
 
 "@sentry/node@^5.18.1":
@@ -1989,15 +1989,15 @@
     tslib "^1.9.3"
 
 "@sentry/node@^6.3.1":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.3.5.tgz#d5cbf941d0a4caf7b8e644d71cc6b463eeda214e"
-  integrity sha512-scPB+DoAEPaqkYuyb8d/gVWbFmX5PhaYSNHybeHncaP/P4itLdq/AoAWGNxl0Hj4EQokfT4OZWxaaJi7SCYnaw==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.6.0.tgz#e535e1e679cf894752810529ffdee93cbfd078f0"
+  integrity sha512-heKie/AOanYq3mCsKR1igPn1sUIxBmGibBp79Xc0iSAgliPKnnLkqUjvAIKu6mcevL9UOUhpMDLzhilkaG+bAA==
   dependencies:
-    "@sentry/core" "6.3.5"
-    "@sentry/hub" "6.3.5"
-    "@sentry/tracing" "6.3.5"
-    "@sentry/types" "6.3.5"
-    "@sentry/utils" "6.3.5"
+    "@sentry/core" "6.6.0"
+    "@sentry/hub" "6.6.0"
+    "@sentry/tracing" "6.6.0"
+    "@sentry/types" "6.6.0"
+    "@sentry/utils" "6.6.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
@@ -2025,15 +2025,15 @@
     "@sentry/utils" "6.2.5"
     tslib "^1.9.3"
 
-"@sentry/tracing@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.3.5.tgz#f76c362159141f860081ec7df80aa9f85b545860"
-  integrity sha512-TNKAST1ge2g24BlTfVxNp4gP5t3drbi0OVCh8h8ah+J7UjHSfdiqhd9W2h5qv1GO61gGlpWeN/TyioyQmOxu0Q==
+"@sentry/tracing@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.6.0.tgz#ce62fcb951faa6447cf47889f91efe3617b9eed2"
+  integrity sha512-tjXrmAOFfVBfx+ZmgE5bkpDPs/euNj0xrUg8MowCWGfCRn01W679tTb+dyNeP6faxQTo2RcaD68xD8oLroJwwA==
   dependencies:
-    "@sentry/hub" "6.3.5"
-    "@sentry/minimal" "6.3.5"
-    "@sentry/types" "6.3.5"
-    "@sentry/utils" "6.3.5"
+    "@sentry/hub" "6.6.0"
+    "@sentry/minimal" "6.6.0"
+    "@sentry/types" "6.6.0"
+    "@sentry/utils" "6.6.0"
     tslib "^1.9.3"
 
 "@sentry/tracing@^6.3.1":
@@ -2062,10 +2062,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.3.1.tgz#af3b54728b29f633f38fbe51b8c10e3834fbc158"
   integrity sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw==
 
-"@sentry/types@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.3.5.tgz#d5eca7e76c250882ab78c01a8df894a9a9ca537d"
-  integrity sha512-tY/3pkAmGYJ3F0BtwInsdt/uclNvF8aNG7XHsTPQNzk7BkNVWjCXx0sjxi6CILirl5nwNxYxVeTr2ZYAEZ/dSQ==
+"@sentry/types@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.6.0.tgz#55cbca23859bad87411f0f32135a968e6e40a639"
+  integrity sha512-lZ1uFN0lSNftAohi0lciEoSL58Gk/Ib1lLKaj0FSOvB1PAUmvo5dPtLdd0qjtNdtoaM8zqhrAbwCTQ8XZCDRsg==
 
 "@sentry/utils@5.30.0":
   version "5.30.0"
@@ -2091,12 +2091,12 @@
     "@sentry/types" "6.3.1"
     tslib "^1.9.3"
 
-"@sentry/utils@6.3.5":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.3.5.tgz#a4805448cb0314d3d119688162aa695598a10bbb"
-  integrity sha512-kHUcZ37QYlNzz7c9LVdApITXHaNmQK7+sw/If3M/qpff1fd5XoecA8laLfcYuz+Cw5mRhVmdhPcCRM3Xi1IGXg==
+"@sentry/utils@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.6.0.tgz#b34d342d05eefc25b7ddd3f27f41c050f1e7e1ef"
+  integrity sha512-FK9yqz2x+ef50B54tueeJ6mfb7Pf3lN75omx/YQBDL5cicyOV4j4kJDqn8/VKYhcSuX+ZaCZ/8bvOf0lxe0aHg==
   dependencies:
-    "@sentry/types" "6.3.5"
+    "@sentry/types" "6.6.0"
     tslib "^1.9.3"
 
 "@sindresorhus/is@^0.14.0":


### PR DESCRIPTION
Three problems:
- The BaseService did not create `pino-sentry` friendly loggers by default
- The MessageRelayer was not configured to use Sentry at all
- The DTL was using STDOUT for logging errors, explaining their absence in Sentry

Three refactors:
- refactor: add logger and metrics to options for BaseService
- refactor: thread sentryOptions through from message-relayer into BaseService
- refactor: ensure DTL Logger is using Sentry for errors

Fixes OP-857
Fixes OP-856