### PR TITLE
proxyd: Handle unexpected JSON-RPC responses

### DIFF
--- a/.changeset/early-cougars-eat.md
+++ b/.changeset/early-cougars-eat.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+Improve robustness against unexpected JSON-RPC from upstream


### PR DESCRIPTION
This fixes a bug where the infura backend would be labeled offline because it
returns an unexpected JSON-RPC response. Unexpected, but well-formed,
JSON-RPC response are handled specially. Such errors are surfaced up to
the backend proxier so failover still occurs.