### PR TITLE
Increase sequencer window & sequncer drift

### DIFF
--- a/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
@@ -4,8 +4,8 @@
   "l2ChainID": 901,
   "l2BlockTime": 2,
 
-  "maxSequencerDrift": 300,
-  "sequencerWindowSize": 15,
+  "maxSequencerDrift": 100,
+  "sequencerWindowSize": 4,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",

--- a/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
@@ -4,8 +4,8 @@
   "l2ChainID": 901,
   "l2BlockTime": 2,
 
-  "maxSequencerDrift": 100,
-  "sequencerWindowSize": 4,
+  "maxSequencerDrift": 300,
+  "sequencerWindowSize": 15,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -3,8 +3,8 @@
   "l2ChainID": 901,
   "l2BlockTime": 2,
 
-  "maxSequencerDrift": 100,
-  "sequencerWindowSize": 4,
+  "maxSequencerDrift": 300,
+  "sequencerWindowSize": 15,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -33,6 +33,7 @@
   "deploymentWaitConfirmations": 1,
   "fundDevAccounts": true,
 
+  "l2GenesisBlockBaseFeePerGas": 1000000000,
   "gasPriceOracleOverhead": 2100,
   "gasPriceOracleScalar": 1000000,
   "eip1559Denominator": 8,

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -20,6 +20,7 @@
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x6925B8704Ff96DEe942623d6FB5e946EF5884b63",
 
+  "l2GenesisBlockBaseFeePerGas": 1000000000,
   "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
   "sequencerFeeVaultRecipient": "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -6,8 +6,8 @@
   "l2ChainID": 901,
   "l2BlockTime": 2,
 
-  "maxSequencerDrift": 10,
-  "sequencerWindowSize": 4,
+  "maxSequencerDrift": 300,
+  "sequencerWindowSize": 15,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",


### PR DESCRIPTION
**Description**

This should hopefully help some of the reorgs we've seen on the devnets.
I think the devnet was too faster for the sequencer window - particularly at startup.
In addition, I think the switch to using wallclock time may have aggravated the issue of the short sequencer window.


**Metadata**

- Fixes ENG-3036