### PR TITLE
Run integration tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+jobs:
+  run-itests:
+    machine:
+      image: ubuntu-2004:202107-02
+      docker_layer_caching: true
+      resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Bring the stack up
+          command: |
+            cd ops && docker-compose up --force-recreate --build -d
+      - run:
+          name: Wait for the sequencer
+          command: |
+            cd ops && ./scripts/wait-for-sequencer.sh
+      - run:
+          name: Run the integration tests
+          command: |
+            cd ops && docker-compose run integration_tests
+
+
+workflows:
+  monorepo-itests:
+    jobs:
+      - run-itests:
+          context: optimism


### PR DESCRIPTION
This PR adds a CircleCI config that runs our integration tests there. You can see sample test output from this job here: https://app.circleci.com/pipelines/github/mslipper/optimism/81/workflows/487f4758-fc37-4a20-bf0f-58bdd66cfd64/jobs/246.

Total runtime is 14m for the whole suite from a cold cache, which is significantly less than our average of 17-25 minutes. Marking as a draft PR since we may want to explore using [Tekton](https://tekton.dev/) as well.