### PR TITLE
go/proxyd: Properly handle null results

### DIFF
--- a/go/proxyd/rpc.go
+++ b/go/proxyd/rpc.go
@@ -15,14 +15,44 @@ type RPCReq struct {
 }
 
 type RPCRes struct {
+	JSONRPC string
+	Result  interface{}
+	Error   *RPCErr
+	ID      json.RawMessage
+}
+
+type rpcResJSON struct {
 	JSONRPC string          `json:"jsonrpc"`
 	Result  interface{}     `json:"result,omitempty"`
 	Error   *RPCErr         `json:"error,omitempty"`
 	ID      json.RawMessage `json:"id"`
 }
 
+type nullResultRPCRes struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  interface{}     `json:"result"`
+	ID      json.RawMessage `json:"id"`
+}
+
 func (r *RPCRes) IsError() bool {
 	return r.Error != nil
+}
+
+func (r *RPCRes) MarshalJSON() ([]byte, error) {
+	if r.Result == nil && r.Error == nil {
+		return json.Marshal(&nullResultRPCRes{
+			JSONRPC: r.JSONRPC,
+			Result:  nil,
+			ID:      r.ID,
+		})
+	}
+
+	return json.Marshal(&rpcResJSON{
+		JSONRPC: r.JSONRPC,
+		Result:  r.Result,
+		Error:   r.Error,
+		ID:      r.ID,
+	})
 }
 
 type RPCErr struct {

--- a/go/proxyd/rpc_test.go
+++ b/go/proxyd/rpc_test.go
@@ -1,0 +1,75 @@
+package proxyd
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRPCResJSON(t *testing.T) {
+	tests := []struct{
+		name string
+		in *RPCRes
+		out string
+	}{
+		{
+			"string result",
+			&RPCRes{
+				JSONRPC: JSONRPCVersion,
+				Result:  "foobar",
+				ID:      []byte("123"),
+			},
+			`{"jsonrpc":"2.0","result":"foobar","id":123}`,
+		},
+		{
+			"object result",
+			&RPCRes{
+				JSONRPC: JSONRPCVersion,
+				Result:  struct{
+					Str string `json:"str"`
+				}{
+					"test",
+				},
+				ID:      []byte("123"),
+			},
+			`{"jsonrpc":"2.0","result":{"str":"test"},"id":123}`,
+		},
+		{
+			"nil result",
+			&RPCRes{
+				JSONRPC: JSONRPCVersion,
+				Result:  nil,
+				ID:      []byte("123"),
+			},
+			`{"jsonrpc":"2.0","result":null,"id":123}`,
+		},
+		{
+			"error result",
+			&RPCRes{
+				JSONRPC: JSONRPCVersion,
+				Error: &RPCErr{
+					Code:          1234,
+					Message:       "test err",
+				},
+				ID:      []byte("123"),
+			},
+			`{"jsonrpc":"2.0","error":{"code":1234,"message":"test err"},"id":123}`,
+		},
+		{
+			"string ID",
+			&RPCRes{
+				JSONRPC: JSONRPCVersion,
+				Result:  "foobar",
+				ID:      []byte("\"123\""),
+			},
+			`{"jsonrpc":"2.0","result":"foobar","id":"123"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := json.Marshal(tt.in)
+			require.NoError(t, err)
+			require.Equal(t, tt.out, string(out))
+		})
+	}
+}


### PR DESCRIPTION
Both the `Error` and `Result` fields on `RPCRes` had `omitempty` tags, so null results were being swallowed. We didn't catch this in integration tests because JavaScript tolerates missing keys. This is now fixed by using a custom JSON marshaler.

Fixes #2049
