### PR TITLE
maintance[smock]: add test and docs for returning multiple arrays

### DIFF
--- a/.changeset/wise-mails-laugh.md
+++ b/.changeset/wise-mails-laugh.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/smock': patch
+---
+
+Add a test and a doc section for returning multiple uint256 arrays

--- a/packages/smock/README.md
+++ b/packages/smock/README.md
@@ -240,6 +240,25 @@ MyMockContract.smocked.myFunction.will.return.with({
 console.log(await MyMockContract.myFunction()) // ['Some value', 1234, true]
 ```
 
+### Returning a Multiple Arrays
+```typescript
+import { ethers } from 'hardhat'
+import { smockit } from '@eth-optimism/smock'
+
+const MyContractFactory = await ethers.getContractFactory('MyContract')
+const MyContract = await MyContractFactory.deploy(...)
+
+// Smockit!
+const MyMockContract = await smockit(MyContract)
+
+MyMockContract.smocked.myFunction.will.return.with([
+  [1234, 5678],
+  [4321, 8765]
+])
+
+console.log(await MyMockContract.myFunction()) // [ [1234, 5678], [4321, 8765] ]
+```
+
 ### Returning a Function
 ```typescript
 import { ethers } from 'hardhat'

--- a/packages/smock/test/contracts/TestHelpers_BasicReturnContract.sol
+++ b/packages/smock/test/contracts/TestHelpers_BasicReturnContract.sol
@@ -132,6 +132,14 @@ contract TestHelpers_BasicReturnContract {
         )
     {}
 
+    function getMultipleUint256Arrays()
+        public
+        returns (
+            uint256[] memory,
+            uint256[] memory
+        )
+    {}
+
     function overloadedFunction(
         uint256 _paramA,
         uint256 _paramB

--- a/packages/smock/test/smockit/function-manipulation.spec.ts
+++ b/packages/smock/test/smockit/function-manipulation.spec.ts
@@ -533,6 +533,25 @@ describe('[smock]: function manipulation tests', () => {
               expect(result[i]).to.deep.equal(expected[i])
             }
           })
+
+          it('should be able to return multiple arrays of uint256 values', async () => {
+            const expected = [
+              [1234, 2345, 3456, 4567, 5678, 6789].map((n) => {
+                return BigNumber.from(n)
+              }),
+              [1234, 2345, 3456, 4567, 5678, 6789].map((n) => {
+                return BigNumber.from(n)
+              }),
+            ]
+            mock.smocked.getMultipleUint256Arrays.will.return.with(expected)
+
+            const result = await mock.callStatic.getMultipleUint256Arrays()
+            for (let i = 0; i < result.length; i++) {
+              for (let j = 0; j < result[i].length; j++) {
+                expect(result[i][j]).to.deep.equal(expected[i][j])
+              }
+            }
+          })
         })
       })
     })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Minor PR, just adding a test and docs for returning more than one array in a smocked function.

**Metadata**
- Fixes #1228 
