### PR TITLE
l2geth: better error message for proxying user txs

### DIFF
--- a/.changeset/happy-lions-divide.md
+++ b/.changeset/happy-lions-divide.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Add a better error message for when the sequencer url is not configured when proxying user requests to the sequencer for `eth_sendRawTransaction` when running as a verifier/replica

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -50,7 +50,10 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
-var errOVMUnsupported = errors.New("OVM: Unsupported RPC Method")
+var (
+	errOVMUnsupported = errors.New("OVM: Unsupported RPC Method")
+	errNoSequencerURL = errors.New("sequencer transaction forwarding not configured")
+)
 
 const (
 	// defaultDialTimeout is default duration the service will wait on
@@ -1678,7 +1681,11 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	}
 
 	if s.b.IsVerifier() {
-		client, err := dialSequencerClientWithTimeout(ctx, s.b.SequencerClientHttp())
+		sequencerURL := s.b.SequencerClientHttp()
+		if sequencerURL == "" {
+			return common.Hash{}, errNoSequencerURL
+		}
+		client, err := dialSequencerClientWithTimeout(ctx, sequencerURL)
 		if err != nil {
 			return common.Hash{}, err
 		}


### PR DESCRIPTION
**Description**

This commit adds a better error message when there
is an error for proxying user requests to the sequencer.
This allows the change to be relatively backwards compatible
as a good error message is returned when the sequencer url
is not configured.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


