### PR TITLE
op-node: Switch to 128 bit channel ID & block # timeout

### DIFF
--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -303,7 +303,7 @@ mainLoop:
 				l.log.Warn("last submitted block lagged behind L2 safe head: batch submission will continue from the safe head now", "last", l.lastSubmittedBlock, "safe", syncStatus.SafeL2)
 				l.lastSubmittedBlock = syncStatus.SafeL2.ID()
 			}
-			if ch, err := derive.NewChannelOut(syncStatus.HeadL1.Time); err != nil {
+			if ch, err := derive.NewChannelOut(); err != nil {
 				l.log.Error("Error creating channel", "err", err)
 				continue
 			} else {

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -137,7 +137,7 @@ func defaultSystemConfig(t *testing.T) SystemConfig {
 			BlockTime:         1,
 			MaxSequencerDrift: 10,
 			SeqWindowSize:     30,
-			ChannelTimeout:    20,
+			ChannelTimeout:    10,
 			L1ChainID:         big.NewInt(900),
 			L2ChainID:         big.NewInt(901),
 			// TODO pick defaults

--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -19,7 +19,8 @@ import (
 // channel may mark itself as ready for reading once all intervening frames have been added
 type Channel struct {
 	// id of the channel
-	id ChannelID
+	id        ChannelID
+	openBlock eth.L1BlockRef
 
 	// estimated memory size, used to drop the channel if we have too much data
 	size uint64
@@ -42,10 +43,11 @@ type Channel struct {
 	highestL1InclusionBlock eth.L1BlockRef
 }
 
-func NewChannel(id ChannelID) *Channel {
+func NewChannel(id ChannelID, openBlock eth.L1BlockRef) *Channel {
 	return &Channel{
-		id:     id,
-		inputs: make(map[uint64][]byte),
+		id:        id,
+		inputs:    make(map[uint64][]byte),
+		openBlock: openBlock,
 	}
 }
 
@@ -78,6 +80,12 @@ func (ch *Channel) AddFrame(frame Frame, l1InclusionBlock eth.L1BlockRef) error 
 	// todo use `IsReady` + state to create final output reader
 
 	return nil
+}
+
+// OpenBlockNumber returns the block number of L1 block that contained
+// the first frame for this channel.
+func (ch *Channel) OpenBlockNumber() uint64 {
+	return ch.openBlock.Number
 }
 
 // Size returns the current size of the channel including frame overhead.

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -34,15 +34,13 @@ func (co *ChannelOut) ID() ChannelID {
 	return co.id
 }
 
-func NewChannelOut(channelTime uint64) (*ChannelOut, error) {
+func NewChannelOut() (*ChannelOut, error) {
 	c := &ChannelOut{
-		id: ChannelID{
-			Time: channelTime,
-		},
+		id:     ChannelID{}, // TODO: use GUID here instead of fully random data
 		frame:  0,
 		offset: 0,
 	}
-	_, err := rand.Read(c.id.Data[:])
+	_, err := rand.Read(c.id[:])
 	if err != nil {
 		return nil, err
 	}
@@ -57,15 +55,14 @@ func NewChannelOut(channelTime uint64) (*ChannelOut, error) {
 }
 
 // TODO: reuse ChannelOut for performance
-func (co *ChannelOut) Reset(channelTime uint64) error {
+func (co *ChannelOut) Reset() error {
 	co.frame = 0
 	co.offset = 0
 	co.buf.Reset()
 	co.scratch.Reset()
 	co.compress.Reset(&co.buf)
 	co.closed = false
-	co.id.Time = channelTime
-	_, err := rand.Read(co.id.Data[:])
+	_, err := rand.Read(co.id[:])
 	if err != nil {
 		return err
 	}

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -17,9 +17,7 @@ const MaxFrameLen = 1_000_000
 //
 // frame = channel_id ++ frame_number ++ frame_data_length ++ frame_data ++ is_last
 //
-// channel_id        = random ++ timestamp
-// random            = bytes32
-// timestamp         = uint64
+// channel_id        = bytes16
 // frame_number      = uint16
 // frame_data_length = uint32
 // frame_data        = bytes
@@ -36,11 +34,8 @@ type Frame struct {
 // It returns any errors encountered while writing, but
 // generally expects the writer very rarely fail.
 func (f *Frame) MarshalBinary(w io.Writer) error {
-	_, err := w.Write(f.ID.Data[:])
+	_, err := w.Write(f.ID[:])
 	if err != nil {
-		return err
-	}
-	if err := binary.Write(w, binary.BigEndian, f.ID.Time); err != nil {
 		return err
 	}
 	if err := binary.Write(w, binary.BigEndian, f.FrameNumber); err != nil {
@@ -74,13 +69,9 @@ type ByteReader interface {
 // If `r` fails a read, it returns the error from the reader
 // The reader will be left in a partially read state.
 func (f *Frame) UnmarshalBinary(r ByteReader) error {
-	if _, err := io.ReadFull(r, f.ID.Data[:]); err != nil {
+	if _, err := io.ReadFull(r, f.ID[:]); err != nil {
 		return fmt.Errorf("error reading ID: %w", err)
 	}
-	if err := binary.Read(r, binary.BigEndian, &f.ID.Time); err != nil {
-		return fmt.Errorf("error reading ID time: %w", err)
-	}
-
 	if err := binary.Read(r, binary.BigEndian, &f.FrameNumber); err != nil {
 		return fmt.Errorf("error reading frame number: %w", err)
 	}

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -1,10 +1,8 @@
 package derive
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"strconv"
 )
 
 // count the tagging info as 200 in terms of buffer size.
@@ -20,50 +18,17 @@ const MaxChannelBankSize = 100_000_000
 // DuplicateErr is returned when a newly read frame is already known
 var DuplicateErr = errors.New("duplicate frame")
 
-// ChannelIDDataSize defines the length of the channel ID data part
-const ChannelIDDataSize = 32
+// ChannelIDLength defines the length of the channel IDs
+const ChannelIDLength = 16
 
-// ChannelID identifies a "channel" a stream encoding a sequence of L2 information.
-// A channelID is part random data (this may become a hash commitment to restrict who opens which channel),
-// and part timestamp. The timestamp invalidates the ID,
-// to ensure channels cannot be re-opened after timeout, or opened too soon.
-//
-// The ChannelID type is flat and can be used as map key.
-type ChannelID struct {
-	Data [ChannelIDDataSize]byte
-	Time uint64
-}
+// ChannelID is an opaque identifier for a channel. It is 128 bits to be globally unique.
+type ChannelID [ChannelIDLength]byte
 
 func (id ChannelID) String() string {
-	return fmt.Sprintf("%x:%d", id.Data[:], id.Time)
-}
-
-func (id ChannelID) MarshalText() ([]byte, error) {
-	return []byte(id.String()), nil
-}
-
-func (id *ChannelID) UnmarshalText(text []byte) error {
-	if id == nil {
-		return errors.New("cannot unmarshal text into nil Channel ID")
-	}
-	if len(text) < ChannelIDDataSize+1 {
-		return fmt.Errorf("channel ID too short: %d", len(text))
-	}
-	if _, err := hex.Decode(id.Data[:], text[:ChannelIDDataSize]); err != nil {
-		return fmt.Errorf("failed to unmarshal hex data part of channel ID: %v", err)
-	}
-	if c := text[ChannelIDDataSize*2]; c != ':' {
-		return fmt.Errorf("expected : separator in channel ID, but got %d", c)
-	}
-	v, err := strconv.ParseUint(string(text[ChannelIDDataSize*2+1:]), 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal decimal time part of channel ID: %v", err)
-	}
-	id.Time = v
-	return nil
+	return fmt.Sprintf("%x", id[:])
 }
 
 // TerminalString implements log.TerminalStringer, formatting a string for console output during logging.
 func (id ChannelID) TerminalString() string {
-	return fmt.Sprintf("%x..%x-%d", id.Data[:3], id.Data[29:], id.Time)
+	return fmt.Sprintf("%x..%x", id[:3], id[13:])
 }

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -32,7 +32,7 @@ type Config struct {
 	MaxSequencerDrift uint64 `json:"max_sequencer_drift"`
 	// Number of epochs (L1 blocks) per sequencing window, including the epoch L1 origin block itself
 	SeqWindowSize uint64 `json:"seq_window_size"`
-	// Number of seconds (w.r.t. L1 time) that a frame can be valid when included in L1
+	// Number of L1 blocks between when a channel can be opened and when it must be closed by.
 	ChannelTimeout uint64 `json:"channel_timeout"`
 	// Required to verify L1 signatures
 	L1ChainID *big.Int `json:"l1_chain_id"`

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -313,38 +313,26 @@ A [channel frame][g-channel-frame] is encoded as:
 ```text
 frame = channel_id ++ frame_number ++ frame_data_length ++ frame_data ++ is_last
 
-channel_id        = random ++ timestamp
-random            = bytes32
-timestamp         = uint64
+channel_id        = bytes16
 frame_number      = uint16
 frame_data_length = uint32
 frame_data        = bytes
 is_last           = bool
 ```
 
-Where `uint64`, `uint32` and `uint16` are all big-endian unsigned integers. Type names should be interpreted to and
+Where `uint32` and `uint16` are all big-endian unsigned integers. Type names should be interpreted to and
 encoded according to [the Solidity ABI][solidity-abi].
 
 [solidity-abi]: https://docs.soliditylang.org/en/v0.8.16/abi-spec.html
 
-All data in a frame is fixed-size, except the `frame_data`. The fixed overhead is `32 + 8 + 2 + 4 + 1 = 47 bytes`.
+All data in a frame is fixed-size, except the `frame_data`. The fixed overhead is `16 + 2 + 4 + 1 = 23 bytes`.
 Fixed-size frame metadata avoids a circular dependency with the target total data length,
 to simplify packing of frames with varying content length.
 
 where:
 
-- `channel_id` uniquely identifies a channel as the concatenation of a random value and a timestamp
-  - `random` is a random value such that two channels with different batches should have a different random value
-  - `timestamp` is the time at which the channel was created (UNIX time in seconds)
-  - The ID includes both the random value and the timestamp, in order to prevent a malicious sequencer from reusing the
-    random value after the channel has [timed out][g-channel-timeout] (refer to the [batcher
-    specification][batcher-spec] to learn more about channel timeouts). This will also allow us substitute `random` by a
-    hash commitment to the batches, should we want to do so in the future.
-  - Frames with a channel ID whose timestamp are higher than that of the L1 block on which the frame appears must be
-    ignored. Note that L1 nodes cannot easily manipulate the L1 block timestamp: L1 nodes have a soft constraint to
-    ignore blocks whose timestamps that are ahead of the wallclock time by a certain margin. (A soft constraint is not a
-    consensus rule — nodes will accept such blocks in the canonical chain but will not attempt to build directly on
-    them.) This issue goes away with Proof of Stake, where timestamps are determined by [L1 time slots][g-time-slot].
+- `channel_id` is an opaque identifier for the channel. It should not be reused and is suggested to be random; however,
+outside of timeout rules, it is not checked for validity
 - `frame_number` identifies the index of the frame within the channel
 - `frame_data_length` is the length of `frame_data` in bytes. It is capped to 1,000,000 bytes.
 - `frame_data` is a sequence of bytes belonging to the channel, logically after the bytes from the previous frames
@@ -505,7 +493,8 @@ However, our current implementation doesn't support streaming decompression, so 
 - We have received all frames in the channel: i.e. we received the last frame in the channel (`is_last == 1`) and every
   frame with a lower number.
 - The channel has timed out (in which we case we read all contiguous sequential frames from the start of the channel).
-  - A channel is considered to be *timed out* if `currentL1Block.timestamp > channeld_id.timestamp + CHANNEL_TIMEOUT`.
+  - A channel is considered to be *timed out* if
+`currentL1Block.number > channeld_id.starting_l1_number + CHANNEL_TIMEOUT`.
     - where `currentL1Block` is the L1 block maintained by this stage, which is the most recent L1 block whose frames
           have been added to the channel bank.
 - The channel is pruned out of the channel bank (see below), in which case it isn't passed to the further stages.
@@ -945,12 +934,12 @@ epoch sequencing window, assuming it is in the same epoch as `safeL2Head`).
 > could post a batch for the L2 block `safeL2Head + 1` on L1 block `safeL2Head.1Origin`.
 
 Keeping things worst case, `safeL2Head.l1Origin` would also be the last allowable block for the frame to land. The
-allowed time range for frames within a channel to land on L1 is `[channel_id.timestamp, channel_id.timestamp +
-CHANNEL_TIMEOUT]`. The allowed L1 block range for these frames are any L1 block whose timestamp falls inside this time
+allowed time range for frames within a channel to land on L1 is `[channel_id.number, channel_id.number +
+CHANNEL_TIMEOUT]`. The allowed L1 block range for these frames are any L1 block whose number falls inside this block
 range.
 
-Therefore, to be safe, we can reset the L1 head of Channel Buffering to the oldest L1 block whose timestamp is higher
-than `safeL2Head.l1Origin.timestamp - CHANNEL_TIMEOUT`.
+Therefore, to be safe, we can reset the L1 head of Channel Buffering to the L1 block whose number is
+`safeL2Head.l1Origin.number - CHANNEL_TIMEOUT`.
 
 > **Note** The above is what the implementation currently does.
 
@@ -958,7 +947,7 @@ In reality it's only strictly necessary to reset the oldest L1 block whose times
 `channel_id.timestamp` found in the batcher transaction that is not older than `safeL2Head.l1Origin.timestamp -
 CHANNEL_TIMEOUT`.
 
-We define `CHANNEL_TIMEOUT = 600`, i.e. 10 hours.
+We define `CHANNEL_TIMEOUT = 600`, i.e. 10 hours. (600s == 10 mins. Choose order 500 blocks as channel timeout?)
 
 > **TODO** does `CHANNEL_TIMEOUT` have a relationship with `SWS`?
 >

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -947,7 +947,7 @@ In reality it's only strictly necessary to reset the oldest L1 block whose times
 `channel_id.timestamp` found in the batcher transaction that is not older than `safeL2Head.l1Origin.timestamp -
 CHANNEL_TIMEOUT`.
 
-We define `CHANNEL_TIMEOUT = 600`, i.e. 10 hours. (600s == 10 mins. Choose order 500 blocks as channel timeout?)
+We define `CHANNEL_TIMEOUT = 50`, i.e. 10mins
 
 > **TODO** does `CHANNEL_TIMEOUT` have a relationship with `SWS`?
 >


### PR DESCRIPTION
**Description**

This PR removes the 256 bit channel ID + timestamp. With the timestamp being removed, the channel timeout is now done with block numbers.

**Tests**

The unit tests needed to be modified, but pass. E2E tests pass

