### PR TITLE
ci: update version of changesets

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -65,7 +65,7 @@ jobs:
         run: yarn changeset version --snapshot
 
       - name: Publish To NPM
-        uses: changesets/action@master
+        uses: changesets/action@v1
         id: changesets
         with:
           publish: yarn changeset publish --tag canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn
 
       - name: Publish To NPM or Create Release Pull Request
-        uses: changesets/action@master
+        uses: changesets/action@v1
         id: changesets
         with:
           publish: yarn release


### PR DESCRIPTION
**Description**

Using the `@master` version has been deprecated
so this updates to `@v1`

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

