### PR TITLE
ops: pin docker-compose version to 3.4

### DIFF
--- a/ops/docker-compose-metrics.yml
+++ b/ops/docker-compose-metrics.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   l2geth:

--- a/ops/docker-compose-nobuild.yml
+++ b/ops/docker-compose-nobuild.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   l1_chain:
     image: ethereumoptimism/hardhat-node:${DOCKER_TAG:-prerelease-0.5.0-rc-7-ee217ce}

--- a/ops/docker-compose-rpc-proxy.yml
+++ b/ops/docker-compose-rpc-proxy.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   rpc-proxy:
     depends_on:

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   # this is a helper service used because there's no official hardhat image


### PR DESCRIPTION
**Description**

The `docker-compose` setup uses features that
are not available in all versions. This pins
the `docker-compose` setup to version `3.4`
instead of just `3`.

It is known to work under the following versions:

```
$ uname -or
5.10.70-1-MANJARO GNU/Linux

$ docker-compose --version
Docker Compose version 2.0.1

$ docker --version
Docker version 20.10.9, build c2ea9bc90b
```

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


Closes https://github.com/ethereum-optimism/optimism/issues/1815

Note that when building on my machine with version `3.7`, there is not problem
or warnings thrown, so I cannot repro the problem locally