### PR TITLE
hardhat-node: trigger a release

### DIFF
--- a/.changeset/lucky-walls-walk.md
+++ b/.changeset/lucky-walls-walk.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-node': patch
+---
+
+Trigger a release of the hardhat-node


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Trigger a release of the hardhat-node docker image because there was a bug that prevented it from being released previously, that bug has been fixed