### PR TITLE
feat: txmgr return ErrReverted if confirmed tx reverts

### DIFF
--- a/.changeset/lucky-cameras-grin.md
+++ b/.changeset/lucky-cameras-grin.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/batch-submitter-service': patch
+'@eth-optimism/teleportr': patch
+---
+
+Count reverted transactions in failed_submissions

--- a/go/bss-core/drivers/clear_pending_tx_test.go
+++ b/go/bss-core/drivers/clear_pending_tx_test.go
@@ -231,6 +231,7 @@ func TestClearPendingTxClearingTxConfirms(t *testing.T) {
 			return &types.Receipt{
 				TxHash:      txHash,
 				BlockNumber: big.NewInt(int64(testBlockNumber)),
+				Status:      types.ReceiptStatusSuccessful,
 			}, nil
 		},
 	})
@@ -296,6 +297,7 @@ func TestClearPendingTxMultipleConfs(t *testing.T) {
 			return &types.Receipt{
 				TxHash:      txHash,
 				BlockNumber: big.NewInt(int64(testBlockNumber)),
+				Status:      types.ReceiptStatusSuccessful,
 			}, nil
 		},
 	}, numConfs)


### PR DESCRIPTION
**Description**
Currently the txmgr treats confirmation of a transaction as successful
if it achieves the proper confirmation depth, however it fails to
acknowledge the possibility that the transaction reverts. Thus to an
external caller the transaction silently succeeds.

This commit now inspects the receipt and returns an ErrReverted failure
in the event that receipt.Status is not 1. This allows higher level
applications to add logging/telemetry or take action on these events.

**Metadata**
- Fixes ENG-2069
