### PR TITLE
ops: update ci-builder

### DIFF
--- a/.changeset/silent-comics-flash.md
+++ b/.changeset/silent-comics-flash.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Update golang, geth and golangci-lint

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:alltools-v1.10.17 as geth
+FROM ethereum/client-go:alltools-v1.10.21 as geth
 
 FROM ethereumoptimism/foundry:latest as foundry
 
@@ -15,8 +15,8 @@ COPY check-changed.sh /usr/local/bin/check-changed
 RUN apt-get update && \
   apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl && \
   curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
-  curl -sL https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd64.tar.gz && \
-  tar -C /usr/local/ -xzvf go1.18.2.linux-amd64.tar.gz && \
+  curl -sL https://go.dev/dl/go1.19.linux-amd64.tar.gz -o go1.19.linux-amd64.tar.gz && \
+  tar -C /usr/local/ -xzvf go1.19.linux-amd64.tar.gz && \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt && \
   bash nodesource_setup.sh && \
   apt-get install -y nodejs && \
@@ -24,7 +24,7 @@ RUN apt-get update && \
   npm i -g depcheck && \
   pip install slither-analyzer && \
   go install gotest.tools/gotestsum@latest && \
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2 && \
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0 && \
   curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash && \
   chmod +x /usr/local/bin/check-changed
 


### PR DESCRIPTION
**Description**

geth to v1.10.21
go to 1.19
golangci-lint to 1.48.0

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


