### PR TITLE
ENG-1670 - improve proxyd metrics, support local rate limiter

### DIFF
--- a/.changeset/swift-ways-glow.md
+++ b/.changeset/swift-ways-glow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Updated metrics, support local rate limiter

--- a/go/proxyd/backend.go
+++ b/go/proxyd/backend.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -24,36 +25,44 @@ const (
 
 var (
 	ErrInvalidRequest = &RPCErr{
-		Code:    -32601,
-		Message: "invalid request",
+		Code:          -32601,
+		Message:       "invalid request",
+		HTTPErrorCode: 400,
 	}
 	ErrParseErr = &RPCErr{
-		Code:    -32700,
-		Message: "parse error",
+		Code:          -32700,
+		Message:       "parse error",
+		HTTPErrorCode: 400,
 	}
 	ErrInternal = &RPCErr{
-		Code:    JSONRPCErrorInternal,
-		Message: "internal error",
+		Code:          JSONRPCErrorInternal,
+		Message:       "internal error",
+		HTTPErrorCode: 500,
 	}
 	ErrMethodNotWhitelisted = &RPCErr{
-		Code:    JSONRPCErrorInternal - 1,
-		Message: "rpc method is not whitelisted",
+		Code:          JSONRPCErrorInternal - 1,
+		Message:       "rpc method is not whitelisted",
+		HTTPErrorCode: 403,
 	}
 	ErrBackendOffline = &RPCErr{
-		Code:    JSONRPCErrorInternal - 10,
-		Message: "backend offline",
+		Code:          JSONRPCErrorInternal - 10,
+		Message:       "backend offline",
+		HTTPErrorCode: 503,
 	}
 	ErrNoBackends = &RPCErr{
-		Code:    JSONRPCErrorInternal - 11,
-		Message: "no backends available for method",
+		Code:          JSONRPCErrorInternal - 11,
+		Message:       "no backends available for method",
+		HTTPErrorCode: 503,
 	}
 	ErrBackendOverCapacity = &RPCErr{
-		Code:    JSONRPCErrorInternal - 12,
-		Message: "backend is over capacity",
+		Code:          JSONRPCErrorInternal - 12,
+		Message:       "backend is over capacity",
+		HTTPErrorCode: 429,
 	}
 	ErrBackendBadResponse = &RPCErr{
-		Code:    JSONRPCErrorInternal - 13,
-		Message: "backend returned an invalid response",
+		Code:          JSONRPCErrorInternal - 13,
+		Message:       "backend returned an invalid response",
+		HTTPErrorCode: 500,
 	}
 )
 
@@ -63,7 +72,7 @@ type Backend struct {
 	wsURL                string
 	authUsername         string
 	authPassword         string
-	redis                Redis
+	rateLimiter          RateLimiter
 	client               *http.Client
 	dialer               *websocket.Dialer
 	maxRetries           int
@@ -122,14 +131,14 @@ func NewBackend(
 	name string,
 	rpcURL string,
 	wsURL string,
-	redis Redis,
+	rateLimiter RateLimiter,
 	opts ...BackendOpt,
 ) *Backend {
 	backend := &Backend{
 		Name:            name,
 		rpcURL:          rpcURL,
 		wsURL:           wsURL,
-		redis:           redis,
+		rateLimiter:     rateLimiter,
 		maxResponseSize: math.MaxInt64,
 		client: &http.Client{
 			Timeout: 5 * time.Second,
@@ -160,7 +169,7 @@ func (b *Backend) Forward(ctx context.Context, req *RPCReq) (*RPCRes, error) {
 	for i := 0; i <= b.maxRetries; i++ {
 		RecordRPCForward(ctx, b.Name, req.Method, RPCRequestSourceHTTP)
 		respTimer := prometheus.NewTimer(rpcBackendRequestDurationSumm.WithLabelValues(b.Name, req.Method))
-		res, err := b.doForward(req)
+		res, err := b.doForward(ctx, req)
 		if err != nil {
 			lastError = err
 			log.Warn(
@@ -210,7 +219,7 @@ func (b *Backend) ProxyWS(clientConn *websocket.Conn, methodWhitelist *StringSet
 	backendConn, _, err := b.dialer.Dial(b.wsURL, nil)
 	if err != nil {
 		b.setOffline()
-		if err := b.redis.DecBackendWSConns(b.Name); err != nil {
+		if err := b.rateLimiter.DecBackendWSConns(b.Name); err != nil {
 			log.Error("error decrementing backend ws conns", "name", b.Name, "err", err)
 		}
 		return nil, wrapErr(err, "error dialing backend")
@@ -221,7 +230,7 @@ func (b *Backend) ProxyWS(clientConn *websocket.Conn, methodWhitelist *StringSet
 }
 
 func (b *Backend) Online() bool {
-	online, err := b.redis.IsBackendOnline(b.Name)
+	online, err := b.rateLimiter.IsBackendOnline(b.Name)
 	if err != nil {
 		log.Warn(
 			"error getting backend availability, assuming it is offline",
@@ -238,7 +247,7 @@ func (b *Backend) IsRateLimited() bool {
 		return false
 	}
 
-	usedLimit, err := b.redis.IncBackendRPS(b.Name)
+	usedLimit, err := b.rateLimiter.IncBackendRPS(b.Name)
 	if err != nil {
 		log.Error(
 			"error getting backend used rate limit, assuming limit is exhausted",
@@ -256,7 +265,7 @@ func (b *Backend) IsWSSaturated() bool {
 		return false
 	}
 
-	incremented, err := b.redis.IncBackendWSConns(b.Name, b.maxWSConns)
+	incremented, err := b.rateLimiter.IncBackendWSConns(b.Name, b.maxWSConns)
 	if err != nil {
 		log.Error(
 			"error getting backend used ws conns, assuming limit is exhausted",
@@ -270,7 +279,7 @@ func (b *Backend) IsWSSaturated() bool {
 }
 
 func (b *Backend) setOffline() {
-	err := b.redis.SetBackendOffline(b.Name, b.outOfServiceInterval)
+	err := b.rateLimiter.SetBackendOffline(b.Name, b.outOfServiceInterval)
 	if err != nil {
 		log.Warn(
 			"error setting backend offline",
@@ -280,7 +289,7 @@ func (b *Backend) setOffline() {
 	}
 }
 
-func (b *Backend) doForward(rpcReq *RPCReq) (*RPCRes, error) {
+func (b *Backend) doForward(ctx context.Context, rpcReq *RPCReq) (*RPCRes, error) {
 	body := mustMarshalJSON(rpcReq)
 
 	httpReq, err := http.NewRequest("POST", b.rpcURL, bytes.NewReader(body))
@@ -299,6 +308,13 @@ func (b *Backend) doForward(rpcReq *RPCReq) (*RPCRes, error) {
 		return nil, wrapErr(err, "error in backend request")
 	}
 
+	rpcBackendHTTPResponseCodesTotal.WithLabelValues(
+		GetAuthCtx(ctx),
+		b.Name,
+		rpcReq.Method,
+		strconv.Itoa(httpRes.StatusCode),
+	).Inc()
+
 	// Alchemy returns a 400 on bad JSONs, so handle that case
 	if httpRes.StatusCode != 200 && httpRes.StatusCode != 400 {
 		return nil, fmt.Errorf("response code %d", httpRes.StatusCode)
@@ -313,6 +329,12 @@ func (b *Backend) doForward(rpcReq *RPCReq) (*RPCRes, error) {
 	res := new(RPCRes)
 	if err := json.Unmarshal(resB, res); err != nil {
 		return nil, ErrBackendBadResponse
+	}
+
+	// capture the HTTP status code in the response. this will only
+	// ever be 400 given the status check on line 318 above.
+	if httpRes.StatusCode != 200 {
+		res.Error.HTTPErrorCode = httpRes.StatusCode
 	}
 
 	return res, nil
@@ -556,7 +578,7 @@ func (w *WSProxier) backendPump(ctx context.Context, errC chan error) {
 func (w *WSProxier) close() {
 	w.clientConn.Close()
 	w.backendConn.Close()
-	if err := w.backend.redis.DecBackendWSConns(w.backend.Name); err != nil {
+	if err := w.backend.rateLimiter.DecBackendWSConns(w.backend.Name); err != nil {
 		log.Error("error decrementing backend ws conns", "name", w.backend.Name, "err", err)
 	}
 	activeBackendWsConnsGauge.WithLabelValues(w.backend.Name).Dec()

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -37,7 +37,7 @@ type BackendConfig struct {
 type BackendsConfig map[string]*BackendConfig
 
 type BackendGroupConfig struct {
-	Backends  []string `toml:"backends"`
+	Backends []string `toml:"backends"`
 }
 
 type BackendGroupsConfig map[string]*BackendGroupConfig

--- a/go/proxyd/metrics.go
+++ b/go/proxyd/metrics.go
@@ -38,6 +38,17 @@ var (
 		"source",
 	})
 
+	rpcBackendHTTPResponseCodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "rpc_backend_http_response_codes_total",
+		Help:      "Count of total backend responses by HTTP status code.",
+	}, []string{
+		"auth",
+		"backend_name",
+		"method_name",
+		"status_code",
+	})
+
 	rpcErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "rpc_errors_total",
@@ -99,6 +110,14 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      "http_requests_total",
 		Help:      "Count of total HTTP requests.",
+	})
+
+	httpResponseCodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "http_response_codes_total",
+		Help:      "Count of total HTTP response codes.",
+	}, []string{
+		"status_code",
 	})
 
 	httpRequestDurationSumm = promauto.NewSummary(prometheus.SummaryOpts{

--- a/go/proxyd/rpc.go
+++ b/go/proxyd/rpc.go
@@ -25,8 +25,9 @@ func (r *RPCRes) IsError() bool {
 }
 
 type RPCErr struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+	Code          int    `json:"code"`
+	Message       string `json:"message"`
+	HTTPErrorCode int    `json:"-"`
 }
 
 func (r *RPCErr) Error() string {


### PR DESCRIPTION
This PR improves `proxyd` metrics, and removes the requirement to use Redis with the rate limiter.

**New metrics** 

`rpc_backend_http_response_codes_total{"auth", "backend_name", "method_name", "status_code"}` - This counter tracks HTTP error codes returned from each proxy backend. It's maintained as a separate metric from `rpc_errors_total` since `rpc_errors_total` keeps track of errors found _in the JSON-RPC response body_.

`http_response_codes_total` - This counter tracks HTTP response codes returned to the client. Usually, this will be 200 except in a couple of exceptional cases:

- 503 when there are no backends available.
- 400 when the request payload is inavlid.
- 401 when a bad auth token is provided.
- 404 when a path can't be found.

Other errors will return either a 500, or a 200 with a JSON-RPC response code. HTTP error codes other than 400s are **not** proxied from the upstream because they are inconsistent among different infrastructure providers.

**Rate limiting**

Redis is no longer required to apply rate limiting. If the `[redis]` stanza is not provided in the config, then `proxyd` will use an in-memory rate limiter instead. To remove rate limiting from an endpoint altogether, remove Redis from the config and set the RPS and concurrency limits to zero.

**User agent logging**

The user agent is now logged. It looks like this:

```
INFO [11-18|09:00:59.516] received RPC request                     req_id=eb133e436364c84a179e auth=foobar user_agent="Paw/3.3.1 (Macintosh; OS X/11.4.0) GCDHTTPRequest"
INFO [11-18|09:00:59.622] forwarded RPC request                    method=eth_chainId auth=foobar req_id=eb133e436364c84a179e
```

You can use the `req_id` to correlate subsequent log lines with the user agent.