### PR TITLE
ci: run hh deploy scripts in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,10 @@ jobs:
           name: Test
           command: yarn test:coverage
           working_directory: packages/contracts
+        - run:
+          name: Deploy
+          command: npx hardhat deploy
+          working_directory: packages/contracts
 
   contracts-periphery-tests:
     docker:
@@ -178,6 +182,10 @@ jobs:
           name: Test
           command: yarn test:coverage
           working_directory: packages/contracts-periphery
+      - run:
+          name: Deploy
+          command: npx hardhat deploy
+          working_directory: packages/contracts-periphery
 
   contracts-governance-tests:
     docker:
@@ -195,6 +203,10 @@ jobs:
       - run:
           name: Test
           command: yarn test
+          working_directory: packages/contracts-governance
+      - run:
+          name: Deploy
+          command: npx hardhat deploy
           working_directory: packages/contracts-governance
 
   dtl-tests:
@@ -413,6 +425,10 @@ jobs:
       - run:
           name: storage snapshot
           command: yarn storage-snapshot && git diff --exit-code .storage-layout
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Deploy
+          command: npx hardhat deploy
           working_directory: packages/contracts-bedrock
       - run:
           name: check go bindings


### PR DESCRIPTION
**Description**

Adds a deploy step to each of the contracts packages: 

```yaml
      - run:
          name: Deploy
          command: npx hardhat deploy
          working_directory: packages/contracts
```

Even if the full devnet integration tests are not running in CI, this will be helpful for ensuring that the deploy scripts are working.