### PR TITLE
op-node: testnet fixes - sanity check L2 block after block derivation reset

### DIFF
--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -43,7 +43,7 @@ func NewAttributesQueue(log log.Logger, cfg *rollup.Config, l1Fetcher L1Receipts
 }
 
 func (aq *AttributesQueue) AddBatch(batch *BatchData) {
-	aq.log.Trace("Received next batch", "batch_epoch", batch.EpochNum, "batch_timestamp", batch.Timestamp, "tx_count", len(batch.Transactions))
+	aq.log.Debug("Received next batch", "batch_epoch", batch.EpochNum, "batch_timestamp", batch.Timestamp, "tx_count", len(batch.Transactions))
 	aq.batches = append(aq.batches, batch)
 }
 

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -43,7 +43,7 @@ func NewAttributesQueue(log log.Logger, cfg *rollup.Config, l1Fetcher L1Receipts
 }
 
 func (aq *AttributesQueue) AddBatch(batch *BatchData) {
-	aq.log.Info("Received next batch", "batch_epoch", batch.EpochNum, "batch_timestamp", batch.Timestamp, "tx_count", len(batch.Transactions))
+	aq.log.Trace("Received next batch", "batch_epoch", batch.EpochNum, "batch_timestamp", batch.Timestamp, "tx_count", len(batch.Transactions))
 	aq.batches = append(aq.batches, batch)
 }
 

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -297,6 +297,10 @@ func (eq *EngineQueue) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error
 				Origin: canonicalRef,
 				Closed: false,
 			}
+			if eq.safeHead.Time < canonicalRef.Time {
+				return fmt.Errorf("cannot reset block derivation to start at L2 block %s with time %d older than its L1 origin %s with time %d, time invariant is broken",
+					eq.safeHead, eq.safeHead.Time, canonicalRef, canonicalRef.Time)
+			}
 			return io.EOF
 		} else {
 			// if the safe head is not canonical, then the unsafe head will not be either


### PR DESCRIPTION
Debugging the testnet with Josh/BenW. This catches a misconfiguration issue in the verifier, just in case it happens again.