### PR TITLE
l2geth: Record rollup transaction metrics

### DIFF
--- a/.changeset/tidy-oranges-float.md
+++ b/.changeset/tidy-oranges-float.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+l2geth: Record rollup transaction metrics


### PR DESCRIPTION
Adds metrics for transaction execution. These metrics were only collected when `USING_OVM=false` as a rollup node uses a different codepath during metrics collection.

The immediate usecase for this is to be able to estimate when indexers and vm tracers will no longer keep up with the increasing rate of transactions executed by replicas.