### PR TITLE
maintaince:removed relayXDomainMessages from integration tests

### DIFF
--- a/.changeset/slimy-pandas-tease.md
+++ b/.changeset/slimy-pandas-tease.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/integration-tests': patch
+---
+
+Removes relayXDomainMessages from integration tests. Uses CrossChainMessenger from SDK instead.


### PR DESCRIPTION
**Description**
Removed `relayXDomainMessages` function from integration tests and replaced it using the `CrossChainMessenger ` class from the SDK.

**Metadata**
- Fixes #2184 
