### PR TITLE
fix(ctb): update ProxyAdmin ordering

### DIFF
--- a/.changeset/sour-ladybugs-confess.md
+++ b/.changeset/sour-ladybugs-confess.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Updates function ordering in ProxyAdmin to match original contract

--- a/packages/contracts-bedrock/contracts/universal/ProxyAdmin.sol
+++ b/packages/contracts-bedrock/contracts/universal/ProxyAdmin.sol
@@ -134,49 +134,6 @@ contract ProxyAdmin is Owned {
     }
 
     /**
-     * @notice Updates the admin of the given proxy address.
-     *
-     * @param _proxy    Address of the proxy to update.
-     * @param _newAdmin Address of the new proxy admin.
-     */
-    function changeProxyAdmin(address payable _proxy, address _newAdmin) external onlyOwner {
-        ProxyType ptype = proxyType[_proxy];
-        if (ptype == ProxyType.ERC1967) {
-            Proxy(_proxy).changeAdmin(_newAdmin);
-        } else if (ptype == ProxyType.CHUGSPLASH) {
-            L1ChugSplashProxy(_proxy).setOwner(_newAdmin);
-        } else if (ptype == ProxyType.RESOLVED) {
-            addressManager.transferOwnership(_newAdmin);
-        } else {
-            revert("ProxyAdmin: unknown proxy type");
-        }
-    }
-
-    /**
-     * @notice Changes a proxy's implementation contract and delegatecalls the new implementation
-     *         with some given data. Useful for atomic upgrade-and-initialize calls.
-     *
-     * @param _proxy          Address of the proxy to upgrade.
-     * @param _implementation Address of the new implementation address.
-     * @param _data           Data to trigger the new implementation with.
-     */
-    function upgradeAndCall(
-        address payable _proxy,
-        address _implementation,
-        bytes memory _data
-    ) external payable onlyOwner {
-        ProxyType ptype = proxyType[_proxy];
-        if (ptype == ProxyType.ERC1967) {
-            Proxy(_proxy).upgradeToAndCall{ value: msg.value }(_implementation, _data);
-        } else {
-            // reverts if proxy type is unknown
-            upgrade(_proxy, _implementation);
-            (bool success, ) = _proxy.call{ value: msg.value }(_data);
-            require(success, "ProxyAdmin: call to proxy after upgrade failed");
-        }
-    }
-
-    /**
      * @custom:legacy
      * @notice Legacy function used to tell ChugSplashProxy contracts if an upgrade is happening.
      *
@@ -229,6 +186,25 @@ contract ProxyAdmin is Owned {
     }
 
     /**
+     * @notice Updates the admin of the given proxy address.
+     *
+     * @param _proxy    Address of the proxy to update.
+     * @param _newAdmin Address of the new proxy admin.
+     */
+    function changeProxyAdmin(address payable _proxy, address _newAdmin) external onlyOwner {
+        ProxyType ptype = proxyType[_proxy];
+        if (ptype == ProxyType.ERC1967) {
+            Proxy(_proxy).changeAdmin(_newAdmin);
+        } else if (ptype == ProxyType.CHUGSPLASH) {
+            L1ChugSplashProxy(_proxy).setOwner(_newAdmin);
+        } else if (ptype == ProxyType.RESOLVED) {
+            addressManager.transferOwnership(_newAdmin);
+        } else {
+            revert("ProxyAdmin: unknown proxy type");
+        }
+    }
+
+    /**
      * @notice Changes a proxy's implementation contract.
      *
      * @param _proxy          Address of the proxy to upgrade.
@@ -251,6 +227,30 @@ contract ProxyAdmin is Owned {
             // It should not be possible to retrieve a ProxyType value which is not matched by
             // one of the previous conditions.
             assert(false);
+        }
+    }
+
+    /**
+     * @notice Changes a proxy's implementation contract and delegatecalls the new implementation
+     *         with some given data. Useful for atomic upgrade-and-initialize calls.
+     *
+     * @param _proxy          Address of the proxy to upgrade.
+     * @param _implementation Address of the new implementation address.
+     * @param _data           Data to trigger the new implementation with.
+     */
+    function upgradeAndCall(
+        address payable _proxy,
+        address _implementation,
+        bytes memory _data
+    ) external payable onlyOwner {
+        ProxyType ptype = proxyType[_proxy];
+        if (ptype == ProxyType.ERC1967) {
+            Proxy(_proxy).upgradeToAndCall{ value: msg.value }(_implementation, _data);
+        } else {
+            // reverts if proxy type is unknown
+            upgrade(_proxy, _implementation);
+            (bool success, ) = _proxy.call{ value: msg.value }(_data);
+            require(success, "ProxyAdmin: call to proxy after upgrade failed");
         }
     }
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates the function ordering for the ProxyAdmin contract to match the function ordering of the original ProxyAdmin by OZ. I think this makes the contract much more readable.
