### PR TITLE
ci: fix proxyd publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: ./go/proxyd
-          file: ./Dockerfile
+          context: .
+          file: ./go/proxyd/Dockerfile
           push: true
           tags: ethereumoptimism/proxyd:${{ needs.release.outputs.proxyd }},ethereumoptimism/proxyd:latest
           build-args: |


### PR DESCRIPTION
**Description**

Updates the github action to properly reference
the `proxyd` dockerfile. The logic is copied from
the canary publish github action.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

