### PR TITLE
teleportr: Improve metrics

### DIFF
--- a/.changeset/curly-swans-crash.md
+++ b/.changeset/curly-swans-crash.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/teleportr': patch
+---
+
+Improve metrics

--- a/teleportr/drivers/disburser/metrics.go
+++ b/teleportr/drivers/disburser/metrics.go
@@ -66,6 +66,10 @@ type Metrics struct {
 	// the disburser contract.
 	ContractNextDisbursementID prometheus.Gauge
 
+	// ContractNextDepositID tracks the next deposit id expected by the deposit
+	// contract.
+	ContractNextDepositID prometheus.Gauge
+
 	// DisburserBalance tracks Teleportr's disburser account balance.
 	DisburserBalance prometheus.Gauge
 
@@ -115,6 +119,11 @@ func NewMetrics(subsystem string) *Metrics {
 		ContractNextDisbursementID: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "contract_next_disbursement_id",
 			Help:      "Next disbursement id expected by the disburser contract",
+			Subsystem: base.SubsystemName(),
+		}),
+		ContractNextDepositID: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "contract_next_deposit_id",
+			Help:      "next deposit id expected by the deposit contract",
 			Subsystem: base.SubsystemName(),
 		}),
 		DisburserBalance: promauto.NewGauge(prometheus.GaugeOpts{

--- a/teleportr/teleportr.go
+++ b/teleportr/teleportr.go
@@ -110,7 +110,8 @@ func Main(gitVersion string) func(ctx *cli.Context) error {
 			DisburserAddr:        disburserAddr,
 			ChainID:              chainID,
 			PrivKey:              disburserPrivKey,
-		})
+			ChainMetricsEnable:   cfg.MetricsServerEnable,
+		}, ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Update metrics collection to happen on an interval in addition to on each tick of the driver loop. This lets us continue collecting on-chain metrics if the driver loop halts for some reason.
- Adds an additional metric to track the last on-chian deposit ID. This will let add Teleportr halting alerts more easily.
