### PR TITLE
l2geth: fix docker release build

### DIFF
--- a/.changeset/green-phones-shop.md
+++ b/.changeset/green-phones-shop.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Rerelease the previous version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./ops/docker/Dockerfile
+          file: ./l2geth/Dockerfile
           push: true
           tags: ethereumoptimism/l2geth:${{ needs.release.outputs.l2geth }},ethereumoptimism/l2geth:latest
 


### PR DESCRIPTION
The previous build didn't work due to a bug
in the CI, this fixes the release

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
The build previously failed in the release, this fixes the build in the release for `l2geth`
