### PR TITLE
Fix: build and publish all bedrock docker images before tagging release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -955,8 +955,6 @@ workflows:
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-          context:
-            - gcr
       - docker-publish:
           name: op-node-docker-publish
           docker_name: op-node
@@ -971,8 +969,6 @@ workflows:
           docker_name: op-batcher
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-          context:
-            - gcr
       - docker-publish:
           name: op-batcher-docker-publish
           docker_name: op-batcher
@@ -987,8 +983,6 @@ workflows:
           docker_name: op-proposer
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-          context:
-            - gcr
       - docker-publish:
           name: op-proposer-docker-publish
           docker_name: op-proposer
@@ -1023,6 +1017,48 @@ workflows:
             - op-proposer-docker-build
   release:
     jobs:
+      - docker-build:
+          name: op-node-docker-build
+          docker_file: op-node/Dockerfile
+          docker_name: op-node
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+      - docker-publish:
+          name: op-node-docker-publish
+          docker_name: op-node
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          context:
+            - gcr
+          requires:
+            - op-node-docker-build
+      - docker-build:
+          name: op-batcher-docker-build
+          docker_file: op-batcher/Dockerfile
+          docker_name: op-batcher
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+      - docker-publish:
+          name: op-batcher-docker-publish
+          docker_name: op-batcher
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          context:
+            - gcr
+          requires:
+            - op-batcher-docker-build
+      - docker-build:
+          name: op-proposer-docker-build
+          docker_file: op-proposer/Dockerfile
+          docker_name: op-proposer
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+      - docker-publish:
+          name: op-proposer-docker-publish
+          docker_name: op-proposer
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          context:
+            - gcr
+          requires:
+            - op-proposer-docker-build
       - docker-tag-op-stack-release:
           name: docker-tag-op-stack-release
           filters:
@@ -1030,5 +1066,9 @@ workflows:
               only: /^op-[a-z0-9\-]*\/v.*/
             branches:
               ignore: /.*/
+          requires:
+            - op-node-docker-publish
+            - op-proposer-docker-publish
+            - op-batcher-docker-publish
           context:
             - gcr-release


### PR DESCRIPTION
**Description**

rebuild and push all images for every git tag and then tag the one image that corresponds to the git tag
this is somewhat wasteful but ensures that the tagging works for any tagging strategy. 
will revisit once we address simplified release process / versioning.

