### PR TITLE
fix: correctly export types in contracts package

### DIFF
--- a/.changeset/eighty-suns-cheat.md
+++ b/.changeset/eighty-suns-cheat.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Correctly export contracts package types

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index",
   "files": [
     "dist/**/*.js",
+    "dist/**/*.d.ts",
     "dist/types/*.ts",
     "artifacts/contracts/**/*.json",
     "deployments/**/*.json",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Correctly exports typescript types in the contracts package.
