### PR TITLE
op-e2e: deploy output oracle with correct config (bedrock)

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -89,9 +89,7 @@ func defaultSystemConfig(t *testing.T) SystemConfig {
 			FinalizationPeriod: big.NewInt(60 * 60 * 24),
 		},
 		L2OOCfg: L2OOContractConfig{
-			// L2 Start time is set based off of the L2 Genesis time
 			SubmissionFrequency:   big.NewInt(4),
-			L2BlockTime:           big.NewInt(2),
 			HistoricalTotalBlocks: big.NewInt(0),
 		},
 		L2OutputHDPath:             l2OutputHDPath,


### PR DESCRIPTION
This PR:
- deploys output oracle with correct config
- de-duplicates block time and genesis setup info.

Previously the contract was being deployed with a block time of 2 instead of 1, and thus failing to confirm the latest outputs, and increasingly lagging behind the L2 chain.
