### PR TITLE
go/proxyd: Various fixes

### DIFF
--- a/.changeset/clever-ducks-rescue.md
+++ b/.changeset/clever-ducks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Various proxyd fixes

--- a/go/proxyd/backend.go
+++ b/go/proxyd/backend.go
@@ -389,7 +389,7 @@ func (b *BackendGroup) Forward(ctx context.Context, rpcReq *RPCReq) (*RPCRes, er
 		if err != nil {
 			log.Error(
 				"error forwarding request to backend",
-				"name", b.Name,
+				"name", back.Name,
 				"req_id", GetReqID(ctx),
 				"auth", GetAuthCtx(ctx),
 				"err", err,
@@ -442,7 +442,7 @@ func (b *BackendGroup) ProxyWS(ctx context.Context, clientConn *websocket.Conn, 
 
 func calcBackoff(i int) time.Duration {
 	jitter := float64(rand.Int63n(250))
-	ms := math.Min(math.Pow(2, float64(i))*1000+jitter, 10000)
+	ms := math.Min(math.Pow(2, float64(i))*1000+jitter, 3000)
 	return time.Duration(ms) * time.Millisecond
 }
 

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -27,7 +27,7 @@ type MetricsConfig struct {
 type BackendOptions struct {
 	ResponseTimeoutSeconds int   `toml:"response_timeout_seconds"`
 	MaxResponseSizeBytes   int64 `toml:"max_response_size_bytes"`
-	MaxRetries             int   `toml:"backend_retries"`
+	MaxRetries             int   `toml:"max_retries"`
 	OutOfServiceSeconds    int   `toml:"out_of_service_seconds"`
 }
 

--- a/go/proxyd/metrics.go
+++ b/go/proxyd/metrics.go
@@ -106,12 +106,6 @@ var (
 		"request_source",
 	})
 
-	httpRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: MetricsNamespace,
-		Name:      "http_requests_total",
-		Help:      "Count of total HTTP requests.",
-	})
-
 	httpResponseCodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "http_response_codes_total",

--- a/go/proxyd/server.go
+++ b/go/proxyd/server.go
@@ -117,7 +117,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Info("rejected request with bad rpc request", "source", "rpc", "err", err)
 		RecordRPCError(ctx, BackendProxyd, MethodUnknown, err)
-		writeRPCError(w, nil, err)
+		writeRPCError(ctx, w, nil, err)
 		return
 	}
 
@@ -132,7 +132,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 			"method", req.Method,
 		)
 		RecordRPCError(ctx, BackendProxyd, MethodUnknown, ErrMethodNotWhitelisted)
-		writeRPCError(w, req.ID, ErrMethodNotWhitelisted)
+		writeRPCError(ctx, w, req.ID, ErrMethodNotWhitelisted)
 		return
 	}
 
@@ -144,21 +144,11 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 			"req_id", GetReqID(ctx),
 			"err", err,
 		)
-		writeRPCError(w, req.ID, err)
+		writeRPCError(ctx, w, req.ID, err)
 		return
 	}
 
-	enc := json.NewEncoder(w)
-	if err := enc.Encode(backendRes); err != nil {
-		log.Error(
-			"error encoding response",
-			"req_id", GetReqID(ctx),
-			"err", err,
-		)
-		RecordRPCError(ctx, BackendProxyd, req.Method, err)
-		writeRPCError(w, req.ID, err)
-		return
-	}
+	writeRPCRes(ctx, w, backendRes)
 }
 
 func (s *Server) HandleWS(w http.ResponseWriter, r *http.Request) {
@@ -232,20 +222,17 @@ func (s *Server) populateContext(w http.ResponseWriter, r *http.Request) context
 	)
 }
 
-func writeRPCError(w http.ResponseWriter, id json.RawMessage, err error) {
+func writeRPCError(ctx context.Context, w http.ResponseWriter, id json.RawMessage, err error) {
 	var res *RPCRes
 	if r, ok := err.(*RPCErr); ok {
 		res = NewRPCErrorRes(id, r)
 	} else {
-		res = NewRPCErrorRes(id, &RPCErr{
-			Code:    JSONRPCErrorInternal,
-			Message: "internal error",
-		})
+		res = NewRPCErrorRes(id, ErrInternal)
 	}
-	writeRPCRes(w, res)
+	writeRPCRes(ctx, w, res)
 }
 
-func writeRPCRes(w http.ResponseWriter, res *RPCRes) {
+func writeRPCRes(ctx context.Context, w http.ResponseWriter, res *RPCRes) {
 	statusCode := 200
 	if res.IsError() && res.Error.HTTPErrorCode != 0 {
 		statusCode = res.Error.HTTPErrorCode
@@ -254,13 +241,14 @@ func writeRPCRes(w http.ResponseWriter, res *RPCRes) {
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(res); err != nil {
 		log.Error("error writing rpc response", "err", err)
+		RecordRPCError(ctx, BackendProxyd, MethodUnknown, err)
+		return
 	}
 	httpResponseCodesTotal.WithLabelValues(strconv.Itoa(statusCode)).Inc()
 }
 
 func instrumentedHdlr(h http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		httpRequestsTotal.Inc()
 		respTimer := prometheus.NewTimer(httpRequestDurationSumm)
 		h.ServeHTTP(w, r)
 		respTimer.ObserveDuration()


### PR DESCRIPTION
- Updates the HTTP response code metric to includes 200s
- Removes the total HTTP requests metric since it's redundant
- Fixes `MaxRetries` to read from the correct config variable
- Reduces max retry backoff to 3 seconds
