### PR TITLE
docker: update node version to 16

### DIFF
--- a/.changeset/wicked-mugs-admire.md
+++ b/.changeset/wicked-mugs-admire.md
@@ -1,0 +1,9 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/builder': patch
+'@eth-optimism/batch-submitter': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Update to node.js version 16

--- a/ops/docker/Dockerfile.batch-submitter
+++ b/ops/docker/Dockerfile.batch-submitter
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache curl bash jq
 

--- a/ops/docker/Dockerfile.data-transport-layer
+++ b/ops/docker/Dockerfile.data-transport-layer
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache curl bash jq
 

--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache git curl python3 bash jq
 

--- a/ops/docker/Dockerfile.integration-tests
+++ b/ops/docker/Dockerfile.integration-tests
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache git curl python3 bash jq
 

--- a/ops/docker/Dockerfile.message-relayer
+++ b/ops/docker/Dockerfile.message-relayer
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache curl bash jq
 

--- a/ops/docker/Dockerfile.monorepo
+++ b/ops/docker/Dockerfile.monorepo
@@ -4,7 +4,7 @@
 # ### BASE: Install deps
 # We do not use Alpine because there's a regression causing it to be very slow
 # when used with typescript/hardhat: https://github.com/nomiclabs/hardhat/issues/1219
-FROM node:14-buster-slim as node
+FROM node:16-buster-slim as node
 RUN apt-get update -y && apt-get install -y git
 
 # Pre-download the compilers so that they do not need to be downloaded inside
@@ -37,7 +37,7 @@ COPY integration-tests/package.json ./integration-tests/package.json
 RUN yarn install --frozen-lockfile
 
 ### BUILDER: Builds the typescript
-FROM node
+FROM node:16
 
 WORKDIR /optimism
 

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -4,7 +4,7 @@
 # ### BASE: Install deps
 # We do not use Alpine because there's a regression causing it to be very slow
 # when used with typescript/hardhat: https://github.com/nomiclabs/hardhat/issues/1219
-FROM node:14.18.1-buster-slim as base
+FROM node:16.13-buster-slim as base
 
 RUN apt-get update -y && apt-get install -y git curl jq python3
 

--- a/ops/docker/Dockerfile.regenesis-surgery
+++ b/ops/docker/Dockerfile.regenesis-surgery
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --no-cache curl bash jq
 

--- a/ops/docker/Dockerfile.replica-healthcheck
+++ b/ops/docker/Dockerfile.replica-healthcheck
@@ -2,7 +2,7 @@ ARG LOCAL_REGISTRY=docker.io
 ARG BUILDER_TAG=latest
 FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
-FROM node:14-alpine
+FROM node:16-alpine
 
 WORKDIR /opt/optimism
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
node.js version 16 is currently the lts version
so this commit updates each of the dockerfiles to
use node version 16

