### PR TITLE
feat: gas oracle event

### DIFF
--- a/.changeset/seven-falcons-promise.md
+++ b/.changeset/seven-falcons-promise.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Emit `GasPriceUpdated(uint256,uint256)` after each time the gas price is updated

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -431,7 +431,7 @@ describe('Basic RPC tests', () => {
     it('should return the L1 and L2 gas prices', async () => {
       const result = await provider.send('rollup_gasPrices', []);
       const l1GasPrice = await env.l1Wallet.provider.getGasPrice()
-      const l2GasPrice = await env.gasPriceOracle.gasPrice()
+      const l2GasPrice = await env.gasPriceOracle.getGasPrice()
 
       expect(BigNumber.from(result.l1GasPrice)).to.deep.eq(l1GasPrice)
       expect((BigNumber.from(result.l2GasPrice))).to.deep.eq(l2GasPrice)

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_GasPriceOracle.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_GasPriceOracle.sol
@@ -3,6 +3,7 @@ pragma solidity >0.5.0 <0.8.0;
 
 /* External Imports */
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { iOVM_GasPriceOracle } from "../../iOVM/predeploys/iOVM_GasPriceOracle.sol";
 
 /**
  * @title OVM_GasPriceOracle
@@ -14,14 +15,14 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
  * Compiler used: optimistic-solc
  * Runtime target: OVM
  */
-contract OVM_GasPriceOracle is Ownable {
+contract OVM_GasPriceOracle is Ownable, iOVM_GasPriceOracle {
 
     /*************
      * Variables *
      *************/
 
     // Current l2 gas price
-    uint256 public gasPrice;
+    uint256 internal gasPrice;
 
     /***************
      * Constructor *
@@ -46,15 +47,34 @@ contract OVM_GasPriceOracle is Ownable {
      ********************/
 
     /**
-     * Allows the owner to modify the l2 gas price.
+     * A getter for the L2 gas price.
+     */
+    function getGasPrice()
+        public
+        view
+        override
+        returns (
+            uint256
+        )
+    {
+        return gasPrice;
+    }
+
+    /**
+     * Allows the owner to modify the L2 gas price.
+     * The GasPriceUpdated event accepts the old
+     * gas price as the first argument and the new
+     * gas price as the second argument.
      * @param _gasPrice New l2 gas price.
      */
     function setGasPrice(
         uint256 _gasPrice
     )
         public
+        override
         onlyOwner
     {
+        emit GasPriceUpdated(gasPrice, _gasPrice);
         gasPrice = _gasPrice;
     }
 }

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/predeploys/iOVM_GasPriceOracle.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/predeploys/iOVM_GasPriceOracle.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+
+/**
+ * @title iOVM_GasPriceOracle
+ */
+interface iOVM_GasPriceOracle {
+
+    /**********
+     * Events *
+     **********/
+
+    event GasPriceUpdated(uint256 _oldPrice, uint256 _newPrice);
+
+    /********************
+     * Public Functions *
+     ********************/
+
+    function getGasPrice() external returns (uint256);
+    function setGasPrice(uint256 _gasPrice) external;
+}

--- a/packages/contracts/test/contracts/OVM/predeploys/OVM_GasPriceOracle.spec.ts
+++ b/packages/contracts/test/contracts/OVM/predeploys/OVM_GasPriceOracle.spec.ts
@@ -49,7 +49,7 @@ describe('OVM_GasPriceOracle', () => {
 
   describe('get gasPrice', () => {
     it('should return zero at first', async () => {
-      expect(await OVM_GasPriceOracle.gasPrice()).to.equal(initialGasPrice)
+      expect(await OVM_GasPriceOracle.getGasPrice()).to.equal(initialGasPrice)
     })
 
     it('should change when setGasPrice is called', async () => {
@@ -57,7 +57,7 @@ describe('OVM_GasPriceOracle', () => {
 
       await OVM_GasPriceOracle.connect(signer1).setGasPrice(gasPrice)
 
-      expect(await OVM_GasPriceOracle.gasPrice()).to.equal(gasPrice)
+      expect(await OVM_GasPriceOracle.getGasPrice()).to.equal(gasPrice)
     })
 
     it('is the 1st storage slot', async () => {
@@ -72,7 +72,7 @@ describe('OVM_GasPriceOracle', () => {
         OVM_GasPriceOracle.address,
         slot
       )
-      expect(await OVM_GasPriceOracle.gasPrice()).to.equal(
+      expect(await OVM_GasPriceOracle.getGasPrice()).to.equal(
         ethers.BigNumber.from(priceAtSlot)
       )
     })


### PR DESCRIPTION
**Description**
Previously the `OVM_GasPriceOracle` did not emit an event when the gas
price was updated. This is bad because it is hard to tell the historical
changes in the smart contract state. With this change, it should be
possible for a user to reconstruct the entire history of the changes in
L2 gas prices based on the append only log data structure of the set of
events.

The event is `GasPriceUpdated(uint256,uint265)` where the first value
is the old price and the second value is the new price.

The ABI is also updated, changing the `gasPrice()(uint256)` getter into
`getGasPrice()(uint265)` by making `gasPrice` be internal. Previously
it was public so a getter was autogenerated.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

