### PR TITLE
style(batch-submitter,bss-core,proxyd): Fix lint Go

### DIFF
--- a/batch-submitter/drivers/sequencer/encoding.go
+++ b/batch-submitter/drivers/sequencer/encoding.go
@@ -68,10 +68,10 @@ func (c BatchContext) MarkerBatchType() BatchType {
 
 // Write encodes the BatchContext into a 16-byte stream using the following
 // encoding:
-//  - num_sequenced_txs:        3 bytes
-//  - num_subsequent_queue_txs: 3 bytes
-//  - timestamp:                5 bytes
-//  - block_number:             5 bytes
+//   - num_sequenced_txs:        3 bytes
+//   - num_subsequent_queue_txs: 3 bytes
+//   - timestamp:                5 bytes
+//   - block_number:             5 bytes
 //
 // Note that writing to a bytes.Buffer cannot
 // error, so errors are ignored here
@@ -85,10 +85,10 @@ func (c *BatchContext) Write(w *bytes.Buffer) {
 // Read decodes the BatchContext from the passed reader. If fewer than 16-bytes
 // remain, an error is returned. Otherwise the first 16-bytes will be read using
 // the expected encoding:
-//  - num_sequenced_txs:        3 bytes
-//  - num_subsequent_queue_txs: 3 bytes
-//  - timestamp:                5 bytes
-//  - block_number:             5 bytes
+//   - num_sequenced_txs:        3 bytes
+//   - num_subsequent_queue_txs: 3 bytes
+//   - timestamp:                5 bytes
+//   - block_number:             5 bytes
 func (c *BatchContext) Read(r io.Reader) error {
 	if err := readUint64(r, &c.NumSequencedTxs, 3); err != nil {
 		return err
@@ -188,13 +188,13 @@ type AppendSequencerBatchParams struct {
 }
 
 // Write encodes the AppendSequencerBatchParams using the following format:
-//  - should_start_at_element:        5 bytes
-//  - total_elements_to_append:       3 bytes
-//  - num_contexts:                   3 bytes
-//    - num_contexts * batch_context: num_contexts * 16 bytes
-//  - [num txs omitted]
-//    - tx_len:                       3 bytes
-//    - tx_bytes:                     tx_len bytes
+//   - should_start_at_element:        5 bytes
+//   - total_elements_to_append:       3 bytes
+//   - num_contexts:                   3 bytes
+//   - num_contexts * batch_context: num_contexts * 16 bytes
+//   - [num txs omitted]
+//   - tx_len:                       3 bytes
+//   - tx_bytes:                     tx_len bytes
 //
 // Typed batches include a dummy context as the first context
 // where the timestamp is 0. The blocknumber is interpreted
@@ -288,13 +288,13 @@ func (p *AppendSequencerBatchParams) Serialize(
 // stream does not terminate cleanly with an EOF while reading a tx_len, this
 // method will return an error. Otherwise, the stream will be parsed according
 // to the following format:
-//  - should_start_at_element:        5 bytes
-//  - total_elements_to_append:       3 bytes
-//  - num_contexts:                   3 bytes
-//    - num_contexts * batch_context: num_contexts * 16 bytes
-//  - [num txs omitted]
-//    - tx_len:                       3 bytes
-//    - tx_bytes:                     tx_len bytes
+//   - should_start_at_element:        5 bytes
+//   - total_elements_to_append:       3 bytes
+//   - num_contexts:                   3 bytes
+//   - num_contexts * batch_context: num_contexts * 16 bytes
+//   - [num txs omitted]
+//   - tx_len:                       3 bytes
+//   - tx_bytes:                     tx_len bytes
 func (p *AppendSequencerBatchParams) Read(r io.Reader) error {
 	if err := readUint64(r, &p.ShouldStartAtElement, 5); err != nil {
 		return err

--- a/batch-submitter/drivers/sequencer/encoding_test.go
+++ b/batch-submitter/drivers/sequencer/encoding_test.go
@@ -15,10 +15,10 @@ import (
 
 // TestBatchContextEncodeDecode tests the (de)serialization of a BatchContext
 // against the spec test vector. The encoding should be:
-//  - num_sequenced_txs:        3 bytes
-//  - num_subsequent_queue_txs: 3 bytes
-//  - timestamp:                5 bytes
-//  - block_number:             5 bytes
+//   - num_sequenced_txs:        3 bytes
+//   - num_subsequent_queue_txs: 3 bytes
+//   - timestamp:                5 bytes
+//   - block_number:             5 bytes
 func TestBatchContextEncodeDecode(t *testing.T) {
 	t.Parallel()
 

--- a/bss-core/crypto.go
+++ b/bss-core/crypto.go
@@ -32,8 +32,8 @@ func ParseAddress(address string) (common.Address, error) {
 
 // GetConfiguredPrivateKey computes the private key for our configured services.
 // The two supported methods are:
-//  - Derived from BIP39 mnemonic and BIP32 HD derivation path.
-//  - Directly from a serialized private key.
+//   - Derived from BIP39 mnemonic and BIP32 HD derivation path.
+//   - Directly from a serialized private key.
 func GetConfiguredPrivateKey(mnemonic, hdPath, privKeyStr string) (
 	*ecdsa.PrivateKey, error) {
 

--- a/bss-core/crypto_test.go
+++ b/bss-core/crypto_test.go
@@ -209,9 +209,9 @@ func TestParsePrivateKeyStr(t *testing.T) {
 }
 
 // TestGetConfiguredPrivateKey asserts that GetConfiguredPrivateKey either:
-//  1) Derives the correct private key assuming the BIP39 mnemonic and BIP32
+//  1. Derives the correct private key assuming the BIP39 mnemonic and BIP32
 //     derivation path are both present and the private key string is omitted.
-//  2) Parses the correct private key assuming only the private key string is
+//  2. Parses the correct private key assuming only the private key string is
 //     present, but the BIP39 mnemonic and BIP32 derivation path are omitted.
 func TestGetConfiguredPrivateKey(t *testing.T) {
 	tests := []struct {

--- a/bss-core/txmgr/txmgr.go
+++ b/bss-core/txmgr/txmgr.go
@@ -330,7 +330,8 @@ func waitMined(
 
 // CalcGasFeeCap deterministically computes the recommended gas fee cap given
 // the base fee and gasTipCap. The resulting gasFeeCap is equal to:
-//   gasTipCap + 2*baseFee.
+//
+//	gasTipCap + 2*baseFee.
 func CalcGasFeeCap(baseFee, gasTipCap *big.Int) *big.Int {
 	return new(big.Int).Add(
 		gasTipCap,

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net/http"
@@ -408,7 +407,7 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 	}
 
 	defer httpRes.Body.Close()
-	resB, err := ioutil.ReadAll(io.LimitReader(httpRes.Body, b.maxResponseSize))
+	resB, err := io.ReadAll(io.LimitReader(httpRes.Body, b.maxResponseSize))
 	if err != nil {
 		return nil, wrapErr(err, "error reading response body")
 	}

--- a/proxyd/integration_tests/mock_backend_test.go
+++ b/proxyd/integration_tests/mock_backend_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -122,7 +122,7 @@ func (h *BatchRPCResponseRouter) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	h.mtx.Lock()
 	defer h.mtx.Unlock()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -241,12 +241,12 @@ func (m *MockBackend) Requests() []*RecordedRequest {
 
 func (m *MockBackend) wrappedHandler(w http.ResponseWriter, r *http.Request) {
 	m.mtx.Lock()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		panic(err)
 	}
 	clone := r.Clone(context.Background())
-	clone.Body = ioutil.NopCloser(bytes.NewReader(body))
+	clone.Body = io.NopCloser(bytes.NewReader(body))
 	m.requests = append(m.requests, &RecordedRequest{
 		Method:  r.Method,
 		Headers: r.Header.Clone(),

--- a/proxyd/integration_tests/util_test.go
+++ b/proxyd/integration_tests/util_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -67,7 +67,7 @@ func (p *ProxydHTTPClient) SendRequest(body []byte) ([]byte, int, error) {
 	}
 	defer res.Body.Close()
 	code := res.StatusCode
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -3,7 +3,6 @@ package proxyd
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"strings"
 )
 
@@ -103,7 +102,7 @@ func ParseBatchRPCReq(body []byte) ([]json.RawMessage, error) {
 }
 
 func ParseRPCRes(r io.Reader) (*RPCRes, error) {
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		return nil, wrapErr(err, "error reading RPC response")
 	}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"strconv"
@@ -236,7 +235,7 @@ func (s *Server) HandleRPC(w http.ResponseWriter, r *http.Request) {
 		"user_agent", userAgent,
 	)
 
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, s.maxBodySize))
+	body, err := io.ReadAll(io.LimitReader(r.Body, s.maxBodySize))
 	if err != nil {
 		log.Error("error reading request body", "err", err)
 		writeRPCError(ctx, w, nil, ErrInternal)

--- a/proxyd/tls.go
+++ b/proxyd/tls.go
@@ -4,11 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
+	"os"
 )
 
 func CreateTLSClient(ca string) (*tls.Config, error) {
-	pem, err := ioutil.ReadFile(ca)
+	pem, err := os.ReadFile(ca)
 	if err != nil {
 		return nil, wrapErr(err, "error reading CA")
 	}


### PR DESCRIPTION
- Go 1.19 introduced some doc markdown formatting, linter picked that up
- Go 1.16 moved away from `ioutil` by making `ioutil` call the `io` and `os` packages under the hood, moving the implementation. It's finally time to fix this now that the linter complains.
