### PR TITLE
l2geth: fix bad flag parsing

### DIFF
--- a/.changeset/six-cobras-fold.md
+++ b/.changeset/six-cobras-fold.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fixes the flags to use float64 instead of bools for the `--rollup.feethresholddown` and `-rollup.feethresholdup` config options

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -898,12 +898,12 @@ var (
 		Usage:  "Disable transactions with 0 gas price",
 		EnvVar: "ROLLUP_ENFORCE_FEES",
 	}
-	RollupFeeThresholdDownFlag = cli.BoolFlag{
+	RollupFeeThresholdDownFlag = cli.Float64Flag{
 		Name:   "rollup.feethresholddown",
 		Usage:  "Allow txs with fees below the current fee up to this amount, must be < 1",
 		EnvVar: "ROLLUP_FEE_THRESHOLD_DOWN",
 	}
-	RollupFeeThresholdUpFlag = cli.BoolFlag{
+	RollupFeeThresholdUpFlag = cli.Float64Flag{
 		Name:   "rollup.feethresholdup",
 		Usage:  "Allow txs with fees above the current fee up to this amount, must be > 1",
 		EnvVar: "ROLLUP_FEE_THRESHOLD_UP",


### PR DESCRIPTION
**Description**

The parsing of the `ROLLUP_FEE_THRESHOLD_UP` and
`ROLLUP_FEE_THRESHOLD_DOWN` config options were set to be boolean flags
instead of float64 flags. The config flags wouldn't parse if a float64
was used as a bool flag.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


