### PR TITLE
refactor: fix typo `NewTransactionManger`

### DIFF
--- a/op-batcher/driver.go
+++ b/op-batcher/driver.go
@@ -147,7 +147,7 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 	return &BatchSubmitter{
 		cfg:   batcherCfg,
 		addr:  addr,
-		txMgr: NewTransactionManger(l, txManagerConfig, batchInboxAddress, chainID, sequencerPrivKey, l1Client),
+		txMgr: NewTransactionManager(l, txManagerConfig, batchInboxAddress, chainID, sequencerPrivKey, l1Client),
 		done:  make(chan struct{}),
 		log:   l,
 		state: NewChannelManager(l, cfg.ChannelTimeout),

--- a/op-batcher/txmgr.go
+++ b/op-batcher/txmgr.go
@@ -31,7 +31,7 @@ type TransactionManager struct {
 	log      log.Logger
 }
 
-func NewTransactionManger(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, privKey *ecdsa.PrivateKey, l1Client *ethclient.Client) *TransactionManager {
+func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, privKey *ecdsa.PrivateKey, l1Client *ethclient.Client) *TransactionManager {
 	signerFn := func(rawTx types.TxData) (*types.Transaction, error) {
 		return types.SignNewTx(privKey, types.LatestSignerForChainID(chainID), rawTx)
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR fixes the typo: `NewTransactionManger` -> `NewTransactionManager`.