### PR TITLE
Add index to msgHash

### DIFF
--- a/.changeset/weak-bugs-raise.md
+++ b/.changeset/weak-bugs-raise.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': minor
+'@eth-optimism/core-utils': minor
+---
+
+Adds an index to the msgHash parameters RelayedMessage and FailedRelayedMessage. This allows for more efficient filtering by the watcher.

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_CrossDomainMessenger.sol
@@ -12,8 +12,8 @@ interface iOVM_CrossDomainMessenger {
      **********/
 
     event SentMessage(bytes message);
-    event RelayedMessage(bytes32 msgHash);
-    event FailedRelayedMessage(bytes32 msgHash);
+    event RelayedMessage(bytes32 indexed msgHash);
+    event FailedRelayedMessage(bytes32 indexed msgHash);
 
 
     /*************

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -81,18 +81,17 @@ export class Watcher {
       const startingBlock = Math.max(blockNumber - this.NUM_BLOCKS_TO_FETCH, 0)
       const successFilter: ethers.providers.Filter = {
         address: layer.messengerAddress,
-        topics: [ethers.utils.id(`RelayedMessage(bytes32)`)],
-        fromBlock: startingBlock
+        topics: [ethers.utils.id(`RelayedMessage(bytes32)`), msgHash],
+        fromBlock: startingBlock,
       }
       const failureFilter: ethers.providers.Filter = {
         address: layer.messengerAddress,
-        topics: [ethers.utils.id(`FailedRelayedMessage(bytes32)`)],
-        fromBlock: startingBlock
+        topics: [ethers.utils.id(`FailedRelayedMessage(bytes32)`), msgHash],
+        fromBlock: startingBlock,
       }
       const successLogs = await layer.provider.getLogs(successFilter)
       const failureLogs = await layer.provider.getLogs(failureFilter)
-      const logs = successLogs.concat(failureLogs)
-      matches = logs.filter((log: ethers.providers.Log) => log.data === msgHash)
+      matches = successLogs.concat(failureLogs)
       // exit loop after first iteration if not polling
       if (!pollForPending) {
         break


### PR DESCRIPTION
**Description**
This PR adds an index to the msgHash argument in the `RelayedMessage` and `FailedRelayedMessage` events. This index is needed since the watcher is filtering logs based on the `msgHash`.

See the discussion here for more context: https://github.com/ethereum-optimism/optimism/pull/1107#r654076328

**Additional context**
This is my first Solidity PR. Let me know if I missed anything!

**Metadata**
- Fixes https://github.com/ethereum-optimism/optimism/issues/1116
- Fixes OP-915
