### PR TITLE
fix: remove extra space in BSS metric names

### DIFF
--- a/.changeset/eleven-lobsters-add.md
+++ b/.changeset/eleven-lobsters-add.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+---
+
+Remove extra space in metric names

--- a/go/bss-core/metrics/metrics.go
+++ b/go/bss-core/metrics/metrics.go
@@ -46,7 +46,7 @@ type Metrics struct {
 }
 
 func NewMetrics(subsystem string) *Metrics {
-	subsystem = "batch_submitter_ " + strings.ToLower(subsystem)
+	subsystem = "batch_submitter_" + strings.ToLower(subsystem)
 	return &Metrics{
 		ETHBalance: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "balance_eth",


### PR DESCRIPTION
**Description**
Removes an extra space in the BSS metrics names that causes the service to die on startup.

**Metadata**
- Fixes ENG-1954