### PR TITLE
op-node: Bedrock l1 cache metrics

### DIFF
--- a/op-node/l1/source.go
+++ b/op-node/l1/source.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-node/sources/caching"
 
 	"github.com/ethereum-optimism/optimism/op-node/client"
-	"github.com/ethereum/go-ethereum"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/sources/caching"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/op-node/l1/source_test.go
+++ b/op-node/l1/source_test.go
@@ -101,7 +101,7 @@ func TestSource_InfoByHash(t *testing.T) {
 	m.On("CallContext", ctx, new(*rpcHeader), "eth_getBlockByHash", []interface{}{h, false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewSource(m, log, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
+	s, err := NewSource(m, log, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
 	assert.NoError(t, err)
 	info, err := s.InfoByHash(ctx, h)
 	assert.NoError(t, err)
@@ -128,7 +128,7 @@ func TestSource_InfoByNumber(t *testing.T) {
 	m.On("CallContext", ctx, new(*rpcHeader), "eth_getBlockByNumber", []interface{}{hexutil.EncodeUint64(n), false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewSource(m, log, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
+	s, err := NewSource(m, log, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
 	assert.NoError(t, err)
 	info, err := s.InfoByNumber(ctx, n)
 	assert.NoError(t, err)
@@ -180,7 +180,7 @@ func TestSource_FetchAllTransactions(t *testing.T) {
 		}
 	}).Return([]error{nil})
 
-	s, err := NewSource(m, log, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
+	s, err := NewSource(m, log, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
 	assert.NoError(t, err)
 	s.batchCall = m.batchCall // override the optimized batch call
 

--- a/op-node/metrics/caching.go
+++ b/op-node/metrics/caching.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// CacheMetrics implements the Metrics interface in the caching package,
+// implementing reusable metrics for different caches.
+type CacheMetrics struct {
+	SizeVec *prometheus.GaugeVec
+	GetVec  *prometheus.CounterVec
+	AddVec  *prometheus.CounterVec
+}
+
+// CacheAdd meters the addition of an item with a given type to the cache,
+// metering the change of the cache size of that type, and indicating a corresponding eviction if any.
+func (m *CacheMetrics) CacheAdd(typeLabel string, typeCacheSize int, evicted bool) {
+	m.SizeVec.WithLabelValues(typeLabel).Set(float64(typeCacheSize))
+	if evicted {
+		m.AddVec.WithLabelValues(typeLabel, "true").Inc()
+	} else {
+		m.AddVec.WithLabelValues(typeLabel, "false").Inc()
+	}
+}
+
+// CacheGet meters a lookup of an item with a given type to the cache
+// and indicating if the lookup was a hit.
+func (m *CacheMetrics) CacheGet(typeLabel string, hit bool) {
+	if hit {
+		m.GetVec.WithLabelValues(typeLabel, "true").Inc()
+	} else {
+		m.GetVec.WithLabelValues(typeLabel, "false").Inc()
+	}
+}
+
+func NewCacheMetrics(registry prometheus.Registerer, ns string, name string, displayName string) *CacheMetrics {
+	return &CacheMetrics{
+		SizeVec: promauto.With(registry).NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      name + "_size",
+			Help:      displayName + " cache size",
+		}, []string{
+			"type",
+		}),
+		GetVec: promauto.With(registry).NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      name + "_get",
+			Help:      displayName + " lookups, hitting or not",
+		}, []string{
+			"type",
+			"hit",
+		}),
+		AddVec: promauto.With(registry).NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      name + "_add",
+			Help:      displayName + " additions, evicting previous values or not",
+		}, []string{
+			"type",
+			"evicted",
+		}),
+	}
+}

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -37,6 +37,9 @@ type Metrics struct {
 	RPCClientRequestDurationSeconds *prometheus.HistogramVec
 	RPCClientResponsesTotal         *prometheus.CounterVec
 
+	L1SourceCache *CacheMetrics
+	// TODO: L2SourceCache *CacheMetrics
+
 	DerivationIdle        prometheus.Gauge
 	PipelineResetsTotal   prometheus.Counter
 	LastPipelineResetUnix prometheus.Gauge
@@ -117,6 +120,8 @@ func NewMetrics(procName string) *Metrics {
 			"method",
 			"error",
 		}),
+
+		L1SourceCache: NewCacheMetrics(registry, ns, "l1_source_cache", "L1 Source cache"),
 
 		DerivationIdle: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -110,7 +110,7 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to get L1 RPC client: %w", err)
 	}
 
-	n.l1Source, err = l1.NewSource(client.NewInstrumentedRPC(l1Node, n.metrics), n.log, l1.DefaultConfig(&cfg.Rollup, trustRPC))
+	n.l1Source, err = l1.NewSource(client.NewInstrumentedRPC(l1Node, n.metrics), n.log, n.metrics.L1SourceCache, l1.DefaultConfig(&cfg.Rollup, trustRPC))
 	if err != nil {
 		return fmt.Errorf("failed to create L1 source: %v", err)
 	}

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -14,7 +14,7 @@ type LRUCache struct {
 	inner *lru.Cache
 }
 
-func (c *LRUCache) Get(key interface{}) (value interface{}, ok bool) {
+func (c *LRUCache) Get(key any) (value any, ok bool) {
 	value, ok = c.inner.Get(key)
 	if c.m != nil {
 		c.m.CacheGet(c.label, ok)
@@ -22,7 +22,7 @@ func (c *LRUCache) Get(key interface{}) (value interface{}, ok bool) {
 	return value, ok
 }
 
-func (c *LRUCache) Add(key, value interface{}) (evicted bool) {
+func (c *LRUCache) Add(key, value any) (evicted bool) {
 	evicted = c.inner.Add(key, value)
 	if c.m != nil {
 		c.m.CacheAdd(c.label, c.inner.Len(), evicted)

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -1,0 +1,43 @@
+package caching
+
+import lru "github.com/hashicorp/golang-lru"
+
+type Metrics interface {
+	CacheAdd(label string, cacheSize int, evicted bool)
+	CacheGet(label string, hit bool)
+}
+
+// LRUCache wraps hashicorp *lru.Cache and tracks cache metrics
+type LRUCache struct {
+	m     Metrics
+	label string
+	inner *lru.Cache
+}
+
+func (c *LRUCache) Get(key interface{}) (value interface{}, ok bool) {
+	value, ok = c.inner.Get(key)
+	if c.m != nil {
+		c.m.CacheGet(c.label, ok)
+	}
+	return value, ok
+}
+
+func (c *LRUCache) Add(key, value interface{}) (evicted bool) {
+	evicted = c.inner.Add(key, value)
+	if c.m != nil {
+		c.m.CacheAdd(c.label, c.inner.Len(), evicted)
+	}
+	return evicted
+}
+
+// NewLRUCache creates a LRU cache with the given metrics, labeling the cache adds/gets.
+// Metrics are optional: no metrics will be tracked if m == nil.
+func NewLRUCache(m Metrics, label string, maxSize int) *LRUCache {
+	// no errors if the size is positive
+	cache, _ := lru.New(maxSize)
+	return &LRUCache{
+		m:     m,
+		label: label,
+		inner: cache,
+	}
+}


### PR DESCRIPTION
This PR:
- Wraps a LRU cache with metrics
- Defines cache metrics as a group of metrics
- Updates the L1 source cache to use the cache with metrics
- Updates the L1 source cache with increased defaults: this should help respond much faster to L1 reorgs, replaying the old data from the cache instead of fetching everything again. On the testnet we see that a L1 reorg that is past the confirmation depth takes up to 3 minutes to resolve. This aims to fix that, and provide metrics so we can watch it.

Note: I moved the cache wrapper into `op-node/source/caching` package.  I'm thinking we can move `op-node/{l1,l2}` into `op-node/source/{l1,l2}`. And then later update `l2` with the same caching too (see ENG-2280)

Fix ENG-2555
