### PR TITLE
op-node: Fix reset bug in batch queue

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -59,7 +59,11 @@ func (bq *BatchQueue) Origin() eth.L1BlockRef {
 }
 
 func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) (*BatchData, error) {
-	originBehind := bq.origin.Number < safeL2Head.L1Origin.Number
+	// Note: We use the origin that we will have to determine if it's behind. This is important
+	// because it's the future origin that gets saved into the l1Blocks array.
+	// We always update the origin of this stage if it is not the same so after the update code
+	// runs, this is consistent.
+	originBehind := bq.prev.Origin().Number < safeL2Head.L1Origin.Number
 
 	// Advance origin if needed
 	// Note: The entire pipeline has the same origin


### PR DESCRIPTION
**Description**

The batch queue was using the previous origin when computing if the origin was behind or not. It would then immediately advance it's internal origin to the next origin (confusingly coming from the `prev` stage). It would take action on the current origin based on out of date data. Specifically, it would not save an origin that should have been saved into the l1Blocks array. This causes errors because the L1 Origin of the safe head would not be present when attempting to derive the next batch after a reset.

**Tests**

Not tested either in a full reproduction or with unit tests. 

**Metadata**
- Fixes ENG-2906
