### PR TITLE
Add additional l2oo sanity check

### DIFF
--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -60,6 +60,13 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		)
 	}
 
+	// Ensure that the starting timestamp is safe
+	if config.L2OutputOracleStartingTimestamp <= 0 {
+		return nil, fmt.Errorf(
+			"L2 output oracle starting timestamp (%d) cannot be <= 0", config.L2OutputOracleStartingTimestamp,
+		)
+	}
+
 	underlyingDB := state.NewDatabaseWithConfig(ldb, &trie.Config{
 		Preimages: true,
 	})


### PR DESCRIPTION
Ensures that the L2OO starting timestamp is not <= 0. When `-1` is used in migration configs, the negative value was being passed into the genesis block directly. This led to a wraparound, since we cast the timestamp to a `uint64` elsewhere in the code.
