### PR TITLE
integration-tests: add tracetransaction simple test

### DIFF
--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -15,6 +15,8 @@ import {
   TransactionRequest,
 } from '@ethersproject/providers'
 import { solidity } from 'ethereum-waffle'
+import axios from 'axios'
+
 chai.use(chaiAsPromised)
 chai.use(solidity)
 
@@ -402,5 +404,24 @@ describe('Basic RPC tests', () => {
       await expect(provider.send('eth_estimateGas', [revertingDeployTx])).to.be
         .reverted
     })
+  })
+
+  /* tslint:disable-next-line */
+  describe('debug', function () {
+    it('debug_traceTransaction', async () => {
+      const tx = await wallet.sendTransaction(DEFAULT_TRANSACTION)
+      const receipt = await tx.wait()
+
+      const res = await axios.post(l2Provider.connection.url, {
+        jsonrpc: '2.0',
+        method: 'debug_traceTransaction',
+        params: [tx.hash],
+        id: '1',
+      })
+
+      const result = res.data.result
+      expect(receipt.gasUsed.toNumber()).to.deep.eq(result.gas)
+      expect(!!receipt.status).to.eq(result.failed)
+    }).timeout(40_000)
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
WIP

**Description**
This PR adds test coverage for the `debug` RPC namespace. It is a known bug that L1 to L2 transactions do not work with tracing.


**Metadata**
- Fixes #[Link to Issue]
