### PR TITLE
specs: fix markdown lint in meta spec doc

### DIFF
--- a/specs/meta/versioning.md
+++ b/specs/meta/versioning.md
@@ -3,26 +3,28 @@
 ## Go modules
 
 Go modules that are currently versioned:
-```
-	./op-batcher
-	./op-bindings
-	./op-node
-	./op-proposer
-	./op-e2e
+
+```text
+./op-batcher
+./op-bindings
+./op-node
+./op-proposer
+./op-e2e
 ```
 
 Go modules which are not yet versioned:
-```
-	./batch-submitter  (changesets)
-	./bss-core
-	./gas-oracle       (changesets)
-	./indexer          (changesets)
-	./l2geth           (changesets)
-	./l2geth-exporter  (changesets)
-	./op-exporter      (changesets)
-	./proxyd           (changesets)
-	./teleportr        (changesets)
-	./state-surgery
+
+```text
+./batch-submitter  (changesets)
+./bss-core
+./gas-oracle       (changesets)
+./indexer          (changesets)
+./l2geth           (changesets)
+./l2geth-exporter  (changesets)
+./op-exporter      (changesets)
+./proxyd           (changesets)
+./teleportr        (changesets)
+./state-surgery
 ```
 
 ### versioning process


### PR DESCRIPTION
Accidentally broke develop CI with markdown formatting during versioning process. This PR fixes that. Just removing tabs and adding a missing language identifier in code-blocks.

