### PR TITLE
op-node: Fixed Integers in channel frame header

### DIFF
--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -136,7 +136,7 @@ func (ib *ChannelBank) IngestData(data []byte) error {
 		}
 
 		ib.log.Debug("ingesting frame", "channel", f.ID, "frame_number", f.FrameNumber, "length", len(f.Data))
-		if err := currentCh.IngestData(f.FrameNumber, f.IsLast, f.Data); err != nil {
+		if err := currentCh.IngestData(uint64(f.FrameNumber), f.IsLast, f.Data); err != nil {
 			ib.log.Debug("failed to ingest frame into channel", "channel", f.ID, "frame_number", f.FrameNumber, "err", err)
 			if done {
 				return nil

--- a/op-node/rollup/derive/channel_bank_test.go
+++ b/op-node/rollup/derive/channel_bank_test.go
@@ -125,7 +125,7 @@ func (bt *bankTestSetup) ingestFrames(frames ...testFrame) {
 	data.WriteByte(DerivationVersion0)
 	for _, fr := range frames {
 		f := fr.ToFrame()
-		if err := (&f).MarshalBinary(data); err != nil {
+		if err := f.MarshalBinary(data); err != nil {
 			panic(fmt.Errorf("error in making frame during test: %w", err))
 		}
 	}

--- a/op-node/rollup/derive/channel_frame.go
+++ b/op-node/rollup/derive/channel_frame.go
@@ -73,8 +73,7 @@ type ByteReader interface {
 // If `r` fails a read, it returns the error from the reader
 // The reader will be left in a partially read state.
 func (f *Frame) UnmarshalBinary(r ByteReader) error {
-	_, err := io.ReadFull(r, f.ID.Data[:])
-	if err != nil {
+	if _, err := io.ReadFull(r, f.ID.Data[:]); err != nil {
 		return fmt.Errorf("error reading ID: %w", err)
 	}
 	if err := binary.Read(r, binary.BigEndian, &f.ID.Time); err != nil {
@@ -107,10 +106,11 @@ func (f *Frame) UnmarshalBinary(r ByteReader) error {
 		return fmt.Errorf("error reading final byte: %w", err)
 	} else if isLastByte == 0 {
 		f.IsLast = false
+		return err
 	} else if isLastByte == 1 {
 		f.IsLast = true
+		return err
 	} else {
 		return errors.New("invalid byte as is_last")
 	}
-	return err
 }

--- a/op-node/rollup/derive/channel_frame.go
+++ b/op-node/rollup/derive/channel_frame.go
@@ -12,70 +12,56 @@ import (
 // but we leave space to grow larger anyway (gas limit allows for more data).
 const MaxFrameLen = 1_000_000
 
-var ErrNotEnoughFrameBytes = errors.New("not enough available bytes for the frame")
-
 // Data Format
 //
 // frame = channel_id ++ frame_number ++ frame_data_length ++ frame_data ++ is_last
 //
 // channel_id        = random ++ timestamp
 // random            = bytes32
-// timestamp         = uvarint
-// frame_number      = uvarint
-// frame_data_length = uvarint
+// timestamp         = uint64
+// frame_number      = uint16
+// frame_data_length = uint32
 // frame_data        = bytes
 // is_last           = bool
 
 type Frame struct {
 	ID          ChannelID
-	FrameNumber uint64
+	FrameNumber uint16
 	Data        []byte
 	IsLast      bool
 }
 
 // MarshalBinary writes the frame to `w`.
-// It returns the number of bytes written as well as any
-// error encountered while writing.
-func (f *Frame) MarshalBinary(w io.Writer) (int, error) {
-	n, err := w.Write(f.ID.Data[:])
+// It returns any errors encountered while writing, but
+// generally expects the writer very rarely fail.
+func (f *Frame) MarshalBinary(w io.Writer) error {
+	_, err := w.Write(f.ID.Data[:])
 	if err != nil {
-		return n, err
+		return err
 	}
-	l, err := w.Write(makeUVarint(f.ID.Time))
-	n += l
-	if err != nil {
-		return n, err
+	if err := binary.Write(w, binary.BigEndian, f.ID.Time); err != nil {
+		return err
 	}
-	l, err = w.Write(makeUVarint(f.FrameNumber))
-	n += l
-	if err != nil {
-		return n, err
+	if err := binary.Write(w, binary.BigEndian, f.FrameNumber); err != nil {
+		return err
 	}
-
-	l, err = w.Write(makeUVarint(uint64(len(f.Data))))
-	n += l
-	if err != nil {
-		return n, err
+	if err := binary.Write(w, binary.BigEndian, uint32(len(f.Data))); err != nil {
+		return err
 	}
-	l, err = w.Write(f.Data)
-	n += l
+	_, err = w.Write(f.Data)
 	if err != nil {
-		return n, err
+		return err
 	}
 	if f.IsLast {
-		l, err = w.Write([]byte{1})
-		n += l
-		if err != nil {
-			return n, err
+		if _, err = w.Write([]byte{1}); err != nil {
+			return err
 		}
 	} else {
-		l, err = w.Write([]byte{0})
-		n += l
-		if err != nil {
-			return n, err
+		if _, err = w.Write([]byte{0}); err != nil {
+			return err
 		}
 	}
-	return n, nil
+	return nil
 }
 
 type ByteReader interface {
@@ -91,21 +77,20 @@ func (f *Frame) UnmarshalBinary(r ByteReader) error {
 	if err != nil {
 		return fmt.Errorf("error reading ID: %w", err)
 	}
-	f.ID.Time, err = binary.ReadUvarint(r)
-	if err != nil {
-		return fmt.Errorf("error reading ID.Time: %w", err)
+	if err := binary.Read(r, binary.BigEndian, &f.ID.Time); err != nil {
+		return fmt.Errorf("error reading ID time: %w", err)
 	}
 	// stop reading and ignore remaining data if we encounter a zeroed ID
 	if f.ID == (ChannelID{}) {
 		return io.EOF
 	}
-	f.FrameNumber, err = binary.ReadUvarint(r)
-	if err != nil {
+
+	if err := binary.Read(r, binary.BigEndian, &f.FrameNumber); err != nil {
 		return fmt.Errorf("error reading frame number: %w", err)
 	}
 
-	frameLength, err := binary.ReadUvarint(r)
-	if err != nil {
+	var frameLength uint32
+	if err := binary.Read(r, binary.BigEndian, &frameLength); err != nil {
 		return fmt.Errorf("error reading frame length: %w", err)
 	}
 
@@ -118,11 +103,9 @@ func (f *Frame) UnmarshalBinary(r ByteReader) error {
 		return fmt.Errorf("error reading frame data: %w", err)
 	}
 
-	isLastByte, err := r.ReadByte()
-	if err != nil && err != io.EOF {
+	if isLastByte, err := r.ReadByte(); err != nil && err != io.EOF {
 		return fmt.Errorf("error reading final byte: %w", err)
-	}
-	if isLastByte == 0 {
+	} else if isLastByte == 0 {
 		f.IsLast = false
 	} else if isLastByte == 1 {
 		f.IsLast = true

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -270,22 +270,16 @@ frame_number      = uint16
 frame_data_length = uint32
 frame_data        = bytes
 is_last           = bool
+
+Where `uint64`, `uint32` and `uint16` are all big-endian unsigned integers.
 ```
 
-> **TODO** replace `uvarint` by fixed size integers
-
-timestamp: 64 bits
-frame_number: 16 bits?
-frame_data_length: 32 bits?
-
-Fixed overhead: 32 + 8 + 2 + 4 + 1 = 47 bytes. Can get down to 16 + 6 = 22 bytes (128 bit UID, 16 bit #, 32 bit len)
-
-Why fixed length: don't have circular dependency b/c have target data length
+All data in a frame is fixed-size, except the `frame_data`. The fixed overhead is `32 + 8 + 2 + 4 + 1 = 47 bytes`.
+Fixed-size frame metadata avoids a circular dependency with the target total data length,
+to simplify packing of frames with varying content length.
 
 where:
 
-- `uvarint` is a variable-length encoding of a 64-bit unsigned integer into between 1 and 9 bytes, [as specified in
-  SQLite 4][sqlite-uvarint].
 - `channel_id` uniquely identifies a channel as the concatenation of a random value and a timestamp
   - `random` is a random value such that two channels with different batches should have a different random value
   - `timestamp` is the time at which the channel was created (UNIX time in seconds)
@@ -298,7 +292,7 @@ where:
       margin. (A soft constraint is not a consensus rule — nodes will accept such blocks in the canonical chain but will
       not attempt to build directly on them.)
 - `frame_number` identifies the index of the frame within the channel
-- `frame_data_length` is the length of `frame_data` in bytes
+- `frame_data_length` is the length of `frame_data` in bytes. It is capped to 1,000,000 bytes.
 - `frame_data` is a sequence of bytes belonging to the channel, logically after the bytes from the previous frames
 - `is_last` is a single byte with a value of 1 if the frame is the last in the channel, 0 if there are frames in the
   channel. Any other value makes the frame invalid (it must be ignored by the rollup node).
@@ -310,8 +304,7 @@ where:
 > - Do we drop the channel or just the first frame? End result is the same but this changes the channel bank size, which
 >   can influence things down the line!!
 
-[sqlite-uvarint]: https://www.sqlite.org/src4/doc/trunk/www/varint.wiki
-[batcher-spec]: batcher.md
+[batcher-spec]: batching.md
 
 ### Channel Format
 

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -265,14 +265,22 @@ frame = channel_id ++ frame_number ++ frame_data_length ++ frame_data ++ is_last
 
 channel_id        = random ++ timestamp
 random            = bytes32
-timestamp         = uvarint
-frame_number      = uvarint
-frame_data_length = uvarint
+timestamp         = uint64
+frame_number      = uint16
+frame_data_length = uint32
 frame_data        = bytes
 is_last           = bool
 ```
 
 > **TODO** replace `uvarint` by fixed size integers
+
+timestamp: 64 bits
+frame_number: 16 bits?
+frame_data_length: 32 bits?
+
+Fixed overhead: 32 + 8 + 2 + 4 + 1 = 47 bytes. Can get down to 16 + 6 = 22 bytes (128 bit UID, 16 bit #, 32 bit len)
+
+Why fixed length: don't have circular dependency b/c have target data length
 
 where:
 


### PR DESCRIPTION
**Description**
This switches the channel frame header over to using fixed integers. This avoids a circular
dependency when filling the serialized frame up to a maximum size. The circular dependency
is caused by the frame data length being a `uvarint` which can vary in size when serialized.

**Metadata**
- Fixes ENG-2371
- Fixes ENG-2537