### PR TITLE
makefile: `clean-node-modules`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,7 @@ semgrep:
 	$(eval DEV_REF := $(shell git rev-parse develop))
 	SEMGREP_REPO_NAME=ethereum-optimism/optimism semgrep ci --baseline-commit=$(DEV_REF)
 .PHONY: semgrep
+
+clean-node-modules:
+	rm -rf node_modules
+	rm -rf packages/**/node_modules


### PR DESCRIPTION
**Description**

Adds a helper to the makefile for deleting all of the js
deps. This is useful for when checking out a new branch
and ensuring that the deps are up to date. I find
myself doing this often manually, so adding a make command
makes sense.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

