### PR TITLE
indexer: filter query - fix cancel

### DIFF
--- a/.changeset/polite-ducks-sip.md
+++ b/.changeset/polite-ducks-sip.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/indexer': patch
+---
+
+Fixed context deadline exceeded

--- a/go/indexer/services/l1/bridge/eth_bridge.go
+++ b/go/indexer/services/l1/bridge/eth_bridge.go
@@ -25,9 +25,8 @@ func (e *EthBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap, err
 	depositsByBlockhash := make(DepositsMap)
 
 	iter, err := FilterETHDepositInitiatedWithRetry(e.filterer, &bind.FilterOpts{
-		Start:   start,
-		End:     &end,
-		Context: e.ctx,
+		Start: start,
+		End:   &end,
 	})
 	if err != nil {
 		logger.Error("Error fetching filter", "err", err)

--- a/go/indexer/services/l1/bridge/filter.go
+++ b/go/indexer/services/l1/bridge/filter.go
@@ -18,12 +18,14 @@ var clientRetryInterval = 5 * time.Second
 func FilterStateBatchAppendedWithRetry(filterer *scc.StateCommitmentChainFilterer, opts *bind.FilterOpts) (*scc.StateCommitmentChainStateBatchAppendedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
-		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterStateBatchAppended(opts, nil)
-		if err != nil {
-			return res, err
+		if err == nil {
+			cancel()
+			return res, nil
 		}
+		cancel()
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }
@@ -33,12 +35,14 @@ func FilterStateBatchAppendedWithRetry(filterer *scc.StateCommitmentChainFiltere
 func FilterETHDepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeETHDepositInitiatedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
-		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterETHDepositInitiated(opts, nil, nil)
-		if err != nil {
-			return res, err
+		if err == nil {
+			cancel()
+			return res, nil
 		}
+		cancel()
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }
@@ -48,12 +52,14 @@ func FilterETHDepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilte
 func FilterERC20DepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeERC20DepositInitiatedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
-		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterERC20DepositInitiated(opts, nil, nil, nil)
-		if err != nil {
-			return res, err
+		if err == nil {
+			cancel()
+			return res, nil
 		}
+		cancel()
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }

--- a/go/indexer/services/l1/bridge/filter.go
+++ b/go/indexer/services/l1/bridge/filter.go
@@ -18,14 +18,11 @@ var clientRetryInterval = 5 * time.Second
 func FilterStateBatchAppendedWithRetry(filterer *scc.StateCommitmentChainFilterer, opts *bind.FilterOpts) (*scc.StateCommitmentChainStateBatchAppendedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterStateBatchAppended(opts, nil)
-		switch err {
-		case nil:
-			cancel()
+		if err != nil {
 			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
 		}
 		time.Sleep(clientRetryInterval)
 	}
@@ -36,14 +33,11 @@ func FilterStateBatchAppendedWithRetry(filterer *scc.StateCommitmentChainFiltere
 func FilterETHDepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeETHDepositInitiatedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterETHDepositInitiated(opts, nil, nil)
-		switch err {
-		case nil:
-			cancel()
+		if err != nil {
 			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
 		}
 		time.Sleep(clientRetryInterval)
 	}
@@ -54,14 +48,11 @@ func FilterETHDepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilte
 func FilterERC20DepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeERC20DepositInitiatedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterERC20DepositInitiated(opts, nil, nil, nil)
-		switch err {
-		case nil:
-			cancel()
+		if err != nil {
 			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
 		}
 		time.Sleep(clientRetryInterval)
 	}

--- a/go/indexer/services/l1/bridge/standard_bridge.go
+++ b/go/indexer/services/l1/bridge/standard_bridge.go
@@ -25,9 +25,8 @@ func (s *StandardBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap
 	depositsByBlockhash := make(DepositsMap)
 
 	iter, err := FilterERC20DepositInitiatedWithRetry(s.filterer, &bind.FilterOpts{
-		Start:   start,
-		End:     &end,
-		Context: s.ctx,
+		Start: start,
+		End:   &end,
 	})
 	if err != nil {
 		logger.Error("Error fetching filter", "err", err)

--- a/go/indexer/services/l2/bridge/filter.go
+++ b/go/indexer/services/l2/bridge/filter.go
@@ -17,14 +17,11 @@ var clientRetryInterval = 5 * time.Second
 func FilterWithdrawalInitiatedWithRetry(filterer *l2bridge.L2StandardBridgeFilterer, opts *bind.FilterOpts) (*l2bridge.L2StandardBridgeWithdrawalInitiatedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterWithdrawalInitiated(opts, nil, nil, nil)
-		switch err {
-		case nil:
-			cancel()
+		if err != nil {
 			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
 		}
 		time.Sleep(clientRetryInterval)
 	}

--- a/go/indexer/services/l2/bridge/filter.go
+++ b/go/indexer/services/l2/bridge/filter.go
@@ -17,12 +17,14 @@ var clientRetryInterval = 5 * time.Second
 func FilterWithdrawalInitiatedWithRetry(filterer *l2bridge.L2StandardBridgeFilterer, opts *bind.FilterOpts) (*l2bridge.L2StandardBridgeWithdrawalInitiatedIterator, error) {
 	for {
 		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
-		defer cancel()
 		opts.Context = ctxt
 		res, err := filterer.FilterWithdrawalInitiated(opts, nil, nil, nil)
-		if err != nil {
-			return res, err
+		if err == nil {
+			cancel()
+			return res, nil
 		}
+		cancel()
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }

--- a/go/indexer/services/l2/bridge/standard_bridge.go
+++ b/go/indexer/services/l2/bridge/standard_bridge.go
@@ -26,9 +26,8 @@ func (s *StandardBridge) GetWithdrawalsByBlockRange(start, end uint64) (Withdraw
 	withdrawalsByBlockhash := make(map[common.Hash][]db.Withdrawal)
 
 	iter, err := FilterWithdrawalInitiatedWithRetry(s.filterer, &bind.FilterOpts{
-		Start:   start,
-		End:     &end,
-		Context: s.ctx,
+		Start: start,
+		End:   &end,
 	})
 	if err != nil {
 		logger.Error("Error fetching filter", "err", err)


### PR DESCRIPTION
**Description**
The indexer was frequently stalling with `Context deadline exceeded`. I found that the `cancel` function wasn't always being executed. Simplified the err handling around Filter Query and replaced `switch/case` with `defer cancel()` and `if/err`.