### PR TITLE
ci: only run changeset integrety on PRs

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   changesets-integrity-checker:
     runs-on: ubuntu-latest
+    on:
+      push:
+        branches:
+          - '*'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
**Description**

It will fail on merges to develop

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

