### PR TITLE
fix[dtl]: log server errors as ERROR instead of INFO

### DIFF
--- a/.changeset/lazy-foxes-jump.md
+++ b/.changeset/lazy-foxes-jump.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Have DTL log failed HTTP requests as ERROR instead of INFO

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -201,7 +201,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         return res.json(json)
       } catch (e) {
         const elapsed = Date.now() - start
-        this.logger.info('Failed HTTP Request', {
+        this.logger.error('Failed HTTP Request', {
           method: req.method,
           url: req.url,
           elapsed,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
One-line fix to the DTL so that failed HTTP requests are marked as errors and not as info log lines.

Fixes OP-888