### PR TITLE
op-node: Switch channel bank to be pull based

### DIFF
--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -10,6 +11,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+type NextDataProvider interface {
+	NextData(ctx context.Context) ([]byte, error)
+	Origin() eth.L1BlockRef
+}
 
 // ChannelBank is a stateful stage that does the following:
 // 1. Unmarshalls frames from L1 transaction data
@@ -22,11 +28,6 @@ import (
 // Specifically, the channel bank is not allowed to become too large between successive calls
 // to `IngestData`. This means that we can do an ingest and then do a read while becoming too large.
 
-type ChannelBankOutput interface {
-	StageProgress
-	WriteChannel(data []byte)
-}
-
 // ChannelBank buffers channel frames, and emits full channel data
 type ChannelBank struct {
 	log log.Logger
@@ -35,28 +36,28 @@ type ChannelBank struct {
 	channels     map[ChannelID]*Channel // channels by ID
 	channelQueue []ChannelID            // channels in FIFO order
 
-	progress Progress
+	origin eth.L1BlockRef
 
-	next ChannelBankOutput
-	prev *L1Retrieval
+	prev    NextDataProvider
+	fetcher L1Fetcher
 }
 
-var _ Stage = (*ChannelBank)(nil)
+var _ PullStage = (*ChannelBank)(nil)
 
 // NewChannelBank creates a ChannelBank, which should be Reset(origin) before use.
-func NewChannelBank(log log.Logger, cfg *rollup.Config, next ChannelBankOutput, prev *L1Retrieval) *ChannelBank {
+func NewChannelBank(log log.Logger, cfg *rollup.Config, prev NextDataProvider, fetcher L1Fetcher) *ChannelBank {
 	return &ChannelBank{
 		log:          log,
 		cfg:          cfg,
 		channels:     make(map[ChannelID]*Channel),
 		channelQueue: make([]ChannelID, 0, 10),
-		next:         next,
 		prev:         prev,
+		fetcher:      fetcher,
 	}
 }
 
-func (ib *ChannelBank) Progress() Progress {
-	return ib.progress
+func (ib *ChannelBank) Origin() eth.L1BlockRef {
+	return ib.prev.Origin()
 }
 
 func (ib *ChannelBank) prune() {
@@ -78,10 +79,7 @@ func (ib *ChannelBank) prune() {
 // IngestData adds new L1 data to the channel bank.
 // Read() should be called repeatedly first, until everything has been read, before adding new data.\
 func (ib *ChannelBank) IngestData(data []byte) {
-	if ib.progress.Closed {
-		panic("write data to bank while closed")
-	}
-	ib.log.Debug("channel bank got new data", "origin", ib.progress.Origin, "data_len", len(data))
+	ib.log.Debug("channel bank got new data", "origin", ib.origin, "data_len", len(data))
 
 	// TODO: Why is the prune here?
 	ib.prune()
@@ -97,19 +95,19 @@ func (ib *ChannelBank) IngestData(data []byte) {
 		currentCh, ok := ib.channels[f.ID]
 		if !ok {
 			// create new channel if it doesn't exist yet
-			currentCh = NewChannel(f.ID, ib.progress.Origin)
+			currentCh = NewChannel(f.ID, ib.origin)
 			ib.channels[f.ID] = currentCh
 			ib.channelQueue = append(ib.channelQueue, f.ID)
 		}
 
 		// check if the channel is not timed out
-		if currentCh.OpenBlockNumber()+ib.cfg.ChannelTimeout < ib.progress.Origin.Number {
+		if currentCh.OpenBlockNumber()+ib.cfg.ChannelTimeout < ib.origin.Number {
 			ib.log.Warn("channel is timed out, ignore frame", "channel", f.ID, "frame", f.FrameNumber)
 			continue
 		}
 
 		ib.log.Trace("ingesting frame", "channel", f.ID, "frame_number", f.FrameNumber, "length", len(f.Data))
-		if err := currentCh.AddFrame(f, ib.progress.Origin); err != nil {
+		if err := currentCh.AddFrame(f, ib.origin); err != nil {
 			ib.log.Warn("failed to ingest frame into channel", "channel", f.ID, "frame_number", f.FrameNumber, "err", err)
 			continue
 		}
@@ -124,7 +122,7 @@ func (ib *ChannelBank) Read() (data []byte, err error) {
 	}
 	first := ib.channelQueue[0]
 	ch := ib.channels[first]
-	timedOut := ch.OpenBlockNumber()+ib.cfg.ChannelTimeout < ib.progress.Origin.Number
+	timedOut := ch.OpenBlockNumber()+ib.cfg.ChannelTimeout < ib.origin.Number
 	if timedOut {
 		ib.log.Debug("channel timed out", "channel", first, "frames", len(ch.inputs))
 		delete(ib.channels, first)
@@ -143,53 +141,35 @@ func (ib *ChannelBank) Read() (data []byte, err error) {
 	return data, nil
 }
 
-// Step does the advancement for the channel bank.
-// Channel bank as the first non-pull stage does it's own progress maintentance.
-// When closed, it checks against the previous origin to determine if to open itself
-func (ib *ChannelBank) Step(ctx context.Context, _ Progress) error {
-	// Open ourselves
-	// This is ok to do b/c we would not have yielded control to the lower stages
-	// of the pipeline without being completely done reading from L1.
-	if ib.progress.Closed {
-		if ib.progress.Origin != ib.prev.Origin() {
-			ib.progress.Closed = false
-			ib.progress.Origin = ib.prev.Origin()
-			return nil
-		}
+// NextData pulls the next piece of data from the channel bank.
+// Note that it attempts to pull data out of the channel bank prior to
+// loading data in (unlike most other stages). This is to ensure maintain
+// consistency around channel bank pruning which depends upon the order
+// of operations.
+func (ib *ChannelBank) NextData(ctx context.Context) ([]byte, error) {
+	if ib.origin != ib.prev.Origin() {
+		ib.origin = ib.prev.Origin()
 	}
 
-	skipIngest := ib.next.Progress().Origin.Number > ib.progress.Origin.Number
-	outOfData := false
-
-	if data, err := ib.prev.NextData(ctx); err == io.EOF {
-		outOfData = true
+	// Do the read from the channel bank first
+	data, err := ib.Read()
+	if err == io.EOF {
+		// continue - We will attempt to load data into the channel bank
 	} else if err != nil {
-		return err
+		return nil, err
+	} else {
+		return data, nil
+	}
+
+	// Then load data into the channel bank
+	if data, err := ib.prev.NextData(ctx); err == io.EOF {
+		return nil, io.EOF
+	} else if err != nil {
+		return nil, err
 	} else {
 		ib.IngestData(data)
+		return nil, NewTemporaryError(errors.New("not enough data"))
 	}
-
-	// otherwise, read the next channel data from the bank
-	data, err := ib.Read()
-	if err == io.EOF { // need new L1 data in the bank before we can read more channel data
-		if outOfData {
-			if !ib.progress.Closed {
-				ib.progress.Closed = true
-				return nil
-			}
-			return io.EOF
-		} else {
-			return nil
-		}
-	} else if err != nil {
-		return err
-	} else {
-		if !skipIngest {
-			ib.next.WriteChannel(data)
-			return nil
-		}
-	}
-	return nil
 }
 
 // ResetStep walks back the L1 chain, starting at the origin of the next stage,
@@ -197,19 +177,18 @@ func (ib *ChannelBank) Step(ctx context.Context, _ Progress) error {
 // to get consistent reads starting at origin.
 // Any channel data before this origin will be timed out by the time the channel bank is synced up to the origin,
 // so it is not relevant to replay it into the bank.
-func (ib *ChannelBank) ResetStep(ctx context.Context, l1Fetcher L1Fetcher) error {
-	ib.progress = ib.next.Progress()
-	ib.log.Debug("walking back to find reset origin for channel bank", "origin", ib.progress.Origin)
+func (ib *ChannelBank) Reset(ctx context.Context, base eth.L1BlockRef) error {
+	ib.log.Debug("walking back to find reset origin for channel bank", "origin", base)
 	// go back in history if we are not distant enough from the next stage
-	resetBlock := ib.progress.Origin.Number - ib.cfg.ChannelTimeout
-	if ib.progress.Origin.Number < ib.cfg.ChannelTimeout {
+	resetBlock := base.Number - ib.cfg.ChannelTimeout
+	if base.Number < ib.cfg.ChannelTimeout {
 		resetBlock = 0 // don't underflow
 	}
-	parent, err := l1Fetcher.L1BlockRefByNumber(ctx, resetBlock)
+	parent, err := ib.fetcher.L1BlockRefByNumber(ctx, resetBlock)
 	if err != nil {
 		return NewTemporaryError(fmt.Errorf("failed to find channel bank block, failed to retrieve L1 reference: %w", err))
 	}
-	ib.progress.Origin = parent
+	ib.origin = parent
 	return io.EOF
 }
 

--- a/op-node/rollup/derive/channel_bank_test.go
+++ b/op-node/rollup/derive/channel_bank_test.go
@@ -2,79 +2,62 @@ package derive
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 )
 
-type MockChannelBankOutput struct {
-	MockOriginStage
-}
-
-func (m *MockChannelBankOutput) WriteChannel(data []byte) {
-	m.MethodCalled("WriteChannel", data)
-}
-
-func (m *MockChannelBankOutput) ExpectWriteChannel(data []byte) {
-	m.On("WriteChannel", data).Once().Return()
-}
-
-var _ ChannelBankOutput = (*MockChannelBankOutput)(nil)
-
-type bankTestSetup struct {
-	origins []eth.L1BlockRef
-	t       *testing.T
-	rng     *rand.Rand
-	cb      *ChannelBank
-	out     *MockChannelBankOutput
-	l1      *testutils.MockL1Source
-}
-
-// nolint - this is getting picked up b/c of a t.Skip that will go away
-type channelBankTestCase struct {
-	name           string
-	originTimes    []uint64
-	nextStartsAt   int
-	channelTimeout uint64
-	fn             func(bt *bankTestSetup)
-}
-
-// nolint
-func (ct *channelBankTestCase) Run(t *testing.T) {
-	cfg := &rollup.Config{
-		ChannelTimeout: ct.channelTimeout,
+type fakeChannelBankInput struct {
+	origin eth.L1BlockRef
+	data   []struct {
+		data []byte
+		err  error
 	}
-
-	bt := &bankTestSetup{
-		t:   t,
-		rng: rand.New(rand.NewSource(1234)),
-		l1:  &testutils.MockL1Source{},
-	}
-
-	bt.origins = append(bt.origins, testutils.RandomBlockRef(bt.rng))
-	for i := range ct.originTimes[1:] {
-		ref := testutils.NextRandomRef(bt.rng, bt.origins[i])
-		bt.origins = append(bt.origins, ref)
-	}
-	for i, x := range ct.originTimes {
-		bt.origins[i].Time = x
-	}
-
-	bt.out = &MockChannelBankOutput{MockOriginStage{progress: Progress{Origin: bt.origins[ct.nextStartsAt], Closed: false}}}
-	bt.cb = NewChannelBank(testlog.Logger(t, log.LvlError), cfg, bt.out, nil)
-
-	ct.fn(bt)
 }
+
+func (f *fakeChannelBankInput) Origin() eth.L1BlockRef {
+	return f.origin
+}
+
+func (f *fakeChannelBankInput) NextData(_ context.Context) ([]byte, error) {
+	out := f.data[0]
+	f.data = f.data[1:]
+	return out.data, out.err
+}
+
+func (f *fakeChannelBankInput) AddOutput(data []byte, err error) {
+	f.data = append(f.data, struct {
+		data []byte
+		err  error
+	}{data: data, err: err})
+}
+
+// ExpectNextFrameData takes a set of test frame & turns into the raw data
+// for reading into the channel bank via `NextData`
+func (f *fakeChannelBankInput) AddFrames(frames ...testFrame) {
+	data := new(bytes.Buffer)
+	data.WriteByte(DerivationVersion0)
+	for _, frame := range frames {
+		ff := frame.ToFrame()
+		if err := ff.MarshalBinary(data); err != nil {
+			panic(fmt.Errorf("error in making frame during test: %w", err))
+		}
+	}
+	f.AddOutput(data.Bytes(), nil)
+}
+
+var _ NextDataProvider = (*fakeChannelBankInput)(nil)
 
 // format: <channelID-data>:<frame-number>:<content><optional-last-frame-marker "!">
 // example: "abc:0:helloworld!"
@@ -115,154 +98,76 @@ func (tf testFrame) ToFrame() Frame {
 	}
 }
 
-func (bt *bankTestSetup) ingestData(data []byte) {
-	bt.cb.IngestData(data)
+func TestChannelBankSimple(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+	a := testutils.RandomBlockRef(rng)
+
+	input := &fakeChannelBankInput{origin: a}
+	input.AddFrames("a:0:first", "a:2:third!")
+	input.AddFrames("a:1:second")
+	input.AddOutput(nil, io.EOF)
+
+	cfg := &rollup.Config{ChannelTimeout: 10}
+
+	cb := NewChannelBank(testlog.Logger(t, log.LvlCrit), cfg, input, nil)
+
+	// Load the first + third frame
+	out, err := cb.NextData(context.Background())
+	require.ErrorIs(t, err, ErrTemporary)
+	require.Equal(t, []byte(nil), out)
+
+	// Load the second frame
+	out, err = cb.NextData(context.Background())
+	require.ErrorIs(t, err, ErrTemporary)
+	require.Equal(t, []byte(nil), out)
+
+	// Pull out the channel data
+	out, err = cb.NextData(context.Background())
+	require.Nil(t, err)
+	require.Equal(t, "firstsecondthird", string(out))
+
+	// No more data
+	out, err = cb.NextData(context.Background())
+	require.Nil(t, out)
+	require.Equal(t, io.EOF, err)
 }
 
-func (bt *bankTestSetup) ingestFrames(frames ...testFrame) {
-	data := new(bytes.Buffer)
-	data.WriteByte(DerivationVersion0)
-	for _, fr := range frames {
-		f := fr.ToFrame()
-		if err := f.MarshalBinary(data); err != nil {
-			panic(fmt.Errorf("error in making frame during test: %w", err))
-		}
-	}
-	bt.ingestData(data.Bytes())
-}
-func (bt *bankTestSetup) repeatStep(max int, outer int, outerClosed bool, err error) {
-	require.Equal(bt.t, err, RepeatStep(bt.t, bt.cb.Step, Progress{Origin: bt.origins[outer], Closed: outerClosed}, max))
-}
-func (bt *bankTestSetup) repeatResetStep(max int, err error) {
-	require.Equal(bt.t, err, RepeatResetStep(bt.t, bt.cb.ResetStep, bt.l1, max))
-}
+func TestChannelBankDuplicates(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+	a := testutils.RandomBlockRef(rng)
 
-func (bt *bankTestSetup) assertOrigin(i int) {
-	require.Equal(bt.t, bt.cb.progress.Origin, bt.origins[i])
-}
-func (bt *bankTestSetup) assertOriginTime(x uint64) {
-	require.Equal(bt.t, x, bt.cb.progress.Origin.Time)
-}
-func (bt *bankTestSetup) expectChannel(data string) {
-	bt.out.ExpectWriteChannel([]byte(data))
-}
-func (bt *bankTestSetup) expectL1BlockRefByNumber(i int) {
-	bt.l1.ExpectL1BlockRefByNumber(bt.origins[i].Number, bt.origins[i], nil)
-}
-func (bt *bankTestSetup) assertExpectations() {
-	bt.l1.AssertExpectations(bt.t)
-	bt.l1.ExpectedCalls = nil
-	bt.out.AssertExpectations(bt.t)
-	bt.out.ExpectedCalls = nil
-}
+	input := &fakeChannelBankInput{origin: a}
+	input.AddFrames("a:0:first", "a:2:third!")
+	input.AddFrames("a:0:altfirst", "a:2:altthird!")
+	input.AddFrames("a:1:second")
+	input.AddOutput(nil, io.EOF)
 
-func TestL1ChannelBank(t *testing.T) {
-	t.Skip("broken b/c the fake L1Retrieval is not yet built")
-	testCases := []channelBankTestCase{
-		{
-			name:           "time outs and buffering",
-			originTimes:    []uint64{0, 1, 2, 3, 4, 5},
-			nextStartsAt:   3, // Start next stage at block #3
-			channelTimeout: 2, // Start at block #1
-			fn: func(bt *bankTestSetup) {
-				bt.expectL1BlockRefByNumber(1)
-				bt.repeatResetStep(10, nil)
-				bt.ingestFrames("a:0:first") // will time out b/c not closed
+	cfg := &rollup.Config{ChannelTimeout: 10}
 
-				bt.repeatStep(10, 1, true, nil)
-				bt.repeatStep(10, 2, false, nil)
-				bt.assertOrigin(2)
+	cb := NewChannelBank(testlog.Logger(t, log.LvlCrit), cfg, input, nil)
 
-				bt.repeatStep(10, 2, true, nil)
-				bt.repeatStep(10, 3, false, nil)
-				bt.assertOrigin(3)
+	// Load the first + third frame
+	out, err := cb.NextData(context.Background())
+	require.ErrorIs(t, err, ErrTemporary)
+	require.Equal(t, []byte(nil), out)
 
-				bt.repeatStep(10, 3, true, nil)
-				bt.repeatStep(10, 4, false, nil)
-				bt.assertOrigin(4)
+	// Load the duplicate frames
+	out, err = cb.NextData(context.Background())
+	require.ErrorIs(t, err, ErrTemporary)
+	require.Equal(t, []byte(nil), out)
 
-				// Properly closed channel
-				bt.expectChannel("foobarclosed")
-				bt.ingestFrames("b:0:foobar")
-				bt.ingestFrames("b:1:closed!")
-				bt.repeatStep(10, 4, true, nil)
-				bt.assertExpectations()
-			},
-		},
-		{
-			name:           "duplicate frames",
-			originTimes:    []uint64{0, 1, 2, 3, 4, 5},
-			nextStartsAt:   3, // Start next stage at block #3
-			channelTimeout: 2, // Start at block #1c
-			fn: func(bt *bankTestSetup) {
-				bt.expectL1BlockRefByNumber(1)
-				bt.repeatResetStep(10, nil)
-				bt.ingestFrames("a:0:first") // will time out b/c not closed
+	// Load the second frame
+	out, err = cb.NextData(context.Background())
+	require.ErrorIs(t, err, ErrTemporary)
+	require.Equal(t, []byte(nil), out)
 
-				bt.repeatStep(10, 1, true, nil)
-				bt.repeatStep(10, 2, false, nil)
-				bt.assertOrigin(2)
+	// Pull out the channel data. Expect to see the original set & not the duplicates
+	out, err = cb.NextData(context.Background())
+	require.Nil(t, err)
+	require.Equal(t, "firstsecondthird", string(out))
 
-				bt.repeatStep(10, 2, true, nil)
-				bt.repeatStep(10, 3, false, nil)
-				bt.assertOrigin(3)
-
-				bt.repeatStep(10, 3, true, nil)
-				bt.repeatStep(10, 4, false, nil)
-				bt.assertOrigin(4)
-
-				bt.ingestFrames("a:0:first")
-				bt.repeatStep(1, 4, false, nil)
-				bt.ingestFrames("a:1:second")
-				bt.repeatStep(1, 4, false, nil)
-				bt.ingestFrames("a:0:altfirst") // ignored as duplicate
-				bt.repeatStep(1, 4, false, nil)
-				bt.ingestFrames("a:1:altsecond") // ignored as duplicate
-				bt.repeatStep(1, 4, false, nil)
-				bt.ingestFrames("b:0:new")
-				bt.repeatStep(1, 4, false, nil)
-
-				// close origin 4
-				bt.repeatStep(2, 4, true, nil)
-
-				// open origin 1
-				bt.repeatStep(2, 5, false, nil)
-				bt.ingestFrames("b:1:hi!") // close the other one first, but blocked
-				bt.repeatStep(1, 5, false, nil)
-				bt.ingestFrames("a:2:!") // empty closing frame
-				bt.expectChannel("firstsecond")
-				bt.expectChannel("newhi")
-				bt.repeatStep(5, 5, false, nil)
-				bt.assertExpectations()
-			},
-		},
-		{
-			name:           "skip bad frames",
-			originTimes:    []uint64{101, 102},
-			nextStartsAt:   0,
-			channelTimeout: 3,
-			fn: func(bt *bankTestSetup) {
-				// don't do the whole setup process, just override where the stages are
-				bt.cb.progress = Progress{Origin: bt.origins[0], Closed: false}
-				bt.out.progress = Progress{Origin: bt.origins[0], Closed: false}
-
-				bt.assertOriginTime(101)
-
-				badTx := new(bytes.Buffer)
-				badTx.WriteByte(DerivationVersion0)
-				goodFrame := testFrame("a:0:helloworld!").ToFrame()
-				if err := goodFrame.MarshalBinary(badTx); err != nil {
-					panic(fmt.Errorf("error in marshalling frame: %w", err))
-				}
-				badTx.Write(testutils.RandomData(bt.rng, 30)) // incomplete frame data
-				bt.ingestData(badTx.Bytes())
-				// Expect the bad frame to render the entire chunk invalid.
-				bt.repeatStep(2, 0, false, nil)
-				bt.assertExpectations()
-			},
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, testCase.Run)
-	}
+	// No more data
+	out, err = cb.NextData(context.Background())
+	require.Nil(t, out)
+	require.Equal(t, io.EOF, err)
 }

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -98,16 +98,16 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	l1Traversal := NewL1Traversal(log, l1Fetcher)
 	dataSrc := NewDataSourceFactory(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
+	bank := NewChannelBank(log, cfg, l1Src, l1Fetcher)
 
 	// Push stages (that act like pull stages b/c we push from the innermost stages prior to the outermost stages)
 	eng := NewEngineQueue(log, cfg, engine, metrics)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, eng)
 	batchQueue := NewBatchQueue(log, cfg, attributesQueue)
-	chInReader := NewChannelInReader(log, batchQueue)
-	bank := NewChannelBank(log, cfg, chInReader, l1Src)
+	chInReader := NewChannelInReader(log, batchQueue, bank)
 
-	stages := []Stage{eng, attributesQueue, batchQueue, chInReader, bank}
-	pullStages := []PullStage{l1Src, l1Traversal}
+	stages := []Stage{eng, attributesQueue, batchQueue, chInReader}
+	pullStages := []PullStage{bank, l1Src, l1Traversal}
 
 	return &DerivationPipeline{
 		log:        log,


### PR DESCRIPTION
**Description**

This again requires a fair amount of changes to channel_in_reader.go for the channel in reader to maintain its progress state.

**Tests**

This fixes up the channel bank unit tests that were skipped in the previous PR.

**Metadata**
- Fixes ENG-2749
