### PR TITLE
Update proxyd github actions

### DIFF
--- a/.changeset/sixty-countries-know.md
+++ b/.changeset/sixty-countries-know.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+Canary release

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -23,8 +23,8 @@ jobs:
       contracts: ${{ steps.packages.outputs.contracts }}
       replica-healthcheck: ${{ steps.packages.outputs.replica-healthcheck }}
       canary-docker-tag: ${{ steps.docker-image-name.outputs.canary-docker-tag }}
-      proxyd: ${{ steps.canary-publish.outputs.proxyd }}
-      rpc-proxy : ${{ steps.canary-publish.outputs.rpc-proxy }}
+      proxyd: ${{ steps.packages.outputs.proxyd }}
+      rpc-proxy : ${{ steps.packages.outputs.rpc-proxy }}
 
     steps:
       - name: Check out source code
@@ -315,7 +315,7 @@ jobs:
     name: Publish proxyd Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
     needs: canary-publish
     if: needs.canary-publish.outputs.proxyd != ''
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -329,26 +329,30 @@ jobs:
           username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
 
-      - name: Set env
+      - name: Set build args
+        id: build_args
         run: |
-          echo "GITDATE=$(date)" >> $GITHUB_ENV"
+          echo ::set-output name=GITDATE::"$(date +%d-%m-%Y)"
+          echo ::set-output name=GITVERSION::$(jq -r .version ./go/proxyd/package.json)
+          echo ::set-output name=GITCOMMIT::"$GITHUB_SHA"
 
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: ./go/proxyd
-          file: ./Dockerfile
+          context: .
+          file: ./go/proxyd/Dockerfile
           push: true
           tags: ethereumoptimism/proxyd:${{ needs.canary-publish.outputs.proxyd }}
           build-args: |
-             GITCOMMIT=$GITHUB_SHA
-             GITDATE=$GITDATE
+            GITDATE=${{ steps.build_args.outputs.GITDATE }}
+            GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}
+            GITVERSION=${{ steps.build_args.outputs.GITVERSION }}
 
   rpc-proxy:
     name: Publish rpc-proxy Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
     needs: canary-publish
     if: needs.canary-publish.outputs.rpc-proxy != ''
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/go/proxyd/Dockerfile
+++ b/go/proxyd/Dockerfile
@@ -1,27 +1,21 @@
-FROM golang:1.17.2-alpine3.14 AS builder
+FROM golang:1.17.2-alpine3.13 AS builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
 ARG GITVERSION=docker
 
-RUN apk add make jq && \
-    mkdir -p /app
+RUN apk add make jq git
 
 WORKDIR /app
-COPY go.mod /app
-COPY go.sum /app
-COPY cmd /app/cmd
-COPY *.go /app/
-COPY package.json /app
-COPY Makefile /app
+COPY ./go/proxyd /app
 
-RUN make proxyd GITCOMMIT=$GITCOMMIT GITDATE=$GITDATE
+RUN make proxyd
 
 FROM alpine:3.14.2
 
 EXPOSE 8080
 
-VOLUME /etc/proxyd.toml
+VOLUME /etc/proxyd
 
 COPY --from=builder /app/bin/proxyd /bin/proxyd
-CMD ["/bin/proxyd", "/etc/proxyd.toml"]
+CMD ["/bin/proxyd", "/etc/proxyd/proxyd.toml"]

--- a/go/proxyd/Makefile
+++ b/go/proxyd/Makefile
@@ -1,7 +1,3 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
-GITVERSION := $(shell cat package.json | jq .version)
-
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
 LDFLAGSSTRING +=-X main.GitVersion=$(GITVERSION)


### PR DESCRIPTION

- Update canary to build proxyd and rpc-proxy
- fixed "runs-on" value
- fixing env step
- Update docker build context
- Alpine 3.14 doesn't play nice with make
- populate version information with Docker
```
$ docker run --rm  ethereumoptimism/proxyd:0.0.0-2021104132020
INFO [11-04|13:29:38.383] starting proxyd                          version=1.0.2 commit=53bf93ef2d041c65ac5f5db9022fe411fcb80066 date=04-11-2021
CRIT [11-04|13:29:38.383] error reading config file                err="open /etc/proxyd/proxyd.toml: no such file or directory"
```