### PR TITLE
op-node: pass L1 finalization for L2 finalization to kick in

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -388,6 +388,34 @@ func TestConfirmationDepth(t *testing.T) {
 	require.LessOrEqual(t, l2VerHead.Time()+cfg.L1BlockTime*verConfDepth, l2SeqHead.Time(), "the L2 verifier head should lag behind the sequencer without delay by at least the verifier conf depth")
 }
 
+// TestFinalize tests if L2 finalizes after sufficient time after L1 finalizes
+func TestFinalize(t *testing.T) {
+	if !verboseGethNodes {
+		log.Root().SetHandler(log.DiscardHandler())
+	}
+
+	cfg := defaultSystemConfig(t)
+
+	sys, err := cfg.start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+
+	// as configured in the extra geth lifecycle in testing setup
+	finalizedDistance := uint64(8)
+	// Wait enough time for L1 to finalize and L2 to confirm its data in finalized L1 blocks
+	<-time.After(time.Duration((finalizedDistance+4)*cfg.L1BlockTime) * time.Second)
+
+	// fetch the finalizes head of geth
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	l2Finalized, err := l2Seq.BlockByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
+	require.NoError(t, err)
+
+	require.NotZerof(t, l2Finalized.NumberU64(), "must have finalized L2 block")
+}
+
 func TestMintOnRevertedDeposit(t *testing.T) {
 	if !verboseGethNodes {
 		log.Root().SetHandler(log.DiscardHandler())

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -55,6 +55,7 @@ type DerivationPipeline interface {
 	Step(ctx context.Context) error
 	SetUnsafeHead(head eth.L2BlockRef)
 	AddUnsafePayload(payload *eth.ExecutionPayload)
+	Finalize(ref eth.BlockID)
 	Finalized() eth.L2BlockRef
 	SafeL2Head() eth.L2BlockRef
 	UnsafeL2Head() eth.L2BlockRef

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -187,7 +187,7 @@ func (s *state) handleNewL1FinalizedBlock(finalized eth.L1BlockRef) {
 	s.log.Info("New L1 finalized block", "l1_finalized", finalized)
 	s.metrics.RecordL1Ref("l1_finalized", finalized)
 	s.l1Finalized = finalized
-	// TODO(proto): forward signal to derivation to finalize L2 chain as well
+	s.derivation.Finalize(finalized.ID())
 }
 
 // findL1Origin determines what the next L1 Origin should be.


### PR DESCRIPTION
We were not passing the L1 finalization signal, preventing the L2 from getting finalized properly.
