### PR TITLE
Update hardcoded gaslimit on deposits of ETH 

### DIFF
--- a/.changeset/orange-chairs-worry.md
+++ b/.changeset/orange-chairs-worry.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Reduce default gasLimit on eth deposits to the L1 Standard Bridge

--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -74,7 +74,7 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
      * default amount is forwarded to L2.
      */
     receive() external payable onlyEOA {
-        _initiateETHDeposit(msg.sender, msg.sender, 1_300_000, bytes(""));
+        _initiateETHDeposit(msg.sender, msg.sender, 200_000, bytes(""));
     }
 
     /**


### PR DESCRIPTION
**Description**
This change reduces the amount of gas forwarded to L2 when the L1 bridges's `receive` function is called, from 1300k, to 120k. We can do this because of the ovm 2.0 changes.  I chose the number simply by running the integration tests to find a lower bound. 120k worked, 117.5k failed. Thus there is a margin of less than 2500 gas. 

**Question to reviewers**

I don't see much in the L2 bridge/messenger that would make the gas costs variable (to the worse side) for a basic ETH deposit. So IMO a small margin is OK. 

**Do you agree? Would you for any reason like to see a larger margin?**

I also don't see much downside to providing a larger gas limit, since the `receive()` function doesn't provide any way to pass arbitrary data, so the depositor has no ability to cause extra computation to happen on the L2 side of the deposit. 
