### PR TITLE
op-chain-ops: modularize setting the state

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -112,14 +112,10 @@ func NewL2ImmutableConfig(config *DeployConfig, block *types.Block, proxyL1Stand
 	return immutable, nil
 }
 
-// StorageConfig represents the storage configuration for the L2 predeploy
-// contracts.
-type StorageConfig map[string]state.StorageValues
-
 // NewL2StorageConfig will create a StorageConfig given an instance of a
 // Hardhat and a DeployConfig.
-func NewL2StorageConfig(config *DeployConfig, block *types.Block, proxyL1StandardBridge common.Address, proxyL1CrossDomainMessenger common.Address) (StorageConfig, error) {
-	storage := make(StorageConfig)
+func NewL2StorageConfig(config *DeployConfig, block *types.Block, proxyL1StandardBridge common.Address, proxyL1CrossDomainMessenger common.Address) (state.StorageConfig, error) {
+	storage := make(state.StorageConfig)
 
 	storage["L2ToL1MessagePasser"] = state.StorageValues{
 		"nonce": 0,

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -62,7 +62,7 @@ func setProxies(db vm.StateDB, proxyAdminAddr common.Address, namespace *big.Int
 // SetImplementations will set the implmentations of the contracts in the state
 // and configure the proxies to point to the implementations. It also sets
 // the appropriate storage values for each contract at the proxy address.
-func SetImplementations(db vm.StateDB, storage StorageConfig, immutable immutables.ImmutableConfig) error {
+func SetImplementations(db vm.StateDB, storage state.StorageConfig, immutable immutables.ImmutableConfig) error {
 	deployResults, err := immutables.BuildOptimism(immutable)
 	if err != nil {
 		return err
@@ -102,17 +102,8 @@ func SetImplementations(db vm.StateDB, storage StorageConfig, immutable immutabl
 
 		// Set the storage values
 		if storageConfig, ok := storage[name]; ok {
-			layout, err := bindings.GetStorageLayout(name)
-			if err != nil {
+			if err := state.SetStorage(name, *address, storageConfig, db); err != nil {
 				return err
-			}
-			slots, err := state.ComputeStorageSlots(layout, storageConfig)
-			if err != nil {
-				return fmt.Errorf("%s: %w", name, err)
-			}
-			// The storage values must go in the proxy address
-			for _, slot := range slots {
-				db.SetState(*address, slot.Key, slot.Value)
 			}
 		}
 


### PR DESCRIPTION
**Description**

This wraps some common functionality of state setting into a single function so that it can easily be reused in other components. I'd like to use this function as part of testing, it can be used to populate a `SimulatedBackend` with a set of contracts and their state pre-initialized.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


