### PR TITLE
{go,js}-builder: bump versions, add to ci

### DIFF
--- a/.changeset/shy-panthers-cough.md
+++ b/.changeset/shy-panthers-cough.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/go-builder': patch
+'@eth-optimism/js-builder': patch
+---
+
+Add to changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       batch-submitter-service: ${{ steps.packages.outputs.batch-submitter-service }}
       indexer: ${{ steps.packages.outputs.indexer }}
       teleportr: ${{ steps.packages.outputs.teleportr }}
+      go-builder: ${{ steps.packages.outputs.go-builder }}
+      js-builder: ${{ steps.packages.outputs.js-builder }}
 
     steps:
       - name: Checkout Repo
@@ -146,6 +148,58 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ethereumoptimism/hardhat-node:${{ needs.release.outputs.gas-oracle }},ethereumoptimism/hardhat-node:latest
+
+  go-builder:
+    name: Publish go-builder ${{ needs.release.outputs.go-builder }}
+    needs: release
+    if: needs.release.go-builder != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Publish go-builder
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ops/docker/go-builder
+          file: ./Dockerfile
+          push: true
+          tags: ethereumoptimism/go-builder:${{ needs.release.outputs.go-builder }},ethereumoptimism/go-builder:latest
+
+  js-builder:
+    name: Publish js-builder ${{ needs.release.outputs.js-builder }}
+    needs: release
+    if: needs.release.js-builder != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Publish js-builder
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ops/docker/js-builder
+          file: ./Dockerfile
+          push: true
+          tags: ethereumoptimism/js-builder:${{ needs.release.outputs.js-builder }},ethereumoptimism/js-builder:latest
 
   proxyd:
     name: Publish proxyd Version ${{ needs.release.outputs.proxyd }}

--- a/ops/docker/go-builder/Dockerfile
+++ b/ops/docker/go-builder/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.17.8-alpine3.15
+FROM golang:1.18.0-alpine3.15
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq curl bash gzip ca-certificates openssh && \
 	go install gotest.tools/gotestsum@latest && \
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
 
 CMD ["bash"]

--- a/ops/docker/go-builder/package.json
+++ b/ops/docker/go-builder/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@eth-optimism/go-builder",
+  "version": "0.0.0",
+  "scripts": {},
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/ops/docker/js-builder/package.json
+++ b/ops/docker/js-builder/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@eth-optimism/js-builder",
+  "version": "0.0.0",
+  "scripts": {},
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
       "integration-tests",
       "go/*",
       "ops/docker/rpc-proxy",
-      "ops/docker/hardhat"
+      "ops/docker/hardhat",
+      "ops/docker/go-builder",
+      "ops/docker/js-builder"
     ],
     "nohoist": [
       "examples/*",


### PR DESCRIPTION
**Description**

Use `golang:1.18.0-alpine3.15`
and `golangci-lint@1.45.2`. This
will allow linting of code that
uses generics

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


