### PR TITLE
fix(cmn): legacy metrics binds to 0.0.0.0

### DIFF
--- a/.changeset/cyan-ravens-swim.md
+++ b/.changeset/cyan-ravens-swim.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Have legacy BaseService metrics bind to 0.0.0.0 by default

--- a/packages/common-ts/src/common/metrics.ts
+++ b/packages/common-ts/src/common/metrics.ts
@@ -56,7 +56,7 @@ export const createMetricsServer = async (
   })
 
   const port = options.port || 7300
-  const hostname = options.hostname || '127.0.0.1'
+  const hostname = options.hostname || '0.0.0.0'
   const server = app.listen(port, hostname, () => {
     logger.info('Metrics server started', {
       port,


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates legacy MetricsServer to bind to 0.0.0.0 instead of 127.0.0.1 by
default which makes it possible to expose the metrics server from inside
docker. Only the DTL is still using legacy metrics, so should be fine.
