### PR TITLE
change  pint log ways

### DIFF
--- a/.changeset/stale-bikes-smoke.md
+++ b/.changeset/stale-bikes-smoke.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter-service": patch
+---
+
+change  pint log ways

--- a/batch-submitter/dial_l2_client.go
+++ b/batch-submitter/dial_l2_client.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/bss-core/dial"
 	"github.com/ethereum-optimism/optimism/l2geth/ethclient"
-	"github.com/ethereum-optimism/optimism/l2geth/log"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum-optimism/optimism/l2geth/rpc"
 )
 


### PR DESCRIPTION
If you use github.com/ethereum-optimism/optimism/l2geth/log, the log will not be printed, because the log initialization uses github.com/ethereum/go-ethereum/log

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

If you use github.com/ethereum-optimism/optimism/l2geth/log, the log will not be printed, because the log initialization uses github.com/ethereum/go-ethereum/log

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
