### PR TITLE
go/proxyd: Make endpoints match Geth, better logging

### DIFF
--- a/.changeset/great-donkeys-buy.md
+++ b/.changeset/great-donkeys-buy.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': major
+---
+
+Make endpoints match Geth, better logging

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -1,8 +1,10 @@
 package proxyd
 
 type ServerConfig struct {
-	Host             string `toml:"host"`
-	Port             int    `toml:"port"`
+	RPCHost          string `toml:"rpc_host"`
+	RPCPort          int    `toml:"rpc_port"`
+	WSHost           string `toml:"ws_host"`
+	WSPort           int    `toml:"ws_port"`
 	MaxBodySizeBytes int64  `toml:"max_body_size_bytes"`
 }
 
@@ -36,7 +38,6 @@ type BackendsConfig map[string]*BackendConfig
 
 type BackendGroupConfig struct {
 	Backends  []string `toml:"backends"`
-	WSEnabled bool     `toml:"ws_enabled"`
 }
 
 type BackendGroupsConfig map[string]*BackendGroupConfig
@@ -44,6 +45,7 @@ type BackendGroupsConfig map[string]*BackendGroupConfig
 type MethodMappingsConfig map[string]string
 
 type Config struct {
+	WSBackendGroup    string              `toml:"ws_backend_group"`
 	Server            *ServerConfig       `toml:"server"`
 	Redis             *RedisConfig        `toml:"redis"`
 	Metrics           *MetricsConfig      `toml:"metrics"`

--- a/go/proxyd/example.config.toml
+++ b/go/proxyd/example.config.toml
@@ -4,12 +4,18 @@ ws_method_whitelist = [
   "eth_call",
   "eth_chainId"
 ]
+# Enable WS on this backend group. There can only be one WS-enabled backend group.
+ws_backend_group = "main"
 
 [server]
-# Host for the proxyd server to listen on.
-host = "0.0.0.0"
+# Host for the proxyd RPC server to listen on.
+rpc_host = "0.0.0.0"
 # Port for the above.
-port = 8080
+rpc_port = 8080
+# Host for the proxyd WS server to listen on.
+ws_host = "0.0.0.0"
+# Port for the above
+ws_port = 8085
 # Maximum client body size, in bytes, that the server will accept.
 max_body_size_bytes = 10485760
 
@@ -59,8 +65,6 @@ max_ws_conns = 1
 [backend_groups]
 [backend_groups.main]
 backends = ["infura"]
-# Enable WS on this backend group. There can only be one WS-enabled backend group.
-ws_enabled = true
 
 [backend_groups.alchemy]
 backends = ["alchemy"]

--- a/go/proxyd/server.go
+++ b/go/proxyd/server.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	ContextKeyAuth = "authorization"
+	ContextKeyAuth  = "authorization"
+	ContextKeyReqID = "req_id"
 )
 
 type Server struct {
@@ -27,7 +28,8 @@ type Server struct {
 	maxBodySize        int64
 	authenticatedPaths map[string]string
 	upgrader           *websocket.Upgrader
-	server             *http.Server
+	rpcServer          *http.Server
+	wsServer           *http.Server
 }
 
 func NewServer(
@@ -51,27 +53,46 @@ func NewServer(
 	}
 }
 
-func (s *Server) ListenAndServe(host string, port int) error {
+func (s *Server) RPCListenAndServe(host string, port int) error {
 	hdlr := mux.NewRouter()
 	hdlr.HandleFunc("/healthz", s.HandleHealthz).Methods("GET")
-	hdlr.HandleFunc("/api/v1/rpc", s.HandleRPC).Methods("POST")
-	hdlr.HandleFunc("/api/v1/{authorization}/rpc", s.HandleRPC).Methods("POST")
-	hdlr.HandleFunc("/api/v1/ws", s.HandleWS)
-	hdlr.HandleFunc("/api/v1/{authorization}/ws", s.HandleWS)
+	hdlr.HandleFunc("/", s.HandleRPC).Methods("POST")
+	hdlr.HandleFunc("/{authorization}", s.HandleRPC).Methods("POST")
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
 	})
 	addr := fmt.Sprintf("%s:%d", host, port)
-	s.server = &http.Server{
+	s.rpcServer = &http.Server{
 		Handler: instrumentedHdlr(c.Handler(hdlr)),
 		Addr:    addr,
 	}
 	log.Info("starting HTTP server", "addr", addr)
-	return s.server.ListenAndServe()
+	return s.rpcServer.ListenAndServe()
+}
+
+func (s *Server) WSListenAndServe(host string, port int) error {
+	hdlr := mux.NewRouter()
+	hdlr.HandleFunc("/", s.HandleWS)
+	hdlr.HandleFunc("/{authorization}", s.HandleWS)
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+	})
+	addr := fmt.Sprintf("%s:%d", host, port)
+	s.wsServer = &http.Server{
+		Handler: instrumentedHdlr(c.Handler(hdlr)),
+		Addr:    addr,
+	}
+	log.Info("starting WS server", "addr", addr)
+	return s.wsServer.ListenAndServe()
 }
 
 func (s *Server) Shutdown() {
-	s.server.Shutdown(context.Background())
+	if s.rpcServer != nil {
+		s.rpcServer.Shutdown(context.Background())
+	}
+	if s.wsServer != nil {
+		s.wsServer.Shutdown(context.Background())
+	}
 }
 
 func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -79,10 +100,12 @@ func (s *Server) HandleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
-	ctx := s.authenticate(w, r)
+	ctx := s.populateContext(w, r)
 	if ctx == nil {
 		return
 	}
+
+	log.Info("received RPC request", "req_id", GetReqID(ctx), "auth", GetAuthCtx(ctx))
 
 	req, err := ParseRPCReq(io.LimitReader(r.Body, s.maxBodySize))
 	if err != nil {
@@ -92,51 +115,66 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-  group := s.rpcMethodMappings[req.Method]
-  if group == "" {
-      // use unknown below to prevent DOS vector that fills up memory
-      // with arbitrary method names.
-      log.Info("blocked request for non-whitelisted method", "source", "ws", "method", req.Method)
-      RecordRPCError(ctx, BackendProxyd, MethodUnknown, ErrMethodNotWhitelisted)
-      writeRPCError(w, req.ID, ErrMethodNotWhitelisted)
-      return
-  }
+	group := s.rpcMethodMappings[req.Method]
+	if group == "" {
+		// use unknown below to prevent DOS vector that fills up memory
+		// with arbitrary method names.
+		log.Info(
+			"blocked request for non-whitelisted method",
+			"source", "rpc",
+			"req_id", GetReqID(ctx),
+			"method", req.Method,
+		)
+		RecordRPCError(ctx, BackendProxyd, MethodUnknown, ErrMethodNotWhitelisted)
+		writeRPCError(w, req.ID, ErrMethodNotWhitelisted)
+		return
+	}
 
 	backendRes, err := s.backendGroups[group].Forward(ctx, req)
 	if err != nil {
-		log.Error("error forwarding RPC request", "method", req.Method, "err", err)
+		log.Error(
+			"error forwarding RPC request",
+			"method", req.Method,
+			"req_id", GetReqID(ctx),
+			"err", err,
+		)
 		writeRPCError(w, req.ID, err)
 		return
 	}
+
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(backendRes); err != nil {
-		log.Error("error encoding response", "err", err)
+		log.Error(
+			"error encoding response",
+			"req_id", GetReqID(ctx),
+			"err", err,
+		)
 		RecordRPCError(ctx, BackendProxyd, req.Method, err)
 		writeRPCError(w, req.ID, err)
 		return
 	}
-
-	log.Debug("forwarded RPC method", "method", req.Method)
 }
 
 func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
-	ctx := s.authenticate(w, r)
+	ctx := s.populateContext(w, r)
 	if ctx == nil {
 		return
 	}
 
+	log.Info("received WS connection", "req_id", GetReqID(ctx))
+
 	clientConn, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Error("error upgrading client conn", "err", err)
+		log.Error("error upgrading client conn", "auth", GetAuthCtx(ctx), "req_id", GetReqID(ctx), "err", err)
 		return
 	}
 
-	proxier, err := s.wsBackendGroup.ProxyWS(clientConn, s.wsMethodWhitelist)
+	proxier, err := s.wsBackendGroup.ProxyWS(ctx, clientConn, s.wsMethodWhitelist)
 	if err != nil {
 		if errors.Is(err, ErrNoBackends) {
 			RecordUnserviceableRequest(ctx, RPCRequestSourceWS)
 		}
-		log.Error("error dialing ws backend", "err", err)
+		log.Error("error dialing ws backend", "auth", GetAuthCtx(ctx), "req_id", GetReqID(ctx), "err", err)
 		clientConn.Close()
 		return
 	}
@@ -145,13 +183,15 @@ func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		// Below call blocks so run it in a goroutine.
 		if err := proxier.Proxy(ctx); err != nil {
-			log.Error("error proxying websocket", "err", err)
+			log.Error("error proxying websocket", "auth", GetAuthCtx(ctx), "req_id", GetReqID(ctx), "err", err)
 		}
 		activeClientWsConnsGauge.WithLabelValues(GetAuthCtx(ctx)).Dec()
 	}()
+
+	log.Info("accepted WS connection", "auth", GetAuthCtx(ctx), "req_id", GetReqID(ctx))
 }
 
-func (s *Server) authenticate(w http.ResponseWriter, r *http.Request) context.Context {
+func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context.Context {
 	vars := mux.Vars(r)
 	authorization := vars["authorization"]
 
@@ -159,18 +199,29 @@ func (s *Server) authenticate(w http.ResponseWriter, r *http.Request) context.Co
 		// handle the edge case where auth is disabled
 		// but someone sends in an auth key anyway
 		if authorization != "" {
+			log.Info("blocked authenticated request against unauthenticated proxy")
 			w.WriteHeader(404)
 			return nil
 		}
-		return r.Context()
+		return context.WithValue(
+			r.Context(),
+			ContextKeyReqID,
+			randStr(10),
+		)
 	}
 
 	if authorization == "" || s.authenticatedPaths[authorization] == "" {
+		log.Info("blocked unauthorized request", "authorization", authorization)
 		w.WriteHeader(401)
 		return nil
 	}
 
-	return context.WithValue(r.Context(), ContextKeyAuth, s.authenticatedPaths[authorization])
+	ctx := context.WithValue(r.Context(), ContextKeyAuth, s.authenticatedPaths[authorization])
+	return context.WithValue(
+		ctx,
+		ContextKeyReqID,
+		randStr(10),
+	)
 }
 
 func writeRPCError(w http.ResponseWriter, id *int, err error) {
@@ -207,4 +258,12 @@ func GetAuthCtx(ctx context.Context) string {
 	}
 
 	return authUser
+}
+
+func GetReqID(ctx context.Context) string {
+	reqId, ok := ctx.Value(ContextKeyReqID).(string)
+	if !ok {
+		return ""
+	}
+	return reqId
 }


### PR DESCRIPTION
This PR makes the following changes:

**Makes the RPC/WS endpoints match Geth**

Rather than use custom paths for RPC/WS endpoints, Geth has the RPC and WS servers listen on different ports. This PR makes proxyd match that behavior. To configure Proxyd in this mode, use the following configuration:

```toml
[server]
# Host for the proxyd RPC server to listen on.
rpc_host = "0.0.0.0"
# Port for the above.
rpc_port = 8080
# Host for the proxyd WS server to listen on.
ws_host = "0.0.0.0"
# Port for the above
ws_port = 8085
# Maximum client body size, in bytes, that the server will accept.
max_body_size_bytes = 10485760
```

**Better logging**

This PR adds logging to all incoming requests, attempted WS connections, and exchanged WS messages. Additionally, it adds a randomly-generated `req_id` field to log output that will allow us to trace requests as they go from the web server, to the proxied backend, and back.

Example WS logs:

```
INFO [11-09|15:31:09.261] received WS connection                   req_id=63cfe34c38d6faec0989
INFO [11-09|15:31:09.774] accepted WS connection                   auth=foobar req_id=63cfe34c38d6faec0989
INFO [11-09|15:31:27.599] error preparing client message           auth=foobar req_id=63cfe34c38d6faec0989 err="parse error"
INFO [11-09|15:31:33.844] forwarded WS message to backend          method=eth_subscribe auth=foobar req_id=63cfe34c38d6faec0989
INFO [11-09|15:31:33.924] forwarded WS message to client           auth=foobar req_id=63cfe34c38d6faec0989
```

RPC:

```
INFO [11-09|15:34:07.287] received RPC request                     req_id=9293a41182a3bbb840fd auth=foobar
INFO [11-09|15:34:07.817] forwarded RPC request                    method=eth_blockNumber auth=foobar req_id=9293a41182a3bbb840fd
```

**Change to how websocket backend groups are defined**

Only one backend group can be websocket-enabled. Previously, this was done by defining a `ws_enabled` property on the backend group to proxy websockets to. To make this simpler, you can now define a single `ws_backend_group` config property at the top of the file. Example:

```toml
# List of WS methods to whitelist.
ws_method_whitelist = [
  "eth_subscribe",
  "eth_call",
  "eth_chainId"
]
# Enable WS on this backend group. There can only be one WS-enabled backend group.
ws_backend_group = "main"

[backends]
# A map of backends by name.
[backends.infura]
# The URL to contact the backend at.
rpc_url = "foo"
# The WS URL to contact the backend at.
ws_url = "bar"
max_rps = 3
max_ws_conns = 1

[backend_groups]
[backend_groups.main]
backends = ["infura"]
```

Note that all backends in the websocket backend group need a websocket URL.

The WS backend group is explicitly defined in the config rather than populated from the backends that have `ws_url`s because we may want the flexibility to create a custom group just for websocket-enabled endpoints in the future.