### PR TITLE
fix fixSkippedDeposits

### DIFF
--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -489,7 +489,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
             break
           }
         }
-        fixedBatch.push(ele)
         if (!ele.isSequencerTx) {
           nextQueueIndex++
         }


### PR DESCRIPTION
**Description**
The batch submitter can't submit batches, because the queued element doesn't match L1. The timestamp of the queued element is 1625222121, but the timestamp of the L1 block is 1625222120. The block numbers of the queued element and L1 block are the same.

**Additional context**
The wrong timestamp can be fixed in the `fixSkippedDeposits` function. However, 
```js
fixedBatch.push(ele)
```
pushes the wrong `element` to `fixBatch` array. `fixBatch` array still has the element that doesn't match to the timestamp of the L1 block. Therefore, we shouldn't push the wrong element to `fixBatch`.

**Metadata**
- Fixes #1214 