### PR TITLE
fix: comment out CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,18 @@
-l2geth/                             @smartcontracts @tynes @karlfloersch
-packages/specs/l2geth/              @smartcontracts @tynes @karlfloersch
-packages/contracts/                 @smartcontracts @ben-chain @maurelian @elenadimitrova
-packages/specs/protocol/            @smartcontracts @ben-chain @maurelian
-ops/                                @tynes @karlfloersch
-packages/hardhat-ovm/               @smartcontracts
-packages/smock/                     @smartcontracts @maurelian
-packages/core-utils/                @smartcontracts @annieke @ben-chain
-packages/common-ts/                 @annieke
-packages/core-utils/src/watcher.ts  @K-Ho
-packages/message-relayer/           @K-Ho
-packages/batch-submitter/           @annieke @karlfloersch
-packages/data-transport-layer/      @annieke
-integration-tests/                  @tynes
+# CODEOWNERS can be disruptive because it automatically requests review from individuals across the
+# board. We still like to use this file to track who's working on what, but all lines are commented
+# out so that GitHub won't trigger review requests.
+
+# l2geth/                             @smartcontracts @tynes @karlfloersch
+# packages/specs/l2geth/              @smartcontracts @tynes @karlfloersch
+# packages/contracts/                 @smartcontracts @ben-chain @maurelian @elenadimitrova
+# packages/specs/protocol/            @smartcontracts @ben-chain @maurelian
+# ops/                                @tynes @karlfloersch
+# packages/hardhat-ovm/               @smartcontracts
+# packages/smock/                     @smartcontracts @maurelian
+# packages/core-utils/                @smartcontracts @annieke @ben-chain
+# packages/common-ts/                 @annieke
+# packages/core-utils/src/watcher.ts  @K-Ho
+# packages/message-relayer/           @K-Ho
+# packages/batch-submitter/           @annieke @karlfloersch
+# packages/data-transport-layer/      @annieke
+# integration-tests/                  @tynes


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Comments out CODEOWNERS so we don't get automatic review requests anymore but can still track who's responsible for what.
