### PR TITLE
fix: wsteth is a dai bridge not a standard bridge

### DIFF
--- a/packages/sdk/src/utils/contracts.ts
+++ b/packages/sdk/src/utils/contracts.ts
@@ -175,7 +175,7 @@ export const BRIDGE_ADAPTER_DATA: {
   },
   [L2ChainID.OPTIMISM_KOVAN]: {
     wstETH: {
-      Adapter: StandardBridgeAdapter,
+      Adapter: DAIBridgeAdapter,
       l1Bridge: '0xa88751C0a08623E11ff38c6B70F2BbEe7865C17c' as const,
       l2Bridge: '0xF9C842dE4381a70eB265d10CF8D43DceFF5bA935' as const,
     },


### PR DESCRIPTION
In previous pr we added wsteth as a standard bridge but it turns out it's a dai bridge actually