### PR TITLE
state-surgery: fix flakey tests

### DIFF
--- a/state-surgery/state/memory_db_test.go
+++ b/state-surgery/state/memory_db_test.go
@@ -28,7 +28,7 @@ func TestAddBalance(t *testing.T) {
 
 		account := db.GetAccount(addr)
 		require.NotNil(t, account)
-		require.Equal(t, account.Balance, value)
+		require.True(t, BigEqual(account.Balance, value))
 	}
 }
 
@@ -59,5 +59,13 @@ func TestCode(t *testing.T) {
 
 		codeHash := db.GetCodeHash(addr)
 		require.Equal(t, codeHash, common.BytesToHash(crypto.Keccak256(code)))
+	}
+}
+
+func BigEqual(a, b *big.Int) bool {
+	if a == nil || b == nil {
+		return a == b
+	} else {
+		return a.Cmp(b) == 0
 	}
 }


### PR DESCRIPTION
**Description**

Sometimes `require.Equal` flakes on the comparison
of `big.Int`.

https://github.com/ethereum-optimism/optimism/blob/b31d35b67755479645dd150e7cc8c6710f0b4a56/op-node/rollup/derive/fuzz_parsers_test.go#L42

Co-authored-by: Joshua Gutow <jgutow@optimism.io>

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

