### PR TITLE
fix: minor OVM_ETH regenesis bugs

### DIFF
--- a/.changeset/nasty-walls-hammer.md
+++ b/.changeset/nasty-walls-hammer.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts': patch
+'@eth-optimism/regenesis-surgery': patch
+---
+
+Minor bugfixes to the regenesis process for OVM_ETH

--- a/packages/contracts/src/make-genesis.ts
+++ b/packages/contracts/src/make-genesis.ts
@@ -1,6 +1,7 @@
 /* External Imports */
 import { promisify } from 'util'
 import { exec } from 'child_process'
+import { ethers } from 'ethers'
 import {
   computeStorageSlots,
   getStorageLayout,
@@ -77,6 +78,7 @@ export const makeL2GenesisFile = async (
     },
     OVM_ETH: {
       l2Bridge: predeploys.L2StandardBridge,
+      l1Token: ethers.constants.AddressZero,
       _name: 'Ether',
       _symbol: 'ETH',
     },
@@ -96,16 +98,6 @@ export const makeL2GenesisFile = async (
   }
 
   const dump = {}
-  // Add the precompiles. Only safe for up to 9
-  for (let i = 1; i <= 9; i++) {
-    const addr = `0x000000000000000000000000000000000000000${i}`
-    if (addr.length !== 42) {
-      throw new Error(`Address length incorrect: ${addr.length}`)
-    }
-    dump[addr] = {
-      balance: '01',
-    }
-  }
   for (const predeployName of Object.keys(predeploys)) {
     const predeployAddress = predeploys[predeployName]
     dump[predeployAddress] = {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes three minor bugs in the regenesis process related to OVM_ETH:
1. Explicitly sets the `l1Token` for `OVM_ETH` to guarantee that we'll override any existing storage slots at that position in the surgery process.
2. ~Correctly updates the `totalSupply` to remove the balances that have been transferred to WETH9.~ (NOT REQUIRED)
3. Removes the balances allocated to the precompile addresses.

Fixes ENG-1565