### PR TITLE
fix: bind dtl functions for missing event codepath

### DIFF
--- a/.changeset/lovely-poems-cough.md
+++ b/.changeset/lovely-poems-cough.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Correctly bind the event handlers to the correct `this` in the missing event error path

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -230,9 +230,9 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         if (err instanceof MissingElementError) {
           // Different functions for getting the last good element depending on the event type.
           const handlers = {
-            SequencerBatchAppended: this.state.db.getLatestTransactionBatch,
-            StateBatchAppended: this.state.db.getLatestStateRootBatch,
-            TransactionEnqueued: this.state.db.getLatestEnqueue,
+            SequencerBatchAppended: this.state.db.getLatestTransactionBatch.bind(this),
+            StateBatchAppended: this.state.db.getLatestStateRootBatch.bind(this),
+            TransactionEnqueued: this.state.db.getLatestEnqueue.bind(this),
           }
 
           // Find the last good element and reset the highest synced L1 block to go back to the

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -228,6 +228,10 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         }
       } catch (err) {
         if (err instanceof MissingElementError) {
+          this.logger.warn('recovering from a missing event', {
+            message: err.toString(),
+          })
+
           // Different functions for getting the last good element depending on the event type.
           const handlers = {
             SequencerBatchAppended: this.state.db.getLatestTransactionBatch.bind(this),
@@ -266,7 +270,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           )
 
           // Something we should be keeping track of.
-          this.logger.warn('recovering from a missing event', {
+          this.logger.warn('recovered from a missing event', {
             eventName,
             lastGoodBlockNumber: lastGoodElement.blockNumber,
           })

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -8,7 +8,7 @@ import { L1IngestionService } from '../l1-ingestion/service'
 import { L1TransportServer } from '../server/service'
 import { validators } from '../../utils'
 import { L2IngestionService } from '../l2-ingestion/service'
-import { Gauge } from 'prom-client'
+import { Counter } from 'prom-client'
 
 export interface L1DataTransportServiceOptions {
   nodeEnv: string
@@ -59,7 +59,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     l2IngestionService?: L2IngestionService
     l1TransportServer: L1TransportServer
     metrics: Metrics
-    failureGauge: Gauge<string>
+    failureCounter: Counter<string>
   } = {} as any
 
   protected async _init(): Promise<void> {
@@ -77,7 +77,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
       }
     })
 
-    this.state.failureGauge = new this.state.metrics.client.Gauge({
+    this.state.failureCounter = new this.state.metrics.client.Counter({
       name: 'data_transport_layer_main_service_failures',
       help: 'Counts the number of times that the main service fails',
       registers: [this.state.metrics.registry],
@@ -126,7 +126,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
         this.options.syncFromL2 ? this.state.l2IngestionService.start() : null,
       ])
     } catch (e) {
-      this.state.failureGauge.inc()
+      this.state.failureCounter.inc()
       throw e
     }
   }
@@ -141,7 +141,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
 
       await this.state.db.close()
     } catch (e) {
-      this.state.failureGauge.inc()
+      this.state.failureCounter.inc()
       throw e
     }
   }

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -8,6 +8,7 @@ import { L1IngestionService } from '../l1-ingestion/service'
 import { L1TransportServer } from '../server/service'
 import { validators } from '../../utils'
 import { L2IngestionService } from '../l2-ingestion/service'
+import { Gauge } from 'prom-client'
 
 export interface L1DataTransportServiceOptions {
   nodeEnv: string
@@ -20,6 +21,7 @@ export interface L1DataTransportServiceOptions {
   l1RpcProvider: string
   l2ChainId: number
   l2RpcProvider: string
+  metrics?: Metrics
   dbPath: string
   logsPerPollingInterval: number
   pollingInterval: number
@@ -56,6 +58,8 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     l1IngestionService?: L1IngestionService
     l2IngestionService?: L2IngestionService
     l1TransportServer: L1TransportServer
+    metrics: Metrics
+    failureGauge: Gauge<string>
   } = {} as any
 
   protected async _init(): Promise<void> {
@@ -64,7 +68,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     this.state.db = level(this.options.dbPath)
     await this.state.db.open()
 
-    const metrics = new Metrics({
+    this.state.metrics = new Metrics({
       labels: {
         environment: this.options.nodeEnv,
         network: this.options.ethNetworkName,
@@ -73,9 +77,15 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
       }
     })
 
+    this.state.failureGauge = new this.state.metrics.client.Gauge({
+      name: 'data_transport_layer_main_service_failures',
+      help: 'Counts the number of times that the main service fails',
+      registers: [this.state.metrics.registry],
+    })
+
     this.state.l1TransportServer = new L1TransportServer({
       ...this.options,
-      metrics,
+      metrics: this.state.metrics,
       db: this.state.db,
     })
 
@@ -83,7 +93,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     if (this.options.syncFromL1) {
       this.state.l1IngestionService = new L1IngestionService({
         ...this.options,
-        metrics,
+        metrics: this.state.metrics,
         db: this.state.db,
       })
     }
@@ -92,7 +102,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
     if (this.options.syncFromL2) {
       this.state.l2IngestionService = new L2IngestionService({
         ...(this.options as any), // TODO: Correct thing to do here is to assert this type.
-        metrics,
+        metrics: this.state.metrics,
         db: this.state.db,
       })
     }
@@ -109,20 +119,30 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
   }
 
   protected async _start(): Promise<void> {
-    await Promise.all([
-      this.state.l1TransportServer.start(),
-      this.options.syncFromL1 ? this.state.l1IngestionService.start() : null,
-      this.options.syncFromL2 ? this.state.l2IngestionService.start() : null,
-    ])
+    try {
+      await Promise.all([
+        this.state.l1TransportServer.start(),
+        this.options.syncFromL1 ? this.state.l1IngestionService.start() : null,
+        this.options.syncFromL2 ? this.state.l2IngestionService.start() : null,
+      ])
+    } catch (e) {
+      this.state.failureGauge.inc()
+      throw e
+    }
   }
 
   protected async _stop(): Promise<void> {
-    await Promise.all([
-      this.state.l1TransportServer.stop(),
-      this.options.syncFromL1 ? this.state.l1IngestionService.stop() : null,
-      this.options.syncFromL2 ? this.state.l2IngestionService.stop() : null,
-    ])
+    try {
+      await Promise.all([
+        this.state.l1TransportServer.stop(),
+        this.options.syncFromL1 ? this.state.l1IngestionService.stop() : null,
+        this.options.syncFromL2 ? this.state.l2IngestionService.stop() : null,
+      ])
 
-    await this.state.db.close()
+      await this.state.db.close()
+    } catch (e) {
+      this.state.failureGauge.inc()
+      throw e
+    }
   }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
We observed an error of `this` not being bound correctly when going through the codepath that recovers from missing events. Still unsure of the root cause of the missing events, but this should help to recover from them.
