### PR TITLE
proxyd: Request-scoped context for fast batch RPC short-circuits

### DIFF
--- a/.changeset/shiny-fishes-buy.md
+++ b/.changeset/shiny-fishes-buy.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+proxyd: Request-scoped context for fast batch RPC short-circuiting

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -12,6 +12,9 @@ type ServerConfig struct {
 	WSHost           string `toml:"ws_host"`
 	WSPort           int    `toml:"ws_port"`
 	MaxBodySizeBytes int64  `toml:"max_body_size_bytes"`
+
+	// TimeoutSeconds specifies the maximum time spent serving an HTTP request. Note that isn't used for websocket connections
+	TimeoutSeconds int `toml:"timeout_seconds"`
 }
 
 type CacheConfig struct {

--- a/go/proxyd/integration_tests/batch_timeout_test.go
+++ b/go/proxyd/integration_tests/batch_timeout_test.go
@@ -1,0 +1,42 @@
+package integration_tests
+
+import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/go/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	batchTimeoutResponse = `{"error":{"code":-32015,"message":"gateway timeout"},"id":null,"jsonrpc":"2.0"}`
+)
+
+func TestBatchTimeout(t *testing.T) {
+	slowBackend := NewMockBackend(nil)
+	defer slowBackend.Close()
+
+	require.NoError(t, os.Setenv("SLOW_BACKEND_RPC_URL", slowBackend.URL()))
+
+	config := ReadConfig("batch_timeout")
+	client := NewProxydClient("http://127.0.0.1:8545")
+	shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	slowBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check the config. The sleep duration should be at least double the server.timeout_seconds config to prevent flakes
+		time.Sleep(time.Second * 2)
+		SingleResponseHandler(200, goodResponse)(w, r)
+	}))
+	res, statusCode, err := client.SendBatchRPC(
+		NewRPCReq("1", "eth_chainId", nil),
+		NewRPCReq("1", "eth_chainId", nil),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 504, statusCode)
+	RequireEqualJSON(t, []byte(batchTimeoutResponse), res)
+	require.Equal(t, 1, len(slowBackend.Requests()))
+}

--- a/go/proxyd/integration_tests/testdata/batch_timeout.toml
+++ b/go/proxyd/integration_tests/testdata/batch_timeout.toml
@@ -1,0 +1,19 @@
+[server]
+rpc_port = 8545
+timeout_seconds = 1
+
+[backend]
+response_timeout_seconds = 1
+max_retries = 3
+
+[backends]
+[backends.slow]
+rpc_url = "$SLOW_BACKEND_RPC_URL"
+ws_url = "$SLOW_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["slow"]
+
+[rpc_method_mappings]
+eth_chainId = "main"

--- a/go/proxyd/proxyd.go
+++ b/go/proxyd/proxyd.go
@@ -211,6 +211,7 @@ func Start(config *Config) (func(), error) {
 		config.RPCMethodMappings,
 		config.Server.MaxBodySizeBytes,
 		resolvedAuth,
+		secondsToDuration(config.Server.TimeoutSeconds),
 		rpcCache,
 	)
 

--- a/go/proxyd/server.go
+++ b/go/proxyd/server.go
@@ -26,6 +26,7 @@ const (
 	ContextKeyXForwardedFor = "x_forwarded_for"
 	MaxBatchRPCCalls        = 100
 	cacheStatusHdr          = "X-Proxyd-Cache-Status"
+	defaultServerTimeout    = time.Second * 10
 )
 
 type Server struct {
@@ -35,6 +36,7 @@ type Server struct {
 	rpcMethodMappings  map[string]string
 	maxBodySize        int64
 	authenticatedPaths map[string]string
+	timeout            time.Duration
 	upgrader           *websocket.Upgrader
 	rpcServer          *http.Server
 	wsServer           *http.Server
@@ -48,6 +50,7 @@ func NewServer(
 	rpcMethodMappings map[string]string,
 	maxBodySize int64,
 	authenticatedPaths map[string]string,
+	timeout time.Duration,
 	cache RPCCache,
 ) *Server {
 	if cache == nil {
@@ -58,6 +61,10 @@ func NewServer(
 		maxBodySize = math.MaxInt64
 	}
 
+	if timeout == 0 {
+		timeout = defaultServerTimeout
+	}
+
 	return &Server{
 		backendGroups:      backendGroups,
 		wsBackendGroup:     wsBackendGroup,
@@ -65,6 +72,7 @@ func NewServer(
 		rpcMethodMappings:  rpcMethodMappings,
 		maxBodySize:        maxBodySize,
 		authenticatedPaths: authenticatedPaths,
+		timeout:            timeout,
 		cache:              cache,
 		upgrader: &websocket.Upgrader{
 			HandshakeTimeout: 5 * time.Second,
@@ -123,6 +131,9 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 	if ctx == nil {
 		return
 	}
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, s.timeout)
+	defer cancel()
 
 	log.Info(
 		"received RPC request",
@@ -162,6 +173,12 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		batchRes := make([]*RPCRes, len(reqs))
 		var batchContainsCached bool
 		for i := 0; i < len(reqs); i++ {
+			if ctx.Err() == context.DeadlineExceeded {
+				log.Info("short-circuiting batch RPC", "index", i, "batch_size", len(reqs))
+				writeRPCError(ctx, w, nil, ErrGatewayTimeout)
+				return
+			}
+
 			req, err := ParseRPCReq(reqs[i])
 			if err != nil {
 				log.Info("error parsing RPC call", "source", "rpc", "err", err)


### PR DESCRIPTION
Currently, proxyd applies timeout logic to each RPC within a batch request individually. If many RPCs within a batch time out, then the initiating request can take a very long time to complete. This occurs as we process RPCs within a batch sequentially and thus each subsequent RPC have increasing deadlines.

We avoid this issue by introducing a timeout that covers an entire serve operation. Once this timeout triggers, we cancel all pending RPCs that would have been sent as part of batch RPC handling. We then return immediately to the user with a 504 error.

A new `server` config, `timeout_seconds`, is added to set the overall timeout of HTTP requests served by proxyd.