### PR TITLE
dtl: smaller range for filter query

### DIFF
--- a/.changeset/clean-jars-check.md
+++ b/.changeset/clean-jars-check.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Smaller filter query for searching for L1 start height. This number should be configured so that the search does not need to happen because using a smaller filter will cause it to take too long.


### PR DESCRIPTION
**Description**

On fresh startup, the DTL attempts to make a range
query that is very large when the starting L1 block
height is not configured. It looks for ownership
transferred events on the address manager, the first
one to happen indicates that the address manager was
deployed at that height.

Now that we use the same address manager over time instead
of the old way of upgrading the system where we would
redeploy the address manager each time, we must pass
the L1 start height as a config option to the DTL,
otherwise it will attempt to sync old transactions
(from a previous regenesis).

This commit will reduce the range at which the DTL
will query for the events, as alchemy only supports
a range of 2000. This will make the search prohibitively
slow, but that is ok as the value ought to be configured
anyways.

This functionality is really only useful for ephemeral networks.

A new logline is added for convenience.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes ENG-1760