### PR TITLE
fix[dtl]: broken stringification function

### DIFF
--- a/.changeset/slimy-donuts-turn.md
+++ b/.changeset/slimy-donuts-turn.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Fixes a broken stringification function inside the DTL

--- a/packages/data-transport-layer/src/db/transport-db.ts
+++ b/packages/data-transport-layer/src/db/transport-db.ts
@@ -400,14 +400,18 @@ export class TransportDB {
   }
 }
 
-const stringify = (entry) => {
+const stringify = (entry: any): any => {
   if (entry === null || entry === undefined) {
     return entry
   }
+
   if (entry.gasLimit) {
     entry.gasLimit = BigNumber.from(entry.gasLimit).toString()
   }
+
   if (entry.decoded) {
     entry.decoded.gasLimit = BigNumber.from(entry.decoded.gasLimit).toString()
   }
+
+  return entry
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
A `stringify` function inside the DTL was not actually returning the value that it was modifying. As a result, range queries were broken and endpoints like `/batch/transaction/latest` would end up breaking.
