### PR TITLE
fix[smock]: add naive support for packed storage slots

### DIFF
--- a/.changeset/loud-rings-beg.md
+++ b/.changeset/loud-rings-beg.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/smock': patch
+---
+
+Adds naive support for packed storage slots

--- a/packages/smock/src/smoddit/storage.ts
+++ b/packages/smock/src/smoddit/storage.ts
@@ -98,10 +98,14 @@ export const getStorageSlots = (
       ethers.BigNumber.from(slotHash).add(inputSlot.slot)
     )
 
+    const slotValue = toHexString32(
+      `0x` + toHexString32(flat[key]).slice(2 + variableDef.offset * 2)
+    )
+
     slots.push({
       label: key,
       hash: slotHash,
-      value: toHexString32(flat[key]),
+      value: slotValue,
     })
   }
 

--- a/packages/smock/test/contracts/SimpleStorageGetter.sol
+++ b/packages/smock/test/contracts/SimpleStorageGetter.sol
@@ -23,6 +23,11 @@ contract SimpleStorageGetter {
     bool internal _packedA;
     address internal _packedB;
 
+    // Regression for #1275.
+    uint256 internal __packingSpacerUnused1; // Spacer to avoid packing with the above two.
+    bool public booleanOne = true;
+    bool public booleanTwo = true;
+
     constructor(
         uint256 _inA
     ) {

--- a/packages/smock/test/smoddit/smoddit.spec.ts
+++ b/packages/smock/test/smoddit/smoddit.spec.ts
@@ -53,8 +53,7 @@ describe('smoddit', () => {
         expect(await smod.getAddress()).to.equal(ret)
       })
 
-      // TODO: Need to solve this with a rewrite.
-      it.skip('should be able to return an address in a packed storage slot', async () => {
+      it('should be able to return an address in a packed storage slot', async () => {
         const ret = '0x558ba9b8d78713fbf768c1f8a584485B4003f43F'
 
         await smod.smodify.put({
@@ -169,6 +168,16 @@ describe('smoddit', () => {
         })
 
         expect(await smod.getAddressToAddressMapValue(key)).to.equal(val)
+      })
+
+      it('should be able to pack two booleans', async () => {
+        const ret = true
+
+        expect(await smod.booleanTwo()).to.equal(ret)
+        await smod.smodify.put({
+          booleanTwo: ret,
+        })
+        expect(await smod.booleanTwo()).to.equal(ret)
       })
     })
   })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes #1275 by adding basic support for packed storage slots. I'm calling this "naive" because I'm not sure if there are edge cases that are not covered by this very simple logic.

**Metadata**
- Fixes #1275 
