### PR TITLE
fix(sdk): correctly handle no batch case

### DIFF
--- a/.changeset/grumpy-ads-smile.md
+++ b/.changeset/grumpy-ads-smile.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Have SDK properly handle case when no batches are submitted yet

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -654,6 +654,11 @@ export class CrossChainMessenger implements ICrossChainMessenger {
     let batchEvent: ethers.Event | null =
       await this.getStateBatchAppendedEventByBatchIndex(upperBound)
 
+    // Only happens when no batches have been submitted yet.
+    if (batchEvent === null) {
+      return null
+    }
+
     if (isEventLo(batchEvent, transactionIndex)) {
       // Upper bound is too low, means this transaction doesn't have a corresponding state batch yet.
       return null


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes the SDK so that it correctly handles the case where no batches
have been submitted to the StateCommitmentChain yet. Only happens in
development or immediately after a new chain is started.

**Metadata**
- Fixes #2211
