### PR TITLE
indexer: fix L1 goerli chain id

### DIFF
--- a/indexer/services/l1/bridge/bridge.go
+++ b/indexer/services/l1/bridge/bridge.go
@@ -36,7 +36,7 @@ var defaultBridgeCfgs = map[uint64][]*implConfig{
 		{"ETH", "ETHBridge", predeploys.DevL1StandardBridge},
 	},
 	// Goerli
-	420: {
+	5: {
 		{"Standard", "StandardBridge", "0xFf94B6C486350aD92561Ba09bad3a59df764Da92"},
 		{"ETH", "ETHBridge", "0xFf94B6C486350aD92561Ba09bad3a59df764Da92"},
 	},


### PR DESCRIPTION
**Description**

This PR fixes the L1 goerli chain id, should have been 5, but was set to 420 (optimstic goerli) by mistake.