### PR TITLE
fix(dtl): retry correctly for non-block result

### DIFF
--- a/.changeset/brown-poems-shave.md
+++ b/.changeset/brown-poems-shave.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Fix minor DTL bug when syncing from public endpoint

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -311,17 +311,25 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
 
         end()
 
-        result = respJson.result
-        if (result === null) {
+        if (Array.isArray(respJson.result)) {
+          result = respJson.result
+        } else {
           retry++
           this.logger.info(
             `request for block range [${startBlockNumber},${endBlockNumber}) returned null, retry ${retry}`
           )
-          await sleep(1000 * retry)
+          await sleep(5000 * retry)
         }
       }
 
       blocks = result
+    }
+
+    // We should be protected against this by the check above, but might as well guard here just in case.
+    if (!Array.isArray(blocks)) {
+      throw new Error(
+        `should not happen: eth_getBlockRange returned non-array result`
+      )
     }
 
     for (const block of blocks) {


### PR DESCRIPTION

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Fixes a small bug in the DTL that would cause the service to error out instead of retrying when eth_getBlockRange returned a non-block result. This would sometimes happen when the DTL was close to the tip and queried for a block that the target node did not have yet. This PR slows down the retries and properly detects bad results (anything except for an array is bad, including but not limited to "null" or "undefined").

Fixes #3341
