### PR TITLE
l2geth: skip flaky tests

### DIFF
--- a/l2geth/eth/downloader/downloader_test.go
+++ b/l2geth/eth/downloader/downloader_test.go
@@ -705,6 +705,7 @@ func TestBoundedHeavyForkedSync64Fast(t *testing.T)  { testBoundedHeavyForkedSyn
 func TestBoundedHeavyForkedSync64Light(t *testing.T) { testBoundedHeavyForkedSync(t, 64, LightSync) }
 
 func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
+	t.Skip("Flaky test")
 	t.Parallel()
 
 	tester := newTester()


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Skip flakey tests in `l2geth`, these tests are not useful to the way we use `l2geth`
