### PR TITLE
feat: add SuggestGasTipCap fallback in teleportr api server

### DIFF
--- a/.changeset/blue-carrots-vanish.md
+++ b/.changeset/blue-carrots-vanish.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/teleportr': patch
+---
+
+Add SuggestGasTipCap fallback


### PR DESCRIPTION
**Description**
Adds the same fallback mechanism for `SuggestGasTipCap` used the batch submitter for
estimating gas prices in the teleportr API server.

**Metadata**
- Fixes ENG-2067
