### PR TITLE
l2geth: configurable min L2 gas limit

### DIFF
--- a/.changeset/popular-tools-jog.md
+++ b/.changeset/popular-tools-jog.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Add in min accepted L2 gas limit config flag

--- a/l2geth/cmd/geth/main.go
+++ b/l2geth/cmd/geth/main.go
@@ -168,6 +168,7 @@ var (
 		utils.RollupMaxCalldataSizeFlag,
 		utils.RollupBackendFlag,
 		utils.RollupEnforceFeesFlag,
+		utils.RollupMinL2GasLimitFlag,
 		utils.RollupFeeThresholdDownFlag,
 		utils.RollupFeeThresholdUpFlag,
 		utils.GasPriceOracleOwnerAddress,

--- a/l2geth/cmd/geth/usage.go
+++ b/l2geth/cmd/geth/usage.go
@@ -81,6 +81,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupMaxCalldataSizeFlag,
 			utils.RollupBackendFlag,
 			utils.RollupEnforceFeesFlag,
+			utils.RollupMinL2GasLimitFlag,
 			utils.RollupFeeThresholdDownFlag,
 			utils.RollupFeeThresholdUpFlag,
 			utils.GasPriceOracleOwnerAddress,

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -892,6 +892,11 @@ var (
 		Usage:  "Disable transactions with 0 gas price",
 		EnvVar: "ROLLUP_ENFORCE_FEES",
 	}
+	RollupMinL2GasLimitFlag = cli.Uint64Flag{
+		Name:   "rollup.minl2gaslimit",
+		Usage:  "Minimum accepted L2 gas limit",
+		EnvVar: "ROLLUP_MIN_L2_GAS_LIMIT",
+	}
 	RollupFeeThresholdDownFlag = cli.Float64Flag{
 		Name:   "rollup.feethresholddown",
 		Usage:  "Allow txs with fees below the current fee up to this amount, must be < 1",
@@ -1202,6 +1207,10 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 	}
 	if ctx.GlobalIsSet(RollupEnforceFeesFlag.Name) {
 		cfg.EnforceFees = true
+	}
+	if ctx.GlobalIsSet(RollupMinL2GasLimitFlag.Name) {
+		val := ctx.GlobalUint64(RollupMinL2GasLimitFlag.Name)
+		cfg.MinL2GasLimit = new(big.Int).SetUint64(val)
 	}
 	if ctx.GlobalIsSet(RollupFeeThresholdDownFlag.Name) {
 		val := ctx.GlobalFloat64(RollupFeeThresholdDownFlag.Name)

--- a/l2geth/rollup/config.go
+++ b/l2geth/rollup/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	Backend Backend
 	// Only accept transactions with fees
 	EnforceFees bool
+	// Prevent transactions with a L2 gas limit lower than this value
+	// The L2 gas limit is parsed from the `tx.gasPrice`, see the
+	// `rollup/fees` package for more information
+	MinL2GasLimit *big.Int
 	// Allow fees within a buffer upwards or downwards
 	// to take fee volatility into account between being
 	// quoted and the transaction being executed

--- a/l2geth/rollup/fees/rollup_fee.go
+++ b/l2geth/rollup/fees/rollup_fee.go
@@ -18,6 +18,9 @@ var (
 	// errMissingInput represents the error case of missing required input to
 	// PaysEnough
 	errMissingInput = errors.New("missing input")
+	// ErrL2GasLimitTooLow represents the error case of when a user sends a
+	// transaction to the sequencer with a L2 gas limit that is too small
+	ErrL2GasLimitTooLow = errors.New("L2 gas limit too low")
 )
 
 // overhead represents the fixed cost of batch submission of a single

--- a/l2geth/rollup/sync_service_test.go
+++ b/l2geth/rollup/sync_service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rollup/fees"
 )
 
 func setupLatestEthContextTest() (*SyncService, *EthContext) {
@@ -545,6 +546,38 @@ func TestSyncServiceL2GasPrice(t *testing.T) {
 
 	if l2GasPrice.Cmp(post) != 0 {
 		t.Fatal("Gas price not updated")
+	}
+}
+
+func TestSyncServiceMinL2GasPrice(t *testing.T) {
+	service, _, _, err := newTestSyncService(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.minL2GasLimit = new(big.Int).SetUint64(10_000_000)
+	signer := types.NewEIP155Signer(big.NewInt(420))
+	// Generate a key
+	key, _ := crypto.GenerateKey()
+	// Create a transaction
+	gasLimit := uint64(100)
+	tx := types.NewTransaction(0, common.Address{}, big.NewInt(0), gasLimit, big.NewInt(15000000), []byte{})
+	// Make sure the gas limit is set correctly
+	if tx.Gas() != gasLimit {
+		t.Fatal("gas limit not set correctly")
+	}
+	// Sign the dummy tx with the owner key
+	signedTx, err := types.SignTx(tx, signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity check the L2 gas limit
+	if tx.L2Gas() > service.minL2GasLimit.Uint64() {
+		t.Fatal("L2 gas limit expected to be smaller than min accepted by sequencer")
+	}
+	// Verify the fee of the signed tx, ensure it does not error
+	err = service.verifyFee(signedTx)
+	if !errors.Is(err, fees.ErrL2GasLimitTooLow) {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
**Description**

This commit adds a new config flag `--rollup.minl2gaslimit` that
defaults to `0` and is used to prevent transactions from being ingested
that have a L2 gas limit smaller than the value configured. This
config flag can also be controlled with the env var
`ROLLUP_MIN_L2_GAS_LIMIT`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


**Additional context**
This can be dropped on the experimental branch

**Metadata**
- Fixes #[Link to Issue]
