### PR TITLE
editorconfig: display Go code with 4 space tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ trim_trailing_whitespace = true
 
 [*.sol]
 indent_size = 4
+
+[*.go]
+indent_size = 4
+indent_style = tab


### PR DESCRIPTION
Github will also pick this up and use this formatting on web.

Old: https://github.com/ethereum-optimism/optimism/blob/c62c48651dbcad6a0e4b21bdd87113d60a57b190/l2geth/miner/worker.go
New: https://github.com/cfromknecht/optimism/blob/b10a1e85387d2b7e1e26e8b25e2b04a6b17c2af9/l2geth/miner/worker.go