### PR TITLE
proxyd: Limit the number of concurrent RPCs to backends

### DIFF
--- a/.changeset/rude-mayflies-shout.md
+++ b/.changeset/rude-mayflies-shout.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+proxyd: Limit the number of concurrent RPCs to backends

--- a/go/proxyd/config.go
+++ b/go/proxyd/config.go
@@ -7,11 +7,12 @@ import (
 )
 
 type ServerConfig struct {
-	RPCHost          string `toml:"rpc_host"`
-	RPCPort          int    `toml:"rpc_port"`
-	WSHost           string `toml:"ws_host"`
-	WSPort           int    `toml:"ws_port"`
-	MaxBodySizeBytes int64  `toml:"max_body_size_bytes"`
+	RPCHost           string `toml:"rpc_host"`
+	RPCPort           int    `toml:"rpc_port"`
+	WSHost            string `toml:"ws_host"`
+	WSPort            int    `toml:"ws_port"`
+	MaxBodySizeBytes  int64  `toml:"max_body_size_bytes"`
+	MaxConcurrentRPCs int64  `toml:"max_concurrent_rpcs"`
 
 	// TimeoutSeconds specifies the maximum time spent serving an HTTP request. Note that isn't used for websocket connections
 	TimeoutSeconds int `toml:"timeout_seconds"`

--- a/go/proxyd/example.config.toml
+++ b/go/proxyd/example.config.toml
@@ -18,6 +18,7 @@ ws_host = "0.0.0.0"
 ws_port = 8085
 # Maximum client body size, in bytes, that the server will accept.
 max_body_size_bytes = 10485760
+max_concurrent_rpcs = 1000
 
 [redis]
 # URL to a Redis instance.

--- a/go/proxyd/go.mod
+++ b/go/proxyd/go.mod
@@ -17,5 +17,6 @@ require (
 	github.com/rs/cors v1.8.0
 	github.com/stretchr/testify v1.7.0
 	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go/proxyd/integration_tests/max_rpc_conns_test.go
+++ b/go/proxyd/integration_tests/max_rpc_conns_test.go
@@ -1,0 +1,79 @@
+package integration_tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/go/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxConcurrentRPCs(t *testing.T) {
+	var (
+		mu                sync.Mutex
+		concurrentRPCs    int
+		maxConcurrentRPCs int
+	)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		concurrentRPCs++
+		if maxConcurrentRPCs < concurrentRPCs {
+			maxConcurrentRPCs = concurrentRPCs
+		}
+		mu.Unlock()
+
+		time.Sleep(time.Second * 2)
+		SingleResponseHandler(200, goodResponse)(w, r)
+
+		mu.Lock()
+		concurrentRPCs--
+		mu.Unlock()
+	}
+	// We don't use the MockBackend because it serializes requests to the handler
+	slowBackend := httptest.NewServer(http.HandlerFunc(handler))
+	defer slowBackend.Close()
+
+	require.NoError(t, os.Setenv("GOOD_BACKEND_RPC_URL", slowBackend.URL))
+
+	config := ReadConfig("max_rpc_conns")
+	client := NewProxydClient("http://127.0.0.1:8545")
+	shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	type resWithCodeErr struct {
+		res  []byte
+		code int
+		err  error
+	}
+	resCh := make(chan *resWithCodeErr)
+	for i := 0; i < 3; i++ {
+		go func() {
+			res, code, err := client.SendRPC("eth_chainId", nil)
+			resCh <- &resWithCodeErr{
+				res:  res,
+				code: code,
+				err:  err,
+			}
+		}()
+	}
+	res1 := <-resCh
+	res2 := <-resCh
+	res3 := <-resCh
+
+	require.NoError(t, res1.err)
+	require.NoError(t, res2.err)
+	require.NoError(t, res3.err)
+	require.Equal(t, 200, res1.code)
+	require.Equal(t, 200, res2.code)
+	require.Equal(t, 200, res3.code)
+	RequireEqualJSON(t, []byte(goodResponse), res1.res)
+	RequireEqualJSON(t, []byte(goodResponse), res2.res)
+	RequireEqualJSON(t, []byte(goodResponse), res3.res)
+
+	require.EqualValues(t, 2, maxConcurrentRPCs)
+}

--- a/go/proxyd/integration_tests/testdata/max_rpc_conns.toml
+++ b/go/proxyd/integration_tests/testdata/max_rpc_conns.toml
@@ -1,0 +1,19 @@
+[server]
+rpc_port = 8545
+max_concurrent_rpcs = 2
+
+[backend]
+# this should cover blocked requests due to max_concurrent_rpcs
+response_timeout_seconds = 12
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"

--- a/go/proxyd/metrics.go
+++ b/go/proxyd/metrics.go
@@ -212,6 +212,14 @@ var (
 		Help:      "Histogram of Redis command durations, in milliseconds.",
 		Buckets:   MillisecondDurationBuckets,
 	}, []string{"command"})
+
+	tooManyRequestErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "too_many_request_errors_total",
+		Help:      "Count of request timneouts due to too many concurrent RPCs.",
+	}, []string{
+		"backend_name",
+	})
 )
 
 func RecordRedisError(source string) {

--- a/go/proxyd/metrics.go
+++ b/go/proxyd/metrics.go
@@ -216,7 +216,7 @@ var (
 	tooManyRequestErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "too_many_request_errors_total",
-		Help:      "Count of request timneouts due to too many concurrent RPCs.",
+		Help:      "Count of request timeouts due to too many concurrent RPCs.",
 	}, []string{
 		"backend_name",
 	})


### PR DESCRIPTION
We add a new config `max_concurrent_rpcs` under the server section to
prevent too many RPC requests. This also sets a limit on the number of open connections to upstream.
However, due to connection reuse, there can be less connections in-use than concurrent RPCs.
Requests are blocked, in a FIFO fashion, until the number of in-flight RPCs is under the limit.
