### PR TITLE
Lower NUM_BLOCKS_TO_FETCH in Watcher

### DIFF
--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -17,7 +17,7 @@ export class Watcher {
   public l1: Layer
   public l2: Layer
   public pollInterval = 3000
-  public NUM_BLOCKS_TO_FETCH = 10_000_000
+  public NUM_BLOCKS_TO_FETCH = 9_999
 
   constructor(opts: WatcherOptions) {
     this.l1 = opts.l1


### PR DESCRIPTION
Using the watcher with the Optimism public nodes (kovan.optimism.io or mainnet.optimism.io) currently throws an error once the watcher gets to the log searching phase, as it passes a super large number of blocks to fetch, and the Optimism nodes cap log searches to 10k blocks in the past.

```
    Error: processing response error (body="{\"jsonrpc\":\"2.0\",\"result\":null,\"error\":{\"code\":-32601,\"message\":\"eth_getLogs are limited to a 10,000 blocks range\"},\"id\":97}\n", error={"code":-32601}, requestBody="{\"method\":\"eth_getLogs\",\"params\":[{\"fromBlock\":\"0x0\",\"address\":\"0x4200000000000000000000000000000000000007\",\"topics\":[\"0x4641df4a962071e12719d8c8c8e5ac7fc4d97b927346a3d7a335b1f7517e133c\"]}],\"id\":97,\"jsonrpc\":\"2.0\"}", requestMethod="POST", url="https://kovan.optimism.io", code=SERVER_ERROR, version=web/5.4.0)
      at Logger.makeError (node_modules/@ethersproject/logger/src.ts/index.ts:213:28)
      at Logger.throwError (node_modules/@ethersproject/logger/src.ts/index.ts:225:20)
      at /Users/benmayer/Desktop/nova/node_modules/@ethersproject/web/src.ts/index.ts:284:28
      at step (node_modules/@ethersproject/web/lib/index.js:33:23)
      at Object.next (node_modules/@ethersproject/web/lib/index.js:14:53)
      at fulfilled (node_modules/@ethersproject/web/lib/index.js:5:58)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      ```
      
