### PR TITLE
feat(sdk): implement L2 message gas estimation

### DIFF
--- a/packages/sdk/src/interfaces/cross-chain-provider.ts
+++ b/packages/sdk/src/interfaces/cross-chain-provider.ts
@@ -201,9 +201,16 @@ export interface ICrossChainProvider {
    * L1 => L2 messages. You would supply this gas limit when sending the message to L2.
    *
    * @param message Message get a gas estimate for.
+   * @param opts Options object.
+   * @param opts.bufferPercent Percentage of gas to add to the estimate. Defaults to 20.
    * @returns Estimates L2 gas limit.
    */
-  estimateL2MessageGasLimit(message: MessageLike): Promise<BigNumber>
+  estimateL2MessageGasLimit(
+    message: MessageLike,
+    opts?: {
+      bufferPercent?: number
+    }
+  ): Promise<BigNumber>
 
   /**
    * Returns the estimated amount of time before the message can be executed. When this is a

--- a/packages/sdk/test/cross-chain-provider.spec.ts
+++ b/packages/sdk/test/cross-chain-provider.spec.ts
@@ -1,4 +1,5 @@
 import { Provider } from '@ethersproject/abstract-provider'
+import { expectApprox } from '@eth-optimism/core-utils'
 import { Contract } from 'ethers'
 import { ethers } from 'hardhat'
 
@@ -1091,7 +1092,93 @@ describe('CrossChainProvider', () => {
   })
 
   describe('estimateL2MessageGasLimit', () => {
-    it('should perform a gas estimation of the L2 action')
+    let provider: CrossChainProvider
+    beforeEach(async () => {
+      provider = new CrossChainProvider({
+        l1Provider: ethers.provider,
+        l2Provider: ethers.provider,
+        l1ChainId: 31337,
+      })
+    })
+
+    describe('when the message is an L1 to L2 message', () => {
+      it('should return an accurate gas estimate plus a ~20% buffer', async () => {
+        const message = {
+          direction: MessageDirection.L1_TO_L2,
+          target: '0x' + '11'.repeat(20),
+          sender: '0x' + '22'.repeat(20),
+          message: '0x' + '33'.repeat(64),
+          messageNonce: 1234,
+          logIndex: 0,
+          blockNumber: 1234,
+          transactionHash: '0x' + '44'.repeat(32),
+        }
+
+        const estimate = await ethers.provider.estimateGas({
+          to: message.target,
+          from: message.sender,
+          data: message.message,
+        })
+
+        // Approximately 20% greater than the estimate, +/- 1%.
+        expectApprox(
+          await provider.estimateL2MessageGasLimit(message),
+          estimate.mul(120).div(100),
+          {
+            percentUpperDeviation: 1,
+            percentLowerDeviation: 1,
+          }
+        )
+      })
+
+      it('should return an accurate gas estimate when a custom buffer is provided', async () => {
+        const message = {
+          direction: MessageDirection.L1_TO_L2,
+          target: '0x' + '11'.repeat(20),
+          sender: '0x' + '22'.repeat(20),
+          message: '0x' + '33'.repeat(64),
+          messageNonce: 1234,
+          logIndex: 0,
+          blockNumber: 1234,
+          transactionHash: '0x' + '44'.repeat(32),
+        }
+
+        const estimate = await ethers.provider.estimateGas({
+          to: message.target,
+          from: message.sender,
+          data: message.message,
+        })
+
+        // Approximately 30% greater than the estimate, +/- 1%.
+        expectApprox(
+          await provider.estimateL2MessageGasLimit(message, {
+            bufferPercent: 30,
+          }),
+          estimate.mul(130).div(100),
+          {
+            percentUpperDeviation: 1,
+            percentLowerDeviation: 1,
+          }
+        )
+      })
+    })
+
+    describe('when the message is an L2 to L1 message', () => {
+      it('should throw an error', async () => {
+        const message = {
+          direction: MessageDirection.L2_TO_L1,
+          target: '0x' + '11'.repeat(20),
+          sender: '0x' + '22'.repeat(20),
+          message: '0x' + '33'.repeat(64),
+          messageNonce: 1234,
+          logIndex: 0,
+          blockNumber: 1234,
+          transactionHash: '0x' + '44'.repeat(32),
+        }
+
+        await expect(provider.estimateL2MessageGasLimit(message)).to.be.rejected
+      })
+    })
   })
 
   describe('estimateMessageWaitTimeBlocks', () => {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Implements the `estimateL2MessageGas` function in the `CrossChainProvider`. This function will be used when attempting to send a message from L1 to L2.

**Metadata**
- Fixes ENG-1802