### PR TITLE
l2geth: remove layer of indirection with state manager

### DIFF
--- a/.changeset/five-toys-impress.md
+++ b/.changeset/five-toys-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove layer of indirection in `callStateManager`

--- a/l2geth/core/vm/ovm_state_manager.go
+++ b/l2geth/core/vm/ovm_state_manager.go
@@ -34,10 +34,7 @@ var funcs = map[string]stateManagerFunction{
 }
 
 func callStateManager(input []byte, evm *EVM, contract *Contract) (ret []byte, err error) {
-	rawabi := evm.Context.OvmStateManager.ABI
-	abi := &rawabi
-
-	method, err := abi.MethodById(input)
+	method, err := evm.Context.OvmStateManager.ABI.MethodById(input)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find method id %s: %w", input, err)
 	}


### PR DESCRIPTION
**Description**

This PR removes the assignment of a pointer to the
state manager abi and just directly uses it instead.
There is an assumption that the state manager abi exists,
but this check happens at startup time, when the abis are
pulled from the state dump.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

