### PR TITLE
chore(ci): Skip check files job on push events

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -64,7 +64,10 @@ jobs:
   # A hack that allows running a job only if a specific directory changed.
   # Ref: https://github.community/t/run-job-only-if-folder-changed/118292
   is-contracts-package:
-    name: Check files
+    name: Check files for changes to the contracts package
+    # This job will break on a push event, so we just skip it,
+    # which in turn skips the test-coverage job.
+    if: ${{ github.event_name != 'push' }}
     outputs:
       run_coverage: ${{ steps.check_files.outputs.run_coverage }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
The recently added (#1209) GHA job which skips `test-coverage` when files are unchanged in `packages/contracts` causes a CI error when the event is a `push`. 

This causes issues for maintainers who want to fix conflicts locally and push to a release branch. 

This PR fixes that.
To be safe, I tested that it will still run the jobs when a push is made to an active PR.

* Fixes OP-679