### PR TITLE
feat: bss plaintext tx size enforcement

### DIFF
--- a/.changeset/stale-ladybugs-smell.md
+++ b/.changeset/stale-ladybugs-smell.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+---
+
+Enforce min/max tx size on plaintext batch encoding

--- a/go/batch-submitter/drivers/sequencer/batch.go
+++ b/go/batch-submitter/drivers/sequencer/batch.go
@@ -78,7 +78,6 @@ func GenSequencerBatchParams(
 	shouldStartAtElement uint64,
 	blockOffset uint64,
 	batch []BatchElement,
-	batchType BatchType,
 ) (*AppendSequencerBatchParams, error) {
 
 	var (
@@ -189,6 +188,5 @@ func GenSequencerBatchParams(
 		TotalElementsToAppend: uint64(len(batch)),
 		Contexts:              contexts,
 		Txs:                   txs,
-		Type:                  batchType,
 	}, nil
 }

--- a/go/batch-submitter/drivers/sequencer/driver.go
+++ b/go/batch-submitter/drivers/sequencer/driver.go
@@ -205,33 +205,51 @@ func (d *Driver) CraftBatchTx(
 			return nil, err
 		}
 
-		batchArguments, err := batchParams.Serialize(d.cfg.BatchType)
+		// Use plaintext encoding to enforce size constraints.
+		plaintextBatchArguments, err := batchParams.Serialize(BatchTypeLegacy)
 		if err != nil {
 			return nil, err
 		}
 
 		appendSequencerBatchID := d.ctcABI.Methods[appendSequencerBatchMethodName].ID
-		batchCallData := append(appendSequencerBatchID, batchArguments...)
+		plaintextCalldata := append(appendSequencerBatchID, plaintextBatchArguments...)
 
-		// Continue pruning until calldata size is less than configured max.
-		calldataSize := uint64(len(batchCallData))
-		if calldataSize > d.cfg.MaxTxSize {
+		// Continue pruning until plaintext calldata size is less than
+		// configured max.
+		plaintextCalldataSize := uint64(len(plaintextCalldata))
+		if plaintextCalldataSize > d.cfg.MaxTxSize {
 			oldLen := len(batchElements)
 			newBatchElementsLen := (oldLen * 9) / 10
 			batchElements = batchElements[:newBatchElementsLen]
-			log.Info(name+" pruned batch", "old_num_txs", oldLen, "new_num_txs", newBatchElementsLen)
+			log.Info(name+" pruned batch",
+				"plaintext_size", plaintextCalldataSize,
+				"max_tx_size", d.cfg.MaxTxSize,
+				"old_num_txs", oldLen,
+				"new_num_txs", newBatchElementsLen)
 			pruneCount++
 			continue
-		} else if calldataSize < d.cfg.MinTxSize {
+		} else if plaintextCalldataSize < d.cfg.MinTxSize {
 			log.Info(name+" batch tx size below minimum",
-				"size", calldataSize, "min_tx_size", d.cfg.MinTxSize)
+				"plaintext_size", plaintextCalldataSize,
+				"min_tx_size", d.cfg.MinTxSize,
+				"num_txs", len(batchElements))
 			return nil, nil
 		}
 
 		d.metrics.NumElementsPerBatch().Observe(float64(len(batchElements)))
 		d.metrics.BatchPruneCount.Set(float64(pruneCount))
 
-		log.Info(name+" batch constructed", "num_txs", len(batchElements), "length", len(batchCallData))
+		// Finally, encode the batch using the configured batch type.
+		var calldata = plaintextCalldata
+		if d.cfg.BatchType != BatchTypeLegacy {
+			batchArguments, err := batchParams.Serialize(d.cfg.BatchType)
+			if err != nil {
+				return nil, err
+			}
+			calldata = append(appendSequencerBatchID, batchArguments...)
+		}
+
+		log.Info(name+" batch constructed", "num_txs", len(batchElements), "length", len(calldata))
 
 		opts, err := bind.NewKeyedTransactorWithChainID(
 			d.cfg.PrivKey, d.cfg.ChainID,
@@ -243,7 +261,7 @@ func (d *Driver) CraftBatchTx(
 		opts.Nonce = nonce
 		opts.NoSend = true
 
-		tx, err := d.rawCtcContract.RawTransact(opts, batchCallData)
+		tx, err := d.rawCtcContract.RawTransact(opts, calldata)
 		switch {
 		case err == nil:
 			return tx, nil
@@ -258,7 +276,7 @@ func (d *Driver) CraftBatchTx(
 			log.Warn(d.cfg.Name + " eth_maxPriorityFeePerGas is unsupported " +
 				"by current backend, using fallback gasTipCap")
 			opts.GasTipCap = drivers.FallbackGasTipCap
-			return d.rawCtcContract.RawTransact(opts, batchCallData)
+			return d.rawCtcContract.RawTransact(opts, calldata)
 
 		default:
 			return nil, err

--- a/go/batch-submitter/drivers/sequencer/driver.go
+++ b/go/batch-submitter/drivers/sequencer/driver.go
@@ -199,13 +199,13 @@ func (d *Driver) CraftBatchTx(
 	var pruneCount int
 	for {
 		batchParams, err := GenSequencerBatchParams(
-			shouldStartAt, d.cfg.BlockOffset, batchElements, d.cfg.BatchType,
+			shouldStartAt, d.cfg.BlockOffset, batchElements,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		batchArguments, err := batchParams.Serialize()
+		batchArguments, err := batchParams.Serialize(d.cfg.BatchType)
 		if err != nil {
 			return nil, err
 		}

--- a/go/batch-submitter/drivers/sequencer/encoding.go
+++ b/go/batch-submitter/drivers/sequencer/encoding.go
@@ -83,26 +83,22 @@ func (c *BatchContext) Read(r io.Reader) error {
 	return readUint64(r, &c.BlockNumber, 5)
 }
 
-// BatchType represents the type of batch being
-// submitted. When the first context in the batch
-// has a timestamp of 0, the blocknumber is interpreted
-// as an enum that represets the type
+// BatchType represents the type of batch being submitted. When the first
+// context in the batch has a timestamp of 0, the blocknumber is interpreted as
+// an enum that represets the type.
 type BatchType int8
 
-// Implements the Stringer interface for BatchType
-func (b BatchType) String() string {
-	switch b {
-	case BatchTypeLegacy:
-		return "LEGACY"
-	case BatchTypeZlib:
-		return "ZLIB"
-	default:
-		return ""
-	}
-}
+const (
+	// BatchTypeLegacy represets the legacy batch type.
+	BatchTypeLegacy BatchType = -1
 
-// BatchTypeFromString returns the BatchType
-// enum based on a human readable string
+	// BatchTypeZlib represents a batch type where the transaction data is
+	// compressed using zlib.
+	BatchTypeZlib BatchType = 0
+)
+
+// BatchTypeFromString returns the BatchType enum based on a human readable
+// string.
 func BatchTypeFromString(s string) BatchType {
 	switch s {
 	case "zlib", "ZLIB":
@@ -114,13 +110,17 @@ func BatchTypeFromString(s string) BatchType {
 	}
 }
 
-const (
-	// BatchTypeLegacy represets the legacy batch type
-	BatchTypeLegacy BatchType = -1
-	// BatchTypeZlib represents a batch type where the
-	// transaction data is compressed using zlib
-	BatchTypeZlib BatchType = 0
-)
+// String implements the Stringer interface for BatchType.
+func (b BatchType) String() string {
+	switch b {
+	case BatchTypeLegacy:
+		return "LEGACY"
+	case BatchTypeZlib:
+		return "ZLIB"
+	default:
+		return ""
+	}
+}
 
 // AppendSequencerBatchParams holds the raw data required to submit a batch of
 // L2 txs to L1 CTC contract. Rather than encoding the objects using the

--- a/go/batch-submitter/drivers/sequencer/encoding_test.go
+++ b/go/batch-submitter/drivers/sequencer/encoding_test.go
@@ -119,7 +119,6 @@ func testAppendSequencerBatchParamsEncodeDecode(
 		TotalElementsToAppend: test.TotalElementsToAppend,
 		Contexts:              test.Contexts,
 		Txs:                   nil,
-		Type:                  sequencer.BatchTypeLegacy,
 	}
 
 	// Decode the batch from the test string.
@@ -133,7 +132,6 @@ func testAppendSequencerBatchParamsEncodeDecode(
 	} else {
 		require.Nil(t, err)
 	}
-	require.Equal(t, params.Type, sequencer.BatchTypeLegacy)
 
 	// Assert that the decoded params match the expected params. The
 	// transactions are compared serparetly (via hash), since the internal
@@ -149,7 +147,7 @@ func testAppendSequencerBatchParamsEncodeDecode(
 
 	// Finally, encode the decoded object and assert it matches the original
 	// hex string.
-	paramsBytes, err := params.Serialize()
+	paramsBytes, err := params.Serialize(sequencer.BatchTypeLegacy)
 
 	// Return early when testing error cases, no need to reserialize again
 	if test.Error {
@@ -161,17 +159,14 @@ func testAppendSequencerBatchParamsEncodeDecode(
 	require.Equal(t, test.HexEncoding, hex.EncodeToString(paramsBytes))
 
 	// Serialize the batches in compressed form
-	params.Type = sequencer.BatchTypeZlib
-	compressedParamsBytes, err := params.Serialize()
+	compressedParamsBytes, err := params.Serialize(sequencer.BatchTypeZlib)
 	require.Nil(t, err)
 
 	// Deserialize the compressed batch
 	var paramsCompressed sequencer.AppendSequencerBatchParams
 	err = paramsCompressed.Read(bytes.NewReader(compressedParamsBytes))
 	require.Nil(t, err)
-	require.Equal(t, paramsCompressed.Type, sequencer.BatchTypeZlib)
 
-	expParams.Type = sequencer.BatchTypeZlib
 	decompressedTxs := paramsCompressed.Txs
 	paramsCompressed.Txs = nil
 


### PR DESCRIPTION
**Description**
This PR modifies the BSS to enforce the configured `MinTxSize` and `MaxTxSize` on the plaintext encoding of calldata, regardless of which encoding scheme is used. Previously the only initial, conservative pass was performed against the plaintext size, after which (when using zlib) the min and max would be applied to the compressed calldata size. To ensure these are applied consistently, we now abort/prune based on the plaintext size before performing the final encoding. This protects against the edge case where the initial pass includes a maximum plaintext-sized batch, but the compressed size ends up being under the minimum.

**Metadata**
- Fixes ENG-2065