### PR TITLE
Add nightly deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  gcp-gke: circleci/gcp-gke@1.3.0
 commands:
   build-dockerfile:
     parameters:
@@ -39,6 +41,13 @@ jobs:
           image-name: batch-submitter
           target: batch-submitter
           dockerfile: ./ops/docker/Dockerfile.packages
+  build-go-batch-submitter:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: go-batch-submitter
+          dockerfile: ./ops/docker/Dockerfile.batch-submitter-service
   build-deployer:
     docker:
       - image: cimg/base:2021.04
@@ -61,6 +70,37 @@ jobs:
       - build-dockerfile:
           image-name: gas-oracle
           dockerfile: ./ops/docker/Dockerfile.gas-oracle
+  build-integration-tests:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - build-dockerfile:
+          image-name: integration-tests
+          target: integration-tests
+          dockerfile: ./ops/docker/Dockerfile.packages
+  deploy-nightly:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - gcp-gke/install
+      - gcp-gke/update-kubeconfig-with-credentials:
+          cluster: $STACKMAN_CLUSTER
+          gcloud-service-key: STACKMAN_SERVICE_KEY
+          google-compute-region: STACKMAN_COMPUTE_REGION
+          google-compute-zone: STACKMAN_COMPUTE_ZONE
+          google-project-id: STACKMAN_PROJECT_ID
+          install-kubectl: yes
+          perform-login: yes
+      - run:
+          name: Deploy
+          command: |
+            echo "Current nightly pods:"
+            kubectl get pods --namespace nightly
+            echo "Redeploying pods:"
+            kubectl rollout restart statefulset nightly-sequencer --namespace nightly
+            kubectl rollout restart statefulset nightly-go-batch-submitter --namespace nightly
+            kubectl rollout restart statefulset nightly-dtl --namespace nightly
+            kubectl rollout restart deployment nightly-gas-oracle --namespace nightly
 
 
 workflows:
@@ -83,3 +123,17 @@ workflows:
           context: optimism
       - build-gas-oracle:
           context: optimism
+      - build-integration-tests:
+          context: optimism
+      - build-go-batch-submitter:
+          context: optimism
+      - deploy-nightly:
+          context: optimism
+          requires:
+            - build-dtl
+            - build-batch-submitter
+            - build-go-batch-submitter
+            - build-deployer
+            - build-l2geth
+            - build-gas-oracle
+            - build-integration-tests


### PR DESCRIPTION
Deploys the nightly image after the build. We can use a `kubectl rollout restart` here because the nightly uses images of the form `image-name:nightly` and have `imagePullPolicy` set to `Always`. This forces Kubernetes to always re-pull images upon pod restart.

Metadata:

- Fixes ENG-1661