### PR TITLE
ci: Codecov ignore checked in vendor code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 comment: false
 ignore:
   - "l2geth"
-  - "**/*.t.sol"
   - "op-bindings/bindings/*.go"
+  - "**/*.t.sol"
+  - "packages/contracts-bedrock/contracts/vendor"


### PR DESCRIPTION
**Description**

Ignores coverage of well tested external code that we've copied into our repo. This code currently [appears to be untested](https://app.codecov.io/gh/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/contracts/vendor).