### PR TITLE
ci: Update remote docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,8 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+            version: 20.10.12
       - when:
           condition: <<parameters.target>>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 20.10.12
+          version: 20.10.12
       - when:
           condition: <<parameters.target>>
           steps:


### PR DESCRIPTION
The nightly CI fails because default remote docker (17.09.0-ce) does
not support DOCKER_BUILDKIT. Updating the remote docker version to be at
least 18.09 fixes this.