### PR TITLE
dtl: fix openapi

### DIFF
--- a/packages/data-transport-layer/openapi.yml
+++ b/packages/data-transport-layer/openapi.yml
@@ -76,8 +76,8 @@ components:
           type: string
         queueOrigin:
           type: string
-        queueIndex: number
-          type: string
+        queueIndex:
+          type: number
         decoded:
           type: object
           $ref: '#/components/schemas/DecodedSequencerBatchTransaction'


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This pull request fix opnenapi typo to enable postman import.

**Additional context**
I try importing openapi through postman. But It doesn't work. So I find typo in openapi

**Metadata**
