### PR TITLE
fix: add dependencies to resolve yarn warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,13 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.16.0",
-    "@codechecks/client": "^0.1.11"
+    "@codechecks/client": "^0.1.11",
+    "@ethersproject/abi": "^5.0.0",
+    "@ethersproject/abstract-signer": "^5",
+    "@ethersproject/bytes": "^5.0.0",
+    "@ethersproject/providers": "^5.0.0",
+    "@nomiclabs/ethereumjs-vm": "^4",
+    "@types/node": "*",
+    "ethers": "^5.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,12 +58,9 @@
   "dependencies": {
     "@changesets/cli": "^2.16.0",
     "@codechecks/client": "^0.1.11",
-    "@ethersproject/abi": "^5.0.0",
+    "@ethersproject/abi": "^5",
     "@ethersproject/abstract-signer": "^5",
-    "@ethersproject/bytes": "^5.0.0",
-    "@ethersproject/providers": "^5.0.0",
     "@nomiclabs/ethereumjs-vm": "^4",
-    "@types/node": "*",
     "ethers": "^5.4.5"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -47,9 +47,16 @@
   },
   "dependencies": {
     "@eth-optimism/core-utils": "0.7.0",
+    "@eth-optimism/smock": "1.1.10",
+    "@ethersproject/abi": "^5",
     "@ethersproject/abstract-provider": "^5.4.1",
-    "@ethersproject/abstract-signer": "^5.4.1",
-    "@ethersproject/hardware-wallets": "^5.4.0"
+    "@ethersproject/abstract-signer": "^5",
+    "@ethersproject/bytes": "^5.0.0",
+    "@ethersproject/hardware-wallets": "^5.4.0",
+    "@ethersproject/providers": "^5.0.0",
+    "@nomiclabs/ethereumjs-vm": "^4",
+    "@types/node": "^16.11.7",
+    "ethers": "^5.4.5"
   },
   "devDependencies": {
     "@codechecks/client": "^0.1.11",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -44,10 +44,12 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@ethersproject/abi": "^5",
     "@ethersproject/abstract-provider": "^5.4.1",
     "@ethersproject/bytes": "^5.5.0",
     "@ethersproject/providers": "^5.4.5",
     "@ethersproject/web": "^5.5.0",
+    "@nomiclabs/ethereumjs-vm": "^4",
     "chai": "^4.3.4",
     "ethers": "^5.4.5",
     "lodash": "^4.17.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,7 +761,7 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
 
-"@ethersproject/abstract-signer@^5.5.0":
+"@ethersproject/abstract-signer@^5", "@ethersproject/abstract-signer@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
   integrity sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,21 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@ethersproject/abi@^5":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.5.0.tgz#fb52820e22e50b854ff15ce1647cc508d6660613"
+  integrity sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==
+  dependencies:
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
 "@ethersproject/abi@^5.0.12":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.1.tgz#6ac28fafc9ef6f5a7a37e30356a2eb31fa05d39b"
@@ -2897,6 +2912,11 @@
   version "15.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
+
+"@types/node@^16.11.7":
+  version "16.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
+  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
 
 "@types/node@^8.0.0":
   version "8.10.66"


### PR DESCRIPTION
With this code when you execute yarn on root route, no warnings are throw