### PR TITLE
op-e2e: last receipt getter

### DIFF
--- a/op-e2e/actions/user.go
+++ b/op-e2e/actions/user.go
@@ -196,6 +196,13 @@ func (s *BasicUser[B]) TxValue() *big.Int {
 	return big.NewInt(0)
 }
 
+func (s *BasicUser[B]) LastTxReceipt(t Testing) *types.Receipt {
+	require.NotEqual(t, s.lastTxHash, common.Hash{}, "must send tx before getting last receipt")
+	receipt, err := s.env.EthCl.TransactionReceipt(t.Ctx(), s.lastTxHash)
+	require.NoError(t, err)
+	return receipt
+}
+
 // ActMakeTx makes a tx with the predetermined contents (see randomization and other actions)
 // and sends it to the tx pool
 func (s *BasicUser[B]) ActMakeTx(t Testing) {


### PR DESCRIPTION
**Description**

Add a getter for fetching the last receipt. This
is useful if values from a receipt need to be parsed as input to additional calls

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

