### PR TITLE
ci: add replica-healthcheck to image publish workflow

### DIFF
--- a/.changeset/red-peaches-kneel.md
+++ b/.changeset/red-peaches-kneel.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Bug fix from leftover error during testing

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -21,6 +21,7 @@ jobs:
       message-relayer: ${{ steps.packages.outputs.message-relayer }}
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
       contracts: ${{ steps.packages.outputs.contracts }}
+      replica-healthcheck: ${{ steps.packages.outputs.replica-healthcheck }}
       canary-docker-tag: ${{ steps.docker-image-name.outputs.canary-docker-tag }}
 
     steps:
@@ -128,6 +129,7 @@ jobs:
       data-transport-layer: ${{ needs.canary-publish.outputs.data-transport-layer }}
       contracts: ${{ needs.canary-publish.outputs.contracts }}
       integration-tests: ${{ needs.canary-publish.outputs.integration-tests }}
+      replica-healthcheck: ${{ needs.canary-publish.outputs.replica-healthcheck }}
       canary-docker-tag: ${{ needs.canary-publish.outputs.canary-docker-tag }}
 
 
@@ -280,3 +282,29 @@ jobs:
           file: ./ops/docker/Dockerfile.integration-tests
           push: true
           tags: ethereumoptimism/integration-tests:${{ needs.builder.outputs.canary-docker-tag }}
+
+  replica-healthcheck:
+    name: Publish Data Transport Layer Version ${{ needs.builder.outputs.canary-docker-tag }}
+    needs: builder
+    if: needs.builder.outputs.replica-healthcheck != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.replica-healthcheck
+          push: true
+          tags: ethereumoptimism/replica-healthcheck:${{ needs.builder.outputs.canary-docker-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
       contracts: ${{ steps.packages.outputs.contracts }}
       gas-oracle: ${{ steps.packages.outputs.gas-oracle }}
+      replica-healthcheck: ${{ steps.packages.outputs.replica-healthcheck }}
 
     steps:
       - name: Checkout Repo
@@ -148,6 +149,7 @@ jobs:
       data-transport-layer: ${{ needs.release.outputs.data-transport-layer }}
       contracts: ${{ needs.release.outputs.contracts }}
       integration-tests: ${{ needs.release.outputs.integration-tests }}
+      replica-healthcheck: ${{ needs.release.outputs.replica-healthcheck }}
 
     steps:
       - name: Checkout
@@ -298,3 +300,29 @@ jobs:
           file: ./ops/docker/Dockerfile.integration-tests
           push: true
           tags: ethereumoptimism/integration-tests:${{ needs.builder.outputs.integration-tests }},ethereumoptimism/integration-tests:latest
+
+    replica-healthcheck:
+      name: Publish Replica Healthcheck Version ${{ needs.builder.outputs.replica-healthcheck }}
+      needs: builder
+      if: needs.builder.outputs.replica-healthcheck != ''
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
+
+        - name: Login to Docker Hub
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+        - name: Build and push
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ./ops/docker/Dockerfile.replica-healthcheck
+            push: true
+            tags: ethereumoptimism/replica-healthcheck:${{ needs.builder.outputs.replica-healthcheck }},ethereumoptimism/replica-healthcheck:latest

--- a/ops/docker/Dockerfile.replica-healthcheck
+++ b/ops/docker/Dockerfile.replica-healthcheck
@@ -1,0 +1,24 @@
+FROM ethereumoptimism/builder AS builder
+
+FROM node:14-alpine
+
+WORKDIR /opt/optimism
+
+# copy top level files
+COPY --from=builder /optimism/*.json ./
+COPY --from=builder /optimism/yarn.lock .
+COPY --from=builder /optimism/node_modules ./node_modules
+
+# copy deps (would have been nice if docker followed the symlinks required)
+COPY --from=builder /optimism/packages/core-utils/package.json ./packages/core-utils/package.json
+COPY --from=builder /optimism/packages/core-utils/dist ./packages/core-utils/dist
+COPY --from=builder /optimism/packages/common-ts/package.json ./packages/common-ts/package.json
+COPY --from=builder /optimism/packages/common-ts/dist ./packages/common-ts/dist
+
+# copy the service
+WORKDIR /opt/optimism/packages/replica-healthcheck
+COPY --from=builder /optimism/packages/replica-healthcheck/dist ./dist
+COPY --from=builder /optimism/packages/replica-healthcheck/package.json .
+COPY --from=builder /optimism/packages/replica-healthcheck/node_modules ./node_modules
+
+ENTRYPOINT ["node", "dist/exec/run-healthcheck-server.js"]

--- a/packages/replica-healthcheck/src/healthcheck-server.ts
+++ b/packages/replica-healthcheck/src/healthcheck-server.ts
@@ -92,7 +92,6 @@ export class HealthcheckServer {
   }
 
   runSyncCheck = async () => {
-    throw new Error('trial')
     const sequencerProvider = injectL2Context(
       new providers.JsonRpcProvider(this.options.sequencerRpcProvider)
     )


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adding replica-healthcheck to be published as a docker image since some providers are interested in using it!

**Additional context**
I didn't add a script for this to be run along the other services and also didn't add it to docker-compose, happy to do so if we think this belongs in the dafault stack though!

**Metadata**
- Fixes OP-1207