### PR TITLE
l2geth: bump to go 1.15

### DIFF
--- a/.changeset/grumpy-spiders-yell.md
+++ b/.changeset/grumpy-spiders-yell.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Bump golang version to 1.15

--- a/l2geth/go.mod
+++ b/l2geth/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum/go-ethereum
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.2 // indirect

--- a/ops/docker/Dockerfile.geth
+++ b/ops/docker/Dockerfile.geth
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.14-alpine as builder
+FROM golang:1.15-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Bumps the version of go used by l2geth to 1.15. This is the same version of go that upstream is using, see https://github.com/ethereum/go-ethereum/blob/master/go.mod


