### PR TITLE
l2geth: Fix NPE in API tracer

### DIFF
--- a/.changeset/stupid-ties-reply.md
+++ b/.changeset/stupid-ties-reply.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+fix NPE in debug_standardTraceBlockToFile

--- a/l2geth/eth/api_tracer.go
+++ b/l2geth/eth/api_tracer.go
@@ -65,7 +65,7 @@ type TraceConfig struct {
 
 // StdTraceConfig holds extra parameters to standard-json trace functions.
 type StdTraceConfig struct {
-	*vm.LogConfig
+	vm.LogConfig
 	Reexec *uint64
 	TxHash common.Hash
 }
@@ -550,9 +550,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		txHash    common.Hash
 	)
 	if config != nil {
-		if config.LogConfig != nil {
-			logConfig = *config.LogConfig
-		}
+		logConfig = config.LogConfig
 		txHash = config.TxHash
 	}
 	logConfig.Debug = true


### PR DESCRIPTION
The `debug_standardTraceBlockToFile` RPC was panicing here:

```go
// Line 572 in eth/api_tracer.go
if config != nil && config.Overrides != nil {
```

`config` is an instance of `StdTraceConfig`, which embeds a pointer to `vm.LogConfig`. This pointer is `nil` when the user doesn't pass in any overrides. Since `vm.LogConfig` exposes the `Overrides` parameter, this caused a panic.

`debug_standardTraceBlockToFile` is required for users like Dune, who need access to transaction traces that are too complex to serve over RPC.
