### PR TITLE
Enforced import ordering in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,7 +101,17 @@ module.exports = {
     'id-match': 'off',
     'import/no-extraneous-dependencies': ['error'],
     'import/no-internal-modules': 'off',
-    'import/order': 'off',
+    'import/order': [
+      "error",
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+        ],
+        'newlines-between': 'always',
+      },
+    ],
     indent: 'off',
     'jsdoc/check-alignment': 'error',
     'jsdoc/check-indentation': 'error',

--- a/integration-tests/actor-tests/deposits.test.ts
+++ b/integration-tests/actor-tests/deposits.test.ts
@@ -1,8 +1,9 @@
 import { utils, Wallet, BigNumber } from 'ethers'
+import { expect } from 'chai'
+
 import { setupActor, setupRun, actor, run } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
 import { Direction } from '../test/shared/watcher-utils'
-import { expect } from 'chai'
 
 interface BenchContext {
   l1Wallet: Wallet

--- a/integration-tests/actor-tests/lib/actor.ts
+++ b/integration-tests/actor-tests/lib/actor.ts
@@ -1,5 +1,7 @@
+import { performance } from 'perf_hooks'
+
 import { Mutex } from 'async-mutex'
-import { sleep } from '../../test/shared/utils'
+
 import {
   sanitizeForMetrics,
   benchDurationsSummary,
@@ -9,7 +11,7 @@ import {
   failedBenchRunsTotal,
 } from './metrics'
 import { ActorLogger, WorkerLogger } from './logger'
-import { performance } from 'perf_hooks'
+import { sleep } from '../../test/shared/utils'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const asyncNoop = async () => {}

--- a/integration-tests/actor-tests/lib/metrics.ts
+++ b/integration-tests/actor-tests/lib/metrics.ts
@@ -1,7 +1,8 @@
 import fs from 'fs'
-import client from 'prom-client'
 import http from 'http'
 import url from 'url'
+
+import client from 'prom-client'
 
 export const metricsRegistry = new client.Registry()
 

--- a/integration-tests/actor-tests/lib/runner.ts
+++ b/integration-tests/actor-tests/lib/runner.ts
@@ -1,9 +1,11 @@
 import * as path from 'path'
+
+import { Command } from 'commander'
+
 import { defaultRuntime } from './convenience'
 import { RunOpts } from './actor'
-import { Command } from 'commander'
-import pkg from '../../package.json'
 import { serveMetrics } from './metrics'
+import pkg from '../../package.json'
 
 const program = new Command()
 program.version(pkg.version)

--- a/integration-tests/actor-tests/nft.test.ts
+++ b/integration-tests/actor-tests/nft.test.ts
@@ -1,8 +1,9 @@
 import { utils, Wallet, Contract } from 'ethers'
+import { expect } from 'chai'
+
 import { actor, run, setupActor, setupRun } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
 import ERC721 from '../artifacts/contracts/NFT.sol/NFT.json'
-import { expect } from 'chai'
 
 interface Context {
   wallet: Wallet

--- a/integration-tests/actor-tests/sends.test.ts
+++ b/integration-tests/actor-tests/sends.test.ts
@@ -1,5 +1,6 @@
 import { utils, Wallet, BigNumber } from 'ethers'
 import { expect } from 'chai'
+
 import { actor, setupRun, setupActor, run } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
 

--- a/integration-tests/actor-tests/state-dos.test.ts
+++ b/integration-tests/actor-tests/state-dos.test.ts
@@ -1,8 +1,9 @@
 import { utils, Wallet, Contract } from 'ethers'
 import { ethers } from 'hardhat'
+import { expect } from 'chai'
+
 import { actor, setupActor, run, setupRun } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
-import { expect } from 'chai'
 
 interface Context {
   wallet: Wallet

--- a/integration-tests/actor-tests/uniswap.test.ts
+++ b/integration-tests/actor-tests/uniswap.test.ts
@@ -1,10 +1,11 @@
 import { Contract, utils, Wallet } from 'ethers'
-import { actor, run, setupActor, setupRun } from './lib/convenience'
-import { OptimismEnv } from '../test/shared/env'
 import { FeeAmount } from '@uniswap/v3-sdk'
-import ERC20 from '../artifacts/contracts/ERC20.sol/ERC20.json'
 import { abi as NFTABI } from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
 import { abi as RouterABI } from '@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json'
+
+import { actor, run, setupActor, setupRun } from './lib/convenience'
+import { OptimismEnv } from '../test/shared/env'
+import ERC20 from '../artifacts/contracts/ERC20.sol/ERC20.json'
 
 interface Context {
   contracts: { [name: string]: Contract }

--- a/integration-tests/test/basic-l1-l2-communication.spec.ts
+++ b/integration-tests/test/basic-l1-l2-communication.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from './shared/setup'
-
 /* Imports: External */
 import { Contract, ContractFactory } from 'ethers'
 import { ethers } from 'hardhat'
 import { applyL1ToL2Alias, awaitCondition } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
+import { expect } from './shared/setup'
 import { Direction } from './shared/watcher-utils'
 import { OptimismEnv } from './shared/env'
 import {

--- a/integration-tests/test/bridged-tokens.spec.ts
+++ b/integration-tests/test/bridged-tokens.spec.ts
@@ -1,9 +1,8 @@
-import { expect } from './shared/setup'
-
 import { BigNumber, Contract, ContractFactory, utils, Wallet } from 'ethers'
 import { ethers } from 'hardhat'
 import * as L2Artifact from '@eth-optimism/contracts/artifacts/contracts/standards/L2StandardERC20.sol/L2StandardERC20.json'
 
+import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
 import { withdrawalTest } from './shared/utils'
 import { Direction } from './shared/watcher-utils'

--- a/integration-tests/test/contracts.spec.ts
+++ b/integration-tests/test/contracts.spec.ts
@@ -1,14 +1,12 @@
-import { expect } from './shared/setup'
-
 import { BigNumber, Contract, ContractFactory, utils, Wallet } from 'ethers'
 import { ethers } from 'hardhat'
 import { UniswapV3Deployer } from 'uniswap-v3-deploy-plugin/dist/deployer/UniswapV3Deployer'
-
-import { OptimismEnv } from './shared/env'
 import { FeeAmount, TICK_SPACINGS } from '@uniswap/v3-sdk'
-
 import { abi as NFTABI } from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
 import { abi as RouterABI } from '@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json'
+
+import { OptimismEnv } from './shared/env'
+import { expect } from './shared/setup'
 
 // Below methods taken from the Uniswap test suite, see
 // https://github.com/Uniswap/v3-periphery/blob/main/test/shared/ticks.ts

--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from './shared/setup'
-
 /* Imports: External */
 import { BigNumber, utils } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
 import { predeploys, getContractFactory } from '@eth-optimism/contracts'
 
 /* Imports: Internal */
+import { expect } from './shared/setup'
 import { hardhatTest } from './shared/utils'
 import { OptimismEnv } from './shared/env'
 import { Direction } from './shared/watcher-utils'

--- a/integration-tests/test/native-eth-ovm-calls.spec.ts
+++ b/integration-tests/test/native-eth-ovm-calls.spec.ts
@@ -1,7 +1,7 @@
-import { expect } from './shared/setup'
-
 import { BigNumber, Contract, ContractFactory, Wallet } from 'ethers'
 import { ethers } from 'hardhat'
+
+import { expect } from './shared/setup'
 import {
   fundUser,
   encodeSolidityRevertMessage,

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from './shared/setup'
-
 /* Imports: External */
 import { Wallet, utils, BigNumber } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
@@ -7,8 +5,8 @@ import { predeploys } from '@eth-optimism/contracts'
 import { expectApprox } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
+import { expect } from './shared/setup'
 import { Direction } from './shared/watcher-utils'
-
 import {
   DEFAULT_TEST_GAS_L1,
   DEFAULT_TEST_GAS_L2,

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from './shared/setup'
-
 /* Imports: External */
 import { ethers } from 'hardhat'
 import { injectL2Context, expectApprox } from '@eth-optimism/core-utils'
@@ -7,6 +5,7 @@ import { predeploys } from '@eth-optimism/contracts'
 import { Contract, BigNumber } from 'ethers'
 
 /* Imports: Internal */
+import { expect } from './shared/setup'
 import {
   l2Provider,
   l1Provider,

--- a/integration-tests/test/predeploys.spec.ts
+++ b/integration-tests/test/predeploys.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from './shared/setup'
-
 /* Imports: Internal */
 import { ethers } from 'ethers'
 import { predeploys, getContractInterface } from '@eth-optimism/contracts'
 
 /* Imports: External */
+import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
 
 describe('predeploys', () => {

--- a/integration-tests/test/queue-ingestion.spec.ts
+++ b/integration-tests/test/queue-ingestion.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from './shared/setup'
-
 /* Imports: Internal */
 import { providers } from 'ethers'
 import { injectL2Context, applyL1ToL2Alias } from '@eth-optimism/core-utils'
 
 /* Imports: External */
+import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
 import { Direction } from './shared/watcher-utils'
 import { DEFAULT_TEST_GAS_L1, envConfig } from './shared/utils'

--- a/integration-tests/test/replica.spec.ts
+++ b/integration-tests/test/replica.spec.ts
@@ -1,3 +1,5 @@
+import { TransactionReceipt } from '@ethersproject/abstract-provider'
+
 import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
 import {
@@ -6,7 +8,6 @@ import {
   sleep,
   envConfig,
 } from './shared/utils'
-import { TransactionReceipt } from '@ethersproject/abstract-provider'
 
 describe('Replica Tests', () => {
   let env: OptimismEnv

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -1,9 +1,12 @@
-import { expect } from './shared/setup'
-
 import { expectApprox, injectL2Context } from '@eth-optimism/core-utils'
 import { Wallet, BigNumber, Contract, ContractFactory, constants } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
 import { ethers } from 'hardhat'
+import {
+  TransactionReceipt,
+  TransactionRequest,
+} from '@ethersproject/providers'
+
 import {
   sleep,
   l2Provider,
@@ -16,10 +19,7 @@ import {
   envConfig,
 } from './shared/utils'
 import { OptimismEnv } from './shared/env'
-import {
-  TransactionReceipt,
-  TransactionRequest,
-} from '@ethersproject/providers'
+import { expect } from './shared/setup'
 
 describe('Basic RPC tests', () => {
   let env: OptimismEnv

--- a/integration-tests/test/shared/watcher-utils.ts
+++ b/integration-tests/test/shared/watcher-utils.ts
@@ -4,7 +4,6 @@ import {
   TransactionResponse,
 } from '@ethersproject/providers'
 import { Watcher } from '@eth-optimism/core-utils'
-
 import { Contract, Transaction } from 'ethers'
 
 export const initWatcher = async (

--- a/integration-tests/test/stress-tests.spec.ts
+++ b/integration-tests/test/stress-tests.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from './shared/setup'
-
 /* Imports: External */
 import { Contract, Wallet, utils } from 'ethers'
 import { ethers } from 'hardhat'
 
 /* Imports: Internal */
+import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
 import {
   executeL1ToL2TransactionsParallel,
@@ -15,7 +14,6 @@ import {
   executeRepeatedL2Transactions,
   fundRandomWallet,
 } from './shared/stress-test-helpers'
-
 /* Imports: Artifacts */
 import { envConfig, fundUser } from './shared/utils'
 

--- a/integration-tests/test/whitelist.spec.ts
+++ b/integration-tests/test/whitelist.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from './shared/setup'
-
 /* Imports: External */
 import { ContractFactory } from 'ethers'
 import { ethers } from 'hardhat'
 import { predeploys } from '@eth-optimism/contracts'
 
 /* Imports: Internal */
+import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
 import { l2Provider } from './shared/utils'
 

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -14,6 +14,7 @@ import { Gauge, Histogram, Counter } from 'prom-client'
 import { RollupInfo, sleep } from '@eth-optimism/core-utils'
 import { Logger, Metrics } from '@eth-optimism/common-ts'
 import { getContractFactory } from 'old-contracts'
+
 /* Internal Imports */
 import { TxSubmissionHooks } from '..'
 

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -12,8 +12,8 @@ import {
 import { Logger, Metrics } from '@eth-optimism/common-ts'
 
 /* Internal Imports */
-import { BlockRange, BatchSubmitter } from '.'
 import { TransactionSubmitter } from '../utils'
+import { BlockRange, BatchSubmitter } from '.'
 
 export class StateBatchSubmitter extends BatchSubmitter {
   // TODO: Change this so that we calculate start = scc.totalElements() and end = ctc.totalElements()!

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -20,9 +20,8 @@ import {
   BatchContext,
   AppendSequencerBatchParams,
 } from '../transaction-chain-contract'
-
-import { BlockRange, BatchSubmitter } from '.'
 import { TransactionSubmitter } from '../utils'
+import { BlockRange, BatchSubmitter } from '.'
 
 export interface AutoFixBatchOptions {
   fixDoublePlayedDeposits: boolean

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -1,8 +1,9 @@
 /* External Imports */
+import { exit } from 'process'
+
 import { injectL2Context, Bcfg } from '@eth-optimism/core-utils'
 import * as Sentry from '@sentry/node'
 import { Logger, Metrics, createMetricsServer } from '@eth-optimism/common-ts'
-import { exit } from 'process'
 import { Signer, Wallet } from 'ethers'
 import {
   StaticJsonRpcProvider,

--- a/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
+++ b/packages/batch-submitter/test/batch-submitter/batch-submitter.spec.ts
@@ -1,24 +1,18 @@
-import { expect } from '../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import '@nomiclabs/hardhat-ethers'
 import { Signer, ContractFactory, Contract, BigNumber } from 'ethers'
 import sinon from 'sinon'
-
 import scc from '@eth-optimism/contracts/artifacts/contracts/L1/rollup/StateCommitmentChain.sol/StateCommitmentChain.json'
 import { getContractInterface } from '@eth-optimism/contracts'
 import { smockit, MockContract } from '@eth-optimism/smock'
-
 import { getContractFactory } from 'old-contracts'
+import { QueueOrigin, Batch, remove0x } from '@eth-optimism/core-utils'
+import { Logger, Metrics } from '@eth-optimism/common-ts'
 
 /* Internal Imports */
 import { MockchainProvider } from './mockchain-provider'
-import {
-  makeAddressManager,
-  setProxyTarget,
-  FORCE_INCLUSION_PERIOD_SECONDS,
-} from '../helpers'
+import { expect } from '../setup'
 import {
   CanonicalTransactionChainContract,
   TransactionBatchSubmitter as RealTransactionBatchSubmitter,
@@ -28,9 +22,11 @@ import {
   YnatmTransactionSubmitter,
   ResubmissionConfig,
 } from '../../src'
-
-import { QueueOrigin, Batch, remove0x } from '@eth-optimism/core-utils'
-import { Logger, Metrics } from '@eth-optimism/common-ts'
+import {
+  makeAddressManager,
+  setProxyTarget,
+  FORCE_INCLUSION_PERIOD_SECONDS,
+} from '../helpers'
 
 const EXAMPLE_STATE_ROOT =
   '0x16b7f83f409c7195b1f4fde5652f1b54a4477eacb6db7927691becafba5f8801'

--- a/packages/batch-submitter/test/utils/tx-submission.spec.ts
+++ b/packages/batch-submitter/test/utils/tx-submission.spec.ts
@@ -1,11 +1,12 @@
-import { expect } from '../setup'
 import { ethers, BigNumber, Signer } from 'ethers'
-import { submitTransactionWithYNATM } from '../../src/utils/tx-submission'
-import { ResubmissionConfig } from '../../src'
 import {
   TransactionReceipt,
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
+
+import { expect } from '../setup'
+import { submitTransactionWithYNATM } from '../../src/utils/tx-submission'
+import { ResubmissionConfig } from '../../src'
 
 const nullFunction = () => undefined
 const nullHooks = {

--- a/packages/common-ts/src/common/metrics.ts
+++ b/packages/common-ts/src/common/metrics.ts
@@ -1,10 +1,11 @@
+import { Server } from 'net'
+
 import prometheus, {
   collectDefaultMetrics,
   DefaultMetricsCollectorConfiguration,
   Registry,
 } from 'prom-client'
 import express from 'express'
-import { Server } from 'net'
 
 import { Logger } from './logger'
 

--- a/packages/contracts/bin/take-dump.ts
+++ b/packages/contracts/bin/take-dump.ts
@@ -1,6 +1,8 @@
 /* External Imports */
+
 import * as fs from 'fs'
 import * as path from 'path'
+
 import * as mkdirp from 'mkdirp'
 
 const ensure = (value, key) => {

--- a/packages/contracts/deploy/000-hardhat-setup.ts
+++ b/packages/contracts/deploy/000-hardhat-setup.ts
@@ -1,6 +1,8 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
 import { ethers } from 'ethers'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import { awaitCondition } from '@eth-optimism/core-utils'
+
 import {
   getContractFromArtifact,
   fundAccount,
@@ -8,7 +10,6 @@ import {
   BIG_BALANCE,
 } from '../src/deploy-utils'
 import { names } from '../src/address-names'
-import { awaitCondition } from '@eth-optimism/core-utils'
 
 const deployFn: DeployFunction = async (hre) => {
   if ((hre as any).deployConfig.forked !== 'true') {

--- a/packages/contracts/deploy/001-Lib_AddressManager.deploy.ts
+++ b/packages/contracts/deploy/001-Lib_AddressManager.deploy.ts
@@ -1,8 +1,9 @@
 /* Imports: Internal */
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+
 import { names } from '../src/address-names'
 
 /* Imports: External */
-import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deploy } = hre.deployments

--- a/packages/contracts/scripts/generate-artifacts.ts
+++ b/packages/contracts/scripts/generate-artifacts.ts
@@ -1,6 +1,7 @@
 import path from 'path'
-import glob from 'glob'
 import fs from 'fs'
+
+import glob from 'glob'
 
 /**
  * Script for automatically generating a file which has a series of `require` statements for

--- a/packages/contracts/scripts/generate-deployed-artifacts.ts
+++ b/packages/contracts/scripts/generate-deployed-artifacts.ts
@@ -1,6 +1,7 @@
 import path from 'path'
-import glob from 'glob'
 import fs from 'fs'
+
+import glob from 'glob'
 
 /**
  * Script for automatically generating a TypeScript file for retrieving deploy artifact JSON files.

--- a/packages/contracts/scripts/generate-markdown.ts
+++ b/packages/contracts/scripts/generate-markdown.ts
@@ -1,6 +1,8 @@
-import dirtree from 'directory-tree'
 import fs from 'fs'
 import path from 'path'
+
+import dirtree from 'directory-tree'
+
 import { predeploys } from '../src'
 
 interface DeploymentInfo {

--- a/packages/contracts/src/make-genesis.ts
+++ b/packages/contracts/src/make-genesis.ts
@@ -1,6 +1,7 @@
 /* External Imports */
-import { promisify } from 'util'
 import { exec } from 'child_process'
+import { promisify } from 'util'
+
 import { ethers } from 'ethers'
 import {
   computeStorageSlots,

--- a/packages/contracts/src/validation-utils.ts
+++ b/packages/contracts/src/validation-utils.ts
@@ -1,4 +1,5 @@
 import { createInterface } from 'readline'
+
 import { hexStringEquals } from '@eth-optimism/core-utils'
 
 export const getInput = (query) => {

--- a/packages/contracts/tasks/validate-address-dictator.ts
+++ b/packages/contracts/tasks/validate-address-dictator.ts
@@ -4,9 +4,9 @@ import { ethers } from 'ethers'
 import { task } from 'hardhat/config'
 import * as types from 'hardhat/internal/core/params/argumentTypes'
 import { hexStringEquals } from '@eth-optimism/core-utils'
+
 import { getContractFactory, getContractDefinition } from '../src/contract-defs'
 import { names } from '../src/address-names'
-
 import {
   getInput,
   color as c,

--- a/packages/contracts/tasks/validate-chugsplash-dictator.ts
+++ b/packages/contracts/tasks/validate-chugsplash-dictator.ts
@@ -3,8 +3,8 @@
 import { ethers } from 'ethers'
 import { task } from 'hardhat/config'
 import * as types from 'hardhat/internal/core/params/argumentTypes'
-import { getContractFactory, getContractDefinition } from '../src/contract-defs'
 
+import { getContractFactory, getContractDefinition } from '../src/contract-defs'
 import {
   getInput,
   color as c,

--- a/packages/contracts/tasks/whitelist.ts
+++ b/packages/contracts/tasks/whitelist.ts
@@ -1,10 +1,12 @@
 'use strict'
 
 import fs from 'fs'
+
 import { ethers } from 'ethers'
 import { task } from 'hardhat/config'
 import * as types from 'hardhat/internal/core/params/argumentTypes'
 import { LedgerSigner } from '@ethersproject/hardware-wallets'
+
 import { getContractFactory } from '../src/contract-defs'
 import { predeploys } from '../src/predeploys'
 

--- a/packages/contracts/tasks/withdraw-fees.ts
+++ b/packages/contracts/tasks/withdraw-fees.ts
@@ -4,6 +4,7 @@ import { ethers } from 'ethers'
 import { task } from 'hardhat/config'
 import * as types from 'hardhat/internal/core/params/argumentTypes'
 import { LedgerSigner } from '@ethersproject/hardware-wallets'
+
 import { getContractFactory } from '../src/contract-defs'
 import { predeploys } from '../src/predeploys'
 

--- a/packages/contracts/test/contracts/L1/messaging/L1CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/L1CrossDomainMessenger.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract, BigNumber } from 'ethers'
@@ -11,6 +9,7 @@ import {
 } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import {
   makeAddressManager,
   setProxyTarget,

--- a/packages/contracts/test/contracts/L1/messaging/L1StandardBridge.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/L1StandardBridge.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract, constants } from 'ethers'
@@ -7,6 +5,7 @@ import { Interface } from 'ethers/lib/utils'
 import { smockit, MockContract, smoddit } from '@eth-optimism/smock'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../../helpers'
 import { getContractInterface, predeploys } from '../../../../src'
 

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
@@ -13,6 +11,7 @@ import { keccak256 } from 'ethers/lib/utils'
 import _ from 'lodash'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import {
   makeAddressManager,
   setProxyTarget,

--- a/packages/contracts/test/contracts/L1/rollup/StateCommitmentChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/StateCommitmentChain.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract, constants } from 'ethers'
 import { smockit, MockContract } from '@eth-optimism/smock'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import {
   makeAddressManager,
   setProxyTarget,

--- a/packages/contracts/test/contracts/L1/verification/BondManager.spec.ts
+++ b/packages/contracts/test/contracts/L1/verification/BondManager.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, Contract } from 'ethers'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { makeAddressManager } from '../../../helpers'
 
 describe('BondManager', () => {

--- a/packages/contracts/test/contracts/L2/messaging/L2CrossDomainMessenger.spec.ts
+++ b/packages/contracts/test/contracts/L2/messaging/L2CrossDomainMessenger.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import hre, { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
@@ -7,6 +5,7 @@ import { smockit, MockContract } from '@eth-optimism/smock'
 import { applyL1ToL2Alias } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import {
   NON_NULL_BYTES32,
   NON_ZERO_ADDRESS,

--- a/packages/contracts/test/contracts/L2/messaging/L2StandardBridge.spec.ts
+++ b/packages/contracts/test/contracts/L2/messaging/L2StandardBridge.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
@@ -11,8 +9,8 @@ import {
 } from '@eth-optimism/smock'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { NON_NULL_BYTES32, NON_ZERO_ADDRESS } from '../../../helpers'
-
 import { getContractInterface } from '../../../../src'
 
 const ERR_INVALID_MESSENGER = 'OVM_XCHAIN: messenger contract unauthenticated'

--- a/packages/contracts/test/contracts/L2/messaging/L2StandardTokenFactory.spec.ts
+++ b/packages/contracts/test/contracts/L2/messaging/L2StandardTokenFactory.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
 import { smoddit } from '@eth-optimism/smock'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { predeploys, getContractInterface } from '../../../../src'
 
 describe('L2StandardTokenFactory', () => {

--- a/packages/contracts/test/contracts/L2/predeploys/OVM_ETH.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/OVM_ETH.spec.ts
@@ -1,8 +1,8 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { ContractFactory, Contract, Signer } from 'ethers'
+
+import { expect } from '../../../setup'
 
 describe('OVM_ETH', () => {
   let signer1: Signer

--- a/packages/contracts/test/contracts/L2/predeploys/OVM_GasPriceOracle.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/OVM_GasPriceOracle.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { ContractFactory, Contract, Signer } from 'ethers'
-
 import { calculateL1GasUsed, calculateL1Fee } from '@eth-optimism/core-utils'
+
+import { expect } from '../../../setup'
 
 describe('OVM_GasPriceOracle', () => {
   const initialGasPrice = 0

--- a/packages/contracts/test/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { ContractFactory, Contract } from 'ethers'
@@ -8,6 +6,7 @@ import { remove0x } from '@eth-optimism/core-utils'
 import { keccak256 } from 'ethers/lib/utils'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { NON_ZERO_ADDRESS } from '../../../helpers/constants'
 
 const ELEMENT_TEST_SIZES = [1, 2, 4, 8, 16]

--- a/packages/contracts/test/contracts/L2/predeploys/OVM_SequencerFeeVault.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/OVM_SequencerFeeVault.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from '../../../setup'
-
 /* Imports: External */
 import hre from 'hardhat'
 import { MockContract, smockit } from '@eth-optimism/smock'
 import { Contract, Signer } from 'ethers'
 
 /* Imports: Internal */
+import { expect } from '../../../setup'
 import { predeploys } from '../../../../src'
 
 describe('OVM_SequencerFeeVault', () => {

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -1,11 +1,10 @@
-import { expect } from '../../setup'
-
 /* Imports: External */
 import hre from 'hardhat'
 import { Contract, Signer } from 'ethers'
 import { smockit } from '@eth-optimism/smock'
 
 /* Imports: Internal */
+import { expect } from '../../setup'
 import { getContractInterface } from '../../../src'
 
 describe('L1ChugSplashProxy', () => {

--- a/packages/contracts/test/contracts/libraries/codec/Lib_OVMCodec.spec.ts
+++ b/packages/contracts/test/contracts/libraries/codec/Lib_OVMCodec.spec.ts
@@ -1,6 +1,5 @@
-import '../../../setup'
-
 /* Internal Imports */
+import '../../../setup'
 import { Lib_OVMCodec_TEST_JSON } from '../../../data'
 import { runJsonTest } from '../../../helpers'
 

--- a/packages/contracts/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
+++ b/packages/contracts/test/contracts/libraries/rlp/Lib_RLPWriter.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Contract } from 'ethers'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { Lib_RLPWriter_TEST_JSON } from '../../../data'
 
 const encode = async (Lib_RLPWriter: Contract, input: any): Promise<void> => {

--- a/packages/contracts/test/contracts/libraries/standards/AddressAliasHelper.spec.ts
+++ b/packages/contracts/test/contracts/libraries/standards/AddressAliasHelper.spec.ts
@@ -1,9 +1,9 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Contract } from 'ethers'
 import { applyL1ToL2Alias, undoL1ToL2Alias } from '@eth-optimism/core-utils'
+
+import { expect } from '../../../setup'
 
 describe('AddressAliasHelper', () => {
   let AddressAliasHelper: Contract

--- a/packages/contracts/test/contracts/libraries/trie/Lib_MerkleTrie.spec.ts
+++ b/packages/contracts/test/contracts/libraries/trie/Lib_MerkleTrie.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import * as rlp from 'rlp'
 import { ethers } from 'hardhat'
@@ -8,6 +6,7 @@ import { fromHexString, toHexString } from '@eth-optimism/core-utils'
 import { Trie } from 'merkle-patricia-tree/dist/baseTrie'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { TrieTestGenerator } from '../../../helpers'
 import * as officialTestJson from '../../../data/json/libraries/trie/trietest.json'
 import * as officialTestAnyOrderJson from '../../../data/json/libraries/trie/trieanyorder.json'

--- a/packages/contracts/test/contracts/libraries/trie/Lib_SecureMerkleTrie.spec.ts
+++ b/packages/contracts/test/contracts/libraries/trie/Lib_SecureMerkleTrie.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Contract } from 'ethers'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { TrieTestGenerator } from '../../../helpers'
 
 const NODE_COUNTS = [1, 2, 128]

--- a/packages/contracts/test/contracts/libraries/utils/Lib_Buffer.spec.ts
+++ b/packages/contracts/test/contracts/libraries/utils/Lib_Buffer.spec.ts
@@ -1,7 +1,7 @@
-import { expect } from '../../../setup'
-
 import hre from 'hardhat'
 import { Contract, ethers } from 'ethers'
+
+import { expect } from '../../../setup'
 
 describe('Lib_Buffer', () => {
   let Lib_Buffer: Contract

--- a/packages/contracts/test/contracts/libraries/utils/Lib_BytesUtils.spec.ts
+++ b/packages/contracts/test/contracts/libraries/utils/Lib_BytesUtils.spec.ts
@@ -1,10 +1,10 @@
 /* Internal Imports */
-import { Lib_BytesUtils_TEST_JSON } from '../../../data'
-import { runJsonTest } from '../../../helpers'
-
-/* External Imports */
 import { ethers } from 'hardhat'
 import { Contract } from 'ethers'
+
+/* External Imports */
+import { Lib_BytesUtils_TEST_JSON } from '../../../data'
+import { runJsonTest } from '../../../helpers'
 import { expect } from '../../../setup'
 
 describe('Lib_BytesUtils', () => {

--- a/packages/contracts/test/contracts/libraries/utils/Lib_MerkleTree.spec.ts
+++ b/packages/contracts/test/contracts/libraries/utils/Lib_MerkleTree.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Contract, BigNumber } from 'ethers'
@@ -7,6 +5,7 @@ import { MerkleTree } from 'merkletreejs'
 import { fromHexString, toHexString } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
+import { expect } from '../../../setup'
 import { NON_NULL_BYTES32 } from '../../../helpers'
 
 const NODE_COUNTS = [

--- a/packages/contracts/test/helpers/dummy/batches.ts
+++ b/packages/contracts/test/helpers/dummy/batches.ts
@@ -1,5 +1,6 @@
-import { NON_ZERO_ADDRESS } from '../constants'
 import { ethers } from 'hardhat'
+
+import { NON_ZERO_ADDRESS } from '../constants'
 
 export const DUMMY_BATCH_HEADERS = [
   {

--- a/packages/contracts/test/helpers/test-runner/json-test-runner.ts
+++ b/packages/contracts/test/helpers/test-runner/json-test-runner.ts
@@ -1,8 +1,8 @@
-import { expect } from '../../setup'
-
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Contract, BigNumber } from 'ethers'
+
+import { expect } from '../../setup'
 
 const bigNumberify = (arr: any[]) => {
   return arr.map((el: any) => {

--- a/packages/core-utils/src/alias.ts
+++ b/packages/core-utils/src/alias.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+
 import { bnToAddress } from './bn'
 
 // Constant representing the alias to apply to the msg.sender when a contract sends an L1 => L2

--- a/packages/core-utils/src/bn.ts
+++ b/packages/core-utils/src/bn.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers'
+
 import { remove0x, add0x } from './common/hex-strings'
 
 /**

--- a/packages/core-utils/src/coders/sequencer-batch.ts
+++ b/packages/core-utils/src/coders/sequencer-batch.ts
@@ -1,5 +1,6 @@
-import { add0x, remove0x, encodeHex } from '../common'
 import { BigNumber, ethers } from 'ethers'
+
+import { add0x, remove0x, encodeHex } from '../common'
 
 export interface BatchContext {
   numSequencedTransactions: number

--- a/packages/core-utils/src/common/test-utils.ts
+++ b/packages/core-utils/src/common/test-utils.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { BigNumber } from 'ethers'
+
 import { sleep } from './misc'
 
 interface deviationRanges {

--- a/packages/core-utils/src/fees.ts
+++ b/packages/core-utils/src/fees.ts
@@ -3,6 +3,7 @@
  */
 
 import { BigNumber } from 'ethers'
+
 import { remove0x } from './common'
 
 const txDataZeroGas = 4

--- a/packages/core-utils/test/batch-encoder.spec.ts
+++ b/packages/core-utils/test/batch-encoder.spec.ts
@@ -1,12 +1,13 @@
 import './setup'
 
 /* Internal Imports */
+import { expect } from 'chai'
+
 import {
   encodeAppendSequencerBatch,
   decodeAppendSequencerBatch,
   sequencerBatch,
 } from '../src'
-import { expect } from 'chai'
 
 describe('BatchEncoder', () => {
   describe('appendSequencerBatch', () => {

--- a/packages/core-utils/test/hex-utils.spec.ts
+++ b/packages/core-utils/test/hex-utils.spec.ts
@@ -1,7 +1,7 @@
-import { expect } from './setup'
 import { BigNumber } from 'ethers'
 
 /* Imports: Internal */
+import { expect } from './setup'
 import {
   toRpcHexString,
   remove0x,

--- a/packages/core-utils/test/misc.spec.ts
+++ b/packages/core-utils/test/misc.spec.ts
@@ -1,6 +1,5 @@
-import { expect } from './setup'
-
 /* Imports: Internal */
+import { expect } from './setup'
 import { sleep } from '../src'
 
 describe('sleep', async () => {

--- a/packages/core-utils/test/test-utils.spec.ts
+++ b/packages/core-utils/test/test-utils.spec.ts
@@ -1,8 +1,8 @@
-import { expect } from './setup'
+import { assert } from 'chai'
 
 /* Imports: Internal */
+import { expect } from './setup'
 import { expectApprox, awaitCondition } from '../src'
-import { assert } from 'chai'
 
 describe('awaitCondition', () => {
   it('should try the condition fn until it returns true', async () => {

--- a/packages/data-transport-layer/src/db/transport-db.ts
+++ b/packages/data-transport-layer/src/db/transport-db.ts
@@ -3,6 +3,7 @@ import { LevelUp } from 'levelup'
 import { BigNumber } from 'ethers'
 
 /* Imports: Internal */
+import { SimpleDB } from './simple-db'
 import {
   EnqueueEntry,
   StateRootBatchEntry,
@@ -10,7 +11,6 @@ import {
   TransactionBatchEntry,
   TransactionEntry,
 } from '../types/database-types'
-import { SimpleDB } from './simple-db'
 
 const TRANSPORT_DB_KEYS = {
   ENQUEUE: `enqueue`,

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -9,6 +9,7 @@ import {
 import { SequencerBatchAppendedEvent } from '@eth-optimism/contracts/dist/types/CanonicalTransactionChain'
 
 /* Imports: Internal */
+import { MissingElementError } from './errors'
 import {
   DecodedSequencerBatchTransaction,
   SequencerBatchAppendedExtraData,
@@ -18,7 +19,6 @@ import {
   EventHandlerSet,
 } from '../../../types'
 import { SEQUENCER_GAS_LIMIT, parseSignatureVParam } from '../../../utils'
-import { MissingElementError } from './errors'
 
 export const handleEventsSequencerBatchAppended: EventHandlerSet<
   SequencerBatchAppendedEvent,

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/state-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/state-batch-appended.ts
@@ -4,6 +4,7 @@ import { getContractFactory } from '@eth-optimism/contracts'
 import { BigNumber } from 'ethers'
 
 /* Imports: Internal */
+import { MissingElementError } from './errors'
 import {
   StateRootBatchEntry,
   StateBatchAppendedExtraData,
@@ -11,7 +12,6 @@ import {
   StateRootEntry,
   EventHandlerSet,
 } from '../../../types'
-import { MissingElementError } from './errors'
 
 export const handleEventsStateBatchAppended: EventHandlerSet<
   StateBatchAppendedEvent,

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/transaction-enqueued.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/transaction-enqueued.ts
@@ -3,8 +3,8 @@ import { BigNumber } from 'ethers'
 import { TransactionEnqueuedEvent } from '@eth-optimism/contracts/dist/types/CanonicalTransactionChain'
 
 /* Imports: Internal */
-import { EnqueueEntry, EventHandlerSet } from '../../../types'
 import { MissingElementError } from './errors'
+import { EnqueueEntry, EventHandlerSet } from '../../../types'
 
 export const handleEventsTransactionEnqueued: EventHandlerSet<
   TransactionEnqueuedEvent,

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -8,6 +8,10 @@ import { constants } from 'ethers'
 import { Gauge, Counter } from 'prom-client'
 
 /* Imports: Internal */
+import { handleEventsTransactionEnqueued } from './handlers/transaction-enqueued'
+import { handleEventsSequencerBatchAppended } from './handlers/sequencer-batch-appended'
+import { handleEventsStateBatchAppended } from './handlers/state-batch-appended'
+import { MissingElementError } from './handlers/errors'
 import { TransportDB } from '../../db/transport-db'
 import {
   OptimismContracts,
@@ -17,11 +21,7 @@ import {
   validators,
 } from '../../utils'
 import { EventHandlerSet } from '../../types'
-import { handleEventsTransactionEnqueued } from './handlers/transaction-enqueued'
-import { handleEventsSequencerBatchAppended } from './handlers/sequencer-batch-appended'
-import { handleEventsStateBatchAppended } from './handlers/state-batch-appended'
 import { L1DataTransportServiceOptions } from '../main/service'
-import { MissingElementError } from './handlers/errors'
 
 interface L1IngestionMetrics {
   highestSyncedL1Block: Gauge<string>

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -8,10 +8,10 @@ import bfj from 'bfj'
 import { Gauge } from 'prom-client'
 
 /* Imports: Internal */
+import { handleSequencerBlock } from './handlers/transaction'
 import { TransportDB } from '../../db/transport-db'
 import { sleep, toRpcHexString, validators } from '../../utils'
 import { L1DataTransportServiceOptions } from '../main/service'
-import { handleSequencerBlock } from './handlers/transaction'
 
 interface L2IngestionMetrics {
   highestSyncedL2Block: Gauge<string>

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -2,13 +2,13 @@
 import { BaseService, Metrics } from '@eth-optimism/common-ts'
 import { LevelUp } from 'levelup'
 import level from 'level'
+import { Counter } from 'prom-client'
 
 /* Imports: Internal */
 import { L1IngestionService } from '../l1-ingestion/service'
 import { L1TransportServer } from '../server/service'
 import { validators } from '../../utils'
 import { L2IngestionService } from '../l2-ingestion/service'
-import { Counter } from 'prom-client'
 
 export interface L1DataTransportServiceOptions {
   nodeEnv: string

--- a/packages/data-transport-layer/src/types/event-handler-types.ts
+++ b/packages/data-transport-layer/src/types/event-handler-types.ts
@@ -2,13 +2,13 @@ import { BaseProvider } from '@ethersproject/providers'
 import { BigNumber } from 'ethers'
 import { TypedEvent } from '@eth-optimism/contracts/dist/types/common'
 
-import { TransportDB } from '../db/transport-db'
 import {
   TransactionBatchEntry,
   TransactionEntry,
   StateRootBatchEntry,
   StateRootEntry,
 } from './database-types'
+import { TransportDB } from '../db/transport-db'
 
 export type GetExtraDataHandler<TEvent extends TypedEvent, TExtraData> = (
   event?: TEvent,

--- a/packages/data-transport-layer/src/utils/validation.ts
+++ b/packages/data-transport-layer/src/utils/validation.ts
@@ -1,5 +1,6 @@
-import { fromHexString } from '@eth-optimism/core-utils'
 import * as url from 'url'
+
+import { fromHexString } from '@eth-optimism/core-utils'
 
 export const validators = {
   isBoolean: (val: any): boolean => {

--- a/packages/data-transport-layer/test/unit-tests/services/l1-ingestion/handlers/state-batch-appended.spec.ts
+++ b/packages/data-transport-layer/test/unit-tests/services/l1-ingestion/handlers/state-batch-appended.spec.ts
@@ -1,10 +1,9 @@
-import { expect } from '../../../../setup'
-
 /* Imports: External */
 import { BigNumber } from 'ethers'
 import { Block } from '@ethersproject/abstract-provider'
 
 /* Imports: Internal */
+import { expect } from '../../../../setup'
 import { handleEventsStateBatchAppended } from '../../../../../src/services/l1-ingestion/handlers/state-batch-appended'
 import { StateBatchAppendedExtraData } from '../../../../../src/types'
 import { l1StateBatchData } from '../../../examples/l1-data'

--- a/packages/data-transport-layer/test/unit-tests/services/l1-ingestion/handlers/transaction-enqueued.spec.ts
+++ b/packages/data-transport-layer/test/unit-tests/services/l1-ingestion/handlers/transaction-enqueued.spec.ts
@@ -1,9 +1,8 @@
-import { expect } from '../../../../setup'
-
 /* Imports: External */
 import { ethers, BigNumber } from 'ethers'
 
 /* Imports: Internal */
+import { expect } from '../../../../setup'
 import { handleEventsTransactionEnqueued } from '../../../../../src/services/l1-ingestion/handlers/transaction-enqueued'
 
 const MAX_ITERATIONS = 128

--- a/packages/data-transport-layer/test/unit-tests/services/l2-ingestion/handlers/transaction.spec.ts
+++ b/packages/data-transport-layer/test/unit-tests/services/l2-ingestion/handlers/transaction.spec.ts
@@ -1,6 +1,5 @@
-import { expect } from '../../../../setup'
-
 /* Imports: Internal */
+import { expect } from '../../../../setup'
 import { l2Block } from '../../../examples/l2-data'
 import { handleSequencerBlock } from '../../../../../src/services/l2-ingestion/handlers/transaction'
 

--- a/packages/message-relayer/src/exec/run.ts
+++ b/packages/message-relayer/src/exec/run.ts
@@ -1,10 +1,11 @@
 import { Wallet, providers } from 'ethers'
-import { MessageRelayerService } from '../service'
 import { Bcfg } from '@eth-optimism/core-utils'
 import { Logger, LoggerOptions } from '@eth-optimism/common-ts'
 import * as Sentry from '@sentry/node'
 import * as dotenv from 'dotenv'
 import Config from 'bcfg'
+
+import { MessageRelayerService } from '../service'
 
 dotenv.config()
 

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -2,16 +2,15 @@
 import { Contract, ethers, Wallet, BigNumber, providers } from 'ethers'
 import * as rlp from 'rlp'
 import { MerkleTree } from 'merkletreejs'
-
-/* Imports: Internal */
 import { fromHexString, sleep } from '@eth-optimism/core-utils'
 import { Logger, BaseService, Metrics } from '@eth-optimism/common-ts'
-
 import {
   loadContract,
   loadContractFromManager,
   predeploys,
 } from '@eth-optimism/contracts'
+
+/* Imports: Internal */
 import { StateRootBatchHeader, SentMessage, SentMessageProof } from './types'
 
 interface MessageRelayerOptions {

--- a/packages/message-relayer/test/unit-tests/relay-tx.spec.ts
+++ b/packages/message-relayer/test/unit-tests/relay-tx.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '../setup'
-
 /* Imports: External */
 import hre from 'hardhat'
 import { Contract, Signer } from 'ethers'
@@ -8,6 +6,7 @@ import { smockit } from '@eth-optimism/smock'
 import { toPlainObject } from 'lodash'
 
 /* Imports: Internal */
+import { expect } from '../setup'
 import {
   getMerkleTreeProof,
   getMessagesAndProofsForL2Transaction,

--- a/packages/regenesis-surgery/scripts/data.ts
+++ b/packages/regenesis-surgery/scripts/data.ts
@@ -6,6 +6,7 @@ import {
   POOL_INIT_CODE_HASH_OPTIMISM_KOVAN,
 } from '@uniswap/v3-sdk'
 import { Token } from '@uniswap/sdk-core'
+
 import { UNISWAP_V3_FACTORY_ADDRESS } from './constants'
 import { downloadAllSolcVersions } from './solc'
 import {

--- a/packages/regenesis-surgery/scripts/handlers.ts
+++ b/packages/regenesis-surgery/scripts/handlers.ts
@@ -5,6 +5,7 @@ import {
   POOL_INIT_CODE_HASH_OPTIMISM_KOVAN,
 } from '@uniswap/v3-sdk'
 import { sleep, add0x, remove0x, clone } from '@eth-optimism/core-utils'
+
 import {
   OLD_ETH_ADDRESS,
   WETH_TRANSFER_ADDRESSES,

--- a/packages/regenesis-surgery/scripts/solc.ts
+++ b/packages/regenesis-surgery/scripts/solc.ts
@@ -1,10 +1,12 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-import fetch from 'node-fetch'
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
+
+import fetch from 'node-fetch'
 import { ethers } from 'ethers'
 import { clone } from '@eth-optimism/core-utils'
 import setupMethods from 'solc/wrapper'
+
 import {
   COMPILER_VERSIONS_TO_SOLC,
   EMSCRIPTEN_BUILD_LIST,

--- a/packages/regenesis-surgery/scripts/surgery.ts
+++ b/packages/regenesis-surgery/scripts/surgery.ts
@@ -1,6 +1,8 @@
-import { ethers } from 'ethers'
 import fs from 'fs'
+
+import { ethers } from 'ethers'
 import { add0x, remove0x, clone } from '@eth-optimism/core-utils'
+
 import { StateDump, SurgeryDataSources, AccountType } from './types'
 import { findAccount } from './utils'
 import { handlers } from './handlers'

--- a/packages/regenesis-surgery/scripts/utils.ts
+++ b/packages/regenesis-surgery/scripts/utils.ts
@@ -1,14 +1,16 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
+import { createReadStream } from 'fs'
+import * as fs from 'fs'
+import * as assert from 'assert'
+
 import { ethers } from 'ethers'
 import { abi as UNISWAP_FACTORY_ABI } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json'
 import { Interface } from '@ethersproject/abi'
 import { parseChunked } from '@discoveryjs/json-ext'
-import { createReadStream } from 'fs'
-import * as fs from 'fs'
 import byline from 'byline'
 import * as dotenv from 'dotenv'
-import * as assert from 'assert'
 import { reqenv, getenv, remove0x } from '@eth-optimism/core-utils'
+
 import {
   Account,
   EtherscanContract,

--- a/packages/regenesis-surgery/test/delete.spec.ts
+++ b/packages/regenesis-surgery/test/delete.spec.ts
@@ -1,6 +1,7 @@
 import { KECCAK256_RLP_S, KECCAK256_NULL_S } from 'ethereumjs-util'
 import { add0x } from '@eth-optimism/core-utils'
 import { ethers } from 'ethers'
+
 import { expect, env } from './setup'
 import { AccountType } from '../scripts/types'
 

--- a/packages/regenesis-surgery/test/eoa.spec.ts
+++ b/packages/regenesis-surgery/test/eoa.spec.ts
@@ -1,5 +1,6 @@
 import { KECCAK256_RLP_S, KECCAK256_NULL_S } from 'ethereumjs-util'
 import { add0x } from '@eth-optimism/core-utils'
+
 import { expect, env } from './setup'
 import { AccountType, Account } from '../scripts/types'
 

--- a/packages/regenesis-surgery/test/erc20.spec.ts
+++ b/packages/regenesis-surgery/test/erc20.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@eth-optimism/core-utils/test/setup'
 import { BigNumber } from 'ethers'
+
 import { env } from './setup'
 
 describe('erc20', () => {

--- a/packages/regenesis-surgery/test/predeploy.spec.ts
+++ b/packages/regenesis-surgery/test/predeploy.spec.ts
@@ -1,7 +1,8 @@
 import { ethers, BigNumber, Contract } from 'ethers'
+
 import { expect, env, ERC20_ABI } from './setup'
-import { AccountType } from '../scripts/types'
 import { GenesisJsonProvider } from './provider'
+import { AccountType } from '../scripts/types'
 
 describe('predeploys', () => {
   const predeploys = {

--- a/packages/regenesis-surgery/test/provider.spec.ts
+++ b/packages/regenesis-surgery/test/provider.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from '@eth-optimism/core-utils/test/setup'
 import { ethers, BigNumber } from 'ethers'
-import { GenesisJsonProvider } from './provider'
 import { Genesis } from '@eth-optimism/core-utils/src/types'
 import {
   remove0x,
   add0x,
 } from '@eth-optimism/core-utils/src/common/hex-strings'
 import { KECCAK256_RLP_S, KECCAK256_NULL_S } from 'ethereumjs-util'
+
+import { GenesisJsonProvider } from './provider'
 
 const account = '0x66a84544bed4ca45b3c024776812abf87728fbaf'
 

--- a/packages/regenesis-surgery/test/provider.ts
+++ b/packages/regenesis-surgery/test/provider.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import { ethers } from 'ethers'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Deferrable } from '@ethersproject/properties'
@@ -16,8 +18,6 @@ import {
   Listener,
 } from '@ethersproject/abstract-provider'
 import { KECCAK256_RLP_S, KECCAK256_NULL_S } from 'ethereumjs-util'
-import path from 'path'
-
 import { bytes32ify, remove0x, add0x } from '@eth-optimism/core-utils'
 
 // Represents the ethereum state

--- a/packages/regenesis-surgery/test/setup.ts
+++ b/packages/regenesis-surgery/test/setup.ts
@@ -6,10 +6,11 @@ import * as dotenv from 'dotenv'
 import { getenv, remove0x } from '@eth-optimism/core-utils'
 import { providers, BigNumber } from 'ethers'
 import { solidity } from 'ethereum-waffle'
+
+import { GenesisJsonProvider } from './provider'
 import { SurgeryDataSources, Account, AccountType } from '../scripts/types'
 import { loadSurgeryData } from '../scripts/data'
 import { classify, classifiers } from '../scripts/classifiers'
-import { GenesisJsonProvider } from './provider'
 
 // Chai plugins go here.
 chai.use(chaiAsPromised)

--- a/packages/regenesis-surgery/test/uniswap.spec.ts
+++ b/packages/regenesis-surgery/test/uniswap.spec.ts
@@ -1,8 +1,9 @@
 import { ethers } from 'ethers'
 import { abi as UNISWAP_POOL_ABI } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json'
+
+import { expect, env, ERC20_ABI } from './setup'
 import { UNISWAP_V3_NFPM_ADDRESS } from '../scripts/constants'
 import { getUniswapV3Factory, replaceWETH } from '../scripts/utils'
-import { expect, env, ERC20_ABI } from './setup'
 import { AccountType } from '../scripts/types'
 
 describe('uniswap contracts', () => {

--- a/packages/regenesis-surgery/test/utils.ts
+++ b/packages/regenesis-surgery/test/utils.ts
@@ -1,6 +1,8 @@
-import { expect } from '@eth-optimism/core-utils/test/setup'
 import fs from 'fs/promises'
 import path from 'path'
+
+import { expect } from '@eth-optimism/core-utils/test/setup'
+
 import { isBytecodeERC20 } from '../scripts/utils'
 
 describe('Utils', () => {

--- a/packages/replica-healthcheck/src/healthcheck-server.ts
+++ b/packages/replica-healthcheck/src/healthcheck-server.ts
@@ -1,5 +1,6 @@
-import express from 'express'
 import { Server } from 'net'
+
+import express from 'express'
 import promBundle from 'express-prom-bundle'
 import { Gauge, Histogram } from 'prom-client'
 import cron from 'node-cron'

--- a/packages/sdk/src/cross-chain-provider.ts
+++ b/packages/sdk/src/cross-chain-provider.ts
@@ -6,6 +6,7 @@ import {
 } from '@ethersproject/abstract-provider'
 import { ethers, BigNumber, Event } from 'ethers'
 import { sleep } from '@eth-optimism/core-utils'
+
 import {
   ICrossChainProvider,
   OEContracts,

--- a/packages/sdk/src/interfaces/cross-chain-erc20-pair.ts
+++ b/packages/sdk/src/interfaces/cross-chain-erc20-pair.ts
@@ -3,6 +3,7 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
+
 import { NumberLike, L1ToL2Overrides } from './types'
 import { ICrossChainMessenger } from './cross-chain-messenger'
 

--- a/packages/sdk/src/interfaces/cross-chain-messenger.ts
+++ b/packages/sdk/src/interfaces/cross-chain-messenger.ts
@@ -3,6 +3,7 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
+
 import {
   MessageLike,
   NumberLike,

--- a/packages/sdk/src/interfaces/cross-chain-provider.ts
+++ b/packages/sdk/src/interfaces/cross-chain-provider.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers'
 import { Provider, BlockTag } from '@ethersproject/abstract-provider'
+
 import {
   MessageLike,
   TransactionLike,

--- a/packages/sdk/src/utils/coercion.ts
+++ b/packages/sdk/src/utils/coercion.ts
@@ -1,10 +1,12 @@
 import assert from 'assert'
+
 import {
   Provider,
   TransactionReceipt,
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
 import { ethers, BigNumber } from 'ethers'
+
 import {
   ProviderLike,
   TransactionLike,

--- a/packages/sdk/src/utils/contracts.ts
+++ b/packages/sdk/src/utils/contracts.ts
@@ -1,5 +1,8 @@
 import { getContractInterface, predeploys } from '@eth-optimism/contracts'
 import { ethers, Contract } from 'ethers'
+
+import { toAddress } from './coercion'
+import { DeepPartial } from './type-utils'
 import {
   OEContracts,
   OEL1Contracts,
@@ -10,8 +13,6 @@ import {
   CustomBridges,
   CustomBridgesLike,
 } from '../interfaces'
-import { toAddress } from './coercion'
-import { DeepPartial } from './type-utils'
 
 /**
  * Full list of default L2 contract addresses.

--- a/packages/sdk/src/utils/message-encoding.ts
+++ b/packages/sdk/src/utils/message-encoding.ts
@@ -1,5 +1,6 @@
 import { getContractInterface } from '@eth-optimism/contracts'
 import { ethers } from 'ethers'
+
 import { CoreCrossChainMessage } from '../interfaces'
 
 /**

--- a/packages/sdk/test/cross-chain-provider.spec.ts
+++ b/packages/sdk/test/cross-chain-provider.spec.ts
@@ -1,7 +1,8 @@
-import { expect } from './setup'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Contract } from 'ethers'
 import { ethers } from 'hardhat'
+
+import { expect } from './setup'
 import {
   CrossChainProvider,
   MessageDirection,

--- a/packages/sdk/test/utils/coercion.spec.ts
+++ b/packages/sdk/test/utils/coercion.spec.ts
@@ -1,7 +1,8 @@
-import { expect } from '../setup'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Contract } from 'ethers'
 import { ethers } from 'hardhat'
+
+import { expect } from '../setup'
 import { toProvider, toTransactionHash } from '../../src'
 
 describe('type coercion utils', () => {

--- a/packages/sdk/test/utils/contracts.spec.ts
+++ b/packages/sdk/test/utils/contracts.spec.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { Signer } from 'ethers'
+import { ethers } from 'hardhat'
+
 import { expect } from '../setup'
 import {
   getOEContract,
@@ -6,8 +9,6 @@ import {
   CONTRACT_ADDRESSES,
   DEFAULT_L2_CONTRACT_ADDRESSES,
 } from '../../src'
-import { Signer } from 'ethers'
-import { ethers } from 'hardhat'
 
 describe('contract connection utils', () => {
   let signers: Signer[]

--- a/packages/sdk/test/utils/message-encoding.spec.ts
+++ b/packages/sdk/test/utils/message-encoding.spec.ts
@@ -1,7 +1,8 @@
-import { expect } from '../setup'
 import { Contract, Signer } from 'ethers'
 import { ethers } from 'hardhat'
 import { getContractFactory } from '@eth-optimism/contracts'
+
+import { expect } from '../setup'
 import {
   CoreCrossChainMessage,
   encodeCrossChainMessage,


### PR DESCRIPTION
**Description**
The order of imports in TS files is now standardized by eslint.
1. ~~external~~ builtin
2. ~~builtin~~ external
3. internal
4. ~~sibling~~
5. ~~parent~~
6. ~~index~~
* New Line is separating each group. 

**Metadata**
- As addition to [PR-2019](https://github.com/ethereum-optimism/optimism/pull/2019)
