### PR TITLE
l2geth: remove dead code

### DIFF
--- a/.changeset/cool-cougars-lick.md
+++ b/.changeset/cool-cougars-lick.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove dead code in l2geth

--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -186,15 +186,7 @@ func (st *StateTransition) buyGas() error {
 		}
 	}
 	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
-		if rcfg.UsingOVM {
-			// Hack to prevent race conditions with the `gas-oracle`
-			// where policy level balance checks pass and then fail
-			// during consensus. The user gets some free gas
-			// in this case.
-			mgval = st.state.GetBalance(st.msg.From())
-		} else {
-			return errInsufficientBalanceForGas
-		}
+		return errInsufficientBalanceForGas
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
 		return err


### PR DESCRIPTION
**Description**

Some left over dead code is removed.
It has never been triggered and cannot
be triggered due to the locks in the syncservice.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


