### PR TITLE
chore(ctp): Bump solidity version to 0.8.15

### DIFF
--- a/.changeset/fresh-peaches-remain.md
+++ b/.changeset/fresh-peaches-remain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-periphery': patch
+---
+
+Update compiler version to 0.8.15

--- a/packages/contracts-periphery/contracts/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L1/L1ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import {
     CrossDomainEnabled

--- a/packages/contracts-periphery/contracts/L1/TeleportrDeposit.sol
+++ b/packages/contracts-periphery/contracts/L1/TeleportrDeposit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.9;
+pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/packages/contracts-periphery/contracts/L1/TeleportrWithdrawer.sol
+++ b/packages/contracts-periphery/contracts/L1/TeleportrWithdrawer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { AssetReceiver } from "../universal/AssetReceiver.sol";
 

--- a/packages/contracts-periphery/contracts/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L2/L2ERC721Bridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import {
     CrossDomainEnabled

--- a/packages/contracts-periphery/contracts/L2/TeleportrDisburser.sol
+++ b/packages/contracts-periphery/contracts/L2/TeleportrDisburser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.9;
+pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/packages/contracts-periphery/contracts/foundry-tests/AssetReceiver.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/AssetReceiver.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity 0.8.15;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-periphery/contracts/foundry-tests/TeleportrWithdrawer.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/TeleportrWithdrawer.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity 0.8.15;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-periphery/contracts/foundry-tests/Transactor.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/Transactor.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.10;
+pragma solidity 0.8.15;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";

--- a/packages/contracts-periphery/contracts/testing/helpers/CallRecorder.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/CallRecorder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 contract CallRecorder {
     struct CallInfo {

--- a/packages/contracts-periphery/contracts/testing/helpers/ExternalContractCompiler.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/ExternalContractCompiler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { ProxyAdmin } from "@eth-optimism/contracts-bedrock/contracts/universal/ProxyAdmin.sol";
 import { Proxy } from "@eth-optimism/contracts-bedrock/contracts/universal/Proxy.sol";

--- a/packages/contracts-periphery/contracts/testing/helpers/FailingReceiver.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/FailingReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 contract FailingReceiver {
     receive() external payable {

--- a/packages/contracts-periphery/contracts/testing/helpers/MockTeleportr.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/MockTeleportr.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 contract MockTeleportr {
     function withdrawBalance() external {

--- a/packages/contracts-periphery/contracts/testing/helpers/Reverter.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/Reverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 contract Reverter {
     function doRevert() public pure {

--- a/packages/contracts-periphery/contracts/testing/helpers/SimpleStorage.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/SimpleStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 contract SimpleStorage {
     mapping(bytes32 => bytes32) public db;

--- a/packages/contracts-periphery/contracts/testing/helpers/TestERC20.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 

--- a/packages/contracts-periphery/contracts/testing/helpers/TestERC721.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/TestERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
 

--- a/packages/contracts-periphery/contracts/universal/AssetReceiver.sol
+++ b/packages/contracts-periphery/contracts/universal/AssetReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";

--- a/packages/contracts-periphery/contracts/universal/Transactor.sol
+++ b/packages/contracts-periphery/contracts/universal/Transactor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { Owned } from "@rari-capital/solmate/src/auth/Owned.sol";
 

--- a/packages/contracts-periphery/contracts/universal/drippie/Drippie.sol
+++ b/packages/contracts-periphery/contracts/universal/drippie/Drippie.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { AssetReceiver } from "../AssetReceiver.sol";
 import { IDripCheck } from "./IDripCheck.sol";

--- a/packages/contracts-periphery/contracts/universal/drippie/IDripCheck.sol
+++ b/packages/contracts-periphery/contracts/universal/drippie/IDripCheck.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 interface IDripCheck {
     // DripCheck contracts that want to take parameters as inputs MUST expose a struct called

--- a/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckBalanceHigh.sol
+++ b/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckBalanceHigh.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckBalanceLow.sol
+++ b/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckBalanceLow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckGelatoLow.sol
+++ b/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckGelatoLow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckTrue.sol
+++ b/packages/contracts-periphery/contracts/universal/drippie/dripchecks/CheckTrue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import { IDripCheck } from "../IDripCheck.sol";
 

--- a/packages/contracts-periphery/contracts/universal/op-erc721/IOptimismMintableERC721.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/IOptimismMintableERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import {
     IERC721Enumerable

--- a/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import {
     ERC721Enumerable

--- a/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721Factory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.15;
 
 import {
     OwnableUpgradeable


### PR DESCRIPTION
**Description**
Bumps the version in the periphery package to match that in the bedrock package. 
Complies with the recent change to the [hardhat config compiler](https://github.com/ethereum-optimism/optimism/commit/1489da48f38df84187a9e3cdd7983cfca3bc172f).

Note: the following Libraries/interfaces have version `^0.8.0`: 

/universal/AssetReceiver.sol
/universal/Transactor.sol
/universal/drippie/IDripCheck.sol
/universal/op-erc721/IOptimismMintableERC721.sol
/universal/op-erc721/OptimismMintableERC721.sol