### PR TITLE
feat[smock]: add support for receive

### DIFF
--- a/.changeset/thick-squids-lick.md
+++ b/.changeset/thick-squids-lick.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/smock': patch
+---
+
+Added support for the receive function as an alias to fallback.

--- a/packages/smock/src/smockit/smockit.ts
+++ b/packages/smock/src/smockit/smockit.ts
@@ -190,6 +190,8 @@ export const smockit = async (
     ),
   }
 
+  contract.smocked.receive = contract.smocked.fallback
+
   // Smock the rest of the contract functions.
   for (const functionName of Object.keys(contract.functions)) {
     contract.smocked[functionName] = smockifyFunction(

--- a/packages/smock/test/smockit/function-manipulation.spec.ts
+++ b/packages/smock/test/smockit/function-manipulation.spec.ts
@@ -70,7 +70,7 @@ describe('[smock]: function manipulation tests', () => {
       ).to.be.revertedWith(expected)
     })
 
-    it('should be able to make a fallback function emit an event', async () => {
+    it.skip('should be able to make a fallback function emit an event', async () => {
       // TODO
     })
 
@@ -173,7 +173,7 @@ describe('[smock]: function manipulation tests', () => {
       ).to.be.revertedWith(expected)
     })
 
-    it('should be able to make a receive function emit an event', async () => {
+    it.skip('should be able to make a receive function emit an event', async () => {
       // TODO
     })
 
@@ -232,7 +232,7 @@ describe('[smock]: function manipulation tests', () => {
       await expect(mock.callStatic.empty()).to.be.reverted
     })
 
-    it('should be able to make a function emit an event', async () => {
+    it.skip('should be able to make a function emit an event', async () => {
       // TODO
     })
 

--- a/packages/smock/test/smockit/function-manipulation.spec.ts
+++ b/packages/smock/test/smockit/function-manipulation.spec.ts
@@ -15,7 +15,7 @@ describe('[smock]: function manipulation tests', () => {
     mock = await smockit('TestHelpers_BasicReturnContract')
   })
 
-  describe('manipulating fallback functions', () => {
+  describe('manipulating fallback()', () => {
     it('should return with no data by default', async () => {
       const expected = '0x'
 
@@ -93,6 +93,8 @@ describe('[smock]: function manipulation tests', () => {
       ).to.equal(expected)
     })
 
+    // Adding this test but skipping it because `reset` is not implemented yet but I need to
+    // remind myself to implement it later.
     describe.skip('resetting the fallback function', () => {
       it('should go back to default behavior when reset', async () => {
         mock.smocked.fallback.will.revert()
@@ -105,6 +107,107 @@ describe('[smock]: function manipulation tests', () => {
 
         const expected = '0x'
         mock.smocked.fallback.reset()
+
+        expect(
+          await ethers.provider.call({
+            to: mock.address,
+          })
+        ).to.equal(expected)
+      })
+    })
+  })
+
+  // Currently just an alias for fallback()
+  describe('manipulating receive()', () => {
+    it('should return with no data by default', async () => {
+      const expected = '0x'
+
+      expect(
+        await ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.equal(expected)
+    })
+
+    it('should be able to make a receive function return without any data', async () => {
+      const expected = '0x'
+      mock.smocked.receive.will.return()
+
+      expect(
+        await ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.equal(expected)
+    })
+
+    it('should be able to make a receive function return with data', async () => {
+      const expected = '0x1234123412341234'
+      mock.smocked.receive.will.return.with(expected)
+
+      expect(
+        await ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.equal(expected)
+    })
+
+    it('should be able to make a receive function revert without any data', async () => {
+      mock.smocked.receive.will.revert()
+
+      await expect(
+        ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.be.reverted
+    })
+
+    it('should be able to make a receive function revert with a string', async () => {
+      const expected = 'this is a revert message'
+
+      mock.smocked.receive.will.revert.with(expected)
+
+      await expect(
+        ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.be.revertedWith(expected)
+    })
+
+    it('should be able to make a receive function emit an event', async () => {
+      // TODO
+    })
+
+    it('should be able to change behaviors', async () => {
+      mock.smocked.receive.will.revert()
+
+      await expect(
+        ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.be.reverted
+
+      const expected = '0x'
+      mock.smocked.receive.will.return()
+
+      expect(
+        await ethers.provider.call({
+          to: mock.address,
+        })
+      ).to.equal(expected)
+    })
+
+    describe.skip('resetting the receive function', () => {
+      it('should go back to default behavior when reset', async () => {
+        mock.smocked.receive.will.revert()
+
+        await expect(
+          ethers.provider.call({
+            to: mock.address,
+          })
+        ).to.be.reverted
+
+        const expected = '0x'
+        mock.smocked.receive.reset()
 
         expect(
           await ethers.provider.call({


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds naive support for the Solidity receive function as an alias to fallback. Actual Solidity behavior is a bit different but ethers throws out fallback/receive from the ABI when it creates the contract object which limits how much we can do. I think this is good enough for now.

**Metadata**
- Fixes #1245 
