### PR TITLE
op-node: Add Epoch Hash to batch

### DIFF
--- a/op-node/l2/util.go
+++ b/op-node/l2/util.go
@@ -113,7 +113,8 @@ func BlockToBatch(config *rollup.Config, block *types.Block) (*derive.BatchData,
 		return nil, fmt.Errorf("invalid L1 info deposit tx in block: %v", err)
 	}
 	return &derive.BatchData{BatchV1: derive.BatchV1{
-		Epoch:        rollup.Epoch(l1Info.Number), // the L1 block number equals the L2 epoch.
+		EpochNum:     rollup.Epoch(l1Info.Number), // the L1 block number equals the L2 epoch.
+		EpochHash:    l1Info.BlockHash,
 		Timestamp:    block.Time(),
 		Transactions: opaqueTxs,
 	}}, nil

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -32,7 +33,8 @@ const (
 )
 
 type BatchV1 struct {
-	Epoch     rollup.Epoch // aka l1 num
+	EpochNum  rollup.Epoch // aka l1 num
+	EpochHash common.Hash  // block hash
 	Timestamp uint64
 	// no feeRecipient address input, all fees go to a L2 contract
 	Transactions []hexutil.Bytes

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -98,7 +98,6 @@ func (bq *BatchQueue) DeriveL2Inputs(ctx context.Context, lastL2Timestamp uint64
 		return nil, fmt.Errorf("failed to derive some deposits: %v", errs)
 	}
 
-	epoch := rollup.Epoch(l1Origin.Number)
 	minL2Time := uint64(lastL2Timestamp) + bq.config.BlockTime
 	maxL2Time := l1Origin.Time + bq.config.MaxSequencerDrift
 	if minL2Time+bq.config.BlockTime > maxL2Time {
@@ -108,8 +107,8 @@ func (bq *BatchQueue) DeriveL2Inputs(ctx context.Context, lastL2Timestamp uint64
 	for _, b := range bq.inputs {
 		batches = append(batches, b.Batches...)
 	}
-	batches = FilterBatches(bq.log, bq.config, epoch, minL2Time, maxL2Time, batches)
-	batches = FillMissingBatches(batches, uint64(epoch), bq.config.BlockTime, minL2Time, nextL1Block.Time)
+	batches = FilterBatches(bq.log, bq.config, l1Origin.ID(), minL2Time, maxL2Time, batches)
+	batches = FillMissingBatches(batches, l1Origin.ID(), bq.config.BlockTime, minL2Time, nextL1Block.Time)
 	var attributes []*eth.PayloadAttributes
 
 	for i, batch := range batches {

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -11,14 +11,14 @@ func TestBatchRoundTrip(t *testing.T) {
 	batches := []*BatchData{
 		{
 			BatchV1: BatchV1{
-				Epoch:        0,
+				EpochNum:     0,
 				Timestamp:    0,
 				Transactions: []hexutil.Bytes{},
 			},
 		},
 		{
 			BatchV1: BatchV1{
-				Epoch:        1,
+				EpochNum:     1,
 				Timestamp:    1647026951,
 				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},
 			},

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -3,7 +3,9 @@ package derive
 import (
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -11,21 +13,27 @@ import (
 type ValidBatchTestCase struct {
 	Name      string
 	Epoch     rollup.Epoch
+	EpochHash common.Hash
 	MinL2Time uint64
 	MaxL2Time uint64
 	Batch     BatchData
 	Valid     bool
 }
 
+var HashA = common.Hash{0x0a}
+var HashB = common.Hash{0x0b}
+
 func TestValidBatch(t *testing.T) {
 	testCases := []ValidBatchTestCase{
 		{
 			Name:      "valid epoch",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    43,
 				Transactions: []hexutil.Bytes{{0x01, 0x13, 0x37}, {0x02, 0x13, 0x37}},
 			}},
@@ -34,10 +42,12 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "ignored epoch",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        122,
+				EpochNum:     122,
+				EpochHash:    HashA,
 				Timestamp:    43,
 				Transactions: nil,
 			}},
@@ -46,10 +56,12 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "too old",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    42,
 				Transactions: nil,
 			}},
@@ -58,10 +70,12 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "too new",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    52,
 				Transactions: nil,
 			}},
@@ -70,10 +84,12 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "wrong time alignment",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    46,
 				Transactions: nil,
 			}},
@@ -82,10 +98,12 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "good time alignment",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    51, // 31 + 2*10
 				Transactions: nil,
 			}},
@@ -94,10 +112,12 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "empty tx",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    43,
 				Transactions: []hexutil.Bytes{{}},
 			}},
@@ -106,12 +126,28 @@ func TestValidBatch(t *testing.T) {
 		{
 			Name:      "sneaky deposit",
 			Epoch:     123,
+			EpochHash: HashA,
 			MinL2Time: 43,
 			MaxL2Time: 52,
 			Batch: BatchData{BatchV1: BatchV1{
-				Epoch:        123,
+				EpochNum:     123,
+				EpochHash:    HashA,
 				Timestamp:    43,
 				Transactions: []hexutil.Bytes{{0x01}, {types.DepositTxType, 0x13, 0x37}, {0xc0, 0x13, 0x37}},
+			}},
+			Valid: false,
+		},
+		{
+			Name:      "wrong epoch hash",
+			Epoch:     123,
+			EpochHash: HashA,
+			MinL2Time: 43,
+			MaxL2Time: 52,
+			Batch: BatchData{BatchV1: BatchV1{
+				EpochNum:     123,
+				EpochHash:    HashB,
+				Timestamp:    43,
+				Transactions: []hexutil.Bytes{{0x01, 0x13, 0x37}, {0x02, 0x13, 0x37}},
 			}},
 			Valid: false,
 		},
@@ -125,7 +161,11 @@ func TestValidBatch(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			err := ValidBatch(&testCase.Batch, &conf, testCase.Epoch, testCase.MinL2Time, testCase.MaxL2Time)
+			epoch := eth.BlockID{
+				Number: uint64(testCase.Epoch),
+				Hash:   testCase.EpochHash,
+			}
+			err := ValidBatch(&testCase.Batch, &conf, epoch, testCase.MinL2Time, testCase.MaxL2Time)
 			if (err == nil) != testCase.Valid {
 				t.Fatalf("case %v was expected to return %v, but got %v (%v)", testCase, testCase.Valid, err == nil, err)
 			}

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -165,6 +165,7 @@ func blockToBatch(block *types.Block, w io.Writer) error {
 
 	batch := &BatchData{BatchV1{
 		EpochNum:     rollup.Epoch(l1Info.Number),
+		EpochHash:    l1Info.BlockHash,
 		Timestamp:    block.Time(),
 		Transactions: opaqueTxs,
 	},

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -164,7 +164,7 @@ func blockToBatch(block *types.Block, w io.Writer) error {
 	}
 
 	batch := &BatchData{BatchV1{
-		Epoch:        rollup.Epoch(l1Info.Number),
+		EpochNum:     rollup.Epoch(l1Info.Number),
 		Timestamp:    block.Time(),
 		Transactions: opaqueTxs,
 	},


### PR DESCRIPTION
**Description**
This commits a batch to a specific L1 origin block by hash rather
than just by number. This help in the case of L1 reorgs by stopping
batches from being applied in weird ways.


**Additional context**
This does not add a block number to the batch. The plan for eager batch derivation
is to continue to use timestamps, but slightly modify derivation rules (similar to how
they would be modified even if it was switched over to using block numbers).

**Metadata**
- Fixes #[Link to Issue]
