### PR TITLE
fix: proxy admin deploy script

### DIFF
--- a/.changeset/moody-yaks-listen.md
+++ b/.changeset/moody-yaks-listen.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Update the L2 genesis hardhat task to use the ProxyAdmin's deployed address as the admin of each predeploy

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -36,7 +36,6 @@ type DeployConfig struct {
 	CliqueSignerAddress              common.Address        `json:"cliqueSignerAddress"`
 	OptimismBaseFeeRecipient         common.Address        `json:"optimismBaseFeeRecipient"`
 	OptimismL1FeeRecipient           common.Address        `json:"optimismL1FeeRecipient"`
-	ProxyAdmin                       common.Address        `json:"proxyAdmin"`
 	FundDevAccounts                  bool                  `json:"fundDevAccounts"`
 	GasPriceOracleOwner              common.Address        `json:"gasPriceOracleOwner"`
 	GasPriceOracleOverhead           uint                  `json:"gasPriceOracleOverhead"`
@@ -157,7 +156,8 @@ func NewStorageConfig(hh *hardhat.Hardhat, config *DeployConfig, chain ethereum.
 	storage["GovernanceToken"] = state.StorageValues{
 		"_name":   "Optimism",
 		"_symbol": "OP",
-		"_owner":  config.ProxyAdmin,
+		// TODO: this should be set to the MintManager
+		"_owner": common.Address{},
 	}
 
 	return storage, nil

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -22,7 +22,6 @@
 
   "optimismBaseFeeRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "optimismL1FeeRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
-  "proxyAdmin": "0x829BD824B016326A401d083B33D092293333A830",
   "fundDevAccounts": true,
 
   "deploymentWaitConfirmations": 1

--- a/packages/contracts-bedrock/deploy-config/goerli.json
+++ b/packages/contracts-bedrock/deploy-config/goerli.json
@@ -19,7 +19,6 @@
 
   "optimismBaseFeeRecipient": "0xf116a24056b647e3211d095c667e951536cdebaa",
   "optimismL1FeeRecipient": "0xc731837b696ca3d9720d23336925368ceaa58f83",
-  "proxyAdmin": "0xe584e1b833ca80020130b1b69f84f90479076168",
   "fundDevAccounts": true,
 
   "deploymentWaitConfirmations": 1

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -17,7 +17,6 @@
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleOwner": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
 
-  "proxyAdmin": "0x0000000000000000000000000000000000000000",
   "fundDevAccounts": true,
 
   "deploymentWaitConfirmations": 1

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -320,10 +320,6 @@ const config: HardhatUserConfig = {
       type: 'number',
       default: 6,
     },
-    proxyAdmin: {
-      type: 'address',
-      // no default, important to get right.
-    },
     fundDevAccounts: {
       type: 'boolean',
       default: false,

--- a/packages/contracts-bedrock/tasks/genesis-l2.ts
+++ b/packages/contracts-bedrock/tasks/genesis-l2.ts
@@ -286,13 +286,15 @@ task('genesis-l2', 'create a genesis config')
       GovernanceToken: {
         name: 'Optimism',
         symbol: 'OP',
-        _owner: deployConfig.proxyAdmin,
+        // TODO: this should be the mint manager
+        // in practice. Just use a hardhat account
+        // because this is only used for devnets
+        _owner: '0x829BD824B016326A401d083B33D092293333A830',
       },
     }
 
     assertEvenLength(implementationSlot)
     assertEvenLength(adminSlot)
-    assertEvenLength(deployConfig.proxyAdmin)
 
     const predeployAddrs = new Set()
     for (const addr of Object.values(predeploys)) {
@@ -300,6 +302,10 @@ task('genesis-l2', 'create a genesis config')
     }
 
     const alloc: State = {}
+
+    // Use the address of the deployed ProxyAdmin as the admin for
+    // each Proxy
+    const Deployment__ProxyAdmin = await hre.deployments.get('ProxyAdmin')
 
     // Set a proxy at each predeploy address
     const proxy = await hre.artifacts.readArtifact('Proxy')
@@ -320,7 +326,7 @@ task('genesis-l2', 'create a genesis config')
         balance: '0x0',
         code: proxy.deployedBytecode,
         storage: {
-          [adminSlot]: deployConfig.proxyAdmin,
+          [adminSlot]: Deployment__ProxyAdmin.address,
         },
       }
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Reduce the amount of config by removing the concept of proxy admin
address because we should be using the address of the deployed
proxy admin contract.

