### PR TITLE
cleanup: Replace getNetwork() calls with getChainId()

### DIFF
--- a/.changeset/nice-sloths-watch.md
+++ b/.changeset/nice-sloths-watch.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/message-relayer': patch
+---
+
+Replaced getNetwork() calls with getChainId()

--- a/integration-tests/tasks/check-block-hashes.ts
+++ b/integration-tests/tasks/check-block-hashes.ts
@@ -1,5 +1,6 @@
 import { task } from 'hardhat/config'
 import { providers } from 'ethers'
+import { getChainId } from '@eth-optimism/core-utils'
 
 import { die, logStderr } from '../test/shared/utils'
 
@@ -13,22 +14,22 @@ task(
     const providerA = new providers.JsonRpcProvider(replicaA)
     const providerB = new providers.JsonRpcProvider(replicaB)
 
-    let netA
-    let netB
+    let netIdA
+    let netIdB
     try {
-      netA = await providerA.getNetwork()
+      netIdA = await getChainId(providerA)
     } catch (e) {
-      console.error(`Error getting network from ${replicaA}:`)
+      console.error(`Error getting chain ID from ${replicaA}:`)
       die(e)
     }
     try {
-      netB = await providerA.getNetwork()
+      netIdB = await getChainId(providerA)
     } catch (e) {
-      console.error(`Error getting network from ${replicaB}:`)
+      console.error(`Error getting chain ID from ${replicaB}:`)
       die(e)
     }
 
-    if (netA.chainId !== netB.chainId) {
+    if (netIdA !== netIdB) {
       die('Chain IDs do not match')
       return
     }

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -1,5 +1,5 @@
 /* Imports: External */
-import { expectApprox, sleep } from '@eth-optimism/core-utils'
+import { expectApprox, getChainId, sleep } from '@eth-optimism/core-utils'
 import { Wallet, BigNumber, Contract, ContractFactory, constants } from 'ethers'
 import { serialize } from '@ethersproject/transactions'
 import { ethers } from 'hardhat'
@@ -471,7 +471,7 @@ describe('Basic RPC tests', () => {
 
   describe('eth_chainId', () => {
     it('should get the correct chainid', async () => {
-      const { chainId } = await env.l2Provider.getNetwork()
+      const chainId = await getChainId(env.l2Provider)
       expect(chainId).to.be.eq(L2_CHAINID)
     })
   })

--- a/integration-tests/test/shared/env.ts
+++ b/integration-tests/test/shared/env.ts
@@ -4,7 +4,7 @@ import {
   TransactionResponse,
   TransactionReceipt,
 } from '@ethersproject/providers'
-import { sleep } from '@eth-optimism/core-utils'
+import { getChainId, sleep } from '@eth-optimism/core-utils'
 import {
   CrossChainMessenger,
   MessageStatus,
@@ -54,12 +54,10 @@ export class OptimismEnv {
   }
 
   static async new(): Promise<OptimismEnv> {
-    const network = await l1Provider.getNetwork()
-
     const messenger = new CrossChainMessenger({
       l1SignerOrProvider: l1Wallet,
       l2SignerOrProvider: l2Wallet,
-      l1ChainId: network.chainId,
+      l1ChainId: await getChainId(l1Provider),
       contracts: {
         l1: {
           AddressManager: envConfig.ADDRESS_MANAGER,
@@ -68,8 +66,8 @@ export class OptimismEnv {
           StateCommitmentChain: envConfig.STATE_COMMITMENT_CHAIN,
           CanonicalTransactionChain: envConfig.CANONICAL_TRANSACTION_CHAIN,
           BondManager: envConfig.BOND_MANAGER,
-        }
-      }
+        },
+      },
     })
 
     // fund the user if needed

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -1,7 +1,7 @@
 /* Imports: External */
 import { BaseService, Metrics } from '@eth-optimism/common-ts'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
-import { sleep, toRpcHexString } from '@eth-optimism/core-utils'
+import { getChainId, sleep, toRpcHexString } from '@eth-optimism/core-utils'
 import { BigNumber } from 'ethers'
 import { LevelUp } from 'levelup'
 import axios from 'axios'
@@ -127,9 +127,9 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
   }
 
   protected async checkConsistency(): Promise<void> {
-    const network = await this.state.l2RpcProvider.getNetwork()
+    const networkId = await getChainId(this.state.l2RpcProvider)
     const shouldDoCheck = !(await this.state.db.getConsistencyCheckFlag())
-    if (shouldDoCheck && network.chainId === 69) {
+    if (shouldDoCheck && networkId === 69) {
       this.logger.info('performing consistency check')
       const highestBlock =
         await this.state.db.getHighestSyncedUnconfirmedBlock()

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import { Signer } from 'ethers'
-import { sleep } from '@eth-optimism/core-utils'
+import { sleep, getChainId } from '@eth-optimism/core-utils'
 import {
   BaseServiceV2,
   validators,
@@ -80,12 +80,10 @@ export class MessageRelayerService extends BaseServiceV2<
       this.options.l1RpcProvider
     )
 
-    const l1Network = await this.state.wallet.provider.getNetwork()
-    const l1ChainId = l1Network.chainId
     this.state.messenger = new CrossChainMessenger({
       l1SignerOrProvider: this.state.wallet,
       l2SignerOrProvider: this.options.l2RpcProvider,
-      l1ChainId,
+      l1ChainId: await getChainId(this.state.wallet.provider),
     })
 
     this.state.highestCheckedL2Tx = this.options.fromL2TransactionIndex || 1


### PR DESCRIPTION
**Description**
Replace getNetwork() calls with getChainId()

**Metadata**
- Fixes #2520
