### PR TITLE
fix: have sdk use ethers peer dep

### DIFF
--- a/.changeset/yellow-steaks-trade.md
+++ b/.changeset/yellow-steaks-trade.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Have SDK include ethers as a peer dependency

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,6 +31,8 @@
     "url": "https://github.com/ethereum-optimism/optimism-monorepo.git"
   },
   "devDependencies": {
+    "@ethersproject/abstract-provider": "^5.5.1",
+    "@ethersproject/abstract-signer": "^5.5.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/chai": "^4.2.18",
@@ -50,6 +52,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-unicorn": "^32.0.1",
     "ethereum-waffle": "^3.4.0",
+    "ethers": "^5.5.4",
     "hardhat": "^2.3.0",
     "lint-staged": "11.0.0",
     "mocha": "^8.4.0",
@@ -61,10 +64,10 @@
   "dependencies": {
     "@eth-optimism/contracts": "0.5.11",
     "@eth-optimism/core-utils": "0.7.5",
-    "@ethersproject/abstract-provider": "^5.5.1",
-    "@ethersproject/abstract-signer": "^5.5.0",
-    "ethers": "^5.5.4",
     "merkletreejs": "^0.2.27",
     "rlp": "^2.2.7"
+  },
+  "peerDependencies": {
+    "ethers": "^5"
   }
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Minor bugfix, has SDK use ethers as a peer dependency instead of including as a direct dependency. This helps with certain ethers-specific typing issues.
