### PR TITLE
op-e2e: actiont test l2 block building - prepare tx before applying it

### DIFF
--- a/op-e2e/actions/l2_engine_api.go
+++ b/op-e2e/actions/l2_engine_api.go
@@ -96,7 +96,7 @@ func (ea *L2EngineAPI) startBlock(parent common.Hash, params *eth.PayloadAttribu
 		if err := tx.UnmarshalBinary(otx); err != nil {
 			return fmt.Errorf("transaction %d is not valid: %v", i, err)
 		}
-
+		ea.l2BuildingState.Prepare(tx.Hash(), i)
 		receipt, err := core.ApplyTransaction(ea.l2Cfg.Config, ea.l2Chain, &ea.l2BuildingHeader.Coinbase,
 			ea.l2GasPool, ea.l2BuildingState, ea.l2BuildingHeader, &tx, &ea.l2BuildingHeader.GasUsed, *ea.l2Chain.GetVMConfig())
 		if err != nil {


### PR DESCRIPTION
**Description**

This fixes a bug in our test framework - deposit with log events need the state to be prepared, or the logs don't make their way into the receipts and logs-bloom (unfortunate non-obvious geth API)

**Tests**

This is covered in #3732 

