### PR TITLE
feat: transfer messenger ownership during deploy

### DIFF
--- a/.changeset/sharp-ants-act.md
+++ b/.changeset/sharp-ants-act.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Adds additional deploy step to transfer messenger ownership

--- a/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
+++ b/packages/contracts/deploy/007-OVM_L1CrossDomainMessenger.deploy.ts
@@ -25,7 +25,7 @@ const deployFn: DeployFunction = async (hre) => {
       // a proxy. However, it's best practice to initialize it anyway just in case there's
       // some unknown security hole. It also prevents another user from appearing like an
       // official address because it managed to call the initialization function.
-      console.log(`Initializing L1CrossDomainMessenger...`)
+      console.log(`Initializing L1CrossDomainMessenger (implementation)...`)
       await contract.initialize(Lib_AddressManager.address)
 
       console.log(`Checking that contract was correctly initialized...`)
@@ -35,6 +35,23 @@ const deployFn: DeployFunction = async (hre) => {
             await contract.libAddressManager(),
             Lib_AddressManager.address
           )
+        },
+        5000,
+        100
+      )
+
+      // Same thing as above, we want to transfer ownership of this contract to the owner of the
+      // AddressManager. Not technically necessary but seems like the right thing to do.
+      console.log(
+        `Transferring ownership of L1CrossDomainMessenger (implementation)...`
+      )
+      const owner = (hre as any).deployConfig.ovmAddressManagerOwner
+      await contract.transferOwnership(owner)
+
+      console.log(`Checking that contract owner was correctly set...`)
+      await awaitCondition(
+        async () => {
+          return hexStringEquals(await contract.owner(), owner)
         },
         5000,
         100

--- a/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
+++ b/packages/contracts/deploy/012-initialize-Proxy__L1CrossDomainMessenger.ts
@@ -9,8 +9,6 @@ import { names } from '../src/address-names'
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
 
-  console.log(`Initializing Proxy__L1CrossDomainMessenger...`)
-
   // There's a risk that we could get front-run during a fresh deployment, which would brick this
   // contract and require that the proxy be re-deployed. We will not have this risk once we move
   // entirely to chugsplash-style deployments. It's unlikely to happen and relatively easy to
@@ -29,6 +27,7 @@ const deployFn: DeployFunction = async (hre) => {
     names.unmanaged.Lib_AddressManager
   )
 
+  console.log(`Initializing Proxy__OVM_L1CrossDomainMessenger...`)
   await Proxy__OVM_L1CrossDomainMessenger.initialize(Lib_AddressManager.address)
 
   console.log(`Checking that contract was correctly initialized...`)
@@ -37,6 +36,22 @@ const deployFn: DeployFunction = async (hre) => {
       return hexStringEquals(
         await Proxy__OVM_L1CrossDomainMessenger.libAddressManager(),
         Lib_AddressManager.address
+      )
+    },
+    5000,
+    100
+  )
+
+  console.log(`Setting Proxy__OVM_L1CrossDomainMessenger owner...`)
+  const owner = (hre as any).deployConfig.ovmAddressManagerOwner
+  await Proxy__OVM_L1CrossDomainMessenger.transferOwnership(owner)
+
+  console.log(`Checking that the contract owner was correctly set...`)
+  await awaitCondition(
+    async () => {
+      return hexStringEquals(
+        await Proxy__OVM_L1CrossDomainMessenger.owner(),
+        owner
       )
     },
     5000,


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds steps to the deployment to transfer away messenger ownership *during* the deployment so we don't have to do it manually afterwards.
