### PR TITLE
ops: Properly set devnet batch submitter address

### DIFF
--- a/ops-bedrock/devnet-up.sh
+++ b/ops-bedrock/devnet-up.sh
@@ -120,7 +120,7 @@ if [ ! -f ./.devnet/rollup.json ]; then
     (
       echo "Building rollup config..."
       cd $CONTRACTS_BEDROCK
-      L2OO_STARTING_BLOCK_TIMESTAMP=$GENESIS_TIMESTAMP npx hardhat rollup-config --network $NETWORK
+      L2OO_STARTING_BLOCK_TIMESTAMP=$GENESIS_TIMESTAMP npx hardhat --network $NETWORK rollup-config
       mv rollup.json ../../.devnet/rollup.json
     )
 else

--- a/packages/contracts-bedrock/deploy-config/devnetL1.ts
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.ts
@@ -52,7 +52,7 @@ const config = {
 
   outputOracleOwner: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
   optimismL2FeeRecipient: '0xd9c09e21b57c98e58a80552c170989b426766aa7',
-  batchSenderAddress: '0xDe3829A23DF1479438622a08a116E8Eb3f620BB5',
+  batchSenderAddress: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
 }
 
 export default config


### PR DESCRIPTION
**Description**
This was being incorrectly set in the rollup json relative to the
HD path supplied to the batcher was. This resulted in L2 reorgs
on the sequencer & the inability to send L2 transactions.
