### PR TITLE
ctb: Naming and comments to clarify interfaces usage

### DIFF
--- a/.changeset/big-schools-explain.md
+++ b/.changeset/big-schools-explain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Clarify intent with mintable token interfaces

--- a/packages/contracts-bedrock/contracts/test/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismMintableERC20.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Bridge_Initializer } from "./CommonTest.t.sol";
-import "../universal/SupportedInterfaces.sol";
+import { IHasL1Token, IHasRemoteToken } from "../universal/SupportedInterfaces.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract OptimismMintableERC20_Test is Bridge_Initializer {
@@ -74,11 +74,11 @@ contract OptimismMintableERC20_Test is Bridge_Initializer {
         assert(L2Token.supportsInterface(iface1));
 
         bytes4 iface2 = L2Token.l1Token.selector ^ L2Token.mint.selector ^ L2Token.burn.selector;
-        assertEq(iface2, type(IL1Token).interfaceId);
+        assertEq(iface2, type(IHasL1Token).interfaceId);
         assert(L2Token.supportsInterface(iface2));
 
         bytes4 iface3 = L2Token.remoteToken.selector ^ L2Token.mint.selector ^ L2Token.burn.selector;
-        assertEq(iface3, type(IRemoteToken).interfaceId);
+        assertEq(iface3, type(IHasRemoteToken).interfaceId);
         assert(L2Token.supportsInterface(iface3));
     }
 }

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
@@ -94,8 +94,10 @@ contract OptimismMintableERC20 is ERC20 {
      */
     function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
         bytes4 iface1 = type(IERC165).interfaceId;
-        bytes4 iface2 = type(IL1Token).interfaceId;
-        bytes4 iface3 = type(IRemoteToken).interfaceId;
+        // Interface corresponding to the legacy L2StandardERC20.
+        bytes4 iface2 = type(IHasL1Token).interfaceId;
+        // Interface corresponding to the updated OptimismMintableERC20 (this contract).
+        bytes4 iface3 = type(IHasRemoteToken).interfaceId;
         return _interfaceId == iface1 || _interfaceId == iface2 || _interfaceId == iface3;
     }
 

--- a/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
@@ -6,7 +6,7 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { IRemoteToken, IL1Token } from "./SupportedInterfaces.sol";
+import { IHasRemoteToken, IHasL1Token } from "./SupportedInterfaces.sol";
 import { CrossDomainMessenger } from "./CrossDomainMessenger.sol";
 import { OptimismMintableERC20 } from "./OptimismMintableERC20.sol";
 
@@ -513,7 +513,7 @@ abstract contract StandardBridge is Initializable {
      * @return True if the token is an OptimismMintableERC20.
      */
     function _isOptimismMintableERC20(address _token) internal view returns (bool) {
-        return ERC165Checker.supportsInterface(_token, type(IL1Token).interfaceId);
+        return ERC165Checker.supportsInterface(_token, type(IHasL1Token).interfaceId);
     }
 
     /**

--- a/packages/contracts-bedrock/contracts/universal/SupportedInterfaces.sol
+++ b/packages/contracts-bedrock/contracts/universal/SupportedInterfaces.sol
@@ -4,18 +4,31 @@ pragma solidity ^0.8.0;
 // Import this here to make it available just by importing this file
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-interface IRemoteToken {
+
+/**
+ * @title IRemoteToken
+ * @notice This interface is available on the OptimismMintableERC20 contract. We declare it as a
+ *         separate interface so that it can be used in custom implementations of
+ *         OptimismMintableERC20.
+ */
+interface IHasRemoteToken {
+    function remoteToken() external;
+
     function mint(address _to, uint256 _amount) external;
 
     function burn(address _from, uint256 _amount) external;
-
-    function remoteToken() external;
 }
 
-interface IL1Token {
+/**
+ * @custom:legacy
+ * @title IHasL1Token
+ * @notice This interface was available on the legacy L2StandardERC20 contract. It remains available
+ *         on the OptimismMintableERC20 contract for backwards compatibility.
+ */
+interface IHasL1Token {
+    function l1Token() external;
+
     function mint(address _to, uint256 _amount) external;
 
     function burn(address _from, uint256 _amount) external;
-
-    function l1Token() external;
 }


### PR DESCRIPTION
The OptimismMintableERC20 token used two interfaces in its
supportsInterface() function. These were confusingly named
after the functions that they contain (ie. IL1Token, IRemoteToken),
rather than the contracts these interfaces represent.
The name has been tweaked slighly, and comments have been added to
clarify the intent.
