### PR TITLE
Updated deployer Dockerfile to use src dir from builder

### DIFF
--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -19,6 +19,7 @@ COPY --from=builder /optimism/packages/contracts/dist ./dist
 COPY --from=builder /optimism/packages/contracts/*.json ./
 COPY --from=builder /optimism/packages/contracts/node_modules ./node_modules
 COPY --from=builder /optimism/packages/contracts/artifacts ./artifacts
+COPY --from=builder /optimism/packages/contracts/src ./src
 
 # get non-build artifacts from the host
 COPY packages/contracts/bin ./bin
@@ -26,7 +27,6 @@ COPY packages/contracts/contracts ./contracts
 COPY packages/contracts/hardhat.config.ts ./
 COPY packages/contracts/deploy ./deploy
 COPY packages/contracts/tasks ./tasks
-COPY packages/contracts/src ./src
 COPY packages/contracts/test/helpers/constants.ts ./test/helpers/constants.ts
 COPY packages/contracts/scripts ./scripts
 


### PR DESCRIPTION

**Description**
The deployer docker image fails to run because it is missing `contract-artifacts.ts`

This resource is generated in the builder container.

This PR updated the deployer Dockerfile to use the `src` dir from the builder container instead of from the host filesystem.

