### PR TITLE
build: remove non-latest tag on ethereumoptimism/builder

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -175,7 +175,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.monorepo
           push: true
-          tags: ethereumoptimism/builder:${{ needs.canary-publish.outputs.canary-docker-tag }}
+          tags: ethereumoptimism/builder
 
   message-relayer:
     name: Publish Message Relayer Version ${{ needs.builder.outputs.canary-docker-tag }}


### PR DESCRIPTION
- `builder` should be private
  - it only exists as an intermediate image during the docker build pipeline
  - if a version is appended to it, then `ethereumoptimism/builder` (which defaults to `latest` tag) will be used, not the versioned one
    - this is bad as intermediate containers must have the exact same version
    - locally overriding `latest` is not a big deal, since this is not a public image

example: https://github.com/ethereum-optimism/optimism/blob/5a0f409d853a23963fa789bbc71386237eaed09c/ops/docker/Dockerfile.deployer#L1-L1