### PR TITLE
fix(ctb): remove old comment block

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1ERC721Bridge.sol
@@ -30,10 +30,6 @@ contract L1ERC721Bridge is ERC721Bridge, Semver {
         ERC721Bridge(_messenger, _otherBridge)
     {}
 
-    /*************************
-     * Cross-chain Functions *
-     *************************/
-
     /**
      * @notice Completes an ERC721 bridge from the other domain and sends the ERC721 token to the
      *         recipient on this domain.


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Removes an old comment block in the L1ERC721Bridge contract.