### PR TITLE
l2geth: copy slices in the state manager precompile

### DIFF
--- a/.changeset/sour-mails-tan.md
+++ b/.changeset/sour-mails-tan.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Copy memory in the state manager implementation

--- a/l2geth/core/vm/ovm_state_manager.go
+++ b/l2geth/core/vm/ovm_state_manager.go
@@ -32,15 +32,15 @@ var funcs = map[string]stateManagerFunction{
 	"commitPendingAccount":                     nativeFunctionVoid,
 }
 
-func callStateManager(input []byte, evm *EVM, contract *Contract) (ret []byte, err error) {
+func callStateManager(input []byte, evm *EVM, contract *Contract) ([]byte, error) {
 	method, err := evm.Context.OvmStateManager.ABI.MethodById(input)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find method id %s: %w", input, err)
 	}
 
 	var inputArgs = make(map[string]interface{})
-	err = method.Inputs.UnpackIntoMap(inputArgs, input[4:])
-	if err != nil {
+	encodedArgs := common.CopyBytes(input[4:])
+	if err := method.Inputs.UnpackIntoMap(inputArgs, encodedArgs); err != nil {
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func callStateManager(input []byte, evm *EVM, contract *Contract) (ret []byte, e
 		return nil, fmt.Errorf("cannot pack returndata: %w", err)
 	}
 
-	return returndata, nil
+	return common.CopyBytes(returndata), nil
 }
 
 func owner(evm *EVM, contract *Contract, args map[string]interface{}) ([]interface{}, error) {


### PR DESCRIPTION
**Description**


This PR copies the slices in the state manager instead of passing them
by reference.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

