### PR TITLE
Make it possible to override mint & burn methods in L2StandardERC20

### DIFF
--- a/.changeset/olive-chicken-heal.md
+++ b/.changeset/olive-chicken-heal.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Make it possible to override mint & burn methods in L2StandardERC20

--- a/packages/contracts/contracts/optimistic-ethereum/libraries/standards/L2StandardERC20.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/libraries/standards/L2StandardERC20.sol
@@ -39,13 +39,13 @@ contract L2StandardERC20 is IL2StandardERC20, ERC20 {
         return _interfaceId == firstSupportedInterface || _interfaceId == secondSupportedInterface;
     }
 
-    function mint(address _to, uint256 _amount) public override onlyL2Bridge {
+    function mint(address _to, uint256 _amount) public virtual override onlyL2Bridge {
         _mint(_to, _amount);
 
         emit Mint(_to, _amount);
     }
 
-    function burn(address _from, uint256 _amount) public override onlyL2Bridge {
+    function burn(address _from, uint256 _amount) public virtual override onlyL2Bridge {
         _burn(_from, _amount);
 
         emit Burn(_from, _amount);


### PR DESCRIPTION
**Description**

Mark `mint` and `burn` functions in the `L2StandardERC20` contract `virtual` so that they can be overridden. 

**Additional context**
This is required by the USDC contract. (Blacklisted addresses should not be able to burn.)
