### PR TITLE
op-chain-ops: add helper function

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"os"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -76,6 +77,14 @@ func NewDeployConfig(path string) (*DeployConfig, error) {
 	}
 
 	return &config, nil
+}
+
+// NewDeployConfigWithNetwork takes a path to a deploy config directory
+// and the network name. The config file in the deploy config directory
+// must match the network name and be a JSON file.
+func NewDeployConfigWithNetwork(network, path string) (*DeployConfig, error) {
+	deployConfig := filepath.Join(path, network+".json")
+	return NewDeployConfig(deployConfig)
 }
 
 // StorageConfig represents the storage configuration for the L2 predeploy

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/urfave/cli"
@@ -66,9 +65,8 @@ var Subcommands = cli.Commands{
 				return err
 			}
 
-			deployConfigDirectory := ctx.String("deploy-config")
-			deployConfig := filepath.Join(deployConfigDirectory, network+".json")
-			config, err := genesis.NewDeployConfig(deployConfig)
+			deployConfig := ctx.String("deploy-config")
+			config, err := genesis.NewDeployConfigWithNetwork(network, deployConfig)
 			if err != nil {
 				return err
 			}
@@ -119,10 +117,9 @@ var Subcommands = cli.Commands{
 		},
 		Action: func(ctx *cli.Context) error {
 			network := ctx.String("network")
-			deployConfigDirectory := ctx.String("deploy-config")
-			deployConfig := filepath.Join(deployConfigDirectory, network+".json")
+			deployConfig := ctx.String("deploy-config")
 
-			config, err := genesis.NewDeployConfig(deployConfig)
+			config, err := genesis.NewDeployConfigWithNetwork(network, deployConfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description**

Deduplicates some code for a common pattern.
Callers will usually pass a network and a path
to a deploy config directory. This comes from
the way that `hardhat-deploy-config` works.
The config directory must include a JSON file
that is named after the network.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

