### PR TITLE
feat(sdk): implement waitForMessageReceipt

### DIFF
--- a/packages/sdk/src/cross-chain-provider.ts
+++ b/packages/sdk/src/cross-chain-provider.ts
@@ -396,7 +396,7 @@ export class CrossChainProvider implements ICrossChainProvider {
     return null
   }
 
-  public async waitForMessageReciept(
+  public async waitForMessageReceipt(
     message: MessageLike,
     opts: {
       confirmations?: number

--- a/packages/sdk/src/interfaces/cross-chain-provider.ts
+++ b/packages/sdk/src/interfaces/cross-chain-provider.ts
@@ -186,7 +186,7 @@ export interface ICrossChainProvider {
    * @returns CrossChainMessage receipt including receipt of the transaction that relayed the
    * given message.
    */
-  waitForMessageReciept(
+  waitForMessageReceipt(
     message: MessageLike,
     opts?: {
       confirmations?: number

--- a/packages/sdk/test/cross-chain-erc20-pair.spec.ts
+++ b/packages/sdk/test/cross-chain-erc20-pair.spec.ts
@@ -1,96 +1,95 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import './setup'
 
 describe('CrossChainERC20Pair', () => {
   describe('construction', () => {
-    it('should have a messenger', () => {})
+    it('should have a messenger')
 
     describe('when the token is a standard bridge token', () => {
-      it('should resolve the correct bridge', () => {})
+      it('should resolve the correct bridge')
     })
 
     describe('when the token is SNX', () => {
-      it('should resolve the correct bridge', () => {})
+      it('should resolve the correct bridge')
     })
 
     describe('when the token is DAI', () => {
-      it('should resolve the correct bridge', () => {})
+      it('should resolve the correct bridge')
     })
 
     describe('when a custom adapter is provided', () => {
-      it('should use the custom adapter', () => {})
+      it('should use the custom adapter')
     })
   })
 
   describe('deposit', () => {
     describe('when the user has enough balance and allowance', () => {
       describe('when the token is a standard bridge token', () => {
-        it('should trigger a token deposit', () => {})
+        it('should trigger a token deposit')
       })
 
       describe('when the token is ETH', () => {
-        it('should trigger a token deposit', () => {})
+        it('should trigger a token deposit')
       })
 
       describe('when the token is SNX', () => {
-        it('should trigger a token deposit', () => {})
+        it('should trigger a token deposit')
       })
 
       describe('when the token is DAI', () => {
-        it('should trigger a token deposit', () => {})
+        it('should trigger a token deposit')
       })
     })
 
     describe('when the user does not have enough balance', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
 
     describe('when the user has not given enough allowance to the bridge', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
   })
 
   describe('withdraw', () => {
     describe('when the user has enough balance', () => {
       describe('when the token is a standard bridge token', () => {
-        it('should trigger a token withdrawal', () => {})
+        it('should trigger a token withdrawal')
       })
 
       describe('when the token is ETH', () => {
-        it('should trigger a token withdrawal', () => {})
+        it('should trigger a token withdrawal')
       })
 
       describe('when the token is SNX', () => {
-        it('should trigger a token withdrawal', () => {})
+        it('should trigger a token withdrawal')
       })
 
       describe('when the token is DAI', () => {
-        it('should trigger a token withdrawal', () => {})
+        it('should trigger a token withdrawal')
       })
     })
 
     describe('when the user does not have enough balance', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
   })
 
   describe('populateTransaction', () => {
     describe('deposit', () => {
-      it('should populate the transaction with the correct values', () => {})
+      it('should populate the transaction with the correct values')
     })
 
     describe('withdraw', () => {
-      it('should populate the transaction with the correct values', () => {})
+      it('should populate the transaction with the correct values')
     })
   })
 
   describe('estimateGas', () => {
     describe('deposit', () => {
-      it('should estimate gas required for the transaction', () => {})
+      it('should estimate gas required for the transaction')
     })
 
     describe('withdraw', () => {
-      it('should estimate gas required for the transaction', () => {})
+      it('should estimate gas required for the transaction')
     })
   })
 })

--- a/packages/sdk/test/cross-chain-messenger.spec.ts
+++ b/packages/sdk/test/cross-chain-messenger.spec.ts
@@ -1,44 +1,43 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import './setup'
 
 describe('CrossChainMessenger', () => {
   describe('sendMessage', () => {
     describe('when no l2GasLimit is provided', () => {
-      it('should send a message with an estimated l2GasLimit', () => {})
+      it('should send a message with an estimated l2GasLimit')
     })
 
     describe('when an l2GasLimit is provided', () => {
-      it('should send a message with the provided l2GasLimit', () => {})
+      it('should send a message with the provided l2GasLimit')
     })
   })
 
   describe('resendMessage', () => {
     describe('when the message being resent exists', () => {
-      it('should resend the message with the new gas limit', () => {})
+      it('should resend the message with the new gas limit')
     })
 
     describe('when the message being resent does not exist', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
   })
 
   describe('finalizeMessage', () => {
     describe('when the message being finalized exists', () => {
       describe('when the message is ready to be finalized', () => {
-        it('should finalize the message', () => {})
+        it('should finalize the message')
       })
 
       describe('when the message is not ready to be finalized', () => {
-        it('should throw an error', () => {})
+        it('should throw an error')
       })
 
       describe('when the message has already been finalized', () => {
-        it('should throw an error', () => {})
+        it('should throw an error')
       })
     })
 
     describe('when the message being finalized does not exist', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
   })
 })

--- a/packages/sdk/test/cross-chain-provider.spec.ts
+++ b/packages/sdk/test/cross-chain-provider.spec.ts
@@ -983,7 +983,7 @@ describe('CrossChainProvider', () => {
     // track of
   })
 
-  describe('waitForMessageReciept', () => {
+  describe('waitForMessageReceipt', () => {
     let l2Messenger: Contract
     let provider: CrossChainProvider
     beforeEach(async () => {
@@ -1020,7 +1020,7 @@ describe('CrossChainProvider', () => {
           hashCrossChainMessage(message),
         ])
 
-        const messageReceipt = await provider.waitForMessageReciept(message)
+        const messageReceipt = await provider.waitForMessageReceipt(message)
         expect(messageReceipt.receiptStatus).to.equal(1)
         expect(
           omit(messageReceipt.transactionReceipt, 'confirmations')
@@ -1054,7 +1054,7 @@ describe('CrossChainProvider', () => {
           }, 5000)
 
           const tick = Date.now()
-          const messageReceipt = await provider.waitForMessageReciept(message)
+          const messageReceipt = await provider.waitForMessageReceipt(message)
           const tock = Date.now()
           expect(messageReceipt.receiptStatus).to.equal(1)
           expect(tock - tick).to.be.greaterThan(5000)
@@ -1080,7 +1080,7 @@ describe('CrossChainProvider', () => {
           }
 
           await expect(
-            provider.waitForMessageReciept(message, {
+            provider.waitForMessageReceipt(message, {
               timeoutMs: 10000,
             })
           ).to.be.rejectedWith('timed out waiting for message receipt')

--- a/packages/sdk/test/cross-chain-provider.spec.ts
+++ b/packages/sdk/test/cross-chain-provider.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { expect } from './setup'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Contract } from 'ethers'
@@ -383,24 +382,26 @@ describe('CrossChainProvider', () => {
   describe('getMessagesByAddress', () => {
     describe('when the address has sent messages', () => {
       describe('when no direction is specified', () => {
-        it('should find all messages sent by the address', () => {})
+        it('should find all messages sent by the address')
       })
 
       describe('when a direction is specified', () => {
-        it('should find all messages only in the given direction', () => {})
+        it('should find all messages only in the given direction')
       })
 
       describe('when a block range is specified', () => {
-        it('should find all messages within the block range', () => {})
+        it('should find all messages within the block range')
       })
 
       describe('when both a direction and a block range are specified', () => {
-        it('should find all messages only in the given direction and within the block range', () => {})
+        it(
+          'should find all messages only in the given direction and within the block range'
+        )
       })
     })
 
     describe('when the address has not sent messages', () => {
-      it('should find nothing', () => {})
+      it('should find nothing')
     })
   })
 
@@ -784,44 +785,44 @@ describe('CrossChainProvider', () => {
   describe('getMessageStatus', () => {
     describe('when the message is an L1 => L2 message', () => {
       describe('when the message has not been executed on L2 yet', () => {
-        it('should return a status of UNCONFIRMED_L1_TO_L2_MESSAGE', () => {})
+        it('should return a status of UNCONFIRMED_L1_TO_L2_MESSAGE')
       })
 
       describe('when the message has been executed on L2', () => {
-        it('should return a status of RELAYED', () => {})
+        it('should return a status of RELAYED')
       })
 
       describe('when the message has been executed but failed', () => {
-        it('should return a status of FAILED_L1_TO_L2_MESSAGE', () => {})
+        it('should return a status of FAILED_L1_TO_L2_MESSAGE')
       })
     })
 
     describe('when the message is an L2 => L1 message', () => {
       describe('when the message state root has not been published', () => {
-        it('should return a status of STATE_ROOT_NOT_PUBLISHED', () => {})
+        it('should return a status of STATE_ROOT_NOT_PUBLISHED')
       })
 
       describe('when the message state root is still in the challenge period', () => {
-        it('should return a status of IN_CHALLENGE_PERIOD', () => {})
+        it('should return a status of IN_CHALLENGE_PERIOD')
       })
 
       describe('when the message is no longer in the challenge period', () => {
         describe('when the message has been relayed successfully', () => {
-          it('should return a status of RELAYED', () => {})
+          it('should return a status of RELAYED')
         })
 
         describe('when the message has been relayed but the relay failed', () => {
-          it('should return a status of READY_FOR_RELAY', () => {})
+          it('should return a status of READY_FOR_RELAY')
         })
 
         describe('when the message has not been relayed', () => {
-          it('should return a status of READY_FOR_RELAY', () => {})
+          it('should return a status of READY_FOR_RELAY')
         })
       })
     })
 
     describe('when the message does not exist', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
   })
 
@@ -977,6 +978,9 @@ describe('CrossChainProvider', () => {
         expect(messageReceipt).to.equal(null)
       })
     })
+
+    // TODO: Go over all of these tests and remove the empty functions so we can accurately keep
+    // track of
   })
 
   describe('waitForMessageReciept', () => {
@@ -1086,42 +1090,50 @@ describe('CrossChainProvider', () => {
   })
 
   describe('estimateL2MessageGasLimit', () => {
-    it('should perform a gas estimation of the L2 action', () => {})
+    it('should perform a gas estimation of the L2 action')
   })
 
   describe('estimateMessageWaitTimeBlocks', () => {
     describe('when the message exists', () => {
       describe('when the message is an L1 => L2 message', () => {
         describe('when the message has not been executed on L2 yet', () => {
-          it('should return the estimated blocks until the message will be confirmed on L2', () => {})
+          it(
+            'should return the estimated blocks until the message will be confirmed on L2'
+          )
         })
 
         describe('when the message has been executed on L2', () => {
-          it('should return 0', () => {})
+          it('should return 0')
         })
       })
 
       describe('when the message is an L2 => L1 message', () => {
         describe('when the state root has not been published', () => {
-          it('should return the estimated blocks until the state root will be published and pass the challenge period', () => {})
+          it(
+            'should return the estimated blocks until the state root will be published and pass the challenge period'
+          )
         })
 
         describe('when the state root is within the challenge period', () => {
-          it('should return the estimated blocks until the state root passes the challenge period', () => {})
+          it(
+            'should return the estimated blocks until the state root passes the challenge period'
+          )
         })
 
         describe('when the state root passes the challenge period', () => {
-          it('should return 0', () => {})
+          it('should return 0')
         })
       })
     })
 
     describe('when the message does not exist', () => {
-      it('should throw an error', () => {})
+      it('should throw an error')
     })
   })
 
   describe('estimateMessageWaitTimeSeconds', () => {
-    it('should be the result of estimateMessageWaitTimeBlocks multiplied by the L1 block time', () => {})
+    it(
+      'should be the result of estimateMessageWaitTimeBlocks multiplied by the L1 block time'
+    )
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Implements the `waitForMessageReceipt` function. Will allow us to replace the `Watcher` globally.

**Metadata**
- Fixes ENG-1801
