### PR TITLE
ci: Delete contract-artifacts-bedrock job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -807,17 +807,6 @@ workflows:
             - gcr
           requires:
             - contracts-bedrock-tests
-      - docker-publish:
-          name: contract-artifacts-bedrock-publish-dev
-          docker_file: ops/docker/Dockerfile.packages
-          docker_tags: us-central1-docker.pkg.dev/bedrock-goerli-development/images/contract-artifacts-bedrock:<<pipeline.git.revision>>
-          target: contract-artifacts-bedrock
-          docker_context: .
-          repo: us-central1-docker.pkg.dev
-          context:
-            - gcr
-          requires:
-            - contracts-bedrock-tests
       - hive-test:
           name: hive-test-rpc
           version: <<pipeline.git.revision>>


### PR DESCRIPTION
This job isn't needed anymore since we're compiling the artifacts into the bindings.
