### PR TITLE
regenesis-script: replaceWETH helper

### DIFF
--- a/packages/regenesis-surgery/scripts/handlers.ts
+++ b/packages/regenesis-surgery/scripts/handlers.ts
@@ -12,6 +12,7 @@ import {
   transferStorageSlot,
   getMappingKey,
   getUniswapV3Factory,
+  replaceWETH,
 } from './utils'
 import { compile } from './solc'
 import {
@@ -233,10 +234,7 @@ export const handlers: {
     }
 
     // Replace references to L1 WETH address with the L2 WETH address.
-    code = code.replace(
-      /c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/g,
-      '4200000000000000000000000000000000000006'
-    )
+    code = replaceWETH(code)
 
     return {
       ...account,

--- a/packages/regenesis-surgery/scripts/utils.ts
+++ b/packages/regenesis-surgery/scripts/utils.ts
@@ -46,6 +46,13 @@ export const hexStringEqual = (a: string, b: string): boolean => {
   return a.toLowerCase() === b.toLowerCase()
 }
 
+export const replaceWETH = (code: string): string => {
+  return code.replace(
+    /c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/g,
+    '4200000000000000000000000000000000000006'
+  )
+}
+
 /**
  * Left-pads a hex string with zeroes to 32 bytes.
  *

--- a/packages/regenesis-surgery/test/integration/uniswap.spec.ts
+++ b/packages/regenesis-surgery/test/integration/uniswap.spec.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers'
 import { abi as UNISWAP_POOL_ABI } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json'
 import { UNISWAP_V3_NFPM_ADDRESS } from '../../scripts/constants'
-import { getUniswapV3Factory } from '../../scripts/utils'
+import { getUniswapV3Factory, replaceWETH } from '../../scripts/utils'
 import { expect, env } from '../setup'
 import { AccountType } from '../../scripts/types'
 
@@ -63,11 +63,12 @@ describe('uniswap contracts', () => {
 
   describe('V3 NFPM', () => {
     it('should have the same code as on mainnet', async () => {
-      const l2Code = await env.postL2Provider.getCode(UNISWAP_V3_NFPM_ADDRESS)
+      let l2Code = await env.postL2Provider.getCode(UNISWAP_V3_NFPM_ADDRESS)
       const l1Code = await env.surgeryDataSources.l1Provider.getCode(
         UNISWAP_V3_NFPM_ADDRESS
       )
       expect(l2Code).to.not.equal('0x')
+      l2Code = replaceWETH(l2Code)
       expect(l2Code).to.equal(l1Code)
     })
 


### PR DESCRIPTION
**Description**

Create a replaceWETH helper function that can be reused in the
tests. WETH is an immutable in the uniswap contracts so a find
and replace is used to replace the weth address with the L2 eth
address on optimism.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

