### PR TITLE
maint: use release instead of regenesis branches

### DIFF
--- a/.github/workflows/batch-submitter.yml
+++ b/.github/workflows/batch-submitter.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/bss-core.yml
+++ b/.github/workflows/bss-core.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/gas-oracle.yml
+++ b/.github/workflows/gas-oracle.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/geth.yml
+++ b/.github/workflows/geth.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
     paths:
       - 'l2geth/**'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/teleportr.yml
+++ b/.github/workflows/teleportr.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
       - 'develop'
       - '*rc'
-      - 'regenesis/*'
+      - 'release/*'
   pull_request:
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Note that we have a [Code of Conduct](https://github.com/ethereum-optimism/.gith
 
 In general, the smaller the diff the easier it will be for us to review quickly.
 
-In order to contribute, fork the appropriate branch, for non-breaking changes to production that is `develop` and for the next regenesis release that is normally `regenesis...` branch, see [details about our branching model](https://github.com/ethereum-optimism/optimism/blob/develop/README.md#branching-model-and-releases).
+In order to contribute, fork the appropriate branch, for non-breaking changes to production that is `develop` and for the next release that is normally `release/X.X.X` branch, see [details about our branching model](https://github.com/ethereum-optimism/optimism/blob/develop/README.md#branching-model-and-releases).
 
 Additionally, if you are writing a new feature, please ensure you add appropriate test cases.
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ root
 | Branch          | Status                                                                           |
 | --------------- | -------------------------------------------------------------------------------- |
 | [master](https://github.com/ethereum-optimism/optimism/tree/master/)                   | Accepts PRs from `develop` when we intend to deploy to mainnet.                                      |
-| [develop](https://github.com/ethereum-optimism/optimism/tree/develop/)                 | Accepts PRs that are compatible with `master` OR from `regenesis/X.X.X` branches.                    |
-| regenesis/X.X.X                                                                        | Accepts PRs for all changes, particularly those not backwards compatible with `develop` and `master`. |
+| [develop](https://github.com/ethereum-optimism/optimism/tree/develop/)                 | Accepts PRs that are compatible with `master` OR from `release/X.X.X` branches.                    |
+| release/X.X.X                                                                          | Accepts PRs for all changes, particularly those not backwards compatible with `develop` and `master`. |
 
 ### Overview
 
@@ -90,10 +90,10 @@ Be sure to not merge other pull requests into `develop` if partially through the
 
 ### Release candidate branches
 
-Branches marked `regenesis/X.X.X` are **release candidate branches**.
+Branches marked `release/X.X.X` are **release candidate branches**.
 Changes that are not backwards compatible and all changes to contracts within `packages/contracts/contracts` MUST be directed towards a release candidate branch.
 Release candidates are merged into `develop` and then into `master` once they've been fully deployed.
-We may sometimes have more than one active `regenesis/X.X.X` branch if we're in the middle of a deployment.
+We may sometimes have more than one active `release/X.X.X` branch if we're in the middle of a deployment.
 See table in the **Active Branches** section above to find the right branch to target.
 
 ### Releasing new versions


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Changes our branching model to use release/ branches instead of
regenesis/ branches now that we no longer plan to perform any
regenesis-style upgrades. Using release/ branches will reduce confusion
from people who see a regenesis/ branch and assume (logically) that this
branch will result in a regenesis.