### PR TITLE
gas-oracle: fix average block gas limit flag

### DIFF
--- a/.changeset/eight-poems-add.md
+++ b/.changeset/eight-poems-add.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/gas-oracle': patch
+---
+
+Update the flag parsing of the average block gas limit

--- a/go/gas-oracle/flags/flags.go
+++ b/go/gas-oracle/flags/flags.go
@@ -77,7 +77,7 @@ var (
 		Usage:  "max percent change of gas price per second",
 		EnvVar: "GAS_PRICE_ORACLE_MAX_PERCENT_CHANGE_PER_EPOCH",
 	}
-	AverageBlockGasLimitPerEpochFlag = cli.Float64Flag{
+	AverageBlockGasLimitPerEpochFlag = cli.Uint64Flag{
 		Name:   "average-block-gas-limit-per-epoch",
 		Value:  11_000_000,
 		Usage:  "average block gas limit per epoch",


### PR DESCRIPTION
**Description**

The average block gas limit was converted to a uint64
from a float64, this commit updates the flag parsing
to parse the correct type.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

