### PR TITLE
Deployment script CI and testing fixes

### DIFF
--- a/.changeset/many-hounds-smile.md
+++ b/.changeset/many-hounds-smile.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Always print dictator messages during deployment

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -1,6 +1,7 @@
 /* Imports: External */
 import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import { defaultHardhatNetworkParams } from 'hardhat/internal/core/config/default-config'
 
 /* Imports: Internal */
 import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
@@ -71,15 +72,11 @@ const deployFn: DeployFunction = async (hre) => {
     (4) Wait for the deploy process to continue.
   `)
 
-  // Check if the hardhat runtime environment has the owner of the AddressManager. This will only
-  // happen in CI. If this is the case, we can skip directly to transferring ownership over to the
-  // AddressDictator contract.
-  const hreSigners = await hre.ethers.getSigners()
-  const hreHasOwner = hreSigners.some((signer) => {
-    return hexStringEquals(signer.address, currentOwner)
-  })
-  if (hreHasOwner) {
-    // Hardhat has the owner loaded into it, we can skip directly to transferOwnership.
+  // Only execute this step if we're on the hardhat chain ID. This will only happen in CI. If this
+  // is the case, we can skip directly to transferring ownership over to the AddressDictator
+  // contract.
+  const { chainId } = await hre.ethers.provider.getNetwork()
+  if (chainId === defaultHardhatNetworkParams.chainId) {
     const owner = await hre.ethers.getSigner(currentOwner)
     await Lib_AddressManager.connect(owner).transferOwnership(
       AddressDictator.address

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -32,6 +32,45 @@ const deployFn: DeployFunction = async (hre) => {
   const finalOwner = await AddressDictator.finalOwner()
   const currentOwner = await Lib_AddressManager.owner()
 
+  console.log(`
+    The AddressDictator contract (glory to Arstotzka) has been deployed.
+
+    FOLLOW THESE INSTRUCTIONS CAREFULLY!
+
+    (1) Review the Contract Name / Contract Address pairs below and confirm that they match
+        the addresses found in the contract artifacts of your current deployment.
+
+    ${namedAddresses
+      .map((namedAddress) => {
+        const padding = ' '.repeat(40 - namedAddress.name.length)
+        return `
+        ${namedAddress.name}${padding}  ${namedAddress.addr}
+      `
+      })
+      .join('\n')}
+
+    (2) Review the CURRENT and FINAL AddressManager owners and verify that these are the expected values:
+
+        Current AddressManager owner: (${currentOwner})
+        Final AddressManager owner:   (${finalOwner})
+
+        [${
+          currentOwner === finalOwner
+            ? 'THESE ARE THE SAME ADDRESSES'
+            : 'THESE ARE >>>NOT<<< THE SAME ADDRESSES'
+        }]
+
+    (3) Transfer ownership of the AddressManager located at (${
+      Lib_AddressManager.address
+    })
+        to the AddressDictator contract located at the following address:
+
+        TRANSFER OWNERSHIP TO THE FOLLOWING ADDRESS ONLY:
+        >>>>> (${AddressDictator.address}) <<<<<
+
+    (4) Wait for the deploy process to continue.
+  `)
+
   // Check if the hardhat runtime environment has the owner of the AddressManager. This will only
   // happen in CI. If this is the case, we can skip directly to transferring ownership over to the
   // AddressDictator contract.
@@ -39,52 +78,12 @@ const deployFn: DeployFunction = async (hre) => {
   const hreHasOwner = hreSigners.some((signer) => {
     return hexStringEquals(signer.address, currentOwner)
   })
-
   if (hreHasOwner) {
     // Hardhat has the owner loaded into it, we can skip directly to transferOwnership.
     const owner = await hre.ethers.getSigner(currentOwner)
     await Lib_AddressManager.connect(owner).transferOwnership(
       AddressDictator.address
     )
-  } else {
-    console.log(`
-      The AddressDictator contract (glory to Arstotzka) has been deployed.
-
-      FOLLOW THESE INSTRUCTIONS CAREFULLY!
-
-      (1) Review the Contract Name / Contract Address pairs below and confirm that they match
-          the addresses found in the contract artifacts of your current deployment.
-
-      ${namedAddresses
-        .map((namedAddress) => {
-          const padding = ' '.repeat(40 - namedAddress.name.length)
-          return `
-          ${namedAddress.name}${padding}  ${namedAddress.addr}
-        `
-        })
-        .join('\n')}
-
-      (2) Review the CURRENT and FINAL AddressManager owners and verify that these are the expected values:
-
-          Current AddressManager owner: (${currentOwner})
-          Final AddressManager owner:   (${finalOwner})
-
-          [${
-            currentOwner === finalOwner
-              ? 'THESE ARE THE SAME ADDRESSES'
-              : 'THESE ARE >>>NOT<<< THE SAME ADDRESSES'
-          }]
-
-      (3) Transfer ownership of the AddressManager located at (${
-        Lib_AddressManager.address
-      })
-          to the AddressDictator contract located at the following address:
-
-          TRANSFER OWNERSHIP TO THE FOLLOWING ADDRESS ONLY:
-          >>>>> (${AddressDictator.address}) <<<<<
-
-      (4) Wait for the deploy process to continue.
-    `)
   }
 
   // Wait for ownership to be transferred to the AddressDictator contract.

--- a/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
@@ -45,6 +45,43 @@ const deployFn: DeployFunction = async (hre) => {
   })
   const finalOwner = await ChugSplashDictator.finalOwner()
 
+  const messengerSlotKey = await ChugSplashDictator.messengerSlotKey()
+  const messengerSlotVal = await ChugSplashDictator.messengerSlotVal()
+  const bridgeSlotKey = await ChugSplashDictator.bridgeSlotKey()
+  const bridgeSlotVal = await ChugSplashDictator.bridgeSlotVal()
+
+  console.log(`
+    The ChugSplashDictator contract (glory to Arstotzka) has been deployed.
+
+    FOLLOW THESE INSTRUCTIONS CAREFULLY!
+
+    (1) Review the storage key/value pairs below and make sure they match the expected values:
+
+        ${messengerSlotKey}:   ${messengerSlotVal}
+        ${bridgeSlotKey}:   ${bridgeSlotVal}
+
+    (2) Review the CURRENT and FINAL proxy owners and verify that these are the expected values:
+
+        Current proxy owner: (${currentOwner})
+        Final proxy owner:   (${finalOwner})
+
+        [${
+          currentOwner === finalOwner
+            ? 'THESE ARE THE SAME ADDRESSES'
+            : 'THESE ARE >>>NOT<<< THE SAME ADDRESSES'
+        }]
+
+    (3) Transfer ownership of the L1ChugSplashProxy located at (${
+      Proxy__OVM_L1StandardBridge.address
+    })
+        to the ChugSplashDictator contract located at the following address:
+
+        TRANSFER OWNERSHIP TO THE FOLLOWING ADDRESS ONLY:
+        >>>>> (${ChugSplashDictator.address}) <<<<<
+
+    (4) Wait for the deploy process to continue.
+  `)
+
   // Check if the hardhat runtime environment has the owner of the proxy. This will only
   // happen in CI. If this is the case, we can skip directly to transferring ownership over to the
   // ChugSplashDictator contract.
@@ -59,43 +96,6 @@ const deployFn: DeployFunction = async (hre) => {
     await Proxy__OVM_L1StandardBridge.connect(owner).setOwner(
       ChugSplashDictator.address
     )
-  } else {
-    const messengerSlotKey = await ChugSplashDictator.messengerSlotKey()
-    const messengerSlotVal = await ChugSplashDictator.messengerSlotVal()
-    const bridgeSlotKey = await ChugSplashDictator.bridgeSlotKey()
-    const bridgeSlotVal = await ChugSplashDictator.bridgeSlotVal()
-
-    console.log(`
-      The ChugSplashDictator contract (glory to Arstotzka) has been deployed.
-
-      FOLLOW THESE INSTRUCTIONS CAREFULLY!
-
-      (1) Review the storage key/value pairs below and make sure they match the expected values:
-
-          ${messengerSlotKey}:   ${messengerSlotVal}
-          ${bridgeSlotKey}:   ${bridgeSlotVal}
-
-      (2) Review the CURRENT and FINAL proxy owners and verify that these are the expected values:
-
-          Current proxy owner: (${currentOwner})
-          Final proxy owner:   (${finalOwner})
-
-          [${
-            currentOwner === finalOwner
-              ? 'THESE ARE THE SAME ADDRESSES'
-              : 'THESE ARE >>>NOT<<< THE SAME ADDRESSES'
-          }]
-
-      (3) Transfer ownership of the L1ChugSplashProxy located at (${
-        Proxy__OVM_L1StandardBridge.address
-      })
-          to the ChugSplashDictator contract located at the following address:
-
-          TRANSFER OWNERSHIP TO THE FOLLOWING ADDRESS ONLY:
-          >>>>> (${ChugSplashDictator.address}) <<<<<
-
-      (4) Wait for the deploy process to continue.
-    `)
   }
 
   // Wait for ownership to be transferred to the AddressDictator contract.

--- a/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
@@ -2,6 +2,7 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import { ethers } from 'ethers'
 import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
+import { defaultHardhatNetworkParams } from 'hardhat/internal/core/config/default-config'
 
 /* Imports: Internal */
 import { getContractDefinition } from '../src/contract-defs'
@@ -82,16 +83,10 @@ const deployFn: DeployFunction = async (hre) => {
     (4) Wait for the deploy process to continue.
   `)
 
-  // Check if the hardhat runtime environment has the owner of the proxy. This will only
-  // happen in CI. If this is the case, we can skip directly to transferring ownership over to the
-  // ChugSplashDictator contract.
-  const hreSigners = await hre.ethers.getSigners()
-  const hreHasOwner = hreSigners.some((signer) => {
-    return hexStringEquals(signer.address, currentOwner)
-  })
-
-  if (hreHasOwner) {
-    // Hardhat has the owner loaded into it, we can skip directly to transferOwnership.
+  // Check if if we're on the hardhat chain ID. This will only happen in CI. If this is the case, we
+  // can skip directly to transferring ownership over to the ChugSplashDictator contract.
+  const { chainId } = await hre.ethers.provider.getNetwork()
+  if (chainId === defaultHardhatNetworkParams.chainId) {
     const owner = await hre.ethers.getSigner(currentOwner)
     await Proxy__OVM_L1StandardBridge.connect(owner).setOwner(
       ChugSplashDictator.address


### PR DESCRIPTION
**Description**
This PR does two things: 

1. ccff1275a7204ea807b6879e117a4ec3a16f9626: Ensures that the address and chugsplash dictator instructions are always printed during deployment. This makes testing feel more realistic, even if the step is being skipped.
2. 3aa51fc656133d565f3999596ef1c383bdee1804: Uses the `chainId` to detect when the deployments are being run in CI. During a fresh system deployment the owner of the AddressManager is the deployer (just like in CI), so the previous method would have resulted in skipping the `waitUntilTrue` loop allowing for verification.

metadata:
fixes: eng-1613