### PR TITLE
contracts-governance: allow deploy by ledger

### DIFF
--- a/packages/contracts-governance/hardhat.config.ts
+++ b/packages/contracts-governance/hardhat.config.ts
@@ -1,11 +1,13 @@
 import dotenv from 'dotenv'
 import { HardhatUserConfig } from 'hardhat/config'
+import { getenv } from '@eth-optimism/core-utils'
 import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-etherscan'
 import '@nomiclabs/hardhat-waffle'
 import 'hardhat-gas-reporter'
 import 'solidity-coverage'
 import '@eth-optimism/hardhat-deploy-config'
+import 'hardhat-deploy'
 
 import './scripts/deploy-token'
 import './scripts/multi-send'
@@ -75,6 +77,14 @@ const config: HardhatUserConfig = {
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,
+  },
+  namedAccounts: {
+    deployer: {
+      default: getenv('LEDGER_ADDRESS')
+        ? `ledger://${getenv('LEDGER_ADDRESS')}`
+        : 0,
+      hardhat: 0,
+    },
   },
 }
 


### PR DESCRIPTION
**Description**

Adds the config for using a ledger with hardhat
deploy. The env var `LEDGER_ADDRESS` must be
set for this to work.

Note that hh deploy is buggy and will always
use the default path when creating a `LedgerSigner`. This means the `LEDGER_ADDRESS` env var is useless, it won't actually use that address when doing a
deployment. Basically, if its set then it just means use the ledger's first derived address at the default path.

This should be an easy thing to fix upstream, although kind of annoying. The paths would need to be searched linearly until a matching address is found, I think a better way to configure this is pass either:

- A path + address
- A path

If both are passed, then it should validate that the path matches the address. If a path is passed, then yolo use the derived account.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->



