### PR TITLE
fix(ctb): gas snapshot rm extra build step

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -24,7 +24,7 @@
     "test": "yarn build:differential && forge test",
     "coverage": "yarn build:differential && forge coverage",
     "coverage:lcov": "yarn build:differential && forge coverage --report lcov",
-    "gas-snapshot": "yarn build:differential && forge snapshot --no-match-test 'differential|fuzz'",
+    "gas-snapshot": "forge snapshot --no-match-test 'differential|fuzz'",
     "storage-snapshot": "./scripts/storage-snapshot.sh",
     "validate-spacers": "hardhat validate-spacers",
     "slither": "./scripts/slither.sh",


### PR DESCRIPTION
**Description**

No need to build the differential ts scripts if we're not using them in the gas snapshot.