### PR TITLE
Fix linting issues in bedrock package

### DIFF
--- a/packages/contracts-bedrock/.eslintignore
+++ b/packages/contracts-bedrock/.eslintignore
@@ -8,3 +8,4 @@ forge-artifacts
 cache
 typechain
 coverage*
+deployments

--- a/packages/contracts-bedrock/.prettierignore
+++ b/packages/contracts-bedrock/.prettierignore
@@ -9,6 +9,7 @@ forge-artifacts
 cache
 typechain
 coverage*
+deployments
 
 contracts/L2/WETH9.sol
 

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -39,10 +39,8 @@ const config: HardhatUserConfig = {
     },
     goerli: {
       chainId: 5,
-      url: (process.env.L1_RPC || ''),
-      accounts: [
-        (process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero),
-      ],
+      url: process.env.L1_RPC || '',
+      accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
     },
   },
   paths: {

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -22,7 +22,7 @@
     "gas-snapshot": "forge snapshot",
     "slither": "slither .",
     "clean": "rm -rf ./dist ./artifacts ./forge-artifacts ./cache ./coverage ./tsconfig.tsbuildinfo",
-    "lint:ts:check": "eslint .",
+    "lint:ts:check": "eslint . --max-warnings=0",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol'",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",
     "lint:ts:fix": "yarn prettier --write .",


### PR DESCRIPTION
**Description**

This PR: 
1. Adds the deployments folder to `.eslintignore` and `.prettierignore`. 
2. Changes the `yarn lint:ts:check` command so that it throws an error on warnings.  This prevents the issue where warnings don't cause an error in CI, but `yarn lint:ts:fix` will modify the code anyways. The approach used is consistent with other packages.
3. Formats the hardhat config file.
