### PR TITLE
feat(op-node): testlog alignment and color by default

### DIFF
--- a/op-node/testlog/README.md
+++ b/op-node/testlog/README.md
@@ -4,3 +4,8 @@
 
 Since we use the same logging, but as an external package, we have to move the test utility to our own internal package.
 
+This fork also made minor modifications:
+
+- Enable color by default.
+- Add `estimateInfoLen` and use this for message padding in `flush()` to align the contents of the log entries,
+  compensating for the different lengths of the log decoration that the Go library adds.


### PR DESCRIPTION
Logs in go tests (including e2e) in bedrock now have aligned lines and color.

New:
![pretty](https://user-images.githubusercontent.com/19571989/175847755-c06ca45f-02cd-40ef-94bc-442ae157d9b5.png)


Old:
![ugly_000](https://user-images.githubusercontent.com/19571989/175847764-1d58db2a-24c8-4f07-a957-c9ad31dd6f83.png)

The improved readability is especially nice when testing things with a mix of long and short file names, and important log kev-value pairs to compare.

Maybe it's worth upstreaming into Geth for their testing too?