### PR TITLE
feat: add git commit hash to genesis file 

### DIFF
--- a/.changeset/good-tigers-explain.md
+++ b/.changeset/good-tigers-explain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Adds a git commit hash to the output of make-genesis.ts

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -243,7 +243,7 @@ describe('BatchSubmitter', () => {
       txBatchTxSubmitter,
       1,
       new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
-      testMetrics,
+      testMetrics
     )
   }
 

--- a/packages/contracts/src/make-genesis.ts
+++ b/packages/contracts/src/make-genesis.ts
@@ -1,4 +1,6 @@
 /* External Imports */
+import { promisify } from 'util'
+import { exec } from 'child_process'
 import {
   computeStorageSlots,
   getStorageLayout,
@@ -127,7 +129,18 @@ export const makeL2GenesisFile = async (
     }
   }
 
+  // Grab the commit hash so we can stick it in the genesis file.
+  let commit: string
+  try {
+    const { stdout } = await promisify(exec)('git rev-parse HEAD')
+    commit = stdout.replace('\n', '')
+  } catch {
+    console.log('unable to get commit hash, using empty hash instead')
+    commit = '0000000000000000000000000000000000000000'
+  }
+
   return {
+    commit,
     config: {
       chainId: cfg.l2ChainId,
       homesteadBlock: 0,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds the git commit hash to the object returned by `make-genesis.ts`. Geth ignores this value but it's useful for keeping track of the exact code used to generate a given genesis.