### PR TITLE
op-chain-ops: allow config of LevelDB in `op-migrate`

### DIFF
--- a/op-chain-ops/cmd/op-migrate/main.go
+++ b/op-chain-ops/cmd/op-migrate/main.go
@@ -80,6 +80,16 @@ func main() {
 				Name:  "no-check",
 				Usage: "Do not perform sanity checks. This should only be used for testing",
 			},
+			cli.IntFlag{
+				Name:  "db-cache",
+				Usage: "LevelDB cache size in mb",
+				Value: 1024,
+			},
+			cli.IntFlag{
+				Name:  "db-handles",
+				Usage: "LevelDB number of handles",
+				Value: 60,
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			deployConfig := ctx.String("deploy-config")
@@ -140,9 +150,12 @@ func main() {
 				return err
 			}
 
+			dbCache := ctx.Int("db-cache")
+			dbHandles := ctx.Int("db-handles")
+
 			chaindataPath := filepath.Join(ctx.String("db-path"), "geth", "chaindata")
 			ancientPath := filepath.Join(chaindataPath, "ancient")
-			ldb, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindataPath, int(1024), int(60), ancientPath, "", false)
+			ldb, err := rawdb.NewLevelDBDatabaseWithFreezer(chaindataPath, dbCache, dbHandles, ancientPath, "", false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description**

Two new flags are added

- `db-cache`
- `db-handles`

These are passed through the the LevelDB constructor

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
