### PR TITLE
ci: Temporarily disable buggy devnet build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,9 +803,9 @@ workflows:
       - bedrock-go-tests
       - fuzz-op-node
       - bedrock-markdown
-      - devnet:
-          name: devnet (with deployed contracts)
-          deploy: true
+      # - devnet:
+      #     name: devnet (with deployed contracts)
+      #     deploy: true
       - devnet:
           name: devnet (with genesis contracts)
           deploy: false


### PR DESCRIPTION
This has been causing us a lot of grief over the last few days. Disabling this until I can get to the bottom of why this is so flaky.
