### PR TITLE
indexer: update finalizations

### DIFF
--- a/indexer/db/l1block.go
+++ b/indexer/db/l1block.go
@@ -6,11 +6,12 @@ import (
 
 // IndexedL1Block contains the L1 block including the deposits in it.
 type IndexedL1Block struct {
-	Hash       common.Hash
-	ParentHash common.Hash
-	Number     uint64
-	Timestamp  uint64
-	Deposits   []Deposit
+	Hash        common.Hash
+	ParentHash  common.Hash
+	Number      uint64
+	Timestamp   uint64
+	Deposits    []Deposit
+	Withdrawals []Withdrawal
 }
 
 // String returns the block hash for the indexed l1 block.
@@ -24,6 +25,7 @@ type IndexedL2Block struct {
 	ParentHash  common.Hash
 	Number      uint64
 	Timestamp   uint64
+	Deposits    []Deposit
 	Withdrawals []Withdrawal
 }
 

--- a/indexer/db/sql.go
+++ b/indexer/db/sql.go
@@ -28,8 +28,10 @@ CREATE TABLE IF NOT EXISTS deposits (
 	amount VARCHAR NOT NULL,
 	data BYTEA NOT NULL,
 	log_index INTEGER NOT NULL,
-	block_hash VARCHAR NOT NULL REFERENCES l1_blocks(hash),
-	tx_hash VARCHAR NOT NULL
+	l1_block_hash VARCHAR NOT NULL REFERENCES l1_blocks(hash),
+	l2_block_hash VARCHAR REFERENCES l2_blocks(hash),
+	tx_hash VARCHAR NOT NULL,
+	failed BOOLEAN NOT NULL DEFAULT false
 )
 `
 
@@ -61,7 +63,8 @@ CREATE TABLE IF NOT EXISTS withdrawals (
 	amount VARCHAR NOT NULL,
 	data BYTEA NOT NULL,
 	log_index INTEGER NOT NULL,
-	block_hash VARCHAR NOT NULL REFERENCES l2_blocks(hash),
+	l1_block_hash VARCHAR REFERENCES l1_blocks(hash),
+	l2_block_hash VARCHAR NOT NULL REFERENCES l2_blocks(hash),
 	tx_hash VARCHAR NOT NULL,
 )
 `

--- a/indexer/db/withdrawal.go
+++ b/indexer/db/withdrawal.go
@@ -26,15 +26,17 @@ func (w Withdrawal) String() string {
 
 // WithdrawalJSON contains Withdrawal data suitable for JSON serialization.
 type WithdrawalJSON struct {
-	GUID           string `json:"guid"`
-	FromAddress    string `json:"from"`
-	ToAddress      string `json:"to"`
-	L1Token        string `json:"l1Token"`
-	L2Token        *Token `json:"l2Token"`
-	Amount         string `json:"amount"`
-	Data           []byte `json:"data"`
-	LogIndex       uint64 `json:"logIndex"`
-	BlockNumber    uint64 `json:"blockNumber"`
-	BlockTimestamp string `json:"blockTimestamp"`
-	TxHash         string `json:"transactionHash"`
+	GUID             string `json:"guid"`
+	FromAddress      string `json:"from"`
+	ToAddress        string `json:"to"`
+	L1Token          string `json:"l1Token"`
+	L2Token          *Token `json:"l2Token"`
+	Amount           string `json:"amount"`
+	Data             []byte `json:"data"`
+	LogIndex         uint64 `json:"logIndex"`
+	L1BlockNumber    uint64 `json:"l1BlockNumber"`
+	L1BlockTimestamp string `json:"l1BlockTimestamp"`
+	L2BlockNumber    uint64 `json:"l2BlockNumber"`
+	L2BlockTimestamp string `json:"l2BlockTimestamp"`
+	TxHash           string `json:"transactionHash"`
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -212,6 +212,7 @@ func (b *Indexer) Serve() error {
 	b.router.HandleFunc("/v1/l1/status", b.l1IndexingService.GetIndexerStatus).Methods("GET")
 	b.router.HandleFunc("/v1/l2/status", b.l2IndexingService.GetIndexerStatus).Methods("GET")
 	b.router.HandleFunc("/v1/deposits/0x{address:[a-fA-F0-9]{40}}", b.l1IndexingService.GetDeposits).Methods("GET")
+	b.router.HandleFunc("/v1/withdrawal/0x{hash:[a-fA-F0-9]{64}}", b.l2IndexingService.GetWithdrawalStatus).Methods("GET")
 	b.router.HandleFunc("/v1/withdrawals/0x{address:[a-fA-F0-9]{40}}", b.l2IndexingService.GetWithdrawals).Methods("GET")
 	b.router.HandleFunc("/v1/airdrops/0x{address:[a-fA-F0-9]{40}}", b.airdropService.GetAirdrop)
 	b.router.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/indexer/services/l1/bridge/bridge.go
+++ b/indexer/services/l1/bridge/bridge.go
@@ -13,10 +13,12 @@ import (
 )
 
 type DepositsMap map[common.Hash][]db.Deposit
+type WithdrawalsMap map[common.Hash][]db.Withdrawal // Finalizations
 
 type Bridge interface {
 	Address() common.Address
 	GetDepositsByBlockRange(uint64, uint64) (DepositsMap, error)
+	GetWithdrawalsByBlockRange(uint64, uint64) (WithdrawalsMap, error)
 	String() string
 }
 

--- a/indexer/services/l1/bridge/eth_bridge.go
+++ b/indexer/services/l1/bridge/eth_bridge.go
@@ -50,6 +50,36 @@ func (e *EthBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap, err
 	return depositsByBlockhash, nil
 }
 
+func (s *EthBridge) GetWithdrawalsByBlockRange(start, end uint64) (WithdrawalsMap, error) {
+	withdrawalsByBlockHash := make(WithdrawalsMap)
+
+	iter, err := FilterETHWithdrawalFinalizedWithRetry(s.ctx, s.filterer, &bind.FilterOpts{
+		Start: start,
+		End:   &end,
+	})
+
+	if err != nil {
+		logger.Error("Error fetching filter", "err", err)
+	}
+
+	for iter.Next() {
+		withdrawalsByBlockHash[iter.Event.Raw.BlockHash] = append(
+			withdrawalsByBlockHash[iter.Event.Raw.BlockHash], db.Withdrawal{
+				TxHash:      iter.Event.Raw.TxHash,
+				FromAddress: iter.Event.From,
+				ToAddress:   iter.Event.To,
+				Amount:      iter.Event.Amount,
+				Data:        iter.Event.ExtraData,
+				LogIndex:    iter.Event.Raw.Index,
+			})
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+
+	return withdrawalsByBlockHash, nil
+}
+
 func (e *EthBridge) String() string {
 	return e.name
 }

--- a/indexer/services/l1/bridge/standard_bridge.go
+++ b/indexer/services/l1/bridge/standard_bridge.go
@@ -52,6 +52,38 @@ func (s *StandardBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap
 	return depositsByBlockhash, nil
 }
 
+func (s *StandardBridge) GetWithdrawalsByBlockRange(start, end uint64) (WithdrawalsMap, error) {
+	withdrawalsByBlockHash := make(WithdrawalsMap)
+
+	iter, err := FilterERC20WithdrawalFinalizedWithRetry(s.ctx, s.filterer, &bind.FilterOpts{
+		Start: start,
+		End:   &end,
+	})
+
+	if err != nil {
+		logger.Error("Error fetching filter", "err", err)
+	}
+
+	for iter.Next() {
+		withdrawalsByBlockHash[iter.Event.Raw.BlockHash] = append(
+			withdrawalsByBlockHash[iter.Event.Raw.BlockHash], db.Withdrawal{
+				TxHash:      iter.Event.Raw.TxHash,
+				L1Token:     iter.Event.L1Token,
+				L2Token:     iter.Event.L2Token,
+				FromAddress: iter.Event.From,
+				ToAddress:   iter.Event.To,
+				Amount:      iter.Event.Amount,
+				Data:        iter.Event.ExtraData,
+				LogIndex:    iter.Event.Raw.Index,
+			})
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+
+	return withdrawalsByBlockHash, nil
+}
+
 func (s *StandardBridge) String() string {
 	return s.name
 }

--- a/indexer/services/l2/bridge/bridge.go
+++ b/indexer/services/l2/bridge/bridge.go
@@ -12,10 +12,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+type DepositsMap map[common.Hash][]db.Deposit // Finalizations
 type WithdrawalsMap map[common.Hash][]db.Withdrawal
 
 type Bridge interface {
 	Address() common.Address
+	GetDepositsByBlockRange(uint64, uint64) (DepositsMap, error)
 	GetWithdrawalsByBlockRange(uint64, uint64) (WithdrawalsMap, error)
 	String() string
 }

--- a/indexer/services/l2/bridge/standard_bridge.go
+++ b/indexer/services/l2/bridge/standard_bridge.go
@@ -22,6 +22,37 @@ func (s *StandardBridge) Address() common.Address {
 	return s.address
 }
 
+func (s *StandardBridge) GetDepositsByBlockRange(start, end uint64) (DepositsMap, error) {
+	depositsByBlockhash := make(DepositsMap)
+
+	iter, err := FilterDepositFinalizedWithRetry(s.ctx, s.filterer, &bind.FilterOpts{
+		Start: start,
+		End:   &end,
+	})
+	if err != nil {
+		logger.Error("Error fetching filter", "err", err)
+	}
+
+	for iter.Next() {
+		depositsByBlockhash[iter.Event.Raw.BlockHash] = append(
+			depositsByBlockhash[iter.Event.Raw.BlockHash], db.Deposit{
+				TxHash:      iter.Event.Raw.TxHash,
+				L1Token:     iter.Event.L1Token,
+				L2Token:     iter.Event.L2Token,
+				FromAddress: iter.Event.From,
+				ToAddress:   iter.Event.To,
+				Amount:      iter.Event.Amount,
+				Data:        iter.Event.ExtraData,
+				LogIndex:    iter.Event.Raw.Index,
+			})
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+
+	return depositsByBlockhash, nil
+}
+
 func (s *StandardBridge) GetWithdrawalsByBlockRange(start, end uint64) (WithdrawalsMap, error) {
 	withdrawalsByBlockhash := make(map[common.Hash][]db.Withdrawal)
 

--- a/indexer/services/l2/service.go
+++ b/indexer/services/l2/service.go
@@ -218,6 +218,7 @@ func (s *Service) Update(newHeader *types.Header) error {
 
 	startHeight := headers[0].Number.Uint64()
 	endHeight := headers[len(headers)-1].Number.Uint64()
+	depositsByBlockHash := make(map[common.Hash][]db.Deposit)
 	withdrawalsByBlockHash := make(map[common.Hash][]db.Withdrawal)
 
 	start := prometheus.NewTimer(s.metrics.UpdateDuration.WithLabelValues("l2"))
@@ -226,10 +227,19 @@ func (s *Service) Update(newHeader *types.Header) error {
 		logger.Info("updated index", "start_height", startHeight, "end_height", endHeight, "duration", dur)
 	}()
 
+	bridgeDepositsCh := make(chan bridge.DepositsMap, len(s.bridges))
 	bridgeWdsCh := make(chan bridge.WithdrawalsMap)
 	errCh := make(chan error, len(s.bridges))
 
 	for _, bridgeImpl := range s.bridges {
+		go func(b bridge.Bridge) {
+			deposits, err := b.GetDepositsByBlockRange(startHeight, endHeight)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			bridgeDepositsCh <- deposits
+		}(bridgeImpl)
 		go func(b bridge.Bridge) {
 			wds, err := b.GetWithdrawalsByBlockRange(startHeight, endHeight)
 			if err != nil {
@@ -246,12 +256,22 @@ func (s *Service) Update(newHeader *types.Header) error {
 		case bridgeWds := <-bridgeWdsCh:
 			for blockHash, withdrawals := range bridgeWds {
 				for _, wd := range withdrawals {
-					if err := s.cacheToken(wd); err != nil {
+					if err := s.cacheToken(wd.L2Token); err != nil {
 						logger.Warn("error caching token", "err", err)
 					}
 				}
 
 				withdrawalsByBlockHash[blockHash] = append(withdrawalsByBlockHash[blockHash], withdrawals...)
+			}
+		case bridgeDeposits := <-bridgeDepositsCh:
+			for blockHash, deposits := range bridgeDeposits {
+				for _, deposit := range deposits {
+					if err := s.cacheToken(deposit.L2Token); err != nil {
+						logger.Warn("error caching token", "err", err)
+					}
+				}
+
+				depositsByBlockHash[blockHash] = append(depositsByBlockHash[blockHash], deposits...)
 			}
 		case err := <-errCh:
 			return err
@@ -266,6 +286,7 @@ func (s *Service) Update(newHeader *types.Header) error {
 	for i, header := range headers {
 		blockHash := header.Hash()
 		number := header.Number.Uint64()
+		deposits := depositsByBlockHash[blockHash]
 		withdrawals := withdrawalsByBlockHash[blockHash]
 
 		if len(withdrawals) == 0 && i != len(headers)-1 {
@@ -277,6 +298,7 @@ func (s *Service) Update(newHeader *types.Header) error {
 			ParentHash:  header.ParentHash,
 			Number:      number,
 			Timestamp:   header.Time,
+			Deposits:    deposits,
 			Withdrawals: withdrawals,
 		}
 
@@ -334,6 +356,18 @@ func (s *Service) GetIndexerStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	server.RespondWithJSON(w, http.StatusOK, status)
+}
+
+func (s *Service) GetWithdrawalStatus(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	withdrawal, err := s.cfg.DB.GetWithdrawalStatus(common.HexToHash(vars["hash"]))
+	if err != nil {
+		server.RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	server.RespondWithJSON(w, http.StatusOK, withdrawal)
 }
 
 func (s *Service) GetWithdrawals(w http.ResponseWriter, r *http.Request) {
@@ -431,32 +465,32 @@ func (s *Service) catchUp(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) cacheToken(withdrawal db.Withdrawal) error {
-	if s.tokenCache[withdrawal.L2Token] != nil {
+func (s *Service) cacheToken(address common.Address) error {
+	if s.tokenCache[address] != nil {
 		return nil
 	}
 
-	token, err := s.cfg.DB.GetL2TokenByAddress(withdrawal.L2Token.String())
+	token, err := s.cfg.DB.GetL2TokenByAddress(address.String())
 	if err != nil {
 		return err
 	}
 	if token != nil {
 		s.metrics.IncL2CachedTokensCount()
-		s.tokenCache[withdrawal.L2Token] = token
+		s.tokenCache[address] = token
 		return nil
 	}
-	token, err = QueryERC20(withdrawal.L2Token, s.cfg.L2Client)
+	token, err = QueryERC20(address, s.cfg.L2Client)
 	if err != nil {
 		logger.Error("Error querying ERC20 token details",
-			"l2_token", withdrawal.L2Token.String(), "err", err)
+			"l2_token", address.String(), "err", err)
 		token = &db.Token{
-			Address: withdrawal.L2Token.String(),
+			Address: address.String(),
 		}
 	}
-	if err := s.cfg.DB.AddL2Token(withdrawal.L2Token.String(), token); err != nil {
+	if err := s.cfg.DB.AddL2Token(address.String(), token); err != nil {
 		return err
 	}
-	s.tokenCache[withdrawal.L2Token] = token
+	s.tokenCache[address] = token
 	s.metrics.IncL2CachedTokensCount()
 	return nil
 }


### PR DESCRIPTION
**Description**
This PR updates the indexer to track deposit / withdrawal finalisations.

**Additional context**
The L1 / L2 services are updated to listen to `DepositFinalized` on L2 and `ETHWithdrawalFinalized` / `ERC20WithdrawalFinalized` on L1 respectively.

The `/withdrawal/<address>` API endpoint has been updated to return finalisation status including the L1 block hash / number at which it finalised.

**Metadata**
- Fixes ENG-2665
- Depends on #3323 
