### PR TITLE
pkgs: add http headers to ethers providers

### DIFF
--- a/.changeset/five-penguins-protect.md
+++ b/.changeset/five-penguins-protect.md
@@ -1,0 +1,10 @@
+---
+'@eth-optimism/builder': patch
+'@eth-optimism/batch-submitter': patch
+'@eth-optimism/core-utils': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/message-relayer': patch
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Add 'User-Agent' to the http headers for ethers providers

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -139,9 +139,10 @@ export const run = async () => {
   )
 
   const getSequencerSigner = async (): Promise<Signer> => {
-    const l1Provider = new StaticJsonRpcProvider(
-      requiredEnvVars.L1_NODE_WEB3_URL
-    )
+    const l1Provider = new StaticJsonRpcProvider({
+      url: requiredEnvVars.L1_NODE_WEB3_URL,
+      headers: { 'User-Agent': 'batch-submitter' },
+    })
 
     if (useHardhat) {
       if (!DEBUG_IMPERSONATE_SEQUENCER_ADDRESS) {
@@ -166,9 +167,10 @@ export const run = async () => {
   }
 
   const getProposerSigner = async (): Promise<Signer> => {
-    const l1Provider = new StaticJsonRpcProvider(
-      requiredEnvVars.L1_NODE_WEB3_URL
-    )
+    const l1Provider = new StaticJsonRpcProvider({
+      url: requiredEnvVars.L1_NODE_WEB3_URL,
+      headers: { 'User-Agent': 'batch-submitter' },
+    })
 
     if (useHardhat) {
       if (!DEBUG_IMPERSONATE_PROPOSER_ADDRESS) {
@@ -204,10 +206,6 @@ export const run = async () => {
   const MIN_GAS_PRICE_IN_GWEI = config.uint(
     'min-gas-price-in-gwei',
     parseInt(env.MIN_GAS_PRICE_IN_GWEI, 10) || 0
-  )
-  const MAX_GAS_PRICE_IN_GWEI = config.uint(
-    'max-gas-price-in-gwei',
-    parseInt(env.MAX_GAS_PRICE_IN_GWEI, 10) || 70
   )
   const GAS_RETRY_INCREMENT = config.uint(
     'gas-retry-increment',
@@ -348,7 +346,10 @@ export const run = async () => {
   const clearPendingTxs = requiredEnvVars.CLEAR_PENDING_TXS
 
   const l2Provider = injectL2Context(
-    new StaticJsonRpcProvider(requiredEnvVars.L2_NODE_WEB3_URL)
+    new StaticJsonRpcProvider({
+      url: requiredEnvVars.L2_NODE_WEB3_URL,
+      headers: { 'User-Agent': 'batch-submitter' },
+    })
   )
 
   const sequencerSigner: Signer = await getSequencerSigner()

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -48,6 +48,7 @@
     "@ethersproject/abstract-provider": "^5.4.1",
     "@ethersproject/bytes": "^5.5.0",
     "@ethersproject/providers": "^5.4.5",
+    "@ethersproject/web": "^5.5.0",
     "chai": "^4.3.4",
     "ethers": "^5.4.5",
     "lodash": "^4.17.21"

--- a/packages/core-utils/src/provider.ts
+++ b/packages/core-utils/src/provider.ts
@@ -4,6 +4,11 @@
 
 import { ethers } from 'ethers'
 import { Provider } from '@ethersproject/providers'
+import { ConnectionInfo } from '@ethersproject/web'
+
+export interface HttpHeaders {
+  [key: string]: string
+}
 
 // Copied from @ethersproject/providers since it is not
 // currently exported
@@ -24,17 +29,26 @@ export interface FallbackProviderConfig {
   weight?: number
 }
 
-export const FallbackProvider = (config: string | FallbackProviderConfig[]) => {
+export const FallbackProvider = (
+  config: string | FallbackProviderConfig[],
+  headers?: HttpHeaders
+) => {
   const configs = []
+  // Handle the case of a string of comma delimited urls
   if (typeof config === 'string') {
     const urls = config.split(',')
     for (const [i, url] of urls.entries()) {
+      const connectionInfo: ConnectionInfo = { url }
+      if (typeof headers === 'object') {
+        connectionInfo.headers = headers
+      }
       configs.push({
         priority: i,
-        provider: new ethers.providers.StaticJsonRpcProvider(url),
+        provider: new ethers.providers.StaticJsonRpcProvider(connectionInfo),
       })
     }
     return new ethers.providers.FallbackProvider(configs)
   }
+
   return new ethers.providers.FallbackProvider(config)
 }

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -1,9 +1,9 @@
 /* Imports: External */
 import { fromHexString, FallbackProvider } from '@eth-optimism/core-utils'
 import { BaseService, Metrics } from '@eth-optimism/common-ts'
-import { StaticJsonRpcProvider, BaseProvider } from '@ethersproject/providers'
+import {  BaseProvider } from '@ethersproject/providers'
 import { LevelUp } from 'levelup'
-import { ethers, constants } from 'ethers'
+import { constants } from 'ethers'
 import { Gauge, Counter } from 'prom-client'
 
 /* Imports: Internal */
@@ -20,7 +20,7 @@ import { handleEventsTransactionEnqueued } from './handlers/transaction-enqueued
 import { handleEventsSequencerBatchAppended } from './handlers/sequencer-batch-appended'
 import { handleEventsStateBatchAppended } from './handlers/state-batch-appended'
 import { L1DataTransportServiceOptions } from '../main/service'
-import { MissingElementError, EventName } from './handlers/errors'
+import { MissingElementError } from './handlers/errors'
 
 interface L1IngestionMetrics {
   highestSyncedL1Block: Gauge<string>
@@ -108,7 +108,9 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
     this.l1IngestionMetrics = registerMetrics(this.metrics)
 
     if (typeof this.options.l1RpcProvider === 'string') {
-      this.state.l1RpcProvider = FallbackProvider(this.options.l1RpcProvider)
+      this.state.l1RpcProvider = FallbackProvider(this.options.l1RpcProvider, {
+        'User-Agent': 'data-transport-layer',
+      })
     } else {
       this.state.l1RpcProvider = this.options.l1RpcProvider
     }

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -88,7 +88,10 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
 
     this.state.l2RpcProvider =
       typeof this.options.l2RpcProvider === 'string'
-        ? new StaticJsonRpcProvider(this.options.l2RpcProvider)
+        ? new StaticJsonRpcProvider({
+          url: this.options.l2RpcProvider,
+          headers: { 'User-Agent': 'data-transport-layer' },
+        })
         : this.options.l2RpcProvider
   }
 

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -81,8 +81,14 @@ const main = async () => {
     throw new Error('Must pass L2_NODE_WEB3_URL')
   }
 
-  const l2Provider = new providers.StaticJsonRpcProvider(L2_NODE_WEB3_URL)
-  const l1Provider = new providers.StaticJsonRpcProvider(L1_NODE_WEB3_URL)
+  const l2Provider = new providers.StaticJsonRpcProvider({
+    url: L2_NODE_WEB3_URL,
+    headers: { 'User-Agent': 'message-relayer' },
+  })
+  const l1Provider = new providers.StaticJsonRpcProvider({
+    url: L1_NODE_WEB3_URL,
+    headers: { 'User-Agent': 'message-relayer' },
+  })
 
   let wallet: Wallet
   if (L1_WALLET_KEY) {

--- a/packages/replica-healthcheck/src/healthcheck-server.ts
+++ b/packages/replica-healthcheck/src/healthcheck-server.ts
@@ -49,7 +49,10 @@ export class HealthcheckServer {
     this.metrics = this.initMetrics()
     this.server = this.initServer()
     this.replicaProvider = injectL2Context(
-      new providers.StaticJsonRpcProvider(this.options.replicaRpcProvider)
+      new providers.StaticJsonRpcProvider({
+        url: this.options.replicaRpcProvider,
+        headers: { 'User-Agent': 'replica-healthcheck' },
+      })
     )
     if (this.options.checkTxWriteLatency) {
       this.initTxLatencyCheck()
@@ -177,7 +180,10 @@ export class HealthcheckServer {
 
   runSyncCheck = async () => {
     const sequencerProvider = injectL2Context(
-      new providers.StaticJsonRpcProvider(this.options.sequencerRpcProvider)
+      new providers.StaticJsonRpcProvider({
+        url: this.options.sequencerRpcProvider,
+        headers: { 'User-Agent': 'replica-healthcheck' },
+      })
     )
 
     // Continuously loop while replica runs


### PR DESCRIPTION
**Description**

Adds the http header 'User-Agent' to the creation
of ethers providers across the services to allow
for more visibility into what services are sending
requests.

Also delete dead imports since they were breaking
during linting.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

