### PR TITLE
ci: handle gas-oracle latest image, skip builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.gas-oracle
           push: true
-          tags: ethereumoptimism/gas-oracle:${{ needs.release.outputs.gas-oracle }}
+          tags: ethereumoptimism/gas-oracle:${{ needs.release.outputs.gas-oracle }},ethereumoptimism/gas-oracle:latest
 
   # pushes the base builder image to dockerhub
   builder:

--- a/ops/scripts/ci-versions.js
+++ b/ops/scripts/ci-versions.js
@@ -6,10 +6,18 @@ const os = require('os')
 data = process.argv[2]
 data = JSON.parse(data)
 
+// Packages that do not depend on the builder.
+// There are more packages that depend on the
+// builder than not, so keep track of this list instead
+const nonBuilders = new Set([
+  'l2geth',
+  'gas-oracle',
+])
+
 builder = false
 for (const i of data) {
   const name = i.name.replace("@eth-optimism/", "")
-  if (name !== 'l2geth') {
+  if (!nonBuilders.has(name)) {
     builder = true
   }
   const version = i.version


### PR DESCRIPTION
**Description**

This PR updates the `ops/scripts/ci-versions.js` file
to skip building the builder image for when there
are changes to the `gas-oracle`. The `builder` contains
all of the JS code required for the various typescript
based services.

This PR also publishes `ethereumoptimism/gas-oracle:latest`.
It is faster to `docker pull` than `docker build`.
This will speed up the workflow for developers building locally
against the `docker compose` setup as well as the CI if it
is refactored to pull the `latest` images for the unchanged images
instead of building them from scratch.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
