### PR TITLE
feat: L1 gas info on receipt

### DIFF
--- a/.changeset/forty-cougars-teach.md
+++ b/.changeset/forty-cougars-teach.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Add tests for optimistic ethereum related fields to the receipt

--- a/.changeset/four-chairs-press.md
+++ b/.changeset/four-chairs-press.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': minor
+---
+
+Parse optimistic ethereum specific fields on transaction receipts

--- a/.changeset/lazy-dingos-perform.md
+++ b/.changeset/lazy-dingos-perform.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': minor
+---
+
+Add optimistic ethereum specific fields to the receipt. These fields are related to the L1 portion of the fee. Note that this is a consensus change as it will impact the blockhash through the receipts root

--- a/l2geth/core/types/gen_receipt_json.go
+++ b/l2geth/core/types/gen_receipt_json.go
@@ -27,6 +27,10 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		BlockHash         common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
 		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
+		L1GasPrice        *big.Int       `json:"l1GasPrice" gencodec:"required"`
+		L1GasUsed         *big.Int       `json:"l1GasUsed" gencodec:"required"`
+		L1Fee             *big.Int       `json:"l1Fee" gencodec:"required"`
+		FeeScalar         *big.Float     `json:"l1FeeScalar" gencodec:"required"`
 	}
 	var enc Receipt
 	enc.PostState = r.PostState
@@ -40,6 +44,10 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
+	enc.L1GasPrice = r.L1GasPrice
+	enc.L1GasUsed = r.L1GasUsed
+	enc.L1Fee = r.L1Fee
+	enc.FeeScalar = r.FeeScalar
 	return json.Marshal(&enc)
 }
 
@@ -57,6 +65,10 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
 		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
+		L1GasPrice        *big.Int        `json:"l1GasPrice" gencodec:"required"`
+		L1GasUsed         *big.Int        `json:"l1GasUsed" gencodec:"required"`
+		L1Fee             *big.Int        `json:"l1Fee" gencodec:"required"`
+		FeeScalar         *big.Float      `json:"l1FeeScalar" gencodec:"required"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -100,5 +112,21 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	if dec.TransactionIndex != nil {
 		r.TransactionIndex = uint(*dec.TransactionIndex)
 	}
+	if dec.L1GasPrice == nil {
+		return errors.New("missing required field 'l1GasPrice' for Receipt")
+	}
+	r.L1GasPrice = dec.L1GasPrice
+	if dec.L1GasUsed == nil {
+		return errors.New("missing required field 'l1GasUsed' for Receipt")
+	}
+	r.L1GasUsed = dec.L1GasUsed
+	if dec.L1Fee == nil {
+		return errors.New("missing required field 'l1Fee' for Receipt")
+	}
+	r.L1Fee = dec.L1Fee
+	if dec.FeeScalar == nil {
+		return errors.New("missing required field 'l1FeeScalar' for Receipt")
+	}
+	r.FeeScalar = dec.FeeScalar
 	return nil
 }

--- a/l2geth/core/types/receipt.go
+++ b/l2geth/core/types/receipt.go
@@ -66,6 +66,12 @@ type Receipt struct {
 	BlockHash        common.Hash `json:"blockHash,omitempty"`
 	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
 	TransactionIndex uint        `json:"transactionIndex"`
+
+	// UsingOVM
+	L1GasPrice *big.Int   `json:"l1GasPrice" gencodec:"required"`
+	L1GasUsed  *big.Int   `json:"l1GasUsed" gencodec:"required"`
+	L1Fee      *big.Int   `json:"l1Fee" gencodec:"required"`
+	FeeScalar  *big.Float `json:"l1FeeScalar" gencodec:"required"`
 }
 
 type receiptMarshaling struct {
@@ -90,6 +96,11 @@ type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*LogForStorage
+	// UsingOVM
+	L1GasUsed  *big.Int
+	L1GasPrice *big.Int
+	L1Fee      *big.Int
+	FeeScalar  string
 }
 
 // v4StoredReceiptRLP is the storage encoding of a receipt used in database version 4.
@@ -191,6 +202,10 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 		PostStateOrStatus: (*Receipt)(r).statusEncoding(),
 		CumulativeGasUsed: r.CumulativeGasUsed,
 		Logs:              make([]*LogForStorage, len(r.Logs)),
+		L1GasUsed:         r.L1GasUsed,
+		L1GasPrice:        r.L1GasPrice,
+		L1Fee:             r.L1Fee,
+		FeeScalar:         r.FeeScalar.String(),
 	}
 	for i, log := range r.Logs {
 		enc.Logs[i] = (*LogForStorage)(log)
@@ -232,6 +247,16 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 		r.Logs[i] = (*Log)(log)
 	}
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+
+	// UsingOVM
+	scalar, ok := new(big.Float).SetString(stored.FeeScalar)
+	if !ok {
+		return errors.New("cannot parse fee scalar")
+	}
+	r.L1GasUsed = stored.L1GasUsed
+	r.L1GasPrice = stored.L1GasPrice
+	r.L1Fee = stored.L1Fee
+	r.FeeScalar = scalar
 
 	return nil
 }

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1438,6 +1438,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 		"contractAddress":   nil,
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
+		// UsingOVM
+		"l1GasPrice":  (*hexutil.Big)(receipt.L1GasPrice),
+		"l1GasUsed":   (*hexutil.Big)(receipt.L1GasUsed),
+		"l1Fee":       (*hexutil.Big)(receipt.L1Fee),
+		"l1FeeScalar": receipt.FeeScalar.String(),
 	}
 
 	// Assign receipt status or post state.

--- a/l2geth/rollup/fees/rollup_fee.go
+++ b/l2geth/rollup/fees/rollup_fee.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rollup/rcfg"
@@ -159,7 +158,6 @@ func CalculateL1GasUsed(data []byte, overhead *big.Int) *big.Int {
 func DeriveL1GasInfo(msg Message, state StateDB) (*big.Int, *big.Int, *big.Int, *big.Float, error) {
 	tx := asTransaction(msg)
 	raw, err := rlpEncode(tx)
-	fmt.Println(hexutil.Encode(raw))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/packages/core-utils/src/l2context.ts
+++ b/packages/core-utils/src/l2context.ts
@@ -1,5 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep'
-import { providers } from 'ethers'
+import { providers, BigNumber } from 'ethers'
 
 /**
  * Helper for adding additional L2 context to transactions
@@ -52,6 +52,18 @@ export const injectL2Context = (l1Provider: providers.JsonRpcProvider) => {
     }
     tx.l1TxOrigin = transaction.l1TxOrigin
     return tx
+  }
+
+  const formatReceiptResponse = provider.formatter.receipt.bind(
+    provider.formatter
+  )
+  provider.formatter.receipt = (receipt) => {
+    const r = formatReceiptResponse(receipt)
+    r.l1GasPrice = BigNumber.from(receipt.l1GasPrice)
+    r.l1GasUsed = BigNumber.from(receipt.l1GasUsed)
+    r.l1Fee = BigNumber.from(receipt.l1Fee)
+    r.l1FeeScalar = parseFloat(receipt.l1FeeScalar)
+    return r
   }
 
   return provider


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds the L1 gas info to the transaction receipt. This makes it easy to know what sort of fee the transaction paid without needing to do historical calls to the `GasPriceOracle` predeploy

The response of the RPC endpoint `eth_getTransactionReceipt`
will now return 4 new fields.

- `l1GasPrice`
- `l1GasUsed`
- `l1Fee`
- `l1FeeScalar`

These fields are added to the database as part of the receipt
itself. This means that it is a consensus change as the
serialization of the receipt has been updated. This impacts
the blockhash because the block header commits to a merkle root
of all of the receipts in the block.

Each of the new fields on the receipt exist in the state but
would require an archive node to query for as the values can
change over time.

**Metadata**
- Fixes ENG-1322
