### PR TITLE
fix(rhc): dockerfile not properly including sdk

### DIFF
--- a/.changeset/big-cycles-listen.md
+++ b/.changeset/big-cycles-listen.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Fix bug in replica healthcheck dockerfile

--- a/ops/docker/Dockerfile.replica-healthcheck
+++ b/ops/docker/Dockerfile.replica-healthcheck
@@ -12,6 +12,8 @@ COPY --from=builder /optimism/yarn.lock .
 COPY --from=builder /optimism/node_modules ./node_modules
 
 # copy deps (would have been nice if docker followed the symlinks required)
+COPY --from=builder /optimism/packages/sdk/package.json ./packages/sdk/package.json
+COPY --from=builder /optimism/packages/sdk/dist ./packages/sdk/dist
 COPY --from=builder /optimism/packages/core-utils/package.json ./packages/core-utils/package.json
 COPY --from=builder /optimism/packages/core-utils/dist ./packages/core-utils/dist
 COPY --from=builder /optimism/packages/common-ts/package.json ./packages/common-ts/package.json


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes an issue in the replica-healthcheck dockerfile where the file was
not properly including the SDK. As a result, the replica-healthcheck
service was not able to import the SDK and the service would break on
start.

**Metadata**
- Fixes #2236
