### PR TITLE
ci: Fix check-changed devnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,7 +594,7 @@ jobs:
       - run:
           name: Check if we should run
           command: |
-            CHANGED=$(bash ./ops/docker/ci-builder/check-changed.sh "(contracts-bedrock|op-bindings|op-batcher|op-node|op-proposer|ops-bedrock|sdk|.circlec)/" || echo "TRUE")
+            CHANGED=$(bash ./ops/docker/ci-builder/check-changed.sh "(contracts-bedrock|op-bindings|op-batcher|op-node|op-proposer|ops-bedrock|op-chain-ops|sdk|.circleci)/" || echo "TRUE")
             if [[ "$CHANGED" = "FALSE" ]]; then
               circleci step halt
             fi


### PR DESCRIPTION
`check-changed` needs to depend on `op-chain-ops`. This let a regression through onto `develop`.
