### PR TITLE
l2geth: remove dead L1 gas price fetching code

### DIFF
--- a/.changeset/soft-berries-cross.md
+++ b/.changeset/soft-berries-cross.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove dead L1 gas price fetching code

--- a/l2geth/rollup/client.go
+++ b/l2geth/rollup/client.go
@@ -130,7 +130,6 @@ type RollupClient interface {
 	GetLatestTransactionBatchIndex() (*uint64, error)
 	GetTransactionBatch(uint64) (*Batch, []*types.Transaction, error)
 	SyncStatus(Backend) (*SyncStatus, error)
-	GetL1GasPrice() (*big.Int, error)
 }
 
 // Client is an HTTP based RollupClient
@@ -604,27 +603,4 @@ func parseTransactionBatchResponse(txBatch *TransactionBatchResponse, signer *ty
 		txs[i] = transaction
 	}
 	return batch, txs, nil
-}
-
-// GetL1GasPrice will return the current gas price on L1
-func (c *Client) GetL1GasPrice() (*big.Int, error) {
-	response, err := c.client.R().
-		SetResult(&L1GasPrice{}).
-		Get("/eth/gasprice")
-
-	if err != nil {
-		return nil, fmt.Errorf("Cannot fetch L1 gas price: %w", err)
-	}
-
-	gasPriceResp, ok := response.Result().(*L1GasPrice)
-	if !ok {
-		return nil, fmt.Errorf("Cannot parse L1 gas price response")
-	}
-
-	gasPrice, ok := new(big.Int).SetString(gasPriceResp.GasPrice, 10)
-	if !ok {
-		return nil, fmt.Errorf("Cannot parse response as big number")
-	}
-
-	return gasPrice, nil
 }

--- a/l2geth/rollup/client_test.go
+++ b/l2geth/rollup/client_test.go
@@ -12,39 +12,6 @@ import (
 
 const url = "http://localhost:9999"
 
-func TestRollupClientGetL1GasPrice(t *testing.T) {
-	endpoint := fmt.Sprintf("%s/eth/gasprice", url)
-	// url/chain-id does not matter, we'll mock the responses
-	client := NewClient(url, big.NewInt(1))
-	// activate the mock
-	httpmock.ActivateNonDefault(client.client.GetClient())
-
-	// The API responds with a string value
-	expectedGasPrice, _ := new(big.Int).SetString("123132132151245817421893", 10)
-	body := map[string]interface{}{
-		"gasPrice": expectedGasPrice.String(),
-	}
-	response, _ := httpmock.NewJsonResponder(
-		200,
-		body,
-	)
-	httpmock.RegisterResponder(
-		"GET",
-		endpoint,
-		response,
-	)
-
-	gasPrice, err := client.GetL1GasPrice()
-
-	if err != nil {
-		t.Fatal("could not get mocked gas price", err)
-	}
-
-	if gasPrice.Cmp(expectedGasPrice) != 0 {
-		t.Fatal("gasPrice is not parsed properly in the client")
-	}
-}
-
 func TestRollupClientCannotConnect(t *testing.T) {
 	endpoint := fmt.Sprintf("%s/eth/context/latest", url)
 	client := NewClient(url, big.NewInt(1))

--- a/l2geth/rollup/sync_service_test.go
+++ b/l2geth/rollup/sync_service_test.go
@@ -1004,11 +1004,6 @@ func (m *mockClient) SyncStatus(backend Backend) (*SyncStatus, error) {
 	}, nil
 }
 
-func (m *mockClient) GetL1GasPrice() (*big.Int, error) {
-	price := big.NewInt(1)
-	return price, nil
-}
-
 func (m *mockClient) GetLatestEnqueueIndex() (*uint64, error) {
 	enqueue, err := m.GetLatestEnqueue()
 	if err != nil {


### PR DESCRIPTION
**Description**

The new gas price scheme no longer fetches the L1 gas price from
a remote L1 node. It now instead will use the L1 gas price
that lives in the L2 state. The `gas-oracle` is responsible for
updating the L1 gas price in the `OVM_GasPriceOracle` predeploy.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

