### PR TITLE
Watcher 10k blocks limit

### DIFF
--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -17,7 +17,7 @@ export class Watcher {
   public l1: Layer
   public l2: Layer
   public pollInterval = 3000
-  public NUM_BLOCKS_TO_FETCH = 10_000_000
+  public NUM_BLOCKS_TO_FETCH = 10_000
 
   constructor(opts: WatcherOptions) {
     this.l1 = opts.l1


### PR DESCRIPTION
There is an error happening on the gateway with the message "eth_getLogs are limited to a 10,000 blocks range". The trace isn't source mapped but I'm pretty sure its coming from Infura via the watcher.