### PR TITLE
contracts-bedrock: L2ToL1MessagePasser event extension

### DIFF
--- a/.changeset/hip-shrimps-cheat.md
+++ b/.changeset/hip-shrimps-cheat.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Emit an extra event when withdrawals are initiated to make chainops easier

--- a/packages/contracts-bedrock/contracts/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2ToL1MessagePasser.sol
@@ -50,6 +50,14 @@ contract L2ToL1MessagePasser is Semver {
     );
 
     /**
+     * @notice Emitted any time a withdrawal is initiated. An extension to
+     *         WithdrawalInitiated so that the interface is maintained.
+     *
+     * @param hash The hash of the withdrawal
+     */
+    event WithdrawalInitiatedExtension1(bytes32 indexed hash);
+
+    /**
      * @notice Emitted when the balance of this contract is burned.
      *
      * @param amount Amount of ETh that was burned.
@@ -106,6 +114,8 @@ contract L2ToL1MessagePasser is Semver {
         sentMessages[withdrawalHash] = true;
 
         emit WithdrawalInitiated(nonce, msg.sender, _target, msg.value, _gasLimit, _data);
+        emit WithdrawalInitiatedExtension1(withdrawalHash);
+
         unchecked {
             ++nonce;
         }


### PR DESCRIPTION
**Description**

Emit an additional event during `initiateWithdrawal` that includes
the withdrawal hash so that it is easy to observe changes to the
`sentMessages` mapping.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


