### PR TITLE
l2geth: skip unused tests

### DIFF
--- a/.changeset/lovely-pigs-return.md
+++ b/.changeset/lovely-pigs-return.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Skip unused tests in l2geth

--- a/l2geth/eth/downloader/downloader_test.go
+++ b/l2geth/eth/downloader/downloader_test.go
@@ -666,6 +666,7 @@ func TestBoundedForkedSync64Fast(t *testing.T)  { testBoundedForkedSync(t, 64, F
 func TestBoundedForkedSync64Light(t *testing.T) { testBoundedForkedSync(t, 64, LightSync) }
 
 func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
+	t.Skip("Unused in Optimism")
 	t.Parallel()
 
 	tester := newTester()


### PR DESCRIPTION
**Description**

The tests include:
- `TestBoundedForkedSync62`
- `TestBoundedForkedSync63Full`
- `TestBoundedForkedSync63Fast`
- `TestBoundedForkedSync64Full`
- `TestBoundedForkedSync64Fast`
- `TestBoundedForkedSync64Light`

None of these tests cover code that we use in production.
These tests were flaky upstream and eventually fixed.
No major changes to this codebase are planned before
deprecating it.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
