### PR TITLE
docs: fix l2-output link

### DIFF
--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -694,7 +694,7 @@ cf. [L1 Attributes Predeployed Contract Specification](deposits.md#l1-attributes
 
 ## L2 Output Root
 
-[l2-output]: glossary.md#l2-output
+[l2-output]: glossary.md#l2-output-root
 
 A 32 byte value which serves as a commitment to the current state of the L2 chain.
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR fixes the `l2-output` link in the `specs/glossary.md`.