### PR TITLE
fix (bedrock): deploy L2OO - fix args

### DIFF
--- a/.changeset/funny-goats-appear.md
+++ b/.changeset/funny-goats-appear.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Fix order of args to L2OO constructor

--- a/packages/contracts-bedrock/deploy/000-L2OutputOracle.deploy.ts
+++ b/packages/contracts-bedrock/deploy/000-L2OutputOracle.deploy.ts
@@ -19,11 +19,11 @@ const deployFn: DeployFunction = async (hre) => {
     from: deployer,
     args: [
       hre.deployConfig.submissionInterval,
-      hre.deployConfig.l2BlockTime,
       hre.deployConfig.genesisOutput,
       hre.deployConfig.historicalBlocks,
       hre.deployConfig.startingBlockNumber,
       hre.deployConfig.startingTimestamp,
+      hre.deployConfig.l2BlockTime,
       hre.deployConfig.sequencerAddress,
     ],
     log: true,


### PR DESCRIPTION
**Description**
Fixed the order of the args to L2OO deploy script recently updated in #2830 which was causing L1 deploy scripts to fail with:


```
2028 [48b901ec] Error: ERROR processing /hive/contracts/deploy/000-L2OutputOracle.deploy.ts:
2029 [48b901ec] Error: incorrect data length (argument="_genesisL2Output", value=2, code=INVALID_ARGUMENT, version=abi/5.6.4)
2030 [48b901ec]     at Logger.makeError (/hive/contracts/node_modules/@ethersproject/logger/src.ts/index.ts:261:28)
2031 [48b901ec]     at Logger.throwError (/hive/contracts/node_modules/@ethersproject/logger/src.ts/index.ts:273:20)
2032 [48b901ec]     at Logger.throwArgumentError (/hive/contracts/node_modules/@ethersproject/logger/src.ts/index.ts:277:21)
2033 [48b901ec]     at FixedBytesCoder.Coder._throwError (/hive/contracts/node_modules/@ethersproject/abi/src.ts/coders/abstract-coder.ts:68:16)
2034 [48b901ec]     at FixedBytesCoder.encode (/hive/contracts/node_modules/@ethersproject/abi/src.ts/coders/fixed-bytes.ts:23:47)
2035 [48b901ec]     at /hive/contracts/node_modules/@ethersproject/abi/src.ts/coders/array.ts:71:19
2036 [48b901ec]     at Array.forEach (<anonymous>)
2037 [48b901ec]     at pack (/hive/contracts/node_modules/@ethersproject/abi/src.ts/coders/array.ts:54:12)
2038 [48b901ec]     at TupleCoder.encode (/hive/contracts/node_modules/@ethersproject/abi/src.ts/coders/tuple.ts:54:20)
2039 [48b901ec]     at AbiCoder.encode (/hive/contracts/node_modules/@ethersproject/abi/src.ts/abi-coder.ts:111:15)
2040 [48b901ec]     at DeploymentsManager.executeDeployScripts (/hive/contracts/node_modules/hardhat-deploy/src/DeploymentsManager.ts:1222:19)
2041 [48b901ec]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
2042 [48b901ec]     at async DeploymentsManager.runDeploy (/hive/contracts/node_modules/hardhat-deploy/src/DeploymentsManager.ts:1052:5)
2043 [48b901ec]     at async SimpleTaskDefinition.action (/hive/contracts/node_modules/hardhat-deploy/src/index.ts:438:5)
2044 [48b901ec]     at async Environment._runTaskDefinition (/hive/contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:219:14)
2045 [48b901ec]     at async Environment.run (/hive/contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:131:14)
2046 [48b901ec]     at async SimpleTaskDefinition.action (/hive/contracts/node_modules/hardhat-deploy/src/index.ts:584:32)
2047 [48b901ec]     at async Environment._runTaskDefinition (/hive/contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:219:14)
2048 [48b901ec]     at async Environment.run (/hive/contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:131:14)
2049 [48b901ec]     at async SimpleTaskDefinition.action (/hive/contracts/node_modules/hardhat-deploy/src/index.ts:669:5)
2050 [48b901ec] error Command failed with exit code 1.
2051 [48b901ec] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2052 [48b901ec] Deployed L1 contracts
```