### PR TITLE
refactor(tests): migrate from smock v1 to smock v2

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@codechecks/client": "^0.1.11",
     "@defi-wonderland/smock": "^2.0.2",
-    "@eth-optimism/smock": "1.1.10",
     "@nomiclabs/ethereumjs-vm": "^4.2.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^2.1.6",

--- a/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/messaging/deposit.gas.spec.ts
@@ -1,7 +1,7 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
-import { smoddit } from '@eth-optimism/smock'
+import { MockContract, smock } from '@defi-wonderland/smock'
 import { expectApprox } from '@eth-optimism/core-utils'
 
 /* Internal Imports */
@@ -92,7 +92,7 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge [ @skip-on-coverage
   })
 
   // 4 Bridge
-  let L1ERC20: Contract
+  let L1ERC20: MockContract<Contract>
   let L1StandardBridge: Contract
   before('Deploy the bridge and setup the token', async () => {
     // Deploy the Bridge
@@ -105,14 +105,12 @@ describe('[GAS BENCHMARK] Depositing via the standard bridge [ @skip-on-coverage
     )
 
     L1ERC20 = await (
-      await smoddit('@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20')
+      await smock.mock('@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20')
     ).deploy('L1ERC20', 'ERC')
     const aliceAddress = await alice.getAddress()
-    await L1ERC20.smodify.put({
-      _totalSupply: INITIAL_TOTAL_L1_SUPPLY,
-      _balances: {
-        [aliceAddress]: INITIAL_TOTAL_L1_SUPPLY,
-      },
+    await L1ERC20.setVariable('_totalSupply', INITIAL_TOTAL_L1_SUPPLY)
+    await L1ERC20.setVariable('_balances', {
+      [aliceAddress]: INITIAL_TOTAL_L1_SUPPLY,
     })
   })
 

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.gas.spec.ts
@@ -1,7 +1,7 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
-import { smockit, MockContract } from '@eth-optimism/smock'
+import { smock, FakeContract } from '@defi-wonderland/smock'
 import {
   AppendSequencerBatchParams,
   BatchContext,
@@ -46,7 +46,7 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain [ @skip-on-coverage ]', () =
   })
 
   let AddressManager: Contract
-  let Mock__StateCommitmentChain: MockContract
+  let Fake__StateCommitmentChain: FakeContract
   before(async () => {
     AddressManager = await makeAddressManager()
     await AddressManager.setAddress(
@@ -54,14 +54,14 @@ describe('[GAS BENCHMARK] CanonicalTransactionChain [ @skip-on-coverage ]', () =
       await sequencer.getAddress()
     )
 
-    Mock__StateCommitmentChain = await smockit(
+    Fake__StateCommitmentChain = await smock.fake<Contract>(
       await ethers.getContractFactory('StateCommitmentChain')
     )
 
     await setProxyTarget(
       AddressManager,
       'StateCommitmentChain',
-      Mock__StateCommitmentChain
+      Fake__StateCommitmentChain
     )
   })
 

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
@@ -1,7 +1,7 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
-import { smockit, MockContract } from '@eth-optimism/smock'
+import { smock, FakeContract } from '@defi-wonderland/smock'
 import {
   AppendSequencerBatchParams,
   encodeAppendSequencerBatch,
@@ -69,7 +69,7 @@ describe('CanonicalTransactionChain', () => {
   })
 
   let AddressManager: Contract
-  let Mock__StateCommitmentChain: MockContract
+  let Fake__StateCommitmentChain: FakeContract
   before(async () => {
     AddressManager = await makeAddressManager()
     await AddressManager.setAddress(
@@ -77,14 +77,14 @@ describe('CanonicalTransactionChain', () => {
       await sequencer.getAddress()
     )
 
-    Mock__StateCommitmentChain = await smockit(
+    Fake__StateCommitmentChain = await smock.fake<Contract>(
       await ethers.getContractFactory('StateCommitmentChain')
     )
 
     await setProxyTarget(
       AddressManager,
       'StateCommitmentChain',
-      Mock__StateCommitmentChain
+      Fake__StateCommitmentChain
     )
   })
 

--- a/packages/contracts/test/contracts/L2/messaging/L2StandardBridge.spec.ts
+++ b/packages/contracts/test/contracts/L2/messaging/L2StandardBridge.spec.ts
@@ -1,13 +1,7 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
-import {
-  smockit,
-  MockContract,
-  smoddit,
-  ModifiableContract,
-} from '@eth-optimism/smock'
-import { smock } from '@defi-wonderland/smock'
+import { smock, FakeContract, MockContract } from '@defi-wonderland/smock'
 
 /* Internal Imports */
 import { expect } from '../../../setup'
@@ -47,10 +41,10 @@ describe('L2StandardBridge', () => {
 
   let L2StandardBridge: Contract
   let L2ERC20: Contract
-  let Mock__L2CrossDomainMessenger: MockContract
+  let Fake__L2CrossDomainMessenger: FakeContract
   beforeEach(async () => {
     // Get a new mock L2 messenger
-    Mock__L2CrossDomainMessenger = await smockit(
+    Fake__L2CrossDomainMessenger = await smock.fake<Contract>(
       await ethers.getContractFactory('L2CrossDomainMessenger'),
       // This allows us to use an ethers override {from: Mock__L2CrossDomainMessenger.address} to mock calls
       { address: await l2MessengerImpersonator.getAddress() }
@@ -59,7 +53,7 @@ describe('L2StandardBridge', () => {
     // Deploy the contract under test
     L2StandardBridge = await (
       await ethers.getContractFactory('L2StandardBridge')
-    ).deploy(Mock__L2CrossDomainMessenger.address, DUMMY_L1BRIDGE_ADDRESS)
+    ).deploy(Fake__L2CrossDomainMessenger.address, DUMMY_L1BRIDGE_ADDRESS)
 
     // Deploy an L2 ERC20
     L2ERC20 = await (
@@ -83,7 +77,7 @@ describe('L2StandardBridge', () => {
     })
 
     it('onlyFromCrossDomainAccount: should revert on calls from the right crossDomainMessenger, but wrong xDomainMessageSender (ie. not the L1L1StandardBridge)', async () => {
-      Mock__L2CrossDomainMessenger.smocked.xDomainMessageSender.will.return.with(
+      Fake__L2CrossDomainMessenger.xDomainMessageSender.returns(
         NON_ZERO_ADDRESS
       )
 
@@ -96,7 +90,7 @@ describe('L2StandardBridge', () => {
           0,
           NON_NULL_BYTES32,
           {
-            from: Mock__L2CrossDomainMessenger.address,
+            from: Fake__L2CrossDomainMessenger.address,
           }
         )
       ).to.be.revertedWith(ERR_INVALID_X_DOMAIN_MSG_SENDER)
@@ -118,11 +112,11 @@ describe('L2StandardBridge', () => {
         0,
         NON_NULL_BYTES32,
         {
-          from: Mock__L2CrossDomainMessenger.address,
+          from: Fake__L2CrossDomainMessenger.address,
         }
       )
 
-      Mock__L2CrossDomainMessenger.smocked.xDomainMessageSender.will.return.with(
+      Fake__L2CrossDomainMessenger.xDomainMessageSender.returns(
         () => DUMMY_L1BRIDGE_ADDRESS
       )
 
@@ -134,15 +128,15 @@ describe('L2StandardBridge', () => {
         100,
         NON_NULL_BYTES32,
         {
-          from: Mock__L2CrossDomainMessenger.address,
+          from: Fake__L2CrossDomainMessenger.address,
         }
       )
 
       const withdrawalCallToMessenger =
-        Mock__L2CrossDomainMessenger.smocked.sendMessage.calls[0]
+        Fake__L2CrossDomainMessenger.sendMessage.getCall(1)
 
-      expect(withdrawalCallToMessenger._target).to.equal(DUMMY_L1BRIDGE_ADDRESS)
-      expect(withdrawalCallToMessenger._message).to.equal(
+      expect(withdrawalCallToMessenger.args[0]).to.equal(DUMMY_L1BRIDGE_ADDRESS)
+      expect(withdrawalCallToMessenger.args[1]).to.equal(
         Factory__L1StandardBridge.interface.encodeFunctionData(
           'finalizeERC20Withdrawal',
           [
@@ -160,7 +154,7 @@ describe('L2StandardBridge', () => {
     it('should credit funds to the depositor', async () => {
       const depositAmount = 100
 
-      Mock__L2CrossDomainMessenger.smocked.xDomainMessageSender.will.return.with(
+      Fake__L2CrossDomainMessenger.xDomainMessageSender.returns(
         () => DUMMY_L1BRIDGE_ADDRESS
       )
 
@@ -172,7 +166,7 @@ describe('L2StandardBridge', () => {
         depositAmount,
         NON_NULL_BYTES32,
         {
-          from: Mock__L2CrossDomainMessenger.address,
+          from: Fake__L2CrossDomainMessenger.address,
         }
       )
 
@@ -183,7 +177,7 @@ describe('L2StandardBridge', () => {
 
   describe('withdrawals', () => {
     const withdrawAmount = 1_000
-    let SmoddedL2Token: ModifiableContract
+    let Mock__L2Token: MockContract<Contract>
 
     let Fake__OVM_ETH
 
@@ -195,8 +189,8 @@ describe('L2StandardBridge', () => {
 
     beforeEach(async () => {
       // Deploy a smodded gateway so we can give some balances to withdraw
-      SmoddedL2Token = await (
-        await smoddit('L2StandardERC20', alice)
+      Mock__L2Token = await (
+        await smock.mock('L2StandardERC20')
       ).deploy(
         L2StandardBridge.address,
         DUMMY_L1TOKEN_ADDRESS,
@@ -204,14 +198,11 @@ describe('L2StandardBridge', () => {
         'L2T'
       )
 
-      // Populate the initial state with a total supply and some money in alice's balance
-      SmoddedL2Token.smodify.put({
-        _totalSupply: INITIAL_TOTAL_SUPPLY,
-        _balances: {
-          [aliceAddress]: ALICE_INITIAL_BALANCE,
-        },
-        l2Bridge: L2StandardBridge.address,
+      await Mock__L2Token.setVariable('_totalSupply', INITIAL_TOTAL_SUPPLY)
+      await Mock__L2Token.setVariable('_balances', {
+        [aliceAddress]: ALICE_INITIAL_BALANCE,
       })
+      await Mock__L2Token.setVariable('l2Bridge', L2StandardBridge.address)
     })
 
     it('withdraw() withdraws and sends the correct withdrawal message for OVM_ETH', async () => {
@@ -223,14 +214,14 @@ describe('L2StandardBridge', () => {
       )
 
       const withdrawalCallToMessenger =
-        Mock__L2CrossDomainMessenger.smocked.sendMessage.calls[0]
+        Fake__L2CrossDomainMessenger.sendMessage.getCall(0)
 
       // Assert the correct cross-chain call was sent:
       // Message should be sent to the L1L1StandardBridge on L1
-      expect(withdrawalCallToMessenger._target).to.equal(DUMMY_L1BRIDGE_ADDRESS)
+      expect(withdrawalCallToMessenger.args[0]).to.equal(DUMMY_L1BRIDGE_ADDRESS)
 
       // Message data should be a call telling the L1StandardBridge to finalize the withdrawal
-      expect(withdrawalCallToMessenger._message).to.equal(
+      expect(withdrawalCallToMessenger.args[1]).to.equal(
         Factory__L1StandardBridge.interface.encodeFunctionData(
           'finalizeETHWithdrawal',
           [
@@ -245,16 +236,16 @@ describe('L2StandardBridge', () => {
 
     it('withdraw() burns and sends the correct withdrawal message', async () => {
       await L2StandardBridge.withdraw(
-        SmoddedL2Token.address,
+        Mock__L2Token.address,
         withdrawAmount,
         0,
         NON_NULL_BYTES32
       )
       const withdrawalCallToMessenger =
-        Mock__L2CrossDomainMessenger.smocked.sendMessage.calls[0]
+        Fake__L2CrossDomainMessenger.sendMessage.getCall(0)
 
       // Assert Alice's balance went down
-      const aliceBalance = await SmoddedL2Token.balanceOf(
+      const aliceBalance = await Mock__L2Token.balanceOf(
         await alice.getAddress()
       )
       expect(aliceBalance).to.deep.equal(
@@ -262,21 +253,21 @@ describe('L2StandardBridge', () => {
       )
 
       // Assert totalSupply went down
-      const newTotalSupply = await SmoddedL2Token.totalSupply()
+      const newTotalSupply = await Mock__L2Token.totalSupply()
       expect(newTotalSupply).to.deep.equal(
         ethers.BigNumber.from(INITIAL_TOTAL_SUPPLY - withdrawAmount)
       )
 
       // Assert the correct cross-chain call was sent:
       // Message should be sent to the L1L1StandardBridge on L1
-      expect(withdrawalCallToMessenger._target).to.equal(DUMMY_L1BRIDGE_ADDRESS)
+      expect(withdrawalCallToMessenger.args[0]).to.equal(DUMMY_L1BRIDGE_ADDRESS)
       // Message data should be a call telling the L1L1StandardBridge to finalize the withdrawal
-      expect(withdrawalCallToMessenger._message).to.equal(
+      expect(withdrawalCallToMessenger.args[1]).to.equal(
         Factory__L1StandardBridge.interface.encodeFunctionData(
           'finalizeERC20Withdrawal',
           [
             DUMMY_L1TOKEN_ADDRESS,
-            SmoddedL2Token.address,
+            Mock__L2Token.address,
             await alice.getAddress(),
             await alice.getAddress(),
             withdrawAmount,
@@ -285,22 +276,22 @@ describe('L2StandardBridge', () => {
         )
       )
       // gaslimit should be correct
-      expect(withdrawalCallToMessenger._gasLimit).to.equal(0)
+      expect(withdrawalCallToMessenger.args[2]).to.equal(0)
     })
 
     it('withdrawTo() burns and sends the correct withdrawal message', async () => {
       await L2StandardBridge.withdrawTo(
-        SmoddedL2Token.address,
+        Mock__L2Token.address,
         await bob.getAddress(),
         withdrawAmount,
         0,
         NON_NULL_BYTES32
       )
       const withdrawalCallToMessenger =
-        Mock__L2CrossDomainMessenger.smocked.sendMessage.calls[0]
+        Fake__L2CrossDomainMessenger.sendMessage.getCall(0)
 
       // Assert Alice's balance went down
-      const aliceBalance = await SmoddedL2Token.balanceOf(
+      const aliceBalance = await Mock__L2Token.balanceOf(
         await alice.getAddress()
       )
       expect(aliceBalance).to.deep.equal(
@@ -308,21 +299,21 @@ describe('L2StandardBridge', () => {
       )
 
       // Assert totalSupply went down
-      const newTotalSupply = await SmoddedL2Token.totalSupply()
+      const newTotalSupply = await Mock__L2Token.totalSupply()
       expect(newTotalSupply).to.deep.equal(
         ethers.BigNumber.from(INITIAL_TOTAL_SUPPLY - withdrawAmount)
       )
 
       // Assert the correct cross-chain call was sent.
       // Message should be sent to the L1L1StandardBridge on L1
-      expect(withdrawalCallToMessenger._target).to.equal(DUMMY_L1BRIDGE_ADDRESS)
+      expect(withdrawalCallToMessenger.args[0]).to.equal(DUMMY_L1BRIDGE_ADDRESS)
       // The message data should be a call telling the L1L1StandardBridge to finalize the withdrawal
-      expect(withdrawalCallToMessenger._message).to.equal(
+      expect(withdrawalCallToMessenger.args[1]).to.equal(
         Factory__L1StandardBridge.interface.encodeFunctionData(
           'finalizeERC20Withdrawal',
           [
             DUMMY_L1TOKEN_ADDRESS,
-            SmoddedL2Token.address,
+            Mock__L2Token.address,
             await alice.getAddress(),
             await bob.getAddress(),
             withdrawAmount,
@@ -331,7 +322,7 @@ describe('L2StandardBridge', () => {
         )
       )
       // gas value is ignored and set to 0.
-      expect(withdrawalCallToMessenger._gasLimit).to.equal(0)
+      expect(withdrawalCallToMessenger.args[2]).to.equal(0)
     })
   })
 

--- a/packages/contracts/test/contracts/L2/messaging/L2StandardTokenFactory.spec.ts
+++ b/packages/contracts/test/contracts/L2/messaging/L2StandardTokenFactory.spec.ts
@@ -1,7 +1,11 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Signer, ContractFactory, Contract } from 'ethers'
-import { smoddit } from '@eth-optimism/smock'
+import {
+  smock,
+  MockContractFactory,
+  MockContract,
+} from '@defi-wonderland/smock'
 
 /* Internal Imports */
 import { expect } from '../../../setup'
@@ -9,13 +13,13 @@ import { predeploys, getContractInterface } from '../../../../src'
 
 describe('L2StandardTokenFactory', () => {
   let signer: Signer
-  let Factory__L1ERC20: ContractFactory
-  let L1ERC20: Contract
+  let Factory__L1ERC20: MockContractFactory<ContractFactory>
+  let L1ERC20: MockContract<Contract>
   let L2StandardTokenFactory: Contract
   before(async () => {
     ;[signer] = await ethers.getSigners()
     // deploy an ERC20 contract on L1
-    Factory__L1ERC20 = await smoddit(
+    Factory__L1ERC20 = await smock.mock(
       '@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20'
     )
     L1ERC20 = await Factory__L1ERC20.deploy('L1ERC20', 'ERC')

--- a/packages/contracts/test/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.spec.ts
@@ -1,7 +1,7 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { ContractFactory, Contract } from 'ethers'
-import { MockContract, smockit } from '@eth-optimism/smock'
+import { smock, FakeContract } from '@defi-wonderland/smock'
 import { remove0x } from '@eth-optimism/core-utils'
 import { keccak256 } from 'ethers/lib/utils'
 
@@ -25,9 +25,9 @@ const callPredeploy = async (
 
 // TODO: rewrite this test to bypass the execution manager
 describe.skip('OVM_L2ToL1MessagePasser', () => {
-  let Mock__OVM_ExecutionManager: MockContract
+  let Fake__OVM_ExecutionManager: FakeContract
   before(async () => {
-    Mock__OVM_ExecutionManager = await smockit(
+    Fake__OVM_ExecutionManager = await smock.fake<Contract>(
       await ethers.getContractFactory('OVM_ExecutionManager')
     )
   })
@@ -38,7 +38,7 @@ describe.skip('OVM_L2ToL1MessagePasser', () => {
       await ethers.getContractFactory('Helper_PredeployCaller')
     ).deploy()
 
-    Helper_PredeployCaller.setTarget(Mock__OVM_ExecutionManager.address)
+    Helper_PredeployCaller.setTarget(Fake__OVM_ExecutionManager.address)
   })
 
   let Factory__OVM_L2ToL1MessagePasser: ContractFactory
@@ -55,9 +55,7 @@ describe.skip('OVM_L2ToL1MessagePasser', () => {
 
   describe('passMessageToL1', () => {
     before(async () => {
-      Mock__OVM_ExecutionManager.smocked.ovmCALLER.will.return.with(
-        NON_ZERO_ADDRESS
-      )
+      Fake__OVM_ExecutionManager.ovmCALLER.returns(NON_ZERO_ADDRESS)
     })
 
     for (const size of ELEMENT_TEST_SIZES) {

--- a/packages/contracts/test/contracts/L2/predeploys/OVM_SequencerFeeVault.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/OVM_SequencerFeeVault.spec.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import hre from 'hardhat'
-import { MockContract, smockit } from '@eth-optimism/smock'
+import { smock, FakeContract } from '@defi-wonderland/smock'
 import { Contract, Signer } from 'ethers'
 
 /* Imports: Internal */
@@ -13,9 +13,9 @@ describe('OVM_SequencerFeeVault', () => {
     ;[signer1] = await hre.ethers.getSigners()
   })
 
-  let Mock__L2StandardBridge: MockContract
+  let Fake__L2StandardBridge: FakeContract
   before(async () => {
-    Mock__L2StandardBridge = await smockit('L2StandardBridge', {
+    Fake__L2StandardBridge = await smock.fake<Contract>('L2StandardBridge', {
       address: predeploys.L2StandardBridge,
     })
   })
@@ -42,13 +42,21 @@ describe('OVM_SequencerFeeVault', () => {
 
       await expect(OVM_SequencerFeeVault.withdraw()).to.not.be.reverted
 
-      expect(Mock__L2StandardBridge.smocked.withdrawTo.calls[0]).to.deep.equal([
-        predeploys.OVM_ETH,
-        await signer1.getAddress(),
-        amount,
-        0,
-        '0x',
-      ])
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(0).args[0]
+      ).to.deep.equal(predeploys.OVM_ETH)
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(0).args[1]
+      ).to.deep.equal(await signer1.getAddress())
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(0).args[2]
+      ).to.deep.equal(amount)
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(0).args[3]
+      ).to.deep.equal(0)
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(0).args[4]
+      ).to.deep.equal('0x')
     })
 
     it('should succeed when the contract has more than sufficient balance', async () => {
@@ -62,14 +70,21 @@ describe('OVM_SequencerFeeVault', () => {
       })
 
       await expect(OVM_SequencerFeeVault.withdraw()).to.not.be.reverted
-
-      expect(Mock__L2StandardBridge.smocked.withdrawTo.calls[0]).to.deep.equal([
-        predeploys.OVM_ETH,
-        await signer1.getAddress(),
-        amount,
-        0,
-        '0x',
-      ])
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(1).args[0]
+      ).to.deep.equal(predeploys.OVM_ETH)
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(1).args[1]
+      ).to.deep.equal(await signer1.getAddress())
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(1).args[2]
+      ).to.deep.equal(amount)
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(1).args[3]
+      ).to.deep.equal(0)
+      expect(
+        Fake__L2StandardBridge.withdrawTo.getCall(1).args[4]
+      ).to.deep.equal('0x')
     })
 
     it('should have an owner in storage slot 0x00...00', async () => {

--- a/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
+++ b/packages/contracts/test/contracts/chugsplash/L1ChugSplashProxy.spec.ts
@@ -1,7 +1,7 @@
 /* Imports: External */
 import hre from 'hardhat'
 import { Contract, Signer } from 'ethers'
-import { smockit } from '@eth-optimism/smock'
+import { smock } from '@defi-wonderland/smock'
 
 /* Imports: Internal */
 import { expect } from '../../setup'
@@ -170,11 +170,13 @@ describe('L1ChugSplashProxy', () => {
     })
 
     it('should throw an error if the owner has signalled an upgrade', async () => {
-      const owner = await smockit(getContractInterface('iL1ChugSplashDeployer'))
+      const owner = await smock.fake<Contract>(
+        getContractInterface('iL1ChugSplashDeployer')
+      )
       const factory = await hre.ethers.getContractFactory('L1ChugSplashProxy')
       const proxy = await factory.deploy(owner.address)
 
-      owner.smocked.isUpgrading.will.return.with(true)
+      owner.isUpgrading.returns(true)
 
       await expect(
         owner.wallet.sendTransaction({

--- a/packages/contracts/test/helpers/resolver/address-manager.ts
+++ b/packages/contracts/test/helpers/resolver/address-manager.ts
@@ -1,11 +1,12 @@
 /* External Imports */
 import { ethers } from 'hardhat'
 import { Contract } from 'ethers'
+import { FakeContract } from '@defi-wonderland/smock'
 
 export const setProxyTarget = async (
   AddressManager: Contract,
   name: string,
-  target: Contract
+  target: FakeContract
 ): Promise<void> => {
   const SimpleProxy: Contract = await (
     await ethers.getContractFactory('Helper_SimpleProxy')

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,23 +497,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eth-optimism/core-utils@^0.5.1":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.5.5.tgz#0e2bb95b23965fb51adfb8ba6841c3afd26a6411"
-  integrity sha512-N/uyZjHltnvnQyBOE498EGlqeYvWRUQTW6BpXhexKljEXZpnria4J4MFO9s1lJOpogLXTaS+lhM1Ic8zUNj8Pg==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.4.1"
-    ethers "^5.4.5"
-    lodash "^4.17.21"
-
-"@eth-optimism/smock@1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/smock/-/smock-1.1.10.tgz#98a6eefc994ccf707f52ab06849468f3cc57bdb7"
-  integrity sha512-XPx1x9odF/noTBHzIhRgL9ihhr769WgUhf9dOm6X7bjSWRAVsII3IqbdB4ssPycaoSuNSmv8HG1xTLgfgcyOYw==
-  dependencies:
-    "@eth-optimism/core-utils" "^0.5.1"
-    bn.js "^5.2.0"
-
 "@ethereum-waffle/chai@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@ethereum-waffle/chai/-/chai-3.4.0.tgz#2477877410a96bf370edd64df905b04fb9aba9d5"
@@ -712,7 +695,7 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
-"@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.0", "@ethersproject/abstract-provider@^5.4.1":
+"@ethersproject/abstract-provider@5.4.1", "@ethersproject/abstract-provider@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
   integrity sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==
@@ -7176,7 +7159,7 @@ ethers@^4.0.32, ethers@^4.0.40:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.4.5:
+ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2:
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.5.tgz#cec133b9f5b514dc55e2561ee7aa7218c33affd7"
   integrity sha512-PPZ6flOAj230sXEWf/r/It6ZZ5c7EOVWx+PU87Glkbg79OtT7pLE1WgL4MRdwx6iF7HzSOvUUI+8cAmcdzo12w==


### PR DESCRIPTION
**Description**
This PR is focused on migration from Smock v1 to Smock v2 since v1 is deprecated

**Metadata**
- Fixes #2258 
