### PR TITLE
Upgrade solidity to 0.8.8

### DIFF
--- a/integration-tests/contracts/ConstructorReverter.sol
+++ b/integration-tests/contracts/ConstructorReverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import { Reverter } from './Reverter.sol';
 

--- a/integration-tests/contracts/ERC20.sol
+++ b/integration-tests/contracts/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract ERC20 {
     event Transfer(address indexed _from, address indexed _to, uint256 _value);

--- a/integration-tests/contracts/OVMContextStorage.sol
+++ b/integration-tests/contracts/OVMContextStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 // Can't do this until the package is published.
 //import { iOVM_L1BlockNumber } from "@eth-optimism/contracts/iOVM_L1BlockNumber";

--- a/integration-tests/contracts/OVMMulticall.sol
+++ b/integration-tests/contracts/OVMMulticall.sol
@@ -18,7 +18,7 @@ copies or substantial portions of the Software.
 
 */
 
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 // Can't do this until the package is published.
 //import { iOVM_L1BlockNumber } from "@eth-optimism/contracts/iOVM_L1BlockNumber";

--- a/integration-tests/contracts/Proxy.sol
+++ b/integration-tests/contracts/Proxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM

--- a/integration-tests/contracts/Reverter.sol
+++ b/integration-tests/contracts/Reverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract Reverter {
     string constant public revertMessage = "This is a simple reversion.";

--- a/integration-tests/contracts/SimpleStorage.sol
+++ b/integration-tests/contracts/SimpleStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract ICrossDomainMessenger {
     address public xDomainMessageSender;

--- a/integration-tests/contracts/TestOOG.sol
+++ b/integration-tests/contracts/TestOOG.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract TestOOG {
     function runOutOfGas() public {

--- a/integration-tests/contracts/ValueCalls.sol
+++ b/integration-tests/contracts/ValueCalls.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract ValueContext {
     function getSelfBalance() external payable returns(uint256) {

--- a/integration-tests/hardhat.config.ts
+++ b/integration-tests/hardhat.config.ts
@@ -17,7 +17,7 @@ const config: HardhatUserConfig = {
     timeout: 50000,
   },
   solidity: {
-    version: '0.8.7',
+    version: '0.8.8',
     settings: {
       optimizer: { enabled: true, runs: 200 },
       metadata: {

--- a/integration-tests/test/whitelist.spec.ts
+++ b/integration-tests/test/whitelist.spec.ts
@@ -98,7 +98,7 @@ describe('Whitelist', async () => {
                 ['0x0000000000000000000000000000000000000000000000000000000000000000']:
                   '0x0000000000000000000000000000000000000000000000000000000000000001',
 
-                // See https://docs.soliditylang.org/en/v0.8.7/internals/layout_in_storage.html for
+                // See https://docs.soliditylang.org/en/v0.8.8/internals/layout_in_storage.html for
                 // reference on how the correct storage slot should be set.
                 // Whitelist mapping is located at storage slot 1.
                 // whitelist[address] will be located at:

--- a/ops/docker/Dockerfile.monorepo
+++ b/ops/docker/Dockerfile.monorepo
@@ -10,8 +10,8 @@ RUN apt-get update -y && apt-get install -y git
 # Pre-download the compilers so that they do not need to be downloaded inside
 # the image when building
 FROM alpine as downloader
-ARG VERSION=v0.8.7
-ARG SOLC_VERSION=${VERSION}+commit.e28d00a7
+ARG VERSION=v0.8.8
+ARG SOLC_VERSION=${VERSION}+commit.dddeac2f
 ARG SOLC_UPSTREAM=https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-${SOLC_VERSION}
 
 ADD $SOLC_UPSTREAM ./solc

--- a/packages/contracts/contracts/L1/messaging/IL1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/IL1CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";

--- a/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
@@ -162,7 +162,6 @@ contract L1CrossDomainMessenger is
 
     function xDomainMessageSender()
         public
-        override
         view
         returns (
             address
@@ -183,7 +182,6 @@ contract L1CrossDomainMessenger is
         bytes memory _message,
         uint32 _gasLimit
     )
-        override
         public
     {
         address ovmCanonicalTransactionChain = resolve("CanonicalTransactionChain");
@@ -218,7 +216,6 @@ contract L1CrossDomainMessenger is
         uint256 _messageNonce,
         L2MessageInclusionProof memory _proof
     )
-        override
         public
         nonReentrant
         onlyRelayer
@@ -292,7 +289,6 @@ contract L1CrossDomainMessenger is
         uint256 _queueIndex,
         uint32 _gasLimit
     )
-        override
         public
     {
         // Verify that the message is in the queue:

--- a/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolver.sol";

--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Interface Imports */
 import { IL1StandardBridge } from "./IL1StandardBridge.sol";

--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -28,7 +28,7 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
      * External Contract References *
      ********************************/
 
-    address public override l2TokenBridge;
+    address public l2TokenBridge;
 
     // Maps L1 token to L2 token to balance of the L1 token deposited
     mapping(address => mapping (address => uint256)) public deposits;
@@ -101,7 +101,6 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         payable
         onlyEOA()
     {
@@ -122,7 +121,6 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         payable
     {
         _initiateETHDeposit(
@@ -184,7 +182,6 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         virtual
         onlyEOA()
     {
@@ -203,7 +200,6 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         virtual
     {
         _initiateERC20Deposit(_l1Token, _l2Token, msg.sender, _to, _amount, _l2Gas, _data);
@@ -280,7 +276,6 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         onlyFromCrossDomainAccount(l2TokenBridge)
     {
         (bool success, ) = _to.call{value: _amount}(new bytes(0));
@@ -301,7 +296,6 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         onlyFromCrossDomainAccount(l2TokenBridge)
     {
         deposits[_l1Token][_l2Token] = deposits[_l1Token][_l2Token] - _amount;

--- a/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
@@ -87,7 +87,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Reference to the batch storage container.
      */
     function batches()
-        override
         public
         view
         returns (
@@ -104,7 +103,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Reference to the queue storage container.
      */
     function queue()
-        override
         public
         view
         returns (
@@ -121,7 +119,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return _totalElements Total submitted elements.
      */
     function getTotalElements()
-        override
         public
         view
         returns (
@@ -137,7 +134,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return _totalBatches Total submitted batches.
      */
     function getTotalBatches()
-        override
         public
         view
         returns (
@@ -152,7 +148,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Index for the next queue element.
      */
     function getNextQueueIndex()
-        override
         public
         view
         returns (
@@ -168,7 +163,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Timestamp for the last transaction.
      */
     function getLastTimestamp()
-        override
         public
         view
         returns (
@@ -184,7 +178,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Blocknumber for the last transaction.
      */
     function getLastBlockNumber()
-        override
         public
         view
         returns (
@@ -203,7 +196,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
     function getQueueElement(
         uint256 _index
     )
-        override
         public
         view
         returns (
@@ -221,7 +213,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Number of pending queue elements.
      */
     function getNumPendingQueueElements()
-        override
         public
         view
         returns (
@@ -237,7 +228,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * @return Length of the queue.
      */
     function getQueueLength()
-        override
         public
         view
         returns (
@@ -260,7 +250,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
         uint256 _gasLimit,
         bytes memory _data
     )
-        override
         public
     {
         require(
@@ -343,7 +332,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
     function appendQueueBatch(
         uint256 // _numQueuedTransactions
     )
-        override
         public
         pure
     {
@@ -399,7 +387,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
      * .param _transactionDataFields Array of raw transaction data.
      */
     function appendSequencerBatch()
-        override
         public
     {
         uint40 shouldStartAtElement;
@@ -553,7 +540,6 @@ contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressRes
         Lib_OVMCodec.ChainBatchHeader memory _batchHeader,
         Lib_OVMCodec.ChainInclusionProof memory _inclusionProof
     )
-        override
         public
         view
         returns (

--- a/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";

--- a/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
+++ b/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_Buffer } from "../../libraries/utils/Lib_Buffer.sol";

--- a/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
+++ b/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
@@ -79,7 +79,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
     function setGlobalMetadata(
         bytes27 _globalMetadata
     )
-        override
         public
         onlyOwner
     {
@@ -90,7 +89,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
      * @inheritdoc IChainStorageContainer
      */
     function getGlobalMetadata()
-        override
         public
         view
         returns (
@@ -104,7 +102,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
      * @inheritdoc IChainStorageContainer
      */
     function length()
-        override
         public
         view
         returns (
@@ -120,7 +117,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
     function push(
         bytes32 _object
     )
-        override
         public
         onlyOwner
     {
@@ -134,7 +130,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
         bytes32 _object,
         bytes27 _globalMetadata
     )
-        override
         public
         onlyOwner
     {
@@ -147,7 +142,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
     function get(
         uint256 _index
     )
-        override
         public
         view
         returns (
@@ -163,7 +157,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
     function deleteElementsAfterInclusive(
         uint256 _index
     )
-        override
         public
         onlyOwner
     {
@@ -179,7 +172,6 @@ contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
         uint256 _index,
         bytes27 _globalMetadata
     )
-        override
         public
         onlyOwner
     {

--- a/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
@@ -74,7 +74,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
      * @inheritdoc IStateCommitmentChain
      */
     function getTotalElements()
-        override
         public
         view
         returns (
@@ -89,7 +88,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
      * @inheritdoc IStateCommitmentChain
      */
     function getTotalBatches()
-        override
         public
         view
         returns (
@@ -103,7 +101,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
      * @inheritdoc IStateCommitmentChain
      */
     function getLastSequencerTimestamp()
-        override
         public
         view
         returns (
@@ -121,7 +118,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
         bytes32[] memory _batch,
         uint256 _shouldStartAtElement
     )
-        override
         public
     {
         // Fail fast in to make sure our batch roots aren't accidentally made fraudulent by the
@@ -163,7 +159,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
     function deleteStateBatch(
         Lib_OVMCodec.ChainBatchHeader memory _batchHeader
     )
-        override
         public
     {
         require(
@@ -192,7 +187,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
         Lib_OVMCodec.ChainBatchHeader memory _batchHeader,
         Lib_OVMCodec.ChainInclusionProof memory _proof
     )
-        override
         public
         view
         returns (
@@ -224,7 +218,6 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
     function insideFraudProofWindow(
         Lib_OVMCodec.ChainBatchHeader memory _batchHeader
     )
-        override
         public
         view
         returns (

--- a/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";

--- a/packages/contracts/contracts/L1/verification/BondManager.sol
+++ b/packages/contracts/contracts/L1/verification/BondManager.sol
@@ -28,7 +28,6 @@ contract BondManager is IBondManager, Lib_AddressResolver {
         address _who,
         uint256 _gasSpent
     )
-        override
         public
     {}
 
@@ -37,36 +36,30 @@ contract BondManager is IBondManager, Lib_AddressResolver {
         address _publisher,
         uint256 _timestamp
     )
-        override
         public
     {}
 
     function deposit()
-        override
         public
     {}
 
     function startWithdrawal()
-        override
         public
     {}
 
     function finalizeWithdrawal()
-        override
         public
     {}
 
     function claim(
         address _who
     )
-        override
         public
     {}
 
     function isCollateralized(
         address _who
     )
-        override
         public
         view
         returns (
@@ -81,7 +74,6 @@ contract BondManager is IBondManager, Lib_AddressResolver {
         bytes32 _preStateRoot,
         address _who
     )
-        override
         public
         pure
         returns (

--- a/packages/contracts/contracts/L1/verification/BondManager.sol
+++ b/packages/contracts/contracts/L1/verification/BondManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Interface Imports */
 import { IBondManager } from "./IBondManager.sol";

--- a/packages/contracts/contracts/L1/verification/IBondManager.sol
+++ b/packages/contracts/contracts/L1/verification/IBondManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title IBondManager

--- a/packages/contracts/contracts/L2/messaging/IL2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/IL2CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Interface Imports */
 import { ICrossDomainMessenger } from "../../libraries/bridge/ICrossDomainMessenger.sol";

--- a/packages/contracts/contracts/L2/messaging/IL2ERC20Bridge.sol
+++ b/packages/contracts/contracts/L2/messaging/IL2ERC20Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title IL2ERC20Bridge

--- a/packages/contracts/contracts/L2/messaging/L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/L2CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_CrossDomainUtils } from "../../libraries/bridge/Lib_CrossDomainUtils.sol";

--- a/packages/contracts/contracts/L2/messaging/L2CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L2/messaging/L2CrossDomainMessenger.sol
@@ -54,7 +54,6 @@ contract L2CrossDomainMessenger is
 
     function xDomainMessageSender()
         public
-        override
         view
         returns (
             address
@@ -75,7 +74,6 @@ contract L2CrossDomainMessenger is
         bytes memory _message,
         uint32 _gasLimit
     )
-        override
         public
     {
         bytes memory xDomainCalldata = Lib_CrossDomainUtils.encodeXDomainCalldata(
@@ -103,7 +101,6 @@ contract L2CrossDomainMessenger is
         bytes memory _message,
         uint256 _messageNonce
     )
-        override
         nonReentrant
         public
     {

--- a/packages/contracts/contracts/L2/messaging/L2StandardBridge.sol
+++ b/packages/contracts/contracts/L2/messaging/L2StandardBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Interface Imports */
 import { IL1StandardBridge } from "../../L1/messaging/IL1StandardBridge.sol";

--- a/packages/contracts/contracts/L2/messaging/L2StandardBridge.sol
+++ b/packages/contracts/contracts/L2/messaging/L2StandardBridge.sol
@@ -29,7 +29,7 @@ contract L2StandardBridge is IL2ERC20Bridge, CrossDomainEnabled {
      * External Contract References *
      ********************************/
 
-    address public override l1TokenBridge;
+    address public l1TokenBridge;
 
     /***************
      * Constructor *
@@ -62,7 +62,6 @@ contract L2StandardBridge is IL2ERC20Bridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         virtual
     {
         _initiateWithdrawal(
@@ -86,7 +85,6 @@ contract L2StandardBridge is IL2ERC20Bridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         virtual
     {
         _initiateWithdrawal(
@@ -175,7 +173,6 @@ contract L2StandardBridge is IL2ERC20Bridge, CrossDomainEnabled {
         bytes calldata _data
     )
         external
-        override
         virtual
         onlyFromCrossDomainAccount(l1TokenBridge)
     {

--- a/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol
+++ b/packages/contracts/contracts/L2/messaging/L2StandardTokenFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Contract Imports */
 import { L2StandardERC20 } from "../../libraries/standards/L2StandardERC20.sol";

--- a/packages/contracts/contracts/L2/predeploys/OVM_DeployerWhitelist.sol
+++ b/packages/contracts/contracts/L2/predeploys/OVM_DeployerWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title OVM_DeployerWhitelist

--- a/packages/contracts/contracts/L2/predeploys/OVM_ETH.sol
+++ b/packages/contracts/contracts/L2/predeploys/OVM_ETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_PredeployAddresses } from "../../libraries/constants/Lib_PredeployAddresses.sol";

--- a/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol
+++ b/packages/contracts/contracts/L2/predeploys/OVM_GasPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* External Imports */
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol
+++ b/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol
@@ -30,7 +30,6 @@ contract OVM_L2ToL1MessagePasser is iOVM_L2ToL1MessagePasser {
     function passMessageToL1(
         bytes memory _message
     )
-        override
         public
     {
         // Note: although this function is public, only messages sent from the

--- a/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol
+++ b/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Interface Imports */
 import { iOVM_L2ToL1MessagePasser } from "./iOVM_L2ToL1MessagePasser.sol";

--- a/packages/contracts/contracts/L2/predeploys/OVM_SequencerFeeVault.sol
+++ b/packages/contracts/contracts/L2/predeploys/OVM_SequencerFeeVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_PredeployAddresses } from "../../libraries/constants/Lib_PredeployAddresses.sol";

--- a/packages/contracts/contracts/L2/predeploys/iOVM_L1BlockNumber.sol
+++ b/packages/contracts/contracts/L2/predeploys/iOVM_L1BlockNumber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title iOVM_L1BlockNumber

--- a/packages/contracts/contracts/L2/predeploys/iOVM_L1MessageSender.sol
+++ b/packages/contracts/contracts/L2/predeploys/iOVM_L1MessageSender.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title iOVM_L1MessageSender

--- a/packages/contracts/contracts/L2/predeploys/iOVM_L2ToL1MessagePasser.sol
+++ b/packages/contracts/contracts/L2/predeploys/iOVM_L2ToL1MessagePasser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title iOVM_L2ToL1MessagePasser

--- a/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
+++ b/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import { iL1ChugSplashDeployer } from "./interfaces/iL1ChugSplashDeployer.sol";
 

--- a/packages/contracts/contracts/chugsplash/interfaces/iL1ChugSplashDeployer.sol
+++ b/packages/contracts/contracts/chugsplash/interfaces/iL1ChugSplashDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title iL1ChugSplashDeployer

--- a/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
@@ -80,7 +80,7 @@ contract CrossDomainEnabled {
         return ICrossDomainMessenger(messenger);
     }
 
-    /**
+    /**q
      * Sends a message to an account on another domain
      * @param _crossDomainTarget The intended recipient on the destination domain
      * @param _message The data to send to the target (usually calldata to a function with

--- a/packages/contracts/contracts/libraries/bridge/Lib_CrossDomainUtils.sol
+++ b/packages/contracts/contracts/libraries/bridge/Lib_CrossDomainUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_RLPReader } from "../rlp/Lib_RLPReader.sol";

--- a/packages/contracts/contracts/libraries/codec/Lib_OVMCodec.sol
+++ b/packages/contracts/contracts/libraries/codec/Lib_OVMCodec.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_RLPReader } from "../rlp/Lib_RLPReader.sol";

--- a/packages/contracts/contracts/libraries/constants/Lib_DefaultValues.sol
+++ b/packages/contracts/contracts/libraries/constants/Lib_DefaultValues.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_DefaultValues

--- a/packages/contracts/contracts/libraries/constants/Lib_PredeployAddresses.sol
+++ b/packages/contracts/contracts/libraries/constants/Lib_PredeployAddresses.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_PredeployAddresses

--- a/packages/contracts/contracts/libraries/resolver/Lib_AddressManager.sol
+++ b/packages/contracts/contracts/libraries/resolver/Lib_AddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* External Imports */
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/contracts/contracts/libraries/resolver/Lib_AddressResolver.sol
+++ b/packages/contracts/contracts/libraries/resolver/Lib_AddressResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_AddressManager } from "./Lib_AddressManager.sol";

--- a/packages/contracts/contracts/libraries/resolver/Lib_ResolvedDelegateProxy.sol
+++ b/packages/contracts/contracts/libraries/resolver/Lib_ResolvedDelegateProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_AddressManager } from "./Lib_AddressManager.sol";

--- a/packages/contracts/contracts/libraries/rlp/Lib_RLPReader.sol
+++ b/packages/contracts/contracts/libraries/rlp/Lib_RLPReader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_RLPReader

--- a/packages/contracts/contracts/libraries/rlp/Lib_RLPWriter.sol
+++ b/packages/contracts/contracts/libraries/rlp/Lib_RLPWriter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_RLPWriter

--- a/packages/contracts/contracts/libraries/standards/IL2StandardERC20.sol
+++ b/packages/contracts/contracts/libraries/standards/IL2StandardERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/packages/contracts/contracts/libraries/standards/IWETH9.sol
+++ b/packages/contracts/contracts/libraries/standards/IWETH9.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title Interface for WETH9. Also contains the non-ERC20 events

--- a/packages/contracts/contracts/libraries/standards/L2StandardERC20.sol
+++ b/packages/contracts/contracts/libraries/standards/L2StandardERC20.sol
@@ -6,7 +6,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./IL2StandardERC20.sol";
 
 contract L2StandardERC20 is IL2StandardERC20, ERC20 {
-    address public override l1Token;
+    address public l1Token;
     address public l2Bridge;
 
     /**
@@ -31,7 +31,7 @@ contract L2StandardERC20 is IL2StandardERC20, ERC20 {
         _;
     }
 
-    function supportsInterface(bytes4 _interfaceId) public override pure returns (bool) {
+    function supportsInterface(bytes4 _interfaceId) public pure returns (bool) {
         bytes4 firstSupportedInterface = bytes4(keccak256("supportsInterface(bytes4)")); // ERC165
         bytes4 secondSupportedInterface = IL2StandardERC20.l1Token.selector
             ^ IL2StandardERC20.mint.selector
@@ -39,13 +39,13 @@ contract L2StandardERC20 is IL2StandardERC20, ERC20 {
         return _interfaceId == firstSupportedInterface || _interfaceId == secondSupportedInterface;
     }
 
-    function mint(address _to, uint256 _amount) public virtual override onlyL2Bridge {
+    function mint(address _to, uint256 _amount) public virtual onlyL2Bridge {
         _mint(_to, _amount);
 
         emit Mint(_to, _amount);
     }
 
-    function burn(address _from, uint256 _amount) public virtual override onlyL2Bridge {
+    function burn(address _from, uint256 _amount) public virtual onlyL2Bridge {
         _burn(_from, _amount);
 
         emit Burn(_from, _amount);

--- a/packages/contracts/contracts/libraries/standards/L2StandardERC20.sol
+++ b/packages/contracts/contracts/libraries/standards/L2StandardERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/contracts/contracts/libraries/trie/Lib_MerkleTrie.sol
+++ b/packages/contracts/contracts/libraries/trie/Lib_MerkleTrie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_BytesUtils } from "../utils/Lib_BytesUtils.sol";

--- a/packages/contracts/contracts/libraries/trie/Lib_SecureMerkleTrie.sol
+++ b/packages/contracts/contracts/libraries/trie/Lib_SecureMerkleTrie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_MerkleTrie } from "./Lib_MerkleTrie.sol";

--- a/packages/contracts/contracts/libraries/utils/Lib_Buffer.sol
+++ b/packages/contracts/contracts/libraries/utils/Lib_Buffer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_Buffer

--- a/packages/contracts/contracts/libraries/utils/Lib_Bytes32Utils.sol
+++ b/packages/contracts/contracts/libraries/utils/Lib_Bytes32Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_Byte32Utils

--- a/packages/contracts/contracts/libraries/utils/Lib_BytesUtils.sol
+++ b/packages/contracts/contracts/libraries/utils/Lib_BytesUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_BytesUtils

--- a/packages/contracts/contracts/libraries/utils/Lib_MerkleTree.sol
+++ b/packages/contracts/contracts/libraries/utils/Lib_MerkleTree.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /**
  * @title Lib_MerkleTree

--- a/packages/contracts/contracts/test-helpers/Helper_GasMeasurer.sol
+++ b/packages/contracts/contracts/test-helpers/Helper_GasMeasurer.sol
@@ -1,6 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract Helper_GasMeasurer {
     function measureCallGas(

--- a/packages/contracts/contracts/test-helpers/Helper_SimpleProxy.sol
+++ b/packages/contracts/contracts/test-helpers/Helper_SimpleProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract Helper_SimpleProxy {
     address internal owner;

--- a/packages/contracts/contracts/test-helpers/TestERC20.sol
+++ b/packages/contracts/contracts/test-helpers/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 // a test ERC20 token with an open mint function
 contract TestERC20 {

--- a/packages/contracts/contracts/test-libraries/codec/TestLib_OVMCodec.sol
+++ b/packages/contracts/contracts/test-libraries/codec/TestLib_OVMCodec.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_OVMCodec } from "../../libraries/codec/Lib_OVMCodec.sol";

--- a/packages/contracts/contracts/test-libraries/rlp/TestLib_RLPReader.sol
+++ b/packages/contracts/contracts/test-libraries/rlp/TestLib_RLPReader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_RLPReader } from "../../libraries/rlp/Lib_RLPReader.sol";

--- a/packages/contracts/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
+++ b/packages/contracts/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_RLPWriter } from "../../libraries/rlp/Lib_RLPWriter.sol";

--- a/packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
+++ b/packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_MerkleTrie } from "../../libraries/trie/Lib_MerkleTrie.sol";

--- a/packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
+++ b/packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_SecureMerkleTrie } from "../../libraries/trie/Lib_SecureMerkleTrie.sol";

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_Buffer.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_Buffer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_Buffer } from "../../libraries/utils/Lib_Buffer.sol";

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_Bytes32Utils.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_Bytes32Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_Bytes32Utils } from "../../libraries/utils/Lib_Bytes32Utils.sol";

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_BytesUtils.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_BytesUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_BytesUtils } from "../../libraries/utils/Lib_BytesUtils.sol";

--- a/packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol
+++ b/packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 /* Library Imports */
 import { Lib_MerkleTree } from "../../libraries/utils/Lib_MerkleTree.sol";

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -59,7 +59,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.7',
+        version: '0.8.8',
       },
       {
         version: '0.5.17', // Required for WETH9

--- a/packages/message-relayer/hardhat.config.ts
+++ b/packages/message-relayer/hardhat.config.ts
@@ -8,7 +8,7 @@ const config: HardhatUserConfig = {
     sources: './test/test-contracts',
   },
   solidity: {
-    version: '0.8.7',
+    version: '0.8.8',
     settings: {
       optimizer: { enabled: true, runs: 200 },
       metadata: {

--- a/packages/message-relayer/test/test-contracts/MockL2CrossDomainMessenger.sol
+++ b/packages/message-relayer/test/test-contracts/MockL2CrossDomainMessenger.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.8;
 
 contract MockL2CrossDomainMessenger {
     struct MessageData {


### PR DESCRIPTION
Solidity 0.8.8 just got released https://blog.soliditylang.org/2021/09/27/solidity-0.8.8-release-announcement/ so upgrading to it here. 

It allows us to remove the `override` keyword for interface function implementations which [I've felt strongly about for some time](https://github.com/ethereum/solidity/issues/8281#issuecomment-634524328).