### PR TITLE
feat(op-node/p2p): resolve advertised hostname to ip for convenience

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -64,7 +64,7 @@ var (
 	}
 	AdvertiseIP = cli.StringFlag{
 		Name:     "p2p.advertise.ip",
-		Usage:    "The IP address to advertise in Discv5, put into the ENR of the node",
+		Usage:    "The IP address to advertise in Discv5, put into the ENR of the node. This may also be a hostname / domain name to resolve to an IP.",
 		Required: false,
 		// Ignored by default, nodes can discover their own external IP in the happy case,
 		// by communicating with bootnodes. Fixed IP is recommended for faster bootstrap though.

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -218,7 +218,17 @@ func (conf *Config) loadDiscoveryOpts(ctx *cli.Context) error {
 	}
 	adIP := ctx.GlobalString(flags.AdvertiseIP.Name)
 	if adIP != "" { // optional
-		conf.AdvertiseIP = net.ParseIP(adIP)
+		ips, err := net.LookupIP(adIP)
+		if err != nil {
+			return fmt.Errorf("failed to lookup IP of %q to advertise in ENR: %v", adIP, err)
+		}
+		// Find the first v4 IP it resolves to
+		for _, ip := range ips {
+			if ipv4 := ip.To4(); ipv4 != nil {
+				conf.AdvertiseIP = ipv4
+				break
+			}
+		}
 		if conf.AdvertiseIP == nil {
 			return fmt.Errorf("failed to parse IP %q", adIP)
 		}


### PR DESCRIPTION
Implements a small request from @optimisticben to resolve the hostname passed to `--p2p.advertise.ip` for convenience