### PR TITLE
indexer: verify flags with chainid instead of hash

### DIFF
--- a/indexer/config.go
+++ b/indexer/config.go
@@ -36,9 +36,6 @@ type Config struct {
 	// L2EthRpc is the HTTP provider URL for L1.
 	L2EthRpc string
 
-	// L2GenesisBlockHash is the l2 genesis block hash.
-	L2GenesisBlockHash string
-
 	// PollInterval is the delay between querying L2 for more transaction
 	// and creating a new batch.
 	PollInterval time.Duration
@@ -79,11 +76,8 @@ type Config struct {
 	// events.
 	SentryTraceRate time.Duration
 
-	// StartBlockNumber is the block number to start indexing from.
-	StartBlockNumber uint64
-
-	// StartBlockHash is the block hash to start indexing from.
-	StartBlockHash string
+	// L1StartBlockNumber is the block number to start indexing L1 from.
+	L1StartBlockNumber uint64
 
 	// ConfDepth is the number of confirmations after which headers are
 	// considered confirmed.
@@ -118,17 +112,16 @@ type Config struct {
 func NewConfig(ctx *cli.Context) (Config, error) {
 	cfg := Config{
 		/* Required Flags */
-		BuildEnv:           ctx.GlobalString(flags.BuildEnvFlag.Name),
-		EthNetworkName:     ctx.GlobalString(flags.EthNetworkNameFlag.Name),
-		ChainID:            ctx.GlobalInt64(flags.ChainIDFlag.Name),
-		L1EthRpc:           ctx.GlobalString(flags.L1EthRPCFlag.Name),
-		L2EthRpc:           ctx.GlobalString(flags.L2EthRPCFlag.Name),
-		L2GenesisBlockHash: ctx.GlobalString(flags.L2GenesisBlockHashFlag.Name),
-		DBHost:             ctx.GlobalString(flags.DBHostFlag.Name),
-		DBPort:             ctx.GlobalUint64(flags.DBPortFlag.Name),
-		DBUser:             ctx.GlobalString(flags.DBUserFlag.Name),
-		DBPassword:         ctx.GlobalString(flags.DBPasswordFlag.Name),
-		DBName:             ctx.GlobalString(flags.DBNameFlag.Name),
+		BuildEnv:       ctx.GlobalString(flags.BuildEnvFlag.Name),
+		EthNetworkName: ctx.GlobalString(flags.EthNetworkNameFlag.Name),
+		ChainID:        ctx.GlobalInt64(flags.ChainIDFlag.Name),
+		L1EthRpc:       ctx.GlobalString(flags.L1EthRPCFlag.Name),
+		L2EthRpc:       ctx.GlobalString(flags.L2EthRPCFlag.Name),
+		DBHost:         ctx.GlobalString(flags.DBHostFlag.Name),
+		DBPort:         ctx.GlobalUint64(flags.DBPortFlag.Name),
+		DBUser:         ctx.GlobalString(flags.DBUserFlag.Name),
+		DBPassword:     ctx.GlobalString(flags.DBPasswordFlag.Name),
+		DBName:         ctx.GlobalString(flags.DBNameFlag.Name),
 		/* Optional Flags */
 		DisableIndexer:      ctx.GlobalBool(flags.DisableIndexer.Name),
 		LogLevel:            ctx.GlobalString(flags.LogLevelFlag.Name),
@@ -136,8 +129,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		SentryEnable:        ctx.GlobalBool(flags.SentryEnableFlag.Name),
 		SentryDsn:           ctx.GlobalString(flags.SentryDsnFlag.Name),
 		SentryTraceRate:     ctx.GlobalDuration(flags.SentryTraceRateFlag.Name),
-		StartBlockNumber:    ctx.GlobalUint64(flags.StartBlockNumberFlag.Name),
-		StartBlockHash:      ctx.GlobalString(flags.StartBlockHashFlag.Name),
+		L1StartBlockNumber:  ctx.GlobalUint64(flags.L1StartBlockNumberFlag.Name),
 		ConfDepth:           ctx.GlobalUint64(flags.ConfDepthFlag.Name),
 		MaxHeaderBatchSize:  ctx.GlobalUint64(flags.MaxHeaderBatchSizeFlag.Name),
 		MetricsServerEnable: ctx.GlobalBool(flags.MetricsServerEnableFlag.Name),

--- a/indexer/flags/flags.go
+++ b/indexer/flags/flags.go
@@ -46,12 +46,6 @@ var (
 		Required: true,
 		EnvVar:   prefixEnvVar("L2_ETH_RPC"),
 	}
-	L2GenesisBlockHashFlag = cli.StringFlag{
-		Name:     "l2-genesis-block-hash",
-		Usage:    "Genesis block hash of the L2 chain",
-		Required: true,
-		EnvVar:   prefixEnvVar("L2_GENESIS_BLOCK_HASH"),
-	}
 	DBHostFlag = cli.StringFlag{
 		Name:     "db-host",
 		Usage:    "Hostname of the database connection",
@@ -120,17 +114,11 @@ var (
 		Value:  50 * time.Millisecond,
 		EnvVar: prefixEnvVar("SENTRY_TRACE_RATE"),
 	}
-	StartBlockNumberFlag = cli.Uint64Flag{
+	L1StartBlockNumberFlag = cli.Uint64Flag{
 		Name:   "start-block-number",
 		Usage:  "The block number to start indexing from. Must be use together with start block hash",
 		Value:  0,
 		EnvVar: prefixEnvVar("START_BLOCK_NUMBER"),
-	}
-	StartBlockHashFlag = cli.StringFlag{
-		Name:   "start-block-hash",
-		Usage:  "The block hash to start indexing from. Must be use together with start block number",
-		Value:  "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-		EnvVar: prefixEnvVar("START_BLOCK_HASH"),
 	}
 	ConfDepthFlag = cli.Uint64Flag{
 		Name:   "conf-depth",
@@ -181,7 +169,6 @@ var requiredFlags = []cli.Flag{
 	ChainIDFlag,
 	L1EthRPCFlag,
 	L2EthRPCFlag,
-	L2GenesisBlockHashFlag,
 	DBHostFlag,
 	DBPortFlag,
 	DBUserFlag,
@@ -198,8 +185,7 @@ var optionalFlags = []cli.Flag{
 	SentryTraceRateFlag,
 	ConfDepthFlag,
 	MaxHeaderBatchSizeFlag,
-	StartBlockNumberFlag,
-	StartBlockHashFlag,
+	L1StartBlockNumberFlag,
 	RESTHostnameFlag,
 	RESTPortFlag,
 	MetricsServerEnableFlag,

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -168,8 +168,7 @@ func NewIndexer(cfg Config, gitVersion string) (*Indexer, error) {
 		DB:                 db,
 		ConfDepth:          cfg.ConfDepth,
 		MaxHeaderBatchSize: cfg.MaxHeaderBatchSize,
-		StartBlockNumber:   cfg.StartBlockNumber,
-		StartBlockHash:     cfg.StartBlockHash,
+		StartBlockNumber:   cfg.L1StartBlockNumber,
 	})
 	if err != nil {
 		return nil, err
@@ -184,7 +183,6 @@ func NewIndexer(cfg Config, gitVersion string) (*Indexer, error) {
 		ConfDepth:          cfg.ConfDepth,
 		MaxHeaderBatchSize: cfg.MaxHeaderBatchSize,
 		StartBlockNumber:   uint64(0),
-		StartBlockHash:     cfg.L2GenesisBlockHash,
 	})
 	if err != nil {
 		return nil, err

--- a/indexer/services/l1/service.go
+++ b/indexer/services/l1/service.go
@@ -73,7 +73,6 @@ type ServiceConfig struct {
 	ConfDepth          uint64
 	MaxHeaderBatchSize uint64
 	StartBlockNumber   uint64
-	StartBlockHash     string
 	DB                 *db.Database
 }
 
@@ -188,7 +187,6 @@ func (s *Service) Loop(ctx context.Context) {
 func (s *Service) Update(newHeader *types.Header) error {
 	var lowest = db.BlockLocator{
 		Number: s.cfg.StartBlockNumber,
-		Hash:   common.HexToHash(s.cfg.StartBlockHash),
 	}
 	highestConfirmed, err := s.cfg.DB.GetHighestL1Block()
 	if err != nil {
@@ -213,7 +211,7 @@ func (s *Service) Update(newHeader *types.Header) error {
 		return nil
 	}
 
-	if lowest.Hash != headers[0].ParentHash {
+	if lowest.Number > 0 && lowest.Hash != headers[0].ParentHash {
 		logger.Error("Parent hash does not connect to ",
 			"block", headers[0].Number.Uint64(), "hash", headers[0].Hash,
 			"lowest_block", lowest.Number, "hash", lowest.Hash)

--- a/indexer/services/l2/service.go
+++ b/indexer/services/l2/service.go
@@ -67,7 +67,6 @@ type ServiceConfig struct {
 	ConfDepth          uint64
 	MaxHeaderBatchSize uint64
 	StartBlockNumber   uint64
-	StartBlockHash     string
 	DB                 *db.Database
 }
 
@@ -184,7 +183,6 @@ func (s *Service) Loop(ctx context.Context) {
 func (s *Service) Update(newHeader *types.Header) error {
 	var lowest = db.BlockLocator{
 		Number: s.cfg.StartBlockNumber,
-		Hash:   common.HexToHash(s.cfg.StartBlockHash),
 	}
 	highestConfirmed, err := s.cfg.DB.GetHighestL2Block()
 	if err != nil {
@@ -209,7 +207,7 @@ func (s *Service) Update(newHeader *types.Header) error {
 		return nil
 	}
 
-	if lowest.Hash != headers[0].ParentHash {
+	if lowest.Number > 0 && lowest.Hash != headers[0].ParentHash {
 		logger.Error("Parent hash does not connect to ",
 			"block", headers[0].Number.Uint64(), "hash", headers[0].Hash(),
 			"lowest_block", lowest.Number, "hash", lowest.Hash)


### PR DESCRIPTION
**Description**

This PR updates the indexer flags and removes the need to pass L1 / L2 block hashes to start indexing.

This simplifies ops for the indexer.