### PR TITLE
op-chain-ops: remove setting owner in GovernanceToken

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -363,8 +363,6 @@ func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.Storage
 	storage["GovernanceToken"] = state.StorageValues{
 		"_name":   "Optimism",
 		"_symbol": "OP",
-		// TODO: this should be set to the MintManager
-		"_owner": common.Address{},
 	}
 	storage["ProxyAdmin"] = state.StorageValues{
 		"_owner": config.ProxyAdminOwner,


### PR DESCRIPTION
**Description**

We do not want to set the `_owner` field in the `GovernanceToken`. This assumes that it is preset in the state, so it will not work for spinning up new networks.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

