### PR TITLE
Lower per tx fee overhead

### DIFF
--- a/.changeset/sweet-actors-hope.md
+++ b/.changeset/sweet-actors-hope.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/core-utils': patch
+'@eth-optimism/l2geth': patch
+---
+
+Lower per tx fee overhead to more accurately represent L1 costs

--- a/go/utils/fees/rollup_fee.go
+++ b/go/utils/fees/rollup_fee.go
@@ -9,7 +9,7 @@ import (
 
 // overhead represents the fixed cost of batch submission of a single
 // transaction in gas.
-const overhead uint64 = 4200 + 200*params.TxDataNonZeroGasEIP2028
+const overhead uint64 = 2750
 
 // feeScalar is used to scale the calculations in EncodeL2GasLimit
 // to prevent them from being too large

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -420,9 +420,7 @@ describe('Basic RPC tests', () => {
         expect(decoded).to.deep.eq(BigNumber.from(l2Gaslimit))
         expect(estimate.toString().endsWith(l2Gaslimit.toString()))
 
-        const l2GasPrice = BigNumber.from(0)
-        // The L2GasPrice should be fetched from the L2GasPrice oracle contract,
-        // but it does not yet exist. Use the default value for now
+        const l2GasPrice = await env.gasPriceOracle.gasPrice()
         const expected = TxGasLimit.encode({
           data: tx.data,
           l1GasPrice,

--- a/l2geth/rollup/fees/rollup_fee.go
+++ b/l2geth/rollup/fees/rollup_fee.go
@@ -25,7 +25,7 @@ var (
 
 // overhead represents the fixed cost of batch submission of a single
 // transaction in gas.
-const overhead uint64 = 4200 + 200*params.TxDataNonZeroGasEIP2028
+const overhead uint64 = 2750
 
 // feeScalar is used to scale the calculations in EncodeL2GasLimit
 // to prevent them from being too large

--- a/packages/core-utils/src/fees.ts
+++ b/packages/core-utils/src/fees.ts
@@ -8,7 +8,7 @@ import { remove0x } from './common'
 const feeScalar = 10_000_000
 const txDataZeroGas = 4
 const txDataNonZeroGasEIP2028 = 16
-const overhead = 4200 + 200 * txDataNonZeroGasEIP2028
+const overhead = 2750
 const tenThousand = BigNumber.from(10_000)
 export const TxGasPrice = BigNumber.from(feeScalar + feeScalar / 2)
 export interface EncodableL2GasLimit {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Lowers per tx fee overhead to more accurately reflect L1 batch submission costs. This overhead value represents the sum of the non-calldata per tx overhead to submit a tx to the CTC (~ 1700 gas) and the per tx cost of submitting a state root to the SCC (~1060 gas)

Fixes ENG-1352