### PR TITLE
l2geth: better error message for when fee is too large

### DIFF
--- a/.changeset/cool-birds-rescue.md
+++ b/.changeset/cool-birds-rescue.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Give a better error message for when the fee is too high when sending transactions to the sequencer

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -868,9 +868,10 @@ func (s *SyncService) verifyFee(tx *types.Transaction) error {
 	}
 
 	userFee := new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice())
+	expectedFee := new(big.Int).Mul(expectedTxGasLimit, fees.BigTxGasPrice)
 	opts := fees.PaysEnoughOpts{
 		UserFee:       userFee,
-		ExpectedFee:   expectedTxGasLimit.Mul(expectedTxGasLimit, fees.BigTxGasPrice),
+		ExpectedFee:   expectedFee,
 		ThresholdUp:   s.feeThresholdUp,
 		ThresholdDown: s.feeThresholdDown,
 	}
@@ -881,7 +882,8 @@ func (s *SyncService) verifyFee(tx *types.Transaction) error {
 				fees.ErrFeeTooLow, userFee, expectedTxGasLimit, fees.BigTxGasPrice)
 		}
 		if errors.Is(err, fees.ErrFeeTooHigh) {
-			return fmt.Errorf("%w: %d", fees.ErrFeeTooHigh, userFee)
+			return fmt.Errorf("%w: %d, use less than %d * %f", fees.ErrFeeTooHigh, userFee,
+				expectedFee, s.feeThresholdDown)
 		}
 		return err
 	}


### PR DESCRIPTION
**Description**

The sequencer will reject transactions when the fee
is too large to prevent users from accidentally sending
transactions with a huge fee.

This PR adds an actionable error message for when
the fee is too large.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

