### PR TITLE
op-proposer,op-service: fix txmgr lint + deprecated func lint

### DIFF
--- a/op-proposer/txmgr/txmgr.go
+++ b/op-proposer/txmgr/txmgr.go
@@ -327,7 +327,8 @@ func waitMined(
 
 // CalcGasFeeCap deterministically computes the recommended gas fee cap given
 // the base fee and gasTipCap. The resulting gasFeeCap is equal to:
-//   gasTipCap + 2*baseFee.
+//
+//	gasTipCap + 2*baseFee.
 func CalcGasFeeCap(baseFee, gasTipCap *big.Int) *big.Int {
 	return new(big.Int).Add(
 		gasTipCap,

--- a/op-service/rpc/server_test.go
+++ b/op-service/rpc/server_test.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"testing"
@@ -41,7 +41,8 @@ func TestBaseServer(t *testing.T) {
 	t.Run("supports GET /healthz", func(t *testing.T) {
 		res, err := http.Get(fmt.Sprintf("http://%s/healthz", server.endpoint))
 		require.NoError(t, err)
-		body, err := ioutil.ReadAll(res.Body)
+		defer res.Body.Close()
+		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.EqualValues(t, fmt.Sprintf("{\"version\":\"%s\"}\n", appVersion), string(body))
 	})

--- a/specs/meta/linting.md
+++ b/specs/meta/linting.md
@@ -64,5 +64,5 @@ Justification for linting rules:
 # Install linter globally (should not affect go.mod)
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
 # run linter, add --fix option to fix problems (where supported)
-golangci-lint run -E asciicheck,goimports,misspell
+golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell
 ```


### PR DESCRIPTION
Fixes op-proposer lint in Go 1.19


