### PR TITLE
fix: use valid default pk in hh config

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -26,9 +26,7 @@ import 'hardhat-gas-reporter'
 dotenv.config()
 
 const enableGasReport = !!process.env.ENABLE_GAS_REPORT
-const privateKey =
-  process.env.PRIVATE_KEY ||
-  '0x0000000000000000000000000000000000000000000000000000000000000000' // this is to avoid hardhat error
+const privateKey = process.env.PRIVATE_KEY || '0x' + '11'.repeat(32) // this is to avoid hardhat error
 
 const config: HardhatUserConfig = {
   networks: {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Minor fix to use a valid default private key in our `contracts` hardhat config. Stuff doesn't work properly without this fix.
