### PR TITLE
op-chain-ops: various cleanup

### DIFF
--- a/op-chain-ops/cmd/migrate/main.go
+++ b/op-chain-ops/cmd/migrate/main.go
@@ -76,6 +76,10 @@ func main() {
 				Name:  "dry-run",
 				Usage: "Dry run the upgrade by not committing the database",
 			},
+			cli.BoolFlag{
+				Name:  "no-check",
+				Usage: "Do not perform sanity checks. This should only be used for testing",
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			deployConfig := ctx.String("deploy-config")
@@ -153,7 +157,8 @@ func main() {
 			}
 
 			dryRun := ctx.Bool("dry-run")
-			if _, err := genesis.MigrateDB(ldb, config, block, &migrationData, !dryRun); err != nil {
+			noCheck := ctx.Bool("no-check")
+			if _, err := genesis.MigrateDB(ldb, config, block, &migrationData, !dryRun, noCheck); err != nil {
 				return err
 			}
 

--- a/op-chain-ops/crossdomain/legacy_withdrawal.go
+++ b/op-chain-ops/crossdomain/legacy_withdrawal.go
@@ -39,7 +39,7 @@ func NewLegacyWithdrawal(target, sender *common.Address, data []byte, nonce *big
 func (w *LegacyWithdrawal) Encode() ([]byte, error) {
 	enc, err := EncodeCrossDomainMessageV0(w.Target, w.Sender, w.Data, w.Nonce)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot encode LegacyWithdrawal: %w", err)
 	}
 
 	out := make([]byte, len(enc)+len(predeploys.L2CrossDomainMessengerAddr.Bytes()))
@@ -107,7 +107,7 @@ func (w *LegacyWithdrawal) Decode(data []byte) error {
 func (w *LegacyWithdrawal) Hash() (common.Hash, error) {
 	encoded, err := w.Encode()
 	if err != nil {
-		return common.Hash{}, nil
+		return common.Hash{}, fmt.Errorf("cannot hash LegacyWithdrawal: %w", err)
 	}
 	hash := crypto.Keccak256(encoded)
 	return common.BytesToHash(hash), nil
@@ -118,7 +118,7 @@ func (w *LegacyWithdrawal) Hash() (common.Hash, error) {
 func (w *LegacyWithdrawal) StorageSlot() (common.Hash, error) {
 	hash, err := w.Hash()
 	if err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, fmt.Errorf("cannot compute storage slot: %w", err)
 	}
 	preimage := make([]byte, 64)
 	copy(preimage, hash.Bytes())

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -28,7 +28,7 @@ type MigrationResult struct {
 }
 
 // MigrateDB will migrate an old l2geth database to the new bedrock style system
-func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, migrationData *migration.MigrationData, commit bool) (*MigrationResult, error) {
+func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, migrationData *migration.MigrationData, commit, noCheck bool) (*MigrationResult, error) {
 	hash := rawdb.ReadHeadHeaderHash(ldb)
 	num := rawdb.ReadHeaderNumber(ldb, hash)
 	header := rawdb.ReadHeader(ldb, hash, *num)
@@ -56,11 +56,18 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		return nil, fmt.Errorf("cannot serialize withdrawals: %w", err)
 	}
 
-	if err := CheckWithdrawals(db, withdrawals); err != nil {
-		return nil, fmt.Errorf("withdrawals mismatch: %w", err)
+	if !noCheck {
+		log.Info("Checking withdrawals...")
+		if err := CheckWithdrawals(db, withdrawals); err != nil {
+			return nil, fmt.Errorf("withdrawals mismatch: %w", err)
+		}
+		log.Info("Withdrawals accounted for!")
+	} else {
+		log.Info("Skipping checking withdrawals")
 	}
 
 	// Now start the migration
+	log.Info("Setting the Proxies")
 	if err := SetL2Proxies(db); err != nil {
 		return nil, fmt.Errorf("cannot set L2Proxies: %w", err)
 	}
@@ -176,7 +183,7 @@ func CheckWithdrawals(db vm.StateDB, withdrawals []*crossdomain.LegacyWithdrawal
 	for _, wd := range withdrawals {
 		slot, err := wd.StorageSlot()
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot check withdrawals: %w", err)
 		}
 		knownSlots[slot] = true
 	}
@@ -190,7 +197,7 @@ func CheckWithdrawals(db vm.StateDB, withdrawals []*crossdomain.LegacyWithdrawal
 		return true
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot iterate over LegacyMessagePasser: %w", err)
 	}
 
 	// Check that all of the slots from storage correspond to a known message
@@ -206,7 +213,7 @@ func CheckWithdrawals(db vm.StateDB, withdrawals []*crossdomain.LegacyWithdrawal
 		_, ok := slots[slot]
 		//nolint:staticcheck
 		if !ok {
-			//return nil, fmt.Errorf("Unknown input message: %s", slot)
+			return fmt.Errorf("Unknown input message: %s", slot)
 		}
 	}
 

--- a/op-chain-ops/genesis/migration_action/action.go
+++ b/op-chain-ops/genesis/migration_action/action.go
@@ -24,6 +24,7 @@ type Config struct {
 	StartingL1BlockNumber uint64
 	L2DBPath              string
 	DryRun                bool
+	NoCheck               bool
 }
 
 func Migrate(cfg *Config) (*genesis.MigrationResult, error) {
@@ -81,5 +82,5 @@ func Migrate(cfg *Config) (*genesis.MigrationResult, error) {
 	}
 	defer ldb.Close()
 
-	return genesis.MigrateDB(ldb, deployConfig, block, &migrationData, !cfg.DryRun)
+	return genesis.MigrateDB(ldb, deployConfig, block, &migrationData, !cfg.DryRun, cfg.NoCheck)
 }


### PR DESCRIPTION
**Description**

Fixes a bug were an error should have been returned and it was not. Wraps some errors so that its easier to tell what the problem is in the case of there being an error. A bit of refactoring that allows the strict withdrawal migration checks to be skipped optionally. This should not be used in production, but can be used in early test iterations.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
