### PR TITLE
docs: point to new specs repository

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -1,15 +1,8 @@
-# Optimistic Specs
+# The Optimistic Ethereum Spec
 
-Welcome to Optimism's specs.
+## Notice
 
-Please refer to the README in each of the subdirectories for a table of contents.
-
-### Usage
-
-We provide some basic yarn scripts to ensure consistent formatting.
-
-After modifying any of the markdown files here, run `yarn format`.
-
-```bash
-yarn format
-```
+We're in the process of moving our specifications to the [optimistic-specs](https://github.com/ethereum-optimism/optimistic-specs) repository.
+**The specifications within this folder may be entirely outdated**.
+Please refer to the `optimistic-specs` repository for the most up-to-date system specifications.
+We will remove this folder once the migration process is complete.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Tiny PR to add a notice to the `specs` folder that the content may be outdated and to look at the `optimistic-specs` repository for latest up-to-date content.