### PR TITLE
op-bindings: speed up build

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -18,22 +18,22 @@ gas-price-oracle-deployed: gas-price-oracle-bindings
 	./gen_deployed_bytecode.sh GasPriceOracle bindings
 
 l1block-bindings:
-	./gen_bindings.sh L1Block bindings
+	./gen_bindings.sh contracts/L2/L1Block.sol:L1Block bindings
 
 l2-to-l1-message-passer-bindings:
-	./gen_bindings.sh L2ToL1MessagePasser bindings
+	./gen_bindings.sh contracts/L2/L2ToL1MessagePasser.sol:L2ToL1MessagePasser bindings
 
 optimism-portal-bindings:
-	./gen_bindings.sh OptimismPortal bindings
+	./gen_bindings.sh contracts/L1/OptimismPortal.sol:OptimismPortal bindings
 
 l2-output-oracle-bindings:
-	./gen_bindings.sh L2OutputOracle bindings
+	./gen_bindings.sh contracts/L1/L2OutputOracle.sol:L2OutputOracle bindings
 
 gas-price-oracle-bindings:
-	./gen_bindings.sh GasPriceOracle bindings
+	./gen_bindings.sh contracts/L2/GasPriceOracle.sol:GasPriceOracle bindings
 
 address-manager-bindings:
-	./gen_bindings.sh AddressManager bindings
+	./gen_bindings.sh contracts/legacy/AddressManager.sol:AddressManager bindings
 
 mkdir:
 	mkdir -p bin bindings

--- a/op-bindings/gen_bindings.sh
+++ b/op-bindings/gen_bindings.sh
@@ -19,8 +19,11 @@ need_cmd() {
 need_cmd forge
 need_cmd abigen
 
-
-TYPE=$1
+NAME=$1
+# This can handle both fully qualified syntax or just
+# the name of the contract.
+# Fully qualified: path-to-contract-file:contract-name
+TYPE=$(echo "$NAME" | cut -d ':' -f2)
 PACKAGE=$2
 
 # Convert to lower case to respect golang package naming conventions
@@ -35,9 +38,9 @@ CWD=$(pwd)
 # Build contracts
 cd ${CONTRACTS_PATH}
 forge build
-forge inspect ${TYPE} abi > ${TEMP}/${TYPE}.abi
-forge inspect ${TYPE} bytecode > ${TEMP}/${TYPE}.bin
-forge inspect ${TYPE} deployedBytecode > ${CWD}/bin/${TYPE_LOWER}_deployed.hex
+forge inspect ${NAME} abi > ${TEMP}/${TYPE}.abi
+forge inspect ${NAME} bytecode > ${TEMP}/${TYPE}.bin
+forge inspect ${NAME} deployedBytecode > ${CWD}/bin/${TYPE_LOWER}_deployed.hex
 
 # Run ABIGEN
 cd ${CWD}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Speeds up the `op-bindings` build as foundry doesn't need to recompile the entire set of contracts if you give it the fully qualified name instead of just the name. I noticed significant speed ups with this.

Building in parallel seems to fail due to contention on downloading the compiler: https://github.com/ethereum-optimism/optimism/pull/3040