### PR TITLE
feat(proxyd): Add X-Forwarded-For header when proxying RPCs

### DIFF
--- a/.changeset/fair-eyes-build.md
+++ b/.changeset/fair-eyes-build.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Add X-Forwarded-For header when proxying RPCs on proxyd

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -32,15 +32,16 @@ type BackendOptions struct {
 }
 
 type BackendConfig struct {
-	Username       string `toml:"username"`
-	Password       string `toml:"password"`
-	RPCURL         string `toml:"rpc_url"`
-	WSURL          string `toml:"ws_url"`
-	MaxRPS         int    `toml:"max_rps"`
-	MaxWSConns     int    `toml:"max_ws_conns"`
-	CAFile         string `toml:"ca_file"`
-	ClientCertFile string `toml:"client_cert_file"`
-	ClientKeyFile  string `toml:"client_key_file"`
+	Username         string `toml:"username"`
+	Password         string `toml:"password"`
+	RPCURL           string `toml:"rpc_url"`
+	WSURL            string `toml:"ws_url"`
+	MaxRPS           int    `toml:"max_rps"`
+	MaxWSConns       int    `toml:"max_ws_conns"`
+	CAFile           string `toml:"ca_file"`
+	ClientCertFile   string `toml:"client_cert_file"`
+	ClientKeyFile    string `toml:"client_key_file"`
+	StripTrailingXFF bool   `toml:"strip_trailing_xff"`
 }
 
 type BackendsConfig map[string]*BackendConfig

--- a/go/proxyd/proxyd.go
+++ b/go/proxyd/proxyd.go
@@ -99,6 +99,7 @@ func Start(config *Config) error {
 		if cfg.StripTrailingXFF {
 			opts = append(opts, WithStrippedTrailingXFF())
 		}
+		opts = append(opts, WithProxydIP(os.Getenv("PROXYD_IP")))
 		back := NewBackend(name, rpcURL, wsURL, lim, opts...)
 		backendNames = append(backendNames, name)
 		backendsByName[name] = back

--- a/go/proxyd/proxyd.go
+++ b/go/proxyd/proxyd.go
@@ -96,6 +96,9 @@ func Start(config *Config) error {
 			log.Info("using custom TLS config for backend", "name", name)
 			opts = append(opts, WithTLSConfig(tlsConfig))
 		}
+		if cfg.StripTrailingXFF {
+			opts = append(opts, WithStrippedTrailingXFF())
+		}
 		back := NewBackend(name, rpcURL, wsURL, lim, opts...)
 		backendNames = append(backendNames, name)
 		backendsByName[name] = back


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Provide the client origin to node providers via the X-Forwarded-For header in order to facilitate IP-based rate limiting on node providers.

This patch also adds a new proxyd backend setting, `strip_trailing_xff`, to remove trailing IP addresses in the X-Forwarded-For header. This is needed for node providers that can't handle multiple entries in the header.

A new env, `PROXYD_IP`, is introduced to indicate the proxy IP address to be added to the XFF.

**Metadata**
- Fixes ENG-1710
