### PR TITLE
integration-tests: verifier

### DIFF
--- a/.changeset/smooth-bags-applaud.md
+++ b/.changeset/smooth-bags-applaud.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Add verifier integration tests

--- a/integration-tests/test/shared/env.ts
+++ b/integration-tests/test/shared/env.ts
@@ -11,6 +11,7 @@ import {
   l1Provider,
   l2Provider,
   replicaProvider,
+  verifierProvider,
   l1Wallet,
   l2Wallet,
   gasPriceOracleWallet,
@@ -57,6 +58,7 @@ export class OptimismEnv {
   l1Provider: providers.JsonRpcProvider
   l2Provider: providers.JsonRpcProvider
   replicaProvider: providers.JsonRpcProvider
+  verifierProvider: providers.JsonRpcProvider
 
   constructor(args: any) {
     this.addressManager = args.addressManager
@@ -74,6 +76,7 @@ export class OptimismEnv {
     this.l1Provider = args.l1Provider
     this.l2Provider = args.l2Provider
     this.replicaProvider = args.replicaProvider
+    this.verifierProvider = args.verifierProvider
     this.ctc = args.ctc
     this.scc = args.scc
   }
@@ -140,6 +143,7 @@ export class OptimismEnv {
       l2Wallet,
       l1Provider,
       l2Provider,
+      verifierProvider,
       replicaProvider,
     })
   }

--- a/integration-tests/test/shared/utils.ts
+++ b/integration-tests/test/shared/utils.ts
@@ -62,6 +62,8 @@ const procEnv = cleanEnv(process.env, {
   REPLICA_URL: str({ default: 'http://localhost:8549' }),
   REPLICA_POLLING_INTERVAL: num({ default: 10 }),
 
+  VERIFIER_URL: str({ default: 'http://localhost:8547' }),
+
   PRIVATE_KEY: str({
     default:
       '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
@@ -93,6 +95,9 @@ const procEnv = cleanEnv(process.env, {
   RUN_STRESS_TESTS: bool({
     default: true,
   }),
+  RUN_VERIFIER_TESTS: bool({
+    default: false,
+  }),
 
   MOCHA_TIMEOUT: num({
     default: 120_000,
@@ -117,6 +122,11 @@ export const replicaProvider = injectL2Context(
   new providers.JsonRpcProvider(procEnv.REPLICA_URL)
 )
 replicaProvider.pollingInterval = procEnv.REPLICA_POLLING_INTERVAL
+
+export const verifierProvider = injectL2Context(
+  new providers.JsonRpcProvider(procEnv.VERIFIER_URL)
+)
+verifierProvider.pollingInterval = procEnv.L2_POLLING_INTERVAL
 
 // The sequencer private key which is funded on L1
 export const l1Wallet = new Wallet(procEnv.PRIVATE_KEY, l1Provider)

--- a/integration-tests/test/verifier.spec.ts
+++ b/integration-tests/test/verifier.spec.ts
@@ -1,0 +1,103 @@
+import { TransactionReceipt } from '@ethersproject/abstract-provider'
+
+import { expect } from './shared/setup'
+import { OptimismEnv } from './shared/env'
+import {
+  defaultTransactionFactory,
+  gasPriceForL2,
+  sleep,
+  envConfig,
+} from './shared/utils'
+
+describe('Verifier Tests', () => {
+  let env: OptimismEnv
+
+  before(async function () {
+    if (!envConfig.RUN_VERIFIER_TESTS) {
+      this.skip()
+      return
+    }
+
+    env = await OptimismEnv.new()
+  })
+
+  describe('Matching blocks', () => {
+    it('should sync a transaction', async () => {
+      const tx = defaultTransactionFactory()
+      tx.gasPrice = await gasPriceForL2()
+      const result = await env.l2Wallet.sendTransaction(tx)
+
+      let receipt: TransactionReceipt
+      while (!receipt) {
+        receipt = await env.verifierProvider.getTransactionReceipt(result.hash)
+        await sleep(200)
+      }
+
+      const sequencerBlock = (await env.l2Provider.getBlock(
+        result.blockNumber
+      )) as any
+
+      const verifierBlock = (await env.verifierProvider.getBlock(
+        result.blockNumber
+      )) as any
+
+      expect(sequencerBlock.stateRoot).to.deep.eq(verifierBlock.stateRoot)
+      expect(sequencerBlock.hash).to.deep.eq(verifierBlock.hash)
+    })
+
+    it('sync an unprotected tx (eip155)', async () => {
+      const tx = {
+        ...defaultTransactionFactory(),
+        nonce: await env.l2Wallet.getTransactionCount(),
+        gasPrice: await gasPriceForL2(),
+        chainId: null, // Disables EIP155 transaction signing.
+      }
+      const signed = await env.l2Wallet.signTransaction(tx)
+      const result = await env.l2Provider.sendTransaction(signed)
+
+      let receipt: TransactionReceipt
+      while (!receipt) {
+        receipt = await env.verifierProvider.getTransactionReceipt(result.hash)
+        await sleep(200)
+      }
+
+      const sequencerBlock = (await env.l2Provider.getBlock(
+        result.blockNumber
+      )) as any
+
+      const verifierBlock = (await env.verifierProvider.getBlock(
+        result.blockNumber
+      )) as any
+
+      expect(sequencerBlock.stateRoot).to.deep.eq(verifierBlock.stateRoot)
+      expect(sequencerBlock.hash).to.deep.eq(verifierBlock.hash)
+    })
+
+    it('should forward tx to sequencer', async () => {
+      const tx = {
+        ...defaultTransactionFactory(),
+        nonce: await env.l2Wallet.getTransactionCount(),
+        gasPrice: await gasPriceForL2(),
+      }
+      const signed = await env.l2Wallet.signTransaction(tx)
+      const result = await env.verifierProvider.sendTransaction(signed)
+
+      let receipt: TransactionReceipt
+      while (!receipt) {
+        receipt = await env.verifierProvider.getTransactionReceipt(result.hash)
+        await sleep(200)
+      }
+
+      const sequencerBlock = (await env.l2Provider.getBlock(
+        result.blockNumber
+      )) as any
+
+      const verifierBlock = (await env.verifierProvider.getBlock(
+        result.blockNumber
+      )) as any
+
+      expect(sequencerBlock.stateRoot).to.deep.eq(verifierBlock.stateRoot)
+      expect(sequencerBlock.hash).to.deep.eq(verifierBlock.hash)
+    })
+  })
+})

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       - l1_chain
       - deployer
       - dtl
+      - l2geth
     deploy:
       replicas: 0
     build:
@@ -146,6 +147,7 @@ services:
       - ./envs/geth.env
     environment:
         ETH1_HTTP: http://l1_chain:8545
+        SEQUENCER_CLIENT_HTTP: http://l2geth:8545
         ROLLUP_STATE_DUMP_PATH: http://deployer:8081/state-dump.latest.json
         ROLLUP_CLIENT_HTTP: http://dtl:7878
         ROLLUP_BACKEND: 'l1'


### PR DESCRIPTION
**Description**

Add verifier integration tests behind the env var
`RUN_VERIFIER_TESTS`. Note that this depends on the
batch submitter correctly submitting batches because
the verifier syncs from the batches submitted by the
batch submitter.

The verifier is not enabled by default with the
`docker-compose.yml` file. To enable it, the replicas
field must be updated from `0` to `1`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Fixes ENG-1911