### PR TITLE
feat(dtl): add L1 sync shutoff block flag

### DIFF
--- a/.changeset/kind-planes-laugh.md
+++ b/.changeset/kind-planes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add L1 sync shutoff block

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -214,10 +214,18 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           (await this.state.db.getHighestSyncedL1Block()) ||
           this.state.startingL1BlockNumber
         const currentL1Block = await this.state.l1RpcProvider.getBlockNumber()
-        const targetL1Block = Math.min(
+        let targetL1Block = Math.min(
           highestSyncedL1Block + this.options.logsPerPollingInterval,
           currentL1Block - this.options.confirmations
         )
+
+        // Don't sync beyond the shutoff block!
+        if (this.options.l1SyncShutoffBlock !== undefined) {
+          targetL1Block = Math.min(
+            targetL1Block,
+            this.options.l1SyncShutoffBlock
+          )
+        }
 
         // We're already at the head, so no point in attempting to sync.
         if (highestSyncedL1Block === targetL1Block) {

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -26,6 +26,7 @@ export interface L1DataTransportServiceOptions {
   l2RpcProvider: string
   l2RpcProviderUser?: string
   l2RpcProviderPassword?: string
+  l1SyncShutoffBlock?: number
   metrics?: Metrics
   dbPath: string
   logsPerPollingInterval: number

--- a/packages/data-transport-layer/src/services/run.ts
+++ b/packages/data-transport-layer/src/services/run.ts
@@ -29,6 +29,7 @@ type ethNetwork = 'mainnet' | 'kovan' | 'goerli'
       l1RpcProviderUser: config.str('l1-rpc-user'),
       l1RpcProviderPassword: config.str('l1-rpc-password'),
       addressManager: config.str('address-manager'),
+      l1SyncShutoffBlock: config.uint('l1-sync-shutoff-block'),
       pollingInterval: config.uint('polling-interval', 5000),
       logsPerPollingInterval: config.uint('logs-per-polling-interval', 2000),
       dangerouslyCatchAllErrors: config.bool(


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds a flag to the DTL that will tell the L1 sync to not sync beyond a given block height. Can be used to prepare forked networks.