### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/many-crabs-visit.md
+++ b/.changeset/many-crabs-visit.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/sdk': minor
----
-
-Update wsteth bridge address

--- a/.changeset/three-cooks-check.md
+++ b/.changeset/three-cooks-check.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/ci-builder': patch
----
-
-Upgrade to Debian 11

--- a/.changeset/three-cooks-check.md
+++ b/.changeset/three-cooks-check.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Upgrade to Debian 11

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -32,7 +32,7 @@
     "@eth-optimism/contracts": "^0.5.32",
     "@eth-optimism/contracts-periphery": "^0.2.1",
     "@eth-optimism/core-utils": "0.9.3",
-    "@eth-optimism/sdk": "1.4.0",
+    "@eth-optimism/sdk": "1.5.0",
     "@ethersproject/abstract-provider": "^5.6.1",
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/transactions": "^5.6.2",

--- a/ops/docker/ci-builder/CHANGELOG.md
+++ b/ops/docker/ci-builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/ci-builder
 
+## 0.2.2
+
+### Patch Changes
+
+- c666fedc: Upgrade to Debian 11
+
 ## 0.2.1
 
 ### Patch Changes

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ethereum/client-go:alltools-v1.10.17 as geth
 
 FROM ethereumoptimism/foundry:latest as foundry
 
-FROM python:3.8.12-slim-buster
+FROM python:3.8.13-slim-bullseye
 
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH

--- a/ops/docker/ci-builder/package.json
+++ b/ops/docker/ci-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/ci-builder",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {},
   "license": "MIT",
   "dependencies": {}

--- a/packages/drippie-mon/CHANGELOG.md
+++ b/packages/drippie-mon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/drippie-mon
 
+## 0.3.10
+
+### Patch Changes
+
+- Updated dependencies [dcd715a6]
+  - @eth-optimism/sdk@1.5.0
+
 ## 0.3.9
 
 ### Patch Changes

--- a/packages/drippie-mon/package.json
+++ b/packages/drippie-mon/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/drippie-mon",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "[Optimism] Service for monitoring Drippie instances",
   "main": "dist/index",
   "types": "dist/index",
@@ -35,7 +35,7 @@
     "@eth-optimism/common-ts": "0.6.3",
     "@eth-optimism/contracts-periphery": "0.2.1",
     "@eth-optimism/core-utils": "0.9.3",
-    "@eth-optimism/sdk": "1.4.0",
+    "@eth-optimism/sdk": "1.5.0",
     "ethers": "^5.6.8"
   },
   "devDependencies": {

--- a/packages/integration-tests-bedrock/package.json
+++ b/packages/integration-tests-bedrock/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@eth-optimism/contracts": "0.5.32",
     "@eth-optimism/core-utils": "0.9.3",
-    "@eth-optimism/sdk": "1.4.0",
+    "@eth-optimism/sdk": "1.5.0",
     "@ethersproject/abstract-provider": "^5.6.1",
     "chai-as-promised": "^7.1.1",
     "chai": "^4.3.4",

--- a/packages/message-relayer/CHANGELOG.md
+++ b/packages/message-relayer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/message-relayer
 
+## 0.5.9
+
+### Patch Changes
+
+- Updated dependencies [dcd715a6]
+  - @eth-optimism/sdk@1.5.0
+
 ## 0.5.8
 
 ### Patch Changes

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/message-relayer",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@eth-optimism/common-ts": "0.6.3",
     "@eth-optimism/core-utils": "0.9.3",
-    "@eth-optimism/sdk": "1.4.0",
+    "@eth-optimism/sdk": "1.5.0",
     "ethers": "^5.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/sdk
 
+## 1.5.0
+
+### Minor Changes
+
+- dcd715a6: Update wsteth bridge address
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
- op-node: More reset & pipeline logging (#3178)
- op-node: Fixed Integers in channel frame header (#3126)
- actor-tests: Bedrock actor tests (#3161)
- ci: only run changeset integrety on pushes (#3177)
- op-node: fix invalid payload insertion error handling (#3180)
- feat: Update wsteth address (#3181)
- pkg driver: use derive error types to optionally retry with backoff (#3130)
- op-node: reorgs should be typed to force pipeline resets (#3185)
- op-node: separate sequencing and publishing errors. Old payloads fail to publish, but should not hold back catch-up work of sequencer (#3186)
- ci: Upgrade ci-builder to Debian 11 (#3189)
- Version Packages
