### PR TITLE
fix: ci publish proxy

### DIFF
--- a/.changeset/blue-games-remember.md
+++ b/.changeset/blue-games-remember.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/proxyd': patch
+'@eth-optimism/rpc-proxy': patch
+---
+
+Trigger patch releases for dockerhub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,69 @@ jobs:
           push: true
           tags: ethereumoptimism/gas-oracle:${{ needs.release.outputs.gas-oracle }},ethereumoptimism/gas-oracle:latest
 
+  proxyd:
+    name: Publish proxyd Version ${{ needs.release.outputs.proxyd }}
+    needs: release
+    if: needs.release.outputs.proxyd != ''
+    runs-on: ubuntu:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set env
+        run: |
+          echo "GITDATE=$(date)" >> $GITHUB_ENV"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./go/proxyd
+          file: ./Dockerfile
+          push: true
+          tags: ethereumoptimism/proxyd:${{ needs.release.outputs.proxyd }},ethereumoptimism/proxyd:latest
+          build-args: |
+            GITCOMMIT=$GITHUB_SHA
+            GITDATE=$GITDATE
+
+  rpc-proxy:
+    name: Publish rpc-proxy Version ${{ needs.release.outputs.rpc-proxy }}
+    needs: release
+    if: needs.release.outputs.rpc-proxy != ''
+    runs-on: ubuntu:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set env
+        run: |
+          echo "GITDATE=$(date)" >> $GITHUB_ENV"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.rpc-proxy
+          push: true
+          tags: ethereumoptimism/rpc-proxy:${{ needs.release.outputs.rpc-proxy }},ethereumoptimism/rpc-proxy:latest
+
   # pushes the base builder image to dockerhub
   builder:
     name: Prepare the base builder image for the services
@@ -328,66 +391,3 @@ jobs:
           file: ./ops/docker/Dockerfile.replica-healthcheck
           push: true
           tags: ethereumoptimism/replica-healthcheck:${{ needs.builder.outputs.replica-healthcheck }},ethereumoptimism/replica-healthcheck:latest
-
-  proxyd:
-    name: Publish proxyd Version ${{ needs.release.outputs.proxyd }}
-    needs: release
-    if: needs.release.outputs.proxyd != ''
-    runs-on: ubuntu:latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
-
-      - name: Set env
-        run: |
-          echo "GITDATE=$(date)" >> $GITHUB_ENV"
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: ./go/proxyd
-          file: ./Dockerfile
-          push: true
-          tags: ethereumoptimism/proxyd:${{ needs.canary-publish.outputs.proxyd }}
-          build-args: |
-            GITCOMMIT=$GITHUB_SHA
-            GITDATE=$GITDATE
-
-  rpc-proxy:
-    name: Publish rpc-proxy Version ${{ needs.release.outputs.rpc-proxy }}
-    needs: release
-    if: needs.release.outputs.rpc-proxy != ''
-    runs-on: ubuntu:latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
-
-      - name: Set env
-        run: |
-          echo "GITDATE=$(date)" >> $GITHUB_ENV"
-
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./ops/docker/Dockerfile.rpc-proxy
-          push: true
-          tags: ethereumoptimism/rpc-proxy:${{ needs.canary-publish.outputs.rpc-proxy }}

--- a/ops/scripts/ci-versions.js
+++ b/ops/scripts/ci-versions.js
@@ -12,6 +12,8 @@ data = JSON.parse(data)
 const nonBuilders = new Set([
   'l2geth',
   'gas-oracle',
+  'proxyd',
+  'rpc-proxy',
 ])
 
 builder = false


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The variables used in the canary release were used in the actual
release, causing it to not have the correct variables in place.
This caused the CI to skip the steps for publishing the `rpc-proxy`
and `proxyd`. This commit should fix the problem.

Add changesets for rpc-proxy and proxyd. Just a patch changeset to trigger
releases as a bug prevented releases previously.

