### PR TITLE
fix: update SDK readme to include warning

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,6 +4,13 @@
 
 The `@eth-optimism/sdk` package provides a set of tools for interacting with Optimistic Ethereum.
 
+## NOTICE
+
+WARNING: This package is currently under construction.
+You can definitely try to use it, but you probably won't have a good time.
+Lots of pieces are missing.
+We will announce the 1.0.0 release on Discord and on Twitter once it's ready, keep an eye out!
+
 ## Installation
 
 ```


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the SDK README to include a warning that the package is not ready to be used.