### PR TITLE
integration-tests: skip all tests on mainnet subject to wd period

### DIFF
--- a/integration-tests/test/bridged-tokens.ts
+++ b/integration-tests/test/bridged-tokens.ts
@@ -4,7 +4,7 @@ import * as L2Artifact from '@eth-optimism/contracts/artifacts/contracts/standar
 import { expect } from 'chai'
 
 import { OptimismEnv } from './shared/env'
-import { isLiveNetwork } from './shared/utils'
+import { isLiveNetwork, isMainnet } from './shared/utils'
 import { Direction } from './shared/watcher-utils'
 
 describe('Bridged tokens', () => {
@@ -89,7 +89,13 @@ describe('Bridged tokens', () => {
     )
   })
 
-  it('should withdraw tokens from L2 to the depositor', async () => {
+  it('should withdraw tokens from L2 to the depositor', async function () {
+    if (await isMainnet(env)) {
+      console.log('Skipping withdrawals test on mainnet.')
+      this.skip()
+      return
+    }
+
     const tx = await env.l2Bridge.withdraw(
       L2__ERC20.address,
       500,
@@ -106,7 +112,13 @@ describe('Bridged tokens', () => {
     )
   }).timeout(isLiveNetwork() ? 300_000 : 120_000)
 
-  it('should withdraw tokens from L2 to the transfer recipient', async () => {
+  it('should withdraw tokens from L2 to the transfer recipient', async function () {
+    if (await isMainnet(env)) {
+      console.log('Skipping withdrawals test on mainnet.')
+      this.skip()
+      return
+    }
+
     const tx = await env.l2Bridge
       .connect(otherWalletL2)
       .withdraw(L2__ERC20.address, 500, 2000000, '0x')

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -9,7 +9,7 @@ import { expectApprox } from '@eth-optimism/core-utils'
 /* Imports: Internal */
 import { Direction } from './shared/watcher-utils'
 
-import { PROXY_SEQUENCER_ENTRYPOINT_ADDRESS } from './shared/utils'
+import { isMainnet, PROXY_SEQUENCER_ENTRYPOINT_ADDRESS } from './shared/utils'
 import { OptimismEnv } from './shared/env'
 
 const DEFAULT_TEST_GAS_L1 = 330_000
@@ -183,7 +183,13 @@ describe('Native ETH Integration Tests', async () => {
     ).to.be.reverted
   })
 
-  it('withdraw', async () => {
+  it('withdraw', async function () {
+    if (await isMainnet(env)) {
+      console.log('Skipping withdrawals test on mainnet.')
+      this.skip()
+      return
+    }
+
     const withdrawAmount = BigNumber.from(3)
     const preBalances = await getBalances(env)
     expect(
@@ -225,7 +231,13 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('withdrawTo', async () => {
+  it('withdrawTo', async function () {
+    if (await isMainnet(env)) {
+      console.log('Skipping withdrawals test on mainnet.')
+      this.skip()
+      return
+    }
+
     const withdrawAmount = BigNumber.from(3)
 
     const preBalances = await getBalances(env)
@@ -283,7 +295,13 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('deposit, transfer, withdraw', async () => {
+  it('deposit, transfer, withdraw', async function () {
+    if (await isMainnet(env)) {
+      console.log('Skipping withdrawals test on mainnet.')
+      this.skip()
+      return
+    }
+
     // 1. deposit
     const amount = utils.parseEther('1')
     await env.waitForXDomainTransaction(


### PR DESCRIPTION
Skips all tests that use L2->L1 comms on mainnet since they are all subject to the withdrawal period.﻿
