### PR TITLE
l2geth: eth_syncing endpoint

### DIFF
--- a/.changeset/lovely-taxis-pump.md
+++ b/.changeset/lovely-taxis-pump.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Update `eth_syncing` to use the `SyncService` instead of the p2p downloader

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -85,6 +85,23 @@ func (s *PublicEthereumAPI) ProtocolVersion() hexutil.Uint {
 // - pulledStates:  number of state entries processed until now
 // - knownStates:   number of known state entries that still need to be pulled
 func (s *PublicEthereumAPI) Syncing() (interface{}, error) {
+	// Alter the syncing endpoint to determine if the node
+	// is syncing based on the sync service
+	if vm.UsingOVM {
+		syncing := s.b.IsSyncing()
+		if !syncing {
+			return false, nil
+		}
+		index, _, _ := s.b.GetRollupContext()
+		return map[string]interface{}{
+			"startingBlock": hexutil.Uint64(0),
+			"currentBlock":  hexutil.Uint64(index),
+			"highestBlock":  hexutil.Uint64(index),
+			"pulledStates":  hexutil.Uint64(index),
+			"knownStates":   hexutil.Uint64(index),
+		}, nil
+	}
+
 	progress := s.b.Downloader().Progress()
 
 	// Return not syncing if the synchronisation already completed


### PR DESCRIPTION
**Description**

Due to the existing L2 geth implementation not using the
p2p network for syncing, the `eth_syncing` endpoint needs to
be updated to provide useful information. Without any change,
it would always return false which is misleading because it
could actually be syncing. This PR updates the endpoint to use
the sync service's native understanding of whether it is syncing
or not.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes ENG-1359