### PR TITLE
Generate codecoverage and upload to CodeCov

### DIFF
--- a/.changeset/famous-pans-battle.md
+++ b/.changeset/famous-pans-battle.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Download and verify codecov uploader binary in the ci-builder image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   go: circleci/go@1.5.0
-
 jobs:
   yarn-monorepo:
     docker:
@@ -33,6 +32,9 @@ jobs:
       - run:
           name: Install dependencies
           command: yarn --frozen-lockfile
+      - run:
+          name: print forge version
+          command: forge --version
       - save_cache:
           key: v2-cache-yarn-install-{{ checksum "yarn.lock" }}
           paths:
@@ -137,6 +139,9 @@ jobs:
             slither --version
             yarn slither || exit 0
           working_directory: packages/contracts-bedrock
+      - run:
+          name: print forge version
+          command: forge --version
       - run:
           name: test
           command: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,9 @@ jobs:
           command: |
             gotestsum --junitfile /test-results/op-chain-ops.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
           working_directory: op-chain-ops
+      - run:
+          name: Upload coverage reports to CodeCov
+          command: ./codecov
       - store_test_results:
           path: /test-results
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,10 +54,22 @@ jobs:
       - run:
           name: Build monorepo
           command: yarn build
+      - run:
+          name: Download and verify Codecov uploader
+          command: |
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os "https://uploader.codecov.io/latest/linux/codecov"
+            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM"
+            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig"
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM
+            unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
+            chmod +x codecov
       - save_cache:
           key: v2-cache-yarn-build-{{ .Revision }}
           paths:
             - "."
+
 
   docker-publish:
     environment:
@@ -142,12 +154,13 @@ jobs:
       - run:
           name: print forge version
           command: forge --version
+          working_directory: packages/contracts-bedrock
       - run:
           name: test
           command: yarn test
-          working_directory: packages/contracts-bedrock
           environment:
             FOUNDRY_PROFILE: ci
+          working_directory: packages/contracts-bedrock
       - run:
           name: gas snapshot
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,17 +54,6 @@ jobs:
       - run:
           name: Build monorepo
           command: yarn build
-      - run:
-          name: Download and verify Codecov uploader
-          command: |
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            curl -Os "https://uploader.codecov.io/latest/linux/codecov"
-            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM"
-            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig"
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM
-            # unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
-            chmod +x codecov
       - save_cache:
           key: v2-cache-yarn-build-{{ .Revision }}
           paths:
@@ -248,17 +237,6 @@ jobs:
             if [[ "$CHANGED" = "FALSE" ]]; then
               circleci step halt
             fi
-      - run:
-          name: Download and verify Codecov uploader
-          command: |
-            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            curl -Os "https://uploader.codecov.io/latest/linux/codecov"
-            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM"
-            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig"
-            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM
-            unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
-            chmod +x codecov
       - run:
           name: lint op-bindings
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,13 +157,13 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: test and generate coverage
-          command: yarn coverage
+          command: yarn coverage:lcov
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
       - run:
           name: upload coverage
-          command: ./codecov -v # -n "${CIRCLE_BUILD_NUM}"
+          command: ./codecov --verbose
           environment:
             FOUNDRY_PROFILE: ci
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,8 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: upload coverage
-          command: ./codecov --verbose
+          command: |
+           ./codecov --verbose || exit 0
           environment:
             FOUNDRY_PROFILE: ci
       - run:
@@ -307,7 +308,8 @@ jobs:
           working_directory: op-chain-ops
       - run:
           name: Upload coverage reports to CodeCov
-          command: ./codecov
+          command: |
+            ./codecov --verbose || exit 0
       - store_test_results:
           path: /test-results
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig"
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM
-            unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
+            # unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
             chmod +x codecov
       - save_cache:
           key: v2-cache-yarn-build-{{ .Revision }}
@@ -156,11 +156,16 @@ jobs:
           command: forge --version
           working_directory: packages/contracts-bedrock
       - run:
-          name: test
-          command: yarn test
+          name: test and generate coverage
+          command: yarn coverage
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
+      - run:
+          name: upload coverage
+          command: ./codecov -v # -n "${CIRCLE_BUILD_NUM}"
+          environment:
+            FOUNDRY_PROFILE: ci
       - run:
           name: gas snapshot
           command: |
@@ -243,6 +248,17 @@ jobs:
             if [[ "$CHANGED" = "FALSE" ]]; then
               circleci step halt
             fi
+      - run:
+          name: Download and verify Codecov uploader
+          command: |
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            curl -Os "https://uploader.codecov.io/latest/linux/codecov"
+            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM"
+            curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig"
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM
+            unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
+            chmod +x codecov
       - run:
           name: lint op-bindings
           command: |

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=geth /usr/local/bin/abigen /usr/local/bin/abigen
 COPY check-changed.sh /usr/local/bin/check-changed
 
 RUN apt-get update && \
-  apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl && \
+  apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl gnupg coreutils && \
   curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
   curl -sL https://go.dev/dl/go1.19.linux-amd64.tar.gz -o go1.19.linux-amd64.tar.gz && \
   tar -C /usr/local/ -xzvf go1.19.linux-amd64.tar.gz && \

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -84,3 +84,12 @@ RUN echo "downloading solidity compilers" && \
   rm solc-linux-amd64-v0.8.9+commit.e5eed63a && \
   rm solc-linux-amd64-v0.8.10+commit.fc410830 && \
   rm solc-linux-amd64-v0.8.12+commit.f00d7308
+
+RUN echo "downloading and verifying Codecov uploader" && \
+  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step && \
+  curl -Os "https://uploader.codecov.io/latest/linux/codecov" && \
+  curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM" && \
+  curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig" && \
+  gpgv codecov.SHA256SUM.sig codecov.SHA256SUM && \
+  shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM && \
+  chmod +x codecov

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -23,6 +23,7 @@
     "deploy": "hardhat deploy",
     "test": "yarn build:differential && forge test",
     "coverage": "yarn build:differential && forge coverage",
+    "coverage:lcov": "yarn build:differential && forge coverage --report lcov",
     "gas-snapshot": "yarn build:differential && forge snapshot",
     "storage-snapshot": "./scripts/storage-snapshot.sh",
     "slither": "./scripts/slither.sh",


### PR DESCRIPTION
Changes CI to upload code coverage results generated by the go modules and contracts-bedrock package.

This job doesn't run on this PR because of the Check Changed step, but it was tested in previous iterations of this branch by disabling that step. The results can be seen [here](https://app.codecov.io/gh/ethereum-optimism/optimism/tree/temp-getcoverage). 

Improvements which are not included in this PR but will be added later: 
1. Moving the codecov uploader installation to the ci-builder image.
2. Failing in CI when the coverage threshold decreases.
3. Adding a coverage badge to the README.