### PR TITLE
Fixed a bug in getL1Price in the SDK

### DIFF
--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -31,7 +31,7 @@ export const getL1GasPrice = async (
   l2Provider: ProviderLike
 ): Promise<BigNumber> => {
   const gpo = connectGasPriceOracle(l2Provider)
-  return gpo.gasPrice()
+  return gpo.l1BaseFee()
 }
 
 /**


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixed a bug in `l2Provider.getL1Price()`.

**Additional context**
It used to provide the l2 price (`gasPrice()`) instead of the l1 price (`l1BaseFee()`)