### PR TITLE
Improve Watcher ability to find transactions

### DIFF
--- a/.changeset/tall-plums-behave.md
+++ b/.changeset/tall-plums-behave.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': patch
+---
+
+improved watcher ability to find transactions during periods of high load

--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-# <h1 align="center"> Optimism Monorepo </h1>
+<p align="center">
+    <img src="https://user-images.githubusercontent.com/14298799/122151157-0b197500-ce2d-11eb-89d8-6240e3ebe130.png" width=280>
+<p>
 
-**Monorepo implementing the Optimistic Ethereum protocol**
+# <h1 align="center"> The Optimism Monorepo </h1>
 
 [![Github Actions](https://github.com/ethereum-optimism/optimism/workflows/typescript%20/%20contracts/badge.svg)](https://github.com/ethereum-optimism/optimism/actions/workflows/ts-packages.yml?query=branch%3Amaster)
 [![Github Actions](https://github.com/ethereum-optimism/optimism/workflows/integration/badge.svg)](https://github.com/ethereum-optimism/optimism/actions/workflows/integration.yml?query=branch%3Amaster)
 [![Github Actions](https://github.com/ethereum-optimism/optimism/workflows/geth%20unit%20tests/badge.svg)](https://github.com/ethereum-optimism/optimism/actions/workflows/geth.yml?query=branch%3Amaster)
 
+## TL;DR
+
+This is the primary place where [Optimism](https://optimism.io) works on stuff related to [Optimistic Ethereum](https://research.paradigm.xyz/optimism).
+
 ## Documentation
 
-Extensive documentation is available [here](http://community.optimism.io/docs/)
+Extensive documentation is available [here](http://community.optimism.io/docs/).
 
 ## Directory Structure
 
@@ -26,65 +32,54 @@ Extensive documentation is available [here](http://community.optimism.io/docs/)
 * [`ops`](./ops): Contains Dockerfiles for containerizing each service involved in the protocol,
 as well as a docker-compose file for bringing up local testnets easily
 
-## Quickstart
+## Development Quick Start
 
-### Installation
+### Setup
 
-Dependency management is done using `yarn`.
+Clone the repository, open it, and install dependencies:
 
 ```bash
 git clone git@github.com:ethereum-optimism/optimism.git
 cd optimism
-yarn
+yarn install
 ```
 
-After installing the dependencies, you must also build them so that the typescript
-is compiled down to javascript:
+### Building the TypeScript packages
 
-```bash
-yarn build
-```
-
-When changing branches, be sure to clean the repo before building.
+To build all of the [TypeScript packages](./packages), run:
 
 ```bash
 yarn clean
+yarn build
 ```
 
-### Unit tests
+Packages compiled when on one branch may not be compatible with packages on a different branch.
+**You should recompile all packages whenever you move from one branch to another.**
+Use the above commands to recompile the packages.
 
-All tests are run in parallel using `lerna`:
+### Building the rest of the system
 
-```bash
-yarn test
+If you want to run an Optimistic Ethereum node OR **if you want to run the integration tests**, you'll need to build the rest of the system.
+
 ```
-
-When you want to run tests only for packages that have changed since `master` (or any other branch)
-you can run `yarn lerna run test --parallel --since master`
-
-### Integration Tests
-
-#### Running the integration tests
-
-The integration tests first require bringing up the Optimism stack. This is done via
-a Docker Compose network. For better performance, we also recommend enabling Docker
-BuildKit
-
-```bash
 cd ops
-export COMPOSE_DOCKER_CLI_BUILD=1
+export COMPOSE_DOCKER_CLI_BUILD=1 # these environment variables significantly speed up build time
 export DOCKER_BUILDKIT=1
 docker-compose build
-cd ../integration-tests
-yarn build:integration
-yarn test:integration
 ```
 
-#### Locally testing and re-building specific services
+This will build the following containers:
+* [`builder`](https://hub.docker.com/r/ethereumoptimism/builder): used to build the TypeScript packages
+* [`l1_chain`](https://hub.docker.com/r/ethereumoptimism/hardhat): simulated L1 chain using hardhat-evm as a backend
+* [`deployer`](https://hub.docker.com/r/ethereumoptimism/deployer): process that deploys L1 smart contracts to the L1 chain
+* [`dtl`](https://hub.docker.com/r/ethereumoptimism/data-transport-layer): service that indexes transaction data from the L1 chain
+* [`l2geth`](https://hub.docker.com/r/ethereumoptimism/l2geth): L2 geth node running in Sequencer mode
+* [`verifier`](https://hub.docker.com/r/ethereumoptimism/go-ethereum): L2 geth node running in Verifier mode
+* [`relayer`](https://hub.docker.com/r/ethereumoptimism/message-relayer): helper process that relays messages between L1 and L2
+* [`batch_submitter`](https://hub.docker.com/r/ethereumoptimism/batch-submitter): service that submits batches of Sequencer transactions to the L1 chain
+* [`integration_tests`](https://hub.docker.com/r/ethereumoptimism/integration-tests): integration tests in a box
 
-If you want to make changes to any of the containers, you'll have to bring one down,
-rebuild it, and then bring it back up.
-
+If you want to make a change to a container, you'll need to take it down and rebuild it.
 For example, if you make a change in l2geth:
 
 ```bash
@@ -104,17 +99,75 @@ docker-compose build -- builder batch_submitter
 docker-compose start batch_submitter
 ```
 
+Source code changes can have an impact on more than one container.
+**If you're unsure about which containers to rebuild, just rebuild them all**:
+
+```
+cd ops
+docker-compose down
+docker-compose build
+docker-compose up
+```
+
+Finally, **if you're running into weird problems and nothing seems to be working**, run:
+
+```
+cd optimism
+yarn clean
+yarn build
+cd ops
+docker-compose down -v
+docker-compose build
+docker-compose up
+```
+
+#### Viewing docker container logs
 By default, the `docker-compose up` command will show logs from all services, and that
 can be hard to filter through. In order to view the logs from a specific service, you can run:
 
 ```
 docker-compose logs --follow <service name>
 ```
-### Static analysis
 
-To run `slither` locally in `./packages/contracts` do
+### Running tests
 
+Before running tests: **follow the above instructions to get everything built.**
+
+#### Running unit tests
+
+Run unit tests for all packages in parallel via:
+
+```bash
+yarn test
 ```
+
+To run unit tests for a specific package:
+
+```bash
+cd packages/package-to-test
+yarn test
+```
+
+#### Running integration tests
+
+Follow above instructions for building the whole stack.
+Build and run the integration tests:
+
+```bash
+cd integration-tests
+yarn build:integration
+yarn test:integration
+```
+
+## Additional Reference Material
+### Running contract static analysis
+
+We perform static analysis with [`slither`](https://github.com/crytic/slither).
+You must have Python 3.x installed to run `slither`.
+To run `slither` locally, do:
+
+```bash
+cd packages/contracts
 pip3 install slither-analyzer
 yarn test:slither
 ```

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:check": "yarn lerna run lint:check",
     "lint:fix": "yarn lerna run lint:fix",
     "postinstall": "patch-package",
+    "ready": "yarn lint && yarn test",
     "release": "yarn build && yarn changeset publish"
   },
   "dependencies": {

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -74,21 +74,21 @@ export class Watcher {
     pollForPending: boolean = true
   ): Promise<TransactionReceipt> {
     let matches: ethers.providers.Log[] = []
-    const successFilter: ethers.providers.Filter = {
-      address: layer.messengerAddress,
-      topics: [ethers.utils.id(`RelayedMessage(bytes32)`)],
-    }
-    const failureFilter: ethers.providers.Filter = {
-      address: layer.messengerAddress,
-      topics: [ethers.utils.id(`FailedRelayedMessage(bytes32)`)],
-    }
 
     // scan for transaction with specified message
     while (matches.length === 0) {
       const blockNumber = await layer.provider.getBlockNumber()
       const startingBlock = Math.max(blockNumber - this.NUM_BLOCKS_TO_FETCH, 0)
-      successFilter.fromBlock = startingBlock
-      failureFilter.fromBlock = startingBlock
+      const successFilter: ethers.providers.Filter = {
+        address: layer.messengerAddress,
+        topics: [ethers.utils.id(`RelayedMessage(bytes32)`)],
+        fromBlock: startingBlock
+      }
+      const failureFilter: ethers.providers.Filter = {
+        address: layer.messengerAddress,
+        topics: [ethers.utils.id(`FailedRelayedMessage(bytes32)`)],
+        fromBlock: startingBlock
+      }
       const successLogs = await layer.provider.getLogs(successFilter)
       const failureLogs = await layer.provider.getLogs(failureFilter)
       const logs = successLogs.concat(failureLogs)

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -73,22 +73,31 @@ export class Watcher {
     msgHash: string,
     pollForPending: boolean = true
   ): Promise<TransactionReceipt> {
-    const blockNumber = await layer.provider.getBlockNumber()
-    const startingBlock = Math.max(blockNumber - this.NUM_BLOCKS_TO_FETCH, 0)
-    const successFilter = {
+    let matches: ethers.providers.Log[] = []
+    const successFilter: ethers.providers.Filter = {
       address: layer.messengerAddress,
       topics: [ethers.utils.id(`RelayedMessage(bytes32)`)],
-      fromBlock: startingBlock,
     }
-    const failureFilter = {
+    const failureFilter: ethers.providers.Filter = {
       address: layer.messengerAddress,
       topics: [ethers.utils.id(`FailedRelayedMessage(bytes32)`)],
-      fromBlock: startingBlock,
     }
-    const successLogs = await layer.provider.getLogs(successFilter)
-    const failureLogs = await layer.provider.getLogs(failureFilter)
-    const logs = successLogs.concat(failureLogs)
-    const matches = logs.filter((log: any) => log.data === msgHash)
+
+    // scan for transaction with specified message
+    while (matches.length === 0) {
+      const blockNumber = await layer.provider.getBlockNumber()
+      const startingBlock = Math.max(blockNumber - this.NUM_BLOCKS_TO_FETCH, 0)
+      successFilter.fromBlock = startingBlock
+      failureFilter.fromBlock = startingBlock
+      const successLogs = await layer.provider.getLogs(successFilter)
+      const failureLogs = await layer.provider.getLogs(failureFilter)
+      const logs = successLogs.concat(failureLogs)
+      matches = logs.filter((log: ethers.providers.Log) => log.data === msgHash)
+      // exit loop after first iteration if not polling
+      if (!pollForPending) {
+        break
+      }
+    }
 
     // Message was relayed in the past
     if (matches.length > 0) {
@@ -98,30 +107,8 @@ export class Watcher {
         )
       }
       return layer.provider.getTransactionReceipt(matches[0].transactionHash)
-    }
-    if (!pollForPending) {
+    } else {
       return Promise.resolve(undefined)
     }
-
-    // Message has yet to be relayed, poll until it is found
-    return new Promise(async (resolve, reject) => {
-      const handleEvent = async (log: any) => {
-        if (log.data === msgHash) {
-          try {
-            const txReceipt = await layer.provider.getTransactionReceipt(
-              log.transactionHash
-            )
-            layer.provider.off(successFilter)
-            layer.provider.off(failureFilter)
-            resolve(txReceipt)
-          } catch (e) {
-            reject(e)
-          }
-        }
-      }
-
-      layer.provider.on(successFilter, handleEvent)
-      layer.provider.on(failureFilter, handleEvent)
-    })
   }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
As per #1018, when transaction volume is high, the watcher can sometimes fail to find a transaction receipt. A solution that iteratively queries the logs of the previous 10K blocks until a matching log is found has been implemented. 10K is an upper bound set by `NUM_BLOCKS_TO_FETCH`.

Additionally, a new script (`yarn ready`) has been added to `package.json` which bundles together linting and testing (`yarn lint && yarn test`). Personally I prefer running one command as a "pre-commit" script as opposed to typing out two but this is minor so can remove if preferred.

**Additional context**
It may be worthwhile to add in a constant that controls the maximum number of iterations the loop that checks for a log with a matching txhash can run for.

It might also be worth optimizing this such that iterations beyond the first do not look at the previous 10K block logs

**Metadata**
- Fixes #1018