### PR TITLE
Fixes codechecks reports

### DIFF
--- a/packages/contracts/codechecks.yml
+++ b/packages/contracts/codechecks.yml
@@ -1,6 +1,7 @@
 checks:
   - name: eth-gas-reporter/codechecks
 settings:
+  speculativeBranchSelection: false
   branches:
     - develop
     - master

--- a/packages/contracts/codechecks.yml
+++ b/packages/contracts/codechecks.yml
@@ -1,2 +1,6 @@
 checks:
   - name: eth-gas-reporter/codechecks
+settings:
+  branches:
+    - develop
+    - master


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Codechecks reports for gas cost differences currently don't show the correct gas cost diff because the base branch where gas numbers are compared against is `master` (default) rather than `develop`. Here we add base branch settings to codechecks that defines `develop` as the first branch to compare to. Additionally we turn off [speculative branch execution](https://github.com/codechecks/docs/blob/master/configuration.md#speculative-branch-execution) which is not recommended outside of Circle CI. 

Additionally the Github action for running codechecks on merge to develop and master works correctly which re-baselines the gas costs that new PRs are compared against. 

**Metadata**
- Fixes #ENG-1328
