### PR TITLE
Factory for creating standard L2 ERC20 tokens

### DIFF
--- a/.changeset/clever-parents-clap.md
+++ b/.changeset/clever-parents-clap.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Add a factory contract we can whitelist for the community phase which will be used by the Gateway to create standard ERC20 tokens on L2

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol
@@ -30,6 +30,8 @@ contract OVM_L2StandardTokenFactory {
     )
         external
     {
+        require (_l1Token != address(0), "Must provide L1 token address");
+
         L2StandardERC20 l2Token = new L2StandardERC20(
             Lib_PredeployAddresses.L2_STANDARD_BRIDGE,
             _l1Token,

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+pragma experimental ABIEncoderV2;
+
+/* Contract Imports */
+import { L2StandardERC20 } from "../../../libraries/standards/L2StandardERC20.sol";
+import { Lib_PredeployAddresses } from "../../../libraries/constants/Lib_PredeployAddresses.sol";
+
+/**
+ * @title OVM_L2StandardTokenFactory
+ * @dev Factory contract for creating standard L2 token representations of L1 ERC20s
+ * compatible with and working on the standard bridge.
+ * Compiler used: optimistic-solc
+ * Runtime target: OVM
+ */
+contract OVM_L2StandardTokenFactory {
+
+    event StandardL2TokenCreated(address indexed _l1Token, address indexed _l2Token);
+
+    /**
+     * @dev Creates an instance of the standard ERC20 token on L2.
+     * @param _l1Token Address of the corresponding L1 token.
+     * @param _name ERC20 name.
+     * @param _symbol ERC20 symbol.
+     */
+    function createStandardL2Token(
+        address _l1Token,
+        string memory _name,
+        string memory _symbol
+    )
+        external
+    {
+        L2StandardERC20 l2Token = new L2StandardERC20(
+            Lib_PredeployAddresses.L2_STANDARD_BRIDGE,
+            _l1Token,
+            _name,
+            _symbol);
+
+        emit StandardL2TokenCreated(_l1Token, address(l2Token));
+    }
+}

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol
@@ -36,7 +36,8 @@ contract OVM_L2StandardTokenFactory {
             Lib_PredeployAddresses.L2_STANDARD_BRIDGE,
             _l1Token,
             _name,
-            _symbol);
+            _symbol
+        );
 
         emit StandardL2TokenCreated(_l1Token, address(l2Token));
     }

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/standards/L2StandardERC20.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/standards/L2StandardERC20.sol
@@ -10,6 +10,7 @@ contract L2StandardERC20 is IL2StandardERC20, ERC20 {
     address public l2Bridge;
 
     /**
+     * @param _l2Bridge Address of the L2 standard bridge.
      * @param _l1Token Address of the corresponding L1 token.
      * @param _name ERC20 name.
      * @param _symbol ERC20 symbol.

--- a/packages/contracts/deploy-l2/000-OVM_L2StandardTokenFactory.deploy.ts
+++ b/packages/contracts/deploy-l2/000-OVM_L2StandardTokenFactory.deploy.ts
@@ -1,0 +1,31 @@
+/* Imports: External */
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+
+/* Imports: Internal */
+import { getContractDefinition } from '../src'
+
+const deployFn: DeployFunction = async (hre: any) => {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  const l2TokenFactory = getContractDefinition('OVM_L2StandardTokenFactory', true)
+
+  const factoryOwner = (hre as any).deployConfig.ovmSequencerAddress
+  const initialGasPrice = (hre as any).deployConfig.initialGasPriceOracleGasPrice
+
+  if (!factoryOwner || !initialGasPrice) {
+    throw new Error('initialGasPrice & ovmSequencerAddress required to deploy gas price oracle')
+  }
+
+  await deploy('OVM_L2StandardTokenFactory', {
+    contract: l2TokenFactory,
+    from: deployer,
+    args: [factoryOwner, initialGasPrice],
+    log: true,
+  });
+}
+
+deployFn.tags = ['OVM_L2StandardTokenFactory']
+
+export default deployFn

--- a/packages/contracts/deploy-l2/000-OVM_L2StandardTokenFactory.deploy.ts
+++ b/packages/contracts/deploy-l2/000-OVM_L2StandardTokenFactory.deploy.ts
@@ -20,8 +20,8 @@ const deployFn: DeployFunction = async (hre: any) => {
 
   await deploy('OVM_L2StandardTokenFactory', {
     contract: l2TokenFactory,
+    args: [],
     from: deployer,
-    args: [factoryOwner, initialGasPrice],
     log: true,
   });
 }

--- a/packages/contracts/deploy-l2/000-OVM_L2StandardTokenFactory.deploy.ts
+++ b/packages/contracts/deploy-l2/000-OVM_L2StandardTokenFactory.deploy.ts
@@ -11,13 +11,6 @@ const deployFn: DeployFunction = async (hre: any) => {
 
   const l2TokenFactory = getContractDefinition('OVM_L2StandardTokenFactory', true)
 
-  const factoryOwner = (hre as any).deployConfig.ovmSequencerAddress
-  const initialGasPrice = (hre as any).deployConfig.initialGasPriceOracleGasPrice
-
-  if (!factoryOwner || !initialGasPrice) {
-    throw new Error('initialGasPrice & ovmSequencerAddress required to deploy gas price oracle')
-  }
-
   await deploy('OVM_L2StandardTokenFactory', {
     contract: l2TokenFactory,
     args: [],

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2StandardTokenFactory.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2StandardTokenFactory.spec.ts
@@ -7,7 +7,6 @@ import { smoddit } from '@eth-optimism/smock'
 import { getContractInterface } from '@eth-optimism/contracts'
 
 /* Internal Imports */
-import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../../../helpers'
 import { predeploys } from '../../../../../src'
 
 describe('OVM_L2StandardTokenFactory', () => {
@@ -53,6 +52,14 @@ describe('OVM_L2StandardTokenFactory', () => {
       expect(await l2Token.l1Token()).to.equal(L1ERC20.address)
       expect(await l2Token.name()).to.equal('L2ERC20')
       expect(await l2Token.symbol()).to.equal('ERC')
+    })
+
+    it('should not be able to create a standard token with a 0 address for l1 token', async () => {
+      await expect(OVM_L2StandardTokenFactory.createStandardL2Token(
+        ethers.constants.AddressZero,
+        'L2ERC20',
+        'ERC'
+      )).to.be.revertedWith('Must provide L1 token address')
     })
   })
 })

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2StandardTokenFactory.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2StandardTokenFactory.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from '../../../../setup'
+
+/* External Imports */
+import { ethers } from 'hardhat'
+import { Signer, ContractFactory, Contract } from 'ethers'
+import { smoddit } from '@eth-optimism/smock'
+import { getContractInterface } from '@eth-optimism/contracts'
+
+/* Internal Imports */
+import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../../../helpers'
+import { predeploys } from '../../../../../src'
+
+describe('OVM_L2StandardTokenFactory', () => {
+  let signer: Signer
+  let Factory__L1ERC20: ContractFactory
+  let L1ERC20: Contract
+  let OVM_L2StandardTokenFactory: Contract
+  before(async () => {
+    ;[signer] = await ethers.getSigners()
+    // deploy an ERC20 contract on L1
+    Factory__L1ERC20 = await smoddit(
+      '@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20'
+    )
+    L1ERC20 = await Factory__L1ERC20.deploy('L1ERC20', 'ERC')
+
+    OVM_L2StandardTokenFactory = await (
+      await ethers.getContractFactory('OVM_L2StandardTokenFactory')
+    ).deploy()
+  })
+
+  describe('Standard token factory', () => {
+    it('should be able to create a standard token', async () => {
+      const tx = await OVM_L2StandardTokenFactory.createStandardL2Token(
+        L1ERC20.address,
+        'L2ERC20',
+        'ERC'
+      )
+      const receipt = await tx.wait()
+      const [tokenCreatedEvent] = receipt.events
+
+      // Expect there to be an event emmited for the standard token creation
+      expect(tokenCreatedEvent.event).to.be.eq('StandardL2TokenCreated')
+
+      // Get the L2 token address from the emmited event and check it was created correctly
+      const l2TokenAddress = tokenCreatedEvent.args._l2Token
+      const l2Token = new Contract(
+        l2TokenAddress,
+        getContractInterface('L2StandardERC20'),
+        signer
+      )
+
+      expect(await l2Token.l2Bridge()).to.equal(predeploys.OVM_L2StandardBridge)
+      expect(await l2Token.l1Token()).to.equal(L1ERC20.address)
+      expect(await l2Token.name()).to.equal('L2ERC20')
+      expect(await l2Token.symbol()).to.equal('ERC')
+    })
+  })
+})

--- a/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2StandardTokenFactory.spec.ts
+++ b/packages/contracts/test/contracts/OVM/bridge/assets/OVM_L2StandardTokenFactory.spec.ts
@@ -55,11 +55,13 @@ describe('OVM_L2StandardTokenFactory', () => {
     })
 
     it('should not be able to create a standard token with a 0 address for l1 token', async () => {
-      await expect(OVM_L2StandardTokenFactory.createStandardL2Token(
-        ethers.constants.AddressZero,
-        'L2ERC20',
-        'ERC'
-      )).to.be.revertedWith('Must provide L1 token address')
+      await expect(
+        OVM_L2StandardTokenFactory.createStandardL2Token(
+          ethers.constants.AddressZero,
+          'L2ERC20',
+          'ERC'
+        )
+      ).to.be.revertedWith('Must provide L1 token address')
     })
   })
 })


### PR DESCRIPTION
We add a factory contract we can whitelist for the community phase which will be used by the Gateway to create standard ERC20 tokens on L2. 

Closes OP-722