### PR TITLE
ci: updates version of bash in ci-builder

### DIFF
--- a/.changeset/slow-peaches-sit.md
+++ b/.changeset/slow-peaches-sit.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Install new version of bash

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=geth /usr/local/bin/abigen /usr/local/bin/abigen
 COPY check-changed.sh /usr/local/bin/check-changed
 
 RUN apt-get update && \
-  apt-get install -y curl openssh-client git build-essential ca-certificates jq musl && \
+  apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl && \
   curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
   curl -sL https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd64.tar.gz && \
   tar -C /usr/local/ -xzvf go1.18.2.linux-amd64.tar.gz && \
@@ -51,4 +51,8 @@ RUN echo "downloading solidity compilers" && \
   mkdir -p ~/.svm/0.8.10 && \
   cp solc-linux-amd64-v0.8.10+commit.fc410830 ~/.svm/0.8.10/solc-0.8.10 && \
   mkdir -p ~/.svm/0.8.12 && \
-  cp solc-linux-amd64-v0.8.12+commit.f00d7308 ~/.svm/0.8.12/solc-0.8.12
+  cp solc-linux-amd64-v0.8.12+commit.f00d7308 ~/.svm/0.8.12/solc-0.8.12 && \
+  rm solc-linux-amd64-v0.5.17+commit.d19bba13 && \
+  rm solc-linux-amd64-v0.8.9+commit.e5eed63a && \
+  rm solc-linux-amd64-v0.8.10+commit.fc410830 && \
+  rm solc-linux-amd64-v0.8.12+commit.f00d7308


### PR DESCRIPTION
Also deletes leftover copies of solc in the
root of the image. They are copied to the places
where they are expected.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates bash in the `ci-builder` image, this seems to fix problems with `vm.ffi` in https://github.com/ethereum-optimism/optimism/pull/2980. That PR works on my machine locally and I rebuilt this docker image locally and ran the tests in it and they all passed. In the existing `ci-builder`, the differential tests fail for some reason.

Will need to trigger a release of `ci-builder`
