### PR TITLE
Fix and usability improvements for L1 gas and cost estimates in L2Provider

### DIFF
--- a/.changeset/spotty-trains-sneeze.md
+++ b/.changeset/spotty-trains-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+1. Fix a bug in `L2Provider.getL1GasPrice()`
+2. Make it easier to get correct estimates from `L2Provider.estimateL1Gas()` and `L2.estimateL2GasCost`.

--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -31,7 +31,7 @@ export const getL1GasPrice = async (
   l2Provider: ProviderLike
 ): Promise<BigNumber> => {
   const gpo = connectGasPriceOracle(l2Provider)
-  return gpo.gasPrice()
+  return gpo.l1BaseFee()
 }
 
 /**

--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -48,7 +48,11 @@ export const estimateL1Gas = async (
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1GasUsed(
     serialize({
-      ...tx,
+      data: tx.data,
+      to: tx.to,
+      gasPrice: tx.gasPrice,
+      type: tx.type,
+      gasLimit: tx.gasLimit,
       nonce: toNumber(tx.nonce as NumberLike),
     })
   )
@@ -68,7 +72,11 @@ export const estimateL1GasCost = async (
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1Fee(
     serialize({
-      ...tx,
+      data: tx.data,
+      to: tx.to,
+      gasPrice: tx.gasPrice,
+      type: tx.type,
+      gasLimit: tx.gasLimit,
       nonce: toNumber(tx.nonce as NumberLike),
     })
   )


### PR DESCRIPTION

**Description**

1. Fix a bug in `L2Provider.getL1GasPrice()`
2. Make it easier to get correct estimates from `L2Provider.estimateL1Gas()` and `L2.estimateL2GasCost`.
