### PR TITLE
op-chain-ops: check for transition block config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -185,10 +185,16 @@ func (d *DeployConfig) Check() error {
 		return fmt.Errorf("%w: OptimismPortalProxy cannot be address(0)", ErrInvalidDeployConfig)
 	}
 	if d.EIP1559Denominator == 0 {
-		return fmt.Errorf("EIP1559Denominator cannot be 0")
+		return fmt.Errorf("%w: EIP1559Denominator cannot be 0", ErrInvalidDeployConfig)
 	}
 	if d.EIP1559Elasticity == 0 {
-		return fmt.Errorf("EIP1559Elasticity cannot be 0")
+		return fmt.Errorf("%w: EIP1559Elasticity cannot be 0", ErrInvalidDeployConfig)
+	}
+	if d.L2GenesisBlockGasLimit == 0 {
+		return fmt.Errorf("%w: L2 genesis block gas limit cannot be 0", ErrInvalidDeployConfig)
+	}
+	if d.L2GenesisBlockBaseFeePerGas == nil {
+		return fmt.Errorf("%w: L2 genesis block base fee per gas cannot be nil", ErrInvalidDeployConfig)
 	}
 	return nil
 }

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -2,7 +2,6 @@ package genesis
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -52,10 +51,6 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 			TransitionTimestamp: header.Time,
 			TransitionBlockHash: hash,
 		}, nil
-	}
-
-	if config.L2GenesisBlockBaseFeePerGas == nil {
-		return nil, errors.New("must configure L2 genesis block base fee per gas")
 	}
 
 	// Ensure monotonic timestamps


### PR DESCRIPTION
**Description**

Adds checks for transition block config. We do not want these values to be 0 because it will mess with eip 1559 in the beginning.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
