### PR TITLE
fix: update CI to avoid running out of memory

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,7 +38,13 @@ jobs:
 
       - name: Bring the stack up
         working-directory: ./ops
-        run: docker-compose up -d
+        run: |
+          ./scripts/stats.sh &
+          docker-compose up -d
+
+      - name: Wait for the Sequencer node
+        working-directory: ./ops
+        run: ./scripts/wait-for-sequencer.sh
 
       - name: Run the integration tests
         working-directory: ./ops
@@ -99,11 +105,11 @@ jobs:
         uses: jwalton/gh-docker-logs@v1
         with:
           images: 'ethereumoptimism/builder,ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth,ethereumoptimism/integration-tests'
-          dest: './logs'
+          dest: '~/logs'
 
       - name: Tar logs
         if: failure()
-        run: tar cvzf ./logs.tgz ./logs
+        run: tar cvzf ./logs.tgz ~/logs
 
       - name: Upload logs to GitHub
         if: failure()

--- a/ops/scripts/stats.sh
+++ b/ops/scripts/stats.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# set up the stats file
+mkdir ~/logs
+touch ~/logs/stats.txt
+
+while true; do
+  {
+    echo "$(date) ----------------";
+    echo "total memory usage --------------------------";
+    free -m;
+    echo "docker stats --------------------------------";
+    docker stats --no-stream;
+    echo "memory munchers -----------------------------";
+    ps aux --sort=-%mem | head;
+  } >> ~/logs/stats.txt
+  sleep 1;
+done


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Resolves most common issues with CI running out of memory by waiting for the Sequencer before starting the integration tests. Also adds a `stats.sh` script that will log current memory usage of different parts of the system once per second while the integration tests are running.

**Metadata**
- Fixes #1057 
