### PR TITLE
fix(contracts): Add coverage to yarn clean and ignore when linting or formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     browser: true,
     es6: true,
   },
-  ignorePatterns: ['dist', 'packages/contracts/hardhat'],
+  ignorePatterns: ['dist', 'coverage', 'packages/contracts/hardhat'],
   extends: ['plugin:prettier/recommended'],
   parser: 'babel-eslint',
   parserOptions: {

--- a/packages/contracts/.prettierignore
+++ b/packages/contracts/.prettierignore
@@ -1,3 +1,4 @@
 # WETH9 is a standard we should not modify it.
 contracts/L2/predeploys/WETH9.sol
 contracts/L2/predeploys/IWETH9.sol
+coverage

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -37,7 +37,7 @@
     "lint:contracts:fix": "yarn prettier --write 'contracts/**/*.sol'",
     "lint:fix": "yarn lint:contracts:fix && yarn lint:ts:fix",
     "lint": "yarn lint:fix && yarn lint:check",
-    "clean": "rm -rf ./dist ./artifacts ./cache ./tsconfig.build.tsbuildinfo",
+    "clean": "rm -rf ./dist ./artifacts ./cache ./coverage ./tsconfig.build.tsbuildinfo",
     "deploy": "ts-node bin/deploy.ts && yarn autogen:markdown",
     "prepublishOnly": "yarn copyfiles -u 1 -e \"**/test-*/**/*\" \"contracts/**/*\" ./",
     "postpublish": "rimraf chugsplash L1 L2 libraries standards",


### PR DESCRIPTION
**Description**

After running `yarn test:coverage` locally, `yarn lint` and `git commit` will fail due to errors raised by eslint.

This PR ensures that test coverage output is ignored during linting and formatting, and is removed by the `yarn clean` script.