### PR TITLE
deployer: expose deployments

### DIFF
--- a/.changeset/hot-panthers-reply.md
+++ b/.changeset/hot-panthers-reply.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts': patch
+---
+
+Expose the deployments in the deployer image

--- a/ops/scripts/deployer.sh
+++ b/ops/scripts/deployer.sh
@@ -54,6 +54,9 @@ npx hardhat take-dump --network $CONTRACTS_TARGET_NETWORK
 mv addresses.json ./genesis
 cp ./genesis/$CONTRACTS_TARGET_NETWORK.json ./genesis/state-dump.latest.json
 
+# expose the deployments
+cp -rf ./deployments ./genesis/deployments
+
 # service the addresses and dumps
 echo "Starting server."
 python3 -m http.server \


### PR DESCRIPTION
**Description**

Will allow for e2e testing of the nft bridge scripts on `ops`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

