### PR TITLE
op-chain-ops: add bedrock transition receipts

### DIFF
--- a/op-chain-ops/crossdomain/legacy_withdrawal.go
+++ b/op-chain-ops/crossdomain/legacy_withdrawal.go
@@ -138,12 +138,14 @@ func (w *LegacyWithdrawal) Value() (*big.Int, error) {
 		return nil, err
 	}
 
-	method, err := abi.MethodById(w.Data)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse withdrawal value: %w", err)
-	}
-
 	value := new(big.Int)
+
+	// Parse the 4byte selector
+	method, err := abi.MethodById(w.Data)
+	// If it is an unknown selector, there is no value
+	if err != nil {
+		return value, nil
+	}
 
 	if w.Sender == nil {
 		return nil, errors.New("sender is nil")

--- a/op-chain-ops/crossdomain/migrate.go
+++ b/op-chain-ops/crossdomain/migrate.go
@@ -1,7 +1,6 @@
 package crossdomain
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -19,7 +18,7 @@ var (
 )
 
 // MigrateWithdrawals will migrate a list of pending withdrawals given a StateDB.
-func MigrateWithdrawals(withdrawals []*LegacyWithdrawal, db vm.StateDB, l1CrossDomainMessenger, l1StandardBridge *common.Address) error {
+func MigrateWithdrawals(withdrawals []*LegacyWithdrawal, db vm.StateDB, l1CrossDomainMessenger *common.Address) error {
 	for i, legacy := range withdrawals {
 		legacySlot, err := legacy.StorageSlot()
 		if err != nil {
@@ -36,7 +35,7 @@ func MigrateWithdrawals(withdrawals []*LegacyWithdrawal, db vm.StateDB, l1CrossD
 			continue
 		}
 
-		withdrawal, err := MigrateWithdrawal(legacy, l1CrossDomainMessenger, l1StandardBridge)
+		withdrawal, err := MigrateWithdrawal(legacy, l1CrossDomainMessenger)
 		if err != nil {
 			return err
 		}
@@ -54,42 +53,11 @@ func MigrateWithdrawals(withdrawals []*LegacyWithdrawal, db vm.StateDB, l1CrossD
 
 // MigrateWithdrawal will turn a LegacyWithdrawal into a bedrock
 // style Withdrawal.
-func MigrateWithdrawal(withdrawal *LegacyWithdrawal, l1CrossDomainMessenger, l1StandardBridge *common.Address) (*Withdrawal, error) {
-	value := new(big.Int)
-
-	isFromL2StandardBridge := *withdrawal.Sender == predeploys.L2StandardBridgeAddr
-
-	if withdrawal.Target == nil {
-		return nil, errors.New("withdrawal target cannot be nil")
-	}
-
-	isToL1StandardBridge := *withdrawal.Target == *l1StandardBridge
-
-	if isFromL2StandardBridge && isToL1StandardBridge {
-		abi, err := bindings.L1StandardBridgeMetaData.GetAbi()
-		if err != nil {
-			return nil, err
-		}
-
-		method, err := abi.MethodById(withdrawal.Data)
-		if err != nil {
-			return nil, err
-		}
-		if method.Name == "finalizeETHWithdrawal" {
-			data, err := method.Inputs.Unpack(withdrawal.Data[4:])
-			if err != nil {
-				return nil, err
-			}
-			// bounds check
-			if len(data) < 3 {
-				return nil, errors.New("not enough data")
-			}
-			var ok bool
-			value, ok = data[2].(*big.Int)
-			if !ok {
-				return nil, errors.New("not big.Int")
-			}
-		}
+func MigrateWithdrawal(withdrawal *LegacyWithdrawal, l1CrossDomainMessenger *common.Address) (*Withdrawal, error) {
+	// Attempt to parse the value
+	value, err := withdrawal.Value()
+	if err != nil {
+		return nil, fmt.Errorf("cannot migrate withdrawal: %w", err)
 	}
 
 	abi, err := bindings.L1CrossDomainMessengerMetaData.GetAbi()

--- a/op-chain-ops/crossdomain/migrate_test.go
+++ b/op-chain-ops/crossdomain/migrate_test.go
@@ -25,11 +25,9 @@ func TestMigrateWithdrawal(t *testing.T) {
 	}
 
 	l1CrossDomainMessenger := common.HexToAddress("0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1")
-	l1StandardBridge := common.HexToAddress("0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1")
-
 	for i, legacy := range withdrawals {
 		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
-			withdrawal, err := crossdomain.MigrateWithdrawal(legacy, &l1CrossDomainMessenger, &l1StandardBridge)
+			withdrawal, err := crossdomain.MigrateWithdrawal(legacy, &l1CrossDomainMessenger)
 			require.Nil(t, err)
 			require.NotNil(t, withdrawal)
 

--- a/op-chain-ops/crossdomain/types.go
+++ b/op-chain-ops/crossdomain/types.go
@@ -10,6 +10,7 @@ var (
 	Uint256Type, _ = abi.NewType("uint256", "", nil)
 	BytesType, _   = abi.NewType("bytes", "", nil)
 	AddressType, _ = abi.NewType("address", "", nil)
+	Bytes32Type, _ = abi.NewType("bytes32", "", nil)
 )
 
 // WithdrawalMessage represents a Withdrawal. The Withdrawal

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -80,7 +80,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 	}
 
 	log.Info("Starting to migrate withdrawals")
-	err = crossdomain.MigrateWithdrawals(withdrawals, db, &config.L1CrossDomainMessengerProxy, &config.L1StandardBridgeProxy)
+	err = crossdomain.MigrateWithdrawals(withdrawals, db, &config.L1CrossDomainMessengerProxy)
 	if err != nil {
 		return nil, fmt.Errorf("cannot migrate withdrawals: %w", err)
 	}
@@ -115,7 +115,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		BaseFee:     (*big.Int)(config.L2GenesisBlockBaseFeePerGas),
 	}
 
-	receipts, err := CreateReceipts(bedrockHeader, withdrawals, &config.L1CrossDomainMessengerProxy, &config.L1StandardBridgeProxy)
+	receipts, err := CreateReceipts(bedrockHeader, withdrawals, &config.L1CrossDomainMessengerProxy)
 	if err != nil {
 		return nil, err
 	}

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -115,7 +115,12 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		BaseFee:     (*big.Int)(config.L2GenesisBlockBaseFeePerGas),
 	}
 
-	bedrockBlock := types.NewBlock(bedrockHeader, nil, nil, nil, trie.NewStackTrie(nil))
+	receipts, err := CreateReceipts(bedrockHeader, withdrawals, &config.L1CrossDomainMessengerProxy, &config.L1StandardBridgeProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	bedrockBlock := types.NewBlock(bedrockHeader, nil, nil, receipts, trie.NewStackTrie(nil))
 
 	res := &MigrationResult{
 		TransitionHeight:    bedrockBlock.NumberU64(),
@@ -130,7 +135,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 
 	rawdb.WriteTd(ldb, bedrockBlock.Hash(), bedrockBlock.NumberU64(), bedrockBlock.Difficulty())
 	rawdb.WriteBlock(ldb, bedrockBlock)
-	rawdb.WriteReceipts(ldb, bedrockBlock.Hash(), bedrockBlock.NumberU64(), nil)
+	rawdb.WriteReceipts(ldb, bedrockBlock.Hash(), bedrockBlock.NumberU64(), receipts)
 	rawdb.WriteCanonicalHash(ldb, bedrockBlock.Hash(), bedrockBlock.NumberU64())
 	rawdb.WriteHeadBlockHash(ldb, bedrockBlock.Hash())
 	rawdb.WriteHeadFastBlockHash(ldb, bedrockBlock.Hash())

--- a/op-chain-ops/genesis/receipts.go
+++ b/op-chain-ops/genesis/receipts.go
@@ -1,0 +1,33 @@
+package genesis
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// CreateReceipts will create the set of bedrock genesis receipts given
+// a list of legacy withdrawals.
+func CreateReceipts(
+	hdr *types.Header,
+	withdrawals []*crossdomain.LegacyWithdrawal,
+	l1CrossDomainMessenger, l1StandardBridge *common.Address,
+) ([]*types.Receipt, error) {
+	receipts := make([]*types.Receipt, 0)
+
+	for _, withdrawal := range withdrawals {
+		wd, err := crossdomain.MigrateWithdrawal(withdrawal, l1CrossDomainMessenger, l1StandardBridge)
+		if err != nil {
+			return nil, err
+		}
+
+		receipt, err := wd.Receipt(hdr)
+		if err != nil {
+			return nil, err
+		}
+
+		receipts = append(receipts, receipt)
+	}
+
+	return receipts, nil
+}

--- a/op-chain-ops/genesis/receipts.go
+++ b/op-chain-ops/genesis/receipts.go
@@ -8,20 +8,16 @@ import (
 
 // CreateReceipts will create the set of bedrock genesis receipts given
 // a list of legacy withdrawals.
-func CreateReceipts(
-	hdr *types.Header,
-	withdrawals []*crossdomain.LegacyWithdrawal,
-	l1CrossDomainMessenger, l1StandardBridge *common.Address,
-) ([]*types.Receipt, error) {
+func CreateReceipts(hdr *types.Header, withdrawals []*crossdomain.LegacyWithdrawal, l1CrossDomainMessenger *common.Address) ([]*types.Receipt, error) {
 	receipts := make([]*types.Receipt, 0)
 
-	for _, withdrawal := range withdrawals {
-		wd, err := crossdomain.MigrateWithdrawal(withdrawal, l1CrossDomainMessenger, l1StandardBridge)
+	for i, withdrawal := range withdrawals {
+		wd, err := crossdomain.MigrateWithdrawal(withdrawal, l1CrossDomainMessenger)
 		if err != nil {
 			return nil, err
 		}
 
-		receipt, err := wd.Receipt(hdr)
+		receipt, err := wd.Receipt(hdr, uint(i))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**Description**

To make withdrawals really easy, we need to add in receipts corresponding to the migrated withdrawals. This will allow the exact same flow to be used when creating the withdrawing transactions as normal
withdrawals.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Closes ENG-3012
