### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/calm-ladybugs-occur.md
+++ b/.changeset/calm-ladybugs-occur.md
@@ -1,6 +1,0 @@
----
-'@eth-optimism/integration-tests': patch
-'@eth-optimism/contracts-periphery': patch
----
-
-Removes NFT refund logic if withdrawals fail.

--- a/.changeset/dirty-trees-kneel.md
+++ b/.changeset/dirty-trees-kneel.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/common-ts': patch
----
-
-Minor update to BaseServiceV2 to keep the raw body around when requests are made.

--- a/.changeset/dull-rice-do.md
+++ b/.changeset/dull-rice-do.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Fixes a small bug in the constructor of the L2OutputOracle contract

--- a/.changeset/forty-walls-fry.md
+++ b/.changeset/forty-walls-fry.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': patch
----
-
-Add customizable whitelist error

--- a/.changeset/fresh-pigs-hide.md
+++ b/.changeset/fresh-pigs-hide.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts': patch
----
-
-Add prefunded accounts to L2 genesis when doing local network

--- a/.changeset/good-bottles-smell.md
+++ b/.changeset/good-bottles-smell.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': minor
----
-
-No refunds!

--- a/.changeset/great-cherries-whisper.md
+++ b/.changeset/great-cherries-whisper.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Updates README to include versioning rules.

--- a/.changeset/hot-panthers-reply.md
+++ b/.changeset/hot-panthers-reply.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts': patch
----
-
-Expose the deployments in the deployer image

--- a/.changeset/khaki-wombats-notice.md
+++ b/.changeset/khaki-wombats-notice.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-periphery': patch
----
-
-Adds input validation to the ERC721Bridge constructor, fixes a typo in the L1ERC721Bridge, and removes the ERC721Refunded event declaration.

--- a/.changeset/many-lizards-drop.md
+++ b/.changeset/many-lizards-drop.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/data-transport-layer': patch
----
-
-Adds consistency checks for transaction entries in L1 syncing nodes

--- a/.changeset/mean-islands-rush.md
+++ b/.changeset/mean-islands-rush.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': patch
----
-
-Batch metrics and max batch size

--- a/.changeset/nice-forks-fry.md
+++ b/.changeset/nice-forks-fry.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Fuzz L2ToL1MessagePasser

--- a/.changeset/old-countries-lie.md
+++ b/.changeset/old-countries-lie.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-periphery': patch
----
-
-Remove ownable upgradable from erc721 factory

--- a/.changeset/soft-steaks-hide.md
+++ b/.changeset/soft-steaks-hide.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Modifies the StandardBridge to move a value check deeper down the call stack to be more defensive.

--- a/.changeset/spicy-points-invent.md
+++ b/.changeset/spicy-points-invent.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-periphery': patch
----
-
-Increased solc version on drip checks to 0.8.16.

--- a/.changeset/tender-items-sparkle.md
+++ b/.changeset/tender-items-sparkle.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/hardhat-deploy-config': patch
----
-
-Allow `paths` to be unset in hardhat config

--- a/integration-tests/CHANGELOG.md
+++ b/integration-tests/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/integration-tests
 
+## 0.5.20
+
+### Patch Changes
+
+- 02c457a5: Removes NFT refund logic if withdrawals fail.
+
 ## 0.5.19
 
 ### Patch Changes

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/integration-tests",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "[Optimism] Integration tests",
   "scripts": {
     "lint": "yarn lint:fix && yarn lint:check",
@@ -29,10 +29,10 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.5.4",
-    "@eth-optimism/contracts": "^0.5.36",
-    "@eth-optimism/contracts-periphery": "^1.0.0",
+    "@eth-optimism/contracts": "^0.5.37",
+    "@eth-optimism/contracts-periphery": "^1.0.1",
     "@eth-optimism/core-utils": "0.10.1",
-    "@eth-optimism/sdk": "1.6.5",
+    "@eth-optimism/sdk": "1.6.6",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",

--- a/op-e2e/actions/action.go
+++ b/op-e2e/actions/action.go
@@ -1,0 +1,71 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+)
+
+// Testing is an interface to Go-like testing,
+// extended with a context getter for the test runner to shut down individual actions without interrupting the test,
+// and a signaling function for when an invalid action is hit.
+// This helps custom test runners navigate slow or invalid actions, e.g. during fuzzing.
+type Testing interface {
+	e2eutils.TestingBase
+	// Ctx shares a context to execute an action with, the test runner may interrupt the action without stopping the test.
+	Ctx() context.Context
+	// InvalidAction indicates the failure is due to action incompatibility, does not stop the test.
+	InvalidAction(format string, args ...any)
+}
+
+// Action is a function that may change the state of one or more actors or check their state.
+// Action definitions are meant to be very small building blocks,
+// and then composed into larger patterns to write more elaborate tests.
+type Action func(t Testing)
+
+// ActionStatus defines the state of an action, to make a basic distinction between InvalidAction() and other calls.
+type ActionStatus uint
+
+const (
+	// ActionOK indicates the action is valid to apply
+	ActionOK ActionStatus = iota
+	// ActionInvalid indicates the action is not applicable, and a different next action may taken.
+	ActionInvalid
+	// More action status types may be used to indicate e.g. required rewinds,
+	// simple skips, or special cases for fuzzing.
+)
+
+// defaultTesting is a simple implementation of Testing that takes standard Go testing framework,
+// and handles invalid actions as errors, and exposes a Reset function to change the context and action state,
+// to recover after an invalid action or cancelled context.
+type defaultTesting struct {
+	e2eutils.TestingBase
+	ctx   context.Context
+	state ActionStatus
+}
+
+// Ctx shares a context to execute an action with, the test runner may interrupt the action without stopping the test.
+func (st *defaultTesting) Ctx() context.Context {
+	return st.ctx
+}
+
+// InvalidAction indicates the failure is due to action incompatibility, does not stop the test.
+// The format and args behave the same as fmt.Sprintf, testing.T.Errorf, etc.
+func (st *defaultTesting) InvalidAction(format string, args ...any) {
+	st.TestingBase.Helper() // report the error on the call-site to make debugging clear, not here.
+	st.Errorf("invalid action err: "+format, args...)
+	st.state = ActionInvalid
+}
+
+// Reset prepares the testing util for the next action, changing the context and state back to OK.
+func (st *defaultTesting) Reset(actionCtx context.Context) {
+	st.state = ActionOK
+	st.ctx = actionCtx
+}
+
+// State shares the current action state.
+func (st *defaultTesting) State() ActionStatus {
+	return st.state
+}
+
+var _ Testing = (*defaultTesting)(nil)

--- a/packages/actor-tests/CHANGELOG.md
+++ b/packages/actor-tests/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @eth-optimism/actor-tests
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [6ed68fa3]
+- Updated dependencies [3d4e8529]
+- Updated dependencies [caf5dd3e]
+- Updated dependencies [a6cbfee2]
+- Updated dependencies [394a26ec]
+  - @eth-optimism/contracts-bedrock@0.8.0
+  - @eth-optimism/sdk@1.6.6
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/actor-tests/package.json
+++ b/packages/actor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/actor-tests",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A library and suite of tests to stress test Optimism Bedrock.",
   "license": "MIT",
   "author": "",
@@ -18,9 +18,9 @@
     "test:coverage": "yarn test"
   },
   "dependencies": {
-    "@eth-optimism/contracts-bedrock": "0.7.0",
+    "@eth-optimism/contracts-bedrock": "0.8.0",
     "@eth-optimism/core-utils": "^0.10.1",
-    "@eth-optimism/sdk": "^1.6.5",
+    "@eth-optimism/sdk": "^1.6.6",
     "@types/chai": "^4.2.18",
     "@types/chai-as-promised": "^7.1.4",
     "async-mutex": "^0.3.2",

--- a/packages/common-ts/CHANGELOG.md
+++ b/packages/common-ts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/common-ts
 
+## 0.6.6
+
+### Patch Changes
+
+- ce7da914: Minor update to BaseServiceV2 to keep the raw body around when requests are made.
+
 ## 0.6.5
 
 ### Patch Changes

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/common-ts",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "[Optimism] Advanced typescript tooling used by various services",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/contracts-bedrock/CHANGELOG.md
+++ b/packages/contracts-bedrock/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @eth-optimism/contracts-bedrock
 
+## 0.8.0
+
+### Minor Changes
+
+- 3d4e8529: No refunds!
+
+### Patch Changes
+
+- 6ed68fa3: Fixes a small bug in the constructor of the L2OutputOracle contract
+- caf5dd3e: Updates README to include versioning rules.
+- a6cbfee2: Fuzz L2ToL1MessagePasser
+- 394a26ec: Modifies the StandardBridge to move a value check deeper down the call stack to be more defensive.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts-bedrock",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Contracts for Optimism Specs",
   "main": "dist/index",
   "types": "dist/index",
@@ -46,7 +46,7 @@
     "hardhat": "^2.9.6"
   },
   "devDependencies": {
-    "@eth-optimism/hardhat-deploy-config": "^0.2.3",
+    "@eth-optimism/hardhat-deploy-config": "^0.2.4",
     "@ethereumjs/trie": "^5.0.0-beta.1",
     "@ethereumjs/util": "^8.0.0-beta.1",
     "ethereumjs-wallet": "^1.0.2",

--- a/packages/contracts-periphery/CHANGELOG.md
+++ b/packages/contracts-periphery/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @eth-optimism/contracts-periphery
 
+## 1.0.1
+
+### Patch Changes
+
+- 02c457a5: Removes NFT refund logic if withdrawals fail.
+- d3fe9b6d: Adds input validation to the ERC721Bridge constructor, fixes a typo in the L1ERC721Bridge, and removes the ERC721Refunded event declaration.
+- 220ad4ef: Remove ownable upgradable from erc721 factory
+- 5d86ff0e: Increased solc version on drip checks to 0.8.16.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts-periphery",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "[Optimism] External (out-of-protocol) L1 and L2 smart contracts for Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -54,10 +54,10 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@eth-optimism/contracts": "^0.5.36",
-    "@eth-optimism/contracts-bedrock": "^0.7.0",
+    "@eth-optimism/contracts": "^0.5.37",
+    "@eth-optimism/contracts-bedrock": "^0.8.0",
     "@eth-optimism/core-utils": "^0.10.1",
-    "@eth-optimism/hardhat-deploy-config": "^0.2.3",
+    "@eth-optimism/hardhat-deploy-config": "^0.2.4",
     "@ethersproject/hardware-wallets": "^5.7.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.37
+
+### Patch Changes
+
+- 628affc7: Add prefunded accounts to L2 genesis when doing local network
+- 740e1bcc: Expose the deployments in the deployer image
+
 ## 0.5.36
 
 ### Patch Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "[Optimism] L1 and L2 smart contracts for Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@codechecks/client": "^0.1.11",
     "@defi-wonderland/smock": "^2.0.2",
-    "@eth-optimism/hardhat-deploy-config": "^0.2.3",
+    "@eth-optimism/hardhat-deploy-config": "^0.2.4",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/hardware-wallets": "^5.7.0",

--- a/packages/data-transport-layer/CHANGELOG.md
+++ b/packages/data-transport-layer/CHANGELOG.md
@@ -1,5 +1,16 @@
 # data transport layer
 
+## 0.5.47
+
+### Patch Changes
+
+- 81c1cd99: Adds consistency checks for transaction entries in L1 syncing nodes
+- Updated dependencies [ce7da914]
+- Updated dependencies [628affc7]
+- Updated dependencies [740e1bcc]
+  - @eth-optimism/common-ts@0.6.6
+  - @eth-optimism/contracts@0.5.37
+
 ## 0.5.46
 
 ### Patch Changes

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/data-transport-layer",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "description": "[Optimism] Service for shuttling data from L1 into L2",
   "main": "dist/index",
   "types": "dist/index",
@@ -36,8 +36,8 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.6.5",
-    "@eth-optimism/contracts": "0.5.36",
+    "@eth-optimism/common-ts": "0.6.6",
+    "@eth-optimism/contracts": "0.5.37",
     "@eth-optimism/core-utils": "0.10.1",
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",

--- a/packages/drippie-mon/CHANGELOG.md
+++ b/packages/drippie-mon/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @eth-optimism/drippie-mon
 
+## 0.3.17
+
+### Patch Changes
+
+- Updated dependencies [02c457a5]
+- Updated dependencies [ce7da914]
+- Updated dependencies [d3fe9b6d]
+- Updated dependencies [220ad4ef]
+- Updated dependencies [5d86ff0e]
+  - @eth-optimism/contracts-periphery@1.0.1
+  - @eth-optimism/common-ts@0.6.6
+  - @eth-optimism/sdk@1.6.6
+
 ## 0.3.16
 
 ### Patch Changes

--- a/packages/drippie-mon/package.json
+++ b/packages/drippie-mon/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/drippie-mon",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "[Optimism] Service for monitoring Drippie instances",
   "main": "dist/index",
   "types": "dist/index",
@@ -32,10 +32,10 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.6.5",
-    "@eth-optimism/contracts-periphery": "1.0.0",
+    "@eth-optimism/common-ts": "0.6.6",
+    "@eth-optimism/contracts-periphery": "1.0.1",
     "@eth-optimism/core-utils": "0.10.1",
-    "@eth-optimism/sdk": "1.6.5",
+    "@eth-optimism/sdk": "1.6.6",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/hardhat-deploy-config/CHANGELOG.md
+++ b/packages/hardhat-deploy-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/hardhat-deploy-config
 
+## 0.2.4
+
+### Patch Changes
+
+- dd5ab8c0: Allow `paths` to be unset in hardhat config
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/hardhat-deploy-config/package.json
+++ b/packages/hardhat-deploy-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/hardhat-deploy-config",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "[Optimism] Hardhat deploy configuration plugin",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/integration-tests-bedrock/package.json
+++ b/packages/integration-tests-bedrock/package.json
@@ -27,9 +27,9 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "devDependencies": {
-    "@eth-optimism/contracts": "0.5.36",
+    "@eth-optimism/contracts": "0.5.37",
     "@eth-optimism/core-utils": "0.10.1",
-    "@eth-optimism/sdk": "1.6.5",
+    "@eth-optimism/sdk": "1.6.6",
     "@ethersproject/abstract-provider": "^5.7.0",
     "chai-as-promised": "^7.1.1",
     "chai": "^4.3.4",

--- a/packages/message-relayer/CHANGELOG.md
+++ b/packages/message-relayer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @eth-optimism/message-relayer
 
+## 0.5.16
+
+### Patch Changes
+
+- Updated dependencies [ce7da914]
+  - @eth-optimism/common-ts@0.6.6
+  - @eth-optimism/sdk@1.6.6
+
 ## 0.5.15
 
 ### Patch Changes

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/message-relayer",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",
@@ -31,9 +31,9 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.6.5",
+    "@eth-optimism/common-ts": "0.6.6",
     "@eth-optimism/core-utils": "0.10.1",
-    "@eth-optimism/sdk": "1.6.5",
+    "@eth-optimism/sdk": "1.6.6",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/replica-healthcheck/CHANGELOG.md
+++ b/packages/replica-healthcheck/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/replica-healthcheck
 
+## 1.1.10
+
+### Patch Changes
+
+- Updated dependencies [ce7da914]
+  - @eth-optimism/common-ts@0.6.6
+
 ## 1.1.9
 
 ### Patch Changes

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/replica-healthcheck",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "[Optimism] Service for monitoring the health of replica nodes",
   "main": "dist/index",
   "types": "dist/index",
@@ -32,7 +32,7 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.6.5",
+    "@eth-optimism/common-ts": "0.6.6",
     "@eth-optimism/core-utils": "0.10.1",
     "@ethersproject/abstract-provider": "^5.7.0"
   },

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @eth-optimism/sdk
 
+## 1.6.6
+
+### Patch Changes
+
+- Updated dependencies [6ed68fa3]
+- Updated dependencies [628affc7]
+- Updated dependencies [3d4e8529]
+- Updated dependencies [caf5dd3e]
+- Updated dependencies [740e1bcc]
+- Updated dependencies [a6cbfee2]
+- Updated dependencies [394a26ec]
+  - @eth-optimism/contracts-bedrock@0.8.0
+  - @eth-optimism/contracts@0.5.37
+
 ## 1.6.5
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -48,9 +48,9 @@
     "mocha": "^10.0.0"
   },
   "dependencies": {
-    "@eth-optimism/contracts": "0.5.36",
+    "@eth-optimism/contracts": "0.5.37",
     "@eth-optimism/core-utils": "0.10.1",
-    "@eth-optimism/contracts-bedrock": "0.7.0",
+    "@eth-optimism/contracts-bedrock": "0.8.0",
     "lodash": "^4.17.21",
     "merkletreejs": "^0.2.27",
     "rlp": "^2.2.7"

--- a/proxyd/CHANGELOG.md
+++ b/proxyd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/proxyd
 
+## 3.10.2
+
+### Patch Changes
+
+- 6bb35fd8: Add customizable whitelist error
+- 7121648c: Batch metrics and max batch size
+
 ## 3.10.1
 
 ### Patch Changes

--- a/proxyd/package.json
+++ b/proxyd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/proxyd",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "private": true,
   "dependencies": {}
 }


### PR DESCRIPTION
- fix(ct): bug in L2OutputOracle constructor (#3322)
- proxyd: Add customizable whitelist error message (#3544)
- proxyd: Add batch size metric and configurable max (#3545)
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- fix: add semver to erc20 factory (#3543)
- contracts-periphery: remove ownable upgradable from erc721 factory (#3541)
- op-node: Fix OPB-10 (#3548)
- Codecov tweaks (#3546)
- chore: Ignore .t.sol and bindings in codecov (#3552)
- op-chain-ops: implement withdrawal hashing (#3469)
- feat(ctb): spacer validation task (#3533)
- fix(ctp): post-audit cleanup for the erc721 bridge (#3549)
- circleci: delete extra op-chain-ops tests (#3556)
- docs(ctb): add versioning rules (#3534)
- ctp: Bump version in drip checks (#3567)
- fix(dtl): consistency checks for L1 sync (#3356)
- op-node: Fix OPB-07 (#3547)
- feat(cmn): keep raw body in requests (#3550)
- ci: Delete contract-artifacts-bedrock job (#3565)
- ctp: remove unnecessary require (#3572)
- op-chain-ops: use PoS consensus in simulated backend in deployer and genesis (#3569)
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- op-node: Cleanup calldata source API (#3532)
- ci: Docker login on push (#3559)
- feat(ctb): more defensive value check (#3571)
- op-chain-ops: address aliasing helpers (#3562)
- contracts-governance: make the governance token immutable (#3566)
- hardhat-deploy-config: easier config (#3564)
- chore: Disable PR commenting by codecov bot (#3574)
- ci: Use workspace rather than cache (#3573)
- deployer: expose deployments (#3575)
- ci: Fix Hive artifacts (#3577)
- ci: Fix contracts tests (#3580)
- ci: Remove publish dependencies (#3578)
- contracts-bedrock: fuzz L2ToL1MessagePasser (#3527)
- ci: Add codecov flags per codebase (#3568)
- feat(ctb): no refunds (#3535)
- ops: fund deployer accounts for local deployment (#3576)
- feat(ctp): no refunds for NFTs (#3582)
- op-e2e: e2eutils package for new action testing setup (#3586)
- op-node: Rename uint642big -> uint64ToBig (#3591)
- ci: Run all tests when check-changed fails (#3595)
- op-node: Switch L1 Retrieval to pull based
- op-node: Switch L1 Traversal to a pull based model
- ctp: fixup deploy scripts for the nft bridge (#3570)
- op-node: Switch channel bank to be pull based
- op-node: Switch channel in reader to a pull based stage
- op-node: Switch batch queue to be pull based
- op-node: Switch attributes queue to be pull based (#3598)
- op-e2e/actions: action tests base test util (#3588)
- Version Packages
