### PR TITLE
Watcher: Even lower num blocks to fetch

### DIFF
--- a/.changeset/quiet-wasps-help.md
+++ b/.changeset/quiet-wasps-help.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/core-utils": patch
+---
+
+Watcher: Even lower num blocks to fetch

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -18,7 +18,7 @@ export class Watcher {
   public l1: Layer
   public l2: Layer
   public pollInterval = 3000
-  public blocksToFetch = 2000
+  public blocksToFetch = 1500
 
   constructor(opts: WatcherOptions) {
     this.l1 = opts.l1


### PR DESCRIPTION
Alchemy's limit of 2k blocks in the past still gets breached with 2k num blocks to fetch because in some cases a new block gets produced during the time between when the call to block number is made and the call to fetch logs.

Lowered to 1.5k to be safe in this PR. maybe even safer to go down to 1k?