### PR TITLE
fix(fd): off by one in metric

### DIFF
--- a/.changeset/wicked-knives-jog.md
+++ b/.changeset/wicked-knives-jog.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': patch
+---
+
+Fix order in which a metric was bumped then emitted to fix off by one issue

--- a/packages/fault-detector/src/service.ts
+++ b/packages/fault-detector/src/service.ts
@@ -162,10 +162,10 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
       }
     }
 
+    this.state.highestCheckedBatchIndex++
     this.metrics.highestCheckedBatchIndex.set(
       this.state.highestCheckedBatchIndex
     )
-    this.state.highestCheckedBatchIndex++
 
     // If we got through the above without throwing an error, we should be fine to reset.
     this.metrics.isCurrentlyMismatched.set(0)


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a simple off-by-one error in the highestCheckedBatchIndex metric.
