### PR TITLE
go/proxyd: ENG-1596 support authenticated client requests

### DIFF
--- a/.changeset/five-baboons-serve.md
+++ b/.changeset/five-baboons-serve.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Update metrics, support authenticated endpoints

--- a/go/proxyd/README.md
+++ b/go/proxyd/README.md
@@ -11,45 +11,13 @@ This tool implements `proxyd`, an RPC request router and proxy. It does the foll
 
 Run `make proxyd` to build the binary. No additional dependencies are necessary.
 
-To configure `proxyd` for use, you'll need to create a configuration file to define your proxy backends and routing rules. An example config that routes `eth_chainId` between Infura and Alchemy is below:
-
-```toml
-[backends]
-[backends.infura]
-base_url = "url-here"
-
-[backends.alchemy]
-base_url = "url-here"
-
-[backend_groups]
-[backend_groups.main]
-backends = ["infura", "alchemy"]
-
-[method_mappings]
-eth_chainId = "main"
-```
-
-Check out [example.config.toml](./example.config.toml) for a full list of all options with commentary.
+To configure `proxyd` for use, you'll need to create a configuration file to define your proxy backends and routing rules.  Check out [example.config.toml](./example.config.toml) for how to do this alongside a full list of all options with commentary.
 
 Once you have a config file, start the daemon via `proxyd <path-to-config>.toml`.
 
 ## Metrics
 
-The following Prometheus metrics are exported:
-
-| Name                                           | Description                                                                                     | Flags                                  |
-|------------------------------------------------|-------------------------------------------------------------------------------------------------|----------------------------------------|
-| `proxyd_backend_requests_total`                  | Count of all successful requests to a backend.                                                  | backend_name: The name of the backend. |
-| `proxyd_backend_errors_total`                    | Count of all backend errors.                                                                    | backend_name: The name of the backend  |
-| `proxyd_http_requests_total`                     | Count of all HTTP requests, successful or not.                                                  |                                        |
-| `proxyd_http_request_duration_histogram_seconds` | Histogram of HTTP request durations.                                                            |                                        |
-| `proxyd_rpc_requests_total`                      | Count of all RPC requests.                                                                      | method_name: The RPC method requested. |
-| `proxyd_blocked_rpc_requests_total`              | Count of all RPC requests with a blacklisted method.                                            | method_name: The RPC method requested. |
-| `proxyd_rpc_errors_total`                        | Count of all RPC errors. **NOTE:** Does not include errors sent from the backend to the client. |                                   
+See `metrics.go` for a list of all available metrics.                                   
 
 The metrics port is configurable via the `metrics.port` and `metrics.host` keys in the config.
 
-## Errata
-
-- RPC errors originating from the backend (e.g., any backend response containing  an `error` key) are passed on to the client directly. This simplifies the code and avoids having to marshal/unmarshal the backend's response JSON.
-- Requests are distributed round-robin between backends in a group.

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -43,11 +43,12 @@ type BackendGroupsConfig map[string]*BackendGroupConfig
 type MethodMappingsConfig map[string]string
 
 type Config struct {
-	AllowedRPCMethods []string        `toml:"allowed_rpc_methods"`
-	AllowedWSMethods  []string        `toml:"allowed_ws_methods"`
-	Server            *ServerConfig   `toml:"server"`
-	Redis             *RedisConfig    `toml:"redis"`
-	Metrics           *MetricsConfig  `toml:"metrics"`
-	BackendOptions    *BackendOptions `toml:"backend_options"`
-	Backends          BackendsConfig  `toml:"backends"`
+	AllowedRPCMethods []string          `toml:"allowed_rpc_methods"`
+	AllowedWSMethods  []string          `toml:"allowed_ws_methods"`
+	Server            *ServerConfig     `toml:"server"`
+	Redis             *RedisConfig      `toml:"redis"`
+	Metrics           *MetricsConfig    `toml:"metrics"`
+	BackendOptions    *BackendOptions   `toml:"backend_options"`
+	Backends          BackendsConfig    `toml:"backends"`
+	Authentication    map[string]string `toml:"authentication"`
 }

--- a/go/proxyd/example.config.toml
+++ b/go/proxyd/example.config.toml
@@ -1,3 +1,16 @@
+# List of allowed RPC methods.
+allowed_rpc_methods = [
+    "eth_call",
+    "eth_blockNumber",
+    "eth_gasPrice",
+    "eth_chainId"
+]
+
+# list of allowed WS methods. Will be combined with allowed_rpc_methods.
+allowed_ws_methods = [
+    "eth_subscribe"
+]
+
 [server]
 # Host for the proxyd server to listen on.
 host = "0.0.0.0"
@@ -5,6 +18,10 @@ host = "0.0.0.0"
 port = 8080
 # Maximum client body size, in bytes, that the server will accept.
 max_body_size_bytes = 10485760
+
+[redis]
+# URL to a Redis instance.
+url = "redis://localhost:6379"
 
 [metrics]
 # Whether or not to enable Prometheus metrics.
@@ -20,9 +37,9 @@ response_timeout_seconds = 5
 # Maximum response size, in bytes, that proxyd will accept from a backend.
 max_response_size_bytes = 5242880
 # Maximum number of times proxyd will try a backend before giving up.
-max_retries = 0
+max_retries = 3
 # Number of seconds to wait before trying an unhealthy backend again.
-unhealthy_backend_retry_interval_seconds = 600
+out_of_service_seconds = 600
 
 [backends]
 # A map of backends by name.
@@ -33,15 +50,16 @@ base_url = "url-here"
 username = ""
 # HTTP basic auth password to use with the backend.
 password = ""
+# Maximum RPC requests per second before rate limiting.
+# This number is global across multiple proxyd instances.
+max_rps = 3
+# Maximum number of concurrent WS connections before dropping them.
+# This number is global across multiple proxyd instances.
+max_ws_conns = 1
 
-[backend_groups]
-# A map of backend groups by name.
-[backend_groups.main]
-# A list of backend names to place in the group.
-backends = ["infura", "alchemy"]
-
-[method_mappings]
-# A mapping between RPC methods and the backend groups that should serve them.
-eth_call = "main"
-eth_chainId = "main"
-# other mappings go here
+# If the authentication group below is in the config,
+# proxyd will only accept authenticated requests.
+[authentication]
+# Mapping of auth key to alias. The alias is used to provide a human-
+# readable name for the auth key in monitoring.
+secret = "uniswap"

--- a/go/proxyd/proxyd.go
+++ b/go/proxyd/proxyd.go
@@ -20,6 +20,12 @@ func Start(config *Config) error {
 		return errors.New("must define at least one allowed RPC method")
 	}
 
+	for authKey := range config.Authentication {
+		if authKey == "none" {
+			return errors.New("cannot use none as an auth key")
+		}
+	}
+
 	allowedRPCs := NewStringSetFromStrings(config.AllowedRPCMethods)
 	allowedWSRPCs := allowedRPCs.Extend(config.AllowedWSMethods)
 
@@ -72,7 +78,11 @@ func Start(config *Config) error {
 		Name:     "main",
 		Backends: backends,
 	}
-	srv := NewServer(backendGroup, config.Server.MaxBodySizeBytes)
+	srv := NewServer(
+		backendGroup,
+		config.Server.MaxBodySizeBytes,
+		config.Authentication,
+	)
 
 	if config.Metrics.Enabled {
 		addr := fmt.Sprintf("%s:%d", config.Metrics.Host, config.Metrics.Port)


### PR DESCRIPTION
We can now specify an auth string in WS/RPC paths. Metrics have been updated to record the authenticated user.

Fixes ENG-1596