### PR TITLE
op-chain-ops: log when setting storage

### DIFF
--- a/op-bindings/bindings/registry.go
+++ b/op-bindings/bindings/registry.go
@@ -1,7 +1,6 @@
 package bindings
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/solc"
@@ -15,7 +14,7 @@ var deployedBytecodes = make(map[string]string)
 func GetStorageLayout(name string) (*solc.StorageLayout, error) {
 	layout := layouts[name]
 	if layout == nil {
-		return nil, errors.New("storage layout not found")
+		return nil, fmt.Errorf("%s: storage layout not found", name)
 	}
 	return layout, nil
 }
@@ -23,7 +22,7 @@ func GetStorageLayout(name string) (*solc.StorageLayout, error) {
 func GetDeployedBytecode(name string) ([]byte, error) {
 	bc := deployedBytecodes[name]
 	if bc == "" {
-		return nil, fmt.Errorf("deployed bytecode %s not found", name)
+		return nil, fmt.Errorf("%s: deployed bytecode not found", name)
 	}
 
 	return common.FromHex(bc), nil

--- a/op-chain-ops/state/state.go
+++ b/op-chain-ops/state/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/solc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
@@ -50,7 +51,7 @@ func EncodeStorage(entry solc.StorageLayoutEntry, value any, storageType solc.St
 func SetStorage(name string, address common.Address, values StorageValues, db vm.StateDB) error {
 	layout, err := bindings.GetStorageLayout(name)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot set storage: %w", err)
 	}
 	slots, err := ComputeStorageSlots(layout, values)
 	if err != nil {
@@ -58,6 +59,7 @@ func SetStorage(name string, address common.Address, values StorageValues, db vm
 	}
 	for _, slot := range slots {
 		db.SetState(address, slot.Key, slot.Value)
+		log.Trace("setting storage", "address", address.Hex(), "key", slot.Key.Hex(), "value", slot.Value.Hex())
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Adds a global logger to the `SetStorage` operation. Not ideal that a global logger is used, but that is currently how the logging is handled for the migration. This will help to prevent errors in misconfiguration of the system. In setups like hive, it is difficult to get insight into the state of the system as it is being brought up, so this should log when the system is being brought up. Bad config should stick out, ie setting an empty value because something was left out of the config.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

