### PR TITLE
op-node: handle special engine RPC user-input error codes

### DIFF
--- a/op-node/eth/types.go
+++ b/op-node/eth/types.go
@@ -20,8 +20,32 @@ import (
 type ErrorCode int
 
 const (
-	UnavailablePayload ErrorCode = -32001
+	UnknownPayload           ErrorCode = -32001 // Payload does not exist / is not available.
+	InvalidForkchoiceState   ErrorCode = -38002 // Forkchoice state is invalid / inconsistent.
+	InvalidPayloadAttributes ErrorCode = -38003 // Payload attributes are invalid / inconsistent.
 )
+
+// InputError distinguishes an user-input error from regular rpc errors,
+// to help the (Engine) API user divert from accidental input mistakes.
+type InputError struct {
+	Inner error
+	Code  ErrorCode
+}
+
+func (ie InputError) Error() string {
+	return fmt.Sprintf("input error %d: %s", ie.Code, ie.Inner.Error())
+}
+
+func (ie InputError) Unwrap() error {
+	return ie.Inner
+}
+
+// Is checks if the error is the given target type.
+// Any type of InputError counts, regardless of code.
+func (ie InputError) Is(target error) bool {
+	_, ok := target.(InputError)
+	return ok // we implement Unwrap, so we do not have to check the inner type now
+}
 
 type Bytes32 [32]byte
 

--- a/op-node/eth/types_test.go
+++ b/op-node/eth/types_test.go
@@ -1,0 +1,20 @@
+package eth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInputError(t *testing.T) {
+	err := InputError{
+		Inner: errors.New("test error"),
+		Code:  InvalidForkchoiceState,
+	}
+	var x InputError
+	if !errors.As(err, &x) {
+		t.Fatalf("need InputError to be detected as such")
+	}
+	require.ErrorIs(t, err, InputError{}, "need to detect input error with errors.Is")
+}

--- a/op-node/rollup/driver/step.go
+++ b/op-node/rollup/driver/step.go
@@ -45,12 +45,9 @@ func (d *outputImpl) createNewBlock(ctx context.Context, l2Head eth.L2BlockRef, 
 	}
 
 	// Actually execute the block and add it to the head of the chain.
-	payload, rpcErr, payloadErr := derive.InsertHeadBlock(ctx, d.log, d.l2, fc, attrs, false)
-	if rpcErr != nil {
-		return l2Head, nil, fmt.Errorf("failed to extend L2 chain due to RPC error: %v", rpcErr)
-	}
-	if payloadErr != nil {
-		return l2Head, nil, fmt.Errorf("failed to extend L2 chain, cannot produce valid payload: %v", payloadErr)
+	payload, errType, err := derive.InsertHeadBlock(ctx, d.log, d.l2, fc, attrs, false)
+	if err != nil {
+		return l2Head, nil, fmt.Errorf("failed to extend L2 chain, error (%d): %w", errType, err)
 	}
 
 	// Generate an L2 block ref from the payload.

--- a/op-node/sources/engine_client.go
+++ b/op-node/sources/engine_client.go
@@ -43,8 +43,10 @@ func NewEngineClient(client client.RPC, log log.Logger, metrics caching.Metrics,
 // ForkchoiceUpdate updates the forkchoice on the execution client. If attributes is not nil, the engine client will also begin building a block
 // based on attributes after the new head block and return the payload ID.
 //
-// The RPC may return an error in ForkchoiceUpdatedResult.PayloadStatusV1.ValidationError or other non-success PayloadStatusV1,
-// and this type of error is kept separate from the returned `error` used for RPC errors, like timeouts.
+// The RPC may return three types of errors:
+// 1. Processing error: ForkchoiceUpdatedResult.PayloadStatusV1.ValidationError or other non-success PayloadStatusV1,
+// 2. `error` as eth.InputError: the forkchoice state or attributes are not valid.
+// 3. Other types of `error`: temporary RPC errors, like timeouts.
 func (s *EngineClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceState, attributes *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	e := s.log.New("state", fc, "attr", attributes)
 	e.Trace("Sharing forkchoice-updated signal")
@@ -59,12 +61,18 @@ func (s *EngineClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceS
 		}
 		return &result, nil
 	} else {
-		e = e.New("err", err)
+		e.Warn("Failed to share forkchoice-updated signal", "err", err)
 		if rpcErr, ok := err.(rpc.Error); ok {
 			code := eth.ErrorCode(rpcErr.ErrorCode())
-			e.Warn("Unexpected error code in forkchoice-updated response", "code", code)
-		} else {
-			e.Error("Failed to share forkchoice-updated signal")
+			switch code {
+			case eth.InvalidForkchoiceState, eth.InvalidPayloadAttributes:
+				return nil, eth.InputError{
+					Inner: err,
+					Code:  code,
+				}
+			default:
+				return nil, fmt.Errorf("unrecognized rpc error: %w", err)
+			}
 		}
 		return nil, err
 	}
@@ -89,23 +97,28 @@ func (s *EngineClient) NewPayload(ctx context.Context, payload *eth.ExecutionPay
 	return &result, nil
 }
 
-// GetPayload gets the execution payload associated with the PayloadId
+// GetPayload gets the execution payload associated with the PayloadId.
+// There may be two types of error:
+// 1. `error` as eth.InputError: the payload ID may be unknown
+// 2. Other types of `error`: temporary RPC errors, like timeouts.
 func (s *EngineClient) GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayload, error) {
 	e := s.log.New("payload_id", payloadId)
 	e.Trace("getting payload")
 	var result eth.ExecutionPayload
 	err := s.client.CallContext(ctx, &result, "engine_getPayloadV1", payloadId)
 	if err != nil {
-		e = e.New("payload_id", payloadId, "err", err)
+		e.Warn("Failed to get payload", "payload_id", payloadId, "err", err)
 		if rpcErr, ok := err.(rpc.Error); ok {
 			code := eth.ErrorCode(rpcErr.ErrorCode())
-			if code != eth.UnavailablePayload {
-				e.Warn("unexpected error code in get-payload response", "code", code)
-			} else {
-				e.Warn("unavailable payload in get-payload request", "code", code)
+			switch code {
+			case eth.UnknownPayload:
+				return nil, eth.InputError{
+					Inner: err,
+					Code:  code,
+				}
+			default:
+				return nil, fmt.Errorf("unrecognized rpc error: %w", err)
 			}
-		} else {
-			e.Error("failed to get payload")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
**Description**

Testnet bugfix:
* The testnet was started without the parent-hash checking (#3221 )
* Reorgs happened (on L1 Goerli testnet, 20+ block deep, well past confirmation distance)
* Frame from data tx was missed again (twice actually). Due to valid reasons: it was just too old, from pre-reorg multiple minutes ago, likely bad L1 data in there too. 
* Batches *after* that frame were still derived, and not dropped, and insertion into engine was attempted
* Nonce errors were hit, but this time we hit a different error path: we received back an RPC error code that we were not properly handling. So the nice payload-attributes validity error we got was assumed to be temporary.
* And then it got stuck retrying those attributes over and over again. At least we have a backoff, but it essentially got stuck due to bad error handling

This PR:
- Adds the missing error type codes that we need to handle. See https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md
- Transforms the RPC error into an `InputError` so we can safely wrap it without losing the ability to distinguish errors
- Handles forkchoice-update errors pre-block-insertion as a reason to reset to regain consistency, not a reason to drop sequencer transactions to try to force forward when the forkchoice is incoherent already.
- Handles input-errors: transactions can be bad, and the payload processing status may not be reached if something is wrong about the input before EVM execution. Nonce values are one example of this.


Depends on #3318 for lint issue in CI.

**Metadata**

Fix ENG-2695
