### PR TITLE
indexer: update l1/l2 filters for new events

### DIFF
--- a/indexer/services/l1/bridge/filter.go
+++ b/indexer/services/l1/bridge/filter.go
@@ -43,3 +43,35 @@ func FilterERC20DepositInitiatedWithRetry(ctx context.Context, filterer *binding
 		time.Sleep(clientRetryInterval)
 	}
 }
+
+// FilterETHWithdrawalFinalizedWithRetry retries the given func until it succeeds,
+// waiting for clientRetryInterval duration after every call.
+func FilterETHWithdrawalFinalizedWithRetry(ctx context.Context, filterer *bindings.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*bindings.L1StandardBridgeETHWithdrawalFinalizedIterator, error) {
+	for {
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
+		opts.Context = ctxt
+		res, err := filterer.FilterETHWithdrawalFinalized(opts, nil, nil)
+		cancel()
+		if err == nil {
+			return res, nil
+		}
+		logger.Error("Error fetching filter", "err", err)
+		time.Sleep(clientRetryInterval)
+	}
+}
+
+// FilterERC20WithdrawalFinalizedWithRetry retries the given func until it succeeds,
+// waiting for clientRetryInterval duration after every call.
+func FilterERC20WithdrawalFinalizedWithRetry(ctx context.Context, filterer *bindings.L1StandardBridgeFilterer, opts *bind.FilterOpts) (*bindings.L1StandardBridgeERC20WithdrawalFinalizedIterator, error) {
+	for {
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
+		opts.Context = ctxt
+		res, err := filterer.FilterERC20WithdrawalFinalized(opts, nil, nil, nil)
+		cancel()
+		if err == nil {
+			return res, nil
+		}
+		logger.Error("Error fetching filter", "err", err)
+		time.Sleep(clientRetryInterval)
+	}
+}

--- a/indexer/services/l2/bridge/filter.go
+++ b/indexer/services/l2/bridge/filter.go
@@ -27,3 +27,35 @@ func FilterWithdrawalInitiatedWithRetry(ctx context.Context, filterer *bindings.
 		time.Sleep(clientRetryInterval)
 	}
 }
+
+// FilterDepositFinalizedWithRetry retries the given func until it succeeds,
+// waiting for clientRetryInterval duration after every call.
+func FilterDepositFinalizedWithRetry(ctx context.Context, filterer *bindings.L2StandardBridgeFilterer, opts *bind.FilterOpts) (*bindings.L2StandardBridgeDepositFinalizedIterator, error) {
+	for {
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
+		opts.Context = ctxt
+		res, err := filterer.FilterDepositFinalized(opts, nil, nil, nil)
+		cancel()
+		if err == nil {
+			return res, nil
+		}
+		logger.Error("Error fetching filter", "err", err)
+		time.Sleep(clientRetryInterval)
+	}
+}
+
+// FilterDepositFailedWithRetry retries the given func until it succeeds,
+// waiting for clientRetryInterval duration after every call.
+func FilterDepositFailedWithRetry(ctx context.Context, filterer *bindings.L2StandardBridgeFilterer, opts *bind.FilterOpts) (*bindings.L2StandardBridgeDepositFailedIterator, error) {
+	for {
+		ctxt, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
+		opts.Context = ctxt
+		res, err := filterer.FilterDepositFailed(opts, nil, nil, nil)
+		cancel()
+		if err == nil {
+			return res, nil
+		}
+		logger.Error("Error fetching filter", "err", err)
+		time.Sleep(clientRetryInterval)
+	}
+}


### PR DESCRIPTION
**Description**
This PR adds additional helpers to listen for events used to finalize deposits / withdrawals.

**Additional context**
These functions will be used to update database state of the deposits / withdrawals in a follow-up PR.

**Metadata**
- Fixes #ENG-2665
