### PR TITLE
l2geth: don't block read rpc when doing initial sync

### DIFF
--- a/.changeset/nasty-boats-type.md
+++ b/.changeset/nasty-boats-type.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Don't block read rpc requests when syncing

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -245,17 +245,16 @@ func (s *SyncService) Start() error {
 	if s.verifier {
 		go s.VerifierLoop()
 	} else {
-		// The sequencer must sync the transactions to the tip and the
-		// pending queue transactions on start before setting sync status
-		// to false and opening up the RPC to accept transactions.
-		if err := s.syncTransactionsToTip(); err != nil {
-			return fmt.Errorf("Sequencer cannot sync transactions to tip: %w", err)
-		}
-		if err := s.syncQueueToTip(); err != nil {
-			return fmt.Errorf("Sequencer cannot sync queue to tip: %w", err)
-		}
-		s.setSyncStatus(false)
-		go s.SequencerLoop()
+		go func() {
+			if err := s.syncTransactionsToTip(); err != nil {
+				log.Crit("Sequencer cannot sync transactions to tip: %w", err)
+			}
+			if err := s.syncQueueToTip(); err != nil {
+				log.Crit("Sequencer cannot sync queue to tip: %w", err)
+			}
+			s.setSyncStatus(false)
+			go s.SequencerLoop()
+		}()
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Allow for read requests during initial sync but
don't allow for write requests during initial sync.
This is done by spawning a goroutine so that the
initial sync logic is non-blocking.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

cc @smartcontracts 
