### PR TITLE
feat(cmn): gracefully handle BaseServiceV2 exits

### DIFF
--- a/.changeset/purple-peaches-serve.md
+++ b/.changeset/purple-peaches-serve.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Have BaseServiceV2 gracefully catch exit signals


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Gracefully handles BaseServiceV2 exits by default. Adds a new function
for stopping the service and catches SIGTERM and SIGINT correctly.
