### PR TITLE
contracts: fix broken contracts tests

### DIFF
--- a/packages/contracts/test/helpers/test-runner/json-test-runner.ts
+++ b/packages/contracts/test/helpers/test-runner/json-test-runner.ts
@@ -1,17 +1,17 @@
 /* External Imports */
 import { ethers } from 'hardhat'
-import { Contract, BigNumber } from 'ethers'
+import { Contract } from 'ethers'
 
 import { expect } from '../../setup'
 
 const bigNumberify = (arr: any[]) => {
   return arr.map((el: any) => {
     if (typeof el === 'number') {
-      return BigNumber.from(el)
+      return ethers.BigNumber.from(el)
     } else if (typeof el === 'string' && /^\d+n$/gm.test(el)) {
-      return BigNumber.from(el.slice(0, el.length - 1))
+      return ethers.BigNumber.from(el.slice(0, el.length - 1))
     } else if (typeof el === 'string' && el.length > 2 && el.startsWith('0x')) {
-      return BigNumber.from(el.toLowerCase())
+      return ethers.BigNumber.from(el.toLowerCase())
     } else if (Array.isArray(el)) {
       return bigNumberify(el)
     } else {
@@ -34,9 +34,10 @@ export const runJsonTest = (contractName: string, json: any): void => {
             await expect(contract.functions[functionName](...test.in)).to.be
               .reverted
           } else {
-            expect(
-              bigNumberify(await contract.functions[functionName](...test.in))
-            ).to.deep.equal(bigNumberify(test.out))
+            const result = await contract.functions[functionName](...test.in)
+            expect(JSON.stringify(bigNumberify(result))).to.deep.equal(
+              JSON.stringify(bigNumberify(test.out))
+            )
           }
         })
       }


### PR DESCRIPTION
**Description**

The `contracts` tests included a test that did a deep equality check
against two bignumbers. This check stopped working due to changes
in the bignumber implementations used, two bignumbers of the same number
no longer were considered equal. This commit fixes that problem by
using the same version of ethers as `hardhat` and also stringifying
the results so that strings are compared instead of objects. This
fixes the broken tests.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
