### PR TITLE
l2geth: use `hexutil.Big` to prevent overflows

### DIFF
--- a/.changeset/many-dots-know.md
+++ b/.changeset/many-dots-know.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Update the `RollupClient` transaction type to use `hexutil.Big`

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -72,7 +72,7 @@ type transaction struct {
 	BatchIndex  uint64          `json:"batchIndex"`
 	BlockNumber uint64          `json:"blockNumber"`
 	Timestamp   uint64          `json:"timestamp"`
-	Value       hexutil.Uint64  `json:"value"`
+	Value       *hexutil.Big    `json:"value"`
 	GasLimit    uint64          `json:"gasLimit,string"`
 	Target      common.Address  `json:"target"`
 	Origin      *common.Address `json:"origin"`
@@ -106,7 +106,7 @@ type signature struct {
 // it means that the decoding failed.
 type decoded struct {
 	Signature signature       `json:"sig"`
-	Value     hexutil.Uint64  `json:"value"`
+	Value     *hexutil.Big    `json:"value"`
 	GasLimit  uint64          `json:"gasLimit,string"`
 	GasPrice  uint64          `json:"gasPrice,string"`
 	Nonce     uint64          `json:"nonce,string"`
@@ -343,7 +343,7 @@ func batchedTransactionToTransaction(res *transaction, signer *types.EIP155Signe
 	if res.Decoded != nil {
 		nonce := res.Decoded.Nonce
 		to := res.Decoded.Target
-		value := new(big.Int).SetUint64(uint64(res.Decoded.Value))
+		value := (*big.Int)(res.Decoded.Value)
 		// Note: there are two gas limits, one top level and
 		// another on the raw transaction itself. Maybe maxGasLimit
 		// for the top level?
@@ -396,7 +396,7 @@ func batchedTransactionToTransaction(res *transaction, signer *types.EIP155Signe
 	gasLimit := res.GasLimit
 	data := res.Data
 	origin := res.Origin
-	value := new(big.Int).SetUint64(uint64(res.Value))
+	value := (*big.Int)(res.Value)
 	tx := types.NewTransaction(nonce, target, value, gasLimit, big.NewInt(0), data)
 	txMeta := types.NewTransactionMeta(
 		new(big.Int).SetUint64(res.BlockNumber),

--- a/l2geth/rollup/client_test.go
+++ b/l2geth/rollup/client_test.go
@@ -1,6 +1,7 @@
 package rollup
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -66,5 +67,42 @@ func TestRollupClientCannotConnect(t *testing.T) {
 	}
 	if !errors.Is(err, errHTTPError) {
 		t.Fatalf("Incorrect error returned: %s", err)
+	}
+}
+func TestDecodedJSON(t *testing.T) {
+	str := []byte(`
+	{
+		"index": 643116,
+		"batchIndex": 21083,
+		"blockNumber": 25954867,
+		"timestamp": 1625605288,
+		"gasLimit": "11000000",
+		"target": "0x4200000000000000000000000000000000000005",
+		"origin": null,
+		"data": "0xf86d0283e4e1c08343eab8941a5245ea5210c3b57b7cfdf965990e63534a7b528901a055690d9db800008081aea019f7c6719f1718475f39fb9e5a6a897c3bd5057488a014666e5ad573ec71cf0fa008836030e686f3175dd7beb8350809b47791c23a19092a8c2fab1f0b4211a466",
+		"queueOrigin": "sequencer",
+		"value": "0x1a055690d9db80000",
+		"queueIndex": null,
+		"decoded": {
+			"nonce": "2",
+			"gasPrice": "15000000",
+			"gasLimit": "4451000",
+			"value": "0x1a055690d9db80000",
+			"target": "0x1a5245ea5210c3b57b7cfdf965990e63534a7b52",
+			"data": "0x",
+			"sig": {
+				"v": 1,
+				"r": "0x19f7c6719f1718475f39fb9e5a6a897c3bd5057488a014666e5ad573ec71cf0f",
+				"s": "0x08836030e686f3175dd7beb8350809b47791c23a19092a8c2fab1f0b4211a466"
+			}
+		},
+		"confirmed": true
+	}`)
+
+	tx := new(transaction)
+	json.Unmarshal(str, tx)
+	cmp, _ := new(big.Int).SetString("1a055690d9db80000", 16)
+	if tx.Value.ToInt().Cmp(cmp) != 0 {
+		t.Fatal("Cannot decode")
 	}
 }


### PR DESCRIPTION
**Description**

The `RollupClient` decodes the JSON from the DTL as a uint64,
this updates it to be a `big.Int`

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

