### PR TITLE
Adds depcheck to CI

### DIFF
--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -138,6 +138,66 @@ jobs:
           verbose: true
           flags: sdk
 
+  depcheck:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        # only install dependencies if there was a change in the deps
+        # if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - name: Check packages/batch-submitter
+        working-directory: ./packages/batch-submitter
+        run: npx depcheck
+
+      - name: Check packages/contracts
+        working-directory: ./packages/contracts
+        run: npx depcheck
+
+      - name: Check packages/core-utils
+        working-directory: ./packages/core-utils
+        run: npx depcheck
+
+      - name: Check packages/data-transport-layer
+        working-directory: ./packages/data-transport-layer
+        run: npx depcheck
+
+      - name: Check packages/message-relayer
+        working-directory: ./packages/message-relayer
+        run: npx depcheck
+
+      - name: Check packages/sdk
+        working-directory: ./packages/sdk
+        run: npx depcheck
+
+      - name: Check integration-tests
+        working-directory: ./integration-tests
+        run: npx depcheck
+
   lint:
     name: Linting
     runs-on: ubuntu-latest

--- a/integration-tests/.depcheckrc
+++ b/integration-tests/.depcheckrc
@@ -1,0 +1,8 @@
+ignores: [
+  "@openzeppelin/contracts",
+  "@types/mocha",
+  "@types/rimraf",
+  "@uniswap/v3-core",
+  "mocha",
+  "typescript",
+]

--- a/packages/contracts/.depcheckrc
+++ b/packages/contracts/.depcheckrc
@@ -1,0 +1,11 @@
+ignores: [
+  "@codechecks/client",
+  "@ethersproject/transactions",
+  "@openzeppelin/contracts",
+  "@openzeppelin/contracts-upgradeable",
+  "@typechain/ethers-v5",
+  "prettier-plugin-solidity",
+  "solhint-plugin-prettier",
+  "ts-generator",
+  "yargs",
+]

--- a/packages/sdk/.depcheckrc
+++ b/packages/sdk/.depcheckrc
@@ -1,0 +1,4 @@
+ignores: [
+  "@eth-optimism/core-utils",
+  "ts-mocha",
+]


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This PR adds depcheck to the `.github/workflows/ts-packages.yml` CI workflow to detect unused packages in the codebase.

**Additional context**
The issue raised by @smartcontracts suggests relying on the `--ignore-path` option to avoid errors being thrown from false positives (such as packages being relied on by Solidity smart contracts, undetected by depcheck). The ignore-path option specifies files to ignore, rather than packages. This won't help with censoring false positives for unused packages. (i.e. depcheck will see packages in `package.json` and not be able to recognize their use in Solidity files; ignoring the Solidity files won't change this.) Instead, I've used the `ignores` option specified in `.depcheckrc` files. 

**Metadata**
- Fixes #1706
