### PR TITLE
Watcher: l1 vs l2 blocksToFetch

### DIFF
--- a/.changeset/yellow-windows-scream.md
+++ b/.changeset/yellow-windows-scream.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': minor
+---
+
+Allow a configurable L1 and L2 blocks to fetch in the watcher


### PR DESCRIPTION
The Watcher utility currently has a single `blocksToFetch` for both layers, which isn't ideal because L2 has much faster block times. This PR defines `l1BlocksToFetch` and `l2BlocksToFeth`


Note - I'm not sure why it added all the change set stuff. Feel free to remove if needed. 