### PR TITLE
fix: deployer dockerfile

### DIFF
--- a/.changeset/five-pandas-reflect.md
+++ b/.changeset/five-pandas-reflect.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Copy the deployments directory into the deployer docker image

--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -19,6 +19,7 @@ COPY --from=builder /optimism/packages/core-utils/dist ./packages/core-utils/dis
 WORKDIR /opt/optimism/packages/contracts
 COPY --from=builder /optimism/packages/contracts/dist ./dist
 COPY --from=builder /optimism/packages/contracts/*.json ./
+COPY --from=builder /optimism/packages/contracts/deployments ./deployments
 COPY --from=builder /optimism/packages/contracts/node_modules ./node_modules
 COPY --from=builder /optimism/packages/contracts/artifacts ./artifacts
 COPY --from=builder /optimism/packages/contracts/src ./src


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a changeset on top of https://github.com/ethereum-optimism/optimism/pull/1843

--------------------------

When `yarn run autogen:markdown` is running on `deployer`, `deployments` directory should be needed.
`deployer` container shows a error and be exited without `deployments` directory.

**errors**

```
$ docker-compose -f docker-compose-nobuild.yml up
...
deployer_1         | $ ts-node scripts/generate-markdown.ts
deployer_1         | Error: Cannot find module '../deployments/goerli/BondManager.json'
deployer_1         | Require stack:
deployer_1         | - /opt/optimism/packages/contracts/src/contract-deployed-artifacts.ts
deployer_1         | - /opt/optimism/packages/contracts/src/connect-contracts.ts
deployer_1         | - /opt/optimism/packages/contracts/src/index.ts
deployer_1         | - /opt/optimism/packages/contracts/scripts/generate-markdown.ts
deployer_1         |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
deployer_1         |     at Function.Module._load (internal/modules/cjs/loader.js:746:27)
deployer_1         |     at Module.require (internal/modules/cjs/loader.js:974:19)
deployer_1         |     at require (internal/modules/cjs/helpers.js:93:18)
deployer_1         |     at Object.<anonymous> (/opt/optimism/packages/contracts/src/contract-deployed-artifacts.ts:7:31)
deployer_1         |     at Module._compile (internal/modules/cjs/loader.js:1085:14)
deployer_1         |     at Module.m._compile (/opt/optimism/node_modules/ts-node/src/index.ts:1310:23)
deployer_1         |     at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
deployer_1         |     at Object.require.extensions.<computed> [as .ts] (/opt/optimism/node_modules/ts-node/src/index.ts:1313:12)
deployer_1         |     at Module.load (internal/modules/cjs/loader.js:950:32) {
deployer_1         |   code: 'MODULE_NOT_FOUND',
deployer_1         |   requireStack: [
deployer_1         |     '/opt/optimism/packages/contracts/src/contract-deployed-artifacts.ts',
deployer_1         |     '/opt/optimism/packages/contracts/src/connect-contracts.ts',
deployer_1         |     '/opt/optimism/packages/contracts/src/index.ts',
deployer_1         |     '/opt/optimism/packages/contracts/scripts/generate-markdown.ts'
deployer_1         |   ]
deployer_1         | }
deployer_1         | error Command failed with exit code 1.
deployer_1         | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
deployer_1         | error Command failed with exit code 1.
deployer_1         | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ops_deployer_1 exited with code 1
```