### PR TITLE
dtl: handle errors in context api

### DIFF
--- a/.changeset/warm-news-punch.md
+++ b/.changeset/warm-news-punch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Handle case where the remote block isn't found for `GET /eth/context/latest` and `GET /eth/context/blocknumber/:number`

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -340,6 +340,9 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         const blockNumber = Math.max(0, tip - this.options.confirmations)
 
         const block = await this.state.l1RpcProvider.getBlock(blockNumber)
+        if (block === null) {
+          throw new Error(`Cannot GET /eth/context/latest at ${blockNumber}`)
+        }
 
         return {
           blockNumber: block.number,
@@ -366,6 +369,10 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         }
 
         const block = await this.state.l1RpcProvider.getBlock(number)
+        if (block === null) {
+          throw new Error(`Cannot GET /eth/context/blocknumber/${number}`)
+        }
+
         return {
           blockNumber: block.number,
           timestamp: block.timestamp,


### PR DESCRIPTION
**Description**

Both `GET /eth/context/latest` and `GET /eth/context/blocknumber/:number`
rely on fetching a remote block to pull the timestamp, blocknumber and
blockhash from. If the fetched block is not found, then properties on
`null` will be attempted to be accessed which will result in a runtime
error. This commit adds handling for this case to prevent that kind of
bug.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

