### PR TITLE
Prevent modification of QueueOrigin during verification

### DIFF
--- a/.changeset/tall-oranges-doubt.md
+++ b/.changeset/tall-oranges-doubt.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Prevent modification of QueueOrigin during verification of enqueued transactions.

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -1177,6 +1177,11 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             "Invalid Queue transaction inclusion proof."
         );
 
+        require(
+            _transaction.l1QueueOrigin == Lib_OVMCodec.QueueOrigin.L1TOL2_QUEUE,
+            "Invalid QueueOrigin."
+        );
+
         bytes32 transactionHash = keccak256(
             abi.encode(
                 _transaction.l1TxOrigin,

--- a/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -26,6 +26,7 @@ import {
   increaseEthTime,
   getBlockTime,
   mineBlock,
+  QUEUE_ORIGIN,
 } from '../../../helpers'
 import { predeploys } from '../../../../src'
 
@@ -528,7 +529,7 @@ describe('OVM_CanonicalTransactionChain', () => {
           {
             timestamp,
             blockNumber,
-            l1QueueOrigin: 1,
+            l1QueueOrigin: QUEUE_ORIGIN.L1TOL2_QUEUE,
             l1TxOrigin: await OVM_CanonicalTransactionChain.signer.getAddress(),
             entrypoint,
             gasLimit,
@@ -589,7 +590,7 @@ describe('OVM_CanonicalTransactionChain', () => {
           {
             timestamp,
             blockNumber,
-            l1QueueOrigin: 0, // QueueOrigin.SEQUENCER_QUEUE = 0
+            l1QueueOrigin: QUEUE_ORIGIN.SEQUENCER_QUEUE,
             l1TxOrigin: await OVM_CanonicalTransactionChain.signer.getAddress(),
             entrypoint,
             gasLimit,
@@ -636,7 +637,7 @@ describe('OVM_CanonicalTransactionChain', () => {
           {
             timestamp,
             blockNumber,
-            l1QueueOrigin: 1,
+            l1QueueOrigin: QUEUE_ORIGIN.L1TOL2_QUEUE,
             l1TxOrigin: await OVM_CanonicalTransactionChain.signer.getAddress(),
             entrypoint,
             gasLimit,
@@ -693,7 +694,7 @@ describe('OVM_CanonicalTransactionChain', () => {
           {
             timestamp,
             blockNumber,
-            l1QueueOrigin: 0,
+            l1QueueOrigin: QUEUE_ORIGIN.SEQUENCER_QUEUE,
             l1TxOrigin: constants.AddressZero,
             entrypoint,
             gasLimit,

--- a/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager.gas-spec.ts
+++ b/packages/contracts/test/contracts/OVM/execution/OVM_ExecutionManager.gas-spec.ts
@@ -12,6 +12,7 @@ import {
   NON_ZERO_ADDRESS,
   NON_NULL_BYTES32,
   GasMeasurement,
+  QUEUE_ORIGIN,
 } from '../../../helpers'
 
 const DUMMY_GASMETERCONFIG = {
@@ -23,11 +24,6 @@ const DUMMY_GASMETERCONFIG = {
 
 const DUMMY_GLOBALCONTEXT = {
   ovmCHAINID: 420,
-}
-
-const QUEUE_ORIGIN = {
-  SEQUENCER_QUEUE: 0,
-  L1TOL2_QUEUE: 1,
 }
 
 const DUMMY_TRANSACTION = {

--- a/packages/contracts/test/helpers/codec/index.ts
+++ b/packages/contracts/test/helpers/codec/index.ts
@@ -1,3 +1,4 @@
 export * from './revert-flags'
 export * from './encoding'
 export * from './bridge'
+export * from './queueOrigin'

--- a/packages/contracts/test/helpers/codec/queueOrigin.ts
+++ b/packages/contracts/test/helpers/codec/queueOrigin.ts
@@ -1,0 +1,4 @@
+export const QUEUE_ORIGIN = {
+  SEQUENCER_QUEUE: 0,
+  L1TOL2_QUEUE: 1,
+}


### PR DESCRIPTION
**Description**
Fixes an issue which allowed an enqueued transaction to be falsely verified with the `l1QueueOrigin` field set to `SEQUENCER_QUEUE` (instead of `L1TOL2_QUEUE`). 

**Additional context**
Although much larger changes are planned for the CTC, this test case should be included in the suite for use during refactoring.

If we object to modifying the code of the CTC as is, an alternative would be to simply add this test case with `.skip`. 