### PR TITLE
integration-tests: Actor updates to run against nightly

### DIFF
--- a/.changeset/beige-zoos-roll.md
+++ b/.changeset/beige-zoos-roll.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Updates to support nightly actor tests

--- a/integration-tests/actor-tests/nft.test.ts
+++ b/integration-tests/actor-tests/nft.test.ts
@@ -1,4 +1,4 @@
-import { utils, Wallet, Contract, ContractFactory } from 'ethers'
+import { utils, Wallet, Contract } from 'ethers'
 import { actor, run, setupActor, setupRun } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
 import ERC721 from '../artifacts/contracts/NFT.sol/NFT.json'
@@ -16,14 +16,7 @@ actor('NFT claimer', () => {
 
   setupActor(async () => {
     env = await OptimismEnv.new()
-
-    const factory = new ContractFactory(
-      ERC721.abi,
-      ERC721.bytecode,
-      env.l2Wallet
-    )
-    contract = await factory.deploy()
-    await contract.deployed()
+    contract = new Contract(process.env.ERC_721_ADDRESS, ERC721.abi)
   })
 
   setupRun(async () => {

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -8,6 +8,7 @@
     "sync-tests/*.ts",
     "./actor-tests/**/*.ts",
     "./artifacts/**/*.json",
+    "./tasks/**/*.ts",
     "./package.json"
   ],
   "files": ["./hardhat.config.ts"]


### PR DESCRIPTION
- Modifies the existing actor tests to use predeployed contract addresses
- Exposes metrics about the actor via Prometheus
- Adds various Hardhat tasks that make is easier to set up new environments with predeployed contracts and funded accounts

To see how the actors are set up using Stackman, see https://github.com/ethereum-optimism/stacks/blob/master/nightly/actors.yml.

Fixes ENG-1667
