### PR TITLE
fix: relayer docs + release

### DIFF
--- a/.changeset/soft-countries-heal.md
+++ b/.changeset/soft-countries-heal.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Fix dockerfile

--- a/ops/README.md
+++ b/ops/README.md
@@ -52,6 +52,17 @@ A Makefile has been provided for convience. The following targets are available.
 - make up-metrics
 - make down-metrics
 
+## Cross domain communication
+
+By default, the `message-relayer` service is turned off. This means that
+any tests must manually submit withdrawals. The `message-relayer` will
+automatically look for withdrawals and submit the proofs. To run with the
+`message-relayer` on, use the command:
+
+```bash
+$ docker-compose up --scale relayer=1
+```
+
 ## Authentication
 
 Influxdb has authentication disabled.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The message relayer is turned off by default,
mention how to turn it on in the docs.

Also trigger a new release so it builds with the updated dockerfile introduced in https://github.com/ethereum-optimism/optimism/pull/1826