### PR TITLE
ci: Parallelize op-e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,11 +286,6 @@ jobs:
             gotestsum --junitfile /test-results/op-batcher.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
           working_directory: op-batcher
       - run:
-          name: test op-e2e
-          command: |
-            gotestsum --junitfile /test-results/op-e2e.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
-          working_directory: op-e2e
-      - run:
           name: test op-service
           command: |
             gotestsum --junitfile /test-results/op-service.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
@@ -344,6 +339,42 @@ jobs:
           name: Fuzz
           command: make fuzz
           working_directory: op-node
+
+  test-op-e2e:
+    docker:
+      - image: ethereumoptimism/ci-builder:latest
+    parallelism: 2
+    steps:
+      - checkout
+      - run:
+          name: Check if we should run
+          command: |
+            shopt -s inherit_errexit
+            CHANGED=$(check-changed "op-(batcher|bindings|e2e|node|proposer|chain-ops)" || echo "TRUE")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: setup
+          command: |
+            go list github.com/ethereum-optimism/optimism/... | grep -vE 'proxyd|teleportr|l2geth|indexer|endpoint-monitor|batch-submitter|gas-oracle' > /coverpkg.txt
+            echo "Covered packages:"
+            sed -z 's/\n/,/g;s/,$//' /coverpkg.txt > /coverpkg.txt.tmp
+            mv /coverpkg.txt.tmp /coverpkg.txt
+            cat /coverpkg.txt
+          working_directory: op-e2e
+      - run:
+          name: test op-e2e
+          command: |
+            SPLITS=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            echo "Test splits: $SPLITS"
+            gotestsum --format standard-verbose --junitfile /test-results/op-e2e.xml -- -coverpkg=$(cat /coverpkg.txt) -coverprofile=coverage.out -covermode=atomic $SPLITS
+          working_directory: op-e2e
+      - run:
+          name: upload coverage
+          command: codecov --verbose --clean --flag bedrock-go-tests
+      - store_test_results:
+          path: /test-results
 
   depcheck:
     docker:
@@ -710,6 +741,7 @@ workflows:
           requires:
             - yarn-monorepo
       - bedrock-go-tests
+      - test-op-e2e
       - fuzz-op-node
       - bedrock-markdown
       - devnet

--- a/op-e2e/finalize/finalize_test.go
+++ b/op-e2e/finalize/finalize_test.go
@@ -1,0 +1,41 @@
+package finalize
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFinalize tests if L2 finalizes after sufficient time after L1 finalizes
+func TestFinalize(t *testing.T) {
+	if !op_e2e.VerboseGethNodes {
+		log.Root().SetHandler(log.DiscardHandler())
+	}
+
+	cfg := op_e2e.DefaultSystemConfig(t)
+
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+
+	// as configured in the extra geth lifecycle in testing setup
+	finalizedDistance := uint64(8)
+	// Wait enough time for L1 to finalize and L2 to confirm its data in finalized L1 blocks
+	<-time.After(time.Duration((finalizedDistance+4)*cfg.L1BlockTime) * time.Second)
+
+	// fetch the finalizes head of geth
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	l2Finalized, err := l2Seq.BlockByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
+	require.NoError(t, err)
+
+	require.NotZerof(t, l2Finalized.NumberU64(), "must have finalized L2 block")
+}

--- a/op-node/README.md
+++ b/op-node/README.md
@@ -87,3 +87,5 @@ $ op-node genesis devnet-l2 \
 Note that both `contracts-bedrock` and `contracts-governance` are required
 as the `GovernanceToken` is also a predeploy and it lives in
 `contracts-governance`.
+
+BUILD KICKER - REMOVE BEFORE MERGE


### PR DESCRIPTION
`op-e2e` can easily be run across multiple executors. To make this work, we need to:

1. Make various helper utilities in `op-e2e` public and in the actual `op-e2e` package rather than the tests so that other packages can use them.
2. Enable test parallelism in `circleci.yml`.
3. Split the tests in `system_test.go` up into discrete packages so that CircleCI can detect timing/test split information for them.

This PR does 1 and 2, and starts 3 with `TestFinalize`. Unfortunately, CircleCI's test splitting mechanism isn't smart enough to split tests within the same Go package.

Ideally, this should reduce our `op-e2e` test runtime from ~3m to ~30s.

I also made the coverage generation a bit more intelligent by excluding things that aren't related to the op-node from the coverage report. This saves additional time, since the report took a while to generate.

Let me know if y'all are in favor of the approach. I'll be stacking the rest of the tests in 3 above as PRs on top of this one.
