### PR TITLE
Patch 3

### DIFF
--- a/l2geth/core/state/state_object.go
+++ b/l2geth/core/state/state_object.go
@@ -289,10 +289,11 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		}
 		s.originStorage[key] = value
 
-		if (value == common.Hash{}) {
-			s.setError(tr.TryDelete(key[:]))
-			continue
-		}
+    //cause in ovm,we do not delete leaf.
+    if !vm.UsingOVM && (value == common.Hash{}) {
+      s.setError(tr.TryDelete(key[:]))
+      continue
+    }
 		// Encoding []byte cannot fail, ok to ignore the error.
 		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
 		s.setError(tr.TryUpdate(key[:], v))

--- a/l2geth/core/state/statedb.go
+++ b/l2geth/core/state/statedb.go
@@ -813,3 +813,8 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		return nil
 	})
 }
+
+//ForceCommitStateDiff to foece commit diff db
+func(s *StateDB)ForceCommitStateDiff()error{
+  return s.diffdb.ForceCommit()
+}

--- a/l2geth/core/state_processor.go
+++ b/l2geth/core/state_processor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+  "math/big"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -103,6 +104,8 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(context, statedb, config, cfg)
+  //set height with header which contain this transaction.to make sure state is correct.
+  vmenv.Height=new(big.Int).Set(header.Number)
 	// Apply the transaction to the current state (included in the env)
 	_, gas, failed, err := ApplyMessage(vmenv, msg, gp)
 	if err != nil {

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -240,6 +240,9 @@ type EVM struct {
 	callGasTemp uint64
 
 	Id string
+
+  //Height is consistent with tx index+l2blockoffset
+  Height *big.Int
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -268,6 +271,9 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 		interpreters: make([]Interpreter, 0, 1),
 
 		Id: hex.EncodeToString(id),
+
+    //set default Height
+    Height: new(big.Int).Set(ctx.BlockNumber),
 	}
 
 	if chainConfig.IsEWASM(ctx.BlockNumber) {

--- a/l2geth/core/vm/ovm_state_manager.go
+++ b/l2geth/core/vm/ovm_state_manager.go
@@ -140,7 +140,7 @@ func putContractStorage(evm *EVM, contract *Contract, args map[string]interface{
 		before := evm.StateDB.GetState(address, key)
 		evm.StateDB.SetState(address, key, val)
 		err := evm.StateDB.SetDiffKey(
-			evm.Context.BlockNumber,
+			evm.Height,
 			address,
 			key,
 			before != val,
@@ -164,7 +164,7 @@ func testAndSetAccount(evm *EVM, contract *Contract, args map[string]interface{}
 
 	if evm.Context.EthCallSender == nil {
 		err := evm.StateDB.SetDiffAccount(
-			evm.Context.BlockNumber,
+			evm.Height,
 			address,
 		)
 
@@ -197,7 +197,7 @@ func testAndSetContractStorage(evm *EVM, contract *Contract, args map[string]int
 
 	if evm.Context.EthCallSender == nil {
 		err := evm.StateDB.SetDiffKey(
-			evm.Context.BlockNumber,
+			evm.Height,
 			address,
 			key,
 			changed,

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -733,6 +733,11 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		w.current.state.RevertToSnapshot(snap)
 		return nil, err
 	}
+	//force commit state diff tx when finishing committing state diff
+  if err := w.current.state.ForceCommitStateDiff();err != nil {
+    w.current.state.RevertToSnapshot(snap)
+    return nil ,err
+  }
 	w.current.txs = append(w.current.txs, tx)
 	w.current.receipts = append(w.current.receipts, receipt)
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
set stateDiff's blockNumber to the blockNumber which contains this transaction in l2,to make the state correct
**Additional context**
old logic set the stateDiff blockNumber with tx's context BlockNumber, this will cause err when some want to execute fraud proof by using ethPublicAPI getStateDiff, this method will get the state at specific blockNumber and select specific blockNumber in stateDiff to find out the state info that fraud proof need.So the logic is not **Self-consistent**:
https://github.com/ethereum-optimism/optimism/blob/b95845381082e5eb4372c9d9afea1df8f51c6982/l2geth/internal/ethapi/api.go#L584
**Metadata**
- Fixes #[Link to Issue]
