### PR TITLE
contracts-bedrock: fix linter

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -23,8 +23,8 @@
     "lint:ts:check": "eslint .",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol'",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",
-    "lint:ts:fix": "prettier --write .",
-    "lint:contracts:fix": "prettier --write 'contracts/**/*.sol'",
+    "lint:ts:fix": "yarn prettier --write .",
+    "lint:contracts:fix": "yarn prettier --write 'contracts/**/*.sol'",
     "lint:fix": "yarn lint:contracts:fix && yarn lint:ts:fix",
     "lint": "yarn lint:fix && yarn lint:check"
   },


### PR DESCRIPTION
Fixes the linter to ensure that the prettier
that was installed is used instead of a global
prettier executable

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes linting in the `contracts-bedrock` package, the old linting command wasn't using the same version as used in the repo