### PR TITLE
l2geth: cleanup `time.Ticker`s in `SyncService`

### DIFF
--- a/.changeset/big-files-smoke.md
+++ b/.changeset/big-files-smoke.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Cleanup `time.Ticker`s

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -359,6 +359,7 @@ func (s *SyncService) Stop() error {
 func (s *SyncService) VerifierLoop() {
 	log.Info("Starting Verifier Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	t := time.NewTicker(s.pollInterval)
+	defer t.Stop()
 	for ; true; <-t.C {
 		if err := s.verify(); err != nil {
 			log.Error("Could not verify", "error", err)
@@ -387,6 +388,7 @@ func (s *SyncService) verify() error {
 func (s *SyncService) SequencerLoop() {
 	log.Info("Starting Sequencer Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	t := time.NewTicker(s.pollInterval)
+	defer t.Stop()
 	for ; true; <-t.C {
 		s.txLock.Lock()
 		if err := s.sequence(); err != nil {


### PR DESCRIPTION
**Description**

Simply clean up the `time.Ticker`s using `defer t.Close()`.
Not having this code should not cause any problems, but
it is best practice to close the tickers as not doing so
can result in memory leaks in certain cases.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

