### PR TITLE
batch-submitter: default tx batch validation to false

### DIFF
--- a/.changeset/curvy-mirrors-heal.md
+++ b/.changeset/curvy-mirrors-heal.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Default tx batch validation to false

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -82,6 +82,11 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     this.autoFixBatchOptions = autoFixBatchOptions
     this.gasThresholdInGwei = gasThresholdInGwei
     this.transactionSubmitter = transactionSubmitter
+
+    this.logger.info('Batch validation options', {
+      autoFixBatchOptions,
+      validateBatch
+    })
   }
 
   /*****************************
@@ -267,6 +272,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     // modify the batch unless an autoFixBatchOption is set
     batch = await this._fixBatch(batch)
     if (this.validateBatch) {
+      this.logger.info('Validating batch')
       if (!(await this._validateBatch(batch))) {
         this.metrics.malformedBatches.inc()
         return
@@ -562,12 +568,15 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     // NOTE: It is unsafe to combine multiple autoFix options.
     // If you must combine them, manually verify the output before proceeding.
     if (this.autoFixBatchOptions.fixDoublePlayedDeposits) {
+      this.logger.info('Fixing double played deposits')
       batch = await fixDoublePlayedDeposits(batch)
     }
     if (this.autoFixBatchOptions.fixMonotonicity) {
+      this.logger.info('Fixing monotonicity')
       batch = await fixMonotonicity(batch)
     }
     if (this.autoFixBatchOptions.fixSkippedDeposits) {
+      this.logger.info('Fixing skipped deposits')
       batch = await fixSkippedDeposits(batch)
     }
     return batch

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -247,7 +247,7 @@ export const run = async () => {
 
   const VALIDATE_TX_BATCH = config.bool(
     'validate-tx-batch',
-    env.VALIDATE_TX_BATCH ? !!env.VALIDATE_TX_BATCH : true
+    env.VALIDATE_TX_BATCH ? env.VALIDATE_TX_BATCH === 'true' : false
   )
 
   // Auto fix batch options -- TODO: Remove this very hacky config


### PR DESCRIPTION
**Description**

Update the batch validation config parsing so
that the tx batch validation is false by default.
This means that to enable transaction batch validation,
the env var `VALIDATE_TX_BATCH` must be explicitly set
to `true`. If it is not set, then it will default to false.
The logic is shown below for the implementation.

```js
> '' ? '' === 'true' : false
false
> 'false' ? 'false' === 'true' : false
false
> 'true' ? 'true' === 'true' : false
true
```



