### PR TITLE
test: improve test coverage for aliasing

### DIFF
--- a/packages/core-utils/test/alias.spec.ts
+++ b/packages/core-utils/test/alias.spec.ts
@@ -18,7 +18,7 @@ describe('address aliasing utils', () => {
     it('should throw if the input is not a valid address', () => {
       expect(() => {
         applyL1ToL2Alias('0x1234')
-      }).to.throw
+      }).to.throw('not a valid address: 0x1234')
     })
   })
 
@@ -38,7 +38,7 @@ describe('address aliasing utils', () => {
     it('should throw if the input is not a valid address', () => {
       expect(() => {
         undoL1ToL2Alias('0x1234')
-      }).to.throw
+      }).to.throw('not a valid address: 0x1234')
     })
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This commit improves the test coverage for address aliasing to 100% in packages/core-utils/alias.spec.ts

**Additional context**
- added two additional error messages to check against

**Metadata**
- Fixes #2054
