### PR TITLE
testlogger: Nicer output

### DIFF
--- a/op-node/testlog/testlog.go
+++ b/op-node/testlog/testlog.go
@@ -146,7 +146,7 @@ func (l *logger) flush() {
 	l.t.Helper()
 	// 2 frame skip for flush() + public logger fn
 	decorationLen := estimateInfoLen(2)
-	padding := 20
+	padding := 0
 	if decorationLen <= 25 {
 		padding = 25 - decorationLen
 	}

--- a/op-node/testlog/testlog.go
+++ b/op-node/testlog/testlog.go
@@ -147,8 +147,9 @@ func (l *logger) flush() {
 	// 2 frame skip for flush() + public logger fn
 	decorationLen := estimateInfoLen(2)
 	padding := 0
-	if decorationLen <= 25 {
-		padding = 25 - decorationLen
+	padLength := 30
+	if decorationLen <= padLength {
+		padding = padLength - decorationLen
 	}
 	for _, r := range l.h.buf {
 		l.t.Logf("%*s%s", padding, "", l.h.fmt.Format(r))


### PR DESCRIPTION
**Description**

This increase the default amount of space given to file names & changes the printing
such that if the filename is longer than the padding length, it gets no padding instead
of the full padding.
