### PR TITLE
ci: Upgrade golangci-lint version to one that handles Go 1.18

### DIFF
--- a/.changeset/thin-carpets-perform.md
+++ b/.changeset/thin-carpets-perform.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/go-builder': patch
+---
+
+Upgrade golangci-lint version for go 1.18

--- a/ops/docker/go-builder/Dockerfile
+++ b/ops/docker/go-builder/Dockerfile
@@ -6,6 +6,6 @@ COPY --from=geth /usr/local/bin/abigen /usr/local/bin/abigen
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq curl bash gzip ca-certificates openssh && \
 	go install gotest.tools/gotestsum@latest && \
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
 
 CMD ["bash"]

--- a/proxyd/integration_tests/mock_backend_test.go
+++ b/proxyd/integration_tests/mock_backend_test.go
@@ -231,9 +231,7 @@ func (m *MockBackend) Requests() []*RecordedRequest {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 	out := make([]*RecordedRequest, len(m.requests))
-	for i := 0; i < len(m.requests); i++ {
-		out[i] = m.requests[i]
-	}
+	copy(out, m.requests)
 	return out
 }
 


### PR DESCRIPTION
This has been pushed as `latest` and `0.0.5` to Docker Hub via a manual push in order to unblock other PRs.