### PR TITLE
fix[dtl]: remove old stringification function

### DIFF
--- a/.changeset/gold-grapes-beg.md
+++ b/.changeset/gold-grapes-beg.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Removes a function that was previously used for backwards compatibility but is no longer necessary

--- a/packages/data-transport-layer/src/db/transport-db.ts
+++ b/packages/data-transport-layer/src/db/transport-db.ts
@@ -387,27 +387,6 @@ export class TransportDB {
     startIndex: number,
     endIndex: number
   ): Promise<TEntry[] | []> {
-    const entries = await this.db.range<TEntry>(
-      `${key}:index`,
-      startIndex,
-      endIndex
-    )
-    const results = []
-    for (const entry of entries) {
-      results.push(stringify(entry))
-    }
-    return results
-  }
-}
-
-const stringify = (entry) => {
-  if (entry === null || entry === undefined) {
-    return entry
-  }
-  if (entry.gasLimit) {
-    entry.gasLimit = BigNumber.from(entry.gasLimit).toString()
-  }
-  if (entry.decoded) {
-    entry.decoded.gasLimit = BigNumber.from(entry.decoded.gasLimit).toString()
+    return this.db.range<TEntry>(`${key}:index`, startIndex, endIndex)
   }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes a `stringify` function that was being used temporarily to guarantee backwards compatibility for older DTL instances. Function is no longer necessary after this regenesis because DTL databases will be wiped and will not have incompatible values anymore.