### PR TITLE
Added a parameter "wantedPackages" to specify only a subset of packages to canary-release

### DIFF
--- a/.github/scripts/get-canary-ignored-packages.js
+++ b/.github/scripts/get-canary-ignored-packages.js
@@ -1,0 +1,20 @@
+const { exec } = require('child_process')
+
+if (process.env['WANTED_PACKAGES'].length == 0) {
+  console.log('0')
+  return
+}
+
+exec('yarn workspaces --json info', (error, stdout, stderr) => {
+  if (error) {
+    return
+  }
+  if (stderr) {
+    return
+  }
+  let output = JSON.parse(stdout)
+  const wantedPackages = process.env['WANTED_PACKAGES'].split(',')
+  let allPackages = Object.keys(JSON.parse(output['data']))
+  var ignoredPackages = allPackages.filter((p) => !wantedPackages.includes(p))
+  console.log(`${ignoredPackages.toString()}`)
+})

--- a/.github/scripts/run-setup-canary-snapshot.js
+++ b/.github/scripts/run-setup-canary-snapshot.js
@@ -1,0 +1,23 @@
+const { exec } = require('child_process')
+
+var command = 'yarn changeset version --snapshot'
+if (process.env['IGNORED_PACKAGES'].length > 0) {
+  var commandArguments = ''
+  var ignoredPackages = process.env['IGNORED_PACKAGES'].split(',')
+  for (let i = 0; i < ignoredPackages.length; i++) {
+    commandArguments += ' --ignore ' + ignoredPackages[i]
+  }
+  command += commandArguments
+}
+
+exec(command, (error, stdout, stderr) => {
+  if (error) {
+    console.log(error)
+    return
+  }
+  if (stderr) {
+    console.log(stderr)
+    return
+  }
+  console.log(stdout)
+})

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -8,6 +8,10 @@ on:
         description: 'Custom Docker Image Tag (keep empty for git hash)'
         required: false
         default: '0.0.0-rc-0'
+      wantedPackages:
+        description: 'List of packages to release'
+        required: false
+        default: ''
 
 jobs:
   canary-publish:
@@ -46,6 +50,15 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Get ignored packages
+        id: get-ignored-packages
+        outputs:
+          ignoredPackages:
+            description: 'packages to ignore in the "Setup Canary Snapshot" step'
+        run: echo "::set-output name=ignoredPackages::$(node .github/scripts/get-canary-ignored-packages.js)"
+        env:
+          WANTED_PACKAGES: ${{ github.event.inputs.wantedPackages }}
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -70,7 +83,15 @@ jobs:
         run: yarn build
 
       - name: Setup Canary Snapshot
-        run: yarn changeset version --snapshot
+        run: |
+          if [[ $IGNORED_PACKAGES -eq '0' ]]
+          then
+              yarn changeset version --snapshot
+          else
+              node .github/scripts/run-setup-canary-snapshot.js
+          fi
+        env:
+          IGNORED_PACKAGES: ${{steps.get-ignored-packages.outputs.ignoredPackages}}
 
       - name: Publish To NPM
         uses: changesets/action@v1


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The "publish-canary.yml" workflow now takes an input called "wantedPackages", which is a comma separated list of packages name.
If this input is passed, then only packages specified in the input are canary-released. If no package is passed, all packages are released.

**Tests**

I tested locally with act, please give me instructions on how to test the Github action in the Github runner if needed.

**Metadata**
- Fixes [#3808](https://github.com/ethereum-optimism/optimism/issues/3808)
