### PR TITLE
maintenance[contracts]: remove onlyRelayer modifier

### DIFF
--- a/.changeset/slimy-bugs-tan.md
+++ b/.changeset/slimy-bugs-tan.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Removes the onlyRelayer modifier from the L1CrossDomainMessenger contract

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/messaging/OVM_L1CrossDomainMessenger.sol
@@ -81,25 +81,6 @@ contract OVM_L1CrossDomainMessenger is
         Lib_AddressResolver(address(0))
     {}
 
-    /**********************
-     * Function Modifiers *
-     **********************/
-
-    /**
-     * Modifier to enforce that, if configured, only the OVM_L2MessageRelayer contract may
-     * successfully call a method.
-     */
-    modifier onlyRelayer() {
-        address relayer = resolve("OVM_L2MessageRelayer");
-        if (relayer != address(0)) {
-            require(
-                msg.sender == relayer,
-                "Only OVM_L2MessageRelayer can relay L2-to-L1 messages."
-            );
-        }
-        _;
-    }
-
 
     /********************
      * Public Functions *
@@ -222,7 +203,6 @@ contract OVM_L1CrossDomainMessenger is
         override
         public
         nonReentrant
-        onlyRelayer
         whenNotPaused
     {
         bytes memory xDomainCalldata = Lib_CrossDomainUtils.encodeXDomainCalldata(

--- a/packages/contracts/src/contract-deployment/config.ts
+++ b/packages/contracts/src/contract-deployment/config.ts
@@ -78,16 +78,6 @@ export const makeContractDeployConfig = async (
     OVM_L1CrossDomainMessenger: {
       factory: getContractFactory('OVM_L1CrossDomainMessenger'),
       params: [],
-      afterDeploy: async (contracts): Promise<void> => {
-        if (config.l1CrossDomainMessengerConfig.relayerAddress) {
-          const relayer = config.l1CrossDomainMessengerConfig.relayerAddress
-          const address =
-            typeof relayer === 'string' ? relayer : await relayer.getAddress()
-          await _sendTx(
-            AddressManager.setAddress('OVM_L2MessageRelayer', address)
-          )
-        }
-      },
     },
     Proxy__OVM_L1CrossDomainMessenger: {
       factory: getContractFactory('Lib_ResolvedDelegateProxy'),

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1CrossDomainMessenger.spec.ts
@@ -521,27 +521,5 @@ describe('OVM_L1CrossDomainMessenger', () => {
         ).to.not.be.reverted
       })
     })
-
-    describe('onlyRelayer', () => {
-      it('when the OVM_L2MessageRelayer address is set, should revert if called by a different account', async () => {
-        // set to a random NON-ZERO address
-        await AddressManager.setAddress(
-          'OVM_L2MessageRelayer',
-          '0x1234123412341234123412341234123412341234'
-        )
-
-        await expect(
-          OVM_L1CrossDomainMessenger.relayMessage(
-            target,
-            sender,
-            message,
-            0,
-            proof
-          )
-        ).to.be.revertedWith(
-          'Only OVM_L2MessageRelayer can relay L2-to-L1 messages.'
-        )
-      })
-    })
   })
 })

--- a/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1MultiMessageRelayer.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/base/OVM_L1MultiMessageRelayer.spec.ts
@@ -100,13 +100,6 @@ describe('OVM_L1MultiMessageRelayer', () => {
       AddressManager.address
     )
 
-    // set the address of the OVM_L1MultiMessageRelayer, which the OVM_L1CrossDomainMessenger will
-    // check in its onlyRelayer modifier.
-    // The string currently used in the AddressManager is 'OVM_L2MessageRelayer'
-    await AddressManager.setAddress(
-      'OVM_L2MessageRelayer',
-      OVM_L1MultiMessageRelayer.address
-    )
     // set the mock return value
     Mock__OVM_L1CrossDomainMessenger.smocked.relayMessage.will.return()
   })

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -154,20 +154,6 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       await sleep(this.options.pollingInterval)
 
       try {
-        // Check that the correct address is set in the address manager
-        const relayer = await this.state.Lib_AddressManager.getAddress(
-          'OVM_L2MessageRelayer'
-        )
-        // If it is address(0), then message relaying is not authenticated
-        if (relayer !== ethers.constants.AddressZero) {
-          const address = await this.options.l1Wallet.getAddress()
-          if (relayer !== address) {
-            throw new Error(
-              `OVM_L2MessageRelayer (${relayer}) is not set to message-passer EOA ${address}`
-            )
-          }
-        }
-
         this.logger.info('Checking for newly finalized transactions...')
         if (
           !(await this._isTransactionFinalized(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes the `onlyRelayer` modifier which should no longer be used in the system since users will now be able to relay their own withdrawals. Also removes references to the modifier and to the `OVM_L2MessageRelayer` address elsewhere.

**Metadata**
- Closes OP-894