### PR TITLE
feat: add autogenerated docs for SDK

### DIFF
--- a/.changeset/fluffy-tomatoes-obey.md
+++ b/.changeset/fluffy-tomatoes-obey.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+README update and fix a docstring typo

--- a/packages/sdk/.depcheckrc
+++ b/packages/sdk/.depcheckrc
@@ -1,4 +1,6 @@
 ignores: [
   "@eth-optimism/core-utils",
   "ts-mocha",
+  "typedoc",
+  "typedoc-plugin-markdown"
 ]

--- a/packages/sdk/docs/.nojekyll
+++ b/packages/sdk/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/packages/sdk/docs/README.md
+++ b/packages/sdk/docs/README.md
@@ -1,3 +1,5 @@
+@eth-optimism/sdk / [Exports](modules.md)
+
 [![codecov](https://codecov.io/gh/ethereum-optimism/optimism/branch/master/graph/badge.svg?token=0VTG7PG7YR&flag=sdk)](https://codecov.io/gh/ethereum-optimism/optimism)
 
 # @eth-optimism/sdk

--- a/packages/sdk/docs/classes/CrossChainMessenger.md
+++ b/packages/sdk/docs/classes/CrossChainMessenger.md
@@ -1,0 +1,1175 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / CrossChainMessenger
+
+# Class: CrossChainMessenger
+
+## Implements
+
+- [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](CrossChainMessenger.md#constructor)
+
+### Properties
+
+- [bridges](CrossChainMessenger.md#bridges)
+- [contracts](CrossChainMessenger.md#contracts)
+- [depositConfirmationBlocks](CrossChainMessenger.md#depositconfirmationblocks)
+- [estimateGas](CrossChainMessenger.md#estimategas)
+- [l1BlockTimeSeconds](CrossChainMessenger.md#l1blocktimeseconds)
+- [l1ChainId](CrossChainMessenger.md#l1chainid)
+- [l1SignerOrProvider](CrossChainMessenger.md#l1signerorprovider)
+- [l2SignerOrProvider](CrossChainMessenger.md#l2signerorprovider)
+- [populateTransaction](CrossChainMessenger.md#populatetransaction)
+
+### Accessors
+
+- [l1Provider](CrossChainMessenger.md#l1provider)
+- [l1Signer](CrossChainMessenger.md#l1signer)
+- [l2Provider](CrossChainMessenger.md#l2provider)
+- [l2Signer](CrossChainMessenger.md#l2signer)
+
+### Methods
+
+- [approval](CrossChainMessenger.md#approval)
+- [approveERC20](CrossChainMessenger.md#approveerc20)
+- [depositERC20](CrossChainMessenger.md#depositerc20)
+- [depositETH](CrossChainMessenger.md#depositeth)
+- [estimateL2MessageGasLimit](CrossChainMessenger.md#estimatel2messagegaslimit)
+- [estimateMessageWaitTimeSeconds](CrossChainMessenger.md#estimatemessagewaittimeseconds)
+- [finalizeMessage](CrossChainMessenger.md#finalizemessage)
+- [getBridgeForTokenPair](CrossChainMessenger.md#getbridgefortokenpair)
+- [getChallengePeriodSeconds](CrossChainMessenger.md#getchallengeperiodseconds)
+- [getDepositsByAddress](CrossChainMessenger.md#getdepositsbyaddress)
+- [getMessageProof](CrossChainMessenger.md#getmessageproof)
+- [getMessageReceipt](CrossChainMessenger.md#getmessagereceipt)
+- [getMessageStateRoot](CrossChainMessenger.md#getmessagestateroot)
+- [getMessageStatus](CrossChainMessenger.md#getmessagestatus)
+- [getMessagesByAddress](CrossChainMessenger.md#getmessagesbyaddress)
+- [getMessagesByTransaction](CrossChainMessenger.md#getmessagesbytransaction)
+- [getStateBatchAppendedEventByBatchIndex](CrossChainMessenger.md#getstatebatchappendedeventbybatchindex)
+- [getStateBatchAppendedEventByTransactionIndex](CrossChainMessenger.md#getstatebatchappendedeventbytransactionindex)
+- [getStateRootBatchByTransactionIndex](CrossChainMessenger.md#getstaterootbatchbytransactionindex)
+- [getWithdrawalsByAddress](CrossChainMessenger.md#getwithdrawalsbyaddress)
+- [resendMessage](CrossChainMessenger.md#resendmessage)
+- [sendMessage](CrossChainMessenger.md#sendmessage)
+- [toCrossChainMessage](CrossChainMessenger.md#tocrosschainmessage)
+- [waitForMessageReceipt](CrossChainMessenger.md#waitformessagereceipt)
+- [waitForMessageStatus](CrossChainMessenger.md#waitformessagestatus)
+- [withdrawERC20](CrossChainMessenger.md#withdrawerc20)
+- [withdrawETH](CrossChainMessenger.md#withdraweth)
+
+## Constructors
+
+### constructor
+
+• **new CrossChainMessenger**(`opts`)
+
+Creates a new CrossChainProvider instance.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts` | `Object` | Options for the provider. |
+| `opts.bridges?` | [`BridgeAdapterData`](../interfaces/BridgeAdapterData.md) | Optional bridge address list. |
+| `opts.contracts?` | [`DeepPartial`](../modules.md#deeppartial)<[`OEContractsLike`](../interfaces/OEContractsLike.md)\> | Optional contract address overrides. |
+| `opts.depositConfirmationBlocks?` | [`NumberLike`](../modules.md#numberlike) | Optional number of blocks before a deposit is confirmed. |
+| `opts.l1BlockTimeSeconds?` | [`NumberLike`](../modules.md#numberlike) | Optional estimated block time in seconds for the L1 chain. |
+| `opts.l1ChainId` | [`NumberLike`](../modules.md#numberlike) | Chain ID for the L1 chain. |
+| `opts.l1SignerOrProvider` | `any` | Signer or Provider for the L1 chain, or a JSON-RPC url. |
+| `opts.l2SignerOrProvider` | `any` | Signer or Provider for the L2 chain, or a JSON-RPC url. |
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:74](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L74)
+
+## Properties
+
+### bridges
+
+• **bridges**: [`BridgeAdapters`](../interfaces/BridgeAdapters.md)
+
+List of custom bridges for the given network.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[bridges](../interfaces/ICrossChainMessenger.md#bridges)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:58](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L58)
+
+___
+
+### contracts
+
+• **contracts**: [`OEContracts`](../interfaces/OEContracts.md)
+
+Contract objects attached to their respective providers and addresses.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[contracts](../interfaces/ICrossChainMessenger.md#contracts)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:57](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L57)
+
+___
+
+### depositConfirmationBlocks
+
+• **depositConfirmationBlocks**: `number`
+
+Number of blocks before a deposit is considered confirmed.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[depositConfirmationBlocks](../interfaces/ICrossChainMessenger.md#depositconfirmationblocks)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:59](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L59)
+
+___
+
+### estimateGas
+
+• **estimateGas**: `Object`
+
+Object that holds the functions that estimates the gas required for a given transaction.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approveERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `depositERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `depositETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `finalizeMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `resendMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `messageGasLimit`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `sendMessage` | (`message`: [`CrossChainMessageRequest`](../interfaces/CrossChainMessageRequest.md), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `withdrawERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `withdrawETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[estimateGas](../interfaces/ICrossChainMessenger.md#estimategas)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:1129](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L1129)
+
+___
+
+### l1BlockTimeSeconds
+
+• **l1BlockTimeSeconds**: `number`
+
+Estimated average L1 block time in seconds.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l1BlockTimeSeconds](../interfaces/ICrossChainMessenger.md#l1blocktimeseconds)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:60](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L60)
+
+___
+
+### l1ChainId
+
+• **l1ChainId**: `number`
+
+Chain ID for the L1 network.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l1ChainId](../interfaces/ICrossChainMessenger.md#l1chainid)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:56](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L56)
+
+___
+
+### l1SignerOrProvider
+
+• **l1SignerOrProvider**: `Signer` \| `Provider`
+
+Provider connected to the L1 chain.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l1SignerOrProvider](../interfaces/ICrossChainMessenger.md#l1signerorprovider)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:54](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L54)
+
+___
+
+### l2SignerOrProvider
+
+• **l2SignerOrProvider**: `Signer` \| `Provider`
+
+Provider connected to the L2 chain.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l2SignerOrProvider](../interfaces/ICrossChainMessenger.md#l2signerorprovider)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:55](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L55)
+
+___
+
+### populateTransaction
+
+• **populateTransaction**: `Object`
+
+Object that holds the functions that generate transactions to be signed by the user.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approveERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `depositERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `depositETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `finalizeMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `resendMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `messageGasLimit`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `sendMessage` | (`message`: [`CrossChainMessageRequest`](../interfaces/CrossChainMessageRequest.md), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `withdrawERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `withdrawETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[populateTransaction](../interfaces/ICrossChainMessenger.md#populatetransaction)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:988](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L988)
+
+## Accessors
+
+### l1Provider
+
+• `get` **l1Provider**(): `Provider`
+
+Provider connected to the L1 chain.
+
+#### Returns
+
+`Provider`
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l1Provider](../interfaces/ICrossChainMessenger.md#l1provider)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:108](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L108)
+
+___
+
+### l1Signer
+
+• `get` **l1Signer**(): `Signer`
+
+Signer connected to the L1 chain.
+
+#### Returns
+
+`Signer`
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l1Signer](../interfaces/ICrossChainMessenger.md#l1signer)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:124](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L124)
+
+___
+
+### l2Provider
+
+• `get` **l2Provider**(): `Provider`
+
+Provider connected to the L2 chain.
+
+#### Returns
+
+`Provider`
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l2Provider](../interfaces/ICrossChainMessenger.md#l2provider)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:116](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L116)
+
+___
+
+### l2Signer
+
+• `get` **l2Signer**(): `Signer`
+
+Signer connected to the L2 chain.
+
+#### Returns
+
+`Signer`
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[l2Signer](../interfaces/ICrossChainMessenger.md#l2signer)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:132](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L132)
+
+## Methods
+
+### approval
+
+▸ **approval**(`l1Token`, `l2Token`, `opts?`): `Promise`<`BigNumber`\>
+
+Queries the account's approval amount for a given L1 token.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Amount of tokens approved for deposits from the account.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[approval](../interfaces/ICrossChainMessenger.md#approval)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:917](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L917)
+
+___
+
+### approveERC20
+
+▸ **approveERC20**(`l1Token`, `l2Token`, `amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Approves a deposit into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the approval transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[approveERC20](../interfaces/ICrossChainMessenger.md#approveerc20)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:928](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L928)
+
+___
+
+### depositERC20
+
+▸ **depositERC20**(`l1Token`, `l2Token`, `amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some ERC20 tokens into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `opts?` | `Object` |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[depositERC20](../interfaces/ICrossChainMessenger.md#depositerc20)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:947](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L947)
+
+___
+
+### depositETH
+
+▸ **depositETH**(`amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some ETH into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `opts?` | `Object` |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[depositETH](../interfaces/ICrossChainMessenger.md#depositeth)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:890](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L890)
+
+___
+
+### estimateL2MessageGasLimit
+
+▸ **estimateL2MessageGasLimit**(`message`, `opts?`): `Promise`<`BigNumber`\>
+
+Estimates the amount of gas required to fully execute a given message on L2. Only applies to
+L1 => L2 messages. You would supply this gas limit when sending the message to L2.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageRequestLike`](../modules.md#messagerequestlike) |
+| `opts?` | `Object` |
+| `opts.bufferPercent?` | `number` |
+| `opts.from?` | `string` |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Estimates L2 gas limit.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[estimateL2MessageGasLimit](../interfaces/ICrossChainMessenger.md#estimatel2messagegaslimit)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:541](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L541)
+
+___
+
+### estimateMessageWaitTimeSeconds
+
+▸ **estimateMessageWaitTimeSeconds**(`message`): `Promise`<`number`\>
+
+Returns the estimated amount of time before the message can be executed. When this is a
+message being sent to L1, this will return the estimated time until the message will complete
+its challenge period. When this is a message being sent to L2, this will return the estimated
+amount of time until the message will be picked up and executed on L2.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+
+#### Returns
+
+`Promise`<`number`\>
+
+Estimated amount of time remaining (in seconds) before the message can be executed.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[estimateMessageWaitTimeSeconds](../interfaces/ICrossChainMessenger.md#estimatemessagewaittimeseconds)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:574](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L574)
+
+___
+
+### finalizeMessage
+
+▸ **finalizeMessage**(`message`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Finalizes a cross chain message that was sent from L2 to L1. Only applicable for L2 to L1
+messages. Will throw an error if the message has not completed its challenge period yet.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the finalization transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[finalizeMessage](../interfaces/ICrossChainMessenger.md#finalizemessage)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:878](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L878)
+
+___
+
+### getBridgeForTokenPair
+
+▸ **getBridgeForTokenPair**(`l1Token`, `l2Token`): `Promise`<[`IBridgeAdapter`](../interfaces/IBridgeAdapter.md)\>
+
+Finds the appropriate bridge adapter for a given L1<>L2 token pair. Will throw if no bridges
+support the token pair or if more than one bridge supports the token pair.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<[`IBridgeAdapter`](../interfaces/IBridgeAdapter.md)\>
+
+The appropriate bridge adapter for the given token pair.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getBridgeForTokenPair](../interfaces/ICrossChainMessenger.md#getbridgefortokenpair)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:228](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L228)
+
+___
+
+### getChallengePeriodSeconds
+
+▸ **getChallengePeriodSeconds**(): `Promise`<`number`\>
+
+Queries the current challenge period in seconds from the StateCommitmentChain.
+
+#### Returns
+
+`Promise`<`number`\>
+
+Current challenge period in seconds.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getChallengePeriodSeconds](../interfaces/ICrossChainMessenger.md#getchallengeperiodseconds)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:633](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L633)
+
+___
+
+### getDepositsByAddress
+
+▸ **getDepositsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all deposits for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All deposit token bridge messages sent by the given address.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getDepositsByAddress](../interfaces/ICrossChainMessenger.md#getdepositsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:250](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L250)
+
+___
+
+### getMessageProof
+
+▸ **getMessageProof**(`message`): `Promise`<[`CrossChainMessageProof`](../interfaces/CrossChainMessageProof.md)\>
+
+Generates the proof required to finalize an L2 to L1 message.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+
+#### Returns
+
+`Promise`<[`CrossChainMessageProof`](../interfaces/CrossChainMessageProof.md)\>
+
+Proof that can be used to finalize the message.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getMessageProof](../interfaces/ICrossChainMessenger.md#getmessageproof)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:797](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L797)
+
+___
+
+### getMessageReceipt
+
+▸ **getMessageReceipt**(`message`): `Promise`<[`MessageReceipt`](../interfaces/MessageReceipt.md)\>
+
+Finds the receipt of the transaction that executed a particular cross chain message.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+
+#### Returns
+
+`Promise`<[`MessageReceipt`](../interfaces/MessageReceipt.md)\>
+
+CrossChainMessage receipt including receipt of the transaction that relayed the
+given message.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getMessageReceipt](../interfaces/ICrossChainMessenger.md#getmessagereceipt)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:390](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L390)
+
+___
+
+### getMessageStateRoot
+
+▸ **getMessageStateRoot**(`message`): `Promise`<[`StateRoot`](../interfaces/StateRoot.md)\>
+
+Returns the state root that corresponds to a given message. This is the state root for the
+block in which the transaction was included, as published to the StateCommitmentChain. If the
+state root for the given message has not been published yet, this function returns null.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+
+#### Returns
+
+`Promise`<[`StateRoot`](../interfaces/StateRoot.md)\>
+
+State root for the block in which the message was created.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getMessageStateRoot](../interfaces/ICrossChainMessenger.md#getmessagestateroot)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:639](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L639)
+
+___
+
+### getMessageStatus
+
+▸ **getMessageStatus**(`message`): `Promise`<[`MessageStatus`](../enums/MessageStatus.md)\>
+
+Retrieves the status of a particular message as an enum.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+
+#### Returns
+
+`Promise`<[`MessageStatus`](../enums/MessageStatus.md)\>
+
+Status of the message.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getMessageStatus](../interfaces/ICrossChainMessenger.md#getmessagestatus)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:349](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L349)
+
+___
+
+### getMessagesByAddress
+
+▸ **getMessagesByAddress**(`address`, `opts?`): `Promise`<[`CrossChainMessage`](../interfaces/CrossChainMessage.md)[]\>
+
+Retrieves all cross chain messages sent by a particular address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.direction?` | [`MessageDirection`](../enums/MessageDirection.md) |
+| `opts.fromBlock?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.toBlock?` | [`NumberLike`](../modules.md#numberlike) |
+
+#### Returns
+
+`Promise`<[`CrossChainMessage`](../interfaces/CrossChainMessage.md)[]\>
+
+All cross chain messages sent by the particular address.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getMessagesByAddress](../interfaces/ICrossChainMessenger.md#getmessagesbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:211](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L211)
+
+___
+
+### getMessagesByTransaction
+
+▸ **getMessagesByTransaction**(`transaction`, `opts?`): `Promise`<[`CrossChainMessage`](../interfaces/CrossChainMessage.md)[]\>
+
+Retrieves all cross chain messages sent within a given transaction.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transaction` | [`TransactionLike`](../modules.md#transactionlike) |
+| `opts` | `Object` |
+| `opts.direction?` | [`MessageDirection`](../enums/MessageDirection.md) |
+
+#### Returns
+
+`Promise`<[`CrossChainMessage`](../interfaces/CrossChainMessage.md)[]\>
+
+All cross chain messages sent within the transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getMessagesByTransaction](../interfaces/ICrossChainMessenger.md#getmessagesbytransaction)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:140](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L140)
+
+___
+
+### getStateBatchAppendedEventByBatchIndex
+
+▸ **getStateBatchAppendedEventByBatchIndex**(`batchIndex`): `Promise`<`Event`\>
+
+Returns the StateBatchAppended event that was emitted when the batch with a given index was
+created. Returns null if no such event exists (the batch has not been submitted).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `batchIndex` | `number` |
+
+#### Returns
+
+`Promise`<`Event`\>
+
+StateBatchAppended event for the batch, or null if no such batch exists.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getStateBatchAppendedEventByBatchIndex](../interfaces/ICrossChainMessenger.md#getstatebatchappendedeventbybatchindex)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:690](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L690)
+
+___
+
+### getStateBatchAppendedEventByTransactionIndex
+
+▸ **getStateBatchAppendedEventByTransactionIndex**(`transactionIndex`): `Promise`<`Event`\>
+
+Returns the StateBatchAppended event for the batch that includes the transaction with the
+given index. Returns null if no such event exists.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transactionIndex` | `number` |
+
+#### Returns
+
+`Promise`<`Event`\>
+
+StateBatchAppended event for the batch that includes the given transaction by index.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getStateBatchAppendedEventByTransactionIndex](../interfaces/ICrossChainMessenger.md#getstatebatchappendedeventbytransactionindex)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:709](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L709)
+
+___
+
+### getStateRootBatchByTransactionIndex
+
+▸ **getStateRootBatchByTransactionIndex**(`transactionIndex`): `Promise`<[`StateRootBatch`](../interfaces/StateRootBatch.md)\>
+
+Returns information about the state root batch that included the state root for the given
+transaction by index. Returns null if no such state root has been published yet.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `transactionIndex` | `number` |
+
+#### Returns
+
+`Promise`<[`StateRootBatch`](../interfaces/StateRootBatch.md)\>
+
+State root batch for the given transaction index, or null if none exists yet.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getStateRootBatchByTransactionIndex](../interfaces/ICrossChainMessenger.md#getstaterootbatchbytransactionindex)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:768](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L768)
+
+___
+
+### getWithdrawalsByAddress
+
+▸ **getWithdrawalsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all withdrawals for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All withdrawal token bridge messages sent by the given address.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[getWithdrawalsByAddress](../interfaces/ICrossChainMessenger.md#getwithdrawalsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:273](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L273)
+
+___
+
+### resendMessage
+
+▸ **resendMessage**(`message`, `messageGasLimit`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Resends a given cross chain message with a different gas limit. Only applies to L1 to L2
+messages. If provided an L2 to L1 message, this function will throw an error.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+| `messageGasLimit` | [`NumberLike`](../modules.md#numberlike) |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the message resending transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[resendMessage](../interfaces/ICrossChainMessenger.md#resendmessage)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:861](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L861)
+
+___
+
+### sendMessage
+
+▸ **sendMessage**(`message`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Sends a given cross chain message. Where the message is sent depends on the direction attached
+to the message itself.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`CrossChainMessageRequest`](../interfaces/CrossChainMessageRequest.md) |
+| `opts?` | `Object` |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.overrides?` | `Overrides` |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the message sending transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[sendMessage](../interfaces/ICrossChainMessenger.md#sendmessage)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:845](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L845)
+
+___
+
+### toCrossChainMessage
+
+▸ **toCrossChainMessage**(`message`): `Promise`<[`CrossChainMessage`](../interfaces/CrossChainMessage.md)\>
+
+Resolves a MessageLike into a CrossChainMessage object.
+Unlike other coercion functions, this function is stateful and requires making additional
+requests. For now I'm going to keep this function here, but we could consider putting a
+similar function inside of utils/coercion.ts if people want to use this without having to
+create an entire CrossChainProvider object.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+
+#### Returns
+
+`Promise`<[`CrossChainMessage`](../interfaces/CrossChainMessage.md)\>
+
+Message coerced into a CrossChainMessage.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[toCrossChainMessage](../interfaces/ICrossChainMessenger.md#tocrosschainmessage)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:296](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L296)
+
+___
+
+### waitForMessageReceipt
+
+▸ **waitForMessageReceipt**(`message`, `opts?`): `Promise`<[`MessageReceipt`](../interfaces/MessageReceipt.md)\>
+
+Waits for a message to be executed and returns the receipt of the transaction that executed
+the given message.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+| `opts` | `Object` |
+| `opts.confirmations?` | `number` |
+| `opts.pollIntervalMs?` | `number` |
+| `opts.timeoutMs?` | `number` |
+
+#### Returns
+
+`Promise`<[`MessageReceipt`](../interfaces/MessageReceipt.md)\>
+
+CrossChainMessage receipt including receipt of the transaction that relayed the
+given message.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[waitForMessageReceipt](../interfaces/ICrossChainMessenger.md#waitformessagereceipt)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:448](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L448)
+
+___
+
+### waitForMessageStatus
+
+▸ **waitForMessageStatus**(`message`, `status`, `opts?`): `Promise`<`void`\>
+
+Waits until the status of a given message changes to the expected status. Note that if the
+status of the given message changes to a status that implies the expected status, this will
+still return. If the status of the message changes to a status that exclues the expected
+status, this will throw an error.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) |
+| `status` | [`MessageStatus`](../enums/MessageStatus.md) |
+| `opts` | `Object` |
+| `opts.pollIntervalMs?` | `number` |
+| `opts.timeoutMs?` | `number` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[waitForMessageStatus](../interfaces/ICrossChainMessenger.md#waitformessagestatus)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:474](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L474)
+
+___
+
+### withdrawERC20
+
+▸ **withdrawERC20**(`l1Token`, `l2Token`, `amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some ERC20 tokens back to the L1 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[withdrawERC20](../interfaces/ICrossChainMessenger.md#withdrawerc20)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:968](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L968)
+
+___
+
+### withdrawETH
+
+▸ **withdrawETH**(`amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some ETH back to the L1 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+| `opts.signer?` | `Signer` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Implementation of
+
+[ICrossChainMessenger](../interfaces/ICrossChainMessenger.md).[withdrawETH](../interfaces/ICrossChainMessenger.md#withdraweth)
+
+#### Defined in
+
+[packages/sdk/src/cross-chain-messenger.ts:904](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L904)

--- a/packages/sdk/docs/classes/DAIBridgeAdapter.md
+++ b/packages/sdk/docs/classes/DAIBridgeAdapter.md
@@ -1,0 +1,381 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / DAIBridgeAdapter
+
+# Class: DAIBridgeAdapter
+
+Bridge adapter for DAI.
+
+## Hierarchy
+
+- [`StandardBridgeAdapter`](StandardBridgeAdapter.md)
+
+  ↳ **`DAIBridgeAdapter`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](DAIBridgeAdapter.md#constructor)
+
+### Properties
+
+- [estimateGas](DAIBridgeAdapter.md#estimategas)
+- [l1Bridge](DAIBridgeAdapter.md#l1bridge)
+- [l2Bridge](DAIBridgeAdapter.md#l2bridge)
+- [messenger](DAIBridgeAdapter.md#messenger)
+- [populateTransaction](DAIBridgeAdapter.md#populatetransaction)
+
+### Methods
+
+- [approval](DAIBridgeAdapter.md#approval)
+- [approve](DAIBridgeAdapter.md#approve)
+- [deposit](DAIBridgeAdapter.md#deposit)
+- [getDepositsByAddress](DAIBridgeAdapter.md#getdepositsbyaddress)
+- [getWithdrawalsByAddress](DAIBridgeAdapter.md#getwithdrawalsbyaddress)
+- [supportsTokenPair](DAIBridgeAdapter.md#supportstokenpair)
+- [withdraw](DAIBridgeAdapter.md#withdraw)
+
+## Constructors
+
+### constructor
+
+• **new DAIBridgeAdapter**(`opts`)
+
+Creates a StandardBridgeAdapter instance.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts` | `Object` | Options for the adapter. |
+| `opts.l1Bridge` | [`AddressLike`](../modules.md#addresslike) | L1 bridge contract. |
+| `opts.l2Bridge` | [`AddressLike`](../modules.md#addresslike) | L2 bridge contract. |
+| `opts.messenger` | [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md) | Provider used to make queries related to cross-chain interactions. |
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[constructor](StandardBridgeAdapter.md#constructor)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:37](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L37)
+
+## Properties
+
+### estimateGas
+
+• **estimateGas**: `Object`
+
+Object that holds the functions that estimates the gas required for a given transaction.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[estimateGas](StandardBridgeAdapter.md#estimategas)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:347](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L347)
+
+___
+
+### l1Bridge
+
+• **l1Bridge**: `Contract`
+
+L1 bridge contract.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[l1Bridge](StandardBridgeAdapter.md#l1bridge)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:26](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L26)
+
+___
+
+### l2Bridge
+
+• **l2Bridge**: `Contract`
+
+L2 bridge contract.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[l2Bridge](StandardBridgeAdapter.md#l2bridge)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:27](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L27)
+
+___
+
+### messenger
+
+• **messenger**: [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md)
+
+Provider used to make queries related to cross-chain interactions.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[messenger](StandardBridgeAdapter.md#messenger)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:25](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L25)
+
+___
+
+### populateTransaction
+
+• **populateTransaction**: `Object`
+
+Object that holds the functions that generate transactions to be signed by the user.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[populateTransaction](StandardBridgeAdapter.md#populatetransaction)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:251](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L251)
+
+## Methods
+
+### approval
+
+▸ **approval**(`l1Token`, `l2Token`, `signer`): `Promise`<`BigNumber`\>
+
+Queries the account's approval amount for a given L1 token.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `signer` | `Signer` |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Amount of tokens approved for deposits from the account.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[approval](StandardBridgeAdapter.md#approval)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:188](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L188)
+
+___
+
+### approve
+
+▸ **approve**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Approves a deposit into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the approval transaction.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[approve](StandardBridgeAdapter.md#approve)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:206](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L206)
+
+___
+
+### deposit
+
+▸ **deposit**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some tokens into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[deposit](StandardBridgeAdapter.md#deposit)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:220](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L220)
+
+___
+
+### getDepositsByAddress
+
+▸ **getDepositsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all deposits for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All deposit token bridge messages sent by the given address.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[getDepositsByAddress](StandardBridgeAdapter.md#getdepositsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:55](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L55)
+
+___
+
+### getWithdrawalsByAddress
+
+▸ **getWithdrawalsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all withdrawals for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All withdrawal token bridge messages sent by the given address.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[getWithdrawalsByAddress](StandardBridgeAdapter.md#getwithdrawalsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:102](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L102)
+
+___
+
+### supportsTokenPair
+
+▸ **supportsTokenPair**(`l1Token`, `l2Token`): `Promise`<`boolean`\>
+
+Checks whether the given token pair is supported by the bridge.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+Whether the given token pair is supported by the bridge.
+
+#### Overrides
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[supportsTokenPair](StandardBridgeAdapter.md#supportstokenpair)
+
+#### Defined in
+
+[packages/sdk/src/adapters/dai-bridge.ts:13](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/dai-bridge.ts#L13)
+
+___
+
+### withdraw
+
+▸ **withdraw**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some tokens back to the L1 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[withdraw](StandardBridgeAdapter.md#withdraw)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:236](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L236)

--- a/packages/sdk/docs/classes/ETHBridgeAdapter.md
+++ b/packages/sdk/docs/classes/ETHBridgeAdapter.md
@@ -1,0 +1,381 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / ETHBridgeAdapter
+
+# Class: ETHBridgeAdapter
+
+Bridge adapter for the ETH bridge.
+
+## Hierarchy
+
+- [`StandardBridgeAdapter`](StandardBridgeAdapter.md)
+
+  ↳ **`ETHBridgeAdapter`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ETHBridgeAdapter.md#constructor)
+
+### Properties
+
+- [estimateGas](ETHBridgeAdapter.md#estimategas)
+- [l1Bridge](ETHBridgeAdapter.md#l1bridge)
+- [l2Bridge](ETHBridgeAdapter.md#l2bridge)
+- [messenger](ETHBridgeAdapter.md#messenger)
+- [populateTransaction](ETHBridgeAdapter.md#populatetransaction)
+
+### Methods
+
+- [approval](ETHBridgeAdapter.md#approval)
+- [approve](ETHBridgeAdapter.md#approve)
+- [deposit](ETHBridgeAdapter.md#deposit)
+- [getDepositsByAddress](ETHBridgeAdapter.md#getdepositsbyaddress)
+- [getWithdrawalsByAddress](ETHBridgeAdapter.md#getwithdrawalsbyaddress)
+- [supportsTokenPair](ETHBridgeAdapter.md#supportstokenpair)
+- [withdraw](ETHBridgeAdapter.md#withdraw)
+
+## Constructors
+
+### constructor
+
+• **new ETHBridgeAdapter**(`opts`)
+
+Creates a StandardBridgeAdapter instance.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts` | `Object` | Options for the adapter. |
+| `opts.l1Bridge` | [`AddressLike`](../modules.md#addresslike) | L1 bridge contract. |
+| `opts.l2Bridge` | [`AddressLike`](../modules.md#addresslike) | L2 bridge contract. |
+| `opts.messenger` | [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md) | Provider used to make queries related to cross-chain interactions. |
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[constructor](StandardBridgeAdapter.md#constructor)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:37](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L37)
+
+## Properties
+
+### estimateGas
+
+• **estimateGas**: `Object`
+
+Object that holds the functions that estimates the gas required for a given transaction.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[estimateGas](StandardBridgeAdapter.md#estimategas)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:347](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L347)
+
+___
+
+### l1Bridge
+
+• **l1Bridge**: `Contract`
+
+L1 bridge contract.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[l1Bridge](StandardBridgeAdapter.md#l1bridge)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:26](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L26)
+
+___
+
+### l2Bridge
+
+• **l2Bridge**: `Contract`
+
+L2 bridge contract.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[l2Bridge](StandardBridgeAdapter.md#l2bridge)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:27](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L27)
+
+___
+
+### messenger
+
+• **messenger**: [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md)
+
+Provider used to make queries related to cross-chain interactions.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[messenger](StandardBridgeAdapter.md#messenger)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:25](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L25)
+
+___
+
+### populateTransaction
+
+• **populateTransaction**: `Object`
+
+Object that holds the functions that generate transactions to be signed by the user.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+
+#### Overrides
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[populateTransaction](StandardBridgeAdapter.md#populatetransaction)
+
+#### Defined in
+
+[packages/sdk/src/adapters/eth-bridge.ts:114](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/eth-bridge.ts#L114)
+
+## Methods
+
+### approval
+
+▸ **approval**(`l1Token`, `l2Token`, `signer`): `Promise`<`BigNumber`\>
+
+Queries the account's approval amount for a given L1 token.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `signer` | `Signer` |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Amount of tokens approved for deposits from the account.
+
+#### Overrides
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[approval](StandardBridgeAdapter.md#approval)
+
+#### Defined in
+
+[packages/sdk/src/adapters/eth-bridge.ts:20](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/eth-bridge.ts#L20)
+
+___
+
+### approve
+
+▸ **approve**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Approves a deposit into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the approval transaction.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[approve](StandardBridgeAdapter.md#approve)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:206](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L206)
+
+___
+
+### deposit
+
+▸ **deposit**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some tokens into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[deposit](StandardBridgeAdapter.md#deposit)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:220](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L220)
+
+___
+
+### getDepositsByAddress
+
+▸ **getDepositsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all deposits for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All deposit token bridge messages sent by the given address.
+
+#### Overrides
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[getDepositsByAddress](StandardBridgeAdapter.md#getdepositsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/adapters/eth-bridge.ts:28](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/eth-bridge.ts#L28)
+
+___
+
+### getWithdrawalsByAddress
+
+▸ **getWithdrawalsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all withdrawals for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All withdrawal token bridge messages sent by the given address.
+
+#### Overrides
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[getWithdrawalsByAddress](StandardBridgeAdapter.md#getwithdrawalsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/adapters/eth-bridge.ts:62](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/eth-bridge.ts#L62)
+
+___
+
+### supportsTokenPair
+
+▸ **supportsTokenPair**(`l1Token`, `l2Token`): `Promise`<`boolean`\>
+
+Checks whether the given token pair is supported by the bridge.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+Whether the given token pair is supported by the bridge.
+
+#### Overrides
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[supportsTokenPair](StandardBridgeAdapter.md#supportstokenpair)
+
+#### Defined in
+
+[packages/sdk/src/adapters/eth-bridge.ts:103](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/eth-bridge.ts#L103)
+
+___
+
+### withdraw
+
+▸ **withdraw**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some tokens back to the L1 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Inherited from
+
+[StandardBridgeAdapter](StandardBridgeAdapter.md).[withdraw](StandardBridgeAdapter.md#withdraw)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:236](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L236)

--- a/packages/sdk/docs/classes/StandardBridgeAdapter.md
+++ b/packages/sdk/docs/classes/StandardBridgeAdapter.md
@@ -1,0 +1,383 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / StandardBridgeAdapter
+
+# Class: StandardBridgeAdapter
+
+Bridge adapter for any token bridge that uses the standard token bridge interface.
+
+## Hierarchy
+
+- **`StandardBridgeAdapter`**
+
+  ↳ [`ETHBridgeAdapter`](ETHBridgeAdapter.md)
+
+  ↳ [`DAIBridgeAdapter`](DAIBridgeAdapter.md)
+
+## Implements
+
+- [`IBridgeAdapter`](../interfaces/IBridgeAdapter.md)
+
+## Table of contents
+
+### Constructors
+
+- [constructor](StandardBridgeAdapter.md#constructor)
+
+### Properties
+
+- [estimateGas](StandardBridgeAdapter.md#estimategas)
+- [l1Bridge](StandardBridgeAdapter.md#l1bridge)
+- [l2Bridge](StandardBridgeAdapter.md#l2bridge)
+- [messenger](StandardBridgeAdapter.md#messenger)
+- [populateTransaction](StandardBridgeAdapter.md#populatetransaction)
+
+### Methods
+
+- [approval](StandardBridgeAdapter.md#approval)
+- [approve](StandardBridgeAdapter.md#approve)
+- [deposit](StandardBridgeAdapter.md#deposit)
+- [getDepositsByAddress](StandardBridgeAdapter.md#getdepositsbyaddress)
+- [getWithdrawalsByAddress](StandardBridgeAdapter.md#getwithdrawalsbyaddress)
+- [supportsTokenPair](StandardBridgeAdapter.md#supportstokenpair)
+- [withdraw](StandardBridgeAdapter.md#withdraw)
+
+## Constructors
+
+### constructor
+
+• **new StandardBridgeAdapter**(`opts`)
+
+Creates a StandardBridgeAdapter instance.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts` | `Object` | Options for the adapter. |
+| `opts.l1Bridge` | [`AddressLike`](../modules.md#addresslike) | L1 bridge contract. |
+| `opts.l2Bridge` | [`AddressLike`](../modules.md#addresslike) | L2 bridge contract. |
+| `opts.messenger` | [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md) | Provider used to make queries related to cross-chain interactions. |
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:37](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L37)
+
+## Properties
+
+### estimateGas
+
+• **estimateGas**: `Object`
+
+Object that holds the functions that estimates the gas required for a given transaction.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[estimateGas](../interfaces/IBridgeAdapter.md#estimategas)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:347](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L347)
+
+___
+
+### l1Bridge
+
+• **l1Bridge**: `Contract`
+
+L1 bridge contract.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[l1Bridge](../interfaces/IBridgeAdapter.md#l1bridge)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:26](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L26)
+
+___
+
+### l2Bridge
+
+• **l2Bridge**: `Contract`
+
+L2 bridge contract.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[l2Bridge](../interfaces/IBridgeAdapter.md#l2bridge)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:27](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L27)
+
+___
+
+### messenger
+
+• **messenger**: [`ICrossChainMessenger`](../interfaces/ICrossChainMessenger.md)
+
+Provider used to make queries related to cross-chain interactions.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[messenger](../interfaces/IBridgeAdapter.md#messenger)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:25](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L25)
+
+___
+
+### populateTransaction
+
+• **populateTransaction**: `Object`
+
+Object that holds the functions that generate transactions to be signed by the user.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[populateTransaction](../interfaces/IBridgeAdapter.md#populatetransaction)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:251](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L251)
+
+## Methods
+
+### approval
+
+▸ **approval**(`l1Token`, `l2Token`, `signer`): `Promise`<`BigNumber`\>
+
+Queries the account's approval amount for a given L1 token.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `signer` | `Signer` |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Amount of tokens approved for deposits from the account.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[approval](../interfaces/IBridgeAdapter.md#approval)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:188](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L188)
+
+___
+
+### approve
+
+▸ **approve**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Approves a deposit into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the approval transaction.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[approve](../interfaces/IBridgeAdapter.md#approve)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:206](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L206)
+
+___
+
+### deposit
+
+▸ **deposit**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some tokens into the L2 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[deposit](../interfaces/IBridgeAdapter.md#deposit)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:220](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L220)
+
+___
+
+### getDepositsByAddress
+
+▸ **getDepositsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all deposits for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All deposit token bridge messages sent by the given address.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[getDepositsByAddress](../interfaces/IBridgeAdapter.md#getdepositsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:55](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L55)
+
+___
+
+### getWithdrawalsByAddress
+
+▸ **getWithdrawalsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+Gets all withdrawals for a given address.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) |
+| `opts?` | `Object` |
+| `opts.fromBlock?` | `BlockTag` |
+| `opts.toBlock?` | `BlockTag` |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](../interfaces/TokenBridgeMessage.md)[]\>
+
+All withdrawal token bridge messages sent by the given address.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[getWithdrawalsByAddress](../interfaces/IBridgeAdapter.md#getwithdrawalsbyaddress)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:102](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L102)
+
+___
+
+### supportsTokenPair
+
+▸ **supportsTokenPair**(`l1Token`, `l2Token`): `Promise`<`boolean`\>
+
+Checks whether the given token pair is supported by the bridge.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+Whether the given token pair is supported by the bridge.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[supportsTokenPair](../interfaces/IBridgeAdapter.md#supportstokenpair)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:145](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L145)
+
+___
+
+### withdraw
+
+▸ **withdraw**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some tokens back to the L1 chain.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) |
+| `amount` | [`NumberLike`](../modules.md#numberlike) |
+| `signer` | `Signer` |
+| `opts?` | `Object` |
+| `opts.overrides?` | `Overrides` |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Implementation of
+
+[IBridgeAdapter](../interfaces/IBridgeAdapter.md).[withdraw](../interfaces/IBridgeAdapter.md#withdraw)
+
+#### Defined in
+
+[packages/sdk/src/adapters/standard-bridge.ts:236](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/adapters/standard-bridge.ts#L236)

--- a/packages/sdk/docs/enums/MessageDirection.md
+++ b/packages/sdk/docs/enums/MessageDirection.md
@@ -1,0 +1,32 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / MessageDirection
+
+# Enumeration: MessageDirection
+
+Enum describing the direction of a message.
+
+## Table of contents
+
+### Enumeration members
+
+- [L1\_TO\_L2](MessageDirection.md#l1_to_l2)
+- [L2\_TO\_L1](MessageDirection.md#l2_to_l1)
+
+## Enumeration members
+
+### L1\_TO\_L2
+
+• **L1\_TO\_L2** = `0`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:136](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L136)
+
+___
+
+### L2\_TO\_L1
+
+• **L2\_TO\_L1** = `1`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:137](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L137)

--- a/packages/sdk/docs/enums/MessageReceiptStatus.md
+++ b/packages/sdk/docs/enums/MessageReceiptStatus.md
@@ -1,0 +1,32 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / MessageReceiptStatus
+
+# Enumeration: MessageReceiptStatus
+
+Enum describing the status of a CrossDomainMessage message receipt.
+
+## Table of contents
+
+### Enumeration members
+
+- [RELAYED\_FAILED](MessageReceiptStatus.md#relayed_failed)
+- [RELAYED\_SUCCEEDED](MessageReceiptStatus.md#relayed_succeeded)
+
+## Enumeration members
+
+### RELAYED\_FAILED
+
+• **RELAYED\_FAILED** = `0`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:192](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L192)
+
+___
+
+### RELAYED\_SUCCEEDED
+
+• **RELAYED\_SUCCEEDED** = `1`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:193](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L193)

--- a/packages/sdk/docs/enums/MessageStatus.md
+++ b/packages/sdk/docs/enums/MessageStatus.md
@@ -1,0 +1,90 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / MessageStatus
+
+# Enumeration: MessageStatus
+
+Enum describing the status of a message.
+
+## Table of contents
+
+### Enumeration members
+
+- [FAILED\_L1\_TO\_L2\_MESSAGE](MessageStatus.md#failed_l1_to_l2_message)
+- [IN\_CHALLENGE\_PERIOD](MessageStatus.md#in_challenge_period)
+- [READY\_FOR\_RELAY](MessageStatus.md#ready_for_relay)
+- [RELAYED](MessageStatus.md#relayed)
+- [STATE\_ROOT\_NOT\_PUBLISHED](MessageStatus.md#state_root_not_published)
+- [UNCONFIRMED\_L1\_TO\_L2\_MESSAGE](MessageStatus.md#unconfirmed_l1_to_l2_message)
+
+## Enumeration members
+
+### FAILED\_L1\_TO\_L2\_MESSAGE
+
+• **FAILED\_L1\_TO\_L2\_MESSAGE** = `1`
+
+Message is an L1 to L2 message and the transaction to execute the message failed.
+When this status is returned, you will need to resend the L1 to L2 message, probably with a
+higher gas limit.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:109](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L109)
+
+___
+
+### IN\_CHALLENGE\_PERIOD
+
+• **IN\_CHALLENGE\_PERIOD** = `3`
+
+Message is an L2 to L1 message and awaiting the challenge period.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:119](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L119)
+
+___
+
+### READY\_FOR\_RELAY
+
+• **READY\_FOR\_RELAY** = `4`
+
+Message is ready to be relayed.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:124](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L124)
+
+___
+
+### RELAYED
+
+• **RELAYED** = `5`
+
+Message has been relayed.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:129](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L129)
+
+___
+
+### STATE\_ROOT\_NOT\_PUBLISHED
+
+• **STATE\_ROOT\_NOT\_PUBLISHED** = `2`
+
+Message is an L2 to L1 message and no state root has been published yet.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:114](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L114)
+
+___
+
+### UNCONFIRMED\_L1\_TO\_L2\_MESSAGE
+
+• **UNCONFIRMED\_L1\_TO\_L2\_MESSAGE** = `0`
+
+Message is an L1 to L2 message and has not been processed by the L2.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:102](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L102)

--- a/packages/sdk/docs/interfaces/BridgeAdapterData.md
+++ b/packages/sdk/docs/interfaces/BridgeAdapterData.md
@@ -1,0 +1,9 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / BridgeAdapterData
+
+# Interface: BridgeAdapterData
+
+Something that looks like the list of custom bridges.
+
+## Indexable
+
+▪ [name: `string`]: { `Adapter`: (`opts`: { `l1Bridge`: [`AddressLike`](../modules.md#addresslike) ; `l2Bridge`: [`AddressLike`](../modules.md#addresslike) ; `messenger`: [`ICrossChainMessenger`](ICrossChainMessenger.md)  }) => [`IBridgeAdapter`](IBridgeAdapter.md) ; `l1Bridge`: [`AddressLike`](../modules.md#addresslike) ; `l2Bridge`: [`AddressLike`](../modules.md#addresslike)  }

--- a/packages/sdk/docs/interfaces/BridgeAdapters.md
+++ b/packages/sdk/docs/interfaces/BridgeAdapters.md
@@ -1,0 +1,9 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / BridgeAdapters
+
+# Interface: BridgeAdapters
+
+Something that looks like the list of custom bridges.
+
+## Indexable
+
+▪ [name: `string`]: [`IBridgeAdapter`](IBridgeAdapter.md)

--- a/packages/sdk/docs/interfaces/CoreCrossChainMessage.md
+++ b/packages/sdk/docs/interfaces/CoreCrossChainMessage.md
@@ -1,0 +1,60 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / CoreCrossChainMessage
+
+# Interface: CoreCrossChainMessage
+
+Core components of a cross chain message.
+
+## Hierarchy
+
+- **`CoreCrossChainMessage`**
+
+  ↳ [`CrossChainMessage`](CrossChainMessage.md)
+
+## Table of contents
+
+### Properties
+
+- [message](CoreCrossChainMessage.md#message)
+- [messageNonce](CoreCrossChainMessage.md#messagenonce)
+- [sender](CoreCrossChainMessage.md#sender)
+- [target](CoreCrossChainMessage.md#target)
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:155](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L155)
+
+___
+
+### messageNonce
+
+• **messageNonce**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:156](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L156)
+
+___
+
+### sender
+
+• **sender**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:153](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L153)
+
+___
+
+### target
+
+• **target**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:154](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L154)

--- a/packages/sdk/docs/interfaces/CrossChainMessage.md
+++ b/packages/sdk/docs/interfaces/CrossChainMessage.md
@@ -1,0 +1,132 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / CrossChainMessage
+
+# Interface: CrossChainMessage
+
+Describes a message that is sent between L1 and L2. Direction determines where the message was
+sent from and where it's being sent to.
+
+## Hierarchy
+
+- [`CoreCrossChainMessage`](CoreCrossChainMessage.md)
+
+  ↳ **`CrossChainMessage`**
+
+## Table of contents
+
+### Properties
+
+- [blockNumber](CrossChainMessage.md#blocknumber)
+- [direction](CrossChainMessage.md#direction)
+- [gasLimit](CrossChainMessage.md#gaslimit)
+- [logIndex](CrossChainMessage.md#logindex)
+- [message](CrossChainMessage.md#message)
+- [messageNonce](CrossChainMessage.md#messagenonce)
+- [sender](CrossChainMessage.md#sender)
+- [target](CrossChainMessage.md#target)
+- [transactionHash](CrossChainMessage.md#transactionhash)
+
+## Properties
+
+### blockNumber
+
+• **blockNumber**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:167](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L167)
+
+___
+
+### direction
+
+• **direction**: [`MessageDirection`](../enums/MessageDirection.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:164](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L164)
+
+___
+
+### gasLimit
+
+• **gasLimit**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:165](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L165)
+
+___
+
+### logIndex
+
+• **logIndex**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:166](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L166)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[CoreCrossChainMessage](CoreCrossChainMessage.md).[message](CoreCrossChainMessage.md#message)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:155](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L155)
+
+___
+
+### messageNonce
+
+• **messageNonce**: `number`
+
+#### Inherited from
+
+[CoreCrossChainMessage](CoreCrossChainMessage.md).[messageNonce](CoreCrossChainMessage.md#messagenonce)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:156](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L156)
+
+___
+
+### sender
+
+• **sender**: `string`
+
+#### Inherited from
+
+[CoreCrossChainMessage](CoreCrossChainMessage.md).[sender](CoreCrossChainMessage.md#sender)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:153](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L153)
+
+___
+
+### target
+
+• **target**: `string`
+
+#### Inherited from
+
+[CoreCrossChainMessage](CoreCrossChainMessage.md).[target](CoreCrossChainMessage.md#target)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:154](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L154)
+
+___
+
+### transactionHash
+
+• **transactionHash**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:168](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L168)

--- a/packages/sdk/docs/interfaces/CrossChainMessageProof.md
+++ b/packages/sdk/docs/interfaces/CrossChainMessageProof.md
@@ -1,0 +1,72 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / CrossChainMessageProof
+
+# Interface: CrossChainMessageProof
+
+Proof data required to finalize an L2 to L1 message.
+
+## Table of contents
+
+### Properties
+
+- [stateRoot](CrossChainMessageProof.md#stateroot)
+- [stateRootBatchHeader](CrossChainMessageProof.md#staterootbatchheader)
+- [stateRootProof](CrossChainMessageProof.md#staterootproof)
+- [stateTrieWitness](CrossChainMessageProof.md#statetriewitness)
+- [storageTrieWitness](CrossChainMessageProof.md#storagetriewitness)
+
+## Properties
+
+### stateRoot
+
+• **stateRoot**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:237](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L237)
+
+___
+
+### stateRootBatchHeader
+
+• **stateRootBatchHeader**: [`StateRootBatchHeader`](StateRootBatchHeader.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:238](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L238)
+
+___
+
+### stateRootProof
+
+• **stateRootProof**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `index` | `number` |
+| `siblings` | `string`[] |
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:239](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L239)
+
+___
+
+### stateTrieWitness
+
+• **stateTrieWitness**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:243](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L243)
+
+___
+
+### storageTrieWitness
+
+• **storageTrieWitness**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:244](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L244)

--- a/packages/sdk/docs/interfaces/CrossChainMessageRequest.md
+++ b/packages/sdk/docs/interfaces/CrossChainMessageRequest.md
@@ -1,0 +1,43 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / CrossChainMessageRequest
+
+# Interface: CrossChainMessageRequest
+
+Partial message that needs to be signed and executed by a specific signer.
+
+## Table of contents
+
+### Properties
+
+- [direction](CrossChainMessageRequest.md#direction)
+- [message](CrossChainMessageRequest.md#message)
+- [target](CrossChainMessageRequest.md#target)
+
+## Properties
+
+### direction
+
+• **direction**: [`MessageDirection`](../enums/MessageDirection.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:144](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L144)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:146](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L146)
+
+___
+
+### target
+
+• **target**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:145](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L145)

--- a/packages/sdk/docs/interfaces/IBridgeAdapter.md
+++ b/packages/sdk/docs/interfaces/IBridgeAdapter.md
@@ -1,0 +1,303 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / IBridgeAdapter
+
+# Interface: IBridgeAdapter
+
+Represents an adapter for an L1<>L2 token bridge. Each custom bridge currently needs its own
+adapter because the bridge interface is not standardized. This may change in the future.
+
+## Implemented by
+
+- [`StandardBridgeAdapter`](../classes/StandardBridgeAdapter.md)
+
+## Table of contents
+
+### Properties
+
+- [estimateGas](IBridgeAdapter.md#estimategas)
+- [l1Bridge](IBridgeAdapter.md#l1bridge)
+- [l2Bridge](IBridgeAdapter.md#l2bridge)
+- [messenger](IBridgeAdapter.md#messenger)
+- [populateTransaction](IBridgeAdapter.md#populatetransaction)
+
+### Methods
+
+- [approval](IBridgeAdapter.md#approval)
+- [approve](IBridgeAdapter.md#approve)
+- [deposit](IBridgeAdapter.md#deposit)
+- [getDepositsByAddress](IBridgeAdapter.md#getdepositsbyaddress)
+- [getWithdrawalsByAddress](IBridgeAdapter.md#getwithdrawalsbyaddress)
+- [supportsTokenPair](IBridgeAdapter.md#supportstokenpair)
+- [withdraw](IBridgeAdapter.md#withdraw)
+
+## Properties
+
+### estimateGas
+
+• **estimateGas**: `Object`
+
+Object that holds the functions that estimates the gas required for a given transaction.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:237](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L237)
+
+___
+
+### l1Bridge
+
+• **l1Bridge**: `Contract`
+
+L1 bridge contract.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:24](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L24)
+
+___
+
+### l2Bridge
+
+• **l2Bridge**: `Contract`
+
+L2 bridge contract.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:29](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L29)
+
+___
+
+### messenger
+
+• **messenger**: [`ICrossChainMessenger`](ICrossChainMessenger.md)
+
+Provider used to make queries related to cross-chain interactions.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:19](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L19)
+
+___
+
+### populateTransaction
+
+• **populateTransaction**: `Object`
+
+Object that holds the functions that generate transactions to be signed by the user.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approve` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `deposit` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `withdraw` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:168](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L168)
+
+## Methods
+
+### approval
+
+▸ **approval**(`l1Token`, `l2Token`, `signer`): `Promise`<`BigNumber`\>
+
+Queries the account's approval amount for a given L1 token.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+| `signer` | `Signer` | Signer to query the approval for. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Amount of tokens approved for deposits from the account.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:89](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L89)
+
+___
+
+### approve
+
+▸ **approve**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Approves a deposit into the L2 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount of the token to approve. |
+| `signer` | `Signer` | Signer used to sign and send the transaction. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the approval transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:106](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L106)
+
+___
+
+### deposit
+
+▸ **deposit**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some tokens into the L2 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount of the token to deposit. |
+| `signer` | `Signer` | Signer used to sign and send the transaction. |
+| `opts?` | `Object` | Additional options. |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) | Optional gas limit to use for the transaction on L2. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) | Optional address to receive the funds on L2. Defaults to sender. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:129](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L129)
+
+___
+
+### getDepositsByAddress
+
+▸ **getDepositsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+Gets all deposits for a given address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) | Address to search for messages from. |
+| `opts?` | `Object` | Options object. |
+| `opts.fromBlock?` | `BlockTag` | Block to start searching for messages from. If not provided, will start from the first block (block #0). |
+| `opts.toBlock?` | `BlockTag` | Block to stop searching for messages at. If not provided, will stop at the latest known block ("latest"). |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+All deposit token bridge messages sent by the given address.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:42](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L42)
+
+___
+
+### getWithdrawalsByAddress
+
+▸ **getWithdrawalsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+Gets all withdrawals for a given address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) | Address to search for messages from. |
+| `opts?` | `Object` | Options object. |
+| `opts.fromBlock?` | `BlockTag` | Block to start searching for messages from. If not provided, will start from the first block (block #0). |
+| `opts.toBlock?` | `BlockTag` | Block to stop searching for messages at. If not provided, will stop at the latest known block ("latest"). |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+All withdrawal token bridge messages sent by the given address.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:61](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L61)
+
+___
+
+### supportsTokenPair
+
+▸ **supportsTokenPair**(`l1Token`, `l2Token`): `Promise`<`boolean`\>
+
+Checks whether the given token pair is supported by the bridge.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+Whether the given token pair is supported by the bridge.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:76](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L76)
+
+___
+
+### withdraw
+
+▸ **withdraw**(`l1Token`, `l2Token`, `amount`, `signer`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some tokens back to the L1 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount of the token to withdraw. |
+| `signer` | `Signer` | Signer used to sign and send the transaction. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) | Optional address to receive the funds on L1. Defaults to sender. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/bridge-adapter.ts:153](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/bridge-adapter.ts#L153)

--- a/packages/sdk/docs/interfaces/ICrossChainMessenger.md
+++ b/packages/sdk/docs/interfaces/ICrossChainMessenger.md
@@ -1,0 +1,969 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / ICrossChainMessenger
+
+# Interface: ICrossChainMessenger
+
+Handles L1/L2 interactions.
+
+## Implemented by
+
+- [`CrossChainMessenger`](../classes/CrossChainMessenger.md)
+
+## Table of contents
+
+### Properties
+
+- [bridges](ICrossChainMessenger.md#bridges)
+- [contracts](ICrossChainMessenger.md#contracts)
+- [depositConfirmationBlocks](ICrossChainMessenger.md#depositconfirmationblocks)
+- [estimateGas](ICrossChainMessenger.md#estimategas)
+- [l1BlockTimeSeconds](ICrossChainMessenger.md#l1blocktimeseconds)
+- [l1ChainId](ICrossChainMessenger.md#l1chainid)
+- [l1Provider](ICrossChainMessenger.md#l1provider)
+- [l1Signer](ICrossChainMessenger.md#l1signer)
+- [l1SignerOrProvider](ICrossChainMessenger.md#l1signerorprovider)
+- [l2Provider](ICrossChainMessenger.md#l2provider)
+- [l2Signer](ICrossChainMessenger.md#l2signer)
+- [l2SignerOrProvider](ICrossChainMessenger.md#l2signerorprovider)
+- [populateTransaction](ICrossChainMessenger.md#populatetransaction)
+
+### Methods
+
+- [approval](ICrossChainMessenger.md#approval)
+- [approveERC20](ICrossChainMessenger.md#approveerc20)
+- [depositERC20](ICrossChainMessenger.md#depositerc20)
+- [depositETH](ICrossChainMessenger.md#depositeth)
+- [estimateL2MessageGasLimit](ICrossChainMessenger.md#estimatel2messagegaslimit)
+- [estimateMessageWaitTimeSeconds](ICrossChainMessenger.md#estimatemessagewaittimeseconds)
+- [finalizeMessage](ICrossChainMessenger.md#finalizemessage)
+- [getBridgeForTokenPair](ICrossChainMessenger.md#getbridgefortokenpair)
+- [getChallengePeriodSeconds](ICrossChainMessenger.md#getchallengeperiodseconds)
+- [getDepositsByAddress](ICrossChainMessenger.md#getdepositsbyaddress)
+- [getMessageProof](ICrossChainMessenger.md#getmessageproof)
+- [getMessageReceipt](ICrossChainMessenger.md#getmessagereceipt)
+- [getMessageStateRoot](ICrossChainMessenger.md#getmessagestateroot)
+- [getMessageStatus](ICrossChainMessenger.md#getmessagestatus)
+- [getMessagesByAddress](ICrossChainMessenger.md#getmessagesbyaddress)
+- [getMessagesByTransaction](ICrossChainMessenger.md#getmessagesbytransaction)
+- [getStateBatchAppendedEventByBatchIndex](ICrossChainMessenger.md#getstatebatchappendedeventbybatchindex)
+- [getStateBatchAppendedEventByTransactionIndex](ICrossChainMessenger.md#getstatebatchappendedeventbytransactionindex)
+- [getStateRootBatchByTransactionIndex](ICrossChainMessenger.md#getstaterootbatchbytransactionindex)
+- [getWithdrawalsByAddress](ICrossChainMessenger.md#getwithdrawalsbyaddress)
+- [resendMessage](ICrossChainMessenger.md#resendmessage)
+- [sendMessage](ICrossChainMessenger.md#sendmessage)
+- [toCrossChainMessage](ICrossChainMessenger.md#tocrosschainmessage)
+- [waitForMessageReceipt](ICrossChainMessenger.md#waitformessagereceipt)
+- [waitForMessageStatus](ICrossChainMessenger.md#waitformessagestatus)
+- [withdrawERC20](ICrossChainMessenger.md#withdrawerc20)
+- [withdrawETH](ICrossChainMessenger.md#withdraweth)
+
+## Properties
+
+### bridges
+
+• **bridges**: [`BridgeAdapters`](BridgeAdapters.md)
+
+List of custom bridges for the given network.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:57](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L57)
+
+___
+
+### contracts
+
+• **contracts**: [`OEContracts`](OEContracts.md)
+
+Contract objects attached to their respective providers and addresses.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:52](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L52)
+
+___
+
+### depositConfirmationBlocks
+
+• **depositConfirmationBlocks**: `number`
+
+Number of blocks before a deposit is considered confirmed.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:82](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L82)
+
+___
+
+### estimateGas
+
+• **estimateGas**: `Object`
+
+Object that holds the functions that estimates the gas required for a given transaction.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approveERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `depositERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `depositETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `finalizeMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `resendMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `messageGasLimit`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `sendMessage` | (`message`: [`CrossChainMessageRequest`](CrossChainMessageRequest.md), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides`  }) => `Promise`<`BigNumber`\> |
+| `withdrawERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+| `withdrawETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`BigNumber`\> |
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:683](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L683)
+
+___
+
+### l1BlockTimeSeconds
+
+• **l1BlockTimeSeconds**: `number`
+
+Estimated average L1 block time in seconds.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:87](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L87)
+
+___
+
+### l1ChainId
+
+• **l1ChainId**: `number`
+
+Chain ID for the L1 network.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:47](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L47)
+
+___
+
+### l1Provider
+
+• **l1Provider**: `Provider`
+
+Provider connected to the L1 chain.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:62](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L62)
+
+___
+
+### l1Signer
+
+• **l1Signer**: `Signer`
+
+Signer connected to the L1 chain.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:72](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L72)
+
+___
+
+### l1SignerOrProvider
+
+• **l1SignerOrProvider**: `Signer` \| `Provider`
+
+Provider connected to the L1 chain.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:37](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L37)
+
+___
+
+### l2Provider
+
+• **l2Provider**: `Provider`
+
+Provider connected to the L2 chain.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:67](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L67)
+
+___
+
+### l2Signer
+
+• **l2Signer**: `Signer`
+
+Signer connected to the L2 chain.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:77](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L77)
+
+___
+
+### l2SignerOrProvider
+
+• **l2SignerOrProvider**: `Signer` \| `Provider`
+
+Provider connected to the L2 chain.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:42](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L42)
+
+___
+
+### populateTransaction
+
+• **populateTransaction**: `Object`
+
+Object that holds the functions that generate transactions to be signed by the user.
+Follows the pattern used by ethers.js.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `approveERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `depositERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `depositETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `finalizeMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `resendMessage` | (`message`: [`MessageLike`](../modules.md#messagelike), `messageGasLimit`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `sendMessage` | (`message`: [`CrossChainMessageRequest`](CrossChainMessageRequest.md), `opts?`: { `l2GasLimit?`: [`NumberLike`](../modules.md#numberlike) ; `overrides?`: `Overrides`  }) => `Promise`<`TransactionRequest`\> |
+| `withdrawERC20` | (`l1Token`: [`AddressLike`](../modules.md#addresslike), `l2Token`: [`AddressLike`](../modules.md#addresslike), `amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+| `withdrawETH` | (`amount`: [`NumberLike`](../modules.md#numberlike), `opts?`: { `overrides?`: `Overrides` ; `recipient?`: [`AddressLike`](../modules.md#addresslike)  }) => `Promise`<`TransactionRequest`\> |
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:525](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L525)
+
+## Methods
+
+### approval
+
+▸ **approval**(`l1Token`, `l2Token`, `opts?`): `Promise`<`BigNumber`\>
+
+Queries the account's approval amount for a given L1 token.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+| `opts?` | `Object` | Additional options. |
+| `opts.signer?` | `Signer` | Optional signer to get the approval for. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Amount of tokens approved for deposits from the account.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:444](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L444)
+
+___
+
+### approveERC20
+
+▸ **approveERC20**(`l1Token`, `l2Token`, `amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Approves a deposit into the L2 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | The L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | The L2 token address. |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount of the token to approve. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the approval transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:463](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L463)
+
+___
+
+### depositERC20
+
+▸ **depositERC20**(`l1Token`, `l2Token`, `amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some ERC20 tokens into the L2 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | Address of the L1 token. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | Address of the L2 token. |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount to deposit. |
+| `opts?` | `Object` | Additional options. |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) | Optional gas limit to use for the transaction on L2. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) | Optional address to receive the funds on L2. Defaults to sender. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:486](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L486)
+
+___
+
+### depositETH
+
+▸ **depositETH**(`amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Deposits some ETH into the L2 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount of ETH to deposit (in wei). |
+| `opts?` | `Object` | Additional options. |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) | Optional gas limit to use for the transaction on L2. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) | Optional address to receive the funds on L2. Defaults to sender. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the deposit transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:406](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L406)
+
+___
+
+### estimateL2MessageGasLimit
+
+▸ **estimateL2MessageGasLimit**(`message`, `opts?`): `Promise`<`BigNumber`\>
+
+Estimates the amount of gas required to fully execute a given message on L2. Only applies to
+L1 => L2 messages. You would supply this gas limit when sending the message to L2.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageRequestLike`](../modules.md#messagerequestlike) | Message get a gas estimate for. |
+| `opts?` | `Object` | Options object. |
+| `opts.bufferPercent?` | `number` | Percentage of gas to add to the estimate. Defaults to 20. |
+| `opts.from?` | `string` | Address to use as the sender. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Estimates L2 gas limit.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:260](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L260)
+
+___
+
+### estimateMessageWaitTimeSeconds
+
+▸ **estimateMessageWaitTimeSeconds**(`message`): `Promise`<`number`\>
+
+Returns the estimated amount of time before the message can be executed. When this is a
+message being sent to L1, this will return the estimated time until the message will complete
+its challenge period. When this is a message being sent to L2, this will return the estimated
+amount of time until the message will be picked up and executed on L2.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to estimate the time remaining for. |
+
+#### Returns
+
+`Promise`<`number`\>
+
+Estimated amount of time remaining (in seconds) before the message can be executed.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:277](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L277)
+
+___
+
+### finalizeMessage
+
+▸ **finalizeMessage**(`message`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Finalizes a cross chain message that was sent from L2 to L1. Only applicable for L2 to L1
+messages. Will throw an error if the message has not completed its challenge period yet.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to finalize. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the finalization transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:387](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L387)
+
+___
+
+### getBridgeForTokenPair
+
+▸ **getBridgeForTokenPair**(`l1Token`, `l2Token`): `Promise`<[`IBridgeAdapter`](IBridgeAdapter.md)\>
+
+Finds the appropriate bridge adapter for a given L1<>L2 token pair. Will throw if no bridges
+support the token pair or if more than one bridge supports the token pair.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | L1 token address. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | L2 token address. |
+
+#### Returns
+
+`Promise`<[`IBridgeAdapter`](IBridgeAdapter.md)\>
+
+The appropriate bridge adapter for the given token pair.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:136](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L136)
+
+___
+
+### getChallengePeriodSeconds
+
+▸ **getChallengePeriodSeconds**(): `Promise`<`number`\>
+
+Queries the current challenge period in seconds from the StateCommitmentChain.
+
+#### Returns
+
+`Promise`<`number`\>
+
+Current challenge period in seconds.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:284](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L284)
+
+___
+
+### getDepositsByAddress
+
+▸ **getDepositsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+Gets all deposits for a given address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) | Address to search for messages from. |
+| `opts?` | `Object` | Options object. |
+| `opts.fromBlock?` | `BlockTag` | Block to start searching for messages from. If not provided, will start from the first block (block #0). |
+| `opts.toBlock?` | `BlockTag` | Block to stop searching for messages at. If not provided, will stop at the latest known block ("latest"). |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+All deposit token bridge messages sent by the given address.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:152](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L152)
+
+___
+
+### getMessageProof
+
+▸ **getMessageProof**(`message`): `Promise`<[`CrossChainMessageProof`](CrossChainMessageProof.md)\>
+
+Generates the proof required to finalize an L2 to L1 message.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to generate a proof for. |
+
+#### Returns
+
+`Promise`<[`CrossChainMessageProof`](CrossChainMessageProof.md)\>
+
+Proof that can be used to finalize the message.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:335](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L335)
+
+___
+
+### getMessageReceipt
+
+▸ **getMessageReceipt**(`message`): `Promise`<[`MessageReceipt`](MessageReceipt.md)\>
+
+Finds the receipt of the transaction that executed a particular cross chain message.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to find the receipt of. |
+
+#### Returns
+
+`Promise`<[`MessageReceipt`](MessageReceipt.md)\>
+
+CrossChainMessage receipt including receipt of the transaction that relayed the
+given message.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:206](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L206)
+
+___
+
+### getMessageStateRoot
+
+▸ **getMessageStateRoot**(`message`): `Promise`<[`StateRoot`](StateRoot.md)\>
+
+Returns the state root that corresponds to a given message. This is the state root for the
+block in which the transaction was included, as published to the StateCommitmentChain. If the
+state root for the given message has not been published yet, this function returns null.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to find a state root for. |
+
+#### Returns
+
+`Promise`<[`StateRoot`](StateRoot.md)\>
+
+State root for the block in which the message was created.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:294](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L294)
+
+___
+
+### getMessageStatus
+
+▸ **getMessageStatus**(`message`): `Promise`<[`MessageStatus`](../enums/MessageStatus.md)\>
+
+Retrieves the status of a particular message as an enum.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Cross chain message to check the status of. |
+
+#### Returns
+
+`Promise`<[`MessageStatus`](../enums/MessageStatus.md)\>
+
+Status of the message.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:197](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L197)
+
+___
+
+### getMessagesByAddress
+
+▸ **getMessagesByAddress**(`address`, `opts?`): `Promise`<[`CrossChainMessage`](CrossChainMessage.md)[]\>
+
+Retrieves all cross chain messages sent by a particular address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) | Address to search for messages from. |
+| `opts?` | `Object` | Options object. |
+| `opts.direction?` | [`MessageDirection`](../enums/MessageDirection.md) | Direction to search for messages in. If not provided, will attempt to find all messages in both directions. |
+| `opts.fromBlock?` | [`NumberLike`](../modules.md#numberlike) | Block to start searching for messages from. If not provided, will start from the first block (block #0). |
+| `opts.toBlock?` | [`NumberLike`](../modules.md#numberlike) | Block to stop searching for messages at. If not provided, will stop at the latest known block ("latest"). |
+
+#### Returns
+
+`Promise`<[`CrossChainMessage`](CrossChainMessage.md)[]\>
+
+All cross chain messages sent by the particular address.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:119](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L119)
+
+___
+
+### getMessagesByTransaction
+
+▸ **getMessagesByTransaction**(`transaction`, `opts?`): `Promise`<[`CrossChainMessage`](CrossChainMessage.md)[]\>
+
+Retrieves all cross chain messages sent within a given transaction.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `transaction` | [`TransactionLike`](../modules.md#transactionlike) | Transaction hash or receipt to find messages from. |
+| `opts?` | `Object` | Options object. |
+| `opts.direction?` | [`MessageDirection`](../enums/MessageDirection.md) | Direction to search for messages in. If not provided, will attempt to automatically search both directions under the assumption that a transaction hash will only exist on one chain. If the hash exists on both chains, will throw an error. |
+
+#### Returns
+
+`Promise`<[`CrossChainMessage`](CrossChainMessage.md)[]\>
+
+All cross chain messages sent within the transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:99](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L99)
+
+___
+
+### getStateBatchAppendedEventByBatchIndex
+
+▸ **getStateBatchAppendedEventByBatchIndex**(`batchIndex`): `Promise`<`Event`\>
+
+Returns the StateBatchAppended event that was emitted when the batch with a given index was
+created. Returns null if no such event exists (the batch has not been submitted).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `batchIndex` | `number` | Index of the batch to find an event for. |
+
+#### Returns
+
+`Promise`<`Event`\>
+
+StateBatchAppended event for the batch, or null if no such batch exists.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:303](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L303)
+
+___
+
+### getStateBatchAppendedEventByTransactionIndex
+
+▸ **getStateBatchAppendedEventByTransactionIndex**(`transactionIndex`): `Promise`<`Event`\>
+
+Returns the StateBatchAppended event for the batch that includes the transaction with the
+given index. Returns null if no such event exists.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `transactionIndex` | `number` | Index of the L2 transaction to find an event for. |
+
+#### Returns
+
+`Promise`<`Event`\>
+
+StateBatchAppended event for the batch that includes the given transaction by index.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:314](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L314)
+
+___
+
+### getStateRootBatchByTransactionIndex
+
+▸ **getStateRootBatchByTransactionIndex**(`transactionIndex`): `Promise`<[`StateRootBatch`](StateRootBatch.md)\>
+
+Returns information about the state root batch that included the state root for the given
+transaction by index. Returns null if no such state root has been published yet.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `transactionIndex` | `number` | Index of the L2 transaction to find a state root batch for. |
+
+#### Returns
+
+`Promise`<[`StateRootBatch`](StateRootBatch.md)\>
+
+State root batch for the given transaction index, or null if none exists yet.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:325](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L325)
+
+___
+
+### getWithdrawalsByAddress
+
+▸ **getWithdrawalsByAddress**(`address`, `opts?`): `Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+Gets all withdrawals for a given address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | [`AddressLike`](../modules.md#addresslike) | Address to search for messages from. |
+| `opts?` | `Object` | Options object. |
+| `opts.fromBlock?` | `BlockTag` | Block to start searching for messages from. If not provided, will start from the first block (block #0). |
+| `opts.toBlock?` | `BlockTag` | Block to stop searching for messages at. If not provided, will stop at the latest known block ("latest"). |
+
+#### Returns
+
+`Promise`<[`TokenBridgeMessage`](TokenBridgeMessage.md)[]\>
+
+All withdrawal token bridge messages sent by the given address.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:171](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L171)
+
+___
+
+### resendMessage
+
+▸ **resendMessage**(`message`, `messageGasLimit`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Resends a given cross chain message with a different gas limit. Only applies to L1 to L2
+messages. If provided an L2 to L1 message, this function will throw an error.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Cross chain message to resend. |
+| `messageGasLimit` | [`NumberLike`](../modules.md#numberlike) | New gas limit to use for the message. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the message resending transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:368](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L368)
+
+___
+
+### sendMessage
+
+▸ **sendMessage**(`message`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Sends a given cross chain message. Where the message is sent depends on the direction attached
+to the message itself.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`CrossChainMessageRequest`](CrossChainMessageRequest.md) | Cross chain message to send. |
+| `opts?` | `Object` | Additional options. |
+| `opts.l2GasLimit?` | [`NumberLike`](../modules.md#numberlike) | Optional gas limit to use for the transaction on L2. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the message sending transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:348](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L348)
+
+___
+
+### toCrossChainMessage
+
+▸ **toCrossChainMessage**(`message`): `Promise`<[`CrossChainMessage`](CrossChainMessage.md)\>
+
+Resolves a MessageLike into a CrossChainMessage object.
+Unlike other coercion functions, this function is stateful and requires making additional
+requests. For now I'm going to keep this function here, but we could consider putting a
+similar function inside of utils/coercion.ts if people want to use this without having to
+create an entire CrossChainProvider object.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | MessageLike to resolve into a CrossChainMessage. |
+
+#### Returns
+
+`Promise`<[`CrossChainMessage`](CrossChainMessage.md)\>
+
+Message coerced into a CrossChainMessage.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:189](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L189)
+
+___
+
+### waitForMessageReceipt
+
+▸ **waitForMessageReceipt**(`message`, `opts?`): `Promise`<[`MessageReceipt`](MessageReceipt.md)\>
+
+Waits for a message to be executed and returns the receipt of the transaction that executed
+the given message.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to wait for. |
+| `opts?` | `Object` | Options to pass to the waiting function. |
+| `opts.confirmations?` | `number` | Number of transaction confirmations to wait for before returning. |
+| `opts.pollIntervalMs?` | `number` | Number of milliseconds to wait between polling for the receipt. |
+| `opts.timeoutMs?` | `number` | Milliseconds to wait before timing out. |
+
+#### Returns
+
+`Promise`<[`MessageReceipt`](MessageReceipt.md)\>
+
+CrossChainMessage receipt including receipt of the transaction that relayed the
+given message.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:220](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L220)
+
+___
+
+### waitForMessageStatus
+
+▸ **waitForMessageStatus**(`message`, `status`, `opts?`): `Promise`<`void`\>
+
+Waits until the status of a given message changes to the expected status. Note that if the
+status of the given message changes to a status that implies the expected status, this will
+still return. If the status of the message changes to a status that exclues the expected
+status, this will throw an error.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`MessageLike`](../modules.md#messagelike) | Message to wait for. |
+| `status` | [`MessageStatus`](../enums/MessageStatus.md) | Expected status of the message. |
+| `opts?` | `Object` | Options to pass to the waiting function. |
+| `opts.pollIntervalMs?` | `number` | Number of milliseconds to wait when polling. |
+| `opts.timeoutMs?` | `number` | Milliseconds to wait before timing out. |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:241](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L241)
+
+___
+
+### withdrawERC20
+
+▸ **withdrawERC20**(`l1Token`, `l2Token`, `amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some ERC20 tokens back to the L1 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1Token` | [`AddressLike`](../modules.md#addresslike) | Address of the L1 token. |
+| `l2Token` | [`AddressLike`](../modules.md#addresslike) | Address of the L2 token. |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount to withdraw. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) | Optional address to receive the funds on L1. Defaults to sender. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:510](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L510)
+
+___
+
+### withdrawETH
+
+▸ **withdrawETH**(`amount`, `opts?`): `Promise`<`TransactionResponse`\>
+
+Withdraws some ETH back to the L1 chain.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `amount` | [`NumberLike`](../modules.md#numberlike) | Amount of ETH to withdraw. |
+| `opts?` | `Object` | Additional options. |
+| `opts.overrides?` | `Overrides` | Optional transaction overrides. |
+| `opts.recipient?` | [`AddressLike`](../modules.md#addresslike) | Optional address to receive the funds on L1. Defaults to sender. |
+| `opts.signer?` | `Signer` | Optional signer to use to send the transaction. |
+
+#### Returns
+
+`Promise`<`TransactionResponse`\>
+
+Transaction response for the withdraw transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/cross-chain-messenger.ts:426](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/cross-chain-messenger.ts#L426)

--- a/packages/sdk/docs/interfaces/L2Block.md
+++ b/packages/sdk/docs/interfaces/L2Block.md
@@ -1,0 +1,223 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / L2Block
+
+# Interface: L2Block
+
+JSON block representation when returned by L2Geth nodes. Just a normal block but with
+an added stateRoot field.
+
+## Hierarchy
+
+- `Block`
+
+  ↳ **`L2Block`**
+
+## Table of contents
+
+### Properties
+
+- [\_difficulty](L2Block.md#_difficulty)
+- [baseFeePerGas](L2Block.md#basefeepergas)
+- [difficulty](L2Block.md#difficulty)
+- [extraData](L2Block.md#extradata)
+- [gasLimit](L2Block.md#gaslimit)
+- [gasUsed](L2Block.md#gasused)
+- [hash](L2Block.md#hash)
+- [miner](L2Block.md#miner)
+- [nonce](L2Block.md#nonce)
+- [number](L2Block.md#number)
+- [parentHash](L2Block.md#parenthash)
+- [stateRoot](L2Block.md#stateroot)
+- [timestamp](L2Block.md#timestamp)
+- [transactions](L2Block.md#transactions)
+
+## Properties
+
+### \_difficulty
+
+• **\_difficulty**: `BigNumber`
+
+#### Inherited from
+
+Block.\_difficulty
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:40
+
+___
+
+### baseFeePerGas
+
+• `Optional` **baseFeePerGas**: `BigNumber`
+
+#### Inherited from
+
+Block.baseFeePerGas
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:45
+
+___
+
+### difficulty
+
+• **difficulty**: `number`
+
+#### Inherited from
+
+Block.difficulty
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:39
+
+___
+
+### extraData
+
+• **extraData**: `string`
+
+#### Inherited from
+
+Block.extraData
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:44
+
+___
+
+### gasLimit
+
+• **gasLimit**: `BigNumber`
+
+#### Inherited from
+
+Block.gasLimit
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:41
+
+___
+
+### gasUsed
+
+• **gasUsed**: `BigNumber`
+
+#### Inherited from
+
+Block.gasUsed
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:42
+
+___
+
+### hash
+
+• **hash**: `string`
+
+#### Inherited from
+
+Block.hash
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:34
+
+___
+
+### miner
+
+• **miner**: `string`
+
+#### Inherited from
+
+Block.miner
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:43
+
+___
+
+### nonce
+
+• **nonce**: `string`
+
+#### Inherited from
+
+Block.nonce
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:38
+
+___
+
+### number
+
+• **number**: `number`
+
+#### Inherited from
+
+Block.number
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:36
+
+___
+
+### parentHash
+
+• **parentHash**: `string`
+
+#### Inherited from
+
+Block.parentHash
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:35
+
+___
+
+### stateRoot
+
+• **stateRoot**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:27](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L27)
+
+___
+
+### timestamp
+
+• **timestamp**: `number`
+
+#### Inherited from
+
+Block.timestamp
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:37
+
+___
+
+### transactions
+
+• **transactions**: `string`[]
+
+#### Inherited from
+
+Block.transactions
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:48

--- a/packages/sdk/docs/interfaces/L2BlockWithTransactions.md
+++ b/packages/sdk/docs/interfaces/L2BlockWithTransactions.md
@@ -1,0 +1,223 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / L2BlockWithTransactions
+
+# Interface: L2BlockWithTransactions
+
+JSON block representation when returned by L2Geth nodes. Just a normal block but with
+L2Transaction objects instead of the standard transaction response object.
+
+## Hierarchy
+
+- `BlockWithTransactions`
+
+  ↳ **`L2BlockWithTransactions`**
+
+## Table of contents
+
+### Properties
+
+- [\_difficulty](L2BlockWithTransactions.md#_difficulty)
+- [baseFeePerGas](L2BlockWithTransactions.md#basefeepergas)
+- [difficulty](L2BlockWithTransactions.md#difficulty)
+- [extraData](L2BlockWithTransactions.md#extradata)
+- [gasLimit](L2BlockWithTransactions.md#gaslimit)
+- [gasUsed](L2BlockWithTransactions.md#gasused)
+- [hash](L2BlockWithTransactions.md#hash)
+- [miner](L2BlockWithTransactions.md#miner)
+- [nonce](L2BlockWithTransactions.md#nonce)
+- [number](L2BlockWithTransactions.md#number)
+- [parentHash](L2BlockWithTransactions.md#parenthash)
+- [stateRoot](L2BlockWithTransactions.md#stateroot)
+- [timestamp](L2BlockWithTransactions.md#timestamp)
+- [transactions](L2BlockWithTransactions.md#transactions)
+
+## Properties
+
+### \_difficulty
+
+• **\_difficulty**: `BigNumber`
+
+#### Inherited from
+
+BlockWithTransactions.\_difficulty
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:40
+
+___
+
+### baseFeePerGas
+
+• `Optional` **baseFeePerGas**: `BigNumber`
+
+#### Inherited from
+
+BlockWithTransactions.baseFeePerGas
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:45
+
+___
+
+### difficulty
+
+• **difficulty**: `number`
+
+#### Inherited from
+
+BlockWithTransactions.difficulty
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:39
+
+___
+
+### extraData
+
+• **extraData**: `string`
+
+#### Inherited from
+
+BlockWithTransactions.extraData
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:44
+
+___
+
+### gasLimit
+
+• **gasLimit**: `BigNumber`
+
+#### Inherited from
+
+BlockWithTransactions.gasLimit
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:41
+
+___
+
+### gasUsed
+
+• **gasUsed**: `BigNumber`
+
+#### Inherited from
+
+BlockWithTransactions.gasUsed
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:42
+
+___
+
+### hash
+
+• **hash**: `string`
+
+#### Inherited from
+
+BlockWithTransactions.hash
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:34
+
+___
+
+### miner
+
+• **miner**: `string`
+
+#### Inherited from
+
+BlockWithTransactions.miner
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:43
+
+___
+
+### nonce
+
+• **nonce**: `string`
+
+#### Inherited from
+
+BlockWithTransactions.nonce
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:38
+
+___
+
+### number
+
+• **number**: `number`
+
+#### Inherited from
+
+BlockWithTransactions.number
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:36
+
+___
+
+### parentHash
+
+• **parentHash**: `string`
+
+#### Inherited from
+
+BlockWithTransactions.parentHash
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:35
+
+___
+
+### stateRoot
+
+• **stateRoot**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:35](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L35)
+
+___
+
+### timestamp
+
+• **timestamp**: `number`
+
+#### Inherited from
+
+BlockWithTransactions.timestamp
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:37
+
+___
+
+### transactions
+
+• **transactions**: [[`L2Transaction`](L2Transaction.md)]
+
+#### Overrides
+
+BlockWithTransactions.transactions
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:36](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L36)

--- a/packages/sdk/docs/interfaces/L2Transaction.md
+++ b/packages/sdk/docs/interfaces/L2Transaction.md
@@ -1,0 +1,405 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / L2Transaction
+
+# Interface: L2Transaction
+
+JSON transaction representation when returned by L2Geth nodes. This is simply an extension to
+the standard transaction response type. You do NOT need to use this type unless you care about
+having typed access to L2-specific fields.
+
+## Hierarchy
+
+- `TransactionResponse`
+
+  ↳ **`L2Transaction`**
+
+## Table of contents
+
+### Properties
+
+- [accessList](L2Transaction.md#accesslist)
+- [blockHash](L2Transaction.md#blockhash)
+- [blockNumber](L2Transaction.md#blocknumber)
+- [chainId](L2Transaction.md#chainid)
+- [confirmations](L2Transaction.md#confirmations)
+- [data](L2Transaction.md#data)
+- [from](L2Transaction.md#from)
+- [gasLimit](L2Transaction.md#gaslimit)
+- [gasPrice](L2Transaction.md#gasprice)
+- [hash](L2Transaction.md#hash)
+- [l1BlockNumber](L2Transaction.md#l1blocknumber)
+- [l1TxOrigin](L2Transaction.md#l1txorigin)
+- [maxFeePerGas](L2Transaction.md#maxfeepergas)
+- [maxPriorityFeePerGas](L2Transaction.md#maxpriorityfeepergas)
+- [nonce](L2Transaction.md#nonce)
+- [queueOrigin](L2Transaction.md#queueorigin)
+- [r](L2Transaction.md#r)
+- [raw](L2Transaction.md#raw)
+- [rawTransaction](L2Transaction.md#rawtransaction)
+- [s](L2Transaction.md#s)
+- [timestamp](L2Transaction.md#timestamp)
+- [to](L2Transaction.md#to)
+- [type](L2Transaction.md#type)
+- [v](L2Transaction.md#v)
+- [value](L2Transaction.md#value)
+
+### Methods
+
+- [wait](L2Transaction.md#wait)
+
+## Properties
+
+### accessList
+
+• `Optional` **accessList**: `AccessList`
+
+#### Inherited from
+
+TransactionResponse.accessList
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:40
+
+___
+
+### blockHash
+
+• `Optional` **blockHash**: `string`
+
+#### Inherited from
+
+TransactionResponse.blockHash
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:25
+
+___
+
+### blockNumber
+
+• `Optional` **blockNumber**: `number`
+
+#### Inherited from
+
+TransactionResponse.blockNumber
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:24
+
+___
+
+### chainId
+
+• **chainId**: `number`
+
+#### Inherited from
+
+TransactionResponse.chainId
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:35
+
+___
+
+### confirmations
+
+• **confirmations**: `number`
+
+#### Inherited from
+
+TransactionResponse.confirmations
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:27
+
+___
+
+### data
+
+• **data**: `string`
+
+#### Inherited from
+
+TransactionResponse.data
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:33
+
+___
+
+### from
+
+• **from**: `string`
+
+#### Inherited from
+
+TransactionResponse.from
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:28
+
+___
+
+### gasLimit
+
+• **gasLimit**: `BigNumber`
+
+#### Inherited from
+
+TransactionResponse.gasLimit
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:31
+
+___
+
+### gasPrice
+
+• `Optional` **gasPrice**: `BigNumber`
+
+#### Inherited from
+
+TransactionResponse.gasPrice
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:32
+
+___
+
+### hash
+
+• **hash**: `string`
+
+#### Inherited from
+
+TransactionResponse.hash
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:23
+
+___
+
+### l1BlockNumber
+
+• **l1BlockNumber**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:16](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L16)
+
+___
+
+### l1TxOrigin
+
+• **l1TxOrigin**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:17](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L17)
+
+___
+
+### maxFeePerGas
+
+• `Optional` **maxFeePerGas**: `BigNumber`
+
+#### Inherited from
+
+TransactionResponse.maxFeePerGas
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:42
+
+___
+
+### maxPriorityFeePerGas
+
+• `Optional` **maxPriorityFeePerGas**: `BigNumber`
+
+#### Inherited from
+
+TransactionResponse.maxPriorityFeePerGas
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:41
+
+___
+
+### nonce
+
+• **nonce**: `number`
+
+#### Inherited from
+
+TransactionResponse.nonce
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:30
+
+___
+
+### queueOrigin
+
+• **queueOrigin**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:18](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L18)
+
+___
+
+### r
+
+• `Optional` **r**: `string`
+
+#### Inherited from
+
+TransactionResponse.r
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:36
+
+___
+
+### raw
+
+• `Optional` **raw**: `string`
+
+#### Inherited from
+
+TransactionResponse.raw
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:29
+
+___
+
+### rawTransaction
+
+• **rawTransaction**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:19](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L19)
+
+___
+
+### s
+
+• `Optional` **s**: `string`
+
+#### Inherited from
+
+TransactionResponse.s
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:37
+
+___
+
+### timestamp
+
+• `Optional` **timestamp**: `number`
+
+#### Inherited from
+
+TransactionResponse.timestamp
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:26
+
+___
+
+### to
+
+• `Optional` **to**: `string`
+
+#### Inherited from
+
+TransactionResponse.to
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:28
+
+___
+
+### type
+
+• `Optional` **type**: `number`
+
+#### Inherited from
+
+TransactionResponse.type
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:39
+
+___
+
+### v
+
+• `Optional` **v**: `number`
+
+#### Inherited from
+
+TransactionResponse.v
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:38
+
+___
+
+### value
+
+• **value**: `BigNumber`
+
+#### Inherited from
+
+TransactionResponse.value
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/node_modules/@ethersproject/transactions/lib/index.d.ts:34
+
+## Methods
+
+### wait
+
+▸ **wait**(`confirmations?`): `Promise`<`TransactionReceipt`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `confirmations?` | `number` |
+
+#### Returns
+
+`Promise`<`TransactionReceipt`\>
+
+#### Inherited from
+
+TransactionResponse.wait
+
+#### Defined in
+
+node_modules/@ethersproject/abstract-provider/lib/index.d.ts:30

--- a/packages/sdk/docs/interfaces/MessageReceipt.md
+++ b/packages/sdk/docs/interfaces/MessageReceipt.md
@@ -1,0 +1,32 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / MessageReceipt
+
+# Interface: MessageReceipt
+
+CrossDomainMessage receipt.
+
+## Table of contents
+
+### Properties
+
+- [receiptStatus](MessageReceipt.md#receiptstatus)
+- [transactionReceipt](MessageReceipt.md#transactionreceipt)
+
+## Properties
+
+### receiptStatus
+
+• **receiptStatus**: [`MessageReceiptStatus`](../enums/MessageReceiptStatus.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:200](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L200)
+
+___
+
+### transactionReceipt
+
+• **transactionReceipt**: `TransactionReceipt`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:201](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L201)

--- a/packages/sdk/docs/interfaces/OEContracts.md
+++ b/packages/sdk/docs/interfaces/OEContracts.md
@@ -1,0 +1,33 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / OEContracts
+
+# Interface: OEContracts
+
+Represents Optimism contracts, assumed to be connected to their appropriate
+providers and addresses.
+
+## Table of contents
+
+### Properties
+
+- [l1](OEContracts.md#l1)
+- [l2](OEContracts.md#l2)
+
+## Properties
+
+### l1
+
+• **l1**: [`OEL1Contracts`](OEL1Contracts.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:44](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L44)
+
+___
+
+### l2
+
+• **l2**: [`OEL2Contracts`](OEL2Contracts.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:45](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L45)

--- a/packages/sdk/docs/interfaces/OEContractsLike.md
+++ b/packages/sdk/docs/interfaces/OEContractsLike.md
@@ -1,0 +1,33 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / OEContractsLike
+
+# Interface: OEContractsLike
+
+Convenience type for something that looks like the OE contract interface but could be
+addresses instead of actual contract objects.
+
+## Table of contents
+
+### Properties
+
+- [l1](OEContractsLike.md#l1)
+- [l2](OEContractsLike.md#l2)
+
+## Properties
+
+### l1
+
+• **l1**: [`OEL1ContractsLike`](../modules.md#oel1contractslike)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:69](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L69)
+
+___
+
+### l2
+
+• **l2**: [`OEL2ContractsLike`](../modules.md#oel2contractslike)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:70](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L70)

--- a/packages/sdk/docs/interfaces/OEL1Contracts.md
+++ b/packages/sdk/docs/interfaces/OEL1Contracts.md
@@ -1,0 +1,76 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / OEL1Contracts
+
+# Interface: OEL1Contracts
+
+L1 contract references.
+
+## Table of contents
+
+### Properties
+
+- [AddressManager](OEL1Contracts.md#addressmanager)
+- [BondManager](OEL1Contracts.md#bondmanager)
+- [CanonicalTransactionChain](OEL1Contracts.md#canonicaltransactionchain)
+- [L1CrossDomainMessenger](OEL1Contracts.md#l1crossdomainmessenger)
+- [L1StandardBridge](OEL1Contracts.md#l1standardbridge)
+- [StateCommitmentChain](OEL1Contracts.md#statecommitmentchain)
+
+## Properties
+
+### AddressManager
+
+• **AddressManager**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:16](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L16)
+
+___
+
+### BondManager
+
+• **BondManager**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:21](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L21)
+
+___
+
+### CanonicalTransactionChain
+
+• **CanonicalTransactionChain**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:20](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L20)
+
+___
+
+### L1CrossDomainMessenger
+
+• **L1CrossDomainMessenger**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:17](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L17)
+
+___
+
+### L1StandardBridge
+
+• **L1StandardBridge**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:18](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L18)
+
+___
+
+### StateCommitmentChain
+
+• **StateCommitmentChain**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:19](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L19)

--- a/packages/sdk/docs/interfaces/OEL2Contracts.md
+++ b/packages/sdk/docs/interfaces/OEL2Contracts.md
@@ -1,0 +1,109 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / OEL2Contracts
+
+# Interface: OEL2Contracts
+
+L2 contract references.
+
+## Table of contents
+
+### Properties
+
+- [L2CrossDomainMessenger](OEL2Contracts.md#l2crossdomainmessenger)
+- [L2StandardBridge](OEL2Contracts.md#l2standardbridge)
+- [OVM\_DeployerWhitelist](OEL2Contracts.md#ovm_deployerwhitelist)
+- [OVM\_ETH](OEL2Contracts.md#ovm_eth)
+- [OVM\_GasPriceOracle](OEL2Contracts.md#ovm_gaspriceoracle)
+- [OVM\_L1BlockNumber](OEL2Contracts.md#ovm_l1blocknumber)
+- [OVM\_L2ToL1MessagePasser](OEL2Contracts.md#ovm_l2tol1messagepasser)
+- [OVM\_SequencerFeeVault](OEL2Contracts.md#ovm_sequencerfeevault)
+- [WETH](OEL2Contracts.md#weth)
+
+## Properties
+
+### L2CrossDomainMessenger
+
+• **L2CrossDomainMessenger**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:28](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L28)
+
+___
+
+### L2StandardBridge
+
+• **L2StandardBridge**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:29](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L29)
+
+___
+
+### OVM\_DeployerWhitelist
+
+• **OVM\_DeployerWhitelist**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:32](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L32)
+
+___
+
+### OVM\_ETH
+
+• **OVM\_ETH**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:33](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L33)
+
+___
+
+### OVM\_GasPriceOracle
+
+• **OVM\_GasPriceOracle**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:34](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L34)
+
+___
+
+### OVM\_L1BlockNumber
+
+• **OVM\_L1BlockNumber**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:30](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L30)
+
+___
+
+### OVM\_L2ToL1MessagePasser
+
+• **OVM\_L2ToL1MessagePasser**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:31](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L31)
+
+___
+
+### OVM\_SequencerFeeVault
+
+• **OVM\_SequencerFeeVault**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:35](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L35)
+
+___
+
+### WETH
+
+• **WETH**: `Contract`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:36](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L36)

--- a/packages/sdk/docs/interfaces/StateRoot.md
+++ b/packages/sdk/docs/interfaces/StateRoot.md
@@ -1,0 +1,43 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / StateRoot
+
+# Interface: StateRoot
+
+Information about a state root, including header, block number, and root iself.
+
+## Table of contents
+
+### Properties
+
+- [batch](StateRoot.md#batch)
+- [stateRoot](StateRoot.md#stateroot)
+- [stateRootIndexInBatch](StateRoot.md#staterootindexinbatch)
+
+## Properties
+
+### batch
+
+• **batch**: [`StateRootBatch`](StateRootBatch.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:221](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L221)
+
+___
+
+### stateRoot
+
+• **stateRoot**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:219](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L219)
+
+___
+
+### stateRootIndexInBatch
+
+• **stateRootIndexInBatch**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:220](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L220)

--- a/packages/sdk/docs/interfaces/StateRootBatch.md
+++ b/packages/sdk/docs/interfaces/StateRootBatch.md
@@ -1,0 +1,43 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / StateRootBatch
+
+# Interface: StateRootBatch
+
+Information about a batch of state roots.
+
+## Table of contents
+
+### Properties
+
+- [blockNumber](StateRootBatch.md#blocknumber)
+- [header](StateRootBatch.md#header)
+- [stateRoots](StateRootBatch.md#stateroots)
+
+## Properties
+
+### blockNumber
+
+• **blockNumber**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:228](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L228)
+
+___
+
+### header
+
+• **header**: [`StateRootBatchHeader`](StateRootBatchHeader.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:229](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L229)
+
+___
+
+### stateRoots
+
+• **stateRoots**: `string`[]
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:230](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L230)

--- a/packages/sdk/docs/interfaces/StateRootBatchHeader.md
+++ b/packages/sdk/docs/interfaces/StateRootBatchHeader.md
@@ -1,0 +1,65 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / StateRootBatchHeader
+
+# Interface: StateRootBatchHeader
+
+Header for a state root batch.
+
+## Table of contents
+
+### Properties
+
+- [batchIndex](StateRootBatchHeader.md#batchindex)
+- [batchRoot](StateRootBatchHeader.md#batchroot)
+- [batchSize](StateRootBatchHeader.md#batchsize)
+- [extraData](StateRootBatchHeader.md#extradata)
+- [prevTotalElements](StateRootBatchHeader.md#prevtotalelements)
+
+## Properties
+
+### batchIndex
+
+• **batchIndex**: `BigNumber`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:208](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L208)
+
+___
+
+### batchRoot
+
+• **batchRoot**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:209](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L209)
+
+___
+
+### batchSize
+
+• **batchSize**: `BigNumber`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:210](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L210)
+
+___
+
+### extraData
+
+• **extraData**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:212](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L212)
+
+___
+
+### prevTotalElements
+
+• **prevTotalElements**: `BigNumber`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:211](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L211)

--- a/packages/sdk/docs/interfaces/TokenBridgeMessage.md
+++ b/packages/sdk/docs/interfaces/TokenBridgeMessage.md
@@ -1,0 +1,121 @@
+[@eth-optimism/sdk](../README.md) / [Exports](../modules.md) / TokenBridgeMessage
+
+# Interface: TokenBridgeMessage
+
+Describes a token withdrawal or deposit, along with the underlying raw cross chain message
+behind the deposit or withdrawal.
+
+## Table of contents
+
+### Properties
+
+- [amount](TokenBridgeMessage.md#amount)
+- [blockNumber](TokenBridgeMessage.md#blocknumber)
+- [data](TokenBridgeMessage.md#data)
+- [direction](TokenBridgeMessage.md#direction)
+- [from](TokenBridgeMessage.md#from)
+- [l1Token](TokenBridgeMessage.md#l1token)
+- [l2Token](TokenBridgeMessage.md#l2token)
+- [logIndex](TokenBridgeMessage.md#logindex)
+- [to](TokenBridgeMessage.md#to)
+- [transactionHash](TokenBridgeMessage.md#transactionhash)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:181](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L181)
+
+___
+
+### blockNumber
+
+• **blockNumber**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:184](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L184)
+
+___
+
+### data
+
+• **data**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:182](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L182)
+
+___
+
+### direction
+
+• **direction**: [`MessageDirection`](../enums/MessageDirection.md)
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:176](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L176)
+
+___
+
+### from
+
+• **from**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:177](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L177)
+
+___
+
+### l1Token
+
+• **l1Token**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:179](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L179)
+
+___
+
+### l2Token
+
+• **l2Token**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:180](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L180)
+
+___
+
+### logIndex
+
+• **logIndex**: `number`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:183](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L183)
+
+___
+
+### to
+
+• **to**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:178](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L178)
+
+___
+
+### transactionHash
+
+• **transactionHash**: `string`
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:185](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L185)

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -1,0 +1,850 @@
+[@eth-optimism/sdk](README.md) / Exports
+
+# @eth-optimism/sdk
+
+## Table of contents
+
+### Enumerations
+
+- [MessageDirection](enums/MessageDirection.md)
+- [MessageReceiptStatus](enums/MessageReceiptStatus.md)
+- [MessageStatus](enums/MessageStatus.md)
+
+### Classes
+
+- [CrossChainMessenger](classes/CrossChainMessenger.md)
+- [DAIBridgeAdapter](classes/DAIBridgeAdapter.md)
+- [ETHBridgeAdapter](classes/ETHBridgeAdapter.md)
+- [StandardBridgeAdapter](classes/StandardBridgeAdapter.md)
+
+### Interfaces
+
+- [BridgeAdapterData](interfaces/BridgeAdapterData.md)
+- [BridgeAdapters](interfaces/BridgeAdapters.md)
+- [CoreCrossChainMessage](interfaces/CoreCrossChainMessage.md)
+- [CrossChainMessage](interfaces/CrossChainMessage.md)
+- [CrossChainMessageProof](interfaces/CrossChainMessageProof.md)
+- [CrossChainMessageRequest](interfaces/CrossChainMessageRequest.md)
+- [IBridgeAdapter](interfaces/IBridgeAdapter.md)
+- [ICrossChainMessenger](interfaces/ICrossChainMessenger.md)
+- [L2Block](interfaces/L2Block.md)
+- [L2BlockWithTransactions](interfaces/L2BlockWithTransactions.md)
+- [L2Transaction](interfaces/L2Transaction.md)
+- [MessageReceipt](interfaces/MessageReceipt.md)
+- [OEContracts](interfaces/OEContracts.md)
+- [OEContractsLike](interfaces/OEContractsLike.md)
+- [OEL1Contracts](interfaces/OEL1Contracts.md)
+- [OEL2Contracts](interfaces/OEL2Contracts.md)
+- [StateRoot](interfaces/StateRoot.md)
+- [StateRootBatch](interfaces/StateRootBatch.md)
+- [StateRootBatchHeader](interfaces/StateRootBatchHeader.md)
+- [TokenBridgeMessage](interfaces/TokenBridgeMessage.md)
+
+### Type aliases
+
+- [AddressLike](modules.md#addresslike)
+- [DeepPartial](modules.md#deeppartial)
+- [L2Provider](modules.md#l2provider)
+- [MessageLike](modules.md#messagelike)
+- [MessageRequestLike](modules.md#messagerequestlike)
+- [NumberLike](modules.md#numberlike)
+- [OEL1ContractsLike](modules.md#oel1contractslike)
+- [OEL2ContractsLike](modules.md#oel2contractslike)
+- [ProviderLike](modules.md#providerlike)
+- [SignerLike](modules.md#signerlike)
+- [SignerOrProviderLike](modules.md#signerorproviderlike)
+- [TransactionLike](modules.md#transactionlike)
+
+### Variables
+
+- [BRIDGE\_ADAPTER\_DATA](modules.md#bridge_adapter_data)
+- [CHAIN\_BLOCK\_TIMES](modules.md#chain_block_times)
+- [CONTRACT\_ADDRESSES](modules.md#contract_addresses)
+- [DEFAULT\_L2\_CONTRACT\_ADDRESSES](modules.md#default_l2_contract_addresses)
+- [DEPOSIT\_CONFIRMATION\_BLOCKS](modules.md#deposit_confirmation_blocks)
+
+### Functions
+
+- [asL2Provider](modules.md#asl2provider)
+- [encodeCrossChainMessage](modules.md#encodecrosschainmessage)
+- [estimateL1Gas](modules.md#estimatel1gas)
+- [estimateL1GasCost](modules.md#estimatel1gascost)
+- [estimateL2GasCost](modules.md#estimatel2gascost)
+- [estimateTotalGasCost](modules.md#estimatetotalgascost)
+- [getAllOEContracts](modules.md#getalloecontracts)
+- [getBridgeAdapters](modules.md#getbridgeadapters)
+- [getL1GasPrice](modules.md#getl1gasprice)
+- [getOEContract](modules.md#getoecontract)
+- [hashCrossChainMessage](modules.md#hashcrosschainmessage)
+- [makeMerkleTreeProof](modules.md#makemerkletreeproof)
+- [makeStateTrieProof](modules.md#makestatetrieproof)
+- [omit](modules.md#omit)
+- [toAddress](modules.md#toaddress)
+- [toBigNumber](modules.md#tobignumber)
+- [toNumber](modules.md#tonumber)
+- [toProvider](modules.md#toprovider)
+- [toSignerOrProvider](modules.md#tosignerorprovider)
+- [toTransactionHash](modules.md#totransactionhash)
+
+## Type aliases
+
+### AddressLike
+
+Ƭ **AddressLike**: `string` \| `Contract`
+
+Stuff that can be coerced into an address.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:287](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L287)
+
+___
+
+### DeepPartial
+
+Ƭ **DeepPartial**<`T`\>: { [P in keyof T]?: DeepPartial<T[P]\> }
+
+Utility type for deep partials.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Defined in
+
+[packages/sdk/src/utils/type-utils.ts:4](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/type-utils.ts#L4)
+
+___
+
+### L2Provider
+
+Ƭ **L2Provider**<`TProvider`\>: `TProvider` & { `estimateL1Gas`: (`tx`: `TransactionRequest`) => `Promise`<`BigNumber`\> ; `estimateL1GasCost`: (`tx`: `TransactionRequest`) => `Promise`<`BigNumber`\> ; `estimateL2GasCost`: (`tx`: `TransactionRequest`) => `Promise`<`BigNumber`\> ; `estimateTotalGasCost`: (`tx`: `TransactionRequest`) => `Promise`<`BigNumber`\> ; `getL1GasPrice`: () => `Promise`<`BigNumber`\>  }
+
+Represents an extended version of an normal ethers Provider that returns additional L2 info and
+has special functions for L2-specific interactions.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `TProvider` | extends `Provider` |
+
+#### Defined in
+
+[packages/sdk/src/interfaces/l2-provider.ts:43](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/l2-provider.ts#L43)
+
+___
+
+### MessageLike
+
+Ƭ **MessageLike**: [`CrossChainMessage`](interfaces/CrossChainMessage.md) \| [`TransactionLike`](modules.md#transactionlike) \| [`TokenBridgeMessage`](interfaces/TokenBridgeMessage.md)
+
+Stuff that can be coerced into a CrossChainMessage.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:255](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L255)
+
+___
+
+### MessageRequestLike
+
+Ƭ **MessageRequestLike**: [`CrossChainMessageRequest`](interfaces/CrossChainMessageRequest.md) \| [`CrossChainMessage`](interfaces/CrossChainMessage.md) \| [`TransactionLike`](modules.md#transactionlike) \| [`TokenBridgeMessage`](interfaces/TokenBridgeMessage.md)
+
+Stuff that can be coerced into a CrossChainMessageRequest.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:263](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L263)
+
+___
+
+### NumberLike
+
+Ƭ **NumberLike**: `string` \| `number` \| `BigNumber`
+
+Stuff that can be coerced into a number.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:292](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L292)
+
+___
+
+### OEL1ContractsLike
+
+Ƭ **OEL1ContractsLike**: { [K in keyof OEL1Contracts]: AddressLike }
+
+Convenience type for something that looks like the L1 OE contract interface but could be
+addresses instead of actual contract objects.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:52](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L52)
+
+___
+
+### OEL2ContractsLike
+
+Ƭ **OEL2ContractsLike**: { [K in keyof OEL2Contracts]: AddressLike }
+
+Convenience type for something that looks like the L2 OE contract interface but could be
+addresses instead of actual contract objects.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:60](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L60)
+
+___
+
+### ProviderLike
+
+Ƭ **ProviderLike**: `string` \| `Provider` \| `any`
+
+Stuff that can be coerced into a provider.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:272](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L272)
+
+___
+
+### SignerLike
+
+Ƭ **SignerLike**: `string` \| `Signer`
+
+Stuff that can be coerced into a signer.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:277](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L277)
+
+___
+
+### SignerOrProviderLike
+
+Ƭ **SignerOrProviderLike**: [`SignerLike`](modules.md#signerlike) \| [`ProviderLike`](modules.md#providerlike)
+
+Stuff that can be coerced into a signer or provider.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:282](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L282)
+
+___
+
+### TransactionLike
+
+Ƭ **TransactionLike**: `string` \| `TransactionReceipt` \| `TransactionResponse`
+
+Stuff that can be coerced into a transaction.
+
+#### Defined in
+
+[packages/sdk/src/interfaces/types.ts:250](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/interfaces/types.ts#L250)
+
+## Variables
+
+### BRIDGE\_ADAPTER\_DATA
+
+• **BRIDGE\_ADAPTER\_DATA**: `Object`
+
+Mapping of L1 chain IDs to the list of custom bridge addresses for each chain.
+
+#### Index signature
+
+▪ [l1ChainId: `number`]: [`BridgeAdapterData`](interfaces/BridgeAdapterData.md)
+
+#### Defined in
+
+[packages/sdk/src/utils/contracts.ts:109](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/contracts.ts#L109)
+
+___
+
+### CHAIN\_BLOCK\_TIMES
+
+• **CHAIN\_BLOCK\_TIMES**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `1` | `number` |
+| `31337` | `number` |
+| `42` | `number` |
+| `5` | `number` |
+
+#### Defined in
+
+[packages/sdk/src/utils/chain-constants.ts:13](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/chain-constants.ts#L13)
+
+___
+
+### CONTRACT\_ADDRESSES
+
+• **CONTRACT\_ADDRESSES**: `Object`
+
+Mapping of L1 chain IDs to the appropriate contract addresses for the OE deployments to the
+given network. Simplifies the process of getting the correct contract addresses for a given
+contract name.
+
+#### Index signature
+
+▪ [l1ChainId: `number`]: [`OEContractsLike`](interfaces/OEContractsLike.md)
+
+#### Defined in
+
+[packages/sdk/src/utils/contracts.ts:53](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/contracts.ts#L53)
+
+___
+
+### DEFAULT\_L2\_CONTRACT\_ADDRESSES
+
+• **DEFAULT\_L2\_CONTRACT\_ADDRESSES**: [`OEL2ContractsLike`](modules.md#oel2contractslike)
+
+Full list of default L2 contract addresses.
+
+#### Defined in
+
+[packages/sdk/src/utils/contracts.ts:26](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/contracts.ts#L26)
+
+___
+
+### DEPOSIT\_CONFIRMATION\_BLOCKS
+
+• **DEPOSIT\_CONFIRMATION\_BLOCKS**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `1` | `number` |
+| `31337` | `number` |
+| `42` | `number` |
+| `5` | `number` |
+
+#### Defined in
+
+[packages/sdk/src/utils/chain-constants.ts:1](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/chain-constants.ts#L1)
+
+## Functions
+
+### asL2Provider
+
+▸ `Const` **asL2Provider**<`TProvider`\>(`provider`): [`L2Provider`](modules.md#l2provider)<`TProvider`\>
+
+Returns an provider wrapped as an Optimism L2 provider. Adds a few extra helper functions to
+simplify the process of estimating the gas usage for a transaction on Optimism. Returns a COPY
+of the original provider.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `TProvider` | extends `Provider`<`TProvider`\> |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `provider` | `TProvider` | Provider to wrap into an L2 provider. |
+
+#### Returns
+
+[`L2Provider`](modules.md#l2provider)<`TProvider`\>
+
+Provider wrapped as an L2 provider.
+
+#### Defined in
+
+[packages/sdk/src/l2-provider.ts:126](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/l2-provider.ts#L126)
+
+___
+
+### encodeCrossChainMessage
+
+▸ `Const` **encodeCrossChainMessage**(`message`): `string`
+
+Returns the canonical encoding of a cross chain message. This encoding is used in various
+locations within the Optimism smart contracts.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`CoreCrossChainMessage`](interfaces/CoreCrossChainMessage.md) | Cross chain message to encode. |
+
+#### Returns
+
+`string`
+
+Canonical encoding of the message.
+
+#### Defined in
+
+[packages/sdk/src/utils/message-encoding.ts:13](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/message-encoding.ts#L13)
+
+___
+
+### estimateL1Gas
+
+▸ `Const` **estimateL1Gas**(`l2Provider`, `tx`): `Promise`<`BigNumber`\>
+
+Estimates the amount of L1 gas required for a given L2 transaction.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l2Provider` | `any` | L2 provider to query the gas usage from. |
+| `tx` | `TransactionRequest` | Transaction to estimate L1 gas for. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Estimated L1 gas.
+
+#### Defined in
+
+[packages/sdk/src/l2-provider.ts:44](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/l2-provider.ts#L44)
+
+___
+
+### estimateL1GasCost
+
+▸ `Const` **estimateL1GasCost**(`l2Provider`, `tx`): `Promise`<`BigNumber`\>
+
+Estimates the amount of L1 gas cost for a given L2 transaction in wei.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l2Provider` | `any` | L2 provider to query the gas usage from. |
+| `tx` | `TransactionRequest` | Transaction to estimate L1 gas cost for. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Estimated L1 gas cost.
+
+#### Defined in
+
+[packages/sdk/src/l2-provider.ts:68](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/l2-provider.ts#L68)
+
+___
+
+### estimateL2GasCost
+
+▸ `Const` **estimateL2GasCost**(`l2Provider`, `tx`): `Promise`<`BigNumber`\>
+
+Estimates the L2 gas cost for a given L2 transaction in wei.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l2Provider` | `any` | L2 provider to query the gas usage from. |
+| `tx` | `TransactionRequest` | Transaction to estimate L2 gas cost for. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Estimated L2 gas cost.
+
+#### Defined in
+
+[packages/sdk/src/l2-provider.ts:92](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/l2-provider.ts#L92)
+
+___
+
+### estimateTotalGasCost
+
+▸ `Const` **estimateTotalGasCost**(`l2Provider`, `tx`): `Promise`<`BigNumber`\>
+
+Estimates the total gas cost for a given L2 transaction in wei.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l2Provider` | `any` | L2 provider to query the gas usage from. |
+| `tx` | `TransactionRequest` | Transaction to estimate total gas cost for. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Estimated total gas cost.
+
+#### Defined in
+
+[packages/sdk/src/l2-provider.ts:109](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/l2-provider.ts#L109)
+
+___
+
+### getAllOEContracts
+
+▸ `Const` **getAllOEContracts**(`l1ChainId`, `opts?`): [`OEContracts`](interfaces/OEContracts.md)
+
+Automatically connects to all contract addresses, both L1 and L2, for the given L1 chain ID. The
+user can provide custom contract address overrides for L1 or L2 contracts. If the given chain ID
+is not known then the user MUST provide custom contract addresses for ALL L1 contracts or this
+function will throw an error.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1ChainId` | `number` | Chain ID for the L1 network where the OE contracts are deployed. |
+| `opts` | `Object` | Additional options for connecting to the contracts. |
+| `opts.l1SignerOrProvider?` | `Signer` \| `Provider` | - |
+| `opts.l2SignerOrProvider?` | `Signer` \| `Provider` | - |
+| `opts.overrides?` | [`DeepPartial`](modules.md#deeppartial)<[`OEContractsLike`](interfaces/OEContractsLike.md)\> | Custom contract address overrides for L1 or L2 contracts. |
+
+#### Returns
+
+[`OEContracts`](interfaces/OEContracts.md)
+
+An object containing ethers.Contract objects connected to the appropriate addresses on
+both L1 and L2.
+
+#### Defined in
+
+[packages/sdk/src/utils/contracts.ts:256](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/contracts.ts#L256)
+
+___
+
+### getBridgeAdapters
+
+▸ `Const` **getBridgeAdapters**(`l1ChainId`, `messenger`, `opts?`): [`BridgeAdapters`](interfaces/BridgeAdapters.md)
+
+Gets a series of bridge adapters for the given L1 chain ID.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l1ChainId` | `number` | L1 chain ID for the L1 network where the custom bridges are deployed. |
+| `messenger` | [`ICrossChainMessenger`](interfaces/ICrossChainMessenger.md) | Cross chain messenger to connect to the bridge adapters |
+| `opts?` | `Object` | Additional options for connecting to the custom bridges. |
+| `opts.overrides?` | [`BridgeAdapterData`](interfaces/BridgeAdapterData.md) | Custom bridge adapters. |
+
+#### Returns
+
+[`BridgeAdapters`](interfaces/BridgeAdapters.md)
+
+An object containing all bridge adapters
+
+#### Defined in
+
+[packages/sdk/src/utils/contracts.ts:309](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/contracts.ts#L309)
+
+___
+
+### getL1GasPrice
+
+▸ `Const` **getL1GasPrice**(`l2Provider`): `Promise`<`BigNumber`\>
+
+Gets the current L1 gas price as seen on L2.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `l2Provider` | `any` | L2 provider to query the L1 gas price from. |
+
+#### Returns
+
+`Promise`<`BigNumber`\>
+
+Current L1 gas price as seen on L2.
+
+#### Defined in
+
+[packages/sdk/src/l2-provider.ts:30](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/l2-provider.ts#L30)
+
+___
+
+### getOEContract
+
+▸ `Const` **getOEContract**(`contractName`, `l1ChainId`, `opts?`): `Contract`
+
+Returns an ethers.Contract object for the given name, connected to the appropriate address for
+the given L1 chain ID. Users can also provide a custom address to connect the contract to
+instead. If the chain ID is not known then the user MUST provide a custom address or this
+function will throw an error.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `contractName` | keyof [`OEL1Contracts`](interfaces/OEL1Contracts.md) \| keyof [`OEL2Contracts`](interfaces/OEL2Contracts.md) | Name of the contract to connect to. |
+| `l1ChainId` | `number` | Chain ID for the L1 network where the OE contracts are deployed. |
+| `opts` | `Object` | Additional options for connecting to the contract. |
+| `opts.address?` | [`AddressLike`](modules.md#addresslike) | Custom address to connect to the contract. |
+| `opts.signerOrProvider?` | `Signer` \| `Provider` | Signer or provider to connect to the contract. |
+
+#### Returns
+
+`Contract`
+
+An ethers.Contract object connected to the appropriate address and interface.
+
+#### Defined in
+
+[packages/sdk/src/utils/contracts.ts:218](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/contracts.ts#L218)
+
+___
+
+### hashCrossChainMessage
+
+▸ `Const` **hashCrossChainMessage**(`message`): `string`
+
+Returns the canonical hash of a cross chain message. This hash is used in various locations
+within the Optimism smart contracts and is the keccak256 hash of the result of
+encodeCrossChainMessage.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | [`CoreCrossChainMessage`](interfaces/CoreCrossChainMessage.md) | Cross chain message to hash. |
+
+#### Returns
+
+`string`
+
+Canonical hash of the message.
+
+#### Defined in
+
+[packages/sdk/src/utils/message-encoding.ts:30](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/message-encoding.ts#L30)
+
+___
+
+### makeMerkleTreeProof
+
+▸ `Const` **makeMerkleTreeProof**(`leaves`, `index`): `string`[]
+
+Generates a Merkle proof (using the particular scheme we use within Lib_MerkleTree).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `leaves` | `string`[] | Leaves of the merkle tree. |
+| `index` | `number` | Index to generate a proof for. |
+
+#### Returns
+
+`string`[]
+
+Merkle proof sibling leaves, as hex strings.
+
+#### Defined in
+
+[packages/sdk/src/utils/merkle-utils.ts:18](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/merkle-utils.ts#L18)
+
+___
+
+### makeStateTrieProof
+
+▸ `Const` **makeStateTrieProof**(`provider`, `blockNumber`, `address`, `slot`): `Promise`<{ `accountProof`: `string` ; `storageProof`: `string`  }\>
+
+Generates a Merkle-Patricia trie proof for a given account and storage slot.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `provider` | `JsonRpcProvider` | RPC provider attached to an EVM-compatible chain. |
+| `blockNumber` | `number` | Block number to generate the proof at. |
+| `address` | `string` | Address to generate the proof for. |
+| `slot` | `string` | Storage slot to generate the proof for. |
+
+#### Returns
+
+`Promise`<{ `accountProof`: `string` ; `storageProof`: `string`  }\>
+
+Account proof and storage proof.
+
+#### Defined in
+
+[packages/sdk/src/utils/merkle-utils.ts:57](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/merkle-utils.ts#L57)
+
+___
+
+### omit
+
+▸ `Const` **omit**(`obj`, ...`keys`): `any`
+
+Returns a copy of the given object ({ ...obj }) with the given keys omitted.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `obj` | `any` | Object to return with the keys omitted. |
+| `...keys` | `string`[] | Keys to omit from the returned object. |
+
+#### Returns
+
+`any`
+
+A copy of the given object with the given keys omitted.
+
+#### Defined in
+
+[packages/sdk/src/utils/misc-utils.ts:11](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/misc-utils.ts#L11)
+
+___
+
+### toAddress
+
+▸ `Const` **toAddress**(`addr`): `string`
+
+Converts an address-like into a 0x-prefixed address string.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `addr` | [`AddressLike`](modules.md#addresslike) | Address-like to convert into an address. |
+
+#### Returns
+
+`string`
+
+Address-like as an address.
+
+#### Defined in
+
+[packages/sdk/src/utils/coercion.ts:106](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/coercion.ts#L106)
+
+___
+
+### toBigNumber
+
+▸ `Const` **toBigNumber**(`num`): `BigNumber`
+
+Converts a number-like into an ethers BigNumber.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `num` | [`NumberLike`](modules.md#numberlike) | Number-like to convert into a BigNumber. |
+
+#### Returns
+
+`BigNumber`
+
+Number-like as a BigNumber.
+
+#### Defined in
+
+[packages/sdk/src/utils/coercion.ts:86](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/coercion.ts#L86)
+
+___
+
+### toNumber
+
+▸ `Const` **toNumber**(`num`): `number`
+
+Converts a number-like into a number.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `num` | [`NumberLike`](modules.md#numberlike) | Number-like to convert into a number. |
+
+#### Returns
+
+`number`
+
+Number-like as a number.
+
+#### Defined in
+
+[packages/sdk/src/utils/coercion.ts:96](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/coercion.ts#L96)
+
+___
+
+### toProvider
+
+▸ `Const` **toProvider**(`provider`): `Provider`
+
+Converts a ProviderLike into a Provider. Assumes that if the input is a string then it is a
+JSON-RPC url.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `provider` | `any` | ProviderLike to turn into a Provider. |
+
+#### Returns
+
+`Provider`
+
+Input as a Provider.
+
+#### Defined in
+
+[packages/sdk/src/utils/coercion.ts:47](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/coercion.ts#L47)
+
+___
+
+### toSignerOrProvider
+
+▸ `Const` **toSignerOrProvider**(`signerOrProvider`): `Signer` \| `Provider`
+
+Converts a SignerOrProviderLike into a Signer or a Provider. Assumes that if the input is a
+string then it is a JSON-RPC url.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `signerOrProvider` | `any` | SignerOrProviderLike to turn into a Signer or Provider. |
+
+#### Returns
+
+`Signer` \| `Provider`
+
+Input as a Signer or Provider.
+
+#### Defined in
+
+[packages/sdk/src/utils/coercion.ts:26](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/coercion.ts#L26)
+
+___
+
+### toTransactionHash
+
+▸ `Const` **toTransactionHash**(`transaction`): `string`
+
+Pulls a transaction hash out of a TransactionLike object.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `transaction` | [`TransactionLike`](modules.md#transactionlike) | TransactionLike to convert into a transaction hash. |
+
+#### Returns
+
+`string`
+
+Transaction hash corresponding to the TransactionLike input.
+
+#### Defined in
+
+[packages/sdk/src/utils/coercion.ts:63](https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/utils/coercion.ts#L63)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "yarn lint:check --fix",
     "pre-commit": "lint-staged",
     "test": "hardhat test",
-    "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json"
+    "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json",
+    "autogen:docs": "typedoc --plugin typedoc-plugin-markdown --gitRevision develop --out docs src/index.ts"
   },
   "keywords": [
     "optimism",
@@ -60,6 +61,8 @@
     "nyc": "^15.1.0",
     "prettier": "^2.3.1",
     "ts-mocha": "^8.0.0",
+    "typedoc": "^0.22.11",
+    "typedoc-plugin-markdown": "^3.11.13",
     "typescript": "^4.3.5"
   },
   "dependencies": {

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -64,7 +64,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
    *
    * @param opts Options for the provider.
    * @param opts.l1SignerOrProvider Signer or Provider for the L1 chain, or a JSON-RPC url.
-   * @param opts.l1SignerOrProvider Signer or Provider for the L2 chain, or a JSON-RPC url.
+   * @param opts.l2SignerOrProvider Signer or Provider for the L2 chain, or a JSON-RPC url.
    * @param opts.l1ChainId Chain ID for the L1 chain.
    * @param opts.depositConfirmationBlocks Optional number of blocks before a deposit is confirmed.
    * @param opts.l1BlockTimeSeconds Optional estimated block time in seconds for the L1 chain.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8219,6 +8219,18 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
@@ -8338,7 +8350,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@^4.0.1, handlebars@^4.7.6:
+handlebars@^4.0.1, handlebars@^4.7.6, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -9697,6 +9709,11 @@ json5@^2.1.0, json5@^2.1.2, json5@^2.2.0:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -10418,6 +10435,11 @@ ltgt@~2.1.1:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
   integrity sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -10531,6 +10553,11 @@ marked@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+
+marked@^4.0.10:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
+  integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
 
 match-all@^1.2.6:
   version "1.2.6"
@@ -13700,6 +13727,15 @@ shelljs@^0.8.3:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shiki@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.0.tgz#85f21ecfa95b377ff64db6c71442c22c220e9540"
+  integrity sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-oniguruma "^1.6.1"
+    vscode-textmate "5.2.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -15138,6 +15174,24 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typedoc-plugin-markdown@^3.11.13:
+  version "3.11.13"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.11.13.tgz#d0c937d60bd58b117fa6600a99b9278bcc251fae"
+  integrity sha512-9Y7eWWmUF5i8LMfetPlOP+kTn5L3Q71fm/AUHZhxWYoAiugbybQujhjQk4h09uY2WghPP2BldOivtTxnOwj85A==
+  dependencies:
+    handlebars "^4.7.7"
+
+typedoc@^0.22.11:
+  version "0.22.11"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.11.tgz#a3d7f4577eef9fc82dd2e8f4e2915e69f884c250"
+  integrity sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==
+  dependencies:
+    glob "^7.2.0"
+    lunr "^2.3.9"
+    marked "^4.0.10"
+    minimatch "^3.0.4"
+    shiki "^0.10.0"
+
 typescript@^4.3.4, typescript@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
@@ -15459,6 +15513,16 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vscode-oniguruma@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz#2bf4dfcfe3dd2e56eb549a3068c8ee39e6c30ce5"
+  integrity sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==
+
+vscode-textmate@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds auto-generated documentation for the SDK. This was generated using
TypeDoc + a plugin that outputs as Markdown.
