### PR TITLE
op-exporter version nil deference

### DIFF
--- a/.changeset/empty-deers-buy.md
+++ b/.changeset/empty-deers-buy.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/op-exporter': patch
+---
+
+Fixes panic caused by version initialized to nil

--- a/go/op-exporter/main.go
+++ b/go/op-exporter/main.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+var UnknownStatus = "UNKNOWN"
+
 var (
 	listenAddress = kingpin.Flag(
 		"web.listen-address",
@@ -86,7 +88,7 @@ func main() {
 		healthy:        false,
 		updateTime:     time.Now(),
 		allowedMethods: nil,
-		version:        nil,
+		version:        &UnknownStatus,
 	}
 	http.Handle("/metrics", promhttp.Handler())
 	http.Handle("/health", healthHandler(&health))
@@ -130,8 +132,7 @@ func getSequencerVersion(health *healthCheck, client *kubernetes.Clientset) {
 		}
 		sequencerStatefulSet, err := client.AppsV1().StatefulSets(string(ns)).Get(context.TODO(), "sequencer", getOpts)
 		if err != nil {
-			unknownStatus := "UNKNOWN"
-			health.version = &unknownStatus
+			health.version = &UnknownStatus
 			log.Errorf("Unable to retrieve a sequencer StatefulSet: %s", err)
 			continue
 		}


### PR DESCRIPTION
**Description**
The op-exporter detected `version` was being referenced being set, resulting in the nil deference panics.

**Additional context**
Fixes https://github.com/ethereum-optimism/optimism/issues/1978

