### PR TITLE
contracts-bedrock: speed up compilation time

### DIFF
--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -47,9 +47,6 @@ const config: HardhatUserConfig = {
   },
   foundry: {
     buildInfo: true,
-    // call runSuper in the hardhat task so that
-    // other things execute
-    runSuper: true,
   },
   paths: {
     deploy: './deploy',

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@eth-optimism/hardhat-deploy-config": "^0.2.0",
     "@defi-wonderland/smock": "^2.0.2",
-    "@foundry-rs/hardhat-forge": "^0.1.11",
+    "@foundry-rs/hardhat-forge": "^0.1.12",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@typechain/ethers-v5": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,10 +1614,10 @@
     command-exists "^1.2.9"
     ts-interface-checker "^0.1.9"
 
-"@foundry-rs/hardhat-forge@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.11.tgz#64f604ea6d69d1fec3bbccf1b86e6766453f31ec"
-  integrity sha512-2/52ucRcr2N21UB6qj8zbhceb6Gtac6J6uKvsvUBG1DTafWRtOQotQFo0rPq1BIi7mbUmczUlU6pwEIXZDhp6w==
+"@foundry-rs/hardhat-forge@^0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.12.tgz#0557909762b86033e4699b9dc8e4cb58ddfc3fff"
+  integrity sha512-y05JYP+uvBaWKZZPuMkzc7cWS0gPTb4JzwrBA++9cIe1Aae+atz340cREBsCV9joEUpcK0UMRMURBns3A5nhhQ==
   dependencies:
     "@foundry-rs/easy-foundryup" "^0.1.3"
     "@nomiclabs/hardhat-ethers" "^2.0.0"


### PR DESCRIPTION
**Description**

This commit greatly speeds up the compilation
time for `hardhat compile` by updating to the
latest version of the plugin.

This is known to work with the following forge version:
```
forge 0.2.0 (4ad4bb6 2022-07-06T17:55:43.107018225Z)
```

To use this version:
```
$ foundryup -C 4ad4bb660ad0b429e76e980fd6c1d50aee7c112b
```

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


