### PR TITLE
changeset: cleanup packages

### DIFF
--- a/go/indexer/package.json
+++ b/go/indexer/package.json
@@ -1,11 +1,6 @@
 {
-  "name": "indexer",
+  "name": "@eth-optimism/indexer",
   "version": "0.0.1",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
+  "private": true,
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,7 @@
       "packages/*",
       "l2geth",
       "integration-tests",
-      "specs",
-      "go/gas-oracle",
-      "go/batch-submitter",
-      "go/l2geth-exporter",
-      "go/proxyd",
-      "go/op-exporter",
+      "go/*",
       "ops/docker/rpc-proxy",
       "ops/docker/hardhat"
     ],


### PR DESCRIPTION
**Description**

This commit adds all packages in the `go` directory
to the changesets packages so that they don't need
to be added individually. It also removes `specs` since
that directory no longer exists.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

