### PR TITLE
fix: nonce rpc checks

### DIFF
--- a/.changeset/nervous-bees-whisper.md
+++ b/.changeset/nervous-bees-whisper.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Return a better error message for when the nonce is too high. Previously it would return `nonce too low` for even when the nonce was too high. Now it will return `nonce too high` to the user

--- a/.changeset/yellow-yaks-brake.md
+++ b/.changeset/yellow-yaks-brake.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Add tests for nonce too low and too high

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -72,6 +72,32 @@ describe('Basic RPC tests', () => {
       expect(result.data).to.equal(tx.data)
     })
 
+    it('should reject a transaction with a too low of nonce', async () => {
+      const tx = {
+        ...defaultTransactionFactory(),
+        gasPrice: await gasPriceForL2(env),
+        nonce: (await wallet.getTransactionCount()) - 1,
+      }
+
+      const signed = await wallet.signTransaction(tx)
+      await expect(provider.sendTransaction(signed)).to.be.rejectedWith(
+        'invalid transaction: nonce too low'
+      )
+    })
+
+    it('should reject a transaction with a too high of a nonce', async () => {
+      const tx = {
+        ...defaultTransactionFactory(),
+        gasPrice: await gasPriceForL2(env),
+        nonce: (await wallet.getTransactionCount()) + 10,
+      }
+
+      const signed = await wallet.signTransaction(tx)
+      await expect(provider.sendTransaction(signed)).to.be.rejectedWith(
+        'invalid transaction: nonce too high'
+      )
+    })
+
     it('should not accept a transaction with the wrong chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),

--- a/l2geth/core/tx_pool.go
+++ b/l2geth/core/tx_pool.go
@@ -555,8 +555,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Ensure the transaction adheres to nonce ordering
 	if rcfg.UsingOVM {
-		if pool.currentState.GetNonce(from) != tx.Nonce() {
+		nonce := pool.currentState.GetNonce(from)
+		if nonce > tx.Nonce() {
 			return ErrNonceTooLow
+		} else if nonce < tx.Nonce() {
+			return errors.New("nonce too high")
 		}
 	} else {
 		if pool.currentState.GetNonce(from) > tx.Nonce() {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The current behavior of the sequencer will return the
error message `nonce too low` even in the case when the
nonce it too high. 

This PR changes that functionality so that there are 2 explicit error messages
for when users send transactions with an incorrect nonce.
When the nonce is too low, the user can expect to get the message back:
`invalid transaction: nonce too low`
When the nonce is too high, the user can expect to get the message back:
`invalid transaction: nonce too high`

There isn't a concept of `nonce too high` in the L1 mempool due to the async
nature of the p2p network, but since there is not a p2p network that gossips
transactions, this feature is added to give a better error message back to the users.