### PR TITLE
l2geth: small syntax fix in the syncservice

### DIFF
--- a/.changeset/ten-bugs-cheat.md
+++ b/.changeset/ten-bugs-cheat.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Quick syntax fix in the sync service

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -1092,7 +1092,7 @@ func (s *SyncService) syncTransactionRange(start, end uint64, backend Backend) e
 		if err != nil {
 			return fmt.Errorf("cannot fetch transaction %d: %w", i, err)
 		}
-		if err = s.applyTransaction(tx); err != nil {
+		if err := s.applyTransaction(tx); err != nil {
 			return fmt.Errorf("Cannot apply transaction: %w", err)
 		}
 	}


### PR DESCRIPTION
**Description**

Very minor syntax fix to the syncservice

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
