### PR TITLE
proxyd: Don't hit Redis when the out of service interval is zero

### DIFF
--- a/.changeset/perfect-ties-decide.md
+++ b/.changeset/perfect-ties-decide.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+Don't hit Redis when the out of service interval is zero

--- a/go/proxyd/rate_limiter.go
+++ b/go/proxyd/rate_limiter.go
@@ -85,6 +85,9 @@ func (r *RedisRateLimiter) IsBackendOnline(name string) (bool, error) {
 }
 
 func (r *RedisRateLimiter) SetBackendOffline(name string, duration time.Duration) error {
+	if duration == 0 {
+		return nil
+	}
 	err := r.rdb.SetEX(
 		context.Background(),
 		fmt.Sprintf("backend:%s:offline", name),


### PR DESCRIPTION
When the out of service interval is zero, `proxyd` will send a `SETEX` command to Redis with a zero expiry. This is technically an error, and causes messages like `error setting backend unavailable ERR invalid expire time in setex` to appear in the logs. Users won't notice the issue since `proxyd` can continue working when Redis returns an error, but we should clean this up nonetheless since these problems appear in our alerting.
