### PR TITLE
ci: Fail if new bedrock contract code is not 100% tested

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,11 @@ flag_management:
   individual_flags:
     - name: bedrock-go-tests
     - name: contracts-bedrock-tests
+      paths:
+        - packages/contracts-bedrock/contracts
+      statuses:
+        - type: patch
+          target: 100%
     - name: common-ts-tests
     - name: contracts-tests
     - name: core-utils-tests
@@ -21,3 +26,20 @@ flag_management:
     - name: message-relayer-tests
     - name: replica-healthcheck-tests
     - name: sdk-tests
+coverage:
+  status:
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto
+        # advanced
+        branches:
+          - master
+        if_ci_failed: error #success, error
+        only_pulls: false
+        flags:
+          - "unit"
+        paths:
+          - "src"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-comment: false
+comment: true
 ignore:
   - "l2geth"
   - "**/*.t.sol"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
 Two changes to the codecov config:

1. Fails CI if bedrock contracts test coverage is reduced by a PR. 
2. Turns on the commenting bot.