### PR TITLE
integration-tests: enable rollup_gasPrices test

### DIFF
--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -425,11 +425,10 @@ describe('Basic RPC tests', () => {
     })
   })
 
-  // SKIP: ?
-  describe.skip('rollup_gasPrices', () => {
+  describe('rollup_gasPrices', () => {
     it('should return the L1 and L2 gas prices', async () => {
       const result = await provider.send('rollup_gasPrices', [])
-      const l1GasPrice = await env.l1Wallet.provider.getGasPrice()
+      const l1GasPrice = await env.gasPriceOracle.l1BaseFee()
       const l2GasPrice = await env.gasPriceOracle.gasPrice()
 
       expect(BigNumber.from(result.l1GasPrice)).to.deep.eq(l1GasPrice)


### PR DESCRIPTION
**Description**

Enable the RPC test for `rollup_gasPrices` that
was previously disabled due to how the gas pricing
scheme was changed in `v0.5.0`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

