### PR TITLE
op-node: fieldalignment

### DIFF
--- a/op-node/client/polling.go
+++ b/op-node/client/polling.go
@@ -21,21 +21,17 @@ var ErrSubscriberClosed = errors.New("subscriber closed")
 type PollingClient struct {
 	c        RPC
 	lgr      log.Logger
-	pollRate time.Duration
 	ctx      context.Context
 	cancel   context.CancelFunc
 	currHead *types.Header
-	subID    int
-
 	// pollReqCh is used to request new polls of the upstream
 	// RPC client.
 	pollReqCh chan struct{}
-
-	mtx sync.RWMutex
-
-	subs map[int]chan *types.Header
-
-	closedCh chan struct{}
+	subs      map[int]chan *types.Header
+	closedCh  chan struct{}
+	pollRate  time.Duration
+	subID     int
+	mtx       sync.RWMutex
 }
 
 type WrappedHTTPClientOption func(w *PollingClient)

--- a/op-node/eth/account_proof.go
+++ b/op-node/eth/account_proof.go
@@ -14,13 +14,12 @@ import (
 )
 
 type AccountResult struct {
+	Balance      *hexutil.Big    `json:"balance"`
 	AccountProof []hexutil.Bytes `json:"accountProof"`
-
-	Address     common.Address `json:"address"`
-	Balance     *hexutil.Big   `json:"balance"`
-	CodeHash    common.Hash    `json:"codeHash"`
-	Nonce       hexutil.Uint64 `json:"nonce"`
-	StorageHash common.Hash    `json:"storageHash"`
+	Nonce        hexutil.Uint64  `json:"nonce"`
+	CodeHash     common.Hash     `json:"codeHash"`
+	StorageHash  common.Hash     `json:"storageHash"`
+	Address      common.Address  `json:"address"`
 	// storageProof field is ignored, we only need to proof the account contents,
 	// we do not access any individual storage values.
 }

--- a/op-node/eth/types.go
+++ b/op-node/eth/types.go
@@ -128,22 +128,22 @@ type Data = hexutil.Bytes
 type PayloadID = beacon.PayloadID
 
 type ExecutionPayload struct {
-	ParentHash    common.Hash     `json:"parentHash"`
-	FeeRecipient  common.Address  `json:"feeRecipient"`
-	StateRoot     Bytes32         `json:"stateRoot"`
-	ReceiptsRoot  Bytes32         `json:"receiptsRoot"`
-	LogsBloom     Bytes256        `json:"logsBloom"`
-	PrevRandao    Bytes32         `json:"prevRandao"`
+	ExtraData BytesMax32 `json:"extraData"`
+	// Array of transaction objects, each object is a byte list (DATA) representing
+	// TransactionType || TransactionPayload or LegacyTransaction as defined in EIP-2718
+	Transactions  []Data          `json:"transactions"`
+	BaseFeePerGas Uint256Quantity `json:"baseFeePerGas"`
+	Timestamp     Uint64Quantity  `json:"timestamp"`
 	BlockNumber   Uint64Quantity  `json:"blockNumber"`
 	GasLimit      Uint64Quantity  `json:"gasLimit"`
 	GasUsed       Uint64Quantity  `json:"gasUsed"`
-	Timestamp     Uint64Quantity  `json:"timestamp"`
-	ExtraData     BytesMax32      `json:"extraData"`
-	BaseFeePerGas Uint256Quantity `json:"baseFeePerGas"`
+	LogsBloom     Bytes256        `json:"logsBloom"`
+	PrevRandao    Bytes32         `json:"prevRandao"`
+	ParentHash    common.Hash     `json:"parentHash"`
+	ReceiptsRoot  Bytes32         `json:"receiptsRoot"`
+	StateRoot     Bytes32         `json:"stateRoot"`
 	BlockHash     common.Hash     `json:"blockHash"`
-	// Array of transaction objects, each object is a byte list (DATA) representing
-	// TransactionType || TransactionPayload or LegacyTransaction as defined in EIP-2718
-	Transactions []Data `json:"transactions"`
+	FeeRecipient  common.Address  `json:"feeRecipient"`
 }
 
 func (payload *ExecutionPayload) ID() BlockID {
@@ -224,14 +224,14 @@ func BlockAsPayload(bl *types.Block) (*ExecutionPayload, error) {
 }
 
 type PayloadAttributes struct {
+	// Transactions to force into the block (always at the start of the transactions list).
+	Transactions []Data `json:"transactions,omitempty"`
 	// value for the timestamp field of the new payload
 	Timestamp Uint64Quantity `json:"timestamp"`
 	// value for the random field of the new payload
 	PrevRandao Bytes32 `json:"prevRandao"`
 	// suggested value for the coinbase field of the new payload
 	SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient"`
-	// Transactions to force into the block (always at the start of the transactions list).
-	Transactions []Data `json:"transactions,omitempty"`
 	// NoTxPool to disable adding any transactions from the transaction-pool.
 	NoTxPool bool `json:"noTxPool,omitempty"`
 }
@@ -255,12 +255,12 @@ const (
 )
 
 type PayloadStatusV1 struct {
-	// the result of the payload execution
-	Status ExecutePayloadStatus `json:"status"`
 	// the hash of the most recent valid block in the branch defined by payload and its ancestors (optional field)
 	LatestValidHash *common.Hash `json:"latestValidHash,omitempty"`
 	// additional details on the result (optional field)
 	ValidationError *string `json:"validationError,omitempty"`
+	// the result of the payload execution
+	Status ExecutePayloadStatus `json:"status"`
 }
 
 type ForkchoiceState struct {

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -14,29 +14,19 @@ import (
 type Config struct {
 	L1 L1EndpointSetup
 	L2 L2EndpointSetup
-
-	Driver driver.Config
-
-	Rollup rollup.Config
-
 	// P2PSigner will be used for signing off on published content
 	// if the node is sequencing and if the p2p stack is enabled
 	P2PSigner p2p.SignerSetup
-
-	RPC RPCConfig
-
-	P2P p2p.SetupP2P
-
-	Metrics MetricsConfig
-
-	Pprof PprofConfig
-
+	P2P       p2p.SetupP2P
+	Tracer    Tracer // Optional
+	Pprof     PprofConfig
+	Heartbeat HeartbeatConfig // Optional
+	Metrics   MetricsConfig
+	RPC       RPCConfig
+	Rollup    rollup.Config
+	Driver    driver.Config
 	// Used to poll the L1 for new finalized or safe blocks
 	L1EpochPollInterval time.Duration
-
-	// Optional
-	Tracer    Tracer
-	Heartbeat HeartbeatConfig
 }
 
 type RPCConfig struct {
@@ -50,9 +40,9 @@ func (cfg *RPCConfig) HttpEndpoint() string {
 }
 
 type MetricsConfig struct {
-	Enabled    bool
 	ListenAddr string
 	ListenPort int
+	Enabled    bool
 }
 
 func (m MetricsConfig) Check() error {
@@ -68,9 +58,9 @@ func (m MetricsConfig) Check() error {
 }
 
 type PprofConfig struct {
-	Enabled    bool
 	ListenAddr string
 	ListenPort string
+	Enabled    bool
 }
 
 func (p PprofConfig) Check() error {
@@ -78,9 +68,9 @@ func (p PprofConfig) Check() error {
 }
 
 type HeartbeatConfig struct {
-	Enabled bool
 	Moniker string
 	URL     string
+	Enabled bool
 }
 
 // Check verifies that the given configuration makes sense

--- a/op-node/node/log.go
+++ b/op-node/node/log.go
@@ -12,8 +12,8 @@ import (
 
 type LogConfig struct {
 	Level  string // Log level: trace, debug, info, warn, error, crit. Capitals are accepted too.
-	Color  bool   // Color the log output. Defaults to true if terminal is detected.
 	Format string // Format the log output. Supported formats: 'text', 'json'
+	Color  bool   // Color the log output. Defaults to true if terminal is detected.
 }
 
 func DefaultLogConfig() LogConfig {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -21,26 +21,23 @@ import (
 )
 
 type OpNode struct {
-	log        log.Logger
-	appVersion string
-	metrics    *metrics.Metrics
-
-	l1HeadsSub     ethereum.Subscription // Subscription to get L1 heads (automatically re-subscribes on error)
-	l1SafeSub      ethereum.Subscription // Subscription to get L1 safe blocks, a.k.a. justified data (polling)
-	l1FinalizedSub ethereum.Subscription // Subscription to get L1 safe blocks, a.k.a. justified data (polling)
-
-	l1Source  *sources.L1Client     // L1 Client to fetch data from
-	l2Driver  *driver.Driver        // L2 Engine to Sync
-	l2Source  *sources.EngineClient // L2 Execution Engine RPC bindings
-	server    *rpcServer            // RPC server hosting the rollup-node API
-	p2pNode   *p2p.NodeP2P          // P2P node functionality
-	p2pSigner p2p.Signer            // p2p gogssip application messages will be signed with this signer
-	tracer    Tracer                // tracer to get events for testing/debugging
-
+	p2pSigner p2p.Signer // p2p gogssip application messages will be signed with this signer
 	// some resources cannot be stopped directly, like the p2p gossipsub router (not our design),
 	// and depend on this ctx to be closed.
 	resourcesCtx   context.Context
+	tracer         Tracer                // tracer to get events for testing/debugging
+	l1HeadsSub     ethereum.Subscription // Subscription to get L1 heads (automatically re-subscribes on error)
+	l1SafeSub      ethereum.Subscription // Subscription to get L1 safe blocks, a.k.a. justified data (polling)
+	l1FinalizedSub ethereum.Subscription // Subscription to get L1 safe blocks, a.k.a. justified data (polling)
+	log            log.Logger
+	l1Source       *sources.L1Client     // L1 Client to fetch data from
+	l2Source       *sources.EngineClient // L2 Execution Engine RPC bindings
+	server         *rpcServer            // RPC server hosting the rollup-node API
+	p2pNode        *p2p.NodeP2P          // P2P node functionality
+	l2Driver       *driver.Driver        // L2 Engine to Sync
+	metrics        *metrics.Metrics
 	resourcesClose context.CancelFunc
+	appVersion     string
 }
 
 // The OpNode handles incoming gossip

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -19,13 +19,13 @@ import (
 // TODO(inphi): add metrics
 
 type rpcServer struct {
-	endpoint   string
-	apis       []rpc.API
-	httpServer *http.Server
-	appVersion string
+	sources.L2Client
 	listenAddr net.Addr
 	log        log.Logger
-	sources.L2Client
+	httpServer *http.Server
+	endpoint   string
+	appVersion string
+	apis       []rpc.API
 }
 
 func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, appVersion string, m *metrics.Metrics) (*rpcServer, error) {

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -50,47 +50,35 @@ type SetupP2P interface {
 // Config sets up a p2p host and discv5 service from configuration.
 // This implements SetupP2P.
 type Config struct {
-	Priv *crypto.Secp256k1PrivateKey
-
-	DisableP2P  bool
-	NoDiscovery bool
-
-	ListenIP      net.IP
-	ListenTCPPort uint16
-
-	// Port to bind discv5 to
-	ListenUDPPort uint16
-
-	AdvertiseIP      net.IP
-	AdvertiseTCPPort uint16
-	AdvertiseUDPPort uint16
-	Bootnodes        []*enode.Node
-	DiscoveryDB      *enode.DB
-
-	StaticPeers []core.Multiaddr
-
-	HostMux             []lconf.MsMuxC
-	HostSecurity        []lconf.MsSecC
-	NoTransportSecurity bool
-
-	PeersLo    uint
-	PeersHi    uint
-	PeersGrace time.Duration
-
-	// If true a NAT manager will host a NAT port mapping that is updated with PMP and UPNP by libp2p/go-nat
-	NAT bool
-
-	UserAgent string
-
-	TimeoutNegotiation time.Duration
-	TimeoutAccept      time.Duration
-	TimeoutDial        time.Duration
-
 	// Underlying store that hosts connection-gater and peerstore data.
-	Store ds.Batching
-
-	ConnGater func(conf *Config) (connmgr.ConnectionGater, error)
-	ConnMngr  func(conf *Config) (connmgr.ConnManager, error)
+	Store              ds.Batching
+	DiscoveryDB        *enode.DB
+	ConnMngr           func(conf *Config) (connmgr.ConnManager, error)
+	ConnGater          func(conf *Config) (connmgr.ConnectionGater, error)
+	Priv               *crypto.Secp256k1PrivateKey
+	UserAgent          string
+	HostMux            []lconf.MsMuxC
+	HostSecurity       []lconf.MsSecC
+	ListenIP           net.IP
+	Bootnodes          []*enode.Node
+	AdvertiseIP        net.IP
+	StaticPeers        []core.Multiaddr
+	PeersLo            uint
+	TimeoutDial        time.Duration
+	TimeoutAccept      time.Duration
+	TimeoutNegotiation time.Duration
+	PeersHi            uint
+	PeersGrace         time.Duration
+	ListenTCPPort      uint16
+	AdvertiseTCPPort   uint16
+	// Port to bind discv5 to
+	ListenUDPPort    uint16
+	AdvertiseUDPPort uint16
+	// If true a NAT manager will host a NAT port mapping that is updated with PMP and UPNP by libp2p/go-nat
+	NAT                 bool
+	NoTransportSecurity bool
+	NoDiscovery         bool
+	DisableP2P          bool
 }
 
 type ConnectionGater interface {

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -168,8 +168,8 @@ func logValidationResult(self peer.ID, msg string, log log.Logger, fn pubsub.Val
 }
 
 type seenBlocks struct {
-	sync.Mutex
 	blockHashes []common.Hash
+	sync.Mutex
 }
 
 // hasSeen checks if the hash has been marked as seen, and how many have been seen.

--- a/op-node/p2p/rpc_api.go
+++ b/op-node/p2p/rpc_api.go
@@ -12,30 +12,29 @@ import (
 )
 
 type PeerInfo struct {
-	PeerID          peer.ID  `json:"peerID"`
-	NodeID          enode.ID `json:"nodeID"`
-	UserAgent       string   `json:"userAgent"`
-	ProtocolVersion string   `json:"protocolVersion"`
-	ENR             string   `json:"ENR"`       // might not always be known, e.g. if the peer connected us instead of us discovering them
-	Addresses       []string `json:"addresses"` // multi-addresses. may be mix of LAN / docker / external IPs. All of them are communicated.
-	Protocols       []string `json:"protocols"` // negotiated protocols list
+	ENR             string                `json:"ENR"` // might not always be known, e.g. if the peer connected us instead of us discovering them
+	PeerID          peer.ID               `json:"peerID"`
+	UserAgent       string                `json:"userAgent"`
+	ProtocolVersion string                `json:"protocolVersion"`
+	Protocols       []string              `json:"protocols"`     // negotiated protocols list
+	Addresses       []string              `json:"addresses"`     // multi-addresses. may be mix of LAN / docker / external IPs. All of them are communicated.
+	Connectedness   network.Connectedness `json:"connectedness"` // "NotConnected", "Connected", "CanConnect" (gracefully disconnected), or "CannotConnect" (tried but failed)
+	Direction       network.Direction     `json:"direction"`     // "Unknown", "Inbound" (if the peer contacted us), "Outbound" (if we connected to them)
+	ChainID         uint64                `json:"chainID"`       // some peers might try to connect, but we figure out they are on a different chain later. This may be 0 if the peer is not an optimism node at all.
+	Latency         time.Duration         `json:"latency"`
+	NodeID          enode.ID              `json:"nodeID"`
+	Protected       bool                  `json:"protected"`    // Protected peers do not get
+	GossipBlocks    bool                  `json:"gossipBlocks"` // if the peer is in our gossip topic
 	//GossipScore float64
 	//PeerScore float64
-	Connectedness network.Connectedness `json:"connectedness"` // "NotConnected", "Connected", "CanConnect" (gracefully disconnected), or "CannotConnect" (tried but failed)
-	Direction     network.Direction     `json:"direction"`     // "Unknown", "Inbound" (if the peer contacted us), "Outbound" (if we connected to them)
-	Protected     bool                  `json:"protected"`     // Protected peers do not get
-	ChainID       uint64                `json:"chainID"`       // some peers might try to connect, but we figure out they are on a different chain later. This may be 0 if the peer is not an optimism node at all.
-	Latency       time.Duration         `json:"latency"`
-
-	GossipBlocks bool `json:"gossipBlocks"` // if the peer is in our gossip topic
 }
 
 type PeerDump struct {
-	TotalConnected uint                 `json:"totalConnected"`
 	Peers          map[string]*PeerInfo `json:"peers"`
 	BannedPeers    []peer.ID            `json:"bannedPeers"`
 	BannedIPS      []net.IP             `json:"bannedIPS"`
 	BannedSubnets  []*net.IPNet         `json:"bannedSubnets"`
+	TotalConnected uint                 `json:"totalConnected"`
 }
 
 type API interface {

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -34,12 +34,12 @@ const (
 )
 
 type BatchV1 struct {
-	ParentHash common.Hash  // parent L2 block hash
-	EpochNum   rollup.Epoch // aka l1 num
-	EpochHash  common.Hash  // block hash
-	Timestamp  uint64
 	// no feeRecipient address input, all fees go to a L2 contract
 	Transactions []hexutil.Bytes
+	EpochNum     rollup.Epoch // aka l1 num
+	Timestamp    uint64
+	ParentHash   common.Hash // parent L2 block hash
+	EpochHash    common.Hash // block hash
 }
 
 type BatchData struct {

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -35,14 +35,12 @@ type NextBatchProvider interface {
 // L1 blocks are contiguous and this does not support reorgs.
 type BatchQueue struct {
 	log    log.Logger
-	config *rollup.Config
 	prev   NextBatchProvider
-	origin eth.L1BlockRef
-
-	l1Blocks []eth.L1BlockRef
-
+	config *rollup.Config
 	// batches in order of when we've first seen them, grouped by L2 timestamp
-	batches map[uint64][]*BatchWithL1InclusionBlock
+	batches  map[uint64][]*BatchWithL1InclusionBlock
+	l1Blocks []eth.L1BlockRef
+	origin   eth.L1BlockRef
 }
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -8,8 +8,8 @@ import (
 )
 
 type BatchWithL1InclusionBlock struct {
-	L1InclusionBlock eth.L1BlockRef
 	Batch            *BatchData
+	L1InclusionBlock eth.L1BlockRef
 }
 
 type BatchValidity uint8

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -44,14 +44,12 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, id eth.BlockID) DataI
 // The constructor will never fail & it will instead re-attempt the fetcher
 // at a later point.
 type DataSource struct {
-	// Internal state + data
-	open bool
-	data []eth.Data
-	// Required to re-attempt fetching
-	id      eth.BlockID
-	cfg     *rollup.Config // TODO: `DataFromEVMTransactions` should probably not take the full config
 	fetcher L1TransactionFetcher
 	log     log.Logger
+	cfg     *rollup.Config // TODO: `DataFromEVMTransactions` should probably not take the full config
+	data    []eth.Data
+	id      eth.BlockID
+	open    bool
 }
 
 // NewDataSource creates a new calldata source. It suppresses errors in fetching the L1 block if they occur.

--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -18,16 +18,12 @@ import (
 // Each frame is ingested one by one. Once a frame with `closed` is added to the channel, the
 // channel may mark itself as ready for reading once all intervening frames have been added
 type Channel struct {
-	// id of the channel
-	id        ChannelID
-	openBlock eth.L1BlockRef
-
+	// Store a map of frame number -> frame data for constant time ordering
+	inputs                  map[uint64][]byte
+	openBlock               eth.L1BlockRef
+	highestL1InclusionBlock eth.L1BlockRef
 	// estimated memory size, used to drop the channel if we have too much data
 	size uint64
-
-	// true if we have buffered the last frame
-	closed bool
-
 	// TODO: implement this check
 	// highestFrameNumber is the highest frame number yet seen.
 	// This must be equal to `endFrameNumber`
@@ -36,11 +32,10 @@ type Channel struct {
 	// endFrameNumber is the frame number of the frame where `isLast` is true
 	// No other frame number must be larger than this.
 	endFrameNumber uint16
-
-	// Store a map of frame number -> frame data for constant time ordering
-	inputs map[uint64][]byte
-
-	highestL1InclusionBlock eth.L1BlockRef
+	// id of the channel
+	id ChannelID
+	// true if we have buffered the last frame
+	closed bool
 }
 
 func NewChannel(id ChannelID, openBlock eth.L1BlockRef) *Channel {

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -28,14 +28,12 @@ type NextDataProvider interface {
 
 // ChannelBank buffers channel frames, and emits full channel data
 type ChannelBank struct {
-	log log.Logger
-	cfg *rollup.Config
-
+	log          log.Logger
+	prev         NextDataProvider
+	fetcher      L1Fetcher
+	cfg          *rollup.Config
 	channels     map[ChannelID]*Channel // channels by ID
 	channelQueue []ChannelID            // channels in FIFO order
-
-	prev    NextDataProvider
-	fetcher L1Fetcher
 }
 
 var _ ResetableStage = (*ChannelBank)(nil)

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -18,18 +18,16 @@ var ErrNotDepositTx = errors.New("first transaction in block is not a deposit tx
 var ErrTooManyRLPBytes = errors.New("batch would cause RLP bytes to go over limit")
 
 type ChannelOut struct {
-	id ChannelID
-	// Frame ID of the next frame to emit. Increment after emitting
-	frame uint64
-	// rlpLength is the uncompressed size of the channel. Must be less than MAX_RLP_BYTES_PER_CHANNEL
-	rlpLength int
-
 	// Compressor stage. Write input data to it
 	compress *zlib.Writer
 	// post compression buffer
 	buf bytes.Buffer
-
-	closed bool
+	// Frame ID of the next frame to emit. Increment after emitting
+	frame uint64
+	// rlpLength is the uncompressed size of the channel. Must be less than MAX_RLP_BYTES_PER_CHANNEL
+	rlpLength int
+	id        ChannelID
+	closed    bool
 }
 
 func (co *ChannelOut) ID() ChannelID {

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -60,28 +60,21 @@ type FinalityData struct {
 
 // EngineQueue queues up payload attributes to consolidate or process with the provided Engine
 type EngineQueue struct {
-	log log.Logger
-	cfg *rollup.Config
-
-	finalized  eth.L2BlockRef
-	safeHead   eth.L2BlockRef
-	unsafeHead eth.L2BlockRef
-
-	finalizedL1 eth.BlockID
-
-	safeAttributes []*eth.PayloadAttributes
 	unsafePayloads PayloadsQueue // queue of unsafe payloads, ordered by ascending block number, may have gaps
-
+	l1Fetcher      L1Fetcher
+	metrics        Metrics
+	prev           NextAttributesProvider
+	engine         Engine
+	log            log.Logger
+	cfg            *rollup.Config
+	safeAttributes []*eth.PayloadAttributes
 	// Tracks which L2 blocks where last derived from which L1 block. At most finalityLookback large.
 	finalityData []FinalityData
-
-	engine Engine
-	prev   NextAttributesProvider
-
-	origin eth.L1BlockRef // only used for pipeline resets
-
-	metrics   Metrics
-	l1Fetcher L1Fetcher
+	unsafeHead   eth.L2BlockRef
+	safeHead     eth.L2BlockRef
+	finalized    eth.L2BlockRef
+	origin       eth.L1BlockRef // only used for pipeline resets
+	finalizedL1  eth.BlockID
 }
 
 // NewEngineQueue creates a new EngineQueue, which should be Reset(origin) before use.

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -24,9 +24,9 @@ const MaxFrameLen = 1_000_000
 // is_last           = bool
 
 type Frame struct {
-	ID          ChannelID
-	FrameNumber uint16
 	Data        []byte
+	FrameNumber uint16
+	ID          ChannelID
 	IsLast      bool
 }
 

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -22,13 +22,13 @@ var (
 
 // L1BlockInfo presents the information stored in a L1Block.setL1BlockValues call
 type L1BlockInfo struct {
-	Number    uint64
-	Time      uint64
-	BaseFee   *big.Int
-	BlockHash common.Hash
+	BaseFee *big.Int
+	Number  uint64
+	Time    uint64
 	// Not strictly a piece of L1 information. Represents the number of L2 blocks since the start of the epoch,
 	// i.e. when the actual L1 info was first introduced.
 	SequenceNumber uint64
+	BlockHash      common.Hash
 }
 
 func (info *L1BlockInfo) MarshalBinary() ([]byte, error) {

--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -18,10 +18,10 @@ type L1BlockRefByNumberFetcher interface {
 }
 
 type L1Traversal struct {
-	block    eth.L1BlockRef
-	done     bool
 	l1Blocks L1BlockRefByNumberFetcher
 	log      log.Logger
+	block    eth.L1BlockRef
+	done     bool
 }
 
 var _ ResetableStage = (*L1Traversal)(nil)

--- a/op-node/rollup/derive/payloads_queue.go
+++ b/op-node/rollup/derive/payloads_queue.go
@@ -74,10 +74,10 @@ func payloadMemSize(p *eth.ExecutionPayload) uint64 {
 // When the size grows too large, the first (lowest block-number) payload is removed from the queue.
 // PayloadsQueue allows entries with same block number, or even full duplicates.
 type PayloadsQueue struct {
+	SizeFn      func(p *eth.ExecutionPayload) uint64
 	pq          payloadsByNumber
 	currentSize uint64
 	MaxSize     uint64
-	SizeFn      func(p *eth.ExecutionPayload) uint64
 }
 
 func (upq *PayloadsQueue) Len() int {

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -45,19 +45,16 @@ type EngineQueueStage interface {
 // DerivationPipeline is updated with new L1 data, and the Step() function can be iterated on to keep the L2 Engine in sync.
 type DerivationPipeline struct {
 	log       log.Logger
-	cfg       *rollup.Config
 	l1Fetcher L1Fetcher
-
+	eng       EngineQueueStage
+	metrics   Metrics
+	cfg       *rollup.Config
+	// Special stages to keep track of
+	traversal *L1Traversal
+	stages    []ResetableStage
 	// Index of the stage that is currently being reset.
 	// >= len(stages) if no additional resetting is required
 	resetting int
-	stages    []ResetableStage
-
-	// Special stages to keep track of
-	traversal *L1Traversal
-	eng       EngineQueueStage
-
-	metrics Metrics
 }
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -20,6 +20,10 @@ type Genesis struct {
 }
 
 type Config struct {
+	// Required to verify L1 signatures
+	L1ChainID *big.Int `json:"l1_chain_id"`
+	// Required to identify the L2 network and create p2p signatures unique for this chain.
+	L2ChainID *big.Int `json:"l2_chain_id"`
 	// Genesis anchor point of the rollup
 	Genesis Genesis `json:"genesis"`
 	// Seconds per L2 block
@@ -34,14 +38,8 @@ type Config struct {
 	SeqWindowSize uint64 `json:"seq_window_size"`
 	// Number of L1 blocks between when a channel can be opened and when it must be closed by.
 	ChannelTimeout uint64 `json:"channel_timeout"`
-	// Required to verify L1 signatures
-	L1ChainID *big.Int `json:"l1_chain_id"`
-	// Required to identify the L2 network and create p2p signatures unique for this chain.
-	L2ChainID *big.Int `json:"l2_chain_id"`
-
 	// Address of the key the sequencer uses to sign blocks on the P2P layer
 	P2PSequencerAddress common.Address `json:"p2p_sequencer_address"`
-
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
 

--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -16,20 +16,16 @@ import (
 // and enable the caller to parallelize easily and safely, handle and re-try errors,
 // and pick a batch size all by simply calling Fetch again and again until it returns io.EOF.
 type IterativeBatchCall[K any, V any, O any] struct {
-	completed uint32       // tracks how far to completing all requests we are
-	resetLock sync.RWMutex // ensures we do not concurrently read (incl. fetch) / reset
-
-	requestsKeys []K
-	batchSize    int
-
-	makeRequest func(K) (V, rpc.BatchElem)
-	makeResults func([]K, []V) (O, error)
-	getBatch    BatchCallContextFn
-
-	requestsValues []V
+	makeRequest    func(K) (V, rpc.BatchElem)
+	makeResults    func([]K, []V) (O, error)
+	getBatch       BatchCallContextFn
 	scheduled      chan rpc.BatchElem
-
-	results *O
+	results        *O
+	requestsKeys   []K
+	requestsValues []V
+	batchSize      int
+	resetLock      sync.RWMutex // ensures we do not concurrently read (incl. fetch) / reset
+	completed      uint32       // tracks how far to completing all requests we are
 }
 
 // NewIterativeBatchCall constructs a batch call, fetching the values with the given keys,

--- a/op-node/sources/caching/cache.go
+++ b/op-node/sources/caching/cache.go
@@ -10,8 +10,8 @@ type Metrics interface {
 // LRUCache wraps hashicorp *lru.Cache and tracks cache metrics
 type LRUCache struct {
 	m     Metrics
-	label string
 	inner *lru.Cache
+	label string
 }
 
 func (c *LRUCache) Get(key any) (value any, ok bool) {

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -71,31 +71,23 @@ func (c *EthClientConfig) Check() error {
 // EthClient retrieves ethereum data with optimized batch requests, cached results, and flag to not trust the RPC.
 type EthClient struct {
 	client client.RPC
-
-	maxBatchSize int
-
-	trustRPC bool
-
-	mustBePostMerge bool
-
-	log log.Logger
-
+	log    log.Logger
 	// cache receipts in bundles per block hash
 	// We cache the receipts fetcher to not lose progress when we have to retry the `Fetch` call
 	// common.Hash -> eth.ReceiptsFetcher
 	receiptsCache *caching.LRUCache
-
 	// cache transactions in bundles per block hash
 	// common.Hash -> types.Transactions
 	transactionsCache *caching.LRUCache
-
 	// cache block headers of blocks by hash
 	// common.Hash -> *HeaderInfo
 	headersCache *caching.LRUCache
-
 	// cache payloads by hash
 	// common.Hash -> *eth.ExecutionPayload
-	payloadsCache *caching.LRUCache
+	payloadsCache   *caching.LRUCache
+	maxBatchSize    int
+	trustRPC        bool
+	mustBePostMerge bool
 }
 
 // NewEthClient wraps a RPC with bindings to fetch ethereum data,

--- a/op-node/sources/types.go
+++ b/op-node/sources/types.go
@@ -32,16 +32,16 @@ type BatchCallContextFn func(ctx context.Context, b []rpc.BatchElem) error
 // HeaderInfo contains all the header-info required to implement the eth.BlockInfo interface,
 // used in the rollup state-transition, with pre-computed block hash.
 type HeaderInfo struct {
-	hash        common.Hash
-	parentHash  common.Hash
-	coinbase    common.Address
-	root        common.Hash
+	baseFee     *big.Int
 	number      uint64
 	time        uint64
+	hash        common.Hash
+	parentHash  common.Hash
+	root        common.Hash
 	mixDigest   common.Hash // a.k.a. the randomness field post-merge.
-	baseFee     *big.Int
 	txHash      common.Hash
 	receiptHash common.Hash
+	coinbase    common.Address
 }
 
 var _ eth.BlockInfo = (*HeaderInfo)(nil)
@@ -87,27 +87,25 @@ func (info *HeaderInfo) ReceiptHash() common.Hash {
 }
 
 type rpcHeader struct {
-	ParentHash  common.Hash      `json:"parentHash"`
-	UncleHash   common.Hash      `json:"sha3Uncles"`
-	Coinbase    common.Address   `json:"miner"`
-	Root        common.Hash      `json:"stateRoot"`
-	TxHash      common.Hash      `json:"transactionsRoot"`
-	ReceiptHash common.Hash      `json:"receiptsRoot"`
-	Bloom       eth.Bytes256     `json:"logsBloom"`
-	Difficulty  hexutil.Big      `json:"difficulty"`
-	Number      hexutil.Uint64   `json:"number"`
-	GasLimit    hexutil.Uint64   `json:"gasLimit"`
-	GasUsed     hexutil.Uint64   `json:"gasUsed"`
-	Time        hexutil.Uint64   `json:"timestamp"`
-	Extra       hexutil.Bytes    `json:"extraData"`
-	MixDigest   common.Hash      `json:"mixHash"`
-	Nonce       types.BlockNonce `json:"nonce"`
-
 	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
-	BaseFee *hexutil.Big `json:"baseFeePerGas" rlp:"optional"`
-
+	BaseFee     *hexutil.Big   `json:"baseFeePerGas" rlp:"optional"`
+	Difficulty  hexutil.Big    `json:"difficulty"`
+	Extra       hexutil.Bytes  `json:"extraData"`
+	Number      hexutil.Uint64 `json:"number"`
+	GasLimit    hexutil.Uint64 `json:"gasLimit"`
+	Time        hexutil.Uint64 `json:"timestamp"`
+	GasUsed     hexutil.Uint64 `json:"gasUsed"`
+	Bloom       eth.Bytes256   `json:"logsBloom"`
+	Root        common.Hash    `json:"stateRoot"`
+	ParentHash  common.Hash    `json:"parentHash"`
+	TxHash      common.Hash    `json:"transactionsRoot"`
+	ReceiptHash common.Hash    `json:"receiptsRoot"`
+	MixDigest   common.Hash    `json:"mixHash"`
+	UncleHash   common.Hash    `json:"sha3Uncles"`
 	// untrusted info included by RPC, may have to be checked
-	Hash common.Hash `json:"hash"`
+	Hash     common.Hash      `json:"hash"`
+	Coinbase common.Address   `json:"miner"`
+	Nonce    types.BlockNonce `json:"nonce"`
 }
 
 // checkPostMerge checks that the block header meets all criteria to be a valid ExecutionPayloadHeader,
@@ -183,8 +181,8 @@ func (hdr *rpcHeader) Info(trustCache bool, mustBePostMerge bool) (*HeaderInfo, 
 }
 
 type rpcBlock struct {
-	rpcHeader
 	Transactions []*types.Transaction `json:"transactions"`
+	rpcHeader
 }
 
 func (block *rpcBlock) verify() error {

--- a/op-node/testlog/testlog.go
+++ b/op-node/testlog/testlog.go
@@ -60,8 +60,8 @@ type logger struct {
 }
 
 type bufHandler struct {
-	buf []*log.Record
 	fmt log.Format
+	buf []*log.Record
 }
 
 func (h *bufHandler) Log(r *log.Record) error {

--- a/op-node/testutils/fake_chain.go
+++ b/op-node/testutils/fake_chain.go
@@ -83,17 +83,17 @@ func NewFakeChainSource(l1 []string, l2 []string, l1GenesisNumber int, log log.L
 // what the head block is of the L1 and L2 chains. In addition, it enables re-orgs
 // to easily be implemented
 type FakeChainSource struct {
-	l1reorg     int // Index of the L1 chain to be operating on
-	l2reorg     int // Index of the L2 chain to be operating on
-	l1head      int // Head block of the L1 chain
-	l2head      int // Head block of the L2 chain
+	log         log.Logger
+	l1s         [][]eth.L1BlockRef // l1s[reorg] is the L1 chain in that specific re-org configuration
+	l2s         [][]eth.L2BlockRef // l2s[reorg] is the L2 chain in that specific re-org configuration
+	l1reorg     int                // Index of the L1 chain to be operating on
+	l2reorg     int                // Index of the L2 chain to be operating on
+	l1head      int                // Head block of the L1 chain
+	l2head      int                // Head block of the L2 chain
 	l1safe      int
 	l2safe      int
 	l1finalized int
 	l2finalized int
-	l1s         [][]eth.L1BlockRef // l1s[reorg] is the L1 chain in that specific re-org configuration
-	l2s         [][]eth.L2BlockRef // l2s[reorg] is the L2 chain in that specific re-org configuration
-	log         log.Logger
 }
 
 func (m *FakeChainSource) L1Range(ctx context.Context, base eth.BlockID, max uint64) ([]eth.BlockID, error) {

--- a/op-node/testutils/l1info.go
+++ b/op-node/testutils/l1info.go
@@ -11,16 +11,15 @@ import (
 
 type MockBlockInfo struct {
 	// Prefixed all fields with "Info" to avoid collisions with the interface method names.
-
-	InfoHash        common.Hash
-	InfoParentHash  common.Hash
-	InfoCoinbase    common.Address
-	InfoRoot        common.Hash
+	InfoBaseFee     *big.Int
 	InfoNum         uint64
 	InfoTime        uint64
+	InfoHash        common.Hash
+	InfoParentHash  common.Hash
+	InfoRoot        common.Hash
 	InfoMixDigest   [32]byte
-	InfoBaseFee     *big.Int
 	InfoReceiptRoot common.Hash
+	InfoCoinbase    common.Address
 }
 
 func (l *MockBlockInfo) Hash() common.Hash {

--- a/op-node/withdrawals/utils.go
+++ b/op-node/withdrawals/utils.go
@@ -150,14 +150,14 @@ func NewClient(client *rpc.Client) *Client {
 // FinalizedWithdrawalParameters is the set of parameters to pass to the FinalizedWithdrawal function
 type FinalizedWithdrawalParameters struct {
 	Nonce           *big.Int
-	Sender          common.Address
-	Target          common.Address
 	Value           *big.Int
 	GasLimit        *big.Int
 	BlockNumber     *big.Int
 	Data            []byte
-	OutputRootProof bindings.TypesOutputRootProof
 	WithdrawalProof [][]byte // List of trie nodes to prove L2 storage
+	OutputRootProof bindings.TypesOutputRootProof
+	Sender          common.Address
+	Target          common.Address
 }
 
 // FinalizeWithdrawalParameters queries L2 to generate all withdrawal parameters and proof necessary to finalize an withdrawal on L1.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Order fields in structs to reduce memory consumption

**Additional context**

Used `fieldalignment` and had to re-add comments in fields. 
For some large (or huge 😛 ) structs readability is reduced, so I'd like feedback if this makes sense or feels like premature optimization.

```
➜  op-node git:(develop) ✗ fieldalignment -fix ./...
/Users/estensen/Developer/optimism/op-node/eth/account_proof.go:16:20: struct with 56 pointer bytes could be 16
/Users/estensen/Developer/optimism/op-node/eth/types.go:130:23: struct with 536 pointer bytes could be 32
/Users/estensen/Developer/optimism/op-node/eth/types.go:226:24: struct of size 96 could be 88
/Users/estensen/Developer/optimism/op-node/eth/types.go:257:22: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/client/polling.go:21:20: struct with 128 pointer bytes could be 88
/Users/estensen/Developer/optimism/op-node/rollup/types.go:22:13: struct with 136 pointer bytes could be 16
/Users/estensen/Developer/optimism/op-node/p2p/config.go:52:13: struct of size 296 could be 272
/Users/estensen/Developer/optimism/op-node/p2p/gossip.go:170:17: struct with 16 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/p2p/rpc_api.go:14:15: struct of size 192 could be 184
/Users/estensen/Developer/optimism/op-node/p2p/rpc_api.go:33:15: struct with 72 pointer bytes could be 64
/Users/estensen/Developer/optimism/op-node/rollup/derive/batch.go:36:14: struct with 88 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/rollup/derive/batch_queue.go:36:17: struct with 152 pointer bytes could be 56
/Users/estensen/Developer/optimism/op-node/rollup/derive/batches.go:10:32: struct with 88 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/rollup/derive/calldata_source.go:46:17: struct with 112 pointer bytes could be 48
/Users/estensen/Developer/optimism/op-node/rollup/derive/channel.go:20:14: struct with 120 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/rollup/derive/channel_bank.go:30:18: struct with 88 pointer bytes could be 72
/Users/estensen/Developer/optimism/op-node/rollup/derive/channel_out.go:20:17: struct with 48 pointer bytes could be 16
/Users/estensen/Developer/optimism/op-node/rollup/derive/engine_queue.go:62:18: struct with 688 pointer bytes could be 168
/Users/estensen/Developer/optimism/op-node/rollup/derive/frame.go:26:12: struct of size 56 could be 48
/Users/estensen/Developer/optimism/op-node/rollup/derive/l1_block_info.go:24:18: struct with 24 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/rollup/derive/l1_traversal.go:20:18: struct with 120 pointer bytes could be 32
/Users/estensen/Developer/optimism/op-node/rollup/derive/payloads_queue.go:76:20: struct with 48 pointer bytes could be 16
/Users/estensen/Developer/optimism/op-node/rollup/derive/pipeline.go:46:25: struct with 112 pointer bytes could be 88
/Users/estensen/Developer/optimism/op-node/rollup/driver/state.go:23:13: struct with 240 pointer bytes could be 232
/Users/estensen/Developer/optimism/op-node/sources/caching/cache.go:11:15: struct with 40 pointer bytes could be 32
/Users/estensen/Developer/optimism/op-node/sources/batching.go:18:46: struct with 128 pointer bytes could be 72
/Users/estensen/Developer/optimism/op-node/sources/eth_client.go:72:16: struct with 80 pointer bytes could be 64
/Users/estensen/Developer/optimism/op-node/sources/types.go:34:17: struct with 176 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/sources/types.go:89:16: struct with 576 pointer bytes could be 48
/Users/estensen/Developer/optimism/op-node/sources/types.go:185:15: struct with 616 pointer bytes could be 600
/Users/estensen/Developer/optimism/op-node/node/config.go:14:13: struct with 488 pointer bytes could be 360
/Users/estensen/Developer/optimism/op-node/node/config.go:52:20: struct with 16 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/node/config.go:70:18: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/node/config.go:80:22: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/node/log.go:13:16: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/node/node.go:23:13: struct with 184 pointer bytes could be 176
/Users/estensen/Developer/optimism/op-node/node/server.go:21:16: struct with 120 pointer bytes could be 104
/Users/estensen/Developer/optimism/op-node/testlog/testlog.go:62:17: struct with 40 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/testutils/fake_chain.go:85:22: struct with 128 pointer bytes could be 48
/Users/estensen/Developer/optimism/op-node/testutils/l1info.go:12:20: struct with 176 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/withdrawals/utils.go:151:36: struct with 232 pointer bytes could be 64
/Users/estensen/Developer/optimism/op-node/client/polling_test.go:27:17: struct with 48 pointer bytes could be 16
/Users/estensen/Developer/optimism/op-node/rollup/derive/batch_queue_test.go:20:26: struct with 40 pointer bytes could be 32
/Users/estensen/Developer/optimism/op-node/rollup/derive/batches_test.go:19:25: struct with 256 pointer bytes could be 112
/Users/estensen/Developer/optimism/op-node/rollup/derive/calldata_source_test.go:22:13: struct with 24 pointer bytes could be 16
/Users/estensen/Developer/optimism/op-node/rollup/derive/channel_bank_test.go:21:27: struct with 88 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/rollup/derive/channel_bank_test.go:23:11: struct with 40 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/rollup/derive/channel_bank_test.go:40:26: struct with 40 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/rollup/derive/deposit_log_test.go:46:18: struct with 16 pointer bytes could be 8
/Users/estensen/Developer/optimism/op-node/rollup/derive/fuzz_parsers_test.go:172:13: struct of size 72 could be 64
/Users/estensen/Developer/optimism/op-node/rollup/derive/l1_block_info_test.go:18:15: struct with 32 pointer bytes could be 24
/Users/estensen/Developer/optimism/op-node/rollup/derive/l1_retrieval_test.go:20:19: struct with 40 pointer bytes could be 32
/Users/estensen/Developer/optimism/op-node/rollup/derive/l1_retrieval_test.go:94:13: struct with 184 pointer bytes could be 104
/Users/estensen/Developer/optimism/op-node/rollup/derive/l1_traversal_test.go:55:13: struct with 208 pointer bytes could be 40
/Users/estensen/Developer/optimism/op-node/rollup/sync/start_test.go:43:24: struct of size 128 could be 120
/Users/estensen/Developer/optimism/op-node/sources/batching_test.go:22:16: struct with 72 pointer bytes could be 48
/Users/estensen/Developer/optimism/op-node/sources/batching_test.go:31:20: struct with 128 pointer bytes could be 104
/Users/estensen/Developer/optimism/op-node/withdrawals/utils_test.go:19:13: struct with 40 pointer bytes could be 32
```