### PR TITLE
Use hardhat-ethers for importing factories in integration tests

### DIFF
--- a/integration-tests/actor-tests/state-dos.test.ts
+++ b/integration-tests/actor-tests/state-dos.test.ts
@@ -1,8 +1,10 @@
-import { utils, Wallet, Contract, ContractFactory } from 'ethers'
+import { expect } from 'chai'
+
+import { utils, Wallet, Contract } from 'ethers'
+import { ethers } from 'hardhat'
+
 import { actor, setupActor, run, setupRun } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
-import StateDOS from '../artifacts/contracts/StateDOS.sol/StateDOS.json'
-import { expect } from 'chai'
 
 interface Context {
   wallet: Wallet
@@ -16,11 +18,8 @@ actor('Trie DoS accounts', () => {
   setupActor(async () => {
     env = await OptimismEnv.new()
 
-    const factory = new ContractFactory(
-      StateDOS.abi,
-      StateDOS.bytecode,
-      env.l2Wallet
-    )
+    const factory = await ethers.getContractFactory('StateDOS', env.l1Wallet)
+
     contract = await factory.deploy()
     await contract.deployed()
   })

--- a/integration-tests/test/basic-l1-l2-communication.spec.ts
+++ b/integration-tests/test/basic-l1-l2-communication.spec.ts
@@ -3,10 +3,9 @@ import { expect } from './shared/setup'
 /* Imports: External */
 import { Contract, ContractFactory } from 'ethers'
 import { applyL1ToL2Alias, awaitCondition } from '@eth-optimism/core-utils'
+import { ethers } from 'hardhat'
 
 /* Imports: Internal */
-import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleStorage.json'
-import l2ReverterJson from '../artifacts/contracts/Reverter.sol/Reverter.json'
 import { Direction } from './shared/watcher-utils'
 import { OptimismEnv } from './shared/env'
 import { isMainnet } from './shared/utils'
@@ -22,19 +21,17 @@ describe('Basic L1<>L2 Communication', async () => {
 
   before(async () => {
     env = await OptimismEnv.new()
-    Factory__L1SimpleStorage = new ContractFactory(
-      simpleStorageJson.abi,
-      simpleStorageJson.bytecode,
+
+    Factory__L1SimpleStorage = await ethers.getContractFactory(
+      'SimpleStorage',
       env.l1Wallet
     )
-    Factory__L2SimpleStorage = new ContractFactory(
-      simpleStorageJson.abi,
-      simpleStorageJson.bytecode,
+    Factory__L2SimpleStorage = await ethers.getContractFactory(
+      'SimpleStorage',
       env.l2Wallet
     )
-    Factory__L2Reverter = new ContractFactory(
-      l2ReverterJson.abi,
-      l2ReverterJson.bytecode,
+    Factory__L2Reverter = await ethers.getContractFactory(
+      'Reverter',
       env.l2Wallet
     )
   })

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -1,9 +1,16 @@
 import { expect } from './shared/setup'
 
+/* Imports: External */
 import { expectApprox, injectL2Context } from '@eth-optimism/core-utils'
-import { Wallet, BigNumber, Contract, ContractFactory, constants } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
+import {
+  TransactionReceipt,
+  TransactionRequest,
+} from '@ethersproject/providers'
+import { Wallet, BigNumber, Contract, ContractFactory, constants } from 'ethers'
 import { ethers } from 'hardhat'
+
+/* Imports: Internal */
 import {
   sleep,
   l2Provider,
@@ -14,11 +21,6 @@ import {
   gasPriceForL2,
 } from './shared/utils'
 import { OptimismEnv } from './shared/env'
-import {
-  TransactionReceipt,
-  TransactionRequest,
-} from '@ethersproject/providers'
-import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleStorage.json'
 
 describe('Basic RPC tests', () => {
   let env: OptimismEnv
@@ -491,11 +493,11 @@ describe('Basic RPC tests', () => {
 
   describe('debug_traceTransaction', () => {
     it('should match debug_traceBlock', async () => {
-      const storage = new ContractFactory(
-        simpleStorageJson.abi,
-        simpleStorageJson.bytecode,
+      const storage = await ethers.getContractFactory(
+        'SimpleStorage',
         env.l2Wallet
       )
+
       const tx = (await storage.deploy()).deployTransaction
       const receipt = await tx.wait()
 

--- a/integration-tests/test/stress-tests.spec.ts
+++ b/integration-tests/test/stress-tests.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from './shared/setup'
 
 /* Imports: External */
-import { Contract, ContractFactory, Wallet, utils } from 'ethers'
+import { Contract, Wallet, utils } from 'ethers'
+import { ethers } from 'hardhat'
 
 /* Imports: Internal */
 import { OptimismEnv } from './shared/env'
@@ -16,7 +17,6 @@ import {
 } from './shared/stress-test-helpers'
 
 /* Imports: Artifacts */
-import simpleStorageJson from '../artifacts/contracts/SimpleStorage.sol/SimpleStorage.json'
 import { fundUser, isLiveNetwork, isMainnet } from './shared/utils'
 
 // Need a big timeout to allow for all transactions to be processed.
@@ -60,16 +60,15 @@ describe('stress tests', () => {
   let L2SimpleStorage: Contract
   let L1SimpleStorage: Contract
   beforeEach(async () => {
-    const factory__L1SimpleStorage = new ContractFactory(
-      simpleStorageJson.abi,
-      simpleStorageJson.bytecode,
+    const factory__L1SimpleStorage = await ethers.getContractFactory(
+      'SimpleStorage',
       env.l1Wallet
     )
-    const factory__L2SimpleStorage = new ContractFactory(
-      simpleStorageJson.abi,
-      simpleStorageJson.bytecode,
+    const factory__L2SimpleStorage = await ethers.getContractFactory(
+      'SimpleStorage',
       env.l2Wallet
     )
+
     L1SimpleStorage = await factory__L1SimpleStorage.deploy()
     await L1SimpleStorage.deployTransaction.wait()
     L2SimpleStorage = await factory__L2SimpleStorage.deploy()


### PR DESCRIPTION
Description
Use hardhat-ethers for importing factories in integration tests.

Additional context
Using hardhat-ethers is cleaner and more future-proof than importing the json files directly.

**Metadata**
- Fixes #2022
