### PR TITLE
op-e2e: Change final TestConfirmationDepth check

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -279,11 +279,13 @@ func TestConfirmationDepth(t *testing.T) {
 	l2VerHead, err := l2Verif.BlockByNumber(ctx, nil)
 	require.NoError(t, err)
 
-	info, err := derive.L1InfoDepositTxData(l2SeqHead.Transactions()[0].Data())
+	seqInfo, err := derive.L1InfoDepositTxData(l2SeqHead.Transactions()[0].Data())
 	require.NoError(t, err)
-	require.LessOrEqual(t, info.Number+seqConfDepth, l1Head.NumberU64(), "the L2 head block should have an origin older than the L1 head block by at least the sequencer conf depth")
+	require.LessOrEqual(t, seqInfo.Number+seqConfDepth, l1Head.NumberU64(), "the seq L2 head block should have an origin older than the L1 head block by at least the sequencer conf depth")
 
-	require.LessOrEqual(t, l2VerHead.Time()+cfg.DeployConfig.L1BlockTime*verConfDepth, l2SeqHead.Time(), "the L2 verifier head should lag behind the sequencer without delay by at least the verifier conf depth")
+	verInfo, err := derive.L1InfoDepositTxData(l2VerHead.Transactions()[0].Data())
+	require.NoError(t, err)
+	require.LessOrEqual(t, verInfo.Number+verConfDepth, l1Head.NumberU64(), "the ver L2 head block should have an origin older than the L1 head block by at least the verifier conf depth")
 }
 
 // TestFinalize tests if L2 finalizes after sufficient time after L1 finalizes


### PR DESCRIPTION
**Description**

TestConfirmationDepth was consistently failing on the HTTP versions of the op-e2e test. It was failing at the last line that checked the verifier head block timestamp against the L1 head timestamp. I have changed it to compare the verifier L1 Origin number against the L1 head number.
**Tests**

Ran several times in CI & this seems less flaky.

**Metadata**
- Fixes ENG-3013
