### PR TITLE
fix: update PR labeler to include SDK

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,5 +30,8 @@ M-core-utils:
 M-dtl:
   - any: ['packages/data-transport-layer/**/*']
 
+M-sdk:
+  - any: ['packages/sdk/**/*']
+
 M-ops:
   - any: ['ops/**/*']


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the PR labeler to correctly label the SDK. I noticed that the
SDK was not being correctly labeled and realized that I had to add it to
this file.
