### PR TITLE
fix(sdk): bug causing error when no tx nonce given

### DIFF
--- a/.changeset/smart-readers-remember.md
+++ b/.changeset/smart-readers-remember.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Fixes a bug in the SDK which would cause the SDK to throw if no tx nonce is provided

--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -12,6 +12,27 @@ import { toProvider, toNumber, toBigNumber } from './utils'
 type ProviderTypeIsWrong = any
 
 /**
+ * Gets a reasonable nonce for the transaction.
+ *
+ * @param provider Provider to get the nonce from.
+ * @param tx Requested transaction.
+ * @returns A reasonable nonce for the transaction.
+ */
+const getNonceForTx = async (
+  provider: ProviderLike,
+  tx: TransactionRequest
+): Promise<number> => {
+  if (tx.nonce !== undefined) {
+    return toNumber(tx.nonce as NumberLike)
+  } else if (tx.from !== undefined) {
+    return toProvider(provider).getTransactionCount(tx.from)
+  } else {
+    // Large nonce with lots of non-zero bytes
+    return 0xffffffff
+  }
+}
+
+/**
  * Returns a Contract object for the GasPriceOracle.
  *
  * @param provider Provider to attach the contract to.
@@ -57,7 +78,7 @@ export const estimateL1Gas = async (
       gasPrice: tx.gasPrice,
       type: tx.type,
       gasLimit: tx.gasLimit,
-      nonce: toNumber(tx.nonce as NumberLike),
+      nonce: await getNonceForTx(l2Provider, tx),
     })
   )
 }
@@ -81,7 +102,7 @@ export const estimateL1GasCost = async (
       gasPrice: tx.gasPrice,
       type: tx.type,
       gasLimit: tx.gasLimit,
-      nonce: toNumber(tx.nonce as NumberLike),
+      nonce: await getNonceForTx(l2Provider, tx),
     })
   )
 }


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a bug in the SDK that would throw an error when the user did not
provide a nonce along with the transaction (when estimating gas). If no
nonce is provided, will try to find a reasonable nonce or use a default
(large) nonce that will give a good upper bound for the L1 gas cost.

**Metadata**
- Fixes #2555 