### PR TITLE
contracts-bedrock: fix typechain export

### DIFF
--- a/.changeset/wet-suns-develop.md
+++ b/.changeset/wet-suns-develop.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Fix typechain exports

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -8,7 +8,7 @@
   "files": [
     "dist/**/*.js",
     "dist/**/*.d.ts",
-    "dist/types/*.ts",
+    "dist/types/**/*.ts",
     "artifacts/contracts/**/*.json",
     "deployments/**/*.json",
     "contracts/**/*.sol"


### PR DESCRIPTION
**Description**

The `package.json` defines the files that are included
in the `npm` package, the previous glob did not match
all of the typechain artifacts.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


