### PR TITLE
temp: make sync tests workflow dispatch only

### DIFF
--- a/.github/workflows/sync-tests.yml
+++ b/.github/workflows/sync-tests.yml
@@ -1,13 +1,6 @@
 name: sync-tests
 
-on:
-  push:
-    branches:
-      - 'master'
-      - 'develop'
-      - 'regenesis/*'
-  pull_request:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   integration-sync-test:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Sync tests have been flaky, most likely due to running docker-compose multiple times. As of now, this sync test only runs a trivial test case and likely won't find any actual syncing issues, so I'm removing the workflow.

**Additional context**
As follow ups, the best course of action would be to
1. Fix the root cause of verifier mismatches that's forcing us to do this test in a separate workflow
2. Bring the verifier up with the rest of the stack instead of individually during this test, to fix flakiness

**Metadata**
- replica tests would have the same issues, but because replicas don't have the same bugs, we should be able to do the approach in step 2 immediately https://github.com/ethereum-optimism/optimism/pull/981
