### PR TITLE
fix: no gas price for static fns in deploy

### DIFF
--- a/.changeset/lovely-pumas-sing.md
+++ b/.changeset/lovely-pumas-sing.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Use a gas price of zero for static calls in the deploy process

--- a/packages/contracts/deploy/000-hardhat-setup.ts
+++ b/packages/contracts/deploy/000-hardhat-setup.ts
@@ -6,7 +6,7 @@ import {
   fundAccount,
   sendImpersonatedTx,
   BIG_BALANCE,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 import { awaitCondition } from '@eth-optimism/core-utils'
 

--- a/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
+++ b/packages/contracts/deploy/002-OVM_ChainStorageContainer_ctc_batches.deploy.ts
@@ -5,7 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
+++ b/packages/contracts/deploy/003-OVM_ChainStorageContainer_scc_batches.deploy.ts
@@ -5,7 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
+++ b/packages/contracts/deploy/004-OVM_CanonicalTransactionChain.deploy.ts
@@ -5,7 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
+++ b/packages/contracts/deploy/005-OVM_StateCommitmentChain.deploy.ts
@@ -5,7 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
+++ b/packages/contracts/deploy/006-OVM_BondManager.deploy.ts
@@ -5,7 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
@@ -6,7 +6,7 @@ import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/008-Proxy__OVM_L1CrossDomainMessenger.deploy.ts
@@ -5,7 +5,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/009-Proxy__OVM_L1StandardBridge.deploy.ts
@@ -2,7 +2,7 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { deployAndVerifyAndThen } from '../src/hardhat-deploy-ethers'
+import { deployAndVerifyAndThen } from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/010-AddressDictator.deploy.ts
+++ b/packages/contracts/deploy/010-AddressDictator.deploy.ts
@@ -6,7 +6,7 @@ import { hexStringEquals } from '@eth-optimism/core-utils'
 import {
   deployAndVerifyAndThen,
   getContractFromArtifact,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 import { predeploys } from '../src/predeploys'
 

--- a/packages/contracts/deploy/011-set-addresses.ts
+++ b/packages/contracts/deploy/011-set-addresses.ts
@@ -3,10 +3,7 @@ import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import {
-  getContractFromArtifact,
-  isHardhatNode,
-} from '../src/hardhat-deploy-ethers'
+import { getContractFromArtifact, isHardhatNode } from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
+++ b/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
-import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
+import { getContractFromArtifact } from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
+++ b/packages/contracts/deploy/013-ChugSplashDictator.deploy.ts
@@ -8,7 +8,7 @@ import { getContractDefinition } from '../src/contract-defs'
 import {
   getContractFromArtifact,
   deployAndVerifyAndThen,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
+++ b/packages/contracts/deploy/014-OVM_L1StandardBridge.deploy.ts
@@ -9,7 +9,7 @@ import {
   getContractFromArtifact,
   deployAndVerifyAndThen,
   isHardhatNode,
-} from '../src/hardhat-deploy-ethers'
+} from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 const deployFn: DeployFunction = async (hre) => {

--- a/packages/contracts/deploy/015-finalize.ts
+++ b/packages/contracts/deploy/015-finalize.ts
@@ -3,7 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import { hexStringEquals, awaitCondition } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
-import { getContractFromArtifact } from '../src/hardhat-deploy-ethers'
+import { getContractFromArtifact } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -5,10 +5,7 @@ import { defaultHardhatNetworkHdAccountsConfigParams } from 'hardhat/internal/co
 import { normalizeHardhatNetworkAccountsConfig } from 'hardhat/internal/core/providers/util'
 
 /* Imports: Internal */
-import {
-  getContractFromArtifact,
-  isHardhatNode,
-} from '../src/hardhat-deploy-ethers'
+import { getContractFromArtifact, isHardhatNode } from '../src/deploy-utils'
 import { names } from '../src/address-names'
 
 // This is a TEMPORARY way to fund the default hardhat accounts on L2. The better way to do this is


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes the issue that we experienced yesterday where static calls would fail because we provide a gas price. Now, if the function is constant (static), we provide an explicit gas price of 0.

I also renamed `hardhat-deploy-ethers.ts` (a terrible file name) to `deploy-utils.ts`.