### PR TITLE
ops: turn off message relayer

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -102,6 +102,8 @@ services:
       - l1_chain
       - deployer
       - l2geth
+    deploy:
+      replicas: 0
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.packages


### PR DESCRIPTION
**Description**

Don't bring up the message relayer in the docker-compose setup.
This is a breaking change and will need to be communicated.

Ideally there is time to communicate this but `regenesis/0.5.0` is breaking compared to `develop`, we might as well get this in now. Should save on some CI time

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


