### PR TITLE
op-node: Fillbytes size check in l1 block info

### DIFF
--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -114,12 +114,13 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		l1Info.InfoParentHash = l2Parent.L1Origin.Hash
 		l1Info.InfoNum = l2Parent.L1Origin.Number + 1
 
-		receipts, depositTxs := makeReceipts(rng, l1Info.InfoHash, cfg.DepositContractAddress, []receiptData{
+		receipts, depositTxs, err := makeReceipts(rng, l1Info.InfoHash, cfg.DepositContractAddress, []receiptData{
 			{goodReceipt: true, DepositLogs: []bool{true, false}},
 			{goodReceipt: true, DepositLogs: []bool{true}},
 			{goodReceipt: false, DepositLogs: []bool{true}},
 			{goodReceipt: false, DepositLogs: []bool{false}},
 		})
+		require.NoError(t, err)
 		usedDepositTxs, err := encodeDeposits(depositTxs)
 		require.NoError(t, err)
 

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -40,6 +40,10 @@ func (info *L1BlockInfo) MarshalBinary() ([]byte, error) {
 	offset += 32
 	binary.BigEndian.PutUint64(data[offset+24:offset+32], info.Time)
 	offset += 32
+	// Ensure that the baseFee is not too large.
+	if info.BaseFee.BitLen() > 256 {
+		return nil, fmt.Errorf("base fee exceeds 256 bits: %d", info.BaseFee)
+	}
 	info.BaseFee.FillBytes(data[offset : offset+32])
 	offset += 32
 	copy(data[offset:offset+32], info.BlockHash.Bytes())


### PR DESCRIPTION
**Description**

Prevents unhandled panics in the case that unexpectedly large values are passed to `FillBytes`.


**Tests**

No new tests, it's not clear that these errors are actually reachable.


**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes ENG-2613
