### PR TITLE
ops/docker: Use old directory in packages dockerfile

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -11,7 +11,7 @@ RUN apt-get update -y && apt-get install -y git curl jq python3
 # copy over the needed configs to run the dep installation
 # note: this approach can be a bit unhandy to maintain, but it allows
 # us to cache the installation steps
-WORKDIR /optimism
+WORKDIR /opt/optimism
 COPY *.json yarn.lock ./
 COPY packages/core-utils/package.json ./packages/core-utils/package.json
 COPY packages/common-ts/package.json ./packages/common-ts/package.json
@@ -33,30 +33,30 @@ RUN yarn build
 
 
 FROM base as deployer
-WORKDIR /optimism/packages/contracts
+WORKDIR /opt/optimism/packages/contracts
 COPY ./ops/scripts/deployer.sh .
 CMD ["yarn", "run", "deploy"]
 
 
 FROM base as batch-submitter
-WORKDIR /optimism/packages/batch-submitter
+WORKDIR /opt/optimism/packages/batch-submitter
 COPY ./ops/scripts/batches.sh .
 CMD ["npm", "run", "start"]
 
 
 FROM base as data-transport-layer
-WORKDIR /optimism/packages/data-transport-layer
+WORKDIR /opt/optimism/packages/data-transport-layer
 COPY ./ops/scripts/dtl.sh .
 CMD ["node", "dist/src/services/run.js"]
 
 
 FROM base as integration-tests
-WORKDIR /optimism/integration-tests
+WORKDIR /opt/optimism/integration-tests
 COPY ./ops/scripts/integration-tests.sh ./
 CMD ["yarn", "test:integration"]
 
 
 FROM base as relayer
-WORKDIR /optimism/packages/message-relayer
+WORKDIR /opt/optimism/packages/message-relayer
 COPY ./ops/scripts/relayer.sh .
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
`Dockerfile.packages` placed build artifacts in `/optimism`, whereas all of our other Dockerfiles place build artifactrs in `/opt/optimism`. As a result, downstream consumers of the packages Dockerfile cannot use images created by our other Dockerfiles. This is a problem for the nightly environment, since it relies upon the `/opt/optimism` structure to customize container entrypoints.

This PR fixes the problem by having `Dockerfile.packages` put build artifacts in `/opt/optimism` like everything else.
