### PR TITLE
Remove the progress API from the derivation pipeline

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -26,12 +26,6 @@ import (
 // It is internally responsible for making sure that batches with L1 inclusions block outside it's
 // working range are not considered or pruned.
 
-type BatchQueueOutput interface {
-	StageProgress
-	AddBatch(batch *BatchData)
-	SafeL2Head() eth.L2BlockRef
-}
-
 // BatchQueue contains a set of batches for every L1 block.
 // L1 blocks are contiguous and this does not support reorgs.
 type BatchQueue struct {

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -33,7 +33,7 @@ type ChannelBank struct {
 	fetcher L1Fetcher
 }
 
-var _ PullStage = (*ChannelBank)(nil)
+var _ ResetableStage = (*ChannelBank)(nil)
 
 // NewChannelBank creates a ChannelBank, which should be Reset(origin) before use.
 func NewChannelBank(log log.Logger, cfg *rollup.Config, prev *L1Retrieval, fetcher L1Fetcher) *ChannelBank {

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -13,46 +14,36 @@ import (
 // This is a pure function from the channel, but each channel (or channel fragment)
 // must be tagged with an L1 inclusion block to be passed to the the batch queue.
 
-type BatchQueueStage interface {
-	StageProgress
-	AddBatch(batch *BatchData)
-}
-
 type ChannelInReader struct {
 	log log.Logger
 
 	nextBatchFn func() (BatchWithL1InclusionBlock, error)
 
-	progress Progress
-
-	next BatchQueueStage
 	prev *ChannelBank
 }
 
-var _ Stage = (*ChannelInReader)(nil)
+var _ PullStage = (*ChannelInReader)(nil)
 
 // NewChannelInReader creates a ChannelInReader, which should be Reset(origin) before use.
-func NewChannelInReader(log log.Logger, next BatchQueueStage, prev *ChannelBank) *ChannelInReader {
+func NewChannelInReader(log log.Logger, prev *ChannelBank) *ChannelInReader {
 	return &ChannelInReader{
 		log:  log,
-		next: next,
 		prev: prev,
 	}
 }
 
-func (cr *ChannelInReader) Progress() Progress {
-	return cr.progress
+func (cr *ChannelInReader) Origin() eth.L1BlockRef {
+	return cr.prev.Origin()
 }
 
 // TODO: Take full channel for better logging
-func (cr *ChannelInReader) WriteChannel(data []byte) {
-	if cr.progress.Closed {
-		panic("write channel while closed")
-	}
-	if f, err := BatchReader(bytes.NewBuffer(data), cr.progress.Origin); err == nil {
+func (cr *ChannelInReader) WriteChannel(data []byte) error {
+	if f, err := BatchReader(bytes.NewBuffer(data), cr.Origin()); err == nil {
 		cr.nextBatchFn = f
+		return nil
 	} else {
 		cr.log.Error("Error creating batch reader from channel data", "err", err)
+		return err
 	}
 }
 
@@ -62,50 +53,37 @@ func (cr *ChannelInReader) NextChannel() {
 	cr.nextBatchFn = nil
 }
 
-func (cr *ChannelInReader) Step(ctx context.Context, outer Progress) error {
-	// Close ourselves if required
-	if cr.progress.Closed {
-		if cr.progress.Origin != cr.prev.Origin() {
-			cr.progress.Closed = false
-			cr.progress.Origin = cr.prev.Origin()
-			return nil
-		}
-	}
-
+// NextBatch pulls out the next batch from the channel if it has it.
+// It returns io.EOF when it cannot make any more progress.
+// It will return a temporary error if it needs to be called again to advance some internal state.
+func (cr *ChannelInReader) NextBatch(ctx context.Context) (*BatchData, error) {
 	if cr.nextBatchFn == nil {
 		if data, err := cr.prev.NextData(ctx); err == io.EOF {
-			if !cr.progress.Closed {
-				cr.progress.Closed = true
-				return nil
-			} else {
-				return io.EOF
-			}
+			return nil, io.EOF
 		} else if err != nil {
-			return err
+			return nil, err
 		} else {
-			cr.WriteChannel(data)
-			return nil
+			if err := cr.WriteChannel(data); err != nil {
+				return nil, NewTemporaryError(err)
+			}
 		}
-	} else {
-		// TODO: can batch be non nil while err == io.EOF
-		// This depends on the behavior of rlp.Stream
-		batch, err := cr.nextBatchFn()
-		if err == io.EOF {
-			cr.NextChannel()
-			return io.EOF
-		} else if err != nil {
-			cr.log.Warn("failed to read batch from channel reader, skipping to next channel now", "err", err)
-			cr.NextChannel()
-			return nil
-		}
-		cr.next.AddBatch(batch.Batch)
-		return nil
 	}
 
+	// TODO: can batch be non nil while err == io.EOF
+	// This depends on the behavior of rlp.Stream
+	batch, err := cr.nextBatchFn()
+	if err == io.EOF {
+		cr.NextChannel()
+		return nil, NotEnoughData
+	} else if err != nil {
+		cr.log.Warn("failed to read batch from channel reader, skipping to next channel now", "err", err)
+		cr.NextChannel()
+		return nil, NotEnoughData
+	}
+	return batch.Batch, nil
 }
 
-func (cr *ChannelInReader) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error {
+func (cr *ChannelInReader) Reset(ctx context.Context, _ eth.L1BlockRef) error {
 	cr.nextBatchFn = nil
-	cr.progress = cr.next.Progress()
 	return io.EOF
 }

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -22,7 +22,7 @@ type ChannelInReader struct {
 	prev *ChannelBank
 }
 
-var _ PullStage = (*ChannelInReader)(nil)
+var _ ResetableStage = (*ChannelInReader)(nil)
 
 // NewChannelInReader creates a ChannelInReader, which should be Reset(origin) before use.
 func NewChannelInReader(log log.Logger, prev *ChannelBank) *ChannelInReader {

--- a/op-node/rollup/derive/error.go
+++ b/op-node/rollup/derive/error.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -91,3 +92,7 @@ func NewCriticalError(err error) error {
 var ErrTemporary = NewTemporaryError(nil)
 var ErrReset = NewResetError(nil)
 var ErrCritical = NewCriticalError(nil)
+
+// NotEnoughData implies that the function currently does not have enough data to progress
+// but if it is retried enough times, it will eventually return a real value or io.EOF
+var NotEnoughData = errors.New("not enough data")

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -5,80 +5,63 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
-
-type L1SourceOutput interface {
-	StageProgress
-	IngestData(data []byte)
-}
 
 type L1Retrieval struct {
 	log     log.Logger
 	dataSrc *CalldataSource
-	next    L1SourceOutput
 	prev    *L1Traversal
-
-	progress Progress
 
 	datas *CalldataSourceImpl
 }
 
-var _ Stage = (*L1Retrieval)(nil)
+var _ PullStage = (*L1Retrieval)(nil)
 
-func NewL1Retrieval(log log.Logger, dataSrc *CalldataSource, next L1SourceOutput, prev *L1Traversal) *L1Retrieval {
+func NewL1Retrieval(log log.Logger, dataSrc *CalldataSource, prev *L1Traversal) *L1Retrieval {
 	return &L1Retrieval{
 		log:     log,
 		dataSrc: dataSrc,
-		next:    next,
 		prev:    prev,
 	}
 }
 
-func (l1r *L1Retrieval) Progress() Progress {
-	return l1r.progress
+func (l1r *L1Retrieval) Origin() eth.L1BlockRef {
+	return l1r.prev.Origin()
 }
 
-// Step does an action in the L1 Retrieval stage
+// NextData does an action in the L1 Retrieval stage
 // If there is data, it pushes it to the next stage.
 // If there is no more data open ourselves if we are closed or close ourselves if we are open
-func (l1r *L1Retrieval) Step(ctx context.Context, _ Progress) error {
-	if l1r.datas != nil {
-		l1r.log.Debug("fetching next piece of data")
-		data, err := l1r.datas.Next(ctx)
+func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
+	if l1r.datas == nil {
+		next, err := l1r.prev.NextL1Block(ctx)
 		if err == io.EOF {
-			l1r.datas = nil
-			return io.EOF
+			return nil, io.EOF
 		} else if err != nil {
-			return NewTemporaryError(fmt.Errorf("context to retrieve next L1 data failed: %w", err))
-		} else {
-			l1r.next.IngestData(data)
-			return nil
+			return nil, err
 		}
+		l1r.datas = l1r.dataSrc.OpenData(ctx, next.ID())
+	}
+
+	l1r.log.Debug("fetching next piece of data")
+	data, err := l1r.datas.Next(ctx)
+	if err == io.EOF {
+		l1r.datas = nil
+		return nil, io.EOF
+	} else if err != nil {
+		return nil, NewTemporaryError(fmt.Errorf("context to retrieve next L1 data failed: %w", err))
 	} else {
-		if l1r.progress.Closed {
-			next, err := l1r.prev.NextL1Block(ctx)
-			if err == io.EOF {
-				return io.EOF
-			} else if err != nil {
-				return err
-			}
-			l1r.datas = l1r.dataSrc.OpenData(ctx, next.ID())
-			l1r.progress.Origin = next
-			l1r.progress.Closed = false
-		} else {
-			l1r.progress.Closed = true
-		}
-		return nil
+		return data, nil
 	}
 }
 
 // ResetStep re-initializes the L1 Retrieval stage to block of it's `next` progress.
 // Note that we open up the `l1r.datas` here because it is requires to maintain the
 // internal invariants that later propagate up the derivation pipeline.
-func (l1r *L1Retrieval) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error {
-	l1r.progress = l1r.next.Progress()
-	l1r.datas = l1r.dataSrc.OpenData(ctx, l1r.progress.Origin.ID())
-	l1r.log.Info("Reset of L1Retrieval done", "origin", l1r.progress.Origin)
+func (l1r *L1Retrieval) Reset(ctx context.Context, base eth.L1BlockRef) error {
+	l1r.datas = l1r.dataSrc.OpenData(ctx, base.ID())
+	l1r.log.Info("Reset of L1Retrieval done", "origin", base)
 	return io.EOF
 }

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -17,7 +17,7 @@ type L1Retrieval struct {
 	datas *CalldataSourceImpl
 }
 
-var _ PullStage = (*L1Retrieval)(nil)
+var _ ResetableStage = (*L1Retrieval)(nil)
 
 func NewL1Retrieval(log log.Logger, dataSrc *CalldataSource, prev *L1Traversal) *L1Retrieval {
 	return &L1Retrieval{

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -18,20 +17,21 @@ type L1Retrieval struct {
 	log     log.Logger
 	dataSrc *CalldataSource
 	next    L1SourceOutput
+	prev    *L1Traversal
 
 	progress Progress
 
-	data  eth.Data
 	datas *CalldataSourceImpl
 }
 
 var _ Stage = (*L1Retrieval)(nil)
 
-func NewL1Retrieval(log log.Logger, dataSrc *CalldataSource, next L1SourceOutput) *L1Retrieval {
+func NewL1Retrieval(log log.Logger, dataSrc *CalldataSource, next L1SourceOutput, prev *L1Traversal) *L1Retrieval {
 	return &L1Retrieval{
 		log:     log,
 		dataSrc: dataSrc,
 		next:    next,
+		prev:    prev,
 	}
 }
 
@@ -39,48 +39,46 @@ func (l1r *L1Retrieval) Progress() Progress {
 	return l1r.progress
 }
 
-func (l1r *L1Retrieval) Step(ctx context.Context, outer Progress) error {
-	if changed, err := l1r.progress.Update(outer); err != nil || changed {
-		return err
-	}
-
-	// specific to L1 source: if the L1 origin is closed, there is no more data to retrieve.
-	if l1r.progress.Closed {
-		return io.EOF
-	}
-
-	// create a source if we have none
-	if l1r.datas == nil {
-		l1r.datas = l1r.dataSrc.OpenData(ctx, l1r.progress.Origin.ID())
-		return nil
-	}
-
-	// buffer data if we have none
-	if l1r.data == nil {
+// Step does an action in the L1 Retrieval stage
+// If there is data, it pushes it to the next stage.
+// If there is no more data open ourselves if we are closed or close ourselves if we are open
+func (l1r *L1Retrieval) Step(ctx context.Context, _ Progress) error {
+	if l1r.datas != nil {
 		l1r.log.Debug("fetching next piece of data")
 		data, err := l1r.datas.Next(ctx)
 		if err == io.EOF {
-			l1r.progress.Closed = true
 			l1r.datas = nil
 			return io.EOF
 		} else if err != nil {
 			return NewTemporaryError(fmt.Errorf("context to retrieve next L1 data failed: %w", err))
 		} else {
-			l1r.data = data
+			l1r.next.IngestData(data)
 			return nil
 		}
+	} else {
+		if l1r.progress.Closed {
+			next, err := l1r.prev.NextL1Block(ctx)
+			if err == io.EOF {
+				return io.EOF
+			} else if err != nil {
+				return err
+			}
+			l1r.datas = l1r.dataSrc.OpenData(ctx, next.ID())
+			l1r.progress.Origin = next
+			l1r.progress.Closed = false
+		} else {
+			l1r.progress.Closed = true
+		}
+		return nil
 	}
-
-	// flush the data to next stage
-	l1r.next.IngestData(l1r.data)
-	// and nil the data, the next step will retrieve the next data
-	l1r.data = nil
-	return nil
 }
 
+// ResetStep re-initializes the L1 Retrieval stage to block of it's `next` progress.
+// Note that we open up the `l1r.datas` here because it is requires to maintain the
+// internal invariants that later propagate up the derivation pipeline.
 func (l1r *L1Retrieval) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error {
 	l1r.progress = l1r.next.Progress()
-	l1r.datas = nil
-	l1r.data = nil
+	l1r.datas = l1r.dataSrc.OpenData(ctx, l1r.progress.Origin.ID())
+	l1r.log.Info("Reset of L1Retrieval done", "origin", l1r.progress.Origin)
 	return io.EOF
 }

--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -24,7 +24,7 @@ type L1Traversal struct {
 	log      log.Logger
 }
 
-var _ PullStage = (*L1Traversal)(nil)
+var _ ResetableStage = (*L1Traversal)(nil)
 
 func NewL1Traversal(log log.Logger, l1Blocks L1BlockRefByNumberFetcher) *L1Traversal {
 	return &L1Traversal{

--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -33,6 +33,10 @@ func NewL1Traversal(log log.Logger, l1Blocks L1BlockRefByNumberFetcher) *L1Trave
 	}
 }
 
+func (l1t *L1Traversal) Origin() eth.L1BlockRef {
+	return l1t.block
+}
+
 // NextL1Block returns the next block. It does not advance, but it can only be
 // called once before returning io.EOF
 func (l1t *L1Traversal) NextL1Block(_ context.Context) (eth.L1BlockRef, error) {

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -101,13 +101,13 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	bank := NewChannelBank(log, cfg, l1Src, l1Fetcher)
 	chInReader := NewChannelInReader(log, bank)
 	batchQueue := NewBatchQueue(log, cfg, chInReader)
+	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, batchQueue)
 
 	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
-	eng := NewEngineQueue(log, cfg, engine, metrics)
-	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng, batchQueue)
+	eng := NewEngineQueue(log, cfg, engine, metrics, attributesQueue)
 
-	stages := []Stage{eng, attributesQueue}
-	pullStages := []PullStage{batchQueue, chInReader, bank, l1Src, l1Traversal}
+	stages := []Stage{eng}
+	pullStages := []PullStage{attributesQueue, batchQueue, chInReader, bank, l1Src, l1Traversal}
 
 	return &DerivationPipeline{
 		log:        log,

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -100,14 +100,14 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	bank := NewChannelBank(log, cfg, l1Src, l1Fetcher)
 	chInReader := NewChannelInReader(log, bank)
+	batchQueue := NewBatchQueue(log, cfg, chInReader)
 
 	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
 	eng := NewEngineQueue(log, cfg, engine, metrics)
-	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
-	batchQueue := NewBatchQueue(log, cfg, attributesQueue, chInReader)
+	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng, batchQueue)
 
-	stages := []Stage{eng, attributesQueue, batchQueue}
-	pullStages := []PullStage{chInReader, bank, l1Src, l1Traversal}
+	stages := []Stage{eng, attributesQueue}
+	pullStages := []PullStage{batchQueue, chInReader, bank, l1Src, l1Traversal}
 
 	return &DerivationPipeline{
 		log:        log,

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -98,16 +98,16 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	l1Traversal := NewL1Traversal(log, l1Fetcher)
 	dataSrc := NewCalldataSource(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
+	bank := NewChannelBank(log, cfg, l1Src, l1Fetcher)
 
 	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
 	eng := NewEngineQueue(log, cfg, engine, metrics)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
 	batchQueue := NewBatchQueue(log, cfg, attributesQueue)
-	chInReader := NewChannelInReader(log, batchQueue)
-	bank := NewChannelBank(log, cfg, chInReader, l1Src)
+	chInReader := NewChannelInReader(log, batchQueue, bank)
 
-	stages := []Stage{eng, attributesQueue, batchQueue, chInReader, bank}
-	pullStages := []PullStage{l1Src, l1Traversal}
+	stages := []Stage{eng, attributesQueue, batchQueue, chInReader}
+	pullStages := []PullStage{bank, l1Src, l1Traversal}
 
 	return &DerivationPipeline{
 		log:        log,

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -96,18 +96,18 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 
 	// Pull stages
 	l1Traversal := NewL1Traversal(log, l1Fetcher)
+	dataSrc := NewCalldataSource(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
+	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 
 	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
 	eng := NewEngineQueue(log, cfg, engine, metrics)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
 	batchQueue := NewBatchQueue(log, cfg, attributesQueue)
 	chInReader := NewChannelInReader(log, batchQueue)
-	bank := NewChannelBank(log, cfg, chInReader)
-	dataSrc := NewCalldataSource(log, cfg, l1Fetcher)
-	l1Src := NewL1Retrieval(log, dataSrc, bank, l1Traversal)
+	bank := NewChannelBank(log, cfg, chInReader, l1Src)
 
-	stages := []Stage{eng, attributesQueue, batchQueue, chInReader, bank, l1Src}
-	pullStages := []PullStage{l1Traversal}
+	stages := []Stage{eng, attributesQueue, batchQueue, chInReader, bank}
+	pullStages := []PullStage{l1Src, l1Traversal}
 
 	return &DerivationPipeline{
 		log:        log,

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -28,6 +28,12 @@ type StageProgress interface {
 	Progress() Progress
 }
 
+type PullStage interface {
+	// Reset resets a pull stage. `base` refers to the L1 Block Reference to reset to.
+	// TODO: Return L1 Block reference
+	Reset(ctx context.Context, base eth.L1BlockRef) error
+}
+
 type Stage interface {
 	StageProgress
 
@@ -68,13 +74,17 @@ type DerivationPipeline struct {
 
 	// Index of the stage that is currently being reset.
 	// >= len(stages) if no additional resetting is required
-	resetting int
+	resetting    int
+	pullResetIdx int
 
 	// Index of the stage that is currently being processed.
 	active int
 
 	// stages in execution order. A stage Step that:
 	stages []Stage
+
+	pullStages []PullStage
+	traversal  *L1Traversal
 
 	eng EngineQueueStage
 
@@ -83,30 +93,39 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.
 func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetcher, engine Engine, metrics Metrics) *DerivationPipeline {
+
+	// Pull stages
+	l1Traversal := NewL1Traversal(log, l1Fetcher)
+
+	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
 	eng := NewEngineQueue(log, cfg, engine, metrics)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
 	batchQueue := NewBatchQueue(log, cfg, attributesQueue)
 	chInReader := NewChannelInReader(log, batchQueue)
 	bank := NewChannelBank(log, cfg, chInReader)
 	dataSrc := NewCalldataSource(log, cfg, l1Fetcher)
-	l1Src := NewL1Retrieval(log, dataSrc, bank)
-	l1Traversal := NewL1Traversal(log, l1Fetcher, l1Src)
-	stages := []Stage{eng, attributesQueue, batchQueue, chInReader, bank, l1Src, l1Traversal}
+	l1Src := NewL1Retrieval(log, dataSrc, bank, l1Traversal)
+
+	stages := []Stage{eng, attributesQueue, batchQueue, chInReader, bank, l1Src}
+	pullStages := []PullStage{l1Traversal}
 
 	return &DerivationPipeline{
-		log:       log,
-		cfg:       cfg,
-		l1Fetcher: l1Fetcher,
-		resetting: 0,
-		active:    0,
-		stages:    stages,
-		eng:       eng,
-		metrics:   metrics,
+		log:        log,
+		cfg:        cfg,
+		l1Fetcher:  l1Fetcher,
+		resetting:  0,
+		active:     0,
+		stages:     stages,
+		pullStages: pullStages,
+		eng:        eng,
+		metrics:    metrics,
+		traversal:  l1Traversal,
 	}
 }
 
 func (dp *DerivationPipeline) Reset() {
 	dp.resetting = 0
+	dp.pullResetIdx = 0
 }
 
 func (dp *DerivationPipeline) Progress() Progress {
@@ -160,7 +179,24 @@ func (dp *DerivationPipeline) Step(ctx context.Context) error {
 			return nil
 		}
 	}
+	// Then reset the pull based stages
+	if dp.pullResetIdx < len(dp.pullStages) {
+		// Use the last stage's progress as the one to pull from
+		inner := dp.stages[len(dp.stages)-1].Progress()
 
+		// Do the reset
+		if err := dp.pullStages[dp.pullResetIdx].Reset(ctx, inner.Origin); err == io.EOF {
+			// dp.log.Debug("reset of stage completed", "stage", dp.pullResetIdx, "origin", dp.pullStages[dp.pullResetIdx].Progress().Origin)
+			dp.pullResetIdx += 1
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("stage %d failed resetting: %w", dp.pullResetIdx, err)
+		} else {
+			return nil
+		}
+	}
+
+	// Lastly advance the stages
 	for i, stage := range dp.stages {
 		var outer Progress
 		if i+1 < len(dp.stages) {
@@ -174,5 +210,6 @@ func (dp *DerivationPipeline) Step(ctx context.Context) error {
 			return nil
 		}
 	}
-	return io.EOF
+	// If every stage has returned io.EOF, try to advance the L1 Origin
+	return dp.traversal.AdvanceL1Block(ctx)
 }

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -99,15 +99,15 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	dataSrc := NewCalldataSource(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	bank := NewChannelBank(log, cfg, l1Src, l1Fetcher)
+	chInReader := NewChannelInReader(log, bank)
 
 	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
 	eng := NewEngineQueue(log, cfg, engine, metrics)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
-	batchQueue := NewBatchQueue(log, cfg, attributesQueue)
-	chInReader := NewChannelInReader(log, batchQueue, bank)
+	batchQueue := NewBatchQueue(log, cfg, attributesQueue, chInReader)
 
-	stages := []Stage{eng, attributesQueue, batchQueue, chInReader}
-	pullStages := []PullStage{bank, l1Src, l1Traversal}
+	stages := []Stage{eng, attributesQueue, batchQueue}
+	pullStages := []PullStage{chInReader, bank, l1Src, l1Traversal}
 
 	return &DerivationPipeline{
 		log:        log,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -440,6 +440,10 @@ func (s *state) eventLoop() {
 			} else if err != nil && errors.Is(err, derive.ErrCritical) {
 				s.log.Error("Derivation process critical error", "err", err)
 				return
+			} else if err != nil && errors.Is(err, derive.NotEnoughData) {
+				stepAttempts = 0 // don't do a backoff for this error
+				reqStep()
+				continue
 			} else if err != nil {
 				s.log.Error("Derivation process error", "attempts", stepAttempts, "err", err)
 				reqStep()


### PR DESCRIPTION
**Description**

This is a stack of PRs to incrementally refactor the derivation pipeline with the goal of removing the progress API. This does this by recognizing that the progress API is used for two different things: 1) Recognizing when the a stage will not get any more data from a lower level stage and 2) Tracking where the stage is. There is a third function of advancing the L1 origin of the pipeline by a complex relationship between the progress and step APIs.

The new API is as follows:
- Each stage retains a reference to the previous stage
- Each stage asks the previous stage for more data. If a stage is out of data, it returns io.EOF. If a stage may produce more data but is currently out, it returns derive.NotEnoughData.
- Once the final stage (the engine queue) returns io.EOF, the pipeline advances the L1 traversal stage
- There is a single origin for the entire pipeline. It is set the the origin required of the channel bank. As such, the batch queue needs to reject some batches that if pulls from earlier in the pipeline.

The goal of this refactor (removing the progress API) + defining a new API between stages is to make it easier to test each stage in isolation as well as make it easier to incrementally improve each stage in the future.

**Tests**

Every commit in this sequence passes the op-e2e tests, however no effort was made to make the unit tests pass.

**Additional context**

Each commit in this stack is meant to be able to be reviewed as it's own PR. I've combined them together to show what each PR is driving towards.
