### PR TITLE
multi-arch docker images for amd64, arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
   docker-publish:
     environment:
       DOCKER_BUILDKIT: 1
+      DOCKER_PLATFORMS: linux/amd64,linux/arm64
     parameters:
       docker_tags:
         description: Docker image tags as csv
@@ -110,6 +111,9 @@ jobs:
       resource_class: xlarge
     steps:
       - gcp-oidc-authenticate
+      - run:
+          name: Authenticate docker with GCP
+          command: gcloud auth configure-docker us-central1-docker.pkg.dev
       # Below is CircleCI recommended way of specifying nameservers on an Ubuntu box:
       # https://support.circleci.com/hc/en-us/articles/7323511028251-How-to-set-custom-DNS-on-Ubuntu-based-images-using-netplan
       - run: sudo sed -i '13 i \ \ \ \ \ \ \ \ \ \ \ \ nameservers:' /etc/netplan/50-cloud-init.yaml
@@ -118,14 +122,20 @@ jobs:
       - run: cat /etc/netplan/50-cloud-init.yaml
       - run: sudo netplan apply
       - checkout
+      - run:
+          name: setup qemu
+          command: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run:
+          name: create builder
+          command: docker buildx create --name builder --use
       - when:
           condition: <<parameters.target>>
           steps:
             - run:
-                name: Build with context
+                name: Build multi-arch image with context and push
                 command: |
                   echo "$DOCKER_HUB_READ_ONLY_TOKEN" | docker login -u "$DOCKER_HUB_READ_ONLY_USER" --password-stdin
-                  docker build \
+                  docker buildx build --platform ${DOCKER_PLATFORMS} --push \
                   $(echo -ne "<< parameters.docker_tags >>" | sed "s/,/\n/g" | sed -e 's/^/-t /' | tr '\n' ' ') \
                   -f <<parameters.docker_file>> \
                   --target <<parameters.target>> \
@@ -134,18 +144,13 @@ jobs:
           condition: <<parameters.target>>
           steps:
             - run:
-                name: Build
+                name: Build multi-arch image and push
                 command: |
                   echo "$DOCKER_HUB_READ_ONLY_TOKEN" | docker login -u "$DOCKER_HUB_READ_ONLY_USER" --password-stdin
-                  docker build \
+                  docker buildx build --platform ${DOCKER_PLATFORMS} --push \
                   $(echo -ne "<< parameters.docker_tags >>" | sed "s/,/\n/g" | sed -e 's/^/-t /' | tr '\n' ' ') \
                   -f <<parameters.docker_file>> \
                   <<parameters.docker_context>>
-      - run:
-          name: Publish
-          command: |
-            gcloud auth configure-docker us-central1-docker.pkg.dev
-            docker push <<parameters.docker_tags>>
 
   contracts-bedrock-tests:
     docker:


### PR DESCRIPTION
**Description**

proof of concept for multi-arch images

test with:
```
docker pull us-central1-docker.pkg.dev/bedrock-goerli-development/images/op-proposer:9c165fd6c07e69d2f89a1d6cbffae0adc5f428f1

docker manifest inspect --verbose us-central1-docker.pkg.dev/bedrock-goerli-development/images/op-proposer:9c165fd6c07e69d2f89a1d6cbffae0adc5f428f1
```

output:
```
[
	{
	...
		"Descriptor": {
			"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
			"digest": "sha256:8f53fb085e27cd686789d03c56c4ccc5de65ad65e156681d009764561fa2a01b",
			"size": 740,
			"platform": {
				"architecture": "amd64",
				"os": "linux"
			}
		},
        ...
	},
	{
	...
		"Descriptor": {
			"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
			"digest": "sha256:bfdf06a2801fdc34713066ee1614cb9ca813ccea9ff16f19232ad27dcefd81da",
			"size": 740,
			"platform": {
				"architecture": "arm64",
				"os": "linux"
			}
		},
	...
]
```