### PR TITLE
bedrock-contracts: fix hardhat build

### DIFF
--- a/contracts-bedrock/hardhat.config.ts
+++ b/contracts-bedrock/hardhat.config.ts
@@ -25,7 +25,6 @@ task('accounts', 'Prints the list of accounts', async (_, hre) => {
 })
 
 const config: HardhatUserConfig = {
-  solidity: '0.8.10',
   networks: {
     devnetL1: {
       url: 'http://localhost:8545',
@@ -41,6 +40,32 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 0,
+    },
+  },
+  solidity: {
+    compilers: [
+      {
+        version: '0.8.10',
+        settings: {
+          optimizer: { enabled: true, runs: 10_000 },
+        },
+      },
+      {
+        version: '0.5.17', // Required for WETH9
+        settings: {
+          optimizer: { enabled: true, runs: 10_000 },
+        },
+      },
+    ],
+    settings: {
+      metadata: {
+        bytecodeHash: 'none',
+      },
+      outputSelection: {
+        '*': {
+          '*': ['metadata', 'storageLayout'],
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
**Description**

Adds in a compiler version for WETH9, since
it requires an older compiler version

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

