### PR TITLE
l2geth: fix monotonicity logging bug

### DIFF
--- a/.changeset/warm-ears-float.md
+++ b/.changeset/warm-ears-float.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fix blocknumber monotonicity logging bug

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -838,12 +838,13 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
 	// Set the L1 blocknumber
 	if l1BlockNumber == nil {
 		tx.SetL1BlockNumber(bn)
-	} else if l1BlockNumber.Uint64() > s.GetLatestL1BlockNumber() {
+	} else if l1BlockNumber.Uint64() > bn {
 		s.SetLatestL1BlockNumber(l1BlockNumber.Uint64())
-	} else {
+	} else if l1BlockNumber.Uint64() < bn {
 		// l1BlockNumber < latest l1BlockNumber
 		// indicates an error
-		log.Error("Blocknumber monotonicity violation", "hash", tx.Hash().Hex())
+		log.Error("Blocknumber monotonicity violation", "hash", tx.Hash().Hex(),
+			"new", l1BlockNumber.Uint64(), "old", bn)
 	}
 
 	// Store the latest timestamp value


### PR DESCRIPTION
**Description**

The logline `Blocknumber monotonicity violation`
was being logged erroneously. This commit ensures
that it is not logged when it doesn't need to be
logged.

It would previously log if the L1 blocknumber
was equal to or less than and now it only logs
if the L1 blocknumber is less than.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


**Metadata**
- Fixes https://github.com/ethereum-optimism/optimism/issues/2033
