### PR TITLE
integration-tests: Build using single Dockerfile

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,24 +37,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - uses: actions/cache@v2
-        name: Set up layer cache
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-1-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-1-
-
-      - uses: docker/setup-buildx-action@master
-        name: Set up Docker Buildx
-        id: buildx
-        with:
-          version: latest
-          driver-opts: image=moby/buildkit:master,network=host
-
-      - name: Build the services
-        run: ./ops/scripts/build-ci.sh
-
       - name: Bring the stack up
         working-directory: ./ops
         run: |
@@ -73,7 +55,7 @@ jobs:
         if: failure()
         uses: jwalton/gh-docker-logs@v1
         with:
-          images: 'ethereumoptimism/builder,ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth,ethereumoptimism/integration-tests'
+          images: 'ethereumoptimism/hardhat,ops_deployer,ops_dtl,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ops_batch_submitter,ethereumoptimism/l2geth,ops_integration_tests'
           dest: '/home/runner/logs'
 
       - name: Tar logs
@@ -86,11 +68,3 @@ jobs:
         with:
           name: logs.tgz
           path: ./logs.tgz
-
-      # Needed to address the following bugs:
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -33,3 +33,10 @@ You can also set environment variables on the command line instead of inside `.e
 ```bash
 L1_URL=whatever L2_URL=whatever yarn test:integration:live
 ```
+
+To run the Uniswap integration tests against a deployed set of Uniswap contracts, add the following env vars:
+
+```
+UNISWAP_POSITION_MANAGER_ADDRESS=<non fungible position manager address>
+UNISWAP_ROUTER_ADDRESS=<router address>
+```

--- a/integration-tests/test/basic-l1-l2-communication.spec.ts
+++ b/integration-tests/test/basic-l1-l2-communication.spec.ts
@@ -9,6 +9,7 @@ import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleSt
 import l2ReverterJson from '../artifacts/contracts/Reverter.sol/Reverter.json'
 import { Direction } from './shared/watcher-utils'
 import { OptimismEnv } from './shared/env'
+import { isMainnet } from './shared/utils'
 
 describe('Basic L1<>L2 Communication', async () => {
   let Factory__L1SimpleStorage: ContractFactory
@@ -48,7 +49,13 @@ describe('Basic L1<>L2 Communication', async () => {
   })
 
   describe('L2 => L1', () => {
-    it('should be able to perform a withdrawal from L2 -> L1', async () => {
+    it('should be able to perform a withdrawal from L2 -> L1', async function () {
+      if (await isMainnet(env)) {
+        console.log('Skipping withdrawals test on mainnet.')
+        this.skip()
+        return
+      }
+
       const value = `0x${'77'.repeat(32)}`
 
       // Send L2 -> L1 message.

--- a/integration-tests/test/native-eth-ovm-calls.spec.ts
+++ b/integration-tests/test/native-eth-ovm-calls.spec.ts
@@ -47,7 +47,7 @@ describe('Native ETH value integration tests', () => {
     const there = await wallet.sendTransaction({
       to: other.address,
       value,
-      gasPrice: await gasPriceForL2(),
+      gasPrice: await gasPriceForL2(env),
     })
     const thereReceipt = await there.wait()
     const thereGas = thereReceipt.gasUsed.mul(there.gasPrice)
@@ -65,7 +65,7 @@ describe('Native ETH value integration tests', () => {
     const backAgain = await other.sendTransaction({
       to: wallet.address,
       value: backVal,
-      gasPrice: await gasPriceForL2(),
+      gasPrice: await gasPriceForL2(env),
     })
     const backReceipt = await backAgain.wait()
     const backGas = backReceipt.gasUsed.mul(backAgain.gasPrice)
@@ -171,7 +171,7 @@ describe('Native ETH value integration tests', () => {
     it('should allow ETH to be sent', async () => {
       const sendAmount = 15
       const tx = await ValueCalls0.simpleSend(ValueCalls1.address, sendAmount, {
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
       })
       await tx.wait()
 

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -9,7 +9,6 @@ import {
   defaultTransactionFactory,
   fundUser,
   L2_CHAINID,
-  IS_LIVE_NETWORK,
   isLiveNetwork,
   gasPriceForL2,
 } from './shared/utils'
@@ -62,7 +61,7 @@ describe('Basic RPC tests', () => {
   describe('eth_sendRawTransaction', () => {
     it('should correctly process a valid transaction', async () => {
       const tx = defaultTransactionFactory()
-      tx.gasPrice = await gasPriceForL2()
+      tx.gasPrice = await gasPriceForL2(env)
       const nonce = await wallet.getTransactionCount()
       const result = await wallet.sendTransaction(tx)
 
@@ -76,7 +75,7 @@ describe('Basic RPC tests', () => {
     it('should not accept a transaction with the wrong chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: (await wallet.getChainId()) + 1,
       }
 
@@ -88,7 +87,7 @@ describe('Basic RPC tests', () => {
     it('should not accept a transaction without a chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: null, // Disables EIP155 transaction signing.
       }
 
@@ -100,7 +99,7 @@ describe('Basic RPC tests', () => {
     it('should accept a transaction with a value', async () => {
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: await env.l2Wallet.getChainId(),
         data: '0x',
         value: ethers.utils.parseEther('0.1'),
@@ -120,7 +119,7 @@ describe('Basic RPC tests', () => {
       const balance = await env.l2Wallet.getBalance()
       const tx = {
         ...defaultTransactionFactory(),
-        gasPrice: await gasPriceForL2(),
+        gasPrice: await gasPriceForL2(env),
         chainId: await env.l2Wallet.getChainId(),
         data: '0x',
         value: balance.add(ethers.utils.parseEther('1')),
@@ -284,7 +283,7 @@ describe('Basic RPC tests', () => {
   describe('eth_getTransactionByHash', () => {
     it('should be able to get all relevant l1/l2 transaction data', async () => {
       const tx = defaultTransactionFactory()
-      tx.gasPrice = await gasPriceForL2()
+      tx.gasPrice = await gasPriceForL2(env)
       const result = await wallet.sendTransaction(tx)
       await result.wait()
 
@@ -299,7 +298,7 @@ describe('Basic RPC tests', () => {
     it('should return the block and all included transactions', async () => {
       // Send a transaction and wait for it to be mined.
       const tx = defaultTransactionFactory()
-      tx.gasPrice = await gasPriceForL2()
+      tx.gasPrice = await gasPriceForL2(env)
       const result = await wallet.sendTransaction(tx)
       const receipt = await result.wait()
 
@@ -326,7 +325,7 @@ describe('Basic RPC tests', () => {
     // other people are sending transactions to the Sequencer at the same time
     // as this test is running.
     it('should return the same result when new transactions are not applied', async function () {
-      if (IS_LIVE_NETWORK) {
+      if (isLiveNetwork()) {
         this.skip()
       }
 

--- a/integration-tests/test/shared/env.ts
+++ b/integration-tests/test/shared/env.ts
@@ -78,8 +78,8 @@ export class OptimismEnv {
 
     // fund the user if needed
     const balance = await l2Wallet.getBalance()
-    if (balance.isZero()) {
-      await fundUser(watcher, l1Bridge, utils.parseEther('20'))
+    if (balance.lt(utils.parseEther('1'))) {
+      await fundUser(watcher, l1Bridge, utils.parseEther('1').sub(balance))
     }
     const l1Messenger = getContractFactory('L1CrossDomainMessenger')
       .connect(l1Wallet)

--- a/integration-tests/test/shared/stress-test-helpers.ts
+++ b/integration-tests/test/shared/stress-test-helpers.ts
@@ -71,7 +71,7 @@ export const executeL2ToL1Transaction = async (
         ),
         MESSAGE_GAS,
         {
-          gasPrice: gasPriceForL2(),
+          gasPrice: gasPriceForL2(env),
         }
       )
   )
@@ -90,7 +90,7 @@ export const executeL2Transaction = async (
     tx.contract
       .connect(signer)
       .functions[tx.functionName](...tx.functionParams, {
-        gasPrice: gasPriceForL2(),
+        gasPrice: gasPriceForL2(env),
       })
   )
   await result.wait()

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -174,7 +174,12 @@ export const waitForL2Geth = async (
   return injectL2Context(provider)
 }
 
-export const gasPriceForL2 = async () => {
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export const gasPriceForL2 = async (env: OptimismEnv) => {
+  if (await isMainnet(env)) {
+    return env.l2Wallet.getGasPrice()
+  }
+
   if (isLiveNetwork()) {
     return Promise.resolve(BigNumber.from(10000))
   }
@@ -197,4 +202,10 @@ export const gasPriceForL1 = async (env: OptimismEnv) => {
     default:
       return BigNumber.from(0)
   }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+export const isMainnet = async (env: OptimismEnv) => {
+  const chainId = await env.l1Wallet.getChainId()
+  return chainId === 1
 }

--- a/integration-tests/test/stress-tests.spec.ts
+++ b/integration-tests/test/stress-tests.spec.ts
@@ -17,7 +17,7 @@ import {
 
 /* Imports: Artifacts */
 import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleStorage.json'
-import { fundUser, isLiveNetwork } from './shared/utils'
+import { fundUser, isLiveNetwork, isMainnet } from './shared/utils'
 
 // Need a big timeout to allow for all transactions to be processed.
 // For some reason I can't figure out how to set the timeout on a per-suite basis
@@ -31,8 +31,13 @@ describe('stress tests', () => {
 
   const wallets: Wallet[] = []
 
-  before(async () => {
+  before(async function () {
     env = await OptimismEnv.new()
+    if (await isMainnet(env)) {
+      console.log('Skipping stress tests on mainnet.')
+      this.skip()
+      return
+    }
 
     for (let i = 0; i < numTransactions; i++) {
       wallets.push(Wallet.createRandom())

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,9 +1,6 @@
 build:
 	DOCKER_BUILDKIT=1 \
 	docker-compose \
-		-f docker-compose.yml build builder
-	DOCKER_BUILDKIT=1 \
-	docker-compose \
 		-f docker-compose.yml build
 .PHONY: build
 

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -1,13 +1,6 @@
 version: "3"
 
 services:
-  # base service builder
-  builder:
-    image: ethereumoptimism/builder:${DOCKER_TAG:-latest}
-    build:
-      context: ..
-      dockerfile: ./ops/docker/Dockerfile.monorepo
-
   # this is a helper service used because there's no official hardhat image
   l1_chain:
     image: ethereumoptimism/hardhat:${DOCKER_TAG:-latest}
@@ -21,10 +14,10 @@ services:
   deployer:
     depends_on:
       - l1_chain
-    image: ethereumoptimism/deployer:${DOCKER_TAG:-latest}
     build:
       context: ..
-      dockerfile: ./ops/docker/Dockerfile.deployer
+      dockerfile: ./ops/docker/Dockerfile.packages
+      target: deployer
     entrypoint: ./deployer.sh
     environment:
         FRAUD_PROOF_WINDOW_SECONDS: 0
@@ -56,10 +49,10 @@ services:
       - l1_chain
       - deployer
       - l2geth
-    image: ethereumoptimism/data-transport-layer:${DOCKER_TAG:-latest}
     build:
       context: ..
-      dockerfile: ./ops/docker/Dockerfile.data-transport-layer
+      dockerfile: ./ops/docker/Dockerfile.packages
+      target: data-transport-layer
     # override with the dtl script and the env vars required for it
     entrypoint: ./dtl.sh
     env_file:
@@ -81,7 +74,6 @@ services:
     depends_on:
       - l1_chain
       - deployer
-    image: ethereumoptimism/l2geth:${DOCKER_TAG:-latest}
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.geth
@@ -109,10 +101,10 @@ services:
       - l1_chain
       - deployer
       - l2geth
-    image: ethereumoptimism/message-relayer:${DOCKER_TAG:-latest}
     build:
       context: ..
-      dockerfile: ./ops/docker/Dockerfile.message-relayer
+      dockerfile: ./ops/docker/Dockerfile.packages
+      target: relayer
     entrypoint: ./relayer.sh
     environment:
         L1_NODE_WEB3_URL: http://l1_chain:8545
@@ -129,10 +121,10 @@ services:
       - l1_chain
       - deployer
       - l2geth
-    image: ethereumoptimism/batch-submitter:${DOCKER_TAG:-latest}
     build:
       context: ..
-      dockerfile: ./ops/docker/Dockerfile.batch-submitter
+      dockerfile: ./ops/docker/Dockerfile.packages
+      target: batch-submitter
     entrypoint: ./batches.sh
     env_file:
       - ./envs/batches.env
@@ -147,7 +139,6 @@ services:
       - l1_chain
       - deployer
       - dtl
-    image: ethereumoptimism/l2geth:${DOCKER_TAG:-latest}
     deploy:
       replicas: 0
     build:
@@ -171,7 +162,6 @@ services:
   replica:
     depends_on:
       - dtl
-    image: ethereumoptimism/l2geth:${DOCKER_TAG:-latest}
     deploy:
       replicas: 0
     build:
@@ -193,12 +183,12 @@ services:
       - ${L2GETH_WS_PORT:-8550}:8546
 
   integration_tests:
-    image: ethereumoptimism/integration-tests:${DOCKER_TAG:-latest}
     deploy:
        replicas: 0
     build:
       context: ..
-      dockerfile: ./ops/docker/Dockerfile.integration-tests
+      dockerfile: ./ops/docker/Dockerfile.packages
+      target: integration-tests
     entrypoint: ./integration-tests.sh
     environment:
       L1_URL: http://l1_chain:8545
@@ -208,7 +198,6 @@ services:
       NO_NETWORK: 1
 
   gas_oracle:
-    image: ethereumoptimism/gas-oracle:${DOCKER_TAG:-latest}
     deploy:
        replicas: 0
     build:

--- a/ops/docker/Dockerfile.integration-tests
+++ b/ops/docker/Dockerfile.integration-tests
@@ -25,4 +25,4 @@ WORKDIR /opt/optimism/integration-tests
 COPY --from=builder /optimism/integration-tests ./
 
 COPY ./ops/scripts/integration-tests.sh ./
-ENTRYPOINT yarn test:integration
+CMD ["yarn", "test:integration"]

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -1,0 +1,62 @@
+# This Dockerfile builds all the dependencies needed by the monorepo, and should
+# be used to build any of the follow-on services
+#
+# ### BASE: Install deps
+# We do not use Alpine because there's a regression causing it to be very slow
+# when used with typescript/hardhat: https://github.com/nomiclabs/hardhat/issues/1219
+FROM node:14.18.1-buster-slim as base
+
+RUN apt-get update -y && apt-get install -y git curl jq python3
+
+# copy over the needed configs to run the dep installation
+# note: this approach can be a bit unhandy to maintain, but it allows
+# us to cache the installation steps
+WORKDIR /optimism
+COPY *.json yarn.lock ./
+COPY packages/core-utils/package.json ./packages/core-utils/package.json
+COPY packages/common-ts/package.json ./packages/common-ts/package.json
+COPY packages/contracts/package.json ./packages/contracts/package.json
+COPY packages/data-transport-layer/package.json ./packages/data-transport-layer/package.json
+COPY packages/batch-submitter/package.json ./packages/batch-submitter/package.json
+COPY packages/message-relayer/package.json ./packages/message-relayer/package.json
+COPY packages/replica-healthcheck/package.json ./packages/replica-healthcheck/package.json
+COPY packages/regenesis-surgery/package.json ./packages/regenesis-surgery/package.json
+COPY integration-tests/package.json ./integration-tests/package.json
+
+RUN yarn install --frozen-lockfile
+
+COPY ./packages ./packages
+COPY ./integration-tests ./integration-tests
+
+# build it!
+RUN yarn build
+
+
+FROM base as deployer
+WORKDIR /optimism/packages/contracts
+COPY ./ops/scripts/deployer.sh .
+CMD ["yarn", "run", "deploy"]
+
+
+FROM base as batch-submitter
+WORKDIR /optimism/packages/batch-submitter
+COPY ./ops/scripts/batches.sh .
+CMD ["npm", "run", "start"]
+
+
+FROM base as data-transport-layer
+WORKDIR /optimism/packages/data-transport-layer
+COPY ./ops/scripts/dtl.sh .
+CMD ["node", "dist/src/services/run.js"]
+
+
+FROM base as integration-tests
+WORKDIR /optimism/integration-tests
+COPY ./ops/scripts/integration-tests.sh ./
+CMD ["yarn", "test:integration"]
+
+
+FROM base as relayer
+WORKDIR /opt/optimism/packages/message-relayer
+COPY ./ops/scripts/relayer.sh .
+ENTRYPOINT ["npm", "run", "start"]


### PR DESCRIPTION
This PR updates the integration tests to build JS services using a single Dockerfile rather than multiple Dockerfiles that inherit from a builder image. This fixes the issues we've been seeing where the builder image on Docker Hub gets pulled instead of the locally-build one. The individual service to build is selected via the `target` attribute in `docker-compose.yml`.