### PR TITLE
ci: remove publishing of deprecated images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -692,20 +692,6 @@ workflows:
           context:
             - optimism
       - docker-publish:
-          name: go-builder-release
-          docker_file: ops/docker/go-builder/Dockerfile
-          docker_tags: ethereumoptimism/go-builder:nightly
-          docker_context: .
-          context:
-            - optimism
-      - docker-publish:
-          name: js-builder-release
-          docker_file: ops/docker/js-builder/Dockerfile
-          docker_tags: ethereumoptimism/js-builder:nightly
-          docker_context: .
-          context:
-            - optimism
-      - docker-publish:
           name: proxyd-release
           docker_file: proxyd/Dockerfile
           docker_tags: ethereumoptimism/proxyd:nightly


### PR DESCRIPTION
**Description**

The `js-builder` and `go-builder` are no longer
used, they were replaced by `ci-builder`. Their
dockerfiles have already been deleted from the
repo, this now deletes their reference in the CI
docker build pipeline.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


