### PR TITLE
contracts-bedrock: in place handling of immutables

### DIFF
--- a/.changeset/cool-items-smell.md
+++ b/.changeset/cool-items-smell.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Update genesis-l2 task to set immutables in the bytecode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,7 +451,6 @@ jobs:
           name: Do a deposit
           no_output_timeout: 5m
           command: |
-            npx hardhat compile
             npx hardhat deposit \
                 --to 0xB79f76EF2c5F0286176833E7B2eEe103b1CC3244  \
                 --amount-eth 1 \
@@ -460,8 +459,11 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: Check the status
-          command: |
-            npx hardhat check-op-node
+          command: npx hardhat check-op-node
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Check L2 Config
+          command: npx hardhat check-l2-config
           working_directory: packages/contracts-bedrock
 
   integration-tests:

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -15,6 +15,7 @@ import './tasks/deposits'
 import './tasks/rekey'
 import './tasks/rollup-config'
 import './tasks/check-op-node'
+import './tasks/check-l2-config'
 
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
   async (_, __, runSuper) => {

--- a/packages/contracts-bedrock/tasks/check-l2-config.ts
+++ b/packages/contracts-bedrock/tasks/check-l2-config.ts
@@ -22,6 +22,7 @@ task('check-l2-config', 'Validate L2 config')
     )
 
     const bridge = await OptimismMintableERC20Factory.bridge()
+    console.log(`OptimismMintableERC20Factory.bridge() -> ${bridge}`)
     if (bridge !== predeploys.L2StandardBridge) {
       throw new Error(
         `L2StandardBridge not set correctly. Got ${bridge}, expected ${predeploys.L2StandardBridge}`

--- a/packages/contracts-bedrock/tasks/check-l2-config.ts
+++ b/packages/contracts-bedrock/tasks/check-l2-config.ts
@@ -1,0 +1,30 @@
+import { task, types } from 'hardhat/config'
+import { providers } from 'ethers'
+import '@nomiclabs/hardhat-ethers'
+
+import { predeploys, getContractInterface } from '../src'
+
+task('check-l2-config', 'Validate L2 config')
+  .addParam(
+    'l2ProviderUrl',
+    'L2 provider URL.',
+    'http://localhost:9545',
+    types.string
+  )
+  .setAction(async (args, hre) => {
+    const { l2ProviderUrl } = args
+    const l2Provider = new providers.JsonRpcProvider(l2ProviderUrl)
+
+    const OptimismMintableERC20Factory = new hre.ethers.Contract(
+      predeploys.OptimismMintableERC20Factory,
+      getContractInterface('OptimismMintableERC20Factory'),
+      l2Provider
+    )
+
+    const bridge = await OptimismMintableERC20Factory.bridge()
+    if (bridge !== predeploys.L2StandardBridge) {
+      throw new Error(
+        `L2StandardBridge not set correctly. Got ${bridge}, expected ${predeploys.L2StandardBridge}`
+      )
+    }
+  })

--- a/packages/contracts-bedrock/tasks/genesis-l2.ts
+++ b/packages/contracts-bedrock/tasks/genesis-l2.ts
@@ -165,6 +165,16 @@ const replaceImmutables = async (
         )
       }
 
+      // Ensure that the value being sliced out is 0
+      const val = hexDataSlice(
+        deployedBytecode,
+        offset.start,
+        offset.start + offset.length
+      )
+      if (!BigNumber.from(val).eq(0)) {
+        throw new Error(`Unexpected value in immutable bytecode ${val}`)
+      }
+
       deployedBytecode = ethers.utils.hexConcat([
         hexDataSlice(deployedBytecode, 0, offset.start),
         hexZeroPad(value, 32),

--- a/packages/contracts-bedrock/tasks/genesis-l2.ts
+++ b/packages/contracts-bedrock/tasks/genesis-l2.ts
@@ -69,6 +69,9 @@ const findContractAndSource = (name: string, buildInfo: BuildInfo) => {
       compilerOutputContracts.push(contract[name])
     }
   }
+  if (compilerOutputContracts.length === 0) {
+    throw new Error(`Cannot find compiler output contract for ${name}`)
+  }
   if (compilerOutputContracts.length !== 1) {
     console.log(`Unexpected number of contracts for ${name}`)
   }
@@ -80,7 +83,9 @@ const findContractAndSource = (name: string, buildInfo: BuildInfo) => {
       compilerOutputSources.push(source as CompilerOutputSource)
     }
   }
-
+  if (compilerOutputSources.length === 0) {
+    throw new Error(`Cannot find compiler output source for ${name}`)
+  }
   if (compilerOutputSources.length !== 1) {
     console.log(`Unexpected number of sources for ${name}`)
   }


### PR DESCRIPTION
**Description**

This updates the hardhat task `genesis-l2` to handle
setting the immutables in the deployed bytecode. This
is necessary because the predeploys "live" in the L2
state and are not deployed. Any immutables must be manually
placed into the bytecode by looking at the compiler output
and then finding the offsets and slicing in the values.

A high level API is exposed for setting arbitrary immutables
with the `replaceImmutables` function. This was inspired by
smock's `computeStorageSlots`.

Longer term, this code will be rewritten in go and be able to
operate on either a LevelDB database (upgrade an existing system)
or a `genesis.json` (good for starting a new network). This is
a requirement because the state surgery is large enough such that
it must bind directly to LevelDB and be in a language that is
relatively fast.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


