### PR TITLE
op-chain-ops: add goerli chain params

### DIFF
--- a/op-chain-ops/ether/params.go
+++ b/op-chain-ops/ether/params.go
@@ -21,4 +21,7 @@ var ParamsByChainID = map[int]*Params{
 		// total supply by accidental invocations of the Saurik bug (https://www.saurik.com/optimism.html).
 		new(big.Int).SetUint64(1627270011999999992),
 	},
+	5: {
+		new(big.Int),
+	},
 }


### PR DESCRIPTION
**Description**

Without it, there will be a `nil` dereference.
Each network should be added explicitly

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

