### PR TITLE
state-surgery: fix string slice

### DIFF
--- a/state-surgery/hardhat/hardhat.go
+++ b/state-surgery/hardhat/hardhat.go
@@ -96,7 +96,7 @@ func (h *Hardhat) initDeployments() error {
 				return err
 			}
 
-			deployment.Name = filepath.Base(strings.TrimRight(name, ".json"))
+			deployment.Name = filepath.Base(name[:len(name)-5])
 			h.deployments = append(h.deployments, &deployment)
 			return nil
 		})


### PR DESCRIPTION
**Description**

For some reason `strings.TrimPrefix` is removing
an extra character sometimes. We want to remove the
`.json` extension and using it will sometimes also
remove the final character in the contract name.
This is problematic because when you call
`hh.GetDeployment`, with the name of the contract,
it will not be able to find the deployment because
the name of the deployment will not match the name
passed in by the user. This instead slices off the
`.json` from the string manually.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

