### PR TITLE
ops: use alpine python3 in deployer

### DIFF
--- a/.changeset/perfect-swans-rest.md
+++ b/.changeset/perfect-swans-rest.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Update the `deployer` docker image to build with python3

--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -4,7 +4,7 @@ FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
 FROM node:14-alpine
 
-RUN apk add --no-cache git curl python bash jq
+RUN apk add --no-cache git curl python3 bash jq
 
 WORKDIR /opt/optimism/
 

--- a/ops/docker/Dockerfile.integration-tests
+++ b/ops/docker/Dockerfile.integration-tests
@@ -4,7 +4,7 @@ FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
 FROM node:14-alpine
 
-RUN apk add --no-cache git curl python bash jq
+RUN apk add --no-cache git curl python3 bash jq
 
 WORKDIR /opt/optimism/
 

--- a/ops/scripts/deployer.sh
+++ b/ops/scripts/deployer.sh
@@ -38,6 +38,6 @@ fi
 yarn run build:dump
 
 # service the addresses and dumps
-cd ./dist/dumps
-exec python -c \
-            'import BaseHTTPServer as bhs, SimpleHTTPServer as shs; bhs.HTTPServer(("0.0.0.0", 8081), shs.SimpleHTTPRequestHandler).serve_forever()'
+python3 -m http.server \
+    --bind "0.0.0.0" 8081 \
+    --directory ./dist/dumps


### PR DESCRIPTION
**Description**

The dockerfile was failing on the step due to `python` no longer
existing in the alpinelinux archives. This commit updates the
version of `python` to `python3` so that the deployer image
can build properly.

```
 > [ethereumoptimism/deployer:latest stage-1  2/13] RUN apk add --no-cache git curl python bash jq:
124 2.190 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
124 2.170 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
124 2.803 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
124 2.783 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
124 6.396 ERROR: unable to select packages:
124 6.416 ERROR: unable to select packages:
124 6.431   python (no such package):
124 6.431     required by: world[python]
124 6.451   python (no such package):
124 6.451     required by: world[python]
```

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
