### PR TITLE
op-node: Add p2p utils

### DIFF
--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/cmd/p2p"
+
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 
 	opnode "github.com/ethereum-optimism/optimism/op-node"
@@ -53,13 +55,22 @@ func main() {
 	)
 
 	app := cli.NewApp()
-	app.Flags = flags.Flags
 	app.Version = VersionWithMeta
 	app.Name = "opnode"
 	app.Usage = "Optimism Rollup Node"
 	app.Description = "The deposit only rollup node drives the L2 execution engine based on L1 deposits."
+	app.Commands = []cli.Command{
+		{
+			Name:        "p2p",
+			Subcommands: p2p.Subcommands,
+		},
+		{
+			Name:   "start",
+			Action: RollupNodeMain,
+			Flags:  flags.Flags,
+		},
+	}
 
-	app.Action = RollupNodeMain
 	err := app.Run(os.Args)
 	if err != nil {
 		log.Crit("Application failed", "message", err)

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -56,6 +56,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Version = VersionWithMeta
+	app.Flags = flags.GlobalFlags
 	app.Name = "opnode"
 	app.Usage = "Optimism Rollup Node"
 	app.Description = "The deposit only rollup node drives the L2 execution engine based on L1 deposits."

--- a/op-node/cmd/p2p/cmd.go
+++ b/op-node/cmd/p2p/cmd.go
@@ -97,7 +97,9 @@ var Subcommands = cli.Commands{
 		Usage: "Generates a private key",
 		Action: func(ctx *cli.Context) error {
 			buf := make([]byte, 32)
-			_, _ = rand.Read(buf)
+			if _, err := rand.Read(buf); err != nil {
+						return fmt.Errorf("failed to get entropy: %w", err)
+			}
 			fmt.Println(hex.EncodeToString(buf))
 			return nil
 		},

--- a/op-node/cmd/p2p/cmd.go
+++ b/op-node/cmd/p2p/cmd.go
@@ -1,0 +1,105 @@
+package p2p
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/urfave/cli"
+)
+
+func Priv2PeerID(r io.Reader) (string, error) {
+	b, err := readHexData(r)
+	if err != nil {
+		return "", nil
+	}
+
+	p, err := crypto.UnmarshalSecp256k1PrivateKey(b)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse priv key from %d bytes: %w", len(b), err)
+	}
+
+	pid, err := peer.IDFromPrivateKey(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse peer ID from private key: %w", err)
+	}
+	return pid.String(), nil
+}
+
+func Pub2PeerID(r io.Reader) (string, error) {
+	b, err := readHexData(r)
+	if err != nil {
+		return "", nil
+	}
+
+	p, err := crypto.UnmarshalSecp256k1PublicKey(b)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse pub key from %d bytes: %w", len(b), err)
+	}
+
+	pid, err := peer.IDFromPublicKey(p)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse peer ID from public key: %w", err)
+	}
+
+	return pid.String(), nil
+}
+
+func readHexData(r io.Reader) ([]byte, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	rawStr := strings.TrimSpace(string(data))
+	rawStr = strings.TrimPrefix(rawStr, "0x")
+	b, err := hex.DecodeString(rawStr)
+	if err != nil {
+		return nil, errors.New("p2p key is not formatted in hex chars")
+	}
+	return b, nil
+}
+
+var Subcommands = cli.Commands{
+	{
+		Name:  "priv2id",
+		Usage: "Reads a private key from STDIN, and returns a peer ID",
+		Action: func(ctx *cli.Context) error {
+			key, err := Priv2PeerID(os.Stdin)
+			if err != nil {
+				return err
+			}
+			fmt.Println(key)
+			return nil
+		},
+	},
+	{
+		Name:  "pub2id",
+		Usage: "Reads a public key from STDIN, and returns a peer ID",
+		Action: func(ctx *cli.Context) error {
+			key, err := Pub2PeerID(os.Stdin)
+			if err != nil {
+				return err
+			}
+			fmt.Println(key)
+			return nil
+		},
+	},
+	{
+		Name:  "genkey",
+		Usage: "Generates a private key",
+		Action: func(ctx *cli.Context) error {
+			buf := make([]byte, 32)
+			_, _ = rand.Read(buf)
+			fmt.Println(hex.EncodeToString(buf))
+			return nil
+		},
+	},
+}

--- a/op-node/cmd/p2p/cmd.go
+++ b/op-node/cmd/p2p/cmd.go
@@ -62,7 +62,7 @@ func readHexData(r io.Reader) ([]byte, error) {
 	rawStr = strings.TrimPrefix(rawStr, "0x")
 	b, err := hex.DecodeString(rawStr)
 	if err != nil {
-		return nil, errors.New("p2p key is not formatted in hex chars")
+		return nil, fmt.Errorf("p2p key is not formatted in hex chars: %w", err)
 	}
 	return b, nil
 }

--- a/op-node/cmd/p2p/cmd.go
+++ b/op-node/cmd/p2p/cmd.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -98,7 +97,7 @@ var Subcommands = cli.Commands{
 		Action: func(ctx *cli.Context) error {
 			buf := make([]byte, 32)
 			if _, err := rand.Read(buf); err != nil {
-						return fmt.Errorf("failed to get entropy: %w", err)
+				return fmt.Errorf("failed to get entropy: %w", err)
 			}
 			fmt.Println(hex.EncodeToString(buf))
 			return nil

--- a/op-node/cmd/p2p/cmd_test.go
+++ b/op-node/cmd/p2p/cmd_test.go
@@ -1,0 +1,35 @@
+package p2p
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrivPub2PeerID(t *testing.T) {
+	priv, pub, err := crypto.GenerateKeyPair(crypto.Secp256k1, 32)
+	require.NoError(t, err)
+	privRaw, err := priv.Raw()
+	require.NoError(t, err)
+	pubRaw, err := pub.Raw()
+	require.NoError(t, err)
+
+	t.Run("with a private key", func(t *testing.T) {
+		privPidLib, err := peer.IDFromPrivateKey(priv)
+		require.NoError(t, err)
+		privPidImpl, err := Priv2PeerID(bytes.NewReader([]byte(hex.EncodeToString(privRaw))))
+		require.NoError(t, err)
+		require.Equal(t, privPidLib.String(), privPidImpl)
+	})
+	t.Run("with a public key", func(t *testing.T) {
+		pubPidLib, err := peer.IDFromPublicKey(pub)
+		require.NoError(t, err)
+		pubPidImpl, err := Pub2PeerID(bytes.NewReader([]byte(hex.EncodeToString(pubRaw))))
+		require.NoError(t, err)
+		require.Equal(t, pubPidLib.String(), pubPidImpl)
+	})
+}

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -150,9 +150,6 @@ var optionalFlags = append([]cli.Flag{
 	VerifierL1Confs,
 	SequencerEnabledFlag,
 	SequencerL1Confs,
-	LogLevelFlag,
-	LogFormatFlag,
-	LogColorFlag,
 	MetricsEnabledFlag,
 	MetricsAddrFlag,
 	MetricsPortFlag,
@@ -162,5 +159,12 @@ var optionalFlags = append([]cli.Flag{
 	SnapshotLog,
 }, p2pFlags...)
 
-// Flags contains the list of configuration options available to the binary.
+// GlobalFlags contains the list of configuration options available to every command.
+var GlobalFlags = []cli.Flag{
+	LogLevelFlag,
+	LogFormatFlag,
+	LogColorFlag,
+}
+
+// Flags contains the list of configuration options available to the start command.
 var Flags = append(requiredFlags, optionalFlags...)

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       dockerfile: ./op-node/Dockerfile
     command: >
       op-node
+      start
       --l1=ws://l1:8546
       --l2=ws://l2:8546
       --l2.jwt-secret=/config/test-jwt-secret.txt


### PR DESCRIPTION
Adds utilities for handling P2P keys. Note that to prevent having to specify irrelevant CLI flags, I created a new `start` command that actually stats the node.