### PR TITLE
contracts-bedrock: update hardhat-forge plugin

### DIFF
--- a/.changeset/early-keys-know.md
+++ b/.changeset/early-keys-know.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Update @foundry-rs/hardhat-forge@0.1.16

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@eth-optimism/hardhat-deploy-config": "^0.2.1",
     "@defi-wonderland/smock": "^2.0.2",
-    "@foundry-rs/hardhat-forge": "^0.1.14",
+    "@foundry-rs/hardhat-forge": "^0.1.16",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
     "@typechain/ethers-v5": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,10 +1636,10 @@
     command-exists "^1.2.9"
     ts-interface-checker "^0.1.9"
 
-"@foundry-rs/hardhat-forge@^0.1.14":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.14.tgz#0291db05b7205fc8c65c164394c50f23f10d7ee1"
-  integrity sha512-XZeD7fRPJIEVNl1oPUfb/NftQfY+i23e/uOUICAaKpuJF283ge+vTisEPPUyoOw4zVNLTNFZyVKuuC3npIQmFw==
+"@foundry-rs/hardhat-forge@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@foundry-rs/hardhat-forge/-/hardhat-forge-0.1.16.tgz#73a637b51ac50e95fbcfe4a522efc782f9a078a4"
+  integrity sha512-C0Xz7fnGAg7hOJG7hC90iUjJTQxl+xq20Rbxee3cIIY+w59NzjmCaW4ikNeKidHJVPWiYXq6BNBTFBrSfL/d4Q==
   dependencies:
     "@foundry-rs/easy-foundryup" "^0.1.3"
     "@nomiclabs/hardhat-ethers" "^2.0.0"


### PR DESCRIPTION
**Description**

Updates the hh forge plugin to the following:

```
"@foundry-rs/hardhat-forge": "^0.1.16"
```

Includes bugfixes for when multiple imports
of contracts with the same name happens.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

