### PR TITLE
op-node: Allow *types.Block to satisfy the BlockInfo interface

### DIFF
--- a/op-node/eth/block_info.go
+++ b/op-node/eth/block_info.go
@@ -4,7 +4,10 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
+
+var _ BlockInfo = (&types.Block{})
 
 type BlockInfo interface {
 	Hash() common.Hash
@@ -16,7 +19,6 @@ type BlockInfo interface {
 	// MixDigest field, reused for randomness after The Merge (Bellatrix hardfork)
 	MixDigest() common.Hash
 	BaseFee() *big.Int
-	ID() BlockID
 	ReceiptHash() common.Hash
 }
 
@@ -26,5 +28,17 @@ func InfoToL1BlockRef(info BlockInfo) L1BlockRef {
 		Number:     info.NumberU64(),
 		ParentHash: info.ParentHash(),
 		Time:       info.Time(),
+	}
+}
+
+type NumberAndHash interface {
+	Hash() common.Hash
+	NumberU64() uint64
+}
+
+func ToBlockID(b NumberAndHash) BlockID {
+	return BlockID{
+		Hash:   b.Hash(),
+		Number: b.NumberU64(),
 	}
 }

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -251,7 +251,7 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 		for i := 0; i < len(txs); i++ {
 			txHashes[i] = txs[i].Hash()
 		}
-		fetcher = NewReceiptsFetcher(info.ID(), info.ReceiptHash(), txHashes, s.client.BatchCallContext, s.maxBatchSize)
+		fetcher = NewReceiptsFetcher(eth.ToBlockID(info), info.ReceiptHash(), txHashes, s.client.BatchCallContext, s.maxBatchSize)
 		s.receiptsCache.Add(blockHash, fetcher)
 	}
 	// Fetch all receipts


### PR DESCRIPTION
**Description**

There was a single usage of BlockInfo.ID() which I replaced with a function called `ToBlockID` which can take either a BlockInfo or a types.Block (it uses an interface consisting of Hash and NumberU64).

This change makes our code that depends on `BlockInfo` much more useful because this
is much easier than manually converting types. 
