### PR TITLE
ctb: Natspec say ERC20 instead of ETH where appropriate

### DIFF
--- a/.changeset/fast-mails-hope.md
+++ b/.changeset/fast-mails-hope.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Fixes to natspec docs

--- a/packages/contracts-bedrock/contracts/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1StandardBridge.sol
@@ -108,7 +108,7 @@ contract L1StandardBridge is StandardBridge, Semver {
      * @param _l2Token   Address of the corresponding token on L2.
      * @param _from      Address of the withdrawer on L2.
      * @param _to        Address of the recipient on L1.
-     * @param _amount    Amount of ETH to withdraw.
+     * @param _amount    Amount of the ERC20 to withdraw.
      * @param _extraData Optional data forwarded from L2.
      */
     function finalizeERC20Withdrawal(

--- a/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
@@ -96,7 +96,7 @@ abstract contract StandardBridge {
      * @param remoteToken Address of the ERC20 on the remote chain.
      * @param from        Address of the sender.
      * @param to          Address of the receiver.
-     * @param amount      Amount of ETH sent.
+     * @param amount      Amount of the ERC20 sent.
      * @param extraData   Extra data sent with the transaction.
      */
     event ERC20BridgeInitiated(
@@ -115,7 +115,7 @@ abstract contract StandardBridge {
      * @param remoteToken Address of the ERC20 on the remote chain.
      * @param from        Address of the sender.
      * @param to          Address of the receiver.
-     * @param amount      Amount of ETH sent.
+     * @param amount      Amount of the ERC20 sent.
      * @param extraData   Extra data sent with the transaction.
      */
     event ERC20BridgeFinalized(
@@ -134,7 +134,7 @@ abstract contract StandardBridge {
      * @param remoteToken Address of the ERC20 on the remote chain.
      * @param from        Address of the sender.
      * @param to          Address of the receiver.
-     * @param amount      Amount of ETH sent.
+     * @param amount      Amount of the ERC20 sent.
      * @param extraData   Extra data sent with the transaction.
      */
     event ERC20BridgeFailed(
@@ -325,12 +325,11 @@ abstract contract StandardBridge {
      * @notice Finalizes an ERC20 bridge on this chain. Can only be triggered by the other
      *         StandardBridge contract on the remote chain.
      *
-     *
      * @param _localToken  Address of the ERC20 on this chain.
      * @param _remoteToken Address of the corresponding token on the remote chain.
      * @param _from        Address of the sender.
      * @param _to          Address of the receiver.
-     * @param _amount      Amount of ETH being bridged.
+     * @param _amount      Amount of the ERC20 being bridged.
      * @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
      *                     not be triggered with this data, but it will be emitted and can be used
      *                     to identify the transaction.
@@ -376,7 +375,7 @@ abstract contract StandardBridge {
      * @param _localToken  Address of the ERC20 on this chain.
      * @param _remoteToken Address of the corresponding token on the remote chain.
      * @param _to          Address of the receiver.
-     * @param _amount      Amount of ETH being bridged.
+     * @param _amount      Amount of the ERC20 being bridged.
      */
     function completeOutboundTransfer(
         address _localToken,

--- a/specs/bridges.md
+++ b/specs/bridges.md
@@ -22,18 +22,19 @@ The `L2StandardBridge` is a predeploy contract located at
 
 ```solidity
 interface StandardBridge {
-    event ERC20BridgeFinalized(address indexed _localToken, address indexed _remoteToken, address indexed _from, address _to, uint256 _amount, bytes _data);
-    event ERC20BridgeInitiated(address indexed _localToken, address indexed _remoteToken, address indexed _from, address _to, uint256 _amount, bytes _data);
-    event ETHBridgeFinalized(address indexed _from, address indexed _to, uint256 _amount, bytes _data);
-    event ETHBridgeInitiated(address indexed _from, address indexed _to, uint256 _amount, bytes _data);
+    event ERC20BridgeFinalized(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData);
+    event ERC20BridgeFinalized(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData);
+    event ERC20BridgeInitiated(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData);
+    event ETHBridgeFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData);
+    event ETHBridgeInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData);
 
-    function bridgeERC20(address _localToken, address _remoteToken, uint256 _amount, uint32 _minGasLimit, bytes memory _data) external;
-    function bridgeERC20To(address _localToken, address _remoteToken, address _to, uint256 _amount, uint32 _minGasLimit, bytes memory _data) external;
-    function bridgeETH(uint32 _minGasLimit, bytes memory _data) payable external;
-    function bridgeETHTo(address _to, uint32 _minGasLimit, bytes memory _data) payable external;
+    function bridgeERC20(address _localToken, address _remoteToken, uint256 _amount, uint32 _minGasLimit, bytes memory _extraData) external;
+    function bridgeERC20To(address _localToken, address _remoteToken, address _to, uint256 _amount, uint32 _minGasLimit, bytes memory _extraData) external;
+    function bridgeETH(uint32 _minGasLimit, bytes memory _extraData) payable external;
+    function bridgeETHTo(address _to, uint32 _minGasLimit, bytes memory _extraData) payable external;
     function deposits(address, address) view external returns (uint256);
-    function finalizeBridgeERC20(address _localToken, address _remoteToken, address _from, address _to, uint256 _amount, bytes memory _data) external;
-    function finalizeBridgeETH(address _from, address _to, uint256 _amount, bytes memory _data) payable external;
+    function finalizeBridgeERC20(address _localToken, address _remoteToken, address _from, address _to, uint256 _amount, bytes memory _extraData) external;
+    function finalizeBridgeETH(address _from, address _to, uint256 _amount, bytes memory _extraData) payable external;
     function messenger() view external returns (address);
     function otherBridge() view external returns (address);
 }


### PR DESCRIPTION
**Description**

Very small clean up changes to natspec and spec docs related to the StandardBridge.
