### PR TITLE
feat(mergify reviews): Remove Nick and Imran from mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -114,7 +114,6 @@ pull_request_rules:
       request_reviews:
         users:
           - roninjin10
-          - nickbalestra
   - name: Add sdk tag and ecopod reviewers
     conditions:
       - 'files~=^packages/sdk/'
@@ -125,7 +124,6 @@ pull_request_rules:
       request_reviews:
         users:
           - roninjin10
-          - nickbalestra
   - name: Add common-ts tag and ecopod reviewers
     conditions:
       - 'files~=^packages/common-ts/'
@@ -135,5 +133,4 @@ pull_request_rules:
           - common-ts
       request_reviews:
         users:
-          - imranjami
           - roninjin10


### PR DESCRIPTION
I added this so I could easily stay up to date with changes to the 3 packages in the monorepo I care about following.   Not sure why I added anybody else they never asked to be added