### PR TITLE
ci: Add job to run echidna

### DIFF
--- a/.changeset/breezy-rockets-knock.md
+++ b/.changeset/breezy-rockets-knock.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Add echidna test commands

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,50 @@ jobs:
           command: yarn storage-snapshot && git diff --exit-code .storage-layout
           working_directory: packages/contracts-bedrock
 
+  contracts-bedrock-echidna:
+    docker:
+      - image: ethereumoptimism/ci-builder:latest
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace: {at: "."}
+      - run:
+          name: Check if we should run
+          command: |
+            shopt -s inherit_errexit
+            CHANGED=$(check-changed "(contracts-bedrock/contracts)" || echo "TRUE")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      - run:
+          name: Compile with metadata hash
+          command: yarn build:with-metadata
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Echidna Fuzz Aliasing
+          command: yarn echidna:aliasing || exit 0
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Echidna Fuzz Burn
+          command: yarn echidna:burn || exit 0
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Echidna Fuzz Encoding
+          command: yarn echidna:encoding || exit 0
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Echidna Fuzz Portal
+          command: yarn enchidna:portal || exit 0
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Echidna Fuzz Hashing
+          command: yarn echidna:hashing || exit 0
+          working_directory: packages/contracts-bedrock
+      - run:
+          name: Echidna Fuzz Resource Metering
+          command: yarn echidna:metering || exit 0
+          working_directory: packages/contracts-bedrock
+
   op-bindings-build:
     docker:
       - image: ethereumoptimism/ci-builder:latest
@@ -773,6 +817,9 @@ workflows:
           requires:
             - yarn-monorepo
       - contracts-bedrock-tests:
+          requires:
+            - yarn-monorepo
+      - contracts-bedrock-echidna:
           requires:
             - yarn-monorepo
       - op-bindings-build:

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -77,6 +77,17 @@ yarn build
 yarn test
 ```
 
+#### Running Echidna tests
+
+You must have [Echidna](https://github.com/crytic/echidna) installed.
+
+Contracts targetted for Echidna testing are located in `./contracts/echidna`
+Each target contract is tested with a separate yarn command, for example:
+
+```shell
+yarn echidna:aliasing
+```
+
 ### Deployment
 
 #### Configuration

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -21,3 +21,6 @@ fuzz_runs = 16
 
 [profile.ci]
 fuzz_runs = 512
+
+[profile.echidna]
+bytecode_hash = 'ipfs'

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -10,6 +10,11 @@ import 'hardhat-deploy'
 // Hardhat tasks
 import './tasks'
 
+let bytecodeHash = 'none'
+if (process.env.FOUNDRY_PROFILE === 'echidna') {
+  bytecodeHash = 'ipfs'
+}
+
 const config: HardhatUserConfig = {
   networks: {
     hardhat: {
@@ -371,7 +376,7 @@ const config: HardhatUserConfig = {
     ],
     settings: {
       metadata: {
-        bytecodeHash: 'none',
+        bytecodeHash,
       },
       outputSelection: {
         '*': {

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build:forge": "forge build",
+    "build:with-metadata": "hardhat clean && FOUNDRY_PROFILE=echidna hardhat compile",
     "build:differential": "tsc scripts/differential-testing.ts --outDir dist --moduleResolution node --esModuleInterop",
     "prebuild": "yarn ts-node scripts/verify-foundry-install.ts",
     "build": "hardhat compile && yarn autogen:artifacts && yarn build:ts && yarn typechain",
@@ -36,7 +37,13 @@
     "lint:contracts:fix": "yarn prettier --write 'contracts/**/*.sol'",
     "lint:fix": "yarn lint:contracts:fix && yarn lint:ts:fix",
     "lint": "yarn lint:fix && yarn lint:check",
-    "typechain": "typechain --target ethers-v5 --out-dir dist/types --glob 'artifacts/!(build-info)/**/+([a-zA-Z0-9_]).json'"
+    "typechain": "typechain --target ethers-v5 --out-dir dist/types --glob 'artifacts/!(build-info)/**/+([a-zA-Z0-9_]).json'",
+    "echidna:aliasing": "echidna-test --contract FuzzAddressAliasing --format text --crytic-args --hardhat-ignore-compile .",
+    "echidna:burn": "echidna-test --contract FuzzBurn --format text --crytic-args --hardhat-ignore-compile .",
+    "echidna:encoding": "echidna-test --contract FuzzEncoding --format text --crytic-args --hardhat-ignore-compile .",
+    "echidna:portal": "echidna-test --contract FuzzOptimismPortal --format text --crytic-args --hardhat-ignore-compile .",
+    "echidna:hashing": "echidna-test --contract FuzzHashing --format text --crytic-args --hardhat-ignore-compile .",
+    "echidna:metering": "echidna-test --contract FuzzResourceMetering --format text --crytic-args --hardhat-ignore-compile ."
   },
   "dependencies": {
     "@eth-optimism/core-utils": "^0.11.0",


### PR DESCRIPTION
**Description**

Related to #3944, but this includes only:
- the yarn, hardhat and foundry config changes to run the echidna tests
- adding the job to the ci config

As is, the test commands all end with `|| exit 0` so that they can fail quietly until the test code itself is introduced.

**Testing**

In order to test the new CI job properly, I temporarily (221eb98e434476f60060c618cb14a8290f6f7a97) commented out the `check-changed` step. The job completed successfully [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/9901/workflows/5887a970-bef5-4f31-8341-7947e3f4a266/jobs/232027).