### PR TITLE
fix(hc): reset metrics on ok connection

### DIFF
--- a/.changeset/smooth-bugs-sneeze.md
+++ b/.changeset/smooth-bugs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Have replica-healthcheck reset connection failures when connection is successful


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Has replica healthcheck reset connection failure metrics whenever the
connection is successful. This is more useful on the UI standpoint since
we're generally more interested in consecutive failures, not total
failures.
