### PR TITLE
l2geth: no longer sync batches as sequencer

### DIFF
--- a/.changeset/dull-cheetahs-help.md
+++ b/.changeset/dull-cheetahs-help.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove calls to `syncBatchesToTip` in the main `sequence()` loop

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -412,13 +412,11 @@ func (s *SyncService) SequencerLoop() {
 // compare against the transactions it has in its local state. The sequencer
 // should reorg based on the transaction batches that are posted because
 // L1 is the source of truth. The sequencer concurrently accepts user
-// transactions via the RPC.
+// transactions via the RPC. When reorg logic is enabled, this should
+// also call `syncBatchesToTip`
 func (s *SyncService) sequence() error {
 	if err := s.syncQueueToTip(); err != nil {
 		return fmt.Errorf("Sequencer cannot sequence queue: %w", err)
-	}
-	if err := s.syncBatchesToTip(); err != nil {
-		return fmt.Errorf("Sequencer cannot sync transaction batches: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Previously the sequencer would call the `syncBatchesToTip` method
as part of its `sequence()` loop. This commit removes that as the
call to `syncBatchesToTip` does nothing for the sequencer currently.
Syncing the batches would be useful for triggering reorgs, but
that functionality does not currently exist. It would be better to
remove this functionality for now as it could potentially interfere
with the locking mechanism introduced in
dfaa8fc20f586265f0a5c07ca76c6c793ba49157.

This will also reduce the amount of time the `txLock` is held, meaning
that less transactions sent via RPC will be blocked and held in memory
while waiting to execute.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

