### PR TITLE
feat: move surgery solc cache to disk

### DIFF
--- a/packages/regenesis-surgery/.eslintrc.js
+++ b/packages/regenesis-surgery/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   extends: '../../.eslintrc.js',
-  ignorePatterns: ['/data', '/solc-bin'],
+  ignorePatterns: ['/data', '/solc-bin', '/solc-cache'],
 }

--- a/packages/regenesis-surgery/.gitignore
+++ b/packages/regenesis-surgery/.gitignore
@@ -5,3 +5,4 @@ outputs/
 etherscan/
 state-dumps/
 data/
+solc-cache/

--- a/packages/regenesis-surgery/scripts/constants.ts
+++ b/packages/regenesis-surgery/scripts/constants.ts
@@ -146,3 +146,15 @@ export const SOLC_BIN_PATH = 'https://binaries.soliditylang.org'
 export const EMSCRIPTEN_BUILD_PATH = `${SOLC_BIN_PATH}/emscripten-wasm32`
 export const EMSCRIPTEN_BUILD_LIST = `${EMSCRIPTEN_BUILD_PATH}/list.json`
 export const LOCAL_SOLC_DIR = path.join(__dirname, '..', 'solc-bin')
+export const EVM_SOLC_CACHE_DIR = path.join(
+  __dirname,
+  '..',
+  'solc-cache',
+  'evm'
+)
+export const OVM_SOLC_CACHE_DIR = path.join(
+  __dirname,
+  '..',
+  'solc-cache',
+  'ovm'
+)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Moves the solc cache in the `regenesis-surgery` script to disk so we can take advantage of the cache over multiple runs of the surgery script. Speeds up surgery by >2x. (~2000s => 800s).
