### PR TITLE
feat(ctb): use ERC721Enumerable for standard token

### DIFF
--- a/packages/contracts-periphery/contracts/L1/messaging/L1ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L1/messaging/L1ERC721Bridge.sol
@@ -21,7 +21,7 @@ contract L1ERC721Bridge is CrossDomainEnabled, OwnableUpgradeable {
     /**
      * @notice Contract version number.
      */
-    uint8 public constant VERSION = 1;
+    uint256 public constant VERSION = 2;
 
     /**
      * @notice Emitted when an ERC721 bridge to the other network is initiated.
@@ -85,7 +85,7 @@ contract L1ERC721Bridge is CrossDomainEnabled, OwnableUpgradeable {
      * @param _messenger   Address of the CrossDomainMessenger on this network.
      * @param _otherBridge Address of the ERC721 bridge on the other network.
      */
-    function initialize(address _messenger, address _otherBridge) public reinitializer(VERSION) {
+    function initialize(address _messenger, address _otherBridge) public initializer {
         messenger = _messenger;
         otherBridge = _otherBridge;
 

--- a/packages/contracts-periphery/contracts/L2/messaging/L2ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L2/messaging/L2ERC721Bridge.sol
@@ -23,7 +23,7 @@ contract L2ERC721Bridge is CrossDomainEnabled, OwnableUpgradeable {
     /**
      * @notice Contract version number.
      */
-    uint8 public constant VERSION = 1;
+    uint256 public constant VERSION = 2;
 
     /**
      * @notice Emitted when an ERC721 bridge to the other network is initiated.
@@ -99,7 +99,7 @@ contract L2ERC721Bridge is CrossDomainEnabled, OwnableUpgradeable {
      * @param _messenger   Address of the CrossDomainMessenger on this network.
      * @param _otherBridge Address of the ERC721 bridge on the other network.
      */
-    function initialize(address _messenger, address _otherBridge) public reinitializer(VERSION) {
+    function initialize(address _messenger, address _otherBridge) public initializer {
         messenger = _messenger;
         otherBridge = _otherBridge;
 

--- a/packages/contracts-periphery/contracts/universal/op-erc721/IOptimismMintableERC721.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/IOptimismMintableERC721.sol
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {
+    IERC721Enumerable
+} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
 /**
  * @title IOptimismMintableERC721
  * @notice Interface for contracts that are compatible with the OptimismMintableERC721 standard.
  *         Tokens that follow this standard can be easily transferred across the ERC721 bridge.
  */
-interface IOptimismMintableERC721 is IERC721 {
+interface IOptimismMintableERC721 is IERC721Enumerable {
     /**
      * @notice Emitted when a token is minted.
      *

--- a/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+import {
+    ERC721Enumerable
+} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
@@ -12,7 +15,7 @@ import { IOptimismMintableERC721 } from "./IOptimismMintableERC721.sol";
  *         typically an Optimism representation of an Ethereum-based token. Standard reference
  *         implementation that can be extended or modified according to your needs.
  */
-contract OptimismMintableERC721 is ERC721, IOptimismMintableERC721 {
+contract OptimismMintableERC721 is ERC721Enumerable, IOptimismMintableERC721 {
     /**
      * @inheritdoc IOptimismMintableERC721
      */
@@ -100,7 +103,7 @@ contract OptimismMintableERC721 is ERC721, IOptimismMintableERC721 {
     function supportsInterface(bytes4 _interfaceId)
         public
         view
-        override(ERC721, IERC165)
+        override(ERC721Enumerable, IERC165)
         returns (bool)
     {
         bytes4 iface1 = type(IERC165).interfaceId;


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replaces ERC721 with ERC721Enumerable for the standard version of the
OptimismMintableERC721 token. Enumerable is generally less useful on L1
because it consumes more gas but it makes indexing significantly easier
and gas is cheap on L2. Also removes reinitializer functions because we
don't want to be initializing contracts every time we re-deploy.
