### PR TITLE
fix(ci): properly publish hardhat-node

### DIFF
--- a/.changeset/wild-feet-listen.md
+++ b/.changeset/wild-feet-listen.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-node': patch
+---
+
+Fixes CI to properly release the hardhat-node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
   hardhat-node:
     name: Publish Hardhat Node ${{ needs.release.outputs.hardhat-node }}
     needs: release
-    if: needs.release.hardhat-node != ''
+    if: needs.release.outputs.hardhat-node != ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sync-tests.yml
+++ b/.github/workflows/sync-tests.yml
@@ -61,7 +61,7 @@ jobs:
         if: failure()
         uses: jwalton/gh-docker-logs@v1
         with:
-          images: 'ethereumoptimism/hardhat,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth'
+          images: 'ethereumoptimism/hardhat-node,ethereumoptimism/deployer,ethereumoptimism/data-transport-layer,ethereumoptimism/l2geth,ethereumoptimism/message-relayer,ethereumoptimism/batch-submitter,ethereumoptimism/l2geth'
           dest: './logs'
 
       - name: Tar logs

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -12,7 +12,7 @@ x-system-addr-env: &system-addr-env
 services:
   # this is a helper service used because there's no official hardhat image
   l1_chain:
-    image: ethereumoptimism/hardhat:${DOCKER_TAG_HARDHAT:-latest}
+    image: ethereumoptimism/hardhat-node:${DOCKER_TAG_HARDHAT:-latest}
     build:
       context: ./docker/hardhat
       dockerfile: Dockerfile

--- a/ops/scripts/build-ci.sh
+++ b/ops/scripts/build-ci.sh
@@ -16,7 +16,7 @@ function build() {
 
 mkdir -p /tmp/.buildx-cache-new
 build l2geth "ethereumoptimism/l2geth:latest" "./l2geth/Dockerfile" .
-build l1chain "ethereumoptimism/hardhat:latest" "./ops/docker/hardhat/Dockerfile" ./ops/docker/hardhat
+build l1chain "ethereumoptimism/hardhat-node:latest" "./ops/docker/hardhat/Dockerfile" ./ops/docker/hardhat
 
 wait
 


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
hardhat-node docker image was not being properly published. We were also
using the wrong docker image name.