### PR TITLE
fix: remove 'editor.formatOnSave' from global settings'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true,


### PR DESCRIPTION
#1109 added `"editor.formatOnSave": true` for all files. 
This PR turns that off, though now that it's on, you might also need to disable the setting yourself (`"solidity.formatter": "none"`)

This has caused the [solidity extension](https://github.com/juanfranblanco/vscode-solidity#formatting-using-prettier-and-the-prettier-solidity-plugin) to start formatting our `.sol` files using. We may want to activate this functionality in the near future, but it should be done in a PR which also handles the formatting. 

