### PR TITLE
infra deployment for rpc-proxy

### DIFF
--- a/ops/docker-compose-rpc-proxy.yml
+++ b/ops/docker-compose-rpc-proxy.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: ./ops/docker/Dockerfile.rpc-proxy
     environment:
       SEQUENCER: l2geth:8545
-      ETH_CALLS_ALLOWED: eth_blockNumber,eth_sendRawTransaction
+      RPC_METHODS_ALLOWED: eth_blockNumber,eth_sendRawTransaction
     ports:
       - 9546:8080
       - 9145:9145

--- a/ops/docker/rpc-proxy/docker-entrypoint.sh
+++ b/ops/docker/rpc-proxy/docker-entrypoint.sh
@@ -7,8 +7,8 @@ if [ -z "$SEQUENCER" ];then
   exit 1
 fi
 
-if [ -z "$ETH_CALLS_ALLOWED" ];then
-  echo "ETH_CALLS_ALLOWED env must be set, exiting"
+if [ -z "$RPC_METHODS_ALLOWED" ];then
+  echo "RPC_METHODS_ALLOWED env must be set, exiting"
   exit 1
 fi
 

--- a/ops/docker/rpc-proxy/nginx.template.conf
+++ b/ops/docker/rpc-proxy/nginx.template.conf
@@ -38,7 +38,7 @@ http {
     metric_sequencer_requests = prometheus:counter(
       "nginx_eth_sequencer_requests", "Number of requests going to the sequencer", {"method", "host", "status"})
     metric_replica_requests = prometheus:counter(
-      "nginx_eth_replica_requests", "Number of requests going to the replicas", {"host", "status"})    
+      "nginx_eth_replica_requests", "Number of requests going to the replicas", {"host", "status"})
     metric_latency = prometheus:histogram(
       "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
     metric_connections = prometheus:gauge(
@@ -59,7 +59,7 @@ http {
       return 200 'healthz';
     }
     location / {
-      set $jsonrpc_whitelist {{env.Getenv "ETH_CALLS_ALLOWED"}};
+      set $jsonrpc_whitelist {{env.Getenv "RPC_METHODS_ALLOWED"}};
       access_by_lua_file 'eth-jsonrpc-access.lua';
       proxy_pass http://sequencer;
     }

--- a/ops/infra/rpc-proxy/README.md
+++ b/ops/infra/rpc-proxy/README.md
@@ -10,7 +10,7 @@ Both are configured through environmental variables.
 ```
 - name: SEQUENCER
   value: sequencer:8545
-- name: ETH_CALLS_ALLOWED
+- name: RPC_METHODS_ALLOWED
   value: eth_blockNumber,eth_getBlockByNumber,eth_getBlockRange,eth_sendRawTransaction
 ```
 

--- a/ops/infra/rpc-proxy/README.md
+++ b/ops/infra/rpc-proxy/README.md
@@ -1,0 +1,59 @@
+# RPC-Proxy
+
+## rpc-proxy settings
+
+There are only 2 settings currently surfaced through the container.
+1. What methods to allow
+2. The address of the upstream sequencer
+
+Both are configured through environmental variables.
+```
+- name: SEQUENCER
+  value: sequencer:8545
+- name: ETH_CALLS_ALLOWED
+  value: eth_blockNumber,eth_getBlockByNumber,eth_getBlockRange,eth_sendRawTransaction
+```
+
+## Deploy the rpc-proxy
+
+These deployments use `kustomize` which references base resources and allows overlays for modification.
+
+The overlay directories contain the deviations from the `bases` collection of default resources.
+
+Target the base directory to deploy the base configuration.
+```
+kubectl diff -k ops/infra/rpc-proxy/bases
+kubectl apply -k ops/infra/rpc-proxy/bases
+```
+
+Target an overlay directory to apply environmental specific modifications.
+```
+kubectl diff -k ops/infra/rpc-proxy/goerli-devnet/
+kubectl apply -k ops/infra/rpc-proxy/goerli-devnet/
+```
+
+## Setup once for GCP ingress
+
+Create a ip reservation on GCP with a useful name
+```
+gcloud compute addresses create goerli-sequencer --global
+gcloud compute addresses create kovan-sequencer --global
+gcloud compute addresses create mainnet-sequencer --global
+```
+
+View the assigned IP address
+```
+$ gcloud compute addresses list
+NAME                   ADDRESS/RANGE   TYPE      PURPOSE  NETWORK  REGION  SUBNET  STATUS
+goerli-sequencer       35.190.76.113   EXTERNAL                                    IN_USE
+```
+
+Update Cloudflare dashboard with the address and corresponding hostname.
+
+## Ingress and ManagedCertificates
+
+This deployment uses the GKE Ingress to avoid routing through another pod.
+
+The offical documentation can be found [here](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs)
+
+It's **very important that `readinessProbe` passes** for the pods backing a GKE Ingress, otherwise it will be marked down.

--- a/ops/infra/rpc-proxy/bases/alerts.yaml
+++ b/ops/infra/rpc-proxy/bases/alerts.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rpc-proxy-rules
+  namespace: monitoring
+  labels:
+    prometheus: k8s ### These labels are required for the operator
+    role: alert-rules # to pick up the new rules
+    app: rpc-proxy
+spec:
+  groups:
+    - name: rpc-proxy
+      rules:
+        - alert: RPCProxyHighErrorRate
+          annotations:
+            description: The rpc proxy is generating a high number of errors.
+          expr: sum by (namespace) (nginx_metric_errors_total) > 0
+          for: 10m
+          labels:
+            severity: critical
+        - alert: RPCProxyHighStatusErrorRate
+          annotations:
+            description: The rpc proxy is received a high rate of errors contacting the sequencer.
+          expr: sum by (status, namespace) (rate(nginx_http_requests_total{status=~"5.*"}[1m])) > 0.05
+          for: 3m
+          labels:
+            severity: critical

--- a/ops/infra/rpc-proxy/bases/kustomization.yml
+++ b/ops/infra/rpc-proxy/bases/kustomization.yml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - rpc-proxy.yml
+  - alerts.yaml

--- a/ops/infra/rpc-proxy/bases/kustomization.yml
+++ b/ops/infra/rpc-proxy/bases/kustomization.yml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rpc-proxy.yml

--- a/ops/infra/rpc-proxy/bases/rpc-proxy.yml
+++ b/ops/infra/rpc-proxy/bases/rpc-proxy.yml
@@ -25,7 +25,7 @@ spec:
           env:
             - name: SEQUENCER
               value: sequencer:8545
-            - name: ETH_CALLS_ALLOWED
+            - name: RPC_METHODS_ALLOWED
               value: eth_blockNumber,eth_getBlockByNumber,eth_getBlockRange,eth_sendRawTransaction,eth_chainId,net_version,rollup_gasPrices
           livenessProbe:
             httpGet:

--- a/ops/infra/rpc-proxy/bases/rpc-proxy.yml
+++ b/ops/infra/rpc-proxy/bases/rpc-proxy.yml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rpc-proxy
+  labels:
+    app: rpc-proxy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: rpc-proxy
+  template:
+    metadata:
+      labels:
+        app: rpc-proxy
+    spec:
+      containers:
+        - name: rpc-proxy
+          image: ethereumoptimism/rpc-proxy:0.4.1
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9145
+          env:
+            - name: SEQUENCER
+              value: sequencer:8545
+            - name: ETH_CALLS_ALLOWED
+              value: eth_blockNumber,eth_getBlockByNumber,eth_getBlockRange,eth_sendRawTransaction,eth_chainId,net_version,rollup_gasPrices
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            limits:
+              memory: 256Mi
+              cpu: "1"
+            requests:
+              memory: 128Mi
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: rpc-proxy
+  labels:
+    app: rpc-proxy
+spec:
+  type: NodePort
+  selector:
+    app: rpc-proxy
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+    - name: metrics
+      protocol: TCP
+      port: 9145
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rpc-proxy
+spec:
+  endpoints:
+    - port: metrics
+  selector:
+    matchLabels:
+      app: rpc-proxy

--- a/ops/infra/rpc-proxy/goerli-devnet/ingress.yml
+++ b/ops/infra/rpc-proxy/goerli-devnet/ingress.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: goerli-sequencer
+spec:
+  domains:
+    - goerli-sequencer.optimism.io
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: goerli-sequencer
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: goerli-sequencer
+    networking.gke.io/managed-certificates: goerli-sequencer
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+    - host: goerli-sequencer.optimism.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix  # (all paths)
+            backend:
+              service:
+                name: rpc-proxy
+                port: 
+                  name: http

--- a/ops/infra/rpc-proxy/goerli-devnet/kustomization.yml
+++ b/ops/infra/rpc-proxy/goerli-devnet/kustomization.yml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+bases:
+  - ../bases/
+
+resources:
+  - ingress.yml

--- a/ops/infra/rpc-proxy/kovan-prod/ingress.yml
+++ b/ops/infra/rpc-proxy/kovan-prod/ingress.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: kovan-sequencer
+spec:
+  domains:
+    - kovan-sequencer.optimism.io
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kovan-sequencer
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: kovan-sequencer
+    networking.gke.io/managed-certificates: kovan-sequencer
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+    - host: kovan-sequencer.optimism.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix  # (all paths)
+            backend:
+              service:
+                name: rpc-proxy
+                port: 
+                  name: http

--- a/ops/infra/rpc-proxy/kovan-prod/kustomization.yml
+++ b/ops/infra/rpc-proxy/kovan-prod/kustomization.yml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+bases:
+  - ../bases/
+
+resources:
+  - ingress.yml

--- a/ops/infra/rpc-proxy/mainnet-prod/ingress.yml
+++ b/ops/infra/rpc-proxy/mainnet-prod/ingress.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: mainnet-sequencer
+spec:
+  domains:
+    - mainnet-sequencer.optimism.io
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mainnet-sequencer
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: mainnet-sequencer
+    networking.gke.io/managed-certificates: mainnet-sequencer
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+    - host: mainnet-sequencer.optimism.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix  # (all paths)
+            backend:
+              service:
+                name: rpc-proxy
+                port: 
+                  name: http

--- a/ops/infra/rpc-proxy/mainnet-prod/kustomization.yml
+++ b/ops/infra/rpc-proxy/mainnet-prod/kustomization.yml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+
+bases:
+  - ../bases/
+
+resources:
+  - ingress.yml


### PR DESCRIPTION
**Description**
Kubernetes resources to deploy an instance of the [rpc-proxy](https://github.com/ethereum-optimism/optimism/blob/develop/ops/docker/Dockerfile.rpc-proxy) (jsonrpc method filter)

And kustomizations for currently deployed instances in GCP.

Additional detail in the included README.
