### PR TITLE
Assert upper bound on CTC gas costs

### DIFF
--- a/.changeset/little-donuts-wink.md
+++ b/.changeset/little-donuts-wink.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Assert upper bound on CTC gas costs

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -4,15 +4,12 @@ import { expect } from 'chai'
 import { Wallet, utils, BigNumber } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
 import { predeploys } from '@eth-optimism/contracts'
+import { expectApprox } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import { Direction } from './shared/watcher-utils'
 
-import {
-  expectApprox,
-  fundUser,
-  PROXY_SEQUENCER_ENTRYPOINT_ADDRESS,
-} from './shared/utils'
+import { fundUser, PROXY_SEQUENCER_ENTRYPOINT_ADDRESS } from './shared/utils'
 import { OptimismEnv, useDynamicTimeoutForWithdrawals } from './shared/env'
 
 const DEFAULT_TEST_GAS_L1 = 330_000

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -1,4 +1,4 @@
-import { injectL2Context } from '@eth-optimism/core-utils'
+import { expectApprox, injectL2Context } from '@eth-optimism/core-utils'
 import { Wallet, BigNumber, Contract, ContractFactory } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
 import { ethers } from 'hardhat'
@@ -8,7 +8,6 @@ import {
   l2Provider,
   DEFAULT_TRANSACTION,
   fundUser,
-  expectApprox,
   L2_CHAINID,
   IS_LIVE_NETWORK,
 } from './shared/utils'

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -182,11 +182,11 @@ export const expectApprox = (
 
   expect(
     actual.lte(upper),
-    `Actual value is more than ${upperPercentDeviation}% greater than target`
+    `Actual value (${actual}) is more than ${upperPercentDeviation}% greater than target (${target})`
   ).to.be.true
   expect(
     actual.gte(lower),
-    `Actual value is more than ${lowerPercentDeviation}% less than target`
+    `Actual value (${actual}) is more than ${lowerPercentDeviation}% less than target (${target})`
   ).to.be.true
 }
 

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -154,42 +154,6 @@ export const DEFAULT_TRANSACTION = {
   value: 0,
 }
 
-interface percentDeviationRange {
-  upperPercentDeviation: number
-  lowerPercentDeviation?: number
-}
-
-export const expectApprox = (
-  actual: BigNumber | number,
-  target: BigNumber | number,
-  { upperPercentDeviation, lowerPercentDeviation = 100 }: percentDeviationRange
-) => {
-  actual = BigNumber.from(actual)
-  target = BigNumber.from(target)
-
-  const validDeviations =
-    upperPercentDeviation >= 0 &&
-    upperPercentDeviation <= 100 &&
-    lowerPercentDeviation >= 0 &&
-    lowerPercentDeviation <= 100
-  if (!validDeviations) {
-    throw new Error(
-      'Upper and lower deviation percentage arguments should be between 0 and 100'
-    )
-  }
-  const upper = target.mul(100 + upperPercentDeviation).div(100)
-  const lower = target.mul(100 - lowerPercentDeviation).div(100)
-
-  expect(
-    actual.lte(upper),
-    `Actual value (${actual}) is more than ${upperPercentDeviation}% greater than target (${target})`
-  ).to.be.true
-  expect(
-    actual.gte(lower),
-    `Actual value (${actual}) is more than ${lowerPercentDeviation}% less than target (${target})`
-  ).to.be.true
-}
-
 export const waitForL2Geth = async (
   provider: providers.JsonRpcProvider
 ): Promise<providers.JsonRpcProvider> => {

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -61,7 +61,7 @@ const config: HardhatUserConfig = {
       {
         version: '0.8.8',
         settings: {
-          optimizer: { enabled: true, runs: 200 },
+          optimizer: { enabled: true, runs: 10_000 },
           metadata: {
             bytecodeHash: 'none',
           },
@@ -75,7 +75,7 @@ const config: HardhatUserConfig = {
       {
         version: '0.5.17', // Required for WETH9
         settings: {
-          optimizer: { enabled: true, runs: 200 },
+          optimizer: { enabled: true, runs: 10_000 },
           outputSelection: {
             '*': {
               '*': ['storageLayout'],

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -60,22 +60,30 @@ const config: HardhatUserConfig = {
     compilers: [
       {
         version: '0.8.8',
+        settings: {
+          optimizer: { enabled: true, runs: 200 },
+          metadata: {
+            bytecodeHash: 'none',
+          },
+          outputSelection: {
+            '*': {
+              '*': ['storageLayout'],
+            },
+          },
+        },
       },
       {
         version: '0.5.17', // Required for WETH9
-      },
-    ],
-    settings: {
-      optimizer: { enabled: true, runs: 200 },
-      metadata: {
-        bytecodeHash: 'none',
-      },
-      outputSelection: {
-        '*': {
-          '*': ['storageLayout'],
+        settings: {
+          optimizer: { enabled: true, runs: 200 },
+          outputSelection: {
+            '*': {
+              '*': ['storageLayout'],
+            },
+          },
         },
       },
-    },
+    ],
   },
   typechain: {
     outDir: 'dist/types',

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -163,7 +163,12 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_605_796, { upperPercentDeviation: 0 })
+      expectApprox(gasUsed, 1_605_796, {
+        upperPercentDeviation: 0,
+        // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
+        // contracts are too efficient, consider updating the target value!
+        lowerPercentDeviation: 1,
+      })
     }).timeout(10_000_000)
 
     it('200 transactions in 200 contexts', async () => {
@@ -206,7 +211,12 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_739_811, { upperPercentDeviation: 0 })
+      expectApprox(gasUsed, 1_739_811, {
+        upperPercentDeviation: 0,
+        // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
+        // contracts are too efficient, consider updating the target value!
+        lowerPercentDeviation: 1,
+      })
     }).timeout(10_000_000)
 
     it('100 Sequencer transactions and 100 Queue transactions in 100 contexts', async () => {
@@ -287,7 +297,12 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       console.log('Benchmark complete.')
       console.log('Gas used:', gasUsed)
 
-      expectApprox(gasUsed, 217_615, { upperPercentDeviation: 0 })
+      expectApprox(gasUsed, 217_615, {
+        upperPercentDeviation: 0,
+        // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
+        // contracts are too efficient, consider updating the target value!
+        lowerPercentDeviation: 1,
+      })
     })
 
     it('cost to enqueue a transaction below the prepaid threshold', async () => {
@@ -304,7 +319,12 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       console.log('Benchmark complete.')
       console.log('Gas used:', gasUsed)
 
-      expectApprox(gasUsed, 156_711, { upperPercentDeviation: 0 })
+      expectApprox(gasUsed, 156_711, {
+        upperPercentDeviation: 0,
+        // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
+        // contracts are too efficient, consider updating the target value!
+        lowerPercentDeviation: 1,
+      })
     })
   })
 })

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -21,6 +21,7 @@ import {
   getEthTime,
   getNextBlockNumber,
   NON_ZERO_ADDRESS,
+  expectApprox,
 } from '../../../helpers'
 
 // Still have some duplication from CanonicalTransactionChain.spec.ts, but it's so minimal that
@@ -152,14 +153,17 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       })
 
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
       console.log('Fixed calldata cost:', fixedCalldataCost)
       console.log(
         'Non-calldata overhead gas cost per transaction:',
-        (receipt.gasUsed.toNumber() - fixedCalldataCost) / numTxs
+        (gasUsed - fixedCalldataCost) / numTxs
       )
+      expectApprox(gasUsed, 1_605_796, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
 
     it('200 transactions in 200 contexts', async () => {
@@ -192,14 +196,17 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       })
 
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
       console.log('Fixed calldata cost:', fixedCalldataCost)
       console.log(
         'Non-calldata overhead gas cost per transaction:',
-        (receipt.gasUsed.toNumber() - fixedCalldataCost) / numTxs
+        (gasUsed - fixedCalldataCost) / numTxs
       )
+      expectApprox(gasUsed, 1_739_811, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
 
     it('100 Sequencer transactions and 100 Queue transactions in 100 contexts', async () => {
@@ -242,14 +249,17 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       })
 
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
       console.log('Fixed calldata cost:', fixedCalldataCost)
       console.log(
         'Non-calldata overhead gas cost per transaction:',
-        (receipt.gasUsed.toNumber() - fixedCalldataCost) / numTxs
+        (gasUsed - fixedCalldataCost) / numTxs
       )
+      expectApprox(gasUsed, 1_126_553, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
   })
 
@@ -272,9 +282,12 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         data
       )
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
+      expectApprox(gasUsed, 217_615, { upperPercentDeviation: 0 })
     })
 
     it('cost to enqueue a transaction below the prepaid threshold', async () => {
@@ -286,9 +299,12 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         data
       )
       const receipt = await res.wait()
+      const gasUsed = receipt.gasUsed.toNumber()
 
       console.log('Benchmark complete.')
-      console.log('Gas used:', receipt.gasUsed.toNumber())
+      console.log('Gas used:', gasUsed)
+
+      expectApprox(gasUsed, 156_711, { upperPercentDeviation: 0 })
     })
   })
 })

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -163,7 +163,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_604_975, {
+      expectApprox(gasUsed, 1_767_570, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -211,7 +211,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_738_990, {
+      expectApprox(gasUsed, 1_950_378, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -269,7 +269,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_126_553, { upperPercentDeviation: 0 })
+      expectApprox(gasUsed, 1_293_111, { upperPercentDeviation: 0 })
     }).timeout(10_000_000)
   })
 
@@ -297,7 +297,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       console.log('Benchmark complete.')
       console.log('Gas used:', gasUsed)
 
-      expectApprox(gasUsed, 217_218, {
+      expectApprox(gasUsed, 219_896, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -319,7 +319,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       console.log('Benchmark complete.')
       console.log('Gas used:', gasUsed)
 
-      expectApprox(gasUsed, 156_314, {
+      expectApprox(gasUsed, 158_709, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -163,7 +163,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_605_796, {
+      expectApprox(gasUsed, 1_604_975, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -211,7 +211,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_739_811, {
+      expectApprox(gasUsed, 1_738_990, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -297,7 +297,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       console.log('Benchmark complete.')
       console.log('Gas used:', gasUsed)
 
-      expectApprox(gasUsed, 217_615, {
+      expectApprox(gasUsed, 217_218, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -319,7 +319,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
       console.log('Benchmark complete.')
       console.log('Gas used:', gasUsed)
 
-      expectApprox(gasUsed, 156_711, {
+      expectApprox(gasUsed, 156_314, {
         upperPercentDeviation: 0,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -6,6 +6,7 @@ import {
   AppendSequencerBatchParams,
   BatchContext,
   encodeAppendSequencerBatch,
+  expectApprox,
 } from '@eth-optimism/core-utils'
 import { TransactionResponse } from '@ethersproject/abstract-provider'
 import { keccak256 } from 'ethers/lib/utils'
@@ -21,7 +22,6 @@ import {
   getEthTime,
   getNextBlockNumber,
   NON_ZERO_ADDRESS,
-  expectApprox,
 } from '../../../helpers'
 
 // Still have some duplication from CanonicalTransactionChain.spec.ts, but it's so minimal that

--- a/packages/contracts/test/helpers/gas/gas.ts
+++ b/packages/contracts/test/helpers/gas/gas.ts
@@ -1,5 +1,6 @@
+import { expect } from 'chai'
 import { ethers } from 'hardhat'
-import { Contract, Signer } from 'ethers'
+import { BigNumber, Contract, Signer } from 'ethers'
 
 export class GasMeasurement {
   GasMeasurementContract: Contract
@@ -23,4 +24,40 @@ export class GasMeasurement {
 
     return gasCost
   }
+}
+
+interface percentDeviationRange {
+  upperPercentDeviation: number
+  lowerPercentDeviation?: number
+}
+
+export const expectApprox = (
+  actual: BigNumber | number,
+  target: BigNumber | number,
+  { upperPercentDeviation, lowerPercentDeviation = 100 }: percentDeviationRange
+): void => {
+  actual = BigNumber.from(actual)
+  target = BigNumber.from(target)
+
+  const validDeviations =
+    upperPercentDeviation >= 0 &&
+    upperPercentDeviation <= 100 &&
+    lowerPercentDeviation >= 0 &&
+    lowerPercentDeviation <= 100
+  if (!validDeviations) {
+    throw new Error(
+      'Upper and lower deviation percentage arguments should be between 0 and 100'
+    )
+  }
+  const upper = target.mul(100 + upperPercentDeviation).div(100)
+  const lower = target.mul(100 - lowerPercentDeviation).div(100)
+
+  expect(
+    actual.lte(upper),
+    `Actual value (${actual}) is more than ${upperPercentDeviation}% greater than target (${target})`
+  ).to.be.true
+  expect(
+    actual.gte(lower),
+    `Actual value (${actual}) is more than ${lowerPercentDeviation}% less than target (${target})`
+  ).to.be.true
 }

--- a/packages/contracts/test/helpers/gas/gas.ts
+++ b/packages/contracts/test/helpers/gas/gas.ts
@@ -1,6 +1,5 @@
-import { expect } from 'chai'
 import { ethers } from 'hardhat'
-import { BigNumber, Contract, Signer } from 'ethers'
+import { Contract, Signer } from 'ethers'
 
 export class GasMeasurement {
   GasMeasurementContract: Contract
@@ -24,40 +23,4 @@ export class GasMeasurement {
 
     return gasCost
   }
-}
-
-interface percentDeviationRange {
-  upperPercentDeviation: number
-  lowerPercentDeviation?: number
-}
-
-export const expectApprox = (
-  actual: BigNumber | number,
-  target: BigNumber | number,
-  { upperPercentDeviation, lowerPercentDeviation = 100 }: percentDeviationRange
-): void => {
-  actual = BigNumber.from(actual)
-  target = BigNumber.from(target)
-
-  const validDeviations =
-    upperPercentDeviation >= 0 &&
-    upperPercentDeviation <= 100 &&
-    lowerPercentDeviation >= 0 &&
-    lowerPercentDeviation <= 100
-  if (!validDeviations) {
-    throw new Error(
-      'Upper and lower deviation percentage arguments should be between 0 and 100'
-    )
-  }
-  const upper = target.mul(100 + upperPercentDeviation).div(100)
-  const lower = target.mul(100 - lowerPercentDeviation).div(100)
-
-  expect(
-    actual.lte(upper),
-    `Actual value (${actual}) is more than ${upperPercentDeviation}% greater than target (${target})`
-  ).to.be.true
-  expect(
-    actual.gte(lower),
-    `Actual value (${actual}) is more than ${lowerPercentDeviation}% less than target (${target})`
-  ).to.be.true
 }

--- a/packages/core-utils/src/common/index.ts
+++ b/packages/core-utils/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './hex-strings'
 export * from './misc'
+export * from './test-utils'

--- a/packages/core-utils/src/common/test-utils.ts
+++ b/packages/core-utils/src/common/test-utils.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+
+interface percentDeviationRange {
+  upperPercentDeviation: number
+  lowerPercentDeviation?: number
+}
+
+/**
+ * Assert that a number lies within a custom defined range of the target.
+ */
+export const expectApprox = (
+  actual: BigNumber | number,
+  target: BigNumber | number,
+  { upperPercentDeviation, lowerPercentDeviation = 100 }: percentDeviationRange
+): void => {
+  actual = BigNumber.from(actual)
+  target = BigNumber.from(target)
+
+  const validDeviations =
+    upperPercentDeviation >= 0 &&
+    upperPercentDeviation <= 100 &&
+    lowerPercentDeviation >= 0 &&
+    lowerPercentDeviation <= 100
+  if (!validDeviations) {
+    throw new Error(
+      'Upper and lower deviation percentage arguments should be between 0 and 100'
+    )
+  }
+  const upper = target.mul(100 + upperPercentDeviation).div(100)
+  const lower = target.mul(100 - lowerPercentDeviation).div(100)
+
+  expect(
+    actual.lte(upper),
+    `Actual value (${actual}) is more than ${upperPercentDeviation}% greater than target (${target})`
+  ).to.be.true
+  expect(
+    actual.gte(lower),
+    `Actual value (${actual}) is more than ${lowerPercentDeviation}% less than target (${target})`
+  ).to.be.true
+}

--- a/packages/core-utils/test/common/test-utils.spec.ts
+++ b/packages/core-utils/test/common/test-utils.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from '../setup'
+
+/* Imports: Internal */
+import { expectApprox } from '../../src'
+
+describe('expectApprox', async () => {
+  it('should throw an error if the actual value is higher than expected', async () => {
+    try {
+      expectApprox(121, 100, {
+        upperPercentDeviation: 20,
+      })
+    } catch (error) {
+      expect(error.message).to.equal(
+        'Actual value (121) is more than 20% greater than target (100): expected false to be true'
+      )
+    }
+  })
+
+  it('should throw an error if the actual value is lower than expected', async () => {
+    try {
+      expectApprox(79, 100, {
+        upperPercentDeviation: 0,
+        lowerPercentDeviation: 20,
+      })
+    } catch (error) {
+      expect(error.message).to.equal(
+        'Actual value (79) is more than 20% less than target (100): expected false to be true'
+      )
+    }
+  })
+})


### PR DESCRIPTION
**Description**
Previously our gas specs have only printed the values they record,
without ensuring that the cost doesn't drift up over time. Adding expectApprox will allow these costs to decrease, but not increase.

**Additional context**
I verbatim copy pasted the definition of `expectApprox` from the integration tests' shared utils.
I don't like this code duplication, but I also don't see a good reason to include it in the `@eth-optimism/contracts` package, so this seems like a good enough approach. But I'm open to alternative suggestions.