### PR TITLE
l2geth: fee too high error message

### DIFF
--- a/.changeset/nervous-donuts-laugh.md
+++ b/.changeset/nervous-donuts-laugh.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Return correct value in L2 Geth fee too high error message

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -880,7 +880,7 @@ func (s *SyncService) verifyFee(tx *types.Transaction) error {
 		}
 		if errors.Is(err, fees.ErrFeeTooHigh) {
 			return fmt.Errorf("%w: %d, use less than %d * %f", fees.ErrFeeTooHigh, userFee,
-				expectedFee, s.feeThresholdDown)
+				expectedFee, s.feeThresholdUp)
 		}
 		return err
 	}


### PR DESCRIPTION
**Description**

Update the error message returned when the fee is too
high to return the correct multiplication. It should be
the expected fee * the fee threshold up.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

