### PR TITLE
maint: clean up gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,29 @@
-.DS_Store
+# no comment needed
 node_modules
+
+# log files
+*.log
+
+# environment variables
+.env
+.env*
+
+# os-specific build/temp files
+.DS_Store
+*.sw*
+
+# coverage report files
 results
 temp
 .nyc_output
 coverage.json
+
+# ts build files
 *.tsbuildinfo
 
+# global ts output
 dist
+
+# global hardhat output
 artifacts
 cache
-
-l2geth/build/bin
-packages/contracts/deployments/custom
-packages/contracts/coverage*
-packages/contracts/@ens*
-packages/contracts/@openzeppelin*
-packages/contracts/hardhat*
-
-packages/data-transport-layer/db
-
-# vim
-*.sw*
-
-.env
-.env*
-*.log

--- a/l2geth/.gitignore
+++ b/l2geth/.gitignore
@@ -1,0 +1,2 @@
+# build output
+build/bin/

--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -1,2 +1,12 @@
+# auto-generated files for browser builds
 src/contract-artifacts.ts
 src/contract-deployed-artifacts.ts
+
+# local deployment output folder
+deployments/custom
+
+# hoisted dependencies for builds and tests
+coverage*
+@ens*
+@openzeppelin*
+hardhat*

--- a/packages/data-transport-layer/.gitignore
+++ b/packages/data-transport-layer/.gitignore
@@ -1,0 +1,2 @@
+# default db folder
+db/


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Cleans up various gitignore files and adds comments that explain why the
files are being ignored. Removes some package-specific ignores from the
primary gitignore and moves them into their own files.
