### PR TITLE
maint(ct): cleanup AddressDictator, ChugSplashDicator and WETH9 tests

### DIFF
--- a/packages/contracts/test/contracts/L1/deployment/AddressDictator.spec.ts
+++ b/packages/contracts/test/contracts/L1/deployment/AddressDictator.spec.ts
@@ -1,12 +1,13 @@
 import { ethers } from 'hardhat'
-import { Contract, Signer } from 'ethers'
+import { Contract } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 
 import { expect } from '../../../setup'
 import { deploy, NON_ZERO_ADDRESS } from '../../../helpers'
 
 describe('AddressDictator', () => {
-  let signer1: Signer
-  let signer2: Signer
+  let signer1: SignerWithAddress
+  let signer2: SignerWithAddress
   before(async () => {
     ;[signer1, signer2] = await ethers.getSigners()
   })
@@ -22,15 +23,13 @@ describe('AddressDictator', () => {
       signer: signer1,
       args: [
         Lib_AddressManager.address,
-        await signer1.getAddress(),
+        signer1.address,
         ['addr1'],
         [NON_ZERO_ADDRESS],
       ],
     })
 
-    Lib_AddressManager.connect(signer1).transferOwnership(
-      AddressDictator.address
-    )
+    Lib_AddressManager.transferOwnership(AddressDictator.address)
   })
 
   describe('initialize', () => {
@@ -40,7 +39,7 @@ describe('AddressDictator', () => {
           signer: signer1,
           args: [
             Lib_AddressManager.address,
-            await signer1.getAddress(),
+            signer1.address,
             ['addr1', 'addr2'],
             [NON_ZERO_ADDRESS],
           ],
@@ -70,8 +69,7 @@ describe('AddressDictator', () => {
 
   describe('returnOwnership', () => {
     it('should transfer contract ownership to finalOwner', async () => {
-      await expect(AddressDictator.connect(signer1).returnOwnership()).to.not.be
-        .reverted
+      await expect(AddressDictator.returnOwnership()).to.not.be.reverted
     })
 
     it('should revert when called by non-owner', async () => {

--- a/packages/contracts/test/contracts/L1/deployment/ChugSplashDictator.spec.ts
+++ b/packages/contracts/test/contracts/L1/deployment/ChugSplashDictator.spec.ts
@@ -1,12 +1,13 @@
 import { ethers } from 'hardhat'
-import { Contract, Signer } from 'ethers'
+import { Contract } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 
 import { expect } from '../../../setup'
 import { deploy } from '../../../helpers'
 
 describe('ChugSplashDictator', () => {
-  let signer1: Signer
-  let signer2: Signer
+  let signer1: SignerWithAddress
+  let signer2: SignerWithAddress
   before(async () => {
     ;[signer1, signer2] = await ethers.getSigners()
   })
@@ -16,14 +17,14 @@ describe('ChugSplashDictator', () => {
   beforeEach(async () => {
     L1ChugSplashProxy = await deploy('L1ChugSplashProxy', {
       signer: signer1,
-      args: [await signer1.getAddress()],
+      args: [signer1.address],
     })
 
     ChugSplashDictator = await deploy('ChugSplashDictator', {
       signer: signer1,
       args: [
         L1ChugSplashProxy.address,
-        await signer1.getAddress(),
+        signer1.address,
         ethers.utils.keccak256('0x1111'),
         ethers.utils.keccak256('0x1234'),
         ethers.utils.keccak256('0x5678'),
@@ -32,9 +33,7 @@ describe('ChugSplashDictator', () => {
       ],
     })
 
-    await L1ChugSplashProxy.connect(signer1).setOwner(
-      ChugSplashDictator.address
-    )
+    await L1ChugSplashProxy.setOwner(ChugSplashDictator.address)
   })
 
   describe('doActions', () => {
@@ -45,15 +44,13 @@ describe('ChugSplashDictator', () => {
     })
 
     it('should set the proxy code, storage & owner', async () => {
-      await expect(ChugSplashDictator.connect(signer1).doActions('0x1111')).to
-        .not.be.reverted
+      await expect(ChugSplashDictator.doActions('0x1111')).to.not.be.reverted
     })
   })
 
   describe('returnOwnership', () => {
     it('should transfer contractc ownership to finalOwner', async () => {
-      await expect(ChugSplashDictator.connect(signer1).returnOwnership()).to.not
-        .be.reverted
+      await expect(ChugSplashDictator.returnOwnership()).to.not.be.reverted
     })
 
     it('should revert when called by non-owner', async () => {

--- a/packages/contracts/test/contracts/L2/predeploys/WETH9.spec.ts
+++ b/packages/contracts/test/contracts/L2/predeploys/WETH9.spec.ts
@@ -1,32 +1,21 @@
-/* External Imports */
 import { ethers } from 'hardhat'
-import { Contract, Signer, ContractFactory } from 'ethers'
-import {
-  smock,
-  MockContractFactory,
-  MockContract,
-} from '@defi-wonderland/smock'
+import { Contract } from 'ethers'
+import { smock, MockContract } from '@defi-wonderland/smock'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 
-/* Internal Imports */
 import { expect } from '../../../setup'
 
 describe('WETH9', () => {
-  let signer: Signer
-  let otherSigner: Signer
-  let signerAddress: string
-  let otherSignerAddress: string
+  let signer: SignerWithAddress
+  let otherSigner: SignerWithAddress
 
-  let Mock__Factory_WETH9: MockContractFactory<ContractFactory>
-  let Mock__WETH9: MockContract<Contract>
   before(async () => {
     ;[signer, otherSigner] = await ethers.getSigners()
-    signerAddress = await signer.getAddress()
-    otherSignerAddress = await otherSigner.getAddress()
   })
 
+  let Mock__WETH9: MockContract<Contract>
   beforeEach(async () => {
-    Mock__Factory_WETH9 = await smock.mock('WETH9')
-    Mock__WETH9 = await Mock__Factory_WETH9.deploy()
+    Mock__WETH9 = await (await smock.mock('WETH9')).deploy()
   })
 
   describe('deposit', () => {
@@ -38,26 +27,25 @@ describe('WETH9', () => {
         })
       ).to.not.be.reverted
 
-      expect(await Mock__WETH9.balanceOf(signerAddress)).to.be.equal(200)
+      expect(await Mock__WETH9.balanceOf(signer.address)).to.be.equal(200)
     })
 
     it('should create WETH with deposit function', async () => {
-      await expect(Mock__WETH9.connect(signer).deposit({ value: 100 })).to.not
-        .be.reverted
+      await expect(Mock__WETH9.deposit({ value: 100 })).to.not.be.reverted
 
-      expect(await Mock__WETH9.balanceOf(signerAddress)).to.be.equal(100)
+      expect(await Mock__WETH9.balanceOf(signer.address)).to.be.equal(100)
     })
   })
 
   describe('withdraw', () => {
     it('should revert when withdraw amount is bigger than balance', async () => {
-      await expect(Mock__WETH9.connect(signer).withdraw(10000)).to.be.reverted
+      await expect(Mock__WETH9.withdraw(10000)).to.be.reverted
     })
 
     it('should withdraw to eth', async () => {
-      await Mock__WETH9.connect(signer).deposit({ value: 100 })
-      await expect(Mock__WETH9.connect(signer).withdraw(50)).to.not.be.reverted
-      expect(await Mock__WETH9.balanceOf(signerAddress)).to.be.equal(50)
+      await Mock__WETH9.deposit({ value: 100 })
+      await expect(Mock__WETH9.withdraw(50)).to.not.be.reverted
+      expect(await Mock__WETH9.balanceOf(signer.address)).to.be.equal(50)
     })
   })
 
@@ -69,42 +57,41 @@ describe('WETH9', () => {
 
   describe('transfer', () => {
     it('should revert when sending more than deposited', async () => {
-      await Mock__WETH9.connect(signer).deposit({ value: 100 })
-      await expect(
-        Mock__WETH9.connect(signer).transfer(otherSignerAddress, 500)
-      ).to.be.reverted
+      await Mock__WETH9.deposit({ value: 100 })
+      await expect(Mock__WETH9.transfer(otherSigner.address, 500)).to.be
+        .reverted
     })
 
     it('should transfer WETH to an other address', async () => {
-      await Mock__WETH9.connect(signer).deposit({ value: 100 })
-      await expect(Mock__WETH9.connect(signer).transfer(otherSignerAddress, 50))
-        .to.not.be.reverted
+      await Mock__WETH9.deposit({ value: 100 })
+      await expect(Mock__WETH9.transfer(otherSigner.address, 50)).to.not.be
+        .reverted
 
-      expect(await Mock__WETH9.balanceOf(signerAddress)).to.be.equal(50)
+      expect(await Mock__WETH9.balanceOf(signer.address)).to.be.equal(50)
 
-      expect(await Mock__WETH9.balanceOf(otherSignerAddress)).to.be.equal(50)
+      expect(await Mock__WETH9.balanceOf(otherSigner.address)).to.be.equal(50)
     })
   })
 
   describe('transferFrom', () => {
     it('should revert when there is no allowance', async () => {
-      await Mock__WETH9.connect(signer).deposit({ value: 100 })
+      await Mock__WETH9.deposit({ value: 100 })
       await expect(
         Mock__WETH9.connect(otherSigner).transferFrom(
-          signerAddress,
-          otherSignerAddress,
+          signer.address,
+          otherSigner.address,
           50
         )
       ).to.be.reverted
     })
 
     it('should transfer WETH to an other address when there is approvement', async () => {
-      await Mock__WETH9.connect(signer).deposit({ value: 100 })
-      await Mock__WETH9.connect(signer).approve(otherSignerAddress, 50)
+      await Mock__WETH9.deposit({ value: 100 })
+      await Mock__WETH9.approve(otherSigner.address, 50)
       await expect(
         Mock__WETH9.connect(otherSigner).transferFrom(
-          signerAddress,
-          otherSignerAddress,
+          signer.address,
+          otherSigner.address,
           50
         )
       ).to.not.be.reverted


### PR DESCRIPTION
Another test cleanup, this time for AddressDictator, ChugSplashDictator
and WETH9. Putting them in the same PR since 2 of the files have very
few changes.