### PR TITLE
l2geth: sequencer fee buffer

### DIFF
--- a/.changeset/slimy-experts-travel.md
+++ b/.changeset/slimy-experts-travel.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Add sequencer fee buffer with config options `ROLLUP_FEE_THRESHOLD_UP` and `ROLLUP_FEE_THRESHOLD_DOWN` that are interpreted as floating point numbers

--- a/l2geth/cmd/geth/main.go
+++ b/l2geth/cmd/geth/main.go
@@ -166,6 +166,8 @@ var (
 		utils.RollupMaxCalldataSizeFlag,
 		utils.RollupBackendFlag,
 		utils.RollupEnforceFeesFlag,
+		utils.RollupFeeThresholdDownFlag,
+		utils.RollupFeeThresholdUpFlag,
 		utils.GasPriceOracleOwnerAddress,
 	}
 

--- a/l2geth/cmd/geth/usage.go
+++ b/l2geth/cmd/geth/usage.go
@@ -81,6 +81,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupMaxCalldataSizeFlag,
 			utils.RollupBackendFlag,
 			utils.RollupEnforceFeesFlag,
+			utils.RollupFeeThresholdDownFlag,
+			utils.RollupFeeThresholdUpFlag,
 			utils.GasPriceOracleOwnerAddress,
 		},
 	},

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -898,6 +898,16 @@ var (
 		Usage:  "Disable transactions with 0 gas price",
 		EnvVar: "ROLLUP_ENFORCE_FEES",
 	}
+	RollupFeeThresholdDownFlag = cli.BoolFlag{
+		Name:   "rollup.feethresholddown",
+		Usage:  "Allow txs with fees below the current fee up to this amount, must be < 1",
+		EnvVar: "ROLLUP_FEE_THRESHOLD_DOWN",
+	}
+	RollupFeeThresholdUpFlag = cli.BoolFlag{
+		Name:   "rollup.feethresholdup",
+		Usage:  "Allow txs with fees above the current fee up to this amount, must be > 1",
+		EnvVar: "ROLLUP_FEE_THRESHOLD_UP",
+	}
 	GasPriceOracleOwnerAddress = cli.StringFlag{
 		Name:   "rollup.gaspriceoracleowneraddress",
 		Usage:  "Owner of the OVM_GasPriceOracle",
@@ -1195,6 +1205,14 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 	}
 	if ctx.GlobalIsSet(RollupEnforceFeesFlag.Name) {
 		cfg.EnforceFees = true
+	}
+	if ctx.GlobalIsSet(RollupFeeThresholdDownFlag.Name) {
+		val := ctx.GlobalFloat64(RollupFeeThresholdDownFlag.Name)
+		cfg.FeeThresholdDown = new(big.Float).SetFloat64(val)
+	}
+	if ctx.GlobalIsSet(RollupFeeThresholdUpFlag.Name) {
+		val := ctx.GlobalFloat64(RollupFeeThresholdUpFlag.Name)
+		cfg.FeeThresholdUp = new(big.Float).SetFloat64(val)
 	}
 }
 

--- a/l2geth/rollup/config.go
+++ b/l2geth/rollup/config.go
@@ -39,4 +39,9 @@ type Config struct {
 	Backend Backend
 	// Only accept transactions with fees
 	EnforceFees bool
+	// Allow fees within a buffer upwards or downwards
+	// to take fee volatility into account between being
+	// quoted and the transaction being executed
+	FeeThresholdDown *big.Float
+	FeeThresholdUp   *big.Float
 }

--- a/l2geth/rollup/fees/rollup_fee.go
+++ b/l2geth/rollup/fees/rollup_fee.go
@@ -1,10 +1,22 @@
 package fees
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	// errFeeTooLow represents the error case of then the user pays too little
+	ErrFeeTooLow = errors.New("fee too low")
+	// errFeeTooHigh represents the error case of when the user pays too much
+	ErrFeeTooHigh = errors.New("fee too high")
+	// errMissingInput represents the error case of missing required input to
+	// PaysEnough
+	errMissingInput = errors.New("missing input")
 )
 
 // overhead represents the fixed cost of batch submission of a single
@@ -85,6 +97,52 @@ func DecodeL2GasLimit(gasLimit *big.Int) *big.Int {
 func DecodeL2GasLimitU64(gasLimit uint64) uint64 {
 	scaled := gasLimit % tenThousand
 	return scaled * tenThousand
+}
+
+// PaysEnoughOpts represent the options to PaysEnough
+type PaysEnoughOpts struct {
+	UserFee, ExpectedFee       *big.Int
+	ThresholdUp, ThresholdDown *big.Float
+}
+
+// PaysEnough returns an error if the fee is not large enough
+// `GasPrice` and `Fee` are required arguments.
+func PaysEnough(opts *PaysEnoughOpts) error {
+	if opts.UserFee == nil {
+		return fmt.Errorf("%w: no user fee", errMissingInput)
+	}
+	if opts.ExpectedFee == nil {
+		return fmt.Errorf("%w: no expected fee", errMissingInput)
+	}
+
+	fee := opts.ExpectedFee
+	// Allow for a downward buffer to protect against L1 gas price volatility
+	if opts.ThresholdDown != nil {
+		fee = mulByFloat(fee, opts.ThresholdDown)
+	}
+	// Protect the sequencer from being underpaid
+	// if user fee < expected fee, return error
+	if opts.UserFee.Cmp(fee) == -1 {
+		return ErrFeeTooLow
+	}
+	// Protect users from overpaying by too much
+	if opts.ThresholdUp != nil {
+		// overpaying = user fee - expected fee
+		overpaying := new(big.Int).Sub(opts.UserFee, opts.ExpectedFee)
+		threshold := mulByFloat(overpaying, opts.ThresholdUp)
+		// if overpaying > threshold, return error
+		if overpaying.Cmp(threshold) == 1 {
+			return ErrFeeTooHigh
+		}
+	}
+	return nil
+}
+
+func mulByFloat(num *big.Int, float *big.Float) *big.Int {
+	n := new(big.Float).SetUint64(num.Uint64())
+	n = n.Mul(n, float)
+	value, _ := float.Uint64()
+	return new(big.Int).SetUint64(value)
 }
 
 // calculateL1GasLimit computes the L1 gasLimit based on the calldata and

--- a/l2geth/rollup/fees/rollup_fee_test.go
+++ b/l2geth/rollup/fees/rollup_fee_test.go
@@ -1,9 +1,11 @@
 package fees
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -98,6 +100,77 @@ func TestCalculateRollupFee(t *testing.T) {
 			roundedL2GasLimit := Ceilmod(l2GasLimit, BigTenThousand)
 			if roundedL2GasLimit.Cmp(decodedGasLimit) != 0 {
 				t.Errorf("rollup fee check failed: expected %d, got %d", l2GasLimit.Uint64(), decodedGasLimit)
+			}
+		})
+	}
+}
+
+func TestPaysEnough(t *testing.T) {
+	tests := map[string]struct {
+		opts *PaysEnoughOpts
+		err  error
+	}{
+		"missing-gas-price": {
+			opts: &PaysEnoughOpts{
+				UserFee:       nil,
+				ExpectedFee:   new(big.Int),
+				ThresholdUp:   nil,
+				ThresholdDown: nil,
+			},
+			err: errMissingInput,
+		},
+		"missing-fee": {
+			opts: &PaysEnoughOpts{
+				UserFee:       nil,
+				ExpectedFee:   nil,
+				ThresholdUp:   nil,
+				ThresholdDown: nil,
+			},
+			err: errMissingInput,
+		},
+		"equal-fee": {
+			opts: &PaysEnoughOpts{
+				UserFee:       common.Big1,
+				ExpectedFee:   common.Big1,
+				ThresholdUp:   nil,
+				ThresholdDown: nil,
+			},
+			err: nil,
+		},
+		"fee-too-low": {
+			opts: &PaysEnoughOpts{
+				UserFee:       common.Big1,
+				ExpectedFee:   common.Big2,
+				ThresholdUp:   nil,
+				ThresholdDown: nil,
+			},
+			err: ErrFeeTooLow,
+		},
+		"fee-threshold-down": {
+			opts: &PaysEnoughOpts{
+				UserFee:       common.Big1,
+				ExpectedFee:   common.Big2,
+				ThresholdUp:   nil,
+				ThresholdDown: new(big.Float).SetFloat64(0.5),
+			},
+			err: nil,
+		},
+		"fee-threshold-up": {
+			opts: &PaysEnoughOpts{
+				UserFee:       common.Big3,
+				ExpectedFee:   common.Big1,
+				ThresholdUp:   new(big.Float).SetFloat64(1.5),
+				ThresholdDown: nil,
+			},
+			err: ErrFeeTooHigh,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := PaysEnough(tt.opts)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("%s: got %s, expected %s", name, err, tt.err)
 			}
 		})
 	}

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -26,7 +26,11 @@ import (
 
 // errShortRemoteTip is an error for when the remote tip is shorter than the
 // local tip
-var errShortRemoteTip = errors.New("Unexpected remote less than tip")
+var (
+	errShortRemoteTip = errors.New("unexpected remote less than tip")
+	errBadConfig      = errors.New("bad config")
+	float1            = big.NewFloat(1)
+)
 
 // L2GasPrice slot refers to the storage slot that the execution price is stored
 // in the L2 predeploy contract, the GasPriceOracle
@@ -59,6 +63,8 @@ type SyncService struct {
 	chainHeadCh               chan core.ChainHeadEvent
 	backend                   Backend
 	enforceFees               bool
+	feeThresholdUp            *big.Float
+	feeThresholdDown          *big.Float
 }
 
 // NewSyncService returns an initialized sync service
@@ -74,6 +80,9 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 		log.Info("Running in verifier mode", "sync-backend", cfg.Backend.String())
 	} else {
 		log.Info("Running in sequencer mode", "sync-backend", cfg.Backend.String())
+		log.Info("Fees", "gas-price", fees.BigTxGasPrice, "threshold-up", cfg.FeeThresholdUp,
+			"threshold-down", cfg.FeeThresholdDown)
+		log.Info("Enforce Fees", "set", cfg.EnforceFees)
 	}
 
 	pollInterval := cfg.PollInterval
@@ -95,7 +104,23 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 	// Initialize the rollup client
 	client := NewClient(cfg.RollupClientHttp, chainID)
 	log.Info("Configured rollup client", "url", cfg.RollupClientHttp, "chain-id", chainID.Uint64(), "ctc-deploy-height", cfg.CanonicalTransactionChainDeployHeight)
-	log.Info("Enforce Fees", "set", cfg.EnforceFees)
+
+	// Ensure sane values for the fee thresholds
+	if cfg.FeeThresholdDown != nil {
+		// The fee threshold down should be less than 1
+		if cfg.FeeThresholdDown.Cmp(float1) != -1 {
+			return nil, fmt.Errorf("%w: fee threshold down not lower than 1: %f", errBadConfig,
+				cfg.FeeThresholdDown)
+		}
+	}
+	if cfg.FeeThresholdUp != nil {
+		// The fee threshold up should be greater than 1
+		if cfg.FeeThresholdUp.Cmp(float1) != 1 {
+			return nil, fmt.Errorf("%w: fee threshold up not larger than 1: %f", errBadConfig,
+				cfg.FeeThresholdUp)
+		}
+	}
+
 	service := SyncService{
 		ctx:                       ctx,
 		cancel:                    cancel,
@@ -112,6 +137,8 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 		timestampRefreshThreshold: timestampRefreshThreshold,
 		backend:                   cfg.Backend,
 		enforceFees:               cfg.EnforceFees,
+		feeThresholdDown:          cfg.FeeThresholdDown,
+		feeThresholdUp:            cfg.FeeThresholdUp,
 	}
 
 	// The chainHeadSub is used to synchronize the SyncService with the chain.
@@ -750,28 +777,36 @@ func (s *SyncService) verifyFee(tx *types.Transaction) error {
 	// Calculate the fee based on decoded L2 gas limit
 	gas := new(big.Int).SetUint64(tx.Gas())
 	l2GasLimit := fees.DecodeL2GasLimit(gas)
+
 	// Only count the calldata here as the overhead of the fully encoded
 	// RLP transaction is handled inside of EncodeL2GasLimit
-	fee := fees.EncodeTxGasLimit(tx.Data(), l1GasPrice, l2GasLimit, l2GasPrice)
+	expectedTxGasLimit := fees.EncodeTxGasLimit(tx.Data(), l1GasPrice, l2GasLimit, l2GasPrice)
 	if err != nil {
 		return err
 	}
-	// This should only happen if the transaction fee is greater than 18.44 ETH
-	if !fee.IsUint64() {
-		return fmt.Errorf("fee overflow: %s", fee.String())
+
+	// This should only happen if the unscaled transaction fee is greater than 18.44 ETH
+	if !expectedTxGasLimit.IsUint64() {
+		return fmt.Errorf("fee overflow: %s", expectedTxGasLimit.String())
 	}
-	// Compute the user's fee
-	paying := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice())
-	// Compute the minimum expected fee
-	expecting := new(big.Int).Mul(fee, fees.BigTxGasPrice)
-	if paying.Cmp(expecting) == -1 {
-		return fmt.Errorf("fee too low: %d, use at least tx.gasLimit = %d and tx.gasPrice = %d", paying, fee.Uint64(), fees.BigTxGasPrice)
+
+	userFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice())
+	opts := fees.PaysEnoughOpts{
+		UserFee:       userFee,
+		ExpectedFee:   expectedTxGasLimit.Mul(expectedTxGasLimit, fees.BigTxGasPrice),
+		ThresholdUp:   s.feeThresholdUp,
+		ThresholdDown: s.feeThresholdDown,
 	}
-	// Protect users from overpaying by too much
-	overpaying := new(big.Int).Sub(paying, expecting)
-	threshold := new(big.Int).Mul(expecting, common.Big3)
-	if overpaying.Cmp(threshold) == 1 {
-		return fmt.Errorf("fee too large: %d", paying)
+	// Check the error type and return the correct error message to the user
+	if err := fees.PaysEnough(&opts); err != nil {
+		if errors.Is(err, fees.ErrFeeTooLow) {
+			return fmt.Errorf("%w: %d, use at least tx.gasLimit = %d and tx.gasPrice = %d",
+				fees.ErrFeeTooLow, userFee, expectedTxGasLimit, fees.BigTxGasPrice)
+		}
+		if errors.Is(err, fees.ErrFeeTooHigh) {
+			return fmt.Errorf("%w: %d", fees.ErrFeeTooHigh, userFee)
+		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

The fees are currently calculated as a sum of the L1 fee and the L2 fee
where the L1 fee is the approximate cost of the batch submission of the
transaction (L1 gas price * L1 gas used) and the L2 fee is the
approximate cost of the execution on L2 taking into account congestion
(L2 gas price * L2 gas limit).

When either the L1 or L2 gas price is volatile, it can result in the
quote that the user receives from `eth_estimateGas` to be rejected
as the fee that the Sequencer is expecting has gone up.

This PR adds logic to set a buffer in either direction of the current
price that will allow the sequencer to still accept transactions within.

Two new config options are added:

- `--rollup.feethresholddown` or `ROLLUP_FEE_THRESHOLD_DOWN`
- `--rollup.feethresholdup` or `ROLLUP_FEE_THRESHOLD_UP`

Note that these config options are only useful for when running
in Sequencer mode, they are not useful for replicas/verifiers.
This is because the Sequencer is the only write node in the network.

These config options are interpreted as floating point numbers and are
multiplied against the current fee that the sequencer is expecting.
To allow for a downward buffer of 10% and an upward buffer of 100%,
use the options:

- `ROLLUP_FEE_THRESHOLD_DOWN=0.9`
- `ROLLUP_FEE_THRESHOLD_UP=2`

This will allow for slight fee volatility downwards and prevent users
from excessively overpaying on fees accidentally.

This is a UX and profit tradeoff for the sequencer and can be exploited
by bots. If bots are consistently taking advantage of this, the max
threshold down will have to be calibrated to what the normal fee is
today.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
