### PR TITLE
feat(dtl): handle deposit shutoff

### DIFF
--- a/.changeset/orange-bananas-nail.md
+++ b/.changeset/orange-bananas-nail.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Updates the DTL in preparation for shutoff during the Bedrock migration. So long, DTL!


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates the DTL to correctly handle the deposit shutoff flag. We put the flag inside the AddressManager because the DTL already had easy access to the AddressManager. We parse the address as a uint256 and check if it's non-zero. By checking this every loop we can smoothly recover if the shutoff flag is reset.