### PR TITLE
sdk: fix eth withdraw bug

### DIFF
--- a/.changeset/lazy-singers-sing.md
+++ b/.changeset/lazy-singers-sing.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Fix eth withdrawal bug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,7 +460,7 @@ jobs:
       - run:
           name: Check if we should run
           command: |
-            CHANGED=$(bash ./ops/docker/ci-builder/check-changed.sh "(contracts-bedrock|op-bindings|op-batcher|op-node|op-proposer|ops-bedrock)/")
+            CHANGED=$(bash ./ops/docker/ci-builder/check-changed.sh "(contracts-bedrock|op-bindings|op-batcher|op-node|op-proposer|ops-bedrock|sdk)/")
             if [[ "$CHANGED" = "FALSE" ]]; then
               circleci step halt
             fi

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -1097,7 +1097,6 @@ export class CrossChainMessenger implements ICrossChainMessenger {
           latestBlockhash: block.hash,
         },
         withdrawalProof: ethers.utils.RLP.encode(stateTrieProof.storageProof),
-        // withdrawalProof: toHexString(rlp.encode(stateTrieProof.storageProof)),
       },
       output,
       // TODO(tynes): use better type, typechain?
@@ -1333,15 +1332,6 @@ export class CrossChainMessenger implements ICrossChainMessenger {
         const [proof, output, withdrawalTx] = await this.getBedrockMessageProof(
           message
         )
-        if (!opts) {
-          opts = {}
-        }
-        if (!opts.overrides) {
-          opts.overrides = {}
-        }
-        if (!opts.overrides.value) {
-          opts.overrides.value = withdrawalTx.value
-        }
 
         return this.contracts.l1.OptimismPortal.populateTransaction.finalizeWithdrawalTransaction(
           [
@@ -1360,7 +1350,7 @@ export class CrossChainMessenger implements ICrossChainMessenger {
             proof.outputRootProof.latestBlockhash,
           ],
           proof.withdrawalProof,
-          opts.overrides
+          opts?.overrides || {}
         )
       } else {
         // L1CrossDomainMessenger relayMessage is the only method that isn't fully backwards

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -250,8 +250,9 @@ export class CrossChainMessenger implements ICrossChainMessenger {
         // event which was introduced in the Bedrock upgrade.
         let value = ethers.BigNumber.from(0)
         const next = receipt.logs.find((l) => {
-          return l.logIndex === log.logIndex + 1
-            && l.address === messenger.address
+          return (
+            l.logIndex === log.logIndex + 1 && l.address === messenger.address
+          )
         })
         if (next) {
           const nextParsed = messenger.interface.parseLog(next)

--- a/packages/sdk/src/interfaces/bridge-adapter.ts
+++ b/packages/sdk/src/interfaces/bridge-adapter.ts
@@ -232,7 +232,7 @@ export interface IBridgeAdapter {
       amount: NumberLike,
       opts?: {
         recipient?: AddressLike
-        overrides?: PayableOverrides
+        overrides?: Overrides
       }
     ): Promise<TransactionRequest>
   }

--- a/packages/sdk/tasks/deposit-eth.ts
+++ b/packages/sdk/tasks/deposit-eth.ts
@@ -67,7 +67,7 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
       : utils.parseEther('1')
     const withdrawAmount = args.withdrawAmount
       ? utils.parseEther(args.withdrawAmount)
-      : utils.parseEther(amount.div(2).toString())
+      : amount.div(2)
 
     const l2Signer = new hre.ethers.Wallet(
       hre.network.config.accounts[0],
@@ -313,14 +313,9 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
     const opBalanceFinally = await signer.provider.getBalance(
       OptimismPortal.address
     )
-    // TODO(tynes): fix this bug
-    if (!opBalanceFinally.sub(withdrawAmount).eq(opBalanceAfter)) {
-      console.log('OptimismPortal balance mismatch')
-      console.log(`Balance before deposit: ${opBalanceBefore.toString()}`)
-      console.log(`Balance after deposit: ${opBalanceAfter.toString()}`)
-      console.log(`Balance after withdrawal: ${opBalanceFinally.toString()}`)
-      return
-      // throw new Error('OptimismPortal balance mismatch')
+
+    if (!opBalanceFinally.add(withdrawAmount).eq(opBalanceAfter)) {
+      throw new Error('OptimismPortal balance mismatch')
     }
     console.log('Withdraw success')
   })


### PR DESCRIPTION
**Description**

Fixes the eth withdrawal bug when creating withdrawl
transactions that include value. There is no need to
send ETH on L1 when finalizing the withdrawal since
the `OptimismPortal` is holding onto the ETH that will
be unlocked and sent to the user.

co-authored-by: smartcontracts <kelvin@optimism.io>

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


