### PR TITLE
op-e2e: Use head rather than pending block for gas estimation

### DIFF
--- a/op-e2e/actions/user.go
+++ b/op-e2e/actions/user.go
@@ -122,11 +122,11 @@ func (s *BasicUser[B]) signerFn(address common.Address, tx *types.Transaction) (
 
 // ActResetTxOpts prepares the tx options to default values, based on the current pending block header.
 func (s *BasicUser[B]) ActResetTxOpts(t Testing) {
-	pendingHeader, err := s.env.EthCl.HeaderByNumber(t.Ctx(), big.NewInt(-1))
-	require.NoError(t, err, "need l2 pending header for accurate basefee info")
+	latestHeader, err := s.env.EthCl.HeaderByNumber(t.Ctx(), nil)
+	require.NoError(t, err, "need l2 latest header for accurate basefee info")
 
 	gasTipCap := big.NewInt(2 * params.GWei)
-	gasFeeCap := new(big.Int).Add(gasTipCap, new(big.Int).Mul(pendingHeader.BaseFee, big.NewInt(2)))
+	gasFeeCap := new(big.Int).Add(gasTipCap, new(big.Int).Mul(latestHeader.BaseFee, big.NewInt(2)))
 
 	s.txOpts = bind.TransactOpts{
 		From:      s.address,


### PR DESCRIPTION
**Description**

This should hopefully avoid issues with not being able to find the pending block.

