### PR TITLE
integration-tests: Support networks that aren't specified in the SDK

### DIFF
--- a/.changeset/short-news-cover.md
+++ b/.changeset/short-news-cover.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Support non-well-known networks

--- a/integration-tests/actor-tests/sends.test.ts
+++ b/integration-tests/actor-tests/sends.test.ts
@@ -1,4 +1,4 @@
-import { utils, Wallet, BigNumber } from 'ethers'
+import { utils, Wallet } from 'ethers'
 import { expect } from 'chai'
 
 import { actor, setupRun, setupActor, run } from './lib/convenience'
@@ -34,6 +34,6 @@ actor('Value sender', () => {
         value: 0x42,
       })
     })
-    expect(await randWallet.getBalance()).to.deep.equal(BigNumber.from(0x42))
+    expect((await randWallet.getBalance()).toString()).to.deep.equal('66')
   })
 })


### PR DESCRIPTION
The SDK expects all L1 contracts to be specified if the L1 chain ID isn't well-known. This PR makes the integration test setup always specify the L1 contracts, since networks like the nightly don't use a well-known chain ID.
