### PR TITLE
feat: add extra rubicon weth transfer addresses

### DIFF
--- a/packages/regenesis-surgery/scripts/constants.ts
+++ b/packages/regenesis-surgery/scripts/constants.ts
@@ -114,6 +114,12 @@ export const WETH_TRANSFER_ADDRESSES = [
   '0xF6A47B24e80D12Ac7d3b5Cef67B912BCd3377333',
   // Rubicon Mainnet exchange
   '0x7a512d3609211e719737E82c7bb7271eC05Da70d',
+  // Rubicon Mainnet bathUSDC
+  '0xe0e112e8f33d3f437D1F895cbb1A456836125952',
+  // Rubicon Mainnet bathDAI
+  '0x60daEC2Fc9d2e0de0577A5C708BcaDBA1458A833',
+  // Rubicon Mainnet bathUSDT
+  '0xfFBD695bf246c514110f5DAe3Fa88B8c2f42c411',
   // Rubicon Kovan bathETH
   '0x5790AedddfB25663f7dd58261De8E96274A82BAd',
   // Rubicon Kovan bathETH-USDC


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Add Rubicon contracts that require WETH


**Additional context**
bathUSDC https://optimistic.etherscan.io/address/0xe0e112e8f33d3f437d1f895cbb1a456836125952
bathDAI https://optimistic.etherscan.io/address/0x60daec2fc9d2e0de0577a5c708bcadba1458a833
bathUSDT https://optimistic.etherscan.io/address/0xffbd695bf246c514110f5dae3fa88b8c2f42c411

**Metadata**
- Fixes ENG-1634
