### PR TITLE
op-node/batcher/proposer: Standardize goimports

### DIFF
--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -21,7 +21,8 @@ import (
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-	"github.com/ethereum/go-ethereum/rpc"
+	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
+	"github.com/urfave/cli"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/sequencer"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -34,8 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
-	"github.com/urfave/cli"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 const (

--- a/op-batcher/cmd/main.go
+++ b/op-batcher/cmd/main.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli"
 
 	batcher "github.com/ethereum-optimism/optimism/op-batcher"
 	"github.com/ethereum-optimism/optimism/op-batcher/flags"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (

--- a/op-batcher/config.go
+++ b/op-batcher/config.go
@@ -3,16 +3,13 @@ package op_batcher
 import (
 	"time"
 
-	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-
-	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
-
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
-
 	"github.com/urfave/cli"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/flags"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
 type Config struct {

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -1,12 +1,13 @@
 package flags
 
 import (
+	"github.com/urfave/cli"
+
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-	"github.com/urfave/cli"
 )
 
 const envVarPrefix = "OP_BATCHER"

--- a/op-node/client/rpc.go
+++ b/op-node/client/rpc.go
@@ -3,9 +3,10 @@ package client
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type RPC interface {

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -8,19 +8,17 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/urfave/cli"
+
 	"github.com/ethereum-optimism/optimism/op-bindings/hardhat"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
-
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
-	"github.com/ethereum-optimism/optimism/op-node/eth"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-
-	"github.com/urfave/cli"
-
-	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 )
 
 var Subcommands = cli.Commands{

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -9,22 +9,17 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/heartbeat"
-
-	"github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
-	"github.com/ethereum-optimism/optimism/op-node/cmd/p2p"
-
-	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/urfave/cli"
 
 	opnode "github.com/ethereum-optimism/optimism/op-node"
-
-	"github.com/ethereum-optimism/optimism/op-node/version"
-
+	"github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
+	"github.com/ethereum-optimism/optimism/op-node/cmd/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/flags"
-
+	"github.com/ethereum-optimism/optimism/op-node/heartbeat"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/version"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/urfave/cli"
 )
 
 var (

--- a/op-node/eth/ssz_test.go
+++ b/op-node/eth/ssz_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/google/go-cmp/cmp"
 )
 
 // FuzzExecutionPayloadUnmarshal checks that our SSZ decoding never panics

--- a/op-node/eth/types.go
+++ b/op-node/eth/types.go
@@ -8,13 +8,13 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/ethereum/go-ethereum/trie"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/beacon"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/holiman/uint256"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 type ErrorCode int

--- a/op-node/heartbeat/service_test.go
+++ b/op-node/heartbeat/service_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 const expHeartbeat = `{

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -10,16 +10,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum"
-	"github.com/prometheus/client_golang/prometheus/collectors"
-
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (

--- a/op-node/node/comms.go
+++ b/op-node/node/comms.go
@@ -3,8 +3,9 @@ package node
 import (
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 )
 
 // Tracer configures the OpNode to share events

--- a/op-node/node/log.go
+++ b/op-node/node/log.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/term"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type LogConfig struct {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
-
 	"github.com/hashicorp/go-multierror"
+	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
-
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -7,14 +7,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/ethereum-optimism/optimism/op-node/sources"
-
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
-
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-
+	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -4,28 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"math/rand"
-
-	"github.com/ethereum/go-ethereum/rpc"
-
-	"github.com/ethereum-optimism/optimism/op-node/testutils"
-
-	"github.com/ethereum-optimism/optimism/op-node/metrics"
-
-	"github.com/ethereum-optimism/optimism/op-node/version"
-
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-node/testlog"
-
-	"github.com/ethereum-optimism/optimism/op-node/eth"
-
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum-optimism/optimism/op-node/version"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/assert"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func TestOutputAtBlock(t *testing.T) {

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -11,11 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/flags"
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/p2p/discover"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	leveldb "github.com/ipfs/go-ds-leveldb"
@@ -34,6 +29,12 @@ import (
 	tls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli"
+
+	"github.com/ethereum-optimism/optimism/op-node/flags"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 // SetupP2P provides a host and discovery service for usage in the rollup node.

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -13,6 +13,11 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	decredSecp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -20,10 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/multiformats/go-multiaddr"
 )
 
 const (

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -9,19 +9,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/eth"
-
-	"github.com/ethereum/go-ethereum/common"
-	lru "github.com/hashicorp/golang-lru"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/golang/snappy"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func init() {

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -6,9 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p-core/connmgr"
-
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
@@ -17,6 +15,8 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	ma "github.com/multiformats/go-multiaddr"
 	madns "github.com/multiformats/go-multiaddr-dns"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type ExtraHostFeatures interface {

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -8,15 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/metrics"
-
-	"github.com/ethereum-optimism/optimism/op-node/eth"
-
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/testlog"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/rpc"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
 	"github.com/libp2p/go-libp2p-core/connmgr"
@@ -28,6 +19,14 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	tswarm "github.com/libp2p/go-libp2p/p2p/net/swarm/testing"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func TestingConfig(t *testing.T) *Config {

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -6,17 +6,17 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/libp2p/go-libp2p-core/connmgr"
+	"github.com/libp2p/go-libp2p-core/host"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/hashicorp/go-multierror"
-	"github.com/libp2p/go-libp2p-core/connmgr"
-	"github.com/libp2p/go-libp2p-core/host"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 
 type NodeP2P struct {

--- a/op-node/p2p/notifications.go
+++ b/op-node/p2p/notifications.go
@@ -1,9 +1,10 @@
 package p2p
 
 import (
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p-core/network"
 	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // TODO: add metrics here as well

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -4,14 +4,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/libp2p/go-libp2p-core/host"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 )
 
 // Prepared provides a p2p host and discv5 service that is already set up.

--- a/op-node/p2p/rpc_api.go
+++ b/op-node/p2p/rpc_api.go
@@ -5,9 +5,10 @@ import (
 	"net"
 	"time"
 
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 type PeerInfo struct {

--- a/op-node/p2p/rpc_client.go
+++ b/op-node/p2p/rpc_client.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"net"
 
+	"github.com/libp2p/go-libp2p-core/peer"
+
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 var NamespaceRPC = "opp2p"

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -7,13 +7,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/metrics"
-
 	decredSecp "github.com/decred/dcrd/dcrec/secp256k1/v4"
-	gcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/p2p/discover"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -22,6 +16,12 @@ import (
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p-testing/netutil"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	gcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 )
 
 // TODO: dynamic peering

--- a/op-node/p2p/signer.go
+++ b/op-node/p2p/signer.go
@@ -8,11 +8,12 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/urfave/cli"
+
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/urfave/cli"
 )
 
 var SigningDomainBlocksV1 = [32]byte{}

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -7,13 +7,14 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 type MockAttributesQueueOutput struct {

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -8,12 +8,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPreparePayloadAttributes(t *testing.T) {

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -7,15 +7,15 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 // fakeBatchQueueOutput fakes the next stage (receive only) for the batch queue

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -3,10 +3,10 @@ package derive
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func TestBatchRoundTrip(t *testing.T) {

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -4,16 +4,16 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-node/testlog"
-	"github.com/ethereum-optimism/optimism/op-node/testutils"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type ValidBatchTestCase struct {

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -9,6 +9,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
@@ -18,7 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/stretchr/testify/require"
 )
 
 type testTx struct {

--- a/op-node/rollup/derive/channel_bank_test.go
+++ b/op-node/rollup/derive/channel_bank_test.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 type MockChannelBankOutput struct {

--- a/op-node/rollup/derive/deposit_log.go
+++ b/op-node/rollup/derive/deposit_log.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/holiman/uint256"
 )
 
 var (

--- a/op-node/rollup/derive/deposit_log_test.go
+++ b/op-node/rollup/derive/deposit_log_test.go
@@ -5,11 +5,12 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalLogEvent(t *testing.T) {

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -4,13 +4,14 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEngineQueue_Finalize(t *testing.T) {

--- a/op-node/rollup/derive/fuzz_parsers_test.go
+++ b/op-node/rollup/derive/fuzz_parsers_test.go
@@ -5,6 +5,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -14,8 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm/runtime"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-node/eth"
-
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -5,11 +5,12 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var _ eth.BlockInfo = (*testutils.MockBlockInfo)(nil)

--- a/op-node/rollup/derive/l1_retrieval_test.go
+++ b/op-node/rollup/derive/l1_retrieval_test.go
@@ -5,12 +5,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 type MockDataSource struct {

--- a/op-node/rollup/derive/l1_traversal_test.go
+++ b/op-node/rollup/derive/l1_traversal_test.go
@@ -5,11 +5,12 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 func TestL1Traversal_Step(t *testing.T) {

--- a/op-node/rollup/derive/payloads_queue_test.go
+++ b/op-node/rollup/derive/payloads_queue_test.go
@@ -4,8 +4,9 @@ import (
 	"container/heap"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 )
 
 func TestPayloadsByNumber(t *testing.T) {

--- a/op-node/rollup/derive/pipeline_test.go
+++ b/op-node/rollup/derive/pipeline_test.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
-	"github.com/stretchr/testify/mock"
 )
 
 var _ Engine = (*testutils.MockEngine)(nil)

--- a/op-node/rollup/driver/conf_depth_test.go
+++ b/op-node/rollup/driver/conf_depth_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum"
-	"github.com/stretchr/testify/require"
 )
 
 type confTest struct {

--- a/op-node/rollup/driver/step.go
+++ b/op-node/rollup/driver/step.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-
 	"github.com/ethereum/go-ethereum/log"
 )
 

--- a/op-node/rollup/sync/start_test.go
+++ b/op-node/rollup/sync/start_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 var _ L1Chain = (*testutils.FakeChainSource)(nil)

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 )
 
 func randConfig() *Config {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -8,18 +8,16 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli"
 
 	"github.com/ethereum-optimism/optimism/op-node/flags"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/urfave/cli"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // NewConfig creates a Config from the provided flags or environment variables.

--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hashicorp/go-multierror"
+
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // IterativeBatchCall is an util to create a job to fetch many RPC requests in batches,

--- a/op-node/sources/batching_test.go
+++ b/op-node/sources/batching_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/mock"
 )
 
 type elemCall struct {

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -21,7 +21,6 @@ func (c *LRUCache) Get(key any) (value any, ok bool) {
 	}
 	return value, ok
 }
-
 func (c *LRUCache) Add(key, value any) (evicted bool) {
 	evicted = c.inner.Add(key, value)
 	if c.m != nil {

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -21,6 +21,7 @@ func (c *LRUCache) Get(key any) (value any, ok bool) {
 	}
 	return value, ok
 }
+
 func (c *LRUCache) Add(key, value any) (evicted bool) {
 	evicted = c.inner.Add(key, value)
 	if c.m != nil {

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -6,6 +6,9 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -13,8 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 type mockRPC struct {

--- a/op-node/sources/limit.go
+++ b/op-node/sources/limit.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/client"
-
 	"github.com/ethereum/go-ethereum/rpc"
 )
 

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func makeReceiptsFn(block eth.BlockID, receiptHash common.Hash) func(txHashes []common.Hash, receipts []*types.Receipt) (types.Receipts, error) {

--- a/op-node/sources/types.go
+++ b/op-node/sources/types.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/holiman/uint256"
-
-	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 )
 

--- a/op-node/testutils/fake_chain.go
+++ b/op-node/testutils/fake_chain.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
-
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber int) rollup.Genesis {

--- a/op-node/testutils/mock_eth_client.go
+++ b/op-node/testutils/mock_eth_client.go
@@ -3,11 +3,12 @@ package testutils
 import (
 	"context"
 
+	"github.com/stretchr/testify/mock"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/mock"
 )
 
 type MockEthClient struct {

--- a/op-node/testutils/random.go
+++ b/op-node/testutils/random.go
@@ -6,9 +6,8 @@ import (
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func RandomHash(rng *rand.Rand) (out common.Hash) {

--- a/op-proposer/cmd/main.go
+++ b/op-proposer/cmd/main.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-
-	proposer "github.com/ethereum-optimism/optimism/op-proposer"
-
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli"
 
+	proposer "github.com/ethereum-optimism/optimism/op-proposer"
 	"github.com/ethereum-optimism/optimism/op-proposer/flags"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (

--- a/op-proposer/config.go
+++ b/op-proposer/config.go
@@ -3,14 +3,13 @@ package op_proposer
 import (
 	"time"
 
+	"github.com/urfave/cli"
+
+	"github.com/ethereum-optimism/optimism/op-proposer/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-
-	"github.com/urfave/cli"
-
-	"github.com/ethereum-optimism/optimism/op-proposer/flags"
 )
 
 type Config struct {

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -1,12 +1,13 @@
 package flags
 
 import (
+	"github.com/urfave/cli"
+
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-	"github.com/urfave/cli"
 )
 
 const envVarPrefix = "OP_PROPOSER"

--- a/op-proposer/l2_output_submitter.go
+++ b/op-proposer/l2_output_submitter.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
+	"github.com/urfave/cli"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
@@ -13,23 +15,18 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/sources"
-
-	"github.com/ethereum/go-ethereum/crypto"
-
+	"github.com/ethereum-optimism/optimism/op-proposer/drivers/l2output"
+	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-
-	"github.com/ethereum-optimism/optimism/op-proposer/drivers/l2output"
-	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
-	"github.com/urfave/cli"
 )
 
 const (

--- a/op-proposer/l2_output_submitter.go
+++ b/op-proposer/l2_output_submitter.go
@@ -5,14 +5,15 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
-	"github.com/urfave/cli"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
+
+	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
+	"github.com/urfave/cli"
 
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-proposer/drivers/l2output"

--- a/op-proposer/txmgr/send_state_test.go
+++ b/op-proposer/txmgr/send_state_test.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/stretchr/testify/require"
 )
 
 const testSafeAbortNonceTooLowCount = 3

--- a/op-proposer/txmgr/txmgr_test.go
+++ b/op-proposer/txmgr/txmgr_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/require"
 )
 
 // testHarness houses the necessary resources to test the SimpleTxManager.


### PR DESCRIPTION
**Description**

This standardizes go imports across the three go codebases. This removes
empty lines between import sections & relies on `goimports` to sort the rest.
Imports from the `ethereum-optimism` and `go-ethereum` repositories are
treated as local imports.

**Additional Information**

I used the following script to implement this change:
```
#!/bin/bash                                                                      
                                                                                 
# remove all blank lines in go 'imports' statements,                             
# then sort with goimports                                                       
# Usage over a codebase: find . -name "*.go" -exec ./goimports2.sh {} \;
                                                                                 
if [ $# != 1 ] ; then                                                            
  echo "usage: $0 <filename>"                                                    
  exit 1                                                                         
fi                                                                               

# Remove empty lines inside the import statement                                                                                 
sed -i '' '/^import/,/^)/ {/^$/d;}' $1                                                                             

#goimports -w $1
#goimports -local "github.com/ethereum-optimism/optimism" -w $1
goimports -local "github.com/ethereum/go-ethereum","github.com/ethereum-optimism/optimism" -w $1
```
