### PR TITLE
l2geth: fix deadlock on invalid txs

### DIFF
--- a/.changeset/spicy-spoons-jog.md
+++ b/.changeset/spicy-spoons-jog.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fixes deadlock

--- a/l2geth/core/events.go
+++ b/l2geth/core/events.go
@@ -22,7 +22,10 @@ import (
 )
 
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
-type NewTxsEvent struct{ Txs []*types.Transaction }
+type NewTxsEvent struct {
+	Txs   []*types.Transaction
+	ErrCh chan error
+}
 
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }

--- a/l2geth/core/tx_pool.go
+++ b/l2geth/core/tx_pool.go
@@ -1090,7 +1090,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 		for _, set := range events {
 			txs = append(txs, set.Flatten()...)
 		}
-		pool.txFeed.Send(NewTxsEvent{txs})
+		pool.txFeed.Send(NewTxsEvent{Txs: txs})
 	}
 }
 


### PR DESCRIPTION
**Description**

- Fixes a bug that causes Geth to deadlock if transactions pass the policy checks but fail in the miner.
- Fixes a bug that causes Geth to mine empty blocks, and returns a proper error to users.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


Replaces https://github.com/ethereum-optimism/optimism/pull/1783