### PR TITLE
contracts-bedrock: Fix provider usage in L2OutputOracle deployment script

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/op-node:$_TAG
+      - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/op-proposer:$COMMIT_SHA
       - --dockerfile=op-node/Dockerfile
       - --cache=true
       - --cache-ttl=48h
@@ -9,6 +10,7 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/op-batcher:$_TAG
+      - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/op-proposer:$COMMIT_SHA
       - --dockerfile=./op-batcher/Dockerfile
       - --cache=true
       - --cache-ttl=48h
@@ -16,6 +18,7 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/op-proposer:$_TAG
+      - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/op-proposer:$COMMIT_SHA
       - --dockerfile=./op-proposer/Dockerfile
       - --cache=true
       - --cache-ttl=48h
@@ -23,6 +26,7 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/deployer-bedrock:$_TAG
+      - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/images/deployer-bedrock:$COMMIT_SHA
       - --dockerfile=./ops/docker/Dockerfile.packages
       - --target=deployer-bedrock
       - --cache=true

--- a/packages/contracts-bedrock/deploy/000-L2OutputOracle.deploy.ts
+++ b/packages/contracts-bedrock/deploy/000-L2OutputOracle.deploy.ts
@@ -10,7 +10,7 @@ const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
   const { deployConfig } = hre
 
-  const l1 = hre.ethers.getDefaultProvider()
+  const l1 = hre.ethers.provider
   const l1StartingBlock = await l1.getBlock(deployConfig.l1StartingBlockTag)
   if (l1StartingBlock === null) {
     throw new Error(`Cannot fetch block tag ${deployConfig.l1StartingBlockTag}`)


### PR DESCRIPTION
`getDefaultProvider()` returns a fallback mainnet provider, which doesn't work.

Builds on https://github.com/ethereum-optimism/optimism/pull/3147.