### PR TITLE
Fix runtime target comment

### DIFF
--- a/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L2ToL1MessagePasser.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/predeploys/OVM_L2ToL1MessagePasser.sol
@@ -11,8 +11,8 @@ import { iOVM_L2ToL1MessagePasser } from "../../iOVM/predeploys/iOVM_L2ToL1Messa
  * _verifyStorageProof function, which verifies the existence of the transaction hash in this
  * contract's `sentMessages` mapping.
  *
- * Compiler used: solc
- * Runtime target: EVM
+ * Compiler used: optimistic-solc
+ * Runtime target: OVM
  */
 contract OVM_L2ToL1MessagePasser is iOVM_L2ToL1MessagePasser {
 


### PR DESCRIPTION
**Description**
`OVM_L2ToL1MessagePasser` contract's runtime target should be OVM, not EVM.

