### PR TITLE
batch-submitter: eip1559 logging

### DIFF
--- a/.changeset/yellow-tomatoes-peel.md
+++ b/.changeset/yellow-tomatoes-peel.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Add loglines for eip1559 related fields before sending a transaction

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -195,6 +195,9 @@ export abstract class BatchSubmitter {
       beforeSendTransaction: (tx: PopulatedTransaction) => {
         this.logger.info(`Submitting ${txName} transaction`, {
           gasPrice: tx.gasPrice,
+          maxFeePerGas: tx.maxFeePerGas,
+          maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+          gasLimit: tx.gasLimit,
           nonce: tx.nonce,
           contractAddr: this.chainContract.address,
         })


### PR DESCRIPTION
**Description**

Log values related to eip1559 before sending a transaction.
- `maxFeePerGas`
- `maxPriorityFeePerGas`

Also log the `gasLimit` in case transactions revert.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

A clear and concise description of the features you're adding in this pull request.

**Additional context**
Batches are being submitted to L1 with the same tip and max priority fee, the tip should be set lower. This will help to debug


