### PR TITLE
sdk: add hh task for finalizing withdrawal

### DIFF
--- a/packages/sdk/hardhat.config.ts
+++ b/packages/sdk/hardhat.config.ts
@@ -25,6 +25,10 @@ const config: HardhatUserConfig = {
       url: process.env.L1_RPC || '',
       accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
     },
+    goerli: {
+      url: process.env.L1_RPC || '',
+      accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
+    },
   },
   external: {
     contracts: [
@@ -35,7 +39,10 @@ const config: HardhatUserConfig = {
     deployments: {
       hivenet: ['../contracts-bedrock/deployments/hivenet'],
       devnetL1: ['../contracts-bedrock/deployments/devnetL1'],
-      goerli: ['../contracts-bedrock/deployments/goerli'],
+      goerli: [
+        '../contracts-bedrock/deployments/goerli',
+        '../contracts/deployments/goerli',
+      ],
     },
   },
 }

--- a/packages/sdk/tasks/finalize-withdrawal.ts
+++ b/packages/sdk/tasks/finalize-withdrawal.ts
@@ -1,0 +1,96 @@
+import { task, types } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { Wallet, providers } from 'ethers'
+import { predeploys } from '@eth-optimism/contracts-bedrock'
+import 'hardhat-deploy'
+import '@nomiclabs/hardhat-ethers'
+
+import {
+  CrossChainMessenger,
+  StandardBridgeAdapter,
+  MessageStatus,
+} from '../src'
+
+task('finalize-withdrawal', 'Finalize a withdrawal')
+  .addParam(
+    'transactionHash',
+    'L2 Transaction hash to finalize',
+    '',
+    types.string
+  )
+  .addParam('l2Url', 'L2 HTTP URL', 'http://localhost:9545', types.string)
+  .setAction(async (args, hre: HardhatRuntimeEnvironment) => {
+    const txHash = args.transactionHash
+    if (txHash === '') {
+      console.log('No tx hash')
+    }
+
+    const signers = await hre.ethers.getSigners()
+    if (signers.length === 0) {
+      throw new Error('No configured signers')
+    }
+    const signer = signers[0]
+    const address = await signer.getAddress()
+    console.log(`Using signer: ${address}`)
+
+    const l2Provider = new providers.StaticJsonRpcProvider(args.l2Url)
+    const l2Signer = new Wallet(hre.network.config.accounts[0], l2Provider)
+
+    let Deployment__L1StandardBridgeProxy = await hre.deployments.getOrNull(
+      'L1StandardBridgeProxy'
+    )
+    if (Deployment__L1StandardBridgeProxy === undefined) {
+      Deployment__L1StandardBridgeProxy = await hre.deployments.getOrNull(
+        'Proxy__OVM_L1StandardBridge'
+      )
+    }
+
+    let Deployment__L1CrossDomainMessengerProxy =
+      await hre.deployments.getOrNull('L1CrossDomainMessengerProxy')
+    if (Deployment__L1CrossDomainMessengerProxy === undefined) {
+      Deployment__L1CrossDomainMessengerProxy = await hre.deployments.getOrNull(
+        'Proxy__OVM_L1CrossDomainMessenger'
+      )
+    }
+
+    const Deployment__L2OutputOracleProxy = await hre.deployments.getOrNull(
+      'L2OutputOracleProxy'
+    )
+    const Deployment__OptimismPortalProxy = await hre.deployments.getOrNull(
+      'OptimismPortalProxy'
+    )
+
+    const messenger = new CrossChainMessenger({
+      l1SignerOrProvider: signer,
+      l2SignerOrProvider: l2Signer,
+      l1ChainId: await signer.getChainId(),
+      l2ChainId: await l2Signer.getChainId(),
+      bridges: {
+        Standard: {
+          Adapter: StandardBridgeAdapter,
+          l1Bridge: Deployment__L1StandardBridgeProxy?.address,
+          l2Bridge: predeploys.L2StandardBridge,
+        },
+      },
+      contracts: {
+        l1: {
+          L1StandardBridge: Deployment__L1StandardBridgeProxy?.address,
+          L1CrossDomainMessenger:
+            Deployment__L1CrossDomainMessengerProxy?.address,
+          L2OutputOracle: Deployment__L2OutputOracleProxy?.address,
+          OptimismPortal: Deployment__OptimismPortalProxy?.address,
+        },
+      },
+    })
+
+    console.log(`Fetching message status for ${txHash}`)
+    const status = await messenger.getMessageStatus(txHash)
+    console.log(`Status: ${MessageStatus[status]}`)
+
+    if (status === MessageStatus.READY_FOR_RELAY) {
+      const tx = await messenger.finalizeMessage(txHash)
+      const receipt = await tx.wait()
+      console.log(receipt)
+      console.log('Finalized withdrawal')
+    }
+  })

--- a/packages/sdk/tasks/index.ts
+++ b/packages/sdk/tasks/index.ts
@@ -1,2 +1,3 @@
 import './deposit-eth'
 import './deposit-erc20'
+import './finalize-withdrawal'


### PR DESCRIPTION
**Description**

Now we no longer need to use one off scripts for testing this kind of thing. The hh task will check to see the status of a transaction hash and then finalize the withdrawal on L1 if the message status is ready for relay. It does this by creating a `CrossChainMessenger`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


