### PR TITLE
Inomurko/fix openapi spec for dtl

### DIFF
--- a/packages/data-transport-layer/openapi.yml
+++ b/packages/data-transport-layer/openapi.yml
@@ -207,6 +207,7 @@ paths:
           name: number
           schema:
             type: integer
+            format: "int64"
           required: true
       summary: Returns the Ethereum Layer one context at a specific height
       description: |
@@ -240,6 +241,7 @@ paths:
           name: index
           schema:
             type: integer
+            format: "int64"
           required: true
       summary: Returns the enqueued transaction by index
       description: |
@@ -273,6 +275,7 @@ paths:
           name: index
           schema:
             type: integer
+            format: "int64"
           required: true
       summary: Returns a Canonical Transaction Chain transaction by index
       description: |
@@ -307,6 +310,7 @@ paths:
           name: index
           schema:
             type: integer
+            format: "int64"
           required: true
       summary: Returns the Batch to be appended to the Canonical Transaction Chain by index
       description: |
@@ -340,6 +344,7 @@ paths:
           name: index
           schema:
             type: integer
+            format: "int64"
           required: true
       summary: Returns the state root by index
       description: |
@@ -373,6 +378,7 @@ paths:
           name: index
           schema:
             type: integer
+            format: "int64"
           required: true
       description: |
         This returns a state root batch appended to the State Commitment Chain by index

--- a/packages/data-transport-layer/openapi.yml
+++ b/packages/data-transport-layer/openapi.yml
@@ -11,8 +11,10 @@ components:
       properties:
         blockNumber:
           type: integer
+          format: "int64"
         timestamp:
           type: integer
+          format: "int64"
         blockHash:
           type: string
     EnqueueEntry:
@@ -179,8 +181,10 @@ paths:
                     type: boolean
                   currentTransactionIndex:
                     type: integer
+                    format: "int64"
                   highestKnownTransactionIndex:
                     type: integer
+                    format: "int64"
 
   /eth/context/latest:
     get:

--- a/packages/data-transport-layer/openapi.yml
+++ b/packages/data-transport-layer/openapi.yml
@@ -10,9 +10,9 @@ components:
       type: object
       properties:
         blockNumber:
-          type: uint64
+          type: integer
         timestamp:
-          type: uint64
+          type: integer
         blockHash:
           type: string
     EnqueueEntry:
@@ -131,22 +131,22 @@ components:
     StateRootEntry:
       type: object
       properties:
-      index:
-        type: number
-      batchIndex:
-        type: number
-      value:
-        type: string
+        index:
+          type: number
+        batchIndex:
+          type: number
+        value:
+          type: string
 
     StateRootResponse:
       type: object
       properties:
-      batch:
-        type: object
-        $ref: '#/components/schemas/BatchEntry'
-      stateRoot:
-        type: object
-        $ref: '#/components/schemas/StateRootEntry'
+        batch:
+          type: object
+          $ref: '#/components/schemas/BatchEntry'
+        stateRoot:
+          type: object
+          $ref: '#/components/schemas/StateRootEntry'
 
     StateRootBatchResponse:
       type: object
@@ -178,9 +178,9 @@ paths:
                   syncing:
                     type: boolean
                   currentTransactionIndex:
-                    type: uint64
+                    type: integer
                   highestKnownTransactionIndex:
-                    type: uint64
+                    type: integer
 
   /eth/context/latest:
     get:
@@ -198,6 +198,12 @@ paths:
 
   /eth/context/blocknumber/{number}:
     get:
+      parameters:
+        - in: path
+          name: number
+          schema:
+            type: integer
+          required: true
       summary: Returns the Ethereum Layer one context at a specific height
       description: |
         This returns the L1 blocknumber, block hash and timestamp corresponding to a specific
@@ -225,6 +231,12 @@ paths:
 
   /enqueue/index/{index}:
     get:
+      parameters:
+        - in: path
+          name: index
+          schema:
+            type: integer
+          required: true
       summary: Returns the enqueued transaction by index
       description: |
         This returns the Canonical Transaction Chain `enqueue()` by index
@@ -252,6 +264,12 @@ paths:
 
   /transaction/index/{index}:
     get:
+      parameters:
+        - in: path
+          name: index
+          schema:
+            type: integer
+          required: true
       summary: Returns a Canonical Transaction Chain transaction by index
       description: |
         This returns a transaction that has been appended to the Canonical Transaction
@@ -280,6 +298,12 @@ paths:
 
   /batch/transaction/index/{index}:
     get:
+      parameters:
+        - in: path
+          name: index
+          schema:
+            type: integer
+          required: true
       summary: Returns the Batch to be appended to the Canonical Transaction Chain by index
       description: |
         This returns a batch that has been appended to the Canonical Transaction
@@ -307,6 +331,12 @@ paths:
 
   /stateroot/index/{index}:
     get:
+      parameters:
+        - in: path
+          name: index
+          schema:
+            type: integer
+          required: true
       summary: Returns the state root by index
       description: |
         This returns a state root appended to the State Commitment Chain by index
@@ -334,6 +364,12 @@ paths:
   /batch/stateroot/index/{index}:
     get:
       summary: Returns the state root batch by index
+      parameters:
+        - in: path
+          name: index
+          schema:
+            type: integer
+          required: true
       description: |
         This returns a state root batch appended to the State Commitment Chain by index
       responses:


### PR DESCRIPTION

**Description**
Generating client code from the OpenAPI spec in the repo produced a number of errors. 
Same for using the online editor: https://editor.swagger.io/
```
docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
    -i https://raw.githubusercontent.com/ethereum-optimism/optimism/develop/packages/data-transport-layer/openapi.yml \
    -g java \
    -o /local/out/java
```

