### PR TITLE
op-chain-ops: set initial message passer nonce

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -326,8 +327,11 @@ func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.Storage
 		return storage, errors.New("block base fee not set")
 	}
 
+	// Set the initial L2ToL1MessagePasser nonce to
+	// `type(uint32).max` to prevent nonce collisions
+	// with historical withdrawals.
 	storage["L2ToL1MessagePasser"] = state.StorageValues{
-		"nonce": 0,
+		"nonce": math.MaxUint32,
 	}
 	storage["L2CrossDomainMessenger"] = state.StorageValues{
 		"_initialized": 1,


### PR DESCRIPTION
**Description**

The `L2ToL1MessagePasser` nonce is set to `type(uint32).max` initially to prevent nonce collisions with legacy withdrawals that have been upgraded. The max value for the nonce is `type(uint256).max` so it is not a problem to start at a non zero nonce.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

