### PR TITLE
proxyd: Allow cached RPC keys to be evicted

### DIFF
--- a/.changeset/curly-candles-pretend.md
+++ b/.changeset/curly-candles-pretend.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+proxyd: Allow cached RPCs to be evicted by redis


### PR DESCRIPTION
**Description**
Set TTL for RPC keys in redis. Otherwise they won't get evicted once we've hit max memory.