### PR TITLE
ops: add `make build` command

### DIFF
--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,3 +1,12 @@
+build:
+	DOCKER_BUILDKIT=1 \
+	docker-compose \
+		-f docker-compose.yml build builder
+	DOCKER_BUILDKIT=1 \
+	docker-compose \
+		-f docker-compose.yml build
+.PHONY: build
+
 up: down
 	DOCKER_BUILDKIT=1 \
 	docker-compose \

--- a/ops/README.md
+++ b/ops/README.md
@@ -8,6 +8,12 @@ The docker-compose project runs a local optimism stack.
 - docker-compose
 - make
 
+## Building the services
+
+```bash
+make build
+```
+
 ## Starting and stopping the project
 
 The base `docker-compose.yml` file will start the required components for a full stack.


### PR DESCRIPTION
**Description**

This will ensure the `builder` is built first so that other
services that depend on the `builder` do not pull a remote
`builder` image.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


