### PR TITLE
contracts: lint the tasks directory

### DIFF
--- a/.changeset/plenty-walls-compare.md
+++ b/.changeset/plenty-walls-compare.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Run lint over the tasks directory

--- a/packages/contracts/tasks/l2-gasprice.ts
+++ b/packages/contracts/tasks/l2-gasprice.ts
@@ -8,12 +8,7 @@ import { getContractDefinition } from '../src/contract-defs'
 
 task('set-l2-gasprice')
   .addOptionalParam('l2GasPrice', 'Gas Price to set on L2', 0, types.int)
-  .addOptionalParam(
-    'transactionGasPrice',
-    'tx.gasPrice',
-    undefined,
-    types.int
-  )
+  .addOptionalParam('transactionGasPrice', 'tx.gasPrice', undefined, types.int)
   .addOptionalParam(
     'contractsRpcUrl',
     'Sequencer HTTP Endpoint',


### PR DESCRIPTION
**Description**

This PR lints the tasks directory

It is also a round about way to force a publish of the go based software since the CI only does docker publishes if there are npm packages to publish as well

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
