### PR TITLE
linting: speed up with new config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
       parserOptions: {
         project: 'tsconfig.json',
         sourceType: 'module',
+        allowAutomaticSingleRunInference: true,
       },
       rules: {
         '@typescript-eslint/adjacent-overload-signatures': 'error',
@@ -102,13 +103,9 @@ module.exports = {
     'import/no-extraneous-dependencies': ['error'],
     'import/no-internal-modules': 'off',
     'import/order': [
-      "error",
+      'error',
       {
-        groups: [
-          'builtin',
-          'external',
-          'internal',
-        ],
+        groups: ['builtin', 'external', 'internal'],
         'newlines-between': 'always',
       },
     ],


### PR DESCRIPTION
**Description**

https://github.com/typescript-eslint/typescript-eslint/issues/3528

Cuts the run of linting from 68s to 44s on my local machine
with `yarn lint` at the root of the repo

Attempting to debug https://github.com/ethereum-optimism/optimism/pull/2249, will rebase on top
of this commit to see if it fixes the oom error in that PR. 



