### PR TITLE
integration-tests: update readme, try to fix ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -590,7 +590,6 @@ jobs:
   integration-tests:
     machine:
       image: ubuntu-2204:2022.07.1
-      docker_layer_caching: true
     environment:
       DOCKER_BUILDKIT: 1
     parallelism: 3

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,5 +1,8 @@
 # @eth-optimism/integration-tests
 
+Note that these tests are ran against the legacy system, see `op-e2e` for
+the bedrock test suite.
+
 ## Setup
 
 Follow installation + build instructions in the [primary README](../README.md).


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

integration tests are failing to build in ci due to a cache error, try to fix that here