### PR TITLE
ci: Add echidna to Dockerfile

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -26,6 +26,8 @@ RUN source $HOME/.profile && \
 
 FROM ethereum/client-go:alltools-v1.10.25 as geth
 
+FROM ghcr.io/crytic/echidna/echidna:testing-master as echidna-test
+
 FROM python:3.8.13-slim-bullseye
 
 ENV GOPATH=/go
@@ -36,6 +38,7 @@ COPY --from=foundry-build /opt/foundry/target/release/forge /usr/local/bin/forge
 COPY --from=foundry-build /opt/foundry/target/release/cast /usr/local/bin/cast
 COPY --from=foundry-build /opt/foundry/target/release/anvil /usr/local/bin/anvil
 COPY --from=geth /usr/local/bin/abigen /usr/local/bin/abigen
+COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
 COPY check-changed.sh /usr/local/bin/check-changed
 
 RUN apt-get update && \


### PR DESCRIPTION
**Description**

Adds [echidna](https://github.com/crytic/echidna) to the ci-builder dockerfile. 

**Tests**

I tested the build on my machine using `docker build ops/docker/ci-builder`.

