### PR TITLE
fix[dtl]: use the same L2 chain ID everywhere

### DIFF
--- a/.changeset/modern-pets-tie.md
+++ b/.changeset/modern-pets-tie.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Updates the DTL to use the same L2 chain ID everywhere

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -53,6 +53,9 @@ const optionSettings = {
       return validators.isUrl(val) || validators.isJsonRpcProvider(val)
     },
   },
+  l2ChainId: {
+    validate: validators.isInteger,
+  },
 }
 
 export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
@@ -65,7 +68,6 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
     contracts: OptimismContracts
     l1RpcProvider: JsonRpcProvider
     startingL1BlockNumber: number
-    l2ChainId: number
   } = {} as any
 
   protected async _init(): Promise<void> {
@@ -114,10 +116,6 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
       this.state.l1RpcProvider,
       this.options.addressManager
     )
-
-    this.state.l2ChainId = ethers.BigNumber.from(
-      await this.state.contracts.OVM_ExecutionManager.ovmCHAINID()
-    ).toNumber()
 
     const startingL1BlockNumber = await this.state.db.getStartingL1Block()
     if (startingL1BlockNumber) {
@@ -301,7 +299,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           const parsedEvent = await handlers.parseEvent(
             event,
             extraData,
-            this.state.l2ChainId
+            this.options.l2ChainId
           )
           await handlers.storeEvent(parsedEvent, this.state.db)
         }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Slight modification to the DTL so that we're using the same L2 chain ID everywhere. We already have it as an input argument so we can just use it there. Also removes another dependency on the `OVM_ExecutionManager`.