### PR TITLE
fix: skip an unreliable integration test

### DIFF
--- a/.changeset/wise-weeks-explode.md
+++ b/.changeset/wise-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Skip an unreliable test

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -144,33 +144,32 @@ describe('OVM Context: Layer 2 EVM Context', () => {
    * context. The data returned should match what is actually being used as the
    * OVM context.
    */
-
-  it('should return same timestamp and blocknumbers between `eth_call` and `rollup_getInfo`', async () => {
-    // As atomically as possible, call `rollup_getInfo` and Multicall for the
-    // blocknumber and timestamp. If this is not atomic, then the sequencer can
-    // happend to update the timestamp between the `eth_call` and the `rollup_getInfo`
-    const [info, [, returnData]] = await Promise.all([
-      L2Provider.send('rollup_getInfo', []),
-      Multicall.callStatic.aggregate([
-        [
-          OVMContextStorage.address,
-          OVMContextStorage.interface.encodeFunctionData(
-            'getCurrentBlockTimestamp'
-          ),
-        ],
-        [
-          OVMContextStorage.address,
-          OVMContextStorage.interface.encodeFunctionData(
-            'getCurrentL1BlockNumber'
-          ),
-        ],
-      ]),
-    ])
-
-    const timestamp = BigNumber.from(returnData[0])
-    const blockNumber = BigNumber.from(returnData[1])
-
-    expect(info.ethContext.blockNumber).to.deep.equal(blockNumber.toNumber())
-    expect(info.ethContext.timestamp).to.deep.equal(timestamp.toNumber())
+  // TODO: This test is not reliable. If we really care about this then we need to figure out a
+  // more reliable way to test this behavior.
+  it.skip('should return same timestamp and blocknumbers between `eth_call` and `rollup_getInfo`', async () => {
+    // // As atomically as possible, call `rollup_getInfo` and Multicall for the
+    // // blocknumber and timestamp. If this is not atomic, then the sequencer can
+    // // happend to update the timestamp between the `eth_call` and the `rollup_getInfo`
+    // const [info, [, returnData]] = await Promise.all([
+    //   L2Provider.send('rollup_getInfo', []),
+    //   Multicall.callStatic.aggregate([
+    //     [
+    //       OVMContextStorage.address,
+    //       OVMContextStorage.interface.encodeFunctionData(
+    //         'getCurrentBlockTimestamp'
+    //       ),
+    //     ],
+    //     [
+    //       OVMContextStorage.address,
+    //       OVMContextStorage.interface.encodeFunctionData(
+    //         'getCurrentL1BlockNumber'
+    //       ),
+    //     ],
+    //   ]),
+    // ])
+    // const timestamp = BigNumber.from(returnData[0])
+    // const blockNumber = BigNumber.from(returnData[1])
+    // expect(info.ethContext.blockNumber).to.deep.equal(blockNumber.toNumber())
+    // expect(info.ethContext.timestamp).to.deep.equal(timestamp.toNumber())
   })
 })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Skips the unreliable timestamp/blocknumber test which would often be off
by one or two. Creates an annoying habit of having to rerun the
integration tests until the test passes, which isn't how integration
tests should work.
