### PR TITLE
Remove changesets dir from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,6 @@
 /op-service     @protolambda @trianglesphere @mslipper
 
 # Ops
-/.changeset   @mslipper @zhwrd
 /.circleci    @mslipper @zhwrd
 /.github      @mslipper @zhwrd
 /ops          @mslipper @zhwrd


### PR DESCRIPTION
Removes `.changesets` from `.CODEOWNERS`. This is generated code and doesn't need an owner. It was also pinging Zach and I on almost every PR.
