### PR TITLE
fix(bss): have BSS correctly create new contexts

### DIFF
--- a/.changeset/shaggy-stingrays-compare.md
+++ b/.changeset/shaggy-stingrays-compare.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter': patch
+---
+
+Adds a fix for the BSS to account for new timestamp logic in L2Geth

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -685,10 +685,18 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       queued: BatchElement[]
     }> = []
     for (const block of blocks) {
+      // Create a new context in certain situations
       if (
-        (lastBlockIsSequencerTx === false && block.isSequencerTx === true) ||
+        // If there are no contexts yet, create a new context.
         groupedBlocks.length === 0 ||
-        (block.timestamp !== lastTimestamp && block.isSequencerTx === true) ||
+        // If the last block was an L1 to L2 transaction, but the next block is a Sequencer
+        // transaction, create a new context.
+        (lastBlockIsSequencerTx === false && block.isSequencerTx === true) ||
+        // If the timestamp of the last block differs from the timestamp of the current block,
+        // create a new context. Applies to both L1 to L2 transactions and Sequencer transactions.
+        block.timestamp !== lastTimestamp ||
+        // If the block number of the last block differs from the block number of the current block,
+        // create a new context. ONLY applies to Sequencer transactions.
         (block.blockNumber !== lastBlockNumber && block.isSequencerTx === true)
       ) {
         groupedBlocks.push({
@@ -696,6 +704,7 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
           queued: [],
         })
       }
+
       const cur = groupedBlocks.length - 1
       block.isSequencerTx
         ? groupedBlocks[cur].sequenced.push(block)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug in the batch submitter where new contexts were not being
correctly created for L1 to L2 transactions with a different timestamp.
This bug exists because of recent changes to L2Geth where timestamps are
now being updated more frequently.
