### PR TITLE
ci: Remove publish dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,13 @@ jobs:
             - "packages/*/node_modules"
             - "packages/*/dist"
             - "packages/*/artifacts"
+            - "packages/contracts/src/contract-artifacts.ts"
+            - "packages/contracts/src/contract-deployed-artifacts.ts"
+            - "packages/contracts/chugsplash"
+            - "packages/contracts/L1"
+            - "packages/contracts/L2"
+            - "packages/contracts/libraries"
+            - "packages/contracts/standards"
 
 
   docker-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -763,15 +763,6 @@ workflows:
           repo: us-central1-docker.pkg.dev
           context:
             - gcr
-      - docker-publish:
-          name: deployer-bedrock-publish-dev
-          docker_file: ops/docker/Dockerfile.packages
-          docker_tags: us-central1-docker.pkg.dev/bedrock-goerli-development/images/deployer-bedrock:<<pipeline.git.revision>>
-          target: deployer-bedrock
-          docker_context: .
-          repo: us-central1-docker.pkg.dev
-          context:
-            - gcr
       - hive-test:
           name: hive-test-rpc
           version: <<pipeline.git.revision>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -780,7 +780,6 @@ workflows:
             - op-node-publish-dev
             - op-batcher-publish-dev
             - op-proposer-publish-dev
-            - deployer-bedrock-publish-dev
       - hive-test:
           name: hive-test-p2p
           version: <<pipeline.git.revision>>
@@ -789,7 +788,6 @@ workflows:
             - op-node-publish-dev
             - op-batcher-publish-dev
             - op-proposer-publish-dev
-            - deployer-bedrock-publish-dev
       - hive-test:
           name: hive-test-l1ops
           version: <<pipeline.git.revision>>
@@ -798,4 +796,3 @@ workflows:
             - op-node-publish-dev
             - op-batcher-publish-dev
             - op-proposer-publish-dev
-            - deployer-bedrock-publish-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,9 +747,6 @@ workflows:
           repo: us-central1-docker.pkg.dev
           context:
             - gcr
-          requires:
-            - bedrock-go-tests
-            - op-bindings-build
       - docker-publish:
           name: op-batcher-publish-dev
           docker_file: op-batcher/Dockerfile
@@ -758,9 +755,6 @@ workflows:
           repo: us-central1-docker.pkg.dev
           context:
             - gcr
-          requires:
-            - bedrock-go-tests
-            - op-bindings-build
       - docker-publish:
           name: op-proposer-publish-dev
           docker_file: op-proposer/Dockerfile
@@ -769,9 +763,6 @@ workflows:
           repo: us-central1-docker.pkg.dev
           context:
             - gcr
-          requires:
-            - bedrock-go-tests
-            - op-bindings-build
       - docker-publish:
           name: deployer-bedrock-publish-dev
           docker_file: ops/docker/Dockerfile.packages
@@ -781,8 +772,6 @@ workflows:
           repo: us-central1-docker.pkg.dev
           context:
             - gcr
-          requires:
-            - contracts-bedrock-tests
       - hive-test:
           name: hive-test-rpc
           version: <<pipeline.git.revision>>


### PR DESCRIPTION
The publish tasks don't need to depend on upstream tests. This will let us run Hive tests earlier in the pipeline, and shave off additional CI runtime.
