### PR TITLE
ci: publish canary builder with proper tag

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -175,7 +175,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.monorepo
           push: true
-          tags: ethereumoptimism/builder:${{ needs.builder.outputs.canary-docker-tag }}
+          tags: ethereumoptimism/builder:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   message-relayer:
     name: Publish Message Relayer Version ${{ needs.builder.outputs.canary-docker-tag }}


### PR DESCRIPTION
**Description**

Previously, the builder would not be published with
a tag, meaning that any time that the canary build
was triggered, it would publish `ethereumoptimism/builder:latest`.
This clobbers the release from `master` which may have downstream
effects.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
