### PR TITLE
chore: Disable PR commenting by codecov bot

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+comment: false
 ignore:
   - "l2geth"
   - "**/*.t.sol"


### PR DESCRIPTION
**Description**

Prevents the codecov bot from commenting on PRs. We may wish to enable this again later when the configuration is more mature.