### PR TITLE
Custom branch for OPCraft

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,9 +286,14 @@ jobs:
             gotestsum --junitfile /test-results/op-batcher.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
           working_directory: op-batcher
       - run:
-          name: test op-e2e
+          name: test op-e2e (WS)
           command: |
             gotestsum --junitfile /test-results/op-e2e.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
+          working_directory: op-e2e
+      - run:
+          name: test op-e2e (HTTP)
+          command: |
+            OP_E2E_USE_HTTP=true gotestsum --junitfile /test-results/op-e2e.xml -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out -covermode=atomic ./...
           working_directory: op-e2e
       - run:
           name: test op-service

--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -317,7 +317,7 @@ mainLoop:
 			if l.lastSubmittedBlock.Number+1+maxBlocksPerChannel < upToBlockNumber {
 				upToBlockNumber = l.lastSubmittedBlock.Number + 1 + maxBlocksPerChannel
 			}
-			for i := l.lastSubmittedBlock.Number + 1; i <= syncStatus.UnsafeL2.Number; i++ {
+			for i := l.lastSubmittedBlock.Number + 1; i <= upToBlockNumber; i++ {
 				ctx, cancel := context.WithTimeout(l.ctx, time.Second*10)
 				block, err := l.cfg.L2Client.BlockByNumber(ctx, new(big.Int).SetUint64(i))
 				cancel()

--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -310,6 +310,13 @@ mainLoop:
 				l.ch = ch
 			}
 			prevID := l.lastSubmittedBlock
+			maxBlocksPerChannel := uint64(100)
+			// Hacky min() here to ensure that we don't batch submit more than 100 blocks per channel.
+			// TODO: use proper channel size here instead.
+			upToBlockNumber := syncStatus.UnsafeL2.Number
+			if l.lastSubmittedBlock.Number+1+maxBlocksPerChannel < upToBlockNumber {
+				upToBlockNumber = l.lastSubmittedBlock.Number + 1 + maxBlocksPerChannel
+			}
 			for i := l.lastSubmittedBlock.Number + 1; i <= syncStatus.UnsafeL2.Number; i++ {
 				ctx, cancel := context.WithTimeout(l.ctx, time.Second*10)
 				block, err := l.cfg.L2Client.BlockByNumber(ctx, new(big.Int).SetUint64(i))

--- a/op-e2e/geth.go
+++ b/op-e2e/geth.go
@@ -98,6 +98,8 @@ func initL1Geth(cfg *SystemConfig, wallet *hdwallet.Wallet, genesis *core.Genesi
 	}
 	nodeConfig := &node.Config{
 		Name:        "l1-geth",
+		HTTPHost:    "127.0.0.1",
+		HTTPPort:    0,
 		WSHost:      "127.0.0.1",
 		WSPort:      0,
 		WSModules:   []string{"debug", "admin", "eth", "txpool", "net", "rpc", "web3", "personal", "engine"},

--- a/op-node/client/polling.go
+++ b/op-node/client/polling.go
@@ -1,0 +1,193 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var ErrSubscriberClosed = errors.New("subscriber closed")
+
+// PollingClient is an RPC client that provides newHeads subscriptions
+// via a polling loop. It's designed for HTTP endpoints, but WS will
+// work too.
+type PollingClient struct {
+	c        RPCGeneric
+	lgr      log.Logger
+	pollRate time.Duration
+	ctx      context.Context
+	cancel   context.CancelFunc
+	currHead *types.Header
+	subID    int
+
+	// pollReqCh is used to request new polls of the upstream
+	// RPC client.
+	pollReqCh chan struct{}
+
+	mtx sync.RWMutex
+
+	subs map[int]chan *types.Header
+
+	closedCh chan struct{}
+}
+
+type WrappedHTTPClientOption func(w *PollingClient)
+
+// WithPollRate specifies the rate at which the PollingClient will poll
+// for new heads. Setting this to zero disables polling altogether,
+// which is useful for testing.
+func WithPollRate(duration time.Duration) WrappedHTTPClientOption {
+	return func(w *PollingClient) {
+		w.pollRate = duration
+	}
+}
+
+// NewPollingClient returns a new PollingClient. Canceling the passed-in context
+// will close the client. Callers are responsible for closing the client in order
+// to prevent resource leaks.
+func NewPollingClient(ctx context.Context, lgr log.Logger, c RPCGeneric, opts ...WrappedHTTPClientOption) *PollingClient {
+	ctx, cancel := context.WithCancel(ctx)
+	res := &PollingClient{
+		c:         c,
+		lgr:       lgr,
+		pollRate:  250 * time.Millisecond,
+		ctx:       ctx,
+		cancel:    cancel,
+		pollReqCh: make(chan struct{}, 1),
+		subs:      make(map[int]chan *types.Header),
+		closedCh:  make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(res)
+	}
+	go res.pollHeads()
+	return res
+}
+
+// Close closes the PollingClient and the underlying RPC client it talks to.
+func (w *PollingClient) Close() {
+	w.cancel()
+	<-w.closedCh
+	w.c.Close()
+}
+
+func (w *PollingClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return w.c.CallContext(ctx, result, method, args...)
+}
+
+func (w *PollingClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	return w.c.BatchCallContext(ctx, b)
+}
+
+// EthSubscribe creates a new newHeads subscription. It takes identical arguments
+// to Geth's native EthSubscribe method. It will return an error, however, if the
+// passed in channel is not a *types.Headers channel or the subscription type is not
+// newHeads.
+func (w *PollingClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+	select {
+	case <-w.ctx.Done():
+		return nil, ErrSubscriberClosed
+	default:
+	}
+
+	headerCh, ok := channel.(chan<- *types.Header)
+	if !ok {
+		return nil, errors.New("invalid channel type")
+	}
+	if len(args) != 1 {
+		return nil, errors.New("invalid subscription args")
+	}
+	if args[0] != "newHeads" {
+		return nil, errors.New("unsupported subscription type")
+	}
+
+	sub := make(chan *types.Header, 1)
+	w.mtx.Lock()
+	subID := w.subID
+	w.subID++
+	w.subs[subID] = sub
+	w.mtx.Unlock()
+
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		for {
+			select {
+			case header := <-sub:
+				headerCh <- header
+			case <-quit:
+				w.mtx.Lock()
+				delete(w.subs, subID)
+				w.mtx.Unlock()
+				return nil
+			case <-w.ctx.Done():
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (w *PollingClient) pollHeads() {
+	// To prevent polls from stacking up in case HTTP requests
+	// are slow, use a similar model to the driver in which
+	// polls are requested manually after each header is fetched.
+	reqPollAfter := func() {
+		if w.pollRate == 0 {
+			return
+		}
+		time.AfterFunc(w.pollRate, w.reqPoll)
+	}
+
+	defer close(w.closedCh)
+
+	for {
+		select {
+		case <-w.pollReqCh:
+			// We don't need backoff here because we'll just try again
+			// after the pollRate elapses.
+			head, err := w.getLatestHeader()
+			if err != nil {
+				w.lgr.Error("error getting latest header", "err", err)
+				reqPollAfter()
+				continue
+			}
+			if w.currHead != nil && w.currHead.Hash() == head.Hash() {
+				w.lgr.Trace("no change in head, skipping notifications")
+				reqPollAfter()
+				continue
+			}
+
+			w.lgr.Trace("notifying subscribers of new head", "head", head.Hash())
+			w.currHead = head
+			w.mtx.RLock()
+			for _, sub := range w.subs {
+				sub <- head
+			}
+			w.mtx.RUnlock()
+			reqPollAfter()
+		case <-w.ctx.Done():
+			w.c.Close()
+			return
+		}
+	}
+}
+
+func (w *PollingClient) getLatestHeader() (*types.Header, error) {
+	ctx, cancel := context.WithTimeout(w.ctx, 5*time.Second)
+	defer cancel()
+	var head *types.Header
+	err := w.CallContext(ctx, &head, "eth_getBlockByNumber", "latest", false)
+	if err == nil && head == nil {
+		err = ethereum.NotFound
+	}
+	return head, err
+}
+
+func (w *PollingClient) reqPoll() {
+	w.pollReqCh <- struct{}{}
+}

--- a/op-node/client/polling.go
+++ b/op-node/client/polling.go
@@ -19,7 +19,7 @@ var ErrSubscriberClosed = errors.New("subscriber closed")
 // via a polling loop. It's designed for HTTP endpoints, but WS will
 // work too.
 type PollingClient struct {
-	c        RPCGeneric
+	c        RPC
 	lgr      log.Logger
 	pollRate time.Duration
 	ctx      context.Context
@@ -52,7 +52,7 @@ func WithPollRate(duration time.Duration) WrappedHTTPClientOption {
 // NewPollingClient returns a new PollingClient. Canceling the passed-in context
 // will close the client. Callers are responsible for closing the client in order
 // to prevent resource leaks.
-func NewPollingClient(ctx context.Context, lgr log.Logger, c RPCGeneric, opts ...WrappedHTTPClientOption) *PollingClient {
+func NewPollingClient(ctx context.Context, lgr log.Logger, c RPC, opts ...WrappedHTTPClientOption) *PollingClient {
 	ctx, cancel := context.WithCancel(ctx)
 	res := &PollingClient{
 		c:         c,
@@ -142,6 +142,8 @@ func (w *PollingClient) pollHeads() {
 		}
 		time.AfterFunc(w.pollRate, w.reqPoll)
 	}
+
+	reqPollAfter()
 
 	defer close(w.closedCh)
 

--- a/op-node/client/polling_test.go
+++ b/op-node/client/polling_test.go
@@ -1,0 +1,208 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+type MockRPC struct {
+	t           *testing.T
+	callResults []*callResult
+	mtx         sync.RWMutex
+	callCount   int
+	autopop     bool
+	closed      bool
+}
+
+type callResult struct {
+	root  common.Hash
+	error error
+}
+
+func (m *MockRPC) Close() {
+	m.closed = true
+}
+
+func (m *MockRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if method != "eth_getBlockByNumber" {
+		m.t.Fatalf("invalid method %s", method)
+	}
+	if args[0] != "latest" {
+		m.t.Fatalf("invalid arg %v", args[0])
+	}
+
+	m.callCount++
+	res := m.callResults[0]
+	headerP := result.(**types.Header)
+	*headerP = &types.Header{
+		Root: res.root,
+	}
+	if m.autopop {
+		m.callResults = m.callResults[1:]
+	}
+	return res.error
+}
+
+func (m *MockRPC) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	m.t.Fatal("BatchCallContext should not be called")
+	return nil
+}
+
+func (m *MockRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+	m.t.Fatal("EthSubscribe should not be called")
+	return nil, nil
+}
+
+func (m *MockRPC) popResult() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.callResults = m.callResults[1:]
+}
+
+func TestPollingClientSubscribeUnsubscribe(t *testing.T) {
+	lgr := log.New()
+	lgr.SetHandler(log.DiscardHandler())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root1 := common.Hash{0x01}
+	root2 := common.Hash{0x02}
+	root3 := common.Hash{0x03}
+	mockRPC := &MockRPC{
+		t: t,
+		callResults: []*callResult{
+			{root1, nil},
+			{root2, nil},
+			{root3, nil},
+		},
+	}
+	client := NewPollingClient(ctx, lgr, mockRPC, WithPollRate(0))
+
+	subs := make([]ethereum.Subscription, 0)
+	chans := make([]chan *types.Header, 0)
+	for i := 0; i < 2; i++ {
+		ch := make(chan *types.Header, 2)
+		sub, err := doSubscribe(client, ch)
+		require.NoError(t, err)
+		subs = append(subs, sub)
+		chans = append(chans, ch)
+	}
+
+	client.reqPoll()
+	requireChansEqual(t, chans, root1)
+	mockRPC.popResult()
+	client.reqPoll()
+	requireChansEqual(t, chans, root2)
+	// Poll an additional time to show that responses with the same
+	// data don't notify again.
+	client.reqPoll()
+
+	// Verify that no further notifications have been sent.
+	for _, ch := range chans {
+		select {
+		case <-ch:
+			t.Fatal("unexpected notification")
+		case <-time.NewTimer(10 * time.Millisecond).C:
+			continue
+		}
+	}
+
+	mockRPC.popResult()
+	subs[0].Unsubscribe()
+	client.reqPoll()
+	select {
+	case <-chans[0]:
+		t.Fatal("unexpected notification")
+	case <-time.NewTimer(10 * time.Millisecond).C:
+	}
+
+	header := <-chans[1]
+	require.Equal(t, root3, header.Root)
+}
+
+func TestPollingClientErrorRecovery(t *testing.T) {
+	lgr := log.New()
+	lgr.SetHandler(log.DiscardHandler())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root := common.Hash{0x01}
+	mockRPC := &MockRPC{
+		t: t,
+		callResults: []*callResult{
+			{common.Hash{}, errors.New("foobar")},
+			{common.Hash{}, errors.New("foobar")},
+			{root, nil},
+		},
+		autopop: true,
+	}
+	client := NewPollingClient(ctx, lgr, mockRPC, WithPollRate(0))
+	ch := make(chan *types.Header, 1)
+	sub, err := doSubscribe(client, ch)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	for i := 0; i < 3; i++ {
+		client.reqPoll()
+	}
+
+	header := <-ch
+	require.Equal(t, root, header.Root)
+	require.Equal(t, 3, mockRPC.callCount)
+}
+
+func TestPollingClientClose(t *testing.T) {
+	lgr := log.New()
+	lgr.SetHandler(log.DiscardHandler())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root := common.Hash{0x01}
+	mockRPC := &MockRPC{
+		t: t,
+		callResults: []*callResult{
+			{root, nil},
+		},
+		autopop: true,
+	}
+	client := NewPollingClient(ctx, lgr, mockRPC, WithPollRate(0))
+	ch := make(chan *types.Header, 1)
+	sub, err := doSubscribe(client, ch)
+	require.NoError(t, err)
+	client.reqPoll()
+	header := <-ch
+	cancel()
+	require.Nil(t, <-sub.Err())
+	require.Equal(t, root, header.Root)
+	require.Equal(t, 1, mockRPC.callCount)
+
+	// unsubscribe should be safe
+	sub.Unsubscribe()
+
+	_, err = doSubscribe(client, ch)
+	require.Equal(t, ErrSubscriberClosed, err)
+}
+
+func requireChansEqual(t *testing.T, chans []chan *types.Header, root common.Hash) {
+	for _, ch := range chans {
+		header := <-ch
+		require.Equal(t, root, header.Root)
+	}
+}
+
+func doSubscribe(client RPCGeneric, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	return client.EthSubscribe(context.Background(), ch, "newHeads")
+}

--- a/op-node/client/polling_test.go
+++ b/op-node/client/polling_test.go
@@ -203,6 +203,6 @@ func requireChansEqual(t *testing.T, chans []chan *types.Header, root common.Has
 	}
 }
 
-func doSubscribe(client RPCGeneric, ch chan<- *types.Header) (ethereum.Subscription, error) {
+func doSubscribe(client RPC, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	return client.EthSubscribe(context.Background(), ch, "newHeads")
 }

--- a/op-node/client/rpc.go
+++ b/op-node/client/rpc.go
@@ -2,42 +2,99 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
+	"github.com/ethereum-optimism/optimism/op-node/backoff"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-type RPC interface {
-	Close()
-	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
-	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
-	EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error)
-}
+var httpRegex = regexp.MustCompile("^http(s)?://")
 
-// RPCGeneric is a temporary interface added to make compilation work until interfaces
-// are updated to support the generic EthSubscribe that returns ethereum.Subscription
-// below
-type RPCGeneric interface {
+type RPC interface {
 	Close()
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error)
 }
 
+// NewRPC returns the correct client.RPC instance for a given RPC url.
+func NewRPC(ctx context.Context, lgr log.Logger, addr string, opts ...rpc.ClientOption) (RPC, error) {
+	underlying, err := DialRPCClientWithBackoff(ctx, lgr, addr, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	wrapped := &BaseRPCClient{
+		c: underlying,
+	}
+	if httpRegex.MatchString(addr) {
+		return NewPollingClient(ctx, lgr, wrapped), nil
+	}
+	return wrapped, nil
+}
+
+// Dials a JSON-RPC endpoint repeatedly, with a backoff, until a client connection is established. Auth is optional.
+func DialRPCClientWithBackoff(ctx context.Context, log log.Logger, addr string, opts ...rpc.ClientOption) (*rpc.Client, error) {
+	bOff := backoff.Exponential()
+	var ret *rpc.Client
+	err := backoff.Do(10, bOff, func() error {
+		client, err := rpc.DialOptions(ctx, addr, opts...)
+		if err != nil {
+			if client == nil {
+				return fmt.Errorf("failed to dial address (%s): %w", addr, err)
+			}
+			log.Warn("failed to dial address, but may connect later", "addr", addr, "err", err)
+		}
+		ret = client
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// BaseRPCClient is a wrapper around a concrete *rpc.Client instance to make it compliant
+// with the client.RPC interface.
+type BaseRPCClient struct {
+	c *rpc.Client
+}
+
+func NewBaseRPCClient(c *rpc.Client) *BaseRPCClient {
+	return &BaseRPCClient{c: c}
+}
+
+func (b *BaseRPCClient) Close() {
+	b.c.Close()
+}
+
+func (b *BaseRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return b.c.CallContext(ctx, result, method, args...)
+}
+
+func (b *BaseRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
+	return b.c.BatchCallContext(ctx, batch)
+}
+
+func (b *BaseRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+	return b.c.EthSubscribe(ctx, channel, args...)
+}
+
 // InstrumentedRPCClient is an RPC client that tracks
 // Prometheus metrics for each call.
 type InstrumentedRPCClient struct {
-	c *rpc.Client
+	c RPC
 	m *metrics.Metrics
 }
 
-// NewInstrumentedRPC creates a new instrumented RPC client. It takes
-// a concrete *rpc.Client to prevent people from passing in an already
-// instrumented client.
-func NewInstrumentedRPC(c *rpc.Client, m *metrics.Metrics) *InstrumentedRPCClient {
+// NewInstrumentedRPC creates a new instrumented RPC client.
+func NewInstrumentedRPC(c RPC, m *metrics.Metrics) *InstrumentedRPCClient {
 	return &InstrumentedRPCClient{
 		c: c,
 		m: m,
@@ -60,12 +117,8 @@ func (ic *InstrumentedRPCClient) BatchCallContext(ctx context.Context, b []rpc.B
 	}, b)
 }
 
-func (ic *InstrumentedRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+func (ic *InstrumentedRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
 	return ic.c.EthSubscribe(ctx, channel, args...)
-}
-
-func (ic *InstrumentedRPCClient) Client() Client {
-	return NewInstrumentedClient(ic.c, ic.m)
 }
 
 // instrumentBatch handles metrics for batch calls. Request metrics are

--- a/op-node/client/rpc.go
+++ b/op-node/client/rpc.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -14,6 +15,16 @@ type RPC interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error)
+}
+
+// RPCGeneric is a temporary interface added to make compilation work until interfaces
+// are updated to support the generic EthSubscribe that returns ethereum.Subscription
+// below
+type RPCGeneric interface {
+	Close()
+	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
+	EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error)
 }
 
 // InstrumentedRPCClient is an RPC client that tracks

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-node/backoff"
+	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum/go-ethereum/log"
 	gn "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -13,13 +13,13 @@ import (
 
 type L2EndpointSetup interface {
 	// Setup a RPC client to a L2 execution engine to process rollup blocks with.
-	Setup(ctx context.Context, log log.Logger) (cl *rpc.Client, err error)
+	Setup(ctx context.Context, log log.Logger) (cl client.RPC, err error)
 	Check() error
 }
 
 type L1EndpointSetup interface {
 	// Setup a RPC client to a L1 node to pull rollup input-data from.
-	Setup(ctx context.Context, log log.Logger) (cl *rpc.Client, trust bool, err error)
+	Setup(ctx context.Context, log log.Logger) (cl client.RPC, trust bool, err error)
 }
 
 type L2EndpointConfig struct {
@@ -40,12 +40,12 @@ func (cfg *L2EndpointConfig) Check() error {
 	return nil
 }
 
-func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger) (*rpc.Client, error) {
+func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger) (client.RPC, error) {
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
 	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(cfg.L2EngineJWTSecret))
-	l2Node, err := dialRPCClientWithBackoff(ctx, log, cfg.L2EngineAddr, auth)
+	l2Node, err := client.NewRPC(ctx, log, cfg.L2EngineAddr, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger) (*rpc.Cl
 
 // PreparedL2Endpoints enables testing with in-process pre-setup RPC connections to L2 engines
 type PreparedL2Endpoints struct {
-	Client *rpc.Client
+	Client client.RPC
 }
 
 func (p *PreparedL2Endpoints) Check() error {
@@ -67,7 +67,7 @@ func (p *PreparedL2Endpoints) Check() error {
 
 var _ L2EndpointSetup = (*PreparedL2Endpoints)(nil)
 
-func (p *PreparedL2Endpoints) Setup(ctx context.Context, log log.Logger) (*rpc.Client, error) {
+func (p *PreparedL2Endpoints) Setup(ctx context.Context, log log.Logger) (client.RPC, error) {
 	return p.Client, nil
 }
 
@@ -82,8 +82,8 @@ type L1EndpointConfig struct {
 
 var _ L1EndpointSetup = (*L1EndpointConfig)(nil)
 
-func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger) (cl *rpc.Client, trust bool, err error) {
-	l1Node, err := dialRPCClientWithBackoff(ctx, log, cfg.L1NodeAddr)
+func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger) (cl client.RPC, trust bool, err error) {
+	l1Node, err := client.NewRPC(ctx, log, cfg.L1NodeAddr)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to dial L1 address (%s): %w", cfg.L1NodeAddr, err)
 	}
@@ -92,33 +92,12 @@ func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger) (cl *rpc
 
 // PreparedL1Endpoint enables testing with an in-process pre-setup RPC connection to L1
 type PreparedL1Endpoint struct {
-	Client   *rpc.Client
+	Client   client.RPC
 	TrustRPC bool
 }
 
 var _ L1EndpointSetup = (*PreparedL1Endpoint)(nil)
 
-func (p *PreparedL1Endpoint) Setup(ctx context.Context, log log.Logger) (cl *rpc.Client, trust bool, err error) {
+func (p *PreparedL1Endpoint) Setup(ctx context.Context, log log.Logger) (cl client.RPC, trust bool, err error) {
 	return p.Client, p.TrustRPC, nil
-}
-
-// Dials a JSON-RPC endpoint repeatedly, with a backoff, until a client connection is established. Auth is optional.
-func dialRPCClientWithBackoff(ctx context.Context, log log.Logger, addr string, opts ...rpc.ClientOption) (*rpc.Client, error) {
-	bOff := backoff.Exponential()
-	var ret *rpc.Client
-	err := backoff.Do(10, bOff, func() error {
-		client, err := rpc.DialOptions(ctx, addr, opts...)
-		if err != nil {
-			if client == nil {
-				return fmt.Errorf("failed to dial address (%s): %w", addr, err)
-			}
-			log.Warn("failed to dial address, but may connect later", "addr", addr, "err", err)
-		}
-		ret = client
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
 }

--- a/op-node/node/log.go
+++ b/op-node/node/log.go
@@ -44,7 +44,7 @@ func (cfg *LogConfig) Check() error {
 func (cfg *LogConfig) NewLogger() log.Logger {
 	handler := log.StreamHandler(os.Stdout, format(cfg.Format, cfg.Color))
 	handler = log.SyncHandler(handler)
-	log.LvlFilterHandler(level(cfg.Level), handler)
+	handler = log.LvlFilterHandler(level(cfg.Level), handler)
 	logger := log.New()
 	logger.SetHandler(handler)
 	return logger

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
+	rpcclient "github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -101,7 +102,7 @@ func TestOutputAtBlock(t *testing.T) {
 	assert.NoError(t, server.Start())
 	defer server.Stop()
 
-	client, err := dialRPCClientWithBackoff(context.Background(), log, "http://"+server.Addr().String())
+	client, err := rpcclient.DialRPCClientWithBackoff(context.Background(), log, "http://"+server.Addr().String())
 	assert.NoError(t, err)
 
 	var out []eth.Bytes32
@@ -127,7 +128,7 @@ func TestVersion(t *testing.T) {
 	assert.NoError(t, server.Start())
 	defer server.Stop()
 
-	client, err := dialRPCClientWithBackoff(context.Background(), log, "http://"+server.Addr().String())
+	client, err := rpcclient.DialRPCClientWithBackoff(context.Background(), log, "http://"+server.Addr().String())
 	assert.NoError(t, err)
 
 	var out string
@@ -162,7 +163,7 @@ func TestSyncStatus(t *testing.T) {
 	assert.NoError(t, server.Start())
 	defer server.Stop()
 
-	client, err := dialRPCClientWithBackoff(context.Background(), log, "http://"+server.Addr().String())
+	client, err := rpcclient.DialRPCClientWithBackoff(context.Background(), log, "http://"+server.Addr().String())
 	assert.NoError(t, err)
 
 	var out *eth.SyncStatus

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -473,7 +473,7 @@ func (s *state) eventLoop() {
 // It waits for the reset to occur. It simply unblocks the caller rather
 // than fully cancelling the reset request upon a context cancellation.
 func (s *state) ResetDerivationPipeline(ctx context.Context) error {
-	respCh := make(chan struct{})
+	respCh := make(chan struct{}, 1)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -488,7 +488,7 @@ func (s *state) ResetDerivationPipeline(ctx context.Context) error {
 }
 
 func (s *state) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
-	respCh := make(chan eth.SyncStatus)
+	respCh := make(chan eth.SyncStatus, 1)
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -417,7 +417,7 @@ func (s *state) eventLoop() {
 			s.metrics.SetDerivationIdle(false)
 			s.idleDerivation = false
 			s.log.Debug("Derivation process step", "onto_origin", s.derivation.Progress().Origin, "onto_closed", s.derivation.Progress().Closed, "attempts", stepAttempts)
-			stepCtx, cancel := context.WithTimeout(ctx, time.Minute) // TODO pick a timeout for executing a single step
+			stepCtx, cancel := context.WithTimeout(ctx, 5*time.Minute) // TODO pick a timeout for executing a single step
 			err := s.derivation.Step(stepCtx)
 			cancel()
 			stepAttempts += 1 // count as attempt by default. We reset to 0 if we are making healthy progress.

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -417,7 +417,7 @@ func (s *state) eventLoop() {
 			s.metrics.SetDerivationIdle(false)
 			s.idleDerivation = false
 			s.log.Debug("Derivation process step", "onto_origin", s.derivation.Progress().Origin, "onto_closed", s.derivation.Progress().Closed, "attempts", stepAttempts)
-			stepCtx, cancel := context.WithTimeout(ctx, time.Second*10) // TODO pick a timeout for executing a single step
+			stepCtx, cancel := context.WithTimeout(ctx, time.Minute) // TODO pick a timeout for executing a single step
 			err := s.derivation.Step(stepCtx)
 			cancel()
 			stepAttempts += 1 // count as attempt by default. We reset to 0 if we are making healthy progress.

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -30,7 +31,7 @@ func (m *mockRPC) CallContext(ctx context.Context, result interface{}, method st
 	return m.MethodCalled("CallContext", ctx, result, method, args).Get(0).([]error)[0]
 }
 
-func (m *mockRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+func (m *mockRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
 	called := m.MethodCalled("EthSubscribe", channel, args)
 	return called.Get(0).(*rpc.ClientSubscription), called.Get(1).([]error)[0]
 }

--- a/op-node/sources/limit.go
+++ b/op-node/sources/limit.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -39,7 +40,7 @@ func (lc *limitClient) CallContext(ctx context.Context, result interface{}, meth
 	return lc.c.CallContext(ctx, result, method, args...)
 }
 
-func (lc *limitClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+func (lc *limitClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
 	// subscription doesn't count towards request limit
 	return lc.c.EthSubscribe(ctx, channel, args...)
 }


### PR DESCRIPTION
- port over deadlock fix
- op-node: Add wrapper to support EthSubscribe in HTTP clients (#3629)
- op-node: Integrate PollingClient with op-node (#3630)
