### PR TITLE
fix(sdk): use correct overrides type

### DIFF
--- a/.changeset/yellow-pandas-help.md
+++ b/.changeset/yellow-pandas-help.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Fixes a bug where the wrong Overrides type was being used for gas estimation functions

--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ethers, Contract, Overrides, Signer, BigNumber } from 'ethers'
+import {
+  ethers,
+  Contract,
+  Overrides,
+  Signer,
+  BigNumber,
+  CallOverrides,
+} from 'ethers'
 import {
   TransactionRequest,
   TransactionResponse,
@@ -350,7 +357,7 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       l2Token: AddressLike,
       amount: NumberLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.messenger.l1Provider.estimateGas(
@@ -365,7 +372,7 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       opts?: {
         recipient?: AddressLike
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.messenger.l1Provider.estimateGas(
@@ -379,7 +386,7 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.messenger.l2Provider.estimateGas(

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -7,7 +7,7 @@ import {
   TransactionRequest,
 } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
-import { ethers, BigNumber, Overrides } from 'ethers'
+import { ethers, BigNumber, Overrides, CallOverrides } from 'ethers'
 import { sleep, remove0x } from '@eth-optimism/core-utils'
 import { predeploys } from '@eth-optimism/contracts'
 
@@ -1128,7 +1128,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       message: CrossChainMessageRequest,
       opts?: {
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       const tx = await this.populateTransaction.sendMessage(message, opts)
@@ -1143,7 +1143,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       message: MessageLike,
       messageGasLimit: NumberLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
@@ -1158,7 +1158,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
     finalizeMessage: async (
       message: MessageLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
@@ -1171,7 +1171,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       opts?: {
         recipient?: AddressLike
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
@@ -1183,7 +1183,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l2Provider.estimateGas(
@@ -1196,7 +1196,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       l2Token: AddressLike,
       amount: NumberLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
@@ -1216,7 +1216,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       opts?: {
         recipient?: AddressLike
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
@@ -1235,7 +1235,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber> => {
       return this.l2Provider.estimateGas(

--- a/packages/sdk/src/interfaces/bridge-adapter.ts
+++ b/packages/sdk/src/interfaces/bridge-adapter.ts
@@ -1,4 +1,4 @@
-import { Contract, Overrides, Signer, BigNumber } from 'ethers'
+import { Contract, Overrides, Signer, BigNumber, CallOverrides } from 'ethers'
 import {
   TransactionRequest,
   TransactionResponse,
@@ -250,7 +250,7 @@ export interface IBridgeAdapter {
       l2Token: AddressLike,
       amount: NumberLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -273,7 +273,7 @@ export interface IBridgeAdapter {
       opts?: {
         recipient?: AddressLike
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -294,7 +294,7 @@ export interface IBridgeAdapter {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
   }

--- a/packages/sdk/src/interfaces/cross-chain-messenger.ts
+++ b/packages/sdk/src/interfaces/cross-chain-messenger.ts
@@ -1,4 +1,4 @@
-import { Event, BigNumber, Overrides } from 'ethers'
+import { Event, BigNumber, Overrides, CallOverrides } from 'ethers'
 import {
   Provider,
   BlockTag,
@@ -697,7 +697,7 @@ export interface ICrossChainMessenger {
       message: CrossChainMessageRequest,
       opts?: {
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ) => Promise<BigNumber>
 
@@ -714,7 +714,7 @@ export interface ICrossChainMessenger {
       message: MessageLike,
       messageGasLimit: NumberLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -729,7 +729,7 @@ export interface ICrossChainMessenger {
     finalizeMessage(
       message: MessageLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -748,7 +748,7 @@ export interface ICrossChainMessenger {
       l2Token: AddressLike,
       amount: NumberLike,
       opts?: {
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -767,7 +767,7 @@ export interface ICrossChainMessenger {
       opts?: {
         recipient?: AddressLike
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -784,7 +784,7 @@ export interface ICrossChainMessenger {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -807,7 +807,7 @@ export interface ICrossChainMessenger {
       opts?: {
         recipient?: AddressLike
         l2GasLimit?: NumberLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
 
@@ -828,7 +828,7 @@ export interface ICrossChainMessenger {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: Overrides
+        overrides?: CallOverrides
       }
     ): Promise<BigNumber>
   }


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replaces Overrides with CallOverrides for estimateGas functions so you
can specify the "from" address.