### PR TITLE
fix: trigger node 16 releases

### DIFF
--- a/.changeset/flat-mirrors-sort.md
+++ b/.changeset/flat-mirrors-sort.md
@@ -1,0 +1,8 @@
+---
+'@eth-optimism/hardhat-node': patch
+'@eth-optimism/batch-submitter': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Build docker images with node.js version 16

--- a/ops/docker/hardhat/Dockerfile
+++ b/ops/docker/hardhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:16-alpine
 
 # bring in the config files for installing deps
 COPY [ \


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
A bug caused the previous releases to not build in CI, so re triggering. The root cause of the bug was fixed so this should not happen again.
