### PR TITLE
dtl: Use Basic Auth in L1TransportServer

### DIFF
--- a/.changeset/popular-birds-whisper.md
+++ b/.changeset/popular-birds-whisper.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Use Basic Authentication in L1TransportServer

--- a/packages/data-transport-layer/src/services/server/service.ts
+++ b/packages/data-transport-layer/src/services/server/service.ts
@@ -93,12 +93,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
 
     this.state.l1RpcProvider =
       typeof this.options.l1RpcProvider === 'string'
-        ? new JsonRpcProvider(this.options.l1RpcProvider)
+        ? new JsonRpcProvider({
+            url: this.options.l1RpcProvider,
+            user: this.options.l1RpcProviderUser,
+            password: this.options.l1RpcProviderPassword,
+            headers: { 'User-Agent': 'data-transport-layer' },
+          })
         : this.options.l1RpcProvider
 
     this.state.l2RpcProvider =
       typeof this.options.l2RpcProvider === 'string'
-        ? new JsonRpcProvider(this.options.l2RpcProvider)
+        ? new JsonRpcProvider({
+            url: this.options.l2RpcProvider,
+            user: this.options.l2RpcProviderUser,
+            password: this.options.l2RpcProviderPassword,
+            headers: { 'User-Agent': 'data-transport-layer' },
+          })
         : this.options.l2RpcProvider
 
     this._initializeApp()


### PR DESCRIPTION
Basic auth support was previously added by 29f13641dd434f0ef0ce7750ec830e826566c0e3 but I neglected to update the L1TransportServer to use it when available.