### PR TITLE
Removes obsoleted and unused contract code

### DIFF
--- a/.changeset/unlucky-beds-train.md
+++ b/.changeset/unlucky-beds-train.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Remove obsoleted contract code. Improve events usability by indexing helpful params. Switch using encoded message and use decoded message from event

--- a/packages/contracts/contracts/L1/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/OVM_L1CrossDomainMessenger.sol
@@ -212,7 +212,7 @@ contract OVM_L1CrossDomainMessenger is
             _gasLimit
         );
 
-        emit SentMessage(_target, _message, nonce, _gasLimit);
+        emit SentMessage(_target, msg.sender, _message, nonce, _gasLimit);
     }
 
     /**

--- a/packages/contracts/contracts/L1/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/OVM_L1CrossDomainMessenger.sol
@@ -212,7 +212,7 @@ contract OVM_L1CrossDomainMessenger is
             _gasLimit
         );
 
-        emit SentMessage(xDomainCalldata);
+        emit SentMessage(_target, _message, nonce, _gasLimit);
     }
 
     /**

--- a/packages/contracts/contracts/L1/rollup/iOVM_CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/L1/rollup/iOVM_CanonicalTransactionChain.sol
@@ -18,11 +18,11 @@ interface iOVM_CanonicalTransactionChain {
      **********/
 
     event TransactionEnqueued(
-        address _l1TxOrigin,
-        address _target,
+        address indexed _l1TxOrigin,
+        address indexed _target,
         uint256 _gasLimit,
         bytes _data,
-        uint256 _queueIndex,
+        uint256 indexed _queueIndex,
         uint256 _timestamp
     );
 

--- a/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
@@ -102,7 +102,7 @@ contract OVM_L2CrossDomainMessenger is
         sentMessages[keccak256(xDomainCalldata)] = true;
 
         _sendXDomainMessage(xDomainCalldata, _gasLimit);
-        emit SentMessage(_target, _message, messageNonce, _gasLimit);
+        emit SentMessage(_target, msg.sender, _message, messageNonce, _gasLimit);
     }
 
     /**

--- a/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
@@ -98,11 +98,12 @@ contract OVM_L2CrossDomainMessenger is
             messageNonce
         );
 
-        messageNonce += 1;
         sentMessages[keccak256(xDomainCalldata)] = true;
 
         _sendXDomainMessage(xDomainCalldata, _gasLimit);
         emit SentMessage(_target, msg.sender, _message, messageNonce, _gasLimit);
+
+        messageNonce += 1;
     }
 
     /**

--- a/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
@@ -102,7 +102,7 @@ contract OVM_L2CrossDomainMessenger is
         sentMessages[keccak256(xDomainCalldata)] = true;
 
         _sendXDomainMessage(xDomainCalldata, _gasLimit);
-        emit SentMessage(xDomainCalldata);
+        emit SentMessage(_target, _message, messageNonce, _gasLimit);
     }
 
     /**

--- a/packages/contracts/contracts/libraries/bridge/iOVM_CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/libraries/bridge/iOVM_CrossDomainMessenger.sol
@@ -11,7 +11,12 @@ interface iOVM_CrossDomainMessenger {
      * Events *
      **********/
 
-    event SentMessage(address indexed target, bytes message, uint256 messageNonce, uint256 gasLimit);
+    event SentMessage(
+        address indexed target,
+        address sender,
+        bytes message,
+        uint256 messageNonce,
+        uint256 gasLimit);
     event RelayedMessage(bytes32 indexed msgHash);
     event FailedRelayedMessage(bytes32 indexed msgHash);
 

--- a/packages/contracts/contracts/libraries/bridge/iOVM_CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/libraries/bridge/iOVM_CrossDomainMessenger.sol
@@ -11,9 +11,9 @@ interface iOVM_CrossDomainMessenger {
      * Events *
      **********/
 
-    event SentMessage(bytes message);
-    event RelayedMessage(bytes32 msgHash);
-    event FailedRelayedMessage(bytes32 msgHash);
+    event SentMessage(address indexed target, bytes message, uint256 messageNonce, uint256 gasLimit);
+    event RelayedMessage(bytes32 indexed msgHash);
+    event FailedRelayedMessage(bytes32 indexed msgHash);
 
 
     /*************

--- a/packages/contracts/contracts/libraries/codec/Lib_OVMCodec.sol
+++ b/packages/contracts/contracts/libraries/codec/Lib_OVMCodec.sol
@@ -27,15 +27,6 @@ library Lib_OVMCodec {
      * Structs *
      ***********/
 
-    struct Account {
-        uint256 nonce;
-        uint256 balance;
-        bytes32 storageRoot;
-        bytes32 codeHash;
-        address ethAddress;
-        bool isFresh;
-    }
-
     struct EVMAccount {
         uint256 nonce;
         uint256 balance;
@@ -125,28 +116,6 @@ library Lib_OVMCodec {
         )
     {
         return keccak256(encodeTransaction(_transaction));
-    }
-
-    /**
-     * Converts an OVM account to an EVM account.
-     * @param _in OVM account to convert.
-     * @return Converted EVM account.
-     */
-    function toEVMAccount(
-        Account memory _in
-    )
-        internal
-        pure
-        returns (
-            EVMAccount memory
-        )
-    {
-        return EVMAccount({
-            nonce: _in.nonce,
-            balance: _in.balance,
-            storageRoot: _in.storageRoot,
-            codeHash: _in.codeHash
-        });
     }
 
     /**

--- a/packages/contracts/contracts/libraries/codec/Lib_OVMCodec.sol
+++ b/packages/contracts/contracts/libraries/codec/Lib_OVMCodec.sol
@@ -119,41 +119,6 @@ library Lib_OVMCodec {
     }
 
     /**
-     * @notice RLP-encodes an account state struct.
-     * @param _account Account state struct.
-     * @return RLP-encoded account state.
-     */
-    function encodeEVMAccount(
-        EVMAccount memory _account
-    )
-        internal
-        pure
-        returns (
-            bytes memory
-        )
-    {
-        bytes[] memory raw = new bytes[](4);
-
-        // Unfortunately we can't create this array outright because
-        // Lib_RLPWriter.writeList will reject fixed-size arrays. Assigning
-        // index-by-index circumvents this issue.
-        raw[0] = Lib_RLPWriter.writeBytes(
-            Lib_Bytes32Utils.removeLeadingZeros(
-                bytes32(_account.nonce)
-            )
-        );
-        raw[1] = Lib_RLPWriter.writeBytes(
-            Lib_Bytes32Utils.removeLeadingZeros(
-                bytes32(_account.balance)
-            )
-        );
-        raw[2] = Lib_RLPWriter.writeBytes(abi.encodePacked(_account.storageRoot));
-        raw[3] = Lib_RLPWriter.writeBytes(abi.encodePacked(_account.codeHash));
-
-        return Lib_RLPWriter.writeList(raw);
-    }
-
-    /**
      * @notice Decodes an RLP-encoded account state into a useful struct.
      * @param _encoded RLP-encoded account state.
      * @return Account state struct.

--- a/packages/contracts/contracts/libraries/rlp/Lib_RLPWriter.sol
+++ b/packages/contracts/contracts/libraries/rlp/Lib_RLPWriter.sol
@@ -90,23 +90,6 @@ library Lib_RLPWriter {
     }
 
     /**
-     * RLP encodes a bytes32 value.
-     * @param _in The bytes32 to encode.
-     * @return _out The RLP encoded bytes32 in bytes.
-     */
-    function writeBytes32(
-        bytes32 _in
-    )
-        internal
-        pure
-        returns (
-            bytes memory _out
-        )
-    {
-        return writeBytes(abi.encodePacked(_in));
-    }
-
-    /**
      * RLP encodes a uint.
      * @param _in The uint256 to encode.
      * @return The RLP encoded uint256 in bytes.

--- a/packages/contracts/contracts/libraries/utils/Lib_Bytes32Utils.sol
+++ b/packages/contracts/contracts/libraries/utils/Lib_Bytes32Utils.sol
@@ -77,41 +77,4 @@ library Lib_Bytes32Utils {
     {
         return bytes32(uint256(_in));
     }
-
-    /**
-     * Removes the leading zeros from a bytes32 value and returns a new (smaller) bytes value.
-     * @param _in Input bytes32 value.
-     * @return Bytes32 without any leading zeros.
-     */
-    function removeLeadingZeros(
-        bytes32 _in
-    )
-        internal
-        pure
-        returns (
-            bytes memory
-        )
-    {
-        bytes memory out;
-
-        assembly {
-            // Figure out how many leading zero bytes to remove.
-            let shift := 0
-            for { let i := 0 } and(lt(i, 32), eq(byte(i, _in), 0)) { i := add(i, 1) } {
-                shift := add(shift, 1)
-            }
-
-            // Reserve some space for our output and fix the free memory pointer.
-            out := mload(0x40)
-            mstore(0x40, add(out, 0x40))
-
-            // Shift the value and store it into the output bytes.
-            mstore(add(out, 0x20), shl(mul(shift, 8), _in))
-
-            // Store the new size (with leading zero bytes removed) in the output byte size.
-            mstore(out, sub(32, shift))
-        }
-
-        return out;
-    }
 }

--- a/packages/contracts/contracts/libraries/utils/Lib_BytesUtils.sol
+++ b/packages/contracts/contracts/libraries/utils/Lib_BytesUtils.sol
@@ -100,23 +100,6 @@ library Lib_BytesUtils {
         return slice(_bytes, _start, _bytes.length - _start);
     }
 
-    function toBytes32PadLeft(
-        bytes memory _bytes
-    )
-        internal
-        pure
-        returns (
-            bytes32
-        )
-    {
-        bytes32 ret;
-        uint256 len = _bytes.length <= 32 ? _bytes.length : 32;
-        assembly {
-            ret := shr(mul(sub(32, len), 8), mload(add(_bytes, 32)))
-        }
-        return ret;
-    }
-
     function toBytes32(
         bytes memory _bytes
     )
@@ -147,69 +130,6 @@ library Lib_BytesUtils {
         )
     {
         return uint256(toBytes32(_bytes));
-    }
-
-    function toUint24(
-        bytes memory _bytes,
-        uint256 _start
-    )
-        internal
-        pure
-        returns (
-            uint24
-        )
-    {
-        require(_start + 3 >= _start, "toUint24_overflow");
-        require(_bytes.length >= _start + 3 , "toUint24_outOfBounds");
-        uint24 tempUint;
-
-        assembly {
-            tempUint := mload(add(add(_bytes, 0x3), _start))
-        }
-
-        return tempUint;
-    }
-
-    function toUint8(
-        bytes memory _bytes,
-        uint256 _start
-    )
-        internal
-        pure
-        returns (
-            uint8
-        )
-    {
-        require(_start + 1 >= _start, "toUint8_overflow");
-        require(_bytes.length >= _start + 1 , "toUint8_outOfBounds");
-        uint8 tempUint;
-
-        assembly {
-            tempUint := mload(add(add(_bytes, 0x1), _start))
-        }
-
-        return tempUint;
-    }
-
-    function toAddress(
-        bytes memory _bytes,
-        uint256 _start
-    )
-        internal
-        pure
-        returns (
-            address
-        )
-    {
-        require(_start + 20 >= _start, "toAddress_overflow");
-        require(_bytes.length >= _start + 20, "toAddress_outOfBounds");
-        address tempAddress;
-
-        assembly {
-            tempAddress := div(mload(add(add(_bytes, 0x20), _start)), 0x1000000000000000000000000)
-        }
-
-        return tempAddress;
     }
 
     function toNibbles(

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -58,7 +58,9 @@ export class Watcher {
     }
 
     const msgHashes = []
-    const sentMessageEventId = ethers.utils.id('SentMessage(address,address,bytes,uint256,uint256)')
+    const sentMessageEventId = ethers.utils.id(
+      'SentMessage(address,address,bytes,uint256,uint256)'
+    )
     const l2CrossDomainMessengerRelayAbi = [
       'function relayMessage(address _target,address _sender,bytes memory _message,uint256 _messageNonce)',
     ]
@@ -68,8 +70,7 @@ export class Watcher {
     for (const log of receipt.logs) {
       if (
         log.address === layer.messengerAddress &&
-        log.topics[0] ===
-          sentMessageEventId
+        log.topics[0] === sentMessageEventId
       ) {
         const [sender, message, messageNonce] =
           ethers.utils.defaultAbiCoder.decode(

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -61,10 +61,11 @@ export class Watcher {
     for (const log of receipt.logs) {
       if (
         log.address === layer.messengerAddress &&
-        log.topics[0] === ethers.utils.id('SentMessage(bytes)')
+        log.topics[0] ===
+          ethers.utils.id('SentMessage(address,address,bytes,uint256,uint256)')
       ) {
-        const [message] = ethers.utils.defaultAbiCoder.decode(
-          ['bytes'],
+        const [, , message, ,] = ethers.utils.defaultAbiCoder.decode(
+          ['address', 'address', 'bytes', 'uint256', 'uint256'],
           log.data
         )
         msgHashes.push(ethers.utils.solidityKeccak256(['bytes'], [message]))

--- a/packages/core-utils/src/watcher.ts
+++ b/packages/core-utils/src/watcher.ts
@@ -58,17 +58,39 @@ export class Watcher {
     }
 
     const msgHashes = []
+    const sentMessageEventId = ethers.utils.id('SentMessage(address,address,bytes,uint256,uint256)')
+    const l2CrossDomainMessengerRelayAbi = [
+      'function relayMessage(address _target,address _sender,bytes memory _message,uint256 _messageNonce)',
+    ]
+    const l2CrossDomainMessengerRelayinterface = new ethers.utils.Interface(
+      l2CrossDomainMessengerRelayAbi
+    )
     for (const log of receipt.logs) {
       if (
         log.address === layer.messengerAddress &&
         log.topics[0] ===
-          ethers.utils.id('SentMessage(address,address,bytes,uint256,uint256)')
+          sentMessageEventId
       ) {
-        const [, , message, ,] = ethers.utils.defaultAbiCoder.decode(
-          ['address', 'address', 'bytes', 'uint256', 'uint256'],
-          log.data
+        const [sender, message, messageNonce] =
+          ethers.utils.defaultAbiCoder.decode(
+            ['address', 'bytes', 'uint256'],
+            log.data
+          )
+
+        const [target] = ethers.utils.defaultAbiCoder.decode(
+          ['address'],
+          log.topics[1]
         )
-        msgHashes.push(ethers.utils.solidityKeccak256(['bytes'], [message]))
+
+        const encodedMessage =
+          l2CrossDomainMessengerRelayinterface.encodeFunctionData(
+            'relayMessage',
+            [target, sender, message, messageNonce]
+          )
+
+        msgHashes.push(
+          ethers.utils.solidityKeccak256(['bytes'], [encodedMessage])
+        )
       }
     }
     return msgHashes
@@ -98,7 +120,9 @@ export class Watcher {
       const successLogs = await layer.provider.getLogs(successFilter)
       const failureLogs = await layer.provider.getLogs(failureFilter)
       const logs = successLogs.concat(failureLogs)
-      matches = logs.filter((log: ethers.providers.Log) => log.data === msgHash)
+      matches = logs.filter(
+        (log: ethers.providers.Log) => log.topics[1] === msgHash
+      )
 
       // exit loop after first iteration if not polling
       if (!pollForPending) {

--- a/packages/message-relayer/src/relay-tx.ts
+++ b/packages/message-relayer/src/relay-tx.ts
@@ -92,17 +92,11 @@ export const getMessagesByTransactionHash = async (
 
   // Decode the messages and turn them into a nicer struct.
   const sentMessages = sentMessageEvents.map((sentMessageEvent) => {
-    const encodedMessage = sentMessageEvent.args.message
-    const decodedMessage = l2CrossDomainMessenger.interface.decodeFunctionData(
-      'relayMessage',
-      encodedMessage
-    )
-
     return {
-      target: decodedMessage._target,
-      sender: decodedMessage._sender,
-      message: decodedMessage._message,
-      messageNonce: decodedMessage._messageNonce.toNumber(),
+      target: sentMessageEvent.args.target,
+      sender: sentMessageEvent.args.sender,
+      message: sentMessageEvent.args.message, // decoded message
+      messageNonce: sentMessageEvent.args.messageNonce.toNumber(),
     }
   })
 

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -387,20 +387,24 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
     )
 
     const messages = events.map((event) => {
-      const message = event.args.message
-      const decoded =
-        this.state.OVM_L2CrossDomainMessenger.interface.decodeFunctionData(
+      const encodedMessage =
+        this.state.OVM_L2CrossDomainMessenger.interface.encodeFunctionData(
           'relayMessage',
-          message
+          [
+            event.args.target,
+            event.args.sender,
+            event.args.message,
+            event.args.messageNonce,
+          ]
         )
 
       return {
-        target: decoded._target,
-        sender: decoded._sender,
-        message: decoded._message,
-        messageNonce: decoded._messageNonce,
-        encodedMessage: message,
-        encodedMessageHash: ethers.utils.keccak256(message),
+        target: event.args.target,
+        sender: event.args.sender,
+        message: event.args.message,
+        messageNonce: event.args.messageNonce,
+        encodedMessage,
+        encodedMessageHash: ethers.utils.keccak256(encodedMessage),
         parentTransactionIndex: event.blockNumber - this.options.l2BlockOffset,
         parentTransactionHash: event.transactionHash,
       }

--- a/packages/message-relayer/test/test-contracts/MockL2CrossDomainMessenger.sol
+++ b/packages/message-relayer/test/test-contracts/MockL2CrossDomainMessenger.sol
@@ -10,7 +10,7 @@ contract MockL2CrossDomainMessenger {
         uint256 messageNonce;
     }
 
-    event SentMessage(bytes message);
+    event SentMessage(address indexed target, bytes message, uint256 messageNonce, uint256 gasLimit);
 
     function emitSentMessageEvent(
         MessageData memory _message
@@ -18,13 +18,10 @@ contract MockL2CrossDomainMessenger {
         public
     {
         emit SentMessage(
-            abi.encodeWithSignature(
-                "relayMessage(address,address,bytes,uint256)",
-                _message.target,
-                _message.sender,
-                _message.message,
-                _message.messageNonce
-            )
+            _message.target,
+            _message.message,
+            _message.messageNonce,
+            0
         );
     }
 

--- a/packages/message-relayer/test/test-contracts/MockL2CrossDomainMessenger.sol
+++ b/packages/message-relayer/test/test-contracts/MockL2CrossDomainMessenger.sol
@@ -10,7 +10,12 @@ contract MockL2CrossDomainMessenger {
         uint256 messageNonce;
     }
 
-    event SentMessage(address indexed target, bytes message, uint256 messageNonce, uint256 gasLimit);
+    event SentMessage(
+        address indexed target,
+        address sender,
+        bytes message,
+        uint256 messageNonce,
+        uint256 gasLimit);
 
     function emitSentMessageEvent(
         MessageData memory _message
@@ -19,6 +24,7 @@ contract MockL2CrossDomainMessenger {
     {
         emit SentMessage(
             _message.target,
+            _message.sender,
             _message.message,
             _message.messageNonce,
             0


### PR DESCRIPTION
### Removes obsoleted code such as
- `Account` struct in `Lib_OVMCodec`
- suggested dead code reported by `slither` 
```
Lib_Bytes32Utils.removeLeadingZeros(bytes32) (contracts/libraries/utils/Lib_Bytes32Utils.sol#86-116) is never used and should be removed
Lib_BytesUtils.toAddress(bytes,uint256) (contracts/libraries/utils/Lib_BytesUtils.sol#194-213) is never used and should be removed
Lib_BytesUtils.toBytes32PadLeft(bytes) (contracts/libraries/utils/Lib_BytesUtils.sol#103-118) is never used and should be removed
Lib_BytesUtils.toUint24(bytes,uint256) (contracts/libraries/utils/Lib_BytesUtils.sol#152-171) is never used and should be removed
Lib_BytesUtils.toUint8(bytes,uint256) (contracts/libraries/utils/Lib_BytesUtils.sol#173-192) is never used and should be removed
Lib_OVMCodec.encodeEVMAccount(Lib_OVMCodec.EVMAccount) (contracts/libraries/codec/Lib_OVMCodec.sol#126-154) is never used and should be removed
Lib_RLPWriter.writeBytes32(bytes32) (contracts/libraries/rlp/Lib_RLPWriter.sol#97-107) is never used and should be removed
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#dead-code
```
### Improve events usability by indexing helpful params
`RelayedMessage` index msgHash
`FailedRelayedMessage` index msgHash
`SentMessage` updated to include target, message, messageNonce, and gasLimit instead of just the final encoded message, indexed by target.  This also allows us to switch away from using encoded message and use decoded message from event instead.
`TransactionEnqueued` indexed by `l1TxOrigin`, `target`, and `queueIndex`

Indexing an event parameter caused the indexed property to move from `logs.data` to `logs.topics` so had to adjust the watcher for this.