### PR TITLE
fix(sdk): comment out getMessagesByAddress

### DIFF
--- a/.changeset/slimy-walls-appear.md
+++ b/.changeset/slimy-walls-appear.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Comment out non-functional getMessagesByAddress function

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -208,22 +208,22 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       })
   }
 
-  public async getMessagesByAddress(
-    address: AddressLike,
-    opts?: {
-      direction?: MessageDirection
-      fromBlock?: NumberLike
-      toBlock?: NumberLike
-    }
-  ): Promise<CrossChainMessage[]> {
-    throw new Error(`
-      The function getMessagesByAddress is currently not enabled because the sender parameter of
-      the SentMessage event is not indexed within the CrossChainMessenger contracts.
-      getMessagesByAddress will be enabled by plugging in an Optimism Indexer (coming soon).
-      See the following issue on GitHub for additional context:
-      https://github.com/ethereum-optimism/optimism/issues/2129
-    `)
-  }
+  // public async getMessagesByAddress(
+  //   address: AddressLike,
+  //   opts?: {
+  //     direction?: MessageDirection
+  //     fromBlock?: NumberLike
+  //     toBlock?: NumberLike
+  //   }
+  // ): Promise<CrossChainMessage[]> {
+  //   throw new Error(`
+  //     The function getMessagesByAddress is currently not enabled because the sender parameter of
+  //     the SentMessage event is not indexed within the CrossChainMessenger contracts.
+  //     getMessagesByAddress will be enabled by plugging in an Optimism Indexer (coming soon).
+  //     See the following issue on GitHub for additional context:
+  //     https://github.com/ethereum-optimism/optimism/issues/2129
+  //   `)
+  // }
 
   public async getBridgeForTokenPair(
     l1Token: AddressLike,

--- a/packages/sdk/src/interfaces/cross-chain-messenger.ts
+++ b/packages/sdk/src/interfaces/cross-chain-messenger.ts
@@ -103,27 +103,30 @@ export interface ICrossChainMessenger {
     }
   ): Promise<CrossChainMessage[]>
 
-  /**
-   * Retrieves all cross chain messages sent by a particular address.
-   *
-   * @param address Address to search for messages from.
-   * @param opts Options object.
-   * @param opts.direction Direction to search for messages in. If not provided, will attempt to
-   * find all messages in both directions.
-   * @param opts.fromBlock Block to start searching for messages from. If not provided, will start
-   * from the first block (block #0).
-   * @param opts.toBlock Block to stop searching for messages at. If not provided, will stop at the
-   * latest known block ("latest").
-   * @returns All cross chain messages sent by the particular address.
-   */
-  getMessagesByAddress(
-    address: AddressLike,
-    opts?: {
-      direction?: MessageDirection
-      fromBlock?: NumberLike
-      toBlock?: NumberLike
-    }
-  ): Promise<CrossChainMessage[]>
+  // TODO: Make this function work. Likely requires indexer or the function will be prohibitively
+  // slow to query all of the necessary data.
+  //
+  // /**
+  //  * Retrieves all cross chain messages sent by a particular address.
+  //  *
+  //  * @param address Address to search for messages from.
+  //  * @param opts Options object.
+  //  * @param opts.direction Direction to search for messages in. If not provided, will attempt to
+  //  * find all messages in both directions.
+  //  * @param opts.fromBlock Block to start searching for messages from. If not provided, will start
+  //  * from the first block (block #0).
+  //  * @param opts.toBlock Block to stop searching for messages at. If not provided, will stop at the
+  //  * latest known block ("latest").
+  //  * @returns All cross chain messages sent by the particular address.
+  //  */
+  // getMessagesByAddress(
+  //   address: AddressLike,
+  //   opts?: {
+  //     direction?: MessageDirection
+  //     fromBlock?: NumberLike
+  //     toBlock?: NumberLike
+  //   }
+  // ): Promise<CrossChainMessage[]>
 
   /**
    * Finds the appropriate bridge adapter for a given L1<>L2 token pair. Will throw if no bridges

--- a/packages/sdk/test/cross-chain-messenger.spec.ts
+++ b/packages/sdk/test/cross-chain-messenger.spec.ts
@@ -383,7 +383,8 @@ describe('CrossChainMessenger', () => {
     })
   })
 
-  describe('getMessagesByAddress', () => {
+  // Skipped until getMessagesByAddress can be implemented
+  describe.skip('getMessagesByAddress', () => {
     describe('when the address has sent messages', () => {
       describe('when no direction is specified', () => {
         it('should find all messages sent by the address')


### PR DESCRIPTION
**Description**
Removes getMessagesByAddress from the SDK until we can get the function
to work properly. Likely requires the indexer to be integrated into the
SDK or to figure out some new way to quickly get all of the data we
need. Better to comment this out to avoid confusion.
