### PR TITLE
Set bedrock block in migration

### DIFF
--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -200,6 +200,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		EIP1559Denominator: config.EIP1559Denominator,
 		EIP1559Elasticity:  config.EIP1559Elasticity,
 	}
+	cfg.BedrockBlock = bedrockBlock.Number()
 	rawdb.WriteChainConfig(ldb, genesisHash, cfg)
 
 	log.Info(


### PR DESCRIPTION
**Description**

This sets the bedrock fork block number in the stored chain config during the migration.

**Tests**

Not tested.

**Metadata**

- Fixes ENG-3076
