### PR TITLE
fix: rollup client check err

### DIFF
--- a/.changeset/thick-birds-jog.md
+++ b/.changeset/thick-birds-jog.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Handle errors correctly in the RollupClient and retry in the SyncService when initially attempting to connect to the DTL

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -129,28 +129,28 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 	if service.enable {
 		// Ensure that the rollup client can connect to a remote server
 		// before starting. Retry until it can connect.
-		t1 := time.NewTicker(10 * time.Second)
-		for ; true; <-t1.C {
+		tEnsure := time.NewTicker(10 * time.Second)
+		for ; true; <-tEnsure.C {
 			err := service.ensureClient()
 			if err != nil {
 				log.Info("Cannot connect to upstream service", "msg", err)
 			} else {
 				log.Info("Connected to upstream service")
-				t1.Stop()
+				tEnsure.Stop()
 				break
 			}
 		}
 
 		// Wait until the remote service is done syncing
-		t2 := time.NewTicker(10 * time.Second)
-		for ; true; <-t2.C {
+		tStatus := time.NewTicker(10 * time.Second)
+		for ; true; <-tStatus.C {
 			status, err := service.client.SyncStatus(service.backend)
 			if err != nil {
 				log.Error("Cannot get sync status")
 				continue
 			}
 			if !status.Syncing {
-				t2.Stop()
+				tStatus.Stop()
 				break
 			}
 			log.Info("Still syncing", "index", status.CurrentTransactionIndex, "tip", status.HighestKnownTransactionIndex)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The `RollupClient` was not explicitly checking for remote server errors when querying the DTL. This now will check for remote errors and pass through an error. It also causes the `SyncService` to retry its initial connection to the DTL on startup so that it doesn't shut down on boot up if it intends to connect to a DTL but receives a server error instead.

**Additional context**
Fixes problems with a misconfigured DTL, specifically when a L1 Eth Provider is set up properly

