### PR TITLE
feat: set high default l2xdm message nonce for next regenesis

### DIFF
--- a/packages/contracts/src/make-genesis.ts
+++ b/packages/contracts/src/make-genesis.ts
@@ -85,6 +85,8 @@ export const makeL2GenesisFile = async (
       // See usage of this default in the L2CrossDomainMessenger contract.
       xDomainMsgSender: '0x000000000000000000000000000000000000dEaD',
       l1CrossDomainMessenger: cfg.l1CrossDomainMessengerAddress,
+      // Set the messageNonce to a high value to avoid overwriting old sent messages.
+      messageNonce: 100000,
     },
     WETH9: {
       name: 'Wrapped Ether',


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Sets a high default `messageNonce` for the next regenesis. We're going to wipe the state of the account in the next regenesis and reset it to the new code. If we don't set the nonce to some high value then we could theoretically have a collision here: https://github.com/ethereum-optimism/optimism/blob/4c7a82e3a2167459036a2010e0aa2b35cc8b121b/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol#L38-L43

Which would prevent a user from withdrawing their funds.