### PR TITLE
contracts-bedrock: fix typechain

### DIFF
--- a/.changeset/yellow-readers-vanish.md
+++ b/.changeset/yellow-readers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Update typechain pipeline

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -4,7 +4,6 @@ import { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } from 'hardhat/builtin-tasks/ta
 
 // Hardhat plugins
 import '@nomiclabs/hardhat-ethers'
-import '@typechain/hardhat'
 import 'hardhat-deploy'
 import '@foundry-rs/hardhat-forge'
 import '@eth-optimism/hardhat-deploy-config'
@@ -48,15 +47,14 @@ const config: HardhatUserConfig = {
   },
   foundry: {
     buildInfo: true,
+    // call runSuper in the hardhat task so that
+    // other things execute
+    runSuper: true,
   },
   paths: {
     deploy: './deploy',
     deployments: './deployments',
     deployConfig: './deploy-config',
-  },
-  typechain: {
-    outDir: 'dist/types',
-    target: 'ethers-v5',
   },
   namedAccounts: {
     deployer: {

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "build:forge": "forge build",
     "prebuild": "yarn ts-node scripts/verifyFoundryInstall.ts",
-    "build": "hardhat compile && tsc && hardhat typechain",
-    "build:ts": "tsc",
+    "build": "hardhat compile && yarn build:ts && yarn typechain",
+    "build:ts": "tsc -p tsconfig.json",
     "deploy": "hardhat deploy",
     "test": "forge test",
     "gas-snapshot": "forge snapshot",
@@ -30,7 +30,8 @@
     "lint:ts:fix": "yarn prettier --write .",
     "lint:contracts:fix": "yarn prettier --write 'contracts/**/*.sol'",
     "lint:fix": "yarn lint:contracts:fix && yarn lint:ts:fix",
-    "lint": "yarn lint:fix && yarn lint:check"
+    "lint": "yarn lint:fix && yarn lint:check",
+    "typechain": "typechain --target ethers-v5 --out-dir dist/types --glob 'artifacts/!(build-info)/**/+([a-zA-Z0-9_]).json'"
   },
   "dependencies": {
     "@eth-optimism/core-utils": "^0.9.0",
@@ -50,11 +51,10 @@
   "devDependencies": {
     "@eth-optimism/hardhat-deploy-config": "^0.2.0",
     "@defi-wonderland/smock": "^2.0.2",
-    "@foundry-rs/hardhat-forge": "^0.1.10",
+    "@foundry-rs/hardhat-forge": "^0.1.11",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@typechain/ethers-v5": "^10.1.0",
-    "@typechain/hardhat": "^6.1.2",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^4.29.1",
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,10 +1614,10 @@
     command-exists "^1.2.9"
     ts-interface-checker "^0.1.9"
 
-"@foundry-rs/hardhat-forge@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.10.tgz#031a85c1c8e51bbf72390d950721611d83f089df"
-  integrity sha512-L5E+zXF/AazR2yO0ZoHtj74uyetO/mXxjSx5hOtjEpUX6czRbGP+tPbbTGjKnoMUzUP5uF1N0TjfCe7T9UpBbA==
+"@foundry-rs/hardhat-forge@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.11.tgz#64f604ea6d69d1fec3bbccf1b86e6766453f31ec"
+  integrity sha512-2/52ucRcr2N21UB6qj8zbhceb6Gtac6J6uKvsvUBG1DTafWRtOQotQFo0rPq1BIi7mbUmczUlU6pwEIXZDhp6w==
   dependencies:
     "@foundry-rs/easy-foundryup" "^0.1.3"
     "@nomiclabs/hardhat-ethers" "^2.0.0"
@@ -3189,14 +3189,6 @@
   integrity sha512-C6Be6l+vTpao19PvMH2CB/lhL1TRLkhdPkvQCF/zqkY1e+0iqY2Bb9Jd3PTt6I8QvMm89ZDerrCJC9927ZHmlg==
   dependencies:
     fs-extra "^9.1.0"
-
-"@typechain/hardhat@^6.1.2":
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/@typechain/hardhat/-/hardhat-6.1.2.tgz#d3beccc6937d93f9b437616b741f839a8b953693"
-  integrity sha512-k4Ea3pVITKB2DH8p1a5U38cyy7KZPD04Spo4q5b4wO+n2mT+uAz5dxckPtbczn/Kk5wiFq+ZkuOtw5ZKFhL/+w==
-  dependencies:
-    fs-extra "^9.1.0"
-    lodash "^4.17.15"
 
 "@types/abstract-leveldown@*":
   version "5.0.2"


### PR DESCRIPTION
**Description**

Update to the latest version of typechain and no longer
use the hh plugin. Directly call typechain as the hardhat
plugin is unreliable when using foundry.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

