### PR TITLE
op-node: fix execution payload fuzzing target [bedrock]

### DIFF
--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -21,8 +21,8 @@ lint:
 	golangci-lint run -E asciicheck,goimports,misspell ./...
 
 fuzz:
-	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzExecutionPayloadUnmarshal ./l2
-	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzExecutionPayloadMarshalUnmarshal ./l2
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzExecutionPayloadUnmarshal ./eth
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzExecutionPayloadMarshalUnmarshal ./eth
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzL1InfoRoundTrip ./rollup/derive
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzL1InfoAgainstContract ./rollup/derive
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzUnmarshallLogEvent ./rollup/derive


### PR DESCRIPTION
The execution payload fuzzing happens in the `eth` package, not the `l2` package.