### PR TITLE
fix: correctly replay messages

### DIFF
--- a/.changeset/ten-planes-carry.md
+++ b/.changeset/ten-planes-carry.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Fixes a bug that made replayMessage useless.

--- a/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_L1CrossDomainMessenger.sol
@@ -52,13 +52,15 @@ interface iOVM_L1CrossDomainMessenger is iOVM_CrossDomainMessenger {
      * @param _sender Original sender address.
      * @param _message Message to send to the target.
      * @param _queueIndex CTC Queue index for the message to replay.
-     * @param _gasLimit Gas limit for the provided message.
+     * @param _oldGasLimit Original gas limit used to send the message.
+     * @param _newGasLimit New gas limit to be used for this message.
      */
     function replayMessage(
         address _target,
         address _sender,
         bytes memory _message,
         uint256 _queueIndex,
-        uint32 _gasLimit
+        uint32 _oldGasLimit,
+        uint32 _newGasLimit
     ) external;
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
We are NOT correctly encoding messages inside of `replayMessage`. This makes it impossible to actually replay the message in question. Specifically, we are double-encoding the messages that we replay. We also had no option to increase the gas limit, which was the whole point of being able to replay messages.

**Metadata**
- Fixes #1386
