### PR TITLE
op-replica env should include new values

### DIFF
--- a/infra/op-replica/docker-compose/default-kovan.env
+++ b/infra/op-replica/docker-compose/default-kovan.env
@@ -3,7 +3,6 @@ COMPOSE_FILE=replica.yml:replica-shared.yml:replica-toml.yml
 ETH_NETWORK=kovan
 DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT=WONT_WORK_UNLESS_YOU_PROVIDE_A_VALID_ETHEREUM_L1_ENDPOINT
 DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT=https://kovan.optimism.io
-REPLICA_HEALTHCHECK__ETH_NETWORK_RPC_PROVIDER=https://kovan.optimism.io
 SEQUENCER_CLIENT_HTTP=https://kovan.optimism.io
 SHARED_ENV_PATH=../envs/kovan
 GCMODE=archive

--- a/infra/op-replica/docker-compose/default-kovan.env
+++ b/infra/op-replica/docker-compose/default-kovan.env
@@ -14,5 +14,7 @@ L2GETH_HTTP_PORT=9991
 L2GETH_WS_PORT=9992
 DTL_PORT=7878
 GETH_INIT_SCRIPT=check-for-chaindata-berlin.sh
+HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://kovan.optimism.io
+HEALTHCHECK__TARGET_RPC_PROVIDER=http://l2geth-replica:8545
 
 RESTART=unless-stopped

--- a/infra/op-replica/docker-compose/default-mainnet.env
+++ b/infra/op-replica/docker-compose/default-mainnet.env
@@ -3,7 +3,6 @@ COMPOSE_FILE=replica.yml:replica-shared.yml:replica-toml.yml
 ETH_NETWORK=mainnet
 DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT=WONT_WORK_UNLESS_YOU_PROVIDE_A_VALID_ETHEREUM_L1_ENDPOINT
 DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT=https://mainnet.optimism.io
-REPLICA_HEALTHCHECK__ETH_NETWORK_RPC_PROVIDER=https://mainnet.optimism.io
 SEQUENCER_CLIENT_HTTP=https://mainnet.optimism.io
 SHARED_ENV_PATH=../envs/mainnet
 GCMODE=archive
@@ -14,6 +13,8 @@ L2GETH_HTTP_PORT=9991
 L2GETH_WS_PORT=9992
 DTL_PORT=7878
 GETH_INIT_SCRIPT=check-for-chaindata-berlin.sh
+HEALTHCHECK__REFERENCE_RPC_PROVIDER=https://mainnet.optimism.io
+HEALTHCHECK__TARGET_RPC_PROVIDER=http://l2geth-replica:8545
 
 RESTART=unless-stopped
 


### PR DESCRIPTION
**Description**
The v1+ version of the replica-healthcheck requires new env values.

Closes https://github.com/ethereum-optimism/optimism/issues/2798
