### PR TITLE
l2geth: cleanly shut down the syncservice

### DIFF
--- a/.changeset/healthy-steaks-impress.md
+++ b/.changeset/healthy-steaks-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Close down the syncservice more cleanly


### PR DESCRIPTION
**Description**

The ss was not previously being shut down cleanly, which can result in a corrupted db state. This makes the shutdown more clean.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

