### PR TITLE
gas-oracle: allow configurable base fee poll interval

### DIFF
--- a/.changeset/thirty-stingrays-reply.md
+++ b/.changeset/thirty-stingrays-reply.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/gas-oracle': patch
+---
+
+Allow configurable base fee update poll time with `GAS_PRICE_ORACLE_L1_BASE_FEE_EPOCH_LENGTH_SECONDS`

--- a/go/gas-oracle/flags/flags.go
+++ b/go/gas-oracle/flags/flags.go
@@ -89,6 +89,12 @@ var (
 		Usage:  "length of epochs in seconds",
 		EnvVar: "GAS_PRICE_ORACLE_EPOCH_LENGTH_SECONDS",
 	}
+	L1BaseFeeEpochLengthSecondsFlag = cli.Uint64Flag{
+		Name:   "l1-base-fee-epoch-length-seconds",
+		Value:  15,
+		Usage:  "polling time for updating the L1 base fee",
+		EnvVar: "GAS_PRICE_ORACLE_L1_BASE_FEE_EPOCH_LENGTH_SECONDS",
+	}
 	L1BaseFeeSignificanceFactorFlag = cli.Float64Flag{
 		Name:   "l1-base-fee-significant-factor",
 		Value:  0.10,
@@ -169,6 +175,7 @@ var Flags = []cli.Flag{
 	MaxPercentChangePerEpochFlag,
 	AverageBlockGasLimitPerEpochFlag,
 	EpochLengthSecondsFlag,
+	L1BaseFeeEpochLengthSecondsFlag,
 	L2GasPriceSignificanceFactorFlag,
 	WaitForReceiptFlag,
 	EnableL1BaseFeeFlag,

--- a/go/gas-oracle/oracle/config.go
+++ b/go/gas-oracle/oracle/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	maxPercentChangePerEpoch     float64
 	averageBlockGasLimitPerEpoch uint64
 	epochLengthSeconds           uint64
+	l1BaseFeeEpochLengthSeconds  uint64
 	l2GasPriceSignificanceFactor float64
 	l1BaseFeeSignificanceFactor  float64
 	enableL1BaseFee              bool
@@ -54,6 +55,7 @@ func NewConfig(ctx *cli.Context) *Config {
 	cfg.maxPercentChangePerEpoch = ctx.GlobalFloat64(flags.MaxPercentChangePerEpochFlag.Name)
 	cfg.averageBlockGasLimitPerEpoch = ctx.GlobalUint64(flags.AverageBlockGasLimitPerEpochFlag.Name)
 	cfg.epochLengthSeconds = ctx.GlobalUint64(flags.EpochLengthSecondsFlag.Name)
+	cfg.l1BaseFeeEpochLengthSeconds = ctx.GlobalUint64(flags.L1BaseFeeEpochLengthSecondsFlag.Name)
 	cfg.l2GasPriceSignificanceFactor = ctx.GlobalFloat64(flags.L2GasPriceSignificanceFactorFlag.Name)
 	cfg.floorPrice = ctx.GlobalUint64(flags.FloorPriceFlag.Name)
 	cfg.l1BaseFeeSignificanceFactor = ctx.GlobalFloat64(flags.L1BaseFeeSignificanceFactorFlag.Name)

--- a/go/gas-oracle/oracle/gas_price_oracle.go
+++ b/go/gas-oracle/oracle/gas_price_oracle.go
@@ -111,6 +111,7 @@ func (g *GasPriceOracle) ensure() error {
 func (g *GasPriceOracle) Loop() {
 	timer := time.NewTicker(time.Duration(g.config.epochLengthSeconds) * time.Second)
 	defer timer.Stop()
+
 	for {
 		select {
 		case <-timer.C:
@@ -126,7 +127,7 @@ func (g *GasPriceOracle) Loop() {
 }
 
 func (g *GasPriceOracle) BaseFeeLoop() {
-	timer := time.NewTicker(15 * time.Second)
+	timer := time.NewTicker(time.Duration(g.config.l1BaseFeeEpochLengthSeconds) * time.Second)
 	defer timer.Stop()
 
 	updateBaseFee, err := wrapUpdateBaseFee(g.l1Backend, g.l2Backend, g.config)


### PR DESCRIPTION
**Description**


This commit adds a new config option that can be
configured via argv with `--l1-base-fee-epoch-length-seconds`
or an env var `GAS_PRICE_ORACLE_L1_BASE_FEE_EPOCH_LENGTH_SECONDS`.
It defaults to 15 seconds. Ideally the implementation uses a
duration flag instead of a uint64 flag, but that would be a
breaking change for the config and this service will be
deprecated in the future with the release of bedrock.

By setting this value to a larger number, we are able to update
the L1 base fee that is held in the L2 state less often.
This will save the sequencer money, because it needs to
front the costs of submitting these transactions.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

