### PR TITLE
fix(batch-submitter): clear state root batches

### DIFF
--- a/.changeset/pink-frogs-report.md
+++ b/.changeset/pink-frogs-report.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Properly clear state root batch txs on startup


### PR DESCRIPTION
**Description**
Fixes a bug where both the sequencer and proposer main loops were
attempting to clear the pending transactions from the batch-tx
submitter's wallet. The impact is that we may have been overspending on
fees due to conflicting/reverting state batches. However the impact
overall should be minor given the relative size of state batches in
comparison to tx-batches.

**Metadata**
- Fixes ENG-1890
