### PR TITLE
Update README.md

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -30,6 +30,10 @@ docker-compose \
 
 *Note*: This generates a large amount of log data which docker stores by default. See [Disk Usage](#disk-usage).
 
+Also note that Docker Desktop only allocates 2GB of memory by default, which isn't enough to run the docker-compose services reliably.
+
+To allocate more memory, go to Settings > Resources in the Docker UI and use the slider to change the value (_4GB recommended_). Make sure to click Apply & Restart for the changes to take effect.
+
 To start the stack with monitoring enabled, just add the metric composition file.
 ```
 docker-compose \


### PR DESCRIPTION
**Description**
Added a note to the ops readme that calls out the Docker Desktop default memory setting and instructions on how to change it.

**Additional context**
I ran into a similar issue while running the ops tool and allocating more memory fixed the problem. Calling this out in the instructions should help prevent others from getting stuck here.

**Metadata**
- Closes #1738
