### PR TITLE
maint: update readme links and remove smockv1 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Our update process takes the form of a PR merging the `develop` branch into the 
 ### The `develop` branch
 
 Our primary development branch is [`develop`](https://github.com/ethereum-optimism/optimism/tree/develop/).
-`develop` contains the most up-to-date software that remains backwards compatible with our latest experimental [network deployments](https://community.optimism.io/docs/developers/networks.html).
+`develop` contains the most up-to-date software that remains backwards compatible with our latest experimental [network deployments](https://community.optimism.io/docs/useful-tools/networks/).
 If you're making a backwards compatible change, please direct your pull request towards `develop`.
 
 **Changes to contracts within `packages/contracts/contracts` are usually NOT considered backwards compatible and SHOULD be made against a release candidate branch**.

--- a/l2geth/README.md
+++ b/l2geth/README.md
@@ -26,7 +26,7 @@ $ make geth
 ### Running a Sequencer
 
 Running a sequencer that ingests L1 to L2 transactions requires running the
-[Data Transport Layer](https://github.com/ethereum-optimism/data-transport-layer).
+[Data Transport Layer](https://github.com/ethereum-optimism/optimism/tree/develop/packages/data-transport-layer).
 The data transport layer is responsible for indexing transactions
 from layer one Ethereum. It is possible to run a local development sequencer
 without the data transport layer by turning off the sync service. To turn on

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -23,7 +23,7 @@ import { SomeContract } from "@eth-optimism/contracts/path/to/SomeContract.sol";
 ```
 
 Note that the `/path/to/SomeContract.sol` is the path to the target contract within the [contracts folder](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/contracts) inside of this package.
-For example, the [L1CrossDomainMessenger](/contracts/L1/messaging/L1CrossDomainMessenger.sol) contract is located at `/contracts/L1/messaging/L1CrossDomainMessenger.sol`, relative to this README.
+For example, the [L1CrossDomainMessenger](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol) contract is located at `packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol`, relative to this README.
 You would therefore import the contract as:
 
 

--- a/packages/data-transport-layer/README.md
+++ b/packages/data-transport-layer/README.md
@@ -19,7 +19,7 @@ We run two sub-services, the [`L1IngestionService`](./src/services/l1-ingestion/
 
 See an example config at [.env.example](.env.example); copy into a `.env` file before running.
 
-`L1_TRANSPORT__L1_RPC_ENDPOINT` can be the JSON RPC endpoint of any L1 Ethereum node. `L1_TRANSPORT__ADDRESS_MANAGER` should be the contract addresss of the Address Manager on the corresponding network; find their values in the [Regenesis repo](https://github.com/ethereum-optimism/regenesis).
+`L1_TRANSPORT__L1_RPC_ENDPOINT` can be the JSON RPC endpoint of any L1 Ethereum node. `L1_TRANSPORT__ADDRESS_MANAGER` should be the contract addresss of the Address Manager on the corresponding network; find their values in the [contracts package](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments).
 
 ### Building and usage
 
@@ -47,7 +47,7 @@ Here's the list of environment variables you can change:
 | Variable                                                | Default     | Description                                                                                                                                                   |
 | ------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | DATA_TRANSPORT_LAYER__DB_PATH                           | ./db        | Path to the database for this service.                                                                                                                        |
-| DATA_TRANSPORT_LAYER__ADDRESS_MANAGER                   | -           | Address of the AddressManager contract on L1. See [regenesis](https://github.com/ethereum-optimism/regenesis) repo to find this address for mainnet or kovan. |
+| DATA_TRANSPORT_LAYER__ADDRESS_MANAGER                   | -           | Address of the AddressManager contract on L1. See [contracts](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts/deployments) package to find this address for mainnet or kovan. |
 | DATA_TRANSPORT_LAYER__POLLING_INTERVAL                  | 5000        | Period of time between execution loops.                                                                                                                       |
 | DATA_TRANSPORT_LAYER__DANGEROUSLY_CATCH_ALL_ERRORS      | false       | If true, will catch all errors without throwing.                                                                                                              |
 | DATA_TRANSPORT_LAYER__CONFIRMATIONS                     | 12          | Number of confirmations to wait before accepting transactions as "canonical".                                                                                 |

--- a/packages/smock/README.md
+++ b/packages/smock/README.md
@@ -1,7 +1,0 @@
-# @eth-optimism/smock
-
-## NOTICE
-
-Smock v1 is being deprecated.
-Please migrate to [Smock v2](https://github.com/defi-wonderland/smock).
-You can find an archive of the Smock v1 codebase at [optimism@d337713c91](https://github.com/ethereum-optimism/optimism/tree/d337713c91c6634f546b8d6572392c0784ab8217/packages/smock).


### PR DESCRIPTION
**Description**
I noticed a couple of outdated links in the READMEs throughout the repo and updated them. Also deleted smockv1 folden since we use `@defi-wonderland/smock`.
