### PR TITLE
Remove redundant declaration of address names

### DIFF
--- a/.changeset/stupid-dogs-turn.md
+++ b/.changeset/stupid-dogs-turn.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Adds an exported `names` object with contract and account names

--- a/packages/contracts/deploy/000-hardhat-setup.ts
+++ b/packages/contracts/deploy/000-hardhat-setup.ts
@@ -7,6 +7,7 @@ import {
   sendImpersonatedTx,
   BIG_BALANCE,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 import { awaitCondition } from '@eth-optimism/core-utils'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -24,7 +25,7 @@ const deployFn: DeployFunction = async (hre) => {
   // Get a reference to the AddressManager contract.
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   // Transfer ownership of the AddressManager to the deployer.

--- a/packages/contracts/deploy/000-hardhat-setup.ts
+++ b/packages/contracts/deploy/000-hardhat-setup.ts
@@ -7,7 +7,7 @@ import {
   sendImpersonatedTx,
   BIG_BALANCE,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 import { awaitCondition } from '@eth-optimism/core-utils'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/001-Lib_AddressManager.deploy.ts
+++ b/packages/contracts/deploy/001-Lib_AddressManager.deploy.ts
@@ -1,5 +1,5 @@
 /* Imports: Internal */
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'

--- a/packages/contracts/deploy/001-Lib_AddressManager.deploy.ts
+++ b/packages/contracts/deploy/001-Lib_AddressManager.deploy.ts
@@ -1,3 +1,6 @@
+/* Imports: Internal */
+import { names } from '../src'
+
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
@@ -5,7 +8,7 @@ const deployFn: DeployFunction = async (hre) => {
   const { deploy } = hre.deployments
   const { deployer } = await hre.getNamedAccounts()
 
-  await deploy('Lib_AddressManager', {
+  await deploy(names.unmanaged.Lib_AddressManager, {
     from: deployer,
     args: [],
     log: true,

--- a/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
+++ b/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
@@ -6,7 +6,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
+++ b/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
@@ -6,16 +6,17 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'ChainStorageContainer-CTC-batches',
+    name: names.managed.contracts.ChainStorageContainer_CTC_batches,
     contract: 'ChainStorageContainer',
     args: [Lib_AddressManager.address, 'CanonicalTransactionChain'],
   })

--- a/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
+++ b/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
@@ -6,16 +6,17 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'ChainStorageContainer-SCC-batches',
+    name: names.managed.contracts.ChainStorageContainer_SCC_batches,
     contract: 'ChainStorageContainer',
     args: [Lib_AddressManager.address, 'StateCommitmentChain'],
   })

--- a/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
+++ b/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
@@ -6,7 +6,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
+++ b/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
@@ -6,16 +6,17 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'CanonicalTransactionChain',
+    name: names.managed.contracts.CanonicalTransactionChain,
     args: [
       Lib_AddressManager.address,
       (hre as any).deployConfig.ctcMaxTransactionGasLimit,

--- a/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
+++ b/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
@@ -6,7 +6,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
+++ b/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
@@ -6,16 +6,17 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'StateCommitmentChain',
+    name: names.managed.contracts.StateCommitmentChain,
     args: [
       Lib_AddressManager.address,
       (hre as any).deployConfig.sccFraudProofWindow,

--- a/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
+++ b/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
@@ -6,7 +6,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
+++ b/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
@@ -6,7 +6,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
+++ b/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
@@ -6,16 +6,17 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'BondManager',
+    name: names.managed.contracts.BondManager,
     args: [Lib_AddressManager.address],
   })
 }

--- a/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
@@ -7,16 +7,17 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'OVM_L1CrossDomainMessenger',
+    name: names.managed.contracts.OVM_L1CrossDomainMessenger,
     contract: 'L1CrossDomainMessenger',
     args: [],
     postDeployAction: async (contract) => {

--- a/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
@@ -7,7 +7,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
@@ -6,11 +6,12 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await deployAndVerifyAndThen({

--- a/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
@@ -6,7 +6,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(

--- a/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
@@ -3,13 +3,14 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import { deployAndVerifyAndThen } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'Proxy__OVM_L1StandardBridge',
+    name: names.managed.contracts.Proxy__OVM_L1StandardBridge,
     contract: 'L1ChugSplashProxy',
     iface: 'L1StandardBridge',
     args: [deployer],

--- a/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import { deployAndVerifyAndThen } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts/deploy/010-AddressDictator.deploy.ts
+++ b/packages/contracts/deploy/010-AddressDictator.deploy.ts
@@ -7,30 +7,20 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 import { predeploys } from '../src/predeploys'
 
 const deployFn: DeployFunction = async (hre) => {
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
-
-  const allContractNames = [
-    'ChainStorageContainer-CTC-batches',
-    'ChainStorageContainer-SCC-batches',
-    'CanonicalTransactionChain',
-    'StateCommitmentChain',
-    'BondManager',
-    'OVM_L1CrossDomainMessenger',
-    'Proxy__OVM_L1CrossDomainMessenger',
-    'Proxy__OVM_L1StandardBridge',
-  ]
 
   let namesAndAddresses: {
     name: string
     address: string
   }[] = await Promise.all(
-    allContractNames.map(async (name) => {
+    Object.values(names.managed.contracts).map(async (name) => {
       return {
         name,
         address: (await getContractFromArtifact(hre, name)).address,
@@ -51,13 +41,13 @@ const deployFn: DeployFunction = async (hre) => {
     // OVM_Sequencer is the address allowed to submit "Sequencer" blocks to the
     // CanonicalTransactionChain.
     {
-      name: 'OVM_Sequencer',
+      name: names.managed.accounts.OVM_Sequencer,
       address: (hre as any).deployConfig.ovmSequencerAddress,
     },
     // OVM_Proposer is the address allowed to submit state roots (transaction results) to the
     // StateCommitmentChain.
     {
-      name: 'OVM_Proposer',
+      name: names.managed.accounts.OVM_Proposer,
       address: (hre as any).deployConfig.ovmProposerAddress,
     },
   ]
@@ -76,8 +66,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'AddressDictator',
-    contract: 'AddressDictator',
+    name: names.unmanaged.AddressDictator,
     args: [
       Lib_AddressManager.address,
       (hre as any).deployConfig.ovmAddressManagerOwner,

--- a/packages/contracts/deploy/010-AddressDictator.deploy.ts
+++ b/packages/contracts/deploy/010-AddressDictator.deploy.ts
@@ -7,7 +7,7 @@ import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 import { predeploys } from '../src/predeploys'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -6,9 +6,8 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   getContractFromArtifact,
   isHardhatNode,
-  getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -6,7 +6,9 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   getContractFromArtifact,
   isHardhatNode,
+  getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
@@ -21,14 +23,14 @@ const deployFn: DeployFunction = async (hre) => {
   // First get relevant contract references.
   const AddressDictator = await getContractFromArtifact(
     hre,
-    'AddressDictator',
+    names.unmanaged.AddressDictator,
     {
       signerOrProvider: deployer,
     }
   )
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
   const namedAddresses: Array<{ name: string; addr: string }> =
     await AddressDictator.getNamedAddresses()

--- a/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
+++ b/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
@@ -4,7 +4,7 @@ import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
+++ b/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
@@ -4,6 +4,7 @@ import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
@@ -16,7 +17,7 @@ const deployFn: DeployFunction = async (hre) => {
   // recover from so let's just ignore it for now.
   const Proxy__OVM_L1CrossDomainMessenger = await getContractFromArtifact(
     hre,
-    'Proxy__OVM_L1CrossDomainMessenger',
+    names.managed.contracts.Proxy__OVM_L1CrossDomainMessenger,
     {
       iface: 'L1CrossDomainMessenger',
       signerOrProvider: deployer,
@@ -25,7 +26,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   const Lib_AddressManager = await getContractFromArtifact(
     hre,
-    'Lib_AddressManager'
+    names.unmanaged.Lib_AddressManager
   )
 
   await Proxy__OVM_L1CrossDomainMessenger.initialize(Lib_AddressManager.address)

--- a/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
+++ b/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
@@ -9,7 +9,7 @@ import {
   getContractFromArtifact,
   deployAndVerifyAndThen,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const Proxy__OVM_L1StandardBridge = await getContractFromArtifact(

--- a/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
+++ b/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
@@ -9,6 +9,7 @@ import {
   getContractFromArtifact,
   deployAndVerifyAndThen,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const Proxy__OVM_L1StandardBridge = await getContractFromArtifact(
@@ -22,13 +23,12 @@ const deployFn: DeployFunction = async (hre) => {
 
   const Proxy__OVM_L1CrossDomainMessenger = await getContractFromArtifact(
     hre,
-    'Proxy__OVM_L1CrossDomainMessenger'
+    names.managed.contracts.Proxy__OVM_L1CrossDomainMessenger
   )
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'ChugSplashDictator',
-    contract: 'ChugSplashDictator',
+    name: names.unmanaged.ChugSplashDictator,
     args: [
       Proxy__OVM_L1StandardBridge.address,
       (hre as any).deployConfig.ovmAddressManagerOwner,

--- a/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
@@ -10,7 +10,7 @@ import {
   deployAndVerifyAndThen,
   isHardhatNode,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
@@ -10,13 +10,14 @@ import {
   deployAndVerifyAndThen,
   isHardhatNode,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
 
   const ChugSplashDictator = await getContractFromArtifact(
     hre,
-    'ChugSplashDictator',
+    names.unmanaged.ChugSplashDictator,
     {
       signerOrProvider: deployer,
     }
@@ -24,7 +25,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   const Proxy__OVM_L1StandardBridge = await getContractFromArtifact(
     hre,
-    'Proxy__OVM_L1StandardBridge',
+    names.managed.contracts.Proxy__OVM_L1StandardBridge,
     {
       iface: 'L1ChugSplashProxy',
       signerOrProvider: deployer,

--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -9,6 +9,7 @@ import {
   getContractFromArtifact,
   isHardhatNode,
 } from '../src/hardhat-deploy-ethers'
+import { names } from '../src'
 
 // This is a TEMPORARY way to fund the default hardhat accounts on L2. The better way to do this is
 // to make a modification to hardhat-ovm. However, I don't have the time right now to figure the
@@ -18,7 +19,7 @@ const deployFn: DeployFunction = async (hre) => {
   if (await isHardhatNode(hre)) {
     const L1StandardBridge = await getContractFromArtifact(
       hre,
-      'Proxy__OVM_L1StandardBridge',
+      names.managed.contracts.Proxy__OVM_L1StandardBridge,
       {
         iface: 'L1StandardBridge',
       }

--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -9,7 +9,7 @@ import {
   getContractFromArtifact,
   isHardhatNode,
 } from '../src/hardhat-deploy-ethers'
-import { names } from '../src'
+import { names } from '../src/address-names'
 
 // This is a TEMPORARY way to fund the default hardhat accounts on L2. The better way to do this is
 // to make a modification to hardhat-ovm. However, I don't have the time right now to figure the

--- a/packages/contracts/src/address-names.ts
+++ b/packages/contracts/src/address-names.ts
@@ -1,0 +1,23 @@
+/**
+ * This object defines the correct names to be used in the Address Manager and deployment artifacts.
+ */
+export const names = {
+  managed: {
+    contracts: {
+      ChainStorageContainer_CTC_batches: 'ChainStorageContainer-CTC-batches',
+      ChainStorageContainer_SCC_batches: 'ChainStorageContainer-SCC-batches',
+      CanonicalTransactionChain: 'CanonicalTransactionChain',
+      StateCommitmentChain: 'StateCommitmentChain',
+      BondManager: 'BondManager',
+      OVM_L1CrossDomainMessenger: 'OVM_L1CrossDomainMessenger',
+      Proxy__OVM_L1CrossDomainMessenger: 'Proxy__OVM_L1CrossDomainMessenger',
+      Proxy__OVM_L1StandardBridge: 'Proxy__OVM_L1StandardBridge',
+    },
+    accounts: { OVM_Sequencer: 'OVM_Sequencer', OVM_Proposer: 'OVM_Proposer' },
+  },
+  unmanaged: {
+    AddressDictator: 'AddressDictator',
+    ChugSplashDictator: 'ChugSplashDictator',
+    Lib_AddressManager: 'Lib_AddressManager',
+  },
+}

--- a/packages/contracts/src/hardhat-deploy-ethers.ts
+++ b/packages/contracts/src/hardhat-deploy-ethers.ts
@@ -5,6 +5,15 @@ import { Signer } from '@ethersproject/abstract-signer'
 import { sleep, awaitCondition } from '@eth-optimism/core-utils'
 import { HttpNetworkConfig } from 'hardhat/types'
 
+/**
+ * @param  {Any} hre Hardhat runtime environment
+ * @param  {String} name Contract name from the names object
+ * @param  {Any[]} args Constructor arguments
+ * @param  {String} contract Name of the solidity contract
+ * @param  {String} iface Alternative interface for calling the contract
+ * @param  {Function} postDeployAction Called after deployment
+ */
+
 export const deployAndVerifyAndThen = async ({
   hre,
   name,

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,3 @@
 export * from './contract-defs'
 export * from './predeploys'
 export * from './connect-contracts'
-export * from './address-names'

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
 export * from './contract-defs'
 export * from './predeploys'
 export * from './connect-contracts'
+export * from './address-names'

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
@@ -23,7 +23,7 @@ import {
   getEthTime,
   getNextBlockNumber,
 } from '../../../helpers'
-import { names } from '../../../../src'
+import { names } from '../../../../src/address-names'
 
 const ELEMENT_TEST_SIZES = [1, 2, 4, 8, 16]
 const MAX_GAS_LIMIT = 8_000_000

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
@@ -23,6 +23,7 @@ import {
   getEthTime,
   getNextBlockNumber,
 } from '../../../helpers'
+import { names } from '../../../../src'
 
 const ELEMENT_TEST_SIZES = [1, 2, 4, 8, 16]
 const MAX_GAS_LIMIT = 8_000_000
@@ -113,10 +114,6 @@ describe('CanonicalTransactionChain', () => {
       AddressManager.address,
       'CanonicalTransactionChain'
     )
-    await Factory__ChainStorageContainer.deploy(
-      AddressManager.address,
-      'CanonicalTransactionChain'
-    )
 
     await AddressManager.setAddress(
       'ChainStorageContainer-CTC-batches',
@@ -124,7 +121,7 @@ describe('CanonicalTransactionChain', () => {
     )
 
     await AddressManager.setAddress(
-      'CanonicalTransactionChain',
+      names.managed.contracts.CanonicalTransactionChain,
       CanonicalTransactionChain.address
     )
   })


### PR DESCRIPTION
**Description**
The strings used to resolve system contracts in the Address Manager must be correct, but they are declared independently in many places. 

This PR defines an exported object to act as a dictionary of correct names.

