### PR TITLE
fix: actually allow BSS log level to be set via flags

### DIFF
--- a/.changeset/happy-poems-impress.md
+++ b/.changeset/happy-poems-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+---
+
+fix BSS log-level flag parsing

--- a/go/batch-submitter/config.go
+++ b/go/batch-submitter/config.go
@@ -190,6 +190,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		SafeMinimumEtherBalance: ctx.GlobalUint64(flags.SafeMinimumEtherBalanceFlag.Name),
 		ClearPendingTxs:         ctx.GlobalBool(flags.ClearPendingTxsFlag.Name),
 		/* Optional Flags */
+		LogLevel:            ctx.GlobalString(flags.LogLevelFlag.Name),
 		SentryEnable:        ctx.GlobalBool(flags.SentryEnableFlag.Name),
 		SentryDsn:           ctx.GlobalString(flags.SentryDsnFlag.Name),
 		SentryTraceRate:     ctx.GlobalDuration(flags.SentryTraceRateFlag.Name),
@@ -217,10 +218,6 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 // ensure that it is well-formed.
 func ValidateConfig(cfg *Config) error {
 	// Sanity check log level.
-	if cfg.LogLevel == "" {
-		cfg.LogLevel = "debug"
-	}
-
 	_, err := log.LvlFromString(cfg.LogLevel)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Description**
This was a known bug, but recently caught the reason in combing through
the new copy in the specs repo. The old hack that auto defaulted to
debug has been removed.

**Metadata**
- Fixes ENG-1935