### PR TITLE
Make the gas burn amount configurable

### DIFF
--- a/.changeset/tall-apples-refuse.md
+++ b/.changeset/tall-apples-refuse.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': minor
+---
+
+Make the CTC's gas burn amount configurable at create time

--- a/packages/contracts/bin/deploy.ts
+++ b/packages/contracts/bin/deploy.ts
@@ -36,6 +36,8 @@ const parseEnv = () => {
       'number'
     ),
     ctcMaxTransactionGasLimit: ensure('MAX_TRANSACTION_GAS_LIMIT', 'number'),
+    ctcL2GasDiscountDivisor: ensure('L2_GAS_DISCOUNT_DIVISOR', 'number'),
+    ctcEnqueueGasCost: ensure('ENQUEUE_GAS_COST', 'number'),
     sccFraudProofWindow: ensure('FRAUD_PROOF_WINDOW_SECONDS', 'number'),
     sccSequencerPublishWindow: ensure(
       'SEQUENCER_PUBLISH_WINDOW_SECONDS',
@@ -51,6 +53,8 @@ const main = async () => {
     l1BlockTimeSeconds: config.l1BlockTimeSeconds,
     ctcForceInclusionPeriodSeconds: config.ctcForceInclusionPeriodSeconds,
     ctcMaxTransactionGasLimit: config.ctcMaxTransactionGasLimit,
+    ctcL2GasDiscountDivisor: config.ctcL2GasDiscountDivisor,
+    ctcEnqueueGasCost: config.ctcEnqueueGasCost,
     sccFraudProofWindow: config.sccFraudProofWindow,
     sccSequencerPublishWindow: config.sccFraudProofWindow,
     ovmSequencerAddress: sequencer.address,

--- a/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
@@ -34,9 +34,9 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
     // L2 tx gas-related
     uint256 constant public MIN_ROLLUP_TX_GAS = 100000;
     uint256 constant public MAX_ROLLUP_TX_SIZE = 50000;
-    uint256 constant public L2_GAS_DISCOUNT_DIVISOR = 32;
-    uint256 constant public ENQUEUE_GAS_COST = 60000;
-    uint256 public ENQUEUE_L2_GAS_PREPAID = L2_GAS_DISCOUNT_DIVISOR * ENQUEUE_GAS_COST;
+    uint256 immutable public L2_GAS_DISCOUNT_DIVISOR;
+    uint256 immutable public ENQUEUE_GAS_COST;
+    uint256 immutable public ENQUEUE_L2_GAS_PREPAID;
 
     // Encoding-related (all in bytes)
     uint256 constant internal BATCH_CONTEXT_SIZE = 16;
@@ -63,13 +63,18 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
         address _libAddressManager,
         uint256 _forceInclusionPeriodSeconds,
         uint256 _forceInclusionPeriodBlocks,
-        uint256 _maxTransactionGasLimit
+        uint256 _maxTransactionGasLimit,
+        uint256 _l2GasDiscountDivisor,
+        uint256 _enqueueGasCost
     )
         Lib_AddressResolver(_libAddressManager)
     {
         forceInclusionPeriodSeconds = _forceInclusionPeriodSeconds;
         forceInclusionPeriodBlocks = _forceInclusionPeriodBlocks;
         maxTransactionGasLimit = _maxTransactionGasLimit;
+        L2_GAS_DISCOUNT_DIVISOR = _l2GasDiscountDivisor;
+        ENQUEUE_GAS_COST  = _enqueueGasCost;
+        ENQUEUE_L2_GAS_PREPAID = _l2GasDiscountDivisor * _enqueueGasCost;
     }
 
 

--- a/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
+++ b/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
@@ -21,6 +21,8 @@ const deployFn: DeployFunction = async (hre) => {
       (hre as any).deployConfig.ctcForceInclusionPeriodSeconds,
       (hre as any).deployConfig.ctcForceInclusionPeriodBlocks,
       (hre as any).deployConfig.ctcMaxTransactionGasLimit,
+      (hre as any).deployConfig.ctcL2GasDiscountDivisor,
+      (hre as any).deployConfig.ctcEnqueueGasCost,
     ],
   })
 }

--- a/packages/contracts/tasks/deploy.ts
+++ b/packages/contracts/tasks/deploy.ts
@@ -6,6 +6,8 @@ import * as types from 'hardhat/internal/core/params/argumentTypes'
 const DEFAULT_L1_BLOCK_TIME_SECONDS = 15
 const DEFAULT_CTC_FORCE_INCLUSION_PERIOD_SECONDS = 60 * 60 * 24 * 30 // 30 days
 const DEFAULT_CTC_MAX_TRANSACTION_GAS_LIMIT = 11_000_000
+const DEFAULT_CTC_L2_GAS_DISCOUNT_DIVISOR = 32
+const DEFAULT_CTC_ENQUEUE_GAS_COST = 60_000
 const DEFAULT_SCC_FRAUD_PROOF_WINDOW = 60 * 60 * 24 * 7 // 7 days
 const DEFAULT_SCC_SEQUENCER_PUBLISH_WINDOW = 60 * 30 // 30 minutes
 
@@ -26,6 +28,18 @@ task('deploy')
     'ctcMaxTransactionGasLimit',
     'Max gas limit for L1 queue transactions.',
     DEFAULT_CTC_MAX_TRANSACTION_GAS_LIMIT,
+    types.int
+  )
+  .addOptionalParam(
+    'ctcL2GasDiscountDivisor',
+    'Max gas limit for L1 queue transactions.',
+    DEFAULT_CTC_L2_GAS_DISCOUNT_DIVISOR,
+    types.int
+  )
+  .addOptionalParam(
+    'ctcEnqueueGasCost',
+    'Max gas limit for L1 queue transactions.',
+    DEFAULT_CTC_ENQUEUE_GAS_COST,
     types.int
   )
   .addOptionalParam(

--- a/packages/contracts/test/contracts/L1/messaging/L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/L1CrossDomainMessenger.spec.ts
@@ -16,6 +16,8 @@ import {
   DUMMY_BATCH_PROOFS,
   FORCE_INCLUSION_PERIOD_SECONDS,
   FORCE_INCLUSION_PERIOD_BLOCKS,
+  L2_GAS_DISCOUNT_DIVISOR,
+  ENQUEUE_GAS_COST,
   TrieTestGenerator,
   getNextBlockNumber,
   encodeXDomainCalldata,
@@ -100,7 +102,9 @@ describe('L1CrossDomainMessenger', () => {
       AddressManager.address,
       FORCE_INCLUSION_PERIOD_SECONDS,
       FORCE_INCLUSION_PERIOD_BLOCKS,
-      MAX_GAS_LIMIT
+      MAX_GAS_LIMIT,
+      L2_GAS_DISCOUNT_DIVISOR,
+      ENQUEUE_GAS_COST
     )
 
     const batches = await Factory__ChainStorageContainer.deploy(

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -16,6 +16,8 @@ import {
   makeAddressManager,
   setProxyTarget,
   FORCE_INCLUSION_PERIOD_SECONDS,
+  L2_GAS_DISCOUNT_DIVISOR,
+  ENQUEUE_GAS_COST,
   getEthTime,
   getNextBlockNumber,
   NON_ZERO_ADDRESS,
@@ -85,7 +87,9 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       AddressManager.address,
       FORCE_INCLUSION_PERIOD_SECONDS,
       forceInclusionPeriodBlocks,
-      MAX_GAS_LIMIT
+      MAX_GAS_LIMIT,
+      L2_GAS_DISCOUNT_DIVISOR,
+      ENQUEUE_GAS_COST
     )
 
     const batches = await Factory__ChainStorageContainer.deploy(

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
@@ -19,6 +19,8 @@ import {
   setProxyTarget,
   FORCE_INCLUSION_PERIOD_SECONDS,
   FORCE_INCLUSION_PERIOD_BLOCKS,
+  L2_GAS_DISCOUNT_DIVISOR,
+  ENQUEUE_GAS_COST,
   setEthTime,
   NON_ZERO_ADDRESS,
   getEthTime,
@@ -132,7 +134,9 @@ describe('CanonicalTransactionChain', () => {
       AddressManager.address,
       FORCE_INCLUSION_PERIOD_SECONDS,
       FORCE_INCLUSION_PERIOD_BLOCKS,
-      MAX_GAS_LIMIT
+      MAX_GAS_LIMIT,
+      L2_GAS_DISCOUNT_DIVISOR,
+      ENQUEUE_GAS_COST
     )
 
     const batches = await Factory__ChainStorageContainer.deploy(
@@ -200,19 +204,19 @@ describe('CanonicalTransactionChain', () => {
     })
 
     it('should revert if transaction gas limit does not cover rollup burn', async () => {
-      const ENQUEUE_L2_GAS_PREPAID =
+      const _enqueueL2GasPrepaid =
         await CanonicalTransactionChain.ENQUEUE_L2_GAS_PREPAID()
-      const L2_GAS_DISCOUNT_DIVISOR =
+      const l2GasDiscountDivisor =
         await CanonicalTransactionChain.L2_GAS_DISCOUNT_DIVISOR()
       const data = '0x' + '12'.repeat(1234)
 
       // Create a tx with high L2 gas limit, but insufficient L1 gas limit to cover burn.
-      const l2GasLimit = 2 * ENQUEUE_L2_GAS_PREPAID
+      const l2GasLimit = 2 * _enqueueL2GasPrepaid
       // This l1GasLimit is equivalent to the gasToConsume amount calculated in the CTC. After
       // additional gas overhead, it will be enough trigger the gas burn, but not enough to cover
       // it.
       const l1GasLimit =
-        (l2GasLimit - ENQUEUE_L2_GAS_PREPAID) / L2_GAS_DISCOUNT_DIVISOR
+        (l2GasLimit - _enqueueL2GasPrepaid) / l2GasDiscountDivisor
 
       await expect(
         CanonicalTransactionChain.enqueue(target, l2GasLimit, data, {

--- a/packages/contracts/test/helpers/constants.ts
+++ b/packages/contracts/test/helpers/constants.ts
@@ -11,6 +11,8 @@ export const DEFAULT_ACCOUNTS_HARDHAT = defaultAccounts.map((account) => {
 
 export const RUN_OVM_TEST_GAS = 20_000_000
 export const FORCE_INCLUSION_PERIOD_SECONDS = 600
+export const L2_GAS_DISCOUNT_DIVISOR = 32
+export const ENQUEUE_GAS_COST = 60_000
 export const FORCE_INCLUSION_PERIOD_BLOCKS = 600 / 12
 
 export const NON_NULL_BYTES32 =


### PR DESCRIPTION
**Description**

Allows us to modify the gas burn threshold (`ENQUEUE_L2_GAS_PREPAID`), by converting it to an `immutable` variable which can be set at create time. 

As before, it is calculated as the product of `L2_GAS_DISCOUNT_DIVISOR` and `ENQUEUE_GAS_COST`, so these variables are also now `immutable`s. 


**Additional context**
Pretty sure this will pass the integration tests 👌

**Metadata**
- Fixes #ENG-1407
