### PR TITLE
fix: errors in mainnet trial deploy script

### DIFF
--- a/packages/contracts/scripts/deploy-scripts/mainnet-trial.sh
+++ b/packages/contracts/scripts/deploy-scripts/mainnet-trial.sh
@@ -1,29 +1,5 @@
 #!/bin/bash
 
-# ### All available deploy options at the time of deployment: ###
-# --ctc-enqueue-gas-cost         	Max gas limit for L1 queue transactions. (default: 60000)
-# --ctc-l2-gas-discount-divisor  	Max gas limit for L1 queue transactions. (default: 32)
-# --ctc-max-transaction-gas-limit	Max gas limit for L1 queue transactions. (default: 11000000)
-# --deploy-scripts               	override deploy script folder path
-# --export                       	export current network deployments
-# --export-all                   	export all deployments into one file
-# --gasprice                     	gas price to use for transactions
-# --l1-block-time-seconds        	Number of seconds on average between every L1 block. (default: 15)
-# --no-compile                   	disable pre compilation
-# --no-impersonation             	do not impersonate unknown accounts
-# --num-deploy-confirmations     	Number of confirmations to wait for each transaction in the deployment. More is safer. (default: 12)
-# --ovm-address-manager-owner    	Address that will own the Lib_AddressManager. Must be provided or this deployment will fail.
-# --ovm-proposer-address         	Address of the account that will propose state roots. Must be provided or this deployment will fail.
-# --ovm-sequencer-address        	Address of the sequencer. Must be provided or this deployment will fail.
-# --reset                        	whether to delete deployments files first
-# --scc-fraud-proof-window       	Number of seconds until a transaction is considered finalized. (default: 604800)
-# --scc-sequencer-publish-window 	Number of seconds that the sequencer is exclusively allowed to post state roots. (default: 1800)
-# --silent                       	whether to remove log
-# --tags                         	specify which deploy script to execute via tags, separated by commas
-# --watch                        	redeploy on every change of contract or deploy script
-# --write                        	whether to write deployments to file
-
-
 ### DEPLOYMENT SCRIPT ###
 # To be called from root of contracts dir #
 
@@ -43,15 +19,17 @@ fi
 
 CONTRACTS_TARGET_NETWORK=mainnet-trial \
 npx hardhat deploy \
- --ctc-max-transaction-gas-limit 15000000 \
- --ctc-enqueue-gas-cost 60000 \
- --ctc-l2-gas-discount-divisor 32 \
- --l1-block-time-seconds 15 \
- --ovm-address-manager-owner 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A \
- --ovm-sequencer-address 0xB79f76EF2c5F0286176833E7B2eEe103b1CC3244 \
- --ovm-proposer-address 0x9A2F243c605e6908D96b18e21Fb82Bf288B19EF3 \
- --scc-fraud-proof-window 10 \
- --scc-sequencer-publish-window 12592000 \
- --network mainnet-trial \
- --gasprice 100 \
- --tags upgrade
+  --ctc-max-transaction-gas-limit 15000000 \
+  --ctc-enqueue-gas-cost 60000 \
+  --ctc-l2-gas-discount-divisor 32 \
+  --l1-block-time-seconds 15 \
+  --ovm-address-manager-owner 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A \
+  --ovm-sequencer-address 0xB79f76EF2c5F0286176833E7B2eEe103b1CC3244 \
+  --ovm-proposer-address 0x9A2F243c605e6908D96b18e21Fb82Bf288B19EF3 \
+  --scc-fraud-proof-window 10 \
+  --scc-sequencer-publish-window 12592000 \
+  --network mainnet-trial \
+  --gasprice 2000000000000 \
+  --forked true \
+  --num-deploy-confirmations 0 \
+  --tags upgrade


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR fixes three key issues with the `mainnet-trial.sh` script:
1. Set `--gasprice` to an acceptable value.
2. Added the `--forked` flag.
3. Set the number of deploy confirmations to 0.

I also cleaned up the `mainnet-trial.sh` file a bit by removing the unnecessary comments at the top and fixing some whitespace issues.