### PR TITLE
feat(ci): check deploy markdown correctness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,10 @@ jobs:
           command: yarn lint:check
           working_directory: packages/contracts
       - run:
+          name: Check deployment docs
+          command: yarn autogen:markdown && git diff --exit-code
+          working_directory: packages/contracts
+      - run:
           name: Slither
           command: yarn test:slither
           working_directory: packages/contracts

--- a/packages/contracts/deployments/kovan/README.md
+++ b/packages/contracts/deployments/kovan/README.md
@@ -95,6 +95,16 @@ StateCommitmentChain
 </a>
 </td>
 </tr>
+<tr>
+<td>
+TeleportrDeposit
+</td>
+<td align="center">
+<a href="https://kovan.etherscan.io/address/0x4821975ca220601c153d02353300d6ad34adc362">
+<code>0x4821975ca220601c153d02353300d6ad34adc362</code>
+</a>
+</td>
+</tr>
 </table>
 
 ## Layer 2 Contracts


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a step to the contract tests to confirm that the contract
deployment docs are up to date. Will only fail if a deployment has been
modified but yarn autogen:markdown was not run properly.