### PR TITLE
feat(sdk): have SDK sort messages descending by bn

### DIFF
--- a/.changeset/selfish-numbers-tan.md
+++ b/.changeset/selfish-numbers-tan.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Have SDK sort deposits/withdrawals descending by block number

--- a/packages/sdk/src/adapters/eth-bridge.ts
+++ b/packages/sdk/src/adapters/eth-bridge.ts
@@ -30,20 +30,25 @@ export class ETHBridgeAdapter extends StandardBridgeAdapter {
       opts?.toBlock
     )
 
-    return events.map((event) => {
-      return {
-        direction: MessageDirection.L1_TO_L2,
-        from: event.args._from,
-        to: event.args._to,
-        l1Token: ethers.constants.AddressZero,
-        l2Token: predeploys.OVM_ETH,
-        amount: event.args._amount,
-        data: event.args._data,
-        logIndex: event.logIndex,
-        blockNumber: event.blockNumber,
-        transactionHash: event.transactionHash,
-      }
-    })
+    return events
+      .map((event) => {
+        return {
+          direction: MessageDirection.L1_TO_L2,
+          from: event.args._from,
+          to: event.args._to,
+          l1Token: ethers.constants.AddressZero,
+          l2Token: predeploys.OVM_ETH,
+          amount: event.args._amount,
+          data: event.args._data,
+          logIndex: event.logIndex,
+          blockNumber: event.blockNumber,
+          transactionHash: event.transactionHash,
+        }
+      })
+      .sort((a, b) => {
+        // Sort descending by block number
+        return b.blockNumber - a.blockNumber
+      })
   }
 
   public async getWithdrawalsByAddress(
@@ -80,6 +85,10 @@ export class ETHBridgeAdapter extends StandardBridgeAdapter {
           blockNumber: event.blockNumber,
           transactionHash: event.transactionHash,
         }
+      })
+      .sort((a, b) => {
+        // Sort descending by block number
+        return b.blockNumber - a.blockNumber
       })
   }
 

--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -93,6 +93,10 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
           transactionHash: event.transactionHash,
         }
       })
+      .sort((a, b) => {
+        // Sort descending by block number
+        return b.blockNumber - a.blockNumber
+      })
   }
 
   public async getWithdrawalsByAddress(
@@ -131,6 +135,10 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
           blockNumber: event.blockNumber,
           transactionHash: event.transactionHash,
         }
+      })
+      .sort((a, b) => {
+        // Sort descending by block number
+        return b.blockNumber - a.blockNumber
       })
   }
 

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -253,9 +253,14 @@ export class CrossChainMessenger implements ICrossChainMessenger {
           return bridge.getDepositsByAddress(address, opts)
         })
       )
-    ).reduce((acc, val) => {
-      return acc.concat(val)
-    }, [])
+    )
+      .reduce((acc, val) => {
+        return acc.concat(val)
+      }, [])
+      .sort((a, b) => {
+        // Sort descending by block number
+        return b.blockNumber - a.blockNumber
+      })
   }
 
   public async getWithdrawalsByAddress(
@@ -271,9 +276,14 @@ export class CrossChainMessenger implements ICrossChainMessenger {
           return bridge.getWithdrawalsByAddress(address, opts)
         })
       )
-    ).reduce((acc, val) => {
-      return acc.concat(val)
-    }, [])
+    )
+      .reduce((acc, val) => {
+        return acc.concat(val)
+      }, [])
+      .sort((a, b) => {
+        // Sort descending by block number
+        return b.blockNumber - a.blockNumber
+      })
   }
 
   public async toCrossChainMessage(


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Has the SDK sort messages (deposits/withdrawals) descending by block
number. Makes for a better experience when presenting this data to
users.

**Metadata**
- Fixes ENG-1949
