### PR TITLE
feat: remove onlyRelayer modifier

### DIFF
--- a/.changeset/tender-bees-jump.md
+++ b/.changeset/tender-bees-jump.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Removes the onlyRelayer modifier from the L1CrossDomainMessenger

--- a/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
@@ -33,11 +33,11 @@ import { ReentrancyGuardUpgradeable } from
  * Runtime target: EVM
  */
 contract L1CrossDomainMessenger is
-        IL1CrossDomainMessenger,
-        Lib_AddressResolver,
-        OwnableUpgradeable,
-        PausableUpgradeable,
-        ReentrancyGuardUpgradeable
+    IL1CrossDomainMessenger,
+    Lib_AddressResolver,
+    OwnableUpgradeable,
+    PausableUpgradeable,
+    ReentrancyGuardUpgradeable
 {
 
     /**********
@@ -76,26 +76,6 @@ contract L1CrossDomainMessenger is
     constructor()
         Lib_AddressResolver(address(0))
     {}
-
-
-    /**********************
-     * Function Modifiers *
-     **********************/
-
-    /**
-     * Modifier to enforce that, if configured, only the OVM_L2MessageRelayer contract may
-     * successfully call a method.
-     */
-    modifier onlyRelayer() {
-        address relayer = resolve("OVM_L2MessageRelayer");
-        if (relayer != address(0)) {
-            require(
-                msg.sender == relayer,
-                "Only OVM_L2MessageRelayer can relay L2-to-L1 messages."
-            );
-        }
-        _;
-    }
 
 
     /********************
@@ -221,7 +201,6 @@ contract L1CrossDomainMessenger is
     )
         public
         nonReentrant
-        onlyRelayer
         whenNotPaused
     {
         bytes memory xDomainCalldata = Lib_CrossDomainUtils.encodeXDomainCalldata(

--- a/packages/contracts/test/contracts/L1/messaging/L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/L1CrossDomainMessenger.spec.ts
@@ -521,21 +521,5 @@ describe('L1CrossDomainMessenger', () => {
         ).to.not.be.reverted
       })
     })
-
-    describe('onlyRelayer', () => {
-      it('when the OVM_L2MessageRelayer address is set, should revert if called by a different account', async () => {
-        // set to a random NON-ZERO address
-        await AddressManager.setAddress(
-          'OVM_L2MessageRelayer',
-          '0x1234123412341234123412341234123412341234'
-        )
-
-        await expect(
-          L1CrossDomainMessenger.relayMessage(target, sender, message, 0, proof)
-        ).to.be.revertedWith(
-          'Only OVM_L2MessageRelayer can relay L2-to-L1 messages.'
-        )
-      })
-    })
   })
 })

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -154,20 +154,6 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       await sleep(this.options.pollingInterval)
 
       try {
-        // Check that the correct address is set in the address manager
-        const relayer = await this.state.Lib_AddressManager.getAddress(
-          'OVM_L2MessageRelayer'
-        )
-        // If it is address(0), then message relaying is not authenticated
-        if (relayer !== ethers.constants.AddressZero) {
-          const address = await this.options.l1Wallet.getAddress()
-          if (relayer !== address) {
-            throw new Error(
-              `OVM_L2MessageRelayer (${relayer}) is not set to message-passer EOA ${address}`
-            )
-          }
-        }
-
         this.logger.info('Checking for newly finalized transactions...')
         if (
           !(await this._isTransactionFinalized(


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes the `onlyRelayer` modifier from the L1CrossDomainMessenger (which hasn't been used for a while now).

**Metadata**
- Fixes #623
