### PR TITLE
fix(ct): make funding step of deploy more robust

### DIFF
--- a/packages/contracts/deploy/016-fund-accounts.ts
+++ b/packages/contracts/deploy/016-fund-accounts.ts
@@ -1,8 +1,6 @@
 /* Imports: External */
 import { sleep } from '@eth-optimism/core-utils'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import { defaultHardhatNetworkHdAccountsConfigParams } from 'hardhat/internal/core/config/default-config'
-import { normalizeHardhatNetworkAccountsConfig } from 'hardhat/internal/core/providers/util'
 
 /* Imports: Internal */
 import { getContractFromArtifact, isHardhatNode } from '../src/deploy-utils'
@@ -24,29 +22,24 @@ const deployFn: DeployFunction = async (hre) => {
 
     // Default has 20 accounts but we restrict to 20 accounts manually as well just to prevent
     // future problems if the number of default accounts increases for whatever reason.
-    const accounts = normalizeHardhatNetworkAccountsConfig(
-      defaultHardhatNetworkHdAccountsConfigParams
-    ).slice(0, 20)
+    const signers = (await hre.ethers.getSigners()).slice(0, 20)
 
     // Fund the accounts in parallel to speed things up.
     await Promise.all(
-      accounts.map(async (account, index) => {
+      signers.map(async (signer, index) => {
         // Add a sleep here to avoid any potential issues with spamming hardhat. Not sure if this
         // is strictly necessary but it can't hurt.
         await sleep(200 * index)
 
-        const wallet = new hre.ethers.Wallet(
-          account.privateKey,
-          hre.ethers.provider
-        )
-        const balance = await wallet.getBalance()
+        const balance = await signer.getBalance()
         const depositAmount = balance.div(2) // Deposit half of the wallet's balance into L2.
-        await L1StandardBridge.connect(wallet).depositETH(8_000_000, '0x', {
+        await L1StandardBridge.connect(signer).depositETH(8_000_000, '0x', {
           value: depositAmount,
           gasLimit: 2_000_000, // Idk, gas estimation was broken and this fixes it.
         })
+
         console.log(
-          `✓ Funded ${wallet.address} on L2 with ${hre.ethers.utils.formatEther(
+          `✓ Funded ${signer.address} on L2 with ${hre.ethers.utils.formatEther(
             depositAmount
           )} ETH`
         )


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Tweaks the funding step of the deployment process to make it a bit more
robust against situations where different accounts are used to start up
the hardhat node. Current funding step made the assumption that the
accounts being used were the default hardhat accounts, but the hardhat
config within the contracts repo actually uses different accounts. It's
working fine right now since we actually deploy the contracts using an
entirely different hardhat config (the one found within
ops/docker/hardhat/hardhat.config.js) which *does* use the default
hardhat accounts.

Fixes #2419
