### PR TITLE
op-node: Preallocate slice

### DIFF
--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -164,7 +164,7 @@ func (co *ChannelOut) OutputFrame(w *bytes.Buffer, maxSize uint64) error {
 
 // blockToBatch transforms a block into a batch object that can easily be RLP encoded.
 func blockToBatch(block *types.Block) (*BatchData, error) {
-	var opaqueTxs []hexutil.Bytes
+	opaqueTxs := make([]hexutil.Bytes, 0, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
 		if tx.Type() == types.DepositTxType {
 			continue


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Pre-allocate slice to reduce allocations and CPU for GC
