### PR TITLE
indexer: filter withdrawals by finalization

### DIFF
--- a/indexer/services/l2/service.go
+++ b/indexer/services/l2/service.go
@@ -390,12 +390,19 @@ func (s *Service) GetWithdrawals(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	finalizedStr := r.URL.Query().Get("finalized")
+	finalized, err := strconv.ParseBool(finalizedStr)
+	if err != nil && finalizedStr != "" {
+		server.RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
 	page := db.PaginationParam{
 		Limit:  uint64(limit),
 		Offset: uint64(offset),
 	}
 
-	withdrawals, err := s.cfg.DB.GetWithdrawalsByAddress(common.HexToAddress(vars["address"]), page)
+	withdrawals, err := s.cfg.DB.GetWithdrawalsByAddress(common.HexToAddress(vars["address"]), page, finalized)
 	if err != nil {
 		server.RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
**Description**

This PR updates the `/withdrawals` endpoint to filter withdrawals by finalization status as requested by the frontend team.

**Tests**

There will be a follow up PR with tests.

**Additional context**

This change affects the frontend API. The backed will only return ready to finalize withdrawals by default. Finalized withdrawals can be query separately by using the `?finalized=true` query string. cc @roninjin10 

**Metadata**
- Fixes #ENG-2670
