### PR TITLE
fix: message relayer docker build

### DIFF
--- a/.changeset/mean-llamas-speak.md
+++ b/.changeset/mean-llamas-speak.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/message-relayer': patch
+---
+
+Fix docker build

--- a/ops/docker/Dockerfile.message-relayer
+++ b/ops/docker/Dockerfile.message-relayer
@@ -28,7 +28,6 @@ COPY --from=builder /optimism/packages/contracts/artifacts ./packages/contracts/
 WORKDIR /opt/optimism/packages/message-relayer
 COPY --from=builder /optimism/packages/message-relayer/dist ./dist
 COPY --from=builder /optimism/packages/message-relayer/package.json .
-COPY --from=builder /optimism/packages/message-relayer/exec ./exec
 COPY --from=builder /optimism/packages/message-relayer/node_modules ./node_modules
 
 # copy this over in case you want to run alongside other services


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
After https://github.com/ethereum-optimism/optimism/commit/3a673322e4ac22d565a902d82f3c0d5fd567584d
was merged, it broke the docker build of the `message-relayer`. See:
https://github.com/ethereum-optimism/optimism/runs/4600810001?check_suite_focus=true

```
#25 [stage-1 18/20] COPY --from=builder /optimism/packages/message-relayer/exec ./exec
#25 ERROR: "/optimism/packages/message-relayer/exec": not found
------
 > [stage-1 18/20] COPY --from=builder /optimism/packages/message-relayer/exec ./exec:
------
Dockerfile.message-relayer:31
--------------------
  29 |     COPY --from=builder /optimism/packages/message-relayer/dist ./dist
  30 |     COPY --from=builder /optimism/packages/message-relayer/package.json .
  31 | >>> COPY --from=builder /optimism/packages/message-relayer/exec ./exec
  32 |     COPY --from=builder /optimism/packages/message-relayer/node_modules ./node_modules
  33 |     
--------------------
```

This PR removes the reference to `exec` which no longer exists