### PR TITLE
l2geth: Add OVM ETH and message passer state dump

### DIFF
--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -18,6 +18,7 @@ package vm
 
 import (
 	"fmt"
+	"github.com/ethereum-optimism/optimism/l2geth/statedumper"
 	"math/big"
 	"sync/atomic"
 	"time"
@@ -198,6 +199,10 @@ func (evm *EVM) Interpreter() Interpreter {
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	if addr == dump.MessagePasserAddress {
+		statedumper.WriteMessage(caller.Address(), input)
+	}
+
 	if evm.vmConfig.NoRecursion && evm.depth > 0 {
 		return nil, gas, nil
 	}

--- a/l2geth/rollup/dump/constants.go
+++ b/l2geth/rollup/dump/constants.go
@@ -7,3 +7,4 @@ import (
 var OvmEthAddress = common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")
 var OvmFeeWallet = common.HexToAddress("0x4200000000000000000000000000000000000011")
 var OvmWhitelistAddress = common.HexToAddress("0x4200000000000000000000000000000000000002")
+var MessagePasserAddress = common.HexToAddress("0x4200000000000000000000000000000000000000")

--- a/l2geth/statedumper/dumper.go
+++ b/l2geth/statedumper/dumper.go
@@ -1,0 +1,74 @@
+package statedumper
+
+import (
+	"fmt"
+	"github.com/ethereum-optimism/optimism/l2geth/common"
+	"io"
+	"os"
+	"sync"
+)
+
+type StateDumper interface {
+	WriteETH(address common.Address)
+	WriteMessage(sender common.Address, msg []byte)
+}
+
+var DefaultStateDumper StateDumper
+
+func NewStateDumper() StateDumper {
+	path := os.Getenv("L2GETH_STATE_DUMP_PATH")
+	if path == "" {
+		return &noopStateDumper{}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE, 0o755)
+	if err != nil {
+		panic(err)
+	}
+
+	return &FileStateDumper{
+		f: f,
+	}
+}
+
+type FileStateDumper struct {
+	f   io.Writer
+	mtx sync.Mutex
+}
+
+func (s *FileStateDumper) WriteETH(address common.Address) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if _, err := s.f.Write([]byte(fmt.Sprintf("ETH|%s\n", address.Hex()))); err != nil {
+		panic(err)
+	}
+}
+
+func (s *FileStateDumper) WriteMessage(sender common.Address, msg []byte) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if _, err := s.f.Write([]byte(fmt.Sprintf("MSG|%s|%x\n", sender.Hex(), msg))); err != nil {
+		panic(err)
+	}
+}
+
+type noopStateDumper struct {
+}
+
+func (n *noopStateDumper) WriteETH(address common.Address) {
+}
+
+func (n *noopStateDumper) WriteMessage(sender common.Address, msg []byte) {
+}
+
+func init() {
+	DefaultStateDumper = NewStateDumper()
+}
+
+func WriteETH(address common.Address) {
+	DefaultStateDumper.WriteETH(address)
+}
+
+func WriteMessage(sender common.Address, msg []byte) {
+	DefaultStateDumper.WriteMessage(sender, msg)
+}


### PR DESCRIPTION
This is necessary in order to perform the mainnet OVM ETH and withdrawal hashes migration. Operates using a L2GETH_STATE_DUMP_PATH environment variable that specifies the file that addresses should be dump to. They are not deduplicated. The format of the file is:

```
ETH|<ovm eth address>
MSG|<sender>|<msg>
```