### PR TITLE
docs: Remove runtime target from docstrings

### DIFF
--- a/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
+++ b/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol
@@ -33,7 +33,6 @@ import {
  * from L2 onto L1. In the event that a message sent from L1 to L2 is rejected for exceeding the L2
  * epoch gas limit, it can be resubmitted via this contract's replay function.
  *
- * Runtime target: EVM
  */
 contract L1CrossDomainMessenger is
     IL1CrossDomainMessenger,

--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -19,7 +19,6 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
  * tokens that are in use on L2. It synchronizes a corresponding L2 Bridge, informing it of deposits
  * and listening to it for newly finalized withdrawals.
  *
- * Runtime target: EVM
  */
 contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
     using SafeERC20 for IERC20;

--- a/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
+++ b/packages/contracts/contracts/L1/rollup/CanonicalTransactionChain.sol
@@ -18,7 +18,6 @@ import { IChainStorageContainer } from "./IChainStorageContainer.sol";
  * The CTC also allows any account to 'enqueue' an L2 transaction, which will require that the
  * Sequencer will eventually append it to the rollup state.
  *
- * Runtime target: EVM
  */
 contract CanonicalTransactionChain is ICanonicalTransactionChain, Lib_AddressResolver {
     /*************

--- a/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
+++ b/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
@@ -19,7 +19,6 @@ import { IChainStorageContainer } from "./IChainStorageContainer.sol";
  * 2. Stores queued transactions for the Canonical Transaction Chain
  * 3. Stores chain state batches for the State Commitment Chain
  *
- * Runtime target: EVM
  */
 contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {
     /*************

--- a/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
@@ -19,7 +19,6 @@ import { IChainStorageContainer } from "./IChainStorageContainer.sol";
  * Elements here have a 1:1 correspondence with transactions in the CTC, and should be the unique
  * state root calculated off-chain by applying the canonical transactions one by one.
  *
- * Runtime target: EVM
  */
 contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
     /*************

--- a/packages/contracts/contracts/L1/verification/BondManager.sol
+++ b/packages/contracts/contracts/L1/verification/BondManager.sol
@@ -12,7 +12,6 @@ import { Lib_AddressResolver } from "../../libraries/resolver/Lib_AddressResolve
  * @dev This contract is, for now, a stub of the "real" BondManager that does nothing but
  * allow the "OVM_Proposer" to submit state root batches.
  *
- * Runtime target: EVM
  */
 contract BondManager is IBondManager, Lib_AddressResolver {
     /**

--- a/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
+++ b/packages/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol
@@ -9,7 +9,6 @@ import { ICrossDomainMessenger } from "./ICrossDomainMessenger.sol";
  * @dev Helper contract for contracts performing cross-domain communications
  *
  * Compiler used: defined by inheriting contract
- * Runtime target: defined by inheriting contract
  */
 contract CrossDomainEnabled {
     /*************


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Remove runtime target from doc strings and identify contracts with missing descriptions

**Additional context**
Contracts in the contracts package with missing descriptions are:

packages/contracts/L2/predeploys/WETH9.sol
packages/contracts/libraries/resolver/Lib_AddressManager.sol
packages/contracts/libraries/resolver/Lib_AddressResolver.
packages/contracts/libraries/resolver/Lib_ResolvedDelegateProxy.sol
packages/contracts/standards/L2StandardERC20.sol
packages/contracts/test-helpers/Helper_GasMeasurer.sol
packages/contracts/test-helpers/Helper_SimpleProxy.sol
packages/contracts/test-helpers/TestERC20.sol
packages/contracts/test-libraries/codec/TestLib_OVMCodec.sol
packages/contracts/contracts/test-libraries/rlp/TestLib_RLPReader.sol
packages/contracts/contracts/test-libraries/rlp/TestLib_RLPWriter.sol
packages/contracts/contracts/test-libraries/standards/TestLib_AddressAliasHelper.sol
packages/contracts/contracts/test-libraries/trie/TestLib_MerkleTrie.sol
packages/contracts/contracts/test-libraries/trie/TestLib_SecureMerkleTrie.sol
packages/contracts/contracts/test-libraries/utils/TestLib_Buffer.sol
packages/contracts/contracts/test-libraries/utils/TestLib_Bytes32Utils.sol
packages/contracts/contracts/test-libraries/utils/TestLib_BytesUtils.sol
packages/contracts/contracts/test-libraries/utils/TestLib_MerkleTree.sol

**Metadata**
- Fixes #1710 
