### PR TITLE
fix: use correct token for label-requires-review

### DIFF
--- a/.github/workflows/label-requires-reviews.yml
+++ b/.github/workflows/label-requires-reviews.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Require-reviewers
         uses: travelperk/label-requires-reviews-action@v0.1
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PERSONAL_ACCESS_TOKEN doesn't seem to exist or is expired (also no other check uses this token). Works now with GITHUB_TOKEN.