### PR TITLE
fix(dtl): sync status bug

### DIFF
--- a/.changeset/afraid-coats-cheer.md
+++ b/.changeset/afraid-coats-cheer.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Fix bug in DTL that would sometimes crash geth on startup

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -20,6 +20,7 @@ import {
   SyncingResponse,
   TransactionBatchResponse,
   TransactionResponse,
+  TransactionEntry,
 } from '../../types'
 import { validators } from '../../utils'
 import { L1DataTransportServiceOptions } from '../main/service'
@@ -260,8 +261,8 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       async (req): Promise<SyncingResponse> => {
         const backend = req.query.backend || this.options.defaultBackend
 
-        let currentL2Block
-        let highestL2BlockNumber
+        let currentL2Block: TransactionEntry
+        let highestL2BlockNumber: number
         switch (backend) {
           case 'l1':
             currentL2Block = await this.state.db.getLatestTransaction()
@@ -276,6 +277,10 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
           default:
             throw new Error(`Unknown transaction backend ${backend}`)
         }
+
+        // Prevent highestL2BlockNumber from being negative.
+        // highestL2BlockNumber isn't used anywhere, so it's safe to set this to 0.
+        highestL2BlockNumber = Math.max(highestL2BlockNumber, 0)
 
         if (currentL2Block === null) {
           if (highestL2BlockNumber === null) {


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug in the DTL where highestKnownTransactionIndex would be
negative when the DTL has not started syncing yet. Geth would attempt to
parse this negative value and crash, killing geth. Only applies when
syncing from L2.

**Metadata**
- Fixes #1970
