### PR TITLE
op-bindings: Use common.Address predeploy types

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -234,7 +234,7 @@ func (cfg SystemConfig) start() (*System, error) {
 	}
 
 	l2Alloc[cfg.L1InfoPredeployAddress] = core.GenesisAccount{Code: common.FromHex(bindings.L1BlockDeployedBin), Balance: common.Big0}
-	l2Alloc[common.HexToAddress(predeploys.L2ToL1MessagePasser)] = core.GenesisAccount{Code: common.FromHex(bindings.L2ToL1MessagePasserDeployedBin), Balance: common.Big0}
+	l2Alloc[predeploys.L2ToL1MessagePasserAddr] = core.GenesisAccount{Code: common.FromHex(bindings.L2ToL1MessagePasserDeployedBin), Balance: common.Big0}
 
 	genesisTimestamp := uint64(time.Now().Unix())
 

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -17,7 +17,7 @@ var (
 	L1InfoFuncSignature    = "setL1BlockValues(uint64,uint64,uint256,bytes32,uint64)"
 	L1InfoFuncBytes4       = crypto.Keccak256([]byte(L1InfoFuncSignature))[:4]
 	L1InfoDepositerAddress = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
-	L1BlockAddress         = common.HexToAddress(predeploys.L1Block)
+	L1BlockAddress         = predeploys.L1BlockAddr
 )
 
 type L1Info interface {

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -164,7 +164,7 @@ func FinalizeWithdrawalParameters(ctx context.Context, l2client ProofClient, txH
 		return FinalizedWithdrawalParameters{}, err
 	}
 	slot := StorageSlotOfWithdrawalHash(withdrawalHash)
-	p, err := l2client.GetProof(ctx, common.HexToAddress(predeploys.L2ToL1MessagePasser), []string{slot.String()}, header.Number)
+	p, err := l2client.GetProof(ctx, predeploys.L2ToL1MessagePasserAddr, []string{slot.String()}, header.Number)
 	if err != nil {
 		return FinalizedWithdrawalParameters{}, err
 	}


### PR DESCRIPTION
**Description**

Use common.Address predeploy types. These are a couple fixes that I forgot to commit.