### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/fifty-ears-fly.md
+++ b/.changeset/fifty-ears-fly.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Add logging when BSS HF1 is active

--- a/.changeset/grumpy-ads-smile.md
+++ b/.changeset/grumpy-ads-smile.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/sdk': patch
----
-
-Have SDK properly handle case when no batches are submitted yet

--- a/.changeset/healthy-hotels-build.md
+++ b/.changeset/healthy-hotels-build.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/l2geth': patch
----
-
-Bump the timeout to download the genesis file on l2geth

--- a/.changeset/large-keys-punch.md
+++ b/.changeset/large-keys-punch.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Deletes common.ts in data-transport-layer. Uses core-utils.

--- a/.changeset/lemon-chefs-walk.md
+++ b/.changeset/lemon-chefs-walk.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/sdk': patch
----
-
-Have SDK wait for transactions in getMessagesByTransaction

--- a/.changeset/metal-files-draw.md
+++ b/.changeset/metal-files-draw.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/batch-submitter-service': patch
----
-
-Fixes a bug that causes the txmgr to not wait for the configured numConfirmations

--- a/.changeset/moody-singers-hunt.md
+++ b/.changeset/moody-singers-hunt.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/core-utils': minor
----
-
-Deletes the Watcher and injectL2Context functions. Use the SDK instead.

--- a/.changeset/nasty-donkeys-collect.md
+++ b/.changeset/nasty-donkeys-collect.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/integration-tests': patch
----
-
-Deletes watcher-utils.ts. Moves it's utilities into env.ts.

--- a/.changeset/popular-lies-yell.md
+++ b/.changeset/popular-lies-yell.md
@@ -1,6 +1,0 @@
----
-'@eth-optimism/batch-submitter': patch
-'@eth-optimism/replica-healthcheck': patch
----
-
-Use asL2Provider instead of injectL2Context in bss and healthcheck service.

--- a/.changeset/rotten-mugs-complain.md
+++ b/.changeset/rotten-mugs-complain.md
@@ -1,6 +1,0 @@
----
-'@eth-optimism/message-relayer': minor
-'@eth-optimism/integration-tests': patch
----
-
-Removes message relaying utilities from the Message Relayer, to be replaced by the SDK

--- a/.changeset/spicy-camels-fly.md
+++ b/.changeset/spicy-camels-fly.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts': patch
----
-
-Contracts are additionally verified on sourcify during deploy. This should reduce manual labor during future regeneses.

--- a/.changeset/tasty-seahorses-tie.md
+++ b/.changeset/tasty-seahorses-tie.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Handle null response for `eth_getBlockRange` query

--- a/.changeset/thin-moles-learn.md
+++ b/.changeset/thin-moles-learn.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/message-relayer': patch
----
-
-Update message relayer to log sent tx hashes

--- a/.changeset/thin-seahorses-fry.md
+++ b/.changeset/thin-seahorses-fry.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/sdk': patch
----
-
-Add approval functions to the SDK

--- a/.changeset/young-gorillas-raise.md
+++ b/.changeset/young-gorillas-raise.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Add logs displaying current sync from l2

--- a/.changeset/young-gorillas-raise.md
+++ b/.changeset/young-gorillas-raise.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add logs displaying current sync from l2

--- a/go/batch-submitter/CHANGELOG.md
+++ b/go/batch-submitter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/batch-submitter-service
 
+## 0.1.4
+
+### Patch Changes
+
+- bcbde5f3: Fixes a bug that causes the txmgr to not wait for the configured numConfirmations
+
 ## 0.1.3
 
 ### Patch Changes

--- a/go/batch-submitter/package.json
+++ b/go/batch-submitter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eth-optimism/batch-submitter-service",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"private": true,
 	"devDependencies": {}
 }

--- a/integration-tests/CHANGELOG.md
+++ b/integration-tests/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/integration-tests
 
+## 0.5.4
+
+### Patch Changes
+
+- dc5f6517: Deletes watcher-utils.ts. Moves it's utilities into env.ts.
+- dcdcc757: Removes message relaying utilities from the Message Relayer, to be replaced by the SDK
+
 ## 0.5.3
 
 ### Patch Changes

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/integration-tests",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "[Optimism] Integration tests",
   "scripts": {
     "lint": "yarn lint:fix && yarn lint:check",
@@ -28,9 +28,9 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "devDependencies": {
-    "@eth-optimism/contracts": "0.5.14",
-    "@eth-optimism/core-utils": "0.7.7",
-    "@eth-optimism/sdk": "0.2.2",
+    "@eth-optimism/contracts": "0.5.15",
+    "@eth-optimism/core-utils": "0.8.0",
+    "@eth-optimism/sdk": "0.2.3",
     "@ethersproject/abstract-provider": "^5.5.1",
     "@ethersproject/providers": "^5.5.3",
     "@ethersproject/transactions": "^5.5.0",

--- a/l2geth/CHANGELOG.md
+++ b/l2geth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.12
+
+### Patch Changes
+
+- 84e6a158: Bump the timeout to download the genesis file on l2geth
+
 ## 0.5.11
 
 ### Patch Changes

--- a/l2geth/package.json
+++ b/l2geth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/l2geth",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "private": true,
   "devDependencies": {}
 }

--- a/packages/batch-submitter/CHANGELOG.md
+++ b/packages/batch-submitter/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.20
+
+### Patch Changes
+
+- d3d70291: Use asL2Provider instead of injectL2Context in bss and healthcheck service.
+- Updated dependencies [f37c283c]
+- Updated dependencies [3f4d3c13]
+- Updated dependencies [0b4453f7]
+- Updated dependencies [78298782]
+- Updated dependencies [0c54e60e]
+  - @eth-optimism/sdk@0.2.3
+  - @eth-optimism/core-utils@0.8.0
+  - @eth-optimism/contracts@0.5.15
+
 ## 0.4.19
 
 ### Patch Changes

--- a/packages/batch-submitter/package.json
+++ b/packages/batch-submitter/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/batch-submitter",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "[Optimism] Service for submitting transactions and transaction results",
   "main": "dist/index",
   "types": "dist/index",
@@ -34,9 +34,9 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.1",
-    "@eth-optimism/contracts": "0.5.14",
-    "@eth-optimism/core-utils": "0.7.7",
-    "@eth-optimism/sdk": "^0.2.1",
+    "@eth-optimism/contracts": "0.5.15",
+    "@eth-optimism/core-utils": "0.8.0",
+    "@eth-optimism/sdk": "^0.2.3",
     "@eth-optimism/ynatm": "^0.2.2",
     "@ethersproject/abstract-provider": "^5.5.1",
     "@ethersproject/providers": "^5.5.3",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.15
+
+### Patch Changes
+
+- 78298782: Contracts are additionally verified on sourcify during deploy. This should reduce manual labor during future regeneses.
+- Updated dependencies [0b4453f7]
+  - @eth-optimism/core-utils@0.8.0
+
 ## 0.5.14
 
 ### Patch Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "[Optimism] L1 and L2 smart contracts for Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -58,7 +58,7 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/core-utils": "0.7.7",
+    "@eth-optimism/core-utils": "0.8.0",
     "@ethersproject/abstract-provider": "^5.5.1",
     "@ethersproject/abstract-signer": "^5.5.0",
     "@ethersproject/hardware-wallets": "^5.5.0"

--- a/packages/core-utils/CHANGELOG.md
+++ b/packages/core-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/core-utils
 
+## 0.8.0
+
+### Minor Changes
+
+- 0b4453f7: Deletes the Watcher and injectL2Context functions. Use the SDK instead.
+
 ## 0.7.7
 
 ### Patch Changes

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/core-utils",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "description": "[Optimism] Core typescript utilities",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/data-transport-layer/CHANGELOG.md
+++ b/packages/data-transport-layer/CHANGELOG.md
@@ -1,5 +1,18 @@
 # data transport layer
 
+## 0.5.18
+
+### Patch Changes
+
+- b8ee3e05: Add logging when BSS HF1 is active
+- 4878667a: Deletes common.ts in data-transport-layer. Uses core-utils.
+- e9602d86: Handle null response for `eth_getBlockRange` query
+- e63f3b61: Add logs displaying current sync from l2
+- Updated dependencies [0b4453f7]
+- Updated dependencies [78298782]
+  - @eth-optimism/core-utils@0.8.0
+  - @eth-optimism/contracts@0.5.15
+
 ## 0.5.17
 
 ### Patch Changes

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/data-transport-layer",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "[Optimism] Service for shuttling data from L1 into L2",
   "main": "dist/index",
   "types": "dist/index",
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.1",
-    "@eth-optimism/contracts": "0.5.14",
-    "@eth-optimism/core-utils": "0.7.7",
+    "@eth-optimism/contracts": "0.5.15",
+    "@eth-optimism/core-utils": "0.8.0",
     "@ethersproject/providers": "^5.5.3",
     "@ethersproject/transactions": "^5.5.0",
     "@sentry/node": "^6.3.1",

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -119,6 +119,13 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
           highestSyncedL2BlockNumber === targetL2Block ||
           currentL2Block === 0
         ) {
+          this.logger.info(
+            'All Layer 2 (Optimism) transactions are synchronized',
+            {
+              currentL2Block,
+              targetL2Block,
+            }
+          )
           await sleep(this.options.pollingInterval)
           continue
         }

--- a/packages/message-relayer/CHANGELOG.md
+++ b/packages/message-relayer/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @eth-optimism/message-relayer
 
+## 0.3.0
+
+### Minor Changes
+
+- dcdcc757: Removes message relaying utilities from the Message Relayer, to be replaced by the SDK
+
+### Patch Changes
+
+- 189f63be: Update message relayer to log sent tx hashes
+- Updated dependencies [f37c283c]
+- Updated dependencies [3f4d3c13]
+- Updated dependencies [0b4453f7]
+- Updated dependencies [0c54e60e]
+  - @eth-optimism/sdk@0.2.3
+  - @eth-optimism/core-utils@0.8.0
+
 ## 0.2.18
 
 ### Patch Changes

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/message-relayer",
-  "version": "0.2.18",
+  "version": "0.3.0",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.1",
-    "@eth-optimism/core-utils": "0.7.7",
-    "@eth-optimism/sdk": "^0.2.1",
+    "@eth-optimism/core-utils": "0.8.0",
+    "@eth-optimism/sdk": "^0.2.3",
     "@sentry/node": "^6.3.1",
     "bcfg": "^0.1.6",
     "dotenv": "^10.0.0",

--- a/packages/replica-healthcheck/CHANGELOG.md
+++ b/packages/replica-healthcheck/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @eth-optimism/replica-healthcheck
 
+## 0.3.8
+
+### Patch Changes
+
+- d3d70291: Use asL2Provider instead of injectL2Context in bss and healthcheck service.
+- Updated dependencies [f37c283c]
+- Updated dependencies [3f4d3c13]
+- Updated dependencies [0b4453f7]
+- Updated dependencies [0c54e60e]
+  - @eth-optimism/sdk@0.2.3
+  - @eth-optimism/core-utils@0.8.0
+
 ## 0.3.7
 
 ### Patch Changes

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/replica-healthcheck",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "[Optimism] Service for monitoring the health of replica nodes",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,8 +33,8 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.1",
-    "@eth-optimism/core-utils": "0.7.7",
-    "@eth-optimism/sdk": "^0.2.1",
+    "@eth-optimism/core-utils": "0.8.0",
+    "@eth-optimism/sdk": "^0.2.3",
     "dotenv": "^10.0.0",
     "ethers": "^5.5.4",
     "express": "^4.17.1",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @eth-optimism/sdk
 
+## 0.2.3
+
+### Patch Changes
+
+- f37c283c: Have SDK properly handle case when no batches are submitted yet
+- 3f4d3c13: Have SDK wait for transactions in getMessagesByTransaction
+- 0c54e60e: Add approval functions to the SDK
+- Updated dependencies [0b4453f7]
+- Updated dependencies [78298782]
+  - @eth-optimism/core-utils@0.8.0
+  - @eth-optimism/contracts@0.5.15
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -63,8 +63,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@eth-optimism/contracts": "0.5.14",
-    "@eth-optimism/core-utils": "0.7.7",
+    "@eth-optimism/contracts": "0.5.15",
+    "@eth-optimism/core-utils": "0.8.0",
     "lodash": "^4.17.21",
     "merkletreejs": "^0.2.27",
     "rlp": "^2.2.7"


### PR DESCRIPTION
- maintenance: minor README updates
- Deleted common.ts in data-transport-layer and replaced them from core-utils
- feat: split up SubmitBatchTx driver method
- feat: add failing Test for txmgr edge case
- fix: add SendState to determine when to abort Send
- feat: add SAFE_ABORT_NONCE_TOO_LOW_COUNT flag
- feat: stop publishing txs after receiving confirmation
- feat: update message-relayer to use the SDK
- feat: add teleport Postgres APIs
- fix: add missing "*" to pull_request path for bathc-submitter and bss-core
- feat: add teleportr unit tests to GH Actions with Postgres service
- maintenance: use new asL2Provider function
- feat(core-utils): remove Watcher and injectL2Context
- fix: update recommended memory for ops setup
- deleted watch-utils and added the utilities in env.ts
- fix: update PR labeler to include SDK
- dtl: add retry loop to `eth_getBlockRange`
- l2geth: Increase genesis file fetch timeout
- feat(mr): log when txs are sent
- fix(sdk): correctly handle no batch case
- fix(sdk): have sdk properly wait for transactions
- dtl: Periodically log current l2 sync
- feat: verify contracts on sourcify during deploy
- feat: add base TeleportrDeposit.sol contract
- feat: make contract variables public, remove getters
- feat: remove TeleportDeposit destory method
- feat: inline/simplify receive modifiers
- feat: add minDepositAmount to TeleportrDeposit.sol
- feat: emit depositId in TeleportrDeposit.EtherReceived event
- feat: make Teleportr contract inherit from Ownable
- feat: add NatSpec comments and tests to TeleportrDeposit
- feat: add L2 TeleportrDisburser contract
- feat: add missing Initializable contract docs
- feat(sdk): add approval fns to the SDK
- Fix slither warnings
- fix: add logging to the DTL when BSS HF1 is live
- Remove .only
- Version Packages
