### PR TITLE
interface bss-core metrics to allow for driver-specific metrics extensions

### DIFF
--- a/.changeset/lovely-shrimps-explain.md
+++ b/.changeset/lovely-shrimps-explain.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+---
+
+Refactors the bss-core service to use a metrics interface to allow
+driver-specific metric extensions

--- a/go/batch-submitter/drivers/proposer/driver.go
+++ b/go/batch-submitter/drivers/proposer/driver.go
@@ -82,7 +82,7 @@ func NewDriver(cfg Config) (*Driver, error) {
 		rawSccContract: rawSccContract,
 		ctcContract:    ctcContract,
 		walletAddr:     walletAddr,
-		metrics:        metrics.NewBase(cfg.Name),
+		metrics:        metrics.NewBase("batch_submitter", cfg.Name),
 	}, nil
 }
 

--- a/go/batch-submitter/drivers/proposer/driver.go
+++ b/go/batch-submitter/drivers/proposer/driver.go
@@ -45,7 +45,7 @@ type Driver struct {
 	rawSccContract *bind.BoundContract
 	ctcContract    *ctc.CanonicalTransactionChain
 	walletAddr     common.Address
-	metrics        *metrics.Metrics
+	metrics        *metrics.Base
 }
 
 func NewDriver(cfg Config) (*Driver, error) {
@@ -82,7 +82,7 @@ func NewDriver(cfg Config) (*Driver, error) {
 		rawSccContract: rawSccContract,
 		ctcContract:    ctcContract,
 		walletAddr:     walletAddr,
-		metrics:        metrics.NewMetrics(cfg.Name),
+		metrics:        metrics.NewBase(cfg.Name),
 	}, nil
 }
 
@@ -97,7 +97,7 @@ func (d *Driver) WalletAddr() common.Address {
 }
 
 // Metrics returns the subservice telemetry object.
-func (d *Driver) Metrics() *metrics.Metrics {
+func (d *Driver) Metrics() metrics.Metrics {
 	return d.metrics
 }
 
@@ -184,7 +184,7 @@ func (d *Driver) CraftBatchTx(
 		stateRoots = append(stateRoots, block.Root())
 	}
 
-	d.metrics.NumElementsPerBatch.Observe(float64(len(stateRoots)))
+	d.metrics.NumElementsPerBatch().Observe(float64(len(stateRoots)))
 
 	log.Info(name+" batch constructed", "num_state_roots", len(stateRoots))
 

--- a/go/batch-submitter/drivers/sequencer/driver.go
+++ b/go/batch-submitter/drivers/sequencer/driver.go
@@ -44,7 +44,7 @@ type Driver struct {
 	rawCtcContract *bind.BoundContract
 	walletAddr     common.Address
 	ctcABI         *abi.ABI
-	metrics        *metrics.Metrics
+	metrics        *metrics.Base
 }
 
 func NewDriver(cfg Config) (*Driver, error) {
@@ -80,7 +80,7 @@ func NewDriver(cfg Config) (*Driver, error) {
 		rawCtcContract: rawCtcContract,
 		walletAddr:     walletAddr,
 		ctcABI:         ctcABI,
-		metrics:        metrics.NewMetrics(cfg.Name),
+		metrics:        metrics.NewBase(cfg.Name),
 	}, nil
 }
 
@@ -95,7 +95,7 @@ func (d *Driver) WalletAddr() common.Address {
 }
 
 // Metrics returns the subservice telemetry object.
-func (d *Driver) Metrics() *metrics.Metrics {
+func (d *Driver) Metrics() metrics.Metrics {
 	return d.metrics
 }
 
@@ -219,8 +219,8 @@ func (d *Driver) CraftBatchTx(
 			continue
 		}
 
-		d.metrics.NumElementsPerBatch.Observe(float64(len(batchElements)))
-		d.metrics.BatchPruneCount.Set(float64(pruneCount))
+		d.metrics.NumElementsPerBatch().Observe(float64(len(batchElements)))
+		d.metrics.BatchPruneCount().Set(float64(pruneCount))
 
 		log.Info(name+" batch constructed", "num_txs", len(batchElements), "length", len(batchCallData))
 

--- a/go/batch-submitter/drivers/sequencer/driver.go
+++ b/go/batch-submitter/drivers/sequencer/driver.go
@@ -44,7 +44,7 @@ type Driver struct {
 	rawCtcContract *bind.BoundContract
 	walletAddr     common.Address
 	ctcABI         *abi.ABI
-	metrics        *metrics.Base
+	metrics        *Metrics
 }
 
 func NewDriver(cfg Config) (*Driver, error) {
@@ -80,7 +80,7 @@ func NewDriver(cfg Config) (*Driver, error) {
 		rawCtcContract: rawCtcContract,
 		walletAddr:     walletAddr,
 		ctcABI:         ctcABI,
-		metrics:        metrics.NewBase(cfg.Name),
+		metrics:        NewMetrics(cfg.Name),
 	}, nil
 }
 
@@ -220,7 +220,7 @@ func (d *Driver) CraftBatchTx(
 		}
 
 		d.metrics.NumElementsPerBatch().Observe(float64(len(batchElements)))
-		d.metrics.BatchPruneCount().Set(float64(pruneCount))
+		d.metrics.BatchPruneCount.Set(float64(pruneCount))
 
 		log.Info(name+" batch constructed", "num_txs", len(batchElements), "length", len(batchCallData))
 

--- a/go/batch-submitter/drivers/sequencer/metrics.go
+++ b/go/batch-submitter/drivers/sequencer/metrics.go
@@ -1,0 +1,30 @@
+package sequencer
+
+import (
+	"github.com/ethereum-optimism/optimism/go/bss-core/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics extends the BSS core metrics with additional metrics tracked by the
+// sequencer driver.
+type Metrics struct {
+	*metrics.Base
+
+	// BatchPruneCount tracks the number of times a batch of sequencer
+	// transactions is pruned in order to meet the desired size requirements.
+	BatchPruneCount prometheus.Gauge
+}
+
+// NewMetrics initializes a new, extended metrics object.
+func NewMetrics(subsystem string) *Metrics {
+	base := metrics.NewBase("batch_submitter", subsystem)
+	return &Metrics{
+		Base: base,
+		BatchPruneCount: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "batch_prune_count",
+			Help:      "Number of times a batch is pruned",
+			Subsystem: base.SubsystemName(),
+		}),
+	}
+}

--- a/go/batch-submitter/go.mod
+++ b/go/batch-submitter/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum-optimism/optimism/l2geth v1.0.0
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/getsentry/sentry-go v0.11.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
 )

--- a/go/bss-core/metrics/interface.go
+++ b/go/bss-core/metrics/interface.go
@@ -3,6 +3,9 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 type Metrics interface {
+	// SubsystemName returns the subsystem name for the metrics group.
+	SubsystemName() string
+
 	// BalanceETH tracks the amount of ETH in the submitter's account.
 	BalanceETH() prometheus.Gauge
 
@@ -32,8 +35,4 @@ type Metrics interface {
 	// BatchConfirmationTimeMs tracks the duration it takes to confirm a batch
 	// transaction.
 	BatchConfirmationTimeMs() prometheus.Gauge
-
-	// BatchPruneCount tracks the number of times a batch of sequencer
-	// transactions is pruned in order to meet the desired size requirements.
-	BatchPruneCount() prometheus.Gauge
 }

--- a/go/bss-core/metrics/interface.go
+++ b/go/bss-core/metrics/interface.go
@@ -1,0 +1,39 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type Metrics interface {
+	// BalanceETH tracks the amount of ETH in the submitter's account.
+	BalanceETH() prometheus.Gauge
+
+	// BatchSizeBytes tracks the size of batch submission transactions.
+	BatchSizeBytes() prometheus.Summary
+
+	// NumElementsPerBatch tracks the number of L2 transactions in each batch
+	// submission.
+	NumElementsPerBatch() prometheus.Summary
+
+	// SubmissionTimestamp tracks the time at which each batch was confirmed.
+	SubmissionTimestamp() prometheus.Gauge
+
+	// SubmissionGasUsedWei tracks the amount of gas used to submit each batch.
+	SubmissionGasUsedWei() prometheus.Gauge
+
+	// BatchsSubmitted tracks the total number of successful batch submissions.
+	BatchesSubmitted() prometheus.Counter
+
+	// FailedSubmissions tracks the total number of failed batch submissions.
+	FailedSubmissions() prometheus.Counter
+
+	// BatchTxBuildTimeMs tracks the duration it takes to construct a batch
+	// transaction.
+	BatchTxBuildTimeMs() prometheus.Gauge
+
+	// BatchConfirmationTimeMs tracks the duration it takes to confirm a batch
+	// transaction.
+	BatchConfirmationTimeMs() prometheus.Gauge
+
+	// BatchPruneCount tracks the number of times a batch of sequencer
+	// transactions is pruned in order to meet the desired size requirements.
+	BatchPruneCount() prometheus.Gauge
+}

--- a/go/bss-core/metrics/metrics.go
+++ b/go/bss-core/metrics/metrics.go
@@ -7,98 +7,154 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-type Metrics struct {
-	// ETHBalance tracks the amount of ETH in the submitter's account.
-	ETHBalance prometheus.Gauge
+type Base struct {
+	// balanceETH tracks the amount of ETH in the submitter's account.
+	balanceETH prometheus.Gauge
 
-	// BatchSizeInBytes tracks the size of batch submission transactions.
-	BatchSizeInBytes prometheus.Summary
+	// batchSizeBytes tracks the size of batch submission transactions.
+	batchSizeBytes prometheus.Summary
 
-	// NumElementsPerBatch tracks the number of L2 transactions in each batch
+	// numElementsPerBatch tracks the number of L2 transactions in each batch
 	// submission.
-	NumElementsPerBatch prometheus.Summary
+	numElementsPerBatch prometheus.Summary
 
-	// SubmissionTimestamp tracks the time at which each batch was confirmed.
-	SubmissionTimestamp prometheus.Gauge
+	// submissionTimestamp tracks the time at which each batch was confirmed.
+	submissionTimestamp prometheus.Gauge
 
-	// SubmissionGasUsed tracks the amount of gas used to submit each batch.
-	SubmissionGasUsed prometheus.Gauge
+	// submissionGasUsedWei tracks the amount of gas used to submit each batch.
+	submissionGasUsedWei prometheus.Gauge
 
-	// BatchsSubmitted tracks the total number of successful batch submissions.
-	BatchesSubmitted prometheus.Counter
+	// batchsSubmitted tracks the total number of successful batch submissions.
+	batchesSubmitted prometheus.Counter
 
-	// FailedSubmissions tracks the total number of failed batch submissions.
-	FailedSubmissions prometheus.Counter
+	// failedSubmissions tracks the total number of failed batch submissions.
+	failedSubmissions prometheus.Counter
 
-	// BatchTxBuildTime tracks the duration it takes to construct a batch
+	// batchTxBuildTimeMs tracks the duration it takes to construct a batch
 	// transaction.
-	BatchTxBuildTime prometheus.Gauge
+	batchTxBuildTimeMs prometheus.Gauge
 
-	// BatchConfirmationTime tracks the duration it takes to confirm a batch
+	// batchConfirmationTimeMs tracks the duration it takes to confirm a batch
 	// transaction.
-	BatchConfirmationTime prometheus.Gauge
+	batchConfirmationTimeMs prometheus.Gauge
 
-	// BatchPruneCount tracks the number of times a batch of sequencer
+	// batchPruneCount tracks the number of times a batch of sequencer
 	// transactions is pruned in order to meet the desired size requirements.
 	//
 	// NOTE: This is currently only active in the sequencer driver.
-	BatchPruneCount prometheus.Gauge
+	batchPruneCount prometheus.Gauge
 }
 
-func NewMetrics(subsystem string) *Metrics {
+func NewBase(subsystem string) *Base {
 	subsystem = "batch_submitter_" + strings.ToLower(subsystem)
-	return &Metrics{
-		ETHBalance: promauto.NewGauge(prometheus.GaugeOpts{
+	return &Base{
+		balanceETH: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "balance_eth",
 			Help:      "ETH balance of the batch submitter",
 			Subsystem: subsystem,
 		}),
-		BatchSizeInBytes: promauto.NewSummary(prometheus.SummaryOpts{
+		batchSizeBytes: promauto.NewSummary(prometheus.SummaryOpts{
 			Name:       "batch_size_bytes",
 			Help:       "Size of batches in bytes",
 			Subsystem:  subsystem,
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}),
-		NumElementsPerBatch: promauto.NewSummary(prometheus.SummaryOpts{
+		numElementsPerBatch: promauto.NewSummary(prometheus.SummaryOpts{
 			Name:       "num_elements_per_batch",
 			Help:       "Number of elements in each batch",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			Subsystem:  subsystem,
 		}),
-		SubmissionTimestamp: promauto.NewGauge(prometheus.GaugeOpts{
+		submissionTimestamp: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "submission_timestamp_ms",
 			Help:      "Timestamp of last batch submitter submission",
 			Subsystem: subsystem,
 		}),
-		SubmissionGasUsed: promauto.NewGauge(prometheus.GaugeOpts{
+		submissionGasUsedWei: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "submission_gas_used_wei",
 			Help:      "Gas used to submit each batch",
 			Subsystem: subsystem,
 		}),
-		BatchesSubmitted: promauto.NewCounter(prometheus.CounterOpts{
+		batchesSubmitted: promauto.NewCounter(prometheus.CounterOpts{
 			Name:      "batches_submitted",
 			Help:      "Count of batches submitted",
 			Subsystem: subsystem,
 		}),
-		FailedSubmissions: promauto.NewCounter(prometheus.CounterOpts{
+		failedSubmissions: promauto.NewCounter(prometheus.CounterOpts{
 			Name:      "failed_submissions",
 			Help:      "Count of failed batch submissions",
 			Subsystem: subsystem,
 		}),
-		BatchTxBuildTime: promauto.NewGauge(prometheus.GaugeOpts{
+		batchTxBuildTimeMs: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "batch_tx_build_time_ms",
 			Help:      "Time to construct batch transactions",
 			Subsystem: subsystem,
 		}),
-		BatchConfirmationTime: promauto.NewGauge(prometheus.GaugeOpts{
+		batchConfirmationTimeMs: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "batch_confirmation_time_ms",
 			Help:      "Time to confirm batch transactions",
 			Subsystem: subsystem,
 		}),
-		BatchPruneCount: promauto.NewGauge(prometheus.GaugeOpts{
+		batchPruneCount: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "batch_prune_count",
 			Help:      "Number of times a batch is pruned",
 			Subsystem: subsystem,
 		}),
 	}
+}
+
+// BalanceETH tracks the amount of ETH in the submitter's account.
+func (b *Base) BalanceETH() prometheus.Gauge {
+	return b.balanceETH
+}
+
+// BatchSizeBytes tracks the size of batch submission transactions.
+func (b *Base) BatchSizeBytes() prometheus.Summary {
+	return b.batchSizeBytes
+}
+
+// NumElementsPerBatch tracks the number of L2 transactions in each batch
+// submission.
+func (b *Base) NumElementsPerBatch() prometheus.Summary {
+	return b.numElementsPerBatch
+}
+
+// SubmissionTimestamp tracks the time at which each batch was confirmed.
+func (b *Base) SubmissionTimestamp() prometheus.Gauge {
+	return b.submissionTimestamp
+}
+
+// SubmissionGasUsedWei tracks the amount of gas used to submit each batch.
+func (b *Base) SubmissionGasUsedWei() prometheus.Gauge {
+	return b.submissionGasUsedWei
+}
+
+// BatchsSubmitted tracks the total number of successful batch submissions.
+func (b *Base) BatchesSubmitted() prometheus.Counter {
+	return b.batchesSubmitted
+}
+
+// FailedSubmissions tracks the total number of failed batch submissions.
+func (b *Base) FailedSubmissions() prometheus.Counter {
+	return b.failedSubmissions
+}
+
+// BatchTxBuildTimeMs tracks the duration it takes to construct a batch
+// transaction.
+func (b *Base) BatchTxBuildTimeMs() prometheus.Gauge {
+	return b.batchTxBuildTimeMs
+}
+
+// BatchConfirmationTimeMs tracks the duration it takes to confirm a batch
+// transaction.
+func (b *Base) BatchConfirmationTimeMs() prometheus.Gauge {
+	return b.batchConfirmationTimeMs
+}
+
+// BatchPruneCount tracks the number of times a batch of sequencer transactions
+// is pruned in order to meet the desired size requirements.
+//
+// NOTE: This is currently only active in the sequencer driver.
+func (b *Base) BatchPruneCount() prometheus.Gauge {
+	return b.batchPruneCount
 }


### PR DESCRIPTION
**Description**
Modifies the bss-core `Service` to operate on a `metrics.Metrics` interface rather than a concrete struct.
The interface is now implemented by `metrics.Base` which can embedded in driver-specific metrics extensions.
Some extra functionality is added to make this process simpler, e.g  exposing the `SubsystemName()` to ensure the extensions all have the same metrics prefix. To demonstrate the behavior, the `BatchPruneCount` metrics is moved into an extended metrics object specific to the sequencer, since the proposer does not have this concept.

**Metadata**
- Fixes ENG-1969
