### PR TITLE
ctp: fixup deploy scripts for the nft bridge

### DIFF
--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeImplementation.ts
@@ -1,13 +1,33 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import '@eth-optimism/hardhat-deploy-config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
+import fetch from 'node-fetch'
+
+// Handle the `ops` deployment
+const getL1CrossDomainMessengerProxyDeployment = async (
+  hre: HardhatRuntimeEnvironment
+) => {
+  const network = hre.network.name
+  if (network === 'ops-l1') {
+    const res = await fetch(
+      'http://localhost:8080/deployments/local/Proxy__OVM_L1CrossDomainMessenger.json'
+    )
+    return res.json()
+  } else {
+    return hre.deployments.get('Proxy__OVM_L1CrossDomainMessenger')
+  }
+}
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
   const { deploy } = hre.deployments
   const { getAddress } = hre.ethers.utils
+
+  console.log(`Deploying L1ERC721Bridge to ${hre.network.name}`)
+  console.log(`Using deployer ${deployer}`)
 
   const Deployment__L1ERC721BridgeProxy = await hre.deployments.get(
     'L1ERC721BridgeProxy'
@@ -17,18 +37,18 @@ const deployFn: DeployFunction = async (hre) => {
     'Proxy',
     Deployment__L1ERC721BridgeProxy.address
   )
-  const admin = await L1ERC721BridgeProxy.admin()
+  const admin = await L1ERC721BridgeProxy.callStatic.admin()
   if (getAddress(admin) !== getAddress(deployer)) {
     throw new Error('deployer is not proxy admin')
   }
 
   // Get the address of the currently deployed L1CrossDomainMessenger.
   // This should be the address of the proxy
-  const Deployment__L1CrossDomainMessenger = await hre.deployments.get(
-    'Proxy__OVM_L1CrossDomainMessenger'
-  )
+  const Deployment__L1CrossDomainMessengerProxy =
+    await getL1CrossDomainMessengerProxyDeployment(hre)
+
   const L1CrossDomainMessengerAddress =
-    Deployment__L1CrossDomainMessenger.address
+    Deployment__L1CrossDomainMessengerProxy.address
 
   const predeploy = '0x4200000000000000000000000000000000000014'
   // Deploy the L1ERC721Bridge. The arguments are
@@ -76,13 +96,16 @@ const deployFn: DeployFunction = async (hre) => {
   {
     if (
       hre.network.name === 'optimism' ||
-      hre.network.name === 'optimism-goerli'
+      hre.network.name === 'optimism-goerli' ||
+      hre.network.name === 'ops-l2'
     ) {
       let newAdmin: string
       if (hre.network.name === 'optimism') {
         newAdmin = '0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0'
       } else if (hre.network.name === 'optimism-goerli') {
         newAdmin = '0xf80267194936da1E98dB10bcE06F3147D580a62e'
+      } else {
+        newAdmin = deployer
       }
       const tx = await L1ERC721BridgeProxy.changeAdmin(newAdmin)
       const receipt = await tx.wait()

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeImplementation.ts
@@ -3,23 +3,53 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import '@eth-optimism/hardhat-deploy-config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
-import { predeploys } from '@eth-optimism/contracts-bedrock'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
+  const { deploy } = hre.deployments
+  const { getAddress } = hre.ethers.utils
 
+  // Get the address of the currently deployed L1CrossDomainMessenger.
+  // This should be the address of the proxy
   const Deployment__L1CrossDomainMessenger = await hre.deployments.get(
     'Proxy__OVM_L1CrossDomainMessenger'
   )
+  const L1CrossDomainMessengerAddress =
+    Deployment__L1CrossDomainMessenger.address
 
-  await hre.deployments.deploy('L1ERC721Bridge', {
+  const predeploy = '0x4200000000000000000000000000000000000014'
+  // Deploy the L1ERC721Bridge. The arguments are
+  // - messenger
+  // - otherBridge
+  // Since this is the L1ERC721Bridge, the otherBridge is the
+  // predeploy address
+  await deploy('L1ERC721Bridge', {
     from: deployer,
-    args: [
-      Deployment__L1CrossDomainMessenger.address,
-      predeploys.L2ERC721Bridge,
-    ],
+    args: [L1CrossDomainMessengerAddress, predeploy],
     log: true,
+    waitConfirmations: 1,
   })
+
+  const Deployment__L1ERC721Bridge = await hre.deployments.get('L1ERC721Bridge')
+  console.log(
+    `L1ERC721Bridge deployed to ${Deployment__L1ERC721Bridge.address}`
+  )
+
+  const L1ERC721Bridge = await hre.ethers.getContractAt(
+    'L1ERC721Bridge',
+    Deployment__L1ERC721Bridge.address
+  )
+
+  // Check to make sure that it was initialized correctly
+  const messenger = await L1ERC721Bridge.messenger()
+  if (getAddress(messenger) !== getAddress(L1CrossDomainMessengerAddress)) {
+    throw new Error(`L1ERC721Bridge.messenger misconfigured`)
+  }
+
+  const otherBridge = await L1ERC721Bridge.otherBridge()
+  if (getAddress(otherBridge) !== getAddress(predeploy)) {
+    throw new Error('L1ERC721Bridge.otherBridge misconfigured')
+  }
 }
 
 deployFn.tags = ['L1ERC721BridgeImplementation']

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeImplementation.ts
@@ -1,13 +1,23 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import { ethers } from 'hardhat'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
+import { predeploys } from '@eth-optimism/contracts-bedrock'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
 
+  const Deployment__L1CrossDomainMessenger = await hre.deployments.get(
+    'Proxy__OVM_L1CrossDomainMessenger'
+  )
+
   await hre.deployments.deploy('L1ERC721Bridge', {
     from: deployer,
-    args: [ethers.constants.AddressZero, ethers.constants.AddressZero],
+    args: [
+      Deployment__L1CrossDomainMessenger.address,
+      predeploys.L2ERC721Bridge,
+    ],
     log: true,
   })
 }

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
@@ -6,23 +6,15 @@ import 'hardhat-deploy'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
+  const { deploy } = hre.deployments
 
-  const { deploy } = await hre.deployments.deterministic(
-    'L1ERC721BridgeProxy',
-    {
-      contract: 'Proxy',
-      salt: hre.ethers.utils.solidityKeccak256(
-        ['string'],
-        ['L1ERC721BridgeProxy']
-      ),
-      from: deployer,
-      args: [hre.deployConfig.ddd],
-      log: true,
-      waitConfirmations: 1,
-    }
-  )
-
-  await deploy()
+  await deploy('L1ERC721BridgeProxy', {
+    contract: 'Proxy',
+    from: deployer,
+    args: [deployer],
+    log: true,
+    waitConfirmations: 1,
+  })
 
   const Deployment__L1ERC721BridgeProxy = await hre.deployments.get(
     'L1ERC721BridgeProxy'

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
@@ -4,9 +4,16 @@ import '@eth-optimism/hardhat-deploy-config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
 
+import { isTargetL1Network } from '../../src/nft-bridge-deploy-helpers'
+
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
   const { deploy } = hre.deployments
+
+  if (!isTargetL1Network(hre.network.name)) {
+    console.log(`Deploying to unsupported network ${hre.network.name}`)
+    return
+  }
 
   console.log(`Deploying L1ERC721BridgeProxy to ${hre.network.name}`)
   console.log(`Using deployer ${deployer}`)

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
@@ -23,6 +23,13 @@ const deployFn: DeployFunction = async (hre) => {
   )
 
   await deploy()
+
+  const Deployment__L1ERC721BridgeProxy = await hre.deployments.get(
+    'L1ERC721BridgeProxy'
+  )
+  console.log(
+    `L1ERC721BridgeProxy deployed to ${Deployment__L1ERC721BridgeProxy.address}`
+  )
 }
 
 deployFn.tags = ['L1ERC721BridgeProxy']

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
@@ -18,6 +18,7 @@ const deployFn: DeployFunction = async (hre) => {
       from: deployer,
       args: [hre.deployConfig.ddd],
       log: true,
+      waitConfirmations: 1,
     }
   )
 

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
@@ -1,5 +1,8 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L1ERC721BridgeProxy.ts
@@ -8,6 +8,9 @@ const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
   const { deploy } = hre.deployments
 
+  console.log(`Deploying L1ERC721BridgeProxy to ${hre.network.name}`)
+  console.log(`Using deployer ${deployer}`)
+
   await deploy('L1ERC721BridgeProxy', {
     contract: 'Proxy',
     from: deployer,

--- a/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeImplementation.ts
@@ -7,11 +7,28 @@ import { predeploys } from '@eth-optimism/contracts'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
+  const { getAddress } = hre.ethers.utils
 
   const Deployment__L1ERC721Bridge = await hre.deployments.get(
     'L1ERC721BridgeProxy'
   )
 
+  const L2ERC721BridgeProxy = await hre.ethers.getContractAt(
+    'Proxy',
+    '0x4200000000000000000000000000000000000014'
+  )
+
+  // Check to make sure that the admin of the proxy is the deployer.
+  // The deployer of the L2ERC721Bridge should be the same as the
+  // admin of the L2ERC721BridgeProxy so that it is easy to upgrade
+  // the implementation. The admin is then changed depending on the
+  // network after the L2ERC721BridgeProxy is upgraded to the implementation
+  const admin = L2ERC721BridgeProxy.admin()
+  if (getAddress(admin) !== getAddress(deployer)) {
+    throw new Error(`Unexpected admin ${admin}`)
+  }
+
+  // Deploy the L2ERC721Bridge implementation
   await hre.deployments.deploy('L2ERC721Bridge', {
     from: deployer,
     args: [
@@ -19,7 +36,49 @@ const deployFn: DeployFunction = async (hre) => {
       Deployment__L1ERC721Bridge.address,
     ],
     log: true,
+    waitConfirmations: 1,
   })
+
+  const Deployment__L2ERC721Bridge = await hre.deployments.get('L2ERC721Bridge')
+  console.log(
+    `L2ERC721Bridge deployed to ${Deployment__L2ERC721Bridge.address}`
+  )
+
+  {
+    // Upgrade the implementation of the proxy to the newly deployed
+    // L2ERC721Bridge
+    const tx = await L2ERC721BridgeProxy.upgradeTo(
+      Deployment__L2ERC721Bridge.address
+    )
+    const receipt = await tx.wait()
+    console.log(
+      `Upgraded the implementation of the L2ERC721BridgeProxy: ${receipt.transactionhash}`
+    )
+  }
+
+  {
+    // On production networks transfer the admin privilege to the
+    // appropriate address
+    if (
+      hre.network.name === 'optimism' ||
+      hre.network.name === 'optimism-goerli'
+    ) {
+      let owner: string
+      if (hre.network.name === 'optimism') {
+        // L2 Foundation Multisig
+        owner = '0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0'
+      } else if (hre.network.name === 'optimism-goerli') {
+        // Goerli admin key
+        owner = '0xf80267194936da1E98dB10bcE06F3147D580a62e'
+      }
+
+      const tx = await L2ERC721BridgeProxy.changeAdmin(owner)
+      const receipt = await tx.wait()
+      console.log(
+        `Changed admin of the L2ERC721BridgeProxy: ${receipt.transactionhash}`
+      )
+    }
+  }
 }
 
 deployFn.tags = ['L2ERC721BridgeImplementation']

--- a/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeImplementation.ts
@@ -1,18 +1,28 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import { ethers } from 'hardhat'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
+import { predeploys } from '@eth-optimism/contracts'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
 
+  const Deployment__L1ERC721Bridge = await hre.deployments.get(
+    'L1ERC721BridgeProxy'
+  )
+
   await hre.deployments.deploy('L2ERC721Bridge', {
     from: deployer,
-    args: [ethers.constants.AddressZero, ethers.constants.AddressZero],
+    args: [
+      predeploys.L2CrossDomainMessenger,
+      Deployment__L1ERC721Bridge.address,
+    ],
     log: true,
   })
 }
 
 deployFn.tags = ['L2ERC721BridgeImplementation']
-deployFn.dependencies = ['L2ERC721BridgeProxy']
+deployFn.dependencies = ['L2ERC721BridgeProxy', 'L1ERC721BridgeProxy']
 
 export default deployFn

--- a/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeProxy.ts
@@ -1,24 +1,37 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
+  const { getAddress } = hre.ethers.utils
 
-  const { deploy } = await hre.deployments.deterministic(
-    'L2ERC721BridgeProxy',
-    {
-      contract: 'Proxy',
-      salt: hre.ethers.utils.solidityKeccak256(
-        ['string'],
-        ['L2ERC721BridgeProxy']
-      ),
-      from: deployer,
-      args: [hre.deployConfig.ddd],
-      log: true,
-    }
+  const mainnetDeployer = getAddress(
+    '0x53A6eecC2dD4795Fcc68940ddc6B4d53Bd88Bd9E'
+  )
+  const goerliDeployer = getAddress(
+    '0x5c679a57e018f5f146838138d3e032ef4913d551'
   )
 
-  await deploy()
+  if (hre.network.name === 'optimism') {
+    if (getAddress(deployer) !== mainnetDeployer) {
+      throw new Error(`Incorrect deployer: ${deployer}`)
+    }
+    //
+  } else if (hre.network.name === 'optimism-goerli') {
+    if (getAddress(deployer) !== goerliDeployer) {
+      throw new Error(`Incorrect deployer: ${deployer}`)
+    }
+  }
+
+  await hre.deployments.deploy('L2ERC721BridgeProxy', {
+    contract: 'Proxy',
+    from: deployer,
+    args: [],
+    log: true,
+  })
 }
 
 deployFn.tags = ['L2ERC721BridgeProxy']

--- a/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeProxy.ts
@@ -15,23 +15,51 @@ const deployFn: DeployFunction = async (hre) => {
     '0x5c679a57e018f5f146838138d3e032ef4913d551'
   )
 
+  // Deploy the L2ERC721BridgeProxy as a predeploy address.
+  // A special deployer account must be used.
   if (hre.network.name === 'optimism') {
     if (getAddress(deployer) !== mainnetDeployer) {
       throw new Error(`Incorrect deployer: ${deployer}`)
     }
-    //
   } else if (hre.network.name === 'optimism-goerli') {
     if (getAddress(deployer) !== goerliDeployer) {
       throw new Error(`Incorrect deployer: ${deployer}`)
     }
   }
 
+  // Set the deployer as the admin of the Proxy. This is
+  // temporary, the admin will be updated when deploying
+  // the implementation
   await hre.deployments.deploy('L2ERC721BridgeProxy', {
     contract: 'Proxy',
     from: deployer,
-    args: [],
+    args: [deployer],
     log: true,
+    waitConfirmations: 1,
   })
+
+  // Check that the Proxy was deployed to the correct address
+  if (
+    hre.network.name === 'optimism' ||
+    hre.network.name === 'optimism-goerli'
+  ) {
+    const code = await hre.ethers.provider.getCode(
+      '0x4200000000000000000000000000000000000014'
+    )
+    if (code === '0x') {
+      throw new Error('Code is not set at expected predeploy address')
+    }
+    console.log(
+      'L2ERC721BridgeProxy deployed to 0x4200000000000000000000000000000000000014'
+    )
+  } else {
+    const Deployment__L2ERC721BridgeProxy = await hre.deployments.get(
+      'L2ERC721BridgeProxy'
+    )
+    console.log(
+      `L2ERC721BridgeProxy deployed to ${Deployment__L2ERC721BridgeProxy.address}`
+    )
+  }
 }
 
 deployFn.tags = ['L2ERC721BridgeProxy']

--- a/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/L2ERC721BridgeProxy.ts
@@ -4,19 +4,32 @@ import '@eth-optimism/hardhat-deploy-config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
 
+const predeploy = '0x4200000000000000000000000000000000000014'
+
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
   const { getAddress } = hre.ethers.utils
 
+  console.log(`Deploying L2ERC721BridgeProxy to ${hre.network.name}`)
+  console.log(`Using deployer ${deployer}`)
+
+  // Check to make sure that the Proxy has not been deployed yet
+  const pre = await hre.ethers.provider.getCode(predeploy, 'latest')
+  if (pre !== '0x') {
+    console.log(`Code already deployed to ${predeploy}`)
+    return
+  }
+
+  // A special deployer account must be used
   const mainnetDeployer = getAddress(
     '0x53A6eecC2dD4795Fcc68940ddc6B4d53Bd88Bd9E'
   )
   const goerliDeployer = getAddress(
     '0x5c679a57e018f5f146838138d3e032ef4913d551'
   )
+  const localDeployer = getAddress('0xdfc82d475833a50de90c642770f34a9db7deb725')
 
-  // Deploy the L2ERC721BridgeProxy as a predeploy address.
-  // A special deployer account must be used.
+  // Deploy the L2ERC721BridgeProxy as a predeploy address
   if (hre.network.name === 'optimism') {
     if (getAddress(deployer) !== mainnetDeployer) {
       throw new Error(`Incorrect deployer: ${deployer}`)
@@ -25,6 +38,12 @@ const deployFn: DeployFunction = async (hre) => {
     if (getAddress(deployer) !== goerliDeployer) {
       throw new Error(`Incorrect deployer: ${deployer}`)
     }
+  } else if (hre.network.name === 'ops-l2') {
+    if (getAddress(deployer) !== localDeployer) {
+      throw new Error(`Incorrect deployer: ${deployer}`)
+    }
+  } else {
+    throw new Error(`Unknown network: ${hre.network.name}`)
   }
 
   // Set the deployer as the admin of the Proxy. This is
@@ -39,27 +58,11 @@ const deployFn: DeployFunction = async (hre) => {
   })
 
   // Check that the Proxy was deployed to the correct address
-  if (
-    hre.network.name === 'optimism' ||
-    hre.network.name === 'optimism-goerli'
-  ) {
-    const code = await hre.ethers.provider.getCode(
-      '0x4200000000000000000000000000000000000014'
-    )
-    if (code === '0x') {
-      throw new Error('Code is not set at expected predeploy address')
-    }
-    console.log(
-      'L2ERC721BridgeProxy deployed to 0x4200000000000000000000000000000000000014'
-    )
-  } else {
-    const Deployment__L2ERC721BridgeProxy = await hre.deployments.get(
-      'L2ERC721BridgeProxy'
-    )
-    console.log(
-      `L2ERC721BridgeProxy deployed to ${Deployment__L2ERC721BridgeProxy.address}`
-    )
+  const code = await hre.ethers.provider.getCode(predeploy)
+  if (code === '0x') {
+    throw new Error('Code is not set at expected predeploy address')
   }
+  console.log(`L2ERC721BridgeProxy deployed to ${predeploy}`)
 }
 
 deployFn.tags = ['L2ERC721BridgeProxy']

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryImplementation.ts
@@ -1,13 +1,17 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import { ethers } from 'hardhat'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
+import { predeploys } from '@eth-optimism/contracts-bedrock'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
+  const remoteChainId = hre.deployConfig.remoteChainId
 
   await hre.deployments.deploy('OptimismMintableERC721Factory', {
     from: deployer,
-    args: [ethers.constants.AddressZero, 0],
+    args: [predeploys.L2ERC721Bridge, remoteChainId],
     log: true,
   })
 }

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryImplementation.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryImplementation.ts
@@ -3,17 +3,32 @@ import { DeployFunction } from 'hardhat-deploy/dist/types'
 import '@eth-optimism/hardhat-deploy-config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
-import { predeploys } from '@eth-optimism/contracts-bedrock'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
-  const remoteChainId = hre.deployConfig.remoteChainId
+
+  let remoteChainId: number
+  if (hre.network.name === 'optimism') {
+    remoteChainId = 1
+  } else if (hre.network.name === 'optimism-goerli') {
+    remoteChainId = 5
+  } else {
+    remoteChainId = hre.deployConfig.remoteChainId
+  }
 
   await hre.deployments.deploy('OptimismMintableERC721Factory', {
     from: deployer,
-    args: [predeploys.L2ERC721Bridge, remoteChainId],
+    args: ['0x4200000000000000000000000000000000000014', remoteChainId],
     log: true,
+    waitConfirmations: 1,
   })
+
+  const Deployment__OptimismMintableERC721Factory = await hre.deployments.get(
+    'OptimismMintableERC721Factory'
+  )
+  console.log(
+    `OptimismMintableERC721Factory deployed to ${Deployment__OptimismMintableERC721Factory.address}`
+  )
 }
 
 deployFn.tags = ['OptimismMintableERC721FactoryImplementation']

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
@@ -23,6 +23,12 @@ const deployFn: DeployFunction = async (hre) => {
   )
 
   await deploy()
+
+  const Deployment__OptimismMintableERC721FactoryProxy =
+    await hre.deployments.get('OptimismMintableERC721FactoryProxy')
+  console.log(
+    `OptimismMintableERC721FactoryProxy deployed to ${Deployment__OptimismMintableERC721FactoryProxy.address}`
+  )
 }
 
 deployFn.tags = ['OptimismMintableERC721FactoryProxy']

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
@@ -8,6 +8,11 @@ const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
   const { deploy } = hre.deployments
 
+  console.log(
+    `Deploying OptimismMintableERC721FactoryProxy to ${hre.network.name}`
+  )
+  console.log(`Using deployer ${deployer}`)
+
   // Deploy the OptimismMintableERC721FactoryProxy with
   // the deployer as the admin. The admin and implementation
   // will be updated with the deployment of the implementation

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
@@ -18,6 +18,7 @@ const deployFn: DeployFunction = async (hre) => {
       from: deployer,
       args: [hre.deployConfig.ddd],
       log: true,
+      waitConfirmations: 1,
     }
   )
 

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
@@ -1,5 +1,8 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
+import 'hardhat-deploy'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()

--- a/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
+++ b/packages/contracts-periphery/deploy/nft-bridge/OptimismMintableERC721FactoryProxy.ts
@@ -6,23 +6,18 @@ import 'hardhat-deploy'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
+  const { deploy } = hre.deployments
 
-  const { deploy } = await hre.deployments.deterministic(
-    'OptimismMintableERC721FactoryProxy',
-    {
-      contract: 'Proxy',
-      salt: hre.ethers.utils.solidityKeccak256(
-        ['string'],
-        ['OptimismMintableERC721FactoryProxy']
-      ),
-      from: deployer,
-      args: [hre.deployConfig.ddd],
-      log: true,
-      waitConfirmations: 1,
-    }
-  )
-
-  await deploy()
+  // Deploy the OptimismMintableERC721FactoryProxy with
+  // the deployer as the admin. The admin and implementation
+  // will be updated with the deployment of the implementation
+  await deploy('OptimismMintableERC721FactoryProxy', {
+    contract: 'Proxy',
+    from: deployer,
+    args: [deployer],
+    log: true,
+    waitConfirmations: 1,
+  })
 
   const Deployment__OptimismMintableERC721FactoryProxy =
     await hre.deployments.get('OptimismMintableERC721FactoryProxy')

--- a/packages/contracts-periphery/hardhat.config.ts
+++ b/packages/contracts-periphery/hardhat.config.ts
@@ -112,6 +112,21 @@ const config: HardhatUserConfig = {
         },
       },
     },
+    'ops-l2': {
+      chainId: 17,
+      accounts: [
+        '0x3b8d2345102cce2443acb240db6e87c8edd4bb3f821b17fab8ea2c9da08ea132',
+        '0xa6aecc98b63bafb0de3b29ae9964b14acb4086057808be29f90150214ebd4a0f',
+      ],
+      url: 'http://127.0.0.1:8545',
+    },
+    'ops-l1': {
+      chainId: 31337,
+      accounts: [
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      ],
+      url: 'http://127.0.0.1:9545',
+    },
   },
   paths: {
     deployConfig: './config/deploy',

--- a/packages/contracts-periphery/scripts/deploy-nft-bridge.sh
+++ b/packages/contracts-periphery/scripts/deploy-nft-bridge.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
+set -e
+
+L1_NETWORK=ops-l1
+L2_NETWORK=ops-l2
+
 # Step 1: deploy the Proxy to the predeploy address on L2
-npx hardhat deploy --tags L2ERC721BridgeProxy --network ops-l2
+npx hardhat deploy --tags L2ERC721BridgeProxy --network $L2_NETWORK
 
 # Step 2: deploy the Proxy for the L1ERC721Bridge to L1
-npx hardhat deploy --tags L1ERC721BridgeProxy --network ops-l1
+npx hardhat deploy --tags L1ERC721BridgeProxy --network $L1_NETWORK
 
 # Step 3: deploy the L2ERC721Bridge implementation
-npx hardhat deploy --tags L2ERC721BridgeImplementation --network ops-l2
+npx hardhat deploy --tags L2ERC721BridgeImplementation --network $L2_NETWORK
 
 # Step 4: deploy the L1ERC721Bridge implementation to L1
-npx hardhat deploy --tags L1ERC721BridgeImplementation --network ops-l1
+npx hardhat deploy --tags L1ERC721BridgeImplementation --network $L1_NETWORK
 
 # Step 5: deploy the Proxy for the OptimismMintableERC721Factory to L2
-npx hardhat deploy --tags OptimismMintableERC721FactoryProxy --network ops-l2
+npx hardhat deploy --tags OptimismMintableERC721FactoryProxy --network $L2_NETWORK
 
 # Step 5: deploy the OptimismMintableERC721Factory to L2
-npx hardhat deploy --tags OptimismMintableERC721FactoryImplementation --network ops-l2
+npx hardhat deploy --tags OptimismMintableERC721FactoryImplementation --network $L2_NETWORK

--- a/packages/contracts-periphery/scripts/deploy-nft-bridge.sh
+++ b/packages/contracts-periphery/scripts/deploy-nft-bridge.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Step 1: deploy the Proxy to the predeploy address on L2
+npx hardhat deploy --tags L2ERC721BridgeProxy --network ops-l2
+
+# Step 2: deploy the Proxy for the L1ERC721Bridge to L1
+npx hardhat deploy --tags L1ERC721BridgeProxy --network ops-l1
+
+# Step 3: deploy the L2ERC721Bridge implementation
+npx hardhat deploy --tags L2ERC721BridgeImplementation --network ops-l2
+
+# Step 4: deploy the L1ERC721Bridge implementation to L1
+npx hardhat deploy --tags L1ERC721BridgeImplementation --network ops-l1
+
+# Step 5: deploy the Proxy for the OptimismMintableERC721Factory to L2
+npx hardhat deploy --tags OptimismMintableERC721FactoryProxy --network ops-l2
+
+# Step 5: deploy the OptimismMintableERC721Factory to L2
+npx hardhat deploy --tags OptimismMintableERC721FactoryImplementation --network ops-l2

--- a/packages/contracts-periphery/src/nft-bridge-deploy-helpers.ts
+++ b/packages/contracts-periphery/src/nft-bridge-deploy-helpers.ts
@@ -1,0 +1,63 @@
+import { utils } from 'ethers'
+
+export const l2MainnetMultisig = '0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0'
+export const l1MainnetMultisig = '0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A'
+export const goerliAdmin = '0xf80267194936da1E98dB10bcE06F3147D580a62e'
+export const predeploy = '0x4200000000000000000000000000000000000014'
+export const predeployDeployer = '0xdfc82d475833a50de90c642770f34a9db7deb725'
+
+export const isTargetL2Network = (network: string): boolean => {
+  switch (network) {
+    case 'optimism':
+    case 'optimism-goerli':
+    case 'ops-l2':
+      return true
+    default:
+      return false
+  }
+}
+
+export const isTargetL1Network = (network: string): boolean => {
+  switch (network) {
+    case 'mainnet':
+    case 'goerli':
+    case 'ops-l1':
+      return true
+    default:
+      return false
+  }
+}
+
+export const getProxyAdmin = (network: string): string => {
+  switch (network) {
+    case 'optimism':
+      return l2MainnetMultisig
+    case 'mainnet':
+      return l1MainnetMultisig
+    case 'goerli':
+    case 'optimism-goerli':
+      return goerliAdmin
+    case 'ops-l1':
+    case 'ops-l2':
+      return predeployDeployer
+    default:
+      throw new Error(`unknown network ${network}`)
+  }
+}
+
+export const validateERC721Bridge = async (hre, address: string, expected) => {
+  const L1ERC721Bridge = await hre.ethers.getContractAt('ERC721Bridge', address)
+
+  const messenger = await L1ERC721Bridge.messenger()
+  const otherBridge = await L1ERC721Bridge.otherBridge()
+
+  if (utils.getAddress(messenger) !== utils.getAddress(expected.messenger)) {
+    throw new Error(`messenger mismatch`)
+  }
+
+  if (
+    utils.getAddress(otherBridge) !== utils.getAddress(expected.otherBridge)
+  ) {
+    throw new Error(`otherBridge mismatch`)
+  }
+}

--- a/packages/contracts-periphery/src/nft-bridge-deploy-helpers.ts
+++ b/packages/contracts-periphery/src/nft-bridge-deploy-helpers.ts
@@ -1,7 +1,10 @@
 import { utils } from 'ethers'
 
+// https://optimistic.etherscan.io/address/0x2501c477d0a35545a387aa4a3eee4292a9a8b3f0
 export const l2MainnetMultisig = '0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0'
+// https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A
 export const l1MainnetMultisig = '0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A'
+// https://goerli.etherscan.io/address/0xf80267194936da1E98dB10bcE06F3147D580a62e
 export const goerliAdmin = '0xf80267194936da1E98dB10bcE06F3147D580a62e'
 export const predeploy = '0x4200000000000000000000000000000000000014'
 export const predeployDeployer = '0xdfc82d475833a50de90c642770f34a9db7deb725'


### PR DESCRIPTION
**Description**

The most important one is the deploy script for the `Proxy` that will end up at the predeploy on L2. There are specific checks for the correct deployer account being used. Will likely require some changes to the hardhat config when doing the actual deployment.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


