### PR TITLE
indexer: fix context reuse in bridge filter query

### DIFF
--- a/.changeset/stupid-apples-glow.md
+++ b/.changeset/stupid-apples-glow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/indexer': patch
+---
+
+fix context reuse

--- a/go/indexer/services/l1/bridge/eth_bridge.go
+++ b/go/indexer/services/l1/bridge/eth_bridge.go
@@ -24,10 +24,9 @@ func (e *EthBridge) Address() common.Address {
 func (e *EthBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap, error) {
 	depositsByBlockhash := make(DepositsMap)
 
-	iter, err := FilterETHDepositInitiatedWithRetry(e.filterer, &bind.FilterOpts{
-		Start:   start,
-		End:     &end,
-		Context: e.ctx,
+	iter, err := FilterETHDepositInitiatedWithRetry(e.ctx, e.filterer, &bind.FilterOpts{
+		Start: start,
+		End:   &end,
 	})
 	if err != nil {
 		logger.Error("Error fetching filter", "err", err)

--- a/go/indexer/services/l1/bridge/filter.go
+++ b/go/indexer/services/l1/bridge/filter.go
@@ -15,54 +15,48 @@ var clientRetryInterval = 5 * time.Second
 
 // FilterStateBatchAppendedWithRetry retries the given func until it succeeds,
 // waiting for clientRetryInterval duration after every call.
-func FilterStateBatchAppendedWithRetry(filterer *scc.StateCommitmentChainFilterer, opts *bind.FilterOpts) (*scc.StateCommitmentChainStateBatchAppendedIterator, error) {
+func FilterStateBatchAppendedWithRetry(ctx context.Context, filterer *scc.StateCommitmentChainFilterer, opts *bind.FilterOpts) (*scc.StateCommitmentChainStateBatchAppendedIterator, error) {
 	for {
-		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
 		opts.Context = ctxt
 		res, err := filterer.FilterStateBatchAppended(opts, nil)
-		switch err {
-		case nil:
-			cancel()
-			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
+		cancel()
+		if err == nil {
+			return res, nil
 		}
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }
 
 // FilterETHDepositInitiatedWithRetry retries the given func until it succeeds,
 // waiting for clientRetryInterval duration after every call.
-func FilterETHDepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeETHDepositInitiatedIterator, error) {
+func FilterETHDepositInitiatedWithRetry(ctx context.Context, filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeETHDepositInitiatedIterator, error) {
 	for {
-		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
 		opts.Context = ctxt
 		res, err := filterer.FilterETHDepositInitiated(opts, nil, nil)
-		switch err {
-		case nil:
-			cancel()
-			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
+		cancel()
+		if err == nil {
+			return res, nil
 		}
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }
 
 // FilterERC20DepositInitiatedWithRetry retries the given func until it succeeds,
 // waiting for clientRetryInterval duration after every call.
-func FilterERC20DepositInitiatedWithRetry(filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeERC20DepositInitiatedIterator, error) {
+func FilterERC20DepositInitiatedWithRetry(ctx context.Context, filterer *l1bridge.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*l1bridge.L1StandardBridgeERC20DepositInitiatedIterator, error) {
 	for {
-		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
 		opts.Context = ctxt
 		res, err := filterer.FilterERC20DepositInitiated(opts, nil, nil, nil)
-		switch err {
-		case nil:
-			cancel()
-			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
+		cancel()
+		if err == nil {
+			return res, nil
 		}
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }

--- a/go/indexer/services/l1/bridge/standard_bridge.go
+++ b/go/indexer/services/l1/bridge/standard_bridge.go
@@ -24,10 +24,9 @@ func (s *StandardBridge) Address() common.Address {
 func (s *StandardBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap, error) {
 	depositsByBlockhash := make(DepositsMap)
 
-	iter, err := FilterERC20DepositInitiatedWithRetry(s.filterer, &bind.FilterOpts{
-		Start:   start,
-		End:     &end,
-		Context: s.ctx,
+	iter, err := FilterERC20DepositInitiatedWithRetry(s.ctx, s.filterer, &bind.FilterOpts{
+		Start: start,
+		End:   &end,
 	})
 	if err != nil {
 		logger.Error("Error fetching filter", "err", err)

--- a/go/indexer/services/l1/query.go
+++ b/go/indexer/services/l1/query.go
@@ -44,10 +44,9 @@ func QueryERC20(address common.Address, client *ethclient.Client) (*db.Token, er
 func QueryStateBatches(filterer *scc.StateCommitmentChainFilterer, startHeight, endHeight uint64, ctx context.Context) (map[common.Hash][]db.StateBatch, error) {
 	batches := make(map[common.Hash][]db.StateBatch)
 
-	iter, err := bridge.FilterStateBatchAppendedWithRetry(filterer, &bind.FilterOpts{
-		Start:   startHeight,
-		End:     &endHeight,
-		Context: ctx,
+	iter, err := bridge.FilterStateBatchAppendedWithRetry(ctx, filterer, &bind.FilterOpts{
+		Start: startHeight,
+		End:   &endHeight,
 	})
 	if err != nil {
 		return nil, err

--- a/go/indexer/services/l2/bridge/filter.go
+++ b/go/indexer/services/l2/bridge/filter.go
@@ -14,18 +14,16 @@ var clientRetryInterval = 5 * time.Second
 
 // FilterWithdrawalInitiatedWithRetry retries the given func until it succeeds,
 // waiting for clientRetryInterval duration after every call.
-func FilterWithdrawalInitiatedWithRetry(filterer *l2bridge.L2StandardBridgeFilterer, opts *bind.FilterOpts) (*l2bridge.L2StandardBridgeWithdrawalInitiatedIterator, error) {
+func FilterWithdrawalInitiatedWithRetry(ctx context.Context, filterer *l2bridge.L2StandardBridgeFilterer, opts *bind.FilterOpts) (*l2bridge.L2StandardBridgeWithdrawalInitiatedIterator, error) {
 	for {
-		ctxt, cancel := context.WithTimeout(opts.Context, DefaultConnectionTimeout)
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
 		opts.Context = ctxt
 		res, err := filterer.FilterWithdrawalInitiated(opts, nil, nil, nil)
-		switch err {
-		case nil:
-			cancel()
-			return res, err
-		default:
-			logger.Error("Error fetching filter", "err", err)
+		cancel()
+		if err == nil {
+			return res, nil
 		}
+		logger.Error("Error fetching filter", "err", err)
 		time.Sleep(clientRetryInterval)
 	}
 }

--- a/go/indexer/services/l2/bridge/standard_bridge.go
+++ b/go/indexer/services/l2/bridge/standard_bridge.go
@@ -25,10 +25,9 @@ func (s *StandardBridge) Address() common.Address {
 func (s *StandardBridge) GetWithdrawalsByBlockRange(start, end uint64) (WithdrawalsMap, error) {
 	withdrawalsByBlockhash := make(map[common.Hash][]db.Withdrawal)
 
-	iter, err := FilterWithdrawalInitiatedWithRetry(s.filterer, &bind.FilterOpts{
-		Start:   start,
-		End:     &end,
-		Context: s.ctx,
+	iter, err := FilterWithdrawalInitiatedWithRetry(s.ctx, s.filterer, &bind.FilterOpts{
+		Start: start,
+		End:   &end,
 	})
 	if err != nil {
 		logger.Error("Error fetching filter", "err", err)


### PR DESCRIPTION
**Description**
This PR addresses an issue with the indexer where a long running service stalls with the error: `context deadline exceeded`.

This was happening because the context for the first `FilterWithdrawalInitiatedWithRetry` call was being re-used in _all subsequent_ calls. This means that if for whatever reason, _one_ request to the API fails to complete within the deadline, _all_ subsequent calls will fail with the same error.

I have reproduced the underlying cause of the error in this minimal gist: [https://gist.github.com/tuxcanfly/28bee3ef233764d9d7ea6d63cbae48f6
](https://gist.github.com/tuxcanfly/28bee3ef233764d9d7ea6d63cbae48f6)

With this fix the parent context remains separate from all the retry context which are all the direct children of the parent context.

The parent context is passed in to the `FilterWithdrawalInitiatedWithRetry` method as the first argument, then the child context is drawn from it and used for the API call by using `Opts.Context`. Separating out the contexts like this avoids the confusion around the context scope which lead to this bug.

Aside from this reuse bug, we were also not calling `cancel` for the retry context in the error case. This has been fixed.