### PR TITLE
fix(sdk): have sdk properly wait for transactions

### DIFF
--- a/.changeset/lemon-chefs-walk.md
+++ b/.changeset/lemon-chefs-walk.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Have SDK wait for transactions in getMessagesByTransaction

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -143,6 +143,13 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       direction?: MessageDirection
     } = {}
   ): Promise<CrossChainMessage[]> {
+    // Wait for the transaction receipt if the input is waitable.
+    // TODO: Maybe worth doing this with more explicit typing but whatever for now.
+    if (typeof (transaction as any).wait === 'function') {
+      await (transaction as any).wait()
+    }
+
+    // Convert the input to a transaction hash.
     const txHash = toTransactionHash(transaction)
 
     let receipt: TransactionReceipt


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Minor fix to the SDK to guarantee that transactions are `wait`ed to avoid situations in which the receipt does not yet exist because the transaction has not been processed yet.