### PR TITLE
fix: submit batch if at max size

### DIFF
--- a/.changeset/cyan-bulldogs-destroy.md
+++ b/.changeset/cyan-bulldogs-destroy.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Allow batch submission when batch has the max number of elements but too is still too small in bytes.

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -149,9 +149,15 @@ export abstract class BatchSubmitter {
     }
   }
 
-  protected _shouldSubmitBatch(batchSizeInBytes: number): boolean {
+  protected _shouldSubmitBatch(
+    batchSizeInBytes: number,
+    numberOfElements: number
+  ): boolean {
     const currentTimestamp = Date.now()
-    if (batchSizeInBytes < this.minTxSize) {
+    if (
+      batchSizeInBytes < this.minTxSize &&
+      numberOfElements < this.maxBatchSize
+    ) {
       const timeSinceLastSubmission =
         currentTimestamp - this.lastBatchSubmissionTimestamp
       if (timeSinceLastSubmission < this.maxBatchSubmissionTime) {

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -169,7 +169,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
       tx,
     })
 
-    if (!this._shouldSubmitBatch(batchSizeInBytes)) {
+    if (!this._shouldSubmitBatch(batchSizeInBytes, batch.length)) {
       return
     }
 

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -240,7 +240,13 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     // 1. it was truncated
     // 2. it is large enough
     // 3. enough time has passed since last submission
-    if (!wasBatchTruncated && !this._shouldSubmitBatch(batchSizeInBytes)) {
+    if (
+      !wasBatchTruncated &&
+      !this._shouldSubmitBatch(
+        batchSizeInBytes,
+        batchParams.totalElementsToAppend
+      )
+    ) {
       return
     }
     this.metrics.numTxPerBatch.observe(endBlock - startBlock)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Add an extra condition which allows batches to be submitted if they are at the max batch size (total number of elements in the batch) but even with that batch size the batch is less than the min tx size in bytes.

**Additional context**
There are no unit tests for the function `_shouldSubmitBatch(...)` but there definitely should be. Prioritizing a batch submitter unit test fest is very important because it would allow fixes like the one I just made to be done with confidence & make it a lot easier to add features because adding a new feature wouldn't require also adding missing tests.

I am submitting this as a draft pull request because it does not have proper unit tests. If desired we _can_ merge this as it should work, but alternatively we can accept the current behavior and instead just set a lower `MIN_L1_TX_SIZE` which should accomplish what we need. 

Fixes OP-1129