### PR TITLE
contracts-bedrock: move core-utils to deps

### DIFF
--- a/.changeset/tricky-hotels-crash.md
+++ b/.changeset/tricky-hotels-crash.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Move core-utils to deps instead of devdeps

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -13,6 +13,7 @@
     "deployments/**/*.json"
   ],
   "dependencies": {
+    "@eth-optimism/core-utils": "^0.8.6",
     "@openzeppelin/contracts": "^4.5.0",
     "@openzeppelin/contracts-upgradeable": "^4.5.2",
     "ethers": "^5.6.8",
@@ -40,7 +41,6 @@
     "lint": "yarn lint:fix && yarn lint:check"
   },
   "devDependencies": {
-    "@eth-optimism/core-utils": "^0.8.6",
     "@foundry-rs/hardhat-forge": "^0.1.5",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^2.1.3",


### PR DESCRIPTION
It was previously in dev dependencies which could
cause problems for production builds

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Moves core-utils to deps from devdeps, should resolve build issues