### PR TITLE
l2geth: small style fix to the state manager precompile

### DIFF
--- a/.changeset/brave-bananas-bow.md
+++ b/.changeset/brave-bananas-bow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Style fix to the ovm state manager precompile

--- a/l2geth/core/vm/ovm_state_manager.go
+++ b/l2geth/core/vm/ovm_state_manager.go
@@ -39,8 +39,7 @@ func callStateManager(input []byte, evm *EVM, contract *Contract) (ret []byte, e
 	}
 
 	var inputArgs = make(map[string]interface{})
-	err = method.Inputs.UnpackIntoMap(inputArgs, input[4:])
-	if err != nil {
+	if err := method.Inputs.UnpackIntoMap(inputArgs, input[4:]); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**Description**

Updates the style to encapsulate the `err` so that it
doesn't need to reassign `err` and can instead keep
the `err` in its own scope.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

