### PR TITLE
disable snyk for infra/op-replica

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+exclude:
+  global:
+    - infra/op-replica/**  # snyk does not respect kustomizations, so not useful here


### PR DESCRIPTION
**Description**

Snyk IaC repo checks does not respect kustomizations, so it's not useful here.