### PR TITLE
contracts: add set-l2-gasprice task

### DIFF
--- a/.changeset/big-bags-grow.md
+++ b/.changeset/big-bags-grow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Add a hardhat task for setting the L2 gas price

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -14,6 +14,7 @@ import 'hardhat-deploy'
 import '@typechain/hardhat'
 import '@eth-optimism/hardhat-ovm'
 import './tasks/deploy'
+import './tasks/l2-gasprice'
 import 'hardhat-gas-reporter'
 
 // Load environment variables from .env

--- a/packages/contracts/tasks/l2-gasprice.ts
+++ b/packages/contracts/tasks/l2-gasprice.ts
@@ -1,0 +1,64 @@
+/* Imports: External */
+import { ethers } from 'ethers'
+import { task } from 'hardhat/config'
+import * as types from 'hardhat/internal/core/params/argumentTypes'
+
+import { predeploys } from '../src/predeploys'
+import { getContractDefinition } from '../src/contract-defs'
+
+task('set-l2-gasprice')
+  .addOptionalParam('l2GasPrice', 'Gas Price to set on L2', 0, types.int)
+  .addOptionalParam(
+    'transactionGasPrice',
+    'tx.gasPrice',
+    undefined,
+    types.int
+  )
+  .addOptionalParam(
+    'contractsRpcUrl',
+    'Sequencer HTTP Endpoint',
+    process.env.CONTRACTS_RPC_URL,
+    types.string
+  )
+  .addOptionalParam(
+    'contractsDeployerKey',
+    'Private Key',
+    process.env.CONTRACTS_DEPLOYER_KEY,
+    types.string
+  )
+  .setAction(async (args, hre: any, runSuper) => {
+    const provider = new ethers.providers.JsonRpcProvider(args.contractsRpcUrl)
+    const signer = new ethers.Wallet(args.contractsDeployerKey).connect(
+      provider
+    )
+
+    const GasPriceOracleArtifact = getContractDefinition(
+      'OVM_GasPriceOracle',
+      true
+    )
+
+    const GasPriceOracle = new ethers.Contract(
+      predeploys.OVM_GasPriceOracle,
+      GasPriceOracleArtifact.abi,
+      provider
+    )
+
+    const addr = await signer.getAddress()
+    console.log(`Using signer ${addr}`)
+    const owner = await GasPriceOracle.callStatic.owner()
+    if (owner !== addr) {
+      throw new Error(`Incorrect key. Owner ${owner}, Signer ${addr}`)
+    }
+
+    const gasPrice = await GasPriceOracle.callStatic.gasPrice()
+    console.log(`Gas Price is currently ${gasPrice.toString()}`)
+    console.log(`Setting Gas Price to ${args.l2GasPrice}`)
+
+    const tx = await GasPriceOracle.connect(signer).setGasPrice(
+      args.l2GasPrice,
+      { gasPrice: args.transactionGasPrice }
+    )
+
+    const receipt = await tx.wait()
+    console.log(`Success - ${receipt.transactionHash}`)
+  })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a simple task for updating the L2 Gas Price. This shouldn't be used in production but is useful for testnet/local deployments. It checks that the correct key was passed through and then will set the L2 gas price in the `OVM_GasPriceOracle`.

This contract is owned so only a single key can update the gas price currently

```
CONTRACTS_TARGET_NETWORK=... \
CONTRACTS_DEPLOYER_KEY=... \
CONTRACTS_RPC_URL=... \
    npx hardhat set-l2-gasprice --network ... --l2-gas-price $(seth --to-wei 10 gwei)
```

**Additional context**
Is automated in https://github.com/ethereum-optimism/optimism/pull/1103
