### PR TITLE
op-migrate: use correct ancient path

### DIFF
--- a/op-chain-ops/cmd/op-migrate/main.go
+++ b/op-chain-ops/cmd/op-migrate/main.go
@@ -141,7 +141,7 @@ func main() {
 			}
 
 			chaindataPath := filepath.Join(ctx.String("db-path"), "geth", "chaindata")
-			ancientPath := filepath.Join(ctx.String("db-path"), "ancient")
+			ancientPath := filepath.Join(chaindataPath, "ancient")
 			ldb, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindataPath, int(1024), int(60), ancientPath, "", false)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Bugfix for the ancients path in the migration script