### PR TITLE
fix(ci): no changeset nag for ts tests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -100,7 +100,7 @@ pull_request_rules:
   - name: Nag changesets
     conditions:
       - and:
-        - 'files~=\.(ts|go|js|mod|sum)$'
+        - 'files~=\.((?<!\.spec\.)ts|go|js|mod|sum)$'
         - '-files~=^\.changeset/(.*)\.md'
     actions:
       comment:


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Modifies mergify.yml to no longer yell at me to add a changeset
when a PR only modifies .spec.ts files.
