### PR TITLE
ci: parallel build of bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Check if we should run
           command: |
             shopt -s inherit_errexit
-            CHANGED=$(check-changed "packages/")
+            CHANGED=$(check-changed "op-bindings|packages/")
             if [[ "$CHANGED" = "FALSE" ]]; then
               circleci step halt
             fi
@@ -165,7 +165,10 @@ jobs:
             fi
       - run:
           name: check go bindings
-          command: make && git diff --exit-code
+          command: |
+            make contracts
+            make -j $(nproc)
+            git diff --exit-code
           working_directory: op-bindings
 
   js-lint-test:

--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -38,5 +38,9 @@ address-manager-bindings:
 mkdir:
 	mkdir -p bin bindings
 
+contracts:
+	cd ../packages/contracts-bedrock
+	forge build
+
 clean:
 	rm -rf bin bindings

--- a/op-bindings/README.md
+++ b/op-bindings/README.md
@@ -1,0 +1,9 @@
+# op-bindings
+
+Contains prebuilt golang bindings for Optimism contracts.
+
+## Build
+
+```bash
+$ make
+```


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Should speed up CI by building the `op-bindings` in parallel based on the number of cores on the machine
