### PR TITLE
fix: canary publish

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -21,6 +21,7 @@ jobs:
       message-relayer: ${{ steps.packages.outputs.message-relayer }}
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
       contracts: ${{ steps.packages.outputs.contracts }}
+      gas-oracle: ${{ steps.packages.outputs.gas-oracle }}
       replica-healthcheck: ${{ steps.packages.outputs.replica-healthcheck }}
       canary-docker-tag: ${{ steps.docker-image-name.outputs.canary-docker-tag }}
 
@@ -85,7 +86,6 @@ jobs:
         env:
           CUSTOM_IMAGE_NAME: ${{ github.event.inputs.customImageName }}
 
-
   # The below code is duplicated, would be ideal if we could use a matrix with a
   # key/value being dynamically generated from the `publishedPackages` output
   # while also allowing for parallelization (i.e. `l2geth` not depending on `builder`)
@@ -116,22 +116,11 @@ jobs:
           push: true
           tags: ethereumoptimism/l2geth:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
-  # pushes the base builder image to dockerhub
-  builder:
-    name: Prepare the base builder image for the services
+  gas-oracle:
+    name: Publish Gas Oracle ${{ needs.builder.outputs.canary-docker-tag }}
     needs: canary-publish
-    if: needs.canary-publish.outputs.builder == 'true'
+    if: needs.canary-publish.outputs.gas-oracle != ''
     runs-on: ubuntu-latest
-    # we re-output the variables so that the child jobs can access them
-    outputs:
-      batch-submitter: ${{ needs.canary-publish.outputs.batch-submitter }}
-      message-relayer: ${{ needs.canary-publish.outputs.message-relayer }}
-      data-transport-layer: ${{ needs.canary-publish.outputs.data-transport-layer }}
-      contracts: ${{ needs.canary-publish.outputs.contracts }}
-      integration-tests: ${{ needs.canary-publish.outputs.integration-tests }}
-      replica-healthcheck: ${{ needs.canary-publish.outputs.replica-healthcheck }}
-      canary-docker-tag: ${{ needs.canary-publish.outputs.canary-docker-tag }}
-
 
     steps:
       - name: Checkout
@@ -149,9 +138,44 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./ops/docker/Dockerfile.gas-oracle
+          push: true
+          tags: ethereumoptimism/gas-oracle:${{ needs.builder.outputs.canary-docker-tag }}
+
+  builder:
+    name: Prepare the base builder image for the services
+    needs: canary-publish
+    runs-on: ubuntu-latest
+    # we re-output the variables so that the child jobs can access them
+    outputs:
+      batch-submitter: ${{ needs.canary-publish.outputs.batch-submitter }}
+      message-relayer: ${{ needs.canary-publish.outputs.message-relayer }}
+      data-transport-layer: ${{ needs.canary-publish.outputs.data-transport-layer }}
+      contracts: ${{ needs.canary-publish.outputs.contracts }}
+      integration-tests: ${{ needs.canary-publish.outputs.integration-tests }}
+      replica-healthcheck: ${{ needs.canary-publish.outputs.replica-healthcheck }}
+      canary-docker-tag: ${{ needs.canary-publish.outputs.canary-docker-tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
           file: ./ops/docker/Dockerfile.monorepo
           push: true
-          tags: ethereumoptimism/builder
+          tags: ethereumoptimism/builder:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   message-relayer:
     name: Publish Message Relayer Version ${{ needs.builder.outputs.canary-docker-tag }}


### PR DESCRIPTION
**Description**

Adds the ability to publish the builder as well as the
gas-oracle for the canary releases.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


