### PR TITLE
ci: devnet foundry version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,7 @@ jobs:
       - run:
           name: foundryup
           command: |
+            curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
             foundryup -C 64fe4ac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,9 +434,10 @@ jobs:
       - run:
           name: foundryup
           command: |
-            curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
+            curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
+            export CARGO_NET_GIT_FETCH_WITH_CLI=true
             foundryup -C 64fe4ac
             echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ jobs:
           command: |
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
-            foundryup
+            foundryup -C 64fe4ac
             echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
       - run:
           name: Install and build

--- a/ops-bedrock/README.md
+++ b/ops-bedrock/README.md
@@ -1,0 +1,22 @@
+# ops-bedrock
+
+This package is made usable by the root `Makefile`. It can spin up
+a `docker-compose` based bedrock developer network.
+
+To spin up a local devnet:
+
+```bash
+$ make devnet-up
+```
+
+To spin down the devnet:
+
+```bash
+$ make devnet-down
+```
+
+To wipe the devnet:
+
+```bash
+$ make devnet-clean
+```


### PR DESCRIPTION
**Description**

Pin foundry to `64fe4ac` using the command:

```bash
$ foundryup -C 64fe4ac
```

This will require foundry to be compiled from scratch instead
of downloading a github release. We can add caching later as
well as a better scheme for controlling the versioning.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
