### PR TITLE
l2geth: make block hashes deterministic

### DIFF
--- a/.changeset/wet-foxes-collect.md
+++ b/.changeset/wet-foxes-collect.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Make the extradata deterministic for deterministic block hashes

--- a/l2geth/eth/backend.go
+++ b/l2geth/eth/backend.go
@@ -241,6 +241,16 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 }
 
 func makeExtraData(extra []byte) []byte {
+	if vm.UsingOVM {
+		// Make the extradata deterministic
+		extra, _ = rlp.EncodeToBytes([]interface{}{
+			uint(params.VersionMajor<<16 | params.VersionMinor<<8 | params.VersionPatch),
+			"geth",
+			"go1.15.13",
+			"linux",
+		})
+		return extra
+	}
 	if len(extra) == 0 {
 		// create default extradata
 		extra, _ = rlp.EncodeToBytes([]interface{}{


### PR DESCRIPTION
**Description**

The blockhashes can be non deterministic because there is not a global
consensus in the existing deployment of the optimism network, instead
each node runs with `--dev 0` meaning that it auto mines transactions
itself. Previously, block hashes were non deterministic due to a
different clique signing key being used but that was fixed so that
a deterministic key is used for all nodes.

This fixes the possibility of the block extradata being different which
would result in different block hashes. The extradata is hard coded
to be the same value as the release @eth-optimism/l2geth@0.4.6. In
version 0.4.7, the underlying Dockerfile pulled in a patch release of
the Go runtime which caused the extradata field to become different.
The extradata field by default is the version of the software (which
cannot change until the next regenesis), "geth", the go runtime version
and the operating system.

This will require a resync to make block hashes deterministic across the
network.

