### PR TITLE
fix(ci): add bedrock contracts to PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,6 +6,7 @@
   - 'packages/batch-submitter/**/*'
   - 'packages/contracts/**/*'
   - 'packages/contracts-periphery/**/*'
+  - 'packages/contracts-bedrock/**/*'
   - 'packages/data-transport-layer/**/*'
   - 'packages/drippie-mon/**/*'
   - 'packages/message-relayer/**/*'
@@ -29,6 +30,9 @@ M-contracts:
 
 M-contracts-periphery:
   - any: ['packages/contracts-periphery/**/*']
+
+M-contracts-bedrock:
+  - any: ['packages/contracts-bedrock/**/*']
 
 M-core-utils:
   - any: ['packages/core-utils/**/*']


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Has PR labeler correctly label PRs to the contracts-bedrock package.
