### PR TITLE
proxyd: Integrate custom rate limiter

### DIFF
--- a/.changeset/loud-pigs-hang.md
+++ b/.changeset/loud-pigs-hang.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Adds new Redis rate limiter

--- a/proxyd/backend_rate_limiter.go
+++ b/proxyd/backend_rate_limiter.go
@@ -57,22 +57,14 @@ type RedisBackendRateLimiter struct {
 	tkMtx     sync.Mutex
 }
 
-func NewRedisRateLimiter(url string) (BackendRateLimiter, error) {
-	opts, err := redis.ParseURL(url)
-	if err != nil {
-		return nil, err
-	}
-	rdb := redis.NewClient(opts)
-	if err := rdb.Ping(context.Background()).Err(); err != nil {
-		return nil, wrapErr(err, "error connecting to redis")
-	}
+func NewRedisRateLimiter(rdb *redis.Client) BackendRateLimiter {
 	out := &RedisBackendRateLimiter{
 		rdb:       rdb,
 		randID:    randStr(20),
 		touchKeys: make(map[string]time.Duration),
 	}
 	go out.touch()
-	return out, nil
+	return out
 }
 
 func (r *RedisBackendRateLimiter) IsBackendOnline(name string) (bool, error) {

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -46,16 +46,8 @@ type redisCache struct {
 	rdb *redis.Client
 }
 
-func newRedisCache(url string) (*redisCache, error) {
-	opts, err := redis.ParseURL(url)
-	if err != nil {
-		return nil, err
-	}
-	rdb := redis.NewClient(opts)
-	if err := rdb.Ping(context.Background()).Err(); err != nil {
-		return nil, wrapErr(err, "error connecting to redis")
-	}
-	return &redisCache{rdb}, nil
+func newRedisCache(rdb *redis.Client) *redisCache {
+	return &redisCache{rdb}
 }
 
 func (c *redisCache) Get(ctx context.Context, key string) (string, error) {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -42,7 +42,8 @@ type MetricsConfig struct {
 
 type RateLimitConfig struct {
 	UseRedis         bool                                `toml:"use_redis"`
-	RatePerSecond    int                                 `toml:"rate_per_second"`
+	BaseRate         int                                 `toml:"base_rate"`
+	BaseInterval     TOMLDuration                        `toml:"base_interval"`
 	ExemptOrigins    []string                            `toml:"exempt_origins"`
 	ExemptUserAgents []string                            `toml:"exempt_user_agents"`
 	ErrorMessage     string                              `toml:"error_message"`

--- a/proxyd/frontend_rate_limiter_test.go
+++ b/proxyd/frontend_rate_limiter_test.go
@@ -20,32 +20,32 @@ func TestFrontendRateLimiter(t *testing.T) {
 		Addr: fmt.Sprintf("127.0.0.1:%s", redisServer.Port()),
 	})
 
+	max := 2
 	lims := []struct {
 		name string
 		frl  FrontendRateLimiter
 	}{
-		{"memory", NewMemoryFrontendRateLimit(2 * time.Second)},
-		{"redis", NewRedisFrontendRateLimiter(redisClient, 2*time.Second)},
+		{"memory", NewMemoryFrontendRateLimit(2*time.Second, max)},
+		{"redis", NewRedisFrontendRateLimiter(redisClient, 2*time.Second, max, "")},
 	}
 
-	max := 2
 	for _, cfg := range lims {
 		frl := cfg.frl
 		ctx := context.Background()
 		t.Run(cfg.name, func(t *testing.T) {
 			for i := 0; i < 4; i++ {
-				ok, err := frl.Take(ctx, "foo", max)
+				ok, err := frl.Take(ctx, "foo")
 				require.NoError(t, err)
 				require.Equal(t, i < max, ok)
-				ok, err = frl.Take(ctx, "bar", max)
+				ok, err = frl.Take(ctx, "bar")
 				require.NoError(t, err)
 				require.Equal(t, i < max, ok)
 			}
 			time.Sleep(2 * time.Second)
 			for i := 0; i < 4; i++ {
-				ok, _ := frl.Take(ctx, "foo", max)
+				ok, _ := frl.Take(ctx, "foo")
 				require.Equal(t, i < max, ok)
-				ok, _ = frl.Take(ctx, "bar", max)
+				ok, _ = frl.Take(ctx, "bar")
 				require.Equal(t, i < max, ok)
 			}
 		})

--- a/proxyd/integration_tests/failover_test.go
+++ b/proxyd/integration_tests/failover_test.go
@@ -261,6 +261,8 @@ func TestInfuraFailoverOnUnexpectedResponse(t *testing.T) {
 	config.BackendOptions.MaxRetries = 2
 	// Setup redis to detect offline backends
 	config.Redis.URL = fmt.Sprintf("redis://127.0.0.1:%s", redis.Port())
+	redisClient, err := proxyd.NewRedisClient(config.Redis.URL)
+	require.NoError(t, err)
 
 	goodBackend := NewMockBackend(BatchedResponseHandler(200, goodResponse, goodResponse))
 	defer goodBackend.Close()
@@ -285,7 +287,7 @@ func TestInfuraFailoverOnUnexpectedResponse(t *testing.T) {
 	require.Equal(t, 1, len(badBackend.Requests()))
 	require.Equal(t, 1, len(goodBackend.Requests()))
 
-	rr, err := proxyd.NewRedisRateLimiter(config.Redis.URL)
+	rr := proxyd.NewRedisRateLimiter(redisClient)
 	require.NoError(t, err)
 	online, err := rr.IsBackendOnline("bad")
 	require.NoError(t, err)

--- a/proxyd/integration_tests/testdata/frontend_rate_limit.toml
+++ b/proxyd/integration_tests/testdata/frontend_rate_limit.toml
@@ -18,7 +18,8 @@ eth_chainId = "main"
 eth_foobar = "main"
 
 [rate_limit]
-rate_per_second = 2
+base_rate = 2
+base_interval = "1s"
 exempt_origins = ["exempt_origin"]
 exempt_user_agents = ["exempt_agent"]
 error_message = "over rate limit with special message"

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -236,6 +236,12 @@ var (
 			100,
 		},
 	})
+
+	frontendRateLimitTakeErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "rate_limit_take_errors",
+		Help:      "Count of errors taking frontend rate limits",
+	})
 )
 
 func RecordRedisError(source string) {

--- a/proxyd/redis.go
+++ b/proxyd/redis.go
@@ -1,0 +1,22 @@
+package proxyd
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func NewRedisClient(url string) (*redis.Client, error) {
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		return nil, err
+	}
+	client := redis.NewClient(opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, wrapErr(err, "error connecting to redis")
+	}
+	return client, nil
+}


### PR DESCRIPTION
Integrates the custom rate limiter in the previous PR into the rest of the application. Also takes the opportunity to clean up how we instantiate Redis clients so that we can share them among multiple different services.

There are some config changes in this PR. Specifically, you must specify a `base_rate` and `base_interval` in the rate limit config.