### PR TITLE
ci: Add a job to nag when changesets are missing

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,22 +5,22 @@ queue_rules:
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-        - and:
-          - "#review-threads-unresolved=0"
-          - "#approved-reviews-by>=2"
-          - "#changes-requested-reviews-by=0"
-          - or:
-            - and:
-              - "label!=SR-Risk"
-              - "label!=C-Protocol-Critical"
-            - and:
-              - "label=SR-Risk"
-              - "approved-reviews-by=maurelian"
-            - and:
-              - "label=C-Protocol-Critical"
-              - or:
-                - "approved-reviews-by=tynes"
-                - "approved-reviews-by=smartcontracts"
+      - and:
+        - "#review-threads-unresolved=0"
+        - "#approved-reviews-by>=2"
+        - "#changes-requested-reviews-by=0"
+        - or:
+          - and:
+            - "label!=SR-Risk"
+            - "label!=C-Protocol-Critical"
+          - and:
+            - "label=SR-Risk"
+            - "approved-reviews-by=maurelian"
+          - and:
+            - "label=C-Protocol-Critical"
+            - or:
+              - "approved-reviews-by=tynes"
+              - "approved-reviews-by=smartcontracts"
     actions:
       queue:
         name: default
@@ -97,3 +97,12 @@ pull_request_rules:
       label:
         remove:
           - on-merge-train
+  - name: Nag changesets
+    conditions:
+      - and:
+        - 'files~=\.(ts|go|js|mod|sum)$'
+        - '-files~=^\.changeset/(.*)\.md'
+    actions:
+      comment:
+        message: |
+          This PR changes implementation code, but doesn't include a changeset. Did you forget to add one?


### PR DESCRIPTION
Mergify will now add a comment asking if you forgot a changeset if you change TS, Go, or JS code without adding one.
