### PR TITLE
fix(ctb): move deps to dev to fix npm

### DIFF
--- a/.changeset/hot-cups-impress.md
+++ b/.changeset/hot-cups-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Moves forge-std and ds-test to devDependencies to avoid breaking npm

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -40,10 +40,8 @@
     "@openzeppelin/contracts": "4.6.0",
     "@openzeppelin/contracts-upgradeable": "4.7.1",
     "@rari-capital/solmate": "https://github.com/rari-capital/solmate.git#8f9b23f8838670afda0fd8983f2c41e8037ae6bc",
-    "ds-test": "https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5",
     "ethers": "^5.6.8",
     "excessively-safe-call": "https://github.com/nomad-xyz/ExcessivelySafeCall.git#81cd99ce3e69117d665d7601c330ea03b97acce0",
-    "forge-std": "https://github.com/foundry-rs/forge-std.git#f18682b2874fc57d7c80a511fed0b35ec4201ffa",
     "hardhat": "^2.9.6"
   },
   "devDependencies": {
@@ -63,8 +61,10 @@
     "chai": "^4.2.0",
     "command-exists": "1.2.9",
     "dotenv": "^16.0.0",
+    "ds-test": "https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5",
     "ethereum-waffle": "^3.0.0",
     "ethers": "^5.6.8",
+    "forge-std": "https://github.com/foundry-rs/forge-std.git#f18682b2874fc57d7c80a511fed0b35ec4201ffa",
     "glob": "^7.1.6",
     "hardhat-deploy": "^0.11.4",
     "solhint": "^3.3.6",


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes issues with npm by moving certain dependencies from "dependencies"
to "devDependencies" and therefore not including them in the bundle that
gets uploaded to npm. These dependencies did not include a package.json
file, which was causing certain versions of npm to complain loudly.
