### PR TITLE
fix: use the same nonce for each batch submission

### DIFF
--- a/.changeset/rotten-kids-fly.md
+++ b/.changeset/rotten-kids-fly.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Fixes a bug in the batch submitted that would cause it to submit transactions with increasing nonces

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -173,9 +173,11 @@ export class StateBatchSubmitter extends BatchSubmitter {
     this.logger.debug('Submitting batch.', { calldata })
 
     // Generate the transaction we will repeatedly submit
+    const nonce = await this.signer.getTransactionCount()
     const tx = await this.chainContract.populateTransaction.appendStateBatch(
       batch,
-      offsetStartsAtIndex
+      offsetStartsAtIndex,
+      { nonce }
     )
     const submitTransaction = (): Promise<TransactionReceipt> => {
       return this.transactionSubmitter.submitTransaction(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes the state batch submitter to use the same nonce when submitting transactions. Otherwise it tries to submit lots of transactions with increasing nonces.