### PR TITLE
op-batcher: Rewrite ChannelManager

### DIFF
--- a/op-batcher/channel_manager.go
+++ b/op-batcher/channel_manager.go
@@ -116,6 +116,11 @@ func (s *channelManager) pendingChannelIsTimedOut() bool {
 	if s.pendingChannel == (derive.ChannelID{}) {
 		return false // no channel to be timed out
 	}
+	// No confirmed transactions => not timed out
+	if len(s.confirmedTransactions) == 0 {
+		return false
+	}
+	// If there are confirmed transactions, find the first + last confirmed block numbers
 	min := uint64(math.MaxUint64)
 	max := uint64(0)
 	for _, inclusionBlock := range s.confirmedTransactions {

--- a/op-batcher/channel_manager.go
+++ b/op-batcher/channel_manager.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"math"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var ErrReorg = errors.New("block does not extend existing chain")
@@ -22,10 +24,42 @@ type taggedData struct {
 	id   txID
 }
 
+// channelManager stores a contiguous set of blocks & turns them into channels.
+// Upon receiving tx confirmation (or a tx failure), it does channel error handling.
+//
+// For simplicity, it only creates a single pending channel at a time & waits for
+// the channel to either successfully be submitted or timeout before creating a new
+// channel.
+// Functions on channelManager are not safe for concurrent access.
 type channelManager struct {
-	// All blocks since the last request for new tx data
+	log            log.Logger
+	channelTimeout uint64
+
+	// All blocks since the last request for new tx data.
 	blocks []*types.Block
 	datas  []taggedData
+
+	// Pending data returned by TxData waiting on Tx Confirmed/Failed
+	// channelPending is true if there is an unconfirmed channel
+	channelPending bool
+	// id of the pending channel
+	pendingChannel derive.ChannelID
+	// list of blocks in the channel. Saved in case the channel must be rebuilt
+	pendingBlocks []*types.Block
+	// Set of unconfirmed txID -> frame data. For tx resubmission
+	pendingTransactions map[txID][]byte
+	// Set of confirmed txID -> inclusion block. For determining if the channel is timed out
+	confirmedTransactions map[txID]eth.BlockID
+}
+
+func NewChannelManager(log log.Logger, channelTimeout uint64) *channelManager {
+	return &channelManager{
+		log:                   log,
+		channelTimeout:        channelTimeout,
+		channelPending:        false,
+		pendingTransactions:   make(map[txID][]byte),
+		confirmedTransactions: make(map[txID]eth.BlockID),
+	}
 }
 
 // Clear clears the entire state of the channel manager.
@@ -35,90 +69,174 @@ func (s *channelManager) Clear() {
 	s.datas = s.datas[:0]
 }
 
-// func (s *channelManager) TxConfirmed(id txID, inclusionBlock eth.BlockID) {
-// 	// todo: implement
-// }
+func (s *channelManager) TxConfirmed(id txID, inclusionBlock eth.BlockID) {
+	if _, ok := s.pendingTransactions[id]; !ok {
+		s.log.Info("marked transaction as confirmed despite having no record of it")
+		// TODO: This can occur if we clear the channel while there are still pending transactions
+		// We need to keep track of stale transactions instead
+		return
+	}
+	delete(s.pendingTransactions, id)
+	s.confirmedTransactions[id] = inclusionBlock
+
+	// If this channel timed out, put the pending blocks back into the local saved blocks
+	// and then reset this state so it can try to build a new channel.
+	if s.pendingChannelIsTimedOut() {
+		s.log.Warn("Channel timed out", "id", s.pendingChannel)
+		s.blocks = append(s.pendingBlocks, s.blocks...)
+		s.clearPendingChannel()
+	}
+	// If we are done with this channel, record that.
+	if s.pendingChannelIsFullySubmitted() {
+		s.log.Info("Channel is fully submitted", "id", s.pendingChannel)
+		s.clearPendingChannel()
+	}
+}
+
+// TODO: Create separate "pending" state
+func (s *channelManager) clearPendingChannel() {
+	s.channelPending = false
+	s.pendingChannel = derive.ChannelID{}
+	s.pendingBlocks = nil
+	s.pendingTransactions = make(map[txID][]byte)
+	s.confirmedTransactions = make(map[txID]eth.BlockID)
+}
+
+func (s *channelManager) pendingChannelIsTimedOut() bool {
+	if !s.channelPending {
+		return false // no channel to be timed out
+	}
+	min := uint64(math.MaxUint64)
+	max := uint64(0)
+	for _, inclusionBlock := range s.confirmedTransactions {
+		if inclusionBlock.Number < min {
+			min = inclusionBlock.Number
+		}
+		if inclusionBlock.Number > max {
+			max = inclusionBlock.Number
+		}
+	}
+	return max-min >= s.channelTimeout
+}
+
+func (s *channelManager) pendingChannelIsFullySubmitted() bool {
+	if !s.channelPending {
+		return false // todo: can decide either way here. Nonsensical answer though
+	}
+	return len(s.pendingTransactions)+len(s.datas) == 0
+}
+
+func (s *channelManager) TxFailed(id txID) {
+	if data, ok := s.pendingTransactions[id]; ok {
+		s.datas = append(s.datas, taggedData{data, id})
+		delete(s.pendingTransactions, id)
+	} else {
+		s.log.Warn("marked transaction as failed despite having no record of it.")
+	}
+}
+
+// blocksToFrames turns a set of blocks into a set of frames inside a channel.
+// It will only create a single channel which contains up to `MAX_RLP_BYTES`. Any
+// blocks not added to the channel are returned. It uses the max supplied frame size.
+func blocksToFrames(blocks []*types.Block, maxFrameSize uint64) (derive.ChannelID, [][]byte, []*types.Block, error) {
+	ch, err := derive.NewChannelOut()
+	if err != nil {
+		return derive.ChannelID{}, nil, nil, err
+	}
+
+	i := 0
+	for ; i < len(blocks); i++ {
+		if err := ch.AddBlock(blocks[i]); err == derive.ErrTooManyRLPBytes {
+			break
+		} else if err != nil {
+			return derive.ChannelID{}, nil, nil, err
+		}
+	}
+	if err := ch.Close(); err != nil {
+		return derive.ChannelID{}, nil, nil, err
+	}
+
+	var frames [][]byte
+	for {
+		var buf bytes.Buffer
+		buf.WriteByte(derive.DerivationVersion0)
+		err := ch.OutputFrame(&buf, maxFrameSize-1)
+		if err != io.EOF && err != nil {
+			return derive.ChannelID{}, nil, nil, err
+		}
+		frames = append(frames, buf.Bytes())
+		if err == io.EOF {
+			break
+		}
+	}
+	return ch.ID(), frames, blocks[i:], nil
+}
+
+// nextTxData pops off s.datas & handles updating the internal state
+func (s *channelManager) nextTxData() ([]byte, txID, error) {
+	if len(s.datas) != 0 {
+		r := s.datas[0]
+		s.pendingTransactions[r.id] = r.data
+		s.datas = s.datas[1:]
+		return r.data, r.id, nil
+	} else {
+		return nil, txID{}, io.EOF // TODO: not enough data error instead
+	}
+}
 
 // TxData returns the next tx.data that should be submitted to L1.
 // It is very simple & currently ignores the l1Head provided (this will change).
 // It may buffer very large channels as well.
 func (s *channelManager) TxData(l1Head eth.L1BlockRef) ([]byte, txID, error) {
-	// Note: l1Head is not actually used in this function.
+	s.log.Trace("Requested tx data")
 
-	// Return a pre-existing frame if we have it.
-	if len(s.datas) != 0 {
-		r := s.datas[0]
-		s.datas = s.datas[1:]
-		return r.data, r.id, nil
+	// Short circuit if there is a pending channel.
+	// We either submit the next frame from that channel or
+	if s.channelPending {
+		return s.nextTxData()
 	}
-
-	// Also return io.EOF if we cannot create a channel
+	// If we have no saved blocks, we will not be able to create valid frames
 	if len(s.blocks) == 0 {
 		return nil, txID{}, io.EOF
 	}
 
-	// Add all pending blocks to a channel
-	ch, err := derive.NewChannelOut()
+	// Select range of blocks
+	end := len(s.blocks)
+	if end > 100 {
+		end = 100
+	}
+	blocks := s.blocks[:end]
+	s.blocks = s.blocks[end:]
+
+	chID, frames, leftOverBlocks, err := blocksToFrames(blocks, 120_000)
+	// If the range of blocks serialized to be too large, restore
+	// blocks that could not be included inside the channel
+	if len(leftOverBlocks) != 0 {
+		s.blocks = append(leftOverBlocks, s.blocks...)
+	}
 	if err != nil {
-		return nil, txID{}, err
-	}
-	// TODO: use peek/pop paradigm here instead of manually slicing
-	i := 0
-	// Cap length at 100 blocks
-	l := len(s.blocks)
-	if l > 100 {
-		l = 100
-	}
-	for ; i < l; i++ {
-		if err := ch.AddBlock(s.blocks[i]); err == derive.ErrTooManyRLPBytes {
-			break
-		} else if err != nil {
-			return nil, txID{}, err
-		}
-		// TODO: limit the RLP size of the channel to be lower than the limit to enable
-		// channels to be fully submitted on time.
-	}
-	if err := ch.Close(); err != nil {
 		return nil, txID{}, err
 	}
 
 	var t []taggedData
-	frameNumber := uint16(0)
-	for {
-		var buf bytes.Buffer
-		buf.WriteByte(derive.DerivationVersion0)
-		err := ch.OutputFrame(&buf, 120_000)
-		if err != io.EOF && err != nil {
-			return nil, txID{}, err
-		}
-
-		t = append(t, taggedData{
-			data: buf.Bytes(),
-			id:   txID{ch.ID(), frameNumber},
-		})
-		frameNumber += 1
-		if err == io.EOF {
-			break
-		}
+	for i, data := range frames {
+		t = append(t, taggedData{data: data, id: txID{chID: chID, frameNumber: uint16(i)}})
 	}
 
-	s.datas = append(s.datas, t...)
-	// Say i = 0, 1 are added to the channel, but i = 2 returns ErrTooManyRLPBytes. i remains 2 & is inclusive, so this works.
-	// Say all blocks are added, i will be len(blocks) after exiting the loop (but never inside the loop).
-	s.blocks = s.blocks[i:]
+	// Load up pending state. Note: pending transactions is taken care of by nextTxData
+	s.datas = t
+	s.channelPending = true
+	s.pendingChannel = chID
+	s.pendingBlocks = blocks[:len(leftOverBlocks)]
 
-	if len(s.datas) == 0 {
-		return nil, txID{}, io.EOF // TODO: not enough data error instead
-	}
+	return s.nextTxData()
 
-	r := s.datas[0]
-	s.datas = s.datas[1:]
-	return r.data, r.id, nil
 }
 
 // AddL2Block saves an L2 block to the internal state. It returns ErrReorg
 // if the block does not extend the last block loaded into the state.
 // If no block is already in the channel, the the parent hash check is skipped.
+// TODO: Phantom last block b/c if the local state is fully drained we can reorg without realizing it.
 func (s *channelManager) AddL2Block(block *types.Block) error {
 	if len(s.blocks) > 0 {
 		if s.blocks[len(s.blocks)-1].Hash() != block.ParentHash() {

--- a/op-batcher/channel_manager.go
+++ b/op-batcher/channel_manager.go
@@ -3,6 +3,7 @@ package op_batcher
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 
@@ -14,9 +15,22 @@ import (
 
 var ErrReorg = errors.New("block does not extend existing chain")
 
+// txID is an opaque identifier for a transaction.
+// It's internal fields should not be inspected after creation & are subject to change.
+// This ID must be trivially comparable & work as a map key.
 type txID struct {
 	chID        derive.ChannelID
 	frameNumber uint16
+}
+
+func (id txID) String() string {
+	return fmt.Sprintf("%s:%d", id.chID.String(), id.frameNumber)
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (id txID) TerminalString() string {
+	return fmt.Sprintf("%s:%d", id.chID.TerminalString(), id.frameNumber)
 }
 
 type taggedData struct {

--- a/op-batcher/driver.go
+++ b/op-batcher/driver.go
@@ -279,11 +279,12 @@ func (l *BatchSubmitter) loop() {
 					l.log.Error("unable to get tx data", "err", err)
 					break
 				}
-				// Drop receipt + error for now
+				// Record TX Status
 				if receipt, err := l.txMgr.SendTransaction(l.ctx, data); err != nil {
 					l.log.Error("Failed to send transaction", "err", err)
 					l.state.TxFailed(id)
 				} else {
+					l.log.Info("Transaction confirmed", "tx_hash", receipt.TxHash, "status", receipt.Status, "block_hash", receipt.BlockHash, "block_number", receipt.BlockNumber)
 					l.state.TxConfirmed(id, eth.BlockID{Number: receipt.BlockNumber.Uint64(), Hash: receipt.BlockHash})
 				}
 			}


### PR DESCRIPTION
**Description**

The channel manager is now responsible for tracking in flight frames and properly handling different error conditions.

A channel is a collection of frames. We have a single frame per L1 transaction.
When frames are submitted to L1 even if all frames are successfully included, their
inclusion may not be timely. The tx confirmation method handles resubmitting frames
if the transaction fails or voiding the entire channel if the channel times out.

It has hook points for how large a range of blocks to select, but does not use them
yet. It simply chooses up to 100 blocks (but it will also not submit channels that
are too large).

**Tests**

No unit tests yet. op-e2e still passing.

