### PR TITLE
op-migration: add extra L2OutoutOracle timestamp check

### DIFF
--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -67,6 +67,15 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		)
 	}
 
+	if uint64(config.L2OutputOracleStartingTimestamp) > l1Block.Time() {
+		return nil, fmt.Errorf(
+			"L2OutputOracleStartingTimestamp (%d) cannot be greater than the L1 block time (%d)",
+			config.L2OutputOracleStartingTimestamp,
+			l1Block.Time(),
+		)
+
+	}
+
 	underlyingDB := state.NewDatabaseWithConfig(ldb, &trie.Config{
 		Preimages: true,
 	})


### PR DESCRIPTION
**Description**

Errors if the L2OutoutOracle starting timestamp is greater than the L1 block time that is used as the initial L1 origin.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

