### PR TITLE
op-e2e: user action allow set calldata

### DIFF
--- a/op-e2e/actions/user.go
+++ b/op-e2e/actions/user.go
@@ -149,6 +149,13 @@ func (s *BasicUser[B]) ActRandomTxToAddr(t Testing) {
 	s.txToAddr = to
 }
 
+func (s *BasicUser[B]) ActSetTxCalldata(calldata []byte) Action {
+	return func(t Testing) {
+		require.NotNil(t, calldata)
+		s.txCallData = calldata
+	}
+}
+
 func (s *BasicUser[B]) ActSetTxToAddr(to *common.Address) Action {
 	return func(t Testing) {
 		s.txToAddr = to


### PR DESCRIPTION
**Description**

This commit adds a function to the `BasicUser` that allows a more complex flow where the calldata can be set. This allows for the user to make specific contract calls.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


