### PR TITLE
fix: don't use `decoded`, use RLP decode/encode

### DIFF
--- a/.changeset/chilly-pumas-relax.md
+++ b/.changeset/chilly-pumas-relax.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove usage of txmeta.rawTransaction and no longer use the DTL `.decoded` response as part of the consensus code path

--- a/l2geth/core/state_transition_ovm.go
+++ b/l2geth/core/state_transition_ovm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rollup/dump"
 )
 
@@ -79,11 +80,12 @@ func AsOvmMessage(tx *types.Transaction, signer types.Signer, decompressor commo
 
 	// Sequencer transactions get sent to the "sequencer entrypoint," a contract that decompresses
 	// the incoming transaction data.
+	raw, err := rlp.EncodeToBytes(tx)
 	outmsg, err := modMessage(
 		msg,
 		msg.From(),
 		&decompressor,
-		tx.GetMeta().RawTransaction,
+		raw,
 		gasLimit,
 	)
 

--- a/l2geth/core/state_transition_ovm.go
+++ b/l2geth/core/state_transition_ovm.go
@@ -81,6 +81,9 @@ func AsOvmMessage(tx *types.Transaction, signer types.Signer, decompressor commo
 	// Sequencer transactions get sent to the "sequencer entrypoint," a contract that decompresses
 	// the incoming transaction data.
 	raw, err := rlp.EncodeToBytes(tx)
+	if err != nil {
+		return msg, fmt.Errorf("Cannot rlp encode ovm message: %w", err)
+	}
 	outmsg, err := modMessage(
 		msg,
 		msg.From(),

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1358,7 +1358,8 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	}
 
 	if meta := tx.GetMeta(); meta != nil {
-		result.RawTransaction = meta.RawTransaction
+		raw, _ := rlp.EncodeToBytes(tx)
+		result.RawTransaction = raw
 		result.L1TxOrigin = meta.L1MessageSender
 		result.L1Timestamp = (hexutil.Uint64)(meta.L1Timestamp)
 		if meta.L1BlockNumber != nil {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR uses the RLP serialization instead of relying on the `.decoded` field returned from the DTL for consensus. It simplifies the code. The follow up PR should remove  `txmeta.rawTransaction` so that it does not get saved to the database

Willing to remove particular commits from this if desired