### PR TITLE
l2geth: fix `eth_subscribe` for events

### DIFF
--- a/.changeset/light-zebras-marry.md
+++ b/.changeset/light-zebras-marry.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/l2geth': patch
+---
+
+Fix `eth_subscribe` so it returns the correct blocknumber when subscribing to topics

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -105,7 +105,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v1
         with:
           images: 'ethereumoptimism/builder,ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth,ethereumoptimism/integration-tests'
-          dest: '~/logs'
+          dest: '/home/runner/logs'
 
       - name: Tar logs
         if: failure()

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -31,6 +31,7 @@ if (process.env.IS_LIVE_NETWORK === 'true') {
 const env = cleanEnv(process.env, {
   L1_URL: str({ default: 'http://localhost:9545' }),
   L2_URL: str({ default: 'http://localhost:8545' }),
+  L2_WEBSOCKET_URL: str({ default: 'ws://localhost:8546' }),
   VERIFIER_URL: str({ default: 'http://localhost:8547' }),
   REPLICA_URL: str({ default: 'http://localhost:8549' }),
   L1_POLLING_INTERVAL: num({ default: 10 }),
@@ -54,6 +55,8 @@ l1Provider.pollingInterval = env.L1_POLLING_INTERVAL
 
 export const l2Provider = new providers.JsonRpcProvider(env.L2_URL)
 l2Provider.pollingInterval = env.L2_POLLING_INTERVAL
+
+export const l2WebsocketProvider = new providers.WebSocketProvider(env.L2_WEBSOCKET_URL)
 
 export const verifierProvider = new providers.JsonRpcProvider(env.VERIFIER_URL)
 verifierProvider.pollingInterval = env.VERIFIER_POLLING_INTERVAL

--- a/integration-tests/test/websocket.spec.ts
+++ b/integration-tests/test/websocket.spec.ts
@@ -1,0 +1,74 @@
+import { injectL2Context } from '@eth-optimism/core-utils'
+import { Wallet, Contract, ContractFactory } from 'ethers'
+import { ethers } from 'hardhat'
+import chai, { expect } from 'chai'
+import {
+  sleep,
+  l2WebsocketProvider,
+  l2Provider,
+  IS_LIVE_NETWORK,
+} from './shared/utils'
+import chaiAsPromised from 'chai-as-promised'
+import { OptimismEnv } from './shared/env'
+import { solidity } from 'ethereum-waffle'
+chai.use(chaiAsPromised)
+chai.use(solidity)
+
+describe('Basic Websocket tests', () => {
+  let env: OptimismEnv
+  let wallet: Wallet
+  let ERC20: Contract
+  const provider = injectL2Context(l2Provider)
+  let other: Wallet
+
+  before(async () => {
+    env = await OptimismEnv.new()
+    wallet = env.l2Wallet
+    const Factory__ERC20 = await ethers.getContractFactory('ERC20', wallet)
+
+    other = Wallet.createRandom().connect(provider)
+    ERC20 = await Factory__ERC20.deploy(100, 'OVM Test', 8, 'OVM')
+  })
+
+  describe('eth_subscribe', () => {
+    it('should subscribe to new blocks', async () => {
+      let seen = false
+      const height = await provider.getBlockNumber()
+
+      l2WebsocketProvider.once('block', (blockNumber) => {
+        seen = true
+        expect(blockNumber).to.deep.eq(height + 1)
+      })
+
+      const transfer = await ERC20.transfer(other.address, 10)
+      transfer.wait()
+      while (!seen) {
+        await sleep(500)
+      }
+
+      expect(seen).to.equal(true)
+    })
+
+    it('should filter by topic', async () => {
+      let seen = false
+      const filter = ERC20.filters.Transfer()
+
+      let event
+      l2WebsocketProvider.once(filter, (ev) => {
+        seen = true
+        event = ev
+      })
+
+      const transfer = await ERC20.transfer(other.address, 10)
+      const receipt = await transfer.wait()
+      while (!seen) {
+        await sleep(500)
+      }
+
+      expect(seen).to.equal(true)
+      expect(event.blockNumber).to.deep.eq(receipt.blockNumber)
+      expect(event.blockHash).to.deep.eq(receipt.blockHash)
+      expect(event.transactionHash).to.deep.eq(receipt.transactionHash)
+    })
+  })
+})

--- a/l2geth/core/blockchain.go
+++ b/l2geth/core/blockchain.go
@@ -1485,6 +1485,10 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	if status == CanonStatTy {
 		bc.chainFeed.Send(ChainEvent{Block: block, Hash: block.Hash(), Logs: logs})
 		if len(logs) > 0 {
+			// Set the correct blocknumber on the log before sending the event
+			for _, ethlog := range logs {
+				ethlog.BlockNumber = block.NumberU64()
+			}
 			bc.logsFeed.Send(logs)
 		}
 		// In theory we should fire a ChainHeadEvent when we inject


### PR DESCRIPTION
**Description**

Previously the logs that matched an `eth_subscribe` would not return
the correct block number. This patch explicitly sets the block number on
the logs before they are sent through the filter system.

Tests are added to prevent future regressions. This patch differs from
upstream but works for us for now. The upstream code has been refactored
a bit so this is the minimal change required for the behavior to work
for us.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes OP-1101