### PR TITLE
fix: replace OE with Optimism

### DIFF
--- a/.changeset/fair-starfishes-admire.md
+++ b/.changeset/fair-starfishes-admire.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/gas-oracle': patch
+'@eth-optimism/contracts': patch
+'@eth-optimism/data-transport-layer': patch
+---
+
+String update to change the system name from OE to Optimism

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Use the above commands to recompile the packages.
 
 ### Building the rest of the system
 
-If you want to run an Optimistic Ethereum node OR **if you want to run the integration tests**, you'll need to build the rest of the system.
+If you want to run an Optimism node OR **if you want to run the integration tests**, you'll need to build the rest of the system.
 
 ```bash
 cd ops

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## TL;DR
 
-This is the primary place where [Optimism](https://optimism.io) works on stuff related to [Optimistic Ethereum](https://optimistic.etherscan.io/).
+This is where [Optimism](https://optimism.io) gets built.
 
 ## Documentation
 
@@ -31,16 +31,16 @@ Then check out our list of [good first issues](https://github.com/ethereum-optim
 <pre>
 root
 ├── <a href="./packages">packages</a>
-│   ├── <a href="./packages/contracts">contracts</a>: L1 and L2 smart contracts for Optimistic Ethereum
-│   ├── <a href="./packages/core-utils">core-utils</a>: Low-level utilities that make building Optimistic Ethereum easier
+│   ├── <a href="./packages/contracts">contracts</a>: L1 and L2 smart contracts for Optimism
+│   ├── <a href="./packages/core-utils">core-utils</a>: Low-level utilities that make building Optimism easier
 │   ├── <a href="./packages/common-ts">common-ts</a>: Common tools for building apps in TypeScript
-│   ├── <a href="./packages/data-transport-layer">data-transport-layer</a>: Service for indexing Optimistic Ethereum-related L1 data
+│   ├── <a href="./packages/data-transport-layer">data-transport-layer</a>: Service for indexing Optimism-related L1 data
 │   ├── <a href="./packages/batch-submitter">batch-submitter</a>: Service for submitting batches of transactions and results to L1
 │   ├── <a href="./packages/message-relayer">message-relayer</a>: Tool for automatically relaying L1<>L2 messages in development
 │   └── <a href="./packages/replica-healthcheck">replica-healthcheck</a>: Service for monitoring the health of a replica node
-├── <a href="./l2geth">l2geth</a>: Optimistic Ethereum client software, a fork of <a href="https://github.com/ethereum/go-ethereum/tree/v1.9.10">geth v1.9.10</a>
-├── <a href="./integration-tests">integration-tests</a>: Various integration tests for an Optimistic Ethereum network
-└── <a href="./ops">ops</a>: Tools for running Optimistic Ethereum nodes and networks
+├── <a href="./l2geth">l2geth</a>: Optimism client software, a fork of <a href="https://github.com/ethereum/go-ethereum/tree/v1.9.10">geth v1.9.10</a>
+├── <a href="./integration-tests">integration-tests</a>: Various integration tests for the Optimism network
+└── <a href="./ops">ops</a>: Tools for running Optimism nodes and networks
 </pre>
 
 ## Branching Model and Releases
@@ -64,7 +64,7 @@ Please read the linked post if you're planning to make frequent PRs into this re
 
 The `master` branch contains the code for our latest "stable" releases.
 Updates from `master` always come from the `develop` branch.
-We only ever update the `master` branch when we intend to deploy code within the `develop` to the Optimistic Ethereum mainnet.
+We only ever update the `master` branch when we intend to deploy code within the `develop` to the Optimism mainnet.
 Our update process takes the form of a PR merging the `develop` branch into the `master` branch.
 
 ### The `develop` branch

--- a/go/gas-oracle/README.md
+++ b/go/gas-oracle/README.md
@@ -40,7 +40,7 @@ options.
 
 ```
 NAME:
-   gas-oracle - Remotely Control the Optimistic Ethereum Gas Price
+   gas-oracle - Remotely Control the Optimism Gas Price
 
 USAGE:
    gas-oracle [global options] command [command options] [arguments...]
@@ -49,7 +49,7 @@ VERSION:
    0.0.0-1.10.4-stable
 
 DESCRIPTION:
-   Configure with a private key and an Optimistic Ethereum HTTP endpoint to send transactions that update the L2 gas price.
+   Configure with a private key and an Optimism HTTP endpoint to send transactions that update the L2 gas price.
 
 COMMANDS:
      help, h  Shows a list of commands or help for one command

--- a/go/gas-oracle/main.go
+++ b/go/gas-oracle/main.go
@@ -26,8 +26,8 @@ func main() {
 
 	app.Version = GitVersion + "-" + params.VersionWithCommit(GitCommit, GitDate)
 	app.Name = "gas-oracle"
-	app.Usage = "Remotely Control the Optimistic Ethereum Gas Price"
-	app.Description = "Configure with a private key and an Optimistic Ethereum HTTP endpoint " +
+	app.Usage = "Remotely Control the Optimism Gas Price"
+	app.Description = "Configure with a private key and an Optimism HTTP endpoint " +
 		"to send transactions that update the L2 gas price."
 
 	// Configure the logging

--- a/go/op-exporter/README.md
+++ b/go/op-exporter/README.md
@@ -1,6 +1,6 @@
 # op_exporter
 
-A prometheus exporter to collect information from an Optimistic Ethereum node and serve metrics for collection
+A prometheus exporter to collect information from an Optimism node and serve metrics for collection
 
 ## Usage
 

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -286,7 +286,7 @@ describe('Basic RPC tests', () => {
       expect(receipt.status).to.eq(0)
     })
 
-    // Optimistic Ethereum special fields on the receipt
+    // Optimism special fields on the receipt
     it('includes L1 gas price and L1 gas used', async () => {
       const tx = await env.l2Wallet.populateTransaction({
         to: env.l2Wallet.address,

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,9 +1,9 @@
 [![codecov](https://codecov.io/gh/ethereum-optimism/optimism/branch/master/graph/badge.svg?token=0VTG7PG7YR&flag=contracts)](https://codecov.io/gh/ethereum-optimism/optimism)
 
-# Optimistic Ethereum Smart Contracts
+# Optimism Smart Contracts
 
-`@eth-optimism/contracts` contains the various Solidity smart contracts used within the Optimistic Ethereum system.
-Some of these contracts are deployed on Ethereum ("Layer 1"), while others are meant to be deployed to Optimistic Ethereum ("Layer 2").
+`@eth-optimism/contracts` contains the various Solidity smart contracts used within the Optimism system.
+Some of these contracts are deployed on Ethereum ("Layer 1"), while others are meant to be deployed to Optimism ("Layer 2").
 
 Within each contract file you'll find a comment that lists:
 1. The compiler with which a contract is intended to be compiled, `solc` or `optimistic-solc`.

--- a/packages/contracts/deployments/README.md
+++ b/packages/contracts/deployments/README.md
@@ -1,4 +1,4 @@
-# Optimistic Ethereum Deployments
-- [Optimistic Ethereum (mainnet)](./mainnet#readme)
-- [Optimistic Kovan (public testnet)](./kovan#readme)
-- [Optimistic Goerli (internal devnet)](./goerli#readme)
+# Optimism Deployments
+- [Optimism (mainnet)](./mainnet#readme)
+- [Optimism Kovan (public testnet)](./kovan#readme)
+- [Optimism Goerli (internal devnet)](./goerli#readme)

--- a/packages/contracts/deployments/goerli/README.md
+++ b/packages/contracts/deployments/goerli/README.md
@@ -1,6 +1,6 @@
-# Optimistic Goerli (internal devnet)
+# Optimism Goerli (internal devnet)
 ## Notice
-Optimistic Goerli is an internal Optimism development network. You're probably looking for [Optimistic Kovan](../kovan#readme), the public Optimistic Ethereum testnet.
+Optimism Goerli is an internal Optimism development network. You're probably looking for [Optimism Kovan](../kovan#readme), the public Optimism testnet.
 ## Network Info
 - **Chain ID**: 420
 ## Layer 1 Contracts

--- a/packages/contracts/deployments/kovan/README.md
+++ b/packages/contracts/deployments/kovan/README.md
@@ -1,4 +1,4 @@
-# Optimistic Kovan (public testnet)
+# Optimism Kovan (public testnet)
 ## Network Info
 - **Chain ID**: 69
 - **Public RPC**: https://kovan.optimism.io

--- a/packages/contracts/deployments/mainnet/README.md
+++ b/packages/contracts/deployments/mainnet/README.md
@@ -1,4 +1,4 @@
-# Optimistic Ethereum (mainnet)
+# Optimism (mainnet)
 ## Network Info
 - **Chain ID**: 10
 - **Public RPC**: https://mainnet.optimism.io

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/contracts",
   "version": "0.5.7",
-  "description": "[Optimism] L1 and L2 smart contracts for Optimistic Ethereum",
+  "description": "[Optimism] L1 and L2 smart contracts for Optimism",
   "main": "dist/index",
   "types": "dist/index",
   "files": [

--- a/packages/contracts/scripts/generate-markdown.ts
+++ b/packages/contracts/scripts/generate-markdown.ts
@@ -16,7 +16,7 @@ interface DeploymentInfo {
 const PUBLIC_DEPLOYMENTS: DeploymentInfo[] = [
   {
     folder: 'mainnet',
-    name: 'Optimistic Ethereum (mainnet)',
+    name: 'Optimism (mainnet)',
     chainid: 10,
     rpc: 'https://mainnet.optimism.io',
     l1Explorer: 'https://etherscan.io',
@@ -24,7 +24,7 @@ const PUBLIC_DEPLOYMENTS: DeploymentInfo[] = [
   },
   {
     folder: 'kovan',
-    name: 'Optimistic Kovan (public testnet)',
+    name: 'Optimism Kovan (public testnet)',
     chainid: 69,
     rpc: 'https://kovan.optimism.io',
     l1Explorer: 'https://kovan.etherscan.io',
@@ -32,9 +32,9 @@ const PUBLIC_DEPLOYMENTS: DeploymentInfo[] = [
   },
   {
     folder: 'goerli',
-    name: 'Optimistic Goerli (internal devnet)',
+    name: 'Optimism Goerli (internal devnet)',
     chainid: 420,
-    notice: `Optimistic Goerli is an internal Optimism development network. You're probably looking for [Optimistic Kovan](../kovan#readme), the public Optimistic Ethereum testnet.`,
+    notice: `Optimism Goerli is an internal Optimism development network. You're probably looking for [Optimism Kovan](../kovan#readme), the public Optimism testnet.`,
     l1Explorer: 'https://goerli.etherscan.io',
   },
 ]
@@ -221,7 +221,7 @@ const main = async () => {
   }
 
   let primary = ``
-  primary = addline(primary, `# Optimistic Ethereum Deployments`)
+  primary = addline(primary, `# Optimism Deployments`)
   for (const deployment of PUBLIC_DEPLOYMENTS) {
     primary = addline(
       primary,

--- a/packages/data-transport-layer/README.md
+++ b/packages/data-transport-layer/README.md
@@ -3,7 +3,7 @@
 
 ## What is this?
 
-The Optimistic Ethereum Data Transport Layer is a long-running software service (written in TypeScript) designed to reliably index Optimistic Ethereum transaction data from Layer 1 (Ethereum). Specifically, this service indexes:
+The Optimism Data Transport Layer is a long-running software service (written in TypeScript) designed to reliably index Optimism transaction data from Layer 1 (Ethereum). Specifically, this service indexes:
 
 * Transactions that have been enqueued for submission to the CanonicalTransactionChain via [`CanonicalTransactionChain.enqueue`].
 * Transactions that have been included in the CanonicalTransactionChain via [`CanonicalTransactionChain.appendQueueBatch`] or [`CanonicalTransactionChain.appendSequencerBatch`].

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -121,7 +121,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
         }
 
         this.logger.info(
-          'Synchronizing unconfirmed transactions from Layer 2 (Optimistic Ethereum)',
+          'Synchronizing unconfirmed transactions from Layer 2 (Optimism)',
           {
             fromBlock: highestSyncedL2BlockNumber,
             toBlock: targetL2Block,

--- a/packages/regenesis-surgery/test/eoa.spec.ts
+++ b/packages/regenesis-surgery/test/eoa.spec.ts
@@ -68,7 +68,7 @@ describe('EOAs', () => {
     // eslint-disable-next-line
     before(function() {
       if (env.surgeryDataSources.configs.l2NetworkName === 'kovan') {
-        console.log('1inch deployer does not exist on optimistic kovan')
+        console.log('1inch deployer does not exist on Optimism Kovan')
         this.skip()
       }
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,7 +2,7 @@
 
 # @eth-optimism/sdk
 
-The `@eth-optimism/sdk` package provides a set of tools for interacting with Optimistic Ethereum.
+The `@eth-optimism/sdk` package provides a set of tools for interacting with Optimism.
 
 ## NOTICE
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eth-optimism/sdk",
   "version": "0.0.3",
-  "description": "[Optimism] Tools for working with Optimistic Ethereum",
+  "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",
   "files": [

--- a/packages/sdk/src/interfaces/types.ts
+++ b/packages/sdk/src/interfaces/types.ts
@@ -34,7 +34,7 @@ export interface OEL2Contracts {
 }
 
 /**
- * Represents Optimistic Ethereum contracts, assumed to be connected to their appropriate
+ * Represents Optimism contracts, assumed to be connected to their appropriate
  * providers and addresses.
  */
 export interface OEContracts {

--- a/packages/sdk/src/utils/message-encoding.ts
+++ b/packages/sdk/src/utils/message-encoding.ts
@@ -4,7 +4,7 @@ import { CoreCrossChainMessage } from '../interfaces'
 
 /**
  * Returns the canonical encoding of a cross chain message. This encoding is used in various
- * locations within the Optimistic Ethereum smart contracts.
+ * locations within the Optimism smart contracts.
  *
  * @param message Cross chain message to encode.
  * @returns Canonical encoding of the message.
@@ -20,7 +20,7 @@ export const encodeCrossChainMessage = (
 
 /**
  * Returns the canonical hash of a cross chain message. This hash is used in various locations
- * within the Optimistic Ethereum smart contracts and is the keccak256 hash of the result of
+ * within the Optimism smart contracts and is the keccak256 hash of the result of
  * encodeCrossChainMessage.
  *
  * @param message Cross chain message to hash.


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
As per our recent decision to start calling the network "Optimism", this PR modifies all references of Optimistic Ethereum to just "Optimism".
