### PR TITLE
ERC20 Bridge interfaces: Add a getter to return the cross-domain bridge address

### DIFF
--- a/.changeset/ninety-years-smell.md
+++ b/.changeset/ninety-years-smell.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Add a getter to the ERC20 bridge interfaces, to return the address of the corresponding cross domain bridge

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1StandardBridge.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L1StandardBridge.sol
@@ -33,7 +33,7 @@ contract OVM_L1StandardBridge is iOVM_L1StandardBridge, OVM_CrossDomainEnabled {
      * External Contract References *
      ********************************/
 
-    address public l2TokenBridge;
+    address public override l2TokenBridge;
 
     // Maps L1 token to L2 token to balance of the L1 token deposited
     mapping(address => mapping (address => uint256)) public deposits;

--- a/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardBridge.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardBridge.sol
@@ -33,7 +33,7 @@ contract OVM_L2StandardBridge is iOVM_L2ERC20Bridge, OVM_CrossDomainEnabled {
      * External Contract References *
      ********************************/
 
-    address public l1TokenBridge;
+    address public override l1TokenBridge;
 
     /***************
      * Constructor *

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ERC20Bridge.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L1ERC20Bridge.sol
@@ -34,6 +34,12 @@ interface iOVM_L1ERC20Bridge {
      ********************/
 
     /**
+     * @dev get the address of the corresponding L2 bridge contract.
+     * @return Address of the corresponding L2 bridge contract.
+     */
+    function l2TokenBridge() external returns(address);
+
+    /**
      * @dev deposit an amount of the ERC20 to the caller's balance on L2.
      * @param _l1Token Address of the L1 ERC20 we are depositing
      * @param _l2Token Address of the L1 respective L2 ERC20

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2ERC20Bridge.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/tokens/iOVM_L2ERC20Bridge.sol
@@ -44,6 +44,12 @@ interface iOVM_L2ERC20Bridge {
      ********************/
 
     /**
+     * @dev get the address of the corresponding L1 bridge contract.
+     * @return Address of the corresponding L1 bridge contract.
+     */
+    function l1TokenBridge() external returns(address);
+
+    /**
      * @dev initiate a withdraw of some tokens to the caller's account on L1
      * @param _l2Token Address of L2 token where withdrawal was initiated.
      * @param _amount Amount of the token to withdraw.

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -25,8 +25,9 @@ import 'hardhat-gas-reporter'
 dotenv.config()
 
 const enableGasReport = !!process.env.ENABLE_GAS_REPORT
-const privateKey = process.env.PRIVATE_KEY ||
-  "0x0000000000000000000000000000000000000000000000000000000000000000"; // this is to avoid hardhat error
+const privateKey =
+  process.env.PRIVATE_KEY ||
+  '0x0000000000000000000000000000000000000000000000000000000000000000' // this is to avoid hardhat error
 
 const config: HardhatUserConfig = {
   networks: {


### PR DESCRIPTION
**Description**

Some of the custom L1 bridges don't have an `l2TokenBridge()` address getter. 
This change would prevent that by adding the getter to the interface. The same is done on the L2 interface.

**Metadata**

Fixes ENG-1174