### PR TITLE
l2geth: config enable arbitrary contract deployment

### DIFF
--- a/.changeset/witty-feet-sniff.md
+++ b/.changeset/witty-feet-sniff.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Add ROLLUP_ENABLE_ARBITRARY_CONTRACT_DEPLOYMENT_FLAG

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -135,6 +135,24 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 			}
 			return callStateManager(input, evm, contract)
 		}
+
+		// Only in the case where EnableArbitraryContractDeployment is
+		// set, allows codepath to be skipped when it is not set
+		if EnableArbitraryContractDeployment != nil {
+			// When the address manager is called
+			if contract.Address() == WhitelistAddress {
+				// If the first four bytes match `isDeployerAllowed(address)`
+				if bytes.Equal(input[0:4], isDeployerAllowedSig) {
+					// Already checked to make sure this value is not nil
+					switch *EnableArbitraryContractDeployment {
+					case EnableArbitraryContractDeploymentTrue:
+						return AbiBytesTrue, nil
+					case EnableArbitraryContractDeploymentFalse:
+						return AbiBytesFalse, nil
+					}
+				}
+			}
+		}
 	}
 
 	if contract.CodeAddr != nil {

--- a/l2geth/core/vm/ovm_state_dump.go
+++ b/l2geth/core/vm/ovm_state_dump.go
@@ -1,20 +1,45 @@
 package vm
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// AbiBytesTrue represents the ABI encoding of "true" as a byte slice
-var AbiBytesTrue = common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000001")
+var (
+	// AbiBytesTrue represents the ABI encoding of "true" as a byte slice
+	AbiBytesTrue = common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000001")
 
-// AbiBytesFalse represents the ABI encoding of "false" as a byte slice
-var AbiBytesFalse = common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000000")
+	// AbiBytesFalse represents the ABI encoding of "false" as a byte slice
+	AbiBytesFalse = common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000000")
 
-// UsingOVM is used to enable or disable functionality necessary for the OVM.
-var UsingOVM bool
+	// UsingOVM is used to enable or disable functionality necessary for the OVM.
+	UsingOVM bool
+	// EnableArbitraryContractDeployment is used to override the
+	// deployer whitelist
+	EnableArbitraryContractDeployment *bool
+
+	// These are aliases to the pointer EnableArbitraryContractDeployment
+	EnableArbitraryContractDeploymentTrue  bool = true
+	EnableArbitraryContractDeploymentFalse bool = false
+
+	WhitelistAddress     = common.HexToAddress("0x4200000000000000000000000000000000000002")
+	isDeployerAllowedSig = crypto.Keccak256([]byte("isDeployerAllowed(address)"))[:4]
+)
 
 func init() {
 	UsingOVM = os.Getenv("USING_OVM") == "true"
+	value := os.Getenv("ROLLUP_ENABLE_ARBITRARY_CONTRACT_DEPLOYMENT")
+	if value != "" {
+		switch value {
+		case "true":
+			EnableArbitraryContractDeployment = &EnableArbitraryContractDeploymentTrue
+		case "false":
+			EnableArbitraryContractDeployment = &EnableArbitraryContractDeploymentFalse
+		default:
+			panic(fmt.Sprintf("Unknown ROLLUP_ENABLE_ARBITRARY_CONTRACT_DEPLOYMENT value: %s", value))
+		}
+	}
 }

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -140,6 +141,10 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 		value := new(big.Int)
 		log.Info("Sanitizing minimum L2 gas limit", "value", value)
 		cfg.MinL2GasLimit = value
+	}
+
+	if vm.EnableArbitraryContractDeployment != nil {
+		log.Info("Setting arbitrary contract deployment", "value", *vm.EnableArbitraryContractDeployment)
 	}
 
 	service := SyncService{


### PR DESCRIPTION
**Description**

Add a new config option `ROLLUP_ENABLE_ARBITRARY_CONTRACT_DEPLOYMENT`.
This config option must be set with an env var, there is no flag to
set it with.

If it is not set, the functionality is unchanged. If it is set, then it
will override the function `isDeployerAllowed(address)` on the
`OVM_DeployerWhitelist`

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


