### PR TITLE
test(contracts): Assert upper bound on CTC gas costs.

### DIFF
--- a/.changeset/six-peas-admire.md
+++ b/.changeset/six-peas-admire.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Assert maximum values for CTC gas costs

--- a/packages/contracts/test/contracts/L1/rollup/OVM_CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/OVM_CanonicalTransactionChain.gas.spec.ts
@@ -19,6 +19,7 @@ import {
   getEthTime,
   getNextBlockNumber,
   NON_ZERO_ADDRESS,
+  expectApprox,
 } from '../../../helpers'
 
 // Still have some duplication from OVM_CanonicalTransactionChain.spec.ts, but it's so minimal that
@@ -150,14 +151,17 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
       })
 
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
       console.log('Fixed calldata cost:', fixedCalldataCost)
       console.log(
         'Non-calldata overhead gas cost per transaction:',
-        (receipt.gasUsed.toNumber() - fixedCalldataCost) / numTxs
+        (gasUsed - fixedCalldataCost) / numTxs
       )
+      expectApprox(gasUsed, 1_605_971, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
 
     it('200 transactions in 200 contexts', async () => {
@@ -190,14 +194,17 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
       })
 
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
       console.log('Fixed calldata cost:', fixedCalldataCost)
       console.log(
         'Non-calldata overhead gas cost per transaction:',
-        (receipt.gasUsed.toNumber() - fixedCalldataCost) / numTxs
+        (gasUsed - fixedCalldataCost) / numTxs
       )
+      expectApprox(gasUsed, 1_739_992, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
 
     it('100 Sequencer transactions and 100 Queue transactions in 100 contexts', async () => {
@@ -240,14 +247,17 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
       })
 
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
       console.log('Fixed calldata cost:', fixedCalldataCost)
       console.log(
         'Non-calldata overhead gas cost per transaction:',
-        (receipt.gasUsed.toNumber() - fixedCalldataCost) / numTxs
+        (gasUsed - fixedCalldataCost) / numTxs
       )
+      expectApprox(gasUsed, 1_125_554, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
   })
 
@@ -271,9 +281,12 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
         data
       )
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
+      expectApprox(gasUsed, 217_789, { upperPercentDeviation: 0 })
     })
 
     it('cost to enqueue a transaction below the prepaid threshold', async () => {
@@ -285,9 +298,12 @@ describe('[GAS BENCHMARK] OVM_CanonicalTransactionChain', () => {
         data
       )
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
+      expectApprox(gasUsed, 156_885, { upperPercentDeviation: 0 })
     })
   })
 })

--- a/packages/contracts/test/helpers/gas/gas.ts
+++ b/packages/contracts/test/helpers/gas/gas.ts
@@ -1,5 +1,6 @@
+import { expect } from 'chai'
 import { ethers } from 'hardhat'
-import { Contract, Signer } from 'ethers'
+import { BigNumber, Contract, Signer } from 'ethers'
 
 export class GasMeasurement {
   GasMeasurementContract: Contract
@@ -23,4 +24,40 @@ export class GasMeasurement {
 
     return gasCost
   }
+}
+
+interface percentDeviationRange {
+  upperPercentDeviation: number
+  lowerPercentDeviation?: number
+}
+
+export const expectApprox = (
+  actual: BigNumber | number,
+  target: BigNumber | number,
+  { upperPercentDeviation, lowerPercentDeviation = 100 }: percentDeviationRange
+): void => {
+  actual = BigNumber.from(actual)
+  target = BigNumber.from(target)
+
+  const validDeviations =
+    upperPercentDeviation >= 0 &&
+    upperPercentDeviation <= 100 &&
+    lowerPercentDeviation >= 0 &&
+    lowerPercentDeviation <= 100
+  if (!validDeviations) {
+    throw new Error(
+      'Upper and lower deviation percentage arguments should be between 0 and 100'
+    )
+  }
+  const upper = target.mul(100 + upperPercentDeviation).div(100)
+  const lower = target.mul(100 - lowerPercentDeviation).div(100)
+
+  expect(
+    actual.lte(upper),
+    `Actual value is more than ${upperPercentDeviation}% greater than target`
+  ).to.be.true
+  expect(
+    actual.gte(lower),
+    `Actual value is more than ${lowerPercentDeviation}% less than target`
+  ).to.be.true
 }


### PR DESCRIPTION
**Description**
Previously our gas specs have only printed the values they record,
without ensuring that the cost doesn't drift up over time. Adding `expectApprox` will allow these costs to decrease, but not increase.

**Additional context**
I verbatim copy pasted the definition of `expectApprox` from the [integration tests' shared utils](https://github.com/ethereum-optimism/optimism/blob/e23a79b9caa3141111a60bab9644a4f6b989c167/integration-tests/test/shared/utils.ts#L162). 
I don't like this code duplication, but I also don't see a good reason to include it in the `@eth-optimism/contracts` package, so this seems like a good enough approach. But I'm open to alternative suggestions. 