### PR TITLE
dtl: Periodically log current l2 sync

### DIFF
--- a/.changeset/young-gorillas-raise.md
+++ b/.changeset/young-gorillas-raise.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add logs displaying current sync from l2

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -119,6 +119,13 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
           highestSyncedL2BlockNumber === targetL2Block ||
           currentL2Block === 0
         ) {
+          this.logger.info(
+            'All Layer 2 (Optimism) transactions are synchronized',
+            {
+              currentL2Block,
+              targetL2Block,
+            }
+          )
           await sleep(this.options.pollingInterval)
           continue
         }


### PR DESCRIPTION
**Description**
Log the current synchronized tx number and block tip reported by the rpc provider at l2-ingestion.

We observed an issue where the dtl thinks it has reached the tip and thus stopped syncing transactions on l2. There isn't enough visibility to determine if this was because the l2 rpc provider returned an incorrect block tip or not.