### PR TITLE
core-utils: parse L1 timestamp in injectContext

### DIFF
--- a/.changeset/witty-dingos-confess.md
+++ b/.changeset/witty-dingos-confess.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': patch
+---
+
+Parse the L1 timestamp in `injectContext`

--- a/packages/core-utils/src/l2context.ts
+++ b/packages/core-utils/src/l2context.ts
@@ -1,6 +1,16 @@
 import cloneDeep from 'lodash/cloneDeep'
 import { providers } from 'ethers'
 
+const parseNumber = (n: string | number): number => {
+  if (typeof n === 'string' && n.startsWith('0x')) {
+    return parseInt(n, 16)
+  }
+  if (typeof n === 'number') {
+    return n
+  }
+  return parseInt(n, 10)
+}
+
 /**
  * Helper for adding additional L2 context to transactions
  */
@@ -25,9 +35,14 @@ export const injectL2Context = (l1Provider: providers.JsonRpcProvider) => {
     for (let i = 0; i < b.transactions.length; i++) {
       b.transactions[i].l1BlockNumber = block.transactions[i].l1BlockNumber
       if (b.transactions[i].l1BlockNumber != null) {
-        b.transactions[i].l1BlockNumber = parseInt(
-          b.transactions[i].l1BlockNumber,
-          16
+        b.transactions[i].l1BlockNumber = parseNumber(
+          b.transactions[i].l1BlockNumber
+        )
+      }
+      b.transactions[i].l1Timestamp = block.transactions[i].l1Timestamp
+      if (b.transactions[i].l1Timestamp != null) {
+        b.transactions[i].l1Timestamp = parseNumber(
+          b.transactions[i].l1Timestamp
         )
       }
       b.transactions[i].l1TxOrigin = block.transactions[i].l1TxOrigin


### PR DESCRIPTION
**Description**

Also parse the L1 timestamp in `injectContext`.
This value is useful but was not previously parsed
and added to the ethers provider

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

