### PR TITLE
indexer: support public alpha testnet

### DIFF
--- a/indexer/services/l1/bridge/bridge.go
+++ b/indexer/services/l1/bridge/bridge.go
@@ -35,6 +35,11 @@ var defaultBridgeCfgs = map[uint64][]*implConfig{
 		{"Standard", "StandardBridge", predeploys.DevL1StandardBridge},
 		{"ETH", "ETHBridge", predeploys.DevL1StandardBridge},
 	},
+	// Goerli
+	420: {
+		{"Standard", "StandardBridge", "0xFf94B6C486350aD92561Ba09bad3a59df764Da92"},
+		{"ETH", "ETHBridge", "0xFf94B6C486350aD92561Ba09bad3a59df764Da92"},
+	},
 }
 
 var customBridgeCfgs = map[uint64][]*implConfig{

--- a/indexer/services/l2/bridge/bridge.go
+++ b/indexer/services/l2/bridge/bridge.go
@@ -33,6 +33,10 @@ var defaultBridgeCfgs = map[uint64][]*implConfig{
 	901: {
 		{"Standard", "StandardBridge", L2StandardBridgeAddr},
 	},
+	// Goerli Alpha Testnet
+	28528: {
+		{"Standard", "StandardBridge", L2StandardBridgeAddr},
+	},
 }
 
 var customBridgeCfgs = map[uint64][]*implConfig{


### PR DESCRIPTION
**Description**

This PR adds support for the public alpha testnet on Goerli.

**Tests**

Only updates the contract addresses and chain id.

**Additional context**

Need help from @optimisticben to deploy an instance.
