### PR TITLE
op-node: update readme with genesis docs

### DIFF
--- a/op-node/README.md
+++ b/op-node/README.md
@@ -47,3 +47,43 @@ op \
   --rpc.addr=127.0.0.1 \
   --rpc.port=7000
 ```
+
+## Devnet Genesis Generation
+
+The `op-node` can generate geth compatible `genesis.json` files. These files
+can be used with `geth init` to initialize the `StateDB` with accounts, storage,
+code and balances. The L2 state must be initialized with predeploy contracts
+that exist in the state and act as system level contracts. The `op-node` can
+generate a genesis file with these predeploys configured correctly given
+hardhat compilation artifacts, hardhat deployment artifacts, a L1 RPC URL
+and a deployment config.
+
+The hardhat compilation artifacts are produced by `hardhat compile`. The native
+hardhat compiler toolchain produces them by default and the
+`@foundry-rs/hardhat` plugin can also produce them when using the foundry
+compiler toolchain. They can usually be found in an `artifacts` directory.
+
+The hardhat deployment artifacts are produced by running `hardhat deploy`. These
+exist to make it easy to track deployments of smart contract systems over time.
+They can usually be found in a `deployments` directory.
+
+The deployment config contains all of the information required to deploy the
+system. It can be found in `packages/contracts-bedrock/deploy-config`. Each
+deploy config file can be JSON or TypeScript, although only JSON files are
+supported by the `op-node`. The network name must match the name of the file
+in the deploy config directory.
+
+Example usage:
+
+```bash
+$ op-node genesis devnet-l2 \
+   --artifacts $CONTRACTS_BEDROCK/artifacts,$CONTRACTS_GOVERNANCE/artifacts \
+   --network $NETWORK \
+   --deployments $CONTRACTS_BEDROCK/deployments \
+   --deploy-config $CONTRACTS_BEDROCK/deploy-config \
+   --rpc-url http://localhost:8545 \
+```
+
+Note that both `contracts-bedrock` and `contracts-governance` are required
+as the `GovernanceToken` is also a predeploy and it lives in
+`contracts-governance`.


### PR DESCRIPTION
**Description**

Add documentation on how to use the `op-node` to generate
L2 devnet genesis blocks. This will be expanded in the future
to include upgrading pre-bedrock databases.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

