### PR TITLE
ci: fix canary build for publishing gpo

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -117,7 +117,7 @@ jobs:
           tags: ethereumoptimism/l2geth:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   gas-oracle:
-    name: Publish Gas Oracle ${{ needs.builder.outputs.canary-docker-tag }}
+    name: Publish Gas Oracle ${{ needs.canary-publish.outputs.canary-docker-tag }}
     needs: canary-publish
     if: needs.canary-publish.outputs.gas-oracle != ''
     runs-on: ubuntu-latest
@@ -140,7 +140,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.gas-oracle
           push: true
-          tags: ethereumoptimism/gas-oracle:${{ needs.builder.outputs.canary-docker-tag }}
+          tags: ethereumoptimism/gas-oracle:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   builder:
     name: Prepare the base builder image for the services


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a typo in the canary build for gpo

