### PR TITLE
ops: Use correct sequencer inbox value for the batch

### DIFF
--- a/ops-bedrock/devnet-up.sh
+++ b/ops-bedrock/devnet-up.sh
@@ -129,7 +129,7 @@ fi
 
 L2OO_ADDRESS=$(jq -r .address < $CONTRACTS_BEDROCK/deployments/$NETWORK/L2OutputOracleProxy.json)
 SEQUENCER_GENESIS_HASH="$(jq -r '.l2.hash' < .devnet/rollup.json)"
-SEQUENCER_BATCH_INBOX_ADDRESS="$(cat ./ops-bedrock/rollup.json | jq -r '.batch_inbox_address')"
+SEQUENCER_BATCH_INBOX_ADDRESS="$(cat ./.devnet/rollup.json | jq -r '.batch_inbox_address')"
 
 # Bring up everything else.
 (


### PR DESCRIPTION
**Description**
The value is pulled in from the rollup.json config; however it
was still using the old config that was checked in (& deleted
a while ago) instead of using the generated config.

**Additional context**
Tested locally.


