### PR TITLE
[op-node] Set fallback UDP port

### DIFF
--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -61,8 +61,10 @@ func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort 
 	if conf.AdvertiseIP != nil {
 		localNode.SetStaticIP(conf.AdvertiseIP)
 	}
-	if conf.AdvertiseUDPPort != 0 {
+	if conf.AdvertiseUDPPort != 0 { // explicitly advertised port gets priority
 		localNode.SetFallbackUDP(int(conf.AdvertiseUDPPort))
+	} else if conf.ListenUDPPort != 0 { // otherwise default to the port we configured it to listen on
+		localNode.SetFallbackUDP(int(conf.ListenUDPPort))
 	}
 	if conf.AdvertiseTCPPort != 0 { // explicitly advertised port gets priority
 		localNode.Set(enr.TCP(conf.AdvertiseTCPPort))


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

`op-node`'s `p2p.advertise.udp` flag says that it will fallback on `p2p.listen.udp` if not set. However in practice, this does not happen.

This PR adds this fallback.

See https://github.com/ethereum-optimism/optimism/blob/cba069eff6d8951ec3d58f72c089a0bb0b8e1f2d/op-node/flags/p2p_flags.go#L83

**Tests**

I've tested this behavior in an internal devnet. It causes the advertised ENR address to have a UDP key/value pair, as verified by https://enr-viewer.com/.
