### PR TITLE
feat: surface miner nonce too high errors

### DIFF
--- a/.changeset/olive-pots-camp.md
+++ b/.changeset/olive-pots-camp.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+expose ErrNonceTooHigh from miner

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -884,13 +884,8 @@ func (w *worker) commitTransactionsWithError(txs *types.TransactionsByPriceAndNo
 		// Return specific execution errors directly to the user to
 		// avoid returning the generic ErrCannotCommitTxnErr. It is safe
 		// to return the error directly since l2geth only processes at
-		// most one transaction per block. Currently, we map
-		// ErrNonceTooHigh to ErrNonceTooLow to match the behavior of
-		// the mempool, but this mapping will be removed at a later
-		// point once we decided to expose ErrNonceTooHigh to users.
-		if err == core.ErrNonceTooHigh {
-			return core.ErrNonceTooLow
-		} else if err != nil {
+		// most one transaction per block.
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**Description**
This commit exposes the ErrNonceTooHigh at the execution level to
external users. Previously the error was mapped to ErrNonceTooLow to
match the mempool behavior. As this is a new error, and one not
currently exposed in L1, this could be a breaking change for some
applications depending on how the error messages are parsed.

This PR should be merged in conjunction with #1882, so that the errors
are returned at the mempool and miner level simultaneously.

**Metadata**
- Fixes ENG-1775
