### PR TITLE
Maurelian/refactor nuisance gas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true,

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -429,12 +429,12 @@ describe('Basic RPC tests', () => {
 
   describe('rollup_gasPrices', () => {
     it('should return the L1 and L2 gas prices', async () => {
-      const result = await provider.send('rollup_gasPrices', []);
+      const result = await provider.send('rollup_gasPrices', [])
       const l1GasPrice = await env.l1Wallet.provider.getGasPrice()
       const l2GasPrice = await env.gasPriceOracle.gasPrice()
 
       expect(BigNumber.from(result.l1GasPrice)).to.deep.eq(l1GasPrice)
-      expect((BigNumber.from(result.l2GasPrice))).to.deep.eq(l2GasPrice)
+      expect(BigNumber.from(result.l2GasPrice)).to.deep.eq(l2GasPrice)
     })
   })
 })

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -1505,6 +1505,7 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     // Essentially the same as a standard OUT_OF_GAS, except we also retain a record of the gas
     // refund to be given at the end of the transaction.
     if (messageRecord.nuisanceGasLeft < _amount) {
+        messageRecord.nuisanceGasLeft = 0;
       _revertWithFlag(RevertFlag.EXCEEDS_NUISANCE_GAS);
     }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -1244,8 +1244,9 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     address _ethAddress,
     bytes32 _codeHash
   ) internal {
-    _checkAccountChange(_address);
+    // We need to commit the account first so that we can look up the _ethAddress in _checkAccountChange
     ovmStateManager.commitPendingAccount(_address, _ethAddress, _codeHash);
+    _checkAccountChange(_address);
   }
 
   /**
@@ -1720,7 +1721,6 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     transactionContext.ovmL1TXORIGIN = _transaction.l1TxOrigin;
     transactionContext.ovmGASLIMIT = gasMeterConfig.maxGasPerQueuePerEpoch;
 
-    // Initialize this to
     messageRecord.nuisanceGasLeft = Math.min(_transaction.gasLimit, gasleft());
   }
 

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol
@@ -951,8 +951,12 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     // expensive by touching a lot of different accounts or storage slots. Since most contracts
     // only use a few storage slots during any given transaction, this shouldn't be a limiting
     // factor.
+    // Here we will limit the Nuisance Gas forwarded to the external message to the minimum of
+    // the nuisance gas left in this call frame, and the gas limit provided to the call. This protects
+    // against an attack where an untrusted contract intentionally uses up all available nuisance
+    // gas.
     uint256 prevNuisanceGasLeft = messageRecord.nuisanceGasLeft;
-    uint256 nuisanceGasLimit = _getNuisanceGasLimit(_gasLimit);
+    uint256 nuisanceGasLimit = Math.min(_gasLimit, prevNuisanceGasLeft);
     messageRecord.nuisanceGasLeft = nuisanceGasLimit;
 
     // Make the call and make sure to pass in the gas limit. Another instance of hidden
@@ -960,7 +964,6 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     // behavior can be controlled. In particular, we enforce that flags are passed through
     // revert data as to retrieve execution metadata that would normally be reverted out of
     // existence.
-
     bool success;
     bytes memory returndata;
     if (_isCreateType(_messageType)) {
@@ -1494,22 +1497,6 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
    ******************************************/
 
   /**
-   * Computes the nuisance gas limit from the gas limit.
-   * @dev This function is currently using a naive implementation whereby the nuisance gas limit
-   *      is set to exactly equal the lesser of the gas limit or remaining gas. It's likely that
-   *      this implementation is perfectly fine, but we may change this formula later.
-   * @param _gasLimit Gas limit to compute from.
-   * @return _nuisanceGasLimit Computed nuisance gas limit.
-   */
-  function _getNuisanceGasLimit(uint256 _gasLimit)
-    internal
-    view
-    returns (uint256 _nuisanceGasLimit)
-  {
-    return _gasLimit < gasleft() ? _gasLimit : gasleft();
-  }
-
-  /**
    * Uses a certain amount of nuisance gas.
    * @param _amount Amount of nuisance gas to use.
    */
@@ -1733,7 +1720,8 @@ contract OVM_ExecutionManager is iOVM_ExecutionManager, Lib_AddressResolver {
     transactionContext.ovmL1TXORIGIN = _transaction.l1TxOrigin;
     transactionContext.ovmGASLIMIT = gasMeterConfig.maxGasPerQueuePerEpoch;
 
-    messageRecord.nuisanceGasLeft = _getNuisanceGasLimit(_transaction.gasLimit);
+    // Initialize this to
+    messageRecord.nuisanceGasLeft = Math.min(_transaction.gasLimit, gasleft());
   }
 
   /**

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/verification/OVM_StateTransitioner.sol
@@ -333,15 +333,6 @@ contract OVM_StateTransitioner is Lib_AddressResolver, Abs_FraudContributor, iOV
             "Invalid transaction provided."
         );
 
-        // We require gas to complete the logic here in run() before/after execution,
-        // But must ensure the full _tx.gasLimit can be given to the ovmCALL (determinism)
-        // This includes 1/64 of the gas getting lost because of EIP-150 (lost twice--first
-        // going into EM, then going into the code contract).
-        require(
-            gasleft() >= 100000 + _transaction.gasLimit * 1032 / 1000, // 1032/1000 = 1.032 = (64/63)^2 rounded up
-            "Not enough gas to execute transaction deterministically."
-        );
-
         iOVM_ExecutionManager ovmExecutionManager = iOVM_ExecutionManager(resolve("OVM_ExecutionManager"));
 
         // We call `setExecutionManager` right before `run` (and not earlier) just in case the


### PR DESCRIPTION
Change nuisance gas handling to conform with the following rough specification.

 ## Why is Nuisance Gas necessary?

1. Nuisance gas is required to limit the cost of a proof to the available bond for proving fraud.
2. The cost of a proof is proportional to:
    1. gas prices
    2. gas amount required to prove and commit state which is accessed and modified during execution
      1. Proportional to the amount of state accessed (+ type of state)
      2. For a storage slot, need key (32 bytes) + value (32 bytes) + account (?? bytes) + proof (~depends on depth of trie) → fixed cost for each storage access
      3. For account, need account (?? bytes) + code (?? bytes) + proof (~depends on depth of trie) → fixed cost for each account access + dynamic cost based on code size
3. Therefore we must meter state access to limit the cost of the proof to ≤ bond
  1. During execution, need to determine if the tx exceeded the allowable number of state accesses


 ## How and when to charge nuisance gas

The intention of Nuisance Gas is to limit the number of items that have to be proven in the pre-state and post-state so that the cost of a proof doesn't become too high.

Thus charges should correspond directly with the cost of proving and committing items during a fraud proof.

Thus during execution, we must track events that will require a call to the following `StateTransitioner` functions, and charge accordingly:

**1. Loading an account** (covers the cost of `proveContractState()`)
- For an empty account charge `MIN_NUISANCE_GAS_PER_CONTRACT`
- Otherwise charge `MIN_NUISANCE_GAS_PER_CONTRACT + NUISANCE_GAS_PER_CONTRACT_BYTE * contractBytelength`

**2. Loading a storage slot** (covers the cost of `proveStorageSlot()`)
  - Charge `NUISANCE_GAS_SLOAD`

**3. Changing a storage slot** (covers the cost of both `commitContractState()` and `commitStorageSlot()`)
  - Charge `NUISANCE_GAS_PER_CONTRACT_BYTE * contractByteLength + MIN_NUISANCE_GAS_PER_CONTRACT + NUISANCE_GAS_SSTORE`

**4. Creating a contract** (covers the cost of `commitContractState()`)
  - Charge `NUISANCE_GAS_PER_CONTRACT_BYTE * contractByteLength + MIN_NUISANCE_GAS_PER_CONTRACT`

**TODO:** confirm that contract cost should be as above, not `min(NUISANCE_GAS_PER_CONTRACT_BYTE * contractByteLength , MIN_NUISANCE_GAS_PER_CONTRACT)`. 


## Metering nuisance gas during execution

1. `nuisanceGas` should be initialized to a value based on the minimum of `gasleft()` and `_transaction.gasLimit`
    1. Alternative: could this just be a function of the available bond.
    2. Simplification: just use a constant maximum nuisance gas limit for now.
2. Nuisance gas passed to call frame should be limited to the minimum of gas passed to the call frame and the nuisance gas remaining
3. If a child call frame uses `X` nuisance gas, then the parent frame should also have `X` nuisance gas deducted from it.
    1. We need to enforce nuisance gas reporting back via reverts. If the contract reverts with OOG, then we have no way of reporting on the remaining nuisance gas, so we also just take all the nuisance gas.

### Internal issue tracking

- Fixes OP-648 - "Unbounded nuisance gas" by limiting the nuisance gas forwarded to child calls

