### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/flat-windows-trade.md
+++ b/.changeset/flat-windows-trade.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': minor
----
-
-Allow disabling backend rate limiter

--- a/.changeset/shy-trainers-sneeze.md
+++ b/.changeset/shy-trainers-sneeze.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': minor
----
-
-Support pattern matching in exempt origins/user agents

--- a/.changeset/wet-cameras-cover.md
+++ b/.changeset/wet-cameras-cover.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': minor
----
-
-adds server.log_level config

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -309,9 +309,7 @@ func (s *Driver) eventLoop() {
 			s.metrics.SetDerivationIdle(false)
 			s.idleDerivation = false
 			s.log.Debug("Derivation process step", "onto_origin", s.derivation.Origin(), "attempts", stepAttempts)
-			stepCtx, cancel := context.WithTimeout(ctx, 20*time.Minute) // TODO pick a timeout for executing a single step
-			err := s.derivation.Step(stepCtx)
-			cancel()
+			err := s.derivation.Step(context.Background())
 			stepAttempts += 1 // count as attempt by default. We reset to 0 if we are making healthy progress.
 			if err == io.EOF {
 				s.log.Debug("Derivation process went idle", "progress", s.derivation.Origin())

--- a/proxyd/CHANGELOG.md
+++ b/proxyd/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @eth-optimism/proxyd
 
+## 3.12.0
+
+### Minor Changes
+
+- e9f2c701: Allow disabling backend rate limiter
+- ca45a85e: Support pattern matching in exempt origins/user agents
+- f4faa44c: adds server.log_level config
+
 ## 3.11.0
 
 ### Minor Changes

--- a/proxyd/package.json
+++ b/proxyd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/proxyd",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "private": true,
   "dependencies": {}
 }


### PR DESCRIPTION
- op-e2e: action testing user
- op-node: reset buildingID in CompleteBuildingBlock to also do so when not calling the legacy start/complete combination
- op-e2e: action testing batcher actor
- op-e2e: user action test review fixes
- op-e2e: batcher action testing review fixes
- proxyd: Allow disabling backend rate limiting
- op-node: Use DoCtx in DialRPClientWithBackoff
- op-node: Allow *types.Block to satisfy the BlockInfo interface
- adds log level conf to proxyd (#3704)
- fix tests
- proxyd: Support pattern matching in origin and user agent
- contracts-bedrock: Fix L2OO deployment (#3685)
- op-node: Fix reset bug in batch queue (#3694)
- op-node: Increase step timeout (#3713)
- op-node: Log sync start (#3716)
- op-node: Use background context (#3718)
