### PR TITLE
l2geth: remove dead code in `blockchain.go` and `miner/worker.go`

### DIFF
--- a/.changeset/small-swans-punch.md
+++ b/.changeset/small-swans-punch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove dead code in `blockchain.go` and `miner/worker.go`

--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -323,10 +323,6 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	return b.eth.txPool.AddLocal(signedTx)
 }
 
-func (b *EthAPIBackend) SetTimestamp(timestamp int64) {
-	b.eth.blockchain.SetCurrentTimestamp(timestamp)
-}
-
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {
 	pending, err := b.eth.txPool.Pending()
 	if err != nil {

--- a/l2geth/internal/ethapi/backend.go
+++ b/l2geth/internal/ethapi/backend.go
@@ -86,7 +86,6 @@ type Backend interface {
 	CurrentBlock() *types.Block
 
 	// Optimism-specific API
-	SetTimestamp(timestamp int64)
 	IsVerifier() bool
 	IsSyncing() bool
 	GetEthContext() (uint64, uint64)

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -352,7 +352,6 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		select {
 		case <-w.startCh:
 			clearPending(w.chain.CurrentBlock().NumberU64())
-			timestamp = w.chain.CurrentTimestamp()
 			commit(false, commitInterruptNewHead)
 
 		case <-timer.C:
@@ -364,7 +363,6 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 					timer.Reset(recommit)
 					continue
 				}
-				timestamp = w.chain.CurrentTimestamp()
 				commit(true, commitInterruptResubmit)
 			}
 
@@ -510,7 +508,7 @@ func (w *worker) mainLoop() {
 				// If clique is running in dev mode(period is 0), disable
 				// advance sealing here.
 				if w.chainConfig.Clique != nil && w.chainConfig.Clique.Period == 0 {
-					w.commitNewWork(nil, true, w.chain.CurrentTimestamp())
+					w.commitNewWork(nil, true, time.Now().Unix())
 				}
 			}
 			atomic.AddInt32(&w.newTxs, int32(len(ev.Txs)))


### PR DESCRIPTION
**Description**

This PR removes dead code that was responsible for timestamp management.
This codepath is no longer used so removing it will reduce the diff.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
