### PR TITLE
contracts-bedrock: Fix L2OO deployment

### DIFF
--- a/packages/contracts-bedrock/deploy/001-InitImplementations.deploy.ts
+++ b/packages/contracts-bedrock/deploy/001-InitImplementations.deploy.ts
@@ -7,7 +7,7 @@ import '@eth-optimism/hardhat-deploy-config'
 
 const upgradeABIs = {
   L2OutputOracleProxy: async (deployConfig) => [
-    'initialize(bytes32,uint256,address,address)',
+    'initialize(bytes32,uint256,address)',
     [
       deployConfig.l2OutputOracleGenesisL2Output,
       deployConfig.l2OutputOracleProposer,


### PR DESCRIPTION
The function signature wasn't updated with the arguments.
