### PR TITLE
chore: Use yarn command to lint markdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,14 +371,17 @@ jobs:
             docker push <<parameters.docker_tags>>
 
   bedrock-markdown:
-    machine:
-      image: ubuntu-2004:202111-02
+    docker:
+      - image: ethereumoptimism/js-builder:latest
     steps:
+      - restore_cache:
+          keys:
+            - v2-cache-yarn-build-{{ .Revision }}
       - checkout
       - run:
           name: markdown lint
           command: |
-            docker run -v `pwd`:/workdir davidanson/markdownlint-cli2:0.4.0 "op-node/README.md" "./specs/**/*.md" "#**/node_modules"
+            yarn markdownlint-cli2 "op-node/README.md" "./specs/**/*.md" "#**/node_modules"
       - run:
           name: link lint
           command: |


### PR DESCRIPTION
**Description**

The `bedrock-markdown` workflow seems to fail quite frequently due to an issue pulling an image from docker. ([example](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/3366/workflows/98f454e7-92ee-4460-9ea8-0cfbaf6f2018/jobs/42775/parallel-runs/0/steps/0-102))

This PR changes the command to use yarn instead of docker. 

**Metadata**
- Fixes #[Link to Issue]
