### PR TITLE
contracts-bedrock: add in alpha-1 network

### DIFF
--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -45,6 +45,11 @@ const config: HardhatUserConfig = {
       url: process.env.L1_RPC || '',
       accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
     },
+    'alpha-1': {
+      chainId: 5,
+      url: process.env.L1_RPC || '',
+      accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
+    },
     deployer: {
       chainId: Number(process.env.CHAIN_ID),
       url: process.env.L1_RPC || '',


### PR DESCRIPTION
**Description**

The hardhat config needs to have the network that corresponds to the new deploy artifacts. This adds `alpha-1` to the hh config so that the contracts can be verified easily.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

