### PR TITLE
fix(common-ts): fix coverage command

### DIFF
--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "yarn lint:check --fix",
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",
-    "test": "ts-mocha test/*.spec.ts"
+    "test": "ts-mocha test/*.spec.ts",
+    "test:coverage": "echo 'no coverage'"
   },
   "keywords": [
     "optimism",


### PR DESCRIPTION
**Description**

CI breaks since it runs coverage against all
packages and there is no coverage command for
`common-ts`. This adds a simple no-op so that
coverage can be ran for all tests

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


