### PR TITLE
batch-submitter: remove call to `appendQueueBatch`

### DIFF
--- a/.changeset/olive-coins-run.md
+++ b/.changeset/olive-coins-run.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Removes the call to `appendQueueBatch` from the batch submitter

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -34,7 +34,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   protected chainContract: CanonicalTransactionChainContract
   protected l2ChainId: number
   protected syncing: boolean
-  private disableQueueBatchAppend: boolean
   private autoFixBatchOptions: AutoFixBatchOptions
   private transactionSubmitter: TransactionSubmitter
   private gasThresholdInGwei: number
@@ -55,7 +54,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     blockOffset: number,
     logger: Logger,
     metrics: Metrics,
-    disableQueueBatchAppend: boolean,
     autoFixBatchOptions: AutoFixBatchOptions = {
       fixDoublePlayedDeposits: false,
       fixMonotonicity: false,
@@ -78,7 +76,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       logger,
       metrics
     )
-    this.disableQueueBatchAppend = disableQueueBatchAppend
     this.autoFixBatchOptions = autoFixBatchOptions
     this.gasThresholdInGwei = gasThresholdInGwei
     this.transactionSubmitter = transactionSubmitter
@@ -137,11 +134,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
         'Syncing mode enabled! Skipping batch submission and clearing queue elements',
         { pendingQueueElements }
       )
-
-      if (!this.disableQueueBatchAppend) {
-        return this.submitAppendQueueBatch()
-      }
     }
+
     this.logger.info('Syncing mode enabled but queue is empty. Skipping...')
     return
   }
@@ -228,20 +222,6 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   /*********************
    * Private Functions *
    ********************/
-
-  private async submitAppendQueueBatch(): Promise<TransactionReceipt> {
-    const tx = await this.chainContract.populateTransaction.appendQueueBatch(
-      ethers.constants.MaxUint256 // Completely empty the queue by appending (up to) an enormous number of queue elements.
-    )
-    const submitTransaction = (): Promise<TransactionReceipt> => {
-      return this.transactionSubmitter.submitTransaction(
-        tx,
-        this._makeHooks('appendQueueBatch')
-      )
-    }
-    // Empty the queue with a huge `appendQueueBatch(..)` call
-    return this._submitAndLogTx(submitTransaction, 'Cleared queue!')
-  }
 
   private async submitAppendSequencerBatch(
     batchParams: AppendSequencerBatchParams

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -61,7 +61,6 @@ interface RequiredEnvVars {
 
 /* Optional Env Vars
  * FRAUD_SUBMISSION_ADDRESS
- * DISABLE_QUEUE_BATCH_APPEND
  * SEQUENCER_PRIVATE_KEY
  * PROPOSER_PRIVATE_KEY
  * MNEMONIC
@@ -193,10 +192,6 @@ export const run = async () => {
   const FRAUD_SUBMISSION_ADDRESS = config.str(
     'fraud-submisison-address',
     env.FRAUD_SUBMISSION_ADDRESS || 'no fraud'
-  )
-  const DISABLE_QUEUE_BATCH_APPEND = config.bool(
-    'disable-queue-batch-append',
-    !!env.DISABLE_QUEUE_BATCH_APPEND
   )
   const MIN_GAS_PRICE_IN_GWEI = config.uint(
     'min-gas-price-in-gwei',
@@ -382,7 +377,6 @@ export const run = async () => {
     BLOCK_OFFSET,
     logger.child({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
     metrics,
-    DISABLE_QUEUE_BATCH_APPEND,
     autoFixBatchOptions
   )
 

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -230,7 +230,6 @@ describe('BatchSubmitter', () => {
       1,
       new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
       testMetrics,
-      false
     )
   }
 


### PR DESCRIPTION
**Description**

The batch submitter is normally ran without running the call to
`appendQueueBatch`. The contracts have `appendQueueBatch` disabled
currently. This means that calling `appendQueueBatch` will result
in a revert. This PR removes the config option that is responsible
for turning of the call to `appendQueueBatch` so it is more likely
to "just work".

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

