### PR TITLE
fix(l2geth): revert rpcGasCap logic to upstream geth behavior

### DIFF
--- a/.changeset/nasty-tools-wink.md
+++ b/.changeset/nasty-tools-wink.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+revert rpcGasCap logic to upstream geth behavior

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -905,7 +905,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		}
 	}
 	// Set default gas & gas price if none were set
-	gas := b.GasLimit()
+	gas := uint64(math.MaxUint64 / 2)
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)
 	}


### PR DESCRIPTION
**Description**
Fixes the `rpcGasCap` logic by reverting to the upstream geth behavior:
https://github.com/ethereum/go-ethereum/blob/v1.9.10/internal/ethapi/api.go#L807

**Additional context**
This was erroneously loading the value of `MinerGasLimitFlag` and using that for the rpc gas limit, which is a much lower value.

