### PR TITLE
ci: fix workflow for exporting logs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,7 @@ jobs:
         uses: jwalton/gh-docker-logs@v1
         with:
           images: 'ethereumoptimism/builder,ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth,ethereumoptimism/integration-tests'
-          dest: '~/logs'
+          dest: '/home/runner/logs'
 
       - name: Tar logs
         if: failure()


### PR DESCRIPTION
The logs after failure are not being exported correctly as they are not
being written to the correct location. Previously `~` was not being
interpreted as `$HOME`. This assumes that the `cwd` is `$HOME`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The CI doesn't export logs on failure, this PR fixes that.

**Additional context**
Makes debugging easier
