### PR TITLE
fix(rhc): typo in healthcheck docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
           command: yarn --frozen-lockfile
       - save_cache:
           key: v1-yarn-install-{{ checksum "yarn.lock" }}
-          paths: 
+          paths:
             - node_modules
             - packages/common-ts/node_modules
             - packages/contracts/node_modules
@@ -362,7 +362,7 @@ jobs:
           name: Bring up the stack
           command: |
             docker-compose build --progress=plain
-            docker-compose up -d --scale replica-healthcheck=1
+            docker-compose up -d --scale replica_healthcheck=1
           working_directory: ops
       - run:
           name: Wait for sequencer

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ./ops
         run: |
           ./scripts/stats.sh &
-          docker-compose -f docker-compose.yml up -d --scale replica-healthcheck=1
+          docker-compose -f docker-compose.yml up -d --scale replica_healthcheck=1
 
       - name: Wait for the Sequencer node
         working-directory: ./ops

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -174,7 +174,7 @@ services:
       - ${REPLICA_HTTP_PORT:-8549}:8545
       - ${REPLICA_WS_PORT:-8550}:8546
 
-  replica-healthcheck:
+  replica_healthcheck:
     depends_on:
       - l2geth
       - replica
@@ -203,7 +203,7 @@ services:
     environment:
       L1_URL: http://l1_chain:8545
       L2_URL: http://l2geth:8545
-      HEALTHCHECK_URL: http://replica-healthcheck:7300/metrics
+      HEALTHCHECK_URL: http://replica_healthcheck:7300/metrics
       REPLICA_URL: http://replica:8545
       VERIFIER_URL: http://verifier:8545
       URL: http://deployer:8081/addresses.json


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a typo in the primary docker-compose file. replica-healthcheck
should be replica_healthcheck to conform with the style used everywhere
else.
