### PR TITLE
feat[integration-tests]: make integration tests work against production networks

### DIFF
--- a/.changeset/clean-crabs-wash.md
+++ b/.changeset/clean-crabs-wash.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': minor
+---
+
+Various updates to integration tests so that they can be executed against production networks

--- a/integration-tests/.env.example
+++ b/integration-tests/.env.example
@@ -1,0 +1,6 @@
+# only need to fill these out if you want to test against a prod network
+PRIVATE_KEY=
+L1_URL=
+L2_URL=
+ADDRESS_MANAGER=
+L2_CHAINID=

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,31 @@
+# @eth-optimism/integration-tests
+
+## Setup
+
+Follow installation + build instructions in the [primary README](../README.md).
+Then, run:
+
+```bash
+yarn build:integration
+```
+
+## Running tests
+
+### Testing a live network
+
+Create an `.env` file and fill it out.
+Look at `.env.example` to know which variables to include.
+
+Once you have your environment set up, run:
+
+```bash
+yarn test:integration:live
+```
+
+You can also set environment variables on the command line instead of inside `.env` if you want:
+
+```bash
+L1_URL=whatever L2_URL=whatever yarn test:integration:live
+```
+
+Note that this can take an extremely long time (~1hr).

--- a/integration-tests/hardhat.config.ts
+++ b/integration-tests/hardhat.config.ts
@@ -9,14 +9,19 @@ import 'hardhat-gas-reporter'
 const enableGasReport = !!process.env.ENABLE_GAS_REPORT
 
 const config: HardhatUserConfig = {
-  mocha: {
-    timeout: 20000,
-  },
   networks: {
     optimism: {
       url: process.env.L2_URL || 'http://localhost:8545',
       ovm: true,
     },
+    'optimism-live': {
+      url: process.env.L2_URL || 'http://localhost:8545',
+      ovm: true,
+      timeout: 150000,
+    },
+  },
+  mocha: {
+    timeout: 50000,
   },
   solidity: '0.7.6',
   ovm: {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -13,6 +13,7 @@
     "build:contracts": "hardhat compile",
     "build:contracts:ovm": "hardhat compile --network optimism",
     "test:integration": "hardhat --network optimism test",
+    "test:integration:live": "IS_LIVE_NETWORK=true hardhat --network optimism-live test",
     "test:sync": "hardhat --network optimism test sync-tests/*.spec.ts --no-compile",
     "clean": "rimraf cache artifacts artifacts-ovm cache-ovm"
   },
@@ -20,6 +21,7 @@
     "@eth-optimism/contracts": "^0.4.2",
     "@eth-optimism/core-utils": "^0.5.0",
     "@eth-optimism/hardhat-ovm": "^0.2.2",
+    "@eth-optimism/message-relayer": "^0.1.6",
     "@ethersproject/providers": "^5.0.24",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -33,6 +35,7 @@
     "chai": "^4.3.3",
     "chai-as-promised": "^7.1.1",
     "docker-compose": "^0.23.8",
+    "dotenv": "^10.0.0",
     "envalid": "^7.1.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.27.0",

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -1,15 +1,14 @@
+import { expect } from 'chai'
+
+/* Imports: External */
 import { ethers } from 'hardhat'
 import { injectL2Context } from '@eth-optimism/core-utils'
-import { expect } from 'chai'
-import {
-  sleep,
-  l2Provider,
-  l1Provider,
-  getAddressManager,
-} from './shared/utils'
+import { Contract, BigNumber } from 'ethers'
+
+/* Imports: Internal */
+import { l2Provider, l1Provider, IS_LIVE_NETWORK } from './shared/utils'
 import { OptimismEnv } from './shared/env'
-import { getContractFactory } from '@eth-optimism/contracts'
-import { Contract, ContractFactory, Wallet, BigNumber } from 'ethers'
+import { Direction } from './shared/watcher-utils'
 
 /**
  * These tests cover the OVM execution contexts. In the OVM execution
@@ -17,72 +16,50 @@ import { Contract, ContractFactory, Wallet, BigNumber } from 'ethers'
  * must be equal to the blocknumber/timestamp of the L1 transaction.
  */
 describe('OVM Context: Layer 2 EVM Context', () => {
-  let address: string
-  let CanonicalTransactionChain: Contract
+  const L2Provider = injectL2Context(l2Provider)
+  let env: OptimismEnv
+  before(async () => {
+    env = await OptimismEnv.new()
+  })
+
   let OVMMulticall: Contract
   let OVMContextStorage: Contract
-
-  const L1Provider = l1Provider
-  const L2Provider = injectL2Context(l2Provider)
-
-  before(async () => {
-    const env = await OptimismEnv.new()
-    // Create providers and signers
-    const l1Wallet = env.l1Wallet
-    const l2Wallet = env.l2Wallet
-    const addressManager = env.addressManager
-
-    // deploy the contract
+  beforeEach(async () => {
     const OVMContextStorageFactory = await ethers.getContractFactory(
       'OVMContextStorage',
-      l2Wallet
+      env.l2Wallet
+    )
+    const OVMMulticallFactory = await ethers.getContractFactory(
+      'OVMMulticall',
+      env.l2Wallet
     )
 
     OVMContextStorage = await OVMContextStorageFactory.deploy()
-    const receipt = await OVMContextStorage.deployTransaction.wait()
-    address = OVMContextStorage.address
-
-    const ctcAddress = await addressManager.getAddress(
-      'OVM_CanonicalTransactionChain'
-    )
-    const CanonicalTransactionChainFactory = getContractFactory(
-      'OVM_CanonicalTransactionChain'
-    )
-
-    CanonicalTransactionChain =
-      CanonicalTransactionChainFactory.connect(l1Wallet).attach(ctcAddress)
-
-    const OVMMulticallFactory = await ethers.getContractFactory(
-      'OVMMulticall',
-      l2Wallet
-    )
-
+    await OVMContextStorage.deployTransaction.wait()
     OVMMulticall = await OVMMulticallFactory.deploy()
     await OVMMulticall.deployTransaction.wait()
   })
 
-  it('Enqueue: `block.number` and `block.timestamp` have L1 values', async () => {
-    for (let i = 0; i < 5; i++) {
-      const l2Tip = await L2Provider.getBlock('latest')
-      const tx = await CanonicalTransactionChain.enqueue(
-        OVMContextStorage.address,
-        500_000,
-        '0x'
-      )
+  let numTxs = 5
+  if (IS_LIVE_NETWORK) {
+    // Tests take way too long if we don't reduce the number of txs here.
+    numTxs = 1
+  }
 
-      // Wait for the enqueue to be ingested
-      while (true) {
-        const tip = await L2Provider.getBlock('latest')
-        if (tip.number === l2Tip.number + 1) {
-          break
-        }
-        await sleep(500)
-      }
+  it('enqueue: `block.number` and `block.timestamp` have L1 values', async () => {
+    for (let i = 0; i < numTxs; i++) {
+      const tx = await env.l1Messenger.sendMessage(
+        OVMContextStorage.address,
+        '0x',
+        2_000_000
+      )
+      const receipt = await tx.wait()
 
       // Get the receipt
-      const receipt = await tx.wait()
       // The transaction did not revert
       expect(receipt.status).to.equal(1)
+
+      await env.waitForXDomainTransaction(tx, Direction.L1ToL2)
 
       // Get the L1 block that the enqueue transaction was in so that
       // the timestamp can be compared against the layer two contract
@@ -96,14 +73,18 @@ describe('OVM Context: Layer 2 EVM Context', () => {
       const timestamp = await OVMContextStorage.timestamps(i)
       expect(block.timestamp).to.deep.equal(timestamp.toNumber())
     }
-  })
+  }).timeout(150000) // this specific test takes a while because it involves L1 to L2 txs
 
   it('should set correct OVM Context for `eth_call`', async () => {
-    const tip = await L2Provider.getBlockWithTransactions('latest')
-    const start = Math.max(0, tip.number - 5)
+    for (let i = 0; i < numTxs; i++) {
+      // Make an empty transaction to bump the latest block number.
+      const dummyTx = await env.l2Wallet.sendTransaction({
+        to: `0x${'11'.repeat(20)}`,
+        data: '0x',
+      })
+      await dummyTx.wait()
 
-    for (let i = start; i < tip.number; i++) {
-      const block = await L2Provider.getBlockWithTransactions(i)
+      const block = await L2Provider.getBlockWithTransactions('latest')
       const [, returnData] = await OVMMulticall.callStatic.aggregate(
         [
           [
@@ -117,7 +98,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
             OVMMulticall.interface.encodeFunctionData('getCurrentBlockNumber'),
           ],
         ],
-        { blockTag: i }
+        { blockTag: block.number }
       )
 
       const timestamp = BigNumber.from(returnData[0])

--- a/integration-tests/test/queue-ingestion.spec.ts
+++ b/integration-tests/test/queue-ingestion.spec.ts
@@ -1,99 +1,65 @@
-/* Imports: Internal */
-import { injectL2Context } from '@eth-optimism/core-utils'
-import { sleep } from './shared/utils'
-import { OptimismEnv } from './shared/env'
-
-/* Imports: External */
-import { providers } from 'ethers'
 import { expect } from 'chai'
 
-// This test ensures that the transactions which get `enqueue`d get
-// added to the L2 blocks by the Sync Service (which queries the DTL)
+/* Imports: Internal */
+import { providers } from 'ethers'
+import { injectL2Context } from '@eth-optimism/core-utils'
+
+/* Imports: External */
+import { OptimismEnv } from './shared/env'
+import { Direction } from './shared/watcher-utils'
+
 describe('Queue Ingestion', () => {
-  const RETRIES = 20
-  const numTxs = 5
-  let startBlock: number
-  let endBlock: number
   let env: OptimismEnv
   let l2Provider: providers.JsonRpcProvider
-  const receipts = []
-
   before(async () => {
     env = await OptimismEnv.new()
     l2Provider = injectL2Context(env.l2Wallet.provider as any)
-  })
-
-  // The transactions are enqueue'd with a `to` address of i.repeat(40)
-  // meaning that the `to` value is different each iteration in a deterministic
-  // way. They need to be inserted into the L2 chain in an ascending order.
-  // Keep track of the receipts so that the blockNumber can be compared
-  // against the `L1BlockNumber` on the tx objects.
-  before(async () => {
-    // Keep track of the L2 tip before submitting any transactions so that
-    // the subsequent transactions can be queried for in the next test
-    startBlock = (await l2Provider.getBlockNumber()) + 1
-    endBlock = startBlock + numTxs - 1
-
-    // Enqueue some transactions by building the calldata and then sending
-    // the transaction to Layer 1
-    for (let i = 0; i < numTxs; i++) {
-      const input = ['0x' + `${i}`.repeat(40), 500_000, `0x0${i}`]
-      const calldata = env.ctc.interface.encodeFunctionData('enqueue', input)
-
-      const txResponse = await env.l1Wallet.sendTransaction({
-        data: calldata,
-        to: env.ctc.address,
-      })
-
-      const receipt = await txResponse.wait()
-      receipts.push(receipt)
-    }
   })
 
   // The batch submitter will notice that there are transactions
   // that are in the queue and submit them. L2 will pick up the
   // sequencer batch appended event and play the transactions.
   it('should order transactions correctly', async () => {
-    // Wait until each tx from the previous test has
-    // been executed
-    let i: number
-    for (i = 0; i < RETRIES; i++) {
-      const tip = await l2Provider.getBlockNumber()
-      if (tip >= endBlock) {
-        break
-      }
-      await sleep(1000)
-    }
+    const numTxs = 5
 
-    if (i === RETRIES) {
-      throw new Error(
-        'timed out waiting for queued transactions to be inserted'
+    // Enqueue some transactions by building the calldata and then sending
+    // the transaction to Layer 1
+    const txs = []
+    for (let i = 0; i < numTxs; i++) {
+      const tx = await env.l1Messenger.sendMessage(
+        `0x${`${i}`.repeat(40)}`,
+        `0x0${i}`,
+        1_000_000
       )
+      await tx.wait()
+      txs.push(tx)
     }
 
-    const from = await env.l1Wallet.getAddress()
-    // Keep track of an index into the receipts list and
-    // increment it for each block fetched.
-    let receiptIndex = 0
-    // Fetch blocks
-    for (i = 0; i < numTxs; i++) {
-      const block = await l2Provider.getBlock(startBlock + i)
-      const hash = block.transactions[0]
-      // Use as any hack because additional properties are
-      // added to the transaction response
-      const tx = await (l2Provider.getTransaction(hash) as any)
+    for (let i = 0; i < numTxs; i++) {
+      const l1Tx = txs[i]
+      const l1TxReceipt = await txs[i].wait()
+      const receipt = await env.waitForXDomainTransaction(
+        l1Tx,
+        Direction.L1ToL2
+      )
+      const l2Tx = (await l2Provider.getTransaction(
+        receipt.remoteTx.hash
+      )) as any
 
-      // The `to` addresses are defined in the previous test and
-      // increment sequentially.
-      expect(tx.to).to.be.equal('0x' + `${i}`.repeat(40))
-      // The queue origin is Layer 1
-      expect(tx.queueOrigin).to.be.equal('l1')
-      // the L1TxOrigin is equal to the Layer one from
-      expect(tx.l1TxOrigin).to.be.equal(from.toLowerCase())
-      expect(typeof tx.l1BlockNumber).to.be.equal('number')
-      // Get the receipt and increment the recept index
-      const receipt = receipts[receiptIndex++]
-      expect(tx.l1BlockNumber).to.be.equal(receipt.blockNumber)
+      const params = env.l2Messenger.interface.decodeFunctionData(
+        'relayMessage',
+        l2Tx.data
+      )
+
+      expect(params._sender.toLowerCase()).to.equal(
+        env.l1Wallet.address.toLowerCase()
+      )
+      expect(params._target).to.equal('0x' + `${i}`.repeat(40))
+      expect(l2Tx.queueOrigin).to.equal('l1')
+      expect(l2Tx.l1TxOrigin.toLowerCase()).to.equal(
+        env.l1Messenger.address.toLowerCase()
+      )
+      expect(l2Tx.l1BlockNumber).to.equal(l1TxReceipt.blockNumber)
     }
-  })
+  }).timeout(100_000)
 })

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -2,7 +2,6 @@ import {
   injectL2Context,
   TxGasLimit,
   TxGasPrice,
-  toRpcHexString,
 } from '@eth-optimism/core-utils'
 import { Wallet, BigNumber, Contract, ContractFactory } from 'ethers'
 import { ethers } from 'hardhat'
@@ -13,6 +12,8 @@ import {
   DEFAULT_TRANSACTION,
   fundUser,
   expectApprox,
+  L2_CHAINID,
+  IS_LIVE_NETWORK,
 } from './shared/utils'
 import chaiAsPromised from 'chai-as-promised'
 import { OptimismEnv } from './shared/env'
@@ -132,10 +133,9 @@ describe('Basic RPC tests', () => {
         gasPrice: TxGasPrice,
       }
       const fee = tx.gasPrice.mul(tx.gasLimit)
-      const gasLimit = 5920001
 
       await expect(env.l2Wallet.sendTransaction(tx)).to.be.rejectedWith(
-        `fee too low: ${fee}, use at least tx.gasLimit = ${gasLimit} and tx.gasPrice = ${TxGasPrice.toString()}`
+        `fee too low: ${fee}, use at least tx.gasLimit =`
       )
     })
 
@@ -317,7 +317,15 @@ describe('Basic RPC tests', () => {
     // canonical transaction chain. This test catches this by
     // querying for the latest block and then waits and then queries
     // the latest block again and then asserts that they are the same.
-    it('should return the same result when new transactions are not applied', async () => {
+    //
+    // Needs to be skipped on Prod networks because this test doesn't work when
+    // other people are sending transactions to the Sequencer at the same time
+    // as this test is running.
+    it('should return the same result when new transactions are not applied', async function () {
+      if (IS_LIVE_NETWORK) {
+        this.skip()
+      }
+
       // Get latest block once to start.
       const prev = await provider.getBlockWithTransactions('latest')
 
@@ -341,7 +349,7 @@ describe('Basic RPC tests', () => {
   describe('eth_chainId', () => {
     it('should get the correct chainid', async () => {
       const { chainId } = await provider.getNetwork()
-      expect(chainId).to.be.eq(420)
+      expect(chainId).to.be.eq(L2_CHAINID)
     })
   })
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -1,13 +1,6 @@
 import { expect } from 'chai'
 
-import { Direction, waitForXDomainTransaction } from './watcher-utils'
-
-import {
-  getContractFactory,
-  getContractInterface,
-  predeploys,
-} from '@eth-optimism/contracts'
-import { injectL2Context, remove0x, Watcher } from '@eth-optimism/core-utils'
+/* Imports: External */
 import {
   Contract,
   Wallet,
@@ -17,9 +10,23 @@ import {
   BigNumber,
   utils,
 } from 'ethers'
-import { cleanEnv, str, num } from 'envalid'
+import {
+  getContractFactory,
+  getContractInterface,
+  predeploys,
+} from '@eth-optimism/contracts'
+import { injectL2Context, remove0x, Watcher } from '@eth-optimism/core-utils'
+import { cleanEnv, str, num, bool } from 'envalid'
+import dotenv from 'dotenv'
+
+/* Imports: Internal */
+import { Direction, waitForXDomainTransaction } from './watcher-utils'
 
 export const GWEI = BigNumber.from(1e9)
+
+if (process.env.IS_LIVE_NETWORK === 'true') {
+  dotenv.config()
+}
 
 const env = cleanEnv(process.env, {
   L1_URL: str({ default: 'http://localhost:9545' }),
@@ -37,6 +44,8 @@ const env = cleanEnv(process.env, {
   ADDRESS_MANAGER: str({
     default: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
   }),
+  L2_CHAINID: num({ default: 420 }),
+  IS_LIVE_NETWORK: bool({ default: false }),
 })
 
 // The hardhat instance
@@ -63,6 +72,9 @@ export const l2Wallet = l1Wallet.connect(l2Provider)
 export const PROXY_SEQUENCER_ENTRYPOINT_ADDRESS =
   '0x4200000000000000000000000000000000000004'
 export const OVM_ETH_ADDRESS = predeploys.OVM_ETH
+
+export const L2_CHAINID = env.L2_CHAINID
+export const IS_LIVE_NETWORK = env.IS_LIVE_NETWORK
 
 export const getAddressManager = (provider: any) => {
   return getContractFactory('Lib_AddressManager')

--- a/ops/docker/Dockerfile.integration-tests
+++ b/ops/docker/Dockerfile.integration-tests
@@ -13,6 +13,9 @@ COPY --from=builder /optimism/node_modules ./node_modules
 COPY --from=builder /optimism/packages/core-utils/package.json ./packages/core-utils/package.json
 COPY --from=builder /optimism/packages/core-utils/dist ./packages/core-utils/dist
 
+COPY --from=builder /optimism/packages/message-relayer/package.json ./packages/message-relayer/package.json
+COPY --from=builder /optimism/packages/message-relayer/dist ./packages/message-relayer/dist
+
 COPY --from=builder /optimism/packages/hardhat-ovm/package.json ./packages/hardhat-ovm/package.json
 COPY --from=builder /optimism/packages/hardhat-ovm/dist ./packages/hardhat-ovm/dist
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,6 +5636,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR contains the following set of tweaks to the integration tests so that the tests can be executed directly against a live network deployment:
- Default mocha timeout for the integration tests is increased from `20000ms` to `150000ms`.
- We no longer rely on the `message-relayer` during the integration tests. Instead, all tests that previously relied on the integration tests must now use a new utility `env.relayXDomainMessages(transaction)`.
- Introduces a new utility `useDynamicTimeoutForWithdrawals` that will dynamically increase the timeout of the current function based on the current challenge period timeout.
- Reduces ETH transfer amounts in tests to `0.0000001` to reduce the amount of ETH that the main wallet needs to have on hand.
- Less strict checks on certain revert messages because RPC providers sometimes do not include these messages depending on the software they're running (cannot guarantee that they will run recent geth).
- Add a new `L2_CHAINID` environment variable so we can inform the test suite of the *expected* L2 chain ID.
- Add a new `IS_PROD_NETWORK` environment variable so we can inform the test suite that it's running against a production network and we can selectively skip/modify/etc a test when necessary.
- Adds a README explaining how to test against a prod network.

**Metadata**
Fixes OP-895