### PR TITLE
investigating: change nonce to hex

### DIFF
--- a/packages/regenesis-surgery/scripts/surgery.ts
+++ b/packages/regenesis-surgery/scripts/surgery.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers'
 import fs from 'fs'
+import { add0x } from '@eth-optimism/core-utils'
 import {
   StateDump,
   UniswapPoolData,
@@ -40,7 +41,8 @@ const doGenesisSurgery = async (
       )
       const newAccount = await handler(clone(account), data)
       if (newAccount !== undefined) {
-        output.push(newAccount)
+        newAccount.nonce = add0x(newAccount.nonce.toString(16))
+        output.push(newAccount) as any
       }
     }
   }

--- a/packages/regenesis-surgery/scripts/types.ts
+++ b/packages/regenesis-surgery/scripts/types.ts
@@ -16,7 +16,7 @@ export interface SurgeryConfigs {
 
 export interface Account {
   address: string
-  nonce: number
+  nonce: number | string
   balance: string
   codeHash: string
   root: string


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
 `geth init` fails with the current state dump output, this PR attempted to find out why but is still running into 
```
Fatal: invalid genesis file: json: cannot unmarshal hex string without 0x prefix into Go struct field Genesis.alloc of type hexutil.Bytes
```

**Additional context**
Before this change, we got the error
```
Fatal: invalid genesis file: json: cannot unmarshal number into Go struct field Genesis.alloc of type *math.HexOrDecimal64
```

**Metadata**
- Fixes
