### PR TITLE
feat: always run go unit tests/golangci-lint on every PR

### DIFF
--- a/.github/workflows/batch-submitter.yml
+++ b/.github/workflows/batch-submitter.yml
@@ -10,8 +10,8 @@ on:
       - '*rc'
       - 'regenesis/*'
   pull_request:
-    paths:
-      - 'go/batch-submitter/**'
+    branches:
+      - '*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/bss-core.yml
+++ b/.github/workflows/bss-core.yml
@@ -10,8 +10,8 @@ on:
       - '*rc'
       - 'regenesis/*'
   pull_request:
-    paths:
-      - 'go/bss-core/**'
+    branches:
+      - '*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/gas-oracle.yml
+++ b/.github/workflows/gas-oracle.yml
@@ -10,8 +10,8 @@ on:
       - '*rc'
       - 'regenesis/*'
   pull_request:
-    paths:
-      - 'go/gas-oracle/**'
+    branches:
+      - '*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,11 +12,8 @@ on:
       - '*rc'
       - 'regenesis/*'
   pull_request:
-    paths:
-      - 'go/gas-oracle/**'
-      - 'go/batch-submitter/**'
-      - 'go/bss-core/**'
-      - 'go/teleportr/**'
+    branches:
+      - '*'
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/proxyd.yml
+++ b/.github/workflows/proxyd.yml
@@ -6,8 +6,8 @@ on:
       - 'master'
       - 'develop'
   pull_request:
-    paths:
-      - 'go/proxyd/**'
+    branches:
+      - '*'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
The current methodology only attempts to run unit tests when changes to
the package paths are detected. However, this is brittle and most
notably doesn't capture when changes are made to the workflow itself. As
a result, a green build in a PR doesn't neccessarily correlate to a
green build after merge. Unit tests are cheap, so this should prevent
needless false positives.

I've intentionally left the l2geth tests with path selection on since that isn't likely
to receive many changes, and they are considerably more expensive than the unit
tests in our services.