### PR TITLE
Rollup contracts optimisations

### DIFF
--- a/.changeset/angry-paws-type.md
+++ b/.changeset/angry-paws-type.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Simplify the CrossDomainEnabled logic and improve gas costs for bridge deposits and withdrawals

--- a/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
@@ -391,7 +391,7 @@ contract L1CrossDomainMessenger is
         L2MessageInclusionProof memory _proof
     )
         internal
-        view
+        pure
         returns (
             bool
         )

--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -9,7 +9,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /* Library Imports */
 import { CrossDomainEnabled } from "../../libraries/bridge/CrossDomainEnabled.sol";
-import { ICrossDomainMessenger } from "../../libraries/bridge/ICrossDomainMessenger.sol";
 import { Lib_PredeployAddresses } from "../../libraries/constants/Lib_PredeployAddresses.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -29,7 +28,7 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
      * External Contract References *
      ********************************/
 
-    address public l2TokenBridge;
+    address public immutable l2TokenBridge;
 
     // Maps L1 token to L2 token to balance of the L1 token deposited
     mapping(address => mapping (address => uint256)) public deposits;
@@ -39,26 +38,16 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
      ***************/
 
     // This contract lives behind a proxy, so the constructor parameters will go unused.
-    constructor()
-        CrossDomainEnabled(address(0))
-    {}
-
-    /******************
-     * Initialization *
-     ******************/
-
-    /**
+        /**
      * @param _l1messenger L1 Messenger address being used for cross-chain communications.
      * @param _l2TokenBridge L2 standard bridge address.
      */
-    function initialize(
+    constructor(
         address _l1messenger,
         address _l2TokenBridge
     )
-        public
+        CrossDomainEnabled(_l1messenger)
     {
-        require(address(messenger) == address(0), "Contract has already been initialized.");
-        messenger = ICrossDomainMessenger(_l1messenger);
         l2TokenBridge = _l2TokenBridge;
     }
 

--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -9,6 +9,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /* Library Imports */
 import { CrossDomainEnabled } from "../../libraries/bridge/CrossDomainEnabled.sol";
+import { ICrossDomainMessenger } from "../../libraries/bridge/ICrossDomainMessenger.sol";
 import { Lib_PredeployAddresses } from "../../libraries/constants/Lib_PredeployAddresses.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -56,8 +57,8 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
     )
         public
     {
-        require(messenger == address(0), "Contract has already been initialized.");
-        messenger = _l1messenger;
+        require(address(messenger) == address(0), "Contract has already been initialized.");
+        messenger = ICrossDomainMessenger(_l1messenger);
         l2TokenBridge = _l2TokenBridge;
     }
 

--- a/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
@@ -8,14 +8,14 @@ import { ICrossDomainMessenger } from "./ICrossDomainMessenger.sol";
  * @title CrossDomainEnabled
  * @dev Helper contract for contracts performing cross-domain communications
  */
-contract CrossDomainEnabled {
+abstract contract CrossDomainEnabled {
 
     /*************
      * Variables *
      *************/
 
     // Messenger contract used to send and recieve messages from the other domain.
-    ICrossDomainMessenger public messenger;
+    ICrossDomainMessenger public immutable messenger;
 
 
     /***************

--- a/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
@@ -7,9 +7,6 @@ import { ICrossDomainMessenger } from "./ICrossDomainMessenger.sol";
 /**
  * @title CrossDomainEnabled
  * @dev Helper contract for contracts performing cross-domain communications
- *
- * Compiler used: defined by inheriting contract
- * Runtime target: defined by inheriting contract
  */
 contract CrossDomainEnabled {
 
@@ -18,7 +15,7 @@ contract CrossDomainEnabled {
      *************/
 
     // Messenger contract used to send and recieve messages from the other domain.
-    address public messenger;
+    ICrossDomainMessenger public messenger;
 
 
     /***************
@@ -31,7 +28,7 @@ contract CrossDomainEnabled {
     constructor(
         address _messenger
     ) {
-        messenger = _messenger;
+        messenger = ICrossDomainMessenger(_messenger);
     }
 
 
@@ -48,12 +45,12 @@ contract CrossDomainEnabled {
         address _sourceDomainAccount
     ) {
         require(
-            msg.sender == address(getCrossDomainMessenger()),
+            msg.sender == address(messenger),
             "OVM_XCHAIN: messenger contract unauthenticated"
         );
 
         require(
-            getCrossDomainMessenger().xDomainMessageSender() == _sourceDomainAccount,
+            messenger.xDomainMessageSender() == _sourceDomainAccount,
             "OVM_XCHAIN: wrong sender of cross-domain message"
         );
 
@@ -64,23 +61,7 @@ contract CrossDomainEnabled {
     /**********************
      * Internal Functions *
      **********************/
-
     /**
-     * Gets the messenger, usually from storage. This function is exposed in case a child contract
-     * needs to override.
-     * @return The address of the cross-domain messenger contract which should be used.
-     */
-    function getCrossDomainMessenger()
-        internal
-        virtual
-        returns (
-            ICrossDomainMessenger
-        )
-    {
-        return ICrossDomainMessenger(messenger);
-    }
-
-    /**q
      * Sends a message to an account on another domain
      * @param _crossDomainTarget The intended recipient on the destination domain
      * @param _message The data to send to the target (usually calldata to a function with
@@ -94,6 +75,6 @@ contract CrossDomainEnabled {
     )
         internal
     {
-        getCrossDomainMessenger().sendMessage(_crossDomainTarget, _message, _gasLimit);
+        messenger.sendMessage(_crossDomainTarget, _message, _gasLimit);
     }
 }

--- a/packages/contracts/test/contracts/L1/messaging/L1StandardBridge.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/L1StandardBridge.spec.ts
@@ -13,7 +13,6 @@ import { getContractInterface, predeploys } from '../../../../src'
 const ERR_INVALID_MESSENGER = 'OVM_XCHAIN: messenger contract unauthenticated'
 const ERR_INVALID_X_DOMAIN_MSG_SENDER =
   'OVM_XCHAIN: wrong sender of cross-domain message'
-const ERR_ALREADY_INITIALIZED = 'Contract has already been initialized.'
 const DUMMY_L2_ERC20_ADDRESS = ethers.utils.getAddress('0x' + 'abba'.repeat(10))
 const DUMMY_L2_BRIDGE_ADDRESS = ethers.utils.getAddress(
   '0x' + 'acdc'.repeat(10)
@@ -64,11 +63,7 @@ describe('L1StandardBridge', () => {
     // Deploy the contract under test
     L1StandardBridge = await (
       await ethers.getContractFactory('L1StandardBridge')
-    ).deploy()
-    await L1StandardBridge.initialize(
-      Mock__L1CrossDomainMessenger.address,
-      DUMMY_L2_BRIDGE_ADDRESS
-    )
+    ).deploy(Mock__L1CrossDomainMessenger.address, DUMMY_L2_BRIDGE_ADDRESS)
 
     L1ERC20 = await Factory__L1ERC20.deploy('L1ERC20', 'ERC')
     await L1ERC20.smodify.put({
@@ -76,17 +71,6 @@ describe('L1StandardBridge', () => {
       _balances: {
         [aliceAddress]: INITIAL_TOTAL_L1_SUPPLY,
       },
-    })
-  })
-
-  describe('initialize', () => {
-    it('Should only be callable once', async () => {
-      await expect(
-        L1StandardBridge.initialize(
-          ethers.constants.AddressZero,
-          DUMMY_L2_BRIDGE_ADDRESS
-        )
-      ).to.be.revertedWith(ERR_ALREADY_INITIALIZED)
     })
   })
 
@@ -212,11 +196,7 @@ describe('L1StandardBridge', () => {
     it('onlyFromCrossDomainAccount: should revert on calls from the right crossDomainMessenger, but wrong xDomainMessageSender (ie. not the L2ETHToken)', async () => {
       L1StandardBridge = await (
         await ethers.getContractFactory('L1StandardBridge')
-      ).deploy()
-      await L1StandardBridge.initialize(
-        Mock__L1CrossDomainMessenger.address,
-        DUMMY_L2_BRIDGE_ADDRESS
-      )
+      ).deploy(Mock__L1CrossDomainMessenger.address, DUMMY_L2_BRIDGE_ADDRESS)
 
       Mock__L1CrossDomainMessenger.smocked.xDomainMessageSender.will.return.with(
         '0x' + '22'.repeat(20)

--- a/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
@@ -107,11 +107,7 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
     // Deploy the Bridge
     L1StandardBridge = await (
       await ethers.getContractFactory('L1StandardBridge')
-    ).deploy()
-    await L1StandardBridge.initialize(
-      L1CrossDomainMessenger.address,
-      NON_ZERO_ADDRESS
-    )
+    ).deploy(L1CrossDomainMessenger.address, NON_ZERO_ADDRESS)
 
     L1ERC20 = await (
       await smoddit('@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20')


### PR DESCRIPTION
Simplify the `CrossDomainEnabled` logic.

Remove the initialization logic for the L1StandardBridge and use immutable constructor params instead to save gas.

Overall this brings [a ~2,000 gas reduction in bridge deposits and withdrawals](https://github.com/ethereum-optimism/optimism/pull/1492/checks?check_run_id=3732457017).

**Metadata**
Fixes ENG-1463