### PR TITLE
fix(cmn): correctly ignore invalid routes

### DIFF
--- a/.changeset/heavy-buttons-impress.md
+++ b/.changeset/heavy-buttons-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Fix potential metrics DoS vector in recent commit to BSV2

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -400,6 +400,19 @@ export abstract class BaseServiceV2<
         })
       )
 
+      // Health status.
+      app.get('/healthz', async (req, res) => {
+        return res.json({
+          ok: this.healthy,
+        })
+      })
+
+      // Register user routes.
+      const router = express.Router()
+      if (this.routes) {
+        this.routes(router)
+      }
+
       // Metrics.
       // Will expose a /metrics endpoint by default.
       app.use(
@@ -408,22 +421,19 @@ export abstract class BaseServiceV2<
           includeMethod: true,
           includePath: true,
           includeStatusCode: true,
+          normalizePath: (req) => {
+            for (const layer of router.stack) {
+              if (layer.route && req.path.match(layer.regexp)) {
+                return layer.route.path
+              }
+            }
+
+            return '/invalid_path_not_a_real_route'
+          }
         })
       )
 
-      // Health status.
-      app.get('/healthz', async (req, res) => {
-        return res.json({
-          ok: this.healthy,
-        })
-      })
-
-      // Registery user routes.
-      if (this.routes) {
-        const router = express.Router()
-        this.routes(router)
-        app.use('/api', router)
-      }
+      app.use('/api', router)
 
       // Wait for server to come up.
       await new Promise((resolve) => {


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes BSV2 to correctly ignore invalid routes in metrics by normalizing
them to /invalid_path_not_a_real_route.
