### PR TITLE
docker: pin to alpine 3.13 for l2geth

### DIFF
--- a/ops/docker/Dockerfile.geth
+++ b/ops/docker/Dockerfile.geth
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.15-alpine as builder
+FROM golang:1.15-alpine3.13 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
@@ -7,7 +7,7 @@ ADD ./l2geth /go-ethereum
 RUN cd /go-ethereum && make geth
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates jq curl
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/


### PR DESCRIPTION
**Description**
A bug has appeared when older versions of Docker are used to build
alpine based images in alpine version 3.14. To prevent this problem
from happening to the users, this PR pins the version to 3.13.

The observed problem is that `make` cannot run any command and
the error message states `Operation not permitted.` Removing
`make` was one way to solve the problem but that would increase
the diff from upstream geth.

See these links for details:
https://github.com/alpinelinux/docker-alpine/issues/182
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0

