### PR TITLE
[op-node] Check that BlockNumber is non-nil in the receipt validation

### DIFF
--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -30,6 +30,9 @@ func makeReceiptsFn(block eth.BlockID, receiptHash common.Hash) func(txHashes []
 			if r.TransactionIndex != uint(i) {
 				return nil, fmt.Errorf("receipt %d has unexpected tx index %d", i, r.TransactionIndex)
 			}
+			if r.BlockNumber == nil {
+				return nil, fmt.Errorf("receipt %d has unexpected nil block number, expected %d", i, block.Number)
+			}
 			if r.BlockNumber.Uint64() != block.Number {
 				return nil, fmt.Errorf("receipt %d has unexpected block number %d, expected %d", i, r.BlockNumber, block.Number)
 			}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We saw `op-node` panic in an internal PoA testnet, I believe due to a reorg that happened during a deploy (having multiple PoA signers with the same key during the deploy). This caused some of the tx receipts returned from the L1 have a `null` `blockNumber` value, causing a `panic: runtime error: invalid memory address or nil pointer dereference` error.

**Tests**

There doesn't appear to be any existing tests for this logic, but happy to add some if I'm missing where those are.

**Additional context**

Stacktrace:
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe276b4]
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 217 [running]:
math/big.(*Int).Uint64(...)
	/usr/local/go/src/math/big/int.go:384
github.com/ethereum-optimism/optimism/op-node/sources.makeReceiptsFn.func1({0xc0038d7780?, 0x1371e40?, 0x19?}, {0xc0003899f8, 0x1, 0x1})
	/app/op-node/sources/receipts.go:33 +0xd8
github.com/ethereum-optimism/optimism/op-node/sources.(*IterativeBatchCall[...]).Result(0xc003aa8000)
	/app/op-node/sources/batching.go:170 +0x169
github.com/ethereum-optimism/optimism/op-node/sources.(*EthClient).FetchReceipts(0xc000180140, {0x1718b80, 0xc0038fad80}, {0x5f, 0xb0, 0x7e, 0x59, 0x1c, 0x67, 0x50, ...})
	/app/op-node/sources/eth_client.go:265 +0x1fc
github.com/ethereum-optimism/optimism/op-node/rollup/derive.PreparePayloadAttributes({0x1718b80?, 0xc0038fad80?}, 0xc0002e2438, {0x7ff8045043e8?, 0xc00007e0c0?}, {{0xd9, 0xe6, 0x83, 0xa9, 0x9d, ...}, ...}, ...)
	/app/op-node/rollup/derive/attributes.go:34 +0x97
github.com/ethereum-optimism/optimism/op-node/rollup/driver.(*Sequencer).StartBuildingBlock(_, {_, _}, {{0xd9, 0xe6, 0x83, 0xa9, 0x9d, 0x31, 0x31, ...}, ...}, ...)
	/app/op-node/rollup/driver/sequencer.go:53 +0x50b
github.com/ethereum-optimism/optimism/op-node/rollup/driver.(*Sequencer).CreateNewBlock(_, {_, _}, {{0xd9, 0xe6, 0x83, 0xa9, 0x9d, 0x31, 0x31, ...}, ...}, ...)
	/app/op-node/rollup/driver/sequencer.go:100 +0x105
github.com/ethereum-optimism/optimism/op-node/rollup/driver.(*Driver).createNewL2Block(0xc0003f4000, {0x1718b80, 0xc003a3cc00})
	/app/op-node/rollup/driver/state.go:161 +0x789
github.com/ethereum-optimism/optimism/op-node/rollup/driver.(*Driver).eventLoop(0xc0003f4000)
	/app/op-node/rollup/driver/state.go:270 +0x5ce
created by github.com/ethereum-optimism/optimism/op-node/rollup/driver.(*Driver).Start
	/app/op-node/rollup/driver/state.go:79 +0x85
```