### PR TITLE
Enforce monotonicity between batches

### DIFF
--- a/.changeset/plenty-flies-wink.md
+++ b/.changeset/plenty-flies-wink.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Ensure that within a call to `appendSequencerBatch()` sequencer transactions must have monotonically increasing context relative to previous queue transactions.

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -429,12 +429,12 @@ describe('Basic RPC tests', () => {
 
   describe('rollup_gasPrices', () => {
     it('should return the L1 and L2 gas prices', async () => {
-      const result = await provider.send('rollup_gasPrices', []);
+      const result = await provider.send('rollup_gasPrices', [])
       const l1GasPrice = await env.l1Wallet.provider.getGasPrice()
       const l2GasPrice = await env.gasPriceOracle.gasPrice()
 
       expect(BigNumber.from(result.l1GasPrice)).to.deep.eq(l1GasPrice)
-      expect((BigNumber.from(result.l2GasPrice))).to.deep.eq(l2GasPrice)
+      expect(BigNumber.from(result.l2GasPrice)).to.deep.eq(l2GasPrice)
     })
   })
 })

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -1009,7 +1009,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     }
 
     /**
-     * Checks that a given batch context is valid based on its previous context, and the next queue elemtent.
+     * Checks that a given batch context is valid based on its previous context, and the next queue element.
      * @param _prevContext The previously validated batch context.
      * @param _nextContext The batch context to validate with this call.
      * @param _nextQueueIndex Index of the next queue element to process for the _nextContext's subsequentQueueElements.
@@ -1034,6 +1034,25 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             _nextContext.blockNumber >= _prevContext.blockNumber,
             "Context blockNumber values must monotonically increase."
         );
+
+        // All sequencer transactions' times must also be greater than or equal to previously
+        // appended queueElements.
+        if (_nextQueueIndex > 0) {
+            Lib_OVMCodec.QueueElement memory lastQueueElement = _getQueueElement(
+                _nextQueueIndex - 1,
+                _queueRef
+            );
+            require(
+                _nextContext.timestamp >= lastQueueElement.timestamp,
+                "Context timestamp value must be greater than last queue element appended."
+            );
+
+            require(
+                _nextContext.blockNumber >= lastQueueElement.blockNumber,
+                "Context block number value must be greater than last queue element appended."
+            );
+        }
+
 
         // If there is going to be a queue element pulled in from this context:
         if (_nextContext.numSubsequentQueueTransactions > 0) {

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/chain/OVM_CanonicalTransactionChain.sol
@@ -2,7 +2,7 @@
 // @unsupported: ovm
 pragma solidity >0.5.0 <0.8.0;
 pragma experimental ABIEncoderV2;
-import "hardhat/console.sol";
+
 /* Library Imports */
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";
@@ -453,7 +453,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
         // We will sequentially append leaves which are pointers to the queue.
         // The initial queue index is what is currently in storage.
-        uint40 nextQueueIndex = getNextQueueIndex();
+        uint40 subsequentQueueIndex = getNextQueueIndex();
 
         // Note that the curContext is uninitialized for the first set of checks
         BatchContext memory curContext;
@@ -467,10 +467,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
 
             if(i < numContexts) {
                 // Execute this check on every single context, except the final one.
-                _validateCurrentBatchContext(
+                _validateConsecutiveBatchContexts(
                     curContext,
                     nextContext,
-                    nextQueueIndex,
+                    subsequentQueueIndex,
                     queueRef
                 );
             }
@@ -503,19 +503,19 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
             // Now process any subsequent queue transactions.
             for (uint32 j = 0; j < curContext.numSubsequentQueueTransactions; j++) {
                 require(
-                    nextQueueIndex < queueLength,
+                    subsequentQueueIndex < queueLength,
                     "Not enough queued transactions to append."
                 );
 
-                leaves[leafIndex] = _getQueueLeafHash(nextQueueIndex);
-                nextQueueIndex++;
+                leaves[leafIndex] = _getQueueLeafHash(subsequentQueueIndex);
+                subsequentQueueIndex++;
                 leafIndex++;
             }
         }
 
         _validateFinalBatchContext(
             curContext,
-            nextQueueIndex,
+            subsequentQueueIndex,
             queueLength,
             queueRef
         );
@@ -541,10 +541,10 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         } else {
             // The last element is a queue tx, therefore pull timestamp and block number from the queue element.
             // curContext.numSubsequentQueueTransactions > 0 which means that we've processed at least one queue element.
-            // We increment nextQueueIndex after processing each queue element,
-            // so the index of the last element we processed is nextQueueIndex - 1.
+            // We increment subsequentQueueIndex after processing each queue element,
+            // so the index of the last element we processed is subsequentQueueIndex - 1.
             Lib_OVMCodec.QueueElement memory lastElement = _getQueueElement(
-                nextQueueIndex - 1,
+                subsequentQueueIndex - 1,
                 queueRef
             );
 
@@ -564,7 +564,7 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         );
 
         emit SequencerBatchAppended(
-            nextQueueIndex - numQueuedTransactions,
+            subsequentQueueIndex - numQueuedTransactions,
             numQueuedTransactions,
             getTotalElements()
         );
@@ -973,30 +973,38 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     }
 
     /**
-     * Checks that a given batch context has a time context which is below a given que element TODO fix this line
+     * Checks that a pair of adjacent batch contexts are monotonic with respect to each other,
+     * and with respect to any queue elements which may be appended between them.
+     * Also checks that any queue elements between are not yet older than the force inclusion period, which would force them to come next.
      * @param _earlierContext The batch context to validate has values lower.
-     * @param _firstSubsequentQueueIndex Index of the queue element we are validating came later than the _earlierContext
      * @param _laterContext The batch context whose time values should come AFTER all of _earlierContext's subsequent queue transactions
+     * @param _subsequentQueueIndex Index of the queue element we are validating came later than the _earlierContext
      * @param _queueRef The storage container for the queue.
      */
     function _validateEnqueuesBetweenContexts(
         BatchContext memory _earlierContext,
         BatchContext memory _laterContext,
-        uint40 _firstSubsequentQueueIndex,
+        uint40 _subsequentQueueIndex,
         iOVM_ChainStorageContainer _queueRef
     )
         internal
         view
     {
             Lib_OVMCodec.QueueElement memory earliestQueueElementBetween = _getQueueElement(
-                _firstSubsequentQueueIndex,
+                _subsequentQueueIndex,
                 _queueRef
             );
 
-            Lib_OVMCodec.QueueElement memory latestQueueElementBetween = _getQueueElement(
-                _firstSubsequentQueueIndex + uint40(_earlierContext.numSubsequentQueueTransactions) - 1,
-                _queueRef
-            );
+            // Assume the earliest and latest are the same, update the latest if not
+            Lib_OVMCodec.QueueElement memory latestQueueElementBetween;
+            if(_earlierContext.numSubsequentQueueTransactions > 1) {
+                latestQueueElementBetween = _getQueueElement(
+                    _subsequentQueueIndex + uint40(_earlierContext.numSubsequentQueueTransactions) - 1,
+                    _queueRef
+                );
+            } else {
+                latestQueueElementBetween = earliestQueueElementBetween;
+            }
 
             // If the force inclusion period has passed for an enqueued transaction, it MUST be the next chain element.
             require(
@@ -1016,29 +1024,28 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
                 "Sequencer transaction blockNumber exceeds that of next queue element."
             );
 
-            // TODO explain and improve consistency of these require strings
             require(
                 _laterContext.timestamp >= latestQueueElementBetween.timestamp,
-                "Context timestamp value must be greater than last queue element appended."
+                "Sequencer transaction timestamp is less than that of last queue element appended."
             );
 
             require(
                 _laterContext.blockNumber >= latestQueueElementBetween.blockNumber,
-                "Context block number value must be greater than last queue element appended."
+                "Sequencer transaction block number must be greater than last queue element appended."
             );
     }
 
     /**
-     * Checks that a given batch context is valid based on the next queue element, and the next context.
-     * @param _curContext The current batch context being validated.
-     * @param _nextContext The batch context that follows this one.
-     * @param _nextQueueIndex Index of the next queue element to process for the _curContext's subsequentQueueElements.
+     * Checks that consecutve batches, and the queue elements between them, are monotonic
+     * @param _firstContext The first batch context being validated.
+     * @param _secondContext The batch context that follows this one.
+     * @param _subsequentQueueIndex Index of the next queue element to process for the _firstContext's subsequentQueueElements.
      * @param _queueRef The storage container for the queue.
      */
-    function _validateCurrentBatchContext(
-        BatchContext memory _curContext,
-        BatchContext memory _nextContext,
-        uint40 _nextQueueIndex,
+    function _validateConsecutiveBatchContexts(
+        BatchContext memory _firstContext,
+        BatchContext memory _secondContext,
+        uint40 _subsequentQueueIndex,
         iOVM_ChainStorageContainer _queueRef
     )
         internal
@@ -1046,36 +1053,37 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
     {
         // All sequencer transactions' times must be greater than or equal to the previous ones.
         require(
-            _nextContext.timestamp >= _curContext.timestamp,
+            _secondContext.timestamp >= _firstContext.timestamp,
             "Context timestamp values must monotonically increase."
         );
 
         require(
-            _nextContext.blockNumber >= _curContext.blockNumber,
+            _secondContext.blockNumber >= _firstContext.blockNumber,
             "Context blockNumber values must monotonically increase."
         );
 
         // If there is going to be a queue element pulled between the current and next context
-        if (_curContext.numSubsequentQueueTransactions > 0) {
+        if (_firstContext.numSubsequentQueueTransactions > 0) {
             _validateEnqueuesBetweenContexts(
-                _curContext,
-                _nextContext,
-                _nextQueueIndex,
+                _firstContext,
+                _secondContext,
+                _subsequentQueueIndex,
                 _queueRef
             );
         }
     }
 
     /**
-     * Checks that the final batch context in a sequencer submission is valid.
+     * Checks that the final batch context in a sequencer submission cannot have a higher
+     * timestamp/blocknumber than the first queue element in a future submission.
      * @param _finalContext The batch context to validate.
      * @param _queueLength The length of the queue at the start of the batchAppend call.
-     * @param _nextQueueIndex The next element in the queue that will be pulled into the CTC.
+     * @param _subsequentQueueIndex The next element in the queue that will be pulled into the CTC.
      * @param _queueRef The storage container for the queue.
      */
     function _validateFinalBatchContext(
         BatchContext memory _finalContext,
-        uint40 _nextQueueIndex,
+        uint40 _subsequentQueueIndex,
         uint40 _queueLength,
         iOVM_ChainStorageContainer _queueRef
     )
@@ -1083,27 +1091,27 @@ contract OVM_CanonicalTransactionChain is iOVM_CanonicalTransactionChain, Lib_Ad
         view
     {
         // If the queue is not now empty, check the mononoticity of whatever the next batch that will come in is.
-        if (_queueLength - _nextQueueIndex > 0) {
-            Lib_OVMCodec.QueueElement memory nextQueueElement = _getQueueElement(
-                _nextQueueIndex,
+        if (_queueLength - _subsequentQueueIndex > 0) {
+            Lib_OVMCodec.QueueElement memory firstSubsequentQueueElement = _getQueueElement(
+                _subsequentQueueIndex,
                 _queueRef
             );
 
             // If the force inclusion period has passed for an enqueued transaction, it MUST be the next chain element.
             require(
-                block.timestamp < nextQueueElement.timestamp + forceInclusionPeriodSeconds,
+                block.timestamp < firstSubsequentQueueElement.timestamp + forceInclusionPeriodSeconds,
                 "Previously enqueued batches have expired and must be appended before a new sequencer batch."
             );
 
             // Just like sequencer transaction times must be increasing relative to each other,
             // We also require that they be increasing relative to any interspersed queue elements.
             require(
-                _finalContext.timestamp <= nextQueueElement.timestamp,
+                _finalContext.timestamp <= firstSubsequentQueueElement.timestamp,
                 "Sequencer transaction timestamp exceeds that of next queue element."
             );
 
             require(
-                _finalContext.blockNumber <= nextQueueElement.blockNumber,
+                _finalContext.blockNumber <= firstSubsequentQueueElement.blockNumber,
                 "Sequencer transaction blockNumber exceeds that of next queue element."
             );
         }

--- a/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -868,7 +868,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               shouldStartAtElement: 0,
               totalElementsToAppend: 1,
             })
-          ).to.be.revertedWith('Index out of bounds.')
+          ).to.be.revertedWith('Not enough queued transactions to append.')
         })
 
         it('reverts when there are insufficient (but nonzero) transactions in the queue', async () => {
@@ -1063,7 +1063,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   totalElementsToAppend: 2 * numQueuedTransactions,
                 })
               ).to.be.revertedWith(
-                'Sequencer transaction timestamp exceeds that of next queue element.'
+                'Context timestamp values must monotonically increase.'
               )
             })
 
@@ -1081,7 +1081,7 @@ describe('OVM_CanonicalTransactionChain', () => {
                   totalElementsToAppend: 2 * numQueuedTransactions,
                 })
               ).to.be.revertedWith(
-                'Sequencer transaction blockNumber exceeds that of next queue element.'
+                'Context blockNumber values must monotonically increase.'
               )
             })
           })
@@ -1223,8 +1223,10 @@ describe('OVM_CanonicalTransactionChain', () => {
         let firstContext: { timestamp: number; blockNumber: number }
         let secondContext: { timestamp: number; blockNumber: number }
         beforeEach(async () => {
-          // Pre-populate the queue with a transaction to append later
+          // Pre-populate the queue with a couple transaction to append later
           await OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data)
+          await OVM_CanonicalTransactionChain.enqueue(target, gasLimit, data)
+          // Get the first queue element, which we'll set our test contexts relative to.
           queueElement = await OVM_CanonicalTransactionChain.getQueueElement(0)
 
           // Set the first context sufficiently below the QueueElement's context

--- a/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/OVM/chain/OVM_CanonicalTransactionChain.spec.ts
@@ -1281,7 +1281,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               totalElementsToAppend: 4,
             })
           ).to.be.revertedWith(
-            'Context timestamp value must be greater than last queue element appended.'
+            'Sequencer transaction timestamp is less than that of last queue element appended.'
           )
         })
 
@@ -1328,7 +1328,7 @@ describe('OVM_CanonicalTransactionChain', () => {
               totalElementsToAppend: 4,
             })
           ).to.be.revertedWith(
-            'Context block number value must be greater than last queue element appended.'
+            'Sequencer transaction block number must be greater than last queue element appended.'
           )
         })
       })


### PR DESCRIPTION
**Description**
During `appendSequencerBatch()` there are checks to ensure that the new batch context is greater than the previous, but not that it is also greater than the last queue element in the previous batch.

**Additional context**
Although much larger changes are planned for the CTC, this test case should be included in the suite for use during refactoring.

If we object to modifying the code of the CTC as is, an alternative would be to simply add this test case with .skip.
