### PR TITLE
ci: use common ubuntu image across jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
 
   bedrock-markdown:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2204:2022.07.1
     steps:
       - checkout
       - run:
@@ -460,7 +460,7 @@ jobs:
 
   devnet:
     machine:
-      image: ubuntu-2004:202201-01
+      image: ubuntu-2204:2022.07.1
       docker_layer_caching: true
     environment:
       DOCKER_BUILDKIT: 1
@@ -517,7 +517,7 @@ jobs:
 
   integration-tests:
     machine:
-      image: ubuntu-2004:202201-01
+      image: ubuntu-2204:2022.07.1
       docker_layer_caching: true
     environment:
       DOCKER_BUILDKIT: 1
@@ -607,7 +607,7 @@ jobs:
       sim:
         type: string
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:2022.07.1
       docker_layer_caching: true
       resource_class: xlarge
     steps:


### PR DESCRIPTION
**Description**

Helps with caching to use the same docker image
across jobs. This updates jobs on an older ubuntu
docker image to the latest ubuntu docker image
provided by circleci.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


