### PR TITLE
contracts-bedrock: standard initializable

### DIFF
--- a/.changeset/dry-bears-beg.md
+++ b/.changeset/dry-bears-beg.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Use the same initializable across codebase

--- a/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
@@ -5,7 +5,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { IRemoteToken, IL1Token } from "./SupportedInterfaces.sol";
 import { CrossDomainMessenger } from "./CrossDomainMessenger.sol";
 import { OptimismMintableERC20 } from "./OptimismMintableERC20.sol";


### PR DESCRIPTION
**Description**

Use only 1 initializable instead of two different initializable
imports. Using contracts with the same name will break hardhat.

The two different initializable imports were:

```solidity
import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
```

```solidity
import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
```

This standardizes on not using `contracts-upgradeable`.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
