### PR TITLE
fix: monotonicity auto healer

### DIFF
--- a/.changeset/slimy-snails-roll.md
+++ b/.changeset/slimy-snails-roll.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Fix a bug in fixMonotonicity auto healer

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -569,12 +569,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
             oldBlockNumber: ele.blockNumber,
             newBlockNumber: earliestBlockNumber,
           })
-          fixedBatch.push({
-            ...ele,
-            timestamp: earliestTimestamp,
-            blockNumber: earliestBlockNumber,
-          })
-          continue
+          ele.timestamp = earliestTimestamp
+          ele.blockNumber = earliestBlockNumber
         }
         // Fix the element if its timestammp/blockNumber is too large
         if (
@@ -587,14 +583,11 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
             oldBlockNumber: ele.blockNumber,
             newBlockNumber: latestBlockNumber,
           })
-          fixedBatch.push({
-            ...ele,
-            timestamp: latestTimestamp,
-            blockNumber: latestBlockNumber,
-          })
-          continue
+          ele.timestamp = latestTimestamp
+          ele.blockNumber = latestBlockNumber
         }
-        // No fixes needed!
+        earliestTimestamp = ele.timestamp
+        earliestBlockNumber = ele.blockNumber
         fixedBatch.push(ele)
       }
       return fixedBatch


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fix a bug in the fixMonotonicity auto healer. The bug was: when we increase a block's timestamp to fix a monotonicity violation, we did not update the `earliestTimestamp` to be AT MINIMUM the timestamp that we just used. This caused the SUBSEQUENT block to fail with a monotonicity violation.

To address this I simplified the logic we use to heal the timestamps & also updated the earliest timestamp to be AT LEAST the timestamp we just set the block to.