### PR TITLE
op-chain-ops: add weth9 as a L1 predeploy

### DIFF
--- a/op-bindings/predeploys/dev_addresses.go
+++ b/op-bindings/predeploys/dev_addresses.go
@@ -10,6 +10,7 @@ const (
 	DevOptimismMintableERC20Factory = "0x6900000000000000000000000000000000000004"
 	DevAddressManager               = "0x6900000000000000000000000000000000000005"
 	DevProxyAdmin                   = "0x6900000000000000000000000000000000000006"
+	DevWETH9                        = "0x6900000000000000000000000000000000000007"
 )
 
 var (
@@ -20,6 +21,7 @@ var (
 	DevOptimismMintableERC20FactoryAddr = common.HexToAddress(DevOptimismMintableERC20Factory)
 	DevAddressManagerAddr               = common.HexToAddress(DevAddressManager)
 	DevProxyAdminAddr                   = common.HexToAddress(DevProxyAdmin)
+	DevWETH9Addr                        = common.HexToAddress(DevWETH9)
 
 	DevPredeploys = make(map[string]*common.Address)
 )
@@ -32,4 +34,5 @@ func init() {
 	DevPredeploys["OptimismMintableERC20Factory"] = &DevOptimismMintableERC20FactoryAddr
 	DevPredeploys["AddressManager"] = &DevAddressManagerAddr
 	DevPredeploys["Admin"] = &DevProxyAdminAddr
+	DevPredeploys["WETH9"] = &DevWETH9Addr
 }

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -165,6 +165,16 @@ func BuildL1DeveloperGenesis(config *DeployConfig) (*core.Genesis, error) {
 
 	for name, proxyAddr := range predeploys.DevPredeploys {
 		memDB.SetState(*proxyAddr, ImplementationSlot, depsByName[name].Address.Hash())
+
+		// Special case for WETH since it was not designed to be behind a proxy
+		if name == "WETH9" {
+			name, _ := state.EncodeStringValue("Wrapped Ether", 0)
+			symbol, _ := state.EncodeStringValue("WETH", 0)
+			decimals, _ := state.EncodeUintValue(18, 0)
+			memDB.SetState(*proxyAddr, common.Hash{}, name)
+			memDB.SetState(*proxyAddr, common.Hash{31: 0x01}, symbol)
+			memDB.SetState(*proxyAddr, common.Hash{31: 0x02}, decimals)
+		}
 	}
 
 	stateDB, err := backend.Blockchain().State()
@@ -183,6 +193,7 @@ func BuildL1DeveloperGenesis(config *DeployConfig) (*core.Genesis, error) {
 
 		memDB.CreateAccount(depAddr)
 		memDB.SetCode(depAddr, dep.Bytecode)
+
 		for iter.Next() {
 			_, data, _, err := rlp.Split(iter.Value)
 			if err != nil {
@@ -250,6 +261,9 @@ func deployL1Contracts(config *DeployConfig, backend *backends.SimulatedBackend)
 				common.Address{19: 0x01},
 			},
 		},
+		{
+			Name: "WETH9",
+		},
 	}...)
 	return deployer.Deploy(backend, constructors, l1Deployer)
 }
@@ -307,6 +321,11 @@ func l1Deployer(backend *backends.SimulatedBackend, opts *bind.TransactOpts, dep
 			opts,
 			backend,
 			common.Address{},
+		)
+	case "WETH9":
+		_, tx, _, err = bindings.DeployWETH9(
+			opts,
+			backend,
 		)
 	default:
 		if strings.HasSuffix(deployment.Name, "Proxy") {

--- a/op-chain-ops/genesis/layer_one_test.go
+++ b/op-chain-ops/genesis/layer_one_test.go
@@ -92,6 +92,18 @@ func TestBuildL1DeveloperGenesis(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, predeploys.DevL1StandardBridgeAddr, bridgeAddr)
 
+	weth9, err := bindings.NewWETH9(predeploys.DevWETH9Addr, sim)
+	require.NoError(t, err)
+	decimals, err := weth9.Decimals(callOpts)
+	require.NoError(t, err)
+	require.Equal(t, uint8(18), decimals)
+	symbol, err := weth9.Symbol(callOpts)
+	require.NoError(t, err)
+	require.Equal(t, "WETH", symbol)
+	name, err := weth9.Name(callOpts)
+	require.NoError(t, err)
+	require.Equal(t, "Wrapped Ether", name)
+
 	// test that we can do deposits, etc.
 	priv, err := crypto.HexToECDSA("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
 	require.NoError(t, err)


### PR DESCRIPTION
**Description**

This will make e2e testing that requires and erc20 token that is mintable easy. Just send eth to the
correct address and then you will have an erc20
token.

This will be used for e2e tests for token deposits and withdrawals.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
