### PR TITLE
op-node: avoid block building on bad L1 origin

### DIFF
--- a/op-node/rollup/driver/origin_selector.go
+++ b/op-node/rollup/driver/origin_selector.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -64,6 +65,10 @@ func (los *L1OriginSelector) FindL1Origin(ctx context.Context, l1Head eth.L1Bloc
 	if err != nil {
 		log.Error("Failed to get next origin. Falling back to current origin", "err", err)
 		return currentOrigin, nil
+	}
+
+	if nextOrigin.ParentHash != currentOrigin.Hash {
+		return eth.L1BlockRef{}, fmt.Errorf("next L1 origin %s builds on parent %s and not on top of previous L1 origin %s", nextOrigin, nextOrigin.ParentID(), currentOrigin)
 	}
 
 	// If the next L2 block time is greater than the next origin block's time, we can choose to


### PR DESCRIPTION
**Description**

The block building code already has a check like this, but it's odd to even return an inconsistent L1 origin. Returning an error until the derivation code reorgs towards a proper L2 head to build on top of seems like the most minimal solution.

**Tests**

Planning to write an action test for this. Draft PR.
