### PR TITLE
feat: generate genesis with op-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,7 +460,7 @@ jobs:
 
   devnet:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2004:2022.07.1
       docker_layer_caching: true
     environment:
       DOCKER_BUILDKIT: 1
@@ -473,6 +473,14 @@ jobs:
             if [[ "$CHANGED" = "FALSE" ]]; then
               circleci step halt
             fi
+      - run:
+          name: Install latest golang
+          command: |
+            wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
+            sudo rm -rf /usr/local/go
+            sudo tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz
+            export PATH=$PATH:/usr/local/go/bin
+            go version
       - run:
           name: foundryup
           command: |
@@ -489,6 +497,10 @@ jobs:
           name: Bring up the stack
           command: |
             make devnet-up
+      - run:
+          name: Check L2 Config
+          command: npx hardhat check-l2-config --network devnetL1
+          working_directory: packages/contracts-bedrock
       - run:
           name: Do a deposit
           command: |
@@ -509,10 +521,6 @@ jobs:
       - run:
           name: Check the status
           command: npx hardhat check-op-node
-          working_directory: packages/contracts-bedrock
-      - run:
-          name: Check L2 Config
-          command: npx hardhat check-l2-config
           working_directory: packages/contracts-bedrock
 
   integration-tests:

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -158,6 +158,5 @@ func NewStorageConfig(hh *hardhat.Hardhat, config *DeployConfig, chain ethereum.
 		// TODO: this should be set to the MintManager
 		"_owner": common.Address{},
 	}
-
 	return storage, nil
 }

--- a/op-chain-ops/immutables/immutables.go
+++ b/op-chain-ops/immutables/immutables.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
@@ -57,6 +58,9 @@ func BuildOptimism() (DeploymentResults, error) {
 		},
 		{
 			Name: "SequencerFeeVault",
+		},
+		{
+			Name: "OptimismMintableERC20Factory",
 		},
 	}
 	return Build(deployments)
@@ -115,6 +119,8 @@ func Build(deployments []Deployment) (DeploymentResults, error) {
 		case "SequencerFeeVault":
 			// No arguments to SequencerFeeVault
 			addr, _, _, err = bindings.DeploySequencerFeeVault(opts, backend)
+		case "OptimismMintableERC20Factory":
+			addr, _, _, err = bindings.DeployOptimismMintableERC20Factory(opts, backend, predeploys.L2StandardBridgeAddr)
 		default:
 			return nil, fmt.Errorf("unknown contract: %s", deployment.Name)
 		}

--- a/op-chain-ops/immutables/immutables_test.go
+++ b/op-chain-ops/immutables/immutables_test.go
@@ -12,18 +12,19 @@ func TestBuildOptimism(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, results)
 
+	contracts := map[string]bool{
+		"GasPriceOracle":               true,
+		"L1Block":                      true,
+		"L2CrossDomainMessenger":       true,
+		"L2StandardBridge":             true,
+		"L2ToL1MessagePasser":          true,
+		"SequencerFeeVault":            true,
+		"OptimismMintableERC20Factory": true,
+	}
+
 	// Only the exact contracts that we care about are being
 	// modified
-	require.Equal(t, len(results), 6)
-
-	contracts := map[string]bool{
-		"GasPriceOracle":         true,
-		"L1Block":                true,
-		"L2CrossDomainMessenger": true,
-		"L2StandardBridge":       true,
-		"L2ToL1MessagePasser":    true,
-		"SequencerFeeVault":      true,
-	}
+	require.Equal(t, len(results), len(contracts))
 
 	for name, bytecode := range results {
 		// There is bytecode there

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 COPY ./op-node/docker.go.work /app/go.work
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
+COPY ./op-chain-ops /app/op-chain-ops
 
 WORKDIR /app/op-node
 

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -1,0 +1,104 @@
+package genesis
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/urfave/cli"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/hardhat"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+var Subcommands = cli.Commands{
+	{
+		Name:  "devnet-l2",
+		Usage: "Initialized a new devnet genesis file",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "artifacts",
+				Usage: "Comma delimeted list of hardhat artifact directories",
+			},
+			cli.StringFlag{
+				Name:  "network",
+				Usage: "Name of hardhat deploy network",
+			},
+			cli.StringFlag{
+				Name:  "deployments",
+				Usage: "Comma delimated list of hardhat deploy artifact directories",
+			},
+			cli.StringFlag{
+				Name:  "deploy-config",
+				Usage: "Path to hardhat deploy config directory",
+			},
+			cli.StringFlag{
+				Name:  "rpc-url",
+				Usage: "L1 RPC URL",
+			},
+			cli.StringFlag{
+				Name:  "outfile",
+				Usage: "Path to file to write output to",
+			},
+		},
+		Action: func(ctx *cli.Context) error {
+			// Turn off logging for this command unless it is a critical
+			// error so that the output can be piped to jq
+			log.Root().SetHandler(
+				log.LvlFilterHandler(
+					log.LvlCrit,
+					log.StreamHandler(os.Stdout, log.TerminalFormat(true)),
+				),
+			)
+
+			artifact := ctx.String("artifacts")
+			artifacts := strings.Split(artifact, ",")
+
+			deployment := ctx.String("deployments")
+			deployments := strings.Split(deployment, ",")
+
+			network := ctx.String("network")
+
+			rpcUrl := ctx.String("rpc-url")
+
+			hh, err := hardhat.New(network, artifacts, deployments)
+			if err != nil {
+				return err
+			}
+
+			deployConfigDirectory := ctx.String("deploy-config")
+			deployConfig := filepath.Join(deployConfigDirectory, network+".json")
+
+			config, err := genesis.NewDeployConfig(deployConfig)
+			if err != nil {
+				return err
+			}
+
+			client, err := ethclient.Dial(rpcUrl)
+			if err != nil {
+				return err
+			}
+
+			gen, err := genesis.BuildOptimismDeveloperGenesis(hh, config, client)
+			if err != nil {
+				return err
+			}
+
+			file, _ := json.MarshalIndent(gen, "", " ")
+
+			outfile := ctx.String("outfile")
+			if outfile == "" {
+				fmt.Println(string(file))
+			} else {
+				_ = ioutil.WriteFile(outfile, file, 0644)
+			}
+			return nil
+		},
+	},
+}

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
 	"github.com/ethereum-optimism/optimism/op-node/cmd/p2p"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -65,6 +66,10 @@ func main() {
 		{
 			Name:        "p2p",
 			Subcommands: p2p.Subcommands,
+		},
+		{
+			Name:        "genesis",
+			Subcommands: genesis.Subcommands,
 		},
 	}
 

--- a/op-node/docker.go.work
+++ b/op-node/docker.go.work
@@ -3,4 +3,5 @@ go 1.18
 use (
 	./op-bindings
 	./op-node
+    ./op-chain-ops
 )

--- a/op-node/go.mod
+++ b/op-node/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/ethereum-optimism/optimism/op-bindings v0.5.0
+	github.com/ethereum-optimism/optimism/op-chain-ops v0.0.0-20220822214343-2106bdb7fc11
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.8
@@ -41,6 +42,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect
 	github.com/fjl/memsize v0.0.1 // indirect
 	github.com/flynn/noise v1.0.0 // indirect

--- a/op-node/go.sum
+++ b/op-node/go.sum
@@ -175,8 +175,9 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/4=
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
@@ -191,6 +192,8 @@ github.com/ethereum-optimism/op-geth v0.0.0-20220819161933-acfde114de61 h1:+Wfrw
 github.com/ethereum-optimism/op-geth v0.0.0-20220819161933-acfde114de61/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/ethereum-optimism/optimism/op-bindings v0.5.0 h1:bJT8KmDu5YAVOqPQHxHkntGlRrtRdTIsH+X28LOIcqU=
 github.com/ethereum-optimism/optimism/op-bindings v0.5.0/go.mod h1:Ft+sL57mlBysH6nuXZA11GLMMajfBa8SjpEBtitl1Vw=
+github.com/ethereum-optimism/optimism/op-chain-ops v0.0.0-20220822214343-2106bdb7fc11 h1:be6PccBLLuTZZKC9FuwArNjMVX8R83TCnwknncWJqQw=
+github.com/ethereum-optimism/optimism/op-chain-ops v0.0.0-20220822214343-2106bdb7fc11/go.mod h1:D+q1th05BC1WA2kq3yyRxYiF8ZwQUbhNA2iwbG8qODE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.1 h1:+zhkb+dhUgx0/e+M8sF0QqiouvMQUiKR+QYvdxIOKcQ=
 github.com/fjl/memsize v0.0.1/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=

--- a/packages/contracts-bedrock/tasks/check-l2-config.ts
+++ b/packages/contracts-bedrock/tasks/check-l2-config.ts
@@ -1,8 +1,18 @@
 import { task, types } from 'hardhat/config'
-import { providers } from 'ethers'
+import { providers, Contract } from 'ethers'
 import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
 
-import { predeploys, getContractInterface } from '../src'
+import { predeploys } from '../src'
+
+const checkCode = async (provider: providers.JsonRpcProvider) => {
+  for (const [name, address] of Object.entries(predeploys)) {
+    const code = await provider.getCode(address)
+    if (code === '0x') {
+      throw new Error(`Missing code for ${name}`)
+    }
+  }
+}
 
 task('check-l2-config', 'Validate L2 config')
   .addParam(
@@ -15,17 +25,66 @@ task('check-l2-config', 'Validate L2 config')
     const { l2ProviderUrl } = args
     const l2Provider = new providers.JsonRpcProvider(l2ProviderUrl)
 
-    const OptimismMintableERC20Factory = new hre.ethers.Contract(
+    await checkCode(l2Provider)
+
+    const Artifact__L2CrossDomainMessenger = await hre.artifacts.readArtifact(
+      'L2CrossDomainMessenger'
+    )
+    const Artifact__L2StandardBridge = await hre.artifacts.readArtifact(
+      'L2StandardBridge'
+    )
+    const Artifact__OptimismMintableERC20Factory =
+      await hre.artifacts.readArtifact('OptimismMintableERC20Factory')
+
+    const L2CrossDomainMessenger = new Contract(
+      predeploys.L2CrossDomainMessenger,
+      Artifact__L2CrossDomainMessenger.abi,
+      l2Provider
+    )
+
+    const Deployment__L1CrossDomainMessenger = await hre.deployments.get(
+      'L1CrossDomainMessengerProxy'
+    )
+    const otherMessenger = await L2CrossDomainMessenger.otherMessenger()
+    if (otherMessenger !== Deployment__L1CrossDomainMessenger.address) {
+      throw new Error(
+        `L2CrossDomainMessenger otherMessenger not set correctly. Got ${otherMessenger}, expected ${Deployment__L1CrossDomainMessenger.address}`
+      )
+    }
+
+    const L2StandardBridge = new Contract(
+      predeploys.L2StandardBridge,
+      Artifact__L2StandardBridge.abi,
+      l2Provider
+    )
+
+    const messenger = await L2StandardBridge.messenger()
+    if (messenger !== predeploys.L2CrossDomainMessenger) {
+      throw new Error(
+        `L2StandardBridge messenger not set correctly. Got ${messenger}, expected ${predeploys.L2CrossDomainMessenger}`
+      )
+    }
+
+    const Deployment__L1StandardBridge = await hre.deployments.get(
+      'L1StandardBridgeProxy'
+    )
+    const otherBridge = await L2StandardBridge.otherBridge()
+    if (otherBridge !== Deployment__L1StandardBridge.address) {
+      throw new Error(
+        `L2StandardBridge otherBridge not set correctly. Got ${otherBridge}, expected ${Deployment__L1StandardBridge.address}`
+      )
+    }
+
+    const OptimismMintableERC20Factory = new Contract(
       predeploys.OptimismMintableERC20Factory,
-      getContractInterface('OptimismMintableERC20Factory'),
+      Artifact__OptimismMintableERC20Factory.abi,
       l2Provider
     )
 
     const bridge = await OptimismMintableERC20Factory.bridge()
-    console.log(`OptimismMintableERC20Factory.bridge() -> ${bridge}`)
     if (bridge !== predeploys.L2StandardBridge) {
       throw new Error(
-        `L2StandardBridge not set correctly. Got ${bridge}, expected ${predeploys.L2StandardBridge}`
+        `OptimismMintableERC20Factory bridge not set correctly. Got ${bridge}, expected ${predeploys.L2StandardBridge}`
       )
     }
   })


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds the `genesis` subcommand to the `op-node` so that it can be used to create genesis files. To create a L2 developer genesis file that is suitable for devnets, use the following command:

```bash
$ op-node genesis devnet-l2
```

This name was chosen such that it is obvious that it is creating a genesis block for a devnet instead of trying to upgrade an existing database. The code to upgrade an existing database will be implemented in the future.

This PR also includes a fix to `op-chain-ops` because it was skipping the correct implementation of the `OptimismMintableERC20Factory`, which is required for ERC20 deposits to work.

The hardhat task responsible for checking that a L2 node's predeploys were configured properly was updated to catch this sort of error and then moved to the front of the `devnet` CI job so that it can fail before a mysterious error message comes from the sdk trying to do a deposit.