### PR TITLE
Ignore the hardhat folder from linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     "extends": [
         "prettier",
     ],
-    "ignorePatterns": ["dist/**/*.ts"],
+    "ignorePatterns": ["dist/**/*.ts", "packages/contracts/hardhat"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": "tsconfig.json",


### PR DESCRIPTION
When the `packages/contracts/hardhat` folder is present in the fs, the linter fails. Here we use the [eslint config option](https://eslint.org/docs/user-guide/configuring/ignoring-code#ignorepatterns-in-config-files) to exclude it from linting.