### PR TITLE
Add nightly builds via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,85 @@
+version: 2.1
+commands:
+  build-dockerfile:
+    parameters:
+      image-name:
+        description: Image name
+        type: string
+      target:
+        description: Dockerfile target
+        type: string
+        default: ""
+      dockerfile:
+        description: Dockerfile to use
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+      - run:
+          name: Build
+          command: |
+            echo -n "$STACKMAN_REPO_AUTH" | docker login -u _json_key --password-stdin https://us-east4-docker.pkg.dev
+            docker build -t "$STACKMAN_REPO/<<parameters.image-name>>:nightly" -f <<parameters.dockerfile>> <<#parameters.target>>--target <<parameters.target>><</parameters.target>> .
+            docker push "$STACKMAN_REPO/<<parameters.image-name>>:nightly"
+jobs:
+  build-dtl:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: data-transport-layer
+          target: data-transport-layer
+          dockerfile: ./ops/docker/Dockerfile.packages
+  build-batch-submitter:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: batch-submitter
+          target: batch-submitter
+          dockerfile: ./ops/docker/Dockerfile.packages
+  build-deployer:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: deployer
+          target: deployer
+          dockerfile: ./ops/docker/Dockerfile.packages
+  build-l2geth:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: l2geth
+          dockerfile: ./ops/docker/Dockerfile.geth
+  build-gas-oracle:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: gas-oracle
+          dockerfile: ./ops/docker/Dockerfile.gas-oracle
+
+
+workflows:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * * "
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - build-dtl:
+          context: optimism
+      - build-batch-submitter:
+          context: optimism
+      - build-deployer:
+          context: optimism
+      - build-l2geth:
+          context: optimism
+      - build-gas-oracle:
+          context: optimism


### PR DESCRIPTION
Uses CircleCI to push our main services to the Stackman Docker registry on a nightly basis.

Metadata:

- Fixes ENG-1660
