### PR TITLE
l2geth: clean up mutex logic

### DIFF
--- a/.changeset/fast-humans-lick.md
+++ b/.changeset/fast-humans-lick.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove complex mutex logic in favor of simple mutex logic in the `SyncService`


### PR DESCRIPTION
**Description**

Reverts 341580e8f4e7c83d0382fc7d40281b5ac973e568 in favor of more simple
logic. A longer term solution needs to be implemented for the race
condition where the `gas-oracle` front runs a tx that has already passed
gas validation at the policy layer.

The `gas-oracle` tx can increase the L1 gas portion of the fee,
causing the tx that already passed the policy check to fail during
consensus execution. This should never happen.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


