### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/hungry-turkeys-repeat.md
+++ b/.changeset/hungry-turkeys-repeat.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/teleportr': patch
----
-
-Fix confs_remaining calculation to prevent underflow

--- a/.changeset/strange-falcons-punch.md
+++ b/.changeset/strange-falcons-punch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+proxyd: Proxy requests using batch JSON-RPC

--- a/.changeset/strange-falcons-punch.md
+++ b/.changeset/strange-falcons-punch.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': patch
----
-
-proxyd: Proxy requests using batch JSON-RPC

--- a/.changeset/thirty-garlics-know.md
+++ b/.changeset/thirty-garlics-know.md
@@ -1,8 +1,0 @@
----
-'@eth-optimism/integration-tests': patch
-'@eth-optimism/contracts': patch
-'@eth-optimism/data-transport-layer': patch
-'@eth-optimism/message-relayer': patch
----
-
-Replace calls to getNetwork() with getChainId util

--- a/integration-tests/CHANGELOG.md
+++ b/integration-tests/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/integration-tests
 
+## 0.5.13
+
+### Patch Changes
+
+- 412688d5: Replace calls to getNetwork() with getChainId util
+
 ## 0.5.12
 
 ### Patch Changes

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/integration-tests",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "[Optimism] Integration tests",
   "scripts": {
     "lint": "yarn lint:fix && yarn lint:check",
@@ -28,9 +28,9 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "devDependencies": {
-    "@eth-optimism/contracts": "0.5.22",
+    "@eth-optimism/contracts": "0.5.23",
     "@eth-optimism/core-utils": "0.8.4",
-    "@eth-optimism/sdk": "1.1.2",
+    "@eth-optimism/sdk": "1.1.3",
     "@ethersproject/abstract-provider": "^5.5.1",
     "@ethersproject/providers": "^5.5.3",
     "@ethersproject/transactions": "^5.5.0",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.23
+
+### Patch Changes
+
+- 412688d5: Replace calls to getNetwork() with getChainId util
+
 ## 0.5.22
 
 ### Patch Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "[Optimism] L1 and L2 smart contracts for Optimism",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/data-transport-layer/CHANGELOG.md
+++ b/packages/data-transport-layer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # data transport layer
 
+## 0.5.29
+
+### Patch Changes
+
+- 412688d5: Replace calls to getNetwork() with getChainId util
+- Updated dependencies [412688d5]
+  - @eth-optimism/contracts@0.5.23
+
 ## 0.5.28
 
 ### Patch Changes

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/data-transport-layer",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "description": "[Optimism] Service for shuttling data from L1 into L2",
   "main": "dist/index",
   "types": "dist/index",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.7",
-    "@eth-optimism/contracts": "0.5.22",
+    "@eth-optimism/contracts": "0.5.23",
     "@eth-optimism/core-utils": "0.8.4",
     "@ethersproject/providers": "^5.5.3",
     "@ethersproject/transactions": "^5.5.0",

--- a/packages/message-relayer/CHANGELOG.md
+++ b/packages/message-relayer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/message-relayer
 
+## 0.4.8
+
+### Patch Changes
+
+- 412688d5: Replace calls to getNetwork() with getChainId util
+  - @eth-optimism/sdk@1.1.3
+
 ## 0.4.7
 
 ### Patch Changes

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/message-relayer",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@eth-optimism/common-ts": "0.2.7",
     "@eth-optimism/core-utils": "0.8.4",
-    "@eth-optimism/sdk": "1.1.2",
+    "@eth-optimism/sdk": "1.1.3",
     "ethers": "^5.5.4"
   },
   "devDependencies": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/sdk
 
+## 1.1.3
+
+### Patch Changes
+
+- Updated dependencies [412688d5]
+  - @eth-optimism/contracts@0.5.23
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -65,7 +65,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@eth-optimism/contracts": "0.5.22",
+    "@eth-optimism/contracts": "0.5.23",
     "@eth-optimism/core-utils": "0.8.4",
     "lodash": "^4.17.21",
     "merkletreejs": "^0.2.27",

--- a/proxyd/CHANGELOG.md
+++ b/proxyd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/proxyd
 
+## 3.8.6
+
+### Patch Changes
+
+- d79d40c4: proxyd: Proxy requests using batch JSON-RPC
+
 ## 3.8.5
 
 ### Patch Changes

--- a/proxyd/package.json
+++ b/proxyd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/proxyd",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "private": true,
   "dependencies": {}
 }

--- a/teleportr/CHANGELOG.md
+++ b/teleportr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/teleportr
 
+## 0.0.5
+
+### Patch Changes
+
+- 44c293d8: Fix confs_remaining calculation to prevent underflow
+
 ## 0.0.4
 
 ### Patch Changes

--- a/teleportr/package.json
+++ b/teleportr/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eth-optimism/teleportr",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"private": true,
 	"devDependencies": {}
 }


### PR DESCRIPTION
* contracts - Replace calls to getNetwork() with getChainId util
* sdk - Updated dependencies [https://github.com/ethereum-optimism/optimism/commit/412688d5129485f8b86c23c6c23c0fea219d5621]
@eth-optimism/contracts@0.5.23
* integration-tests - replace calls to getNetwork() with getChainId util
* message-relayer - Replace calls to getNetwork() with getChainId util
@eth-optimism/sdk@1.1.3
* proxyd - Proxy requests using batch JSON-RPC
* teleportr - Fix confs_remaining calculation to prevent underflow