### PR TITLE
test(integration): replace watcher with sdk CrossChainMessenger

### DIFF
--- a/.changeset/fresh-planes-report.md
+++ b/.changeset/fresh-planes-report.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Remove Watcher usage from itests

--- a/integration-tests/actor-tests/deposits.test.ts
+++ b/integration-tests/actor-tests/deposits.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai'
 
 import { setupActor, setupRun, actor, run } from './lib/convenience'
 import { OptimismEnv } from '../test/shared/env'
-import { Direction } from '../test/shared/watcher-utils'
 
 interface BenchContext {
   l1Wallet: Wallet
@@ -42,8 +41,7 @@ actor('Funds depositor', () => {
           .depositETH(DEFAULT_TEST_GAS_L2, '0xFFFF', {
             value: 0x42,
             gasLimit: DEFAULT_TEST_GAS_L1,
-          }),
-        Direction.L1ToL2
+          })
       )
     })
     expect((await l2Wallet.getBalance()).sub(balBefore)).to.deep.equal(

--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -7,7 +7,6 @@ import { predeploys, getContractFactory } from '@eth-optimism/contracts'
 import { expect } from './shared/setup'
 import { hardhatTest } from './shared/utils'
 import { OptimismEnv } from './shared/env'
-import { Direction } from './shared/watcher-utils'
 
 const setPrices = async (env: OptimismEnv, value: number | BigNumber) => {
   const gasPrice = await env.gasPriceOracle.setGasPrice(value)
@@ -171,7 +170,7 @@ describe('Fee Payment Integration Tests', async () => {
       // Wait for the withdrawal to be relayed to L1.
       await withdrawTx.wait()
       await env.relayXDomainMessages(withdrawTx)
-      await env.waitForXDomainTransaction(withdrawTx, Direction.L2ToL1)
+      await env.waitForXDomainTransaction(withdrawTx)
 
       // Balance difference should be equal to old L2 balance.
       const balanceAfter = await env.l1Wallet.provider.getBalance(l1FeeWallet)

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -6,7 +6,6 @@ import { expectApprox } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import { expect } from './shared/setup'
-import { Direction } from './shared/watcher-utils'
 import {
   DEFAULT_TEST_GAS_L1,
   DEFAULT_TEST_GAS_L2,
@@ -71,8 +70,7 @@ describe('Native ETH Integration Tests', async () => {
         to: env.l1Bridge.address,
         value: depositAmount,
         gasLimit: DEFAULT_TEST_GAS_L1,
-      }),
-      Direction.L1ToL2
+      })
     )
 
     const l1FeePaid = receipt.gasUsed.mul(tx.gasPrice)
@@ -96,8 +94,7 @@ describe('Native ETH Integration Tests', async () => {
       env.l1Bridge.depositETH(DEFAULT_TEST_GAS_L2, '0xFFFF', {
         value: depositAmount,
         gasLimit: DEFAULT_TEST_GAS_L1,
-      }),
-      Direction.L1ToL2
+      })
     )
 
     const l1FeePaid = receipt.gasUsed.mul(tx.gasPrice)
@@ -121,8 +118,7 @@ describe('Native ETH Integration Tests', async () => {
       env.l1Bridge.depositETHTo(l2Bob.address, DEFAULT_TEST_GAS_L2, '0xFFFF', {
         value: depositAmount,
         gasLimit: DEFAULT_TEST_GAS_L1,
-      }),
-      Direction.L1ToL2
+      })
     )
 
     const l1FeePaid = depositReceipts.receipt.gasUsed.mul(
@@ -152,8 +148,7 @@ describe('Native ETH Integration Tests', async () => {
       env.l1Bridge.depositETH(ASSUMED_L2_GAS_LIMIT, data, {
         value: depositAmount,
         gasLimit: 4_000_000,
-      }),
-      Direction.L1ToL2
+      })
     )
 
     const l1FeePaid = receipt.gasUsed.mul(tx.gasPrice)
@@ -196,10 +191,7 @@ describe('Native ETH Integration Tests', async () => {
     )
     await transaction.wait()
     await env.relayXDomainMessages(transaction)
-    const receipts = await env.waitForXDomainTransaction(
-      transaction,
-      Direction.L2ToL1
-    )
+    const receipts = await env.waitForXDomainTransaction(transaction)
     const fee = receipts.tx.gasLimit.mul(receipts.tx.gasPrice)
 
     const postBalances = await getBalances(env)
@@ -242,10 +234,7 @@ describe('Native ETH Integration Tests', async () => {
 
     await transaction.wait()
     await env.relayXDomainMessages(transaction)
-    const receipts = await env.waitForXDomainTransaction(
-      transaction,
-      Direction.L2ToL1
-    )
+    const receipts = await env.waitForXDomainTransaction(transaction)
 
     const l2Fee = receipts.tx.gasPrice.mul(receipts.receipt.gasUsed)
 
@@ -289,8 +278,7 @@ describe('Native ETH Integration Tests', async () => {
         env.l1Bridge.depositETH(DEFAULT_TEST_GAS_L2, '0xFFFF', {
           value: amount,
           gasLimit: DEFAULT_TEST_GAS_L1,
-        }),
-        Direction.L1ToL2
+        })
       )
 
       // 2. transfer to another address
@@ -317,10 +305,7 @@ describe('Native ETH Integration Tests', async () => {
         )
       await transaction.wait()
       await env.relayXDomainMessages(transaction)
-      const receipts = await env.waitForXDomainTransaction(
-        transaction,
-        Direction.L2ToL1
-      )
+      const receipts = await env.waitForXDomainTransaction(transaction)
 
       // Compute the L1 portion of the fee
       const l1Fee = await env.gasPriceOracle.getL1Fee(

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -14,7 +14,6 @@ import {
   DEFAULT_TEST_GAS_L1,
 } from './shared/utils'
 import { OptimismEnv } from './shared/env'
-import { Direction } from './shared/watcher-utils'
 
 /**
  * These tests cover the OVM execution contexts. In the OVM execution
@@ -63,7 +62,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
 
       // Wait for the transaction to be sent over to L2.
       await tx.wait()
-      const pair = await env.waitForXDomainTransaction(tx, Direction.L1ToL2)
+      const pair = await env.waitForXDomainTransaction(tx)
 
       // Get the L1 block that the enqueue transaction was in so that
       // the timestamp can be compared against the layer two contract

--- a/integration-tests/test/queue-ingestion.spec.ts
+++ b/integration-tests/test/queue-ingestion.spec.ts
@@ -6,7 +6,6 @@ import { asL2Provider } from '@eth-optimism/sdk'
 /* Imports: External */
 import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
-import { Direction } from './shared/watcher-utils'
 import { DEFAULT_TEST_GAS_L1, envConfig } from './shared/utils'
 
 describe('Queue Ingestion', () => {
@@ -42,10 +41,7 @@ describe('Queue Ingestion', () => {
     for (let i = 0; i < numTxs; i++) {
       const l1Tx = txs[i]
       const l1TxReceipt = await txs[i].wait()
-      const receipt = await env.waitForXDomainTransaction(
-        l1Tx,
-        Direction.L1ToL2
-      )
+      const receipt = await env.waitForXDomainTransaction(l1Tx)
       const l2Tx = (await l2Provider.getTransaction(
         receipt.remoteTx.hash
       )) as any

--- a/integration-tests/test/shared/stress-test-helpers.ts
+++ b/integration-tests/test/shared/stress-test-helpers.ts
@@ -4,7 +4,6 @@ import { sleep } from '@eth-optimism/core-utils'
 
 /* Imports: Internal */
 import { OptimismEnv } from './env'
-import { Direction } from './watcher-utils'
 import { gasPriceForL1, gasPriceForL2 } from './utils'
 
 interface TransactionParams {
@@ -52,7 +51,7 @@ export const executeL1ToL2Transaction = async (
         }
       )
   )
-  await env.waitForXDomainTransaction(receipt, Direction.L1ToL2)
+  await env.waitForXDomainTransaction(receipt)
 }
 
 export const executeL2ToL1Transaction = async (
@@ -78,7 +77,7 @@ export const executeL2ToL1Transaction = async (
   )
 
   await env.relayXDomainMessages(receipt)
-  await env.waitForXDomainTransaction(receipt, Direction.L2ToL1)
+  await env.waitForXDomainTransaction(receipt)
 }
 
 export const executeL2Transaction = async (

--- a/integration-tests/test/shared/watcher-utils.ts
+++ b/integration-tests/test/shared/watcher-utils.ts
@@ -1,33 +1,9 @@
 import {
-  JsonRpcProvider,
   TransactionReceipt,
   TransactionResponse,
 } from '@ethersproject/providers'
-import { Watcher } from '@eth-optimism/core-utils'
-import { Contract, Transaction } from 'ethers'
-
-export const initWatcher = async (
-  l1Provider: JsonRpcProvider,
-  l2Provider: JsonRpcProvider,
-  AddressManager: Contract
-) => {
-  const l1MessengerAddress = await AddressManager.getAddress(
-    'Proxy__OVM_L1CrossDomainMessenger'
-  )
-  const l2MessengerAddress = await AddressManager.getAddress(
-    'L2CrossDomainMessenger'
-  )
-  return new Watcher({
-    l1: {
-      provider: l1Provider,
-      messengerAddress: l1MessengerAddress,
-    },
-    l2: {
-      provider: l2Provider,
-      messengerAddress: l2MessengerAddress,
-    },
-  })
-}
+import { Transaction } from 'ethers'
+import { CrossChainMessenger, MessageDirection } from '@eth-optimism/sdk'
 
 export interface CrossDomainMessagePair {
   tx: Transaction
@@ -42,41 +18,33 @@ export enum Direction {
 }
 
 export const waitForXDomainTransaction = async (
-  watcher: Watcher,
-  tx: Promise<TransactionResponse> | TransactionResponse,
-  direction: Direction
+  messenger: CrossChainMessenger,
+  tx: Promise<TransactionResponse> | TransactionResponse
 ): Promise<CrossDomainMessagePair> => {
-  const { src, dest } =
-    direction === Direction.L1ToL2
-      ? { src: watcher.l1, dest: watcher.l2 }
-      : { src: watcher.l2, dest: watcher.l1 }
-
   // await it if needed
   tx = await tx
-  // get the receipt and the full transaction
+
   const receipt = await tx.wait()
-  const fullTx = await src.provider.getTransaction(tx.hash)
-
-  // get the message hash which was created on the SentMessage
-  const [xDomainMsgHash] = await watcher.getMessageHashesFromTx(src, tx.hash)
-
-  if (!xDomainMsgHash) {
-    throw new Error(`No x-domain message hash for tx hash ${tx.hash}, bailing.`)
+  const resolved = await messenger.toCrossChainMessage(tx)
+  const messageReceipt = await messenger.waitForMessageReceipt(tx)
+  let fullTx: any
+  let remoteTx: any
+  if (resolved.direction === MessageDirection.L1_TO_L2) {
+    fullTx = await messenger.l1Provider.getTransaction(tx.hash)
+    remoteTx = await messenger.l2Provider.getTransaction(
+      messageReceipt.transactionReceipt.transactionHash
+    )
+  } else {
+    fullTx = await messenger.l2Provider.getTransaction(tx.hash)
+    remoteTx = await messenger.l1Provider.getTransaction(
+      messageReceipt.transactionReceipt.transactionHash
+    )
   }
-
-  // Get the transaction and receipt on the remote layer
-  const remoteReceipt = await watcher.getTransactionReceipt(
-    dest,
-    xDomainMsgHash
-  )
-  const remoteTx = await dest.provider.getTransaction(
-    remoteReceipt.transactionHash
-  )
 
   return {
     tx: fullTx,
     receipt,
     remoteTx,
-    remoteReceipt,
+    remoteReceipt: messageReceipt.transactionReceipt,
   }
 }


### PR DESCRIPTION
**Description**
Removes all remaining usage of the Watcher from the integration tests.

**Additional context**
Makes it possible to entirely remove the Watcher in a following commit.

**Metadata**
- Fixes #2055 
