### PR TITLE
fix(ct): use default hardhat accounts

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -2,11 +2,6 @@ import { HardhatUserConfig } from 'hardhat/types'
 import 'solidity-coverage'
 import * as dotenv from 'dotenv'
 
-import {
-  DEFAULT_ACCOUNTS_HARDHAT,
-  RUN_OVM_TEST_GAS,
-} from './test/helpers/constants'
-
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
@@ -28,8 +23,6 @@ const deploy = process.env.DEPLOY_DIRECTORY || 'deploy'
 const config: HardhatUserConfig = {
   networks: {
     hardhat: {
-      accounts: DEFAULT_ACCOUNTS_HARDHAT,
-      blockGasLimit: RUN_OVM_TEST_GAS * 2,
       live: false,
       saveDeployments: false,
       tags: ['local'],

--- a/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
+++ b/packages/contracts/test/contracts/L1/rollup/CanonicalTransactionChain.spec.ts
@@ -168,7 +168,7 @@ describe('CanonicalTransactionChain', () => {
 
       await expect(
         CanonicalTransactionChain.enqueue(target, gasLimit, data, {
-          gasLimit: 40000000,
+          gasLimit: 30_000_000,
         })
       ).to.be.revertedWith(
         'Transaction data size exceeds maximum for rollup transaction.'

--- a/packages/contracts/test/helpers/constants.ts
+++ b/packages/contracts/test/helpers/constants.ts
@@ -1,17 +1,5 @@
-/* External Imports */
-import { defaultAccounts } from 'ethereum-waffle'
-
-export const DEFAULT_ACCOUNTS_HARDHAT = defaultAccounts.map((account) => {
-  return {
-    balance: account.balance,
-    privateKey: account.secretKey,
-  }
-})
-
-export const RUN_OVM_TEST_GAS = 20_000_000
 export const L2_GAS_DISCOUNT_DIVISOR = 32
 export const ENQUEUE_GAS_COST = 60_000
-
 export const NON_NULL_BYTES32 =
   '0x1111111111111111111111111111111111111111111111111111111111111111'
 export const NON_ZERO_ADDRESS = '0x1111111111111111111111111111111111111111'


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Uses the default configuration for the hardhat network, including the
accounts. We no longer need to use custom accounts (to be honest, I
don't remember why we ever needed that in the first place). Making this
change also fixes the problem where deployment to the hardhat network
would fail because the hardhat accounts did not have a balance.

Fixes #2419
