### PR TITLE
proxyd: Allow disabling backend rate limiting

### DIFF
--- a/.changeset/flat-windows-trade.md
+++ b/.changeset/flat-windows-trade.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Allow disabling backend rate limiter

--- a/proxyd/backend_rate_limiter.go
+++ b/proxyd/backend_rate_limiter.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -256,5 +257,30 @@ func randStr(l int) string {
 	return hex.EncodeToString(b)
 }
 
-type ServerRateLimiter struct {
+type NoopBackendRateLimiter struct{}
+
+var noopBackendRateLimiter = &NoopBackendRateLimiter{}
+
+func (n *NoopBackendRateLimiter) IsBackendOnline(name string) (bool, error) {
+	return true, nil
+}
+
+func (n *NoopBackendRateLimiter) SetBackendOffline(name string, duration time.Duration) error {
+	return nil
+}
+
+func (n *NoopBackendRateLimiter) IncBackendRPS(name string) (int, error) {
+	return math.MaxInt, nil
+}
+
+func (n *NoopBackendRateLimiter) IncBackendWSConns(name string, max int) (bool, error) {
+	return true, nil
+}
+
+func (n *NoopBackendRateLimiter) DecBackendWSConns(name string) error {
+	return nil
+}
+
+func (n *NoopBackendRateLimiter) FlushBackendWSConns(names []string) error {
+	return nil
 }

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -41,13 +41,14 @@ type MetricsConfig struct {
 }
 
 type RateLimitConfig struct {
-	UseRedis         bool                                `toml:"use_redis"`
-	BaseRate         int                                 `toml:"base_rate"`
-	BaseInterval     TOMLDuration                        `toml:"base_interval"`
-	ExemptOrigins    []string                            `toml:"exempt_origins"`
-	ExemptUserAgents []string                            `toml:"exempt_user_agents"`
-	ErrorMessage     string                              `toml:"error_message"`
-	MethodOverrides  map[string]*RateLimitMethodOverride `toml:"method_overrides"`
+	UseRedis                 bool                                `toml:"use_redis"`
+	EnableBackendRateLimiter bool                                `toml:"enable_backend_rate_limiter"`
+	BaseRate                 int                                 `toml:"base_rate"`
+	BaseInterval             TOMLDuration                        `toml:"base_interval"`
+	ExemptOrigins            []string                            `toml:"exempt_origins"`
+	ExemptUserAgents         []string                            `toml:"exempt_user_agents"`
+	ErrorMessage             string                              `toml:"error_message"`
+	MethodOverrides          map[string]*RateLimitMethodOverride `toml:"method_overrides"`
 }
 
 type RateLimitMethodOverride struct {

--- a/proxyd/integration_tests/testdata/backend_rate_limit.toml
+++ b/proxyd/integration_tests/testdata/backend_rate_limit.toml
@@ -16,3 +16,6 @@ backends = ["good"]
 
 [rpc_method_mappings]
 eth_chainId = "main"
+
+[rate_limit]
+enable_backend_limiter = true

--- a/proxyd/integration_tests/testdata/backend_rate_limit.toml
+++ b/proxyd/integration_tests/testdata/backend_rate_limit.toml
@@ -18,4 +18,4 @@ backends = ["good"]
 eth_chainId = "main"
 
 [rate_limit]
-enable_backend_limiter = true
+enable_backend_rate_limiter = true

--- a/proxyd/integration_tests/testdata/out_of_service_interval.toml
+++ b/proxyd/integration_tests/testdata/out_of_service_interval.toml
@@ -20,3 +20,6 @@ backends = ["bad", "good"]
 
 [rpc_method_mappings]
 eth_chainId = "main"
+
+[rate_limit]
+enable_backend_rate_limiter = true

--- a/proxyd/integration_tests/testdata/ws.toml
+++ b/proxyd/integration_tests/testdata/ws.toml
@@ -26,3 +26,6 @@ backends = ["good"]
 
 [rpc_method_mappings]
 eth_chainId = "main"
+
+[rate_limit]
+enable_backend_rate_limiter = true

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -53,11 +53,15 @@ func Start(config *Config) (func(), error) {
 
 	var lim BackendRateLimiter
 	var err error
-	if redisClient == nil {
-		log.Warn("redis is not configured, using local rate limiter")
-		lim = NewLocalBackendRateLimiter()
+	if config.RateLimit.EnableBackendRateLimiter {
+		if redisClient != nil {
+			lim = NewRedisRateLimiter(redisClient)
+		} else {
+			log.Warn("redis is not configured, using local rate limiter")
+			lim = NewLocalBackendRateLimiter()
+		}
 	} else {
-		lim = NewRedisRateLimiter(redisClient)
+		lim = noopBackendRateLimiter
 	}
 
 	// While modifying shared globals is a bad practice, the alternative


### PR DESCRIPTION
The backend rate limiter is in place to protect upstreams like the sequencer. However, in many cases it isn't needed and it causes unnecessary requests to Redis. This PR allows this to be disabled, and disables this by default.
