### PR TITLE
fix(op-e2e): less flakey TestL2OutputSubmitter

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -790,7 +790,7 @@ func TestWithdrawals(t *testing.T) {
 	require.Nil(t, err)
 
 	// Wait for finalization and then create the Finalized Withdrawal Transaction
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Duration(cfg.L1BlockTime)*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Duration(cfg.L1BlockTime)*time.Second)
 	defer cancel()
 	blockNumber, err := withdrawals.WaitForFinalizationPeriod(ctx, l1Client, sys.DepositContractAddr, receipt.BlockNumber)
 	require.Nil(t, err)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -87,7 +87,8 @@ func defaultSystemConfig(t *testing.T) SystemConfig {
 		},
 		L2OOCfg: L2OOContractConfig{
 			// L2 Start time is set based off of the L2 Genesis time
-			SubmissionFrequency:   big.NewInt(2),
+			SubmissionFrequency:   big.NewInt(4),
+			L2BlockTime:           big.NewInt(2),
 			HistoricalTotalBlocks: big.NewInt(0),
 		},
 		L2OutputHDPath:             l2OutputHDPath,


### PR DESCRIPTION
**Description**
Increase SubmissionFrequency and L2BlockTime in system_test.go which appears to greatly reduce the failures in TestL2OutputSubmitter.
