### PR TITLE
ci: Use conditional builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,75 +1,23 @@
 version: 2.1
 
-orbs:
-  node: circleci/node@5.0.2
-
-executors:
-  go-builder:
-    docker:
-      - image: ethereumoptimism/go-builder:latest
-
-commands:
-  go-lint-test:
-    parameters:
-      working_directory:
-        description: Working directory
-        type: string
-    steps:
-      - checkout
-      - run:
-          name: Lint
-          command: golangci-lint run -E goimports -E sqlclosecheck -E bodyclose -E asciicheck ./...
-          working_directory: <<parameters.working_directory>>
-      - run:
-          name: Test
-          command: |
-            mkdir -p /test-results
-            gotestsum --junitfile /test-results/tests.xml
-          working_directory: <<parameters.working_directory>>
-      - store_test_results:
-          path: /test-results
-
 jobs:
-  go-lint-test:
-    parameters:
-      working_directory:
-        description: Working directory
-        type: string
-    docker:
-      - image: ethereumoptimism/go-builder:latest
-      - image: cimg/postgres:14.1
-    steps:
-      - go-lint-test:
-          working_directory: <<parameters.working_directory>>
-
-  go-lint-test-build:
-    parameters:
-      binary_name:
-        description: Binary name to build
-        type: string
-      working_directory:
-        description: Working directory
-        type: string
-    docker:
-      - image: ethereumoptimism/go-builder:latest
-      - image: cimg/postgres:14.1
-    steps:
-      - go-lint-test:
-          working_directory: <<parameters.working_directory>>
-      - run:
-          name: Build
-          command: make <<parameters.binary_name>>
-          working_directory: <<parameters.working_directory>>
-
   yarn-monorepo:
     docker:
-      - image: ethereumoptimism/js-builder:latest
+      - image: ethereumoptimism/ci-builder:latest
+    resource_class: xlarge
     steps:
       - restore_cache:
           keys:
             - v2-cache-source-{{ .Branch }}-{{ .Revision }}
             - v2-cache-source-{{ .Branch }}
       - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "packages/")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
       - save_cache:
           key: v2-cache-source-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -105,221 +53,6 @@ jobs:
           paths:
             - "."
 
-  contracts-slither:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Run Slither
-          command: yarn test:slither
-          working_directory: packages/contracts
-
-  contracts-periphery-slither:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Run Slither
-          command: yarn test:slither
-          working_directory: packages/contracts-periphery
-
-  contracts-tests:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    resource_class: xlarge
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Lint
-          command: yarn lint:check
-          working_directory: packages/contracts
-      - run:
-          name: Check deployment docs
-          command: yarn autogen:markdown && git diff --exit-code
-          working_directory: packages/contracts
-      - run:
-          name: Slither
-          command: yarn test:slither
-          working_directory: packages/contracts
-      - run:
-          name: Test
-          command: yarn test:coverage
-          working_directory: packages/contracts
-
-  contracts-periphery-tests:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    resource_class: xlarge
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Lint
-          command: yarn lint:check
-          working_directory: packages/contracts-periphery
-      - run:
-          name: Slither
-          command: yarn test:slither
-          working_directory: packages/contracts
-      - run:
-          name: Test
-          command: yarn test:coverage
-          working_directory: packages/contracts-periphery
-
-  contracts-governance-tests:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    resource_class: xlarge
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Lint
-          command: yarn lint:check
-          working_directory: packages/contracts-governance
-      - run:
-          name: Test
-          command: yarn test
-          working_directory: packages/contracts-governance
-
-  dtl-tests:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Test
-          command: yarn test:coverage
-          working_directory: packages/data-transport-layer
-
-  geth-tests:
-    docker:
-      - image: ethereumoptimism/go-builder:latest
-    steps:
-      - checkout
-      - run:
-          name: Test
-          command: make test
-          working_directory: l2geth
-
-  depcheck:
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      # Note: The below needs to be manually configured whenever we
-      # add a new package to CI.
-      - run:
-          name: Check contracts
-          command: npx depcheck
-          working_directory: packages/contracts
-      - run:
-          name: Check contracts-periphery
-          command: npx depcheck
-          working_directory: packages/contracts-periphery
-      - run:
-          name: Check core-utils
-          command: npx depcheck
-          working_directory: packages/core-utils
-      - run:
-          name: Check data-transport-layer
-          command: npx depcheck
-          working_directory: packages/data-transport-layer
-      - run:
-          name: Check sdk
-          command: npx depcheck
-          working_directory: packages/sdk
-      - run:
-          name: Check integration-tests
-          command: npx depcheck
-          working_directory: integration-tests
-
-  bss-core-tests:
-    docker:
-      - image: ethereumoptimism/go-builder:latest
-    steps:
-      - checkout
-      - run:
-          name: Lint
-          command: golangci-lint run -E goimports -E sqlclosecheck -E bodyclose -E asciicheck ./...
-          working_directory: bss-core
-      - run:
-          name: Test
-          command: |
-            mkdir -p /test-results
-            gotestsum --junitfile /test-results/tests.xml
-          working_directory: bss-core
-      - store_test_results:
-          path: /test-results
-
-  integration-tests:
-    machine:
-      image: ubuntu-2004:202111-02
-      docker_layer_caching: true
-    environment:
-      DOCKER_BUILDKIT: 1
-    parallelism: 3
-    steps:
-      - checkout
-      - run:
-          name: Bring up the stack
-          command: |
-            docker-compose build --progress=plain
-            docker-compose up -d --scale replica_healthcheck=1
-          working_directory: ops
-      - run:
-          name: Wait for sequencer
-          command: bash scripts/wait-for-sequencer.sh
-          working_directory: ops
-      - run:
-          name: Run integration tests
-          command: |
-            circleci tests glob "../integration-tests/test/*.spec.ts" | circleci tests split | tee splits.txt
-            docker-compose run integration_tests $(cat splits.txt)
-          working_directory: ops
-
-  js-lint-test:
-    parameters:
-      package_name:
-        description: Package name
-        type: string
-    docker:
-      - image: ethereumoptimism/js-builder:latest
-    steps:
-      - restore_cache:
-          keys:
-            - v2-cache-yarn-build-{{ .Revision }}
-      - checkout
-      - run:
-          name: Lint
-          command: yarn lint:check
-          working_directory: packages/<<parameters.package_name>>
-      - run:
-          name: Test
-          command: yarn test:coverage
-          working_directory: packages/<<parameters.package_name>>
-
   docker-publish:
     environment:
       DOCKER_BUILDKIT: 1
@@ -349,45 +82,39 @@ jobs:
             - run:
                 name: Build with context
                 command: |
-                    docker build \
-                    $(echo -ne "<< parameters.docker_tags >>" | sed "s/,/\n/g" | sed -e 's/^/-t /' | tr '\n' ' ') \
-                    -f <<parameters.docker_file>> \
-                    --target <<parameters.target>> \
-                    <<parameters.docker_context>>
+                  docker build \
+                  $(echo -ne "<< parameters.docker_tags >>" | sed "s/,/\n/g" | sed -e 's/^/-t /' | tr '\n' ' ') \
+                  -f <<parameters.docker_file>> \
+                  --target <<parameters.target>> \
+                  <<parameters.docker_context>>
       - unless:
           condition: <<parameters.target>>
           steps:
             - run:
                 name: Build
                 command: |
-                    docker build \
-                    $(echo -ne "<< parameters.docker_tags >>" | sed "s/,/\n/g" | sed -e 's/^/-t /' | tr '\n' ' ') \
-                    -f <<parameters.docker_file>> \
-                    <<parameters.docker_context>>
+                  docker build \
+                  $(echo -ne "<< parameters.docker_tags >>" | sed "s/,/\n/g" | sed -e 's/^/-t /' | tr '\n' ' ') \
+                  -f <<parameters.docker_file>> \
+                  <<parameters.docker_context>>
       - run:
           name: Publish
           command: |
             echo "$DOCKER_PASS" | docker login -u "$DOCKER_USERNAME" --password-stdin
             docker push <<parameters.docker_tags>>
 
-  bedrock-markdown:
-    machine:
-      image: ubuntu-2004:202111-02
-    steps:
-      - checkout
-      - run:
-          name: markdown lint
-          command: |
-            docker run -v `pwd`:/workdir davidanson/markdownlint-cli2:0.4.0 "op-node/README.md" "./specs/**/*.md" "#**/node_modules"
-      - run:
-          name: link lint
-          command: |
-            docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback --exclude twitter.com --exclude-mail /input/README.md "/input/specs/**/*.md" "/input/meta/**/*.md" "/input/op-node/**/*.md" || exit 0
-
   contracts-bedrock-tests:
     docker:
-      - image: ethereumoptimism/js-builder:latest
+      - image: ethereumoptimism/ci-builder:latest
+    resource_class: medium
     steps:
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "(contracts-bedrock|hardhat-deploy-config)")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
       - restore_cache:
           keys:
             - v2-cache-yarn-build-{{ .Revision }}
@@ -419,11 +146,51 @@ jobs:
           command: make && git diff --exit-code
           working_directory: op-bindings
 
+  js-lint-test:
+    parameters:
+      package_name:
+        description: Package name
+        type: string
+      dependencies:
+        description: Regex matching dependent packages
+        type: string
+        default: this-package-does-not-exist
+    docker:
+      - image: ethereumoptimism/ci-builder:latest
+    resource_class: large
+    steps:
+      - restore_cache:
+          keys:
+            - v2-cache-yarn-build-{{ .Revision }}
+      - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "(packages/<<parameters.package_name>>|packages/<<parameters.dependencies>>")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: Lint
+          command: yarn lint:check
+          working_directory: packages/<<parameters.package_name>>
+      - run:
+          name: Test
+          command: yarn test:coverage
+          working_directory: packages/<<parameters.package_name>>
+
   bedrock-go-tests:
     docker:
-      - image: ethereumoptimism/go-builder:latest
+      - image: ethereumoptimism/ci-builder:latest
     steps:
       - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "op-(batcher|bindings|e2e|node|proposer)")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
       - run:
           name: lint op-bindings
           command: |
@@ -474,10 +241,26 @@ jobs:
           working_directory: op-e2e
       - store_test_results:
           path: /test-results
+      - run:
+          command: echo "Done."
+
+  bedrock-markdown:
+    machine:
+      image: ubuntu-2004:202111-02
+    steps:
+      - checkout
+      - run:
+          name: markdown lint
+          command: |
+            docker run -v `pwd`:/workdir davidanson/markdownlint-cli2:0.4.0 "op-node/README.md" "./specs/**/*.md" "#**/node_modules"
+      - run:
+          name: link lint
+          command: |
+            docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback --exclude twitter.com --exclude-mail /input/README.md "/input/specs/**/*.md" "/input/meta/**/*.md" "/input/op-node/**/*.md" || exit 0
 
   fuzz-op-node:
     docker:
-      - image: ethereumoptimism/go-builder:latest
+      - image: ethereumoptimism/ci-builder:latest
     steps:
       - checkout
       - run:
@@ -485,30 +268,155 @@ jobs:
           command: make fuzz
           working_directory: op-node
 
-  bedrock-integration-tests:
-    machine:
-      image: ethereumoptimism/js-builder:latest
-      docker_layer_caching: true
+  depcheck:
+    docker:
+      - image: ethereumoptimism/ci-builder:latest
+    steps:
+      - restore_cache:
+          keys:
+            - v2-cache-yarn-build-{{ .Revision }}
+      - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "packages/")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      # Note: The below needs to be manually configured whenever we
+      # add a new package to CI.
+      - run:
+          name: Check contracts
+          command: npx depcheck
+          working_directory: packages/contracts
+      - run:
+          name: Check contracts-periphery
+          command: npx depcheck
+          working_directory: packages/contracts-periphery
+      - run:
+          name: Check core-utils
+          command: npx depcheck
+          working_directory: packages/core-utils
+      - run:
+          name: Check data-transport-layer
+          command: npx depcheck
+          working_directory: packages/data-transport-layer
+      - run:
+          name: Check sdk
+          command: npx depcheck
+          working_directory: packages/sdk
+      - run:
+          name: Check integration-tests
+          command: npx depcheck
+          working_directory: integration-tests
+
+  go-lint-test-build:
+    parameters:
+      binary_name:
+        description: Binary name to build
+        type: string
+      working_directory:
+        description: Working directory
+        type: string
+      build:
+        description: Whether or not to build the binary
+        type: boolean
+        default: true
+      dependencies:
+        description: Regex matching dependent packages
+        type: string
+        default: this-package-does-not-exist
+    docker:
+      - image: ethereumoptimism/ci-builder:latest
+      - image: cimg/postgres:14.1
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
-          node-version: '16.13'
       - run:
-          name: build typescript
-          command: make build-ts
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "(<<parameters.working_directory>>|<<parameters.dependencies>>)")
+            echo $CHANGED
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
       - run:
-          name: start devnet
-          command: make devnet-up
+          name: Lint
+          command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell ./...
+          working_directory: <<parameters.working_directory>>
+      - store_test_results:
+          path: /test-results
       - run:
-          name: run itests
-          command: make test-integration
+          name: Test
+          command: |
+            mkdir -p /test-results
+            gotestsum --junitfile /test-results/tests.xml
+          working_directory: <<parameters.working_directory>>
+      - when:
+          condition:
+            equal: [ true, <<parameters.build>> ]
+          steps:
+            - run:
+                name: Build
+                command: make <<parameters.binary_name>>
+                working_directory: <<parameters.working_directory>>
+
+  geth-tests:
+    docker:
+      - image: ethereumoptimism/ci-builder:latest
+    steps:
+      - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(check-changed "l2geth")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: Test
+          command: make test
+          working_directory: l2geth
+
+  integration-tests:
+    machine:
+      image: ubuntu-2004:202201-01
+      docker_layer_caching: true
+    environment:
+      DOCKER_BUILDKIT: 1
+    parallelism: 3
+    steps:
+      - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            CHANGED=$(bash ./ops/docker/ci-builder/check-changed.sh "(l2geth|common-ts|contracts|core-utils|message-relayer|data-transport-layer|replica-healthcheck|sdk|batch-submitter|gas-oracle|bss-core|integration-tests)")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: Bring up the stack
+          command: |
+            docker-compose build --progress=plain
+            docker-compose up -d --scale replica_healthcheck=1
+          working_directory: ops
+      - run:
+          name: Wait for sequencer
+          command: bash scripts/wait-for-sequencer.sh
+          working_directory: ops
+      - run:
+          name: Run integration tests
+          command: |
+            circleci tests glob "../integration-tests/test/*.spec.ts" | circleci tests split | tee splits.txt
+            docker-compose run integration_tests $(cat splits.txt)
+          working_directory: ops
+      - run:
+          command: echo "Done."
 
   semgrep-scan:
     parameters:
-        diff_branch:
-          type: string
-          default: develop
+      diff_branch:
+        type: string
+        default: develop
     environment:
       TEMPORARY_BASELINE_REF: << parameters.diff_branch >>
       SEMGREP_REPO_URL: << pipeline.project.git_url >>
@@ -525,20 +433,20 @@ jobs:
       - checkout
       - unless:
           condition:
-            equal: [ "develop", << pipeline.git.branch >>]
+            equal: [ "develop", << pipeline.git.branch >> ]
           steps:
             - run:
                 # Scan changed files in PRs, block on new issues only (existing issues ignored)
                 # Do a full scan when scanning develop, otherwise do an incremental scan.
                 name: "Conditionally set BASELINE env var"
                 command: |
-                    echo 'export SEMGREP_BASELINE_REF=${TEMPORARY_BASELINE_REF}' >> $BASH_ENV
+                  echo 'export SEMGREP_BASELINE_REF=${TEMPORARY_BASELINE_REF}' >> $BASH_ENV
       - run:
           name: "Set environment variables" # for PR comments and in-app hyperlinks to findings
           command: |
-              echo 'export SEMGREP_PR_ID=${CIRCLE_PULL_REQUEST##*/}' >> $BASH_ENV
-              echo 'export SEMGREP_JOB_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
-              echo 'export SEMGREP_REPO_NAME=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
+            echo 'export SEMGREP_PR_ID=${CIRCLE_PULL_REQUEST##*/}' >> $BASH_ENV
+            echo 'export SEMGREP_JOB_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
+            echo 'export SEMGREP_REPO_NAME=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
       - run:
           name: "Semgrep scan"
           command: semgrep ci
@@ -546,15 +454,85 @@ jobs:
 workflows:
   main:
     jobs:
-      - semgrep-scan
       - yarn-monorepo
+      - js-lint-test:
+          name: common-ts-tests
+          package_name: common-ts
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: contracts-tests
+          package_name: contracts
+          dependencies: hardhat-deploy-config
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: core-utils-tests
+          package_name: core-utils
+          requires:
+            - yarn-monorepo
+      - contracts-bedrock-tests:
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: contracts-governance-tests
+          package_name: contracts-governance
+          dependencies: "core-utils|sdk"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: contracts-periphery-tests
+          package_name: contracts-periphery
+          dependencies: "contracts|contracts-bedrock|core-utils|hardhat-deploy-config"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: dtl-tests
+          package_name: data-transport-layer
+          dependencies: "common-ts|contracts|core-utils"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: drippie-mon-tests
+          package_name: drippie-mon
+          dependencies: "common-ts|contracts-periphery|core-utils|sdk"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: fault-detector-tests
+          package_name: fault-detector
+          dependencies: "common-ts|contracts|core-utils|sdk"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: message-relayer-tests
+          package_name: message-relayer
+          dependencies: "common-ts|core-utils|sdk"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: replica-healthcheck-tests
+          package_name: replica-healthcheck
+          dependencies: "common-ts|core-utils"
+          requires:
+            - yarn-monorepo
+      - js-lint-test:
+          name: sdk-tests
+          package_name: sdk
+          dependencies: "contracts|core-utils"
+          requires:
+            - yarn-monorepo
+      - depcheck:
+          requires:
+            - yarn-monorepo
       - bedrock-go-tests
-      - bedrock-markdown
       - fuzz-op-node
+      - bedrock-markdown
       - go-lint-test-build:
           name: batch-submitter-tests
           binary_name: batch-submitter
           working_directory: batch-submitter
+          dependencies: bss-core
       - go-lint-test-build:
           name: proxyd-tests
           binary_name: proxyd
@@ -563,6 +541,7 @@ workflows:
           name: teleportr-tests
           binary_name: teleportr
           working_directory: teleportr
+          dependencies: bss-core
       - go-lint-test-build:
           name: gas-oracle-tests
           binary_name: gas-oracle
@@ -571,61 +550,14 @@ workflows:
           name: indexer-tests
           binary_name: indexer
           working_directory: indexer
-      - go-lint-test:
+      - go-lint-test-build:
           name: bss-core-tests
+          binary_name: bss-core
           working_directory: bss-core
-      - contracts-tests:
-          requires:
-            - yarn-monorepo
-      - contracts-periphery-tests:
-          requires:
-            - yarn-monorepo
-      - contracts-bedrock-tests:
-          requires:
-            - yarn-monorepo
-      - contracts-governance-tests:
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: dtl-tests
-          package_name: data-transport-layer
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: core-utils-tests
-          package_name: core-utils
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: sdk-tests
-          package_name: sdk
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: fault-detector-tests
-          package_name: fault-detector
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: drippie-mon-tests
-          package_name: drippie-mon
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: message-relayer-tests
-          package_name: message-relayer
-          requires:
-            - yarn-monorepo
-      - js-lint-test:
-          name: replica-healthcheck-tests
-          package_name: replica-healthcheck
-          requires:
-            - yarn-monorepo
-      - depcheck:
-          requires:
-            - yarn-monorepo
+          build: false
       - geth-tests
       - integration-tests
+      - semgrep-scan
 
   nightly:
     triggers:

--- a/batch-submitter/drivers/sequencer/batch.go
+++ b/batch-submitter/drivers/sequencer/batch.go
@@ -90,7 +90,7 @@ func GenSequencerBatchParams(
 	)
 
 	// Iterate over the batch elements, grouping the elements according to
-	// the following critera:
+	// the following criteria:
 	//  - All txs in the same group must have the same timestamp.
 	//  - All sequencer txs in the same group must have the same block number.
 	//  - If sequencer txs exist in a group, they must come before all

--- a/batch-submitter/drivers/sequencer/encoding.go
+++ b/batch-submitter/drivers/sequencer/encoding.go
@@ -179,7 +179,7 @@ type AppendSequencerBatchParams struct {
 	// Contexts aggregates redundant L1 block numbers and L1 timestamps for
 	// the txns encoded in the Tx slice. Further, they specify consecutive
 	// tx windows in Txs and implicitly allow one to compute how many
-	// (ommitted) queued txs are in a given window.
+	// (omitted) queued txs are in a given window.
 	Contexts []BatchContext
 
 	// Txs contains all sequencer txs that will be recorded in the L1 CTC
@@ -192,7 +192,7 @@ type AppendSequencerBatchParams struct {
 //  - total_elements_to_append:       3 bytes
 //  - num_contexts:                   3 bytes
 //    - num_contexts * batch_context: num_contexts * 16 bytes
-//  - [num txs ommitted]
+//  - [num txs omitted]
 //    - tx_len:                       3 bytes
 //    - tx_bytes:                     tx_len bytes
 //
@@ -292,7 +292,7 @@ func (p *AppendSequencerBatchParams) Serialize(
 //  - total_elements_to_append:       3 bytes
 //  - num_contexts:                   3 bytes
 //    - num_contexts * batch_context: num_contexts * 16 bytes
-//  - [num txs ommitted]
+//  - [num txs omitted]
 //    - tx_len:                       3 bytes
 //    - tx_bytes:                     tx_len bytes
 func (p *AppendSequencerBatchParams) Read(r io.Reader) error {
@@ -349,7 +349,7 @@ func (p *AppendSequencerBatchParams) Read(r io.Reader) error {
 		r = bufio.NewReader(zr)
 	}
 
-	// Deserialize any transactions. Since the number of txs is ommitted
+	// Deserialize any transactions. Since the number of txs is omitted
 	// from the encoding, loop until the stream is consumed.
 	for {
 		var txLen uint64

--- a/bss-core/crypto.go
+++ b/bss-core/crypto.go
@@ -21,8 +21,8 @@ var (
 		"or mnemonic+hdpath")
 )
 
-// ParseAddress parses an ETH addres from a hex string. This method will fail if
-// the address is not a valid hexidecimal address.
+// ParseAddress parses an ETH address from a hex string. This method will fail if
+// the address is not a valid hexadecimal address.
 func ParseAddress(address string) (common.Address, error) {
 	if common.IsHexAddress(address) {
 		return common.HexToAddress(address), nil
@@ -101,7 +101,7 @@ func DerivePrivateKey(mnemonic, hdPath string) (*ecdsa.PrivateKey, error) {
 	return crypto.ToECDSA(rawPrivKey)
 }
 
-// ParsePrivateKeyStr parses a hexidecimal encoded private key, the encoding may
+// ParsePrivateKeyStr parses a hexadecimal encoded private key, the encoding may
 // optionally have an "0x" prefix.
 func ParsePrivateKeyStr(privKeyStr string) (*ecdsa.PrivateKey, error) {
 	hex := strings.TrimPrefix(privKeyStr, "0x")

--- a/bss-core/crypto_test.go
+++ b/bss-core/crypto_test.go
@@ -45,7 +45,7 @@ var (
 )
 
 // TestParseAddress asserts that ParseAddress correctly parses 40-characater
-// hexidecimal strings with optional 0x prefix into valid 20-byte addresses.
+// hexadecimal strings with optional 0x prefix into valid 20-byte addresses.
 func TestParseAddress(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -157,7 +157,7 @@ func TestDerivePrivateKey(t *testing.T) {
 }
 
 // TestParsePrivateKeyStr asserts that ParsePrivateKey properly parses
-// 64-character hexidecimal strings with optional 0x prefix into valid ECDSA
+// 64-character hexadecimal strings with optional 0x prefix into valid ECDSA
 // private keys.
 func TestParsePrivateKeyStr(t *testing.T) {
 	tests := []struct {
@@ -210,9 +210,9 @@ func TestParsePrivateKeyStr(t *testing.T) {
 
 // TestGetConfiguredPrivateKey asserts that GetConfiguredPrivateKey either:
 //  1) Derives the correct private key assuming the BIP39 mnemonic and BIP32
-//     derivation path are both present and the private key string is ommitted.
+//     derivation path are both present and the private key string is omitted.
 //  2) Parses the correct private key assuming only the private key string is
-//     present, but the BIP39 mnemonic and BIP32 derivation path are ommitted.
+//     present, but the BIP39 mnemonic and BIP32 derivation path are omitted.
 func TestGetConfiguredPrivateKey(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/bss-core/metrics/metrics.go
+++ b/bss-core/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 
 type Base struct {
 	// subsystemName stores the name that will prefix all metrics. This can be
-	// used by drivers to futher extend the core metrics and ensure they use the
+	// used by drivers to further extend the core metrics and ensure they use the
 	// same prefix.
 	subsystemName string
 

--- a/bss-core/txmgr/send_state.go
+++ b/bss-core/txmgr/send_state.go
@@ -11,7 +11,7 @@ import (
 // SendState tracks information about the publication state of a given txn. In
 // this context, a txn may correspond to multiple different txn hashes due to
 // varying gas prices, though we treat them all as the same logical txn. This
-// struct is primarly used to determine whether or not the txmgr should abort a
+// struct is primarily used to determine whether or not the txmgr should abort a
 // given txn and retry with a higher nonce.
 type SendState struct {
 	minedTxs         map[common.Hash]struct{}

--- a/bss-core/txmgr/send_state_test.go
+++ b/bss-core/txmgr/send_state_test.go
@@ -80,7 +80,7 @@ func TestSendStateMiningTxCancelsAbort(t *testing.T) {
 }
 
 // TestSendStateReorgingTxResetsAbort asserts that unmining a tx does not
-// consider ErrNonceTooLow's prior to being mined when determing whether to
+// consider ErrNonceTooLow's prior to being mined when determine whether to
 // abort.
 func TestSendStateReorgingTxResetsAbort(t *testing.T) {
 	sendState := newSendState()

--- a/bss-core/txmgr/txmgr.go
+++ b/bss-core/txmgr/txmgr.go
@@ -204,16 +204,18 @@ func (m *SimpleTxManager) Send(
 	wg.Add(1)
 	go sendTxAsync()
 
+	tick := time.NewTicker(m.cfg.ResubmissionTimeout)
+
 	for {
 		select {
 
 		// Whenever a resubmission timeout has elapsed, bump the gas
 		// price and publish a new transaction.
-		case <-time.After(m.cfg.ResubmissionTimeout):
+		case <-tick.C:
 			// Avoid republishing if we are waiting for confirmation on an
 			// existing tx. This is primarily an optimization to reduce the
 			// number of API calls we make, but also reduces the chances of
-			// getting a false postive reading for ShouldAbortImmediately.
+			// getting a false positive reading for ShouldAbortImmediately.
 			if sendState.IsWaitingForConfirmation() {
 				continue
 			}

--- a/bss-core/txmgr/txmgr_test.go
+++ b/bss-core/txmgr/txmgr_test.go
@@ -37,7 +37,7 @@ func newTestHarnessWithConfig(cfg txmgr.Config) *testHarness {
 	}
 }
 
-// newTestHarness initializes a testHarness with a defualt configuration that is
+// newTestHarness initializes a testHarness with a default configuration that is
 // suitable for most tests.
 func newTestHarness() *testHarness {
 	return newTestHarnessWithConfig(configWithNumConfs(1))

--- a/gas-oracle/gasprices/gas_price_updater_test.go
+++ b/gas-oracle/gasprices/gas_price_updater_test.go
@@ -17,7 +17,7 @@ func makeTestGasPricerAndUpdater(curPrice uint64) (*GasPricer, *GasPriceUpdater,
 	getGasTarget := func() float64 { return gpsTarget }
 	epochLengthSeconds := uint64(10)
 	averageBlockGasLimit := uint64(11000000)
-	// Based on our 10 second epoch, we are targetting 3 blocks per epoch.
+	// Based on our 10 second epoch, we are targeting 3 blocks per epoch.
 	gasPricer, err := NewGasPricer(curPrice, 1, getGasTarget, 10)
 	if err != nil {
 		return nil, nil, nil, err

--- a/indexer/crypto.go
+++ b/indexer/crypto.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// ParseL1Address parses a L1 ETH addres from a hex string. This method will
-// fail if the address is not a valid hexidecimal address.
+// ParseL1Address parses a L1 ETH address from a hex string. This method will
+// fail if the address is not a valid hexadecimal address.
 func ParseL1Address(address string) (common.Address, error) {
 	if common.IsHexAddress(address) {
 		return common.HexToAddress(address), nil
@@ -16,8 +16,8 @@ func ParseL1Address(address string) (common.Address, error) {
 	return common.Address{}, fmt.Errorf("invalid address: %v", address)
 }
 
-// ParseL2Address parses a L2 ETH addres from a hex string. This method will
-// fail if the address is not a valid hexidecimal address.
+// ParseL2Address parses a L2 ETH address from a hex string. This method will
+// fail if the address is not a valid hexadecimal address.
 func ParseL2Address(address string) (l2common.Address, error) {
 	if l2common.IsHexAddress(address) {
 		return l2common.HexToAddress(address), nil

--- a/indexer/crypto_test.go
+++ b/indexer/crypto_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestParseL1Address asserts that ParseL1Address correctly parses
-// 40-characater hexidecimal strings with optional 0x prefix into valid 20-byte
+// 40-characater hexadecimal strings with optional 0x prefix into valid 20-byte
 // addresses for the L1 chain.
 func TestParseL1Address(t *testing.T) {
 	tests := []struct {
@@ -57,7 +57,7 @@ func TestParseL1Address(t *testing.T) {
 }
 
 // TestParseL2Address asserts that ParseL2Address correctly parses
-// 40-characater hexidecimal strings with optional 0x prefix into valid 20-byte
+// 40-characater hexadecimal strings with optional 0x prefix into valid 20-byte
 // addresses for the L2 chain.
 func TestParseL2Address(t *testing.T) {
 	tests := []struct {

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -1,0 +1,54 @@
+FROM ethereum/client-go:alltools-v1.10.17 as geth
+
+FROM ghcr.io/foundry-rs/foundry:latest as foundry
+
+FROM python:3.8.12-slim-buster
+
+ENV GOPATH /go
+ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
+
+COPY --from=foundry /usr/local/bin/forge /usr/local/bin/forge
+COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast
+COPY --from=geth /usr/local/bin/abigen /usr/local/bin/abigen
+COPY check-changed.sh /usr/local/bin/check-changed
+
+RUN apt-get update && \
+  apt-get install -y curl openssh-client git build-essential ca-certificates jq musl && \
+  curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
+  curl -sL https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd64.tar.gz && \
+  tar -C /usr/local/ -xzvf go1.18.2.linux-amd64.tar.gz && \
+  ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt && \
+  bash nodesource_setup.sh && \
+  apt-get install -y nodejs && \
+  npm i -g yarn && \
+  npm i -g depcheck && \
+  pip install slither-analyzer && \
+  go install gotest.tools/gotestsum@latest && \
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2 && \
+  curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash && \
+  chmod +x /usr/local/bin/check-changed
+
+RUN echo "downloading solidity compilers" && \
+  curl -o solc-linux-amd64-v0.5.17+commit.d19bba13 -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.5.17+commit.d19bba13 && \
+  curl -o solc-linux-amd64-v0.8.9+commit.e5eed63a -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a  && \
+  curl -o solc-linux-amd64-v0.8.10+commit.fc410830 -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.10+commit.fc410830 && \
+  curl -o solc-linux-amd64-v0.8.12+commit.f00d7308 -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.12+commit.f00d7308 && \
+  echo "verifying checksums" && \
+  (echo "c35ce7a4d3ffa5747c178b1e24c8541b2e5d8a82c1db3719eb4433a1f19e16f3 solc-linux-amd64-v0.5.17+commit.d19bba13" | sha256sum --check --status - || exit 1) && \
+  (echo "f851f11fad37496baabaf8d6cb5c057ca0d9754fddb7a351ab580d7fd728cb94 solc-linux-amd64-v0.8.9+commit.e5eed63a"  | sha256sum --check --status - || exit 1) && \
+  (echo "c7effacf28b9d64495f81b75228fbf4266ac0ec87e8f1adc489ddd8a4dd06d89 solc-linux-amd64-v0.8.10+commit.fc410830" | sha256sum --check --status - || exit 1) && \
+  (echo "556c3ec44faf8ff6b67933fa8a8a403abe82c978d6e581dbfec4bd07360bfbf3 solc-linux-amd64-v0.8.12+commit.f00d7308" | sha256sum --check --status - || exit 1) && \
+  echo "caching compilers" && \
+  mkdir -p ~/.cache/hardhat-nodejs/compilers/linux-amd64 && \
+  cp solc-linux-amd64-v0.5.17+commit.d19bba13 ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  cp solc-linux-amd64-v0.8.9+commit.e5eed63a  ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  cp solc-linux-amd64-v0.8.10+commit.fc410830 ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  cp solc-linux-amd64-v0.8.12+commit.f00d7308 ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  mkdir -p ~/.svm/0.5.17 && \
+  cp solc-linux-amd64-v0.5.17+commit.d19bba13 ~/.svm/0.5.17/solc-0.5.17 && \
+  mkdir -p ~/.svm/0.8.9  && \
+  cp solc-linux-amd64-v0.8.9+commit.e5eed63a  ~/.svm/0.8.9/solc-0.8.9   && \
+  mkdir -p ~/.svm/0.8.10 && \
+  cp solc-linux-amd64-v0.8.10+commit.fc410830 ~/.svm/0.8.10/solc-0.8.10 && \
+  mkdir -p ~/.svm/0.8.12 && \
+  cp solc-linux-amd64-v0.8.12+commit.f00d7308 ~/.svm/0.8.12/solc-0.8.12

--- a/ops/docker/ci-builder/check-changed.sh
+++ b/ops/docker/ci-builder/check-changed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Usage: check-changed.sh <diff-pattern>.
+#
+# This script compares the files changed in the <diff-pattern> to the git diff,
+# and writes TRUE or FALSE to stdout if the diff matches/does not match. It is
+# used by CircleCI jobs to determine if they need to run.
+
+set -e
+
+echoerr() { echo "$@" 1>&2; }
+
+# Check if this is a CircleCI PR.
+if [[ -n $CIRCLE_PULL_REQUEST ]]; then
+	PACKAGE=$1
+	# Craft the URL to the GitHub API. The access token is optional for the monorepo since it's an open-source repo.
+	GITHUB_API_URL=$(echo "https://api.github.com/repos/${CIRCLE_PULL_REQUEST}?access_token=$GITHUB_ACCESS_TOKEN" | sed "s/\/pull\//\/pulls\//")
+	# Grab the PR's base ref using the GitHub API.
+	REF=$(curl -s "$GITHUB_API_URL" | jq -r ".base.ref")
+
+	echoerr "Base Ref:     $REF"
+	echoerr "Base Ref SHA: $(git show-branch --sha1-name "$REF")"
+ 	echoerr "Curr Ref:     $(git rev-parse --short HEAD)"
+
+ 	# Compare HEAD to the PR's base ref, stripping out the change percentages that come with git diff --dirstat.
+ 	# Pass in the diff pattern to grep, and echo TRUE if there's a match. False otherwise.
+ 	(git diff --dirstat=files,0 "$REF...HEAD" | sed 's/^[ 0-9.]\+% //g' | grep -q -E "$PACKAGE" && echo "TRUE") || echo "FALSE"
+else
+	# Non-PR builds always require a rebuild.
+	echoerr "Not a PR build, requiring a total rebuild."
+	echo "TRUE"
+fi

--- a/ops/docker/ci-builder/package.json
+++ b/ops/docker/ci-builder/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@eth-optimism/ci-builder",
+  "version": "0.0.0",
+  "scripts": {},
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/teleportr/db/db.go
+++ b/teleportr/db/db.go
@@ -144,7 +144,7 @@ func (c Config) WithoutDB() string {
 	)
 }
 
-// sslMode retuns "enabled" if EnableSSL is true, otherwise returns "disabled".
+// sslMode returns "enabled" if EnableSSL is true, otherwise returns "disabled".
 func (c Config) sslMode() string {
 	if c.EnableSSL {
 		return "require"

--- a/teleportr/drivers/disburser/driver.go
+++ b/teleportr/drivers/disburser/driver.go
@@ -407,7 +407,7 @@ func (d *Driver) processPendingTxs(ctx context.Context) error {
 		return errors.New("unable to find receipt for any pending tx")
 	}
 
-	// Useing the block number, load the header so that we can get accurate
+	// Using the block number, load the header so that we can get accurate
 	// timestamps for the disbursements.
 	header, err := d.cfg.L2Client.HeaderByNumber(ctx, receipt.BlockNumber)
 	if err != nil {


### PR DESCRIPTION
- Updates CircleCI jobs to exit early if the git diff doesn't require them to run. This will dramatically reduce our CircleCI usage and speed up the pipeline for projects like Bedrock that don't touch legacy code. The entire pipeline will still run on `develop` and `master`. The conditional logic is aware of package dependencies, so changing an upstream package will correctly trigger a build on downstream dependencies.
- Creates a new `ci-builder` image to replace `js-builder` and `go-builder`. The `ci-builder` image contains everything we need to run builds on CircleCI.
- Fixes a bunch of misspellings that should have failed the linter, but didn't.

You can see the conditional builds in action on this PR. The JS tests in the monorepo exit early but the integration tests still run since `bss-core` and the batch submitter changed. Here's a screenshot:

<img width="881" alt="Screen Shot 2022-06-26 at 7 03 13 PM" src="https://user-images.githubusercontent.com/67953/175842263-78f6381a-6758-41cc-af64-1920911d49a7.png">
