### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/forty-pigs-draw.md
+++ b/.changeset/forty-pigs-draw.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Has ProxyAdmin use Ownable instead of Owned

--- a/.changeset/long-cameras-laugh.md
+++ b/.changeset/long-cameras-laugh.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Tweaks variable ordering in OptimismPortal

--- a/.changeset/lucky-walls-walk.md
+++ b/.changeset/lucky-walls-walk.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/hardhat-node': patch
----
-
-Trigger a release of the hardhat-node

--- a/.changeset/silver-nails-grab.md
+++ b/.changeset/silver-nails-grab.md
@@ -1,8 +1,0 @@
----
-'@eth-optimism/drippie-mon': patch
-'@eth-optimism/fault-detector': patch
-'@eth-optimism/message-relayer': patch
-'@eth-optimism/replica-healthcheck': patch
----
-
-Fixes how versions are imported for BaseServiceV2 services

--- a/.changeset/thin-trees-visit.md
+++ b/.changeset/thin-trees-visit.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Removes the unused DeployConfig contract

--- a/.changeset/tricky-dryers-speak.md
+++ b/.changeset/tricky-dryers-speak.md
@@ -1,6 +1,0 @@
----
-'@eth-optimism/endpoint-monitor': patch
-'@eth-optimism/indexer': patch
----
-
-Update go-ethereum to v1.10.26

--- a/.changeset/tricky-rockets-remain.md
+++ b/.changeset/tricky-rockets-remain.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Add comments to SystemConfig.sol

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,18 +171,17 @@ jobs:
         type: string
         default: "bedrock-goerli-development/images"
     docker:
-      - image: google/cloud-sdk:latest
+      - image: cimg/python:3.7
     resource_class: small
     steps:
-      - run:
-          command: mkdir -p /home/circleci
+      - gcp-cli/install
       - gcp-oidc-authenticate
       - checkout
       - run:
           name: Tag
           command: |
             gcloud auth configure-docker <<parameters.registry>>
-            ./ops/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
+            ./ops/scripts/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
 
   contracts-bedrock-tests:
     docker:

--- a/endpoint-monitor/CHANGELOG.md
+++ b/endpoint-monitor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/endpoint-monitor
 
+## 1.0.1
+
+### Patch Changes
+
+- f505078be: Update go-ethereum to v1.10.26
+
 ## 1.0.0
 
 ### Major Changes

--- a/endpoint-monitor/package.json
+++ b/endpoint-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/endpoint-monitor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {}
 }

--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/indexer
 
+## 0.3.2
+
+### Patch Changes
+
+- f505078be: Update go-ethereum to v1.10.26
+
 ## 0.3.1
 
 ### Patch Changes

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/indexer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "license": "MIT"
 }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -32,7 +32,7 @@
     "@eth-optimism/contracts": "^0.5.38",
     "@eth-optimism/contracts-periphery": "^1.0.2",
     "@eth-optimism/core-utils": "0.11.0",
-    "@eth-optimism/sdk": "1.6.10",
+    "@eth-optimism/sdk": "1.6.11",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",

--- a/ops/docker/hardhat/CHANGELOG.md
+++ b/ops/docker/hardhat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/hardhat-node
 
+## 0.2.3
+
+### Patch Changes
+
+- 6c238212d: Trigger a release of the hardhat-node
+
 ## 0.2.2
 
 ### Patch Changes

--- a/ops/docker/hardhat/package.json
+++ b/ops/docker/hardhat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/hardhat-node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "scripts": {
     "start": "hardhat node --network hardhat"
   },

--- a/ops/scripts/ci-docker-tag-op-stack-release.sh
+++ b/ops/scripts/ci-docker-tag-op-stack-release.sh
@@ -6,8 +6,16 @@ DOCKER_REPO=$1
 GIT_TAG=$2
 GIT_SHA=$3
 
-IMAGE_NAME=$(echo "$GIT_TAG" | grep -Eow '^op-[a-z0-9\-]*')
-IMAGE_TAG=$(echo "$GIT_TAG" | grep -Eow 'v.*')
+IMAGE_NAME=$(echo "$GIT_TAG" | grep -Eow '^op-[a-z0-9\-]*' || true)
+if [ -z "$IMAGE_NAME" ]; then
+  echo "image name could not be parsed from git tag '$GIT_TAG'"
+  exit 1
+fi
+IMAGE_TAG=$(echo "$GIT_TAG" | grep -Eow 'v.*' || true)
+if [ -z "$IMAGE_TAG" ]; then
+  echo "image tag could not be parsed from git tag '$GIT_TAG'"
+  exit 1
+fi
 
 SOURCE_IMAGE_TAG="$DOCKER_REPO/$IMAGE_NAME:$GIT_SHA"
 TARGET_IMAGE_TAG="$DOCKER_REPO/$IMAGE_NAME:$IMAGE_TAG"

--- a/packages/actor-tests/CHANGELOG.md
+++ b/packages/actor-tests/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @eth-optimism/actor-tests
 
+## 0.0.13
+
+### Patch Changes
+
+- Updated dependencies [52079cc12]
+- Updated dependencies [13bfafb21]
+- Updated dependencies [eeae96941]
+- Updated dependencies [427831d86]
+  - @eth-optimism/contracts-bedrock@0.9.1
+  - @eth-optimism/sdk@1.6.11
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/actor-tests/package.json
+++ b/packages/actor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/actor-tests",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A library and suite of tests to stress test Optimism Bedrock.",
   "license": "MIT",
   "author": "",
@@ -18,9 +18,9 @@
     "test:coverage": "yarn test"
   },
   "dependencies": {
-    "@eth-optimism/contracts-bedrock": "0.9.0",
+    "@eth-optimism/contracts-bedrock": "0.9.1",
     "@eth-optimism/core-utils": "^0.11.0",
-    "@eth-optimism/sdk": "^1.6.10",
+    "@eth-optimism/sdk": "^1.6.11",
     "@types/chai": "^4.2.18",
     "@types/chai-as-promised": "^7.1.4",
     "async-mutex": "^0.3.2",

--- a/packages/contracts-bedrock/CHANGELOG.md
+++ b/packages/contracts-bedrock/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @eth-optimism/contracts-bedrock
 
+## 0.9.1
+
+### Patch Changes
+
+- 52079cc12: Has ProxyAdmin use Ownable instead of Owned
+- 13bfafb21: Tweaks variable ordering in OptimismPortal
+- eeae96941: Removes the unused DeployConfig contract
+- 427831d86: Add comments to SystemConfig.sol
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts-bedrock",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Contracts for Optimism Specs",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/drippie-mon/CHANGELOG.md
+++ b/packages/drippie-mon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/drippie-mon
 
+## 0.3.22
+
+### Patch Changes
+
+- 97b5f578c: Fixes how versions are imported for BaseServiceV2 services
+  - @eth-optimism/sdk@1.6.11
+
 ## 0.3.21
 
 ### Patch Changes

--- a/packages/drippie-mon/package.json
+++ b/packages/drippie-mon/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/drippie-mon",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "[Optimism] Service for monitoring Drippie instances",
   "main": "dist/index",
   "types": "dist/index",
@@ -35,7 +35,7 @@
     "@eth-optimism/common-ts": "0.6.7",
     "@eth-optimism/contracts-periphery": "1.0.2",
     "@eth-optimism/core-utils": "0.11.0",
-    "@eth-optimism/sdk": "1.6.10",
+    "@eth-optimism/sdk": "1.6.11",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/fault-detector/CHANGELOG.md
+++ b/packages/fault-detector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/fault-detector
 
+## 0.3.2
+
+### Patch Changes
+
+- 97b5f578c: Fixes how versions are imported for BaseServiceV2 services
+  - @eth-optimism/sdk@1.6.11
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/fault-detector/package.json
+++ b/packages/fault-detector/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/fault-detector",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "[Optimism] Service for detecting faulty L2 output proposals",
   "main": "dist/index",
   "types": "dist/index",
@@ -50,7 +50,7 @@
     "@eth-optimism/common-ts": "^0.6.7",
     "@eth-optimism/contracts": "^0.5.38",
     "@eth-optimism/core-utils": "^0.11.0",
-    "@eth-optimism/sdk": "^1.6.10",
+    "@eth-optimism/sdk": "^1.6.11",
     "@ethersproject/abstract-provider": "^5.7.0"
   }
 }

--- a/packages/message-relayer/CHANGELOG.md
+++ b/packages/message-relayer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @eth-optimism/message-relayer
 
+## 0.5.21
+
+### Patch Changes
+
+- 97b5f578c: Fixes how versions are imported for BaseServiceV2 services
+  - @eth-optimism/sdk@1.6.11
+
 ## 0.5.20
 
 ### Patch Changes

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/message-relayer",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@eth-optimism/common-ts": "0.6.7",
     "@eth-optimism/core-utils": "0.11.0",
-    "@eth-optimism/sdk": "1.6.10",
+    "@eth-optimism/sdk": "1.6.11",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/replica-healthcheck/CHANGELOG.md
+++ b/packages/replica-healthcheck/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/replica-healthcheck
 
+## 1.1.12
+
+### Patch Changes
+
+- 97b5f578c: Fixes how versions are imported for BaseServiceV2 services
+
 ## 1.1.11
 
 ### Patch Changes

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/replica-healthcheck",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "[Optimism] Service for monitoring the health of replica nodes",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @eth-optimism/sdk
 
+## 1.6.11
+
+### Patch Changes
+
+- Updated dependencies [52079cc12]
+- Updated dependencies [13bfafb21]
+- Updated dependencies [eeae96941]
+- Updated dependencies [427831d86]
+  - @eth-optimism/contracts-bedrock@0.9.1
+
 ## 1.6.10
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -50,7 +50,7 @@
   "dependencies": {
     "@eth-optimism/contracts": "0.5.38",
     "@eth-optimism/core-utils": "0.11.0",
-    "@eth-optimism/contracts-bedrock": "0.9.0",
+    "@eth-optimism/contracts-bedrock": "0.9.1",
     "lodash": "^4.17.21",
     "merkletreejs": "^0.2.27",
     "rlp": "^2.2.7"


### PR DESCRIPTION
- op-node: catch up L2 sequencing based on time, not L1 origins
- Bumped compiler version for contracts-bedrock
- Check that BlockNumber is non-nil in the receipt validation
- contracts-periphery: make the network name match contracts
- op-node,contracts-bedrock: dynamic gas limit via SystemConfig (#3814)
- op-chain-ops: wrap errors
- deps: replace deprecated package with updated package
- deps: use ethereum-optimism
- deps: run make-tidy
- ci: fix hardhat-node release
- op-node: Prefer following seq drift instead of conf depth (#3861)
- testmig: Remove in favor of op-e2e
- op-batcher: Rewrite ChannelManager (#3859)
- bedrock: update op-geth dependency (#3892)
- feat(ctb): SystemConfig comments
- op-node: set initial system config gaslimit, check initial values
- ci: Fix devnet
- Update ops-bedrock/docker-compose.yml
- Update ops-bedrock/entrypoint.sh
- op-e2e: run with l1 fees enabled by default
- feat(ctb): remove DeployConfig
- op-node,op-e2e: update libp2p libs, update libp2p gossip settings (#3875)
- contracts-bedrock: remove ownable from GasPriceOracle
- contracts-bedrock: regenerate snapshot
- op-chain-ops: fix gpo constructor
- system: delete dead config
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- op-bindings: regenerate
- contracts-bedrock: regenerate storage layout
- contracts-bedrock: update spacer type
- contracts-bedrock: fix layout-lock
- contracts-bedrock: fix layout-lock
- contracts-bedrock: regenerate storage snapshot
- op-e2e: remove temporary go.mod workaround
- op-bindings: fix erc20
- op-chain-ops: parse the new config
- op-chain-ops: update config
- fix(ctb): tweak OptimismPortal variable ordering
- op-bindings: Canonicalize bindings, regenerate
- op-bindings: modularize errors
- op-chain-ops: add helper function for deployments
- op-e2e: clean up config
- op-node: clean up config usage
- op-chain-ops: clean up migrate command
- contracts-bedrock: update deploy config
- contracts-bedrock: configure devnetL1
- feat(ctb): use Ownable for ProxyAdmin
- op-e2e: Use head rather than pending block for gas estimation
- op-chain-ops: delete concepts of `L2Addrs`
- op-node: update genesis commands
- op-e2e: use cleaned up interfaces
- indexer: update tests
- op-chain-ops: rename method
- integration-tests-bedrock: Remove superfluous packages
- op-bindings: Canonicalize storage types too (#3930)
- ctb: Add system config deployment
- feat(ctb): assert dictator config
- fix: better version imports for services
- hardhat-node: trigger a release (#3936)
- op-chain-ops: Updates for the migration
- fix(ctb): remove old comment block
- testlog: Don't excessivly pad on long file names
- testlog: Increase file name padding to 30 chars
- fix: move MintableERC721 interface
- op-e2e: Add envvar to disable t.Parallel
- testlog: Provide option to disable colored logging
- Use parallel test runners in circle CI
- Re-enable code cov
- Add meta go-bedrock job
- Enable stricter lints
- Fix lint in op-e2e
- op-e2e: Increase sequencer drift in sequencer conf depth test
- Fix lints in op-node
- ENG-2990 updates ci to tag docker images with sha, branch, release tags
- fix missing directory in docker-tag job
- fixing few bugs and better error handling for docker-tag job
- Version Packages
