### PR TITLE
l2geth: remove unnecessary reflect

### DIFF
--- a/.changeset/fifty-vans-camp.md
+++ b/.changeset/fifty-vans-camp.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove an unnecessary use of `reflect` in l2geth

--- a/l2geth/core/vm/ovm_state_manager.go
+++ b/l2geth/core/vm/ovm_state_manager.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -90,7 +89,7 @@ func getAccountNonce(evm *EVM, contract *Contract, args map[string]interface{}) 
 		return nil, errors.New("Could not parse address arg in getAccountNonce")
 	}
 	nonce := evm.StateDB.GetNonce(address)
-	return []interface{}{new(big.Int).SetUint64(reflect.ValueOf(nonce).Uint())}, nil
+	return []interface{}{new(big.Int).SetUint64(nonce)}, nil
 }
 
 func getAccountEthAddress(evm *EVM, contract *Contract, args map[string]interface{}) ([]interface{}, error) {


### PR DESCRIPTION
**Description**

There was a usage of `refect` that was not required. This PR removes its
usage so that the code is simplified.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


