### PR TITLE
fix[relayer]: update exported files list in package.json

### DIFF
--- a/.changeset/lazy-ghosts-shop.md
+++ b/.changeset/lazy-ghosts-shop.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Update relayer package JSON to correctly export all files in dist

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/index"
+    "dist/*"
   ],
   "scripts": {
     "start": "node ./exec/run-message-relayer.js",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates `package.json` inside the message relayer to correctly export ALL files within `/dist` instead of just the index.