### PR TITLE
op-node: improve derivation pipeline error handling

### DIFF
--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -116,8 +116,7 @@ func TestBatchQueueEager(t *testing.T) {
 	// Add batches
 	batches := []*BatchData{b(12, l1[0]), b(14, l1[0])}
 	for _, batch := range batches {
-		err := bq.AddBatch(batch)
-		require.Nil(t, err)
+		bq.AddBatch(batch)
 	}
 	// Step
 	for {
@@ -170,8 +169,7 @@ func TestBatchQueueFull(t *testing.T) {
 	// Add batches
 	batches := []*BatchData{b(14, l1[0]), b(16, l1[0]), b(18, l1[1])}
 	for _, batch := range batches {
-		err := bq.AddBatch(batch)
-		require.Nil(t, err)
+		bq.AddBatch(batch)
 	}
 	// Missing first batch
 	err = bq.Step(context.Background(), prevProgress)
@@ -205,8 +203,7 @@ func TestBatchQueueFull(t *testing.T) {
 
 	// Finally add batch
 	firstBatch := b(12, l1[0])
-	err = bq.AddBatch(firstBatch)
-	require.Equal(t, err, nil)
+	bq.AddBatch(firstBatch)
 
 	// Close the origin
 	prevProgress.Closed = true
@@ -271,8 +268,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	// that batch timestamp 12 & 14 is created & 16 is used.
 	batches := []*BatchData{b(16, l1[0]), b(20, l1[1])}
 	for _, batch := range batches {
-		err := bq.AddBatch(batch)
-		require.Nil(t, err)
+		bq.AddBatch(batch)
 	}
 	// Missing first batch
 	err = bq.Step(context.Background(), prevProgress)

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -66,29 +66,28 @@ func (ib *ChannelBank) prune() {
 }
 
 // IngestData adds new L1 data to the channel bank.
-// Read() should be called repeatedly first, until everything has been read, before adding new data.
-// Then NextL1(ref) should be called to move forward to the next L1 input
-func (ib *ChannelBank) IngestData(data []byte) error {
+// Read() should be called repeatedly first, until everything has been read, before adding new data.\
+func (ib *ChannelBank) IngestData(data []byte) {
 	if ib.progress.Closed {
 		panic("write data to bank while closed")
 	}
 	ib.log.Debug("channel bank got new data", "origin", ib.progress.Origin, "data_len", len(data))
 	if len(data) < 1 {
-		return NewTemporaryError(
-			nil,
-			"data must be at least have a version byte, but got empty string",
-		)
+		ib.log.Warn("data must be at least have a version byte, but got empty string")
+		return
 	}
 
 	if data[0] != DerivationVersion0 {
-		return fmt.Errorf("unrecognized derivation version: %d", data)
+		ib.log.Warn("unrecognized derivation version", "version", data)
+		return
 	}
 	buf := bytes.NewBuffer(data[1:])
 
 	ib.prune()
 
 	if buf.Len() < minimumFrameSize {
-		return fmt.Errorf("data must be at least have one frame")
+		ib.log.Warn("data must be at least have one frame", "length", buf.Len())
+		return
 	}
 
 	// Iterate over all frames. They may have different channel IDs to indicate that they stream consumer should reset.
@@ -96,36 +95,37 @@ func (ib *ChannelBank) IngestData(data []byte) error {
 		// Don't try to unmarshal from an empty buffer.
 		// The if done checks should catch most/all of this case though.
 		if buf.Len() < ChannelIDDataSize+1 {
-			return nil
+			return
 		}
 		done := false
 		var f Frame
 		if err := (&f).UnmarshalBinary(buf); err == io.EOF {
 			done = true
 		} else if err != nil {
-			return fmt.Errorf("failed to unmarshal a frame: %w", err)
-
+			ib.log.Warn("malformed frame: %w", err)
+			return
 		}
 
-		// stop reading and ignore remaining data if we encounter a zeroed ID
+		// stop reading and ignore remaining data if we encounter a zeroed ID,
+		// this happens when there is zero padding at the end.
 		if f.ID == (ChannelID{}) {
-			ib.log.Info("empty channel ID")
-			return nil
+			ib.log.Trace("empty channel ID")
+			return
 		}
 
 		// check if the channel is not timed out
 		if f.ID.Time+ib.cfg.ChannelTimeout < ib.progress.Origin.Time {
-			ib.log.Info("channel is timed out, ignore frame", "channel", f.ID, "id_time", f.ID.Time, "frame", f.FrameNumber)
+			ib.log.Warn("channel is timed out, ignore frame", "channel", f.ID, "id_time", f.ID.Time, "frame", f.FrameNumber)
 			if done {
-				return nil
+				return
 			}
 			continue
 		}
 		// check if the channel is not included too soon (otherwise timeouts wouldn't be effective)
 		if f.ID.Time > ib.progress.Origin.Time {
-			ib.log.Info("channel claims to be from the future, ignore frame", "channel", f.ID, "id_time", f.ID.Time, "frame", f.FrameNumber)
+			ib.log.Warn("channel claims to be from the future, ignore frame", "channel", f.ID, "id_time", f.ID.Time, "frame", f.FrameNumber)
 			if done {
-				return nil
+				return
 			}
 			continue
 		}
@@ -137,17 +137,17 @@ func (ib *ChannelBank) IngestData(data []byte) error {
 			ib.channelQueue = append(ib.channelQueue, f.ID)
 		}
 
-		ib.log.Debug("ingesting frame", "channel", f.ID, "frame_number", f.FrameNumber, "length", len(f.Data))
+		ib.log.Trace("ingesting frame", "channel", f.ID, "frame_number", f.FrameNumber, "length", len(f.Data))
 		if err := currentCh.IngestData(uint64(f.FrameNumber), f.IsLast, f.Data); err != nil {
-			ib.log.Debug("failed to ingest frame into channel", "channel", f.ID, "frame_number", f.FrameNumber, "err", err)
+			ib.log.Warn("failed to ingest frame into channel", "channel", f.ID, "frame_number", f.FrameNumber, "err", err)
 			if done {
-				return nil
+				return
 			}
 			continue
 		}
 
 		if done {
-			return nil
+			return
 		}
 	}
 }
@@ -221,10 +221,7 @@ func (ib *ChannelBank) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error
 	// go back in history if we are not distant enough from the next stage
 	parent, err := l1Fetcher.L1BlockRefByHash(ctx, ib.progress.Origin.ParentHash)
 	if err != nil {
-		return NewTemporaryError(
-			err,
-			fmt.Sprintf("failed to find channel bank block, failed to retrieve L1 reference: %v", err),
-		)
+		return NewTemporaryError(fmt.Errorf("failed to find channel bank block, failed to retrieve L1 reference: %w", err))
 	}
 	ib.progress.Origin = parent
 	return nil

--- a/op-node/rollup/derive/channel_bank_test.go
+++ b/op-node/rollup/derive/channel_bank_test.go
@@ -118,8 +118,9 @@ func (tf testFrame) ToFrame() Frame {
 }
 
 func (bt *bankTestSetup) ingestData(data []byte) {
-	require.NoError(bt.t, bt.cb.IngestData(data))
+	bt.cb.IngestData(data)
 }
+
 func (bt *bankTestSetup) ingestFrames(frames ...testFrame) {
 	data := new(bytes.Buffer)
 	data.WriteByte(DerivationVersion0)

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -19,7 +19,7 @@ type zlibReader interface {
 
 type BatchQueueStage interface {
 	StageProgress
-	AddBatch(batch *BatchData) error
+	AddBatch(batch *BatchData)
 }
 
 type ChannelInReader struct {
@@ -115,7 +115,8 @@ func (cr *ChannelInReader) Step(ctx context.Context, outer Progress) error {
 		cr.NextChannel()
 		return nil
 	}
-	return cr.next.AddBatch(&batch)
+	cr.next.AddBatch(&batch)
+	return nil
 }
 
 func (cr *ChannelInReader) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error {

--- a/op-node/rollup/derive/error.go
+++ b/op-node/rollup/derive/error.go
@@ -7,6 +7,19 @@ import (
 // Level is the severity level of the error.
 type Level uint
 
+func (lvl Level) String() string {
+	switch lvl {
+	case LevelTemporary:
+		return "temp"
+	case LevelReset:
+		return "reset"
+	case LevelCritical:
+		return "crit"
+	default:
+		return fmt.Sprintf("unknown(%d)", lvl)
+	}
+}
+
 // There are three levels currently, out of which only 2 are being used
 // to classify error by severity. LevelTemporary
 const (
@@ -22,16 +35,15 @@ const (
 // Error is a wrapper for error, description and a severity level.
 type Error struct {
 	err   error
-	desc  string
 	level Level
 }
 
 // Error satisfies the error interface.
 func (e Error) Error() string {
 	if e.err != nil {
-		return fmt.Errorf("%w: %s", e.err, e.desc).Error()
+		return fmt.Sprintf("%s: %v", e.level, e.err)
 	}
-	return e.desc
+	return e.level.String()
 }
 
 // Unwrap satisfies the Is/As interface.
@@ -52,43 +64,30 @@ func (e Error) Is(target error) bool {
 }
 
 // NewError returns a custom Error.
-func NewError(err error, desc string, level Level) error {
+func NewError(err error, level Level) error {
 	return Error{
 		err:   err,
-		desc:  desc,
 		level: level,
 	}
 }
 
 // NewTemporaryError returns a temporary error.
-func NewTemporaryError(err error, desc string) error {
-	return NewError(
-		err,
-		desc,
-		LevelTemporary,
-	)
+func NewTemporaryError(err error) error {
+	return NewError(err, LevelTemporary)
 }
 
 // NewResetError returns a pipeline reset error.
-func NewResetError(err error, desc string) error {
-	return NewError(
-		err,
-		desc,
-		LevelReset,
-	)
+func NewResetError(err error) error {
+	return NewError(err, LevelReset)
 }
 
 // NewCriticalError returns a critical error.
-func NewCriticalError(err error, desc string) error {
-	return NewError(
-		err,
-		desc,
-		LevelCritical,
-	)
+func NewCriticalError(err error) error {
+	return NewError(err, LevelCritical)
 }
 
 // Sentinel errors, use these to get the severity of errors by calling
 // errors.Is(err, ErrTemporary) for example.
-var ErrTemporary = NewTemporaryError(nil, "temporary error")
-var ErrReset = NewResetError(nil, "pipeline reset error")
-var ErrCritical = NewCriticalError(nil, "critical error")
+var ErrTemporary = NewTemporaryError(nil)
+var ErrReset = NewResetError(nil)
+var ErrCritical = NewCriticalError(nil)

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -24,7 +24,7 @@ type DataAvailabilitySource interface {
 
 type L1SourceOutput interface {
 	StageProgress
-	IngestData(data []byte) error
+	IngestData(data []byte)
 }
 
 type L1Retrieval struct {
@@ -66,10 +66,7 @@ func (l1r *L1Retrieval) Step(ctx context.Context, outer Progress) error {
 	if l1r.datas == nil {
 		datas, err := l1r.dataSrc.OpenData(ctx, l1r.progress.Origin.ID())
 		if err != nil {
-			return NewTemporaryError(
-				err,
-				fmt.Sprintf("can't fetch L1 data: %v, %v", l1r.progress.Origin, err),
-			)
+			return NewTemporaryError(fmt.Errorf("can't fetch L1 data: %v: %w", l1r.progress.Origin, err))
 		}
 		l1r.datas = datas
 		return nil
@@ -79,25 +76,21 @@ func (l1r *L1Retrieval) Step(ctx context.Context, outer Progress) error {
 	if l1r.data == nil {
 		l1r.log.Debug("fetching next piece of data")
 		data, err := l1r.datas.Next(ctx)
-		if err != nil && err == ctx.Err() {
-			l1r.log.Warn("context to retrieve next L1 data failed", "err", err)
-			return nil
-		} else if err == io.EOF {
+		if err == io.EOF {
 			l1r.progress.Closed = true
 			l1r.datas = nil
 			return io.EOF
 		} else if err != nil {
-			return err
+			return NewTemporaryError(fmt.Errorf("context to retrieve next L1 data failed: %w", err))
 		} else {
 			l1r.data = data
 			return nil
 		}
 	}
 
-	// try to flush the data to next stage
-	if err := l1r.next.IngestData(l1r.data); err != nil {
-		return err
-	}
+	// flush the data to next stage
+	l1r.next.IngestData(l1r.data)
+	// and nil the data, the next step will retrieve the next data
 	l1r.data = nil
 	return nil
 }

--- a/op-node/rollup/derive/l1_retrieval_test.go
+++ b/op-node/rollup/derive/l1_retrieval_test.go
@@ -32,13 +32,12 @@ type MockIngestData struct {
 	MockOriginStage
 }
 
-func (im *MockIngestData) IngestData(data []byte) error {
-	out := im.Mock.MethodCalled("IngestData", data)
-	return *out[0].(*error)
+func (im *MockIngestData) IngestData(data []byte) {
+	im.Mock.MethodCalled("IngestData", data)
 }
 
-func (im *MockIngestData) ExpectIngestData(data []byte, err error) {
-	im.Mock.On("IngestData", data).Return(&err)
+func (im *MockIngestData) ExpectIngestData(data []byte) {
+	im.Mock.On("IngestData", data).Return()
 }
 
 var _ L1SourceOutput = (*MockIngestData)(nil)
@@ -58,8 +57,8 @@ func TestL1Retrieval_Step(t *testing.T) {
 	// mock some L1 data to open for the origin that is opened by the outer stage
 	dataSrc.ExpectOpenData(outer.Origin.ID(), iter, nil)
 
-	next.ExpectIngestData(a, nil)
-	next.ExpectIngestData(b, nil)
+	next.ExpectIngestData(a)
+	next.ExpectIngestData(b)
 
 	defer dataSrc.AssertExpectations(t)
 	defer next.AssertExpectations(t)

--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -52,11 +52,10 @@ func (l1t *L1Traversal) Step(ctx context.Context, outer Progress) error {
 		l1t.log.Debug("can't find next L1 block info (yet)", "number", origin.Number+1, "origin", origin)
 		return io.EOF
 	} else if err != nil {
-		l1t.log.Warn("failed to find L1 block info by number", "number", origin.Number+1, "origin", origin, "err", err)
-		return nil // nil, don't make the pipeline restart if the RPC fails
+		return NewTemporaryError(fmt.Errorf("failed to find L1 block info by number, at origin %s next %d: %w", origin, origin.Number+1, err))
 	}
 	if l1t.progress.Origin.Hash != nextL1Origin.ParentHash {
-		return NewResetError(ReorgErr, fmt.Sprintf("detected L1 reorg from %s to %s", l1t.progress.Origin, nextL1Origin))
+		return NewResetError(fmt.Errorf("detected L1 reorg from %s to %s with conflicting parent %s", l1t.progress.Origin, nextL1Origin, nextL1Origin.ParentID()))
 	}
 	l1t.progress.Origin = nextL1Origin
 	l1t.progress.Closed = false

--- a/op-node/rollup/derive/l1_traversal_test.go
+++ b/op-node/rollup/derive/l1_traversal_test.go
@@ -47,9 +47,10 @@ func TestL1Traversal_Step(t *testing.T) {
 	require.Equal(t, a, tr.Progress().Origin, "stage needs to adopt the origin of next stage on reset")
 	require.False(t, tr.Progress().Closed, "stage needs to be open after reset")
 
+	require.ErrorIs(t, RepeatStep(t, tr.Step, Progress{}, 10), ErrTemporary, "expected temporary error because of RPC mock fail")
 	require.NoError(t, RepeatStep(t, tr.Step, Progress{}, 10))
 	require.Equal(t, c, tr.Progress().Origin, "expected to be stuck on ethereum.NotFound on d")
 	require.NoError(t, RepeatStep(t, tr.Step, Progress{}, 1))
 	require.Equal(t, c, tr.Progress().Origin, "expected to be stuck again, should get the EOF within 1 step")
-	require.ErrorIs(t, RepeatStep(t, tr.Step, Progress{}, 10), ReorgErr, "completed pipeline, until L1 input f that causes a reorg")
+	require.ErrorIs(t, RepeatStep(t, tr.Step, Progress{}, 10), ErrReset, "completed pipeline, until L1 input f that causes a reorg")
 }

--- a/op-node/rollup/derive/progress.go
+++ b/op-node/rollup/derive/progress.go
@@ -1,13 +1,10 @@
 package derive
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 )
-
-var ReorgErr = errors.New("reorg")
 
 // Progress represents the progress of a derivation stage:
 // the input L1 block that is being processed, and whether it's fully processed yet.
@@ -24,12 +21,12 @@ func (pr *Progress) Update(outer Progress) (changed bool, err error) {
 	if pr.Closed {
 		if outer.Closed {
 			if pr.Origin.ID() != outer.Origin.ID() {
-				return true, NewResetError(ReorgErr, fmt.Sprintf("outer stage changed origin from %s to %s without opening it", pr.Origin, outer.Origin))
+				return true, NewResetError(fmt.Errorf("outer stage changed origin from %s to %s without opening it", pr.Origin, outer.Origin))
 			}
 			return false, nil
 		} else {
 			if pr.Origin.Hash != outer.Origin.ParentHash {
-				return true, NewResetError(ReorgErr, fmt.Sprintf("detected internal pipeline reorg of L1 origin data from %s to %s", pr.Origin, outer.Origin))
+				return true, NewResetError(fmt.Errorf("detected internal pipeline reorg of L1 origin data from %s to %s", pr.Origin, outer.Origin))
 			}
 			pr.Origin = outer.Origin
 			pr.Closed = false
@@ -37,7 +34,7 @@ func (pr *Progress) Update(outer Progress) (changed bool, err error) {
 		}
 	} else {
 		if pr.Origin.ID() != outer.Origin.ID() {
-			return true, NewResetError(ReorgErr, fmt.Sprintf("outer stage changed origin from %s to %s before closing it", pr.Origin, outer.Origin))
+			return true, NewResetError(fmt.Errorf("outer stage changed origin from %s to %s before closing it", pr.Origin, outer.Origin))
 		}
 		if outer.Closed {
 			pr.Closed = true


### PR DESCRIPTION
This PR aims to polish the error handling in the derivation pipeline more (after #3185 introduced initial error typing), and fixes minor issues in it.

Notable changes:
- `NewTemporaryError, NewResetError, NewCriticalError` now only wrap an error. We add the description to the error before we wrap it. Previously there were many places where the error ended up in the description, but then was also wrapped. This duplicated the error description when stringified. Now this can't happen anymore.
- Remove `ReorgErr` in favor of using just using `NewResetError`. They were indicating the same thing, but `ReorgErr` needed to be wrapped by `NewResetError` previously, complicating the error more than necessary.
- When we fail to convert receipts into deposits, or fail to convert L1 header info into a info transaction, then we emit a critical error. This is not a temporary rpc error or a reorg thing, something would be critically wrong.
- Update `validExtension` in the batch queue to propagate an error when necessary.
  - This is an important **bugfix**: when we check the epoch hash, we must be sure it's either correct or not. Ignoring the check when we hit an RPC error is bad. Now we emit a temporary error instead, to redo the check properly when we can.
- Update `AddBatch` and `IngestData` functions to not emit errors: these errors would have halted the chain if the batch-submitter malforms data. Instead we should always keep going, and just log+ignore if the batch-submitter misbehaves.
- One error in the batch queue is now a panic, since it only hits when a preparation step is missing, i.e. a code error that never hits if the code is right, but a useful sanity check.
- Add typing where errors where previously being emitted by the pipeline without proper typing.
- In the L1 retrieval stage, don't silence a possible data-fetching error, emit a temporary-level error instead
- In the L1 traversal stage, don't silence a possible RPC error, emit a temporary-level error instead
- Reduce log level of some common internal errors that are not so important
