### PR TITLE
Remove HH's hardfork setting

### DIFF
--- a/.changeset/yellow-pots-push.md
+++ b/.changeset/yellow-pots-push.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Test contracts against london fork

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -36,7 +36,6 @@ const config: HardhatUserConfig = {
       live: false,
       saveDeployments: false,
       tags: ['local'],
-      hardfork: 'istanbul',
     },
     optimism: {
       url: 'http://127.0.0.1:8545',

--- a/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
@@ -25,8 +25,7 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
   let sequencer: Signer
   let alice: Signer
   before(async () => {
-    ;[sequencer] = await ethers.getSigners()
-    ;[alice] = await ethers.getSigners()
+    ;[sequencer, alice] = await ethers.getSigners()
   })
 
   let AddressManager: Contract
@@ -139,14 +138,13 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
         NON_NULL_BYTES32,
         {
           value: depositAmount,
-          gasPrice: 0,
         }
       )
 
       const receipt = await res.wait()
       const gasUsed = receipt.gasUsed.toNumber()
       console.log('    - Gas used:', gasUsed)
-      expectApprox(gasUsed, 116_781, {
+      expectApprox(gasUsed, 132_481, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -169,11 +167,10 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge', () => {
         FINALIZATION_GAS,
         NON_NULL_BYTES32
       )
-
       const receipt = await res.wait()
       const gasUsed = receipt.gasUsed.toNumber()
       console.log('    - Gas used:', gasUsed)
-      expectApprox(gasUsed, 164_622, {
+      expectApprox(gasUsed, 192_822, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -157,7 +157,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
         'Non-calldata overhead gas cost per transaction:',
         (gasUsed - fixedCalldataCost) / numTxs
       )
-      expectApprox(gasUsed, 1_422_181, {
+      expectApprox(gasUsed, 1_402_638, {
         absoluteUpperDeviation: 1000,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -293,7 +293,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
 
       console.log('Benchmark complete.')
 
-      expectApprox(gasUsed, 189_487, {
+      expectApprox(gasUsed, 196_687, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!
@@ -314,7 +314,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain', () => {
 
       console.log('Benchmark complete.')
 
-      expectApprox(gasUsed, 127_500, {
+      expectApprox(gasUsed, 134_100, {
         absoluteUpperDeviation: 500,
         // Assert a lower bound of 1% reduction on gas cost. If your tests are breaking because your
         // contracts are too efficient, consider updating the target value!


### PR DESCRIPTION
**Description**

Removes the `hardfork` setting in the contracts package's `hardhat.config.ts` file, falling back to hardhat's default, which for our [current hardhat version](https://github.com/nomiclabs/hardhat/releases/tag/hardhat-core-v2.6.0) is 'london'. 

**Additional context**

It's worth noting that the `contracts` package contains solidity files which are intended to run in at least two different domains: 

1. L1 contracts will run on `london`
2. L2 contracts will run on `berlin` until we've updated our L2Geth to `london`

Perhaps this is the basis for why we'd specified a non-default `hardfork`?

IMO it is better to get the "right fork" for running the L2 contracts, rather than the L2 contracts, largely because they are more gas sensitive, and gas considerations are the primary difference between `berlin` and `london`. 

Ideally, we'd actually have separate packages for the L1 and L2 contracts, so this is just a first baby step towards that state.


**Metadata**
- Fixes ENG-1474
