### PR TITLE
fix[contracts]: remove part of MultiMessageRelayer deployment

### DIFF
--- a/.changeset/red-hornets-design.md
+++ b/.changeset/red-hornets-design.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Updates the deployment of the L1MultiMessageRelayer to NOT set the OVM_L2MessageRelayer address in the AddressManager

--- a/packages/contracts/deploy/014-OVM_L1MultiMessageRelayer.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1MultiMessageRelayer.deploy.ts
@@ -5,7 +5,6 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndRegister,
   getDeployedContract,
-  registerAddress,
 } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -19,20 +18,6 @@ const deployFn: DeployFunction = async (hre) => {
     name: 'OVM_L1MultiMessageRelayer',
     args: [Lib_AddressManager.address],
   })
-
-  // OVM_L2MessageRelayer *must* be set to multi message relayer address on mainnet.
-  if (hre.network.name.includes('mainnet')) {
-    const OVM_L1MultiMessageRelayer = await getDeployedContract(
-      hre,
-      'OVM_L1MultiMessageRelayer'
-    )
-
-    await registerAddress({
-      hre,
-      name: 'OVM_L2MessageRelayer',
-      address: OVM_L1MultiMessageRelayer.address,
-    })
-  }
 }
 
 deployFn.dependencies = ['Lib_AddressManager']


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Portion of the deployment removed in this PR *only* impacts mainnet deployments because of the check that network == `mainnet`. If this part of the deployment were executed then only the `OVM_L1MultiMessageRelayer` would be allowed to relay L2 => L1 messages.