### PR TITLE
feat(BaseServiceV2):End immediately when looping

### DIFF
--- a/.changeset/tasty-drinks-rhyme.md
+++ b/.changeset/tasty-drinks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': minor
+---
+
+More gracefully shut down base service

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -72,16 +72,6 @@ export abstract class BaseServiceV2<
    */
   private mainPromise: ReturnType<typeof this.main>
 
-  private stopMainLoop = async () => {
-    this.logger.info('Stopping main loop...')
-    this.running = false
-    clearTimeout(this.pollingTimeout)
-    this.logger.info('Waiting for main to complete')
-    // if main is in the middle of running wait for it to complete
-    await this.mainPromise
-    this.logger.info('Main loop stoped.')
-  }
-
   /**
    * Whether or not the service will loop.
    */
@@ -490,7 +480,13 @@ export abstract class BaseServiceV2<
    * iteration is finished and will then stop looping.
    */
   public async stop(): Promise<void> {
-    await this.stopMainLoop()
+    this.logger.info('Stopping main loop...')
+    this.running = false
+    clearTimeout(this.pollingTimeout)
+    this.logger.info('Waiting for main to complete')
+    // if main is in the middle of running wait for it to complete
+    await this.mainPromise
+    this.logger.info('Main loop stoped.')
 
     // Shut down the metrics server if it's running.
     if (this.server) {

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -480,13 +480,13 @@ export abstract class BaseServiceV2<
    * iteration is finished and will then stop looping.
    */
   public async stop(): Promise<void> {
-    this.logger.info('Stopping main loop...')
+    this.logger.info('stopping main loop...')
     this.running = false
     clearTimeout(this.pollingTimeout)
-    this.logger.info('Waiting for main to complete')
+    this.logger.info('waiting for main to complete')
     // if main is in the middle of running wait for it to complete
     await this.mainPromise
-    this.logger.info('Main loop stoped.')
+    this.logger.info('main loop stoped.')
 
     // Shut down the metrics server if it's running.
     if (this.server) {

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -18,6 +18,16 @@ import { validators } from './validators'
 export type Options = {
   [key: string]: any
 }
+interface BaseServiceV2Params<TOptions, TMetrics extends MetricsV2> {
+  name: string
+  optionsSpec: OptionsSpec<TOptions>
+  metricsSpec: MetricsSpec<TMetrics>
+  options?: Partial<TOptions>
+  loop?: boolean
+  loopIntervalMs?: number
+  port?: number
+  hostname?: string
+}
 
 export type StandardOptions = {
   loopIntervalMs?: number
@@ -81,11 +91,6 @@ export abstract class BaseServiceV2<
    * Waiting period in ms between loops, if the service will loop.
    */
   protected loopIntervalMs: number
-
-  /**
-   * Whether or not the service is currently running.
-   */
-  protected running: boolean
 
   /**
    * Whether or not the service is currently healthy.
@@ -378,6 +383,8 @@ export abstract class BaseServiceV2<
    * main function. Will also catch unhandled errors.
    */
   public async run(): Promise<void> {
+    // reset this.loop to the user provided option
+    this.loop = this.params.loop
     // Start the app server if not yet running.
     if (!this.server) {
       this.logger.info('starting app server')
@@ -448,7 +455,6 @@ export abstract class BaseServiceV2<
 
     if (this.loop) {
       this.logger.info('starting main loop')
-      this.running = true
 
       const doLoop = async () => {
         try {
@@ -464,7 +470,7 @@ export abstract class BaseServiceV2<
         }
 
         // Sleep between loops if we're still running (service not stopped).
-        if (this.running) {
+        if (this.loop) {
           this.pollingTimeout = setTimeout(doLoop, this.loopIntervalMs)
         }
       }
@@ -481,7 +487,7 @@ export abstract class BaseServiceV2<
    */
   public async stop(): Promise<void> {
     this.logger.info('Stopping main loop...')
-    this.running = false
+    this.loop = false
     clearTimeout(this.pollingTimeout)
     this.logger.info('Waiting for main to complete')
     // if main is in the middle of running wait for it to complete

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -72,9 +72,14 @@ export abstract class BaseServiceV2<
    */
   private mainPromise: ReturnType<typeof this.main>
 
-  private stopMainLoop = () => {
+  private stopMainLoop = async () => {
+    this.logger.info('Stopping main loop...')
     this.running = false
     clearTimeout(this.pollingTimeout)
+    this.logger.info('Waiting for main to complete')
+    // if main is in the middle of running wait for it to complete
+    await this.mainPromise
+    this.logger.info('Main loop stoped.')
   }
 
   /**
@@ -485,12 +490,7 @@ export abstract class BaseServiceV2<
    * iteration is finished and will then stop looping.
    */
   public async stop(): Promise<void> {
-    this.logger.info('Stopping main loop...')
-    this.stopMainLoop()
-    this.logger.info('Waiting for main to complete')
-    // if main is in the middle of running wait for it to complete
-    await this.mainPromise
-    this.logger.info('Main loop stoped.')
+    await this.stopMainLoop()
 
     // Shut down the metrics server if it's running.
     if (this.server) {

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -485,9 +485,12 @@ export abstract class BaseServiceV2<
    * iteration is finished and will then stop looping.
    */
   public async stop(): Promise<void> {
+    this.logger.info('Stopping main loop...')
     this.stopMainLoop()
+    this.logger.info('Waiting for main to complete')
     // if main is in the middle of running wait for it to complete
     await this.mainPromise
+    this.logger.info('Main loop stoped.')
 
     // Shut down the metrics server if it's running.
     if (this.server) {


### PR DESCRIPTION
The server does not end when we call stop because async loops do not end.  This makes it so the async loop stops right away.  