### PR TITLE
ci: Fix merge bug in CircleCI YAML

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,11 @@ workflows:
             - optimism
             - slack
           <<: *slack-fail-post-step
+      - build-proxyd:
+          context:
+            - optimism
+            - slack
+          <<: *slack-fail-post-step
       - deploy-nightly:
           context:
             - optimism


### PR DESCRIPTION
I encountered merge conflicts in the CircleCI YAML, and missed a stanza that builds proxyd.
