### PR TITLE
ci: Use Alpine to reduce image size

### DIFF
--- a/.changeset/popular-plants-change.md
+++ b/.changeset/popular-plants-change.md
@@ -1,0 +1,12 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/common-ts': patch
+'@eth-optimism/contracts': patch
+'@eth-optimism/core-utils': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/message-relayer': patch
+'@eth-optimism/replica-healthcheck': patch
+'@eth-optimism/sdk': patch
+---
+
+Update Dockerfile to use Alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,22 +208,22 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - v1-source-{{ .Branch }}-{{ .Revision }}
-            - v1-source-{{ .Branch }}
+            - v2-source-{{ .Branch }}-{{ .Revision }}
+            - v2-source-{{ .Branch }}
       - checkout
       - save_cache:
-          key: v1-source-{{ .Branch }}-{{ .Revision }}
+          key: v2-source-{{ .Branch }}-{{ .Revision }}
           paths:
             - ".git"
       - restore_cache:
           keys:
-            - v1-yarn-install-{{ checksum "yarn.lock" }}
-            - v1-yarn-install
+            - v2-yarn-install-{{ checksum "yarn.lock" }}
+            - v2-yarn-install
       - run:
           name: Install dependencies
           command: yarn --frozen-lockfile
       - save_cache:
-          key: v1-yarn-install-{{ checksum "yarn.lock" }}
+          key: v2-yarn-install-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
             - packages/common-ts/node_modules
@@ -238,7 +238,7 @@ jobs:
           name: Build monorepo
           command: yarn build
       - save_cache:
-          key: v1-yarn-build-{{ .Revision }}
+          key: v2-yarn-build-{{ .Revision }}
           paths:
             - "."
 
@@ -248,7 +248,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - v1-yarn-build-{{ .Revision }}
+            - v2-yarn-build-{{ .Revision }}
       - checkout
       - run:
           name: Run Slither
@@ -262,7 +262,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - v1-yarn-build-{{ .Revision }}
+            - v2-yarn-build-{{ .Revision }}
       - checkout
       - run:
           name: Lint
@@ -283,7 +283,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - v1-yarn-build-{{ .Revision }}
+            - v2-yarn-build-{{ .Revision }}
       - checkout
       - run:
           name: Test
@@ -306,7 +306,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - v1-yarn-build-{{ .Revision }}
+            - v2-yarn-build-{{ .Revision }}
       - checkout
       # Note: The below needs to be manually configured whenever we
       # add a new package to CI.
@@ -385,7 +385,7 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - v1-yarn-build-{{ .Revision }}
+            - v2-yarn-build-{{ .Revision }}
       - checkout
       - run:
           name: Lint

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -2,16 +2,9 @@
 # be used to build any of the follow-on services
 #
 # ### BASE: Install deps
-# We do not use Alpine because there's a regression causing it to be very slow
-# when used with typescript/hardhat: https://github.com/nomiclabs/hardhat/issues/1219
-FROM node:16.13-buster-slim as base
+FROM node:16-alpine3.14 as base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends git \
-      curl \
-      jq \
-      python3 \
-      ca-certificates \
-  &&  rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add curl jq python3 ca-certificates git make gcc musl-dev linux-headers bash
 
 # copy over the needed configs to run the dep installation
 # note: this approach can be a bit unhandy to maintain, but it allows

--- a/ops/scripts/wait-for-sequencer.sh
+++ b/ops/scripts/wait-for-sequencer.sh
@@ -8,7 +8,7 @@ do
     sleep 1
     if [ $i -eq $RETRIES ]; then
         echo 'Timed out waiting for sequencer'
-        break
+        exit 1
     fi
     echo 'Waiting for sequencer...'
     ((i=i+1))


### PR DESCRIPTION
Image sizes were increased because the packages Dockerfile used `buster-slim` rather than Alpine. Unfortunately, the images will still be large because the `node_modules` directory contains dev dependencies. This is how it was before the CircleCI migration/larger build cleanup, and will need a larger rethink of how we build TypeScript projects in the monorepo before it can be solved.
