### PR TITLE
fix: add missed tx recovery to l2 dtl sync

### DIFF
--- a/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/handlers/transaction.ts
@@ -110,6 +110,18 @@ export const handleSequencerBlock = {
     },
     db: TransportDB
   ): Promise<void> => {
+    // Defend against situations where we somehow miss a transaction during sync
+    if (entry.transactionEntry.index > 0) {
+      const prevTransactionEntry = await db.getUnconfirmedTransactionByIndex(
+        entry.transactionEntry.index - 1
+      )
+
+      // We should *always* have a previous transaction here.
+      if (prevTransactionEntry === null) {
+        throw new Error('missing transaction entry in L2 sync')
+      }
+    }
+
     // Having separate indices for confirmed/unconfirmed means we never have to worry about
     // accidentally overwriting a confirmed transaction with an unconfirmed one. Unconfirmed
     // transactions are purely extra information.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds logic to the L2 dtl sync path to avoid situations in which there are missed transactions during the sync process.