### PR TITLE
op-node: fix invalid payload insertion error handling

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -3,6 +3,8 @@ package derive
 import (
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"io"
 	"time"
 
@@ -238,17 +240,29 @@ func (eq *EngineQueue) forceNextSafeAttributes(ctx context.Context) error {
 		SafeBlockHash:      eq.safeHead.Hash,
 		FinalizedBlockHash: eq.finalized.Hash,
 	}
-	payload, rpcErr, payloadErr := InsertHeadBlock(ctx, eq.log, eq.engine, fc, eq.safeAttributes[0], true)
+	attrs := eq.safeAttributes[0]
+	payload, rpcErr, payloadErr := InsertHeadBlock(ctx, eq.log, eq.engine, fc, attrs, true)
 	if rpcErr != nil {
 		// RPC errors are recoverable, we can retry the buffered payload attributes later.
 		eq.log.Error("failed to insert new block", "err", rpcErr)
 		return nil
 	}
 	if payloadErr != nil {
-		// invalid payloads are dropped, we move on to the next attributes
-		eq.log.Warn("could not derive valid payload from L1 data", "err", payloadErr)
-		eq.safeAttributes = eq.safeAttributes[1:]
-		return nil
+		eq.log.Warn("could not process payload derived from L1 data", "err", payloadErr)
+		// filter everything but the deposits
+		var deposits []hexutil.Bytes
+		for _, tx := range attrs.Transactions {
+			if len(tx) > 0 && tx[0] == types.DepositTxType {
+				deposits = append(deposits, tx)
+			}
+		}
+		if len(attrs.Transactions) > len(deposits) {
+			eq.log.Warn("dropping sequencer transactions from payload for re-attempt, batcher may have included invalid transactions",
+				"txs", len(attrs.Transactions), "deposits", len(deposits), "parent", eq.safeHead)
+			eq.safeAttributes[0].Transactions = deposits
+			return nil
+		}
+		return fmt.Errorf("critical: failed to process block with only deposit transactions: %v", payloadErr)
 	}
 	ref, err := PayloadToBlockRef(payload, &eq.cfg.Genesis)
 	if err != nil {

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -3,10 +3,11 @@ package derive
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"io"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"

--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -75,6 +75,9 @@ func InsertHeadBlock(ctx context.Context, log log.Logger, eng Engine, fc eth.For
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new block via forkchoice: %w", err), nil
 	}
+	if fcRes.PayloadStatus.Status == eth.ExecutionInvalid || fcRes.PayloadStatus.Status == eth.ExecutionInvalidBlockHash {
+		return nil, nil, eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)
+	}
 	if fcRes.PayloadStatus.Status != eth.ExecutionValid {
 		return nil, eth.ForkchoiceUpdateErr(fcRes.PayloadStatus), nil
 	}
@@ -93,6 +96,9 @@ func InsertHeadBlock(ctx context.Context, log log.Logger, eng Engine, fc eth.For
 	status, err := eng.NewPayload(ctx, payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert execution payload: %w", err), nil
+	}
+	if status.Status == eth.ExecutionInvalid || status.Status == eth.ExecutionInvalidBlockHash {
+		return nil, nil, eth.NewPayloadErr(payload, status)
 	}
 	if status.Status != eth.ExecutionValid {
 		return nil, eth.NewPayloadErr(payload, status), nil


### PR DESCRIPTION
This PR relies on https://github.com/ethereum-optimism/reference-optimistic-geth/pull/40 to return `INVALID` when the payload attributes cannot be processed.

When payload attributes cannot be processed due to a true payload-error (i.e. rpc errors, syncing state, etc. don't count) then we first re-attempt with only the deposits, and then return a critical error if we cannot even process a block with just the deposits.

I've chosen this approach, instead of looking for alternative batches, to keep the batch derivation simple (i.e. allow multiple batches to be queued up with the eager-batch-derivation logic, instead of having to check them 1 by 1 with the engine).

When the typed error handling lands we can handle the deposit processing error as critical, and stop the syncing entirely. Safety over liveness, deposits always have to work.

During goerli devnet testing there was a batch with invalid nonce usage, and so we have to drop the user transaction(s) from that batch to continue rollup processing, or we get stuck. This is attributable to the batch-submitter, who should not have included the invalid transaction. So we drop the batch transactions as a whole, instead of finding a single invalid transaction, to keep things simple.

