### PR TITLE
batch-submitter: add `VALIDATE_TX_BATCH` config

### DIFF
--- a/.changeset/empty-suits-rest.md
+++ b/.changeset/empty-suits-rest.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Add `VALIDATE_TX_BATCH` config option that can disable batch validation

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -72,6 +72,7 @@ interface RequiredEnvVars {
  * SEQUENCER_HD_PATH
  * PROPOSER_HD_PATH
  * BLOCK_OFFSET
+ * VALIDATE_TX_BATCH
  * USE_HARDHAT
  * DEBUG_IMPERSONATE_SEQUENCER_ADDRESS
  * DEBUG_IMPERSONATE_PROPOSER_ADDRESS
@@ -244,6 +245,11 @@ export const run = async () => {
     env.PROPOSER_HD_PATH || env.HD_PATH
   )
 
+  const VALIDATE_TX_BATCH = config.bool(
+    'validate-tx-batch',
+    env.VALIDATE_TX_BATCH ? !!env.VALIDATE_TX_BATCH : true
+  )
+
   // Auto fix batch options -- TODO: Remove this very hacky config
   const AUTO_FIX_BATCH_OPTIONS_CONF = config.str(
     'auto-fix-batch-conf',
@@ -387,6 +393,7 @@ export const run = async () => {
     GAS_THRESHOLD_IN_GWEI,
     txBatchTxSubmitter,
     BLOCK_OFFSET,
+    VALIDATE_TX_BATCH,
     logger.child({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
     metrics,
     autoFixBatchOptions

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -242,6 +242,7 @@ describe('BatchSubmitter', () => {
       GAS_THRESHOLD_IN_GWEI,
       txBatchTxSubmitter,
       1,
+      false,
       new Logger({ name: TX_BATCH_SUBMITTER_LOG_TAG }),
       testMetrics
     )


### PR DESCRIPTION
**Description**

Add a new config option to the batch submitter that can enable
or disable the transaction batch validation. This can be configured
using `VALIDATE_TX_BATCH` or `BATCH_SUBMITTER_VALIDATE_TX_BATCH`
or `--validate-tx-batch`. It defaults to true.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes ENG-1567