### PR TITLE
Extended test coverage of core-utils

### DIFF
--- a/.changeset/nice-waves-jog.md
+++ b/.changeset/nice-waves-jog.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': patch
+---
+
+increased coverage of core-utils

--- a/packages/core-utils/test/coders/batch-encoder.spec.ts
+++ b/packages/core-utils/test/coders/batch-encoder.spec.ts
@@ -50,5 +50,28 @@ describe('BatchEncoder', () => {
         expect(encoded).to.equal(calldata)
       }
     })
+
+    it('should throw an error', () => {
+      const batch = {
+        shouldStartAtElement: 10,
+        totalElementsToAppend: 1,
+        contexts: [
+          {
+            numSequencedTransactions: 2,
+            numSubsequentQueueTransactions: 1,
+            timestamp: 100,
+            blockNumber: 200,
+          },
+        ],
+        transactions: ['0x454234000000112', '0x45423400000012'],
+      }
+      expect(() => encodeAppendSequencerBatch(batch)).to.throw(
+        'Unexpected uneven hex string value!'
+      )
+
+      expect(() => sequencerBatch.decode('0x')).to.throw(
+        'Incorrect function signature'
+      )
+    })
   })
 })

--- a/packages/core-utils/test/common/hex-utils.spec.ts
+++ b/packages/core-utils/test/common/hex-utils.spec.ts
@@ -2,7 +2,105 @@ import { expect } from '../setup'
 import { BigNumber } from 'ethers'
 
 /* Imports: Internal */
-import { toRpcHexString } from '../../src'
+import {
+  toRpcHexString,
+  remove0x,
+  add0x,
+  fromHexString,
+  toHexString,
+  padHexString,
+} from '../../src'
+
+describe('remove0x', () => {
+  it('should return undefined', () => {
+    expect(remove0x(undefined)).to.deep.equal(undefined)
+  })
+
+  it('should return without a 0x', () => {
+    const cases = [
+      { input: '0x', output: '' },
+      {
+        input: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        output: '1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+      },
+      { input: 'a', output: 'a' },
+    ]
+    for (const test of cases) {
+      expect(remove0x(test.input)).to.deep.equal(test.output)
+    }
+  })
+})
+
+describe('add0x', () => {
+  it('should return undefined', () => {
+    expect(add0x(undefined)).to.deep.equal(undefined)
+  })
+
+  it('should return with a 0x', () => {
+    const cases = [
+      { input: '0x', output: '0x' },
+      {
+        input: '1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        output: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+      },
+      { input: '', output: '0x' },
+    ]
+    for (const test of cases) {
+      expect(add0x(test.input)).to.deep.equal(test.output)
+    }
+  })
+})
+
+describe('toHexString', () => {
+  it('should return undefined', () => {
+    expect(add0x(undefined)).to.deep.equal(undefined)
+  })
+
+  it('should return with a hex string', () => {
+    const cases = [
+      { input: 0, output: '0x00' },
+      {
+        input: '0',
+        output: '0x30',
+      },
+      { input: '', output: '0x' },
+    ]
+    for (const test of cases) {
+      expect(toHexString(test.input)).to.deep.equal(test.output)
+    }
+  })
+})
+
+describe('fromHexString', () => {
+  it('should return a buffer from a hex string', () => {
+    const cases = [
+      { input: '0x', output: Buffer.from('', 'hex') },
+      {
+        input: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+        output: Buffer.from('1f9840a85d5af5bf1d1762f925bdaddc4201f984', 'hex'),
+      },
+      { input: '', output: Buffer.from('', 'hex') },
+      {
+        input: Buffer.from('1f9840a85d5af5bf1d1762f925bdaddc4201f984'),
+        output: Buffer.from('1f9840a85d5af5bf1d1762f925bdaddc4201f984'),
+      },
+    ]
+
+    for (const test of cases) {
+      expect(fromHexString(test.input)).to.deep.equal(test.output)
+    }
+  })
+})
+
+describe('padHexString', () => {
+  it('should return return input string if length is 2 + length * 2', () => {
+    expect(padHexString('abcd', 1)).to.deep.equal('abcd')
+    expect(padHexString('abcdefgh', 3).length).to.deep.equal(8)
+  })
+  it('should return a string padded with 0x and zeros', () => {
+    expect(padHexString('0xabcd', 3)).to.deep.equal('0x00abcd')
+  })
+})
 
 describe('toRpcHexString', () => {
   it('should parse 0', () => {

--- a/packages/core-utils/test/common/misc.spec.ts
+++ b/packages/core-utils/test/common/misc.spec.ts
@@ -1,0 +1,13 @@
+import { expect } from '../setup'
+
+/* Imports: Internal */
+import { sleep } from '../../src'
+
+describe('sleep', async () => {
+  it('should return wait input amount of ms', async () => {
+    const startTime = Date.now()
+    await sleep(1000)
+    const endTime = Date.now()
+    expect(startTime + 1000 <= endTime).to.deep.equal(true)
+  })
+})

--- a/packages/core-utils/test/fees/fees.spec.ts
+++ b/packages/core-utils/test/fees/fees.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from '../setup'
 import * as fees from '../../src/fees'
-import { utils } from 'ethers'
+import { BigNumber, utils } from 'ethers'
 
 const hundredBillion = 10 ** 11
+const tenThousand = 10 ** 4
 
 describe('Fees', () => {
   it('should count zeros and ones', () => {
@@ -116,5 +117,12 @@ describe('Fees', () => {
         expect(decoded).to.deep.eq(roundedL2GasLimit)
       })
     }
+
+    it('should decode numbers', () => {
+      const x = 1
+      expect(fees.TxGasLimit.decode(x)).to.deep.equal(
+        BigNumber.from(x * tenThousand)
+      )
+    })
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
- Increase coverage in `core-utils` package (71.3% up from 64%, 100% for all files excluding `l2context.ts` and `watcher.ts`)
- This doesn't currently handler increased coverage around `l2context` and `watcher` but that can be included if preferred.

**Additional context**
This shouldn't be merged until #1412 is merged.

**Metadata**
- Directly a follow up to #1412 
