### PR TITLE
bedrock: make fee recipient be SequencerFeeVault

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -30,7 +30,6 @@ type DeployConfig struct {
 	SequencerWindowSize       uint64         `json:"sequencerWindowSize"`
 	ChannelTimeout            uint64         `json:"channelTimeout"`
 	P2PSequencerAddress       common.Address `json:"p2pSequencerAddress"`
-	OptimismL2FeeRecipient    common.Address `json:"optimismL2FeeRecipient"`
 	BatchInboxAddress         common.Address `json:"batchInboxAddress"`
 	BatchSenderAddress        common.Address `json:"batchSenderAddress"`
 

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -52,6 +52,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 		Optimism: &params.OptimismConfig{
+			L1FeeRecipient:     config.OptimismL1FeeRecipient,
 			BaseFeeRecipient:   config.OptimismBaseFeeRecipient,
 			EIP1559Denominator: eip1559Denom,
 			EIP1559Elasticity:  eip1559Elasticity,

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -53,7 +53,6 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		TerminalTotalDifficultyPassed: true,
 		Optimism: &params.OptimismConfig{
 			BaseFeeRecipient:   config.OptimismBaseFeeRecipient,
-			L1FeeRecipient:     config.OptimismL2FeeRecipient,
 			EIP1559Denominator: eip1559Denom,
 			EIP1559Elasticity:  eip1559Elasticity,
 		},

--- a/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
@@ -8,7 +8,6 @@
   "sequencerWindowSize": 4,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
-  "optimismL2FeeRecipient": "0xd9c09e21b57c98e58a80552c170989b426766aa7",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
 

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -7,7 +7,6 @@
   "sequencerWindowSize": 100,
   "channelTimeout": 30,
   "p2pSequencerAddress": "0x0000000000000000000000000000000000000000",
-  "optimismL2FeeRecipient": "0x42000000000000000000000000000000000000f0",
   "batchInboxAddress": "0x42000000000000000000000000000000000000ff",
   "batchSenderAddress": "0x0000000000000000000000000000000000000000",
   "l2OutputOracleSubmissionInterval": 6,

--- a/op-e2e/e2eutils/addresses.go
+++ b/op-e2e/e2eutils/addresses.go
@@ -41,7 +41,6 @@ func CollectAddresses(sd *SetupData, dp *DeployParams) (out []common.Address) {
 		sd.L1Cfg.Coinbase,
 		sd.L2Cfg.Coinbase,
 		sd.RollupCfg.P2PSequencerAddress,
-		sd.RollupCfg.FeeRecipientAddress,
 		sd.RollupCfg.BatchInboxAddress,
 		sd.RollupCfg.BatchSenderAddress,
 		sd.RollupCfg.DepositContractAddress,

--- a/op-e2e/e2eutils/addresses.go
+++ b/op-e2e/e2eutils/addresses.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
 )
 
@@ -41,6 +42,7 @@ func CollectAddresses(sd *SetupData, dp *DeployParams) (out []common.Address) {
 		sd.L1Cfg.Coinbase,
 		sd.L2Cfg.Coinbase,
 		sd.RollupCfg.P2PSequencerAddress,
+		predeploys.SequencerFeeVaultAddr,
 		sd.RollupCfg.BatchInboxAddress,
 		sd.RollupCfg.BatchSenderAddress,
 		sd.RollupCfg.DepositContractAddress,

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -58,13 +58,12 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 		L2ChainID:   902,
 		L2BlockTime: 2,
 
-		MaxSequencerDrift:      tp.MaxSequencerDrift,
-		SequencerWindowSize:    tp.SequencerWindowSize,
-		ChannelTimeout:         tp.ChannelTimeout,
-		P2PSequencerAddress:    addresses.SequencerP2P,
-		OptimismL2FeeRecipient: common.Address{0: 0x42, 19: 0xf0}, // tbd
-		BatchInboxAddress:      common.Address{0: 0x42, 19: 0xff}, // tbd
-		BatchSenderAddress:     addresses.Batcher,
+		MaxSequencerDrift:   tp.MaxSequencerDrift,
+		SequencerWindowSize: tp.SequencerWindowSize,
+		ChannelTimeout:      tp.ChannelTimeout,
+		P2PSequencerAddress: addresses.SequencerP2P,
+		BatchInboxAddress:   common.Address{0: 0x42, 19: 0xff}, // tbd
+		BatchSenderAddress:  addresses.Batcher,
 
 		L2OutputOracleSubmissionInterval: 6,
 		L2OutputOracleStartingTimestamp:  -1,
@@ -89,7 +88,7 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 		L2GenesisBlockGasLimit:      15_000_000,
 		L2GenesisBlockDifficulty:    uint64ToBig(0),
 		L2GenesisBlockMixHash:       common.Hash{},
-		L2GenesisBlockCoinbase:      common.Address{0: 0x42, 19: 0xf0}, // matching OptimismL2FeeRecipient
+		L2GenesisBlockCoinbase:      predeploys.SequencerFeeVaultAddr,
 		L2GenesisBlockNumber:        0,
 		L2GenesisBlockGasUsed:       0,
 		L2GenesisBlockParentHash:    common.Hash{},
@@ -201,7 +200,6 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		L1ChainID:              new(big.Int).SetUint64(deployConf.L1ChainID),
 		L2ChainID:              new(big.Int).SetUint64(deployConf.L2ChainID),
 		P2PSequencerAddress:    deployConf.P2PSequencerAddress,
-		FeeRecipientAddress:    deployConf.OptimismL2FeeRecipient,
 		BatchInboxAddress:      deployConf.BatchInboxAddress,
 		BatchSenderAddress:     deployConf.BatchSenderAddress,
 		DepositContractAddress: predeploys.DevOptimismPortalAddr,

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -94,7 +94,6 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 
 			OptimismBaseFeeRecipient:    common.Address{0: 0x52, 19: 0xf0}, // tbd
 			OptimismL1FeeRecipient:      common.Address{0: 0x52, 19: 0xf1},
-			OptimismL2FeeRecipient:      common.Address{0: 0x52, 19: 0xf2}, // tbd
 			L2CrossDomainMessengerOwner: common.Address{0: 0x52, 19: 0xf3}, // tbd
 			GasPriceOracleOwner:         addresses.Alice,                   // tbd
 			GasPriceOracleOverhead:      0,
@@ -283,7 +282,6 @@ func (cfg SystemConfig) Start() (*System, error) {
 			L1ChainID:              cfg.L1ChainIDBig(),
 			L2ChainID:              cfg.L2ChainIDBig(),
 			P2PSequencerAddress:    cfg.DeployConfig.P2PSequencerAddress,
-			FeeRecipientAddress:    l2Genesis.Coinbase,
 			BatchInboxAddress:      cfg.DeployConfig.BatchInboxAddress,
 			BatchSenderAddress:     cfg.DeployConfig.BatchSenderAddress,
 			DepositContractAddress: predeploys.DevOptimismPortalAddr,

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -915,7 +915,7 @@ func TestFees(t *testing.T) {
 	// L1Fee Recipient
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	l1FeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, cfg.DeployConfig.OptimismL2FeeRecipient, nil)
+	l1FeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, predeploys.SequencerFeeVaultAddr, nil)
 	require.Nil(t, err)
 
 	// Simple transfer from signer to random account
@@ -976,7 +976,7 @@ func TestFees(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	l1FeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, cfg.DeployConfig.OptimismL2FeeRecipient, nil)
+	l1FeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, predeploys.SequencerFeeVaultAddr, nil)
 	require.Nil(t, err)
 
 	// Diff fee recipient + coinbase balances

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -915,7 +915,7 @@ func TestFees(t *testing.T) {
 	// L1Fee Recipient
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	l1FeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, predeploys.SequencerFeeVaultAddr, nil)
+	l1FeeRecipientStartBalance, err := l2Seq.BalanceAt(ctx, cfg.DeployConfig.OptimismL1FeeRecipient, nil)
 	require.Nil(t, err)
 
 	// Simple transfer from signer to random account
@@ -976,7 +976,7 @@ func TestFees(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	l1FeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, predeploys.SequencerFeeVaultAddr, nil)
+	l1FeeRecipientEndBalance, err := l2Seq.BalanceAt(ctx, cfg.DeployConfig.OptimismL1FeeRecipient, header.Number)
 	require.Nil(t, err)
 
 	// Diff fee recipient + coinbase balances

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -193,7 +193,6 @@ func makeRollupConfig(
 		L1ChainID:              new(big.Int).SetUint64(config.L1ChainID),
 		L2ChainID:              new(big.Int).SetUint64(config.L2ChainID),
 		P2PSequencerAddress:    config.P2PSequencerAddress,
-		FeeRecipientAddress:    config.OptimismL2FeeRecipient,
 		BatchInboxAddress:      config.BatchInboxAddress,
 		BatchSenderAddress:     config.BatchSenderAddress,
 		DepositContractAddress: portalAddr,

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum/go-ethereum/common"
@@ -74,7 +75,7 @@ func PreparePayloadAttributes(ctx context.Context, cfg *rollup.Config, dl L1Rece
 	return &eth.PayloadAttributes{
 		Timestamp:             hexutil.Uint64(timestamp),
 		PrevRandao:            eth.Bytes32(l1Info.MixDigest()),
-		SuggestedFeeRecipient: cfg.FeeRecipientAddress,
+		SuggestedFeeRecipient: predeploys.SequencerFeeVaultAddr,
 		Transactions:          txs,
 		NoTxPool:              true,
 	}, nil

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
@@ -25,7 +26,6 @@ func TestAttributesQueue(t *testing.T) {
 		BlockTime:              2,
 		L1ChainID:              big.NewInt(101),
 		L2ChainID:              big.NewInt(102),
-		FeeRecipientAddress:    common.Address{0xaa},
 		DepositContractAddress: common.Address{0xbb},
 	}
 	rng := rand.New(rand.NewSource(1234))
@@ -52,7 +52,7 @@ func TestAttributesQueue(t *testing.T) {
 	attrs := eth.PayloadAttributes{
 		Timestamp:             eth.Uint64Quantity(safeHead.Time + cfg.BlockTime),
 		PrevRandao:            eth.Bytes32(l1Info.InfoMixDigest),
-		SuggestedFeeRecipient: cfg.FeeRecipientAddress,
+		SuggestedFeeRecipient: predeploys.SequencerFeeVaultAddr,
 		Transactions:          []eth.Data{l1InfoTx, eth.Data("foobar"), eth.Data("example")},
 		NoTxPool:              true,
 	}

--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
@@ -23,7 +24,6 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		BlockTime:              2,
 		L1ChainID:              big.NewInt(101),
 		L2ChainID:              big.NewInt(102),
-		FeeRecipientAddress:    common.Address{0xaa},
 		DepositContractAddress: common.Address{0xbb},
 	}
 
@@ -99,7 +99,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.NotNil(t, attrs)
 		require.Equal(t, l2Parent.Time+cfg.BlockTime, uint64(attrs.Timestamp))
 		require.Equal(t, eth.Bytes32(l1Info.InfoMixDigest), attrs.PrevRandao)
-		require.Equal(t, cfg.FeeRecipientAddress, attrs.SuggestedFeeRecipient)
+		require.Equal(t, predeploys.SequencerFeeVaultAddr, attrs.SuggestedFeeRecipient)
 		require.Equal(t, 1, len(attrs.Transactions))
 		require.Equal(t, l1InfoTx, []byte(attrs.Transactions[0]))
 		require.True(t, attrs.NoTxPool)
@@ -136,7 +136,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.NotNil(t, attrs)
 		require.Equal(t, l2Parent.Time+cfg.BlockTime, uint64(attrs.Timestamp))
 		require.Equal(t, eth.Bytes32(l1Info.InfoMixDigest), attrs.PrevRandao)
-		require.Equal(t, cfg.FeeRecipientAddress, attrs.SuggestedFeeRecipient)
+		require.Equal(t, predeploys.SequencerFeeVaultAddr, attrs.SuggestedFeeRecipient)
 		require.Equal(t, len(l2Txs), len(attrs.Transactions), "Expected txs to equal l1 info tx + user deposit txs")
 		require.Equal(t, l2Txs, attrs.Transactions)
 		require.True(t, attrs.NoTxPool)
@@ -161,7 +161,7 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		require.NotNil(t, attrs)
 		require.Equal(t, l2Parent.Time+cfg.BlockTime, uint64(attrs.Timestamp))
 		require.Equal(t, eth.Bytes32(l1Info.InfoMixDigest), attrs.PrevRandao)
-		require.Equal(t, cfg.FeeRecipientAddress, attrs.SuggestedFeeRecipient)
+		require.Equal(t, predeploys.SequencerFeeVaultAddr, attrs.SuggestedFeeRecipient)
 		require.Equal(t, 1, len(attrs.Transactions))
 		require.Equal(t, l1InfoTx, []byte(attrs.Transactions[0]))
 		require.True(t, attrs.NoTxPool)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -45,8 +45,6 @@ type Config struct {
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
 
-	// L2 address used to send all priority fees to, also known as the coinbase address in the block.
-	FeeRecipientAddress common.Address `json:"fee_recipient_address"`
 	// L1 address that batches are sent to.
 	BatchInboxAddress common.Address `json:"batch_inbox_address"`
 	// Acceptable batch-sender address
@@ -80,9 +78,6 @@ func (cfg *Config) Check() error {
 	}
 	if cfg.P2PSequencerAddress == (common.Address{}) {
 		return errors.New("missing p2p sequencer address")
-	}
-	if cfg.FeeRecipientAddress == (common.Address{}) {
-		return errors.New("missing fee recipient address")
 	}
 	if cfg.BatchInboxAddress == (common.Address{}) {
 		return errors.New("missing batch inbox address")

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -28,13 +28,12 @@ func randConfig() *Config {
 			L2:     eth.BlockID{Hash: randHash(), Number: 1337},
 			L2Time: uint64(time.Now().Unix()),
 		},
-		BlockTime:           2,
-		MaxSequencerDrift:   100,
-		SeqWindowSize:       2,
-		L1ChainID:           big.NewInt(900),
-		FeeRecipientAddress: randAddr(),
-		BatchInboxAddress:   randAddr(),
-		BatchSenderAddress:  randAddr(),
+		BlockTime:          2,
+		MaxSequencerDrift:  100,
+		SeqWindowSize:      2,
+		L1ChainID:          big.NewInt(900),
+		BatchInboxAddress:  randAddr(),
+		BatchSenderAddress: randAddr(),
 	}
 }
 

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -7,7 +7,6 @@
   "sequencerWindowSize": 4,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
-  "optimismL2FeeRecipient": "0xd9c09e21b57c98e58a80552c170989b426766aa7",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
 

--- a/packages/contracts-bedrock/deploy-config/goerli.json
+++ b/packages/contracts-bedrock/deploy-config/goerli.json
@@ -8,7 +8,6 @@
   "sequencerWindowSize": 120,
   "channelTimeout": 120,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
-  "optimismL2FeeRecipient": "0x26862c200bd48c19f39d9e1cd88a3b439611d911",
   "batchInboxAddress": "0xff00000000000000000000000000000000000002",
   "batchSenderAddress": "0xa11d2b908470e17923fff184d48269bebbd9b2a5",
 

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -10,7 +10,6 @@
   "sequencerWindowSize": 4,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
-  "optimismL2FeeRecipient": "0xd9c09e21b57c98e58a80552c170989b426766aa7",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
 

--- a/packages/contracts-bedrock/deploy/007-L1CrossDomainMessengerImpl.ts
+++ b/packages/contracts-bedrock/deploy/007-L1CrossDomainMessengerImpl.ts
@@ -13,8 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
   )
   await deployAndVerifyAndThen({
     hre,
-    name: 'L1CrossDomainMessengerImpl',
-    contract: 'L1CrossDomainMessenger',
+    name: 'L1CrossDomainMessenger',
     args: [OptimismPortalProxy.address],
     postDeployAction: async (contract) => {
       await assertContractVariable(

--- a/packages/contracts-bedrock/deploy/008-L1StandardBridgeImpl.ts
+++ b/packages/contracts-bedrock/deploy/008-L1StandardBridgeImpl.ts
@@ -14,8 +14,7 @@ const deployFn: DeployFunction = async (hre) => {
   )
   await deployAndVerifyAndThen({
     hre,
-    name: 'L1StandardBridgeImpl',
-    contract: 'L1StandardBridge',
+    name: 'L1StandardBridge',
     args: [L1CrossDomainMessengerProxy.address],
     postDeployAction: async (contract) => {
       await assertContractVariable(

--- a/packages/contracts-bedrock/deploy/009-L2OutputOracleImpl.ts
+++ b/packages/contracts-bedrock/deploy/009-L2OutputOracleImpl.ts
@@ -2,6 +2,8 @@ import assert from 'assert'
 
 import { ethers } from 'ethers'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
+import '@nomiclabs/hardhat-ethers'
 
 import {
   assertContractVariable,
@@ -26,8 +28,7 @@ const deployFn: DeployFunction = async (hre) => {
 
   await deployAndVerifyAndThen({
     hre,
-    name: 'L2OutputOracleImpl',
-    contract: 'L2OutputOracle',
+    name: 'L2OutputOracle',
     args: [
       hre.deployConfig.l2OutputOracleSubmissionInterval,
       hre.deployConfig.l2OutputOracleGenesisL2Output,

--- a/packages/contracts-bedrock/deploy/010-OptimismPortalImpl.ts
+++ b/packages/contracts-bedrock/deploy/010-OptimismPortalImpl.ts
@@ -1,4 +1,5 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
 
 import {
   assertContractVariable,
@@ -13,8 +14,7 @@ const deployFn: DeployFunction = async (hre) => {
   )
   await deployAndVerifyAndThen({
     hre,
-    name: 'OptimismPortalImpl',
-    contract: 'OptimismPortal',
+    name: 'OptimismPortal',
     args: [
       L2OutputOracleProxy.address,
       hre.deployConfig.finalizationPeriodSeconds,

--- a/packages/contracts-bedrock/deploy/011-OptimismMintableERC20FactoryImpl.ts
+++ b/packages/contracts-bedrock/deploy/011-OptimismMintableERC20FactoryImpl.ts
@@ -13,8 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
   )
   await deployAndVerifyAndThen({
     hre,
-    name: 'OptimismMintableERC20FactoryImpl',
-    contract: 'OptimismMintableERC20Factory',
+    name: 'OptimismMintableERC20Factory',
     args: [L1StandardBridgeProxy.address],
     postDeployAction: async (contract) => {
       await assertContractVariable(

--- a/packages/contracts-bedrock/deploy/012-L1ERC721BridgeImpl.ts
+++ b/packages/contracts-bedrock/deploy/012-L1ERC721BridgeImpl.ts
@@ -14,8 +14,7 @@ const deployFn: DeployFunction = async (hre) => {
   )
   await deployAndVerifyAndThen({
     hre,
-    name: 'L1ERC721BridgeImpl',
-    contract: 'L1ERC721Bridge',
+    name: 'L1ERC721Bridge',
     args: [L1CrossDomainMessengerProxy.address, predeploys.L2ERC721Bridge],
     postDeployAction: async (contract) => {
       await assertContractVariable(

--- a/packages/contracts-bedrock/deploy/013-PortalSenderImpl.ts
+++ b/packages/contracts-bedrock/deploy/013-PortalSenderImpl.ts
@@ -13,8 +13,7 @@ const deployFn: DeployFunction = async (hre) => {
   )
   await deployAndVerifyAndThen({
     hre,
-    name: 'PortalSenderImpl',
-    contract: 'PortalSender',
+    name: 'PortalSender',
     args: [OptimismPortalProxy.address],
     postDeployAction: async (contract) => {
       await assertContractVariable(

--- a/packages/contracts-bedrock/deploy/014-FreshSystemDicator.ts
+++ b/packages/contracts-bedrock/deploy/014-FreshSystemDicator.ts
@@ -1,4 +1,6 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
+import 'hardhat-deploy'
 
 import {
   getDeploymentAddress,
@@ -46,31 +48,22 @@ const deployFn: DeployFunction = async (hre) => {
           ),
         },
         implementationAddressConfig: {
-          l2OutputOracleImpl: await getDeploymentAddress(
-            hre,
-            'L2OutputOracleImpl'
-          ),
-          optimismPortalImpl: await getDeploymentAddress(
-            hre,
-            'OptimismPortalImpl'
-          ),
+          l2OutputOracleImpl: await getDeploymentAddress(hre, 'L2OutputOracle'),
+          optimismPortalImpl: await getDeploymentAddress(hre, 'OptimismPortal'),
           l1CrossDomainMessengerImpl: await getDeploymentAddress(
             hre,
-            'L1CrossDomainMessengerImpl'
+            'L1CrossDomainMessenger'
           ),
           l1StandardBridgeImpl: await getDeploymentAddress(
             hre,
-            'L1StandardBridgeImpl'
+            'L1StandardBridge'
           ),
           optimismMintableERC20FactoryImpl: await getDeploymentAddress(
             hre,
-            'OptimismMintableERC20FactoryImpl'
+            'OptimismMintableERC20Factory'
           ),
-          l1ERC721BridgeImpl: await getDeploymentAddress(
-            hre,
-            'L1ERC721BridgeImpl'
-          ),
-          portalSenderImpl: await getDeploymentAddress(hre, 'PortalSenderImpl'),
+          l1ERC721BridgeImpl: await getDeploymentAddress(hre, 'L1ERC721Bridge'),
+          portalSenderImpl: await getDeploymentAddress(hre, 'PortalSender'),
         },
         l2OutputOracleConfig: {
           l2OutputOracleGenesisL2Output:

--- a/packages/contracts-bedrock/deploy/015-MigrationSystemDictator.ts
+++ b/packages/contracts-bedrock/deploy/015-MigrationSystemDictator.ts
@@ -1,6 +1,8 @@
 import { awaitCondition } from '@eth-optimism/core-utils'
 import { ethers } from 'ethers'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
+import '@eth-optimism/hardhat-deploy-config'
+import 'hardhat-deploy'
 
 import {
   getDeploymentAddress,
@@ -69,31 +71,22 @@ const deployFn: DeployFunction = async (hre) => {
           ),
         },
         implementationAddressConfig: {
-          l2OutputOracleImpl: await getDeploymentAddress(
-            hre,
-            'L2OutputOracleImpl'
-          ),
-          optimismPortalImpl: await getDeploymentAddress(
-            hre,
-            'OptimismPortalImpl'
-          ),
+          l2OutputOracleImpl: await getDeploymentAddress(hre, 'L2OutputOracle'),
+          optimismPortalImpl: await getDeploymentAddress(hre, 'OptimismPortal'),
           l1CrossDomainMessengerImpl: await getDeploymentAddress(
             hre,
-            'L1CrossDomainMessengerImpl'
+            'L1CrossDomainMessenger'
           ),
           l1StandardBridgeImpl: await getDeploymentAddress(
             hre,
-            'L1StandardBridgeImpl'
+            'L1StandardBridge'
           ),
           optimismMintableERC20FactoryImpl: await getDeploymentAddress(
             hre,
-            'OptimismMintableERC20FactoryImpl'
+            'OptimismMintableERC20Factory'
           ),
-          l1ERC721BridgeImpl: await getDeploymentAddress(
-            hre,
-            'L1ERC721BridgeImpl'
-          ),
-          portalSenderImpl: await getDeploymentAddress(hre, 'PortalSenderImpl'),
+          l1ERC721BridgeImpl: await getDeploymentAddress(hre, 'L1ERC721Bridge'),
+          portalSenderImpl: await getDeploymentAddress(hre, 'PortalSender'),
         },
         l2OutputOracleConfig: {
           l2OutputOracleGenesisL2Output:

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -133,11 +133,6 @@ const config: HardhatUserConfig = {
     p2pSequencerAddress: {
       type: 'address',
     },
-    // L2 address used to send all priority fees to, also known as the coinbase address in the block.
-    // "fee_recipient_address" in rollup config.
-    optimismL2FeeRecipient: {
-      type: 'address',
-    },
     // L1 address that batches are sent to.
     // "batch_inbox_address" in rollup config.
     batchInboxAddress: {

--- a/packages/contracts-bedrock/tasks/rekey.ts
+++ b/packages/contracts-bedrock/tasks/rekey.ts
@@ -11,7 +11,6 @@ task('rekey', 'Generates a new set of keys for a test network').setAction(
       'proxyAdminOwner',
       'optimismBaseFeeRecipient',
       'optimismL1FeeRecipient',
-      'optimismL2FeeRecipient',
       'p2pSequencerAddress',
       'l2OutputOracleOwner',
       'batchSenderAddress',

--- a/packages/contracts-bedrock/tasks/rollup-config.ts
+++ b/packages/contracts-bedrock/tasks/rollup-config.ts
@@ -65,7 +65,6 @@ task('rollup-config', 'create a genesis config')
       l2_chain_id: deployConfig.l2ChainID,
 
       p2p_sequencer_address: deployConfig.p2pSequencerAddress,
-      fee_recipient_address: deployConfig.optimismL2FeeRecipient,
       batch_inbox_address: deployConfig.batchInboxAddress,
       batch_sender_address: deployConfig.batchSenderAddress,
       deposit_contract_address: portal.address,

--- a/packages/core-utils/src/optimism/op-node.ts
+++ b/packages/core-utils/src/optimism/op-node.ts
@@ -17,7 +17,6 @@ export interface OpNodeConfig {
   l1_chain_id: number
   l2_chain_id: number
   p2p_sequencer_address: string
-  fee_recipient_address: string
   batch_inbox_address: string
   batch_sender_address: string
   deposit_contract_address: string

--- a/packages/sdk/tasks/deposit-erc20.ts
+++ b/packages/sdk/tasks/deposit-erc20.ts
@@ -32,8 +32,10 @@ const deployWETH9 = async (
     signer
   )
 
+  console.log('Sending deployment transaction')
   const WETH9 = await Factory__WETH9.deploy()
-  await WETH9.deployTransaction.wait()
+  const receipt = await WETH9.deployTransaction.wait()
+  console.log(`WETH9 deployed: ${receipt.transactionHash}`)
 
   if (wrap) {
     const deposit = await signer.sendTransaction({


### PR DESCRIPTION
**Description**

The fee recipient or `block.coinbase` is now set to a hardcoded value of the predeploy `SequencerFeeVault`. This reduces configuration that is consensus criticial.

The config value `OptimismL2FeeRecipient` is removed in favor of a hardcoded predeploy. The fees already accumulate to this address, so it is in line with the way that the current system works.

A bug is also fixed for the tests of the L1 fee recipient, the value was never being set correctly in the L2 chain config, the value is now set as expected and the correct address is asserted against in the tests

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
