### PR TITLE
proxyd: Record latency of redis cache operations

### DIFF
--- a/.changeset/late-swans-drum.md
+++ b/.changeset/late-swans-drum.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+proxyd: Record redis cache operation latency

--- a/go/proxyd/cache.go
+++ b/go/proxyd/cache.go
@@ -59,7 +59,10 @@ func newRedisCache(url string) (*redisCache, error) {
 }
 
 func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
+	start := time.Now()
 	val, err := c.rdb.Get(ctx, key).Result()
+	redisCacheDurationSumm.WithLabelValues("GET").Observe(float64(time.Since(start).Milliseconds()))
+
 	if err == redis.Nil {
 		return "", nil
 	} else if err != nil {
@@ -70,7 +73,10 @@ func (c *redisCache) Get(ctx context.Context, key string) (string, error) {
 }
 
 func (c *redisCache) Put(ctx context.Context, key string, value string) error {
+	start := time.Now()
 	err := c.rdb.SetEX(ctx, key, value, redisTTL).Err()
+	redisCacheDurationSumm.WithLabelValues("SETEX").Observe(float64(time.Since(start).Milliseconds()))
+
 	if err != nil {
 		RecordRedisError("CacheSet")
 	}

--- a/go/proxyd/metrics.go
+++ b/go/proxyd/metrics.go
@@ -22,6 +22,7 @@ const (
 )
 
 var PayloadSizeBuckets = []float64{10, 50, 100, 500, 1000, 5000, 10000, 100000, 1000000}
+var MillisecondDurationBuckets = []float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 100000}
 
 var (
 	rpcRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
@@ -198,6 +199,13 @@ var (
 		"gas price too low",
 		"invalid parameters",
 	}
+
+	redisCacheDurationSumm = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: MetricsNamespace,
+		Name:      "redis_cache_duration_milliseconds",
+		Help:      "Histogram of Redis command durations, in milliseconds.",
+		Buckets:   MillisecondDurationBuckets,
+	}, []string{"command"})
 )
 
 func RecordRedisError(source string) {


### PR DESCRIPTION
We don't have alot of visibility into redis cache latencies. Logging these can help us consider using pipelining to reduce the roundtrip latency of retrieving batched RPCs from the cache.