### PR TITLE
op-node: supprt block finalization [bedrock]

### DIFF
--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -1,0 +1,145 @@
+package derive
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineQueue_Finalize(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	rng := rand.New(rand.NewSource(1234))
+	// create a short test L2 chain:
+	//
+	// L2:
+	//	A0: genesis
+	//	A1: finalized, incl in B
+	//  B0: safe, incl in C
+	//  B1: not yet included in L1
+	//  C0: head, not included in L1 yet
+	//
+	// L1:
+	//  A: genesis
+	//  B: finalized, incl A1
+	//  C: safe, incl B0
+	//  D: unsafe, not yet referenced by L2
+
+	l1Time := uint64(2)
+	refA := testutils.RandomBlockRef(rng)
+
+	refB := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refA.Number + 1,
+		ParentHash: refA.Hash,
+		Time:       refA.Time + l1Time,
+	}
+	refC := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refB.Number + 1,
+		ParentHash: refB.Hash,
+		Time:       refB.Time + l1Time,
+	}
+	refD := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refC.Number + 1,
+		ParentHash: refC.Hash,
+		Time:       refC.Time + l1Time,
+	}
+
+	refA0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           refA.Time,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     refA.ID(),
+			L2:     refA0.ID(),
+			L2Time: refA0.Time,
+		},
+		BlockTime:     1,
+		SeqWindowSize: 2,
+	}
+	refA1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refA0.Number + 1,
+		ParentHash:     refA0.Hash,
+		Time:           refA0.Time + cfg.BlockTime,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 1,
+	}
+	refB0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refA1.Number + 1,
+		ParentHash:     refA1.Hash,
+		Time:           refA1.Time + cfg.BlockTime,
+		L1Origin:       refB.ID(),
+		SequenceNumber: 0,
+	}
+	refB1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refB0.Number + 1,
+		ParentHash:     refB0.Hash,
+		Time:           refB0.Time + cfg.BlockTime,
+		L1Origin:       refB.ID(),
+		SequenceNumber: 1,
+	}
+	refC0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refB1.Number + 1,
+		ParentHash:     refB1.Hash,
+		Time:           refB1.Time + cfg.BlockTime,
+		L1Origin:       refC.ID(),
+		SequenceNumber: 0,
+	}
+
+	metrics := &TestMetrics{}
+	eng := &testutils.MockEngine{}
+	eng.ExpectL2BlockRefByLabel(eth.Finalized, refA1, nil)
+	// TODO(Proto): update expectation once we're using safe block label properly for sync starting point
+	eng.ExpectL2BlockRefByLabel(eth.Unsafe, refC0, nil)
+
+	// we find the common point to initialize to by comparing the L1 origins in the L2 chain with the L1 chain
+	l1F := &testutils.MockL1Source{}
+	l1F.ExpectL1BlockRefByLabel(eth.Unsafe, refD, nil)
+	l1F.ExpectL1BlockRefByNumber(refC0.L1Origin.Number, refC, nil)
+	eng.ExpectL2BlockRefByHash(refC0.ParentHash, refB1, nil)   // good L1 origin
+	eng.ExpectL2BlockRefByHash(refB1.ParentHash, refB0, nil)   // need a block with seqnr == 0, don't stop at above
+	l1F.ExpectL1BlockRefByHash(refB0.L1Origin.Hash, refB, nil) // the origin of the safe L2 head will be the L1 starting point for derivation.
+
+	eq := NewEngineQueue(logger, cfg, eng, metrics)
+	require.NoError(t, RepeatResetStep(t, eq.ResetStep, l1F, 3))
+
+	// TODO(proto): this is changing, needs to be a sequence window ago, but starting traversal back from safe block,
+	// safe blocks with canon origin are good, but we go back a full window to ensure they are all included in L1,
+	// by forcing them to be consolidated with L1 again.
+	require.Equal(t, eq.SafeL2Head(), refB0, "L2 reset should go back to sequence window ago")
+
+	require.Equal(t, refA1, eq.Finalized(), "A1 is recognized as finalized before we run any steps")
+
+	// we are not adding blocks in this test,
+	// but we can still trigger post-processing for the already existing safe head,
+	// so the engine can prepare to finalize that.
+	eq.postProcessSafeL2()
+	// let's finalize C, which included B0, but not B1
+	eq.Finalize(refC.ID())
+
+	// Now a few steps later, without consuming any additional L1 inputs,
+	// we should be able to resolve that B0 is now finalized
+	require.NoError(t, RepeatStep(t, eq.Step, eq.progress, 10))
+	require.Equal(t, refB0, eq.Finalized(), "B0 was included in finalized C, and should now be finalized")
+
+	l1F.AssertExpectations(t)
+	eng.AssertExpectations(t)
+}

--- a/op-node/rollup/derive/pipeline_test.go
+++ b/op-node/rollup/derive/pipeline_test.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/stretchr/testify/mock"
 )
 
 var _ Engine = (*testutils.MockEngine)(nil)
@@ -58,3 +58,24 @@ func RepeatStep(t *testing.T, step func(ctx context.Context, outer Progress) err
 	t.Fatal("ran out of steps")
 	return nil
 }
+
+// TestMetrics implements the metrics used in the derivation pipeline as no-op operations.
+// Optionally a test may hook into the metrics
+type TestMetrics struct {
+	recordL1Ref func(name string, ref eth.L1BlockRef)
+	recordL2Ref func(name string, ref eth.L2BlockRef)
+}
+
+func (t *TestMetrics) RecordL1Ref(name string, ref eth.L1BlockRef) {
+	if t.recordL1Ref != nil {
+		t.recordL1Ref(name, ref)
+	}
+}
+
+func (t *TestMetrics) RecordL2Ref(name string, ref eth.L2BlockRef) {
+	if t.recordL2Ref != nil {
+		t.recordL2Ref(name, ref)
+	}
+}
+
+var _ Metrics = (*TestMetrics)(nil)

--- a/op-node/testutils/mock_l1.go
+++ b/op-node/testutils/mock_l1.go
@@ -12,7 +12,7 @@ type MockL1Source struct {
 }
 
 func (m *MockL1Source) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByLabel")
+	out := m.Mock.MethodCalled("L1BlockRefByLabel", label)
 	return out[0].(eth.L1BlockRef), *out[1].(*error)
 }
 

--- a/op-node/testutils/mock_l2.go
+++ b/op-node/testutils/mock_l2.go
@@ -15,7 +15,7 @@ func (c *MockL2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLab
 	return c.Mock.MethodCalled("L2BlockRefByLabel", label).Get(0).(eth.L2BlockRef), nil
 }
 
-func (m *MockL1Source) ExpectL2BlockRefByLabel(label eth.BlockLabel, ref eth.L2BlockRef, err error) {
+func (m *MockL2Client) ExpectL2BlockRefByLabel(label eth.BlockLabel, ref eth.L2BlockRef, err error) {
 	m.Mock.On("L2BlockRefByLabel", label).Once().Return(ref, &err)
 }
 
@@ -23,7 +23,7 @@ func (c *MockL2Client) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.
 	return c.Mock.MethodCalled("L2BlockRefByNumber", num).Get(0).(eth.L2BlockRef), nil
 }
 
-func (m *MockL1Source) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, err error) {
+func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, err error) {
 	m.Mock.On("L2BlockRefByNumber", num).Once().Return(ref, &err)
 }
 
@@ -31,6 +31,6 @@ func (c *MockL2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (
 	return c.Mock.MethodCalled("L2BlockRefByHash", hash).Get(0).(eth.L2BlockRef), nil
 }
 
-func (m *MockL1Source) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockRef, err error) {
+func (m *MockL2Client) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockRef, err error) {
 	m.Mock.On("L2BlockRefByHash", hash).Once().Return(ref, &err)
 }


### PR DESCRIPTION
**Description**

Update the Engine Queue to maintain a small buffer of L1<>L2 relation data: when a L2 safe block is produced, remember the L1 block the progress was at, this is the L1 block the L2 block was fully derived from.

Once this L1 block is finalized, we can finalize the L2 blocks that were fully derived from up to and including this point.

We only maintain a buffer of `4*32 + 1` items, since finality can only change by reaching new finality over recent data of no more than 4 epochs old. Some obscure testnets have smaller epochs, but buffering a few blocks extra does not hurt.

Per L1 block we only track the latest L2 block that was fully derived from it.

If the buffer is outdated or incomplete then it'll just repair itself as we rotate into new L1 blocks. Finalization cannot cause divergence, at worst it's a lagging finalization signal for `(4*32 + 1)*12/60 = 25.8` minutes (and it only really updates every 6.4 minutes anyway). The extended more complex version of backfilling old finalization data is not worth it: that would require us to reset the pipeline even further back, to reproduce the L2 inclusion-data of the last 65 L1 blocks.

This depends on #3291 to provide the `L2BlockRefByLabel` RPC method.

**Metadata**

Fix ENG-2312
