### PR TITLE
feat: add batchTxBuildTime performance gauge

### DIFF
--- a/.changeset/spicy-mayflies-complain.md
+++ b/.changeset/spicy-mayflies-complain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+adds batchTxBuildTime gauge

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -31,6 +31,7 @@ interface BatchSubmitterMetrics {
   batchesSubmitted: Counter<string>
   failedSubmissions: Counter<string>
   malformedBatches: Counter<string>
+  batchTxBuildTime: Gauge<string>
 }
 
 export abstract class BatchSubmitter {
@@ -291,6 +292,11 @@ export abstract class BatchSubmitter {
       malformedBatches: new metrics.client.Counter({
         name: 'malformed_batches',
         help: 'Count of malformed batches',
+        registers: [metrics.registry],
+      }),
+      batchTxBuildTime: new metrics.client.Gauge({
+        name: 'batch_tx_build_time',
+        help: 'Time to construct batch transaction',
         registers: [metrics.registry],
       }),
     }

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -154,6 +154,9 @@ export class StateBatchSubmitter extends BatchSubmitter {
     startBlock: number,
     endBlock: number
   ): Promise<TransactionReceipt> {
+
+    const batchTxBuildStart = performance.now()
+
     const batch = await this._generateStateCommitmentBatch(startBlock, endBlock)
     const calldata = this.chainContract.interface.encodeFunctionData(
       'appendStateBatch',
@@ -168,6 +171,9 @@ export class StateBatchSubmitter extends BatchSubmitter {
     if (!this._shouldSubmitBatch(batchSizeInBytes)) {
       return
     }
+
+    const batchTxBuildEnd = performance.now()
+    this.metrics.batchTxBuildTime.set(batchTxBuildEnd - batchTxBuildStart)
 
     const offsetStartsAtIndex = startBlock - this.blockOffset
     this.logger.debug('Submitting batch.', { calldata })

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -203,6 +203,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       return
     }
 
+    const batchTxBuildStart = performance.now()
+
     const params = await this._generateSequencerBatchParams(
       startBlock,
       endBlock
@@ -226,6 +228,10 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     if (!wasBatchTruncated && !this._shouldSubmitBatch(batchSizeInBytes)) {
       return
     }
+
+    const batchTxBuildEnd = performance.now()
+    this.metrics.batchTxBuildTime.set(batchTxBuildEnd - batchTxBuildStart)
+
     this.metrics.numTxPerBatch.observe(endBlock - startBlock)
     const l1tipHeight = await this.signer.provider.getBlockNumber()
     this.logger.debug('Submitting batch.', {


### PR DESCRIPTION
**Description**
Adds a `batchTxBuildTime` gauge, allowing us to track the time it
takes to construct a batch transaction before attempting to publish.
This will allow us to accurately track how long we spend building
batches as we look to increase maxTxBatchSize.

**Metadata**
- Fixes ENG-1771