### PR TITLE
go/batch-submitter: Fix metrics server

### DIFF
--- a/.changeset/purple-squids-taste.md
+++ b/.changeset/purple-squids-taste.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+---
+
+Fix metrics server

--- a/go/batch-submitter/batch_submitter.go
+++ b/go/batch-submitter/batch_submitter.go
@@ -293,7 +293,7 @@ func parseWalletPrivKeyAndContractAddr(
 // NOTE: This method MUST be run as a goroutine.
 func runMetricsServer(hostname string, port uint64) {
 	metricsPortStr := strconv.FormatUint(port, 10)
-	metricsAddr := fmt.Sprintf("%s: %s", hostname, metricsPortStr)
+	metricsAddr := fmt.Sprintf("%s:%s", hostname, metricsPortStr)
 
 	http.Handle("/metrics", promhttp.Handler())
 	_ = http.ListenAndServe(metricsAddr, nil)


### PR DESCRIPTION
The metrics server wasn't running because of a space between the host and port.
