### PR TITLE
batch-submitter: handle error case explicitly

### DIFF
--- a/.changeset/great-buckets-bow.md
+++ b/.changeset/great-buckets-bow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Handle error case more explicity when creating invalid batch

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -195,8 +195,12 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       return
     }
 
-    const [batchParams, wasBatchTruncated] =
-      await this._generateSequencerBatchParams(startBlock, endBlock)
+    const params = await this._generateSequencerBatchParams(startBlock, endBlock)
+    if (!params) {
+      throw new Error(`Cannot create sequencer batch with params start ${startBlock} and end ${endBlock}`)
+    }
+
+    const [batchParams, wasBatchTruncated] = params
     const batchSizeInBytes = encodeAppendSequencerBatch(batchParams).length / 2
     this.logger.debug('Sequencer batch generated', {
       batchSizeInBytes,


### PR DESCRIPTION
**Description**

It was possible to return from a function directly
into destructuring an array when the return value
was polymorphic in either being an array or undefined.
The undefined case is handled explicitly now and an
error is thrown with a useful error message instead of
something that would require looking at the source code
and knowing nodejs error types to find out what the
problem was.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


