### PR TITLE
Run etherscan validation during the deployment process

### DIFF
--- a/.changeset/clean-buttons-think.md
+++ b/.changeset/clean-buttons-think.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Run etherscan verification after each contract is deployed.

--- a/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
+++ b/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -13,7 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'ChainStorageContainer-CTC-batches',
     contract: 'ChainStorageContainer',

--- a/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
+++ b/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -13,7 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'ChainStorageContainer-SCC-batches',
     contract: 'ChainStorageContainer',

--- a/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
+++ b/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -13,7 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'CanonicalTransactionChain',
     args: [

--- a/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
+++ b/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -13,7 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'StateCommitmentChain',
     args: [

--- a/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
+++ b/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -13,7 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'BondManager',
     args: [Lib_AddressManager.address],

--- a/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
@@ -4,7 +4,7 @@ import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -14,7 +14,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'OVM_L1CrossDomainMessenger',
     contract: 'L1CrossDomainMessenger',

--- a/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 
@@ -13,7 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Lib_AddressManager'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'Proxy__OVM_L1CrossDomainMessenger',
     contract: 'Lib_ResolvedDelegateProxy',

--- a/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
@@ -2,12 +2,12 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { deployAndPostDeploy } from '../src/hardhat-deploy-ethers'
+import { deployAndVerifyAndThen } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'Proxy__OVM_L1StandardBridge',
     contract: 'L1ChugSplashProxy',

--- a/packages/contracts/deploy/010-AddressDictator.deploy.ts
+++ b/packages/contracts/deploy/010-AddressDictator.deploy.ts
@@ -4,7 +4,7 @@ import { hexStringEquals } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import {
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
   getContractFromArtifact,
 } from '../src/hardhat-deploy-ethers'
 import { predeploys } from '../src/predeploys'
@@ -74,7 +74,7 @@ const deployFn: DeployFunction = async (hre) => {
     return !hexStringEquals(existingAddresses[name], address)
   })
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'AddressDictator',
     contract: 'AddressDictator',

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -76,7 +76,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   // Check if if we're on the hardhat chain ID. This will only happen in CI. If this is the case, we
   // can skip directly to transferring ownership over to the ChugSplashDictator contract.
-  if (isHardhatNode(hre)) {
+  if (await isHardhatNode(hre)) {
     const owner = await hre.ethers.getSigner(currentOwner)
     await Lib_AddressManager.connect(owner).transferOwnership(
       AddressDictator.address

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -1,10 +1,12 @@
 /* Imports: External */
 import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import { defaultHardhatNetworkParams } from 'hardhat/internal/core/config/default-config'
 
 /* Imports: Internal */
-import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
+import {
+  getContractFromArtifact,
+  isHardhatNode,
+} from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
@@ -72,11 +74,9 @@ const deployFn: DeployFunction = async (hre) => {
     (4) Wait for the deploy process to continue.
   `)
 
-  // Only execute this step if we're on the hardhat chain ID. This will only happen in CI. If this
-  // is the case, we can skip directly to transferring ownership over to the AddressDictator
-  // contract.
-  const { chainId } = await hre.ethers.provider.getNetwork()
-  if (chainId === defaultHardhatNetworkParams.chainId) {
+  // Check if if we're on the hardhat chain ID. This will only happen in CI. If this is the case, we
+  // can skip directly to transferring ownership over to the ChugSplashDictator contract.
+  if (isHardhatNode(hre)) {
     const owner = await hre.ethers.getSigner(currentOwner)
     await Lib_AddressManager.connect(owner).transferOwnership(
       AddressDictator.address

--- a/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
+++ b/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
@@ -7,7 +7,7 @@ import { predeploys } from '../src/predeploys'
 import { getContractDefinition } from '../src/contract-defs'
 import {
   getContractFromArtifact,
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
 } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -25,7 +25,7 @@ const deployFn: DeployFunction = async (hre) => {
     'Proxy__OVM_L1CrossDomainMessenger'
   )
 
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'ChugSplashDictator',
     contract: 'ChugSplashDictator',

--- a/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
@@ -2,13 +2,13 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import { ethers } from 'ethers'
 import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
-import { defaultHardhatNetworkParams } from 'hardhat/internal/core/config/default-config'
 
 /* Imports: Internal */
 import { getContractDefinition } from '../src/contract-defs'
 import {
   getContractFromArtifact,
-  deployAndPostDeploy,
+  deployAndVerifyAndThen,
+  isHardhatNode,
 } from '../src/hardhat-deploy-ethers'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -85,8 +85,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   // Check if if we're on the hardhat chain ID. This will only happen in CI. If this is the case, we
   // can skip directly to transferring ownership over to the ChugSplashDictator contract.
-  const { chainId } = await hre.ethers.provider.getNetwork()
-  if (chainId === defaultHardhatNetworkParams.chainId) {
+  if (isHardhatNode(hre)) {
     const owner = await hre.ethers.getSigner(currentOwner)
     await Proxy__OVM_L1StandardBridge.connect(owner).setOwner(
       ChugSplashDictator.address
@@ -131,7 +130,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   // Deploy a copy of the implementation so it can be successfully verified on Etherscan.
   console.log(`Deploying a copy of the bridge for Etherscan verification...`)
-  await deployAndPostDeploy({
+  await deployAndVerifyAndThen({
     hre,
     name: 'L1StandardBridge_for_verification_only',
     contract: 'L1StandardBridge',

--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -1,22 +1,21 @@
 /* Imports: External */
 import { sleep } from '@eth-optimism/core-utils'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import {
-  defaultHardhatNetworkHdAccountsConfigParams,
-  defaultHardhatNetworkParams,
-} from 'hardhat/internal/core/config/default-config'
+import { defaultHardhatNetworkHdAccountsConfigParams } from 'hardhat/internal/core/config/default-config'
 import { normalizeHardhatNetworkAccountsConfig } from 'hardhat/internal/core/providers/util'
 
 /* Imports: Internal */
-import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
+import {
+  getContractFromArtifact,
+  isHardhatNode,
+} from '../src/hardhat-deploy-ethers'
 
 // This is a TEMPORARY way to fund the default hardhat accounts on L2. The better way to do this is
 // to make a modification to hardhat-ovm. However, I don't have the time right now to figure the
 // details of how to make that work cleanly. This is fine in the meantime.
 const deployFn: DeployFunction = async (hre) => {
   // Only execute this step if we're on the hardhat chain ID.
-  const { chainId } = await hre.ethers.provider.getNetwork()
-  if (chainId === defaultHardhatNetworkParams.chainId) {
+  if (isHardhatNode(hre)) {
     const L1StandardBridge = await getContractFromArtifact(
       hre,
       'Proxy__OVM_L1StandardBridge',

--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -15,7 +15,7 @@ import {
 // details of how to make that work cleanly. This is fine in the meantime.
 const deployFn: DeployFunction = async (hre) => {
   // Only execute this step if we're on the hardhat chain ID.
-  if (isHardhatNode(hre)) {
+  if (await isHardhatNode(hre)) {
     const L1StandardBridge = await getContractFromArtifact(
       hre,
       'Proxy__OVM_L1StandardBridge',


### PR DESCRIPTION
**Description**

Adds a `try/catch` wrapped attempt to verify each contract on etherscan immediately after deployment.

**Testing instructions**

1. Download and apply the patch file attached: 
[0001-TEMP-commit-for-testing-eng-1632.patch.txt](https://github.com/ethereum-optimism/optimism/files/7505734/0001-TEMP-commit-for-testing-eng-1632.patch.txt)

2. Set and source the appropriate values in your `.env `file.
3. Open `./scripts/deploy-scripts/kovan.sh` and modify according to the instructions therein.
4. Run that script.

**Expected results**

I think that on Kovan, all verification attempts will just give an "error", since identical source code has already been verified on Kovan, but that's OK. 

```
Error when verifying bytecode on etherscan:
NomicLabsHardhatPluginError: The Etherscan API responded with a failure status.
The verification may still succeed but should be checked manually.
Reason: Already Verified
```

You could try testing on another testnet for a more representative simulation of mainnet.



