### PR TITLE
ci: Speculative checks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    speculative_checks: 3
     conditions: []
 
 pull_request_rules:
@@ -11,6 +12,7 @@ pull_request_rules:
         - "#changes-requested-reviews-by=0"
         - "label!=do-not-merge"
         - "label!=mergify-ignore"
+        - "base=develop"
         - or:
           - and:
             - "label!=SR-Risk"
@@ -89,23 +91,19 @@ pull_request_rules:
       comment:
         message: |
           This PR is next in line to be merged, and will be merged as soon as checks pass.
-  - name: Notify author when merge queue failed
+  - name: Notify author on queue failure
     conditions:
-      - "check-failure=Queue: Embarked in merge train"
+      - 'check-failure=Queue: Embarked in merge train'
     actions:
       comment:
-        message: |
-          Merge failed. Please see automated check logs for more details.
-  - name: Nag changesets
-    conditions:
-      - and:
-        - 'files~=\.((?<!\.spec\.)ts|(?<!\.t\.)sol|go|js|mod|sum)$'
-        - '-files~=^\.changeset/(.*)\.md'
-    actions:
-      comment:
-        message: |
-          This PR changes implementation code, but doesn't include a changeset. Did you forget to add one?
+        message: >
+          Hey @{{ author }}, this pull request failed to merge and has been
+          dequeued from the merge train.  If you believe your PR failed in
+          the merge train because of a flaky test, requeue it by commenting
+          with `@mergifyio requeue`.
 
+          More details can be found on the `Queue: Embarked in merge train`
+          check-run.
   - name: Add indexer tag and ecopod reviewers
     conditions:
       - 'files~=^indexer/'
@@ -117,7 +115,6 @@ pull_request_rules:
         users:
           - roninjin10
           - nickbalestra
-
   - name: Add sdk tag and ecopod reviewers
     conditions:
       - 'files~=^packages/sdk/'
@@ -129,7 +126,6 @@ pull_request_rules:
         users:
           - roninjin10
           - nickbalestra
-
   - name: Add common-ts tag and ecopod reviewers
     conditions:
       - 'files~=^packages/common-ts/'


### PR DESCRIPTION
Updates Mergify rules to support speculative checks. This will allow Mergify to speculatively run checks against multiple queued PRs at once, and reduce the maount of time we spend waiting for PRs to get merged in the queue.

Also removes the changeset nag, and updates the messaging around Mergify queue failures.