### PR TITLE
batch-submitter: ENG-1688 fix bug causing Kovan to fall behind

### DIFF
--- a/.changeset/slow-dodos-argue.md
+++ b/.changeset/slow-dodos-argue.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Immediately reject on nonce errors to stop falling behind

--- a/packages/batch-submitter/src/utils/tx-submission.ts
+++ b/packages/batch-submitter/src/utils/tx-submission.ts
@@ -28,6 +28,21 @@ const getGasPriceInGwei = async (signer: Signer): Promise<number> => {
   )
 }
 
+export const ynatmRejectOn = (e) => {
+  // taken almost verbatim from the readme,
+  // see https://github.com/ethereum-optimism/ynatm.
+  // immediately rejects on reverts and nonce errors
+  const errMsg = e.toString().toLowerCase()
+  const conditions = ['revert', 'nonce']
+  for (const cond of conditions) {
+    if (errMsg.includes(cond)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export const submitTransactionWithYNATM = async (
   tx: PopulatedTransaction,
   signer: Signer,
@@ -55,6 +70,7 @@ export const submitTransactionWithYNATM = async (
     maxGasPrice: ynatm.toGwei(config.maxGasPriceInGwei),
     gasPriceScalingFunction: ynatm.LINEAR(config.gasRetryIncrement),
     delay: config.resubmissionTimeout,
+    rejectImmediatelyOnCondition: ynatmRejectOn,
   })
   return receipt
 }


### PR DESCRIPTION
YNATM was retrying transactions with bad nonces for up to an hour on Kovan. This PR causes YNATM to immediately reject when bad nonce errors are encountered.