### PR TITLE
ops-bedrock: use the latest geth release for L1

### DIFF
--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.17
+FROM ethereum/client-go:v1.10.22
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
**Description**

Adds some nice new tracers and is more close to what
we would see on mainnet

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


