### PR TITLE
fix: have SDK generate coverage reports

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -131,6 +131,13 @@ jobs:
           fail_ci_if_error: false
           verbose: true
           flags: message-relayer
+      - uses: codecov/codecov-action@v1
+        with:
+          files: ./packages/sdk/coverage.json
+          fail_ci_if_error: false
+          verbose: true
+          flags: sdk
+
   lint:
     name: Linting
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Modifies CI so that the SDK package correctly generates coverage reports.
