### PR TITLE
Correct l33t sp34k in toCodeAddr

### DIFF
--- a/.changeset/mighty-rockets-provide.md
+++ b/.changeset/mighty-rockets-provide.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+correct l33t sp34k in toCodeAddrr

--- a/packages/contracts-bedrock/tasks/genesis-l2.ts
+++ b/packages/contracts-bedrock/tasks/genesis-l2.ts
@@ -16,7 +16,7 @@ const adminSlot =
 
 const toCodeAddr = (addr: string) => {
   const address = ethers.utils.hexConcat([
-    '0xc0d3c0d3c03dc03dc03dc03dc03dc03dc03d',
+    '0xc0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3c0d3',
     '0x' + addr.slice(prefix.length),
   ])
   return ethers.utils.getAddress(address)


### PR DESCRIPTION
A small change to ensure the code address prefix is repeated correctly. Not a big deal, but could prevent errors of manually rewriting an address.