### PR TITLE
feat: add confirmation depth awareness to txmgr

### DIFF
--- a/.changeset/fuzzy-rivers-double.md
+++ b/.changeset/fuzzy-rivers-double.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+---
+
+Adds confirmation depth awareness to txmgr

--- a/go/batch-submitter/batch_submitter.go
+++ b/go/batch-submitter/batch_submitter.go
@@ -164,6 +164,7 @@ func NewBatchSubmitter(cfg Config, gitVersion string) (*BatchSubmitter, error) {
 		GasRetryIncrement:    utils.GasPriceFromGwei(cfg.GasRetryIncrement),
 		ResubmissionTimeout:  cfg.ResubmissionTimeout,
 		ReceiptQueryInterval: time.Second,
+		NumConfirmations:     cfg.NumConfirmations,
 	}
 
 	var batchTxService *Service

--- a/go/batch-submitter/drivers/clear_pending_tx_test.go
+++ b/go/batch-submitter/drivers/clear_pending_tx_test.go
@@ -32,12 +32,13 @@ func init() {
 }
 
 var (
-	testPrivKey    *ecdsa.PrivateKey
-	testWalletAddr common.Address
-	testChainID    *big.Int // 1
-	testNonce      = uint64(2)
-	testGasPrice   *big.Int // 3
-	testGasLimit   = uint64(4)
+	testPrivKey     *ecdsa.PrivateKey
+	testWalletAddr  common.Address
+	testChainID     = big.NewInt(1)
+	testNonce       = uint64(2)
+	testGasPrice    = big.NewInt(3)
+	testGasLimit    = uint64(4)
+	testBlockNumber = uint64(5)
 )
 
 // TestCraftClearingTx asserts that CraftClearingTx produces the expected
@@ -107,6 +108,12 @@ type clearPendingTxHarness struct {
 }
 
 func newClearPendingTxHarness(l1ClientConfig mock.L1ClientConfig) *clearPendingTxHarness {
+
+	if l1ClientConfig.BlockNumber == nil {
+		l1ClientConfig.BlockNumber = func(_ context.Context) (uint64, error) {
+			return testBlockNumber, nil
+		}
+	}
 	if l1ClientConfig.NonceAt == nil {
 		l1ClientConfig.NonceAt = func(_ context.Context, _ common.Address, _ *big.Int) (uint64, error) {
 			return testNonce, nil

--- a/go/batch-submitter/drivers/clear_pending_tx_test.go
+++ b/go/batch-submitter/drivers/clear_pending_tx_test.go
@@ -103,11 +103,14 @@ func TestSignClearingTxEstimateGasFail(t *testing.T) {
 }
 
 type clearPendingTxHarness struct {
-	l1Client drivers.L1Client
+	l1Client *mock.L1Client
 	txMgr    txmgr.TxManager
 }
 
-func newClearPendingTxHarness(l1ClientConfig mock.L1ClientConfig) *clearPendingTxHarness {
+func newClearPendingTxHarnessWithNumConfs(
+	l1ClientConfig mock.L1ClientConfig,
+	numConfirmations uint64,
+) *clearPendingTxHarness {
 
 	if l1ClientConfig.BlockNumber == nil {
 		l1ClientConfig.BlockNumber = func(_ context.Context) (uint64, error) {
@@ -132,12 +135,17 @@ func newClearPendingTxHarness(l1ClientConfig mock.L1ClientConfig) *clearPendingT
 		GasRetryIncrement:    utils.GasPriceFromGwei(5),
 		ResubmissionTimeout:  time.Second,
 		ReceiptQueryInterval: 50 * time.Millisecond,
+		NumConfirmations:     numConfirmations,
 	}, l1Client)
 
 	return &clearPendingTxHarness{
 		l1Client: l1Client,
 		txMgr:    txMgr,
 	}
+}
+
+func newClearPendingTxHarness(l1ClientConfig mock.L1ClientConfig) *clearPendingTxHarness {
+	return newClearPendingTxHarnessWithNumConfs(l1ClientConfig, 1)
 }
 
 // TestClearPendingTxClearingTxÇonfirms asserts the happy path where our
@@ -149,7 +157,8 @@ func TestClearPendingTxClearingTxConfirms(t *testing.T) {
 		},
 		TransactionReceipt: func(_ context.Context, txHash common.Hash) (*types.Receipt, error) {
 			return &types.Receipt{
-				TxHash: txHash,
+				TxHash:      txHash,
+				BlockNumber: big.NewInt(int64(testBlockNumber)),
 			}, nil
 		},
 	})
@@ -196,4 +205,43 @@ func TestClearPendingTxTimeout(t *testing.T) {
 		testPrivKey, testChainID,
 	)
 	require.Equal(t, txmgr.ErrPublishTimeout, err)
+}
+
+// TestClearPendingTxMultipleConfs tests we wait the appropriate number of
+// confirmations for the clearing transaction to confirm.
+func TestClearPendingTxMultipleConfs(t *testing.T) {
+	const numConfs = 2
+
+	// Instantly confirm transaction.
+	h := newClearPendingTxHarnessWithNumConfs(mock.L1ClientConfig{
+		SendTransaction: func(_ context.Context, _ *types.Transaction) error {
+			return nil
+		},
+		TransactionReceipt: func(_ context.Context, txHash common.Hash) (*types.Receipt, error) {
+			return &types.Receipt{
+				TxHash:      txHash,
+				BlockNumber: big.NewInt(int64(testBlockNumber)),
+			}, nil
+		},
+	}, numConfs)
+
+	// The txmgr should timeout waiting for the txn to confirm.
+	err := drivers.ClearPendingTx(
+		"test", context.Background(), h.txMgr, h.l1Client, testWalletAddr,
+		testPrivKey, testChainID,
+	)
+	require.Equal(t, txmgr.ErrPublishTimeout, err)
+
+	// Now set the chain height to the earliest the transaction will be
+	// considered sufficiently confirmed.
+	h.l1Client.SetBlockNumberFunc(func(_ context.Context) (uint64, error) {
+		return testBlockNumber + numConfs - 1, nil
+	})
+
+	// Publishing should succeed.
+	err = drivers.ClearPendingTx(
+		"test", context.Background(), h.txMgr, h.l1Client, testWalletAddr,
+		testPrivKey, testChainID,
+	)
+	require.Nil(t, err)
 }

--- a/go/batch-submitter/txmgr/txmgr.go
+++ b/go/batch-submitter/txmgr/txmgr.go
@@ -71,6 +71,9 @@ type TxManager interface {
 //
 // NOTE: This is a subset of bind.DeployBackend.
 type ReceiptSource interface {
+	// BlockNumber returns the most recent block number.
+	BlockNumber(ctx context.Context) (uint64, error)
+
 	// TransactionReceipt queries the backend for a receipt associated with
 	// txHash. If lookup does not fail, but the transaction is not found,
 	// nil should be returned for both values.


### PR DESCRIPTION
This PR adds functionality to the `txmgr`, allowing it to be configured with a desired confirmation depth. As a result the `Send` function will block until `NumConfirmations` has been reached.

**Metadata**
- Fixes ENG-1884
