### PR TITLE
fix(infra): use older version of hc by default

### DIFF
--- a/infra/op-replica/docker-compose/replica.yml
+++ b/infra/op-replica/docker-compose/replica.yml
@@ -34,7 +34,8 @@ services:
       - ../scripts/:/scripts/
     <<: *logging
   replica-healthcheck:
-    image: ethereumoptimism/replica-healthcheck:${HC_IMAGE_TAG:-latest}
+    # TODO: Update this to latest when we fix the environment variables
+    image: ethereumoptimism/replica-healthcheck:${HC_IMAGE_TAG:-0.3.11}
     restart: ${RESTART}
     env_file:
       - ${SHARED_ENV_PATH}/replica-healthcheck.env


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates replica.yml in our infra folder to use an older version of the
healthcheck service by default. We'll use latest when we update our
environment variables everywhere later.
