### PR TITLE
fix(cmn): have BaseService throw on missing options

### DIFF
--- a/.changeset/sharp-terms-pay.md
+++ b/.changeset/sharp-terms-pay.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Have BaseServiceV2 throw when options are undefined

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -218,6 +218,16 @@ export abstract class BaseServiceV2<
       return acc
     }, {}) as TOptions
 
+    // Make sure all options are defined.
+    for (const [optionName, optionSpec] of Object.entries(params.optionsSpec)) {
+      if (
+        optionSpec.default === undefined &&
+        this.options[optionName] === undefined
+      ) {
+        throw new Error(`missing required option: ${optionName}`)
+      }
+    }
+
     // Create the metrics objects.
     this.metrics = Object.keys(params.metricsSpec || {}).reduce((acc, key) => {
       const spec = params.metricsSpec[key]


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug where BaseServiceV2 was not properly throwing when options
were missing.