### PR TITLE
op-chain-ops: fix tests

### DIFF
--- a/op-chain-ops/genesis/layer_two_test.go
+++ b/op-chain-ops/genesis/layer_two_test.go
@@ -32,7 +32,7 @@ var testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d
 
 func TestBuildL2DeveloperGenesis(t *testing.T) {
 	hh, err := hardhat.New(
-		"goerli",
+		"alpha-1",
 		nil,
 		[]string{"../../packages/contracts-bedrock/deployments"},
 	)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes the tests that depend on the existence of deployments by network in the contracts bedrock deployments directory