### PR TITLE
maintance: replaced l2Provider with env.l2Provider

### DIFF
--- a/.changeset/brown-foxes-hang.md
+++ b/.changeset/brown-foxes-hang.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Replaces l1Provider and l2Provider with env.l1Provider and env.l2Provider respectively.

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -2,17 +2,11 @@
 import { ethers } from 'hardhat'
 import { expectApprox } from '@eth-optimism/core-utils'
 import { predeploys } from '@eth-optimism/contracts'
-import { asL2Provider } from '@eth-optimism/sdk'
 import { Contract, BigNumber } from 'ethers'
 
 /* Imports: Internal */
 import { expect } from './shared/setup'
-import {
-  l2Provider,
-  l1Provider,
-  envConfig,
-  DEFAULT_TEST_GAS_L1,
-} from './shared/utils'
+import { envConfig, DEFAULT_TEST_GAS_L1 } from './shared/utils'
 import { OptimismEnv } from './shared/env'
 
 /**
@@ -21,7 +15,6 @@ import { OptimismEnv } from './shared/env'
  * must be equal to the blocknumber/timestamp of the L1 transaction.
  */
 describe('OVM Context: Layer 2 EVM Context', () => {
-  const L2Provider = asL2Provider(l2Provider)
   let env: OptimismEnv
   before(async () => {
     env = await OptimismEnv.new()
@@ -66,8 +59,10 @@ describe('OVM Context: Layer 2 EVM Context', () => {
 
       // Get the L1 block that the enqueue transaction was in so that
       // the timestamp can be compared against the layer two contract
-      const l1Block = await l1Provider.getBlock(pair.receipt.blockNumber)
-      const l2Block = await l2Provider.getBlock(pair.remoteReceipt.blockNumber)
+      const l1Block = await env.l1Provider.getBlock(pair.receipt.blockNumber)
+      const l2Block = await env.l2Provider.getBlock(
+        pair.remoteReceipt.blockNumber
+      )
 
       // block.number should return the value of the L2 block number.
       const l2BlockNumber = await OVMContextStorage.blockNumbers(i)
@@ -103,7 +98,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
       })
       await dummyTx.wait()
 
-      const block = await L2Provider.getBlockWithTransactions('latest')
+      const block = await env.l2Provider.getBlockWithTransactions('latest')
       const [, returnData] = await Multicall.callStatic.aggregate(
         [
           [

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -1,6 +1,5 @@
 /* Imports: External */
 import { expectApprox, sleep } from '@eth-optimism/core-utils'
-import { asL2Provider } from '@eth-optimism/sdk'
 import { Wallet, BigNumber, Contract, ContractFactory, constants } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
 import { ethers } from 'hardhat'
@@ -11,7 +10,6 @@ import {
 
 /* Imports: Internal */
 import {
-  l2Provider,
   defaultTransactionFactory,
   fundUser,
   L2_CHAINID,
@@ -26,8 +24,6 @@ import { expect } from './shared/setup'
 describe('Basic RPC tests', () => {
   let env: OptimismEnv
   let wallet: Wallet
-
-  const provider = asL2Provider(l2Provider)
 
   let Reverter: Contract
   let ValueContext: Contract
@@ -86,7 +82,7 @@ describe('Basic RPC tests', () => {
       }
 
       await expect(
-        provider.sendTransaction(await wallet.signTransaction(tx))
+        env.l2Provider.sendTransaction(await wallet.signTransaction(tx))
       ).to.be.rejectedWith('invalid transaction: invalid sender')
     })
 
@@ -98,7 +94,7 @@ describe('Basic RPC tests', () => {
         chainId: null, // Disables EIP155 transaction signing.
       }
       const signed = await wallet.signTransaction(tx)
-      const response = await provider.sendTransaction(signed)
+      const response = await env.l2Provider.sendTransaction(signed)
 
       expect(response.chainId).to.equal(0)
       const v = response.v
@@ -114,12 +110,14 @@ describe('Basic RPC tests', () => {
         value: ethers.utils.parseEther('0.1'),
       }
 
-      const balanceBefore = await provider.getBalance(env.l2Wallet.address)
+      const balanceBefore = await env.l2Provider.getBalance(
+        env.l2Wallet.address
+      )
       const result = await env.l2Wallet.sendTransaction(tx)
       const receipt = await result.wait()
       expect(receipt.status).to.deep.equal(1)
 
-      const balAfter = await provider.getBalance(env.l2Wallet.address)
+      const balAfter = await env.l2Provider.getBalance(env.l2Wallet.address)
       expect(balAfter.lte(balanceBefore.sub(ethers.utils.parseEther('0.1')))).to
         .be.true
     })
@@ -187,7 +185,7 @@ describe('Basic RPC tests', () => {
   describe('eth_call', () => {
     it('should correctly identify call out-of-gas', async () => {
       await expect(
-        provider.call({
+        env.l2Provider.call({
           ...revertingTx,
           gasLimit: 1,
         })
@@ -195,7 +193,9 @@ describe('Basic RPC tests', () => {
     })
 
     it('should correctly return solidity revert data from a call', async () => {
-      await expect(provider.call(revertingTx)).to.be.revertedWith(revertMessage)
+      await expect(env.l2Provider.call(revertingTx)).to.be.revertedWith(
+        revertMessage
+      )
     })
 
     it('should produce error when called from ethers', async () => {
@@ -203,14 +203,14 @@ describe('Basic RPC tests', () => {
     })
 
     it('should correctly return revert data from contract creation', async () => {
-      await expect(provider.call(revertingDeployTx)).to.be.revertedWith(
+      await expect(env.l2Provider.call(revertingDeployTx)).to.be.revertedWith(
         revertMessage
       )
     })
 
     it('should correctly identify contract creation out of gas', async () => {
       await expect(
-        provider.call({
+        env.l2Provider.call({
           ...revertingDeployTx,
           gasLimit: 1,
         })
@@ -225,7 +225,7 @@ describe('Basic RPC tests', () => {
 
       // Do the call and check msg.value
       const data = ValueContext.interface.encodeFunctionData('getCallValue')
-      const res = await provider.call({
+      const res = await env.l2Provider.call({
         to: ValueContext.address,
         from,
         data,
@@ -239,7 +239,7 @@ describe('Basic RPC tests', () => {
     it('should use address(0) as the default "from" value', async () => {
       // Do the call and check msg.sender
       const data = ValueContext.interface.encodeFunctionData('getCaller')
-      const res = await provider.call({
+      const res = await env.l2Provider.call({
         to: ValueContext.address,
         data,
       })
@@ -257,7 +257,7 @@ describe('Basic RPC tests', () => {
 
       // Do the call and check msg.sender
       const data = ValueContext.interface.encodeFunctionData('getCaller')
-      const res = await provider.call({
+      const res = await env.l2Provider.call({
         to: ValueContext.address,
         from,
         data,
@@ -297,9 +297,8 @@ describe('Basic RPC tests', () => {
       }
       expect(errored).to.be.true
 
-      const receipt: TransactionReceipt = await provider.getTransactionReceipt(
-        tx.hash
-      )
+      const receipt: TransactionReceipt =
+        await env.l2Provider.getTransactionReceipt(tx.hash)
 
       expect(receipt.status).to.eq(0)
     })
@@ -320,9 +319,8 @@ describe('Basic RPC tests', () => {
       }
       expect(errored).to.be.true
 
-      const receipt: TransactionReceipt = await provider.getTransactionReceipt(
-        tx.hash
-      )
+      const receipt: TransactionReceipt =
+        await env.l2Provider.getTransactionReceipt(tx.hash)
 
       expect(receipt.status).to.eq(0)
     })
@@ -354,7 +352,9 @@ describe('Basic RPC tests', () => {
       const res = await env.l2Wallet.sendTransaction(tx)
       await res.wait()
 
-      const json = await provider.send('eth_getTransactionReceipt', [res.hash])
+      const json = await env.l2Provider.send('eth_getTransactionReceipt', [
+        res.hash,
+      ])
 
       expect(l1GasUsed).to.deep.equal(BigNumber.from(json.l1GasUsed))
       expect(l1GasPrice).to.deep.equal(BigNumber.from(json.l1GasPrice))
@@ -370,7 +370,9 @@ describe('Basic RPC tests', () => {
       const result = await wallet.sendTransaction(tx)
       await result.wait()
 
-      const transaction = (await provider.getTransaction(result.hash)) as any
+      const transaction = (await env.l2Provider.getTransaction(
+        result.hash
+      )) as any
       expect(transaction.queueOrigin).to.equal('sequencer')
       expect(transaction.transactionIndex).to.be.eq(0)
       expect(transaction.gasLimit).to.be.deep.eq(BigNumber.from(tx.gasLimit))
@@ -385,7 +387,7 @@ describe('Basic RPC tests', () => {
       const result = await wallet.sendTransaction(tx)
       const receipt = await result.wait()
 
-      const block = (await provider.getBlockWithTransactions(
+      const block = (await env.l2Provider.getBlockWithTransactions(
         receipt.blockHash
       )) as any
 
@@ -411,13 +413,13 @@ describe('Basic RPC tests', () => {
       'should return the same result when new transactions are not applied',
       async () => {
         // Get latest block once to start.
-        const prev = await provider.getBlockWithTransactions('latest')
+        const prev = await env.l2Provider.getBlockWithTransactions('latest')
         // set wait to null to allow a deep object comparison
         prev.transactions[0].wait = null
 
         // Over ten seconds, repeatedly check the latest block to make sure nothing has changed.
         for (let i = 0; i < 5; i++) {
-          const latest = await provider.getBlockWithTransactions('latest')
+          const latest = await env.l2Provider.getBlockWithTransactions('latest')
           latest.transactions[0].wait = null
           // Check each key of the transaction individually
           // for easy debugging if one field changes
@@ -436,7 +438,7 @@ describe('Basic RPC tests', () => {
 
   describe('eth_getBalance', () => {
     it('should get the OVM_ETH balance', async () => {
-      const rpcBalance = await provider.getBalance(env.l2Wallet.address)
+      const rpcBalance = await env.l2Provider.getBalance(env.l2Wallet.address)
       const contractBalance = await env.ovmEth.balanceOf(env.l2Wallet.address)
       expect(rpcBalance).to.be.deep.eq(contractBalance)
     })
@@ -444,7 +446,7 @@ describe('Basic RPC tests', () => {
 
   describe('eth_chainId', () => {
     it('should get the correct chainid', async () => {
-      const { chainId } = await provider.getNetwork()
+      const { chainId } = await env.l2Provider.getNetwork()
       expect(chainId).to.be.eq(L2_CHAINID)
     })
   })
@@ -453,7 +455,7 @@ describe('Basic RPC tests', () => {
     it('simple send gas estimation is deterministic', async () => {
       let lastEstimate: BigNumber
       for (let i = 0; i < 10; i++) {
-        const estimate = await l2Provider.estimateGas({
+        const estimate = await env.l2Provider.estimateGas({
           to: defaultTransactionFactory().to,
           value: 0,
         })
@@ -476,7 +478,7 @@ describe('Basic RPC tests', () => {
     })
 
     it('should return a gas estimate for txs with empty data', async () => {
-      const estimate = await l2Provider.estimateGas({
+      const estimate = await env.l2Provider.estimateGas({
         to: defaultTransactionFactory().to,
         value: 0,
       })
@@ -485,13 +487,13 @@ describe('Basic RPC tests', () => {
     })
 
     it('should fail for a reverting call transaction', async () => {
-      await expect(provider.send('eth_estimateGas', [revertingTx])).to.be
+      await expect(env.l2Provider.send('eth_estimateGas', [revertingTx])).to.be
         .reverted
     })
 
     it('should fail for a reverting deploy transaction', async () => {
-      await expect(provider.send('eth_estimateGas', [revertingDeployTx])).to.be
-        .reverted
+      await expect(env.l2Provider.send('eth_estimateGas', [revertingDeployTx]))
+        .to.be.reverted
     })
   })
 
@@ -510,10 +512,10 @@ describe('Basic RPC tests', () => {
       const tx = (await storage.deploy()).deployTransaction
       const receipt = await tx.wait()
 
-      const txTrace = await provider.send('debug_traceTransaction', [
+      const txTrace = await env.l2Provider.send('debug_traceTransaction', [
         receipt.transactionHash,
       ])
-      const blockTrace = await provider.send('debug_traceBlockByHash', [
+      const blockTrace = await env.l2Provider.send('debug_traceBlockByHash', [
         receipt.blockHash,
       ])
       expect(txTrace).to.deep.equal(blockTrace[0].result)
@@ -522,7 +524,7 @@ describe('Basic RPC tests', () => {
 
   describe('rollup_gasPrices', () => {
     it('should return the L1 and L2 gas prices', async () => {
-      const result = await provider.send('rollup_gasPrices', [])
+      const result = await env.l2Provider.send('rollup_gasPrices', [])
       const l1GasPrice = await env.gasPriceOracle.l1BaseFee()
       const l2GasPrice = await env.gasPriceOracle.gasPrice()
 

--- a/integration-tests/test/whitelist.spec.ts
+++ b/integration-tests/test/whitelist.spec.ts
@@ -6,7 +6,6 @@ import { predeploys } from '@eth-optimism/contracts'
 /* Imports: Internal */
 import { expect } from './shared/setup'
 import { OptimismEnv } from './shared/env'
-import { l2Provider } from './shared/utils'
 
 describe('Whitelist', async () => {
   const initialAmount = 1000
@@ -24,7 +23,7 @@ describe('Whitelist', async () => {
   describe('when the whitelist is disabled', () => {
     it('should be able to deploy a contract', async () => {
       await expect(
-        l2Provider.send('eth_call', [
+        env.l2Provider.send('eth_call', [
           Factory__ERC20.getDeployTransaction(
             initialAmount,
             tokenName,
@@ -50,7 +49,7 @@ describe('Whitelist', async () => {
 
     it('should fail if the user is not whitelisted', async () => {
       await expect(
-        l2Provider.send('eth_call', [
+        env.l2Provider.send('eth_call', [
           {
             ...Factory__ERC20.getDeployTransaction(
               initialAmount,
@@ -77,7 +76,7 @@ describe('Whitelist', async () => {
 
     it('should succeed if the user is whitelisted', async () => {
       await expect(
-        l2Provider.send('eth_call', [
+        env.l2Provider.send('eth_call', [
           {
             ...Factory__ERC20.getDeployTransaction(
               initialAmount,


### PR DESCRIPTION
**Description**
Replaced l2Provider with env.l2Provider in [whitelist.spec.ts](https://github.com/ethereum-optimism/optimism/blob/develop/integration-tests/test/whitelist.spec.ts), [rpc.spec.ts](https://github.com/ethereum-optimism/optimism/blob/develop/integration-tests/test/rpc.spec.ts) & [ovmcontext.spec.ts](https://github.com/ethereum-optimism/optimism/blob/develop/integration-tests/test/ovmcontext.spec.ts)

**Metadata**
- Fixes #2154 