### PR TITLE
ci: fix `hardhat-node` docker publish

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -165,7 +165,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./ops/docker/hardhat
-          file: ./Dockerfile
+          file: ./ops/docker/hardhat/Dockerfile
           push: true
           tags: ethereumoptimism/hardhat-node:${{ needs.canary-publish.outputs.canary-docker-tag }}
 


### PR DESCRIPTION
**Description**

There was a bug in the config, the `file`
was not relative to the `context`

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

