### PR TITLE
Action-testing: extend user actor with withdrawal txs

### DIFF
--- a/indexer/integration_tests/bedrock_test.go
+++ b/indexer/integration_tests/bedrock_test.go
@@ -11,6 +11,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum-optimism/optimism/indexer"
 	"github.com/ethereum-optimism/optimism/indexer/db"
 	"github.com/ethereum-optimism/optimism/indexer/services/l1"
@@ -20,12 +29,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/stretchr/testify/require"
 
 	_ "github.com/lib/pq"
 )
@@ -196,8 +199,9 @@ func TestBedrockIndexer(t *testing.T) {
 
 		rpcClient, err := rpc.Dial(sys.Nodes["sequencer"].HTTPEndpoint())
 		require.NoError(t, err)
-		proofClient := withdrawals.NewClient(rpcClient)
-		wParams, err := withdrawals.FinalizeWithdrawalParameters(context.Background(), proofClient, wdTx.Hash(), finHeader)
+		proofCl := gethclient.New(rpcClient)
+		receiptCl := ethclient.NewClient(rpcClient)
+		wParams, err := withdrawals.FinalizeWithdrawalParameters(context.Background(), proofCl, receiptCl, wdTx.Hash(), finHeader)
 		require.NoError(t, err)
 
 		l1Opts.Value = big.NewInt(0)

--- a/op-e2e/actions/l2_engine.go
+++ b/op-e2e/actions/l2_engine.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -115,6 +116,11 @@ func NewL2Engine(t Testing, log log.Logger, genesis *core.Genesis, rollupGenesis
 func (s *L2Engine) EthClient() *ethclient.Client {
 	cl, _ := s.node.Attach() // never errors
 	return ethclient.NewClient(cl)
+}
+
+func (s *L2Engine) GethClient() *gethclient.Client {
+	cl, _ := s.node.Attach() // never errors
+	return gethclient.New(cl)
 }
 
 func (e *L2Engine) RPCClient() client.RPC {

--- a/op-e2e/actions/user_test.go
+++ b/op-e2e/actions/user_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
-	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 )
 
 func TestCrossLayerUser(gt *testing.T) {
@@ -19,13 +19,23 @@ func TestCrossLayerUser(gt *testing.T) {
 	log := testlog.Logger(t, log.LvlDebug)
 
 	miner, seqEngine, seq := setupSequencerTest(t, sd, log)
+	batcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{
+		MinL1TxSize: 0,
+		MaxL1TxSize: 128_000,
+		BatcherKey:  dp.Secrets.Batcher,
+	}, seq.RollupClient(), miner.EthClient(), seqEngine.EthClient())
+	proposer := NewL2Proposer(t, log, &ProposerCfg{
+		OutputOracleAddr:  sd.DeploymentsL1.L2OutputOracleProxy,
+		ProposerKey:       dp.Secrets.Proposer,
+		AllowNonFinalized: true,
+	}, miner.EthClient(), seq.RollupClient())
 
 	// need to start derivation before we can make L2 blocks
 	seq.ActL2PipelineFull(t)
 
 	l1Cl := miner.EthClient()
 	l2Cl := seqEngine.EthClient()
-	withdrawalsCl := &withdrawals.Client{} // TODO: need a rollup node actor to wrap for output root proof RPC
+	l2ProofCl := seqEngine.GethClient()
 
 	addresses := e2eutils.CollectAddresses(sd, dp)
 
@@ -39,7 +49,7 @@ func TestCrossLayerUser(gt *testing.T) {
 		EthCl:          l2Cl,
 		Signer:         types.LatestSigner(sd.L2Cfg.Config),
 		AddressCorpora: addresses,
-		Bindings:       NewL2Bindings(t, l2Cl, withdrawalsCl),
+		Bindings:       NewL2Bindings(t, l2Cl, l2ProofCl),
 	}
 
 	alice := NewCrossLayerUser(log, dp.Secrets.Alice, rand.New(rand.NewSource(1234)))
@@ -79,4 +89,50 @@ func TestCrossLayerUser(gt *testing.T) {
 	}
 	// Now that the L2 chain adopted the latest L1 block, check that we processed the deposit
 	alice.ActCheckDepositStatus(true, true)(t)
+
+	// regular withdrawal, in new L2 block
+	alice.ActStartWithdrawal(t)
+	seq.ActL2StartBlock(t)
+	seqEngine.ActL2IncludeTx(alice.Address())(t)
+	seq.ActL2EndBlock(t)
+	alice.ActCheckStartWithdrawal(true)(t)
+
+	// build a L1 block and more L2 blocks,
+	// to ensure the L2 withdrawal is old enough to be able to get into an output root proposal on L1
+	miner.ActEmptyBlock(t)
+	seq.ActL1HeadSignal(t)
+	seq.ActBuildToL1Head(t)
+
+	// submit everything to L1
+	batcher.ActSubmitAll(t)
+	// include batch on L1
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
+	miner.ActL1EndBlock(t)
+
+	// derive from L1, blocks will now become safe to propose
+	seq.ActL2PipelineFull(t)
+
+	// make proposals until there is nothing left to propose
+	for proposer.CanPropose(t) {
+		// propose it to L1
+		proposer.ActMakeProposalTx(t)
+		// include proposal on L1
+		miner.ActL1StartBlock(12)(t)
+		miner.ActL1IncludeTx(dp.Addresses.Proposer)(t)
+		miner.ActL1EndBlock(t)
+		// Check proposal was successful
+		receipt, err := miner.EthClient().TransactionReceipt(t.Ctx(), proposer.LastProposalTx())
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "proposal failed")
+	}
+
+	// make the L1 side of the withdrawal tx
+	alice.ActCompleteWithdrawal(t)
+	// include completed withdrawal in new L1 block
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(alice.Address())(t)
+	miner.ActL1EndBlock(t)
+	// check withdrawal succeeded
+	alice.L1.ActCheckReceiptStatusOfLastTx(true)(t)
 }

--- a/op-e2e/actions/user_test.go
+++ b/op-e2e/actions/user_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 )
 
+// TestCrossLayerUser tests that common actions of the CrossLayerUser actor work:
+// - transact on L1
+// - transact on L2
+// - deposit on L1
+// - withdraw from L2
+// - finalize withdrawal on L1
 func TestCrossLayerUser(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -791,12 +792,13 @@ func TestWithdrawals(t *testing.T) {
 	header, err = l2Verif.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
 	require.Nil(t, err)
 
-	rpc, err := rpc.Dial(sys.Nodes["verifier"].WSEndpoint())
+	rpcClient, err := rpc.Dial(sys.Nodes["verifier"].WSEndpoint())
 	require.Nil(t, err)
-	l2client := withdrawals.NewClient(rpc)
+	proofCl := gethclient.New(rpcClient)
+	receiptCl := ethclient.NewClient(rpcClient)
 
 	// Now create withdrawal
-	params, err := withdrawals.FinalizeWithdrawalParameters(context.Background(), l2client, tx.Hash(), header)
+	params, err := withdrawals.FinalizeWithdrawalParameters(context.Background(), proofCl, receiptCl, tx.Hash(), header)
 	require.Nil(t, err)
 
 	portal, err := bindings.NewOptimismPortal(predeploys.DevOptimismPortalAddr, l1Client)


### PR DESCRIPTION
**Description**

Withdrawals depend on the proposer working in action-testing. So this is now split from the main user-actor PR (#3628) to integrate with the proposer actor.

Update the withdrawals RPC client input to use minimal interfaces, and refactor to not tightly couple geth and eth client functionality. This enables the use of an instrumented `client.RPC` and mocks.

~~Depends on #3628~~

~~Depends on #3805~~

**Tests**

Test creates a withdrawal tx on L2, includes it, then makes proposal on L1 for the L2 blocks including the withdrawal, includes those on L1, checks the withdrawal period, and then completes the withdrawal.

Fix ENG-2763