### PR TITLE
ci: fix hardhat-node docker image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./ops/docker/hardhat
-          file: ./Dockerfile
+          file: ./ops/docker/hardhat/Dockerfile
           push: true
           tags: ethereumoptimism/hardhat-node:${{ needs.release.outputs.hardhat-node }},ethereumoptimism/hardhat-node:latest
 


### PR DESCRIPTION
**Description**

The `hardhat-node` docker image couldn't find the
`Dockerfile` when building. This updates the path to the dockerfile.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


