### PR TITLE
ctb: Add simple script for enforcing test conventions

### DIFF
--- a/packages/contracts-bedrock/scripts/forge-test-names.ts
+++ b/packages/contracts-bedrock/scripts/forge-test-names.ts
@@ -1,0 +1,81 @@
+import fs from 'fs'
+import path from 'path'
+
+const testPath = './contracts/test'
+const testFiles = fs.readdirSync(testPath)
+
+// Given a test function name, ensures it matches the expected format
+const handleFunctionName = (name: string) => {
+  if (!name.startsWith('test')) {
+    return
+  }
+  const parts = name.split('_')
+  parts.forEach((part) => {
+    // Good enough approximation for camelCase
+    if (part[0] !== part[0].toLowerCase()) {
+      throw new Error(
+        `Invalid test name: ${name}.\n Test name parts should be in camelCase`
+      )
+    }
+  })
+  if (parts.length < 3 || parts.length > 4) {
+    throw new Error(
+      `Invalid test name: ${name}.\n Test names should have either 3 or 4 parts, each separated by underscores`
+    )
+  }
+  if (!['test', 'testFuzz', 'testDiff'].includes(parts[0])) {
+    throw new Error(
+      `Invalid test name: ${name}.\n Names should begin with either "test" or "testFuzz"`
+    )
+  }
+  if (
+    !['succeeds', 'reverts', 'fails', 'benchmark', 'works'].includes(
+      parts[parts.length - 1]
+    ) &&
+    parts[parts.length - 2] !== 'benchmark'
+  ) {
+    throw new Error(
+      `Invalid test name: ${name}.\n Test names should end with either "succeeds", "reverts", "fails", "differential" or "benchmark[_num]"`
+    )
+  }
+  if (
+    ['reverts', 'fails'].includes(parts[parts.length - 1]) &&
+    parts.length < 4
+  ) {
+    throw new Error(
+      `Invalid test name: ${name}.\n Failure tests should have 4 parts. The third part should indicate the reason for failure.`
+    )
+  }
+}
+
+// Todo: define this function for validating contract names
+// Given a test contract name, ensures it matches the expected format
+const handleContractName = (name: string) => {
+  name
+}
+
+for (const testFile of testFiles) {
+  const filePath = path.join(testPath, testFile)
+  const lines = fs
+    .readFileSync(filePath, 'utf-8')
+    .split('\n')
+    .map((l) => l.trim())
+  let currentContract: string
+  for (const line of lines) {
+    if (line.startsWith('contract')) {
+      currentContract = line.split(' ')[1]
+      handleContractName(line)
+      continue
+    } else if (line.startsWith('function')) {
+      const funcName = line.split(' ')[1].split('(')[0]
+      try {
+        handleFunctionName(funcName)
+      } catch (error) {
+        throw new Error(
+          `In ${filePath}::${currentContract}:\n ${error.message}`
+        )
+      }
+      continue
+    }
+  }
+}

--- a/packages/contracts-bedrock/scripts/forge-test-names.ts
+++ b/packages/contracts-bedrock/scripts/forge-test-names.ts
@@ -2,42 +2,48 @@ import fs from 'fs'
 import path from 'path'
 
 type Check = {
-  check: (name: string, parts: string[]) => void,
-  makeError: (name: string) => Error,
+  check: (name: string, parts: string[]) => void
+  makeError: (name: string) => Error
 }
 
 /**
-  * Function name checks
-  */
+ * Function name checks
+ */
 const FunctionNameChecks: { [name: string]: Check } = {
   invalidCase: {
     check: (name: string, parts: string[]): void => {
       parts.forEach((part) => {
-        if (part[0] !== part[0].toLowerCase())
+        if (part[0] !== part[0].toLowerCase()) {
           throw FunctionNameChecks.invalidCase.makeError(name)
+        }
       })
     },
-    makeError: (name: string): Error => new Error(
-      `Invalid test name: ${name}.\n Test name parts should be in camelCase.`
-    )
+    makeError: (name: string): Error =>
+      new Error(
+        `Invalid test name "${name}".\n Test name parts should be in camelCase.`
+      ),
   },
   invalidNumParts: {
     check: (name: string, parts: string[]): void => {
-      if (parts.length < 3 || parts.length > 4)
+      if (parts.length < 3 || parts.length > 4) {
         throw FunctionNameChecks.invalidNumParts.makeError(name)
+      }
     },
-    makeError: (name: string): Error => new Error(
-      `Invalid test name: ${name}.\n Test names should have either 3 or 4 parts, each separated by underscores.`
-    )
+    makeError: (name: string): Error =>
+      new Error(
+        `Invalid test name "${name}".\n Test names should have either 3 or 4 parts, each separated by underscores.`
+      ),
   },
   invalidPrefix: {
     check: (name: string, parts: string[]): void => {
-      if (!['test', 'testFuzz', 'testDiff'].includes(parts[0]))
+      if (!['test', 'testFuzz', 'testDiff'].includes(parts[0])) {
         throw FunctionNameChecks.invalidPrefix.makeError(name)
+      }
     },
-    makeError: (name: string): Error => new Error(
-      `Invalid test name: ${name}.\n Names should begin with "test", "testFuzz", or "testDiff".`
-    )
+    makeError: (name: string): Error =>
+      new Error(
+        `Invalid test name "${name}".\n Names should begin with "test", "testFuzz", or "testDiff".`
+      ),
   },
   invalidTestResult: {
     check: (name: string, parts: string[]): void => {
@@ -46,69 +52,69 @@ const FunctionNameChecks: { [name: string]: Check } = {
           parts[parts.length - 1]
         ) &&
         parts[parts.length - 2] !== 'benchmark'
-      )
+      ) {
         throw FunctionNameChecks.invalidTestResult.makeError(name)
+      }
     },
-    makeError: (name: string): Error => new Error(
-      `Invalid test name: ${name}.\n Test names should end with either "succeeds", "reverts", "fails", "works" or "benchmark[_num]".`
-    )
+    makeError: (name: string): Error =>
+      new Error(
+        `Invalid test name "${name}".\n Test names should end with either "succeeds", "reverts", "fails", "works" or "benchmark[_num]".`
+      ),
   },
   noFailureReason: {
     check: (name: string, parts: string[]): void => {
       if (
         ['reverts', 'fails'].includes(parts[parts.length - 1]) &&
         parts.length < 4
-      )
+      ) {
         throw FunctionNameChecks.noFailureReason.makeError(name)
+      }
     },
-    makeError: (name: string): Error => new Error(
-      `Invalid test name: ${name}.\n Failure tests should have 4 parts. The third part should indicate the reason for failure.`
-    )
-  }
+    makeError: (name: string): Error =>
+      new Error(
+        `Invalid test name "${name}".\n Failure tests should have 4 parts. The third part should indicate the reason for failure.`
+      ),
+  },
 }
 
 // Given a test function name, ensures it matches the expected format
 const handleFunctionName = (name: string) => {
-  if (!name.startsWith('test'))
+  if (!name.startsWith('test')) {
     return
+  }
   const parts = name.split('_')
   Object.values(FunctionNameChecks).forEach(({ check }) => check(name, parts))
 }
 
-// Todo: define this function for validating contract names
-// Given a test contract name, ensures it matches the expected format
-const handleContractName = (name: string) => {
-  name
-}
-
 const main = async () => {
-  const testPath = './contracts/test'
-  const testFiles = fs.readdirSync(testPath)
+  const artifactsPath = './forge-artifacts'
 
-  for (const testFile of testFiles) {
-    const filePath = path.join(testPath, testFile)
-    const lines = fs
-      .readFileSync(filePath, 'utf-8')
-      .split('\n')
-      .map((l) => l.trim())
-    let currentContract: string
-    for (const line of lines) {
-      if (line.startsWith('contract')) {
-        currentContract = line.split(' ')[1]
-        handleContractName(line)
-        continue
-      } else if (line.startsWith('function')) {
-        const funcName = line.split(' ')[1].split('(')[0]
+  // Get a list of all solidity files with the extension t.sol
+  const solTestFiles = fs
+    .readdirSync(artifactsPath)
+    .filter((solFile) => solFile.includes('.t.sol'))
+
+  // Build a list of artifacts for contracts which include the string Test in them
+  let testArtifacts: string[] = []
+  for (const file of solTestFiles) {
+    testArtifacts = testArtifacts.concat(
+      fs
+        .readdirSync(path.join(artifactsPath, file))
+        .filter((x) => x.includes('Test'))
+        .map((x) => path.join(artifactsPath, stf, x))
+    )
+  }
+
+  for (const artifact of testArtifacts) {
+    JSON.parse(fs.readFileSync(artifact, 'utf8'))
+      .abi.filter((el) => el.type === 'function')
+      .forEach((el) => {
         try {
-          handleFunctionName(funcName)
+          handleFunctionName(el.name)
         } catch (error) {
-          throw new Error(
-            `In ${filePath}::${currentContract}:\n ${error.message}`
-          )
+          throw new Error(`In ${path.parse(artifact).name}: ${error.message}`)
         }
-        continue
-      }
-    }
+      })
   }
 }
 

--- a/packages/contracts-bedrock/scripts/forge-test-names.ts
+++ b/packages/contracts-bedrock/scripts/forge-test-names.ts
@@ -1,51 +1,78 @@
 import fs from 'fs'
 import path from 'path'
 
-const testPath = './contracts/test'
-const testFiles = fs.readdirSync(testPath)
+type Check = {
+  check: (name: string, parts: string[]) => void,
+  makeError: (name: string) => Error,
+}
 
-// Given a test function name, ensures it matches the expected format
-const handleFunctionName = (name: string) => {
-  if (!name.startsWith('test')) {
-    return
-  }
-  const parts = name.split('_')
-  parts.forEach((part) => {
-    // Good enough approximation for camelCase
-    if (part[0] !== part[0].toLowerCase()) {
-      throw new Error(
-        `Invalid test name: ${name}.\n Test name parts should be in camelCase`
+/**
+  * Function name checks
+  */
+const FunctionNameChecks: { [name: string]: Check } = {
+  invalidCase: {
+    check: (name: string, parts: string[]): void => {
+      parts.forEach((part) => {
+        if (part[0] !== part[0].toLowerCase())
+          throw FunctionNameChecks.invalidCase.makeError(name)
+      })
+    },
+    makeError: (name: string): Error => new Error(
+      `Invalid test name: ${name}.\n Test name parts should be in camelCase.`
+    )
+  },
+  invalidNumParts: {
+    check: (name: string, parts: string[]): void => {
+      if (parts.length < 3 || parts.length > 4)
+        throw FunctionNameChecks.invalidNumParts.makeError(name)
+    },
+    makeError: (name: string): Error => new Error(
+      `Invalid test name: ${name}.\n Test names should have either 3 or 4 parts, each separated by underscores.`
+    )
+  },
+  invalidPrefix: {
+    check: (name: string, parts: string[]): void => {
+      if (!['test', 'testFuzz', 'testDiff'].includes(parts[0]))
+        throw FunctionNameChecks.invalidPrefix.makeError(name)
+    },
+    makeError: (name: string): Error => new Error(
+      `Invalid test name: ${name}.\n Names should begin with "test", "testFuzz", or "testDiff".`
+    )
+  },
+  invalidTestResult: {
+    check: (name: string, parts: string[]): void => {
+      if (
+        !['succeeds', 'reverts', 'fails', 'benchmark', 'works'].includes(
+          parts[parts.length - 1]
+        ) &&
+        parts[parts.length - 2] !== 'benchmark'
       )
-    }
-  })
-  if (parts.length < 3 || parts.length > 4) {
-    throw new Error(
-      `Invalid test name: ${name}.\n Test names should have either 3 or 4 parts, each separated by underscores`
+        throw FunctionNameChecks.invalidTestResult.makeError(name)
+    },
+    makeError: (name: string): Error => new Error(
+      `Invalid test name: ${name}.\n Test names should end with either "succeeds", "reverts", "fails", "works" or "benchmark[_num]".`
     )
-  }
-  if (!['test', 'testFuzz', 'testDiff'].includes(parts[0])) {
-    throw new Error(
-      `Invalid test name: ${name}.\n Names should begin with either "test" or "testFuzz"`
-    )
-  }
-  if (
-    !['succeeds', 'reverts', 'fails', 'benchmark', 'works'].includes(
-      parts[parts.length - 1]
-    ) &&
-    parts[parts.length - 2] !== 'benchmark'
-  ) {
-    throw new Error(
-      `Invalid test name: ${name}.\n Test names should end with either "succeeds", "reverts", "fails", "differential" or "benchmark[_num]"`
-    )
-  }
-  if (
-    ['reverts', 'fails'].includes(parts[parts.length - 1]) &&
-    parts.length < 4
-  ) {
-    throw new Error(
+  },
+  noFailureReason: {
+    check: (name: string, parts: string[]): void => {
+      if (
+        ['reverts', 'fails'].includes(parts[parts.length - 1]) &&
+        parts.length < 4
+      )
+        throw FunctionNameChecks.noFailureReason.makeError(name)
+    },
+    makeError: (name: string): Error => new Error(
       `Invalid test name: ${name}.\n Failure tests should have 4 parts. The third part should indicate the reason for failure.`
     )
   }
+}
+
+// Given a test function name, ensures it matches the expected format
+const handleFunctionName = (name: string) => {
+  if (!name.startsWith('test'))
+    return
+  const parts = name.split('_')
+  Object.values(FunctionNameChecks).forEach(({ check }) => check(name, parts))
 }
 
 // Todo: define this function for validating contract names
@@ -54,28 +81,35 @@ const handleContractName = (name: string) => {
   name
 }
 
-for (const testFile of testFiles) {
-  const filePath = path.join(testPath, testFile)
-  const lines = fs
-    .readFileSync(filePath, 'utf-8')
-    .split('\n')
-    .map((l) => l.trim())
-  let currentContract: string
-  for (const line of lines) {
-    if (line.startsWith('contract')) {
-      currentContract = line.split(' ')[1]
-      handleContractName(line)
-      continue
-    } else if (line.startsWith('function')) {
-      const funcName = line.split(' ')[1].split('(')[0]
-      try {
-        handleFunctionName(funcName)
-      } catch (error) {
-        throw new Error(
-          `In ${filePath}::${currentContract}:\n ${error.message}`
-        )
+const main = async () => {
+  const testPath = './contracts/test'
+  const testFiles = fs.readdirSync(testPath)
+
+  for (const testFile of testFiles) {
+    const filePath = path.join(testPath, testFile)
+    const lines = fs
+      .readFileSync(filePath, 'utf-8')
+      .split('\n')
+      .map((l) => l.trim())
+    let currentContract: string
+    for (const line of lines) {
+      if (line.startsWith('contract')) {
+        currentContract = line.split(' ')[1]
+        handleContractName(line)
+        continue
+      } else if (line.startsWith('function')) {
+        const funcName = line.split(' ')[1].split('(')[0]
+        try {
+          handleFunctionName(funcName)
+        } catch (error) {
+          throw new Error(
+            `In ${filePath}::${currentContract}:\n ${error.message}`
+          )
+        }
+        continue
       }
-      continue
     }
   }
 }
+
+main()


### PR DESCRIPTION
**Description**

Adds a ts script which checks to ensure that tests conform to the convention. It can be run from within the contracts-bedrock package using `ts-node scripts/forges-test-names.ts`.

The script should eventually run in CI, when all tests are conformant.

Builds on #4122.