### PR TITLE
fix: update statement for skipping codechecks

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -55,7 +55,7 @@ jobs:
         run: cat packages/contracts/gas-report.txt
 
       - name: Run codechecks
-        if: ${{ github.repository == 'ethereum-optimism/optimism' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         working-directory: ./packages/contracts
         run: yarn codechecks
         env:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes the statement meant to skip codechecks on PRs from external repositories based on this github thread: https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363/2. Original statement did not work correctly.

**Metadata**
- Fixes #1202 
