### PR TITLE
op-e2e: user action allow set value

### DIFF
--- a/op-e2e/actions/user.go
+++ b/op-e2e/actions/user.go
@@ -165,6 +165,12 @@ func (s *BasicUser[B]) ActRandomTxValue(t Testing) {
 	s.txOpts.Value = big.NewInt(s.rng.Int63())
 }
 
+func (s *BasicUser[B]) ActSetTxValue(value *big.Int) Action {
+	return func(t Testing) {
+		s.txOpts.Value = value
+	}
+}
+
 func (s *BasicUser[B]) ActRandomTxData(t Testing) {
 	dataLen := s.rng.Intn(128_000)
 	out := make([]byte, dataLen)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Allows a specific transaction value to be sent by a user in the e2e tests