### PR TITLE
ci: Upgrade devnet machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,7 +581,7 @@ jobs:
 
   devnet:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
     parameters:
       deploy:


### PR DESCRIPTION
Upgrades our devnet machine images to use Ubuntu 22.04 to fix issues with Forge and glibc. While there's an open [Forge 
PR](https://github.com/foundry-rs/foundry/pull/3828) to fix this, GitHub is transitioning actions to 22.04 so this issue will happen 
again unless we upgrade.
