### PR TITLE
op-node: fix l2_safe missing metrics line

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -303,6 +303,7 @@ func (eq *EngineQueue) consolidateNextSafeAttributes(ctx context.Context) error 
 		return NewResetError(fmt.Errorf("failed to decode L2 block ref from payload: %v", err))
 	}
 	eq.safeHead = ref
+	eq.metrics.RecordL2Ref("l2_safe", ref)
 	// unsafe head stays the same, we did not reorg the chain.
 	eq.safeAttributes = eq.safeAttributes[1:]
 	eq.postProcessSafeL2()


### PR DESCRIPTION
Forgot a metrics update line