### PR TITLE
workflows: fix build-args syntax

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -340,9 +340,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ethereumoptimism/proxyd:${{ needs.canary-publish.outputs.proxyd }}
-          build-args:
-            - GITCOMMIT=$GITHUB_SHA
-            - GITDATE=$GITDATE
+          build-args: |
+             GITCOMMIT=$GITHUB_SHA
+             GITDATE=$GITDATE
 
   rpc-proxy:
     name: Publish rpc-proxy Version ${{ needs.canary-publish.outputs.canary-docker-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,9 +358,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ethereumoptimism/proxyd:${{ needs.canary-publish.outputs.proxyd }}
-          build-args:
-            - GITCOMMIT=$GITHUB_SHA
-            - GITDATE=$GITDATE
+          build-args: |
+            GITCOMMIT=$GITHUB_SHA
+            GITDATE=$GITDATE
 
   rpc-proxy:
     name: Publish rpc-proxy Version ${{ needs.release.outputs.rpc-proxy }}


### PR DESCRIPTION
**Description**

The docs specify that `build-args` for the Github action
`docker/build-push-action@v2` should be a list, but
doing so results in an error:

`The workflow is not valid. .github/workflows/release.yml (Line: 362,
Col: 13): A sequence was not expected`

This updates the syntax to copy the example here:
https://github.com/docker/build-push-action/blob/3c507bedc4de3249e107413a7358ae1af558fd79/UPGRADE.md#L68

Uncertain if the env var parsing will work with this syntax

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

