### PR TITLE
proxyd: Parameterize full RPC request logging

### DIFF
--- a/.changeset/quiet-books-design.md
+++ b/.changeset/quiet-books-design.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': patch
+---
+
+Parameterize full RPC request logging

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -18,6 +18,9 @@ type ServerConfig struct {
 	TimeoutSeconds int `toml:"timeout_seconds"`
 
 	MaxUpstreamBatchSize int `toml:"max_upstream_batch_size"`
+
+	EnableRequestLog     bool `toml:"enable_request_log"`
+	MaxRequestBodyLogLen int  `toml:"max_request_body_log_len"`
 }
 
 type CacheConfig struct {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -222,6 +222,8 @@ func Start(config *Config) (func(), error) {
 		secondsToDuration(config.Server.TimeoutSeconds),
 		config.Server.MaxUpstreamBatchSize,
 		rpcCache,
+		config.Server.EnableRequestLog,
+		config.Server.MaxRequestBodyLogLen,
 	)
 
 	if config.Metrics.Enabled {


### PR DESCRIPTION
Adds two new config params:

- `enable_request_log`, which enables/disables the full RPC request log
- `max_request_body_log_len`, which configures the maximum number of characters that will be logged for each RPC request. Values over 2000 are ignored.

This should reduce our GCP spend.