### PR TITLE
gas-oracle: fix the gas price metric

### DIFF
--- a/.changeset/flat-bags-chew.md
+++ b/.changeset/flat-bags-chew.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/gas-oracle': patch
+---
+
+Fix the gas oracle gas price prometheus metric

--- a/go/gas-oracle/oracle/updater_interface.go
+++ b/go/gas-oracle/oracle/updater_interface.go
@@ -19,7 +19,7 @@ import (
 var (
 	txSendCounter           = metrics.NewRegisteredCounter("tx/send", ometrics.DefaultRegistry)
 	txNotSignificantCounter = metrics.NewRegisteredCounter("tx/not-significant", ometrics.DefaultRegistry)
-	gasPriceGauge           = metrics.NewRegisteredGauge("gas-price", ometrics.DefaultRegistry)
+	gasPriceGauge           = metrics.NewRegisteredGauge("gas_price", ometrics.DefaultRegistry)
 	txConfTimer             = metrics.NewRegisteredTimer("tx/confirmed", ometrics.DefaultRegistry)
 	txSendTimer             = metrics.NewRegisteredTimer("tx/send", ometrics.DefaultRegistry)
 )


### PR DESCRIPTION
**Description**

The `gas-price` metric was renamed to `gas_price`
as using a `-` is invalid syntax in a prometheus metric.

Fixes https://github.com/ethereum-optimism/optimism/issues/1819

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


