### PR TITLE
feat(cmn): BaseServiceV2 exposes internal options

### DIFF
--- a/.changeset/ten-owls-return.md
+++ b/.changeset/ten-owls-return.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Expose service internal options as environment or cli options


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
BaseServiceV2 will expose internal options (loop interval, metrics port,
etc) as environment variables or command line options.
