### PR TITLE
op-node/specs: refactor batch queue, add parent_hash to batches, extend testing

### DIFF
--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -68,6 +68,7 @@ func TestAttributesQueue_Step(t *testing.T) {
 	out.ExpectSafeL2Head(safeHead)
 
 	batch := &BatchData{BatchV1{
+		ParentHash:   safeHead.Hash,
 		EpochNum:     rollup.Epoch(l1Info.InfoNum),
 		EpochHash:    l1Info.InfoHash,
 		Timestamp:    safeHead.Time + cfg.BlockTime,

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -35,9 +35,10 @@ const (
 )
 
 type BatchV1 struct {
-	EpochNum  rollup.Epoch // aka l1 num
-	EpochHash common.Hash  // block hash
-	Timestamp uint64
+	ParentHash common.Hash  // parent L2 block hash
+	EpochNum   rollup.Epoch // aka l1 num
+	EpochHash  common.Hash  // block hash
+	Timestamp  uint64
 	// no feeRecipient address input, all fees go to a L2 contract
 	Transactions []hexutil.Bytes
 }

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sort"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -33,15 +31,6 @@ type BatchQueueOutput interface {
 	SafeL2Head() eth.L2BlockRef
 }
 
-type BatchWithL1InclusionBlock struct {
-	L1InclusionBlock eth.L1BlockRef
-	Batch            *BatchData
-}
-
-func (b BatchWithL1InclusionBlock) Epoch() eth.BlockID {
-	return b.Batch.Epoch()
-}
-
 // BatchQueue contains a set of batches for every L1 block.
 // L1 blocks are contiguous and this does not support reorgs.
 type BatchQueue struct {
@@ -49,24 +38,19 @@ type BatchQueue struct {
 	config   *rollup.Config
 	next     BatchQueueOutput
 	progress Progress
-	dl       L1BlockRefByNumberFetcher
 
 	l1Blocks []eth.L1BlockRef
 
-	// All batches with the same L2 block number. Batches are ordered by when they are seen.
-	// Do a linear scan over the batches rather than deeply nested maps.
-	// Note: Only a single batch with the same tuple (block number, timestamp, epoch) is allowed.
-	batchesByTimestamp map[uint64][]*BatchWithL1InclusionBlock
+	// batches in order of when we've first seen them
+	batches []*BatchWithL1InclusionBlock
 }
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.
-func NewBatchQueue(log log.Logger, cfg *rollup.Config, dl L1BlockRefByNumberFetcher, next BatchQueueOutput) *BatchQueue {
+func NewBatchQueue(log log.Logger, cfg *rollup.Config, next BatchQueueOutput) *BatchQueue {
 	return &BatchQueue{
-		log:                log,
-		config:             cfg,
-		next:               next,
-		dl:                 dl,
-		batchesByTimestamp: make(map[uint64][]*BatchWithL1InclusionBlock),
+		log:    log,
+		config: cfg,
+		next:   next,
 	}
 }
 
@@ -83,35 +67,26 @@ func (bq *BatchQueue) Step(ctx context.Context, outer Progress) error {
 		}
 		return nil
 	}
-	batches, err := bq.deriveBatches(ctx, bq.next.SafeL2Head())
+	batch, err := bq.deriveNextBatch(ctx)
 	if err == io.EOF {
-		bq.log.Trace("Out of batches")
+		// very noisy, commented for now, or we should bump log level from trace to debug
+		// bq.log.Trace("need more L1 data before deriving next batch", "progress", bq.progress.Origin)
 		return io.EOF
 	} else if err != nil {
 		return err
 	}
-
-	for _, batch := range batches {
-		if uint64(batch.Timestamp) <= bq.next.SafeL2Head().Time {
-			bq.log.Debug("Dropping batch", "SafeL2Head", bq.next.SafeL2Head(), "SafeL2Head_Time", bq.next.SafeL2Head().Time, "batch_timestamp", batch.Timestamp)
-			// drop attributes if we are still progressing towards the next stage
-			// (after a reset rolled us back a full sequence window)
-			continue
-		}
-		bq.next.AddBatch(batch)
-	}
+	bq.next.AddBatch(batch)
 	return nil
 }
 
 func (bq *BatchQueue) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error {
-	// Copy over the Origin the from the next stage
+	// Copy over the Origin from the next stage
 	// It is set in the engine queue (two stages away) such that the L2 Safe Head origin is the progress
 	bq.progress = bq.next.Progress()
-	bq.batchesByTimestamp = make(map[uint64][]*BatchWithL1InclusionBlock)
-	// Include the new origin as an origin to build off of.
+	bq.batches = bq.batches[:0]
+	// Include the new origin as an origin to build on
 	bq.l1Blocks = bq.l1Blocks[:0]
 	bq.l1Blocks = append(bq.l1Blocks, bq.progress.Origin)
-
 	return io.EOF
 }
 
@@ -122,196 +97,132 @@ func (bq *BatchQueue) AddBatch(batch *BatchData) {
 	if len(bq.l1Blocks) == 0 {
 		panic(fmt.Errorf("cannot add batch with timestamp %d, no origin was prepared", batch.Timestamp))
 	}
-	bq.log.Trace("queuing batch", "origin", bq.progress.Origin, "tx_count", len(batch.Transactions), "timestamp", batch.Timestamp)
+	log := bq.log.New(
+		"current_l1", bq.progress.Origin,
+		"batch_timestamp", batch.Timestamp,
+		"batch_epoch", batch.Epoch(),
+		"txs", len(batch.Transactions),
+	)
+	log.Trace("queuing batch")
 
 	data := BatchWithL1InclusionBlock{
 		L1InclusionBlock: bq.progress.Origin,
 		Batch:            batch,
 	}
-	batches, ok := bq.batchesByTimestamp[batch.Timestamp]
-	// Filter complete duplicates. This step is not strictly needed as we always append, but it is nice to avoid lots of spam.
-	if ok {
-		for _, b := range batches {
-			if b.Batch.Timestamp == batch.Timestamp && b.Batch.Epoch() == batch.Epoch() {
-				bq.log.Warn("duplicate batch", "epoch", batch.Epoch(), "timestamp", batch.Timestamp, "txs", len(batch.Transactions))
-				return
-			}
-		}
-	} else {
-		bq.log.Debug("First seen batch", "epoch", batch.Epoch(), "timestamp", batch.Timestamp, "txs", len(batch.Transactions))
+	validity := CheckBatch(bq.config, bq.log, bq.l1Blocks, bq.next.SafeL2Head(), &data)
+	if validity == BatchDrop {
+		log.Warn("ingested invalid batch from L1, dropping it instead of buffering it")
+		return
 	}
-	// May have duplicate block numbers or individual fields, but have limited complete duplicates
-	bq.batchesByTimestamp[batch.Timestamp] = append(batches, &data)
+	bq.batches = append(bq.batches, &data)
 }
 
-// validExtension determines if a batch follows the previous attributes
-func (bq *BatchQueue) validExtension(batch *BatchWithL1InclusionBlock, prevTime, prevEpoch uint64) (valid bool, err error) {
-	if batch.Batch.Timestamp != prevTime+bq.config.BlockTime {
-		bq.log.Debug("Batch does not extend the block time properly", "time", batch.Batch.Timestamp, "prev_time", prevTime)
-		return false, nil
-	}
-	if batch.Batch.EpochNum != rollup.Epoch(prevEpoch) && batch.Batch.EpochNum != rollup.Epoch(prevEpoch+1) {
-		bq.log.Debug("Batch does not extend the epoch properly", "epoch", batch.Batch.EpochNum, "prev_epoch", prevEpoch)
-		return false, nil
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	l1BlockRef, err := bq.dl.L1BlockRefByNumber(ctx, batch.Batch.Epoch().Number)
-	cancel()
-	if err != nil {
-		return false, err
-	}
-
-	if l1BlockRef.Hash != batch.Batch.EpochHash {
-		bq.log.Debug("Batch epoch hash does not match expected L1 block hash", "batch_epoch", batch.Batch.Epoch(), "expected", l1BlockRef.ID())
-		return false, nil
-	}
-
-	// Note: `Batch.EpochNum` is an external input, but it is constrained to be a reasonable size by the
-	// above equality checks.
-	if uint64(batch.Batch.EpochNum)+bq.config.SeqWindowSize < batch.L1InclusionBlock.Number {
-		bq.log.Debug("Batch submitted outside sequence window", "epoch", batch.Batch.EpochNum, "inclusion_block", batch.L1InclusionBlock.Number)
-		return false, nil
-	}
-	return true, nil
-}
-
-// deriveBatches pulls a single batch eagerly or a collection of batches if it is the end of
-// the sequencing window.
-func (bq *BatchQueue) deriveBatches(ctx context.Context, l2SafeHead eth.L2BlockRef) ([]*BatchData, error) {
+// deriveNextBatch derives the next batch.
+// If no batch can be derived yet, then (nil, io.EOF) is returned.
+func (bq *BatchQueue) deriveNextBatch(ctx context.Context) (*BatchData, error) {
 	if len(bq.l1Blocks) == 0 {
-		return nil, io.EOF
+		panic("cannot derive next batch, no origin was prepared")
 	}
 	epoch := bq.l1Blocks[0]
+	l2SafeHead := bq.next.SafeL2Head()
 
-	// Decide if need to fill out empty batches & process an epoch at once
-	// If not, just return a single batch
-	// Note: can't process a full epoch until we are closed
-	if bq.progress.Origin.Number >= epoch.Number+bq.config.SeqWindowSize && bq.progress.Closed {
-		bq.log.Info("Advancing full epoch", "origin", epoch, "tip", bq.progress.Origin)
-		// 2a. Gather all batches. First sort by timestamp and then by first seen.
-		var bns []uint64
-		for n := range bq.batchesByTimestamp {
-			bns = append(bns, n)
+	if l2SafeHead.L1Origin != epoch.ID() {
+		return nil, NewResetError(fmt.Errorf("buffered L1 chain epoch %s in batch queue does not match safe head %s", epoch, l2SafeHead))
+	}
+
+	// Find the first-seen batch that matches all validity conditions.
+	// We may not have sufficient information to proceed filtering, and then we stop.
+	// There may be none: in that case we force-create an empty batch
+	nextTimestamp := l2SafeHead.Time + bq.config.BlockTime
+	var nextBatch *BatchWithL1InclusionBlock
+
+	// Go over all batches, in order of inclusion, and find the first batch we can accept.
+	// We filter in-place by only remembering the batches that may be processed in the future, or those we are undecided on.
+	remaining := bq.batches[:0]
+batchLoop:
+	for i, batch := range bq.batches {
+		validity := CheckBatch(bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch)
+		switch validity {
+		case BatchFuture:
+			remaining = append(remaining, batch)
+			continue
+		case BatchDrop:
+			bq.log.Warn("dropping batch",
+				"batch_timestamp", batch.Batch.Timestamp,
+				"parent_hash", batch.Batch.ParentHash,
+				"batch_epoch", batch.Batch.Epoch(),
+				"txs", len(batch.Batch.Transactions),
+				"l2_safe_head", l2SafeHead.ID(),
+				"l2_safe_head_time", l2SafeHead.Time,
+			)
+			continue
+		case BatchAccept:
+			nextBatch = batch
+			// remove the current batch since we are processing it now, and retain every batch we didn't get to yet.
+			remaining = append(remaining, bq.batches[i+1:]...)
+			break batchLoop
+		case BatchUndecided:
+			remaining = append(remaining, batch)
+			bq.batches = remaining
+			return nil, io.EOF
+		default:
+			panic(fmt.Errorf("unknown batch validity type: %d", validity))
 		}
-		sort.Slice(bns, func(i, j int) bool { return bns[i] < bns[j] })
+	}
+	bq.batches = remaining
 
-		var batches []*BatchData
-		for _, n := range bns {
-			for _, batch := range bq.batchesByTimestamp[n] {
-				// Filter out batches that were submitted too late.
-				if uint64(batch.Batch.EpochNum)+bq.config.SeqWindowSize < batch.L1InclusionBlock.Number {
-					continue
-				}
-				// Pre filter batches in the correct epoch
-				if batch.Batch.EpochNum == rollup.Epoch(epoch.Number) {
-					batches = append(batches, batch.Batch)
-				}
-			}
+	if nextBatch == nil {
+		// If the current epoch is too old compared to the L1 block we are at,
+		// i.e. if the sequence window expired, we create empty batches
+		expiryEpoch := epoch.Number + bq.config.SeqWindowSize
+		forceNextEpoch :=
+			(expiryEpoch == bq.progress.Origin.Number && bq.progress.Closed) ||
+				expiryEpoch < bq.progress.Origin.Number
+
+		if !forceNextEpoch {
+			// sequence window did not expire yet, still room to receive batches for the current epoch,
+			// no need to force-create empty batch(es) towards the next epoch yet.
+			return nil, io.EOF
+		}
+		if len(bq.l1Blocks) < 2 {
+			// need next L1 block to proceed towards
+			return nil, io.EOF
 		}
 
-		// 2b. Determine the valid time window
-		l1OriginTime := bq.l1Blocks[0].Time
-		nextL1BlockTime := bq.l1Blocks[1].Time // Safe b/c the epoch is the L1 Block number of the first block in L1Blocks
-		minL2Time := l2SafeHead.Time + bq.config.BlockTime
-		maxL2Time := l1OriginTime + bq.config.MaxSequencerDrift
-		newEpoch := l2SafeHead.L1Origin != epoch.ID() // Only guarantee a L2 block if we have not already produced one for this epoch.
-		if newEpoch && minL2Time+bq.config.BlockTime > maxL2Time {
-			maxL2Time = minL2Time + bq.config.BlockTime
+		nextEpoch := bq.l1Blocks[1]
+		// Fill with empty L2 blocks of the same epoch until we meet the time of the next L1 origin,
+		// to preserve that L2 time >= L1 time
+		if nextTimestamp < nextEpoch.Time {
+			return &BatchData{
+				BatchV1{
+					ParentHash:   l2SafeHead.Hash,
+					EpochNum:     rollup.Epoch(epoch.Number),
+					EpochHash:    epoch.Hash,
+					Timestamp:    nextTimestamp,
+					Transactions: nil,
+				},
+			}, nil
 		}
-
-		bq.log.Trace("found batches", "len", len(batches))
-		// Filter + Fill batches
-		batches = FilterBatches(bq.log, bq.config, epoch.ID(), minL2Time, maxL2Time, batches)
-		bq.log.Trace("filtered batches", "len", len(batches), "l1Origin", bq.l1Blocks[0], "nextL1Block", bq.l1Blocks[1], "minL2Time", minL2Time, "maxL2Time", maxL2Time)
-		batches = FillMissingBatches(batches, epoch.ID(), bq.config.BlockTime, minL2Time, nextL1BlockTime)
-		bq.log.Trace("added missing batches", "len", len(batches), "l1OriginTime", l1OriginTime, "nextL1BlockTime", nextL1BlockTime)
-		// Advance an epoch after filling all batches.
+		// As we move the safe head origin forward, we also drop the old L1 block reference
 		bq.l1Blocks = bq.l1Blocks[1:]
-
-		return batches, nil
-
+		return &BatchData{
+			BatchV1{
+				ParentHash:   l2SafeHead.Hash,
+				EpochNum:     rollup.Epoch(nextEpoch.Number),
+				EpochHash:    nextEpoch.Hash,
+				Timestamp:    nextTimestamp,
+				Transactions: nil,
+			},
+		}, nil
 	} else {
-		bq.log.Trace("Trying to eagerly find batch")
-		next, err := bq.tryPopNextBatch(ctx, l2SafeHead)
-		if err != nil {
-			return nil, err
-		} else {
-			bq.log.Info("found eager batch", "batch", next.Batch)
-			return []*BatchData{next.Batch}, nil
+		// advance epoch if necessary
+		if nextBatch.Batch.EpochNum == rollup.Epoch(epoch.Number)+1 {
+			bq.l1Blocks = bq.l1Blocks[1:]
 		}
+		// sanity check
+		if nextBatch.Batch.EpochNum > rollup.Epoch(epoch.Number)+1 {
+			return nil, NewCriticalError(fmt.Errorf("batch is advancing more than 1 epoch, from %s to %s", epoch, nextBatch.Batch.Epoch()))
+		}
+		return nextBatch.Batch, nil
 	}
-}
-
-// tryPopNextBatch tries to get the next batch from the batch queue using an eager approach.
-// It returns nil upon success, io.EOF if it does not have enough data, and a non-nil error
-// upon a temporary processing error.
-func (bq *BatchQueue) tryPopNextBatch(ctx context.Context, l2SafeHead eth.L2BlockRef) (*BatchWithL1InclusionBlock, error) {
-	// We require at least 1 L1 blocks to look at.
-	if len(bq.l1Blocks) == 0 {
-		return nil, io.EOF
-	}
-	batches, ok := bq.batchesByTimestamp[l2SafeHead.Time+bq.config.BlockTime]
-	// No more batches found.
-	if !ok {
-		return nil, io.EOF
-	}
-
-	// Find the first batch saved for this timestamp.
-	// Note that we expect the number of batches for the same timestamp to be small (frequently just 1 ).
-	for _, batch := range batches {
-		l1OriginTime := bq.l1Blocks[0].Time
-
-		// If this batch advances the epoch, check it's validity against the next L1 Origin
-		if batch.Batch.EpochNum != rollup.Epoch(l2SafeHead.L1Origin.Number) {
-			// With only 1 l1Block we cannot look at the next L1 Origin.
-			// Note: This means that we are unable to determine validity of a batch
-			// without more information. In this case we should bail out until we have
-			// more information otherwise the eager algorithm may diverge from a non-eager
-			// algorithm.
-			if len(bq.l1Blocks) < 2 {
-				bq.log.Warn("eager batch wants to advance epoch, but could not")
-				return nil, io.EOF
-			}
-			l1OriginTime = bq.l1Blocks[1].Time
-		}
-
-		// Timestamp bounds
-		minL2Time := l2SafeHead.Time + bq.config.BlockTime
-		maxL2Time := l1OriginTime + bq.config.MaxSequencerDrift
-		newEpoch := l2SafeHead.L1Origin != batch.Epoch() // Only guarantee a L2 block if we have not already produced one for this epoch.
-		if newEpoch && minL2Time+bq.config.BlockTime > maxL2Time {
-			maxL2Time = minL2Time + bq.config.BlockTime
-		}
-
-		// Note: Don't check epoch change here, check it in `validExtension`
-		epoch, err := bq.dl.L1BlockRefByNumber(ctx, uint64(batch.Batch.EpochNum))
-		if err != nil {
-			return nil, NewTemporaryError(fmt.Errorf("error fetching origin: %w", err))
-		}
-		if err := ValidBatch(batch.Batch, bq.config, epoch.ID(), minL2Time, maxL2Time); err != nil {
-			bq.log.Warn("Invalid batch", "err", err)
-			break
-		}
-
-		// We have a valid batch, no make sure that it builds off the previous L2 block
-		if valid, err := bq.validExtension(batch, l2SafeHead.Time, l2SafeHead.L1Origin.Number); err != nil {
-			return nil, err
-		} else if valid {
-			// Advance the epoch if needed
-			if l2SafeHead.L1Origin.Number != uint64(batch.Batch.EpochNum) {
-				bq.l1Blocks = bq.l1Blocks[1:]
-			}
-			// Don't leak data in the map
-			delete(bq.batchesByTimestamp, batch.Batch.Timestamp)
-
-			bq.log.Debug("Batch was valid extension")
-
-			// We have found the fist valid batch.
-			return batch, nil
-		} else {
-			bq.log.Warn("batch was not valid extension", "inclusion", batch.L1InclusionBlock, "safe_origin", l2SafeHead.L1Origin, "l2_time", l2SafeHead.Time)
-		}
-	}
-
-	return nil, io.EOF
 }

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -3,6 +3,8 @@ package derive
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,6 +13,7 @@ func TestBatchRoundTrip(t *testing.T) {
 	batches := []*BatchData{
 		{
 			BatchV1: BatchV1{
+				ParentHash:   common.Hash{},
 				EpochNum:     0,
 				Timestamp:    0,
 				Transactions: []hexutil.Bytes{},
@@ -18,6 +21,7 @@ func TestBatchRoundTrip(t *testing.T) {
 		},
 		{
 			BatchV1: BatchV1{
+				ParentHash:   common.Hash{31: 0x42},
 				EpochNum:     1,
 				Timestamp:    1647026951,
 				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -1,106 +1,121 @@
 package derive
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var DifferentEpoch = errors.New("batch is of different epoch")
-
-func FilterBatches(log log.Logger, config *rollup.Config, epoch eth.BlockID, minL2Time uint64, maxL2Time uint64, batches []*BatchData) (out []*BatchData) {
-	uniqueTime := make(map[uint64]struct{})
-	for _, batch := range batches {
-		if err := ValidBatch(batch, config, epoch, minL2Time, maxL2Time); err != nil {
-			if err == DifferentEpoch {
-				log.Trace("ignoring batch of different epoch", "expected_epoch", epoch,
-					"epoch", batch.Epoch(), "timestamp", batch.Timestamp, "txs", len(batch.Transactions))
-			} else {
-				log.Warn("filtered batch", "expected_epoch", epoch, "min", minL2Time, "max", maxL2Time,
-					"epoch", batch.Epoch(), "timestamp", batch.Timestamp, "txs", len(batch.Transactions), "err", err)
-			}
-			continue
-		}
-		// Check if we have already seen a batch for this L2 block
-		if _, ok := uniqueTime[batch.Timestamp]; ok {
-			log.Warn("duplicate batch", "epoch", batch.Epoch(), "timestamp", batch.Timestamp, "txs", len(batch.Transactions))
-			// block already exists, batch is duplicate (first batch persists, others are ignored)
-			continue
-		}
-		uniqueTime[batch.Timestamp] = struct{}{}
-		out = append(out, batch)
-	}
-	return
+type BatchWithL1InclusionBlock struct {
+	L1InclusionBlock eth.L1BlockRef
+	Batch            *BatchData
 }
 
-func ValidBatch(batch *BatchData, config *rollup.Config, epoch eth.BlockID, minL2Time uint64, maxL2Time uint64) error {
-	if batch.EpochNum != rollup.Epoch(epoch.Number) {
-		// Batch was tagged for past or future epoch,
-		// i.e. it was included too late or depends on the given L1 block to be processed first.
-		// This is a very common error, batches may just be buffered for a later epoch.
-		return DifferentEpoch
+type BatchValidity uint8
+
+const (
+	// BatchDrop indicates that the batch is invalid, and will always be in the future, unless we reorg
+	BatchDrop = iota
+	// BatchAccept indicates that the batch is valid and should be processed
+	BatchAccept
+	// BatchUndecided indicates we are lacking L1 information until we can proceed batch filtering
+	BatchUndecided
+	// BatchFuture indicates that the batch may be valid, but cannot be processed yet and should be checked again later
+	BatchFuture
+)
+
+func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock) BatchValidity {
+	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
+	if batch.Batch.Timestamp > nextTimestamp {
+		// no log, very common case, this happens when batches are included early or out of order.
+		return BatchFuture
 	}
-	if batch.EpochHash != epoch.Hash {
-		return fmt.Errorf("batch was meant for alternative L1 chain")
+	// add details to the log
+	log = log.New(
+		"batch_timestamp", batch.Batch.Timestamp,
+		"parent_hash", batch.Batch.ParentHash,
+		"batch_epoch", batch.Batch.Epoch(),
+		"txs", len(batch.Batch.Transactions),
+	)
+
+	// sanity check we have consistent inputs
+	if len(l1Blocks) == 0 {
+		log.Warn("missing L1 block input, cannot proceed with batch checking")
+		return BatchUndecided
 	}
-	if (batch.Timestamp-config.Genesis.L2Time)%config.BlockTime != 0 {
-		return fmt.Errorf("bad timestamp %d, not a multiple of the block time", batch.Timestamp)
+	if l1Blocks[0].Hash != l2SafeHead.L1Origin.Hash {
+		log.Warn("safe L2 head L1 origin does not match batch first l1 block",
+			"safe_l2", l2SafeHead, "safe_origin", l2SafeHead.L1Origin, "l1_block", l1Blocks[0])
+		return BatchUndecided
 	}
-	if batch.Timestamp < minL2Time {
-		return fmt.Errorf("old batch: %d < %d", batch.Timestamp, minL2Time)
+
+	if batch.Batch.Timestamp < nextTimestamp {
+		log.Debug("dropping batch with old timestamp", "min_timestamp", nextTimestamp)
+		return BatchDrop
 	}
-	// limit timestamp upper bound to avoid huge amount of empty blocks
-	if batch.Timestamp >= maxL2Time {
-		return fmt.Errorf("batch too far into future: %d > %d", batch.Timestamp, maxL2Time)
+
+	// dependent on above timestamp check. If the timestamp is correct, then it must build on top of the safe head.
+	if batch.Batch.ParentHash != l2SafeHead.Hash {
+		log.Warn("ignoring batch with mismatching parent hash", "current_safe_head", l2SafeHead.Hash)
+		return BatchDrop
 	}
-	for i, txBytes := range batch.Transactions {
+
+	// Filter out batches that were included too late.
+	if uint64(batch.Batch.EpochNum)+cfg.SeqWindowSize < batch.L1InclusionBlock.Number {
+		log.Warn("batch was included too late, sequence window expired")
+		return BatchDrop
+	}
+
+	epoch := l1Blocks[0]
+
+	// Check the L1 origin of the batch
+	batchOrigin := epoch
+	if uint64(batch.Batch.EpochNum) < epoch.Number {
+		log.Warn("dropped batch, epoch is too old", "minimum", epoch.ID())
+		// batch epoch too old
+		return BatchDrop
+	} else if uint64(batch.Batch.EpochNum) == epoch.Number {
+		// Batch is sticking to the current epoch, continue.
+	} else if uint64(batch.Batch.EpochNum) == epoch.Number+1 {
+		// With only 1 l1Block we cannot look at the next L1 Origin.
+		// Note: This means that we are unable to determine validity of a batch
+		// without more information. In this case we should bail out until we have
+		// more information otherwise the eager algorithm may diverge from a non-eager
+		// algorithm.
+		if len(l1Blocks) < 2 {
+			log.Info("eager batch wants to advance epoch, but could not without more L1 blocks", "current_epoch", epoch.ID())
+			return BatchUndecided
+		}
+		batchOrigin = l1Blocks[1]
+	} else {
+		log.Warn("batch is for future epoch too far ahead, while it has the next timestamp, so it must be invalid", "current_epoch", epoch.ID())
+		return BatchDrop
+	}
+
+	if batch.Batch.EpochHash != batchOrigin.Hash {
+		log.Warn("batch is for different L1 chain, epoch hash does not match", "expected", batchOrigin.ID())
+		return BatchDrop
+	}
+
+	// If we ran out of sequencer time drift, then we drop the batch and produce an empty batch instead,
+	// as the sequencer is not allowed to include anything past this point without moving to the next epoch.
+	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Batch.Timestamp > max {
+		log.Warn("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again", "max_time", max)
+		return BatchDrop
+	}
+
+	// We can do this check earlier, but it's a more intensive one, so we do this last.
+	for i, txBytes := range batch.Batch.Transactions {
 		if len(txBytes) == 0 {
-			return fmt.Errorf("transaction data must not be empty, but tx %d is empty", i)
+			log.Debug("transaction data must not be empty, but found empty tx", "tx_index", i)
+			return BatchDrop
 		}
 		if txBytes[0] == types.DepositTxType {
-			return fmt.Errorf("sequencers may not embed any deposits into batch data, but tx %d has one", i)
+			log.Debug("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", i)
+			return BatchDrop
 		}
 	}
-	return nil
-}
 
-// FillMissingBatches turns a collection of batches to the input batches for a series of blocks
-func FillMissingBatches(batches []*BatchData, epoch eth.BlockID, blockTime, minL2Time, nextL1Time uint64) []*BatchData {
-	m := make(map[uint64]*BatchData)
-	// The number of L2 blocks per sequencing window is variable, we do not immediately fill to maxL2Time:
-	// - ensure at least 1 block
-	// - fill up to the next L1 block timestamp, if higher, to keep up with L1 time
-	// - fill up to the last valid batch, to keep up with L2 time
-	newHeadL2Timestamp := minL2Time
-	if nextL1Time > newHeadL2Timestamp+1 {
-		newHeadL2Timestamp = nextL1Time - 1
-	}
-	for _, b := range batches {
-		m[b.Timestamp] = b
-		if b.Timestamp > newHeadL2Timestamp {
-			newHeadL2Timestamp = b.Timestamp
-		}
-	}
-	var out []*BatchData
-	for t := minL2Time; t <= newHeadL2Timestamp; t += blockTime {
-		b, ok := m[t]
-		if ok {
-			out = append(out, b)
-		} else {
-			out = append(out,
-				&BatchData{
-					BatchV1{
-						EpochNum:  rollup.Epoch(epoch.Number),
-						EpochHash: epoch.Hash,
-						Timestamp: t,
-					},
-				})
-		}
-
-	}
-	return out
+	return BatchAccept
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -25,6 +25,9 @@ const (
 	BatchFuture
 )
 
+// CheckBatch checks if the given batch can be applied on top of the given l2SafeHead, given the contextual L1 blocks the batch was included in.
+// The first entry of the l1Blocks should match the origin of the l2SafeHead. One or more consecutive l1Blocks should be provided.
+// In case of only a single L1 block, the decision whether a batch is valid may have to stay undecided.
 func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock) BatchValidity {
 	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
 	if batch.Batch.Timestamp > nextTimestamp {

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -1,174 +1,448 @@
 package derive
 
 import (
+	"math/rand"
 	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type ValidBatchTestCase struct {
-	Name      string
-	Epoch     rollup.Epoch
-	EpochHash common.Hash
-	MinL2Time uint64
-	MaxL2Time uint64
-	Batch     BatchData
-	Valid     bool
+	Name       string
+	L1Blocks   []eth.L1BlockRef
+	L2SafeHead eth.L2BlockRef
+	Batch      BatchWithL1InclusionBlock
+	Expected   BatchValidity
 }
 
 var HashA = common.Hash{0x0a}
 var HashB = common.Hash{0x0b}
 
 func TestValidBatch(t *testing.T) {
-	testCases := []ValidBatchTestCase{
-		{
-			Name:      "valid epoch",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    43,
-				Transactions: []hexutil.Bytes{{0x01, 0x13, 0x37}, {0x02, 0x13, 0x37}},
-			}},
-			Valid: true,
-		},
-		{
-			Name:      "ignored epoch",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     122,
-				EpochHash:    HashA,
-				Timestamp:    43,
-				Transactions: nil,
-			}},
-			Valid: false,
-		},
-		{
-			Name:      "too old",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    42,
-				Transactions: nil,
-			}},
-			Valid: false,
-		},
-		{
-			Name:      "too new",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    52,
-				Transactions: nil,
-			}},
-			Valid: false,
-		},
-		{
-			Name:      "wrong time alignment",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    46,
-				Transactions: nil,
-			}},
-			Valid: false,
-		},
-		{
-			Name:      "good time alignment",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    51, // 31 + 2*10
-				Transactions: nil,
-			}},
-			Valid: true,
-		},
-		{
-			Name:      "empty tx",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    43,
-				Transactions: []hexutil.Bytes{{}},
-			}},
-			Valid: false,
-		},
-		{
-			Name:      "sneaky deposit",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashA,
-				Timestamp:    43,
-				Transactions: []hexutil.Bytes{{0x01}, {types.DepositTxType, 0x13, 0x37}, {0xc0, 0x13, 0x37}},
-			}},
-			Valid: false,
-		},
-		{
-			Name:      "wrong epoch hash",
-			Epoch:     123,
-			EpochHash: HashA,
-			MinL2Time: 43,
-			MaxL2Time: 52,
-			Batch: BatchData{BatchV1: BatchV1{
-				EpochNum:     123,
-				EpochHash:    HashB,
-				Timestamp:    43,
-				Transactions: []hexutil.Bytes{{0x01, 0x13, 0x37}, {0x02, 0x13, 0x37}},
-			}},
-			Valid: false,
-		},
-	}
 	conf := rollup.Config{
 		Genesis: rollup.Genesis{
 			L2Time: 31, // a genesis time that itself does not align to make it more interesting
 		},
-		BlockTime: 2,
+		BlockTime:         2,
+		SeqWindowSize:     4,
+		MaxSequencerDrift: 6,
 		// other config fields are ignored and can be left empty.
 	}
+
+	rng := rand.New(rand.NewSource(1234))
+	l1A := testutils.RandomBlockRef(rng)
+	l1B := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1A.Number + 1,
+		ParentHash: l1A.Hash,
+		Time:       l1A.Time + 7,
+	}
+	l1C := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1B.Number + 1,
+		ParentHash: l1B.Hash,
+		Time:       l1B.Time + 7,
+	}
+	l1D := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1C.Number + 1,
+		ParentHash: l1C.Hash,
+		Time:       l1C.Time + 7,
+	}
+	l1E := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1D.Number + 1,
+		ParentHash: l1D.Hash,
+		Time:       l1D.Time + 7,
+	}
+	l1F := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1E.Number + 1,
+		ParentHash: l1E.Hash,
+		Time:       l1E.Time + 7,
+	}
+
+	l2A0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         100,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           l1A.Time,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 0,
+	}
+
+	l2A1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A0.Number + 1,
+		ParentHash:     l2A0.Hash,
+		Time:           l2A0.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 1,
+	}
+
+	l2A2 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A1.Number + 1,
+		ParentHash:     l2A1.Hash,
+		Time:           l2A1.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 2,
+	}
+
+	l2A3 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A2.Number + 1,
+		ParentHash:     l2A2.Hash,
+		Time:           l2A2.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 3,
+	}
+
+	l2B0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A3.Number + 1,
+		ParentHash:     l2A3.Hash,
+		Time:           l2A3.Time + conf.BlockTime, // 8 seconds larger than l1A0, 1 larger than origin
+		L1Origin:       l1B.ID(),
+		SequenceNumber: 0,
+	}
+
+	l1X := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     42,
+		ParentHash: testutils.RandomHash(rng),
+		Time:       10_000,
+	}
+	l1Y := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1X.Number + 1,
+		ParentHash: l1X.Hash,
+		Time:       l1X.Time + 12,
+	}
+	l1Z := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1Y.Number + 1,
+		ParentHash: l1Y.Hash,
+		Time:       l1Y.Time + 12,
+	}
+	l2X0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         1000,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           10_000 + 12 + 6 - 1, // add one block, and you get ahead of next l1 block by more than the drift
+		L1Origin:       l1X.ID(),
+		SequenceNumber: 0,
+	}
+	l2Y0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2X0.Number + 1,
+		ParentHash:     l2X0.Hash,
+		Time:           l2X0.Time + conf.BlockTime, // exceeds sequencer time drift, forced to be empty block
+		L1Origin:       l1Y.ID(),
+		SequenceNumber: 0,
+	}
+
+	testCases := []ValidBatchTestCase{
+		{
+			Name:       "future timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time + 1, // 1 too high
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchFuture,
+		},
+		{
+			Name:       "missing L1 info",
+			L1Blocks:   []eth.L1BlockRef{},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "inconsistent L1 info",
+			L1Blocks:   []eth.L1BlockRef{l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "old timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A0.Time, // repeating the same time
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "misaligned timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time - 1, // block time is 2, so this is 1 too low
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "invalid parent block hash",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   testutils.RandomHash(rng),
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequence window expired",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D, l1E, l1F},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1F, // included in 5th block after epoch of batch, while seq window is 4
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch too old", // repeat of now outdated l2A3 data
+			L1Blocks:   []eth.L1BlockRef{l1B, l1C, l1D},
+			L2SafeHead: l2B0, // we already moved on to B
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A3.ParentHash,
+					EpochNum:     rollup.Epoch(l2A3.L1Origin.Number), // epoch A is no longer valid
+					EpochHash:    l2A3.L1Origin.Hash,
+					Timestamp:    l2A3.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "insufficient L1 info for eager derivation",
+			L1Blocks:   []eth.L1BlockRef{l1A}, // don't know about l1B yet
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2B0.ParentHash,
+					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:    l2B0.L1Origin.Hash,
+					Timestamp:    l2B0.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "epoch too new",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1D,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2B0.ParentHash,
+					EpochNum:     rollup.Epoch(l1C.Number), // invalid, we need to adopt epoch B before C
+					EpochHash:    l1C.Hash,
+					Timestamp:    l2B0.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch hash wrong",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2B0.ParentHash,
+					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
+					Timestamp:    l2B0.Time,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on same epoch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+					ParentHash:   l2A3.Hash,
+					EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+					EpochHash:    l2A3.L1Origin.Hash,
+					Timestamp:    l2A3.Time + conf.BlockTime,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on changing epoch",
+			L1Blocks:   []eth.L1BlockRef{l1X, l1Y, l1Z},
+			L2SafeHead: l2X0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1Z,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2Y0.ParentHash,
+					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+					EpochHash:    l2Y0.L1Origin.Hash,
+					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "empty tx included",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash: l2A1.ParentHash,
+					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:  l2A1.L1Origin.Hash,
+					Timestamp:  l2A1.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{}, // empty tx data
+					},
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "deposit tx included",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash: l2A1.ParentHash,
+					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:  l2A1.L1Origin.Hash,
+					Timestamp:  l2A1.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{types.DepositTxType, 0}, // piece of data alike to a deposit
+					},
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "valid batch same epoch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash: l2A1.ParentHash,
+					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:  l2A1.L1Origin.Hash,
+					Timestamp:  l2A1.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{0x02, 0x42, 0x13, 0x37},
+						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "valid batch changing epoch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV1{
+					ParentHash: l2B0.ParentHash,
+					EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:  l2B0.L1Origin.Hash,
+					Timestamp:  l2B0.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{0x02, 0x42, 0x13, 0x37},
+						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+	}
+
+	// Log level can be increased for debugging purposes
+	logger := testlog.Logger(t, log.LvlError)
+
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			epoch := eth.BlockID{
-				Number: uint64(testCase.Epoch),
-				Hash:   testCase.EpochHash,
-			}
-			err := ValidBatch(&testCase.Batch, &conf, epoch, testCase.MinL2Time, testCase.MaxL2Time)
-			if (err == nil) != testCase.Valid {
-				t.Fatalf("case %v was expected to return %v, but got %v (%v)", testCase, testCase.Valid, err == nil, err)
-			}
+			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch)
+			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
 		})
 	}
 }

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -153,22 +153,6 @@ func TestValidBatch(t *testing.T) {
 
 	testCases := []ValidBatchTestCase{
 		{
-			Name:       "future timestamp",
-			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
-			L2SafeHead: l2A0,
-			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
-					ParentHash:   l2A1.ParentHash,
-					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:    l2A1.L1Origin.Hash,
-					Timestamp:    l2A1.Time + 1, // 1 too high
-					Transactions: nil,
-				}},
-			},
-			Expected: BatchFuture,
-		},
-		{
 			Name:       "missing L1 info",
 			L1Blocks:   []eth.L1BlockRef{},
 			L2SafeHead: l2A0,
@@ -199,6 +183,22 @@ func TestValidBatch(t *testing.T) {
 				}},
 			},
 			Expected: BatchUndecided,
+		},
+		{
+			Name:       "future timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time + 1, // 1 too high
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchFuture,
 		},
 		{
 			Name:       "old timestamp",

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -162,6 +162,7 @@ func blockToBatch(block *types.Block, w io.Writer) error {
 	}
 
 	batch := &BatchData{BatchV1{
+		ParentHash:   block.ParentHash(),
 		EpochNum:     rollup.Epoch(l1Info.Number),
 		EpochHash:    l1Info.BlockHash,
 		Timestamp:    block.Time(),

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -77,7 +77,7 @@ type DerivationPipeline struct {
 func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetcher, engine Engine) *DerivationPipeline {
 	eng := NewEngineQueue(log, cfg, engine)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
-	batchQueue := NewBatchQueue(log, cfg, l1Fetcher, attributesQueue)
+	batchQueue := NewBatchQueue(log, cfg, attributesQueue)
 	chInReader := NewChannelInReader(log, batchQueue)
 	bank := NewChannelBank(log, cfg, chInReader)
 	dataSrc := NewCalldataSource(log, cfg, l1Fetcher)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -30,7 +30,7 @@ type Config struct {
 	// Note: When L1 has many 1 second consecutive blocks, and L2 grows at fixed 2 seconds,
 	// the L2 time may still grow beyond this difference.
 	MaxSequencerDrift uint64 `json:"max_sequencer_drift"`
-	// Number of epochs (L1 blocks) per sequencing window
+	// Number of epochs (L1 blocks) per sequencing window, including the epoch L1 origin block itself
 	SeqWindowSize uint64 `json:"seq_window_size"`
 	// Number of seconds (w.r.t. L1 time) that a frame can be valid when included in L1
 	ChannelTimeout uint64 `json:"channel_timeout"`

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -392,14 +392,15 @@ Recall that a batch contains a list of transactions to be included in a specific
 
 A batch is encoded as `batch_version ++ content`, where `content` depends on the version:
 
-| `batch_version` | `content`                                                             |
-| --------------- | --------------------------------------------------------------------- |
-| 0               | `rlp_encode([epoch_number, epoch_hash, timestamp, transaction_list])` |
+| `batch_version` | `content`                                                                          |
+| --------------- |------------------------------------------------------------------------------------|
+| 0               | `rlp_encode([parent_hash, epoch_number, epoch_hash, timestamp, transaction_list])` |
 
 where:
 
 - `rlp_encode` is a function that encodes a batch according to the [RLP format], and `[x, y, z]` denotes a list
   containing items `x`, `y` and `z`
+- `parent_hash` is the block hash of the previous L2 block
 - `epoch_number` and `epoch_hash` are the number and hash of the L1 block corresponding to the [sequencing
   epoch][g-sequencing-epoch] of the L2 block
 - `timestamp` is the timestamp of the L2 block
@@ -552,28 +553,63 @@ Note that the presence of any gaps in the batches derived from L1 means that thi
 [sequencing window][g-sequencing-window] before it can generate empty batches (because the missing batch(es) could have
 data in the last L1 block of the window in the worst case).
 
-We also ignore invalid batches, which do not satisfy one of the following constraints:
+A batch can have 4 different forms of validity:
 
-- The timestamp is aligned to the [block time][g-block-time]:
-  `(batch.timestamp - genesis_l2_timestamp) % block_time == 0`
-- The timestamp is within the allowed range: `min_l2_timestamp <= batch.timestamp < max_l2_timestamp`, where
-  - all these values are denominated in seconds
-  - `min_l2_timestamp = prev_l2_timestamp + l2_block_time`
-    - `prev_l2_timestamp` is the timestamp of the previous L2 block: the last block of the previous epoch,
-      or the L2 genesis block timestamp if there is no previous epoch.
-    - `l2_block_time` is a configurable parameter of the time between L2 blocks (on Optimism, 2s)
-  - `max_l2_timestamp = max(l1_timestamp + max_sequencer_drift, min_l2_timestamp + l2_block_time)`
-    - `l1_timestamp` is the timestamp of the L1 block associated with the L2 block's epoch
-    - `max_sequencer_drift` is the maximum amount of time an L2 block's timestamp is allowed to get ahead of the
-       timestamp of its [L1 origin][g-l1-origin]
-  - Note that we always have `min_l2_timestamp >= l1_timestamp`, i.e. a L2 block timestamp is always equal or ahead of
-    the timestamp of its [L1 origin][g-l1-origin].
-- The batch is the first batch with `batch.timestamp` in this sequencing window, i.e. one batch per L2 block number.
-- The batch only contains sequenced transactions, i.e. it must NOT contain any [deposited-type transactions][
-  g-deposit-tx-type].
+- `drop`: the batch is invalid, and will always be in the future, unless we reorg. It can be removed from the buffer.
+- `accept`: the batch is valid and should be processed.
+- `undecided`: we are lacking L1 information until we can proceed batch filtering.
+- `future`: the batch may be valid, but cannot be processed yet and should be checked again later.
 
-> **TODO** specify `max_sequencer_drift` (see TODO above) (current thinking: on the order of 10 minutes, we've been
-> using 2-4 minutes in testnets)
+The batches are processed in order of the inclusion on L1: if multiple batches can be `accept`-ed the first is applied.
+
+The batches validity is derived as follows:
+
+Definitions:
+
+- `batch` as defined in the [Batch format section][batch-format].
+- `epoch = safe_l2_head.l1_origin` a [L1 origin][g-l1-origin] coupled to the batch, with properties:
+  `number` (L1 block number), `hash` (L1 block hash), and `timestamp` (L1 block timestamp).
+- `inclusion_block_number` is the L1 block number when `batch` was first *fully* derived.
+- `next_timestamp = safe_l2_head.timestamp + block_time` is the expected L2 timestamp the next batch should have,
+  see [block time information][g-block-time].
+- `next_epoch` may not be known yet, but would be the L1 block after `epoch` if available.
+- `batch_origin` is either `epoch` or `next_epoch`, depending on validation.
+
+Rules:
+
+- `batch.timestamp > next_timestamp` -> `future`: i.e. the batch must be ready to process.
+- `batch.timestamp < next_timestamp` -> `drop`: i.e. the batch must not be too old.
+- `batch.parent_hash != safe_l2_head.hash` -> `drop`: i.e. the parent hash must be equal to the L2 safe head block hash.
+- `batch.epoch_num + sequence_window_size < inclusion_block_number` -> `drop`: i.e. the batch must be included timely.
+- `batch.epoch_num < epoch.number` -> `drop`: i.e. the batch origin is not older than that of the L2 safe head.
+- `batch.epoch_num == epoch.number`: define `batch_origin` as `epoch`.
+- `batch.epoch_num == epoch.number+1`:
+  - If `next_epoch` is not known -> `undecided`:
+    i.e. a batch that changes the L1 origin cannot be processed until we have the L1 origin data.
+  - If known, then define `batch_origin` as `next_epoch`
+- `batch.epoch_num > epoch.number+1` -> `drop`: i.e. the L1 origin cannot change by more than one L1 block per L2 block.
+- `batch.epoch_hash != batch_origin.hash` -> `drop`: i.e. a batch must reference a canonical L1 origin,
+  to prevent batches from being replayed onto unexpected L1 chains.
+- `batch.timestamp > batch_origin.time + max_sequencer_drift` -> `drop`: i.e. a batch that does not adopt the next L1
+  within time will be dropped, in favor of an empty batch that can advance the L1 origin.
+- `batch.transactions`: `drop` if the `batch.transactions` list contains a transaction
+  that is invalid or derived by other means exclusively:
+  - any transaction that is empty (zero length byte string)
+  - any [deposited transactions][g-deposit-tx-type] (identified by the transaction type prefix byte)
+
+If no batch can be `accept`-ed, and the stage has completed buffering of all batches that can fully be read from the L1
+block at height `epoch.number + sequence_window_size`, and the `next_epoch` is available,
+then an empty batch can be derived with the following properties:
+
+- `parent_hash = safe_l2_head.hash`
+- `timestamp = next_timestamp`
+- `transactions` is empty, i.e. no sequencer transactions. Deposited transactions may be added in the next stage.
+- If `next_timestamp < next_epoch.time`: the current L1 origin is repeated, to preserve the L2 time invariant.
+  - `epoch_num = epoch.number`
+  - `epoch_hash = epoch.hash`
+- Otherwise,
+  - `epoch_num = next_epoch.number`
+  - `epoch_hash = next_epoch.hash`
 
 ### Payload Attributes Derivation
 

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -569,13 +569,17 @@ Definitions:
 - `batch` as defined in the [Batch format section][batch-format].
 - `epoch = safe_l2_head.l1_origin` a [L1 origin][g-l1-origin] coupled to the batch, with properties:
   `number` (L1 block number), `hash` (L1 block hash), and `timestamp` (L1 block timestamp).
-- `inclusion_block_number` is the L1 block number when `batch` was first *fully* derived.
+- `inclusion_block_number` is the L1 block number when `batch` was first *fully* derived,
+   i.e. decoded and output by the previous stage.
 - `next_timestamp = safe_l2_head.timestamp + block_time` is the expected L2 timestamp the next batch should have,
   see [block time information][g-block-time].
 - `next_epoch` may not be known yet, but would be the L1 block after `epoch` if available.
 - `batch_origin` is either `epoch` or `next_epoch`, depending on validation.
 
-Rules:
+Note that processing of a batch can be deferred until `batch.timestamp <= next_timestamp`,
+since `future` batches will have to be retained anyway.
+
+Rules, in validation order:
 
 - `batch.timestamp > next_timestamp` -> `future`: i.e. the batch must be ready to process.
 - `batch.timestamp < next_timestamp` -> `drop`: i.e. the batch must not be too old.

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -390,7 +390,7 @@ contain.
 
 Recall that a batch contains a list of transactions to be included in a specific L2 block.
 
-A batch is encoded as `batch_version ++ content`, where `content` depends on the version:
+A batch is encoded as `batch_version ++ content`, where `content` depends on the `batch_version`:
 
 | `batch_version` | `content`                                                                          |
 | --------------- |------------------------------------------------------------------------------------|
@@ -398,6 +398,7 @@ A batch is encoded as `batch_version ++ content`, where `content` depends on the
 
 where:
 
+- `batch_version` is a single byte, prefixed before the RLP contents, alike to transaction typing.
 - `rlp_encode` is a function that encodes a batch according to the [RLP format], and `[x, y, z]` denotes a list
   containing items `x`, `y` and `z`
 - `parent_hash` is the block hash of the previous L2 block


### PR DESCRIPTION
This adds `parent_hash` to the batch definition, to ensure we never skip a batch. Skipping a batch can cause transactions with invalid nonce values to be inserted into the execution engine, causing reorgs or complete halts.

The `parent_hash` matches the L2 block hash of the block the batch will be building on top of, i.e. the L2 safe head.
To enable this, we have to change the batch-queue processing to only output 1 batch at the time. Without this, the previous L2 block hash would not be available, and so we could not check the hash otherwise.

In a previous iteration of this I considered hashing just the batch inputs, and chaining those hashes. However, we can't include those hashes into the L2 chain elegantly, which is required to find a sync continuation point without loading all historical batches. I.e. we would need to add additional data to the L1 block info transaction, and it would almost be self-referencing, as it hashes together the other transactions, which are included later.
Using the native block hashes thus is preferred to not add additional data to the info deposit, and avoid the near cyclic dependency issue.

Not outputting multiple batches at a time really means that we are not filling multiple batches at a time when there is a gap to fill. The eager batch derivation already outputted a single batch otherwise.

Previously the validity conditions on batches were spread between the batch-filtering, batch-filling, extension-checking and batch queue main function. I changed this so we can output 1 batch at a time, check all validity conditions, and isolate the validity conditions in one function that now has 100% test coverage.

Part of this unwinding of the different checks also meant we can now remove the L1 RPC from the function: all necessary L1 data is there, and is easy to access (first L1 block always matches L2 safe head L1 origin, second L1 block is optional).

And validating the batches this way means there is no difference between eager and regular batch-derivation: we always consider the validity of the first batch, since we output one at a time.

The spec is updated to reflect this same methodology, so we don't need eager batch queue <> regular batch queue distinction anymore.

I hope the PR is not too large to review, this was not an easy change, at least it should reduce total lines of regular code, while adding more tests + ensuring 100% coverage of batch validation.

Fix ENG-2593