### PR TITLE
feat[contracts]: slightly better account funding for hardhat accounts (rebased)

### DIFF
--- a/.changeset/poor-owls-wash.md
+++ b/.changeset/poor-owls-wash.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Adds a temporary way to fund hardhat accounts when testing locally

--- a/packages/contracts/deploy/014-OVM_L1MultiMessageRelayer.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1MultiMessageRelayer.deploy.ts
@@ -30,7 +30,7 @@ const deployFn: DeployFunction = async (hre) => {
     await registerAddress({
       hre,
       name: 'OVM_L2MessageRelayer',
-      address: OVM_L1MultiMessageRelayer.address
+      address: OVM_L1MultiMessageRelayer.address,
     })
   }
 }

--- a/packages/contracts/deploy/018-fund-accounts.ts
+++ b/packages/contracts/deploy/018-fund-accounts.ts
@@ -25,9 +25,11 @@ const deployFn: DeployFunction = async (hre) => {
       }
     )
 
+    // Default has 20 accounts but we restrict to 20 accounts manually as well just to prevent
+    // future problems if the number of default accounts increases for whatever reason.
     const accounts = normalizeHardhatNetworkAccountsConfig(
       defaultHardhatNetworkHdAccountsConfigParams
-    )
+    ).slice(0, 20)
 
     // Fund the accounts in parallel to speed things up.
     await Promise.all(

--- a/packages/contracts/deploy/018-fund-accounts.ts
+++ b/packages/contracts/deploy/018-fund-accounts.ts
@@ -1,4 +1,5 @@
 /* Imports: External */
+import { sleep } from '@eth-optimism/core-utils'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   defaultHardhatNetworkHdAccountsConfigParams,
@@ -30,7 +31,11 @@ const deployFn: DeployFunction = async (hre) => {
 
     // Fund the accounts in parallel to speed things up.
     await Promise.all(
-      accounts.map(async (account) => {
+      accounts.map(async (account, index) => {
+        // Add a sleep here to avoid any potential issues with spamming hardhat. Not sure if this
+        // is strictly necessary but it can't hurt.
+        await sleep(100 * index)
+
         const wallet = new hre.ethers.Wallet(
           account.privateKey,
           hre.ethers.provider

--- a/packages/contracts/deploy/018-fund-accounts.ts
+++ b/packages/contracts/deploy/018-fund-accounts.ts
@@ -34,7 +34,7 @@ const deployFn: DeployFunction = async (hre) => {
       accounts.map(async (account, index) => {
         // Add a sleep here to avoid any potential issues with spamming hardhat. Not sure if this
         // is strictly necessary but it can't hurt.
-        await sleep(100 * index)
+        await sleep(200 * index)
 
         const wallet = new hre.ethers.Wallet(
           account.privateKey,
@@ -42,14 +42,10 @@ const deployFn: DeployFunction = async (hre) => {
         )
         const balance = await wallet.getBalance()
         const depositAmount = balance.div(2) // Deposit half of the wallet's balance into L2.
-        await Proxy__OVM_L1ETHGateway.connect(wallet).depositTo(
-          wallet.address,
-          8_000_000,
-          '0x',
-          {
-            value: depositAmount,
-          }
-        )
+        await Proxy__OVM_L1ETHGateway.connect(wallet).deposit(8_000_000, '0x', {
+          value: depositAmount,
+          gasLimit: 2_000_000, // Idk, gas estimation was broken and this fixes it.
+        })
         console.log(
           `✓ Funded ${wallet.address} on L2 with ${hre.ethers.utils.formatEther(
             depositAmount

--- a/packages/contracts/deploy/018-fund-accounts.ts
+++ b/packages/contracts/deploy/018-fund-accounts.ts
@@ -1,0 +1,61 @@
+/* Imports: External */
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+import {
+  defaultHardhatNetworkHdAccountsConfigParams,
+  defaultHardhatNetworkParams,
+} from 'hardhat/internal/core/config/default-config'
+import { normalizeHardhatNetworkAccountsConfig } from 'hardhat/internal/core/providers/util'
+
+/* Imports: Internal */
+import { getDeployedContract } from '../src/hardhat-deploy-ethers'
+
+// This is a TEMPORARY way to fund the default hardhat accounts on L2. The better way to do this is
+// to make a modification to hardhat-ovm. However, I don't have the time right now to figure the
+// details of how to make that work cleanly. This is fine in the meantime.
+const deployFn: DeployFunction = async (hre) => {
+  // Only execute this step if we're on the hardhat chain ID.
+  const { chainId } = await hre.ethers.provider.getNetwork()
+  if (chainId === defaultHardhatNetworkParams.chainId) {
+    const Proxy__OVM_L1ETHGateway = await getDeployedContract(
+      hre,
+      'Proxy__OVM_L1ETHGateway',
+      {
+        iface: 'OVM_L1ETHGateway',
+      }
+    )
+
+    const accounts = normalizeHardhatNetworkAccountsConfig(
+      defaultHardhatNetworkHdAccountsConfigParams
+    )
+
+    // Fund the accounts in parallel to speed things up.
+    await Promise.all(
+      accounts.map(async (account) => {
+        const wallet = new hre.ethers.Wallet(
+          account.privateKey,
+          hre.ethers.provider
+        )
+        const balance = await wallet.getBalance()
+        const depositAmount = balance.div(2) // Deposit half of the wallet's balance into L2.
+        await Proxy__OVM_L1ETHGateway.connect(wallet).depositTo(
+          wallet.address,
+          8_000_000,
+          '0x',
+          {
+            value: depositAmount,
+          }
+        )
+        console.log(
+          `✓ Funded ${wallet.address} on L2 with ${hre.ethers.utils.formatEther(
+            depositAmount
+          )} ETH`
+        )
+      })
+    )
+  }
+}
+
+deployFn.dependencies = ['Proxy__OVM_L1ETHGateway']
+deployFn.tags = ['fund-accounts']
+
+export default deployFn

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -37,7 +37,7 @@
     "posttest:slither": "rm -f @openzeppelin && rm -f @ens && rm -f hardhat",
     "lint": "yarn lint:fix && yarn lint:check",
     "lint:fix": "yarn run lint:fix:typescript",
-    "lint:fix:typescript": "prettier --config .prettierrc.json --write \"hardhat.config.ts\" \"{src,test}/**/*.ts\"",
+    "lint:fix:typescript": "prettier --config .prettierrc.json --write \"hardhat.config.ts\" \"{src,test,deploy}/**/*.ts\"",
     "lint:check": "yarn run lint:typescript",
     "lint:typescript": "tslint --format stylish --project .",
     "clean": "rm -rf ./dist ./artifacts ./artifacts-ovm ./cache ./cache-ovm ./tsconfig.build.tsbuildinfo",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Slightly improves the funding mechanism by (1) making it parallel and (2) making it always fund the default hardhat accounts instead of funding whichever accounts are present in the config.

Cherry-picked @smartcontracts work from https://github.com/ethereum-optimism/optimism/pull/1056