### PR TITLE
fix: skip codechecks for PRs from external repos

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -55,6 +55,7 @@ jobs:
         run: cat packages/contracts/gas-report.txt
 
       - name: Run codechecks
+        if: ${{ github.repository == 'ethereum-optimism/optimism' }}
         working-directory: ./packages/contracts
         run: yarn codechecks
         env:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the `ts-packages.yml` workflow so we skip `codechecks` if running from an external repo. This is necessary because codechecks throws errors whenever it's triggered from an external repo. 
