### PR TITLE
l2geth: removes the id from the evm

### DIFF
--- a/.changeset/new-elephants-rush.md
+++ b/.changeset/new-elephants-rush.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Removes `id` field from EVM and no longer logs the EVM execution id

--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -249,7 +249,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 			l1MessageSender = msg.L1MessageSender().Hex()
 		}
 		if st.evm.EthCallSender == nil {
-			log.Debug("Applying transaction", "ID", st.evm.Id, "from", sender.Address().Hex(), "to", to, "nonce", msg.Nonce(), "gasPrice", msg.GasPrice().Uint64(), "gasLimit", msg.Gas(), "value", msg.Value().Uint64(), "l1MessageSender", l1MessageSender, "data", hexutil.Encode(msg.Data()))
+			log.Debug("Applying transaction", "from", sender.Address().Hex(), "to", to, "nonce", msg.Nonce(), "gasPrice", msg.GasPrice().Uint64(), "gasLimit", msg.Gas(), "value", msg.Value().Uint64(), "l1MessageSender", l1MessageSender, "data", hexutil.Encode(msg.Data()))
 		}
 	}
 

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -18,8 +18,6 @@ package vm
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strings"
@@ -120,7 +118,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 		// OVM_ENABLED
 		// Only log for non `eth_call`s
 		if evm.Context.EthCallSender == nil {
-			log.Debug("Calling contract", "ID", evm.Id, "Address", contract.Address().Hex(), "Data", hexutil.Encode(input))
+			log.Debug("Calling contract", "Address", contract.Address().Hex(), "Data", hexutil.Encode(input))
 		}
 
 		// Uncomment to make Safety checker always returns true.
@@ -132,7 +130,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 		if contract.Address() == evm.Context.OvmStateManager.Address {
 			// The caller must be the execution manager
 			if contract.Caller() != evm.Context.OvmExecutionManager.Address {
-				log.Error("StateManager called by non ExecutionManager", "ID", evm.Id, "caller", contract.Caller().Hex())
+				log.Error("StateManager called by non ExecutionManager", "caller", contract.Caller().Hex())
 				return nil, ErrOvmSandboxEscape
 			}
 			return callStateManager(input, evm, contract)
@@ -238,8 +236,6 @@ type EVM struct {
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
-
-	Id string
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -256,9 +252,6 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 		ctx.OvmL2StandardBridge = chainConfig.StateDump.Accounts["OVM_L2StandardBridge"]
 	}
 
-	id := make([]byte, 4)
-	rand.Read(id)
-
 	evm := &EVM{
 		Context:      ctx,
 		StateDB:      statedb,
@@ -266,8 +259,6 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 		chainConfig:  chainConfig,
 		chainRules:   chainConfig.Rules(ctx.BlockNumber),
 		interpreters: make([]Interpreter, 0, 1),
-
-		Id: hex.EncodeToString(id),
 	}
 
 	if chainConfig.IsEWASM(ctx.BlockNumber) {
@@ -467,7 +458,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 				}
 			}
 			if evm.Context.EthCallSender == nil {
-				log.Debug("Reached the end of an OVM execution", "ID", evm.Id, "Return Data", hexutil.Encode(ret), "Error", err)
+				log.Debug("Reached the end of an OVM execution", "Return Data", hexutil.Encode(ret), "Error", err)
 			}
 		}
 	}
@@ -700,7 +691,7 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 		contractAddr = evm.OvmADDRESS()
 
 		if evm.Context.EthCallSender == nil {
-			log.Debug("[EM] Creating contract.", "ID", evm.Id, "New contract address", contractAddr.Hex(), "Caller Addr", caller.Address().Hex(), "Caller nonce", evm.StateDB.GetNonce(caller.Address()))
+			log.Debug("[EM] Creating contract.", "New contract address", contractAddr.Hex(), "Caller Addr", caller.Address().Hex(), "Caller nonce", evm.StateDB.GetNonce(caller.Address()))
 		}
 	}
 
@@ -726,7 +717,7 @@ func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *
 		contractAddr = evm.OvmADDRESS()
 
 		if evm.Context.EthCallSender == nil {
-			log.Debug("[EM] Creating contract [create2].", "ID", evm.Id, "New contract address", contractAddr.Hex(), "Caller Addr", caller.Address().Hex(), "Caller nonce", evm.StateDB.GetNonce(caller.Address()))
+			log.Debug("[EM] Creating contract [create2].", "New contract address", contractAddr.Hex(), "Caller Addr", caller.Address().Hex(), "Caller nonce", evm.StateDB.GetNonce(caller.Address()))
 		}
 	}
 


### PR DESCRIPTION
**Description**

The `id` field was added to the EVM to allow for the logs to make sense
during concurrent calls to EVM execution. It adds a diff and is not
required now that `eth_call` is no longer logged.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

