### PR TITLE
fix: better version imports for services

### DIFF
--- a/.changeset/silver-nails-grab.md
+++ b/.changeset/silver-nails-grab.md
@@ -1,0 +1,8 @@
+---
+'@eth-optimism/drippie-mon': patch
+'@eth-optimism/fault-detector': patch
+'@eth-optimism/message-relayer': patch
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Fixes how versions are imported for BaseServiceV2 services

--- a/packages/drippie-mon/src/service.ts
+++ b/packages/drippie-mon/src/service.ts
@@ -8,6 +8,8 @@ import { Provider } from '@ethersproject/abstract-provider'
 import { ethers } from 'ethers'
 import * as DrippieArtifact from '@eth-optimism/contracts-periphery/artifacts/contracts/universal/drippie/Drippie.sol/Drippie.json'
 
+import { version } from '../package.json'
+
 type DrippieMonOptions = {
   rpc: Provider
   drippieAddress: string
@@ -30,8 +32,7 @@ export class DrippieMonService extends BaseServiceV2<
 > {
   constructor(options?: Partial<DrippieMonOptions>) {
     super({
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      version: require('../package.json').version,
+      version,
       name: 'drippie-mon',
       loop: true,
       loopIntervalMs: 60_000,

--- a/packages/drippie-mon/tsconfig.json
+++ b/packages/drippie-mon/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist"
   },
   "include": [
+    "package.json",
     "src/**/*"
   ]
 }

--- a/packages/fault-detector/src/service.ts
+++ b/packages/fault-detector/src/service.ts
@@ -10,6 +10,7 @@ import { Provider } from '@ethersproject/abstract-provider'
 import { Contract, ethers, Transaction } from 'ethers'
 import dateformat from 'dateformat'
 
+import { version } from '../package.json'
 import {
   findFirstUnfinalizedStateBatchIndex,
   findEventForStateBatch,
@@ -38,8 +39,7 @@ type State = {
 export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
   constructor(options?: Partial<Options>) {
     super({
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      version: require('../package.json').version,
+      version,
       name: 'fault-detector',
       loop: true,
       loopIntervalMs: 1000,

--- a/packages/fault-detector/tsconfig.json
+++ b/packages/fault-detector/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist"
   },
   "include": [
+    "package.json",
     "src/**/*"
   ]
 }

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -10,6 +10,8 @@ import {
 import { CrossChainMessenger, MessageStatus } from '@eth-optimism/sdk'
 import { Provider } from '@ethersproject/abstract-provider'
 
+import { version } from '../package.json'
+
 type MessageRelayerOptions = {
   l1RpcProvider: Provider
   l2RpcProvider: Provider
@@ -37,8 +39,7 @@ export class MessageRelayerService extends BaseServiceV2<
 > {
   constructor(options?: Partial<MessageRelayerOptions>) {
     super({
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      version: require('../package.json').version,
+      version,
       name: 'message-relayer',
       options,
       optionsSpec: {

--- a/packages/message-relayer/tsconfig.json
+++ b/packages/message-relayer/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist"
   },
   "include": [
+    "package.json",
     "src/**/*"
   ]
 }

--- a/packages/replica-healthcheck/src/service.ts
+++ b/packages/replica-healthcheck/src/service.ts
@@ -7,6 +7,8 @@ import {
 } from '@eth-optimism/common-ts'
 import { sleep } from '@eth-optimism/core-utils'
 
+import { version } from '../package.json'
+
 type HealthcheckOptions = {
   referenceRpcProvider: Provider
   targetRpcProvider: Provider
@@ -32,8 +34,7 @@ export class HealthcheckService extends BaseServiceV2<
 > {
   constructor(options?: Partial<HealthcheckOptions>) {
     super({
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      version: require('../package.json').version,
+      version,
       name: 'healthcheck',
       loopIntervalMs: 5000,
       options,

--- a/packages/replica-healthcheck/tsconfig.json
+++ b/packages/replica-healthcheck/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-
   "compilerOptions": {
-    "rootDir": "./src",
     "outDir": "./dist"
   },
-
   "include": [
+    "package.json",
     "src/**/*"
   ]
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Improves the way that package versions are imported for BaseServiceV2 services. By importing directly (in typescript, rather than using require) TypeScript will properly embed the package.json in the /dist folder which makes it possible to run the services using the compiled JavaScript.