### PR TITLE
batch-submitter: trigger release

### DIFF
--- a/.changeset/proud-bears-do.md
+++ b/.changeset/proud-bears-do.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Trigger release of the batch submitter with yatm retry fix


### PR DESCRIPTION
**Description**

Trigger a release of the batch submitter with the yatm fix.
The batch submitter would get stuck in a loop on kovan,
attempting to submit a transaction with a bad nonce over
and over again. The fix was to add a hook function
that can notice when there is a nonce error.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

