### PR TITLE
l2geth: fix startup logic for repairing queue index

### DIFF
--- a/.changeset/quick-tables-double.md
+++ b/.changeset/quick-tables-double.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fix queue index comparison

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -348,10 +348,10 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 			qi := tx.GetMeta().QueueIndex
 			// When the queue index is set
 			if qi != nil {
-				if qi == queueIndex {
-					log.Info("Found correct staring queue index", "queue-index", qi)
+				if *qi == *queueIndex {
+					log.Info("Found correct staring queue index", "queue-index", *qi)
 				} else {
-					log.Info("Found incorrect staring queue index, fixing", "old", queueIndex, "new", qi)
+					log.Info("Found incorrect staring queue index, fixing", "old", *queueIndex, "new", *qi)
 					queueIndex = qi
 				}
 				break


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fix a comparison on startup


