### PR TITLE
ops: remove git dir from deployer docker image

### DIFF
--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -19,7 +19,6 @@ COPY --from=builder /optimism/packages/contracts/dist ./dist
 COPY --from=builder /optimism/packages/contracts/*.json ./
 COPY --from=builder /optimism/packages/contracts/node_modules ./node_modules
 COPY --from=builder /optimism/packages/contracts/artifacts ./artifacts
-COPY --from=builder /optimism/.git ./.git
 
 # get non-build artifacts from the host
 COPY packages/contracts/bin ./bin


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This was causing a build error in CI. We want to be able to run `git rev-parse HEAD` inside of the image.

