### PR TITLE
op-batcher: Restructure source code

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -1,4 +1,4 @@
-package op_batcher
+package batcher
 
 import (
 	"bytes"

--- a/op-batcher/batcher/cli_config.go
+++ b/op-batcher/batcher/cli_config.go
@@ -1,4 +1,4 @@
-package op_batcher
+package batcher
 
 import (
 	"time"
@@ -12,7 +12,7 @@ import (
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
-type Config struct {
+type CLIConfig struct {
 	/* Required Params */
 
 	// L1EthRpc is the HTTP provider URL for L1.
@@ -78,7 +78,7 @@ type Config struct {
 	PprofConfig oppprof.CLIConfig
 }
 
-func (c Config) Check() error {
+func (c CLIConfig) Check() error {
 	if err := c.RPCConfig.Check(); err != nil {
 		return err
 	}
@@ -95,8 +95,8 @@ func (c Config) Check() error {
 }
 
 // NewConfig parses the Config from the provided flags or environment variables.
-func NewConfig(ctx *cli.Context) Config {
-	return Config{
+func NewConfig(ctx *cli.Context) CLIConfig {
+	return CLIConfig{
 		/* Required Flags */
 		L1EthRpc:                   ctx.GlobalString(flags.L1EthRpcFlag.Name),
 		L2EthRpc:                   ctx.GlobalString(flags.L2EthRpcFlag.Name),

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -1,4 +1,4 @@
-package sequencer
+package batcher
 
 import (
 	"crypto/ecdsa"

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -1,4 +1,4 @@
-package op_batcher
+package batcher
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-batcher/sequencer"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -25,7 +24,7 @@ import (
 type BatchSubmitter struct {
 	txMgr txmgr.TxManager
 	addr  common.Address
-	cfg   sequencer.Config
+	cfg   Config
 	wg    sync.WaitGroup
 	done  chan struct{}
 	log   log.Logger
@@ -40,7 +39,7 @@ type BatchSubmitter struct {
 
 // NewBatchSubmitter initializes the BatchSubmitter, gathering any resources
 // that will be needed during operation.
-func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
+func NewBatchSubmitter(cfg CLIConfig, l log.Logger) (*BatchSubmitter, error) {
 	ctx := context.Background()
 
 	var err error
@@ -125,7 +124,7 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 		SafeAbortNonceTooLowCount: cfg.SafeAbortNonceTooLowCount,
 	}
 
-	batcherCfg := sequencer.Config{
+	batcherCfg := Config{
 		Log:               l,
 		Name:              "Batch Submitter",
 		L1Client:          l1Client,

--- a/op-batcher/batcher/main.go
+++ b/op-batcher/batcher/main.go
@@ -1,4 +1,4 @@
-package op_batcher
+package batcher
 
 import (
 	"context"

--- a/op-batcher/batcher/txmgr.go
+++ b/op-batcher/batcher/txmgr.go
@@ -1,4 +1,4 @@
-package op_batcher
+package batcher
 
 import (
 	"context"

--- a/op-batcher/batcher/utils.go
+++ b/op-batcher/batcher/utils.go
@@ -1,4 +1,4 @@
-package op_batcher
+package batcher
 
 import (
 	"context"

--- a/op-batcher/cmd/main.go
+++ b/op-batcher/cmd/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/urfave/cli"
 
-	batcher "github.com/ethereum-optimism/optimism/op-batcher"
+	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-batcher/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/log"

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	bss "github.com/ethereum-optimism/optimism/op-batcher"
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
@@ -503,7 +503,7 @@ func (cfg SystemConfig) Start() (*System, error) {
 	}
 
 	// Batch Submitter
-	sys.BatchSubmitter, err = bss.NewBatchSubmitter(bss.Config{
+	sys.BatchSubmitter, err = bss.NewBatchSubmitter(bss.CLIConfig{
 		L1EthRpc:                  sys.Nodes["l1"].WSEndpoint(),
 		L2EthRpc:                  sys.Nodes["sequencer"].WSEndpoint(),
 		RollupRpc:                 sys.RollupNodes["sequencer"].HTTPEndpoint(),


### PR DESCRIPTION
**Description**

This moves everything into a `batcher` directory. It's maybe not the perfect name yet, but this is getting split into enough components that having all of the source files in the top level directory was becoming annoying.

**Additional context**

I think the code is getting large enough to make this change, but I don't love the stutter with `op-batcher/batcher`. If people have others ideas here I'd love to hear them.
