### PR TITLE
chore: Ignore .t.sol and bindings in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 ignore:
   - "l2geth"
+  - "**/*.t.sol"
+  - "op-bindings/bindings/*.go"


### PR DESCRIPTION
**Description**

Forge coverage currently includes [some of the test files in the output](https://app.codecov.io/gh/ethereum-optimism/optimism/tree/ci%2Fcodecov-improvements/packages/contracts-bedrock/contracts/test). This will exclude them from code coverage. 

I've also ignored coverage of the go bindings.

