### PR TITLE
SDK Quality of life improvement: Easier L1 gas estimates

### DIFF
--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -47,8 +47,14 @@ export const estimateL1Gas = async (
 ): Promise<BigNumber> => {
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1GasUsed(
+    // Only use the tx fields we need. That way there's no
+    // need to delete fields before calling the SDK
     serialize({
-      ...tx,
+      data: tx.data,
+      to: tx.to,
+      gasPrice: tx.gasPrice,
+      type: tx.type,
+      gasLimit: tx.gasLimit,
       nonce: toNumber(tx.nonce as NumberLike),
     })
   )
@@ -67,8 +73,14 @@ export const estimateL1GasCost = async (
 ): Promise<BigNumber> => {
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1Fee(
+    // Only use the tx fields we need. That way there's no
+    // need to delete fields before calling the SDK      
     serialize({
-      ...tx,
+      data: tx.data,
+      to: tx.to,
+      gasPrice: tx.gasPrice,
+      type: tx.type,
+      gasLimit: tx.gasLimit,
       nonce: toNumber(tx.nonce as NumberLike),
     })
   )


### PR DESCRIPTION
Ignore additional transaction fields, such as `from` and `chainId`, when calling `estimateL1Gas` or `estimateL1GasCost`.

Doing this means that you can use this pattern:

```js
const fakeTxReq = await greeter.populateTransaction.setGreeting(greeting)
const fakeTx = await signer.populateTransaction(fakeTxReq)
```

Instead of the longer

```js
const fakeTxReq = await greeter.populateTransaction.setGreeting(greeting)
const fakeTx = await signer.populateTransaction(fakeTxReq)
delete fakeTx.from
delete fakeTx.chainId
```

Note: I don't know enough TypeScript to verify this works correctly.
I assume it does because `TransactionRequest` is defined:

```ts

export type TransactionRequest = {
    to?: string,
    from?: string,
    nonce?: BigNumberish,

    gasLimit?: BigNumberish,
    gasPrice?: BigNumberish,

    data?: BytesLike,
    value?: BigNumberish,
    chainId?: number

    type?: number;
    accessList?: AccessListish;

    maxPriorityFeePerGas?: BigNumberish;
    maxFeePerGas?: BigNumberish;

    customData?: Record<string, any>;
}
```

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
A clear and concise description of the features you're adding in this pull request.

**Additional context**
Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
