### PR TITLE
ci(contracts): only run codecov if contracts package is modified

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -61,8 +61,42 @@ jobs:
         env:
           CC_SECRET: ${{ secrets.CC_SECRET }}
 
+  # A hack that allows running a job only if a specific directory changed.
+  # Ref: https://github.community/t/run-job-only-if-folder-changed/118292
+  is-contracts-package:
+    name: Check files
+    outputs:
+      run_coverage: ${{ steps.check_files.outputs.run_coverage }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: git fetch origin $GITHUB_BASE_REF
+
+      - name: check modified files
+        id: check_files
+        run: |
+          echo "=============== list modified files ==============="
+          git diff --name-only origin/$GITHUB_BASE_REF HEAD -- .
+
+          echo "========== check paths of modified files =========="
+          git diff --name-only origin/$GITHUB_BASE_REF HEAD -- . > files.txt
+          while IFS= read -r file
+          do
+            echo $file
+            if [[ $file != packages/contracts/* ]]; then
+              echo "This modified files are not in the contracts package."
+              echo "::set-output name=run_coverage::false"
+              break
+            else
+              echo "::set-output name=run_coverage::true"
+            fi
+          done < files.txt
+
   test-coverage:
     name: Generate test coverage
+    needs: is-contracts-package
+    if: needs.is-contracts-package.outputs.run_coverage == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
In order to skip running the CodeCov job when it isn't relevant, a new job was added to the ts-packges workflow. For a PR, this job identifies all the files modified between the base branch and the tip of the PR branch, and writes to a variable which can be used to decide if subsequent jobs should run.

Github Actions provides an easy method for achieving this at the level of a workflow, but not for specific jobs within a workflow.

This work is based on GitHub community post [here](https://github.community/t/run-job-only-if-folder-changed/118292), and at the time of writing, I have no idea if it will work. 

I have not included a changeset, as no package files were changed.