### PR TITLE
contracts-bedrock: poc OptimismSystemConfig

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/OptimismSystemConfig.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismSystemConfig.sol
@@ -3,23 +3,33 @@ pragma solidity 0.8.15;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Semver } from "../universal/Semver.sol";
+import { L2OutputOracle } from "./L2OutputOracle.sol";
 
 contract OptimismSystemConfig is Ownable, Semver {
 
+    L2OutputOracle immutable public l2OutputOracle;
     address public unsafeBlockSigner;
 
     event SetBatcher(address indexed batcher);
     event SetUnsafeBlockSigner(address indexed previous, address indexed next);
 
-    constructor(address _unsafeBlockSigner) Semver(0, 0, 1) {
+    constructor(
+        L2OutputOracle _l2OutputOracle,
+        address _unsafeBlockSigner
+    ) Semver(0, 0, 1) {
         unsafeBlockSigner = _unsafeBlockSigner;
+        l2OutputOracle = _l2OutputOracle;
     }
 
-    function setBatcher(address batcher) onlyOwner public {
+    function safeBlockSigner() external view returns (address) {
+        return l2OutputOracle.proposer();
+    }
+
+    function setBatcher(address batcher) onlyOwner external {
         emit SetBatcher(batcher);
     }
 
-    function setUnsafeBlockSigner(address _unsafeBlockSigner) public {
+    function setUnsafeBlockSigner(address _unsafeBlockSigner) onlyOwner external {
         address prev = unsafeBlockSigner;
         unsafeBlockSigner = _unsafeBlockSigner;
         emit SetUnsafeBlockSigner(prev, _unsafeBlockSigner);

--- a/packages/contracts-bedrock/contracts/L1/OptimismSystemConfig.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismSystemConfig.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Semver } from "../universal/Semver.sol";
+
+contract OptimismSystemConfig is Ownable, Semver {
+
+    address public unsafeBlockSigner;
+
+    event SetBatcher(address indexed batcher);
+    event SetUnsafeBlockSigner(address indexed previous, address indexed next);
+
+    constructor(address _unsafeBlockSigner) Semver(0, 0, 1) {
+        unsafeBlockSigner = _unsafeBlockSigner;
+    }
+
+    function setBatcher(address batcher) onlyOwner public {
+        emit SetBatcher(batcher);
+    }
+
+    function setUnsafeBlockSigner(address _unsafeBlockSigner) public {
+        address prev = unsafeBlockSigner;
+        unsafeBlockSigner = _unsafeBlockSigner;
+        emit SetUnsafeBlockSigner(prev, _unsafeBlockSigner);
+    }
+}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
PoC for the L1 optimism system config contract. The `OptimismPortal` would need a reference to it so that we know what the canonical system config contract is. It would be deployed behind a proxy so that it could be upgraded easily. This needs comments but is a poc to show how simple this contract could be.