### PR TITLE
Bwilson/proxyd fix headers process response

### DIFF
--- a/.changeset/tricky-tomatoes-pretend.md
+++ b/.changeset/tricky-tomatoes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+Added Content-Type headers and response error processing


### PR DESCRIPTION
**Description**
Should have been 2 PRs, my bad.

Fix: 
We're striping all headers from client requests, this is probably a good thing!
Geth requires the `Content-type` header is present though (infra providers seem to let this slide, lol)

```
// Required when connecting directly to geth
	httpReq.Header.Add("Content-type", "application/json")
```

Added:
Process RPC responses and create metrics based on errors.
