### PR TITLE
proxyd: Reduce RPC request logging

### DIFF
--- a/.changeset/flat-goats-itch.md
+++ b/.changeset/flat-goats-itch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+proxyd: Reduced RPC request logging


### PR DESCRIPTION
Logging the entire RPC request can be too "expensive" when logging request
objects in a large JSON-RPC batch request. We log the raw HTTP request
body instead so we can truncate effectively when the entire body
exceeds the maxLogLength.