### PR TITLE
chore(contracts): defaults lib w/ xdomain msg sender

### DIFF
--- a/.changeset/four-news-drive.md
+++ b/.changeset/four-news-drive.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Added default values library for contracts

--- a/packages/contracts/contracts/L1/messaging/OVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/OVM_L1CrossDomainMessenger.sol
@@ -7,6 +7,7 @@ import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolve
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";
 import { Lib_AddressManager } from "../../libraries/resolver/Lib_AddressManager.sol";
 import { Lib_SecureMerkleTrie } from "../../libraries/trie/Lib_SecureMerkleTrie.sol";
+import { Lib_DefaultValues } from "../../libraries/constants/Lib_DefaultValues.sol";
 import { Lib_PredeployAddresses } from "../../libraries/constants/Lib_PredeployAddresses.sol";
 import { Lib_CrossDomainUtils } from "../../libraries/bridge/Lib_CrossDomainUtils.sol";
 
@@ -51,14 +52,6 @@ contract OVM_L1CrossDomainMessenger is
         bytes32 indexed _xDomainCalldataHash
     );
 
-    /*************
-     * Constants *
-     *************/
-
-    // The default x-domain message sender being set to a non-zero value makes
-    // deployment a bit more expensive, but in exchange the refund on every call to
-    // `relayMessage` by the L1 and L2 messengers will be higher.
-    address internal constant DEFAULT_XDOMAIN_SENDER = 0x000000000000000000000000000000000000dEaD;
 
     /**********************
      * Contract Variables *
@@ -68,7 +61,7 @@ contract OVM_L1CrossDomainMessenger is
     mapping (bytes32 => bool) public relayedMessages;
     mapping (bytes32 => bool) public successfulMessages;
 
-    address internal xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+    address internal xDomainMsgSender = Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER;
 
     /***************
      * Constructor *
@@ -121,7 +114,7 @@ contract OVM_L1CrossDomainMessenger is
             "L1CrossDomainMessenger already intialized."
         );
         libAddressManager = Lib_AddressManager(_libAddressManager);
-        xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+        xDomainMsgSender = Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER;
 
         // Initialize upgradable OZ contracts
         __Context_init_unchained(); // Context is a dependency for both Ownable and Pausable
@@ -176,7 +169,7 @@ contract OVM_L1CrossDomainMessenger is
             address
         )
     {
-        require(xDomainMsgSender != DEFAULT_XDOMAIN_SENDER, "xDomainMessageSender is not set");
+        require(xDomainMsgSender != Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER, "xDomainMessageSender is not set");
         return xDomainMsgSender;
     }
 
@@ -266,7 +259,7 @@ contract OVM_L1CrossDomainMessenger is
 
         xDomainMsgSender = _sender;
         (bool success, ) = _target.call(_message);
-        xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+        xDomainMsgSender = Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER;
 
         // Mark the message as received if the call was successful. Ensures that a message can be
         // relayed multiple times in the case that the call reverted.

--- a/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/OVM_L2CrossDomainMessenger.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 /* Library Imports */
 import { Lib_CrossDomainUtils } from "../../libraries/bridge/Lib_CrossDomainUtils.sol";
+import { Lib_DefaultValues } from "../../libraries/constants/Lib_DefaultValues.sol";
 import { Lib_PredeployAddresses } from "../../libraries/constants/Lib_PredeployAddresses.sol";
 
 /* Interface Imports */
@@ -30,15 +31,6 @@ contract OVM_L2CrossDomainMessenger is
 {
 
     /*************
-     * Constants *
-     *************/
-
-    // The default x-domain message sender being set to a non-zero value makes
-    // deployment a bit more expensive, but in exchange the refund on every call to
-    // `relayMessage` by the L1 and L2 messengers will be higher.
-    address internal constant DEFAULT_XDOMAIN_SENDER = 0x000000000000000000000000000000000000dEaD;
-
-    /*************
      * Variables *
      *************/
 
@@ -46,7 +38,7 @@ contract OVM_L2CrossDomainMessenger is
     mapping (bytes32 => bool) public successfulMessages;
     mapping (bytes32 => bool) public sentMessages;
     uint256 public messageNonce;
-    address internal xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+    address internal xDomainMsgSender = Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER;
     address public l1CrossDomainMessenger;
 
     /***************
@@ -73,7 +65,7 @@ contract OVM_L2CrossDomainMessenger is
             address
         )
     {
-        require(xDomainMsgSender != DEFAULT_XDOMAIN_SENDER, "xDomainMessageSender is not set");
+        require(xDomainMsgSender != Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER, "xDomainMessageSender is not set");
         return xDomainMsgSender;
     }
 
@@ -149,7 +141,7 @@ contract OVM_L2CrossDomainMessenger is
 
         xDomainMsgSender = _sender;
         (bool success, ) = _target.call(_message);
-        xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+        xDomainMsgSender = Lib_DefaultValues.DEFAULT_XDOMAIN_SENDER;
 
         // Mark the message as received if the call was successful. Ensures that a message can be
         // relayed multiple times in the case that the call reverted.

--- a/packages/contracts/contracts/libraries/constants/Lib_DefaultValues.sol
+++ b/packages/contracts/contracts/libraries/constants/Lib_DefaultValues.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >0.5.0 <0.8.0;
+
+/**
+ * @title Lib_DefaultValues
+ */
+library Lib_DefaultValues {
+
+    // The default x-domain message sender being set to a non-zero value makes
+    // deployment a bit more expensive, but in exchange the refund on every call to
+    // `relayMessage` by the L1 and L2 messengers will be higher.
+    address internal constant DEFAULT_XDOMAIN_SENDER = 0x000000000000000000000000000000000000dEaD;
+
+}


### PR DESCRIPTION
**Description**
Adds default values library for xdomain msg sender.

**Additional context**
n/a

**Metadata**
- Fixes #803 
- Targets `experimental` based on https://github.com/ethereum-optimism/optimism/pull/1442#issuecomment-918520261