### PR TITLE
feat: add telemetry to go batch-submitter

### DIFF
--- a/go/batch-submitter/batch_submitter.go
+++ b/go/batch-submitter/batch_submitter.go
@@ -119,8 +119,6 @@ func NewBatchSubmitter(cfg Config, gitVersion string) (*BatchSubmitter, error) {
 
 	log.Root().SetHandler(log.LvlFilterHandler(logLevel, logHandler))
 
-	log.Info("Config", "config", fmt.Sprintf("%#v", cfg))
-
 	// Parse sequencer private key and CTC contract address.
 	sequencerPrivKey, ctcAddress, err := parseWalletPrivKeyAndContractAddr(
 		"Sequencer", cfg.Mnemonic, cfg.SequencerHDPath,
@@ -171,7 +169,7 @@ func NewBatchSubmitter(cfg Config, gitVersion string) (*BatchSubmitter, error) {
 	var batchTxService *Service
 	if cfg.RunTxBatchSubmitter {
 		batchTxDriver, err := sequencer.NewDriver(sequencer.Config{
-			Name:        "SEQUENCER",
+			Name:        "Sequencer",
 			L1Client:    l1Client,
 			L2Client:    l2Client,
 			BlockOffset: cfg.BlockOffset,
@@ -196,7 +194,7 @@ func NewBatchSubmitter(cfg Config, gitVersion string) (*BatchSubmitter, error) {
 	var batchStateService *Service
 	if cfg.RunStateBatchSubmitter {
 		batchStateDriver, err := proposer.NewDriver(proposer.Config{
-			Name:        "PROPOSER",
+			Name:        "Proposer",
 			L1Client:    l1Client,
 			L2Client:    l2Client,
 			BlockOffset: cfg.BlockOffset,

--- a/go/batch-submitter/metrics/metrics.go
+++ b/go/batch-submitter/metrics/metrics.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Metrics struct {
+	// ETHBalance tracks the amount of ETH in the submitter's account.
+	ETHBalance prometheus.Gauge
+
+	// BatchSizeInBytes tracks the size of batch submission transactions.
+	BatchSizeInBytes prometheus.Histogram
+
+	// NumTxPerBatch tracks the number of L2 transactions in each batch
+	// submission.
+	NumTxPerBatch prometheus.Histogram
+
+	// SubmissionGasUsed tracks the amount of gas used to submit each batch.
+	SubmissionGasUsed prometheus.Histogram
+
+	// BatchsSubmitted tracks the total number of successful batch submissions.
+	BatchesSubmitted prometheus.Counter
+
+	// FailedSubmissions tracks the total number of failed batch submissions.
+	FailedSubmissions prometheus.Counter
+
+	// BatchTxBuildTime tracks the duration it takes to construct a batch
+	// transaction.
+	BatchTxBuildTime prometheus.Gauge
+
+	// BatchConfirmationTime tracks the duration it takes to confirm a batch
+	// transaction.
+	BatchConfirmationTime prometheus.Gauge
+}
+
+func NewMetrics(subsystem string) *Metrics {
+	return &Metrics{
+		ETHBalance: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "batch_submitter_eth_balance",
+			Help:      "ETH balance of the batch submitter",
+			Subsystem: subsystem,
+		}),
+		BatchSizeInBytes: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name:      "batch_submitter_batch_size_in_bytes",
+			Help:      "Size of batches in bytes",
+			Subsystem: subsystem,
+		}),
+		NumTxPerBatch: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name:      "batch_submitter_num_txs_per_batch",
+			Help:      "Number of transaction in each batch",
+			Subsystem: subsystem,
+		}),
+		SubmissionGasUsed: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name:      "batch_submitter_submission_gas_used",
+			Help:      "Gas used to submit each batch",
+			Subsystem: subsystem,
+		}),
+		BatchesSubmitted: promauto.NewCounter(prometheus.CounterOpts{
+			Name:      "batch_submitter_batches_submitted",
+			Help:      "Count of batches submitted",
+			Subsystem: subsystem,
+		}),
+		FailedSubmissions: promauto.NewCounter(prometheus.CounterOpts{
+			Name:      "batch_submitter_failed_submissions",
+			Help:      "Count of failed batch submissions",
+			Subsystem: subsystem,
+		}),
+		BatchTxBuildTime: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "batch_submitter_batch_tx_build_time",
+			Help:      "Time to construct batch transactions",
+			Subsystem: subsystem,
+		}),
+		BatchConfirmationTime: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "batch_submitter_batch_confirmation_time",
+			Help:      "Time to confirm batch transactions",
+			Subsystem: subsystem,
+		}),
+	}
+}

--- a/go/batch-submitter/service.go
+++ b/go/batch-submitter/service.go
@@ -6,11 +6,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/go/batch-submitter/metrics"
 	"github.com/ethereum-optimism/optimism/go/batch-submitter/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	// weiToGwei is the conversion rate from wei to gwei.
+	weiToGwei = new(big.Float).SetFloat64(1e-18)
 )
 
 // Driver is an interface for creating and submitting batch transactions for a
@@ -22,6 +28,9 @@ type Driver interface {
 	// WalletAddr is the wallet address used to pay for batch transaction
 	// fees.
 	WalletAddr() common.Address
+
+	// Metrics returns the subservice telemetry object.
+	Metrics() *metrics.Metrics
 
 	// GetBatchBlockRange returns the start and end L2 block heights that
 	// need to be processed. Note that the end value is *exclusive*,
@@ -51,7 +60,8 @@ type Service struct {
 	ctx    context.Context
 	cancel func()
 
-	txMgr txmgr.TxManager
+	txMgr   txmgr.TxManager
+	metrics *metrics.Metrics
 
 	wg sync.WaitGroup
 }
@@ -64,10 +74,11 @@ func NewService(cfg ServiceConfig) *Service {
 	)
 
 	return &Service{
-		cfg:    cfg,
-		ctx:    ctx,
-		cancel: cancel,
-		txMgr:  txMgr,
+		cfg:     cfg,
+		ctx:     ctx,
+		cancel:  cancel,
+		txMgr:   txMgr,
+		metrics: cfg.Driver.Metrics(),
 	}
 }
 
@@ -91,21 +102,35 @@ func (s *Service) eventLoop() {
 	for {
 		select {
 		case <-time.After(s.cfg.PollInterval):
-			log.Info(name + " fetching current block range")
+			// Record the submitter's current ETH balance. This is done first in
+			// case any of the remaining steps fail, we can at least have an
+			// accurate view of the submitter's balance.
+			balance, err := s.cfg.L1Client.BalanceAt(
+				s.ctx, s.cfg.Driver.WalletAddr(), nil,
+			)
+			if err != nil {
+				log.Error(name+" unable to get current balance", "err", err)
+				continue
+			}
+			s.metrics.ETHBalance.Set(weiToGwei64(balance))
 
+			// Determine the range of L2 blocks that the batch submitter has not
+			// processed, and needs to take action on.
+			log.Info(name + " fetching current block range")
 			start, end, err := s.cfg.Driver.GetBatchBlockRange(s.ctx)
 			if err != nil {
 				log.Error(name+" unable to get block range", "err", err)
 				continue
 			}
 
-			log.Info(name+" block range", "start", start, "end", end)
-
 			// No new updates.
 			if start.Cmp(end) == 0 {
+				log.Info(name+" no updates", "start", start, "end", end)
 				continue
 			}
+			log.Info(name+" block range", "start", start, "end", end)
 
+			// Query for the submitter's current nonce.
 			nonce64, err := s.cfg.L1Client.NonceAt(
 				s.ctx, s.cfg.Driver.WalletAddr(), nil,
 			)
@@ -116,6 +141,8 @@ func (s *Service) eventLoop() {
 			}
 			nonce := new(big.Int).SetUint64(nonce64)
 
+			// Construct the transaction submission clousure that will attempt
+			// to send the next transaction at the given nonce and gas price.
 			sendTx := func(
 				ctx context.Context,
 				gasPrice *big.Int,
@@ -123,24 +150,49 @@ func (s *Service) eventLoop() {
 				log.Info(name+" attempting batch tx", "start", start,
 					"end", end, "nonce", nonce,
 					"gasPrice", gasPrice)
-				return s.cfg.Driver.SubmitBatchTx(
+
+				tx, err := s.cfg.Driver.SubmitBatchTx(
 					ctx, start, end, nonce, gasPrice,
 				)
+				if err != nil {
+					return nil, err
+				}
+
+				s.metrics.BatchSizeInBytes.Observe(float64(tx.Size()))
+
+				return tx, nil
 			}
 
+			// Wait until one of our submitted transactions confirms. If no
+			// receipt is received it's likely our gas price was too low.
+			batchConfirmationStart := time.Now()
 			receipt, err := s.txMgr.Send(s.ctx, sendTx)
 			if err != nil {
 				log.Error(name+" unable to publish batch tx",
 					"err", err)
+				s.metrics.FailedSubmissions.Inc()
 				continue
 			}
 
+			// The transaction was successfully submitted.
 			log.Info(name+" batch tx successfully published",
 				"tx_hash", receipt.TxHash)
+			batchConfirmationTime := time.Since(batchConfirmationStart) /
+				time.Millisecond
+			s.metrics.BatchConfirmationTime.Set(float64(batchConfirmationTime))
+			s.metrics.BatchesSubmitted.Inc()
+			s.metrics.SubmissionGasUsed.Observe(float64(receipt.GasUsed))
 
 		case err := <-s.ctx.Done():
 			log.Error(name+" service shutting down", "err", err)
 			return
 		}
 	}
+}
+
+func weiToGwei64(wei *big.Int) float64 {
+	gwei := new(big.Float).SetInt(wei)
+	gwei.Mul(gwei, weiToGwei)
+	gwei64, _ := gwei.Float64()
+	return gwei64
 }


### PR DESCRIPTION
**Description**
Adds prometheus metrics to the Go batch-submitter. [All of the existing metrics](https://github.com/ethereum-optimism/optimism/blob/develop/packages/batch-submitter/src/batch-submitter/batch-submitter.ts#L256L302) are included here with the exception of `malformed_batches`, which is no longer used after the monotonicity checks were disabled. `submission_timestamp` is also removed since we currently don't use it in any of our dashboards.

Additionally, a new `batch_submitter_confirmation_time` gauge is added to be able to directly measure the confirmation latency experienced by the batch submitter.

**Metadata**
- Fixes ENG-1671
