### PR TITLE
Bumped compiler version for contracts-bedrock

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -17,7 +17,7 @@ module.exports = {
         bracketSpacing: true,
         // These options are specific to the Solidity Plugin
         explicitTypes: 'always',
-        compiler: '>=0.8.10',
+        compiler: '>=0.8.15',
       },
     },
   ],

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -357,7 +357,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.10',
+        version: '0.8.15',
         settings: {
           optimizer: { enabled: true, runs: 10_000 },
         },


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Bumped compiler version from 0.8.10 to 0.8.15 in contracts-bedrock & in .prettierrc.js

**Tests**

No tests required. 

**Additional context**


**Metadata**
- Fixes #https://github.com/ethereum-optimism/optimism/issues/3839#issue-1432296592
