### PR TITLE
l2geth: prevent too low of fees from getting through

### DIFF
--- a/.changeset/dry-chairs-watch.md
+++ b/.changeset/dry-chairs-watch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fix a bug in the fee logic that allowed for fees that were too low to get through

--- a/l2geth/rollup/fees/rollup_fee_test.go
+++ b/l2geth/rollup/fees/rollup_fee_test.go
@@ -157,12 +157,39 @@ func TestPaysEnough(t *testing.T) {
 		},
 		"fee-threshold-up": {
 			opts: &PaysEnoughOpts{
-				UserFee:       common.Big3,
+				UserFee:       common.Big256,
 				ExpectedFee:   common.Big1,
 				ThresholdUp:   new(big.Float).SetFloat64(1.5),
 				ThresholdDown: nil,
 			},
 			err: ErrFeeTooHigh,
+		},
+		"fee-too-low-high": {
+			opts: &PaysEnoughOpts{
+				UserFee:       new(big.Int).SetUint64(10_000),
+				ExpectedFee:   new(big.Int).SetUint64(1),
+				ThresholdUp:   new(big.Float).SetFloat64(3),
+				ThresholdDown: new(big.Float).SetFloat64(0.8),
+			},
+			err: ErrFeeTooHigh,
+		},
+		"fee-too-low-down": {
+			opts: &PaysEnoughOpts{
+				UserFee:       new(big.Int).SetUint64(1),
+				ExpectedFee:   new(big.Int).SetUint64(10_000),
+				ThresholdUp:   new(big.Float).SetFloat64(3),
+				ThresholdDown: new(big.Float).SetFloat64(0.8),
+			},
+			err: ErrFeeTooLow,
+		},
+		"fee-too-low-down-2": {
+			opts: &PaysEnoughOpts{
+				UserFee:       new(big.Int).SetUint64(0),
+				ExpectedFee:   new(big.Int).SetUint64(10_000),
+				ThresholdUp:   new(big.Float).SetFloat64(3),
+				ThresholdDown: new(big.Float).SetFloat64(0.8),
+			},
+			err: ErrFeeTooLow,
 		},
 	}
 

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -858,9 +858,6 @@ func (s *SyncService) verifyFee(tx *types.Transaction) error {
 	// Only count the calldata here as the overhead of the fully encoded
 	// RLP transaction is handled inside of EncodeL2GasLimit
 	expectedTxGasLimit := fees.EncodeTxGasLimit(tx.Data(), l1GasPrice, l2GasLimit, l2GasPrice)
-	if err != nil {
-		return err
-	}
 
 	// This should only happen if the unscaled transaction fee is greater than 18.44 ETH
 	if !expectedTxGasLimit.IsUint64() {


### PR DESCRIPTION
**Description**

There was a bug in the floating point math that allowed
for transactions with extremely low fees to get through.
This PR fixes that bug as well as adds additional test
cases.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

