### PR TITLE
ENG-2835 adds release configs for endpoint-monitor

### DIFF
--- a/.changeset/red-trains-run.md
+++ b/.changeset/red-trains-run.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/endpoint-monitor': major
+---
+
+Initial release of endpoint monitor

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -32,6 +32,7 @@ jobs:
       batch-submitter-service: ${{ steps.packages.outputs.batch-submitter-service }}
       indexer: ${{ steps.packages.outputs.indexer }}
       teleportr: ${{ steps.packages.outputs.teleportr }}
+      endpoint-monitor: ${{ steps.packages.outputs.l2geth-exporter }}
 
     steps:
       - name: Check out source code
@@ -599,6 +600,44 @@ jobs:
           file: ./teleportr/Dockerfile
           push: true
           tags: ethereumoptimism/teleportr:${{ needs.canary-publish.outputs.teleportr }}
+          build-args: |
+            GITDATE=${{ steps.build_args.outputs.GITDATE }}
+            GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}
+            GITVERSION=${{ steps.build_args.outputs.GITVERSION }}
+
+  endpoint-monitor:
+    name: Publish endpoint-monitor Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
+    needs: canary-publish
+    if: needs.canary-publish.outputs.endpoint-monitor != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set build args
+        id: build_args
+        run: |
+          echo ::set-output name=GITDATE::"$(date +%d-%m-%Y)"
+          echo ::set-output name=GITVERSION::$(jq -r .version ./endpoint-monitor/package.json)
+          echo ::set-output name=GITCOMMIT::"$GITHUB_SHA"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./endpoint-monitor/Dockerfile
+          push: true
+          tags: ethereumoptimism/endpoint-monitor:${{ needs.canary-publish.outputs.endpoint-monitor }}
           build-args: |
             GITDATE=${{ steps.build_args.outputs.GITDATE }}
             GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       teleportr: ${{ steps.packages.outputs.teleportr }}
       ci-builder: ${{ steps.packages.outputs.ci-builder }}
       foundry: ${{ steps.packages.outputs.foundry }}
+      endpoint-monitor: ${{ steps.packages.outputs.endpoint-monitor }}
 
     steps:
       - name: Checkout Repo
@@ -631,6 +632,43 @@ jobs:
           file: ./teleportr/Dockerfile
           push: true
           tags: ethereumoptimism/teleportr:${{ needs.release.outputs.teleportr }},ethereumoptimism/teleportr:latest
+          build-args: |
+            GITDATE=${{ steps.build_args.outputs.GITDATE }}
+            GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}
+            GITVERSION=${{ steps.build_args.outputs.GITVERSION }}
+
+  endpoint-monitor:
+    name: Publish endpoint-monitor Version ${{ needs.release.outputs.endpoint-monitor}}
+    needs: release
+    if: needs.release.outputs.endpoint-monitor != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Set build args
+        id: build_args
+        run: |
+          echo ::set-output name=GITDATE::"$(date +%d-%m-%Y)"
+          echo ::set-output name=GITVERSION::$(jq -r .version ./endpoint-monitor/package.json)
+          echo ::set-output name=GITCOMMIT::"$GITHUB_SHA"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./endpoint-monitor/Dockerfile
+          push: true
+          tags: ethereumoptimism/endpoint-monitor:${{ needs.release.outputs.endpoint-monitor }},ethereumoptimism/endpoint-monitor:latest
           build-args: |
             GITDATE=${{ steps.build_args.outputs.GITDATE }}
             GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}

--- a/endpoint-monitor/CHANGELOG.md
+++ b/endpoint-monitor/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @eth-optimism/endpoint-monitor

--- a/endpoint-monitor/config.go
+++ b/endpoint-monitor/config.go
@@ -50,9 +50,9 @@ func CLIFlags(envPrefix string) []cli.Flag {
 }
 
 type Config struct {
-	Providers     []string      `envconfig:"PROVIDERS" required:"true"`
-	CheckInterval time.Duration `envconfig:"CHECK_INTERVAL" default:"5m"`
-	CheckDuration time.Duration `envconfig:"CHECK_DURATION" default:"4m"`
+	Providers     []string
+	CheckInterval time.Duration
+	CheckDuration time.Duration
 
 	LogConfig     oplog.CLIConfig
 	MetricsConfig opmetrics.CLIConfig

--- a/endpoint-monitor/package.json
+++ b/endpoint-monitor/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@eth-optimism/endpoint-monitor",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "ops/docker/ci-builder",
       "ops/docker/foundry",
       "proxyd",
-      "teleportr"
+      "teleportr",
+      "endpoint-monitor"
     ],
     "nohoist": [
       "**/typechain/*",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds release configs and changeset for endpoint-monitor

**Metadata**
- [ENG-2835](https://linear.app/optimism/issue/ENG-2835/create-websocket-monitoring-service-for-edge-proxyd-and-infra)
