### PR TITLE
l2geth: only accept txs with exact nonce

### DIFF
--- a/.changeset/tidy-swans-mate.md
+++ b/.changeset/tidy-swans-mate.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Prevents the sequencer from accepting transactions with a too high nonce

--- a/l2geth/core/tx_pool.go
+++ b/l2geth/core/tx_pool.go
@@ -560,8 +560,14 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering
-	if pool.currentState.GetNonce(from) > tx.Nonce() {
-		return ErrNonceTooLow
+	if vm.UsingOVM {
+		if pool.currentState.GetNonce(from) != tx.Nonce() {
+			return ErrNonceTooLow
+		}
+	} else {
+		if pool.currentState.GetNonce(from) > tx.Nonce() {
+			return ErrNonceTooLow
+		}
 	}
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL


### PR DESCRIPTION
**Description**

This PR makes it so that the sequencer will
only accept transactions if the nonce exactly
matches what is in the state. This is because the
mempool in upstream geth has different rules than
what l2geth needs.

This prevents issues with local nonce managers that
send transactions with a too large of nonce and
end up having all of the transactions revert since
the transaction is still accepted but reverts
in the OVM

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

