### PR TITLE
op-batcher: Limit number of blocks per channel

### DIFF
--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -317,7 +317,7 @@ mainLoop:
 			if l.lastSubmittedBlock.Number+1+maxBlocksPerChannel < upToBlockNumber {
 				upToBlockNumber = l.lastSubmittedBlock.Number + 1 + maxBlocksPerChannel
 			}
-			for i := l.lastSubmittedBlock.Number + 1; i <= syncStatus.UnsafeL2.Number; i++ {
+			for i := l.lastSubmittedBlock.Number + 1; i <= upToBlockNumber; i++ {
 				ctx, cancel := context.WithTimeout(l.ctx, time.Second*10)
 				block, err := l.cfg.L2Client.BlockByNumber(ctx, new(big.Int).SetUint64(i))
 				cancel()

--- a/op-batcher/batch_submitter.go
+++ b/op-batcher/batch_submitter.go
@@ -310,6 +310,13 @@ mainLoop:
 				l.ch = ch
 			}
 			prevID := l.lastSubmittedBlock
+			maxBlocksPerChannel := uint64(100)
+			// Hacky min() here to ensure that we don't batch submit more than 100 blocks per channel.
+			// TODO: use proper channel size here instead.
+			upToBlockNumber := syncStatus.UnsafeL2.Number
+			if l.lastSubmittedBlock.Number+1+maxBlocksPerChannel < upToBlockNumber {
+				upToBlockNumber = l.lastSubmittedBlock.Number + 1 + maxBlocksPerChannel
+			}
 			for i := l.lastSubmittedBlock.Number + 1; i <= syncStatus.UnsafeL2.Number; i++ {
 				ctx, cancel := context.WithTimeout(l.ctx, time.Second*10)
 				block, err := l.cfg.L2Client.BlockByNumber(ctx, new(big.Int).SetUint64(i))


### PR DESCRIPTION
**Description**

This limits the number of blocks per channel to hopefully enable batch submitting
large chunks at once.
