### PR TITLE
ops-bedrock: move docker files into their module dirs

### DIFF
--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.18.0-alpine3.15 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+# build op-batcher with local monorepo go modules
+COPY ./op-batcher/docker.go.work /app/go.work
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-proposer /app/op-proposer

--- a/op-batcher/docker.go.work
+++ b/op-batcher/docker.go.work
@@ -1,0 +1,8 @@
+go 1.18
+
+use (
+	./op-batcher
+	./op-bindings
+	./op-node
+	./op-proposer
+)

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -2,15 +2,12 @@ FROM golang:1.18.0-alpine3.15 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
-COPY ./op-node/go.mod /app/op-node/go.mod
-COPY ./op-node/go.sum /app/op-node/go.sum
-
+# build op-node with local monorepo go modules
+COPY ./op-node/docker.go.work /app/go.work
 COPY ./op-bindings /app/op-bindings
+COPY ./op-node /app/op-node
 
 WORKDIR /app/op-node
-RUN go mod download -x
-
-COPY ./op-node /app/op-node
 
 RUN make op-node
 

--- a/op-node/docker.go.work
+++ b/op-node/docker.go.work
@@ -1,0 +1,6 @@
+go 1.18
+
+use (
+	./op-bindings
+	./op-node
+)

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.18.0-alpine3.15 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+# build op-proposer with local monorepo go modules
+COPY ./op-proposer/docker.go.work /app/go.work
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-proposer /app/op-proposer

--- a/op-proposer/docker.go.work
+++ b/op-proposer/docker.go.work
@@ -1,0 +1,7 @@
+go 1.18
+
+use (
+	./op-bindings
+	./op-node
+	./op-proposer
+)

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - l2
     build:
       context: ../
-      dockerfile: ./ops-bedrock/Dockerfile.node
+      dockerfile: ./op-node/Dockerfile
     command: >
       op-node
       --l1=ws://l1:8546
@@ -81,7 +81,7 @@ services:
       - op-node
     build:
       context: ../
-      dockerfile: ./ops-bedrock/Dockerfile.proposer
+      dockerfile: ./op-proposer/Dockerfile
     environment:
       L1_ETH_RPC: http://l1:8545
       L2_ETH_RPC: http://l2:8545
@@ -102,7 +102,7 @@ services:
       - op-node
     build:
       context: ../
-      dockerfile: ./ops-bedrock/Dockerfile.batcher
+      dockerfile: ./op-batcher/Dockerfile
     environment:
       L1_ETH_RPC: http://l1:8545
       L2_ETH_RPC: http://l2:8545


### PR DESCRIPTION
In preparation of the go module versioning work: move the dockerfiles to the dir of their module, and use a temporary `go.work` for the docker build so the modules build with the local monorepo contents.

We still have the `replace github.com/ethereum-optimism/optimism/op-something v0.0.0 => ../op-something` directives in the mod files, but the `use` directives in the new `docker.go.work` files make those unnecessary during the docker build now.
So we can remove them in the next PR that introduces versioning for them.

With a separate toy go workspace project I tested that:
- the go.work file thing in docker works: it's not building with the module version referenced in the `require` of the  `go.mod`, but rather with the local copy referenced by the `docker.go.work`.
- we don't need to copy the go-ethereum replace statement into the `docker.go.work`, the `go.work` is adding/overriding, but not remove directives of the `go.mod`.

