### PR TITLE
fix(deposits.md): Typo

### DIFF
--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -257,7 +257,7 @@ The deposit contract handles two special cases:
 
 If the caller is a contract, the address will be transformed by adding
 `0x1111000000000000000000000000000000001111` to it. This is the reverse of the
-transformation described in the [deposits spec](./withdrawals.md#address-aliasing). This prevents attacks in which a
+transformation described in the [withdrawal spec](./withdrawals.md#address-aliasing). This prevents attacks in which a
 contract on L1 has the same address as a contract on L2 but doesn't have the same code. We can safely ignore this
 for EOAs because they're guaranteed to have the same "code" (i.e. no code at all). This also makes
 it possible for users to interact with contracts on L2 even when the Sequencer is down.


### PR DESCRIPTION
Change link to say withdrawal spec rather than deposit spec, when it really goes to withdrawals.md

Instead of https://github.com/ethereum-optimism/optimistic-specs/pull/448/

