### PR TITLE
l2geth: update EVM context to use pointers for custom ovm fields

### DIFF
--- a/.changeset/small-cats-refuse.md
+++ b/.changeset/small-cats-refuse.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Uses pointers for large structs on the evm context

--- a/l2geth/core/state_processor.go
+++ b/l2geth/core/state_processor.go
@@ -133,5 +133,14 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(statedb.TxIndex())
 
+	if vm.UsingOVM {
+		vmenv.Context.OvmExecutionManager = nil
+		vmenv.Context.OvmStateManager = nil
+		vmenv.Context.OvmSafetyChecker = nil
+		vmenv.Context.OvmL2CrossDomainMessenger = nil
+		vmenv.Context.OvmETH = nil
+		vmenv.Context.OvmL2StandardBridge = nil
+	}
+
 	return receipt, err
 }

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -195,12 +195,12 @@ type Context struct {
 	EthCallSender             *common.Address
 	IsL1ToL2Message           bool
 	IsSuccessfulL1ToL2Message bool
-	OvmExecutionManager       dump.OvmDumpAccount
-	OvmStateManager           dump.OvmDumpAccount
-	OvmSafetyChecker          dump.OvmDumpAccount
-	OvmL2CrossDomainMessenger dump.OvmDumpAccount
-	OvmETH                    dump.OvmDumpAccount
-	OvmL2StandardBridge       dump.OvmDumpAccount
+	OvmExecutionManager       *dump.OvmDumpAccount
+	OvmStateManager           *dump.OvmDumpAccount
+	OvmSafetyChecker          *dump.OvmDumpAccount
+	OvmL2CrossDomainMessenger *dump.OvmDumpAccount
+	OvmETH                    *dump.OvmDumpAccount
+	OvmL2StandardBridge       *dump.OvmDumpAccount
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides
@@ -248,12 +248,18 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 	// Add the ExecutionManager and StateManager to the Context here to
 	// prevent the need to update function signatures across the codebase.
 	if chainConfig != nil && chainConfig.StateDump != nil {
-		ctx.OvmExecutionManager = chainConfig.StateDump.Accounts["OVM_ExecutionManager"]
-		ctx.OvmStateManager = chainConfig.StateDump.Accounts["OVM_StateManager"]
-		ctx.OvmSafetyChecker = chainConfig.StateDump.Accounts["OVM_SafetyChecker"]
-		ctx.OvmL2CrossDomainMessenger = chainConfig.StateDump.Accounts["OVM_L2CrossDomainMessenger"]
-		ctx.OvmETH = chainConfig.StateDump.Accounts["OVM_ETH"]
-		ctx.OvmL2StandardBridge = chainConfig.StateDump.Accounts["OVM_L2StandardBridge"]
+		executionManager := chainConfig.StateDump.Accounts["OVM_ExecutionManager"]
+		ctx.OvmExecutionManager = &executionManager
+		stateManager := chainConfig.StateDump.Accounts["OVM_StateManager"]
+		ctx.OvmStateManager = &stateManager
+		safetyChecker := chainConfig.StateDump.Accounts["OVM_SafetyChecker"]
+		ctx.OvmSafetyChecker = &safetyChecker
+		xdomainMessenger := chainConfig.StateDump.Accounts["OVM_L2CrossDomainMessenger"]
+		ctx.OvmL2CrossDomainMessenger = &xdomainMessenger
+		ovmEth := chainConfig.StateDump.Accounts["OVM_ETH"]
+		ctx.OvmETH = &ovmEth
+		l2StandardBridge := chainConfig.StateDump.Accounts["OVM_L2StandardBridge"]
+		ctx.OvmL2StandardBridge = &l2StandardBridge
 	}
 
 	id := make([]byte, 4)


### PR DESCRIPTION
**Description**

Custom fields that are configured at runtime must be present at runtime
due to the way that the OVM is implemented. This PR turns the fields
into pointers as the structs are rather large and sets them to nil in an
attempt to find a memory leak. These changes have no impact on increasing
memory usage over time.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


