### PR TITLE
feat(l2geth): add configurable genesis timeout

### DIFF
--- a/.changeset/tiny-melons-float.md
+++ b/.changeset/tiny-melons-float.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Adds a flag for changing the genesis fetch timeout

--- a/l2geth/cmd/geth/chaincmd.go
+++ b/l2geth/cmd/geth/chaincmd.go
@@ -56,6 +56,7 @@ var (
 		ArgsUsage: "<genesisPathOrUrl> (<genesisHash>)",
 		Flags: []cli.Flag{
 			utils.DataDirFlag,
+			utils.RollupGenesisTimeoutSecondsFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -65,7 +66,7 @@ participating.
 
 It expects either a path or an HTTP URL to the genesis file as an argument. If an
 HTTP URL is specified for the genesis file, then a hex-encoded SHA256 hash of the
-genesis file must be included as a second argument. The hash provided on the CLI 
+genesis file must be included as a second argument. The hash provided on the CLI
 will be checked against the hash of the genesis file downloaded from the URL.`,
 	}
 	dumpChainCfgCommand = cli.Command{
@@ -236,7 +237,7 @@ func initGenesis(ctx *cli.Context) error {
 
 		log.Info("Fetching genesis file", "url", genesisPathOrURL)
 
-		genesisData, err := fetchGenesis(genesisPathOrURL)
+		genesisData, err := fetchGenesis(genesisPathOrURL, time.Duration(ctx.GlobalInt(utils.RollupGenesisTimeoutSecondsFlag.Name)))
 		if err != nil {
 			utils.Fatalf("Failed to fetch genesis file: %v", err)
 		}
@@ -640,9 +641,9 @@ func hashish(x string) bool {
 	return err != nil
 }
 
-func fetchGenesis(url string) ([]byte, error) {
+func fetchGenesis(url string, timeout time.Duration) ([]byte, error) {
 	client := &http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: timeout,
 	}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/l2geth/cmd/geth/main.go
+++ b/l2geth/cmd/geth/main.go
@@ -163,6 +163,7 @@ var (
 		utils.RollupEnforceFeesFlag,
 		utils.RollupFeeThresholdDownFlag,
 		utils.RollupFeeThresholdUpFlag,
+		utils.RollupGenesisTimeoutSecondsFlag,
 		utils.SequencerClientHttpFlag,
 		utils.TxPublisherEnableFlag,
 		utils.TxPublisherProjectIDFlag,

--- a/l2geth/cmd/geth/usage.go
+++ b/l2geth/cmd/geth/usage.go
@@ -77,6 +77,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupEnforceFeesFlag,
 			utils.RollupFeeThresholdDownFlag,
 			utils.RollupFeeThresholdUpFlag,
+			utils.RollupGenesisTimeoutSecondsFlag,
 			utils.SequencerClientHttpFlag,
 			utils.TxPublisherEnableFlag,
 			utils.TxPublisherProjectIDFlag,

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -862,6 +862,12 @@ var (
 		Usage:  "Allow txs with fees above the current fee up to this amount, must be > 1",
 		EnvVar: "ROLLUP_FEE_THRESHOLD_UP",
 	}
+	RollupGenesisTimeoutSecondsFlag = cli.DurationFlag{
+		Name:   "rollup.genesistimeoutseconds",
+		Usage:  "Timeout for the genesis file to be fetched",
+		Value:  time.Second * 60,
+		EnvVar: "ROLLUP_GENESIS_TIMEOUT_SECONDS",
+	}
 	SequencerClientHttpFlag = cli.StringFlag{
 		Name:   "sequencer.clienthttp",
 		Usage:  "HTTP endpoint for the sequencer client",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -23,7 +23,7 @@
     "autogen:markdown": "ts-node scripts/generate-markdown.ts",
     "autogen:artifacts": "ts-node scripts/generate-artifacts.ts && ts-node scripts/generate-deployed-artifacts.ts",
     "test": "yarn test:contracts",
-    "test:contracts": "hardhat test --show-stack-traces --parallel",
+    "test:contracts": "hardhat test --show-stack-traces",
     "test:coverage": "NODE_OPTIONS=--max_old_space_size=8192 hardhat coverage && istanbul check-coverage --statements 90 --branches 84 --functions 88 --lines 90",
     "test:slither": "slither .",
     "pretest:slither": "rm -f @openzeppelin && rm -f @ens && rm -f hardhat && ln -s ../../node_modules/@openzeppelin @openzeppelin && ln -s ../../node_modules/@ens @ens && ln -s ../../node_modules/hardhat hardhat",


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a configurable timeout for fetching the genesis file when running
l2Geth. Useful for people who want to run a node on slower internet and
need more than 60 seconds to fetch the genesis file.
