### PR TITLE
fix: minor improvements to empty sequencer block handling

### DIFF
--- a/.changeset/new-nails-arrive.md
+++ b/.changeset/new-nails-arrive.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+fixes empty block detection and removes empty worker tasks

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -352,7 +352,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		select {
 		case <-w.startCh:
 			clearPending(w.chain.CurrentBlock().NumberU64())
-			commit(false, commitInterruptNewHead)
+			commit(true, commitInterruptNewHead)
 
 		// Remove this code for the OVM implementation. It is responsible for
 		// cleaning up memory with the call to `clearPending`, so be sure to

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -1076,6 +1076,15 @@ func (w *worker) commit(uncles []*types.Header, interval func(), start time.Time
 	if err != nil {
 		return err
 	}
+
+	// As a sanity check, ensure all new blocks have exactly one
+	// transaction. This check is done here just in case any of our
+	// higher-evel checks failed to catch empty blocks passed to commit.
+	txs := block.Transactions()
+	if len(txs) != 1 {
+		return fmt.Errorf("Block created with %d transactions rather than 1 at %d", len(txs), block.NumberU64())
+	}
+
 	if w.isRunning() {
 		if interval != nil {
 			interval()
@@ -1092,10 +1101,6 @@ func (w *worker) commit(uncles []*types.Header, interval func(), start time.Time
 			}
 			feesEth := new(big.Float).Quo(new(big.Float).SetInt(feesWei), new(big.Float).SetInt(big.NewInt(params.Ether)))
 
-			txs := block.Transactions()
-			if len(txs) != 1 {
-				return fmt.Errorf("Block created with not %d transactions at %d", len(txs), block.NumberU64())
-			}
 			tx := txs[0]
 			bn := tx.L1BlockNumber()
 			if bn == nil {

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -457,7 +457,7 @@ func (w *worker) mainLoop() {
 						uncles = append(uncles, uncle.Header())
 						return false
 					})
-					w.commit(uncles, nil, true, start)
+					w.commit(uncles, nil, start)
 				}
 			}
 		// Read from the sync service and mine single txs
@@ -955,7 +955,7 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 	if w.commitTransactions(txs, w.coinbase, nil) {
 		return errors.New("Cannot commit transaction in miner")
 	}
-	return w.commit(nil, w.fullTaskHook, true, tstart)
+	return w.commit(nil, w.fullTaskHook, tstart)
 }
 
 // commitNewWork generates several new sealing tasks based on the parent block.
@@ -1066,12 +1066,12 @@ func (w *worker) commitNewWork(interrupt *int32, timestamp int64) {
 			return
 		}
 	}
-	w.commit(uncles, w.fullTaskHook, true, tstart)
+	w.commit(uncles, w.fullTaskHook, tstart)
 }
 
 // commit runs any post-transaction state modifications, assembles the final block
 // and commits new work if consensus engine is running.
-func (w *worker) commit(uncles []*types.Header, interval func(), update bool, start time.Time) error {
+func (w *worker) commit(uncles []*types.Header, interval func(), start time.Time) error {
 	// Deep copy receipts here to avoid interaction between different tasks.
 	receipts := make([]*types.Receipt, len(w.current.receipts))
 	for i, l := range w.current.receipts {
@@ -1115,9 +1115,7 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 			log.Info("Worker has exited")
 		}
 	}
-	if update {
-		w.updateSnapshot()
-	}
+	w.updateSnapshot()
 	return nil
 }
 

--- a/l2geth/miner/worker_test.go
+++ b/l2geth/miner/worker_test.go
@@ -328,15 +328,35 @@ func TestStreamUncleBlock(t *testing.T) {
 	taskIndex := 0
 	w.newTaskHook = func(task *task) {
 		if task.block.NumberU64() == 2 {
-			// The first task is an empty task, the second
-			// one has 1 pending tx, the third one has 1 tx
-			// and 1 uncle.
-			if taskIndex == 2 {
+			// The first task has 1 pending tx, the second one has 1
+			// tx and 1 uncle.
+			numTxs := len(task.block.Transactions())
+			numUncles := len(task.block.Uncles())
+
+			switch taskIndex {
+			case 0:
+				if numTxs != 1 {
+					t.Errorf("expected 1 tx in first task, got: %d", numTxs)
+				}
+				if numUncles != 0 {
+					t.Errorf("expected no uncles in first task, got: %d", numUncles)
+				}
+
+			case 1:
+				if numTxs != 1 {
+					t.Errorf("expected 1 tx in second task, got: %d", numTxs)
+				}
+				if numUncles != 1 {
+					t.Errorf("expected 1 uncle in second task, got: %d", numUncles)
+				}
 				have := task.block.Header().UncleHash
 				want := types.CalcUncleHash([]*types.Header{b.uncleBlock.Header()})
 				if have != want {
 					t.Errorf("uncle hash mismatch: have %s, want %s", have.Hex(), want.Hex())
 				}
+
+			default:
+				t.Errorf("only expected two tasks")
 			}
 			taskCh <- struct{}{}
 			taskIndex += 1
@@ -350,12 +370,10 @@ func TestStreamUncleBlock(t *testing.T) {
 	}
 	w.start()
 
-	for i := 0; i < 2; i += 1 {
-		select {
-		case <-taskCh:
-		case <-time.NewTimer(time.Second).C:
-			t.Error("new task timeout")
-		}
+	select {
+	case <-taskCh:
+	case <-time.NewTimer(time.Second).C:
+		t.Error("new task timeout")
 	}
 
 	w.postSideBlock(core.ChainSideEvent{Block: b.uncleBlock})


### PR DESCRIPTION
**Description**
This PR makes some minor improvements to the sequencers empty block detection, specifically:
 - fixes the empty block detection within `commitTransactions` to only count transactions if they are successfully executed
 - handles an edge case in `commitTransactions` where an empty block can be produced when the execution is interrupted
 - moves the low-level empty block check up in `commit`, to avoid sending empty blocks on `w.taskCh`

Note, the empty block production in this case was never accepted by the chain, but this improves our detection of these cases locally instead of relying on the catch-all check in `commit`.

**Metadata**
- Fixes ENG-1703
