### PR TITLE
batch-submitter,dtl: use ethers.StaticJsonRpcProvider

### DIFF
--- a/.changeset/empty-colts-attack.md
+++ b/.changeset/empty-colts-attack.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Migrate to using `ethers.StaticJsonRpcProvider`

--- a/.changeset/healthy-dragons-worry.md
+++ b/.changeset/healthy-dragons-worry.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Migrate to using `ethers.StaticJsonRpcProvider`

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -43,7 +43,7 @@ export abstract class BatchSubmitter {
 
   constructor(
     readonly signer: Signer,
-    readonly l2Provider: providers.JsonRpcProvider,
+    readonly l2Provider: providers.StaticJsonRpcProvider,
     readonly minTxSize: number,
     readonly maxTxSize: number,
     readonly maxBatchSize: number,

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -28,7 +28,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
 
   constructor(
     signer: Signer,
-    l2Provider: providers.JsonRpcProvider,
+    l2Provider: providers.StaticJsonRpcProvider,
     minTxSize: number,
     maxTxSize: number,
     maxBatchSize: number,

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -41,7 +41,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
   constructor(
     signer: Signer,
-    l2Provider: providers.JsonRpcProvider,
+    l2Provider: providers.StaticJsonRpcProvider,
     minTxSize: number,
     maxTxSize: number,
     maxBatchSize: number,

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -4,7 +4,10 @@ import * as Sentry from '@sentry/node'
 import { Logger, Metrics, createMetricsServer } from '@eth-optimism/common-ts'
 import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
-import { JsonRpcProvider, TransactionReceipt } from '@ethersproject/providers'
+import {
+  StaticJsonRpcProvider,
+  TransactionReceipt,
+} from '@ethersproject/providers'
 import * as dotenv from 'dotenv'
 import Config from 'bcfg'
 
@@ -136,7 +139,9 @@ export const run = async () => {
   )
 
   const getSequencerSigner = async (): Promise<Signer> => {
-    const l1Provider = new JsonRpcProvider(requiredEnvVars.L1_NODE_WEB3_URL)
+    const l1Provider = new StaticJsonRpcProvider(
+      requiredEnvVars.L1_NODE_WEB3_URL
+    )
 
     if (useHardhat) {
       if (!DEBUG_IMPERSONATE_SEQUENCER_ADDRESS) {
@@ -161,7 +166,9 @@ export const run = async () => {
   }
 
   const getProposerSigner = async (): Promise<Signer> => {
-    const l1Provider = new JsonRpcProvider(requiredEnvVars.L1_NODE_WEB3_URL)
+    const l1Provider = new StaticJsonRpcProvider(
+      requiredEnvVars.L1_NODE_WEB3_URL
+    )
 
     if (useHardhat) {
       if (!DEBUG_IMPERSONATE_PROPOSER_ADDRESS) {
@@ -335,7 +342,7 @@ export const run = async () => {
   const clearPendingTxs = requiredEnvVars.CLEAR_PENDING_TXS
 
   const l2Provider = injectL2Context(
-    new JsonRpcProvider(requiredEnvVars.L2_NODE_WEB3_URL)
+    new StaticJsonRpcProvider(requiredEnvVars.L2_NODE_WEB3_URL)
   )
 
   const sequencerSigner: Signer = await getSequencerSigner()

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -1,7 +1,7 @@
 /* Imports: External */
 import { fromHexString } from '@eth-optimism/core-utils'
 import { BaseService, Metrics } from '@eth-optimism/common-ts'
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { LevelUp } from 'levelup'
 import { ethers, constants } from 'ethers'
 import { Gauge, Counter } from 'prom-client'
@@ -98,7 +98,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
   private state: {
     db: TransportDB
     contracts: OptimismContracts
-    l1RpcProvider: JsonRpcProvider
+    l1RpcProvider: StaticJsonRpcProvider
     startingL1BlockNumber: number
   } = {} as any
 
@@ -109,7 +109,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
 
     this.state.l1RpcProvider =
       typeof this.options.l1RpcProvider === 'string'
-        ? new JsonRpcProvider(this.options.l1RpcProvider)
+        ? new StaticJsonRpcProvider(this.options.l1RpcProvider)
         : this.options.l1RpcProvider
 
     this.logger.info('Using AddressManager', {


### PR DESCRIPTION
**Description**

This PR migrates the applications to use the Ethers.js
StaticJsonRpcProvider to reduce the number of requests
that are being sent.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes  ENG-1161