### PR TITLE
fix: prevent overflow in abi encoding

### DIFF
--- a/.changeset/happy-dancers-raise.md
+++ b/.changeset/happy-dancers-raise.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Prevent overflows in abi encoding of ovm codec transaction from geth types.Transaction

--- a/l2geth/core/state_transition_ovm.go
+++ b/l2geth/core/state_transition_ovm.go
@@ -111,7 +111,7 @@ func EncodeSimulatedMessage(msg Message, timestamp, blockNumber *big.Int, execut
 		uint8(msg.QueueOrigin()),
 		*msg.L1MessageSender(),
 		*to,
-		big.NewInt(int64(msg.Gas())),
+		new(big.Int).SetUint64(msg.Gas()),
 		msg.Data(),
 	}
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
It is possible to overflow the ABI encoding of the `Lib_OVMCodec.Transaction` from the geth `types.Transaction` on the way into the `OVM_SequencerEntrypoint` due to a type conversion from a `uin64` to an `int64`. This ensures that the types stay the same so that an overflow isn't possible


