### PR TITLE
fix(hive): fix CI, do not use op-contracts client in hive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,7 @@ jobs:
             -sim=<<parameters.sim>> \
             -sim.loglevel=5 \
             -docker.pull=true \
-            -client=go-ethereum,op-geth_optimism-history,op-proposer_<<parameters.version>>,op-batcher_<<parameters.version>>,op-node_<<parameters.version>>,op-contracts_<<parameters.version>> |& tee /tmp/hive.log
+            -client=go-ethereum,op-geth_optimism-history,op-proposer_<<parameters.version>>,op-batcher_<<parameters.version>>,op-node_<<parameters.version>> |& tee /tmp/hive.log
       - run:
           command: |
             tar -cvf /tmp/workspace.tgz -C /home/circleci/project /home/circleci/project/workspace


### PR DESCRIPTION
The go contracts/genesis building code in op-chain-ops + hive devnet replaced it.

