### PR TITLE
Bedrock: fix new batcher, use sync status api, start from safe head

### DIFF
--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -12,6 +12,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-proposer/rollupclient"
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum-optimism/optimism/op-batcher/sequencer"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -100,7 +103,7 @@ type BatchSubmitter struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	l2HeadNumber uint64
+	lastSubmittedBlock eth.BlockID
 
 	ch *derive.ChannelOut
 }
@@ -143,6 +146,11 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 		return nil, err
 	}
 
+	rollupClient, err := dialRollupClientWithTimeout(ctx, cfg.RollupRpc)
+	if err != nil {
+		return nil, err
+	}
+
 	chainID, err := l1Client.ChainID(ctx)
 	if err != nil {
 		return nil, err
@@ -162,6 +170,7 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 		Name:              "Batch Submitter",
 		L1Client:          l1Client,
 		L2Client:          l2Client,
+		RollupNode:        rollupClient,
 		MinL1TxSize:       cfg.MinL1TxSize,
 		MaxL1TxSize:       cfg.MaxL1TxSize,
 		BatchInboxAddress: batchInboxAddress,
@@ -209,17 +218,21 @@ mainLoop:
 			// Do the simplest thing of one channel per range of blocks since the iteration of this loop.
 			// The channel is closed at the end of this loop (to avoid lifecycle management of the channel).
 			ctx, cancel := context.WithTimeout(l.ctx, time.Second*10)
-			head, err := l.cfg.L2Client.BlockByNumber(ctx, nil)
+			syncStatus, err := l.cfg.RollupNode.SyncStatus(ctx)
 			cancel()
 			if err != nil {
 				l.log.Error("issue fetching L2 head", "err", err)
 				continue
 			}
-			l.log.Info("Got new L2 Block", "block", head.Number())
-			if head.NumberU64() <= l.l2HeadNumber {
-				// Didn't advance
-				l.log.Trace("Old block")
+			l.log.Info("Got new L2 sync status", "safe_head", syncStatus.SafeL2, "unsafe_head", syncStatus.UnsafeL2, "last_submitted", l.lastSubmittedBlock)
+			if syncStatus.SafeL2.Number >= syncStatus.UnsafeL2.Number {
+				l.log.Trace("No unsubmitted blocks from sequencer")
 				continue
+			}
+			// the lastSubmittedBlock may be zeroed, or just lag behind. If it's lagging behind, catch it up.
+			if l.lastSubmittedBlock.Number < syncStatus.SafeL2.Number {
+				l.log.Warn("last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", l.lastSubmittedBlock, "safe", syncStatus.SafeL2)
+				l.lastSubmittedBlock = syncStatus.SafeL2.ID()
 			}
 			if ch, err := derive.NewChannelOut(uint64(time.Now().Unix())); err != nil {
 				l.log.Error("Error creating channel", "err", err)
@@ -227,7 +240,8 @@ mainLoop:
 			} else {
 				l.ch = ch
 			}
-			for i := l.l2HeadNumber + 1; i <= head.NumberU64(); i++ {
+			prevID := l.lastSubmittedBlock
+			for i := l.lastSubmittedBlock.Number + 1; i <= syncStatus.UnsafeL2.Number; i++ {
 				ctx, cancel := context.WithTimeout(l.ctx, time.Second*10)
 				block, err := l.cfg.L2Client.BlockByNumber(ctx, new(big.Int).SetUint64(i))
 				cancel()
@@ -235,15 +249,18 @@ mainLoop:
 					l.log.Error("issue fetching L2 block", "err", err)
 					continue mainLoop
 				}
+				if block.ParentHash() != prevID.Hash {
+					l.log.Error("detected a reorg in L2 chain vs previous submitted information, resetting to safe head now", "safe_head", syncStatus.SafeL2)
+					l.lastSubmittedBlock = syncStatus.SafeL2.ID()
+					continue mainLoop
+				}
 				if err := l.ch.AddBlock(block); err != nil {
 					l.log.Error("issue adding L2 Block to the channel", "err", err, "channel_id", l.ch.ID())
 					continue mainLoop
 				}
-				l.log.Info("added L2 block to channel", "block", eth.BlockID{Hash: block.Hash(), Number: block.NumberU64()}, "channel_id", l.ch.ID(), "tx_count", len(block.Transactions()), "time", block.Time())
+				prevID = eth.BlockID{Hash: block.Hash(), Number: block.NumberU64()}
+				l.log.Info("added L2 block to channel", "block", prevID, "channel_id", l.ch.ID(), "tx_count", len(block.Transactions()), "time", block.Time())
 			}
-			// TODO: above there are ugly "continue mainLoop" because we shouldn't progress if we're missing blocks, since the submitter logic can't handle gaps yet.
-			l.l2HeadNumber = head.NumberU64()
-
 			if err := l.ch.Close(); err != nil {
 				l.log.Error("issue getting adding L2 Block", "err", err)
 				continue
@@ -306,6 +323,13 @@ mainLoop:
 					break // local do-while loop
 				}
 			}
+			// TODO: if we exit to the mainLoop early on an error,
+			// it would be nice if we can determine which blocks are still readable from the partially submitted data.
+			// We can open a channel-in-reader, parse the data up to which we managed to submit it,
+			// and then take the block hash (if we remember which blocks we put in the channel)
+			//
+			// Now we just continue batch submission from the end of the channel.
+			l.lastSubmittedBlock = prevID
 
 		case <-l.done:
 			return
@@ -392,6 +416,21 @@ func dialEthClientWithTimeout(ctx context.Context, url string) (
 	defer cancel()
 
 	return ethclient.DialContext(ctxt, url)
+}
+
+// dialRollupClientWithTimeout attempts to dial the RPC provider using the provided
+// URL. If the dial doesn't complete within defaultDialTimeout seconds, this
+// method will return an error.
+func dialRollupClientWithTimeout(ctx context.Context, url string) (*rollupclient.RollupClient, error) {
+	ctxt, cancel := context.WithTimeout(ctx, defaultDialTimeout)
+	defer cancel()
+
+	client, err := rpc.DialContext(ctxt, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return rollupclient.NewRollupClient(client), nil
 }
 
 // parseAddress parses an ETH address from a hex string. This method will fail if

--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -271,7 +271,8 @@ mainLoop:
 				data := new(bytes.Buffer)
 				data.WriteByte(derive.DerivationVersion0)
 				done := false
-				if err := l.ch.OutputFrame(data, l.cfg.MaxL1TxSize); err == io.EOF {
+				// subtract one, to account for the version byte
+				if err := l.ch.OutputFrame(data, l.cfg.MaxL1TxSize-1); err == io.EOF {
 					done = true
 				} else if err != nil {
 					l.log.Error("error outputting frame", "err", err)

--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -12,12 +12,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-proposer/rollupclient"
-	"github.com/ethereum/go-ethereum/rpc"
-
 	"github.com/ethereum-optimism/optimism/op-batcher/sequencer"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-proposer/rollupclient"
 	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -26,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 	"github.com/urfave/cli"
 )

--- a/op-batcher/config.go
+++ b/op-batcher/config.go
@@ -14,8 +14,11 @@ type Config struct {
 	// L1EthRpc is the HTTP provider URL for L1.
 	L1EthRpc string
 
-	// L2EthRpc is the HTTP provider URL for the rollup node.
+	// L2EthRpc is the HTTP provider URL for the L2 execution engine.
 	L2EthRpc string
+
+	// RollupRpc is the HTTP provider URL for the L2 rollup node.
+	RollupRpc string
 
 	// MinL1TxSize is the minimum size of a batch tx submitted to L1.
 	MinL1TxSize uint64
@@ -73,6 +76,7 @@ func NewConfig(ctx *cli.Context) Config {
 		/* Required Flags */
 		L1EthRpc:                   ctx.GlobalString(flags.L1EthRpcFlag.Name),
 		L2EthRpc:                   ctx.GlobalString(flags.L2EthRpcFlag.Name),
+		RollupRpc:                  ctx.GlobalString(flags.RollupRpcFlag.Name),
 		MinL1TxSize:                ctx.GlobalUint64(flags.MinL1TxSizeBytesFlag.Name),
 		MaxL1TxSize:                ctx.GlobalUint64(flags.MaxL1TxSizeBytesFlag.Name),
 		ChannelTimeout:             ctx.GlobalUint64(flags.ChannelTimeoutFlag.Name),

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -25,6 +25,12 @@ var (
 		Required: true,
 		EnvVar:   "L2_ETH_RPC",
 	}
+	RollupRpcFlag = cli.StringFlag{
+		Name:     "rollup-rpc",
+		Usage:    "HTTP provider URL for Rollup node",
+		Required: true,
+		EnvVar:   "ROLLUP_RPC",
+	}
 	MinL1TxSizeBytesFlag = cli.Uint64Flag{
 		Name:     "min-l1-tx-size-bytes",
 		Usage:    "The minimum size of a batch tx submitted to L1.",
@@ -112,6 +118,7 @@ var (
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	L2EthRpcFlag,
+	RollupRpcFlag,
 	MinL1TxSizeBytesFlag,
 	MaxL1TxSizeBytesFlag,
 	ChannelTimeoutFlag,

--- a/op-batcher/sequencer/driver.go
+++ b/op-batcher/sequencer/driver.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-proposer/rollupclient"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -19,6 +21,8 @@ type Config struct {
 
 	// API to hit for batch data
 	L2Client *ethclient.Client
+
+	RollupNode *rollupclient.RollupClient
 
 	// Limit the size of txs
 	MinL1TxSize uint64

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -573,6 +573,7 @@ func (cfg SystemConfig) start() (*System, error) {
 	sys.batchSubmitter, err = bss.NewBatchSubmitter(bss.Config{
 		L1EthRpc:                   sys.nodes["l1"].WSEndpoint(),
 		L2EthRpc:                   sys.nodes["sequencer"].WSEndpoint(),
+		RollupRpc:                  rollupEndpoint,
 		MinL1TxSize:                1,
 		MaxL1TxSize:                120000,
 		ChannelTimeout:             sys.cfg.RollupConfig.ChannelTimeout,

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -5,16 +5,13 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
-
-	"github.com/ethereum-optimism/optimism/op-node/metrics"
-
-	"github.com/ethereum-optimism/optimism/op-node/version"
-
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/l2"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/version"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -155,7 +155,7 @@ func (n *OpNode) initRPCServer(ctx context.Context, cfg *Config) error {
 	if err != nil {
 		return err
 	}
-	n.server, err = newRPCServer(ctx, &cfg.RPC, &cfg.Rollup, client, n.log, n.appVersion, n.metrics)
+	n.server, err = newRPCServer(ctx, &cfg.RPC, &cfg.Rollup, client, n.l2Engine, n.log, n.appVersion, n.metrics)
 	if err != nil {
 		return err
 	}

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -31,8 +31,8 @@ type rpcServer struct {
 	l2.Source
 }
 
-func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, log log.Logger, appVersion string, m *metrics.Metrics) (*rpcServer, error) {
-	api := newNodeAPI(rollupCfg, l2Client, log.New("rpc", "node"), m)
+func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, appVersion string, m *metrics.Metrics) (*rpcServer, error) {
+	api := newNodeAPI(rollupCfg, l2Client, dr, log.New("rpc", "node"), m)
 	// TODO: extend RPC config with options for WS, IPC and HTTP RPC connections
 	endpoint := net.JoinHostPort(rpcCfg.ListenAddr, strconv.Itoa(rpcCfg.ListenPort))
 	r := &rpcServer{

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -79,6 +79,10 @@ func (d *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPa
 	return d.s.OnUnsafeL2Payload(ctx, payload)
 }
 
+func (d *Driver) SyncStatus(ctx context.Context) (*SyncStatus, error) {
+	return d.s.SyncStatus(ctx)
+}
+
 func (d *Driver) Start(ctx context.Context) error {
 	return d.s.Start(ctx)
 }

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -13,11 +13,26 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// SyncStatus is a snapshot of the driver
 type SyncStatus struct {
-	CurrentL1   eth.L1BlockRef `json:"current_l1"`
-	HeadL1      eth.L1BlockRef `json:"head_l1"`
-	UnsafeL2    eth.L2BlockRef `json:"unsafe_l2"`
-	SafeL2      eth.L2BlockRef `json:"safe_l2"`
+	// CurrentL1 is the block that the derivation process is currently at,
+	// this may not be fully derived into L2 data yet.
+	// If the node is synced, this matches the HeadL1, minus the verifier confirmation distance.
+	CurrentL1 eth.L1BlockRef `json:"current_l1"`
+	// HeadL1 is the perceived head of the L1 chain, no confirmation distance.
+	// The head is not guaranteed to build on the other L1 sync status fields,
+	// as the node may be in progress of resetting to adapt to a L1 reorg.
+	HeadL1 eth.L1BlockRef `json:"head_l1"`
+	// UnsafeL2 is the absolute tip of the L2 chain,
+	// pointing to block data that has not been submitted to L1 yet.
+	// The sequencer is building this, and verifiers may also be ahead of the
+	// SafeL2 block if they sync blocks via p2p or other offchain sources.
+	UnsafeL2 eth.L2BlockRef `json:"unsafe_l2"`
+	// SafeL2 points to the L2 block that was derived from the L1 chain.
+	// This point may still reorg if the L1 chain reorgs.
+	SafeL2 eth.L2BlockRef `json:"safe_l2"`
+	// FinalizedL2 points to the L2 block that was derived fully from
+	// finalized L1 information, thus irreversible.
 	FinalizedL2 eth.L2BlockRef `json:"finalized_l2"`
 }
 

--- a/op-node/testutils/random.go
+++ b/op-node/testutils/random.go
@@ -66,6 +66,17 @@ func NextRandomRef(rng *rand.Rand, parent eth.L1BlockRef) eth.L1BlockRef {
 	}
 }
 
+func RandomL2BlockRef(rng *rand.Rand) eth.L2BlockRef {
+	return eth.L2BlockRef{
+		Hash:           RandomHash(rng),
+		Number:         rng.Uint64(),
+		ParentHash:     RandomHash(rng),
+		Time:           rng.Uint64(),
+		L1Origin:       RandomBlockID(rng),
+		SequenceNumber: rng.Uint64(),
+	}
+}
+
 func NextRandomL2Ref(rng *rand.Rand, l2BlockTime uint64, parent eth.L2BlockRef, origin eth.BlockID) eth.L2BlockRef {
 	seq := parent.SequenceNumber + 1
 	if parent.L1Origin != origin {

--- a/op-proposer/rollupclient/rollupclient.go
+++ b/op-proposer/rollupclient/rollupclient.go
@@ -2,10 +2,10 @@ package rollupclient
 
 import (
 	"context"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 )

--- a/op-proposer/rollupclient/rollupclient.go
+++ b/op-proposer/rollupclient/rollupclient.go
@@ -2,6 +2,7 @@ package rollupclient
 
 import (
 	"context"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -20,5 +21,17 @@ func NewRollupClient(rpc *rpc.Client) *RollupClient {
 func (r *RollupClient) OutputAtBlock(ctx context.Context, blockNum *big.Int) ([]eth.Bytes32, error) {
 	var output []eth.Bytes32
 	err := r.rpc.CallContext(ctx, &output, "optimism_outputAtBlock", hexutil.EncodeBig(blockNum))
+	return output, err
+}
+
+func (r *RollupClient) SyncStatus(ctx context.Context) (*driver.SyncStatus, error) {
+	var output *driver.SyncStatus
+	err := r.rpc.CallContext(ctx, &output, "optimism_syncStatus")
+	return output, err
+}
+
+func (r *RollupClient) Version(ctx context.Context) (string, error) {
+	var output string
+	err := r.rpc.CallContext(ctx, &output, "optimism_version")
 	return output, err
 }

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -106,6 +106,7 @@ services:
     environment:
       L1_ETH_RPC: http://l1:8545
       L2_ETH_RPC: http://l2:8545
+      ROLLUP_RPC: http://op-node:8545
       BATCH_SUBMITTER_MIN_L1_TX_SIZE_BYTES: 1
       BATCH_SUBMITTER_MAX_L1_TX_SIZE_BYTES: 120000
       BATCH_SUBMITTER_CHANNEL_TIMEOUT: 40


### PR DESCRIPTION
Previously the batcher would continue batch submitting from the L2 head.
However, if the sequencer runs  while the batch submitter is offline, the L2 chain continues, and the batch-submitter will be skipping a part. This causes a reorg, after which the batch submitter can't recover without restart (since it didn't detect reorgs).

This PR fixes the above, to make restarting of sequencer and batcher work without so much disruption of the L2 chain.
