### PR TITLE
op-node: clip derivation reset to not go past L1 genesis

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -99,6 +99,10 @@ func (bq *BatchQueue) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error 
 	} else {
 		startNumber -= bq.config.SeqWindowSize
 	}
+	// clip to genesis
+	if startNumber < bq.config.Genesis.L1.Number {
+		startNumber = bq.config.Genesis.L1.Number
+	}
 	l1BlockStart, err := l1Fetcher.L1BlockRefByNumber(ctx, startNumber)
 	if err != nil {
 		return err

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -221,7 +221,7 @@ func (ib *ChannelBank) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error
 		ib.resetting = true
 		return nil
 	}
-	if ib.progress.Origin.Time+ib.cfg.ChannelTimeout < ib.next.Progress().Origin.Time || ib.progress.Origin.Number == 0 {
+	if ib.progress.Origin.Time+ib.cfg.ChannelTimeout < ib.next.Progress().Origin.Time || ib.progress.Origin.Number <= ib.cfg.Genesis.L1.Number {
 		ib.log.Debug("found reset origin for channel bank", "origin", ib.progress.Origin)
 		ib.resetting = false
 		return io.EOF


### PR DESCRIPTION
The derivation pipeline was being reset past genesis to buffer data. The previous behavior shouldn't be breaking anything, but also inefficient / unnecessary.



