### PR TITLE
Op Node: Fix one reorg bug

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -234,7 +234,7 @@ func (s *state) createNewL2Block(ctx context.Context) error {
 	}
 
 	// Update our L2 head block based on the new unsafe block we just generated.
-	s.derivation.SetUnsafeHead(s.l2Head)
+	s.derivation.SetUnsafeHead(newUnsafeL2Head)
 	s.l2Head = newUnsafeL2Head
 
 	s.log.Info("Sequenced new l2 block", "l2Head", s.l2Head, "l1Origin", s.l2Head.L1Origin, "txs", len(payload.Transactions), "time", s.l2Head.Time)

--- a/packages/contracts-bedrock/deploy-config/devnetL1.ts
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.ts
@@ -46,7 +46,7 @@ const config = {
 
   deploymentWaitConfirmations: 1,
 
-  maxSequencerDrift: 1000,
+  maxSequencerDrift: 100,
   sequencerWindowSize: 4,
   channelTimeout: 40,
 


### PR DESCRIPTION
**Description**
The `unsafeHead` or `l2Head` is state managed between two separate
processes: the driver state loop and the derivation pipeline. It
is updated during a reorg, during block creation, or during p2p
payload insertion. What happened is that during block creation
the state loop would inform the derivation pipeline of the new
unsafe L2 head; however it was using an old value. This would
cause the communication back from the pipeline to use an old
unsafe head during the setting inside the state loop. Then
the state loop would create a new L2 block with the same L2 parent
thus causing an inadvertent chain reorganization.
    
This commit also reverts the very significant increase in sequencer
drift to a more reasonable value.


**Additional context**
Tested locally with the devnet. Up to block number 350 without a reorg.
Prior to this fix it was consistently reorging by block ~200.

**Metadata**
- Fixes ENG-2390
