### PR TITLE
Add `src` to files so sourcemaps work

### DIFF
--- a/.changeset/cyan-ladybugs-obey.md
+++ b/.changeset/cyan-ladybugs-obey.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/common-ts': minor
+'@eth-optimism/sdk': minor
+---
+
+Add `src` to files so it is included in node_modules so source maps works

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "all": "yarn clean && yarn build && yarn test && yarn lint:fix && yarn lint",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "all": "yarn clean && yarn build && yarn test && yarn lint:fix && yarn lint",

--- a/packages/drippie-mon/package.json
+++ b/packages/drippie-mon/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "start": "ts-node ./src/service.ts",

--- a/packages/fault-detector/package.json
+++ b/packages/fault-detector/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "start": "ts-node ./src/service.ts",

--- a/packages/hardhat-deploy-config/package.json
+++ b/packages/hardhat-deploy-config/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "test:coverage": "echo 'No tests defined.'",

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "start": "ts-node ./src/service.ts",

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "start": "ts-node ./src/service",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index",
   "types": "dist/index",
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "scripts": {
     "all": "yarn clean && yarn build && yarn test && yarn lint:fix && yarn lint",


### PR DESCRIPTION
Source maps did not work before because the source code was not included in npm modules when downloading from npm 
![image](https://user-images.githubusercontent.com/35039927/182460614-21dcc56a-5b8e-4538-bd3e-1f17e9379fec.png)
