### PR TITLE
op-chain-ops: base fee check

### DIFF
--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -2,6 +2,7 @@ package genesis
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -51,6 +52,10 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 			TransitionTimestamp: header.Time,
 			TransitionBlockHash: hash,
 		}, nil
+	}
+
+	if config.L2GenesisBlockBaseFeePerGas == nil {
+		return nil, errors.New("must configure L2 genesis block base fee per gas")
 	}
 
 	underlyingDB := state.NewDatabaseWithConfig(ldb, &trie.Config{


### PR DESCRIPTION
**Description**

Check that the L2 genesis block base fee per gas
is not set to `nil`. If it is, it will cause a segfault in `op-geth` on startup after the migration.

It is configured with the key: `"l2GenesisBlockBaseFeePerGas"`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
