### PR TITLE
contracts-periphery: erc721 factory fixes

### DIFF
--- a/.changeset/lazy-drinks-drop.md
+++ b/.changeset/lazy-drinks-drop.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/integration-tests': patch
+'@eth-optimism/contracts-periphery': patch
+---
+
+Fix erc721 factory to match erc21 factory

--- a/integration-tests/test/nft-bridge.spec.ts
+++ b/integration-tests/test/nft-bridge.spec.ts
@@ -113,12 +113,11 @@ describe('ERC721 Bridge', () => {
     )
 
     // Create a L2 Standard ERC721 with the Standard ERC721 Factory
-    const tx =
-      await OptimismMintableERC721Factory.createStandardOptimismMintableERC721(
-        L1ERC721.address,
-        'L2ERC721',
-        'L2'
-      )
+    const tx = await OptimismMintableERC721Factory.createOptimismMintableERC721(
+      L1ERC721.address,
+      'L2ERC721',
+      'L2'
+    )
     const receipt = await tx.wait()
 
     // Get the OptimismMintableERC721Created event

--- a/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721Factory.sol
@@ -14,8 +14,13 @@ contract OptimismMintableERC721Factory is Semver {
      *
      * @param localToken  Address of the token on the this domain.
      * @param remoteToken Address of the token on the remote domain.
+     * @param deployer    Address of the initiator of the deployment
      */
-    event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken);
+    event OptimismMintableERC721Created(
+        address indexed localToken,
+        address indexed remoteToken,
+        address deployer
+    );
 
     /**
      * @notice Address of the ERC721 bridge on this network.
@@ -30,7 +35,7 @@ contract OptimismMintableERC721Factory is Semver {
     /**
      * @notice Tracks addresses created by this factory.
      */
-    mapping(address => bool) public isStandardOptimismMintableERC721;
+    mapping(address => bool) public isOptimismMintableERC721;
 
     /**
      * @custom:semver 1.0.0
@@ -58,25 +63,23 @@ contract OptimismMintableERC721Factory is Semver {
      * @param _name        ERC721 name.
      * @param _symbol      ERC721 symbol.
      */
-    function createStandardOptimismMintableERC721(
+    function createOptimismMintableERC721(
         address _remoteToken,
         string memory _name,
         string memory _symbol
-    ) external {
+    ) external returns (address) {
         require(
             _remoteToken != address(0),
             "OptimismMintableERC721Factory: L1 token address cannot be address(0)"
         );
 
-        OptimismMintableERC721 localToken = new OptimismMintableERC721(
-            bridge,
-            remoteChainId,
-            _remoteToken,
-            _name,
-            _symbol
+        address localToken = address(
+            new OptimismMintableERC721(bridge, remoteChainId, _remoteToken, _name, _symbol)
         );
 
-        isStandardOptimismMintableERC721[address(localToken)] = true;
-        emit OptimismMintableERC721Created(address(localToken), _remoteToken);
+        isOptimismMintableERC721[localToken] = true;
+        emit OptimismMintableERC721Created(localToken, _remoteToken, msg.sender);
+
+        return localToken;
     }
 }

--- a/packages/contracts-periphery/test/contracts/universal/OptimismMintableERC721Factory.spec.ts
+++ b/packages/contracts-periphery/test/contracts/universal/OptimismMintableERC721Factory.spec.ts
@@ -76,12 +76,11 @@ describe('OptimismMintableERC721Factory', () => {
   })
 
   it('should be able to create a standard ERC721 contract', async () => {
-    const tx =
-      await OptimismMintableERC721Factory.createStandardOptimismMintableERC721(
-        L1ERC721.address,
-        'L2ERC721',
-        'ERC'
-      )
+    const tx = await OptimismMintableERC721Factory.createOptimismMintableERC721(
+      L1ERC721.address,
+      'L2ERC721',
+      'ERC'
+    )
     const receipt = await tx.wait()
 
     // Get the OptimismMintableERC721Created event
@@ -109,7 +108,7 @@ describe('OptimismMintableERC721Factory', () => {
     expect(await OptimismMintableERC721.baseTokenURI()).to.equal(baseURI)
 
     expect(
-      await OptimismMintableERC721Factory.isStandardOptimismMintableERC721(
+      await OptimismMintableERC721Factory.isOptimismMintableERC721(
         OptimismMintableERC721.address
       )
     ).to.equal(true)
@@ -117,7 +116,7 @@ describe('OptimismMintableERC721Factory', () => {
 
   it('should not be able to create a standard token with a 0 address for l1 token', async () => {
     await expect(
-      OptimismMintableERC721Factory.createStandardOptimismMintableERC721(
+      OptimismMintableERC721Factory.createOptimismMintableERC721(
         ethers.constants.AddressZero,
         'L2ERC721',
         'ERC'


### PR DESCRIPTION
**Description**

These changes make the `OptimismMintableERC721Factory` in line with the bedrock version of the `OptimismMintableERC20Factory`. We might as well follow what we are doing with the new erc20 factory to keep things in line with each other.

These changes are very small, they just rename a function to not follow the deprecated naming scheme, the function now returns an address which makes testing/integration a bit easier and also does a slight refactor to prevent the need to cast a type 3 times.

