### PR TITLE
l2geth: forward tx to sequencer

### DIFF
--- a/l2geth/cmd/geth/main.go
+++ b/l2geth/cmd/geth/main.go
@@ -163,6 +163,7 @@ var (
 		utils.RollupEnforceFeesFlag,
 		utils.RollupFeeThresholdDownFlag,
 		utils.RollupFeeThresholdUpFlag,
+		utils.SequencerClientHttpFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/l2geth/cmd/geth/usage.go
+++ b/l2geth/cmd/geth/usage.go
@@ -77,6 +77,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupEnforceFeesFlag,
 			utils.RollupFeeThresholdDownFlag,
 			utils.RollupFeeThresholdUpFlag,
+			utils.SequencerClientHttpFlag,
 		},
 	},
 	{

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -861,6 +861,12 @@ var (
 		Usage:  "Allow txs with fees above the current fee up to this amount, must be > 1",
 		EnvVar: "ROLLUP_FEE_THRESHOLD_UP",
 	}
+	SequencerClientHttpFlag = cli.StringFlag{
+		Name:   "sequencer.clienthttp",
+		Usage:  "HTTP endpoint for the sequencer client",
+		Value:  "http://l2geth:8545",
+		EnvVar: "SEQUENCER_CLIENT_HTTP",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1136,6 +1142,9 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 	if ctx.GlobalIsSet(RollupFeeThresholdUpFlag.Name) {
 		val := ctx.GlobalFloat64(RollupFeeThresholdUpFlag.Name)
 		cfg.FeeThresholdUp = new(big.Float).SetFloat64(val)
+	}
+	if ctx.GlobalIsSet(SequencerClientHttpFlag.Name) {
+		cfg.SequencerClientHttp = ctx.GlobalString(SequencerClientHttpFlag.Name)
 	}
 }
 

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -864,7 +864,6 @@ var (
 	SequencerClientHttpFlag = cli.StringFlag{
 		Name:   "sequencer.clienthttp",
 		Usage:  "HTTP endpoint for the sequencer client",
-		Value:  "http://l2geth:8545",
 		EnvVar: "SEQUENCER_CLIENT_HTTP",
 	}
 )

--- a/l2geth/eth/api_backend.go
+++ b/l2geth/eth/api_backend.go
@@ -136,6 +136,10 @@ func (b *EthAPIBackend) IngestTransactions(txs []*types.Transaction) error {
 	return nil
 }
 
+func (b *EthAPIBackend) SequencerClientHttp() string {
+	return b.eth.config.Rollup.SequencerClientHttp
+}
+
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1659,11 +1659,8 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 		return common.Hash{}, errors.New("Cannot send raw transaction while syncing")
 	}
 
-	// Forward tx to sequencer if config is set
-	// TODO: add forwarding config
 	if s.b.IsVerifier() {
-		// TODO: replace with env var L2_URL
-		client, err := ethclient.Dial("http://l2geth:8545")
+		client, err := ethclient.Dial(s.b.SequencerClientHttp())
 		if err != nil {
 			return common.Hash{}, err
 		}

--- a/l2geth/internal/ethapi/backend.go
+++ b/l2geth/internal/ethapi/backend.go
@@ -96,6 +96,7 @@ type Backend interface {
 	SuggestL2GasPrice(context.Context) (*big.Int, error)
 	SetL2GasPrice(context.Context, *big.Int) error
 	IngestTransactions([]*types.Transaction) error
+	SequencerClientHttp() string
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {

--- a/l2geth/les/api_backend.go
+++ b/l2geth/les/api_backend.go
@@ -86,6 +86,10 @@ func (b *LesApiBackend) IngestTransactions([]*types.Transaction) error {
 	panic("not implemented")
 }
 
+func (b *LesApiBackend) SequencerClientHttp() string {
+	return b.eth.config.Rollup.SequencerClientHttp
+}
+
 func (b *LesApiBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber || number == rpc.PendingBlockNumber {
 		return b.eth.blockchain.CurrentHeader(), nil

--- a/l2geth/rollup/config.go
+++ b/l2geth/rollup/config.go
@@ -37,4 +37,6 @@ type Config struct {
 	// quoted and the transaction being executed
 	FeeThresholdDown *big.Float
 	FeeThresholdUp   *big.Float
+	// HTTP endpoint of the sequencer
+	SequencerClientHttp string
 }

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       - ./envs/geth.env
     environment:
         ETH1_HTTP: http://l1_chain:8545
-        L2_URL: http://l2geth:8545
+        SEQUENCER_CLIENT_HTTP: http://l2geth:8545
         ROLLUP_STATE_DUMP_PATH: http://deployer:8081/state-dump.latest.json
         ROLLUP_CLIENT_HTTP: http://dtl:7878
         ROLLUP_BACKEND: 'l2'

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -155,6 +155,7 @@ services:
   replica:
     depends_on:
       - dtl
+      - l2geth
     deploy:
       replicas: 1
     build:
@@ -165,6 +166,7 @@ services:
       - ./envs/geth.env
     environment:
         ETH1_HTTP: http://l1_chain:8545
+        L2_URL: http://l2geth:8545
         ROLLUP_STATE_DUMP_PATH: http://deployer:8081/state-dump.latest.json
         ROLLUP_CLIENT_HTTP: http://dtl:7878
         ROLLUP_BACKEND: 'l2'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR makes it easier for replica nodes to handle a transaction submitted via RPC and to transparently forward it to the sequencer, based on the configured endpoint.

This allows the consumer of the replica node's RPC to directly submit transactions instead of having to rely on third-party applications.

**Metadata**
- Fixes #1781 
