### PR TITLE
bindings: Notify users if builds deps are not found

### DIFF
--- a/op-bindings/gen_bindings.sh
+++ b/op-bindings/gen_bindings.sh
@@ -9,6 +9,16 @@ if [ "$#" -ne 2 ]; then
 	exit 1
 fi
 
+need_cmd() {
+  if ! command -v "$1" > /dev/null 2>&1; then
+    echo "need '$1' (command not found)"
+    exit 1
+  fi
+}
+
+need_cmd forge
+need_cmd abigen
+
 
 TYPE=$1
 PACKAGE=$2

--- a/op-bindings/gen_deployed_bytecode.sh
+++ b/op-bindings/gen_deployed_bytecode.sh
@@ -7,6 +7,15 @@ if [ "$#" -ne 2 ]; then
 	exit 1
 fi
 
+need_cmd() {
+  if ! command -v "$1" > /dev/null 2>&1; then
+    echo "need '$1' (command not found)"
+    exit 1
+  fi
+}
+
+need_cmd gofmt
+
 
 TYPE=$1
 PACKAGE=$2


### PR DESCRIPTION
**Description**
This specifically notifies users if abigen, forge, and gofmt are
not found in the path. This is to provide an early warning that
the commands are required instead of failing when attempting to
invoke the commands.