### PR TITLE
fix(proxyd): Fix compliance with JSON-RPC 2.0 spec by adding optional RPCError.Data

### DIFF
--- a/.changeset/angry-wombats-marry.md
+++ b/.changeset/angry-wombats-marry.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Fixed JSON-RPC 2.0 specification compliance by adding the optional data field on an RPCError

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -57,7 +57,7 @@ func (r *RPCRes) MarshalJSON() ([]byte, error) {
 type RPCErr struct {
 	Code          int    `json:"code"`
 	Message       string `json:"message"`
-	Data	      string `json:"data,omitempty"`
+	Data          string `json:"data,omitempty"`
 	HTTPErrorCode int    `json:"-"`
 }
 

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -57,6 +57,7 @@ func (r *RPCRes) MarshalJSON() ([]byte, error) {
 type RPCErr struct {
 	Code          int    `json:"code"`
 	Message       string `json:"message"`
+	Data	      string `json:"data,omitempty"`
 	HTTPErrorCode int    `json:"-"`
 }
 

--- a/proxyd/rpc_test.go
+++ b/proxyd/rpc_test.go
@@ -45,7 +45,7 @@ func TestRPCResJSON(t *testing.T) {
 			`{"jsonrpc":"2.0","result":null,"id":123}`,
 		},
 		{
-			"error result",
+			"error result without data",
 			&RPCRes{
 				JSONRPC: JSONRPCVersion,
 				Error: &RPCErr{
@@ -55,6 +55,19 @@ func TestRPCResJSON(t *testing.T) {
 				ID: []byte("123"),
 			},
 			`{"jsonrpc":"2.0","error":{"code":1234,"message":"test err"},"id":123}`,
+		},
+		{
+			"error result with data",
+			&RPCRes{
+				JSONRPC: JSONRPCVersion,
+				Error: &RPCErr{
+					Code:    1234,
+					Message: "test err",
+					Data: "revert",
+				},
+				ID: []byte("123"),
+			},
+			`{"jsonrpc":"2.0","error":{"code":1234,"message":"test err","data":"revert"},"id":123}`,
 		},
 		{
 			"string ID",

--- a/proxyd/rpc_test.go
+++ b/proxyd/rpc_test.go
@@ -63,7 +63,7 @@ func TestRPCResJSON(t *testing.T) {
 				Error: &RPCErr{
 					Code:    1234,
 					Message: "test err",
-					Data: "revert",
+					Data:    "revert",
 				},
 				ID: []byte("123"),
 			},


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The JSON-RPC 2.0 specification indicates that the error object may contain an optional data field. Proxyd currently drops this field from any responses. This PR fixes that.

https://www.jsonrpc.org/specification#error_object

**Tests**

I added a test to check that if a data field is present in the response from a backend, it will be added to the response from proxyd. The existing test should validate that if data field is not present in the response from the backend, the data key should not be present in the JSON response from proxyd.
