### PR TITLE
core/state/state_object.go: ovm do not delete empty node"

### DIFF
--- a/l2geth/core/state/state_object.go
+++ b/l2geth/core/state/state_object.go
@@ -289,10 +289,11 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		}
 		s.originStorage[key] = value
 
-		if (value == common.Hash{}) {
-			s.setError(tr.TryDelete(key[:]))
-			continue
-		}
+    //cause in ovm,we do not delete leaf.
+    if !vm.UsingOVM && (value == common.Hash{}) {
+      s.setError(tr.TryDelete(key[:]))
+      continue
+    }
 		// Encoding []byte cannot fail, ok to ignore the error.
 		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
 		s.setError(tr.TryUpdate(key[:], v))

--- a/l2geth/core/state/statedb.go
+++ b/l2geth/core/state/statedb.go
@@ -813,3 +813,8 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		return nil
 	})
 }
+
+//ForceCommitStateDiff to foece commit diff db
+func(s *StateDB)ForceCommitStateDiff()error{
+  return s.diffdb.ForceCommit()
+}

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -733,6 +733,11 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		w.current.state.RevertToSnapshot(snap)
 		return nil, err
 	}
+	//force commit state diff tx when finishing committing state diff
+  if err := w.current.state.ForceCommitStateDiff();err != nil {
+    w.current.state.RevertToSnapshot(snap)
+    return nil ,err
+  }
 	w.current.txs = append(w.current.txs, tx)
 	w.current.receipts = append(w.current.receipts, receipt)
 


### PR DESCRIPTION
In ovm state , it does not delete empty node.So we should check the chain mode for deleting empty node(this will cause a dismatch storage root even if the node in l2 is totally honest!)

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
this will solve the very big problem in storage root state.
**Additional context**
when a value in contract turned to be zero, it will cause dismatched state root(i.e. withdraw from wallet(0x42000..011))
**Metadata**
- Fixes #[Link to Issue]
