### PR TITLE
ci: fix publishing of ci-builder

### DIFF
--- a/.changeset/itchy-carpets-fail.md
+++ b/.changeset/itchy-carpets-fail.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Fix publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,8 +232,8 @@ jobs:
       - name: Publish ci-builder
         uses: docker/build-push-action@v2
         with:
-          context: .
-          file: ./ops/docker/ci-builder/Dockerfile
+          context: ./ops/docker/ci-builder
+          file: Dockerfile
           push: true
           tags: ethereumoptimism/ci-builder:${{ needs.release.outputs.ci-builder }},ethereumoptimism/ci-builder:latest
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes the broken publish step of `ci-builder`. This is required to update our tooling versions
See https://github.com/ethereum-optimism/optimism/runs/7310233030?check_suite_focus=true
