### PR TITLE
l2geth: set latest queue index and index after tx applied

### DIFF
--- a/.changeset/chilled-pugs-rule.md
+++ b/.changeset/chilled-pugs-rule.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Set the latest queue index and index after the tx has been applied to the chain


### PR DESCRIPTION
**Description**
Repair the latest known queue index on startup to prevent
skipped deposits

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

