### PR TITLE
[bedrock devnet] Fix stateviz: update javascript to new L2Safe variable name

### DIFF
--- a/op-node/cmd/stateviz/assets/main.js
+++ b/op-node/cmd/stateviz/assets/main.js
@@ -69,7 +69,7 @@ async function pageTable() {
                             <th scope="col">L1Head</th>
                             <th scope="col">L1Current</th>
                             <th scope="col">L2Head</th>
-                            <th scope="col">L2SafeHead</th>
+                            <th scope="col">L2Safe</th>
                             <th scope="col">L2FinalizedHead</th>
                         </tr>
                     </thead>
@@ -100,8 +100,8 @@ async function pageTable() {
                         <td title="${tooltipFormat(e.l2Head)}" data-bs-html="true" data-toggle="tooltip" style="background-color:${colorCode(e.l2Head.hash)};">
                             ${prettyHex(e.l2Head.hash)}
                         </td>
-                        <td title="${tooltipFormat(e.l2SafeHead)}" data-bs-html="true" data-toggle="tooltip" style="background-color:${colorCode(e.l2SafeHead.hash)};">
-                            ${prettyHex(e.l2SafeHead.hash)}
+                        <td title="${tooltipFormat(e.l2Safe)}" data-bs-html="true" data-toggle="tooltip" style="background-color:${colorCode(e.l2Safe.hash)};">
+                            ${prettyHex(e.l2Safe.hash)}
                         </td>
                         <td title="${tooltipFormat(e.l2FinalizedHead)}" data-bs-html="true" data-toggle="tooltip" style="background-color:${colorCode(e.l2FinalizedHead.hash)};">
                             ${prettyHex(e.l2FinalizedHead.hash)}


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Fixes the devnet stateviz container. #3511 was half the fix; but when the stateviz server-side variable was changed from `L2SafeHead`  to `L2Safe` with d5bad2845802a75c8f25b1e3ddd249437541b67f, it rebroke the fix at a different layer: the stateviz javascript. This PR fixes that as well.

**Tests**

Tested by browsing to http://localhost:9090 locally.
