### PR TITLE
fix: change relayer workdir and use CMD instead of ENTRYPOINT for docker-compose

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -57,6 +57,6 @@ CMD ["yarn", "test:integration"]
 
 
 FROM base as relayer
-WORKDIR /opt/optimism/packages/message-relayer
+WORKDIR /optimism/packages/message-relayer
 COPY ./ops/scripts/relayer.sh .
 ENTRYPOINT ["npm", "run", "start"]

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -59,4 +59,4 @@ CMD ["yarn", "test:integration"]
 FROM base as relayer
 WORKDIR /optimism/packages/message-relayer
 COPY ./ops/scripts/relayer.sh .
-ENTRYPOINT ["npm", "run", "start"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
**Description**
message-relayer container works badly as building docker-compose on local machine.
`WORKDIR` of relayer section should be changed in `Dockerfile.packages`

And it looks well using `CMD` instead of `ENTRYPOINT` for relayer
