### PR TITLE
fix (op-proposer): use safe head in block range

### DIFF
--- a/op-proposer/drivers/l2output/driver.go
+++ b/op-proposer/drivers/l2output/driver.go
@@ -109,7 +109,12 @@ func (d *Driver) GetBlockRange(
 		d.l.Error(name+" unable to get next block number", "err", err)
 		return nil, nil, err
 	}
-	latestHeader, err := d.cfg.L2Client.HeaderByNumber(ctx, nil)
+	status, err := d.cfg.RollupClient.SyncStatus(ctx)
+	if err != nil {
+		d.l.Error(name+" unable to get sync status", "err", err)
+		return nil, nil, err
+	}
+	latestHeader, err := d.cfg.L2Client.HeaderByNumber(ctx, new(big.Int).SetUint64(status.SafeL2.Number))
 	if err != nil {
 		d.l.Error(name+" unable to retrieve latest header", "err", err)
 		return nil, nil, err


### PR DESCRIPTION
**Description:**

Currently the proposer does not use a safe head for creating output proposal which causes a failure in proposing with: `L2OutputOracle: cannot propose L2 output in the future`, as the output oracle does not know the unsafe head.

To fix this, we limit the block range the output proposer works with to the safe head instead.

Edit: does not include a test atm.

Fixes: ENG-2348