### PR TITLE
op-chain-ops: parse t_bytes32

### DIFF
--- a/op-chain-ops/state/encoding.go
+++ b/op-chain-ops/state/encoding.go
@@ -156,6 +156,8 @@ func getElementEncoder(storageType solc.StorageLayoutType, kind string) (Element
 		return EncodeAddressValue, nil
 	case "t_bool":
 		return EncodeBoolValue, nil
+	case "t_bytes32":
+		return EncodeBytes32Value, nil
 	default:
 		if strings.HasPrefix(target, "t_uint") {
 			return EncodeUintValue, nil


### PR DESCRIPTION
**Description**

Adds extra type parsing to allow setting t_bytes32 in mappings.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->


