### PR TITLE
fix(sdk): clean up tx override api

### DIFF
--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -10,7 +10,6 @@ import {
   CrossChainMessageRequest,
   ICrossChainMessenger,
   ICrossChainProvider,
-  L1ToL2Overrides,
   MessageLike,
   NumberLike,
   MessageDirection,
@@ -42,9 +41,12 @@ export class CrossChainMessenger implements ICrossChainMessenger {
 
   public async sendMessage(
     message: CrossChainMessageRequest,
-    overrides?: L1ToL2Overrides
+    opts?: {
+      l2GasLimit?: NumberLike
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse> {
-    const tx = await this.populateTransaction.sendMessage(message, overrides)
+    const tx = await this.populateTransaction.sendMessage(message, opts)
     if (message.direction === MessageDirection.L1_TO_L2) {
       return this.l1Signer.sendTransaction(tx)
     } else {
@@ -55,46 +57,58 @@ export class CrossChainMessenger implements ICrossChainMessenger {
   public async resendMessage(
     message: MessageLike,
     messageGasLimit: NumberLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse> {
     return this.l1Signer.sendTransaction(
       await this.populateTransaction.resendMessage(
         message,
         messageGasLimit,
-        overrides
+        opts
       )
     )
   }
 
   public async finalizeMessage(
     message: MessageLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse> {
     throw new Error('Not implemented')
   }
 
   public async depositETH(
     amount: NumberLike,
-    overrides?: L1ToL2Overrides
+    opts?: {
+      l2GasLimit?: NumberLike
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse> {
     return this.l1Signer.sendTransaction(
-      await this.populateTransaction.depositETH(amount, overrides)
+      await this.populateTransaction.depositETH(amount, opts)
     )
   }
 
   public async withdrawETH(
     amount: NumberLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse> {
     return this.l2Signer.sendTransaction(
-      await this.populateTransaction.withdrawETH(amount, overrides)
+      await this.populateTransaction.withdrawETH(amount, opts)
     )
   }
 
   populateTransaction = {
     sendMessage: async (
       message: CrossChainMessageRequest,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest> => {
       if (message.direction === MessageDirection.L1_TO_L2) {
         return this.provider.contracts.l1.L1CrossDomainMessenger.connect(
@@ -102,9 +116,9 @@ export class CrossChainMessenger implements ICrossChainMessenger {
         ).populateTransaction.sendMessage(
           message.target,
           message.message,
-          overrides?.l2GasLimit ||
+          opts?.l2GasLimit ||
             (await this.provider.estimateL2MessageGasLimit(message)),
-          omit(overrides || {}, 'l2GasLimit')
+          omit(opts?.overrides || {}, 'l2GasLimit')
         )
       } else {
         return this.provider.contracts.l2.L2CrossDomainMessenger.connect(
@@ -113,7 +127,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
           message.target,
           message.message,
           0, // Gas limit goes unused when sending from L2 to L1
-          omit(overrides || {}, 'l2GasLimit')
+          omit(opts?.overrides || {}, 'l2GasLimit')
         )
       }
     },
@@ -121,7 +135,9 @@ export class CrossChainMessenger implements ICrossChainMessenger {
     resendMessage: async (
       message: MessageLike,
       messageGasLimit: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest> => {
       const resolved = await this.provider.toCrossChainMessage(message)
       if (resolved.direction === MessageDirection.L2_TO_L1) {
@@ -137,26 +153,31 @@ export class CrossChainMessenger implements ICrossChainMessenger {
         resolved.messageNonce,
         resolved.gasLimit,
         messageGasLimit,
-        overrides || {}
+        opts?.overrides || {}
       )
     },
 
     finalizeMessage: async (
       message: MessageLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest> => {
       throw new Error('Not implemented')
     },
 
     depositETH: async (
       amount: NumberLike,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest> => {
       return this.provider.contracts.l1.L1StandardBridge.populateTransaction.depositETH(
-        overrides?.l2GasLimit || 200000, // 200k gas is fine as a default
+        opts?.l2GasLimit || 200000, // 200k gas is fine as a default
         '0x', // No data
         {
-          ...omit(overrides || {}, 'l2GasLimit', 'value'),
+          ...omit(opts?.overrides || {}, 'l2GasLimit', 'value'),
           value: amount,
         }
       )
@@ -164,14 +185,16 @@ export class CrossChainMessenger implements ICrossChainMessenger {
 
     withdrawETH: async (
       amount: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest> => {
       return this.provider.contracts.l2.L2StandardBridge.populateTransaction.withdraw(
         predeploys.OVM_ETH,
         amount,
         0, // No need to supply gas here
         '0x', // No data,
-        overrides || {}
+        opts?.overrides || {}
       )
     },
   }
@@ -179,9 +202,12 @@ export class CrossChainMessenger implements ICrossChainMessenger {
   estimateGas = {
     sendMessage: async (
       message: CrossChainMessageRequest,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<BigNumber> => {
-      const tx = await this.populateTransaction.sendMessage(message, overrides)
+      const tx = await this.populateTransaction.sendMessage(message, opts)
       if (message.direction === MessageDirection.L1_TO_L2) {
         return this.provider.l1Provider.estimateGas(tx)
       } else {
@@ -192,36 +218,45 @@ export class CrossChainMessenger implements ICrossChainMessenger {
     resendMessage: async (
       message: MessageLike,
       messageGasLimit: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<BigNumber> => {
       const tx = await this.populateTransaction.resendMessage(
         message,
         messageGasLimit,
-        overrides
+        opts
       )
       return this.provider.l1Provider.estimateGas(tx)
     },
 
     finalizeMessage: async (
       message: MessageLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<BigNumber> => {
       throw new Error('Not implemented')
     },
 
     depositETH: async (
       amount: NumberLike,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<BigNumber> => {
-      const tx = await this.populateTransaction.depositETH(amount, overrides)
+      const tx = await this.populateTransaction.depositETH(amount, opts)
       return this.provider.l1Provider.estimateGas(tx)
     },
 
     withdrawETH: async (
       amount: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<BigNumber> => {
-      const tx = await this.populateTransaction.withdrawETH(amount, overrides)
+      const tx = await this.populateTransaction.withdrawETH(amount, opts)
       return this.provider.l2Provider.estimateGas(tx)
     },
   }

--- a/packages/sdk/src/interfaces/cross-chain-erc20-pair.ts
+++ b/packages/sdk/src/interfaces/cross-chain-erc20-pair.ts
@@ -4,7 +4,7 @@ import {
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
 
-import { NumberLike, L1ToL2Overrides } from './types'
+import { NumberLike } from './types'
 import { ICrossChainMessenger } from './cross-chain-messenger'
 
 /**
@@ -30,24 +30,32 @@ export interface ICrossChainERC20Pair {
    * Deposits some tokens into the L2 chain.
    *
    * @param amount Amount of the token to deposit.
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the deposit transaction.
    */
   deposit(
     amount: NumberLike,
-    overrides?: L1ToL2Overrides
+    opts?: {
+      l2GasLimit?: NumberLike
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
    * Withdraws some tokens back to the L1 chain.
    *
    * @param amount Amount of the token to withdraw.
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the withdraw transaction.
    */
   withdraw(
     amount: NumberLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
@@ -59,24 +67,32 @@ export interface ICrossChainERC20Pair {
      * Generates a transaction for depositing some tokens into the L2 chain.
      *
      * @param amount Amount of the token to deposit.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to deposit the tokens.
      */
     deposit(
       amount: NumberLike,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<TransactionResponse>
 
     /**
      * Generates a transaction for withdrawing some tokens back to the L1 chain.
      *
      * @param amount Amount of the token to withdraw.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to withdraw the tokens.
      */
     withdraw(
       amount: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest>
   }
 
@@ -89,24 +105,32 @@ export interface ICrossChainERC20Pair {
      * Estimates gas required to deposit some tokens into the L2 chain.
      *
      * @param amount Amount of the token to deposit.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to deposit the tokens.
      */
     deposit(
       amount: NumberLike,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<TransactionResponse>
 
     /**
      * Estimates gas required to withdraw some tokens back to the L1 chain.
      *
      * @param amount Amount of the token to withdraw.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to withdraw the tokens.
      */
     withdraw(
       amount: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest>
   }
 }

--- a/packages/sdk/src/interfaces/cross-chain-messenger.ts
+++ b/packages/sdk/src/interfaces/cross-chain-messenger.ts
@@ -4,12 +4,7 @@ import {
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
 
-import {
-  MessageLike,
-  NumberLike,
-  CrossChainMessageRequest,
-  L1ToL2Overrides,
-} from './types'
+import { MessageLike, NumberLike, CrossChainMessageRequest } from './types'
 import { ICrossChainProvider } from './cross-chain-provider'
 
 /**
@@ -36,12 +31,17 @@ export interface ICrossChainMessenger {
    * to the message itself.
    *
    * @param message Cross chain message to send.
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the message sending transaction.
    */
   sendMessage(
     message: CrossChainMessageRequest,
-    overrides?: L1ToL2Overrides
+    opts?: {
+      l2GasLimit?: NumberLike
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
@@ -50,13 +50,16 @@ export interface ICrossChainMessenger {
    *
    * @param message Cross chain message to resend.
    * @param messageGasLimit New gas limit to use for the message.
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the message resending transaction.
    */
   resendMessage(
     message: MessageLike,
     messageGasLimit: NumberLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
@@ -64,36 +67,47 @@ export interface ICrossChainMessenger {
    * messages. Will throw an error if the message has not completed its challenge period yet.
    *
    * @param message Message to finalize.
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the finalization transaction.
    */
   finalizeMessage(
     message: MessageLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
    * Deposits some ETH into the L2 chain.
    *
    * @param amount Amount of ETH to deposit (in wei).
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the deposit transaction.
    */
   depositETH(
     amount: NumberLike,
-    overrides?: L1ToL2Overrides
+    opts?: {
+      l2GasLimit?: NumberLike
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
    * Withdraws some ETH back to the L1 chain.
    *
    * @param amount Amount of ETH to withdraw.
-   * @param overrides Optional transaction overrides.
+   * @param opts Additional options.
+   * @param opts.overrides Optional transaction overrides.
    * @returns Transaction response for the withdraw transaction.
    */
   withdrawETH(
     amount: NumberLike,
-    overrides?: Overrides
+    opts?: {
+      overrides?: Overrides
+    }
   ): Promise<TransactionResponse>
 
   /**
@@ -106,12 +120,17 @@ export interface ICrossChainMessenger {
      * and executed by a signer.
      *
      * @param message Cross chain message to send.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to send the message.
      */
     sendMessage: (
       message: CrossChainMessageRequest,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ) => Promise<TransactionRequest>
 
     /**
@@ -120,13 +139,16 @@ export interface ICrossChainMessenger {
      *
      * @param message Cross chain message to resend.
      * @param messageGasLimit New gas limit to use for the message.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to resend the message.
      */
     resendMessage(
       message: MessageLike,
       messageGasLimit: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest>
 
     /**
@@ -135,36 +157,47 @@ export interface ICrossChainMessenger {
      * its challenge period yet.
      *
      * @param message Message to generate the finalization transaction for.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to finalize the message.
      */
     finalizeMessage(
       message: MessageLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest>
 
     /**
      * Generates a transaction for depositing some ETH into the L2 chain.
      *
      * @param amount Amount of ETH to deposit.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to deposit the ETH.
      */
     depositETH(
       amount: NumberLike,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest>
 
     /**
      * Generates a transaction for withdrawing some ETH back to the L1 chain.
      *
      * @param amount Amount of ETH to withdraw.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to withdraw the tokens.
      */
     withdrawETH(
       amount: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<TransactionRequest>
   }
 
@@ -177,12 +210,17 @@ export interface ICrossChainMessenger {
      * Estimates gas required to send a cross chain message.
      *
      * @param message Cross chain message to send.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to send the message.
      */
     sendMessage: (
       message: CrossChainMessageRequest,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ) => Promise<BigNumber>
 
     /**
@@ -190,46 +228,63 @@ export interface ICrossChainMessenger {
      *
      * @param message Cross chain message to resend.
      * @param messageGasLimit New gas limit to use for the message.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to resend the message.
      */
     resendMessage(
       message: MessageLike,
       messageGasLimit: NumberLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<BigNumber>
 
     /**
      * Estimates gas required to finalize a cross chain message. Only applies to L2 to L1 messages.
      *
      * @param message Message to generate the finalization transaction for.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to finalize the message.
      */
     finalizeMessage(
       message: MessageLike,
-      overrides?: Overrides
+      opts?: {
+        overrides?: Overrides
+      }
     ): Promise<BigNumber>
 
     /**
      * Estimates gas required to deposit some ETH into the L2 chain.
      *
      * @param amount Amount of ETH to deposit.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.l2GasLimit Optional gas limit to use for the transaction on L2.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to deposit the ETH.
      */
     depositETH(
       amount: NumberLike,
-      overrides?: L1ToL2Overrides
+      opts?: {
+        l2GasLimit?: NumberLike
+        overrides?: Overrides
+      }
     ): Promise<BigNumber>
 
     /**
      * Estimates gas required to withdraw some ETH back to the L1 chain.
      *
      * @param amount Amount of ETH to withdraw.
-     * @param overrides Optional transaction overrides.
+     * @param opts Additional options.
+     * @param opts.overrides Optional transaction overrides.
      * @returns Transaction that can be signed and executed to withdraw the tokens.
      */
-    withdrawETH(amount: NumberLike, overrides?: Overrides): Promise<BigNumber>
+    withdrawETH(
+      amount: NumberLike,
+      opts?: {
+        overrides?: Overrides
+      }
+    ): Promise<BigNumber>
   }
 }

--- a/packages/sdk/src/interfaces/types.ts
+++ b/packages/sdk/src/interfaces/types.ts
@@ -4,7 +4,7 @@ import {
   TransactionResponse,
 } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
-import { Contract, BigNumber, Overrides } from 'ethers'
+import { Contract, BigNumber } from 'ethers'
 
 /**
  * L1 contract references.
@@ -227,15 +227,6 @@ export interface StateRootBatch {
   blockNumber: number
   header: StateRootBatchHeader
   stateRoots: string[]
-}
-
-/**
- * Extended Ethers overrides object with an l2GasLimit field.
- * Only meant to be used for L1 to L2 messages, since L2 to L1 messages don't have a specified gas
- * limit field (gas used depends on the amount of gas provided).
- */
-export type L1ToL2Overrides = Overrides & {
-  l2GasLimit?: NumberLike
 }
 
 /**


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Slightly cleans up the API for overriding transaction options. Previous
API was a bit confusing and didn't leave room for additional optional
parameters. By separating options and overrides, we can add new options
that are unrelated to transaction overrides.