### PR TITLE
teleportr: Fix panic

### DIFF
--- a/.changeset/brown-parrots-type.md
+++ b/.changeset/brown-parrots-type.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/teleportr': patch
+---
+
+Fix panic

--- a/teleportr/drivers/disburser/driver.go
+++ b/teleportr/drivers/disburser/driver.go
@@ -352,6 +352,9 @@ func (d *Driver) SendTransaction(
 		subCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		err := d.cfg.L2Client.SendTransaction(subCtx, tx)
+		if err == nil {
+			return err
+		}
 		if !IsRetryableError(err) {
 			d.metrics.FailedTXSubmissions.WithLabelValues("permanent").Inc()
 			return backoff.Permanent(err)


### PR DESCRIPTION
When `err` is nil, `IsRetryableError` panics.
