### PR TITLE
OPB-02: Raise error on oversized chain id

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -224,7 +224,11 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config) pubsub.ValidatorEx
 		signatureBytes, payloadBytes := data[:65], data[65:]
 
 		// [REJECT] if the signature by the sequencer is not valid
-		signingHash := BlockSigningHash(cfg, payloadBytes)
+		signingHash, err := BlockSigningHash(cfg, payloadBytes)
+		if err != nil {
+			log.Warn("failed to compute block signing hash", "err", err, "peer", id)
+			return pubsub.ValidationReject
+		}
 
 		pub, err := crypto.SigToPub(signingHash[:], signatureBytes)
 		if err != nil {


### PR DESCRIPTION
**Description**

Fixes OPB-02.

This is a draft, POC for how I'd do this in signer.go. Two other locations still need fixing which I'll do in a subsequent PR once this is approved.

**Tests**

No new tests are added as it's unclear how this would actually be reachable, however it was decided to include it as "future proofing".
