### PR TITLE
fix: more config cleanup

### DIFF
--- a/indexer/integration_tests/bedrock_test.go
+++ b/indexer/integration_tests/bedrock_test.go
@@ -79,8 +79,8 @@ func TestBedrockIndexer(t *testing.T) {
 		RESTPort:                       7980,
 		DisableIndexer:                 false,
 		Bedrock:                        true,
-		BedrockL1StandardBridgeAddress: predeploys.DevL1StandardBridgeAddr,
-		BedrockOptimismPortalAddress:   predeploys.DevOptimismPortalAddr,
+		BedrockL1StandardBridgeAddress: cfg.DeployConfig.L1StandardBridgeProxy,
+		BedrockOptimismPortalAddress:   cfg.DeployConfig.OptimismPortalProxy,
 	}
 	idxr, err := indexer.NewIndexer(idxrCfg)
 	require.NoError(t, err)

--- a/op-chain-ops/cmd/migrate/main.go
+++ b/op-chain-ops/cmd/migrate/main.go
@@ -152,18 +152,8 @@ func main() {
 				return err
 			}
 
-			l2Addrs := genesis.L2Addresses{
-				ProxyAdminOwner:             config.ProxyAdminOwner,
-				L1StandardBridgeProxy:       config.L1StandardBridgeProxy,
-				L1CrossDomainMessengerProxy: config.L1CrossDomainMessengerProxy,
-				L1ERC721BridgeProxy:         config.L1ERC721BridgeProxy,
-				BaseFeeVaultRecipient:       config.BaseFeeVaultRecipient,
-				L1FeeVaultRecipient:         config.L1FeeVaultRecipient,
-				SequencerFeeVaultRecipient:  config.SequencerFeeVaultRecipient,
-			}
-
 			dryRun := ctx.Bool("dry-run")
-			if err := genesis.MigrateDB(ldb, config, block, &l2Addrs, &migrationData, !dryRun); err != nil {
+			if err := genesis.MigrateDB(ldb, config, block, &migrationData, !dryRun); err != nil {
 				return err
 			}
 

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -249,8 +249,8 @@ func (d *DeployConfig) GetDeployedAddresses(hh *hardhat.Hardhat) error {
 	return nil
 }
 
-// GetDeveloperDeployedAddresses will set the dev addresses on the DeployConfig
-func (d *DeployConfig) GetDeveloperDeployedAddresses() error {
+// InitDeveloperDeployedAddresses will set the dev addresses on the DeployConfig
+func (d *DeployConfig) InitDeveloperDeployedAddresses() error {
 	d.L1StandardBridgeProxy = predeploys.DevL1StandardBridgeAddr
 	d.L1CrossDomainMessengerProxy = predeploys.DevL1CrossDomainMessengerAddr
 	d.L1ERC721BridgeProxy = predeploys.DevL1ERC721BridgeAddr

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -20,7 +20,7 @@ import (
 var abiTrue = common.Hash{31: 0x01}
 
 // MigrateDB will migrate an old l2geth database to the new bedrock style system
-func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, l2Addrs *L2Addresses, migrationData *migration.MigrationData, commit bool) error {
+func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, migrationData *migration.MigrationData, commit bool) error {
 	hash := rawdb.ReadHeadHeaderHash(ldb)
 	num := rawdb.ReadHeaderNumber(ldb, hash)
 	header := rawdb.ReadHeader(ldb, hash, *num)
@@ -45,12 +45,12 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, l
 		return fmt.Errorf("cannot set L2Proxies: %w", err)
 	}
 
-	storage, err := NewL2StorageConfig(config, l1Block, l2Addrs)
+	storage, err := NewL2StorageConfig(config, l1Block)
 	if err != nil {
 		return fmt.Errorf("cannot create storage config: %w", err)
 	}
 
-	immutable, err := NewL2ImmutableConfig(config, l1Block, l2Addrs)
+	immutable, err := NewL2ImmutableConfig(config, l1Block)
 	if err != nil {
 		return fmt.Errorf("cannot create immutable config: %w", err)
 	}
@@ -59,7 +59,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, l
 		return fmt.Errorf("cannot set implementations: %w", err)
 	}
 
-	err = crossdomain.MigrateWithdrawals(withdrawals, db, &l2Addrs.L1CrossDomainMessengerProxy, &l2Addrs.L1StandardBridgeProxy)
+	err = crossdomain.MigrateWithdrawals(withdrawals, db, &config.L1CrossDomainMessengerProxy, &config.L1StandardBridgeProxy)
 	if err != nil {
 		return fmt.Errorf("cannot migrate withdrawals: %w", err)
 	}

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -1,38 +1,15 @@
 package genesis
 
 import (
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/core"
 )
 
-// L2Addresses represents L1 contract addresses
-// that are required for the construction of an L2 state
-type L2Addresses struct {
-	// ProxyAdminOwner represents the admin of the L2 ProxyAdmin predeploy
-	ProxyAdminOwner common.Address
-	// L1StandardBridgeProxy represents the L1 contract address of the L1StandardBridgeProxy
-	L1StandardBridgeProxy common.Address
-	// L1CrossDomainMessengerProxy represents the L1 contract address of the L1CrossDomainMessengerProxy
-	L1CrossDomainMessengerProxy common.Address
-	// L1ERC721BridgeProxy represents the L1 contract address of the L1ERC721BridgeProxy
-	L1ERC721BridgeProxy common.Address
-	// SequencerFeeVaultRecipient represents the L1 address that the SequencerFeeVault can withdraw to
-	SequencerFeeVaultRecipient common.Address
-	// L1FeeVaultRecipient represents the L1 address that the L1FeeVault can withdraw to
-	L1FeeVaultRecipient common.Address
-	// BaseFeeVaultRecipient represents the L1 address that the BaseFeeVault can withdraw to
-	BaseFeeVaultRecipient common.Address
-	// SystemConfigProxy represents the L1 contract address of the SystemConfigProxy
-	SystemConfigProxy common.Address
-}
-
 // BuildL2DeveloperGenesis will build the developer Optimism Genesis
 // Block. Suitable for devnets.
-func BuildL2DeveloperGenesis(config *DeployConfig, l1StartBlock *types.Block, l2Addrs *L2Addresses) (*core.Genesis, error) {
+func BuildL2DeveloperGenesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Genesis, error) {
 	genspec, err := NewL2Genesis(config, l1StartBlock)
 	if err != nil {
 		return nil, err
@@ -45,36 +22,21 @@ func BuildL2DeveloperGenesis(config *DeployConfig, l1StartBlock *types.Block, l2
 	}
 	SetPrecompileBalances(db)
 
-	// Use the known developer addresses if they are not set
-	if l2Addrs == nil {
-		l2Addrs = &L2Addresses{
-			L1StandardBridgeProxy:       predeploys.DevL1StandardBridgeAddr,
-			L1CrossDomainMessengerProxy: predeploys.DevL1CrossDomainMessengerAddr,
-			L1ERC721BridgeProxy:         predeploys.DevL1ERC721BridgeAddr,
-			SystemConfigProxy:           predeploys.DevSystemConfigAddr,
-			// Hardcoded address corresponds to m/44'/60'/0'/0/1 in the 'test test... junk' mnemonic
-			ProxyAdminOwner:            common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
-			SequencerFeeVaultRecipient: common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
-			L1FeeVaultRecipient:        common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
-			BaseFeeVaultRecipient:      common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
-		}
-	}
-
-	return BuildL2Genesis(db, config, l1StartBlock, l2Addrs)
+	return BuildL2Genesis(db, config, l1StartBlock)
 }
 
 // BuildL2Genesis will build the L2 Optimism Genesis Block
-func BuildL2Genesis(db *state.MemoryStateDB, config *DeployConfig, l1Block *types.Block, l2Addrs *L2Addresses) (*core.Genesis, error) {
+func BuildL2Genesis(db *state.MemoryStateDB, config *DeployConfig, l1Block *types.Block) (*core.Genesis, error) {
 	if err := SetL2Proxies(db); err != nil {
 		return nil, err
 	}
 
-	storage, err := NewL2StorageConfig(config, l1Block, l2Addrs)
+	storage, err := NewL2StorageConfig(config, l1Block)
 	if err != nil {
 		return nil, err
 	}
 
-	immutable, err := NewL2ImmutableConfig(config, l1Block, l2Addrs)
+	immutable, err := NewL2ImmutableConfig(config, l1Block)
 	if err != nil {
 		return nil, err
 	}

--- a/op-chain-ops/genesis/layer_two_test.go
+++ b/op-chain-ops/genesis/layer_two_test.go
@@ -42,7 +42,7 @@ func TestBuildL2DeveloperGenesis(t *testing.T) {
 	block, err := backend.BlockByNumber(context.Background(), common.Big0)
 	require.NoError(t, err)
 
-	gen, err := genesis.BuildL2DeveloperGenesis(config, block, nil)
+	gen, err := genesis.BuildL2DeveloperGenesis(config, block)
 	require.Nil(t, err)
 	require.NotNil(t, gen)
 
@@ -78,6 +78,9 @@ func TestBuildL2DeveloperGenesisDevAccountsFunding(t *testing.T) {
 	require.Nil(t, err)
 	config.FundDevAccounts = false
 
+	err = config.GetDeveloperDeployedAddresses()
+	require.NoError(t, err)
+
 	backend := backends.NewSimulatedBackend(
 		core.GenesisAlloc{
 			crypto.PubkeyToAddress(testKey.PublicKey): {Balance: big.NewInt(10000000000000000)},
@@ -87,7 +90,7 @@ func TestBuildL2DeveloperGenesisDevAccountsFunding(t *testing.T) {
 	block, err := backend.BlockByNumber(context.Background(), common.Big0)
 	require.NoError(t, err)
 
-	gen, err := genesis.BuildL2DeveloperGenesis(config, block, nil)
+	gen, err := genesis.BuildL2DeveloperGenesis(config, block)
 	require.NoError(t, err)
 	require.Equal(t, 2321, len(gen.Alloc))
 }

--- a/op-chain-ops/genesis/layer_two_test.go
+++ b/op-chain-ops/genesis/layer_two_test.go
@@ -78,7 +78,7 @@ func TestBuildL2DeveloperGenesisDevAccountsFunding(t *testing.T) {
 	require.Nil(t, err)
 	config.FundDevAccounts = false
 
-	err = config.GetDeveloperDeployedAddresses()
+	err = config.InitDeveloperDeployedAddresses()
 	require.NoError(t, err)
 
 	backend := backends.NewSimulatedBackend(

--- a/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
@@ -22,6 +22,7 @@
   "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
   "sequencerFeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
+  "l1ERC721BridgeProxy": "0xff000000000000000000000000000000000000ff",
 
   "deploymentWaitConfirmations": 1,
   "fundDevAccounts": true

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -106,6 +106,13 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 
 		FundDevAccounts: false,
 	}
+
+	// Configure the DeployConfig with the expected developer L1
+	// addresses.
+	if err := deployConfig.GetDeveloperDeployedAddresses(); err != nil {
+		panic(err)
+	}
+
 	return &DeployParams{
 		DeployConfig:   deployConfig,
 		MnemonicConfig: mnemonicCfg,
@@ -167,7 +174,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 
 	l1Block := l1Genesis.ToBlock()
 
-	l2Genesis, err := genesis.BuildL2DeveloperGenesis(deployConf, l1Block, nil)
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(deployConf, l1Block)
 	require.NoError(t, err, "failed to create l2 genesis")
 	if alloc.PrefundTestUsers {
 		for _, addr := range deployParams.Addresses.All() {

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -109,7 +109,7 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 
 	// Configure the DeployConfig with the expected developer L1
 	// addresses.
-	if err := deployConfig.GetDeveloperDeployedAddresses(); err != nil {
+	if err := deployConfig.InitDeveloperDeployedAddresses(); err != nil {
 		panic(err)
 	}
 

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -39,7 +39,7 @@ func TestMissingGasLimit(t *testing.T) {
 	require.Nil(t, err)
 	l1Block := l1Genesis.ToBlock()
 
-	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block, nil)
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block)
 	require.Nil(t, err)
 	l2GenesisBlock := l2Genesis.ToBlock()
 
@@ -109,7 +109,7 @@ func TestInvalidDepositInFCU(t *testing.T) {
 	require.Nil(t, err)
 	l1Block := l1Genesis.ToBlock()
 
-	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block, nil)
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block)
 	require.Nil(t, err)
 	l2GenesisBlock := l2Genesis.ToBlock()
 

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -103,7 +103,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 		FundDevAccounts: true,
 	}
 
-	if err := deployConfig.GetDeveloperDeployedAddresses(); err != nil {
+	if err := deployConfig.InitDeveloperDeployedAddresses(); err != nil {
 		panic(err)
 	}
 

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -46,67 +46,73 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 	require.NoError(t, err)
 	addresses := secrets.Addresses()
 
+	deployConfig := &genesis.DeployConfig{
+		L1ChainID:   900,
+		L2ChainID:   901,
+		L2BlockTime: 2,
+
+		FinalizationPeriodSeconds: 60 * 60 * 24,
+		MaxSequencerDrift:         10,
+		SequencerWindowSize:       30,
+		ChannelTimeout:            10,
+		P2PSequencerAddress:       addresses.SequencerP2P,
+		BatchInboxAddress:         common.Address{0: 0x52, 19: 0xff}, // tbd
+		BatchSenderAddress:        addresses.Batcher,
+
+		L2OutputOracleSubmissionInterval: 4,
+		L2OutputOracleStartingTimestamp:  -1,
+		L2OutputOracleProposer:           addresses.Proposer,
+		L2OutputOracleOwner:              common.Address{}, // tbd
+
+		SystemConfigOwner: addresses.SysCfgOwner,
+
+		L1BlockTime:                 2,
+		L1GenesisBlockNonce:         4660,
+		CliqueSignerAddress:         addresses.CliqueSigner,
+		L1GenesisBlockTimestamp:     hexutil.Uint64(time.Now().Unix()),
+		L1GenesisBlockGasLimit:      8_000_000,
+		L1GenesisBlockDifficulty:    uint642big(1),
+		L1GenesisBlockMixHash:       common.Hash{},
+		L1GenesisBlockCoinbase:      common.Address{},
+		L1GenesisBlockNumber:        0,
+		L1GenesisBlockGasUsed:       0,
+		L1GenesisBlockParentHash:    common.Hash{},
+		L1GenesisBlockBaseFeePerGas: uint642big(7),
+
+		L2GenesisBlockNonce:         0,
+		L2GenesisBlockExtraData:     []byte{},
+		L2GenesisBlockGasLimit:      8_000_000,
+		L2GenesisBlockDifficulty:    uint642big(1),
+		L2GenesisBlockMixHash:       common.Hash{},
+		L2GenesisBlockCoinbase:      common.Address{0: 0x12},
+		L2GenesisBlockNumber:        0,
+		L2GenesisBlockGasUsed:       0,
+		L2GenesisBlockParentHash:    common.Hash{},
+		L2GenesisBlockBaseFeePerGas: uint642big(7),
+
+		L2CrossDomainMessengerOwner: common.Address{0: 0x52, 19: 0xf3}, // tbd
+
+		GasPriceOracleOverhead: 2100,
+		GasPriceOracleScalar:   1_000_000,
+
+		DeploymentWaitConfirmations: 1,
+
+		EIP1559Elasticity:  2,
+		EIP1559Denominator: 8,
+
+		FundDevAccounts: true,
+	}
+
+	if err := deployConfig.GetDeveloperDeployedAddresses(); err != nil {
+		panic(err)
+	}
+
 	return SystemConfig{
 		Secrets: secrets,
 
 		Premine: make(map[common.Address]*big.Int),
 
-		DeployConfig: &genesis.DeployConfig{
-			L1ChainID:   900,
-			L2ChainID:   901,
-			L2BlockTime: 2,
-
-			FinalizationPeriodSeconds: 60 * 60 * 24,
-			MaxSequencerDrift:         10,
-			SequencerWindowSize:       30,
-			ChannelTimeout:            10,
-			P2PSequencerAddress:       addresses.SequencerP2P,
-			BatchInboxAddress:         common.Address{0: 0x52, 19: 0xff}, // tbd
-			BatchSenderAddress:        addresses.Batcher,
-
-			L2OutputOracleSubmissionInterval: 4,
-			L2OutputOracleStartingTimestamp:  -1,
-			L2OutputOracleProposer:           addresses.Proposer,
-			L2OutputOracleOwner:              common.Address{}, // tbd
-
-			SystemConfigOwner: addresses.SysCfgOwner,
-
-			L1BlockTime:                 2,
-			L1GenesisBlockNonce:         4660,
-			CliqueSignerAddress:         addresses.CliqueSigner,
-			L1GenesisBlockTimestamp:     hexutil.Uint64(time.Now().Unix()),
-			L1GenesisBlockGasLimit:      8_000_000,
-			L1GenesisBlockDifficulty:    uint642big(1),
-			L1GenesisBlockMixHash:       common.Hash{},
-			L1GenesisBlockCoinbase:      common.Address{},
-			L1GenesisBlockNumber:        0,
-			L1GenesisBlockGasUsed:       0,
-			L1GenesisBlockParentHash:    common.Hash{},
-			L1GenesisBlockBaseFeePerGas: uint642big(7),
-
-			L2GenesisBlockNonce:         0,
-			L2GenesisBlockExtraData:     []byte{},
-			L2GenesisBlockGasLimit:      8_000_000,
-			L2GenesisBlockDifficulty:    uint642big(1),
-			L2GenesisBlockMixHash:       common.Hash{},
-			L2GenesisBlockCoinbase:      common.Address{0: 0x12},
-			L2GenesisBlockNumber:        0,
-			L2GenesisBlockGasUsed:       0,
-			L2GenesisBlockParentHash:    common.Hash{},
-			L2GenesisBlockBaseFeePerGas: uint642big(7),
-
-			L2CrossDomainMessengerOwner: common.Address{0: 0x52, 19: 0xf3}, // tbd
-
-			GasPriceOracleOverhead: 2100,
-			GasPriceOracleScalar:   1_000_000,
-
-			DeploymentWaitConfirmations: 1,
-
-			EIP1559Elasticity:  2,
-			EIP1559Denominator: 8,
-
-			FundDevAccounts: true,
-		},
+		DeployConfig:           deployConfig,
 		L1InfoPredeployAddress: predeploys.L1BlockAddr,
 		JWTFilePath:            writeDefaultJWT(t),
 		JWTSecret:              testingJWTSecret,
@@ -262,7 +268,7 @@ func (cfg SystemConfig) Start() (*System, error) {
 	}
 
 	l1Block := l1Genesis.ToBlock()
-	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block, nil)
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -52,7 +52,7 @@ var Subcommands = cli.Commands{
 			}
 
 			// Add the developer L1 addresses to the config
-			if err := config.GetDeveloperDeployedAddresses(); err != nil {
+			if err := config.InitDeveloperDeployedAddresses(); err != nil {
 				return err
 			}
 

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/hardhat"
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -52,6 +51,11 @@ var Subcommands = cli.Commands{
 				return err
 			}
 
+			// Add the developer L1 addresses to the config
+			if err := config.GetDeveloperDeployedAddresses(); err != nil {
+				return err
+			}
+
 			if err := config.Check(); err != nil {
 				return err
 			}
@@ -62,12 +66,15 @@ var Subcommands = cli.Commands{
 			}
 
 			l1StartBlock := l1Genesis.ToBlock()
-			l2Genesis, err := genesis.BuildL2DeveloperGenesis(config, l1StartBlock, nil)
+			l2Genesis, err := genesis.BuildL2DeveloperGenesis(config, l1StartBlock)
 			if err != nil {
 				return err
 			}
 
-			rollupConfig := makeRollupConfig(config, l1StartBlock, l2Genesis, predeploys.DevOptimismPortalAddr, predeploys.DevSystemConfigAddr)
+			rollupConfig, err := makeRollupConfig(config, l1StartBlock, l2Genesis)
+			if err != nil {
+				return err
+			}
 
 			if err := writeGenesisFile(ctx.String("outfile.l1"), l1Genesis); err != nil {
 				return err
@@ -138,31 +145,24 @@ var Subcommands = cli.Commands{
 				return err
 			}
 
+			// Read the appropriate deployment addresses from disk
 			if err := config.GetDeployedAddresses(hh); err != nil {
 				return err
 			}
-
+			// Sanity check the config
 			if err := config.Check(); err != nil {
 				return err
 			}
-
-			// TODO: delete this struct as everything is now in the DeployConfig
-			l2Addrs := &genesis.L2Addresses{
-				ProxyAdminOwner:             config.ProxyAdminOwner,
-				L1StandardBridgeProxy:       config.L1StandardBridgeProxy,
-				L1CrossDomainMessengerProxy: config.L1CrossDomainMessengerProxy,
-				L1ERC721BridgeProxy:         config.L1ERC721BridgeProxy,
-				BaseFeeVaultRecipient:       config.BaseFeeVaultRecipient,
-				L1FeeVaultRecipient:         config.L1FeeVaultRecipient,
-				SequencerFeeVaultRecipient:  config.SequencerFeeVaultRecipient,
-				SystemConfigProxy:           config.SystemConfigProxy,
-			}
-			l2Genesis, err := genesis.BuildL2DeveloperGenesis(config, l1StartBlock, l2Addrs)
+			// Build the developer L2 genesis block
+			l2Genesis, err := genesis.BuildL2DeveloperGenesis(config, l1StartBlock)
 			if err != nil {
 				return fmt.Errorf("error creating l2 developer genesis: %w", err)
 			}
 
-			rollupConfig := makeRollupConfig(config, l1StartBlock, l2Genesis, config.OptimismPortalProxy, config.SystemConfigProxy)
+			rollupConfig, err := makeRollupConfig(config, l1StartBlock, l2Genesis)
+			if err != nil {
+				return err
+			}
 			if err := rollupConfig.Check(); err != nil {
 				return fmt.Errorf("generated rollup config does not pass validation: %w", err)
 			}
@@ -175,13 +175,14 @@ var Subcommands = cli.Commands{
 	},
 }
 
-func makeRollupConfig(
-	config *genesis.DeployConfig,
-	l1StartBlock *types.Block,
-	l2Genesis *core.Genesis,
-	portalAddr common.Address,
-	sysConfigAddr common.Address,
-) *rollup.Config {
+func makeRollupConfig(config *genesis.DeployConfig, l1StartBlock *types.Block, l2Genesis *core.Genesis) (*rollup.Config, error) {
+	if config.OptimismPortalProxy == (common.Address{}) {
+		return nil, errors.New("OptimismPortalProxy cannot be address(0)")
+	}
+	if config.SystemConfigProxy == (common.Address{}) {
+		return nil, errors.New("SystemConfigProxy cannot be address(0)")
+	}
+
 	return &rollup.Config{
 		Genesis: rollup.Genesis{
 			L1: eth.BlockID{
@@ -208,9 +209,9 @@ func makeRollupConfig(
 		L2ChainID:              new(big.Int).SetUint64(config.L2ChainID),
 		P2PSequencerAddress:    config.P2PSequencerAddress,
 		BatchInboxAddress:      config.BatchInboxAddress,
-		DepositContractAddress: portalAddr,
-		L1SystemConfigAddress:  sysConfigAddr,
-	}
+		DepositContractAddress: config.OptimismPortalProxy,
+		L1SystemConfigAddress:  config.SystemConfigProxy,
+	}, nil
 }
 
 func writeGenesisFile(outfile string, input interface{}) error {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Now all of the config lives in the `DeployConfig`
and there is a method to read dynamic config values
from disk given a hh or the dev addresses can be
added to the config with `GetDeveloperDeployedAddresses`.

This is useful to deduplicate code that has been changing
a lot, resulting in code changes in many places to get
tests passing again.

This will break hive when we do another release of the go
packages.

Fixes ENG-2993

