### PR TITLE
hardhat-node: trigger release

### DIFF
--- a/.changeset/nine-boats-walk.md
+++ b/.changeset/nine-boats-walk.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-node': patch
+---
+
+Bump hardhat to 2.12.2


### PR DESCRIPTION
**Description**

Adds a changeset so that a release can be triggered

This previously bumped the version of `hardhat` being used but that broke the monorepo build due some some leveldb issue in the dtl

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

