### PR TITLE
fix(rhc): bug when target leads reference

### DIFF
--- a/.changeset/tidy-swans-yell.md
+++ b/.changeset/tidy-swans-yell.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Fixes a bug that would cause the service to stop properly checking blocks when the target client consistently leads the reference client


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug that would cause the healthcheck service not to properly
check blocks when the target is advancing faster than the reference
client. RHC will now check the block correpsonding to the lesser of the
two block heights. Also adds a new metric to track the height difference
in the two providers which could be used to alert if the target leads
the reference by too much or vice versa.

**Metadata**
- Fixes #2455
