### PR TITLE
fix: add logging to the DTL when BSS HF1 is live

### DIFF
--- a/.changeset/fifty-ears-fly.md
+++ b/.changeset/fifty-ears-fly.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add logging when BSS HF1 is active

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -68,6 +68,12 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
   protected async _init(): Promise<void> {
     this.logger.info('Initializing L1 Data Transport Service...')
 
+    if (this.options.bssHardfork1Index !== null && this.options.bssHardfork1Index !== undefined) {
+      this.logger.info(`BSS HF1 is active at block: ${this.options.bssHardfork1Index}`)
+    } else {
+      this.logger.info(`BSS HF1 is not active`)
+    }
+
     this.state.db = level(this.options.dbPath)
     await this.state.db.open()
 


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a basic log line to the DTL when BSS HF1 is active. Will also log
when BSS HF1 is not active.
