### PR TITLE
Increase client_body_buffer_size for rpc-proxy

### DIFF
--- a/ops/docker/rpc-proxy/nginx.template.conf
+++ b/ops/docker/rpc-proxy/nginx.template.conf
@@ -11,6 +11,15 @@ events {
 http {
   include    mime.types;
   index    index.html;
+  # The JSONRPC POST body must fit inside this allocation for the method parsing to succeed.
+  # https://github.com/openresty/lua-nginx-module#ngxreqread_body
+  # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+  client_body_buffer_size 128k;
+  # client_max_body_size should match client_body_buffer_size
+  # Values that exceed client_body_buffer_size will be written to a temporary file, which we don't want
+  # Requests above this limit will also be denied with an HTTP 413 response (entity too large)
+  # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+  client_max_body_size 128k;
 
   # See Move default writable paths to a dedicated directory (#119)
   # https://github.com/openresty/docker-openresty/issues/119
@@ -38,7 +47,7 @@ http {
     metric_sequencer_requests = prometheus:counter(
       "nginx_eth_sequencer_requests", "Number of requests going to the sequencer", {"method", "host", "status"})
     metric_replica_requests = prometheus:counter(
-      "nginx_eth_replica_requests", "Number of requests going to the replicas", {"host", "status"})    
+      "nginx_eth_replica_requests", "Number of requests going to the replicas", {"host", "status"})
     metric_latency = prometheus:histogram(
       "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
     metric_connections = prometheus:gauge(


### PR DESCRIPTION
**Description**
Allow HTTP POSTs up to 128k.

**Additional context**
The rpc-proxy was returning 400 - bad request for http POST's above ~ 16K due to the lua not having access to the nginx body (it was showing up as nil).

```
2021/07/05 20:46:25 [error] 15#15: *103 lua entry thread aborted: runtime error: /usr/local/openresty/nginx/eth-jsonrpc-access.lua:54: bad argument #1 to 'decode' (string expected, got nil)
stack traceback:
coroutine 0:
        [C]: in function 'decode'
```

This condition is occurring due to the client_body_buffer_size nginx setting which limits how large the body can be before writing it to a temporary file.
https://github.com/openresty/lua-nginx-module#ngxreqread_body

In my testing this resolved the error.

