### PR TITLE
fix: remove branch restrictions for some workflows

### DIFF
--- a/.github/workflows/batch-submitter.yml
+++ b/.github/workflows/batch-submitter.yml
@@ -12,11 +12,6 @@ on:
   pull_request:
     paths:
       - 'go/batch-submitter/*'
-    branches:
-      - 'master'
-      - 'develop'
-      - '*rc'
-      - 'regenesis/*'
   workflow_dispatch:
 
 defaults:
@@ -31,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x 
+          go-version: 1.16.x
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -40,4 +35,4 @@ jobs:
         run: make
 
       - name: Test
-        run: make test 
+        run: make test

--- a/.github/workflows/gas-oracle.yml
+++ b/.github/workflows/gas-oracle.yml
@@ -12,11 +12,6 @@ on:
   pull_request:
     paths:
       - 'go/gas-oracle/**'
-    branches:
-      - 'master'
-      - 'develop'
-      - '*rc'
-      - 'regenesis/*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -1,6 +1,5 @@
 name: geth unit tests
 
-
 on:
   push:
     paths:
@@ -13,11 +12,6 @@ on:
   pull_request:
     paths:
       - 'l2geth/**'
-    branches:
-      - 'master'
-      - 'develop'
-      - '*rc'
-      - 'regenesis/*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,11 +13,6 @@ on:
     paths:
       - 'go/gas-oracle/**'
       - 'go/batch-submitter/**'
-    branches:
-      - 'master'
-      - 'develop'
-      - '*rc'
-      - 'regenesis/*'
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes branch restrictions for all testing/linting workflows that still had them so that we're running these when working on  *any* base branch.

**Metadata**
- Fixes ENG-1541
