### PR TITLE
op-node: Add L1 reorg depth metrics

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -48,6 +48,7 @@ type Metrics struct {
 	SequencingErrorsTotal prometheus.Counter
 	PublishingErrorsTotal prometheus.Counter
 	Heads                 *prometheus.GaugeVec
+	L1ReorgDepth          prometheus.Histogram
 
 	TransactionsSequencedTotal prometheus.Counter
 
@@ -165,6 +166,12 @@ func NewMetrics(procName string) *Metrics {
 		}, []string{
 			"type",
 		}),
+		L1ReorgDepth: promauto.With(registry).NewHistogram(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "l1_reorg_depth",
+			Buckets:   []float64{0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 20.5, 50.5, 100.5},
+			Help:      "Histogram of L1 Reorg Depths",
+		}),
 
 		TransactionsSequencedTotal: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -250,6 +257,10 @@ func (m *Metrics) SetHead(kind string, num uint64) {
 func (m *Metrics) RecordPipelineReset() {
 	m.PipelineResetsTotal.Inc()
 	m.LastPipelineResetUnix.Set(float64(time.Now().Unix()))
+}
+
+func (m *Metrics) RecordL1ReorgDepth(d uint64) {
+	m.L1ReorgDepth.Observe(float64(d))
 }
 
 // Serve starts the metrics server on the given hostname and port.

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -155,6 +155,9 @@ func (s *state) handleNewL1Block(newL1Head eth.L1BlockRef) {
 		// dealing with a linear extension (new block is the immediate child of the old one).
 		s.log.Debug("L1 head moved forward", "l1Head", newL1Head)
 	} else {
+		if s.l1Head.Number >= newL1Head.Number {
+			s.metrics.RecordL1ReorgDepth(s.l1Head.Number - newL1Head.Number)
+		}
 		// New L1 block is not the same as the current head or a single step linear extension.
 		// This could either be a long L1 extension, or a reorg. Both can be handled the same way.
 		s.log.Warn("L1 Head signal indicates an L1 re-org", "old_l1_head", s.l1Head, "new_l1_head_parent", newL1Head.ParentHash, "new_l1_head", newL1Head)


### PR DESCRIPTION
**Description**

This adds metrics around the L1 reorg depth. Looking at logs, certain reorgs are deeper than expected,
so this helps track down what the actual distribution is.
