### PR TITLE
go/batch-submitter: Downgrade Alpine version

### DIFF
--- a/ops/docker/Dockerfile.batch-submitter-service
+++ b/ops/docker/Dockerfile.batch-submitter-service
@@ -1,4 +1,4 @@
-FROM golang:1.17.6-alpine3.15 as builder
+FROM golang:1.17.3-alpine3.13 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
@@ -9,7 +9,7 @@ RUN go mod graph | grep -v l2geth | awk '{if ($1 !~ "@") print $2}' | xargs -n 1
 COPY ./go/batch-submitter/ ./
 RUN make
 
-FROM alpine:3.15
+FROM alpine:3.13
 
 RUN apk add --no-cache ca-certificates jq curl
 COPY --from=builder /go/batch-submitter/batch-submitter /usr/local/bin/


### PR DESCRIPTION
Alpine 3.14 has an issue (https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2) that prevents it from working on CircleCI at this time.
