### PR TITLE
fix: bad changeset

### DIFF
--- a/.changeset/hip-penguins-camp.md
+++ b/.changeset/hip-penguins-camp.md
@@ -5,7 +5,6 @@
 '@eth-optimism/contracts': patch
 '@eth-optimism/core-utils': patch
 '@eth-optimism/data-transport-layer': patch
-'@eth-optimism/hardhat-ovm': patch
 '@eth-optimism/message-relayer': patch
 '@eth-optimism/replica-healthcheck': patch
 '@eth-optimism/specs': patch


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes changeset containing a reference to hardhat-ovm, which no longer exists in experimental.

