### PR TITLE
gas-oracle: use configured gas-price

### DIFF
--- a/.changeset/tall-chefs-pay.md
+++ b/.changeset/tall-chefs-pay.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/gas-oracle': patch
+---
+
+Use the configured gas price when updating the L1 base fee in L2 state

--- a/go/gas-oracle/oracle/base_fee.go
+++ b/go/gas-oracle/oracle/base_fee.go
@@ -53,6 +53,19 @@ func wrapUpdateBaseFee(l1Backend bind.ContractTransactor, l2Backend DeployContra
 			log.Debug("non significant base fee update", "tip", tip.BaseFee, "current", baseFee)
 			return nil
 		}
+
+		// Use the configured gas price if it is set,
+		// otherwise use gas estimation
+		if cfg.gasPrice != nil {
+			opts.GasPrice = cfg.gasPrice
+		} else {
+			gasPrice, err := l2Backend.SuggestGasPrice(opts.Context)
+			if err != nil {
+				return err
+			}
+			opts.GasPrice = gasPrice
+		}
+
 		tx, err := contract.SetL1BaseFee(opts, tip.BaseFee)
 		if err != nil {
 			return err

--- a/go/gas-oracle/oracle/base_fee_test.go
+++ b/go/gas-oracle/oracle/base_fee_test.go
@@ -26,7 +26,7 @@ func TestBaseFeeUpdate(t *testing.T) {
 		privateKey:            key,
 		l2ChainID:             big.NewInt(1337),
 		gasPriceOracleAddress: addr,
-		gasPrice:              big.NewInt(677228895),
+		gasPrice:              big.NewInt(782049771),
 	}
 
 	update, err := wrapUpdateBaseFee(sim, sim, cfg)
@@ -55,7 +55,7 @@ func TestBaseFeeUpdate(t *testing.T) {
 	}
 	// Call the update function to do the update
 	if err := update(); err != nil {
-		t.Fatal("cannot update base fee")
+		t.Fatalf("cannot update base fee: %s", err)
 	}
 	sim.Commit()
 	// Check the updated base fee


### PR DESCRIPTION
**Description**

Use the configured gas price when updating the L1 base fee.
In production, this should be set to 0 and the sequencer
will allow for transactions with 0 gas price when they are
from the owner of the gas price oracle. This prevents the
need to manage funds on L2 for the `gas-oracle`

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes ENG-1487