### PR TITLE
op-node: Add transactions sequenced metric

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -44,6 +44,8 @@ type Metrics struct {
 	DerivationErrorsTotal prometheus.Counter
 	Heads                 *prometheus.GaugeVec
 
+	TransactionsSequencedTotal prometheus.Counter
+
 	registry *prometheus.Registry
 }
 
@@ -145,6 +147,12 @@ func NewMetrics(procName string) *Metrics {
 			Help:      "Gauge representing the different L1/L2 heads",
 		}, []string{
 			"type",
+		}),
+
+		TransactionsSequencedTotal: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "transactions_sequenced_total",
+			Help:      "Count of total transactions sequenced",
 		}),
 
 		registry: registry,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -244,6 +244,7 @@ func (s *state) createNewL2Block(ctx context.Context) error {
 	s.l2Head = newUnsafeL2Head
 
 	s.log.Info("Sequenced new l2 block", "l2Head", s.l2Head, "l1Origin", s.l2Head.L1Origin, "txs", len(payload.Transactions), "time", s.l2Head.Time)
+	s.metrics.TransactionsSequencedTotal.Add(float64(len(payload.Transactions)))
 
 	if s.network != nil {
 		if err := s.network.PublishL2Payload(ctx, payload); err != nil {


### PR DESCRIPTION
This will allow us to measure opnode throughput.
