### PR TITLE
feat(cmn): add JsonRpcProvider validator

### DIFF
--- a/.changeset/tender-scissors-report.md
+++ b/.changeset/tender-scissors-report.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Adds the jsonRpcProvider validator as an input validator

--- a/packages/common-ts/src/base-service/validators.ts
+++ b/packages/common-ts/src/base-service/validators.ts
@@ -18,6 +18,19 @@ const provider = makeValidator<Provider>((input) => {
   return new ethers.providers.JsonRpcProvider(parsed)
 })
 
+const jsonRpcProvider = makeValidator<ethers.providers.JsonRpcProvider>(
+  (input) => {
+    const parsed = url()._parse(input)
+    return new ethers.providers.JsonRpcProvider(parsed)
+  }
+)
+
+const staticJsonRpcProvider =
+  makeValidator<ethers.providers.StaticJsonRpcProvider>((input) => {
+    const parsed = url()._parse(input)
+    return new ethers.providers.StaticJsonRpcProvider(parsed)
+  })
+
 const wallet = makeValidator<Signer>((input) => {
   if (!ethers.utils.isHexString(input)) {
     throw new Error(`expected wallet to be a hex string`)
@@ -37,4 +50,6 @@ export const validators = {
   json,
   wallet,
   provider,
+  jsonRpcProvider,
+  staticJsonRpcProvider,
 }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds a new JsonRpcProvider validator which specifically parses the input
type into a JsonRpcProvider instead of a generic provider.
