### PR TITLE
fix: correctly export standards contracts

### DIFF
--- a/.changeset/hip-apples-juggle.md
+++ b/.changeset/hip-apples-juggle.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Modifies package.json to correctly export all contracts

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,7 +10,8 @@
     "chugsplash",
     "L1",
     "L2",
-    "libraries"
+    "libraries",
+    "standards"
   ],
   "types": "dist/index",
   "author": "Optimism PBC",
@@ -38,7 +39,7 @@
     "clean": "rm -rf ./dist ./artifacts ./cache ./tsconfig.build.tsbuildinfo",
     "deploy": "ts-node bin/deploy.ts && yarn autogen:markdown",
     "prepublishOnly": "yarn copyfiles -u 1 -e \"**/test-*/**/*\" \"contracts/**/*\" ./",
-    "postpublish": "rimraf chugsplash L1 L2 libraries",
+    "postpublish": "rimraf chugsplash L1 L2 libraries standards",
     "prepack": "yarn prepublishOnly",
     "postpack": "yarn postpublish",
     "pre-commit": "lint-staged"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Correctly exports the `standards` contract folder.

**Metadata**
- Fixes #1585 
