### PR TITLE
fix(rhc): bug in replica-healthcheck dockerfile

### DIFF
--- a/.changeset/healthy-rings-fix.md
+++ b/.changeset/healthy-rings-fix.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Fixes a bug in the replica-healthcheck dockerfile

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -6,7 +6,7 @@
 # when used with typescript/hardhat: https://github.com/nomiclabs/hardhat/issues/1219
 FROM node:16.13-buster-slim as base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends git \ 
+RUN apt-get update -y && apt-get install -y --no-install-recommends git \
       curl \
       jq \
       python3 \
@@ -62,4 +62,4 @@ CMD ["npm", "run", "start"]
 
 FROM base as replica-healthcheck
 WORKDIR /opts/optimism/packages/replica-healthcheck
-ENTRYPOINT ["node", "dist/exec/run-healthcheck-server.js"]
+ENTRYPOINT ["npm", "run", "start"]


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug in the dockerfile for the replica-healthcheck. Healthcheck
does not run properly as a result of this bug.
