### PR TITLE
feat(sdk): use clearer status enums

### DIFF
--- a/.changeset/cyan-laws-glow.md
+++ b/.changeset/cyan-laws-glow.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': minor
+---
+
+Slightly modifies the MessageStatus enum to map to strings instead of integers

--- a/packages/sdk/src/interfaces/types.ts
+++ b/packages/sdk/src/interfaces/types.ts
@@ -120,34 +120,34 @@ export enum MessageStatus {
   /**
    * Message is an L1 to L2 message and has not been processed by the L2.
    */
-  UNCONFIRMED_L1_TO_L2_MESSAGE,
+  UNCONFIRMED_L1_TO_L2_MESSAGE = 'UNCONFIRMED_L1_TO_L2_MESSAGE',
 
   /**
    * Message is an L1 to L2 message and the transaction to execute the message failed.
    * When this status is returned, you will need to resend the L1 to L2 message, probably with a
    * higher gas limit.
    */
-  FAILED_L1_TO_L2_MESSAGE,
+  FAILED_L1_TO_L2_MESSAGE = 'FAILED_L1_TO_L2_MESSAGE',
 
   /**
    * Message is an L2 to L1 message and no state root has been published yet.
    */
-  STATE_ROOT_NOT_PUBLISHED,
+  STATE_ROOT_NOT_PUBLISHED = 'STATE_ROOT_NOT_PUBLISHED',
 
   /**
    * Message is an L2 to L1 message and awaiting the challenge period.
    */
-  IN_CHALLENGE_PERIOD,
+  IN_CHALLENGE_PERIOD = 'IN_CHALLENGE_PERIOD',
 
   /**
    * Message is ready to be relayed.
    */
-  READY_FOR_RELAY,
+  READY_FOR_RELAY = 'READY_FOR_RELAY',
 
   /**
    * Message has been relayed.
    */
-  RELAYED,
+  RELAYED = 'RELAYED',
 }
 
 /**


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Updates the MessageStatus enum to use string values instead of integer
values. Gives the user much better feedback when looking at message
status in a script or on the command line.
