### PR TITLE
op-chain-ops: add logging to db migration

### DIFF
--- a/op-chain-ops/crossdomain/migrate.go
+++ b/op-chain-ops/crossdomain/migrate.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
@@ -19,7 +20,7 @@ var (
 
 // MigrateWithdrawals will migrate a list of pending withdrawals given a StateDB.
 func MigrateWithdrawals(withdrawals []*LegacyWithdrawal, db vm.StateDB, l1CrossDomainMessenger, l1StandardBridge *common.Address) error {
-	for _, legacy := range withdrawals {
+	for i, legacy := range withdrawals {
 		legacySlot, err := legacy.StorageSlot()
 		if err != nil {
 			return err
@@ -46,6 +47,7 @@ func MigrateWithdrawals(withdrawals []*LegacyWithdrawal, db vm.StateDB, l1CrossD
 		}
 
 		db.SetState(predeploys.L2ToL1MessagePasserAddr, slot, abiTrue)
+		log.Info("Migrated withdrawal", "number", i, "slot", slot)
 	}
 	return nil
 }

--- a/op-chain-ops/ether/migrate.go
+++ b/op-chain-ops/ether/migrate.go
@@ -218,6 +218,7 @@ func MigrateLegacyETH(db ethdb.Database, addresses []common.Address, allowances 
 
 	// Set the total supply to 0
 	stateDB.SetState(predeploys.LegacyERC20ETHAddr, getOVMETHTotalSupplySlot(), common.Hash{})
+	log.Info("Set the totalSupply to 0")
 
 	if !commit {
 		log.Info("dry run, skipping commit")

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // FundDevAccounts will fund each of the development accounts.
@@ -51,12 +52,14 @@ func setProxies(db vm.StateDB, proxyAdminAddr common.Address, namespace *big.Int
 		// the proxy admin address. LegacyERC20ETH lives in the
 		// 0xDead namespace so it can be ignored here
 		if addr == predeploys.GovernanceTokenAddr || addr == predeploys.ProxyAdminAddr {
+			log.Info("Skipping setting proxy", "address", addr)
 			continue
 		}
 
 		db.CreateAccount(addr)
 		db.SetCode(addr, depBytecode)
 		db.SetState(addr, AdminSlot, proxyAdminAddr.Hash())
+		log.Info("Set proxy", "address", addr, "admin", proxyAdminAddr)
 	}
 	return nil
 }
@@ -96,17 +99,20 @@ func SetImplementations(db vm.StateDB, storage state.StorageConfig, immutable im
 		// Use the genrated bytecode when there are immutables
 		// otherwise use the artifact deployed bytecode
 		if bytecode, ok := deployResults[name]; ok {
+			log.Info("Setting deployed bytecode with immutables", "name", name, "address", addr)
 			db.SetCode(addr, bytecode)
 		} else {
 			depBytecode, err := bindings.GetDeployedBytecode(name)
 			if err != nil {
 				return err
 			}
+			log.Info("Setting deployed bytecode from solc compiler output", "name", name, "address", addr)
 			db.SetCode(addr, depBytecode)
 		}
 
 		// Set the storage values
 		if storageConfig, ok := storage[name]; ok {
+			log.Info("Setting storage", "name", name, "address", *address)
 			if err := state.SetStorage(name, *address, storageConfig, db); err != nil {
 				return err
 			}

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -59,7 +59,7 @@ func setProxies(db vm.StateDB, proxyAdminAddr common.Address, namespace *big.Int
 		db.CreateAccount(addr)
 		db.SetCode(addr, depBytecode)
 		db.SetState(addr, AdminSlot, proxyAdminAddr.Hash())
-		log.Info("Set proxy", "address", addr, "admin", proxyAdminAddr)
+		log.Trace("Set proxy", "address", addr, "admin", proxyAdminAddr)
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

This commit adds additional logging to the database migration codepath. This is helpful for understanding what is happening in the code, to understand how much of the migration has already happened.

It may also help catch programmer/configuration errors, although we should have testing to catch that and not rely on the programmer watching the logs to catch issues.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

