### PR TITLE
go/proxyd: Add request/response payload size metrics

### DIFF
--- a/.changeset/chilled-mayflies-push.md
+++ b/.changeset/chilled-mayflies-push.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Add request/response payload size metrics to proxyd


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Request and response payload lengths are recorded as histograms.

**Metadata**
- Fixes ENG-1687
