### PR TITLE
feat: final opcode tweaks

### DIFF
--- a/.changeset/many-masks-exercise.md
+++ b/.changeset/many-masks-exercise.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/integration-tests': minor
+'@eth-optimism/l2geth': minor
+---
+
+Opcode tweaks. Coinbase returns SequencerFeeVault address. Difficulty returns zero.

--- a/integration-tests/contracts/OVMContextStorage.sol
+++ b/integration-tests/contracts/OVMContextStorage.sol
@@ -5,11 +5,13 @@ pragma solidity >=0.7.0;
 contract OVMContextStorage {
     mapping (uint256 => uint256) public blockNumbers;
     mapping (uint256 => uint256) public timestamps;
+    mapping (uint256 => uint256) public difficulty;
     uint256 public index = 0;
 
     fallback() external {
         blockNumbers[index] = block.number;
         timestamps[index] = block.timestamp;
+        difficulty[index] = block.difficulty;
         index++;
     }
 }

--- a/integration-tests/contracts/OVMContextStorage.sol
+++ b/integration-tests/contracts/OVMContextStorage.sol
@@ -6,12 +6,14 @@ contract OVMContextStorage {
     mapping (uint256 => uint256) public blockNumbers;
     mapping (uint256 => uint256) public timestamps;
     mapping (uint256 => uint256) public difficulty;
+    mapping (uint256 => address) public coinbases;
     uint256 public index = 0;
 
     fallback() external {
         blockNumbers[index] = block.number;
         timestamps[index] = block.timestamp;
         difficulty[index] = block.difficulty;
+        coinbases[index] = block.coinbase;
         index++;
     }
 }

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai'
 /* Imports: External */
 import { ethers } from 'hardhat'
 import { injectL2Context } from '@eth-optimism/core-utils'
+import { predeploys } from '@eth-optimism/contracts'
 import { Contract, BigNumber } from 'ethers'
 
 /* Imports: Internal */
@@ -76,6 +77,10 @@ describe('OVM Context: Layer 2 EVM Context', () => {
       // Difficulty should always be zero.
       const difficulty = await OVMContextStorage.difficulty(i)
       expect(difficulty.toNumber()).to.equal(0)
+
+      // Coinbase should always be sequencer fee vault.
+      const coinbase = await OVMContextStorage.coinbases(i)
+      expect(coinbase).to.equal(predeploys.OVM_SequencerFeeVault)
     }
   }).timeout(150000) // this specific test takes a while because it involves L1 to L2 txs
 

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -72,6 +72,10 @@ describe('OVM Context: Layer 2 EVM Context', () => {
       expect(receipt.blockNumber).to.deep.equal(blockNumber.toNumber())
       const timestamp = await OVMContextStorage.timestamps(i)
       expect(block.timestamp).to.deep.equal(timestamp.toNumber())
+
+      // Difficulty should always be zero.
+      const difficulty = await OVMContextStorage.difficulty(i)
+      expect(difficulty.toNumber()).to.equal(0)
     }
   }).timeout(150000) // this specific test takes a while because it involves L1 to L2 txs
 

--- a/l2geth/core/evm.go
+++ b/l2geth/core/evm.go
@@ -68,7 +68,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 			Coinbase:        beneficiary,
 			BlockNumber:     msg.L1BlockNumber(),
 			Time:            new(big.Int).SetUint64(msg.L1Timestamp()),
-			Difficulty:      new(big.Int).Set(header.Difficulty),
+			Difficulty:      new(big.Int), // Difficulty always returns zero.
 			GasLimit:        header.GasLimit,
 			GasPrice:        new(big.Int).Set(msg.GasPrice()),
 			L1MessageSender: l1MessageSender,

--- a/l2geth/core/evm.go
+++ b/l2geth/core/evm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/rollup/dump"
 	"github.com/ethereum/go-ethereum/rollup/rcfg"
 )
 
@@ -65,7 +66,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, author
 			Transfer:        Transfer,
 			GetHash:         GetHashFn(header, chain),
 			Origin:          msg.From(),
-			Coinbase:        beneficiary,
+			Coinbase:        dump.OvmFeeWallet, // Coinbase is the fee vault.
 			BlockNumber:     msg.L1BlockNumber(),
 			Time:            new(big.Int).SetUint64(msg.L1Timestamp()),
 			Difficulty:      new(big.Int), // Difficulty always returns zero.

--- a/l2geth/rollup/dump/constants.go
+++ b/l2geth/rollup/dump/constants.go
@@ -5,3 +5,4 @@ import (
 )
 
 var OvmEthAddress = common.HexToAddress("0x4200000000000000000000000000000000000006")
+var OvmFeeWallet = common.HexToAddress("0x4200000000000000000000000000000000000011")


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Some final opcode tweaks:
1. Difficulty always returns ZERO.
2. Coinbase always returns SequencerFeeVault.address.

**Metadata**
- Fixes ENG-1366
- Fixes ENG-1367
