### PR TITLE
ci: publish builder latest only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
           context: .
           file: ./ops/docker/Dockerfile.monorepo
           push: true
-          tags: ethereumoptimism/builder:${{ needs.release.outputs.builder }},ethereumoptimism/builder:latest
+          tags: ethereumoptimism/builder:latest
 
   message-relayer:
     name: Publish Message Relayer Version ${{ needs.builder.outputs.message-relayer }}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fix CI publishing of the builder image
