### PR TITLE
changesets: don't track builder image

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
       "go/batch-submitter",
       "go/proxyd",
       "ops/docker/rpc-proxy",
-      "ops/docker/builder",
       "ops/docker/hardhat"
     ],
     "nohoist": [


### PR DESCRIPTION
**Description**

Tracking the builder image causes problems
in the CI. It started to be tracked when
there was a desire for faster builds. Publishing
a versioned builder image has resulted in
many CI publishing related bugs. This commit
removes tracking of the builder image.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
