### PR TITLE
test: misc.ts in core-utils

### DIFF
--- a/.changeset/eighty-comics-push.md
+++ b/.changeset/eighty-comics-push.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/core-utils': patch
+---
+
+Added tests and docstrings to misc functions

--- a/packages/core-utils/src/common/misc.ts
+++ b/packages/core-utils/src/common/misc.ts
@@ -11,7 +11,12 @@ export const sleep = async (ms: number): Promise<void> => {
   })
 }
 
-// Returns a copy of an object
+/**
+ * Returns a clone of the object.
+ *
+ * @param obj Object to clone.
+ * @returns Clone of the object.
+ */
 export const clone = (obj: any): any => {
   if (typeof obj === 'undefined') {
     throw new Error(`Trying to clone undefined object`)
@@ -33,6 +38,13 @@ export const reqenv = (name: string): string => {
   return value
 }
 
+/**
+ * Loads a variable from the environment and returns a fallback if not found.
+ *
+ * @param name Name of the variable to load.
+ * @param [fallback] Optional value to be returned as fallback.
+ * @returns Value of the variable as a string, fallback or undefined.
+ */
 export const getenv = (name: string, fallback?: string): string | undefined => {
   return process.env[name] || fallback
 }

--- a/packages/core-utils/test/misc.spec.ts
+++ b/packages/core-utils/test/misc.spec.ts
@@ -1,6 +1,6 @@
 /* Imports: Internal */
 import { expect } from './setup'
-import { sleep } from '../src'
+import { sleep, clone, reqenv, getenv } from '../src'
 
 describe('sleep', async () => {
   it('should return wait input amount of ms', async () => {
@@ -8,5 +8,85 @@ describe('sleep', async () => {
     await sleep(1000)
     const endTime = Date.now()
     expect(startTime + 1000 <= endTime).to.deep.equal(true)
+  })
+})
+
+describe('clone', async () => {
+  it('should return a cloned object', async () => {
+    const exampleObject = { example: 'Example' }
+    const clonedObject = clone(exampleObject)
+    expect(clonedObject).to.not.equal(exampleObject)
+    expect(JSON.stringify(clonedObject)).to.equal(JSON.stringify(exampleObject))
+  })
+})
+
+describe('reqenv', async () => {
+  let cachedEnvironment
+  const temporaryEnvironmentKey = 'testVariable'
+  const temporaryEnvironment = {
+    [temporaryEnvironmentKey]: 'This is an environment variable',
+  }
+
+  before(() => {
+    cachedEnvironment = process.env
+    process.env = temporaryEnvironment
+  })
+
+  it('should return an existent environment variable', async () => {
+    const requiredEnvironmentValue = reqenv(temporaryEnvironmentKey)
+    expect(requiredEnvironmentValue).to.equal(
+      temporaryEnvironment[temporaryEnvironmentKey]
+    )
+  })
+
+  it('should throw an error trying to return a variable that does not exist', async () => {
+    const undeclaredVariableName = 'undeclaredVariable'
+    const failedReqenv = () => reqenv(undeclaredVariableName)
+    expect(failedReqenv).to.throw()
+  })
+
+  after(() => {
+    process.env = cachedEnvironment
+  })
+})
+
+describe('getenv', async () => {
+  let cachedEnvironment
+  const temporaryEnvironmentKey = 'testVariable'
+  const temporaryEnvironment = {
+    [temporaryEnvironmentKey]: 'This is an environment variable',
+  }
+  const fallback = 'fallback'
+
+  before(() => {
+    cachedEnvironment = process.env
+    process.env = temporaryEnvironment
+  })
+
+  it('should return an existent environment variable', async () => {
+    const environmentVariable = getenv(temporaryEnvironmentKey)
+    expect(environmentVariable).to.equal(
+      temporaryEnvironment[temporaryEnvironmentKey]
+    )
+  })
+
+  it('should return an existent environment variable even if fallback is passed', async () => {
+    const environmentVariable = getenv(temporaryEnvironmentKey, fallback)
+    expect(environmentVariable).to.equal(
+      temporaryEnvironment[temporaryEnvironmentKey]
+    )
+  })
+
+  it('should return fallback if variable is not defined', async () => {
+    const undeclaredVariableName = 'undeclaredVariable'
+    expect(getenv(undeclaredVariableName, fallback)).to.equal(fallback)
+  })
+
+  it('should return undefined if no fallback is passed and variable is not defined', async () => {
+    expect(getenv('undeclaredVariable')).to.be.undefined
+  })
+
+  after(() => {
+    process.env = cachedEnvironment
   })
 })


### PR DESCRIPTION
**Description**
- Adds docstrings for functions
- Adds tests for said functions

**Additional context**
The [clone](https://github.com/ethereum-optimism/optimism/blob/eb926e2f90b5eec4558f3c82746b639b19ddf9d5/packages/core-utils/src/common/misc.ts#L15) function currently does a shallow copy, deepClone from lodash in being used in other places in the repo, though I've only seen this function being used in places where it's not needed. Let me know if it makes sense to change it.

**Metadata**
- Fixes #2052
