### PR TITLE
fix(cmn): BSV2 exposes default options in metadata

### DIFF
--- a/.changeset/weak-needles-jam.md
+++ b/.changeset/weak-needles-jam.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Include default options in metadata metric

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -155,11 +155,7 @@ export abstract class BaseServiceV2<
     this.loop = params.loop !== undefined ? params.loop : true
     this.state = {} as TServiceState
 
-    // Add default options to options spec.
-    ;(params.optionsSpec as any) = {
-      ...(params.optionsSpec || {}),
-
-      // Users cannot set these options.
+    const stdOptionsSpec: OptionsSpec<StandardOptions> = {
       loopIntervalMs: {
         validator: validators.num,
         desc: 'Loop interval in milliseconds',
@@ -175,6 +171,12 @@ export abstract class BaseServiceV2<
         desc: 'Hostname for the app server',
         default: params.hostname || '0.0.0.0',
       },
+    }
+
+    // Add default options to options spec.
+    ;(params.optionsSpec as any) = {
+      ...(params.optionsSpec || {}),
+      ...stdOptionsSpec,
     }
 
     // List of options that can safely be logged.
@@ -348,7 +350,11 @@ export abstract class BaseServiceV2<
         name: params.name,
         version: params.version,
         ...publicOptionNames.reduce((acc, key) => {
-          acc[key] = config.str(key)
+          if (key in stdOptionsSpec) {
+            acc[key] = this.options[key].toString()
+          } else {
+            acc[key] = config.str(key)
+          }
           return acc
         }, {}),
       },


### PR DESCRIPTION

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fix for BSV2 to expose default options in the metadata metric.
