### PR TITLE
feat: contracts-bedrock `BuildInfo`

### DIFF
--- a/.changeset/curly-spoons-invent.md
+++ b/.changeset/curly-spoons-invent.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Enable hardhat style buildinfo

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -15,4 +15,4 @@ remappings = [
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 
-# build_info = true
+build_info = true

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@eth-optimism/hardhat-deploy-config": "^0.2.0",
     "@defi-wonderland/smock": "^2.0.2",
-    "@foundry-rs/hardhat-forge": "^0.1.7",
+    "@foundry-rs/hardhat-forge": "^0.1.8",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@typechain/ethers-v5": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,10 +1614,10 @@
     command-exists "^1.2.9"
     ts-interface-checker "^0.1.9"
 
-"@foundry-rs/hardhat-forge@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.7.tgz#54f3224d426811cbb2dee5b0516aa593d553a856"
-  integrity sha512-6aDXmzy4V4NyOeclTrskrKFf5A0hOx0xDdjm8e8qAzFdC3Y0HlXdr66uUFBVHMsQbWLRVf6IzqeISzCcc6ZJ2g==
+"@foundry-rs/hardhat-forge@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.8.tgz#2e15b275e7f6672dea96ebddcae312009bb458a1"
+  integrity sha512-jGIK3wBWHdYXeyjJ9ULBVBaSpmXnaL9yTpGYy+2hn8JM5iOvdSXZgxJQuFZQT/BFrjFt/RVWiMynzyhAtJ+nlg==
   dependencies:
     "@foundry-rs/easy-foundryup" "^0.1.3"
     "@nomiclabs/hardhat-ethers" "^2.0.0"


### PR DESCRIPTION
**Description**

Enable hardhat style `BuildInfo` generation that integrates
with the hardhat plugin. The debug files (`*.dbg.json`) are
generated by default and are able to be pulled into hardhat
tasks with `Artifacts.getBuildInfo`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

