### PR TITLE
op-node: Mark functions test helpers

### DIFF
--- a/op-node/client/polling_test.go
+++ b/op-node/client/polling_test.go
@@ -197,6 +197,7 @@ func TestPollingClientClose(t *testing.T) {
 }
 
 func requireChansEqual(t *testing.T, chans []chan *types.Header, root common.Hash) {
+	t.Helper()
 	for _, ch := range chans {
 		header := <-ch
 		require.Equal(t, root, header.Root)

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -29,6 +29,7 @@ type testTx struct {
 }
 
 func (tx *testTx) Create(t *testing.T, signer types.Signer, rng *rand.Rand) *types.Transaction {
+	t.Helper()
 	out, err := types.SignNewTx(tx.author, signer, &types.DynamicFeeTx{
 		ChainID:   signer.ChainID(),
 		Nonce:     0,

--- a/op-node/rollup/derive/fuzz_parsers_test.go
+++ b/op-node/rollup/derive/fuzz_parsers_test.go
@@ -141,6 +141,7 @@ var (
 
 // EncodeDepositOpaqueDataV0 performs ABI encoding to create the opaque data field of the deposit event.
 func EncodeDepositOpaqueDataV0(t *testing.T, mint *big.Int, value *big.Int, gasLimit uint64, isCreation bool, data []byte) []byte {
+	t.Helper()
 	// in OptimismPortal.sol:
 	// bytes memory opaqueData = abi.encodePacked(msg.value, _value, _gasLimit, _isCreation, _data);
 	// Geth does not support abi.encodePacked, so we emulate it here by slicing of the padding from the individual elements

--- a/op-node/rollup/sync/start_test.go
+++ b/op-node/rollup/sync/start_test.go
@@ -22,6 +22,7 @@ var _ L2Chain = (*testutils.FakeChainSource)(nil)
 // - The actual L1 chain is the New L1 chain
 // - Both heads are at the tip of their respective chains
 func (c *syncStartTestCase) generateFakeL2(t *testing.T) (*testutils.FakeChainSource, rollup.Genesis) {
+	t.Helper()
 	log := testlog.Logger(t, log.LvlError)
 	chain := testutils.NewFakeChainSource([]string{c.L1, c.NewL1}, []string{c.L2}, int(c.GenesisL1Num), log)
 	chain.SetL2Head(len(c.L2) - 1)

--- a/op-node/testutils/assertions.go
+++ b/op-node/testutils/assertions.go
@@ -14,6 +14,7 @@ func BigEqual(a, b *big.Int) bool {
 }
 
 func RequireBigEqual(t *testing.T, exp, actual *big.Int) {
+	t.Helper()
 	if !BigEqual(exp, actual) {
 		t.Fatalf("expected %s to be equal to %s", exp.String(), actual.String())
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Mark functions test helpers so filename and line number which call these functions will be reported instead of the test helpers.
