### PR TITLE
contracts-bedrock: add deployer docker image

### DIFF
--- a/.changeset/moody-beds-guess.md
+++ b/.changeset/moody-beds-guess.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Add deployer docker image

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -21,6 +21,7 @@ jobs:
       drippie-mon: ${{ steps.packages.outputs.drippie-mon }}
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
       contracts: ${{ steps.packages.outputs.contracts }}
+      contracts-bedrock: ${{ steps.packages.outputs.contracts-bedrock }}
       gas-oracle: ${{ steps.packages.outputs.gas-oracle }}
       replica-healthcheck: ${{ steps.packages.outputs.replica-healthcheck }}
       hardhat-node: ${{ steps.packages.outputs.hardhat-node }}
@@ -310,6 +311,33 @@ jobs:
           target: deployer
           push: true
           tags: ethereumoptimism/deployer:${{ needs.canary-publish.outputs.canary-docker-tag }}
+
+  contracts-bedrock:
+    name: Publish deployer-bedrock Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
+    needs: canary-publish
+    if: needs.canary-publish.outputs.contracts-bedrock != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.packages
+          target: deployer-bedrock
+          push: true
+          tags: ethereumoptimism/deployer-bedrock:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   integration_tests:
     name: Publish Integration tests ${{ needs.canary-publish.outputs.integration-tests }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       drippie-mon: ${{ steps.packages.outputs.drippie-mon }}
       data-transport-layer: ${{ steps.packages.outputs.data-transport-layer }}
       contracts: ${{ steps.packages.outputs.contracts }}
+      contracts-bedrock: ${{ steps.packages.outputs.contracts-bedrock }}
       gas-oracle: ${{ steps.packages.outputs.gas-oracle }}
       replica-healthcheck: ${{ steps.packages.outputs.replica-healthcheck }}
       proxyd: ${{ steps.packages.outputs.proxyd }}
@@ -453,6 +454,33 @@ jobs:
           target: deployer
           push: true
           tags: ethereumoptimism/deployer:${{ needs.release.outputs.contracts }},ethereumoptimism/deployer:latest
+
+  contracts-bedrock:
+    name: Publish deployer-bedrock Version ${{ needs.release.outputs.contracts-bedrock }}
+    needs: release
+    if: needs.release.outputs.contracts != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.packages
+          target: deployer-bedrock
+          push: true
+          tags: ethereumoptimism/deployer-bedrock:${{ needs.release.outputs.contracts-bedrock }},ethereumoptimism/deployer-bedrock:latest
 
   integration_tests:
     name: Publish Integration tests ${{ needs.release.outputs.integration-tests }}

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -45,6 +45,9 @@ WORKDIR /opt/optimism/packages/contracts
 COPY ./ops/scripts/deployer.sh .
 CMD ["yarn", "run", "deploy"]
 
+FROM base as deployer-bedrock
+WORKDIR /opt/optimism/packages/contracts-bedrock
+CMD ["yarn", "run", "deploy"]
 
 FROM base as data-transport-layer
 WORKDIR /opt/optimism/packages/data-transport-layer

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -18,6 +18,7 @@
     "prebuild": "yarn ts-node scripts/verifyFoundryInstall.ts",
     "build": "hardhat compile && tsc && hardhat typechain",
     "build:ts": "tsc",
+    "deploy": "hardhat deploy",
     "test": "forge test",
     "gas-snapshot": "forge snapshot",
     "storage-snapshot": "./scripts/storage-snapshot.sh",


### PR DESCRIPTION
**Description**

Published as `ethereumoptimism/deployer-bedrock`.
This will be published along with new releases of the `npm` package.
It wraps `hardhat deploy`. The config file will want to be mounted
in at runtime if deploying to a non default network.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


