### PR TITLE
drippie-mon: Fix build

### DIFF
--- a/.changeset/dry-drinks-sneeze.md
+++ b/.changeset/dry-drinks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/drippie-mon': patch
+---
+
+Fix release

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -226,7 +226,7 @@ jobs:
         with:
           context: .
           file: ./ops/docker/Dockerfile.packages
-          target: relayer
+          target: fault-detector
           push: true
           tags: ethereumoptimism/fault-detector:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
@@ -253,7 +253,7 @@ jobs:
         with:
           context: .
           file: ./ops/docker/Dockerfile.packages
-          target: relayer
+          target: drippie-mon
           push: true
           tags: ethereumoptimism/drippie-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
 

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -28,6 +28,7 @@ COPY packages/hardhat-deploy-config/package.json ./packages/hardhat-deploy-confi
 COPY packages/message-relayer/package.json ./packages/message-relayer/package.json
 COPY packages/fault-detector/package.json ./packages/fault-detector/package.json
 COPY packages/replica-healthcheck/package.json ./packages/replica-healthcheck/package.json
+COPY packages/drippie-mon/package.json ./packages/drippie-mon/package.json
 COPY integration-tests/package.json ./integration-tests/package.json
 
 RUN yarn install --frozen-lockfile && yarn cache clean
@@ -71,4 +72,8 @@ CMD ["npm", "run", "start"]
 
 FROM base as replica-healthcheck
 WORKDIR /opt/optimism/packages/replica-healthcheck
+ENTRYPOINT ["npm", "run", "start"]
+
+FROM base as drippie-mon
+WORKDIR /opt/optimism/packages/drippie-mon
 ENTRYPOINT ["npm", "run", "start"]


### PR DESCRIPTION
There was no `drippie-mon` target in `Dockerfile.packages`, and the canary build was using the `relayer` target.
