### PR TITLE
contracts: add hardhat impersonate account step

### DIFF
--- a/.changeset/weak-beans-invite.md
+++ b/.changeset/weak-beans-invite.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Add hardhat fork deploy step

--- a/packages/contracts/deploy/0000-hardhat-setup.ts
+++ b/packages/contracts/deploy/0000-hardhat-setup.ts
@@ -1,0 +1,60 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+import {
+  getAdvancedContract,
+  waitUntilTrue,
+} from '../src/hardhat-deploy-ethers'
+
+const deployFn: DeployFunction = async (hre) => {
+  const { deployer } = await hre.getNamedAccounts()
+
+  if ((hre as any).deployConfig.forked !== 'true') {
+    return
+  }
+
+  console.log(`Running custom setup for forked experimental networks`)
+
+  // Fund the deployer account
+  console.log(`Funding deployer account...`)
+  const amount = `0xFFFFFFFFFFFFFFFFFF`
+  await hre.ethers.provider.send('hardhat_setBalance', [deployer, amount])
+
+  console.log(`Waiting for balance to reflect...`)
+  await waitUntilTrue(async () => {
+    const balance = await hre.ethers.provider.getBalance(deployer)
+    return balance.gte(hre.ethers.BigNumber.from(amount))
+  })
+
+  // Get a reference to the AddressManager contract.
+  const artifact = await hre.deployments.get('Lib_AddressManager')
+  const Lib_AddressManager = getAdvancedContract({
+    hre,
+    contract: new hre.ethers.Contract(
+      artifact.address,
+      artifact.abi,
+      hre.ethers.provider
+    ),
+  })
+
+  // Impersonate the owner of the AddressManager
+  console.log(`Impersonating owner account...`)
+  const owner = await Lib_AddressManager.owner()
+  await hre.ethers.provider.send('hardhat_impersonateAccount', [owner])
+
+  console.log(`Started impersonating ${owner}`)
+  console.log(`Setting AddressManager owner to ${deployer}`)
+  const signer = await hre.ethers.getSigner(owner)
+  await Lib_AddressManager.connect(signer).transferOwnership(deployer)
+
+  console.log(`Waiting for owner to be correctly set...`)
+  await waitUntilTrue(async () => {
+    return (await Lib_AddressManager.owner()) === deployer
+  })
+
+  console.log(`Disabling impersonation...`)
+  await hre.ethers.provider.send('hardhat_stopImpersonatingAccount', [owner])
+}
+
+deployFn.tags = ['hardhat', 'upgrade']
+
+export default deployFn

--- a/packages/contracts/tasks/deploy.ts
+++ b/packages/contracts/tasks/deploy.ts
@@ -72,6 +72,12 @@ task('deploy')
     DEFAULT_DEPLOY_CONFIRMATIONS,
     types.int
   )
+  .addOptionalParam(
+    'forked',
+    'Enable this when using a forked network (use "true")',
+    undefined,
+    types.string
+  )
   .setAction(async (args, hre: any, runSuper) => {
     // Necessary because hardhat doesn't let us attach non-optional parameters to existing tasks.
     const validateAddressArg = (argName: string) => {


### PR DESCRIPTION
**Description**

It can be used with the command:

```
$ npx hardhat deploy --tags hardhat --network fork --fork-network kovan
```

A new parameter `--fork-network` is added which specifies the network
that is being forked. We cannot use the actual network due to it
checking the `.chainId` file in the `deployments/xxx/` directory
and comparing that against the remote network.

It is hidden behind the `hardhat` tag and only runs if the deploy config
has the network set to `fork` with `--network fork`. It is up to the
user to configure `hardhat node` with the correct fork url.

This should be used with the env vars:
```
CONTRACTS_TARGET_NETWORK=fork
CONTRACTS_DEPLOYER_KEY=0x...
CONTRACTS_RPC_URL=<url of forked network>
```

This must run first and I didn't want to rename all of the files,
so I named it with the prefix `0000`.


**Metadata**
- Fixes ENG-1576
