### PR TITLE
op-node: remove parallel batch fetching / deadlock, introduce iterative batch fetching

### DIFF
--- a/op-node/eth/types.go
+++ b/op-node/eth/types.go
@@ -2,7 +2,9 @@ package eth
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"math/big"
 	"reflect"
 
@@ -252,3 +254,28 @@ type ForkchoiceUpdatedResult struct {
 	// the payload id if requested
 	PayloadID *PayloadID `json:"payloadId"`
 }
+
+// ReceiptsFetcher fetches receipts of a block,
+// and enables the caller to parallelize fetching and backoff on fetching errors as needed.
+type ReceiptsFetcher interface {
+	Fetch(ctx context.Context) error
+	Complete() bool
+	Result() (types.Receipts, error)
+}
+
+// FetchedReceipts is a simple util to implement the ReceiptsFetcher with readily available receipts.
+type FetchedReceipts types.Receipts
+
+func (f FetchedReceipts) Fetch(ctx context.Context) error {
+	return io.EOF
+}
+
+func (f FetchedReceipts) Complete() bool {
+	return true
+}
+
+func (f FetchedReceipts) Result() (types.Receipts, error) {
+	return types.Receipts(f), nil
+}
+
+var _ ReceiptsFetcher = (FetchedReceipts)(nil)

--- a/op-node/eth/types.go
+++ b/op-node/eth/types.go
@@ -258,13 +258,24 @@ type ForkchoiceUpdatedResult struct {
 // ReceiptsFetcher fetches receipts of a block,
 // and enables the caller to parallelize fetching and backoff on fetching errors as needed.
 type ReceiptsFetcher interface {
+	// Reset clears the previously fetched results for a fresh re-attempt.
+	Reset()
+	// Fetch retrieves receipts in batches, until it returns io.EOF to indicate completion.
 	Fetch(ctx context.Context) error
+	// Complete indicates when all data has been fetched.
 	Complete() bool
+	// Result returns the receipts, or an error if the Fetch-ing is not Complete,
+	// or an error if the results are invalid.
+	// If an error is returned, the fetcher is Reset automatically.
 	Result() (types.Receipts, error)
 }
 
 // FetchedReceipts is a simple util to implement the ReceiptsFetcher with readily available receipts.
 type FetchedReceipts types.Receipts
+
+func (f FetchedReceipts) Reset() {
+	// nothing to reset
+}
 
 func (f FetchedReceipts) Fetch(ctx context.Context) error {
 	return io.EOF

--- a/op-node/l1/batching.go
+++ b/op-node/l1/batching.go
@@ -2,134 +2,106 @@ package l1
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"time"
+	"io"
+	"sync/atomic"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/hashicorp/go-multierror"
 )
 
-var (
-	TooManyRetries = errors.New("too many retries")
-)
+// IterativeBatchCall is an util to create a job to fetch many RPC requests in batches,
+// and enable the caller to parallelize easily, handle and re-try error,
+// and pick a batch size all by simply calling Fetch again and again until it returns io.EOF.
+type IterativeBatchCall struct {
+	completed uint32
+	getBatch  batchCallContextFn
+	requests  []rpc.BatchElem
+	scheduled chan rpc.BatchElem
+}
 
-// parallelBatchCall creates a drop-in replacement for the standard batchCallContextFn that splits requests into more batch requests, and will parallelize and retry as configured.
-func parallelBatchCall(log log.Logger, getBatch batchCallContextFn, maxRetry int, maxPerBatch int, maxParallel int) batchCallContextFn {
-	return func(ctx context.Context, requests []rpc.BatchElem) error {
-		return fetchBatched(ctx, log, requests, getBatch, maxRetry, maxPerBatch, maxParallel)
+func NewIterativeBatchCall(requests []rpc.BatchElem, getBatch batchCallContextFn) *IterativeBatchCall {
+	scheduled := make(chan rpc.BatchElem, len(requests))
+	for _, r := range requests {
+		scheduled <- r
+	}
+	return &IterativeBatchCall{
+		completed: 0,
+		getBatch:  getBatch,
+		requests:  requests,
+		scheduled: scheduled,
 	}
 }
 
-type batchResult struct {
-	failed  []rpc.BatchElem // if anything has to be retried
-	err     error           // if the batch as a whole failed
-	success int             // amount of items that completed successfully
-}
-
-// fetchBatched fetches the given requests in batches of at most maxPerBatch elements, and with at most maxRetry retries per batch.
-// Batch requests may be split into maxParallel go-routines.
-// Retries only apply to individual request errors, not to the outer batch-requests that combine them into batches.
-func fetchBatched(ctx context.Context, log log.Logger, requests []rpc.BatchElem, getBatch batchCallContextFn, maxRetry int, maxPerBatch int, maxParallel int) error {
-	batchRequest := func(ctx context.Context, missing []rpc.BatchElem) (failed []rpc.BatchElem, err error) {
-		if err := getBatch(ctx, missing); err != nil {
-			return nil, fmt.Errorf("failed batch-retrieval: %w", err)
+// Fetch fetches more of the data, and returns io.EOF when all data has been fetched.
+// This method is safe to call concurrently: it will parallelize the fetching work.
+// If no work is available, but the fetching is not done yet,
+// then Fetch will block until the next thing can be fetched, or until the context expires.
+func (ibc *IterativeBatchCall) Fetch(ctx context.Context, maxBatchSize uint) error {
+	// collect a batch from the requests channel
+	batch := make([]rpc.BatchElem, 0, maxBatchSize)
+	// wait for first element
+	select {
+	case reqElem, ok := <-ibc.scheduled:
+		if !ok { // no more requests to do
+			return io.EOF
 		}
-		for _, elem := range missing {
-			if elem.Error != nil {
-				log.Trace("batch request element failed", "err", elem.Error, "elem", elem.Args[0])
-				elem.Error = nil // reset, we'll try this element again
-				failed = append(failed, elem)
-				continue
-			}
-		}
-		return failed, nil
+		batch = append(batch, reqElem)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
-	// limit capacity, don't write to underlying array on retries
-	requests = requests[:len(requests):len(requests)]
-
-	expectedBatches := (len(requests) + maxPerBatch - 1) / maxPerBatch
-
-	// don't need more go-routines than requests
-	if maxParallel > expectedBatches {
-		maxParallel = expectedBatches
-	}
-
-	// capacity is sufficient for no go-routine to get stuck on writing
-	completed := make(chan batchResult, maxParallel)
-
-	// queue of tasks for worker go-routines
-	batchRequests := make(chan []rpc.BatchElem, maxParallel)
-	defer close(batchRequests)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// starts worker go-routines. Closed when task channel closes
-	for i := 0; i < maxParallel; i++ {
-		go func(ctx context.Context) {
-			for {
-				batch, ok := <-batchRequests
-				if !ok {
-					return // no more batches left
-				}
-				failed, err := batchRequest(ctx, batch)
-				completed <- batchResult{failed: failed, err: err, success: len(batch) - len(failed)}
-			}
-		}(ctx)
-	}
-
-	parallelRequests := func() int {
-		// we split the requests into parallel batch requests, and count how many
-		i := 0
-		for ; i < maxParallel && len(requests) > 0; i++ {
-			nextBatch := requests
-			if len(nextBatch) > maxPerBatch {
-				nextBatch = requests[:maxPerBatch]
-			}
-			// don't retry this batch of requests again, unless we add them back
-			requests = requests[len(nextBatch):]
-
-			// schedule the batch, this may block if all workers are busy and the queue is full
-			batchRequests <- nextBatch
-		}
-		return i
-	}
-
-	maxCount := expectedBatches * maxRetry
-
-	awaited := len(requests)
-
-	// start initial round of parallel requests
-	count := parallelRequests()
-
-	// We slow down additional batch requests to not spam the server.
-	retryTicker := time.NewTicker(time.Millisecond * 20)
-	defer retryTicker.Stop()
-
-	// The main requests slice is only ever mutated by the go-routine running this loop.
-	// Slices of this are sent to worker go-routines, and never overwritten with different requests.
+	// collect more elements, if there are any.
 	for {
-		// check if we've all results back successfully
-		if awaited <= 0 {
-			return nil
-		}
-		if count > maxCount {
-			return TooManyRetries
+		if uint(len(batch)) >= maxBatchSize {
+			break
 		}
 		select {
-		case <-retryTicker.C:
-			count += parallelRequests() // retry batch-requests on interval
-		case result := <-completed:
-			if result.err != nil {
-				// batch failed, RPC may be broken, abort
-				return fmt.Errorf("batch request failed: %w", result.err)
+		case reqElem, ok := <-ibc.scheduled:
+			if !ok { // no more requests to do
+				return io.EOF
 			}
-			// if any element failed, add it to the requests for re-attempt
-			requests = append(requests, result.failed...)
-			awaited -= result.success
+			batch = append(batch, reqElem)
+			continue
 		case <-ctx.Done():
+			for _, r := range batch {
+				ibc.scheduled <- r
+			}
 			return ctx.Err()
+		default:
+			break
+		}
+		break
+	}
+
+	if err := ibc.getBatch(ctx, batch); err != nil {
+		for _, r := range batch {
+			ibc.scheduled <- r
+		}
+		return fmt.Errorf("failed batch-retrieval: %w", err)
+	}
+	var result error
+	for _, elem := range batch {
+		if elem.Error != nil {
+			result = multierror.Append(result, elem.Error)
+			elem.Error = nil // reset, we'll try this element again
+			ibc.scheduled <- elem
+			continue
+		} else {
+			atomic.AddUint32(&ibc.completed, 1)
+			if atomic.LoadUint32(&ibc.completed) >= uint32(len(ibc.requests)) {
+				close(ibc.scheduled)
+				return io.EOF
+			}
 		}
 	}
+	return result
+}
+
+func (ibc *IterativeBatchCall) Complete() bool {
+	return atomic.LoadUint32(&ibc.completed) >= uint32(len(ibc.requests))
+}
+
+func (ibc *IterativeBatchCall) Result() []rpc.BatchElem {
+	return ibc.requests
 }

--- a/op-node/l1/receipts.go
+++ b/op-node/l1/receipts.go
@@ -2,6 +2,7 @@ package l1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -13,44 +14,48 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// fetchReceipts fetches the receipts of the transactions using RPC batching, verifies if the receipts are complete and correct, and then returns results
-func fetchReceipts(ctx context.Context, block eth.BlockID, receiptHash common.Hash, txs types.Transactions, getBatch batchCallContextFn) (types.Receipts, error) {
-	if len(txs) == 0 {
-		if receiptHash != types.EmptyRootHash {
-			return nil, fmt.Errorf("no transactions, but got non-empty receipt trie root: %s", receiptHash)
-		}
-		return nil, nil
-	}
+// ReceiptsFetcher fetches the receipts of the transactions using RPC batching in iterative calls,
+// and then verifies if the receipts are complete and correct, and then returns results.
+type ReceiptsFetcher struct {
+	iterBatchCall *IterativeBatchCall
+	receipts      []*types.Receipt
+	receiptHash   common.Hash
+	block         eth.BlockID
+	txs           types.Transactions
+	batchSize     uint
+}
 
-	receipts := make([]*types.Receipt, len(txs))
-	receiptRequests := make([]rpc.BatchElem, len(txs))
-	for i := 0; i < len(txs); i++ {
-		receipts[i] = new(types.Receipt)
-		receiptRequests[i] = rpc.BatchElem{
-			Method: "eth_getTransactionReceipt",
-			Args:   []interface{}{txs[i].Hash()},
-			Result: &receipts[i], // receipt may become nil, double pointer is intentional
-		}
-	}
-	if err := getBatch(ctx, receiptRequests); err != nil {
-		return nil, fmt.Errorf("failed to fetch batch of receipts: %v", err)
-	}
+// Fetch fetches the next batch. Fetch is safe to call concurrently for parallel fetching.
+// An error will be returned if data, possibly individual calls as multi-error, fails to be fetched.
+// Any individual items that fail to be fetched will automatically be rescheduled for later fetching.
+// An io.EOF error will be returned once the fetching is done.
+func (rf *ReceiptsFetcher) Fetch(ctx context.Context) error {
+	return rf.iterBatchCall.Fetch(ctx, rf.batchSize)
+}
 
+func (rf *ReceiptsFetcher) Complete() bool {
+	return rf.iterBatchCall.Complete()
+}
+
+func (rf *ReceiptsFetcher) Result() (types.Receipts, error) {
+	if !rf.iterBatchCall.Complete() {
+		return nil, errors.New("no result available yet, fetching is not complete")
+	}
 	// We don't trust the RPC to provide consistent cached receipt info that we use for critical rollup derivation work.
 	// Let's check everything quickly.
 	logIndex := uint(0)
-	for i, r := range receipts {
+	for i, r := range rf.receipts {
 		if r == nil { // on reorgs or other cases the receipts may disappear before they can be retrieved.
 			return nil, fmt.Errorf("receipt of tx %d returns nil on retrieval", i)
 		}
 		if r.TransactionIndex != uint(i) {
 			return nil, fmt.Errorf("receipt %d has unexpected tx index %d", i, r.TransactionIndex)
 		}
-		if r.BlockNumber.Uint64() != block.Number {
-			return nil, fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, block.Number)
+		if r.BlockNumber.Uint64() != rf.block.Number {
+			return nil, fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, rf.block.Number)
 		}
-		if r.BlockHash != block.Hash {
-			return nil, fmt.Errorf("receipt %d has unexpected block hash %s, expected %s", i, r.BlockHash, block.Hash)
+		if r.BlockHash != rf.block.Hash {
+			return nil, fmt.Errorf("receipt %d has unexpected block hash %s, expected %s", i, r.BlockHash, rf.block.Hash)
 		}
 		for j, log := range r.Logs {
 			if log.Index != logIndex {
@@ -59,13 +64,13 @@ func fetchReceipts(ctx context.Context, block eth.BlockID, receiptHash common.Ha
 			if log.TxIndex != uint(i) {
 				return nil, fmt.Errorf("log %d has unexpected tx index %d", log.Index, log.TxIndex)
 			}
-			if log.BlockHash != block.Hash {
-				return nil, fmt.Errorf("log %d of block %s has unexpected block hash %s", log.Index, block.Hash, log.BlockHash)
+			if log.BlockHash != rf.block.Hash {
+				return nil, fmt.Errorf("log %d of block %s has unexpected block hash %s", log.Index, rf.block.Hash, log.BlockHash)
 			}
-			if log.BlockNumber != block.Number {
-				return nil, fmt.Errorf("log %d of block %d has unexpected block number %d", log.Index, block.Number, log.BlockNumber)
+			if log.BlockNumber != rf.block.Number {
+				return nil, fmt.Errorf("log %d of block %d has unexpected block number %d", log.Index, rf.block.Number, log.BlockNumber)
 			}
-			if h := txs[i].Hash(); log.TxHash != h {
+			if h := rf.txs[i].Hash(); log.TxHash != h {
 				return nil, fmt.Errorf("log %d of tx %s has unexpected tx hash %s", log.Index, h, log.TxHash)
 			}
 			if log.Removed {
@@ -78,9 +83,45 @@ func fetchReceipts(ctx context.Context, block eth.BlockID, receiptHash common.Ha
 	// Sanity-check: external L1-RPC sources are notorious for not returning all receipts,
 	// or returning them out-of-order. Verify the receipts against the expected receipt-hash.
 	hasher := trie.NewStackTrie(nil)
-	computed := types.DeriveSha(types.Receipts(receipts), hasher)
-	if receiptHash != computed {
-		return nil, fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", receiptHash, computed)
+	computed := types.DeriveSha(types.Receipts(rf.receipts), hasher)
+	if rf.receiptHash != computed {
+		return nil, fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", rf.receiptHash, computed)
 	}
-	return receipts, nil
+	return rf.receipts, nil
+}
+
+// NewReceiptsFetcher creates a receipt fetcher that can iteratively fetch the receipts matching the given t
+func NewReceiptsFetcher(block eth.BlockID, receiptHash common.Hash, txs types.Transactions, getBatch batchCallContextFn, batchSize int) (eth.ReceiptsFetcher, error) {
+	if len(txs) == 0 {
+		if receiptHash != types.EmptyRootHash {
+			return nil, fmt.Errorf("no transactions, but got non-empty receipt trie root: %s", receiptHash)
+		}
+		return eth.FetchedReceipts(nil), nil
+	}
+	if len(txs) < batchSize {
+		batchSize = len(txs)
+	}
+	if batchSize < 1 {
+		batchSize = 1
+	}
+
+	receipts := make([]*types.Receipt, len(txs))
+	receiptRequests := make([]rpc.BatchElem, len(txs))
+	for i := 0; i < len(txs); i++ {
+		receipts[i] = new(types.Receipt)
+		receiptRequests[i] = rpc.BatchElem{
+			Method: "eth_getTransactionReceipt",
+			Args:   []interface{}{txs[i].Hash()},
+			Result: &receipts[i], // receipt may become nil, double pointer is intentional
+		}
+	}
+
+	return &ReceiptsFetcher{
+		iterBatchCall: NewIterativeBatchCall(receiptRequests, getBatch),
+		receipts:      receipts,
+		receiptHash:   receiptHash,
+		block:         block,
+		txs:           txs,
+		batchSize:     uint(batchSize),
+	}, nil
 }

--- a/op-node/l1/receipts.go
+++ b/op-node/l1/receipts.go
@@ -18,12 +18,12 @@ import (
 // ReceiptsFetcher fetches the receipts of the transactions using RPC batching in iterative calls,
 // and then verifies if the receipts are complete and correct, and then returns results.
 type ReceiptsFetcher struct {
-	mu            sync.RWMutex
+	mu            sync.RWMutex // mu locks iterBatchCall, read=fetch (parallel with other reads), reset=write
 	iterBatchCall *IterativeBatchCall
 	receipts      []*types.Receipt
 	receiptHash   common.Hash
 	block         eth.BlockID
-	txs           types.Transactions
+	txHashes      []common.Hash
 	batchSize     uint
 }
 
@@ -50,32 +50,39 @@ func (rf *ReceiptsFetcher) Reset() {
 }
 
 func (rf *ReceiptsFetcher) Result() (types.Receipts, error) {
+	rf.mu.RLock()
 	if !rf.iterBatchCall.Complete() {
+		rf.mu.RUnlock()
 		return nil, errors.New("no result available yet, receipt fetching is not complete")
 	}
-	if err := rf.check(); err != nil {
+	err := checkReceipts(rf.receipts, rf.block, rf.receiptHash, rf.txHashes)
+	rf.mu.RUnlock()
+	if err != nil {
 		rf.Reset() // if we got invalid results then restart the call, we may get valid results after a reorg.
 		return nil, fmt.Errorf("results are invalid, receipt fetching failed: %w", err)
 	}
 	return rf.receipts, nil
 }
 
-func (rf *ReceiptsFetcher) check() error {
+func checkReceipts(receipts []*types.Receipt, block eth.BlockID, receiptHash common.Hash, txHashes []common.Hash) error {
+	if len(receipts) != len(txHashes) {
+		return fmt.Errorf("got %d receipts but expected %d", len(receipts), len(txHashes))
+	}
 	// We don't trust the RPC to provide consistent cached receipt info that we use for critical rollup derivation work.
 	// Let's check everything quickly.
 	logIndex := uint(0)
-	for i, r := range rf.receipts {
+	for i, r := range receipts {
 		if r == nil { // on reorgs or other cases the receipts may disappear before they can be retrieved.
 			return fmt.Errorf("receipt of tx %d returns nil on retrieval", i)
 		}
 		if r.TransactionIndex != uint(i) {
 			return fmt.Errorf("receipt %d has unexpected tx index %d", i, r.TransactionIndex)
 		}
-		if r.BlockNumber.Uint64() != rf.block.Number {
-			return fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, rf.block.Number)
+		if r.BlockNumber.Uint64() != block.Number {
+			return fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, block.Number)
 		}
-		if r.BlockHash != rf.block.Hash {
-			return fmt.Errorf("receipt %d has unexpected block hash %s, expected %s", i, r.BlockHash, rf.block.Hash)
+		if r.BlockHash != block.Hash {
+			return fmt.Errorf("receipt %d has unexpected block hash %s, expected %s", i, r.BlockHash, block.Hash)
 		}
 		for j, log := range r.Logs {
 			if log.Index != logIndex {
@@ -84,14 +91,14 @@ func (rf *ReceiptsFetcher) check() error {
 			if log.TxIndex != uint(i) {
 				return fmt.Errorf("log %d has unexpected tx index %d", log.Index, log.TxIndex)
 			}
-			if log.BlockHash != rf.block.Hash {
-				return fmt.Errorf("log %d of block %s has unexpected block hash %s", log.Index, rf.block.Hash, log.BlockHash)
+			if log.BlockHash != block.Hash {
+				return fmt.Errorf("log %d of block %s has unexpected block hash %s", log.Index, block.Hash, log.BlockHash)
 			}
-			if log.BlockNumber != rf.block.Number {
-				return fmt.Errorf("log %d of block %d has unexpected block number %d", log.Index, rf.block.Number, log.BlockNumber)
+			if log.BlockNumber != block.Number {
+				return fmt.Errorf("log %d of block %d has unexpected block number %d", log.Index, block.Number, log.BlockNumber)
 			}
-			if h := rf.txs[i].Hash(); log.TxHash != h {
-				return fmt.Errorf("log %d of tx %s has unexpected tx hash %s", log.Index, h, log.TxHash)
+			if log.TxHash != txHashes[i] {
+				return fmt.Errorf("log %d of tx %s has unexpected tx hash %s", log.Index, txHashes[i], log.TxHash)
 			}
 			if log.Removed {
 				return fmt.Errorf("canonical log (%d) must never be removed due to reorg", log.Index)
@@ -103,14 +110,14 @@ func (rf *ReceiptsFetcher) check() error {
 	// Sanity-check: external L1-RPC sources are notorious for not returning all receipts,
 	// or returning them out-of-order. Verify the receipts against the expected receipt-hash.
 	hasher := trie.NewStackTrie(nil)
-	computed := types.DeriveSha(types.Receipts(rf.receipts), hasher)
-	if rf.receiptHash != computed {
-		return fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", rf.receiptHash, computed)
+	computed := types.DeriveSha(types.Receipts(receipts), hasher)
+	if receiptHash != computed {
+		return fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", receiptHash, computed)
 	}
 	return nil
 }
 
-// NewReceiptsFetcher creates a receipt fetcher that can iteratively fetch the receipts matching the given t
+// NewReceiptsFetcher creates a receipt fetcher that can iteratively fetch the receipts matching the given txs.
 func NewReceiptsFetcher(block eth.BlockID, receiptHash common.Hash, txs types.Transactions, getBatch batchCallContextFn, batchSize int) (eth.ReceiptsFetcher, error) {
 	if len(txs) == 0 {
 		if receiptHash != types.EmptyRootHash {
@@ -127,11 +134,13 @@ func NewReceiptsFetcher(block eth.BlockID, receiptHash common.Hash, txs types.Tr
 
 	receipts := make([]*types.Receipt, len(txs))
 	receiptRequests := make([]rpc.BatchElem, len(txs))
+	txHashes := make([]common.Hash, len(txs))
 	for i := 0; i < len(txs); i++ {
 		receipts[i] = new(types.Receipt)
+		txHashes[i] = txs[i].Hash()
 		receiptRequests[i] = rpc.BatchElem{
 			Method: "eth_getTransactionReceipt",
-			Args:   []interface{}{txs[i].Hash()},
+			Args:   []interface{}{txHashes[i]},
 			Result: &receipts[i], // receipt may become nil, double pointer is intentional
 		}
 	}
@@ -141,7 +150,7 @@ func NewReceiptsFetcher(block eth.BlockID, receiptHash common.Hash, txs types.Tr
 		receipts:      receipts,
 		receiptHash:   receiptHash,
 		block:         block,
-		txs:           txs,
+		txHashes:      txHashes,
 		batchSize:     uint(batchSize),
 	}, nil
 }

--- a/op-node/l1/receipts.go
+++ b/op-node/l1/receipts.go
@@ -1,10 +1,7 @@
 package l1
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 
@@ -15,142 +12,82 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// ReceiptsFetcher fetches the receipts of the transactions using RPC batching in iterative calls,
-// and then verifies if the receipts are complete and correct, and then returns results.
-type ReceiptsFetcher struct {
-	mu            sync.RWMutex // mu locks iterBatchCall, read=fetch (parallel with other reads), reset=write
-	iterBatchCall *IterativeBatchCall
-	receipts      []*types.Receipt
-	receiptHash   common.Hash
-	block         eth.BlockID
-	txHashes      []common.Hash
-	batchSize     uint
+func makeReceiptsFn(block eth.BlockID, receiptHash common.Hash) func(txHashes []common.Hash, receipts []*types.Receipt) (types.Receipts, error) {
+	return func(txHashes []common.Hash, receipts []*types.Receipt) (types.Receipts, error) {
+		if len(receipts) != len(txHashes) {
+			return nil, fmt.Errorf("got %d receipts but expected %d", len(receipts), len(txHashes))
+		}
+		if len(txHashes) == 0 {
+			if receiptHash != types.EmptyRootHash {
+				return nil, fmt.Errorf("no transactions, but got non-empty receipt trie root: %s", receiptHash)
+			}
+		}
+		// We don't trust the RPC to provide consistent cached receipt info that we use for critical rollup derivation work.
+		// Let's check everything quickly.
+		logIndex := uint(0)
+		for i, r := range receipts {
+			if r == nil { // on reorgs or other cases the receipts may disappear before they can be retrieved.
+				return nil, fmt.Errorf("receipt of tx %d returns nil on retrieval", i)
+			}
+			if r.TransactionIndex != uint(i) {
+				return nil, fmt.Errorf("receipt %d has unexpected tx index %d", i, r.TransactionIndex)
+			}
+			if r.BlockNumber.Uint64() != block.Number {
+				return nil, fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, block.Number)
+			}
+			if r.BlockHash != block.Hash {
+				return nil, fmt.Errorf("receipt %d has unexpected block hash %s, expected %s", i, r.BlockHash, block.Hash)
+			}
+			for j, log := range r.Logs {
+				if log.Index != logIndex {
+					return nil, fmt.Errorf("log %d (%d of tx %d) has unexpected log index %d", logIndex, j, i, log.Index)
+				}
+				if log.TxIndex != uint(i) {
+					return nil, fmt.Errorf("log %d has unexpected tx index %d", log.Index, log.TxIndex)
+				}
+				if log.BlockHash != block.Hash {
+					return nil, fmt.Errorf("log %d of block %s has unexpected block hash %s", log.Index, block.Hash, log.BlockHash)
+				}
+				if log.BlockNumber != block.Number {
+					return nil, fmt.Errorf("log %d of block %d has unexpected block number %d", log.Index, block.Number, log.BlockNumber)
+				}
+				if log.TxHash != txHashes[i] {
+					return nil, fmt.Errorf("log %d of tx %s has unexpected tx hash %s", log.Index, txHashes[i], log.TxHash)
+				}
+				if log.Removed {
+					return nil, fmt.Errorf("canonical log (%d) must never be removed due to reorg", log.Index)
+				}
+				logIndex++
+			}
+		}
+
+		// Sanity-check: external L1-RPC sources are notorious for not returning all receipts,
+		// or returning them out-of-order. Verify the receipts against the expected receipt-hash.
+		hasher := trie.NewStackTrie(nil)
+		computed := types.DeriveSha(types.Receipts(receipts), hasher)
+		if receiptHash != computed {
+			return nil, fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", receiptHash, computed)
+		}
+		return receipts, nil
+	}
 }
 
-// Fetch fetches the next batch. Fetch is safe to call concurrently for parallel fetching.
-// An error will be returned if data, possibly individual calls as multi-error, fails to be fetched.
-// Any individual items that fail to be fetched will automatically be rescheduled for later fetching.
-// An io.EOF error will be returned once the fetching is done.
-func (rf *ReceiptsFetcher) Fetch(ctx context.Context) error {
-	rf.mu.RLock()
-	defer rf.mu.RUnlock()
-	return rf.iterBatchCall.Fetch(ctx, rf.batchSize)
-}
-
-func (rf *ReceiptsFetcher) Complete() bool {
-	rf.mu.RLock()
-	defer rf.mu.RUnlock()
-	return rf.iterBatchCall.Complete()
-}
-
-func (rf *ReceiptsFetcher) Reset() {
-	rf.mu.Lock()
-	defer rf.mu.Unlock()
-	rf.iterBatchCall = NewIterativeBatchCall(rf.iterBatchCall.requests, rf.iterBatchCall.getBatch)
-}
-
-func (rf *ReceiptsFetcher) Result() (types.Receipts, error) {
-	rf.mu.RLock()
-	if !rf.iterBatchCall.Complete() {
-		rf.mu.RUnlock()
-		return nil, errors.New("no result available yet, receipt fetching is not complete")
+func makeReceiptRequest(txHash common.Hash) (*types.Receipt, rpc.BatchElem) {
+	out := new(types.Receipt)
+	return out, rpc.BatchElem{
+		Method: "eth_getTransactionReceipt",
+		Args:   []interface{}{txHash},
+		Result: &out, // receipt may become nil, double pointer is intentional
 	}
-	err := checkReceipts(rf.receipts, rf.block, rf.receiptHash, rf.txHashes)
-	rf.mu.RUnlock()
-	if err != nil {
-		rf.Reset() // if we got invalid results then restart the call, we may get valid results after a reorg.
-		return nil, fmt.Errorf("results are invalid, receipt fetching failed: %w", err)
-	}
-	return rf.receipts, nil
-}
-
-func checkReceipts(receipts []*types.Receipt, block eth.BlockID, receiptHash common.Hash, txHashes []common.Hash) error {
-	if len(receipts) != len(txHashes) {
-		return fmt.Errorf("got %d receipts but expected %d", len(receipts), len(txHashes))
-	}
-	// We don't trust the RPC to provide consistent cached receipt info that we use for critical rollup derivation work.
-	// Let's check everything quickly.
-	logIndex := uint(0)
-	for i, r := range receipts {
-		if r == nil { // on reorgs or other cases the receipts may disappear before they can be retrieved.
-			return fmt.Errorf("receipt of tx %d returns nil on retrieval", i)
-		}
-		if r.TransactionIndex != uint(i) {
-			return fmt.Errorf("receipt %d has unexpected tx index %d", i, r.TransactionIndex)
-		}
-		if r.BlockNumber.Uint64() != block.Number {
-			return fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, block.Number)
-		}
-		if r.BlockHash != block.Hash {
-			return fmt.Errorf("receipt %d has unexpected block hash %s, expected %s", i, r.BlockHash, block.Hash)
-		}
-		for j, log := range r.Logs {
-			if log.Index != logIndex {
-				return fmt.Errorf("log %d (%d of tx %d) has unexpected log index %d", logIndex, j, i, log.Index)
-			}
-			if log.TxIndex != uint(i) {
-				return fmt.Errorf("log %d has unexpected tx index %d", log.Index, log.TxIndex)
-			}
-			if log.BlockHash != block.Hash {
-				return fmt.Errorf("log %d of block %s has unexpected block hash %s", log.Index, block.Hash, log.BlockHash)
-			}
-			if log.BlockNumber != block.Number {
-				return fmt.Errorf("log %d of block %d has unexpected block number %d", log.Index, block.Number, log.BlockNumber)
-			}
-			if log.TxHash != txHashes[i] {
-				return fmt.Errorf("log %d of tx %s has unexpected tx hash %s", log.Index, txHashes[i], log.TxHash)
-			}
-			if log.Removed {
-				return fmt.Errorf("canonical log (%d) must never be removed due to reorg", log.Index)
-			}
-			logIndex++
-		}
-	}
-
-	// Sanity-check: external L1-RPC sources are notorious for not returning all receipts,
-	// or returning them out-of-order. Verify the receipts against the expected receipt-hash.
-	hasher := trie.NewStackTrie(nil)
-	computed := types.DeriveSha(types.Receipts(receipts), hasher)
-	if receiptHash != computed {
-		return fmt.Errorf("failed to fetch list of receipts: expected receipt root %s but computed %s from retrieved receipts", receiptHash, computed)
-	}
-	return nil
 }
 
 // NewReceiptsFetcher creates a receipt fetcher that can iteratively fetch the receipts matching the given txs.
-func NewReceiptsFetcher(block eth.BlockID, receiptHash common.Hash, txs types.Transactions, getBatch batchCallContextFn, batchSize int) (eth.ReceiptsFetcher, error) {
-	if len(txs) == 0 {
-		if receiptHash != types.EmptyRootHash {
-			return nil, fmt.Errorf("no transactions, but got non-empty receipt trie root: %s", receiptHash)
-		}
-		return eth.FetchedReceipts(nil), nil
-	}
-	if len(txs) < batchSize {
-		batchSize = len(txs)
-	}
-	if batchSize < 1 {
-		batchSize = 1
-	}
-
-	receipts := make([]*types.Receipt, len(txs))
-	receiptRequests := make([]rpc.BatchElem, len(txs))
-	txHashes := make([]common.Hash, len(txs))
-	for i := 0; i < len(txs); i++ {
-		receipts[i] = new(types.Receipt)
-		txHashes[i] = txs[i].Hash()
-		receiptRequests[i] = rpc.BatchElem{
-			Method: "eth_getTransactionReceipt",
-			Args:   []interface{}{txHashes[i]},
-			Result: &receipts[i], // receipt may become nil, double pointer is intentional
-		}
-	}
-
-	return &ReceiptsFetcher{
-		iterBatchCall: NewIterativeBatchCall(receiptRequests, getBatch),
-		receipts:      receipts,
-		receiptHash:   receiptHash,
-		block:         block,
-		txHashes:      txHashes,
-		batchSize:     uint(batchSize),
-	}, nil
+func NewReceiptsFetcher(block eth.BlockID, receiptHash common.Hash, txHashes []common.Hash, getBatch batchCallContextFn, batchSize int) eth.ReceiptsFetcher {
+	return NewIterativeBatchCall[common.Hash, *types.Receipt, types.Receipts](
+		txHashes,
+		makeReceiptRequest,
+		makeReceiptsFn(block, receiptHash),
+		getBatch,
+		batchSize,
+	)
 }

--- a/op-node/l1/source_test.go
+++ b/op-node/l1/source_test.go
@@ -9,11 +9,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -88,7 +86,6 @@ func randTxs(offset uint64, count uint64) types.Transactions {
 }
 
 func TestSource_InfoByHash(t *testing.T) {
-	log := testlog.Logger(t, log.LvlError)
 	m := new(mockRPC)
 	hdr := randHeader()
 	rhdr := &rpcHeader{
@@ -101,7 +98,7 @@ func TestSource_InfoByHash(t *testing.T) {
 	m.On("CallContext", ctx, new(*rpcHeader), "eth_getBlockByHash", []interface{}{h, false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewSource(m, log, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
+	s, err := NewSource(m, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
 	assert.NoError(t, err)
 	info, err := s.InfoByHash(ctx, h)
 	assert.NoError(t, err)
@@ -115,7 +112,6 @@ func TestSource_InfoByHash(t *testing.T) {
 }
 
 func TestSource_InfoByNumber(t *testing.T) {
-	log := testlog.Logger(t, log.LvlError)
 	m := new(mockRPC)
 	hdr := randHeader()
 	rhdr := &rpcHeader{
@@ -128,7 +124,7 @@ func TestSource_InfoByNumber(t *testing.T) {
 	m.On("CallContext", ctx, new(*rpcHeader), "eth_getBlockByNumber", []interface{}{hexutil.EncodeUint64(n), false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewSource(m, log, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
+	s, err := NewSource(m, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
 	assert.NoError(t, err)
 	info, err := s.InfoByNumber(ctx, n)
 	assert.NoError(t, err)
@@ -137,7 +133,6 @@ func TestSource_InfoByNumber(t *testing.T) {
 }
 
 func TestSource_FetchAllTransactions(t *testing.T) {
-	log := testlog.Logger(t, log.LvlError)
 	m := new(mockRPC)
 
 	ctx := context.Background()
@@ -180,7 +175,7 @@ func TestSource_FetchAllTransactions(t *testing.T) {
 		}
 	}).Return([]error{nil})
 
-	s, err := NewSource(m, log, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
+	s, err := NewSource(m, nil, DefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))
 	assert.NoError(t, err)
 	s.batchCall = m.batchCall // override the optimized batch call
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -110,7 +110,7 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to get L1 RPC client: %w", err)
 	}
 
-	n.l1Source, err = l1.NewSource(client.NewInstrumentedRPC(l1Node, n.metrics), n.log, n.metrics.L1SourceCache, l1.DefaultConfig(&cfg.Rollup, trustRPC))
+	n.l1Source, err = l1.NewSource(client.NewInstrumentedRPC(l1Node, n.metrics), n.metrics.L1SourceCache, l1.DefaultConfig(&cfg.Rollup, trustRPC))
 	if err != nil {
 		return fmt.Errorf("failed to create L1 source: %v", err)
 	}

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -14,7 +15,7 @@ import (
 // L1ReceiptsFetcher fetches L1 header info and receipts for the payload attributes derivation (the info tx and deposits)
 type L1ReceiptsFetcher interface {
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.L1Info, error)
-	Fetch(ctx context.Context, blockHash common.Hash) (eth.L1Info, types.Transactions, types.Receipts, error)
+	Fetch(ctx context.Context, blockHash common.Hash) (eth.L1Info, types.Transactions, eth.ReceiptsFetcher, error)
 }
 
 // PreparePayloadAttributes prepares a PayloadAttributes template that is ready to build a L2 block with deposits only, on top of the given l2Parent, with the given epoch as L1 origin.
@@ -31,7 +32,7 @@ func PreparePayloadAttributes(ctx context.Context, cfg *rollup.Config, dl L1Rece
 	// case we need to fetch all transaction receipts from the L1 origin block so we can scan for
 	// user deposits.
 	if l2Parent.L1Origin.Number != epoch.Number {
-		info, _, receipts, err := dl.Fetch(ctx, epoch.Hash)
+		info, _, receiptsFetcher, err := dl.Fetch(ctx, epoch.Hash)
 		if err != nil {
 			return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and receipts: %w", err))
 		}
@@ -39,6 +40,17 @@ func PreparePayloadAttributes(ctx context.Context, cfg *rollup.Config, dl L1Rece
 			return nil, NewResetError(
 				fmt.Errorf("cannot create new block with L1 origin %s (parent %s) on top of L1 origin %s",
 					epoch, info.ParentHash(), l2Parent.L1Origin))
+		}
+		for {
+			if err := receiptsFetcher.Fetch(ctx); err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, NewTemporaryError(fmt.Errorf("failed to fetch more receipts: %w", err))
+			}
+		}
+		receipts, err := receiptsFetcher.Result()
+		if err != nil {
+			return nil, NewResetError(fmt.Errorf("fetched bad receipt data: %w", err))
 		}
 		deposits, err := DeriveDeposits(receipts, cfg.DepositContractAddress)
 		if err != nil {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -37,7 +37,7 @@ type Metrics interface {
 
 type Downloader interface {
 	InfoByHash(ctx context.Context, hash common.Hash) (eth.L1Info, error)
-	Fetch(ctx context.Context, blockHash common.Hash) (eth.L1Info, types.Transactions, types.Receipts, error)
+	Fetch(ctx context.Context, blockHash common.Hash) (eth.L1Info, types.Transactions, eth.ReceiptsFetcher, error)
 }
 
 type L1Chain interface {

--- a/op-node/testutils/mock_l1.go
+++ b/op-node/testutils/mock_l1.go
@@ -45,13 +45,13 @@ func (m *MockL1Source) ExpectL1BlockRefByHash(hash common.Hash, ref eth.L1BlockR
 	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, &err)
 }
 
-func (m *MockL1Source) Fetch(ctx context.Context, blockHash common.Hash) (eth.L1Info, types.Transactions, types.Receipts, error) {
+func (m *MockL1Source) Fetch(ctx context.Context, blockHash common.Hash) (eth.L1Info, types.Transactions, eth.ReceiptsFetcher, error) {
 	out := m.Mock.MethodCalled("Fetch", blockHash)
-	return *out[0].(*eth.L1Info), out[1].(types.Transactions), out[2].(types.Receipts), *out[3].(*error)
+	return *out[0].(*eth.L1Info), out[1].(types.Transactions), out[2].(eth.ReceiptsFetcher), *out[3].(*error)
 }
 
 func (m *MockL1Source) ExpectFetch(hash common.Hash, info eth.L1Info, transactions types.Transactions, receipts types.Receipts, err error) {
-	m.Mock.On("Fetch", hash).Once().Return(&info, transactions, receipts, &err)
+	m.Mock.On("Fetch", hash).Once().Return(&info, transactions, eth.FetchedReceipts(receipts), &err)
 }
 
 func (m *MockL1Source) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.L1Info, types.Transactions, error) {


### PR DESCRIPTION
Previously receipts were being fetched in parallel RPC batches, but there was a deadlock risk due to a race-condition between accepting batch results and scheduling new requests, causing the node to lock up.

This PR gets rid of the old parallel batch fetching, in favor of a new design that:
- Lets the caller parallelize by simply calling the Fetch method in multiple go routines, and avoiding that go routine complexity in the fetcher itself.
- Lets the caller stop/pause/backoff on any fetching error, using multi-error to expose the errors of the individual RPC calls.
- Propagates RPC errors to the caller nicely, instead of the previous logging and poor retry attempts
- Eventually completes and exposes the Results

The `l1.ReceiptsFetcher` wraps the `IterativeBatchCall` to fetch receipts this way, in the future we can reuse the batching logic for other RPC interactions.

The `eth.ReceiptsFetcher` is an interface which can be used by the derivation pipeline, which does not directly import any rpc / concurrency related code. And `eth.FetchedReceipts` makes it super easy to provide a list of already available receipts, for testing and a happy path for 0 receipts to fetch.

The current implementation still calls the `Fetch` method repeatedly until complete, but in a follow-up PR I think we can refactor `PreparePayloadAttributes` to also progress more iteratively, since it does many RPC calls it's worth it to recover from any one of them, instead of starting over on any error.

This PR also fixes the L1 receipts cache: we were not adding the receipts to the cache. Now we cache the `eth.ReceiptsFetcher` job of fetching the receipts, which is safe to concurrently fetch for, and stores the results.

And in #3188 I made the mistake of scaling the receipts/transactions cache sizes by a multiple of the blocks cache, even though receipts/transactions are cached as lists per block (@tuxcanfly sorry I misunderstood your comment in that PR, I think you were right about the cache size issue).

Fix ENG-2505
