### PR TITLE
fix(ctb): move inits under constructors

### DIFF
--- a/.changeset/friendly-rats-scream.md
+++ b/.changeset/friendly-rats-scream.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Moves initializers underneath constructors always

--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -100,6 +100,14 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     }
 
     /**
+     * @notice Initializer;
+     */
+    function initialize() public initializer {
+        l2Sender = DEFAULT_L2_SENDER;
+        __ResourceMetering_init();
+    }
+
+    /**
      * @notice Accepts value so that users can send ETH directly to this contract and have the
      *         funds be deposited to their address on L2. This is intended as a convenience
      *         function for EOAs. Contracts should call the depositTransaction() function directly
@@ -212,14 +220,6 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     function isBlockFinalized(uint256 _l2BlockNumber) external view returns (bool) {
         Types.OutputProposal memory proposal = L2_ORACLE.getL2Output(_l2BlockNumber);
         return _isOutputFinalized(proposal);
-    }
-
-    /**
-     * @notice Initializer;
-     */
-    function initialize() public initializer {
-        l2Sender = DEFAULT_L2_SENDER;
-        __ResourceMetering_init();
     }
 
     /**


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Standardizes the location of initializers to be under constructors.