### PR TITLE
ci: fix batch-submitter docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,7 +668,7 @@ workflows:
             - optimism
       - docker-publish:
           name: batch-submitter-service-release
-          docker_file: ops/docker/Dockerfile
+          docker_file: batch-submitter/Dockerfile
           docker_tags: ethereumoptimism/batch-submitter-service:nightly
           docker_context: .
           context:


### PR DESCRIPTION
**Description**

The docker build was broken, this commit fixes
it

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

