### PR TITLE
l2geth: to execution manager run

### DIFF
--- a/.changeset/dirty-beans-fold.md
+++ b/.changeset/dirty-beans-fold.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fix execution manager run

--- a/l2geth/core/state_transition_ovm.go
+++ b/l2geth/core/state_transition_ovm.go
@@ -23,12 +23,20 @@ type ovmTransaction struct {
 }
 
 func toExecutionManagerRun(evm *vm.EVM, msg Message) (Message, error) {
+	to := msg.To()
+	if to == nil {
+		to = &common.Address{}
+	}
+	l1MsgSender := msg.L1MessageSender()
+	if l1MsgSender == nil {
+		l1MsgSender = &common.Address{}
+	}
 	tx := ovmTransaction{
 		evm.Context.Time,
 		msg.L1BlockNumber(),
 		uint8(msg.QueueOrigin()),
-		*msg.L1MessageSender(),
-		*msg.To(),
+		*l1MsgSender,
+		*to,
 		big.NewInt(int64(msg.Gas())),
 		msg.Data(),
 	}


### PR DESCRIPTION
**Description**

Fix `toExecutionManagerRun` in cases where `asOvmMessage` isn't applied.
Note that tracing currently does not work for optimistic ethereum.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

