### PR TITLE
fix: make CI correctly report linting errors

### DIFF
--- a/integration-tests/actor-tests/lib/runner.ts
+++ b/integration-tests/actor-tests/lib/runner.ts
@@ -14,7 +14,7 @@ program
   .option('-r, --runs <n>', 'number of runs. cannot be use with -t/--time')
   .option(
     '-t, --time <ms>',
-    'how long to run in milliseconds. cannot be used with -r/--runs',
+    'how long to run in milliseconds. cannot be used with -r/--runs'
   )
   .option('-c, --concurrency <n>', 'number of concurrent workers to spawn', '1')
   .option('--think-time <n>', 'how long to wait between each run', '0')

--- a/integration-tests/actor-tests/uniswap.test.ts
+++ b/integration-tests/actor-tests/uniswap.test.ts
@@ -87,7 +87,10 @@ actor('Uniswap swapper', () => {
       let tx = await token.transfer(wallet.address, 1000000)
       await tx.wait()
       const boundToken = token.connect(wallet)
-      tx = await boundToken.approve(contracts.positionManager.address, 1000000000)
+      tx = await boundToken.approve(
+        contracts.positionManager.address,
+        1000000000
+      )
       await tx.wait()
       tx = await boundToken.approve(contracts.router.address, 1000000000)
       await tx.wait()

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "yarn lint:fix && yarn lint:check",
     "lint:fix": "yarn lint:check --fix",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "build": "hardhat compile",
     "test:integration": "hardhat --network optimism test",
     "test:actor": "IS_LIVE_NETWORK=true ts-node actor-tests/lib/runner.ts",

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -15,7 +15,7 @@
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",
     "lint:fix": "yarn lint:check --fix",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "test": "hardhat test --show-stack-traces",
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json"
   },

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -154,7 +154,6 @@ export class StateBatchSubmitter extends BatchSubmitter {
     startBlock: number,
     endBlock: number
   ): Promise<TransactionReceipt> {
-
     const batchTxBuildStart = performance.now()
 
     const batch = await this._generateStateCommitmentBatch(startBlock, endBlock)

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -11,7 +11,7 @@
     "all": "yarn clean && yarn build && yarn test && yarn lint:fix && yarn lint",
     "build": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist/ ./tsconfig.build.tsbuildinfo",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "yarn lint:check --fix",
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -29,7 +29,7 @@
     "test:slither": "slither .",
     "pretest:slither": "rm -f @openzeppelin && rm -f @ens && rm -f hardhat && ln -s ../../node_modules/@openzeppelin @openzeppelin && ln -s ../../node_modules/@ens @ens && ln -s ../../node_modules/hardhat hardhat",
     "posttest:slither": "rm -f @openzeppelin && rm -f @ens && rm -f hardhat",
-    "lint:ts:check": "eslint .",
+    "lint:ts:check": "eslint . --max-warnings=0",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol'",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",
     "lint:ts:fix": "eslint --fix .",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist/ ./tsconfig.build.tsbuildinfo",
     "lint": "yarn lint:fix && yarn lint:check",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "yarn lint:check --fix",
     "pre-commit": "lint-staged",
     "test": "ts-mocha test/*.spec.ts",

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -13,7 +13,7 @@
     "clean:db": "rimraf ./db",
     "lint": "yarn run lint:fix && yarn run lint:check",
     "lint:fix": "yarn lint:check --fix",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "start": "ts-node ./src/services/run.ts",
     "start:local": "ts-node ./src/services/run.ts | pino-pretty",
     "test": "hardhat --config test/config/hardhat.config.ts test",

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -17,7 +17,7 @@
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",
     "lint:fix": "yarn lint:check --fix",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "test": "hardhat test --show-stack-traces",
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json"
   },

--- a/packages/regenesis-surgery/package.json
+++ b/packages/regenesis-surgery/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf ./dist ./tsconfig.build.tsbuildinfo",
     "lint": "yarn run lint:fix && yarn run lint:check",
     "lint:fix": "yarn lint:check --fix",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "pre-commit": "lint-staged",
     "test:surgery": "ts-mocha --timeout 50000000 test/*",
     "start": "ts-node ./scripts/surgery.ts"

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf ./dist ./tsconfig.build.tsbuildinfo",
     "lint": "yarn run lint:fix && yarn run lint:check",
     "lint:fix": "yarn lint:check --fix",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "build": "tsc -p tsconfig.build.json",
     "pre-commit": "lint-staged",
     "test": "ts-mocha test/*.spec.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "rimraf dist/ ./tsconfig.build.tsbuildinfo",
     "lint": "yarn lint:fix && yarn lint:check",
-    "lint:check": "eslint .",
+    "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "yarn lint:check --fix",
     "pre-commit": "lint-staged",
     "test": "hardhat test",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
CI hasn't been reporting linting errors for a while. Seems eslint requires that you provide `--max-warnings=0` or it'll just warn instead of throw. Our tooling will automatically lint files when you commit something but stuff slips through if people commit with --no-verify. This PR fixes the issue by adding the `--max-warnings=0` flag to all invokations of eslint and also fixes the few linting issues that slipped through.