### PR TITLE
ops: add .git folder to docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 
 node_modules

--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -19,6 +19,7 @@ COPY --from=builder /optimism/packages/contracts/dist ./dist
 COPY --from=builder /optimism/packages/contracts/*.json ./
 COPY --from=builder /optimism/packages/contracts/node_modules ./node_modules
 COPY --from=builder /optimism/packages/contracts/artifacts ./artifacts
+COPY --from=builder /optimism/.git ./.git
 
 # get non-build artifacts from the host
 COPY packages/contracts/bin ./bin

--- a/ops/docker/Dockerfile.monorepo
+++ b/ops/docker/Dockerfile.monorepo
@@ -22,6 +22,7 @@ FROM node as builder
 # note: this approach can be a bit unhandy to maintain, but it allows
 # us to cache the installation steps
 WORKDIR /optimism
+COPY .git ./.git
 COPY *.json yarn.lock ./
 COPY packages/core-utils/package.json ./packages/core-utils/package.json
 COPY packages/common-ts/package.json ./packages/common-ts/package.json
@@ -45,6 +46,7 @@ WORKDIR /optimism
 COPY --from=builder /optimism/node_modules ./node_modules
 COPY --from=builder /optimism/packages ./packages
 COPY --from=builder /optimism/integration-tests ./integration-tests
+COPY --from=builder /optimism/.git ./.git
 
 # the following steps are cheap
 COPY *.json yarn.lock ./


### PR DESCRIPTION
**Description**

This allows scripts that depend on the git hash
at build/runtime to access it.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
