### PR TITLE
CI: Increase contracts-bedrock timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,7 @@ jobs:
       - run:
           name: test and generate coverage
           command: yarn coverage:lcov
+          no_output_timeout: 15m
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock


### PR DESCRIPTION
**Description**

The test was occasionally failing because of a slow test.
