### PR TITLE
dtl: config for starting L1 block number

### DIFF
--- a/.changeset/tough-coins-poke.md
+++ b/.changeset/tough-coins-poke.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add config for L1 start height to allow for syncing specifically after a regenesis. Using the auto detect method will not work with the regenesis scheme of using the same AddressManager

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -35,6 +35,7 @@ export interface L1DataTransportServiceOptions {
   sentryTraceRate?: number
   defaultBackend: string
   l1GasPriceBackend: string
+  l1StartHeight?: number
 }
 
 const optionSettings = {

--- a/packages/data-transport-layer/src/services/run.ts
+++ b/packages/data-transport-layer/src/services/run.ts
@@ -47,6 +47,7 @@ type ethNetwork = 'mainnet' | 'kovan' | 'goerli'
       ),
       defaultBackend: config.str('default-backend', 'l1'),
       l1GasPriceBackend: config.str('l1-gas-price-backend', 'l1'),
+      l1StartHeight: config.uint('l1-start-height'),
       useSentry: config.bool('use-sentry', false),
       sentryDsn: config.str('sentry-dsn'),
       sentryTraceRate: config.ufloat('sentry-trace-rate', 0.05),


### PR DESCRIPTION
**Description**

Adds the config option `DATA_TRANSPORT_LAYER_STARTING_L1_BLOCK_NUMBER`
or `--starting-l1-blocknumber` that allows for the user to specify
the L1 blocknumber to begin syncing from. This prevents users from
syncing old batches from a previous regenesis.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
