### PR TITLE
ops-bedrock: Increase timeout on wait_up

### DIFF
--- a/ops-bedrock/devnet-up.sh
+++ b/ops-bedrock/devnet-up.sh
@@ -47,7 +47,7 @@ function wait_up {
     sleep 0.25
 
     ((i=i+1))
-    if [ "$i" -eq 200 ]; then
+    if [ "$i" -eq 300 ]; then
       echo " Timeout!" >&2
       exit 1
     fi

--- a/ops-bedrock/test-integration.sh
+++ b/ops-bedrock/test-integration.sh
@@ -13,5 +13,5 @@ if [ ! -f "$DEPLOYMENTS_DIR/OptimismPortal.json" ]; then
 fi
 
 export OPTIMISM_PORTAL_ADDRESS=$(jq -r '.address' < "$DEPLOYMENTS_DIR/OptimismPortal.json")
-cd ./packages/integration-tests
+cd ./packages/integration-tests-bedrock
 yarn test

--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -6,3 +6,4 @@ coverage.out
 .deps
 deployments
 broadcast
+genesis.json


### PR DESCRIPTION
Increases the timeout on waiting for a URL to respond in `devnet-up`. 

Also a couple minor changes related to running `devnet-up`.