### PR TITLE
op-node: fieldalign HeaderInfo

### DIFF
--- a/op-node/sources/types.go
+++ b/op-node/sources/types.go
@@ -32,16 +32,16 @@ type BatchCallContextFn func(ctx context.Context, b []rpc.BatchElem) error
 // HeaderInfo contains all the header-info required to implement the eth.BlockInfo interface,
 // used in the rollup state-transition, with pre-computed block hash.
 type HeaderInfo struct {
-	hash        common.Hash
-	parentHash  common.Hash
-	coinbase    common.Address
-	root        common.Hash
+	baseFee     *big.Int
 	number      uint64
 	time        uint64
+	hash        common.Hash
+	parentHash  common.Hash
+	root        common.Hash
 	mixDigest   common.Hash // a.k.a. the randomness field post-merge.
-	baseFee     *big.Int
 	txHash      common.Hash
 	receiptHash common.Hash
+	coinbase    common.Address
 }
 
 var _ eth.BlockInfo = (*HeaderInfo)(nil)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Order fields in struct to reduce memory consumption

**Additional context**

I realize I should have opened a small PR like this instead of https://github.com/ethereum-optimism/optimism/pull/3766

I think this would be a good improvement as `HeaderInfo` sits in the cache and doesn't have json encoding. Please correct me if I'm wrong.

```
$ fieldalignment -fix ./...
/Users/estensen/Developer/optimism/op-node/sources/types.go:34:17: struct with 176 pointer bytes could be 8
```

