### PR TITLE
fix: don't round down average gas per epoch

### DIFF
--- a/.changeset/silly-bugs-sit.md
+++ b/.changeset/silly-bugs-sit.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/gas-oracle': patch
+---
+
+fix rounding error in average gas/epoch calculation

--- a/go/gas-oracle/gasprices/gas_price_updater.go
+++ b/go/gas-oracle/gasprices/gas_price_updater.go
@@ -78,7 +78,7 @@ func (g *GasPriceUpdater) UpdateGasPrice() error {
 		totalGasUsed += gasUsed
 	}
 
-	averageGasPerSecond := float64(totalGasUsed / g.epochLengthSeconds)
+	averageGasPerSecond := float64(totalGasUsed) / float64(g.epochLengthSeconds)
 
 	log.Debug("UpdateGasPrice", "average-gas-per-second", averageGasPerSecond, "current-price", g.gasPricer.curPrice)
 	_, err = g.gasPricer.CompleteEpoch(averageGasPerSecond)

--- a/go/gas-oracle/gasprices/gas_price_updater_test.go
+++ b/go/gas-oracle/gasprices/gas_price_updater_test.go
@@ -13,7 +13,7 @@ type MockEpoch struct {
 
 // Return a gas pricer that targets 3 blocks per epoch & 10% max change per epoch.
 func makeTestGasPricerAndUpdater(curPrice uint64) (*GasPricer, *GasPriceUpdater, func(uint64), error) {
-	gpsTarget := 3300000.0
+	gpsTarget := 990000.3
 	getGasTarget := func() float64 { return gpsTarget }
 	epochLengthSeconds := uint64(10)
 	averageBlockGasLimit := uint64(11000000)
@@ -135,6 +135,13 @@ func TestUsageOfGasPriceUpdater(t *testing.T) {
 				curPrice := gasPriceUpdater.gasPricer.curPrice
 				if prevGasPrice != curPrice {
 					t.Fatalf("Expected gas price to stablize. Got %d, was %d", curPrice, prevGasPrice)
+				}
+
+				targetGps := gasPriceUpdater.gasPricer.getTargetGasPerSecond()
+				averageGps := gasPriceUpdater.gasPricer.avgGasPerSecondLastEpoch
+				if targetGps != averageGps {
+					t.Fatalf("Average gas/second (%f) did not converge to target (%f)",
+						averageGps, targetGps)
 				}
 			},
 		},

--- a/go/gas-oracle/gasprices/l2_gas_pricer.go
+++ b/go/gas-oracle/gasprices/l2_gas_pricer.go
@@ -11,10 +11,11 @@ import (
 type GetTargetGasPerSecond func() float64
 
 type GasPricer struct {
-	curPrice              uint64
-	floorPrice            uint64
-	getTargetGasPerSecond GetTargetGasPerSecond
-	maxChangePerEpoch     float64
+	curPrice                 uint64
+	avgGasPerSecondLastEpoch float64
+	floorPrice               uint64
+	getTargetGasPerSecond    GetTargetGasPerSecond
+	maxChangePerEpoch        float64
 }
 
 // LinearInterpolation can be used to dynamically update target gas per second
@@ -80,6 +81,7 @@ func (p *GasPricer) CompleteEpoch(avgGasPerSecondLastEpoch float64) (uint64, err
 		return gp, err
 	}
 	p.curPrice = gp
+	p.avgGasPerSecondLastEpoch = avgGasPerSecondLastEpoch
 	return gp, nil
 }
 


### PR DESCRIPTION
**Description**
Also corrects the targetGps constant in the test harness. The constant
was chosen to be the expected Gps of the initial burst, causing the Gps
to stablize in the second part of the test at the floor.

Adding a check that the average measured gas price matches our desired
constant prevents this from silently passing.

Logging the incremental gas prices in the `TestUsageOfGasPriceUpdater` yields the following
on `develop`: 
```
burst
prevGasPrice: 1000, curPrice: 1001
prevGasPrice: 1001, curPrice: 1002
prevGasPrice: 1002, curPrice: 1003
prevGasPrice: 1003, curPrice: 1004
stablize
prevGasPrice: 1004, curPrice: 302
prevGasPrice: 302, curPrice: 91
prevGasPrice: 91, curPrice: 28
prevGasPrice: 28, curPrice: 9
prevGasPrice: 9, curPrice: 3
prevGasPrice: 3, curPrice: 1
prevGasPrice: 1, curPrice: 1
reduce
prevGasPrice: 1, curPrice: 1 floorPrice: 1
prevGasPrice: 1, curPrice: 1 floorPrice: 1
prevGasPrice: 1, curPrice: 1 floorPrice: 1
prevGasPrice: 1, curPrice: 1 floorPrice: 1
prevGasPrice: 1, curPrice: 1 floorPrice: 1
prevGasPrice: 1, curPrice: 1 floorPrice: 1
```

Notice how the gas price is being reduced back to the floor during the `stabilize` phase, as well as the (mostly) stable gas price during the burst phase. After fixing the test constant to the value expected when processing 3 blocks in 10 seconds:

```
burst
prevGasPrice: 1000, curPrice: 3334
prevGasPrice: 3334, curPrice: 11114
prevGasPrice: 11114, curPrice: 37047
prevGasPrice: 37047, curPrice: 123490
stablize
prevGasPrice: 123490, curPrice: 123490
prevGasPrice: 123490, curPrice: 123490
prevGasPrice: 123490, curPrice: 123490
prevGasPrice: 123490, curPrice: 123490
prevGasPrice: 123490, curPrice: 123490
prevGasPrice: 123490, curPrice: 123490
prevGasPrice: 123490, curPrice: 123490
reduce
prevGasPrice: 123490, curPrice: 41164 floorPrice: 1
prevGasPrice: 41164, curPrice: 13722 floorPrice: 1
prevGasPrice: 13722, curPrice: 4574 floorPrice: 1
prevGasPrice: 4574, curPrice: 1525 floorPrice: 1
prevGasPrice: 1525, curPrice: 509 floorPrice: 1
prevGasPrice: 509, curPrice: 170 floorPrice: 1
```

Without fixing the rounding error, the new assertion will fail with `Average gas/second (990000.0) did not converge to target (990000.3)`.

**Metadata**
- Fixes ENG-1725
