### PR TITLE
fix: switch between empty/forked chain without the need to recreate t…

### DIFF
--- a/.changeset/old-carpets-worry.md
+++ b/.changeset/old-carpets-worry.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-node': minor
+---
+
+Correct configuration file behavior

--- a/ops/docker/hardhat/hardhat.config.js
+++ b/ops/docker/hardhat/hardhat.config.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const isForkModeEnabled = !!process.env.FORK_URL
 const forkUrl = process.env.FORK_URL
 const forkStartingBlock =

--- a/ops/docker/hardhat/package.json
+++ b/ops/docker/hardhat/package.json
@@ -6,6 +6,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "dotenv": "^10.0.0",
     "hardhat": "^2.9.6"
   }
 }


### PR DESCRIPTION
…he entire image

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Currently `l1_chain` Docker image doesn't allow to fork a preexistent chain because the `dotenv ` repo is not loaded nor initialized. Adding the latter to the `package.json` and using it in the `hardhat.config.js` file solves the issue.

**Additional context**
The current image works well if you need to run a fresh L1 chain. However, the `l1_chain.env` configuration file is not read correctly by the container, so it's not possible to use a forked mainnet.

**Metadata**
No issues links
