### PR TITLE
l2geth: allow RPC transactions to go to `address(0)`

### DIFF
--- a/.changeset/gentle-geckos-approve.md
+++ b/.changeset/gentle-geckos-approve.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Allow transactions via RPC to `address(0)`

--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -304,9 +304,6 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	if b.UsingOVM {
 		to := signedTx.To()
 		if to != nil {
-			if *to == (common.Address{}) {
-				return errors.New("Cannot send transaction to zero address")
-			}
 			// Prevent QueueOriginSequencer transactions that are too large to
 			// be included in a batch. The `MaxCallDataSize` should be set to
 			// the layer one consensus max transaction size in bytes minus the


### PR DESCRIPTION
**Description**


When the custom batch serialization was being used instead of RLP, a
transaction being sent to `address(0)` was not allowed because that
meant that it was a contract creation because there is no abi encoding
for `nil`. To prevent collisions, transactions sent via RPC to
`address(0)` were banned. Now the RLP transactions are being used, this
check can be removed. It helps to reduce the diff from upstream geth.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

