### PR TITLE
Set the message-relayer package to private

### DIFF
--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@eth-optimism/message-relayer",
   "version": "0.4.0",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",


### PR DESCRIPTION
Tiny pr, marking the `message-relayer` package as private.

- Fixes #2312 
