### PR TITLE
specs,op-node: Clarify channel bank pruning

### DIFF
--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type NextDataProvider interface {
-	NextData(ctx context.Context) ([]byte, error)
+type NextFrameProvider interface {
+	NextFrame(ctx context.Context) (Frame, error)
 	Origin() eth.L1BlockRef
 }
 
@@ -34,14 +34,14 @@ type ChannelBank struct {
 	channels     map[ChannelID]*Channel // channels by ID
 	channelQueue []ChannelID            // channels in FIFO order
 
-	prev    NextDataProvider
+	prev    NextFrameProvider
 	fetcher L1Fetcher
 }
 
 var _ ResetableStage = (*ChannelBank)(nil)
 
 // NewChannelBank creates a ChannelBank, which should be Reset(origin) before use.
-func NewChannelBank(log log.Logger, cfg *rollup.Config, prev NextDataProvider, fetcher L1Fetcher) *ChannelBank {
+func NewChannelBank(log log.Logger, cfg *rollup.Config, prev NextFrameProvider, fetcher L1Fetcher) *ChannelBank {
 	return &ChannelBank{
 		log:          log,
 		cfg:          cfg,
@@ -73,43 +73,34 @@ func (cb *ChannelBank) prune() {
 }
 
 // IngestData adds new L1 data to the channel bank.
-// Read() should be called repeatedly first, until everything has been read, before adding new data.\
-func (cb *ChannelBank) IngestData(data []byte) {
+// Read() should be called repeatedly first, until everything has been read, before adding new data.
+func (cb *ChannelBank) IngestFrame(f Frame) {
 	origin := cb.Origin()
-	cb.log.Debug("channel bank got new data", "origin", origin, "data_len", len(data))
+	log := log.New("origin", origin, "channel", f.ID, "length", len(f.Data), "frame_number", f.FrameNumber)
+	log.Debug("channel bank got new data")
 
-	frames, err := ParseFrames(data)
-	if err != nil {
-		cb.log.Warn("malformed frame", "err", err)
+	currentCh, ok := cb.channels[f.ID]
+	if !ok {
+		// create new channel if it doesn't exist yet
+		currentCh = NewChannel(f.ID, origin)
+		cb.channels[f.ID] = currentCh
+		cb.channelQueue = append(cb.channelQueue, f.ID)
+	}
+
+	// check if the channel is not timed out
+	if currentCh.OpenBlockNumber()+cb.cfg.ChannelTimeout < origin.Number {
+		log.Warn("channel is timed out, ignore frame")
 		return
 	}
 
-	// Process each frame
-	for _, f := range frames {
-		currentCh, ok := cb.channels[f.ID]
-		if !ok {
-			// create new channel if it doesn't exist yet
-			currentCh = NewChannel(f.ID, origin)
-			cb.channels[f.ID] = currentCh
-			cb.channelQueue = append(cb.channelQueue, f.ID)
-		}
-
-		// check if the channel is not timed out
-		if currentCh.OpenBlockNumber()+cb.cfg.ChannelTimeout < origin.Number {
-			cb.log.Warn("channel is timed out, ignore frame", "channel", f.ID, "frame", f.FrameNumber)
-			continue
-		}
-
-		cb.log.Trace("ingesting frame", "channel", f.ID, "frame_number", f.FrameNumber, "length", len(f.Data))
-		if err := currentCh.AddFrame(f, origin); err != nil {
-			cb.log.Warn("failed to ingest frame into channel", "channel", f.ID, "frame_number", f.FrameNumber, "err", err)
-			continue
-		}
-
-		// Prune after the frame is loaded.
-		// TODO: Ingest a single frame at a time (must enable reads before ingesting the data / after this prune.)
-		cb.prune()
+	log.Trace("ingesting frame")
+	if err := currentCh.AddFrame(f, origin); err != nil {
+		log.Warn("failed to ingest frame into channel", "err", err)
+		return
 	}
+
+	// Prune after the frame is loaded.
+	cb.prune()
 }
 
 // Read the raw data of the first channel, if it's timed-out or closed.
@@ -157,12 +148,12 @@ func (cb *ChannelBank) NextData(ctx context.Context) ([]byte, error) {
 	}
 
 	// Then load data into the channel bank
-	if data, err := cb.prev.NextData(ctx); err == io.EOF {
+	if frame, err := cb.prev.NextFrame(ctx); err == io.EOF {
 		return nil, io.EOF
 	} else if err != nil {
 		return nil, err
 	} else {
-		cb.IngestData(data)
+		cb.IngestFrame(frame)
 		return nil, NotEnoughData
 	}
 }

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -78,9 +78,6 @@ func (cb *ChannelBank) IngestData(data []byte) {
 	origin := cb.Origin()
 	cb.log.Debug("channel bank got new data", "origin", origin, "data_len", len(data))
 
-	// TODO: Why is the prune here?
-	cb.prune()
-
 	frames, err := ParseFrames(data)
 	if err != nil {
 		cb.log.Warn("malformed frame", "err", err)
@@ -108,6 +105,10 @@ func (cb *ChannelBank) IngestData(data []byte) {
 			cb.log.Warn("failed to ingest frame into channel", "channel", f.ID, "frame_number", f.FrameNumber, "err", err)
 			continue
 		}
+
+		// Prune after the frame is loaded.
+		// TODO: Ingest a single frame at a time (must enable reads before ingesting the data / after this prune.)
+		cb.prune()
 	}
 }
 

--- a/op-node/rollup/derive/frame_queue.go
+++ b/op-node/rollup/derive/frame_queue.go
@@ -1,0 +1,61 @@
+package derive
+
+import (
+	"context"
+	"io"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var _ NextFrameProvider = &FrameQueue{}
+
+type NextDataProvider interface {
+	NextData(context.Context) ([]byte, error)
+	Origin() eth.L1BlockRef
+}
+
+type FrameQueue struct {
+	log    log.Logger
+	frames []Frame
+	prev   NextDataProvider
+}
+
+func NewFrameQueue(log log.Logger, prev NextDataProvider) *FrameQueue {
+	return &FrameQueue{
+		log:  log,
+		prev: prev,
+	}
+}
+
+func (fq *FrameQueue) Origin() eth.L1BlockRef {
+	return fq.prev.Origin()
+}
+
+func (fq *FrameQueue) NextFrame(ctx context.Context) (Frame, error) {
+	// Find more frames if we need to
+	if len(fq.frames) == 0 {
+		if data, err := fq.prev.NextData(ctx); err != nil {
+			return Frame{}, err
+		} else {
+			if new, err := ParseFrames(data); err == nil {
+				fq.frames = append(fq.frames, new...)
+			} else {
+				fq.log.Warn("Failed to parse frames", "origin", fq.prev.Origin(), "err", err)
+			}
+		}
+	}
+	// If we did not add more frames but still have more data, retry this function.
+	if len(fq.frames) == 0 {
+		return Frame{}, NotEnoughData
+	}
+
+	ret := fq.frames[0]
+	fq.frames = fq.frames[1:]
+	return ret, nil
+}
+
+func (fq *FrameQueue) Reset(ctx context.Context, base eth.L1BlockRef) error {
+	fq.frames = fq.frames[:0]
+	return io.EOF
+}

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -67,7 +67,8 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	l1Traversal := NewL1Traversal(log, l1Fetcher)
 	dataSrc := NewDataSourceFactory(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
-	bank := NewChannelBank(log, cfg, l1Src, l1Fetcher)
+	frameQueue := NewFrameQueue(log, l1Src)
+	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher)
 	chInReader := NewChannelInReader(log, bank)
 	batchQueue := NewBatchQueue(log, cfg, chInReader)
 	attributesQueue := NewAttributesQueue(log, cfg, l1Fetcher, batchQueue)

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -521,6 +521,14 @@ As currently implemented, each step in this stage performs the following actions
           frame are discarded.
   - Concatenate the data of the *contiguous frame sequence* (in sequential order) and push it to the next stage.
 
+The ordering of these actions is very important to be consistent across nodes & pipeline resets. The rollup node
+must attempt to do the following in order to maintain a consistent channel bank even in the presence of pruning.
+
+1. Attempt to read as many channels as possible from the channel bank.
+2. Load in a single frame
+3. Check if channel bank needs to be pruned & do so if needed.
+4. Go to step 1 once the channel bank is under it's size limit.
+
 > **TODO** Instead of waiting on the first seen channel (which might not contain the oldest batches, meaning buffering
 > further down the pipeline), we could process any channel in the queue that is ready. We could do this by checking for
 > channel readiness upon writing into the bank, and moving ready channel to the front of the queue.


### PR DESCRIPTION
**Description**

This clarifies the order of pruning & ingesting data into the channel bank.
It also adds a frame queue to enable frame by frame processing to match the specs.

**Metadata**
- Fixes ENG-2879
