### PR TITLE
specs: Remove outdated portions

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -300,7 +300,7 @@ Batcher transactions are encoded as `version_byte ++ rollup_payload` (where `++`
 
 Unknown versions make the batcher transaction invalid (it must be ignored by the rollup node).
 All frames in a batcher transaction must be parseable. If any one frame fails to parse, the all frames in the
-transaction are rejected. 
+transaction are rejected.
 
 > **TODO** specify batcher authentication (i.e. where do we store / make available the public keys of authorize batcher
 > signers)

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -299,9 +299,8 @@ Batcher transactions are encoded as `version_byte ++ rollup_payload` (where `++`
 | 0              | `frame ...` (one or more frames, concatenated) |
 
 Unknown versions make the batcher transaction invalid (it must be ignored by the rollup node).
-
-The `rollup_payload` may be right-padded with 0s, which will be ignored. It's allowed for them to be
-interpreted as frames for channel 0, which must always be ignored.
+All frames in a batcher transaction must be parseable. If any one frame fails to parse, the all frames in the
+transaction are rejected. 
 
 > **TODO** specify batcher authentication (i.e. where do we store / make available the public keys of authorize batcher
 > signers)

--- a/specs/exec-engine.md
+++ b/specs/exec-engine.md
@@ -101,6 +101,11 @@ The `noTxPool` is optional as well, and extends the `transactions` meaning:
   into the payload, after any of the `transactions`. This is the default behavior a L1 node implements.
 - If `true`, the execution engine must not change anything about the given list of `transactions`.
 
+If the `transactions` field is present, the engine must execute the transactions in order and return `STATUS_INVALID`
+if there is an error processing the transactions. It must return `STATUS_VALID` if all of the transactions could
+be executed without error. **Note**: The state transition rules have been modified such that deposits will never fail
+so if `engine_forkchoiceUpdatedV1` returns `STATUS_INVALID` it is because a batched transaction is invalid.
+
 [rollup-driver]: rollup-node.md
 
 ### `engine_newPayloadV1`


### PR DESCRIPTION
**Description**

This cleans up specs. Specifically:
- We no longer allow right padding on frames.
- Specify that all frames must be parseable in a batcher transaction
- Document changes to `engine_forkChoiceUpdatedV1` made in https://github.com/ethereum-optimism/reference-optimistic-geth/pull/40

**Metadata**

- Fixes ENG-2728
- Fixes ENG-2663
