### PR TITLE
batch-submitter: Fix the numTxPerBatch metric

### DIFF
--- a/.changeset/cyan-owls-grow.md
+++ b/.changeset/cyan-owls-grow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Fix the numTxPerBatch metric

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -232,7 +232,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
     const batchTxBuildEnd = performance.now()
     this.metrics.batchTxBuildTime.set(batchTxBuildEnd - batchTxBuildStart)
 
-    this.metrics.numTxPerBatch.observe(endBlock - startBlock)
+    this.metrics.numTxPerBatch.observe(batchParams.totalElementsToAppend)
     const l1tipHeight = await this.signer.provider.getBlockNumber()
     this.logger.debug('Submitting batch.', {
       calldata: batchParams,


### PR DESCRIPTION
Changes the `numTxPerBatch` metric to observe the actual number of elements inside `batchParams` rather than `endBlock - startBlock`.

Metadata:

- Fixes ENG-1807
