### PR TITLE
ci: fix broken publish + changeset integrity

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Changeset integrity checker'
+name: Changeset integrity checker
 on:
   - pull_request_target
 
@@ -10,5 +10,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: 'changeset status'
+      - name: Install Dependencies
+        uses: yarn
+
+      - name: Changeset Status
         run: npx changeset status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,8 +170,8 @@ jobs:
       - name: Publish go-builder
         uses: docker/build-push-action@v2
         with:
-          context: ./ops/docker/go-builder
-          file: ./Dockerfile
+          context: .
+          file: ./ops/docker/go-builder/Dockerfile
           push: true
           tags: ethereumoptimism/go-builder:${{ needs.release.outputs.go-builder }},ethereumoptimism/go-builder:latest
 
@@ -196,8 +196,8 @@ jobs:
       - name: Publish js-builder
         uses: docker/build-push-action@v2
         with:
-          context: ./ops/docker/js-builder
-          file: ./Dockerfile
+          context: .
+          file: ./ops/docker/js-builder/Dockerfile
           push: true
           tags: ethereumoptimism/js-builder:${{ needs.release.outputs.js-builder }},ethereumoptimism/js-builder:latest
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The `go-builder` and `js-builder` failed to publish again, this time it says that the dockerfile doesn't exist. I updated the config to work differently to see if this works

https://github.com/ethereum-optimism/optimism/runs/5853892666?check_suite_focus=true

**Additional context**
```
/usr/bin/docker buildx build --file ./Dockerfile --iidfile /tmp/docker-build-push-S58KMP/iidfile --tag ethereumoptimism/go-builder:0.0.2 --tag ethereumoptimism/go-builder:latest --metadata-file /tmp/docker-build-push-S58KMP/metadata-file --push ./ops/docker/go-builder
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2B done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context:
error: failed to solve: failed to read dockerfile: open /tmp/buildkit-mount4075667921/Dockerfile: no such file or directory
Error: buildx failed with: error: failed to solve: failed to read dockerfile: open /tmp/buildkit-mount4075667921/Dockerfile: no such file or directory
```

**Metadata**
- Fixes #[Link to Issue]
