### PR TITLE
op-e2e: Migrate withdrawals and fees into their own package

### DIFF
--- a/op-e2e/fees/fees_test.go
+++ b/op-e2e/fees/fees_test.go
@@ -1,0 +1,195 @@
+package fees
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFees checks that L1/L2 fees are handled.
+func TestFees(t *testing.T) {
+	if !op_e2e.VerboseGethNodes {
+		log.Root().SetHandler(log.DiscardHandler())
+	}
+
+	cfg := op_e2e.DefaultSystemConfig(t)
+
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+	l2Verif := sys.Clients["verifier"]
+
+	// Transactor Account
+	ethPrivKey, err := sys.Wallet.PrivateKey(accounts.Account{
+		URL: accounts.URL{
+			Path: op_e2e.TransactorHDPath,
+		},
+	})
+	require.Nil(t, err)
+	fromAddr := crypto.PubkeyToAddress(ethPrivKey.PublicKey)
+
+	// Find gaspriceoracle contract
+	gpoContract, err := bindings.NewGasPriceOracle(common.HexToAddress(predeploys.GasPriceOracle), l2Seq)
+	require.Nil(t, err)
+
+	// GPO signer
+	l2opts, err := bind.NewKeyedTransactorWithChainID(ethPrivKey, cfg.L2ChainID)
+	require.Nil(t, err)
+
+	// Update overhead
+	tx, err := gpoContract.SetOverhead(l2opts, big.NewInt(2100))
+	require.Nil(t, err, "sending overhead update tx")
+
+	receipt, err := op_e2e.WaitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "waiting for overhead update tx")
+	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
+
+	// Update decimals
+	tx, err = gpoContract.SetDecimals(l2opts, big.NewInt(6))
+	require.Nil(t, err, "sending gpo update tx")
+
+	receipt, err = op_e2e.WaitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "waiting for gpo decimals update tx")
+	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
+
+	// Update scalar
+	tx, err = gpoContract.SetScalar(l2opts, big.NewInt(1_000_000))
+	require.Nil(t, err, "sending gpo update tx")
+
+	receipt, err = op_e2e.WaitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "waiting for gpo scalar update tx")
+	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
+
+	overhead, err := gpoContract.Overhead(&bind.CallOpts{})
+	require.Nil(t, err, "reading gpo overhead")
+	decimals, err := gpoContract.Decimals(&bind.CallOpts{})
+	require.Nil(t, err, "reading gpo decimals")
+	scalar, err := gpoContract.Scalar(&bind.CallOpts{})
+	require.Nil(t, err, "reading gpo scalar")
+
+	require.Equal(t, overhead.Uint64(), uint64(2100), "wrong gpo overhead")
+	require.Equal(t, decimals.Uint64(), uint64(6), "wrong gpo decimals")
+	require.Equal(t, scalar.Uint64(), uint64(1_000_000), "wrong gpo scalar")
+
+	// BaseFee Recipient
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	baseFeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, cfg.BaseFeeRecipient, nil)
+	require.Nil(t, err)
+
+	// L1Fee Recipient
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	l1FeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, cfg.L1FeeRecipient, nil)
+	require.Nil(t, err)
+
+	// Simple transfer from signer to random account
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	startBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	toAddr := common.Address{0xff, 0xff}
+	transferAmount := big.NewInt(1_000_000_000)
+	gasTip := big.NewInt(10)
+	tx = types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L2ChainID), &types.DynamicFeeTx{
+		ChainID:   cfg.L2ChainID,
+		Nonce:     3, // Already have deposit
+		To:        &toAddr,
+		Value:     transferAmount,
+		GasTipCap: gasTip,
+		GasFeeCap: big.NewInt(200),
+		Gas:       21000,
+	})
+	err = l2Seq.SendTransaction(context.Background(), tx)
+	require.Nil(t, err, "Sending L2 tx to sequencer")
+
+	_, err = op_e2e.WaitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "Waiting for L2 tx on sequencer")
+
+	receipt, err = op_e2e.WaitForTransaction(tx.Hash(), l2Verif, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "Waiting for L2 tx on verifier")
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "TX should have succeeded")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	header, err := l2Seq.HeaderByNumber(ctx, receipt.BlockNumber)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	coinbaseStartBalance, err := l2Seq.BalanceAt(ctx, header.Coinbase, op_e2e.SafeAddBig(header.Number, big.NewInt(-1)))
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	coinbaseEndBalance, err := l2Seq.BalanceAt(ctx, header.Coinbase, header.Number)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	endBalance, err := l2Seq.BalanceAt(ctx, fromAddr, header.Number)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	baseFeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, cfg.BaseFeeRecipient, header.Number)
+	require.Nil(t, err)
+
+	l1Header, err := sys.Clients["l1"].HeaderByNumber(ctx, nil)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	l1FeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, cfg.L1FeeRecipient, nil)
+	require.Nil(t, err)
+
+	// Diff fee recipient + coinbase balances
+	baseFeeRecipientDiff := new(big.Int).Sub(baseFeeRecipientEndBalance, baseFeeRecipientStartBalance)
+	l1FeeRecipientDiff := new(big.Int).Sub(l1FeeRecipientEndBalance, l1FeeRecipientStartBalance)
+	coinbaseDiff := new(big.Int).Sub(coinbaseEndBalance, coinbaseStartBalance)
+
+	// Tally L2 Fee
+	l2Fee := gasTip.Mul(gasTip, new(big.Int).SetUint64(receipt.GasUsed))
+	require.Equal(t, l2Fee, coinbaseDiff, "l2 fee mismatch")
+
+	// Tally BaseFee
+	baseFee := new(big.Int).Mul(header.BaseFee, new(big.Int).SetUint64(receipt.GasUsed))
+	require.Equal(t, baseFee, baseFeeRecipientDiff, "base fee fee mismatch")
+
+	// Tally L1 Fee
+	bytes, err := tx.MarshalBinary()
+	require.Nil(t, err)
+	l1GasUsed := op_e2e.CalcL1GasUsed(bytes, overhead)
+	divisor := new(big.Int).Exp(big.NewInt(10), decimals, nil)
+	l1Fee := new(big.Int).Mul(l1GasUsed, l1Header.BaseFee)
+	l1Fee = l1Fee.Mul(l1Fee, scalar)
+	l1Fee = l1Fee.Div(l1Fee, divisor)
+	require.Equal(t, l1Fee, l1FeeRecipientDiff, "l1 fee mismatch")
+
+	// Tally L1 fee against GasPriceOracle
+	gpoL1Fee, err := gpoContract.GetL1Fee(&bind.CallOpts{}, bytes)
+	require.Nil(t, err)
+	require.Equal(t, l1Fee, gpoL1Fee, "l1 fee mismatch")
+
+	// Calculate total fee
+	baseFeeRecipientDiff.Add(baseFeeRecipientDiff, coinbaseDiff)
+	totalFee := new(big.Int).Add(baseFeeRecipientDiff, l1FeeRecipientDiff)
+	balanceDiff := new(big.Int).Sub(startBalance, endBalance)
+	balanceDiff.Sub(balanceDiff, transferAmount)
+	require.Equal(t, balanceDiff, totalFee, "balances should add up")
+}

--- a/op-e2e/geth.go
+++ b/op-e2e/geth.go
@@ -27,7 +27,7 @@ import (
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
 )
 
-func waitForTransaction(hash common.Hash, client *ethclient.Client, timeout time.Duration) (*types.Receipt, error) {
+func WaitForTransaction(hash common.Hash, client *ethclient.Client, timeout time.Duration) (*types.Receipt, error) {
 	timeoutCh := time.After(timeout)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -49,7 +49,7 @@ func waitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 	}
 }
 
-func waitForBlock(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
+func WaitForBlock(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
 	timeoutCh := time.After(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -8,19 +8,16 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
-	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -58,7 +55,7 @@ func TestL2OutputSubmitter(t *testing.T) {
 	// for that block and subsequently reorgs to match what the verifier derives when running the
 	// reconcillation process.
 	l2Verif := sys.Clients["verifier"]
-	_, err = waitForBlock(big.NewInt(6), l2Verif, 10*time.Duration(cfg.RollupConfig.BlockTime)*time.Second)
+	_, err = WaitForBlock(big.NewInt(6), l2Verif, 10*time.Duration(cfg.RollupConfig.BlockTime)*time.Second)
 	require.Nil(t, err)
 
 	// Wait for batch submitter to update L2 output oracle.
@@ -153,13 +150,13 @@ func TestSystemE2E(t *testing.T) {
 	tx, err := depositContract.DepositTransaction(opts, fromAddr, common.Big0, 1_000_000, false, nil)
 	require.Nil(t, err, "with deposit tx")
 
-	receipt, err := waitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	receipt, err := WaitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for deposit tx on L1")
 
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(receipt.Logs[0])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
 	tx = types.NewTx(reconstructedDep)
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 6*time.Duration(cfg.L1BlockTime)*time.Second)
+	receipt, err = WaitForTransaction(tx.Hash(), l2Verif, 6*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 
@@ -187,10 +184,10 @@ func TestSystemE2E(t *testing.T) {
 	err = l2Seq.SendTransaction(context.Background(), tx)
 	require.Nil(t, err, "Sending L2 tx to sequencer")
 
-	_, err = waitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	_, err = WaitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L2 tx on sequencer")
 
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
+	receipt, err = WaitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L2 tx on verifier")
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "TX should have succeeded")
 
@@ -304,13 +301,13 @@ func TestMintOnRevertedDeposit(t *testing.T) {
 	tx, err := depositContract.DepositTransaction(opts, toAddr, value, 1_000_000, false, nil)
 	require.Nil(t, err, "with deposit tx")
 
-	receipt, err := waitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	receipt, err := WaitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for deposit tx on L1")
 
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(receipt.Logs[0])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
 	tx = types.NewTx(reconstructedDep)
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	receipt, err = WaitForTransaction(tx.Hash(), l2Verif, 3*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, types.ReceiptStatusFailed)
 
@@ -381,11 +378,11 @@ func TestMissingBatchE2E(t *testing.T) {
 	require.Nil(t, err, "Sending L2 tx to sequencer")
 
 	// Let it show up on the unsafe chain
-	receipt, err := waitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	receipt, err := WaitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L2 tx on sequencer")
 
 	// Wait until the block it was first included in shows up in the safe chain on the verifier
-	_, err = waitForBlock(receipt.BlockNumber, l2Verif, time.Duration(cfg.RollupConfig.SeqWindowSize*cfg.L1BlockTime)*time.Second)
+	_, err = WaitForBlock(receipt.BlockNumber, l2Verif, time.Duration(cfg.RollupConfig.SeqWindowSize*cfg.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for block on verifier")
 
 	// Assert that the transaction is not found on the verifier
@@ -501,11 +498,11 @@ func TestSystemMockP2P(t *testing.T) {
 	require.Nil(t, err, "Sending L2 tx to sequencer")
 
 	// Wait for tx to be mined on the L2 sequencer chain
-	receiptSeq, err := waitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.RollupConfig.BlockTime)*time.Second)
+	receiptSeq, err := WaitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.RollupConfig.BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L2 tx on sequencer")
 
 	// Wait until the block it was first included in shows up in the safe chain on the verifier
-	receiptVerif, err := waitForTransaction(tx.Hash(), l2Verif, 6*time.Duration(cfg.RollupConfig.BlockTime)*time.Second)
+	receiptVerif, err := WaitForTransaction(tx.Hash(), l2Verif, 6*time.Duration(cfg.RollupConfig.BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L2 tx on verifier")
 
 	require.Equal(t, receiptSeq, receiptVerif)
@@ -535,9 +532,9 @@ func TestL1InfoContract(t *testing.T) {
 
 	endVerifBlockNumber := big.NewInt(4)
 	endSeqBlockNumber := big.NewInt(6)
-	endVerifBlock, err := waitForBlock(endVerifBlockNumber, l2Verif, time.Minute)
+	endVerifBlock, err := WaitForBlock(endVerifBlockNumber, l2Verif, time.Minute)
 	require.Nil(t, err)
-	endSeqBlock, err := waitForBlock(endSeqBlockNumber, l2Seq, time.Minute)
+	endSeqBlock, err := WaitForBlock(endSeqBlockNumber, l2Seq, time.Minute)
 	require.Nil(t, err)
 
 	seqL1Info, err := bindings.NewL1Block(cfg.L1InfoPredeployAddress, l2Seq)
@@ -608,361 +605,4 @@ func TestL1InfoContract(t *testing.T) {
 	checkInfoList("On verifier with tx", l1InfosFromVerifierTransactions)
 	checkInfoList("On verifier with state", l1InfosFromVerifierState)
 
-}
-
-// TestWithdrawals checks that a deposit and then withdrawal execution succeeds. It verifies the
-// balance changes on L1 and L2 and has to include gas fees in the balance checks.
-// It does not check that the withdrawal can be executed prior to the end of the finality period.
-func TestWithdrawals(t *testing.T) {
-	if !VerboseGethNodes {
-		log.Root().SetHandler(log.DiscardHandler())
-	}
-
-	cfg := DefaultSystemConfig(t)
-	cfg.DepositCFG.FinalizationPeriod = big.NewInt(2) // 2s finalization period
-
-	sys, err := cfg.Start()
-	require.Nil(t, err, "Error starting up system")
-	defer sys.Close()
-
-	l1Client := sys.Clients["l1"]
-	l2Seq := sys.Clients["sequencer"]
-	l2Verif := sys.Clients["verifier"]
-
-	// Transactor Account
-	ethPrivKey, err := sys.Wallet.PrivateKey(accounts.Account{
-		URL: accounts.URL{
-			Path: TransactorHDPath,
-		},
-	})
-	require.Nil(t, err)
-	fromAddr := crypto.PubkeyToAddress(ethPrivKey.PublicKey)
-
-	// Find deposit contract
-	depositContract, err := bindings.NewOptimismPortal(sys.DepositContractAddr, l1Client)
-	require.Nil(t, err)
-
-	// Create L1 signer
-	opts, err := bind.NewKeyedTransactorWithChainID(ethPrivKey, cfg.L1ChainID)
-	require.Nil(t, err)
-
-	// Start L2 balance
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	startBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	// Finally send TX
-	mintAmount := big.NewInt(1_000_000_000_000)
-	opts.Value = mintAmount
-	tx, err := depositContract.DepositTransaction(opts, fromAddr, common.Big0, 1_000_000, false, nil)
-	require.Nil(t, err, "with deposit tx")
-
-	receipt, err := waitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for deposit tx on L1")
-
-	// Bind L2 Withdrawer Contract
-	l2withdrawer, err := bindings.NewL2ToL1MessagePasser(predeploys.L2ToL1MessagePasserAddr, l2Seq)
-	require.Nil(t, err, "binding withdrawer on L2")
-
-	// Wait for deposit to arrive
-	reconstructedDep, err := derive.UnmarshalDepositLogEvent(receipt.Logs[0])
-	require.NoError(t, err, "Could not reconstruct L2 Deposit")
-	tx = types.NewTx(reconstructedDep)
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 3*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.NoError(t, err)
-	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
-
-	// Confirm L2 balance
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	endBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	diff := new(big.Int)
-	diff = diff.Sub(endBalance, startBalance)
-	require.Equal(t, mintAmount, diff, "Did not get expected balance change after mint")
-
-	// Start L2 balance for withdrawal
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	startBalance, err = l2Seq.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	// Intiate Withdrawal
-	withdrawAmount := big.NewInt(500_000_000_000)
-	l2opts, err := bind.NewKeyedTransactorWithChainID(ethPrivKey, cfg.L2ChainID)
-	require.Nil(t, err)
-	l2opts.Value = withdrawAmount
-	tx, err = l2withdrawer.InitiateWithdrawal(l2opts, fromAddr, big.NewInt(21000), nil)
-	require.Nil(t, err, "sending initiate withdraw tx")
-
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "withdrawal initiated on L2 sequencer")
-	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
-
-	// Verify L2 balance after withdrawal
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	header, err := l2Verif.HeaderByNumber(ctx, receipt.BlockNumber)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	endBalance, err = l2Verif.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	// Take fee into account
-	diff = new(big.Int).Sub(startBalance, endBalance)
-	fees := CalcGasFees(receipt.GasUsed, tx.GasTipCap(), tx.GasFeeCap(), header.BaseFee)
-	diff = diff.Sub(diff, fees)
-	require.Equal(t, withdrawAmount, diff)
-
-	// Take start balance on L1
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	startBalance, err = l1Client.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	// Wait for finalization and then create the Finalized Withdrawal Transaction
-	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Duration(cfg.L1BlockTime)*time.Second)
-	defer cancel()
-	blockNumber, err := withdrawals.WaitForFinalizationPeriod(ctx, l1Client, sys.DepositContractAddr, receipt.BlockNumber)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	header, err = l2Verif.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
-	require.Nil(t, err)
-
-	rpc, err := rpc.Dial(sys.Nodes["verifier"].WSEndpoint())
-	require.Nil(t, err)
-	l2client := withdrawals.NewClient(rpc)
-
-	// Now create withdrawal
-	params, err := withdrawals.FinalizeWithdrawalParameters(context.Background(), l2client, tx.Hash(), header)
-	require.Nil(t, err)
-
-	portal, err := bindings.NewOptimismPortal(sys.DepositContractAddr, l1Client)
-	require.Nil(t, err)
-
-	opts.Value = nil
-	tx, err = portal.FinalizeWithdrawalTransaction(
-		opts,
-		bindings.TypesWithdrawalTransaction{
-			Nonce:    params.Nonce,
-			Sender:   params.Sender,
-			Target:   params.Target,
-			Value:    params.Value,
-			GasLimit: params.GasLimit,
-			Data:     params.Data,
-		},
-		params.BlockNumber,
-		params.OutputRootProof,
-		params.WithdrawalProof,
-	)
-
-	require.Nil(t, err)
-
-	receipt, err = waitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "finalize withdrawal")
-	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
-
-	// Verify balance after withdrawal
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	header, err = l1Client.HeaderByNumber(ctx, receipt.BlockNumber)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	endBalance, err = l1Client.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	// Ensure that withdrawal - gas fees are added to the L1 balance
-	// Fun fact, the fee is greater than the withdrawal amount
-	diff = new(big.Int).Sub(endBalance, startBalance)
-	fees = CalcGasFees(receipt.GasUsed, tx.GasTipCap(), tx.GasFeeCap(), header.BaseFee)
-	withdrawAmount = withdrawAmount.Sub(withdrawAmount, fees)
-	require.Equal(t, withdrawAmount, diff)
-}
-
-// TestFees checks that L1/L2 fees are handled.
-func TestFees(t *testing.T) {
-	if !VerboseGethNodes {
-		log.Root().SetHandler(log.DiscardHandler())
-	}
-
-	cfg := DefaultSystemConfig(t)
-
-	sys, err := cfg.Start()
-	require.Nil(t, err, "Error starting up system")
-	defer sys.Close()
-
-	l2Seq := sys.Clients["sequencer"]
-	l2Verif := sys.Clients["verifier"]
-
-	// Transactor Account
-	ethPrivKey, err := sys.Wallet.PrivateKey(accounts.Account{
-		URL: accounts.URL{
-			Path: TransactorHDPath,
-		},
-	})
-	require.Nil(t, err)
-	fromAddr := crypto.PubkeyToAddress(ethPrivKey.PublicKey)
-
-	// Find gaspriceoracle contract
-	gpoContract, err := bindings.NewGasPriceOracle(common.HexToAddress(predeploys.GasPriceOracle), l2Seq)
-	require.Nil(t, err)
-
-	// GPO signer
-	l2opts, err := bind.NewKeyedTransactorWithChainID(ethPrivKey, cfg.L2ChainID)
-	require.Nil(t, err)
-
-	// Update overhead
-	tx, err := gpoContract.SetOverhead(l2opts, big.NewInt(2100))
-	require.Nil(t, err, "sending overhead update tx")
-
-	receipt, err := waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "waiting for overhead update tx")
-	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
-
-	// Update decimals
-	tx, err = gpoContract.SetDecimals(l2opts, big.NewInt(6))
-	require.Nil(t, err, "sending gpo update tx")
-
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "waiting for gpo decimals update tx")
-	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
-
-	// Update scalar
-	tx, err = gpoContract.SetScalar(l2opts, big.NewInt(1_000_000))
-	require.Nil(t, err, "sending gpo update tx")
-
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "waiting for gpo scalar update tx")
-	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
-
-	overhead, err := gpoContract.Overhead(&bind.CallOpts{})
-	require.Nil(t, err, "reading gpo overhead")
-	decimals, err := gpoContract.Decimals(&bind.CallOpts{})
-	require.Nil(t, err, "reading gpo decimals")
-	scalar, err := gpoContract.Scalar(&bind.CallOpts{})
-	require.Nil(t, err, "reading gpo scalar")
-
-	require.Equal(t, overhead.Uint64(), uint64(2100), "wrong gpo overhead")
-	require.Equal(t, decimals.Uint64(), uint64(6), "wrong gpo decimals")
-	require.Equal(t, scalar.Uint64(), uint64(1_000_000), "wrong gpo scalar")
-
-	// BaseFee Recipient
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	baseFeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, cfg.BaseFeeRecipient, nil)
-	require.Nil(t, err)
-
-	// L1Fee Recipient
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	l1FeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, cfg.L1FeeRecipient, nil)
-	require.Nil(t, err)
-
-	// Simple transfer from signer to random account
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	startBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
-	require.Nil(t, err)
-
-	toAddr := common.Address{0xff, 0xff}
-	transferAmount := big.NewInt(1_000_000_000)
-	gasTip := big.NewInt(10)
-	tx = types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L2ChainID), &types.DynamicFeeTx{
-		ChainID:   cfg.L2ChainID,
-		Nonce:     3, // Already have deposit
-		To:        &toAddr,
-		Value:     transferAmount,
-		GasTipCap: gasTip,
-		GasFeeCap: big.NewInt(200),
-		Gas:       21000,
-	})
-	err = l2Seq.SendTransaction(context.Background(), tx)
-	require.Nil(t, err, "Sending L2 tx to sequencer")
-
-	_, err = waitForTransaction(tx.Hash(), l2Seq, 3*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx on sequencer")
-
-	receipt, err = waitForTransaction(tx.Hash(), l2Verif, 3*time.Duration(cfg.L1BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx on verifier")
-	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "TX should have succeeded")
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	header, err := l2Seq.HeaderByNumber(ctx, receipt.BlockNumber)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	coinbaseStartBalance, err := l2Seq.BalanceAt(ctx, header.Coinbase, safeAddBig(header.Number, big.NewInt(-1)))
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	coinbaseEndBalance, err := l2Seq.BalanceAt(ctx, header.Coinbase, header.Number)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	endBalance, err := l2Seq.BalanceAt(ctx, fromAddr, header.Number)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	baseFeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, cfg.BaseFeeRecipient, header.Number)
-	require.Nil(t, err)
-
-	l1Header, err := sys.Clients["l1"].HeaderByNumber(ctx, nil)
-	require.Nil(t, err)
-
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	l1FeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, cfg.L1FeeRecipient, nil)
-	require.Nil(t, err)
-
-	// Diff fee recipient + coinbase balances
-	baseFeeRecipientDiff := new(big.Int).Sub(baseFeeRecipientEndBalance, baseFeeRecipientStartBalance)
-	l1FeeRecipientDiff := new(big.Int).Sub(l1FeeRecipientEndBalance, l1FeeRecipientStartBalance)
-	coinbaseDiff := new(big.Int).Sub(coinbaseEndBalance, coinbaseStartBalance)
-
-	// Tally L2 Fee
-	l2Fee := gasTip.Mul(gasTip, new(big.Int).SetUint64(receipt.GasUsed))
-	require.Equal(t, l2Fee, coinbaseDiff, "l2 fee mismatch")
-
-	// Tally BaseFee
-	baseFee := new(big.Int).Mul(header.BaseFee, new(big.Int).SetUint64(receipt.GasUsed))
-	require.Equal(t, baseFee, baseFeeRecipientDiff, "base fee fee mismatch")
-
-	// Tally L1 Fee
-	bytes, err := tx.MarshalBinary()
-	require.Nil(t, err)
-	l1GasUsed := CalcL1GasUsed(bytes, overhead)
-	divisor := new(big.Int).Exp(big.NewInt(10), decimals, nil)
-	l1Fee := new(big.Int).Mul(l1GasUsed, l1Header.BaseFee)
-	l1Fee = l1Fee.Mul(l1Fee, scalar)
-	l1Fee = l1Fee.Div(l1Fee, divisor)
-	require.Equal(t, l1Fee, l1FeeRecipientDiff, "l1 fee mismatch")
-
-	// Tally L1 fee against GasPriceOracle
-	gpoL1Fee, err := gpoContract.GetL1Fee(&bind.CallOpts{}, bytes)
-	require.Nil(t, err)
-	require.Equal(t, l1Fee, gpoL1Fee, "l1 fee mismatch")
-
-	// Calculate total fee
-	baseFeeRecipientDiff.Add(baseFeeRecipientDiff, coinbaseDiff)
-	totalFee := new(big.Int).Add(baseFeeRecipientDiff, l1FeeRecipientDiff)
-	balanceDiff := new(big.Int).Sub(startBalance, endBalance)
-	balanceDiff.Sub(balanceDiff, transferAmount)
-	require.Equal(t, balanceDiff, totalFee, "balances should add up")
-}
-
-func safeAddBig(a *big.Int, b *big.Int) *big.Int {
-	return new(big.Int).Add(a, b)
 }

--- a/op-e2e/withdrawals/withdrawals_test.go
+++ b/op-e2e/withdrawals/withdrawals_test.go
@@ -1,0 +1,199 @@
+package withdrawals
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithdrawals checks that a deposit and then withdrawal execution succeeds. It verifies the
+// balance changes on L1 and L2 and has to include gas fees in the balance checks.
+// It does not check that the withdrawal can be executed prior to the end of the finality period.
+func TestWithdrawals(t *testing.T) {
+	if !op_e2e.VerboseGethNodes {
+		log.Root().SetHandler(log.DiscardHandler())
+	}
+
+	cfg := op_e2e.DefaultSystemConfig(t)
+	cfg.DepositCFG.FinalizationPeriod = big.NewInt(2) // 2s finalization period
+
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l1Client := sys.Clients["l1"]
+	l2Seq := sys.Clients["sequencer"]
+	l2Verif := sys.Clients["verifier"]
+
+	// Transactor Account
+	ethPrivKey, err := sys.Wallet.PrivateKey(accounts.Account{
+		URL: accounts.URL{
+			Path: op_e2e.TransactorHDPath,
+		},
+	})
+	require.Nil(t, err)
+	fromAddr := crypto.PubkeyToAddress(ethPrivKey.PublicKey)
+
+	// Find deposit contract
+	depositContract, err := bindings.NewOptimismPortal(sys.DepositContractAddr, l1Client)
+	require.Nil(t, err)
+
+	// Create L1 signer
+	opts, err := bind.NewKeyedTransactorWithChainID(ethPrivKey, cfg.L1ChainID)
+	require.Nil(t, err)
+
+	// Start L2 balance
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	startBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	// Finally send TX
+	mintAmount := big.NewInt(1_000_000_000_000)
+	opts.Value = mintAmount
+	tx, err := depositContract.DepositTransaction(opts, fromAddr, common.Big0, 1_000_000, false, nil)
+	require.Nil(t, err, "with deposit tx")
+
+	receipt, err := op_e2e.WaitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "Waiting for deposit tx on L1")
+
+	// Bind L2 Withdrawer Contract
+	l2withdrawer, err := bindings.NewL2ToL1MessagePasser(predeploys.L2ToL1MessagePasserAddr, l2Seq)
+	require.Nil(t, err, "binding withdrawer on L2")
+
+	// Wait for deposit to arrive
+	reconstructedDep, err := derive.UnmarshalDepositLogEvent(receipt.Logs[0])
+	require.NoError(t, err, "Could not reconstruct L2 Deposit")
+	tx = types.NewTx(reconstructedDep)
+	receipt, err = op_e2e.WaitForTransaction(tx.Hash(), l2Verif, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
+
+	// Confirm L2 balance
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	endBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	diff := new(big.Int)
+	diff = diff.Sub(endBalance, startBalance)
+	require.Equal(t, mintAmount, diff, "Did not get expected balance change after mint")
+
+	// Start L2 balance for withdrawal
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	startBalance, err = l2Seq.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	// Intiate Withdrawal
+	withdrawAmount := big.NewInt(500_000_000_000)
+	l2opts, err := bind.NewKeyedTransactorWithChainID(ethPrivKey, cfg.L2ChainID)
+	require.Nil(t, err)
+	l2opts.Value = withdrawAmount
+	tx, err = l2withdrawer.InitiateWithdrawal(l2opts, fromAddr, big.NewInt(21000), nil)
+	require.Nil(t, err, "sending initiate withdraw tx")
+
+	receipt, err = op_e2e.WaitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "withdrawal initiated on L2 sequencer")
+	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
+
+	// Verify L2 balance after withdrawal
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	header, err := l2Verif.HeaderByNumber(ctx, receipt.BlockNumber)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	endBalance, err = l2Verif.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	// Take fee into account
+	diff = new(big.Int).Sub(startBalance, endBalance)
+	fees := op_e2e.CalcGasFees(receipt.GasUsed, tx.GasTipCap(), tx.GasFeeCap(), header.BaseFee)
+	diff = diff.Sub(diff, fees)
+	require.Equal(t, withdrawAmount, diff)
+
+	// Take start balance on L1
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	startBalance, err = l1Client.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	// Wait for finalization and then create the Finalized Withdrawal Transaction
+	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Duration(cfg.L1BlockTime)*time.Second)
+	defer cancel()
+	blockNumber, err := withdrawals.WaitForFinalizationPeriod(ctx, l1Client, sys.DepositContractAddr, receipt.BlockNumber)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	header, err = l2Verif.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
+	require.Nil(t, err)
+
+	rpc, err := rpc.Dial(sys.Nodes["verifier"].WSEndpoint())
+	require.Nil(t, err)
+	l2client := withdrawals.NewClient(rpc)
+
+	// Now create withdrawal
+	params, err := withdrawals.FinalizeWithdrawalParameters(context.Background(), l2client, tx.Hash(), header)
+	require.Nil(t, err)
+
+	portal, err := bindings.NewOptimismPortal(sys.DepositContractAddr, l1Client)
+	require.Nil(t, err)
+
+	opts.Value = nil
+	tx, err = portal.FinalizeWithdrawalTransaction(
+		opts,
+		bindings.TypesWithdrawalTransaction{
+			Nonce:    params.Nonce,
+			Sender:   params.Sender,
+			Target:   params.Target,
+			Value:    params.Value,
+			GasLimit: params.GasLimit,
+			Data:     params.Data,
+		},
+		params.BlockNumber,
+		params.OutputRootProof,
+		params.WithdrawalProof,
+	)
+
+	require.Nil(t, err)
+
+	receipt, err = op_e2e.WaitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.L1BlockTime)*time.Second)
+	require.Nil(t, err, "finalize withdrawal")
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// Verify balance after withdrawal
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	header, err = l1Client.HeaderByNumber(ctx, receipt.BlockNumber)
+	require.Nil(t, err)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	endBalance, err = l1Client.BalanceAt(ctx, fromAddr, nil)
+	require.Nil(t, err)
+
+	// Ensure that withdrawal - gas fees are added to the L1 balance
+	// Fun fact, the fee is greater than the withdrawal amount
+	diff = new(big.Int).Sub(endBalance, startBalance)
+	fees = op_e2e.CalcGasFees(receipt.GasUsed, tx.GasTipCap(), tx.GasFeeCap(), header.BaseFee)
+	withdrawAmount = withdrawAmount.Sub(withdrawAmount, fees)
+	require.Equal(t, withdrawAmount, diff)
+}

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -60,6 +60,7 @@ func New(ctx context.Context, cfg *Config, log log.Logger, snapshotLog log.Logge
 
 	err := n.init(ctx, cfg, snapshotLog)
 	if err != nil {
+		fmt.Println(err)
 		// ensure we always close the node resources if we fail to initialize the node.
 		if closeErr := n.Close(); closeErr != nil {
 			return nil, multierror.Append(err, closeErr)
@@ -315,6 +316,7 @@ func (n *OpNode) Close() error {
 	var result *multierror.Error
 
 	if n.server != nil {
+		fmt.Println("closing server")
 		n.server.Stop()
 	}
 	if n.p2pNode != nil {


### PR DESCRIPTION
Continues the process of migrating e2e tests into discrete packages so they can be parallelized.
