### PR TITLE
l2geth: fix log.Crit usage

### DIFF
--- a/.changeset/new-hairs-scream.md
+++ b/.changeset/new-hairs-scream.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': minor
+---
+
+rollup: fix log.Crit usage

--- a/.changeset/three-eggs-approve.md
+++ b/.changeset/three-eggs-approve.md
@@ -1,5 +1,5 @@
 ---
-'@eth-optimism/l2geth': minor
+'@eth-optimism/l2geth': patch
 ---
 
 rollup: fix log.Crit usage

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -247,10 +247,10 @@ func (s *SyncService) Start() error {
 	} else {
 		go func() {
 			if err := s.syncTransactionsToTip(); err != nil {
-				log.Crit("Sequencer cannot sync transactions to tip: %w", err)
+				log.Crit("Sequencer cannot sync transactions to tip", "err", err)
 			}
 			if err := s.syncQueueToTip(); err != nil {
-				log.Crit("Sequencer cannot sync queue to tip: %w", err)
+				log.Crit("Sequencer cannot sync queue to tip", "err", err)
 			}
 			s.setSyncStatus(false)
 			go s.SequencerLoop()


### PR DESCRIPTION
fix log.Crit usage
```
log.Crit("Sequencer cannot sync transactions to tip: %w", err)
log.Crit("Sequencer cannot sync queue to tip: %w", err)
```

->

```
log.Crit("Sequencer cannot sync transactions to tip", "err", err)
log.Crit("Sequencer cannot sync queue to tip", "err", err)
```