### PR TITLE
change print log way

### DIFF
--- a/.changeset/bright-balloons-rush.md
+++ b/.changeset/bright-balloons-rush.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/batch-submitter-service": patch
+---
+
+change print log way

--- a/batch-submitter/dial_l2_client.go
+++ b/batch-submitter/dial_l2_client.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/bss-core/dial"
 	"github.com/ethereum-optimism/optimism/l2geth/ethclient"
-	"github.com/ethereum-optimism/optimism/l2geth/log"
 	"github.com/ethereum-optimism/optimism/l2geth/rpc"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // DialL2EthClientWithTimeout attempts to dial the L2 provider using the

--- a/batch-submitter/drivers/proposer/driver.go
+++ b/batch-submitter/drivers/proposer/driver.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/bss-core/metrics"
 	"github.com/ethereum-optimism/optimism/bss-core/txmgr"
 	l2ethclient "github.com/ethereum-optimism/optimism/l2geth/ethclient"
-	"github.com/ethereum-optimism/optimism/l2geth/log"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"

--- a/batch-submitter/drivers/proposer/driver.go
+++ b/batch-submitter/drivers/proposer/driver.go
@@ -13,13 +13,13 @@ import (
 	"github.com/ethereum-optimism/optimism/bss-core/metrics"
 	"github.com/ethereum-optimism/optimism/bss-core/txmgr"
 	l2ethclient "github.com/ethereum-optimism/optimism/l2geth/ethclient"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // stateRootSize is the size in bytes of a state root.


### PR DESCRIPTION
If you use github.com/ethereum-optimism/optimism/l2geth/log, the log will not be printed, because the log initialization uses github.com/ethereum/go-ethereum/log

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
