### PR TITLE
docker: add ethereumoptimism/foundry docker image

### DIFF
--- a/.changeset/big-scissors-remain.md
+++ b/.changeset/big-scissors-remain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/foundry': minor
+---
+
+Initial release, pin to b7b1ec471bdd38221773e1a569dc4f20297bd7db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       go-builder: ${{ steps.packages.outputs.go-builder }}
       js-builder: ${{ steps.packages.outputs.js-builder }}
       ci-builder: ${{ steps.packages.outputs.ci-builder }}
+      foundry: ${{ steps.packages.outputs.foundry }}
 
     steps:
       - name: Checkout Repo
@@ -235,6 +236,32 @@ jobs:
           file: ./ops/docker/ci-builder/Dockerfile
           push: true
           tags: ethereumoptimism/ci-builder:${{ needs.release.outputs.ci-builder }},ethereumoptimism/ci-builder:latest
+
+  foundry:
+    name: Publish foundry ${{ needs.release.outputs.foundry }}
+    needs: release
+    if: needs.release.outputs.foundry != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Publish foundry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/foundry/Dockerfile
+          push: true
+          tags: ethereumoptimism/foundry:${{ needs.release.outputs.foundry }},ethereumoptimism/foundry:latest
 
   proxyd:
     name: Publish proxyd Version ${{ needs.release.outputs.proxyd }}

--- a/ops/docker/foundry/Dockerfile
+++ b/ops/docker/foundry/Dockerfile
@@ -1,0 +1,31 @@
+from alpine as build-environment
+WORKDIR /opt
+RUN apk add clang lld curl build-base linux-headers git \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
+    && chmod +x ./rustup.sh \
+    && ./rustup.sh -y
+WORKDIR /opt/foundry
+
+# Only diff from upstream docker image is this clone instead
+# of COPY. We select a specific commit to use.
+RUN git clone https://github.com/foundry-rs/foundry.git . \
+    && git checkout b7b1ec471bdd38221773e1a569dc4f20297bd7db
+
+RUN source $HOME/.profile && cargo build --release \
+    && strip /opt/foundry/target/release/forge \
+    && strip /opt/foundry/target/release/cast \
+    && strip /opt/foundry/target/release/anvil
+
+from alpine as foundry-client
+ENV GLIBC_KEY=https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+ENV GLIBC_KEY_FILE=/etc/apk/keys/sgerrand.rsa.pub
+ENV GLIBC_RELEASE=https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk
+
+RUN apk add linux-headers gcompat
+RUN wget -q -O ${GLIBC_KEY_FILE} ${GLIBC_KEY} \
+    && wget -O glibc.apk ${GLIBC_RELEASE} \
+    && apk add glibc.apk --force
+COPY --from=build-environment /opt/foundry/target/release/forge /usr/local/bin/forge
+COPY --from=build-environment /opt/foundry/target/release/cast /usr/local/bin/cast
+COPY --from=build-environment /opt/foundry/target/release/anvil /usr/local/bin/anvil
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/ops/docker/foundry/package.json
+++ b/ops/docker/foundry/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@eth-optimism/foundry",
+  "version": "0.0.0",
+  "scripts": {},
+  "license": "MIT",
+  "dependencies": {}
+}
+

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "ops/docker/go-builder",
       "ops/docker/js-builder",
       "ops/docker/ci-builder",
+      "ops/docker/foundry",
       "proxyd",
       "teleportr"
     ],


### PR DESCRIPTION
**Description**

Based on the following commit:
https://github.com/foundry-rs/foundry/commit/b7b1ec471bdd38221773e1a569dc4f20297bd7db

Allows us to control the version of foundry being used in our toolchain. This dockerfile is exactly the same as upstream's but pins to a specific commit hash.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->



