### PR TITLE
Bedrock: driver/batcher refactor (Work in progress)

### DIFF
--- a/op-node/rollup/stages/batcher/batches.go
+++ b/op-node/rollup/stages/batcher/batches.go
@@ -1,0 +1,68 @@
+package batcher
+
+import (
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/l2"
+	"io"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+type BatchReader struct {
+	mu sync.Mutex
+
+	Inner PayloadReaderStage
+
+	Conf *rollup.Config
+}
+
+func (cs *BatchReader) Reset(start, end eth.BlockID) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Reset(start, end)
+}
+
+func (cs *BatchReader) Read(dest *derive.BatchData) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	var payload l2.ExecutionPayload
+	err := cs.Inner.Read(&payload)
+	if err != nil {
+		if err == io.EOF {
+			return io.EOF
+		} else {
+			return fmt.Errorf("failed to read payload: %w", err)
+		}
+	}
+	l2BlockRef, err := l2.PayloadToBlockRef(&payload, &cs.Conf.Genesis)
+	if err != nil {
+		return fmt.Errorf("failed to derive block ref from payload: %v", err)
+	}
+	*dest = derive.BatchData{BatchV1: derive.BatchV1{
+		Epoch:        rollup.Epoch(l2BlockRef.L1Origin.Number),
+		Timestamp:    l2BlockRef.Time,
+		Transactions: payload.Transactions,
+	}}
+	return nil
+}
+
+func (cs *BatchReader) Start() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Start()
+}
+
+func (cs *BatchReader) End() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.End()
+}
+
+func (cs *BatchReader) Close() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Close()
+}

--- a/op-node/rollup/stages/batcher/chunks.go
+++ b/op-node/rollup/stages/batcher/chunks.go
@@ -1,0 +1,107 @@
+package batcher
+
+import (
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"io"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+)
+
+type ChunkReader struct {
+	mu sync.Mutex
+
+	Inner FrameReaderStage
+
+	SelectNextBlock func(start eth.BlockID, immediateSpace uint64) eth.BlockID
+
+	// Track the chunk number
+	ChunkNum uint64
+}
+
+func (cs *ChunkReader) Start() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Start()
+}
+
+func (cs *ChunkReader) End() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.End()
+}
+
+func (cs *ChunkReader) Close() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Close()
+}
+
+func (cs *ChunkReader) Read(dest *stages.Chunk, maxSize uint64) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	dest.ChunkHeader = stages.ChunkHeader{
+		Version:  stages.ChunkVersion0,
+		ChunkNum: cs.ChunkNum,
+		Start:    cs.Inner.Start(),
+	}
+	dest.Frames = nil
+	headerSize := dest.ChunkHeader.HeaderSize()
+	if headerSize+4 > maxSize {
+		return fmt.Errorf("not enough space for chunk with single frame: %d + 4 > %d", headerSize, maxSize)
+	}
+	remainingSize := maxSize - headerSize
+
+	for {
+		// If we run out of space, return.
+		// We always need 4 bytes for the length-prefix of the frame.
+		if remainingSize <= 4 {
+			cs.ChunkNum += 1
+			return nil
+		}
+		start := cs.Inner.Start()
+		end := cs.Inner.End()
+		var frame stages.Frame
+		if err := cs.Inner.Read(&frame, remainingSize-4); err == io.EOF {
+			// Check if we are done with this window yet
+			if start == end {
+				end = cs.SelectNextBlock(start, remainingSize-4)
+				if start == end {
+					// If we can't select a newer window, then we ran out of L2 chain to construct chunks for
+					if len(dest.Frames) > 0 {
+						cs.ChunkNum += 1
+						return nil // Don't return EOF if we have previous frames to return
+					} else {
+						return io.EOF
+					}
+				}
+				if err := cs.Inner.Prepare(start, end, 0); err != nil {
+					return fmt.Errorf("failed to prepare frame reader for window %s, %s: %v", start, end, err)
+				}
+				continue
+			} else {
+				// If the frame reader returns EOF early, before the window is done,
+				// then we are done with this chunk and will need another chunk later to continue the window
+				cs.ChunkNum += 1
+				return nil
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to read frame %d (start: %s, end: %s, remaining size: %d) for chunk: %v",
+				len(dest.Frames), start, end, remainingSize, err)
+		}
+		dest.Frames = append(dest.Frames, frame)
+		remainingSize -= 4 + frame.HeaderSize() + uint64(len(frame.Content))
+	}
+}
+
+func (cs *ChunkReader) Prepare(start, end eth.BlockID, chunkNum uint64, offset uint64) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if err := cs.Inner.Prepare(start, end, offset); err != nil {
+		return fmt.Errorf("failed to prepare ChunkReader for window start: %s end: %s chunk: %d while preparing inner frame stage: %w", start, end, chunkNum, err)
+	}
+	cs.ChunkNum = chunkNum
+	return cs.Inner.Prepare(start, end, offset)
+}

--- a/op-node/rollup/stages/batcher/compression.go
+++ b/op-node/rollup/stages/batcher/compression.go
@@ -1,15 +1,9 @@
 package batcher
 
 import (
-	"bytes"
-	"encoding/binary"
-	"fmt"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
-	"io"
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-	"github.com/golang/snappy"
 )
 
 type Compressor struct {
@@ -25,53 +19,12 @@ func (cs *Compressor) Reset(start, end eth.BlockID) error {
 	return cs.Inner.Reset(start, end)
 }
 
-func (cs *Compressor) nextCompressFrame() error {
-	// TODO pool this
-	var buf bytes.Buffer
-	n, err := io.CopyN(&buf, cs.Inner, stages.CompressionVersion0MaxFrameSize)
-	if err == io.EOF {
-		if n == 0 {
-			// No more contents left to compress
-			return io.EOF
-		} else {
-			// we are compressing less than CompressionVersion0MaxFrameSize
-			err = nil
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("failed to read input data for next compression frame: %w", err)
-	}
-
-	// TODO pool this
-	dest := make([]byte, 1+snappy.MaxEncodedLen(stages.CompressionVersion0MaxFrameSize))
-	dest[0] = stages.CompressionVersion0
-	x := binary.PutUvarint(dest[1:], uint64(len(buf.Bytes())))
-	dest = snappy.Encode(dest[1+x:], buf.Bytes())
-	cs.Buf = dest
-	return nil
-}
-
 func (cs *Compressor) Read(dest []byte) (n int, err error) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	for {
-		if len(dest) == 0 {
-			return n, nil
-		}
-		if len(cs.Buf) > 0 {
-			copied := copy(dest, cs.Buf)
-			dest = dest[copied:]
-			cs.Buf = cs.Buf[copied:]
-			n += copied
-			continue
-		}
-		if len(cs.Buf) == 0 {
-			err := cs.nextCompressFrame()
-			if err != nil {
-				return n, err
-			}
-		}
-	}
+
+	// TODO: cw, err := zlib.NewWriterLevelDict(w, zlib.BestCompression, nil)
+	return 0, nil
 }
 
 func (cs *Compressor) Start() eth.BlockID {

--- a/op-node/rollup/stages/batcher/compression.go
+++ b/op-node/rollup/stages/batcher/compression.go
@@ -1,0 +1,95 @@
+package batcher
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"io"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/golang/snappy"
+)
+
+type Compressor struct {
+	mu sync.Mutex
+
+	Inner BinaryReaderStage
+	Buf   []byte
+}
+
+func (cs *Compressor) Reset(start, end eth.BlockID) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Reset(start, end)
+}
+
+func (cs *Compressor) nextCompressFrame() error {
+	// TODO pool this
+	var buf bytes.Buffer
+	n, err := io.CopyN(&buf, cs.Inner, stages.CompressionVersion0MaxFrameSize)
+	if err == io.EOF {
+		if n == 0 {
+			// No more contents left to compress
+			return io.EOF
+		} else {
+			// we are compressing less than CompressionVersion0MaxFrameSize
+			err = nil
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read input data for next compression frame: %w", err)
+	}
+
+	// TODO pool this
+	dest := make([]byte, 1+snappy.MaxEncodedLen(stages.CompressionVersion0MaxFrameSize))
+	dest[0] = stages.CompressionVersion0
+	x := binary.PutUvarint(dest[1:], uint64(len(buf.Bytes())))
+	dest = snappy.Encode(dest[1+x:], buf.Bytes())
+	cs.Buf = dest
+	return nil
+}
+
+func (cs *Compressor) Read(dest []byte) (n int, err error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	for {
+		if len(dest) == 0 {
+			return n, nil
+		}
+		if len(cs.Buf) > 0 {
+			copied := copy(dest, cs.Buf)
+			dest = dest[copied:]
+			cs.Buf = cs.Buf[copied:]
+			n += copied
+			continue
+		}
+		if len(cs.Buf) == 0 {
+			err := cs.nextCompressFrame()
+			if err != nil {
+				return n, err
+			}
+		}
+	}
+}
+
+func (cs *Compressor) Start() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Start()
+}
+
+func (cs *Compressor) End() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.End()
+}
+
+func (cs *Compressor) Close() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	// TODO: release data back into pool
+	cs.Buf = nil
+	return cs.Inner.Close()
+}

--- a/op-node/rollup/stages/batcher/encoding.go
+++ b/op-node/rollup/stages/batcher/encoding.go
@@ -1,0 +1,96 @@
+package batcher
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const (
+	EncoderVersion0 = 0
+)
+
+type Encoder struct {
+	mu sync.Mutex
+
+	Inner         BatchReaderStage
+	CurrentReader io.Reader
+}
+
+func (cs *Encoder) Reset(start, end eth.BlockID) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Reset(start, end)
+}
+
+func (cs *Encoder) nextBatch() error {
+	var batch derive.BatchData
+	err := cs.Inner.Read(&batch)
+	if err != nil {
+		if err == io.EOF { // when there are no more inputs
+			return io.EOF
+		} else {
+			return fmt.Errorf("failed to read next batch: %w", err)
+		}
+	}
+	_, r, err := rlp.EncodeToReader(batch)
+	if err != nil {
+		return fmt.Errorf("failed to create RLP encoder: %w", err)
+	}
+	cs.CurrentReader = r
+	return nil
+}
+
+func (cs *Encoder) Read(dest []byte) (n int, err error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	for {
+		// stop if we can't read more data
+		if len(dest) == 0 {
+			return n, nil
+		}
+		if cs.CurrentReader == nil {
+			if err := cs.nextBatch(); err != nil {
+				return n, err
+			}
+		}
+		innerN, err := cs.CurrentReader.Read(dest)
+		// remember how much we've read
+		n += innerN
+		dest = dest[innerN:]
+		if err == io.EOF {
+			cs.CurrentReader = nil
+			continue
+		}
+		if err != nil {
+			return n, err
+		}
+	}
+}
+
+func (cs *Encoder) Start() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Start()
+}
+
+func (cs *Encoder) End() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.End()
+}
+
+func (cs *Encoder) Close() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if cs.CurrentReader != nil {
+		// we need to read to EOF to release the RLP reader back into the pool (it has no Close())
+		_, _ = io.Copy(io.Discard, cs.CurrentReader)
+		cs.CurrentReader = nil
+	}
+	return cs.Inner.Close()
+}

--- a/op-node/rollup/stages/batcher/frames.go
+++ b/op-node/rollup/stages/batcher/frames.go
@@ -1,0 +1,107 @@
+package batcher
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"io"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+)
+
+type FrameReader struct {
+	mu sync.Mutex
+
+	Inner BinaryReaderStage
+
+	offset uint64
+}
+
+func (cs *FrameReader) Read(dest *stages.Frame, maxSize uint64) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	start := cs.Inner.Start()
+	end := cs.Inner.End()
+	// Check if we are done yet
+	if start == end {
+		return io.EOF
+	}
+
+	dest.Version = stages.FrameVersion0
+	dest.Offset = cs.offset
+	dest.End = end
+	headerSize := dest.HeaderSize()
+	if headerSize >= maxSize { // end early when we don't have enough space for more frames.
+		return io.EOF
+	}
+	maxBodySize := maxSize - headerSize
+	var buf bytes.Buffer
+	innerN, err := io.CopyN(&buf, cs.Inner, int64(maxBodySize))
+	if err == io.EOF {
+		err = nil // it's fine to not read until the max body size if the stream is exhausted
+		// mark the stream as done by
+		if err := cs.Inner.Reset(end, end); err != nil {
+			return fmt.Errorf("failed to reset stream to mark windo end at %s: %v", end, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to read new frame (offset: %d): %w", cs.offset, err)
+	}
+	dest.Content = buf.Bytes()
+	// update after writing the previous offset
+	cs.offset += uint64(innerN)
+	return err
+}
+
+func (cs *FrameReader) Prepare(start, end eth.BlockID, offset uint64) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	// if the window didn't change, and if the offset is the same or later, then continue with the existing stream
+	if cs.Inner.Start() == start && cs.Inner.End() == end && offset >= cs.offset {
+		innerN, err := io.CopyN(io.Discard, cs.Inner, int64(offset-cs.offset))
+		if err != nil {
+			return fmt.Errorf("failed to reuse FrameReader while skipping to offset %d in window (start: %s end: %s): %w", offset, start, end, err)
+		}
+		if cs.offset+uint64(innerN) != offset {
+			return fmt.Errorf("failed to reuse FrameReader while skipping to offset %d, ended at %d", offset, cs.offset+uint64(innerN))
+		}
+		cs.offset = offset
+		return nil
+	}
+
+	// Reset inner stream
+	if err := cs.Inner.Reset(start, end); err != nil {
+		return fmt.Errorf("failed to prepare FrameReader while resetting inner stream to start %s end %s: %w", start, end, err)
+	}
+	// Now forward to the offset
+	innerN, err := io.CopyN(io.Discard, cs.Inner, int64(offset))
+	if err != nil {
+		return fmt.Errorf("failed to prepare FrameReader while skipping to offset %d in window (start: %s end: %s): %w", offset, start, end, err)
+	}
+	if uint64(innerN) != offset {
+		return fmt.Errorf("failed to prepare FrameReader while skipping to offset %d, ended at %d", offset, innerN)
+	}
+	cs.offset = offset
+	return nil
+}
+
+func (cs *FrameReader) Start() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Start()
+}
+
+func (cs *FrameReader) End() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.End()
+}
+
+func (cs *FrameReader) Close() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.offset = 0
+	return cs.Inner.Close()
+}

--- a/op-node/rollup/stages/batcher/payloads.go
+++ b/op-node/rollup/stages/batcher/payloads.go
@@ -1,0 +1,82 @@
+package batcher
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/l2"
+	"io"
+	"sync"
+)
+
+type PayloadReader struct {
+	mu sync.Mutex
+
+	start eth.BlockID
+	end   eth.BlockID
+
+	Source        func(ctx context.Context, num uint64) (*l2.ExecutionPayload, error)
+	cancelRequest func()
+
+	lastComplete eth.BlockID
+}
+
+func (cs *PayloadReader) Reset(start, end eth.BlockID) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.start = start
+	cs.end = end
+	cs.lastComplete = start
+	return nil
+}
+
+func (cs *PayloadReader) Read(dest *l2.ExecutionPayload) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	// Check if we reached the end already.
+	if cs.lastComplete == cs.end {
+		return io.EOF
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cs.cancelRequest = cancel
+	payload, err := cs.Source(ctx, cs.lastComplete.Number+1)
+	if err != nil {
+		if err == ctx.Err() {
+			// stage was closed gracefully, send an EOF
+			return io.EOF
+		}
+		return fmt.Errorf("failed to retrieve payload at number %d", cs.lastComplete.Number+1)
+	}
+	if payload.ParentHash != cs.lastComplete.Hash {
+		return ReorgErr
+	}
+	if uint64(payload.BlockNumber) == cs.end.Number && payload.BlockHash != cs.end.Hash {
+		return ReorgErr
+	}
+	if uint64(payload.BlockNumber) > cs.end.Number {
+		return fmt.Errorf("retrieved block out of window bounds: %s (end: %s)", payload.ID(), cs.end)
+	}
+	cs.lastComplete = payload.ID()
+	*dest = *payload
+	return nil
+}
+
+func (cs *PayloadReader) Start() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.start
+}
+
+func (cs *PayloadReader) End() eth.BlockID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.start
+}
+
+func (cs *PayloadReader) Close() error {
+	// no locking, Close can be called in parallel to ongoing reads
+	if cs.cancelRequest != nil {
+		cs.cancelRequest()
+	}
+	return nil
+}

--- a/op-node/rollup/stages/batcher/stages.go
+++ b/op-node/rollup/stages/batcher/stages.go
@@ -1,0 +1,83 @@
+package batcher
+
+import (
+	"errors"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/l2"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"io"
+)
+
+// ReorgErr is returned when the canonical source data does not match the window of blocks
+// that is being read or written.
+var ReorgErr = errors.New("reorg detected")
+
+type Windowed interface {
+	// Start of the current window
+	Start() eth.BlockID
+	// End of the current window. If End() == Start() then the stream should return io.EOF upon reading.
+	End() eth.BlockID
+}
+
+type WindowedReader interface {
+	Windowed
+	// Reset clears the buffered data in the stage,
+	// and resets any underlying stream to the given window from start to end.
+	//
+	// The start point is exclusive: this is the parent block of the first block we will stream after.
+	// The end point is inclusive: this is the last block we will include in the stream.
+	//
+	// It returns an error if the start or end cannot be found, or if either is not canonical
+	Reset(start, end eth.BlockID) error
+}
+
+// PayloadReaderStage gets the L2 blocks from some source
+type PayloadReaderStage interface {
+	WindowedReader
+	Read(dest *l2.ExecutionPayload) error
+	io.Closer
+}
+
+// BatchReaderStage gets batches from execution payloads
+type BatchReaderStage interface {
+	WindowedReader
+	Read(dest *derive.BatchData) error
+	io.Closer
+}
+
+// BinaryReaderStage reads input data from an inner stage, and transforms it
+type BinaryReaderStage interface {
+	WindowedReader
+	io.ReadCloser
+}
+
+// FrameReaderStage reads a frame, which will be at most maxSize bytes when marshalled.
+type FrameReaderStage interface {
+	Windowed
+	// Prepare resets the underlying stream to the given window,
+	// and forwards to the given offset, to not read that data from the stream again.
+	Prepare(start, end eth.BlockID, offset uint64) error
+	// Read constructs a new frame from the underlying stream,
+	// which takes at most maxSize bytes when encoded.
+	// The block window may be reset to (end, end) if the stream is fully consumed.
+	// An io.EOF is returned when the window of data is exhausted,
+	// or no additional frame could be read within maxSize.
+	// The caller can identify an exhausted window by checking if start==end.
+	Read(dest *stages.Frame, maxSize uint64) error
+	io.Closer
+}
+
+type ChunkReaderStage interface {
+	Windowed
+	// Prepare resets the underlying stream to the given window and offset,
+	// and sets the current chunk number.
+	Prepare(start, end eth.BlockID, chunkNum uint64, offset uint64) error
+	// Read constructs a new chunk from the underlying stram,
+	// which takes at most maxSize bytes when encoded.
+	// The current block window may change as new frames are read from the stream.
+	// An io.EOF error is returned when the underlying stream is exhausted,
+	// i.e. no more blocks can be read.
+	Read(dest *stages.Chunk, maxSize uint64) error
+	io.Closer
+}

--- a/op-node/rollup/stages/deriver/batch_decoding.go
+++ b/op-node/rollup/stages/deriver/batch_decoding.go
@@ -1,0 +1,20 @@
+package deriver
+
+import (
+	"github.com/ethereum-optimism/optimism/l2geth/rlp"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"sync"
+)
+
+const MaxBatchSize = 10_000_000
+
+type BatchDecoder struct {
+	mu    sync.Mutex
+	Inner BinaryReaderStage
+}
+
+func (cs *BatchDecoder) Read(dest *derive.BatchData) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return rlp.NewStream(cs.Inner, MaxBatchSize).Decode(dest)
+}

--- a/op-node/rollup/stages/deriver/chunks.go
+++ b/op-node/rollup/stages/deriver/chunks.go
@@ -1,0 +1,81 @@
+package deriver
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"io"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+)
+
+type FrameReader struct {
+	mu sync.Mutex
+
+	Source        func(ctx context.Context, chunkNum uint64) (*stages.Chunk, error)
+	cancelRequest func()
+
+	// Track the chunk number
+	ChunkNum uint64
+
+	frames []stages.Frame
+
+	start eth.BlockID
+	end   eth.BlockID
+}
+
+func (cs *FrameReader) Read(frame *stages.Frame) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	if len(cs.frames) > 0 {
+		*frame = cs.frames[0]
+		cs.frames = cs.frames[1:]
+		if cs.end != frame.End {
+			// old end becomes new start when we move the window
+			cs.start = cs.end
+			cs.end = frame.End
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cs.cancelRequest = cancel
+	chunk, err := cs.Source(ctx, cs.ChunkNum)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve chunk: %v", err)
+	}
+
+	cs.frames = chunk.Frames
+	cs.ChunkNum = chunk.ChunkNum + 1
+
+	prevStart := cs.start
+	cs.start = chunk.Start
+
+	// if we changed the start, then we need to return a reset
+	if prevStart != cs.start {
+		return io.EOF
+	}
+
+	if len(cs.frames) > 0 {
+		*frame = cs.frames[0]
+		cs.frames = cs.frames[1:]
+		if cs.end != frame.End {
+			// old end becomes new start when we move the window
+			cs.start = cs.end
+			cs.end = frame.End
+		}
+		return nil
+	} else {
+		return fmt.Errorf("empty chunk %d", chunk.ChunkNum)
+	}
+}
+
+func (cs *FrameReader) Close() error {
+	// no locking, Close can be called in parallel to ongoing reads
+	if cs.cancelRequest != nil {
+		cs.cancelRequest()
+	}
+	return nil
+}

--- a/op-node/rollup/stages/deriver/decompression.go
+++ b/op-node/rollup/stages/deriver/decompression.go
@@ -1,0 +1,78 @@
+package deriver
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"github.com/golang/snappy"
+	"io"
+	"sync"
+)
+
+type byteReader struct {
+	io.Reader
+}
+
+func (b *byteReader) ReadByte() (byte, error) {
+	var tmp [1]byte
+	_, err := b.Read(tmp[:])
+	return tmp[0], err
+}
+
+type Decompressor struct {
+	mu    sync.Mutex
+	Inner BinaryReaderStage
+	buf   []byte
+}
+
+func (cs *Decompressor) next() error {
+	br := byteReader{cs.Inner}
+	version, err := br.ReadByte()
+	if err != nil {
+		return fmt.Errorf("failed to read compression version: %w", err)
+	}
+	if version != stages.CompressionVersion0 {
+		return fmt.Errorf("unknown compression version: %d", version)
+	}
+
+	compressedLen, err := binary.ReadUvarint(&br)
+	if err != nil {
+		return fmt.Errorf("failed to read compressed length: %w", err)
+	}
+	if compressedLen > uint64(snappy.MaxEncodedLen(stages.CompressionVersion0MaxFrameSize)) {
+		return fmt.Errorf("read compressed length is too large: %d", compressedLen)
+	}
+	var buf bytes.Buffer
+	if _, err := io.CopyN(&buf, cs.Inner, int64(compressedLen)); err != nil {
+		return fmt.Errorf("failed to fully read compression frame: %v", err)
+	}
+	inData := buf.Bytes()
+	// zip-bomb protection
+	if len(inData) > stages.CompressionVersion0MaxFrameSize {
+		return fmt.Errorf("bad compressed data, length %d is too large", len(inData))
+	}
+	out, err := snappy.Decode(nil, inData)
+	if err != nil {
+		return fmt.Errorf("failed to decompress: %v", err)
+	}
+	cs.buf = out
+	return nil
+}
+
+func (cs *Decompressor) Read(p []byte) (n int, err error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if len(cs.buf) == 0 {
+		if err := cs.next(); err != nil {
+			return 0, err
+		}
+	}
+	n = copy(p, cs.buf)
+	cs.buf = cs.buf[n:]
+	return n, nil
+}
+
+func (cs *Decompressor) Close() error {
+	return cs.Inner.Close()
+}

--- a/op-node/rollup/stages/deriver/payloads.go
+++ b/op-node/rollup/stages/deriver/payloads.go
@@ -1,0 +1,26 @@
+package deriver
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/l2"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"sync"
+)
+
+type PayloadReader struct {
+	mu    sync.Mutex
+	Inner BatchReaderStage
+}
+
+func (cs *PayloadReader) Read(payload *l2.ExecutionPayload) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	var batch derive.BatchData
+	if err := cs.Inner.Read(&batch); err != nil {
+		return err
+	}
+	// TODO: filter batch
+	// TODO: derive payload attributes
+	// TODO: derive full payload, or consolidate with existing payload
+
+	return nil
+}

--- a/op-node/rollup/stages/deriver/stages.go
+++ b/op-node/rollup/stages/deriver/stages.go
@@ -1,0 +1,30 @@
+package deriver
+
+import (
+	"io"
+
+	"github.com/ethereum-optimism/optimism/op-node/l2"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+)
+
+type PayloadReaderStage interface {
+	Read(payload *l2.ExecutionPayload) error
+	io.Closer
+}
+
+type BatchReaderStage interface {
+	Read(batch *derive.BatchData) error
+	io.Closer
+}
+
+type BinaryReaderStage interface {
+	io.ReadCloser
+}
+
+type FrameReaderStage interface {
+	// Read reads the next frame of the window,
+	// and returns an EOF if the window content is exhausted or not available anymore.
+	Read(frame *stages.Frame) error
+	io.Closer
+}

--- a/op-node/rollup/stages/deriver/unframer.go
+++ b/op-node/rollup/stages/deriver/unframer.go
@@ -1,0 +1,41 @@
+package deriver
+
+import (
+	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
+	"io"
+	"sync"
+)
+
+type Unframer struct {
+	mu     sync.Mutex
+	Inner  FrameReaderStage
+	buf    []byte
+	offset uint64
+}
+
+func (cs *Unframer) Read(dest []byte) (n int, err error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	var frame stages.Frame
+	if err := cs.Inner.Read(&frame); err == io.EOF {
+		return 0, io.EOF
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to pull next frame: %w", err)
+	}
+	if frame.Offset != cs.offset {
+		return 0, fmt.Errorf("frame starts at wrong offset: %d, expected %d", frame.Offset, cs.offset)
+	}
+	cs.offset += uint64(len(frame.Content))
+	cs.buf = append(cs.buf, frame.Content...)
+	n = copy(dest, cs.buf)
+	// TODO: recycle buf better
+	cs.buf = cs.buf[n:]
+	return n, nil
+}
+
+func (cs *Unframer) Close() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.Inner.Close()
+}

--- a/op-node/rollup/stages/types.go
+++ b/op-node/rollup/stages/types.go
@@ -1,0 +1,149 @@
+package stages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	FrameVersion0 byte = 0
+	// FrameVersion0MaxHeaderSize = version (byte) + offset (uvarint) + end block hash (bytes32) + delta num (uvarint)
+	FrameVersion0MaxHeaderSize = 1 + binary.MaxVarintLen64 + 32 + binary.MaxVarintLen64
+
+	ChunkVersion0 byte = 0
+	// ChunkVersion0MaxHeaderSize = version (byte) + chunk num (uvarint) + start block hash (bytes32) + start num (uvarint)
+	ChunkVersion0MaxHeaderSize = 1 + binary.MaxVarintLen64 + 32 + binary.MaxVarintLen64
+
+	// TODO: I just picked snappy compression as placeholder since we already use it on gossip-sub and I'm familiar with the API.
+	// But we should be using the compression algo that was picked for mainnet previously.
+	CompressionVersion0             = 0
+	CompressionVersion0MaxFrameSize = 20_000
+)
+
+type FrameHeader struct {
+	Version byte
+	// Offset to the start of the Content
+	Offset  uint64
+	End     eth.BlockID
+	Content []byte
+}
+
+func (frame *FrameHeader) HeaderSize() uint64 {
+	var tmp [binary.MaxVarintLen64]byte
+	n := 1
+	n += binary.PutUvarint(tmp[:], frame.Offset)
+	n += 32
+	n += binary.PutUvarint(tmp[:], frame.End.Number)
+	return uint64(n)
+}
+
+func (frame *FrameHeader) MarshalBinary() ([]byte, error) {
+	out := make([]byte, FrameVersion0MaxHeaderSize+len(frame.Content))
+	out[0] = FrameVersion0
+	n := 1
+	n += binary.PutUvarint(out[n:], frame.Offset)
+	n += copy(out[n:], frame.End.Hash[:])
+	n += binary.PutUvarint(out[n:], frame.End.Number)
+	n += copy(out[n:], frame.Content)
+	out = out[:n]
+	return out, nil
+}
+
+func (frame *FrameHeader) UnmarshalBinary(data []byte) error {
+	r := bytes.NewReader(data)
+	var err error
+	frame.Version, err = r.ReadByte()
+	if err != nil {
+		return fmt.Errorf("cannot read frame version: %v", err)
+	}
+	if frame.Version != FrameVersion0 {
+		return fmt.Errorf("unexpected frame version: %d", frame.Version)
+	}
+	frame.Offset, err = binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("cannot read frame offset: %v", err)
+	}
+	frame.End.Hash, err = readHash(r)
+	if err != nil {
+		return fmt.Errorf("cannot read frame end block hash: %v", err)
+	}
+	frame.End.Number, err = binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("cannot read frame end block number: %v", err)
+	}
+	return nil
+}
+
+type ChunkHeader struct {
+	Version  byte
+	ChunkNum uint64
+	Start    eth.BlockID
+}
+
+func uvarint(x uint64) []byte {
+	var tmp [binary.MaxVarintLen64]byte
+	return tmp[:binary.PutUvarint(tmp[:], x)]
+}
+
+func readHash(r io.Reader) (out common.Hash, err error) {
+	_, err = io.ReadFull(r, out[:])
+	return
+}
+
+func (chunk *ChunkHeader) HeaderSize() uint64 {
+	var tmp [binary.MaxVarintLen64]byte
+	n := 1
+	n += binary.PutUvarint(tmp[:], chunk.ChunkNum)
+	n += 32
+	n += binary.PutUvarint(tmp[:], chunk.Start.Number)
+	return uint64(n)
+}
+
+func (chunk *ChunkHeader) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte(ChunkVersion0)
+	buf.Write(uvarint(chunk.ChunkNum))
+	buf.Write(chunk.Start.Hash[:])
+	buf.Write(uvarint(chunk.Start.Number))
+	return buf.Bytes(), nil
+}
+
+func (chunk *ChunkHeader) UnmarshalBinary(data []byte) error {
+	r := bytes.NewReader(data)
+	var err error
+	chunk.Version, err = r.ReadByte()
+	if err != nil {
+		return fmt.Errorf("cannot read chunk version: %v", err)
+	}
+	if chunk.Version != ChunkVersion0 {
+		return fmt.Errorf("unexpected chunk version: %d", chunk.Version)
+	}
+	chunk.ChunkNum, err = binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("cannot read chunk number: %v", err)
+	}
+	chunk.Start.Hash, err = readHash(r)
+	if err != nil {
+		return fmt.Errorf("cannot read chunk start block hash: %v", err)
+	}
+	chunk.Start.Number, err = binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("cannot read chunk start block number: %v", err)
+	}
+	return nil
+}
+
+type Frame struct {
+	FrameHeader
+	Content []byte
+}
+
+type Chunk struct {
+	ChunkHeader
+	Frames []Frame
+}


### PR DESCRIPTION
This PR:
- Adds some sanity checks to the driver/derivation code
- Implements new derivation code
- Implements new batch-building code

The new derivation/batching is not integrated yet.

TODO:
- Finish the general design (include latest feedback etc.)
- Update code to latest design
- Polish code: the buffering can be more elegant / efficient in some places
- Testing:
  - [ ] test each reader individually
  - [ ] test the stack of readers (both driver and batcher variants)
 
In a separate PR we can swap out the original functions that derive and build this data.

This implements batching V2, for:
- Fix the L2 tx size problem
- EIP-4844 preparation
- Efficiency (use all data we can)
- Compression
- Reduce verifier sync delay
- Increase sequencing window
- Handle concurrent batch submission
