### PR TITLE
fix(ct): remove yargs as unused dep

### DIFF
--- a/.changeset/khaki-chefs-call.md
+++ b/.changeset/khaki-chefs-call.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Remove yargs as a contracts dependency (unused)

--- a/packages/contracts/.depcheckrc
+++ b/packages/contracts/.depcheckrc
@@ -6,5 +6,4 @@ ignores: [
   "prettier-plugin-solidity",
   "solhint-plugin-prettier",
   "ts-generator",
-  "yargs",
 ]

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -119,8 +119,7 @@
     "ts-generator": "0.0.8",
     "ts-node": "^10.0.0",
     "typechain": "^6.0.2",
-    "typescript": "^4.3.5",
-    "yargs": "^16.2.0"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "ethers": "^5"


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Removes yargs as a dependency from the contracts package since it wasn't
being used. Always good to cut unused dependencies.