### PR TITLE
specs,op-node: Clarify max bytes per channel comparison

### DIFF
--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -84,7 +84,7 @@ func (co *ChannelOut) AddBlock(block *types.Block) error {
 		return err
 	}
 	// We encode to a temporary buffer to determine the encoded length to
-	// ensure that the total size of all RLP elements is less than MAX_RLP_BYTES_PER_CHANNEL
+	// ensure that the total size of all RLP elements is less than or equal to MAX_RLP_BYTES_PER_CHANNEL
 	var buf bytes.Buffer
 	if err := rlp.Encode(&buf, batch); err != nil {
 		return err

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -363,11 +363,10 @@ where:
 
 When decompressing a channel, we limit the amount of decompressed data to `MAX_RLP_BYTES_PER_CHANNEL` (currently
 10,000,000 bytes), in order to avoid "zip-bomb" types of attack (where a small compressed input decompresses to a
-humongous amount of data). If the decompressed data exceeds the limit, things proceeds as thought the channel contained
-only the first `MAX_RLP_BYTES_PER_CHANNEL` decompressed bytes.
-
-When decoding batches, all batches that can be completly decoded below `MAX_RLP_BYTES_PER_CHANNEL` will be accepted
-even if the size of the channel is greater than `MAX_RLP_BYTES_PER_CHANNEL`.
+humongous amount of data). If the decompressed data exceeds the limit, things proceeds as though the channel contained
+only the first `MAX_RLP_BYTES_PER_CHANNEL` decompressed bytes. The limit is set on RLP decoding, so all batches that
+can be decoded in `MAX_RLP_BYTES_PER_CHANNEL` will be accepted ven if the size of the channel is greater than
+`MAX_RLP_BYTES_PER_CHANNEL`. The exact requirement is that `length(input) <= MAX_RLP_BYTES_PER_CHANNEL`.
 
 While the above pseudocode implies that all batches are known in advance, it is possible to perform streaming
 compression and decompression of RLP-encoded batches. This means it is possible to start including channel frames in a


### PR DESCRIPTION
**Description**

The exact requirement is that the input length is less than or equal to the max bytes per channel. This comparison is done with inputLimit in the RLP reader.


**Metadata**
- Fixes ENG-2926
