### PR TITLE
op-node: Improve sequencer scheduler, improve timeliness of blocks

### DIFF
--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -28,7 +28,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, c
 	ver := NewL2Verifier(t, log, l1, eng, cfg)
 	return &L2Sequencer{
 		L2Verifier:              *ver,
-		sequencer:               driver.NewSequencer(log, cfg, l1, eng, metrics.NoopMetrics),
+		sequencer:               driver.NewSequencer(log, cfg, l1, eng, ver.derivation, metrics.NoopMetrics),
 		l1OriginSelector:        driver.NewL1OriginSelector(log, cfg, l1, seqConfDepth),
 		seqOldOrigin:            false,
 		failL2GossipUnsafeBlock: nil,
@@ -61,7 +61,7 @@ func (s *L2Sequencer) ActL2StartBlock(t Testing) {
 		origin = l1Origin
 	}
 
-	err := s.sequencer.StartBuildingBlock(t.Ctx(), parent, s.derivation.SafeL2Head().ID(), s.derivation.Finalized().ID(), origin)
+	err := s.sequencer.StartBuildingBlock(t.Ctx(), origin)
 	require.NoError(t, err, "failed to start block building")
 
 	s.l2Building = true

--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
@@ -27,7 +28,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, c
 	ver := NewL2Verifier(t, log, l1, eng, cfg)
 	return &L2Sequencer{
 		L2Verifier:              *ver,
-		sequencer:               driver.NewSequencer(log, cfg, l1, eng),
+		sequencer:               driver.NewSequencer(log, cfg, l1, eng, metrics.NoopMetrics),
 		l1OriginSelector:        driver.NewL1OriginSelector(log, cfg, l1, seqConfDepth),
 		seqOldOrigin:            false,
 		failL2GossipUnsafeBlock: nil,

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -7,16 +7,15 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/rpc"
 )
-
-// TODO(inphi): add metrics
 
 type rpcServer struct {
 	endpoint   string
@@ -28,7 +27,7 @@ type rpcServer struct {
 	sources.L2Client
 }
 
-func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, appVersion string, m *metrics.Metrics) (*rpcServer, error) {
+func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, appVersion string, m metrics.Metricer) (*rpcServer, error) {
 	api := NewNodeAPI(rollupCfg, l2Client, dr, log.New("rpc", "node"), m)
 	// TODO: extend RPC config with options for WS, IPC and HTTP RPC connections
 	endpoint := net.JoinHostPort(rpcCfg.ListenAddr, strconv.Itoa(rpcCfg.ListenPort))

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -110,7 +110,7 @@ func TestOutputAtBlock(t *testing.T) {
 	status := randomSyncStatus(rand.New(rand.NewSource(123)))
 	drClient.ExpectBlockRefWithStatus(0xdcdc89, ref, status, nil)
 
-	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, drClient, log, "0.0", metrics.NewMetrics(""))
+	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, drClient, log, "0.0", metrics.NoopMetrics)
 	require.NoError(t, err)
 	require.NoError(t, server.Start())
 	defer server.Stop()
@@ -142,7 +142,7 @@ func TestVersion(t *testing.T) {
 	rollupCfg := &rollup.Config{
 		// ignore other rollup config info in this test
 	}
-	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, drClient, log, "0.0", metrics.NewMetrics(""))
+	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, drClient, log, "0.0", metrics.NoopMetrics)
 	assert.NoError(t, err)
 	assert.NoError(t, server.Start())
 	defer server.Stop()
@@ -184,7 +184,7 @@ func TestSyncStatus(t *testing.T) {
 	rollupCfg := &rollup.Config{
 		// ignore other rollup config info in this test
 	}
-	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, drClient, log, "0.0", metrics.NewMetrics(""))
+	server, err := newRPCServer(context.Background(), rpcCfg, rollupCfg, l2Client, drClient, log, "0.0", metrics.NoopMetrics)
 	assert.NoError(t, err)
 	assert.NoError(t, server.Start())
 	defer server.Stop()

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -28,6 +28,8 @@ type Metrics interface {
 
 	RecordL1ReorgDepth(d uint64)
 	CountSequencedTxs(count int)
+
+	SequencerMetrics
 }
 
 type L1Chain interface {
@@ -72,9 +74,6 @@ type L1OriginSelectorIface interface {
 type SequencerIface interface {
 	StartBuildingBlock(ctx context.Context, l2Head eth.L2BlockRef, l2SafeHead eth.BlockID, l2Finalized eth.BlockID, l1Origin eth.L1BlockRef) error
 	CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayload, error)
-
-	// createNewBlock builds a new block based on the L2 Head, L1 Origin, and the current mempool.
-	CreateNewBlock(ctx context.Context, l2Head eth.L2BlockRef, l2SafeHead eth.BlockID, l2Finalized eth.BlockID, l1Origin eth.L1BlockRef) (eth.L2BlockRef, *eth.ExecutionPayload, error)
 }
 
 type Network interface {
@@ -84,7 +83,7 @@ type Network interface {
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
 func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
-	sequencer := NewSequencer(log, cfg, l1, l2)
+	sequencer := NewSequencer(log, cfg, l1, l2, metrics)
 	l1State := NewL1State(log, metrics)
 	findL1Origin := NewL1OriginSelector(log, cfg, l1, driverCfg.SequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"context"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -72,8 +73,9 @@ type L1OriginSelectorIface interface {
 }
 
 type SequencerIface interface {
-	StartBuildingBlock(ctx context.Context, l2Head eth.L2BlockRef, l2SafeHead eth.BlockID, l2Finalized eth.BlockID, l1Origin eth.L1BlockRef) error
+	StartBuildingBlock(ctx context.Context, l1Origin eth.L1BlockRef) error
 	CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayload, error)
+	PlanNextSequencerAction(sequenceErr error) (delay time.Duration, seal bool)
 }
 
 type Network interface {
@@ -83,11 +85,11 @@ type Network interface {
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
 func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
-	sequencer := NewSequencer(log, cfg, l1, l2, metrics)
 	l1State := NewL1State(log, metrics)
 	findL1Origin := NewL1OriginSelector(log, cfg, l1, driverCfg.SequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l2, metrics)
+	sequencer := NewSequencer(log, cfg, l1, l2, derivationPipeline, metrics)
 
 	return &Driver{
 		l1State:          l1State,

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -75,7 +75,7 @@ type L1OriginSelectorIface interface {
 type SequencerIface interface {
 	StartBuildingBlock(ctx context.Context, l1Origin eth.L1BlockRef) error
 	CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayload, error)
-	PlanNextSequencerAction(sequenceErr error) (delay time.Duration, seal bool)
+	PlanNextSequencerAction(sequenceErr error) (delay time.Duration, seal bool, onto eth.BlockID)
 }
 
 type Network interface {

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -106,7 +106,9 @@ func (d *Sequencer) CreateNewBlock(ctx context.Context, l2Head eth.L2BlockRef, l
 	// TODO: allowing to breathe when remaining time is in the negative is very generous,
 	//  we can reduce this if the block building timing gets better with PR 3818
 	d.log.Debug("using remaining time for better block production", "remaining_time", remaining)
-	time.Sleep(500 * time.Millisecond)
+	if remaining < time.Minute {
+		time.Sleep(2 * time.Second * time.Duration(d.config.BlockTime))
+	}
 
 	payload, err := d.CompleteBuildingBlock(ctx)
 	if err != nil {

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -102,16 +102,17 @@ func (d *Sequencer) CreateNewBlock(ctx context.Context, l2Head eth.L2BlockRef, l
 	}
 
 	payloadTime := time.Unix(int64(l2Head.Time+d.config.BlockTime), 0)
-	remaining := -time.Until(payloadTime)
-	// TODO: allowing to breathe when remaining time is in the negative is very generous,
-	//  we can reduce this if the block building timing gets better with PR 3818
-	d.log.Debug("using remaining time for better block production", "remaining_time", remaining)
+	remaining := time.Until(payloadTime)
 	// If there is more than 2 blocks worth of time remaining, then something is wrong with scheduling, abort.
-	if remaining > 2 * time.Second * time.Duration(d.config.BlockTime) {
-		return nil,  fmt.Errorf("block is being created too far in advance: we have %s remaining time", remaining)
-	} else if remaining > 100 * time.Millisecond {
-		// If we are not too close to the head time, then we are not in a rush to produce the block and we can take a breathe to include more transactions.
-		time.Sleep(remaining - 90 * time.Millesecond) // leave 0.09s for sealing the block, and do not sleep(0)
+	if remaining > 2*time.Second*time.Duration(d.config.BlockTime) {
+		return l2Head, nil, fmt.Errorf("block is being created too far in advance: we have %s remaining time", remaining)
+	} else if remaining > 100*time.Millisecond {
+		remaining -= 90 * time.Millisecond // leave 0.09s for sealing the block, and do not sleep(0)
+		d.log.Debug("using remaining time minus margin for better block production", "wait", remaining)
+		// If we are not too close to the head time, then we are not in a rush to produce the block and we can take a breath to include more transactions.
+		time.Sleep(remaining)
+	} else {
+		d.log.Warn("creating block with low time margin for building", "margin", remaining)
 	}
 
 	payload, err := d.CompleteBuildingBlock(ctx)

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -113,6 +113,9 @@ func (d *Sequencer) CreateNewBlock(ctx context.Context, l2Head eth.L2BlockRef, l
 		time.Sleep(remaining)
 	} else {
 		d.log.Warn("creating block with low time margin for building", "margin", remaining)
+		if remaining > -2*time.Second {
+			time.Sleep(time.Millisecond * 100) // temporary workaround: we still need time to include txs if we're lagging behind just a short bit because of bad sequencing scheduling.
+		}
 	}
 
 	payload, err := d.CompleteBuildingBlock(ctx)

--- a/op-node/rollup/driver/state_tob_test.go
+++ b/op-node/rollup/driver/state_tob_test.go
@@ -29,8 +29,8 @@ type TestDummyOutputImpl struct {
 	l2Head   eth.L2BlockRef
 }
 
-func (d *TestDummyOutputImpl) PlanNextSequencerAction(sequenceErr error) (delay time.Duration, seal bool) {
-	return 0, d.l1Origin != (eth.L1BlockRef{})
+func (d *TestDummyOutputImpl) PlanNextSequencerAction(sequenceErr error) (delay time.Duration, seal bool, onto eth.BlockID) {
+	return 0, d.l1Origin != (eth.L1BlockRef{}), d.l2Head.ParentID()
 }
 
 func (d *TestDummyOutputImpl) StartBuildingBlock(ctx context.Context, l1Origin eth.L1BlockRef) error {

--- a/op-node/rollup/driver/state_tob_test.go
+++ b/op-node/rollup/driver/state_tob_test.go
@@ -4,48 +4,76 @@ package driver
 import (
 	"context"
 	"errors"
+	"math/big"
 	"math/rand"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/require"
 )
 
 type TestDummyOutputImpl struct {
 	willError bool
-	SequencerIface
+
+	cfg *rollup.Config
+
+	l1Origin eth.L1BlockRef
+	l2Head   eth.L2BlockRef
 }
 
-func (d TestDummyOutputImpl) CreateNewBlock(ctx context.Context, l2Head eth.L2BlockRef, l2SafeHead eth.BlockID, l2Finalized eth.BlockID, l1Origin eth.L1BlockRef) (eth.L2BlockRef, *eth.ExecutionPayload, error) {
+func (d *TestDummyOutputImpl) StartBuildingBlock(ctx context.Context, l2Head eth.L2BlockRef, l2SafeHead eth.BlockID, l2Finalized eth.BlockID, l1Origin eth.L1BlockRef) error {
+	d.l1Origin = l1Origin
+	d.l2Head = l2Head
+	return nil
+}
+
+func (d *TestDummyOutputImpl) CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayload, error) {
 	// If we're meant to error, return one
 	if d.willError {
-		return l2Head, nil, errors.New("the TestDummyOutputImpl.createNewBlock operation failed")
+		return nil, errors.New("the TestDummyOutputImpl.createNewBlock operation failed")
 	}
-
+	info := &testutils.MockBlockInfo{
+		InfoHash:        d.l1Origin.Hash,
+		InfoParentHash:  d.l1Origin.ParentHash,
+		InfoCoinbase:    common.Address{},
+		InfoRoot:        common.Hash{},
+		InfoNum:         d.l1Origin.Number,
+		InfoTime:        d.l1Origin.Time,
+		InfoMixDigest:   [32]byte{},
+		InfoBaseFee:     big.NewInt(123),
+		InfoReceiptRoot: common.Hash{},
+	}
+	infoTx, err := derive.L1InfoDepositBytes(d.l2Head.SequenceNumber, info, eth.SystemConfig{})
+	if err != nil {
+		panic(err)
+	}
 	payload := eth.ExecutionPayload{
-		ParentHash:    common.Hash{},
+		ParentHash:    d.l2Head.Hash,
 		FeeRecipient:  common.Address{},
 		StateRoot:     eth.Bytes32{},
 		ReceiptsRoot:  eth.Bytes32{},
 		LogsBloom:     eth.Bytes256{},
 		PrevRandao:    eth.Bytes32{},
-		BlockNumber:   0,
+		BlockNumber:   eth.Uint64Quantity(d.l2Head.Number + 1),
 		GasLimit:      0,
 		GasUsed:       0,
-		Timestamp:     0,
+		Timestamp:     eth.Uint64Quantity(d.l2Head.Time + d.cfg.BlockTime),
 		ExtraData:     nil,
 		BaseFeePerGas: eth.Uint256Quantity{},
-		BlockHash:     common.Hash{},
-		Transactions:  []eth.Data{},
+		BlockHash:     common.Hash{123},
+		Transactions:  []eth.Data{infoTx},
 	}
-	return l2Head, &payload, nil
+	return &payload, nil
 }
+
+var _ SequencerIface = (*TestDummyOutputImpl)(nil)
 
 type TestDummyDerivationPipeline struct {
 	DerivationPipeline
@@ -104,27 +132,30 @@ func TestRejectCreateBlockBadTimestamp(t *testing.T) {
 	l2HeadRef.Time = l2l1OriginBlock.Time - (cfg.BlockTime * 2)
 
 	// Create our outputter
-	outputProvider := TestDummyOutputImpl{willError: false}
+	outputProvider := &TestDummyOutputImpl{cfg: &cfg, willError: false}
 
 	// Create our state
 	s := Driver{
 		l1State: &L1State{
 			l1Head:  l1HeadRef,
 			log:     log.New(),
-			metrics: &metrics.Metrics{TransactionsSequencedTotal: prometheus.NewCounter(prometheus.CounterOpts{})},
+			metrics: metrics.NoopMetrics,
 		},
 		log:              log.New(),
 		l1OriginSelector: TestDummyL1OriginSelector{retval: l1HeadRef},
 		config:           &cfg,
 		sequencer:        outputProvider,
 		derivation:       TestDummyDerivationPipeline{},
-		metrics:          &metrics.Metrics{TransactionsSequencedTotal: prometheus.NewCounter(prometheus.CounterOpts{})},
+		metrics:          metrics.NoopMetrics,
 	}
 
 	// Create a new block
 	// - L2Head's L1Origin, its timestamp should be greater than L1 genesis.
 	// - L2Head timestamp + BlockTime should be greater than or equal to the L1 Time.
-	err := s.createNewL2Block(ctx)
+	err := s.startNewL2Block(ctx)
+	if err == nil {
+		err = s.completeNewBlock(ctx)
+	}
 
 	// Verify the L1Origin's block number is greater than L1 genesis in our config.
 	if l2l1OriginBlock.Number < s.config.Genesis.L1.Number {
@@ -187,27 +218,30 @@ func FuzzRejectCreateBlockBadTimestamp(f *testing.F) {
 		l2HeadRef.Time = currentL2HeadTime
 
 		// Create our outputter
-		outputProvider := TestDummyOutputImpl{willError: forceOutputFail}
+		outputProvider := &TestDummyOutputImpl{cfg: &cfg, willError: forceOutputFail}
 
 		// Create our state
 		s := Driver{
 			l1State: &L1State{
 				l1Head:  l1HeadRef,
 				log:     log.New(),
-				metrics: &metrics.Metrics{TransactionsSequencedTotal: prometheus.NewCounter(prometheus.CounterOpts{})},
+				metrics: metrics.NoopMetrics,
 			},
 			log:              log.New(),
 			l1OriginSelector: TestDummyL1OriginSelector{retval: l1HeadRef},
 			config:           &cfg,
 			sequencer:        outputProvider,
 			derivation:       TestDummyDerivationPipeline{},
-			metrics:          &metrics.Metrics{TransactionsSequencedTotal: prometheus.NewCounter(prometheus.CounterOpts{})},
+			metrics:          metrics.NoopMetrics,
 		}
 
 		// Create a new block
 		// - L2Head's L1Origin, its timestamp should be greater than L1 genesis.
 		// - L2Head timestamp + BlockTime should be greater than or equal to the L1 Time.
-		err := s.createNewL2Block(ctx)
+		err := s.startNewL2Block(ctx)
+		if err == nil {
+			err = s.completeNewBlock(ctx)
+		}
 
 		// Verify the L1Origin's timestamp is greater than L1 genesis in our config.
 		if l2l1OriginBlock.Number < s.config.Genesis.L1.Number {


### PR DESCRIPTION
~~Reduces the wait time when sequencing new blocks. The PR referenced in the comment is already merged, and this wait was slowing down sync time on migrated nodes significantly.~~

Refactors the sequencing scheduling to be more timely, reducing the wait time and avoiding one late block from causing the next to be late again too.

Also adds `sequencer_building_diff_seconds/total` and `sequencer_sealing_seconds/total` histogram metrics to track sequencing scheduler accuracy.

Fix ENG-3088