### PR TITLE
ci: decouple rpc-proxy publishing from l2geth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,14 +101,6 @@ jobs:
           push: true
           tags: ethereumoptimism/l2geth:${{ needs.release.outputs.l2geth }},ethereumoptimism/l2geth:latest
 
-      - name: Publish rpc-proxy
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./ops/docker/Dockerfile.rpc-proxy
-          push: true
-          tags: ethereumoptimism/rpc-proxy:${{ needs.release.outputs.l2geth }},ethereumoptimism/rpc-proxy:latest
-
   gas-oracle:
     name: Publish Gas Oracle Version ${{ needs.release.outputs.gas-oracle }}
     needs: release


### PR DESCRIPTION
**Description**

There is a changeset managed `rpc-proxy` publishing step
so we no longer need to publish `rpc-proxy` with `l2geth`.
This was originally added to quickly be able to publish
`rpc-proxy`

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


