### PR TITLE
dtl: configurable gas price backend

### DIFF
--- a/.changeset/ninety-dryers-brush.md
+++ b/.changeset/ninety-dryers-brush.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Allow the L1 gas price to be fetched from either the sequencer or a L1 provider based on the config `--l1-gas-price-backend` as well as overriding the config by using a query param. Valid values are `l1` or `l2` and it defaults to `l1`

--- a/packages/data-transport-layer/README.md
+++ b/packages/data-transport-layer/README.md
@@ -62,6 +62,8 @@ Here's the list of environment variables you can change:
 | DATA_TRANSPORT_LAYER__LEGACY_SEQUENCER_COMPATIBILITY    | false       | Whether or not to enable "legacy" sequencer sync (without the custom `eth_getBlockRange` endpoint)                                                            |
 | DATA_TRANSPORT_LAYER__NODE_ENV                          | development | Environment the service is running in: production, development, or test.                                                                                      |
 | DATA_TRANSPORT_LAYER__ETH_NETWORK_NAME                  | -           | L1 Ethereum network the service is deployed to: mainnet, kovan, goerli.                                                                                  |
+| DATA_TRANSPORT_LAYER__L1_GAS_PRICE_BACKEND                  | l1           | Where to pull the l1 gas price from (l1 or l2)                                                                                  |
+| DATA_TRANSPORT_LAYER__DEFAULT_BACKEND                  | l1           | Where to sync transactions from (l1 or l2)                                                                                  |
 
 To enable proper error tracking via Sentry on deployed instances, make sure `NODE_ENV` and `ETH_NETWORK_NAME` are set in addition to [`SENTRY_DSN`](https://docs.sentry.io/platforms/node/).
 
@@ -85,6 +87,24 @@ GET /eth/context/latest
     "timestamp": number
 }
 ```
+
+### Latest Ethereum L1 Gas Price
+
+#### Request
+
+```
+GET /eth/gasprice
+```
+Defaults to pulling L1 gas price from config option `DATA_TRANSPORT_LAYER__L1_GAS_PRICE_BACKEND`. Can be overridden with query parameter `backend` (`/eth/gasprice?backend=l1`).
+
+#### Response
+
+```ts
+{
+    "gasPrice": string
+}
+```
+
 
 ### Enqueue by Index
 
@@ -145,7 +165,7 @@ GET /transaction/index/{index: number}
         } | null,
         "queueIndex": number | null,
     },
-    
+
     "batch": {
         "index": number,
         "blockNumber": number,
@@ -181,7 +201,7 @@ GET /batch/transaction/index/{index: number}
         "prevTotalElements": number,
         "extraData": string
     },
-    
+
     "transactions": [
       {
         "index": number,
@@ -266,7 +286,7 @@ GET /batch/stateroot/index/{index: number}
         "prevTotalElements": number,
         "extraData": string
     },
-    
+
     "stateRoots": [
         {
             "index": number,

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -34,6 +34,7 @@ export interface L1DataTransportServiceOptions {
   sentryDsn?: string
   sentryTraceRate?: number
   defaultBackend: string
+  l1GasPriceBackend: string
 }
 
 const optionSettings = {

--- a/packages/data-transport-layer/src/services/run.ts
+++ b/packages/data-transport-layer/src/services/run.ts
@@ -46,6 +46,7 @@ type ethNetwork = 'mainnet' | 'kovan' | 'goerli'
         false
       ),
       defaultBackend: config.str('default-backend', 'l1'),
+      l1GasPriceBackend: config.str('l1-gas-price-backend', 'l1'),
       useSentry: config.bool('use-sentry', false),
       sentryDsn: config.str('sentry-dsn'),
       sentryTraceRate: config.ufloat('sentry-trace-rate', 0.05),


### PR DESCRIPTION
**Description**

Adds a new config option `--l1-gas-price-backend` or
`DATA_TRANSPORT_LAYER_L1_GAS_PRICE_BACKEND` that can be set to `l1` or
`l2`. This impacts the behavior of the HTTP endpoint `GET /eth/gasprice`
by changing what is queried to return the L1 gas price. The L1 gas price
is required to compute the L2 fee since the L2 fee consists of
`L1 gas price * L1 gas used + L1 gas price * L2 gas limit`. If the L1
gas price differs too much between different L2 providers, then users
using `eth_estimateGas` may submit transactions with too low of a fee
and be unable to submit transactions to the sequencer.

By configuring the DTL to use L2 as the L1 gas price backend, it will
call the Sequencer's RPC endpoint `rollup_gasPrices` which returns the
L1 and L2 gas prices from the point of view of the sequencer. The L2 gas
price exists in the state, so that will always be the same between the
sequencer and any replicas. The L1 gas price does not live on chain, so
querying for it from the sequencer directly will ensure that users send
transactions with a fee that is large enough.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
