### PR TITLE
l2geth: skip unused flakey tests

### DIFF
--- a/l2geth/eth/downloader/downloader_test.go
+++ b/l2geth/eth/downloader/downloader_test.go
@@ -1391,6 +1391,7 @@ func TestFakedSyncProgress64Fast(t *testing.T)  { testFakedSyncProgress(t, 64, F
 func TestFakedSyncProgress64Light(t *testing.T) { testFakedSyncProgress(t, 64, LightSync) }
 
 func testFakedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
+	t.Skip("Flakey tests unused by Optimism")
 	t.Parallel()
 
 	tester := newTester()


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

Skips some flakey tests that don't pertain to our codebase, we don't sync p2p
