### PR TITLE
fix[l2geth]: off-by-one sometimes breaking replica sync

### DIFF
--- a/.changeset/lazy-toes-teach.md
+++ b/.changeset/lazy-toes-teach.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fixes an off-by-one error that would sometimes break replica syncing when stopping and restarting geth.

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -196,7 +196,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		unconfirmed:        newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
 		pendingTasks:       make(map[common.Hash]*task),
 		txsCh:              make(chan core.NewTxsEvent, txChanSize),
-		rollupCh:           make(chan core.NewTxsEvent, txChanSize),
+		rollupCh:           make(chan core.NewTxsEvent, 1),
 		chainHeadCh:        make(chan core.ChainHeadEvent, chainHeadChanSize),
 		chainSideCh:        make(chan core.ChainSideEvent, chainSideChanSize),
 		newWorkCh:          make(chan *newWorkReq),

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -243,21 +243,22 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 		s.SetLatestL1Timestamp(context.Timestamp)
 		s.SetLatestL1BlockNumber(context.BlockNumber)
 	} else {
-		// Prevent underflows
-		if *index != 0 {
-			*index = *index - 1
-		}
 		log.Info("Found latest index", "index", *index)
-		block := s.bc.GetBlockByNumber(*index)
+		block := s.bc.GetBlockByNumber(*index + 1)
 		if block == nil {
 			block = s.bc.CurrentBlock()
-			idx := block.Number().Uint64()
-			if idx > *index {
+			blockNum := block.Number().Uint64()
+			if blockNum > *index {
 				// This is recoverable with a reorg but should never happen
 				return fmt.Errorf("Current block height greater than index")
 			}
-			s.SetLatestIndex(&idx)
-			log.Info("Block not found, resetting index", "new", idx, "old", *index)
+			var idx *uint64
+			if blockNum > 0 {
+				num := blockNum - 1
+				idx = &num
+			}
+			s.SetLatestIndex(idx)
+			log.Info("Block not found, resetting index", "new", stringify(idx), "old", *index)
 		}
 		txs := block.Transactions()
 		if len(txs) != 1 {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes an off-by-one (actually off-by-two but whatever) error that was breaking replica sync when geth was stopped and restarted. We've tested with hard and soft stops and seems to be working fine now.