### PR TITLE
fix: solc import to avoid annoying crashes

### DIFF
--- a/packages/regenesis-surgery/scripts/solc.ts
+++ b/packages/regenesis-surgery/scripts/solc.ts
@@ -2,9 +2,9 @@
 import fetch from 'node-fetch'
 import path from 'path'
 import fs from 'fs'
-import solc from 'solc'
 import { ethers } from 'ethers'
 import { clone } from '@eth-optimism/core-utils'
+import { setupMethods } from 'solc/wrapper'
 import {
   COMPILER_VERSIONS_TO_SOLC,
   EMSCRIPTEN_BUILD_LIST,
@@ -116,7 +116,7 @@ export const getMainContract = (contract: EtherscanContract, output) => {
 }
 
 export const getSolc = (version: string, ovm?: boolean) => {
-  return solc.setupMethods(
+  return setupMethods(
     require(path.join(
       LOCAL_SOLC_DIR,
       ovm ? version : `solc-emscripten-wasm32-${version}.js`


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Import `setupMethods` from `solc/wrapper` to avoid indirectly `require`ing `soljson.js`, which throws this massive ridiculous error whenever an unhandled promise rejection is thrown because the file is minified and it's dumb.