### PR TITLE
add OwnerUpdated and CodeUpdated events

### DIFF
--- a/.changeset/eighty-toys-build.md
+++ b/.changeset/eighty-toys-build.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+added OwnerUpdated and CodeUpdated events to L1ChugSplashProxy

--- a/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
+++ b/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
@@ -16,6 +16,14 @@ import { iL1ChugSplashDeployer } from "./interfaces/iL1ChugSplashDeployer.sol";
  */
 contract L1ChugSplashProxy {
     /*************
+     * Events *
+     *************/
+
+    event OwnerUpdated(address indexed owner);
+
+    event CodeUpdated(address indexed implementation);
+
+    /*************
      * Constants *
      *************/
 
@@ -145,6 +153,7 @@ contract L1ChugSplashProxy {
         );
 
         _setImplementation(newImplementation);
+        emit CodeUpdated(newImplementation);
     }
 
     /**
@@ -165,6 +174,7 @@ contract L1ChugSplashProxy {
      */
     function setOwner(address _owner) public proxyCallIfNotOwner {
         _setOwner(_owner);
+        emit OwnerUpdated(_owner);
     }
 
     /**


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
- added `CodeUpdated` and `OwnerUpdated` events

**Additional context**
It could be nice for easily tracking implementation and/or owner changes. I did not add a `StorageUpdated` event as I imagined that it could be noisy (assumption being that frequency of implementation and/or owner changes is << frequency of storage changes).


**Metadata**
