### PR TITLE
refactor: remove unused bond manager functions 

### DIFF
--- a/.changeset/sour-pandas-thank.md
+++ b/.changeset/sour-pandas-thank.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': minor
+---
+
+Removes unused functions within OVM_BondManager

--- a/packages/contracts/contracts/L1/verification/BondManager.sol
+++ b/packages/contracts/contracts/L1/verification/BondManager.sol
@@ -16,47 +16,21 @@ import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolve
  */
 contract BondManager is IBondManager, Lib_AddressResolver {
 
+    /**
+     * @param _libAddressManager Address of the Address Manager.
+     */
     constructor(
         address _libAddressManager
     )
         Lib_AddressResolver(_libAddressManager)
     {}
 
-    function recordGasSpent(
-        bytes32 _preStateRoot,
-        bytes32 _txHash,
-        address _who,
-        uint256 _gasSpent
-    )
-        public
-    {}
-
-    function finalize(
-        bytes32 _preStateRoot,
-        address _publisher,
-        uint256 _timestamp
-    )
-        public
-    {}
-
-    function deposit()
-        public
-    {}
-
-    function startWithdrawal()
-        public
-    {}
-
-    function finalizeWithdrawal()
-        public
-    {}
-
-    function claim(
-        address _who
-    )
-        public
-    {}
-
+    /**
+     * Checks whether a given address is properly collateralized and can perform actions within
+     * the system.
+     * @param _who Address to check.
+     * @return true if the address is properly collateralized, false otherwise.
+     */
     function isCollateralized(
         address _who
     )
@@ -68,18 +42,5 @@ contract BondManager is IBondManager, Lib_AddressResolver {
     {
         // Only authenticate sequencer to submit state root batches.
         return _who == resolve("OVM_Proposer");
-    }
-
-    function getGasSpent(
-        bytes32 _preStateRoot,
-        address _who
-    )
-        public
-        pure
-        returns (
-            uint256
-        )
-    {
-        return 0;
     }
 }

--- a/packages/contracts/contracts/L1/verification/IBondManager.sol
+++ b/packages/contracts/contracts/L1/verification/IBondManager.sol
@@ -10,35 +10,7 @@ interface IBondManager {
      * Public Functions *
      ********************/
 
-    function recordGasSpent(
-        bytes32 _preStateRoot,
-        bytes32 _txHash,
-        address _who,
-        uint256 _gasSpent
-    ) external;
-
-    function finalize(
-        bytes32 _preStateRoot,
-        address _publisher,
-        uint256 _timestamp
-    ) external;
-
-    function deposit() external;
-
-    function startWithdrawal() external;
-
-    function finalizeWithdrawal() external;
-
-    function claim(
-        address _who
-    ) external;
-
     function isCollateralized(
         address _who
     ) external view returns (bool);
-
-    function getGasSpent(
-        bytes32 _preStateRoot,
-        address _who
-    ) external view returns (uint256);
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes some unused functions within the `BondManager`. I think it's better to get rid of the code and add it back in later if necessary than to have it just sitting there doing nothing.
