### PR TITLE
op-node/testlog: auto-adjust padding for test log alignment

### DIFF
--- a/op-node/testlog/testlog.go
+++ b/op-node/testlog/testlog.go
@@ -135,17 +135,23 @@ func (l *logger) SetHandler(h log.Handler) {
 	l.l.SetHandler(h)
 }
 
+// tracks the largest seen decoration length, to make alignment between all test loggers consistent.
+var logDecorationLength = 12
+
 // flush writes all buffered messages and clears the buffer.
 func (l *logger) flush() {
 	l.t.Helper()
 	// 2 frame skip for flush() + public logger fn
 	decorationLen := estimateInfoLen(2)
-	padding := 20
-	if decorationLen <= 25 {
-		padding = 25 - decorationLen
+	if decorationLen > 30 { // limit to a maximum size, to avoid huge padding
+		decorationLen = 30
+	}
+	// logDecorationLength is only increasing, should be safe even with inaccurate concurrent use.
+	if decorationLen > logDecorationLength { // increase padding if we encounter larger decoration
+		logDecorationLength = decorationLen
 	}
 	for _, r := range l.h.buf {
-		l.t.Logf("%*s%s", padding, "", l.h.fmt.Format(r))
+		l.t.Logf("%*s%s", logDecorationLength-decorationLen, "", l.h.fmt.Format(r))
 	}
 	l.h.buf = nil
 }


### PR DESCRIPTION
The test-logger now auto-adjusts alignment as the filename decoration grows in length, in case of running tests with long names.

Example:
![testlog](https://user-images.githubusercontent.com/19571989/177410928-813bb39c-910a-423b-8d78-4d091934557d.png)
