### PR TITLE
feat(cmn): BSV2 server logs to logger

### DIFF
--- a/.changeset/eighty-countries-develop.md
+++ b/.changeset/eighty-countries-develop.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Log server messages to logger instead of stdout

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -375,7 +375,17 @@ export abstract class BaseServiceV2<
       app.use(bodyParser.urlencoded({ extended: true }))
 
       // Logging.
-      app.use(morgan('short'))
+      app.use(
+        morgan('short', {
+          stream: {
+            write: (str: string) => {
+              this.logger.info(`server log`, {
+                log: str,
+              })
+            },
+          },
+        })
+      )
 
       // Metrics.
       // Will expose a /metrics endpoint by default.


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Sends BSV2 server logs to this.logger instead of stdout.
