### PR TITLE
contracts-bedrock: buildinfo set to true

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -14,3 +14,4 @@ remappings = [
 ]
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
+build_info = true


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Explicitly set `build_info` to true in the `foundry.toml`. Ideally this should take in the config from the `hardhat.config.js` but for some reason isnt right now