### PR TITLE
contracts-bedrock: fix slither

### DIFF
--- a/.changeset/angry-cameras-arrive.md
+++ b/.changeset/angry-cameras-arrive.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Fix slither script

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -16,6 +16,7 @@ remappings = [
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
 build_info = true
+build_info_path = 'artifacts/build-info'
 ffi = true
 fuzz_runs = 16
 

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-if [ ! -d forge-artifacts/build-info ]; then
-    npx hardhat compile
-fi
+# Handle slither bug unable to work with the foundry tests
+TEMP=$(mktemp -d)
+mv contracts/test $TEMP/test
 
-cp -rf forge-artifacts/build-info artifacts/build-info
 slither .
+
+mv $TEMP/test contracts/test

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+rm -rf artifacts forge-artifacts
+
 # Handle slither bug unable to work with the foundry tests
 TEMP=$(mktemp -d)
 mv contracts/test $TEMP/test


### PR DESCRIPTION
**Description**

`slither` crashes on new solidity features, one is used
in the forge tests. Not exactly sure what it is, but
this will prevent that problem by moving the tests
to a temp dir when running slither and then moving them
back.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

