### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/big-cycles-listen.md
+++ b/.changeset/big-cycles-listen.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/replica-healthcheck': patch
----
-
-Fix bug in replica healthcheck dockerfile

--- a/.changeset/brown-foxes-hang.md
+++ b/.changeset/brown-foxes-hang.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/integration-tests': patch
----
-
-Replaces l1Provider and l2Provider with env.l1Provider and env.l2Provider respectively.

--- a/.changeset/cool-cougars-lick.md
+++ b/.changeset/cool-cougars-lick.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Remove dead code in l2geth

--- a/.changeset/cool-cougars-lick.md
+++ b/.changeset/cool-cougars-lick.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/l2geth': patch
----
-
-Remove dead code in l2geth

--- a/.changeset/grumpy-lemons-laugh.md
+++ b/.changeset/grumpy-lemons-laugh.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Include patch contexts for bss hf1

--- a/.changeset/happy-yaks-clap.md
+++ b/.changeset/happy-yaks-clap.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Hardcodes BSS HF1 block into the DTL

--- a/.changeset/healthy-cycles-jam.md
+++ b/.changeset/healthy-cycles-jam.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': patch
----
-
-Update to go-ethereum v1.10.16

--- a/.changeset/hungry-apples-exist.md
+++ b/.changeset/hungry-apples-exist.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/gas-oracle': patch
----
-
-Update to go-ethereum v1.10.16

--- a/.changeset/khaki-boxes-learn.md
+++ b/.changeset/khaki-boxes-learn.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/batch-submitter-service': patch
----
-
-Update to go-ethereum v1.10.16

--- a/.changeset/lovely-shrimps-explain.md
+++ b/.changeset/lovely-shrimps-explain.md
@@ -1,6 +1,0 @@
----
-'@eth-optimism/batch-submitter-service': patch
----
-
-Refactors the bss-core service to use a metrics interface to allow
-driver-specific metric extensions

--- a/.changeset/nasty-boats-type.md
+++ b/.changeset/nasty-boats-type.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/l2geth': patch
----
-
-Don't block read rpc requests when syncing

--- a/.changeset/quick-tables-double.md
+++ b/.changeset/quick-tables-double.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/l2geth': patch
----
-
-Fix queue index comparison

--- a/.changeset/spotty-trains-sneeze.md
+++ b/.changeset/spotty-trains-sneeze.md
@@ -1,6 +1,0 @@
----
-'@eth-optimism/sdk': patch
----
-
-1. Fix a bug in `L2Provider.getL1GasPrice()`
-2. Make it easier to get correct estimates from `L2Provider.estimateL1Gas()` and `L2.estimateL2GasCost`.

--- a/go/batch-submitter/CHANGELOG.md
+++ b/go/batch-submitter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @eth-optimism/batch-submitter-service
 
+## 0.1.5
+
+### Patch Changes
+
+- 6f2ea193: Update to go-ethereum v1.10.16
+- 87359fd2: Refactors the bss-core service to use a metrics interface to allow
+  driver-specific metric extensions
+
 ## 0.1.4
 
 ### Patch Changes

--- a/go/batch-submitter/package.json
+++ b/go/batch-submitter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eth-optimism/batch-submitter-service",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"private": true,
 	"devDependencies": {}
 }

--- a/go/gas-oracle/CHANGELOG.md
+++ b/go/gas-oracle/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/gas-oracle
 
+## 0.1.7
+
+### Patch Changes
+
+- fed748e0: Update to go-ethereum v1.10.16
+
 ## 0.1.6
 
 ### Patch Changes

--- a/go/gas-oracle/package.json
+++ b/go/gas-oracle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/gas-oracle",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "devDependencies": {}
 }

--- a/go/proxyd/CHANGELOG.md
+++ b/go/proxyd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/proxyd
 
+## 3.8.1
+
+### Patch Changes
+
+- acf7dbd5: Update to go-ethereum v1.10.16
+
 ## 3.8.0
 
 ### Minor Changes

--- a/go/proxyd/package.json
+++ b/go/proxyd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/proxyd",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "private": true,
   "dependencies": {}
 }

--- a/integration-tests/CHANGELOG.md
+++ b/integration-tests/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/integration-tests
 
+## 0.5.5
+
+### Patch Changes
+
+- 45642dc8: Replaces l1Provider and l2Provider with env.l1Provider and env.l2Provider respectively.
+
 ## 0.5.4
 
 ### Patch Changes

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/integration-tests",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "[Optimism] Integration tests",
   "scripts": {
     "lint": "yarn lint:fix && yarn lint:check",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@eth-optimism/contracts": "0.5.15",
     "@eth-optimism/core-utils": "0.8.0",
-    "@eth-optimism/sdk": "0.2.3",
+    "@eth-optimism/sdk": "0.2.4",
     "@ethersproject/abstract-provider": "^5.5.1",
     "@ethersproject/providers": "^5.5.3",
     "@ethersproject/transactions": "^5.5.0",

--- a/l2geth/CHANGELOG.md
+++ b/l2geth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.13
+
+### Patch Changes
+
+- 0002b1df: Remove dead code in l2geth
+- 1187dc9a: Don't block read rpc requests when syncing
+- bc342ec4: Fix queue index comparison
+
 ## 0.5.12
 
 ### Patch Changes

--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -186,15 +186,7 @@ func (st *StateTransition) buyGas() error {
 		}
 	}
 	if st.state.GetBalance(st.msg.From()).Cmp(mgval) < 0 {
-		if rcfg.UsingOVM {
-			// Hack to prevent race conditions with the `gas-oracle`
-			// where policy level balance checks pass and then fail
-			// during consensus. The user gets some free gas
-			// in this case.
-			mgval = st.state.GetBalance(st.msg.From())
-		} else {
-			return errInsufficientBalanceForGas
-		}
+		return errInsufficientBalanceForGas
 	}
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
 		return err

--- a/l2geth/package.json
+++ b/l2geth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/l2geth",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "private": true,
   "devDependencies": {}
 }

--- a/packages/data-transport-layer/CHANGELOG.md
+++ b/packages/data-transport-layer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # data transport layer
 
+## 0.5.19
+
+### Patch Changes
+
+- 275eb818: Include patch contexts for bss hf1
+- baece507: Hardcodes BSS HF1 block into the DTL
+
 ## 0.5.18
 
 ### Patch Changes

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/data-transport-layer",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "[Optimism] Service for shuttling data from L1 into L2",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/replica-healthcheck/CHANGELOG.md
+++ b/packages/replica-healthcheck/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @eth-optimism/replica-healthcheck
 
+## 0.3.9
+
+### Patch Changes
+
+- d4b0e193: Fix bug in replica healthcheck dockerfile
+- Updated dependencies [44420939]
+  - @eth-optimism/sdk@0.2.4
+
 ## 0.3.8
 
 ### Patch Changes

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/replica-healthcheck",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "[Optimism] Service for monitoring the health of replica nodes",
   "main": "dist/index",
   "types": "dist/index",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.1",
     "@eth-optimism/core-utils": "0.8.0",
-    "@eth-optimism/sdk": "^0.2.3",
+    "@eth-optimism/sdk": "^0.2.4",
     "dotenv": "^10.0.0",
     "ethers": "^5.5.4",
     "express": "^4.17.1",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/sdk
 
+## 0.2.4
+
+### Patch Changes
+
+- 44420939: 1. Fix a bug in `L2Provider.getL1GasPrice()`
+  2. Make it easier to get correct estimates from `L2Provider.estimateL1Gas()` and `L2.estimateL2GasCost`.
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
- l2geth: don't block read rpc when doing initial sync
- l2geth: fix startup logic for repairing queue index
- maintenance: minor README updates
- Deleted common.ts in data-transport-layer and replaced them from core-utils
- feat: split up SubmitBatchTx driver method
- feat: add failing Test for txmgr edge case
- fix: add SendState to determine when to abort Send
- feat: add SAFE_ABORT_NONCE_TOO_LOW_COUNT flag
- feat: stop publishing txs after receiving confirmation
- feat: update message-relayer to use the SDK
- feat: add teleport Postgres APIs
- fix: add missing "*" to pull_request path for bathc-submitter and bss-core
- feat: add teleportr unit tests to GH Actions with Postgres service
- maintenance: use new asL2Provider function
- feat(core-utils): remove Watcher and injectL2Context
- fix: update recommended memory for ops setup
- feat(dtl): add patch contexts
- replaced l1Provider and l2Provider with env.l1Provider and env.l2Provider
- deleted watch-utils and added the utilities in env.ts
- chore(deps): bump follow-redirects from 1.14.7 to 1.14.8
- fix: update PR labeler to include SDK
- dtl: add retry loop to `eth_getBlockRange`
- l2geth: Increase genesis file fetch timeout
- feat(mr): log when txs are sent
- fix(sdk): correctly handle no batch case
- fix(sdk): have sdk properly wait for transactions
- dtl: Periodically log current l2 sync
- feat: verify contracts on sourcify during deploy
- feat: add base TeleportrDeposit.sol contract
- feat: make contract variables public, remove getters
- feat: remove TeleportDeposit destory method
- feat: inline/simplify receive modifiers
- feat: add minDepositAmount to TeleportrDeposit.sol
- feat: emit depositId in TeleportrDeposit.EtherReceived event
- feat: make Teleportr contract inherit from Ownable
- feat: add NatSpec comments and tests to TeleportrDeposit
- feat: add L2 TeleportrDisburser contract
- feat: add missing Initializable contract docs
- fix(sdk): Get correct l1 gas price in getL1GasPrice
- feat(sdk): Make it easier to get transaction estimates
- chore: Added a changeset
- feat(sdk): add approval fns to the SDK
- Fix slither warnings
- fix: add logging to the DTL when BSS HF1 is live
- Remove .only
- packages/contracts: Add flag to automatically set ownership
- Version Packages
- batch-submitter: update to go-ethereum v1.10.16
- gas-oracle: update to go-ethereum v1.10.16
- proxyd: update to go-ethereum v1.10.16
- feat: make bss-core Metrics an interface to allow extensions
- feat: extend bsscore metrics for sequencer driver
- fix(rhc): dockerfile not properly including sdk
- feat(dtl): hardcode bss hf1 index into the dtl
- l2geth: remove dead code
- Version Packages
