### PR TITLE
fix: move chai into deps for core-utils

### DIFF
--- a/.changeset/nine-eels-love.md
+++ b/.changeset/nine-eels-love.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': patch
+---
+
+Correctly move chai into deps instead of dev deps

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -28,7 +28,6 @@
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "babel-eslint": "^10.1.0",
-    "chai": "^4.3.4",
     "eslint": "^7.27.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-ban": "^1.5.2",
@@ -48,6 +47,7 @@
   "dependencies": {
     "@ethersproject/abstract-provider": "^5.4.1",
     "@ethersproject/providers": "^5.4.5",
+    "chai": "^4.3.4",
     "ethers": "^5.4.5",
     "lodash": "^4.17.21"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@
   resolved "https://registry.yarnpkg.com/@types/browser-or-node/-/browser-or-node-1.3.0.tgz#896ec59bcb8109fc858d8e68d3c056c176a19622"
   integrity sha512-MVetr65IR7RdJbUxVHsaPFaXAO8fi89zv1g8L/mHygh1Q7xnnK02XZLwfMh57FOpTO6gtnagoPMQ/UOFfctXRQ==
 
-"@types/chai-as-promised@^7.1.3", "@types/chai-as-promised@^7.1.4":
+"@types/chai-as-promised@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz#caf64e76fb056b8c8ced4b761ed499272b737601"
   integrity sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==
@@ -2635,7 +2635,15 @@
   dependencies:
     "@types/tz-offset" "*"
 
-"@types/node-fetch@^2.5.5", "@types/node-fetch@^2.5.8":
+"@types/node-fetch@^2.5.10":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
+"@types/node-fetch@^2.5.5":
   version "2.5.10"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
   integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
We now need `chai` to be included in the normal dependencies for `core-utils` because of the inclusion of the new `test-utils.ts` file.
