### PR TITLE
fix(ctb): remove AddressManager from config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet-forked.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet-forked.json
@@ -28,7 +28,5 @@
   "finalizationPeriodSeconds": 2,
 
   "deploymentWaitConfirmations": 1,
-  "fundDevAccounts": false,
-
-  "addressManager": "0xdE1FCfB0851916CA5101820A69b13a4E276bd81F"
+  "fundDevAccounts": false
 }

--- a/packages/contracts-bedrock/deploy/014-FreshSystemDicator.ts
+++ b/packages/contracts-bedrock/deploy/014-FreshSystemDicator.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import '@eth-optimism/hardhat-deploy-config'
 import 'hardhat-deploy'
@@ -19,7 +20,7 @@ const deployFn: DeployFunction = async (hre) => {
           proxyAdmin: await getDeploymentAddress(hre, 'ProxyAdmin'),
           controller: deployer, // TODO
           finalOwner: hre.deployConfig.proxyAdminOwner,
-          addressManager: hre.deployConfig.addressManager,
+          addressManager: ethers.constants.AddressZero,
         },
         proxyAddressConfig: {
           l2OutputOracleProxy: await getDeploymentAddress(

--- a/packages/contracts-bedrock/deploy/015-MigrationSystemDictator.ts
+++ b/packages/contracts-bedrock/deploy/015-MigrationSystemDictator.ts
@@ -58,7 +58,7 @@ const deployFn: DeployFunction = async (hre) => {
           proxyAdmin: await getDeploymentAddress(hre, 'ProxyAdmin'),
           controller,
           finalOwner,
-          addressManager: hre.deployConfig.addressManager,
+          addressManager: await getDeploymentAddress(hre, 'Lib_AddressManager'),
         },
         proxyAddressConfig: {
           l2OutputOracleProxy: await getDeploymentAddress(

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -66,12 +66,6 @@ const config: HardhatUserConfig = {
       default: ethers.constants.AddressZero,
     },
 
-    // Address of the AddressManager (legacy only).
-    addressManager: {
-      type: 'address',
-      default: ethers.constants.AddressZero,
-    },
-
     // Address of the system controller.
     controller: {
       type: 'address',
@@ -351,6 +345,7 @@ const config: HardhatUserConfig = {
     ],
     deployments: {
       goerli: ['../contracts/deployments/goerli'],
+      mainnet: ['../contracts/deployments/mainnet'],
       'mainnet-forked': ['../contracts/deployments/mainnet'],
     },
   },


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Removes AddressManager from deploy config, not necessary since we can just pull it from the deployments folder.