### PR TITLE
Itests mainnet prep

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -33,3 +33,10 @@ You can also set environment variables on the command line instead of inside `.e
 ```bash
 L1_URL=whatever L2_URL=whatever yarn test:integration:live
 ```
+
+To run the Uniswap integration tests against a deployed set of Uniswap contracts, add the following env vars:
+
+```
+UNISWAP_POSITION_MANAGER_ADDRESS=<non fungible position manager address>
+UNISWAP_ROUTER_ADDRESS=<router address>
+```

--- a/integration-tests/test/basic-l1-l2-communication.spec.ts
+++ b/integration-tests/test/basic-l1-l2-communication.spec.ts
@@ -9,6 +9,7 @@ import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleSt
 import l2ReverterJson from '../artifacts/contracts/Reverter.sol/Reverter.json'
 import { Direction } from './shared/watcher-utils'
 import { OptimismEnv } from './shared/env'
+import { isMainnet } from './shared/utils'
 
 describe('Basic L1<>L2 Communication', async () => {
   let Factory__L1SimpleStorage: ContractFactory
@@ -48,7 +49,13 @@ describe('Basic L1<>L2 Communication', async () => {
   })
 
   describe('L2 => L1', () => {
-    it('should be able to perform a withdrawal from L2 -> L1', async () => {
+    it('should be able to perform a withdrawal from L2 -> L1', async function () {
+      if (await isMainnet(env)) {
+        console.log('Skipping withdrawals test on mainnet.')
+        this.skip()
+        return
+      }
+
       const value = `0x${'77'.repeat(32)}`
 
       // Send L2 -> L1 message.

--- a/integration-tests/test/native-eth-ovm-calls.spec.ts
+++ b/integration-tests/test/native-eth-ovm-calls.spec.ts
@@ -47,7 +47,7 @@ describe('Native ETH value integration tests', () => {
     const there = await wallet.sendTransaction({
       to: other.address,
       value,
-      gasPrice: await gasPriceForL2(),
+      gasPrice: await gasPriceForL2(env),
     })
     const thereReceipt = await there.wait()
     const thereGas = thereReceipt.gasUsed.mul(there.gasPrice)
@@ -65,7 +65,7 @@ describe('Native ETH value integration tests', () => {
     const backAgain = await other.sendTransaction({
       to: wallet.address,
       value: backVal,
-      gasPrice: await gasPriceForL2(),
+      gasPrice: await gasPriceForL2(env),
     })
     const backReceipt = await backAgain.wait()
     const backGas = backReceipt.gasUsed.mul(backAgain.gasPrice)
@@ -171,7 +171,7 @@ describe('Native ETH value integration tests', () => {
     it('should allow ETH to be sent', async () => {
       const sendAmount = 15
       const tx = await ValueCalls0.simpleSend(ValueCalls1.address, sendAmount, {
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
       })
       await tx.wait()
 

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -9,7 +9,6 @@ import {
   defaultTransactionFactory,
   fundUser,
   L2_CHAINID,
-  IS_LIVE_NETWORK,
   isLiveNetwork,
   gasPriceForL2,
 } from './shared/utils'
@@ -60,7 +59,7 @@ describe('Basic RPC tests', () => {
   describe('eth_sendRawTransaction', () => {
     it('should correctly process a valid transaction', async () => {
       const tx = defaultTransactionFactory()
-      tx.gasPrice = await gasPriceForL2()
+      tx.gasPrice = await gasPriceForL2(env)
       const nonce = await wallet.getTransactionCount()
       const result = await wallet.sendTransaction(tx)
 
@@ -74,7 +73,7 @@ describe('Basic RPC tests', () => {
     it('should not accept a transaction with the wrong chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: (await wallet.getChainId()) + 1,
       }
 
@@ -86,7 +85,7 @@ describe('Basic RPC tests', () => {
     it('should not accept a transaction without a chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: null, // Disables EIP155 transaction signing.
       }
 
@@ -98,7 +97,7 @@ describe('Basic RPC tests', () => {
     it('should accept a transaction with a value', async () => {
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: await env.l2Wallet.getChainId(),
         data: '0x',
         value: ethers.utils.parseEther('0.1'),
@@ -118,7 +117,7 @@ describe('Basic RPC tests', () => {
       const balance = await env.l2Wallet.getBalance()
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: await env.l2Wallet.getChainId(),
         data: '0x',
         value: balance.add(ethers.utils.parseEther('1')),
@@ -282,7 +281,7 @@ describe('Basic RPC tests', () => {
   describe('eth_getTransactionByHash', () => {
     it('should be able to get all relevant l1/l2 transaction data', async () => {
       const tx = defaultTransactionFactory()
-      tx.gasPrice = await gasPriceForL2()
+      tx.gasPrice = await gasPriceForL2(env)
       const result = await wallet.sendTransaction(tx)
       await result.wait()
 
@@ -297,7 +296,7 @@ describe('Basic RPC tests', () => {
     it('should return the block and all included transactions', async () => {
       // Send a transaction and wait for it to be mined.
       const tx = defaultTransactionFactory()
-      tx.gasPrice = await gasPriceForL2()
+      tx.gasPrice = await gasPriceForL2(env)
       const result = await wallet.sendTransaction(tx)
       const receipt = await result.wait()
 
@@ -324,7 +323,7 @@ describe('Basic RPC tests', () => {
     // other people are sending transactions to the Sequencer at the same time
     // as this test is running.
     it('should return the same result when new transactions are not applied', async function () {
-      if (IS_LIVE_NETWORK) {
+      if (isLiveNetwork()) {
         this.skip()
       }
 

--- a/integration-tests/test/shared/env.ts
+++ b/integration-tests/test/shared/env.ts
@@ -78,8 +78,8 @@ export class OptimismEnv {
 
     // fund the user if needed
     const balance = await l2Wallet.getBalance()
-    if (balance.isZero()) {
-      await fundUser(watcher, l1Bridge, utils.parseEther('20'))
+    if (balance.lt(utils.parseEther('1'))) {
+      await fundUser(watcher, l1Bridge, utils.parseEther('1').sub(balance))
     }
     const l1Messenger = getContractFactory('L1CrossDomainMessenger')
       .connect(l1Wallet)

--- a/integration-tests/test/shared/stress-test-helpers.ts
+++ b/integration-tests/test/shared/stress-test-helpers.ts
@@ -71,7 +71,7 @@ export const executeL2ToL1Transaction = async (
         ),
         MESSAGE_GAS,
         {
-          gasPrice: gasPriceForL2(),
+          gasPrice: gasPriceForL2(env),
         }
       )
   )
@@ -90,7 +90,7 @@ export const executeL2Transaction = async (
     tx.contract
       .connect(signer)
       .functions[tx.functionName](...tx.functionParams, {
-        gasPrice: gasPriceForL2(),
+        gasPrice: gasPriceForL2(env),
       })
   )
   await result.wait()

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -174,7 +174,12 @@ export const waitForL2Geth = async (
   return injectL2Context(provider)
 }
 
-export const gasPriceForL2 = async () => {
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export const gasPriceForL2 = async (env: OptimismEnv) => {
+  if (await isMainnet(env)) {
+    return env.l2Wallet.getGasPrice()
+  }
+
   if (isLiveNetwork()) {
     return Promise.resolve(BigNumber.from(10000))
   }
@@ -197,4 +202,10 @@ export const gasPriceForL1 = async (env: OptimismEnv) => {
     default:
       return BigNumber.from(0)
   }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export const isMainnet = async (env: OptimismEnv) => {
+  const chainId = await env.l1Wallet.getChainId()
+  return chainId === 1
 }

--- a/integration-tests/test/stress-tests.spec.ts
+++ b/integration-tests/test/stress-tests.spec.ts
@@ -17,7 +17,7 @@ import {
 
 /* Imports: Artifacts */
 import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleStorage.json'
-import { fundUser, isLiveNetwork } from './shared/utils'
+import { fundUser, isLiveNetwork, isMainnet } from './shared/utils'
 
 // Need a big timeout to allow for all transactions to be processed.
 // For some reason I can't figure out how to set the timeout on a per-suite basis
@@ -31,8 +31,13 @@ describe('stress tests', () => {
 
   const wallets: Wallet[] = []
 
-  before(async () => {
+  before(async function () {
     env = await OptimismEnv.new()
+    if (await isMainnet(env)) {
+      console.log('Skipping stress tests on mainnet.')
+      this.skip()
+      return
+    }
 
     for (let i = 0; i < numTransactions; i++) {
       wallets.push(Wallet.createRandom())


### PR DESCRIPTION
This PR gets integration tests into shape to work against mainnet. Specific changes include:

- Stress tests do not run against mainnet since they are very costly.
- You can now provide env vars that define addresses for the Uniswap position manager and router. This avoids the need to deploy them ourselves on mainnet.
- Withdrawal tests are disabled because the withdrawal window on mainnet is 1 week.
- Mainnet L2 gas prices are pulled from the sequencer rather than using a hardcoded value.
- The L2 wallet is funded with 1ETH rather than 20. Subsequent tests runs will "top up" the L2 wallet up to 1 ETH.