### PR TITLE
 Log 'end of OVM execution' correctly

### DIFF
--- a/.changeset/ten-pumas-perform.md
+++ b/.changeset/ten-pumas-perform.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Correctly log 'end of OVM execution' message.

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -464,10 +464,9 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 					ret = []byte{}
 				}
 			}
-		}
-
-		if evm.Context.EthCallSender == nil {
-			log.Debug("Reached the end of an OVM execution", "ID", evm.Id, "Return Data", hexutil.Encode(ret), "Error", err)
+			if evm.Context.EthCallSender == nil {
+				log.Debug("Reached the end of an OVM execution", "ID", evm.Id, "Return Data", hexutil.Encode(ret), "Error", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
**Description**

Currently, Geth logs this statement "`Reached the end of an OVM execution`" a the end of every EVM `CALL`, which is far too noisy, and pretty meaningless for debugging.

This PR changes this log to occur only at the end of an OVM transaction, which I understand to be the original intent. H/T to @smartcontracts for showing me the fix, I'm just submitting. 

Here is an [image](https://user-images.githubusercontent.com/23033765/121917811-75ce9180-cd03-11eb-802d-2fb4f02636eb.png) of the logs after the change tested locally on my machine. Once the integration tests complete for this PR, you should also be able to see them in the `logs.tgz` file attached. 

Compare that to the logs [ops_l2geth_1.log](https://github.com/ethereum-optimism/optimism/files/6649521/ops_l2geth_1.log) taken from another PR, where `Reached the end of an OVM execution` appears 15,031 times.
