### PR TITLE
test: improves test coverage for address aliasing in core utils

### DIFF
--- a/packages/core-utils/test/alias.spec.ts
+++ b/packages/core-utils/test/alias.spec.ts
@@ -18,7 +18,7 @@ describe('address aliasing utils', () => {
     it('should throw if the input is not a valid address', () => {
       expect(() => {
         applyL1ToL2Alias('0x1234')
-      }).to.throw
+      }).to.throw('not a valid address: 0x1234')
     })
   })
 
@@ -38,7 +38,7 @@ describe('address aliasing utils', () => {
     it('should throw if the input is not a valid address', () => {
       expect(() => {
         undoL1ToL2Alias('0x1234')
-      }).to.throw
+      }).to.throw('not a valid address: 0x1234')
     })
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Improve test coverage for address aliasing utils in core-utills alias.spec.ts

**Additional context**
- add error messages to check against on lines 21 - 41

**Metadata**
- Fixes #2054
