### PR TITLE
op-node: Use DoCtx in DialRPClientWithBackoff

### DIFF
--- a/op-node/client/rpc.go
+++ b/op-node/client/rpc.go
@@ -43,7 +43,7 @@ func NewRPC(ctx context.Context, lgr log.Logger, addr string, opts ...rpc.Client
 func DialRPCClientWithBackoff(ctx context.Context, log log.Logger, addr string, opts ...rpc.ClientOption) (*rpc.Client, error) {
 	bOff := backoff.Exponential()
 	var ret *rpc.Client
-	err := backoff.Do(10, bOff, func() error {
+	err := backoff.DoCtx(ctx, 10, bOff, func() error {
 		client, err := rpc.DialOptions(ctx, addr, opts...)
 		if err != nil {
 			if client == nil {


### PR DESCRIPTION
**Description**

This fixes an issue where if a short context was supplied to the call it would still take a long time to complete.
