### PR TITLE
state-surgery: handle fs errors

### DIFF
--- a/state-surgery/hardhat/hardhat.go
+++ b/state-surgery/hardhat/hardhat.go
@@ -67,7 +67,7 @@ func (h *Hardhat) init() error {
 func (h *Hardhat) initDeployments() error {
 	for _, deploymentPath := range h.DeploymentPaths {
 		fileSystem := os.DirFS(filepath.Join(deploymentPath, h.network))
-		fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+		err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -95,6 +95,9 @@ func (h *Hardhat) initDeployments() error {
 			h.deployments = append(h.deployments, &deployment)
 			return nil
 		})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -104,7 +107,7 @@ func (h *Hardhat) initDeployments() error {
 func (h *Hardhat) initArtifacts() error {
 	for _, artifactPath := range h.ArtifactPaths {
 		fileSystem := os.DirFS(artifactPath)
-		fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
+		err := fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -130,6 +133,9 @@ func (h *Hardhat) initArtifacts() error {
 			h.artifacts = append(h.artifacts, &artifact)
 			return nil
 		})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Handle errors when walking the filesystem so that they do
not silently fail.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


