### PR TITLE
Fix deadlock on invalid txs

### DIFF
--- a/.changeset/spicy-spoons-jog.md
+++ b/.changeset/spicy-spoons-jog.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': minor
+---
+
+Fixes deadlock

--- a/l2geth/core/events.go
+++ b/l2geth/core/events.go
@@ -22,7 +22,10 @@ import (
 )
 
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
-type NewTxsEvent struct{ Txs []*types.Transaction }
+type NewTxsEvent struct {
+	Txs   []*types.Transaction
+	ErrCh chan error
+}
 
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }

--- a/l2geth/core/tx_pool.go
+++ b/l2geth/core/tx_pool.go
@@ -1090,7 +1090,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 		for _, set := range events {
 			txs = append(txs, set.Flatten()...)
 		}
-		pool.txFeed.Send(NewTxsEvent{txs})
+		pool.txFeed.Send(NewTxsEvent{Txs: txs})
 	}
 }
 

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -506,7 +506,10 @@ func (w *worker) mainLoop() {
 				}
 				w.pendingMu.Unlock()
 			} else {
-				log.Debug("Problem committing transaction", "msg", err)
+				log.Error("Problem committing transaction", "msg", err)
+				if ev.ErrCh != nil {
+					ev.ErrCh <- err
+				}
 			}
 
 		case ev := <-w.txsCh:
@@ -781,6 +784,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	}
 
 	var coalescedLogs []*types.Log
+	var txCount int
 
 	for {
 		// In the following three cases, we will interrupt the execution of the transaction.
@@ -813,6 +817,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		if tx == nil {
 			break
 		}
+
+		txCount++
 
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance is the transaction pool.
@@ -881,7 +887,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	if interrupt != nil {
 		w.resubmitAdjustCh <- &intervalAdjust{inc: false}
 	}
-	return false
+	return txCount == 0
 }
 
 // commitNewTx is an OVM addition that mines a block with a single tx in it.

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -836,7 +836,6 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
 	// the case where the index is updated but the
 	// transaction isn't yet added to the chain
 	s.SetLatestIndex(tx.GetMeta().Index)
-  enqueueIndex := s.GetLatestEnqueueIndex()
 	if tx.GetMeta().QueueIndex != nil {
 		s.SetLatestEnqueueIndex(tx.GetMeta().QueueIndex)
 	}
@@ -859,7 +858,6 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
     s.SetLatestL1Timestamp(ts)
     s.SetLatestL1BlockNumber(bn)
     s.SetLatestIndex(index)
-    s.SetLatestEnqueueIndex(enqueueIndex)
 		return err
 	case <-s.chainHeadCh:
 		// Update the cache when the transaction is from the owner
@@ -871,7 +869,6 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
         s.SetLatestL1Timestamp(ts)
         s.SetLatestL1BlockNumber(bn)
         s.SetLatestIndex(index)
-        s.SetLatestEnqueueIndex(enqueueIndex)
 				return err
 			}
 		}

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -818,7 +818,7 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
 		// with `enqueue` transactions.
 		s.SetLatestL1Timestamp(tx.L1Timestamp())
 		s.SetLatestL1BlockNumber(tx.L1BlockNumber().Uint64())
-		log.Debug("Updating OVM context based on new transaction", "timestamp", ts, "blocknumber", bn.Uint64(), "queue-origin", tx.QueueOrigin())
+		log.Debug("Updating OVM context based on new transaction", "timestamp", ts, "blocknumber", tx.L1BlockNumber().Uint64(), "queue-origin", tx.QueueOrigin())
 	} else if tx.L1Timestamp() < s.GetLatestL1Timestamp() {
 		log.Error("Timestamp monotonicity violation", "hash", tx.Hash().Hex())
 	}


### PR DESCRIPTION
- Fixes a bug that causes Geth to deadlock if transactions pass the policy checks but fail in the miner.
- Fixes a bug that causes Geth to mine empty blocks, and returns a proper error to users.
