### PR TITLE
Fix Bedrock devnet stateviz container

### DIFF
--- a/op-node/cmd/stateviz/main.go
+++ b/op-node/cmd/stateviz/main.go
@@ -42,7 +42,7 @@ type SnapshotState struct {
 	L1Head          eth.L1BlockRef `json:"l1Head"`          // what we see as head on L1
 	L1Current       eth.L1BlockRef `json:"l1Current"`       // l1 block that the derivation is currently using
 	L2Head          eth.L2BlockRef `json:"l2Head"`          // l2 block that was last optimistically accepted (unsafe head)
-	L2SafeHead      eth.L2BlockRef `json:"l2SafeHead"`      // l2 block that was last derived
+	L2SafeHead      eth.L2BlockRef `json:"l2Safe"`          // l2 block that was last derived
 	L2FinalizedHead eth.BlockID    `json:"l2FinalizedHead"` // l2 block that is irreversible
 }
 
@@ -54,7 +54,7 @@ func (e *SnapshotState) UnmarshalJSON(data []byte) error {
 		L1Head          json.RawMessage `json:"l1Head"`
 		L1Current       json.RawMessage `json:"l1Current"`
 		L2Head          json.RawMessage `json:"l2Head"`
-		L2SafeHead      json.RawMessage `json:"l2SafeHead"`
+		L2SafeHead      json.RawMessage `json:"l2Safe"`
 		L2FinalizedHead json.RawMessage `json:"l2FinalizedHead"`
 	}{}
 	if err := json.Unmarshal(data, &t); err != nil {

--- a/op-node/cmd/stateviz/main.go
+++ b/op-node/cmd/stateviz/main.go
@@ -42,7 +42,7 @@ type SnapshotState struct {
 	L1Head          eth.L1BlockRef `json:"l1Head"`          // what we see as head on L1
 	L1Current       eth.L1BlockRef `json:"l1Current"`       // l1 block that the derivation is currently using
 	L2Head          eth.L2BlockRef `json:"l2Head"`          // l2 block that was last optimistically accepted (unsafe head)
-	L2SafeHead      eth.L2BlockRef `json:"l2Safe"`          // l2 block that was last derived
+	L2Safe          eth.L2BlockRef `json:"l2Safe"`          // l2 block that was last derived
 	L2FinalizedHead eth.BlockID    `json:"l2FinalizedHead"` // l2 block that is irreversible
 }
 
@@ -54,7 +54,7 @@ func (e *SnapshotState) UnmarshalJSON(data []byte) error {
 		L1Head          json.RawMessage `json:"l1Head"`
 		L1Current       json.RawMessage `json:"l1Current"`
 		L2Head          json.RawMessage `json:"l2Head"`
-		L2SafeHead      json.RawMessage `json:"l2Safe"`
+		L2Safe          json.RawMessage `json:"l2Safe"`
 		L2FinalizedHead json.RawMessage `json:"l2FinalizedHead"`
 	}{}
 	if err := json.Unmarshal(data, &t); err != nil {
@@ -78,7 +78,7 @@ func (e *SnapshotState) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(unquote(t.L2Head), &e.L2Head); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(unquote(t.L2SafeHead), &e.L2SafeHead); err != nil {
+	if err := json.Unmarshal(unquote(t.L2Safe), &e.L2Safe); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(unquote(t.L2FinalizedHead), &e.L2FinalizedHead); err != nil {

--- a/ops-bedrock/devnet-up.sh
+++ b/ops-bedrock/devnet-up.sh
@@ -109,7 +109,7 @@ SEQUENCER_BATCH_INBOX_ADDRESS="$(cat $DEVNET/rollup.json | jq -r '.batch_inbox_a
       SEQUENCER_BATCH_INBOX_ADDRESS="$SEQUENCER_BATCH_INBOX_ADDRESS" \
       docker-compose up -d op-proposer op-batcher
 
-  echo "Bringin up stateviz webserver..."
+  echo "Bringing up stateviz webserver..."
   docker-compose up -d stateviz
 )
 


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Currently the Bedrock devnet stateviz container is failing to parse the snapshot logs, due to [this change](https://github.com/ethereum-optimism/optimism/commit/9eea16e31dea037a45cd93e8bdd6a59bb20691b6#diff-511cbf4bb175ffd3df8b49e206073b0cc80140ecfe160a92bfd253cfb5728de2R544) switching the logs JSON key from `l2SafeHead` to `l2Safe`. The `stateviz` JSON parser wasn't updated in the process, causing it to error with `failed to decode snapshot log` errors.

**Tests**

This is a bugfix, tested by browsing to http://localhost:9090 locally and checking that it's working. Although I guess we should build an integration test to ensure this doesn't regress in the future.

**Additional context**

N/A
