### PR TITLE
chore: add changeset for l2geth

### DIFF
--- a/.changeset/dull-ladybugs-learn.md
+++ b/.changeset/dull-ladybugs-learn.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Add changeset for https://github.com/ethereum-optimism/optimism/pull/2011 - replicas forward write requests to the sequencer via a configured parameter `--sequencer.clienthttp` or `SEQUENCER_CLIENT_HTTP`


### PR DESCRIPTION
**Description**

Add missing changeset for https://github.com/ethereum-optimism/optimism/pull/2011

A replica can be configured with the flag
`--sequencer.clienthttp` or the env var
`SEQUENCER_CLIENT_HTTP` which points to the
sequencer and when users hit the RPC endpoint
`eth_sendRawTransaction` it will forward the
value to the sequencer.

If running a mainnet node, this value should be
set to `https://mainnet.optimism.io` or an
infrastructure provider such as Quiknode, Infura
or Alchemy.


