### PR TITLE
op-chain-ops: improve error message

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -3,6 +3,7 @@ package genesis
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -84,7 +85,7 @@ type DeployConfig struct {
 func NewDeployConfig(path string) (*DeployConfig, error) {
 	file, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("deploy config at %s not found: %w", path, err)
 	}
 
 	var config DeployConfig


### PR DESCRIPTION
**Description**

Improves the error message when reading a deploy config to print the path. Will be helpful for CLI tooling that consumes this function to give a better error message at runtime.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

