### PR TITLE
feat: add workflow for running SNX test suite

### DIFF
--- a/.github/workflows/ext-test-snx.yml
+++ b/.github/workflows/ext-test-snx.yml
@@ -1,0 +1,65 @@
+name: Exteral Tests (Synthetix)
+
+on: workflow_dispatch
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      COMPOSE_DOCKER_CLI_BUILD: 1
+    steps:
+      - uses: actions/checkout@v2
+
+      # Required for some installation in the SNX repo
+      - uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_READ }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Build the services
+        working-directory: ./ops
+        run: ./scripts/build-ci.sh
+
+      - name: Bring the stack up
+        working-directory: ./ops
+        run: |
+          ./scripts/stats.sh &
+          docker-compose up -d
+
+      - name: Wait for the Sequencer node
+        working-directory: ./ops
+        run: ./scripts/wait-for-sequencer.sh
+
+      - name: Run the SNX test suite
+        working-directory: ./integration-tests
+        run: ./ext-test/snx.sh
+
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1
+        with:
+          images: 'ethereumoptimism/builder,ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth,ethereumoptimism/integration-tests'
+          dest: '~/logs'
+
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ~/logs
+
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: logs.tgz
+          path: ./logs.tgz

--- a/integration-tests/ext-test/snx.sh
+++ b/integration-tests/ext-test/snx.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git clone --depth=1 --branch develop https://github.com/Synthetixio/synthetix.git
+cd synthetix
+npm install
+npx hardhat --config ./hardhat.config.js test:integration:l2 --compile --deploy


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a workflow file for running the snx test suite. There might be a cleaner way to do this than to use a separate sh script but whatever, hopefully reviewers will know. Currently workflow can only be triggered manually.

**Metadata**
- Fixes OP-837