### PR TITLE
dtl: use `ethers.StaticJsonRpcProvider` to reduce `eth_chainId` requests

### DIFF
--- a/.changeset/happy-candles-burn.md
+++ b/.changeset/happy-candles-burn.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Use ethers.StaticJsonRpcProvider for the L2 Provider to lower API requests

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import { BaseService, Metrics } from '@eth-optimism/common-ts'
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { BigNumber } from 'ethers'
 import { LevelUp } from 'levelup'
 import axios from 'axios'
@@ -72,7 +72,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
 
   private state: {
     db: TransportDB
-    l2RpcProvider: JsonRpcProvider
+    l2RpcProvider: StaticJsonRpcProvider
   } = {} as any
 
   protected async _init(): Promise<void> {
@@ -88,7 +88,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
 
     this.state.l2RpcProvider =
       typeof this.options.l2RpcProvider === 'string'
-        ? new JsonRpcProvider(this.options.l2RpcProvider)
+        ? new StaticJsonRpcProvider(this.options.l2RpcProvider)
         : this.options.l2RpcProvider
   }
 


### PR DESCRIPTION
**Description**


There is no need to query for the chain id over and over again
when syncing from L2 using the DTL. This also reduces the amount
of logs for the `docker-compose` setup and will save requests to
the sequencer in production.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->



