### PR TITLE
fix(contracts): remove broken link in README

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -9,8 +9,6 @@ Within each contract file you'll find a comment that lists:
 1. The compiler with which a contract is intended to be compiled, `solc` or `optimistic-solc`.
 2. The network upon to which the contract will be deployed, `OVM` or `EVM`.
 
-A more detailed overview of these contracts can be found on the [community hub](http://community.optimism.io/docs/protocol/protocol.html#system-overview).
-
 <!-- TODO: Add link to final contract docs here when finished. -->
 
 ## Usage (npm)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes a broken link in the contracts README. The referenced page no longer exists.

**Metadata**
- Fixes #2082
