### PR TITLE
l2geth: remove dead api code

### DIFF
--- a/.changeset/fair-dragons-shop.md
+++ b/.changeset/fair-dragons-shop.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove dead `debug_ingestTransactions` endpoint and `txType` from RPC transactions

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1194,7 +1194,6 @@ type RPCTransaction struct {
 	R                *hexutil.Big    `json:"r"`
 	S                *hexutil.Big    `json:"s"`
 	QueueOrigin      string          `json:"queueOrigin"`
-	TxType           string          `json:"txType"`
 	L1TxOrigin       *common.Address `json:"l1TxOrigin"`
 	L1BlockNumber    *hexutil.Big    `json:"l1BlockNumber"`
 	L1Timestamp      hexutil.Uint64  `json:"l1Timestamp"`
@@ -2027,51 +2026,6 @@ func (api *PrivateDebugAPI) ChaindbCompact() error {
 // SetHead rewinds the head of the blockchain to a previous block.
 func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
-}
-
-func (api *PrivateDebugAPI) IngestTransactions(txs []*RPCTransaction) error {
-	transactions := make([]*types.Transaction, len(txs))
-
-	for i, tx := range txs {
-		nonce := uint64(tx.Nonce)
-		value := tx.Value.ToInt()
-		gasLimit := uint64(tx.Gas)
-		gasPrice := tx.GasPrice.ToInt()
-		data := tx.Input
-		l1BlockNumber := tx.L1BlockNumber.ToInt()
-		l1Timestamp := uint64(tx.L1Timestamp)
-		rawTransaction := tx.RawTransaction
-
-		var queueOrigin types.QueueOrigin
-		switch tx.QueueOrigin {
-		case "sequencer":
-			queueOrigin = types.QueueOriginSequencer
-		case "l1":
-			queueOrigin = types.QueueOriginL1ToL2
-		default:
-			return fmt.Errorf("Transaction with unknown queue origin: %s", tx.TxType)
-		}
-
-		var transaction *types.Transaction
-		if tx.To == nil {
-			transaction = types.NewContractCreation(nonce, value, gasLimit, gasPrice, data)
-		} else {
-			transaction = types.NewTransaction(nonce, *tx.To, value, gasLimit, gasPrice, data)
-		}
-
-		meta := types.TransactionMeta{
-			L1BlockNumber:   l1BlockNumber,
-			L1Timestamp:     l1Timestamp,
-			L1MessageSender: tx.L1TxOrigin,
-			QueueOrigin:     queueOrigin,
-			Index:           (*uint64)(tx.Index),
-			QueueIndex:      (*uint64)(tx.QueueIndex),
-			RawTransaction:  rawTransaction,
-		}
-		transaction.SetTransactionMeta(&meta)
-		transactions[i] = transaction
-	}
-	return api.b.IngestTransactions(transactions)
 }
 
 // PublicNetAPI offers network related RPC methods


### PR DESCRIPTION
**Description**

Removes the dead endpoint `debug_ingestTransactions`
that is no longer needed. Also remove the dead
struct field `txType` from the `RPCTransaction`.
This field was not being set and would return an
empty string when querying for a transaction via
RPC.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

