### PR TITLE
l2geth: fix for `gas-oracle` race condition

### DIFF
--- a/.changeset/chilly-wasps-divide.md
+++ b/.changeset/chilly-wasps-divide.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Handle policy/consensus race condition for balance check

--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -185,7 +185,15 @@ func (st *StateTransition) buyGas() error {
 		}
 	}
 	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
-		return errInsufficientBalanceForGas
+		if rcfg.UsingOVM {
+			// Hack to prevent race conditions with the `gas-oracle`
+			// where policy level balance checks pass and then fail
+			// during consensus. The user gets some free gas
+			// in this case.
+			mgval = st.state.GetBalance(st.msg.From())
+		} else {
+			return errInsufficientBalanceForGas
+		}
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
 		return err


### PR DESCRIPTION
**Description**

Prevent the error being returned in consensus for when
the user does not have enough balance. The policy level
check *must* filter out transactions that do not have
enough gas to pay for their execution. The policy
level check happens in the `SyncService`. This change
gracefully handles the race condition where a user transaction
passes the policy level check as a `gas-oracle` transaction
is executing and updating the gas prices. If the gas price
goes up and the user transaction no longer can afford execution,
then it will return an error from consensus.

Closes https://github.com/ethereum-optimism/optimism/issues/1631

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

