### PR TITLE
fix(contracts): Allow ETH to be burned by calling address(0) with value

### DIFF
--- a/.changeset/forty-buses-talk.md
+++ b/.changeset/forty-buses-talk.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/contracts': patch
+---
+
+Allow sending OVM_ETH to address(0)

--- a/integration-tests/contracts/ValueCalls.sol
+++ b/integration-tests/contracts/ValueCalls.sol
@@ -129,3 +129,9 @@ contract SendETHAwayAndDelegateCall {
         return _delegateTo.delegatecall(_data);
     }
 }
+
+contract EthBurner {
+    function burnETH(uint _amount) public {
+        address(0).call{value: _amount}(hex"");
+    }
+}

--- a/integration-tests/test/native-eth-ovm-calls.spec.ts
+++ b/integration-tests/test/native-eth-ovm-calls.spec.ts
@@ -69,7 +69,10 @@ describe('Native ETH value integration tests', () => {
     })
 
     it('should allow ETH to be burned by sending to zero address', async () => {
-      const Factory__EthBurner: ContractFactory = await ethers.getContractFactory('EthBurner', wallet)
+      const Factory__EthBurner: ContractFactory = await ethers.getContractFactory(
+        'EthBurner',
+        wallet
+      )
       const EthBurner: Contract = await Factory__EthBurner.deploy()
       await EthBurner.deployTransaction.wait()
 


### PR DESCRIPTION
**Description**
Small little PR to improve compatibility with the EVM.  Basically allows for exactly what is done in the integration test.