### PR TITLE
ctb: Configurable verification for deployer network

### DIFF
--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -38,6 +38,7 @@ const config: HardhatUserConfig = {
       chainId: Number(process.env.CHAIN_ID),
       url: process.env.L1_RPC || '',
       accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
+      live: process.env.VERIFY_CONTRACTS === 'true',
     },
     'mainnet-forked': {
       chainId: 1,


### PR DESCRIPTION
Most ephemeral networks created via the regntool don't need verification. This PR allows verification to be enabled on a case-by-case basis by setting an environment variable.
