### PR TITLE
op-node: Provide explicit presence check for L1 State

### DIFF
--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -55,7 +55,8 @@ func (s *L2Sequencer) ActL2StartBlock(t Testing) {
 		s.seqOldOrigin = false // don't repeat this
 	} else {
 		// select origin the real way
-		l1Origin, err := s.l1OriginSelector.FindL1Origin(t.Ctx(), s.l1State.L1Head(), parent)
+		l1Head, _ := s.l1State.L1Head()
+		l1Origin, err := s.l1OriginSelector.FindL1Origin(t.Ctx(), l1Head, parent)
 		require.NoError(t, err)
 		origin = l1Origin
 	}
@@ -96,7 +97,8 @@ func (s *L2Sequencer) ActL2KeepL1Origin(t Testing) {
 
 // ActBuildToL1Head builds empty blocks until (incl.) the L1 head becomes the L2 origin
 func (s *L2Sequencer) ActBuildToL1Head(t Testing) {
-	for s.derivation.UnsafeL2Head().L1Origin.Number < s.l1State.L1Head().Number {
+	l1Head, _ := s.l1State.L1Head()
+	for s.derivation.UnsafeL2Head().L1Origin.Number < l1Head.Number {
 		s.ActL2PipelineFull(t)
 		s.ActL2StartBlock(t)
 		s.ActL2EndBlock(t)
@@ -107,9 +109,10 @@ func (s *L2Sequencer) ActBuildToL1Head(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 	for {
 		s.ActL2PipelineFull(t)
-		nextOrigin, err := s.l1OriginSelector.FindL1Origin(t.Ctx(), s.l1State.L1Head(), s.derivation.UnsafeL2Head())
+		l1Head, _ := s.l1State.L1Head()
+		nextOrigin, err := s.l1OriginSelector.FindL1Origin(t.Ctx(), l1Head, s.derivation.UnsafeL2Head())
 		require.NoError(t, err)
-		if nextOrigin.Number >= s.l1State.L1Head().Number {
+		if nextOrigin.Number >= l1Head.Number {
 			break
 		}
 		s.ActL2StartBlock(t)

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -126,12 +126,15 @@ func (s *L2Verifier) L2Unsafe() eth.L2BlockRef {
 }
 
 func (s *L2Verifier) SyncStatus() *eth.SyncStatus {
+	l1Head, _ := s.l1State.L1Head()
+	l1Safe, _ := s.l1State.L1Safe()
+	l1Finalized, _ := s.l1State.L1Finalized()
 	return &eth.SyncStatus{
 		CurrentL1:          s.derivation.Origin(),
 		CurrentL1Finalized: s.derivation.FinalizedL1(),
-		HeadL1:             s.l1State.L1Head(),
-		SafeL1:             s.l1State.L1Safe(),
-		FinalizedL1:        s.l1State.L1Finalized(),
+		HeadL1:             l1Head,
+		SafeL1:             l1Safe,
+		FinalizedL1:        l1Finalized,
 		UnsafeL2:           s.L2Unsafe(),
 		SafeL2:             s.L2Safe(),
 		FinalizedL2:        s.L2Finalized(),

--- a/op-node/rollup/driver/conf_depth.go
+++ b/op-node/rollup/driver/conf_depth.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // confDepth is an util that wraps the L1 input fetcher used in the pipeline,
@@ -16,11 +15,11 @@ import (
 type confDepth struct {
 	// everything fetched by hash is trusted already, so we implement those by embedding the fetcher
 	derive.L1Fetcher
-	l1Head func() eth.L1BlockRef
+	l1Head func() (eth.L1BlockRef, bool)
 	depth  uint64
 }
 
-func NewConfDepth(depth uint64, l1Head func() eth.L1BlockRef, fetcher derive.L1Fetcher) *confDepth {
+func NewConfDepth(depth uint64, l1Head func() (eth.L1BlockRef, bool), fetcher derive.L1Fetcher) *confDepth {
 	return &confDepth{L1Fetcher: fetcher, l1Head: l1Head, depth: depth}
 }
 
@@ -31,9 +30,12 @@ func (c *confDepth) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1B
 	// TODO: performance optimization: buffer the l1Unsafe, invalidate any reorged previous buffer content,
 	// and instantly return the origin by number from the buffer if we can.
 
-	// Don't apply the conf depth is l1Head is empty (as it is during the startup case before the l1State is initialized).
-	l1Head := c.l1Head()
-	if num == 0 || c.depth == 0 || num+c.depth <= l1Head.Number || l1Head.Hash == (common.Hash{}) {
+	// Don't apply the conf depth if we don't have an l1Head to compare against.
+	l1Head, ok := c.l1Head()
+	if !ok {
+		return c.L1Fetcher.L1BlockRefByNumber(ctx, num)
+	}
+	if num == 0 || c.depth == 0 || num+c.depth <= l1Head.Number {
 		return c.L1Fetcher.L1BlockRefByNumber(ctx, num)
 	}
 	return eth.L1BlockRef{}, ethereum.NotFound

--- a/op-node/rollup/driver/conf_depth_test.go
+++ b/op-node/rollup/driver/conf_depth_test.go
@@ -26,7 +26,7 @@ type confTest struct {
 func (ct *confTest) Run(t *testing.T) {
 	l1Fetcher := &testutils.MockL1Source{}
 	l1Head := eth.L1BlockRef{Number: ct.head, Hash: ct.hash}
-	l1HeadGetter := func() eth.L1BlockRef { return l1Head }
+	l1HeadGetter := func() (eth.L1BlockRef, bool) { return l1Head, l1Head != eth.L1BlockRef{} }
 
 	cd := NewConfDepth(ct.depth, l1HeadGetter, l1Fetcher)
 	if ct.pass {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -60,9 +60,9 @@ type L1StateIface interface {
 	HandleNewL1SafeBlock(safe eth.L1BlockRef)
 	HandleNewL1FinalizedBlock(finalized eth.L1BlockRef)
 
-	L1Head() eth.L1BlockRef
-	L1Safe() eth.L1BlockRef
-	L1Finalized() eth.L1BlockRef
+	L1Head() (eth.L1BlockRef, bool)
+	L1Safe() (eth.L1BlockRef, bool)
+	L1Finalized() (eth.L1BlockRef, bool)
 }
 
 type L1OriginSelectorIface interface {

--- a/op-node/rollup/driver/l1_state.go
+++ b/op-node/rollup/driver/l1_state.go
@@ -20,6 +20,10 @@ type L1State struct {
 	l1Head      eth.L1BlockRef
 	l1Safe      eth.L1BlockRef
 	l1Finalized eth.L1BlockRef
+
+	haveL1Head      bool
+	haveL1Safe      bool
+	haveL1Finalized bool
 }
 
 func NewL1State(log log.Logger, metrics L1Metrics) *L1State {
@@ -49,28 +53,31 @@ func (s *L1State) HandleNewL1HeadBlock(head eth.L1BlockRef) {
 	}
 	s.metrics.RecordL1Ref("l1_head", head)
 	s.l1Head = head
+	s.haveL1Head = true
 }
 
 func (s *L1State) HandleNewL1SafeBlock(safe eth.L1BlockRef) {
 	s.log.Info("New L1 safe block", "l1_safe", safe)
 	s.metrics.RecordL1Ref("l1_safe", safe)
 	s.l1Safe = safe
+	s.haveL1Safe = true
 }
 
 func (s *L1State) HandleNewL1FinalizedBlock(finalized eth.L1BlockRef) {
 	s.log.Info("New L1 finalized block", "l1_finalized", finalized)
 	s.metrics.RecordL1Ref("l1_finalized", finalized)
 	s.l1Finalized = finalized
+	s.haveL1Finalized = true
 }
 
-func (s *L1State) L1Head() eth.L1BlockRef {
-	return s.l1Head
+func (s *L1State) L1Head() (eth.L1BlockRef, bool) {
+	return s.l1Head, s.haveL1Head
 }
 
-func (s *L1State) L1Safe() eth.L1BlockRef {
-	return s.l1Safe
+func (s *L1State) L1Safe() (eth.L1BlockRef, bool) {
+	return s.l1Safe, s.haveL1Safe
 }
 
-func (s *L1State) L1Finalized() eth.L1BlockRef {
-	return s.l1Finalized
+func (s *L1State) L1Finalized() (eth.L1BlockRef, bool) {
+	return s.l1Finalized, s.haveL1Finalized
 }


### PR DESCRIPTION
**Description**

The L1 State struct is not initialized at startup because initialization can fail (because it has to go over the network). This provides an explicit indication that a value is not present & checks for the value or accepts the default value.


**Metadata**
- Fixes ENG-2920
