### PR TITLE
fix: correctly use contract artifact import

### DIFF
--- a/.changeset/many-pants-appear.md
+++ b/.changeset/many-pants-appear.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Patch so contracts package will correctly use the browser-compatible contract artifacts import

--- a/packages/contracts/src/contract-defs.ts
+++ b/packages/contracts/src/contract-defs.ts
@@ -1,5 +1,3 @@
-import * as path from 'path'
-import * as glob from 'glob'
 import {
   ethers,
   ContractFactory,
@@ -11,16 +9,16 @@ import {
 import { Interface } from 'ethers/lib/utils'
 
 export const getContractDefinition = (name: string, ovm?: boolean): any => {
-  const match = glob.sync(
-    path.resolve(__dirname, `../artifacts${ovm ? '-ovm' : ''}`) +
-      `/**/${name.split('-').join(':')}.json`
-  )
-
-  if (match.length > 0) {
-    return require(match[0])
-  } else {
+  // We import this using `require` because hardhat tries to build this file when compiling
+  // the contracts, but we need the contracts to be compiled before the contract-artifacts.ts
+  // file can be generated.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getContractArtifact } = require('./contract-artifacts')
+  const artifact = getContractArtifact(name, ovm)
+  if (artifact === undefined) {
     throw new Error(`Unable to find artifact for contract: ${name}`)
   }
+  return artifact
 }
 
 export const getContractInterface = (


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Guess I missed this the first time around. Necessary to guarantee that the contracts package will be browser compatible.