### PR TITLE
maint(ct): clean up Teleportr tests

### DIFF
--- a/packages/contracts/test/contracts/L1/teleportr/TeleportrDeposit.spec.ts
+++ b/packages/contracts/test/contracts/L1/teleportr/TeleportrDeposit.spec.ts
@@ -1,171 +1,195 @@
-/* External Imports */
 import { ethers } from 'hardhat'
-import { Signer, Contract, BigNumber } from 'ethers'
+import { Contract, BigNumber } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 
-/* Internal Imports */
 import { expect } from '../../../setup'
+import { deploy } from '../../../helpers'
 
 const initialMinDepositAmount = ethers.utils.parseEther('0.01')
 const initialMaxDepositAmount = ethers.utils.parseEther('1')
 const initialMaxBalance = ethers.utils.parseEther('2')
 
 describe('TeleportrDeposit', async () => {
-  let teleportrDeposit: Contract
-  let signer: Signer
-  let signer2: Signer
-  let contractAddress: string
-  let signerAddress: string
-  let signer2Address: string
+  let signer1: SignerWithAddress
+  let signer2: SignerWithAddress
   before(async () => {
-    ;[signer, signer2] = await ethers.getSigners()
-    teleportrDeposit = await (
-      await ethers.getContractFactory('TeleportrDeposit')
-    ).deploy(
-      initialMinDepositAmount,
-      initialMaxDepositAmount,
-      initialMaxBalance
-    )
-    contractAddress = teleportrDeposit.address
-    signerAddress = await signer.getAddress()
-    signer2Address = await signer2.getAddress()
+    ;[signer1, signer2] = await ethers.getSigners()
   })
+
+  let TeleportrDeposit: Contract
+  before(async () => {
+    TeleportrDeposit = await deploy('TeleportrDeposit', {
+      args: [
+        initialMinDepositAmount,
+        initialMaxDepositAmount,
+        initialMaxBalance,
+      ],
+    })
+  })
+
   describe('receive', async () => {
     const oneETH = ethers.utils.parseEther('1.0')
     const twoETH = ethers.utils.parseEther('2.0')
+
     it('should revert if deposit amount is less than min amount', async () => {
       await expect(
-        signer.sendTransaction({
-          to: contractAddress,
+        signer1.sendTransaction({
+          to: TeleportrDeposit.address,
           value: ethers.utils.parseEther('0.001'),
         })
       ).to.be.revertedWith('Deposit amount is too small')
     })
+
     it('should revert if deposit amount is greater than max amount', async () => {
       await expect(
-        signer.sendTransaction({
-          to: contractAddress,
+        signer1.sendTransaction({
+          to: TeleportrDeposit.address,
           value: ethers.utils.parseEther('1.1'),
         })
       ).to.be.revertedWith('Deposit amount is too big')
     })
+
     it('should emit EtherReceived if called by non-owner', async () => {
       await expect(
         signer2.sendTransaction({
-          to: contractAddress,
+          to: TeleportrDeposit.address,
           value: oneETH,
         })
       )
-        .to.emit(teleportrDeposit, 'EtherReceived')
-        .withArgs(BigNumber.from('0'), signer2Address, oneETH)
+        .to.emit(TeleportrDeposit, 'EtherReceived')
+        .withArgs(BigNumber.from('0'), signer2.address, oneETH)
     })
+
     it('should increase the contract balance by deposit amount', async () => {
-      await expect(await ethers.provider.getBalance(contractAddress)).to.equal(
-        oneETH
-      )
+      expect(
+        await ethers.provider.getBalance(TeleportrDeposit.address)
+      ).to.equal(oneETH)
     })
+
     it('should emit EtherReceived if called by owner', async () => {
       await expect(
-        signer.sendTransaction({
-          to: contractAddress,
+        signer1.sendTransaction({
+          to: TeleportrDeposit.address,
           value: oneETH,
         })
       )
-        .to.emit(teleportrDeposit, 'EtherReceived')
-        .withArgs(BigNumber.from('1'), signerAddress, oneETH)
+        .to.emit(TeleportrDeposit, 'EtherReceived')
+        .withArgs(BigNumber.from('1'), signer1.address, oneETH)
     })
+
     it('should increase the contract balance by deposit amount', async () => {
-      await expect(await ethers.provider.getBalance(contractAddress)).to.equal(
-        twoETH
-      )
+      expect(
+        await ethers.provider.getBalance(TeleportrDeposit.address)
+      ).to.equal(twoETH)
     })
+
     it('should revert if deposit will exceed max balance', async () => {
       await expect(
-        signer.sendTransaction({
-          to: contractAddress,
+        signer1.sendTransaction({
+          to: TeleportrDeposit.address,
           value: initialMinDepositAmount,
         })
       ).to.be.revertedWith('Contract max balance exceeded')
     })
   })
+
   describe('withdrawBalance', async () => {
     let initialContractBalance: BigNumber
     let initialSignerBalance: BigNumber
     before(async () => {
-      initialContractBalance = await ethers.provider.getBalance(contractAddress)
-      initialSignerBalance = await ethers.provider.getBalance(signerAddress)
+      initialContractBalance = await ethers.provider.getBalance(
+        TeleportrDeposit.address
+      )
+      initialSignerBalance = await signer1.getBalance()
     })
+
     it('should revert if called by non-owner', async () => {
       await expect(
-        teleportrDeposit.connect(signer2).withdrawBalance()
+        TeleportrDeposit.connect(signer2).withdrawBalance()
       ).to.be.revertedWith('Ownable: caller is not the owner')
     })
+
     it('should emit BalanceWithdrawn if called by owner', async () => {
-      await expect(teleportrDeposit.withdrawBalance())
-        .to.emit(teleportrDeposit, 'BalanceWithdrawn')
-        .withArgs(signerAddress, initialContractBalance)
+      await expect(TeleportrDeposit.withdrawBalance())
+        .to.emit(TeleportrDeposit, 'BalanceWithdrawn')
+        .withArgs(signer1.address, initialContractBalance)
     })
+
     it('should leave the contract with zero balance', async () => {
-      await expect(await ethers.provider.getBalance(contractAddress)).to.equal(
-        ethers.utils.parseEther('0')
-      )
+      expect(
+        await ethers.provider.getBalance(TeleportrDeposit.address)
+      ).to.equal(ethers.utils.parseEther('0'))
     })
+
     it('should credit owner with contract balance - fees', async () => {
       const expSignerBalance = initialSignerBalance.add(initialContractBalance)
-      await expect(
-        await ethers.provider.getBalance(signerAddress)
-      ).to.be.closeTo(expSignerBalance, 10 ** 15)
+      expect(await signer1.getBalance()).to.be.closeTo(
+        expSignerBalance,
+        10 ** 15
+      )
     })
   })
+
   describe('setMinAmount', async () => {
     const newMinDepositAmount = ethers.utils.parseEther('0.02')
+
     it('should revert if called by non-owner', async () => {
       await expect(
-        teleportrDeposit.connect(signer2).setMinAmount(newMinDepositAmount)
+        TeleportrDeposit.connect(signer2).setMinAmount(newMinDepositAmount)
       ).to.be.revertedWith('Ownable: caller is not the owner')
     })
+
     it('should emit MinDepositAmountSet if called by owner', async () => {
-      await expect(teleportrDeposit.setMinAmount(newMinDepositAmount))
-        .to.emit(teleportrDeposit, 'MinDepositAmountSet')
+      await expect(TeleportrDeposit.setMinAmount(newMinDepositAmount))
+        .to.emit(TeleportrDeposit, 'MinDepositAmountSet')
         .withArgs(initialMinDepositAmount, newMinDepositAmount)
     })
+
     it('should have updated minDepositAmount after success', async () => {
-      await expect(await teleportrDeposit.minDepositAmount()).to.be.eq(
+      expect(await TeleportrDeposit.minDepositAmount()).to.be.eq(
         newMinDepositAmount
       )
     })
   })
+
   describe('setMaxAmount', async () => {
     const newMaxDepositAmount = ethers.utils.parseEther('2')
     it('should revert if called non-owner', async () => {
       await expect(
-        teleportrDeposit.connect(signer2).setMaxAmount(newMaxDepositAmount)
+        TeleportrDeposit.connect(signer2).setMaxAmount(newMaxDepositAmount)
       ).to.be.revertedWith('Ownable: caller is not the owner')
     })
+
     it('should emit MaxDepositAmountSet if called by owner', async () => {
-      await expect(teleportrDeposit.setMaxAmount(newMaxDepositAmount))
-        .to.emit(teleportrDeposit, 'MaxDepositAmountSet')
+      await expect(TeleportrDeposit.setMaxAmount(newMaxDepositAmount))
+        .to.emit(TeleportrDeposit, 'MaxDepositAmountSet')
         .withArgs(initialMaxDepositAmount, newMaxDepositAmount)
     })
+
     it('should have an updated maxDepositAmount after success', async () => {
-      await expect(await teleportrDeposit.maxDepositAmount()).to.be.eq(
+      expect(await TeleportrDeposit.maxDepositAmount()).to.be.eq(
         newMaxDepositAmount
       )
     })
   })
+
   describe('setMaxBalance', async () => {
     const newMaxBalance = ethers.utils.parseEther('2000')
+
     it('should revert if called by non-owner', async () => {
       await expect(
-        teleportrDeposit.connect(signer2).setMaxBalance(newMaxBalance)
+        TeleportrDeposit.connect(signer2).setMaxBalance(newMaxBalance)
       ).to.be.revertedWith('Ownable: caller is not the owner')
     })
+
     it('should emit MaxBalanceSet if called by owner', async () => {
-      await expect(teleportrDeposit.setMaxBalance(newMaxBalance))
-        .to.emit(teleportrDeposit, 'MaxBalanceSet')
+      await expect(TeleportrDeposit.setMaxBalance(newMaxBalance))
+        .to.emit(TeleportrDeposit, 'MaxBalanceSet')
         .withArgs(initialMaxBalance, newMaxBalance)
     })
+
     it('should have an updated maxBalance after success', async () => {
-      await expect(await teleportrDeposit.maxBalance()).to.be.eq(newMaxBalance)
+      expect(await TeleportrDeposit.maxBalance()).to.be.eq(newMaxBalance)
     })
   })
 })


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Cleans up the TeleportrDeposit tests using the same techniques as
previous cleanup PRs.
