### PR TITLE
feat(itests): remove Watcher from fundUser

### DIFF
--- a/integration-tests/test/native-eth-ovm-calls.spec.ts
+++ b/integration-tests/test/native-eth-ovm-calls.spec.ts
@@ -38,7 +38,7 @@ describe('Native ETH value integration tests', () => {
     }
 
     const value = ethers.utils.parseEther('0.01')
-    await fundUser(env.watcher, env.l1Bridge, value, wallet.address)
+    await fundUser(env.messenger, value, wallet.address)
 
     const initialBalances = await getBalances()
 
@@ -156,12 +156,7 @@ describe('Native ETH value integration tests', () => {
     beforeEach(async () => {
       ValueCalls0 = await Factory__ValueCalls.deploy()
       ValueCalls1 = await Factory__ValueCalls.deploy()
-      await fundUser(
-        env.watcher,
-        env.l1Bridge,
-        initialBalance0,
-        ValueCalls0.address
-      )
+      await fundUser(env.messenger, initialBalance0, ValueCalls0.address)
       // These tests ass assume ValueCalls0 starts with a balance, but ValueCalls1 does not.
       await checkBalances([initialBalance0, 0])
     })
@@ -203,12 +198,7 @@ describe('Native ETH value integration tests', () => {
     it('should have the correct ovmSELFBALANCE which includes the msg.value', async () => {
       // give an initial balance which the ovmCALLVALUE should be added to when calculating ovmSELFBALANCE
       const initialBalance = 10
-      await fundUser(
-        env.watcher,
-        env.l1Bridge,
-        initialBalance,
-        ValueCalls1.address
-      )
+      await fundUser(env.messenger, initialBalance, ValueCalls1.address)
 
       const sendAmount = 15
       const [success, returndata] = await ValueCalls0.callStatic.sendWithData(

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -219,7 +219,7 @@ describe('Basic RPC tests', () => {
       // Fund account to call from
       const from = wallet.address
       const value = 15
-      await fundUser(env.watcher, env.l1Bridge, value, from)
+      await fundUser(env.messenger, value, from)
 
       // Do the call and check msg.value
       const data = ValueContext.interface.encodeFunctionData('getCallValue')

--- a/integration-tests/test/stress-tests.spec.ts
+++ b/integration-tests/test/stress-tests.spec.ts
@@ -47,12 +47,7 @@ describe('stress tests', () => {
     }
 
     for (const wallet of wallets) {
-      await fundUser(
-        env.watcher,
-        env.l1Bridge,
-        utils.parseEther('0.1'),
-        wallet.address
-      )
+      await fundUser(env.messenger, utils.parseEther('0.1'), wallet.address)
     }
   })
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This commit removes the deprecated Watcher class from the fundUser
function in favor of using the CrossChainMessenger class from the new
Optimism SDK. This is part of a series of commits that are designed to
eventually remove the Watcher entirely from the integration tests (and
then from the entire repository).
