### PR TITLE
contracts-bedrock: fix deployment

### DIFF
--- a/.changeset/many-wasps-notice.md
+++ b/.changeset/many-wasps-notice.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Fix portal deployment to have L2OutputOracle proxy address

--- a/packages/contracts-bedrock/deploy/001-OptimismPortal.deploy.ts
+++ b/packages/contracts-bedrock/deploy/001-OptimismPortal.deploy.ts
@@ -17,7 +17,7 @@ const deployFn: DeployFunction = async (hre) => {
     waitConfirmations: deployConfig.deploymentWaitConfirmations,
   })
 
-  const oracle = await get('L2OutputOracle')
+  const oracle = await get('L2OutputOracleProxy')
 
   await deploy('OptimismPortal', {
     from: deployer,


### PR DESCRIPTION
**Description**

It was being deployed with the implementation address
of the `L2OutputOracle` instead of the proxy. This
was preventing output commitments to actually be posted.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


