### PR TITLE
l2geth: verifier sync in parallel with dtl

### DIFF
--- a/.changeset/rude-ears-lay.md
+++ b/.changeset/rude-ears-lay.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Have L2Geth Verifier sync in parallel with the DTL.

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -172,19 +172,21 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 			}
 		}
 
-		// Wait until the remote service is done syncing
-		tStatus := time.NewTicker(10 * time.Second)
-		for ; true; <-tStatus.C {
-			status, err := service.client.SyncStatus(service.backend)
-			if err != nil {
-				log.Error("Cannot get sync status")
-				continue
+		if !cfg.IsVerifier {
+			// Wait until the remote service is done syncing
+			tStatus := time.NewTicker(10 * time.Second)
+			for ; true; <-tStatus.C {
+				status, err := service.client.SyncStatus(service.backend)
+				if err != nil {
+					log.Error("Cannot get sync status")
+					continue
+				}
+				if !status.Syncing {
+					tStatus.Stop()
+					break
+				}
+				log.Info("Still syncing", "index", status.CurrentTransactionIndex, "tip", status.HighestKnownTransactionIndex)
 			}
-			if !status.Syncing {
-				tStatus.Stop()
-				break
-			}
-			log.Info("Still syncing", "index", status.CurrentTransactionIndex, "tip", status.HighestKnownTransactionIndex)
 		}
 
 		// Initialize the latest L1 data here to make sure that


### PR DESCRIPTION
Have verifier node sync in parallel with dtl to save time.

**Metadata**
- Fixes #2329 
