### PR TITLE
fix: update recommended memory for ops setup

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -34,7 +34,7 @@ docker-compose \
 
 Also note that Docker Desktop only allocates 2GB of memory by default, which isn't enough to run the docker-compose services reliably.
 
-To allocate more memory, go to Settings > Resources in the Docker UI and use the slider to change the value (_4GB recommended_). Make sure to click Apply & Restart for the changes to take effect.
+To allocate more memory, go to Settings > Resources in the Docker UI and use the slider to change the value (_8GB recommended_). Make sure to click Apply & Restart for the changes to take effect.
 
 To start the stack with monitoring enabled, just add the metric composition file.
 ```
@@ -46,15 +46,15 @@ docker-compose \
 ```
 
 Optionally, run a verifier along the rest of the stack. Run a replica with the same command by switching the service name!
+
 ```
-docker-compose 
+docker-compose
     -f docker-compose.yml \
     -f docker-compose.ts-batch-submitter.yml \
     up --scale \
     verifier=1 \
     --build --detach
 ```
-
 
 A Makefile has been provided for convience. The following targets are available.
 - make up


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
An issue was recently reported (#2191) that showed that 4gb was not
sufficient to run the docker setup. This commit updates the recommended
amount of memory to 8gb.
