### PR TITLE
ci: fix hardhat-node release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
           context: ./ops/docker/hardhat
           file: ./Dockerfile
           push: true
-          tags: ethereumoptimism/hardhat-node:${{ needs.release.outputs.gas-oracle }},ethereumoptimism/hardhat-node:latest
+          tags: ethereumoptimism/hardhat-node:${{ needs.release.outputs.hardhat-node }},ethereumoptimism/hardhat-node:latest
 
   ci-builder:
     name: Publish ci-builder ${{ needs.release.outputs.ci-builder }}


### PR DESCRIPTION
**Description**

There was a typo in the config for building/publishing the `ethereumoptimism/hardhat-node` docker image.
This fixes that typo so that builds can be properly published to dockerhub.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

