### PR TITLE
op-node: Fix OPB-04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ jobs:
   bedrock-go-tests:
     docker:
       - image: ethereumoptimism/ci-builder:latest
+    resource_class: xlarge
     steps:
       - checkout
       - run:

--- a/op-node/eth/ssz.go
+++ b/op-node/eth/ssz.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/ethereum-optimism/optimism/l2geth/common/math"
 	"io"
 	"sync"
 )
@@ -17,6 +18,10 @@ const executionPayloadFixedPart = 32 + 20 + 32 + 32 + 256 + 32 + 8 + 8 + 8 + 8 +
 
 // MAX_TRANSACTIONS_PER_PAYLOAD in consensus spec
 const maxTransactionsPerPayload = 1 << 20
+
+// ErrExtraDataTooLarge occurs when the ExecutionPayload's ExtraData field
+// is too large to be properly represented in SSZ.
+var ErrExtraDataTooLarge = errors.New("extra data too large")
 
 // The payloads are small enough to read and write at once.
 // But this happens often enough that we want to avoid re-allocating buffers for this.
@@ -57,6 +62,10 @@ func unmarshalBytes32LE(in []byte, z *Uint256Quantity) {
 
 // MarshalSSZ encodes the ExecutionPayload as SSZ type
 func (payload *ExecutionPayload) MarshalSSZ(w io.Writer) (n int, err error) {
+	if len(payload.ExtraData) > math.MaxUint32-executionPayloadFixedPart {
+		return 0, ErrExtraDataTooLarge
+	}
+
 	scope := payload.SizeSSZ()
 
 	buf := *payloadBufPool.Get().(*[]byte)

--- a/op-node/eth/ssz.go
+++ b/op-node/eth/ssz.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/l2geth/common/math"
 	"io"
+	"math"
 	"sync"
 )
 


### PR DESCRIPTION
The length of the ExtraData field was not being checked, which could lead to panics in the MarshalSSZ function.
