### PR TITLE
Fix: Adding proper debug output for L1 CTC Address env var in l2geth-exporter

### DIFF
--- a/l2geth-exporter/main.go
+++ b/l2geth-exporter/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 	ctcAddress := os.Getenv("OVM_CTC_ADDRESS")
 	if ctcAddress == "" {
-		log.Error("CTC_ADDRESS environmental variable is required")
+		log.Error("OVM_CTC_ADDRESS environmental variable is required")
 		os.Exit(1)
 	}
 	sccAddress := os.Getenv("OVM_SCC_ADDRESS")


### PR DESCRIPTION
**Description**
Added proper debug output for `OVM_CTC_ADDRESS` to ensure output matched expected variable. 

**Tests**
Testing would be unnecessary here. 

**Additional context**
Given use and demand, it could make sense to use separate `Config` struct to store env var references. Furthermore an extraction function could be used for blank env var validation cases instead of copying the same code three times. 

**Metadata**
- Fixes #[Link to Issue]
