### PR TITLE
contracts-bedrock: update max sequencer drift config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/devnetL1.ts
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.ts
@@ -44,7 +44,7 @@ const config = {
 
   deploymentWaitConfirmations: 1,
 
-  maxSequencerDrift: 10,
+  maxSequencerDrift: 1000,
   sequencerWindowSize: 4,
   channelTimeout: 40,
 


### PR DESCRIPTION
**Description**

Update it from 10 to 1000. It seems to reduce the
reorg issues but not completely. The bug should be
fixed, this is just a temporary bandaid to allow the
system to run in a more stable fashion.

Co-authored-by: Joshua Gutow <jgutow@optimism.io>

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

