### PR TITLE
contracts: lint

### DIFF
--- a/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
+++ b/packages/contracts/contracts/L1/rollup/StateCommitmentChain.sol
@@ -35,7 +35,8 @@ contract StateCommitmentChain is IStateCommitmentChain, Lib_AddressResolver {
     /**
      * @param _libAddressManager Address of the Address Manager.
      * @param _fraudProofWindow Number of seconds until fraud proof is in the finalized state.
-     * @param _sequencerPublishWindow Number of seconds that the sequencer is exclusively allowed to post state roots.
+     * @param _sequencerPublishWindow Number of seconds that the sequencer is exclusively allowed
+     *        to post state roots.
      */
     constructor(
         address _libAddressManager,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Lints the SCC contract, which recently started failing linting. Unclear why it was not previously failing linting

