### PR TITLE
Only burn gas on deposits with a high L2 gas limit

### DIFF
--- a/.changeset/khaki-pots-repeat.md
+++ b/.changeset/khaki-pots-repeat.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': minor
+---
+
+Only burn gas in the CTC on deposits with a high gas limit


### PR DESCRIPTION
**Description**

Determines a threshold amount `ENQUEUE_L2_GAS_PREPAID`. If a transaction is enqueued with a gas limit below this value, no gas is burned. 
In the case that gas is burned, the amount burned is reduced proportional to `ENQUEUE_L2_GAS_PREPAID`. 


**Additional context**

The calculation of `ENQUEUE_L2_GAS_PREPAID` is calculated by multiplying the following values:
1. the baseline cost of calling `enqueue()` without the gas burn. ([per tenderly](https://dashboard.tenderly.co/tx/mainnet/0xdf2ca1773f9682df29748ad519cebba7aadde79cd7350741180f60816766ccd4/gas-usage)).
2. the `L2_GAS_DISCOUNT_DIVISOR`, which is an estimate of the ratio of the values of L2 gas to L1 gas ([Currently 32](https://github.com/ethereum-optimism/optimism/blob/8b477943f85443de62700b346d1c6ec0130a1e20/packages/contracts/contracts/L1/rollup/OVM_CanonicalTransactionChain.sol#L39)). 

