### PR TITLE
feat: add BatchPruneCount metric

### DIFF
--- a/go/batch-submitter/drivers/sequencer/driver.go
+++ b/go/batch-submitter/drivers/sequencer/driver.go
@@ -175,6 +175,7 @@ func (d *Driver) SubmitBatchTx(
 	}
 
 	shouldStartAt := start.Uint64()
+	var pruneCount int
 	for {
 		batchParams, err := GenSequencerBatchParams(
 			shouldStartAt, d.cfg.BlockOffset, batchElements,
@@ -197,6 +198,7 @@ func (d *Driver) SubmitBatchTx(
 			newBatchElementsLen := (oldLen * 9) / 10
 			batchElements = batchElements[:newBatchElementsLen]
 			log.Info(name+" pruned batch", "old_num_txs", oldLen, "new_num_txs", newBatchElementsLen)
+			pruneCount++
 			continue
 		}
 
@@ -204,6 +206,7 @@ func (d *Driver) SubmitBatchTx(
 		batchTxBuildTime := float64(time.Since(batchTxBuildStart) / time.Millisecond)
 		d.metrics.BatchTxBuildTime.Set(batchTxBuildTime)
 		d.metrics.NumElementsPerBatch.Observe(float64(len(batchElements)))
+		d.metrics.BatchPruneCount.Set(float64(pruneCount))
 
 		log.Info(name+" batch constructed", "num_txs", len(batchElements), "length", len(batchCallData))
 

--- a/go/batch-submitter/metrics/metrics.go
+++ b/go/batch-submitter/metrics/metrics.go
@@ -35,6 +35,12 @@ type Metrics struct {
 	// BatchConfirmationTime tracks the duration it takes to confirm a batch
 	// transaction.
 	BatchConfirmationTime prometheus.Gauge
+
+	// BatchPruneCount tracks the number of times a batch of sequencer
+	// transactions is pruned in order to meet the desired size requirements.
+	//
+	// NOTE: This is currently only active in the sequencer driver.
+	BatchPruneCount prometheus.Gauge
 }
 
 func NewMetrics(subsystem string) *Metrics {
@@ -97,6 +103,11 @@ func NewMetrics(subsystem string) *Metrics {
 		BatchConfirmationTime: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "batch_submitter_batch_confirmation_time_ms",
 			Help:      "Time to confirm batch transactions",
+			Subsystem: subsystem,
+		}),
+		BatchPruneCount: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "batch_submitter_batch_prune_count",
+			Help:      "Number of times a batch is pruned",
 			Subsystem: subsystem,
 		}),
 	}


### PR DESCRIPTION
This metric gives insight into how many times a batch is pruned to meet
the required MaxL1TxSize.

Follow up from #1993 

**Metadata**
- Fixes ENG-1868
