### PR TITLE
op-bindings: ensure integrity of artifacts

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -24,7 +24,7 @@ bindings: l1block-bindings \
 
 compile:
 	cd ../packages/contracts-bedrock/ && \
-		forge build -o ./tmp-artifacts
+		npx hardhat compile
 
 l1-cross-domain-messenger-bindings: compile
 	./gen_bindings.sh contracts/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger $(pkg)

--- a/op-bindings/gen_bindings.sh
+++ b/op-bindings/gen_bindings.sh
@@ -37,9 +37,9 @@ TEMP=$(mktemp -d)
 CWD=$(pwd)
 # Build contracts
 cd ${CONTRACTS_PATH}
-forge inspect -o ./tmp-artifacts ${NAME} abi > ${TEMP}/${TYPE}.abi
-forge inspect -o ./tmp-artifacts ${NAME} bytecode > ${TEMP}/${TYPE}.bin
-forge inspect -o ./tmp-artifacts ${NAME} deployedBytecode > ${CWD}/bin/${TYPE_LOWER}_deployed.hex
+forge inspect ${NAME} abi > ${TEMP}/${TYPE}.abi
+forge inspect ${NAME} bytecode > ${TEMP}/${TYPE}.bin
+forge inspect ${NAME} deployedBytecode > ${CWD}/bin/${TYPE_LOWER}_deployed.hex
 
 # Run ABIGEN
 cd ${CWD}


### PR DESCRIPTION
**Description**

Use `hardhat compile` so that it ensures that the artifacts used by the generator are up to date

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

