### PR TITLE
l2geth: remove explicit 1 in buffered channel

### DIFF
--- a/.changeset/serious-cups-care.md
+++ b/.changeset/serious-cups-care.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove explicit 1 for buffer size in in `rollupCh`

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -196,7 +196,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		unconfirmed:        newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
 		pendingTasks:       make(map[common.Hash]*task),
 		txsCh:              make(chan core.NewTxsEvent, txChanSize),
-		rollupCh:           make(chan core.NewTxsEvent, 1),
+		rollupCh:           make(chan core.NewTxsEvent),
 		chainHeadCh:        make(chan core.ChainHeadEvent, chainHeadChanSize),
 		chainSideCh:        make(chan core.ChainSideEvent, chainSideChanSize),
 		newWorkCh:          make(chan *newWorkReq),


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes the explicit 1 in the buffer size for the `rollupCh`. All transactions when syncing go through this channel
