### PR TITLE
feat: fix teleportr ci, and lint target

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - 'go/gas-oracle/**'
       - 'go/batch-submitter/**'
+      - 'go/bss-core/**'
+      - 'go/teleportr/**'
     branches:
       - 'master'
       - 'develop'
@@ -13,6 +15,8 @@ on:
     paths:
       - 'go/gas-oracle/**'
       - 'go/batch-submitter/**'
+      - 'go/bss-core/**'
+      - 'go/teleportr/**'
 jobs:
   golangci:
     name: lint
@@ -34,3 +38,8 @@ jobs:
         with:
           version: v1.29
           working-directory: go/bss-core
+      - name: golangci-lint teleportr
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29
+          working-directory: go/teleportr

--- a/.github/workflows/teleportr.yml
+++ b/.github/workflows/teleportr.yml
@@ -25,8 +25,8 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_USER=postgres
-          POSTGRES_PASSWORD=password
+          - POSTGRES_USER=postgres
+          - POSTGRES_PASSWORD=password
         ports:
           - 5432:5432
     steps:

--- a/go/teleportr/db/db.go
+++ b/go/teleportr/db/db.go
@@ -180,7 +180,9 @@ func (d *Database) UpsertDeposits(deposits []Deposit) error {
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer func() {
+		_ = tx.Rollback()
+	}()
 
 	for _, deposit := range deposits {
 


### PR DESCRIPTION
Also fixes a linter error that wasn't caught while the CI was broken.

The yaml failed to parse because the postgres env vars didn't have dashes before them:
```
The workflow is not valid. .github/workflows/teleportr.yml (Line: 28, Col: 11): A sequence was not expected
```

Example of failed run: https://github.com/ethereum-optimism/optimism/actions/runs/1924304434