### PR TITLE
op-node: Replace interface{} with any

### DIFF
--- a/op-node/client/polling.go
+++ b/op-node/client/polling.go
@@ -78,7 +78,7 @@ func (w *PollingClient) Close() {
 	w.c.Close()
 }
 
-func (w *PollingClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (w *PollingClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	return w.c.CallContext(ctx, result, method, args...)
 }
 
@@ -90,7 +90,7 @@ func (w *PollingClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem)
 // to Geth's native EthSubscribe method. It will return an error, however, if the
 // passed in channel is not a *types.Headers channel or the subscription type is not
 // newHeads.
-func (w *PollingClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (w *PollingClient) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	select {
 	case <-w.ctx.Done():
 		return nil, ErrSubscriberClosed

--- a/op-node/client/polling_test.go
+++ b/op-node/client/polling_test.go
@@ -33,7 +33,7 @@ func (m *MockRPC) Close() {
 	m.closed = true
 }
 
-func (m *MockRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (m *MockRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -61,7 +61,7 @@ func (m *MockRPC) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	return nil
 }
 
-func (m *MockRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (m *MockRPC) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	m.t.Fatal("EthSubscribe should not be called")
 	return nil, nil
 }

--- a/op-node/client/rpc.go
+++ b/op-node/client/rpc.go
@@ -18,9 +18,9 @@ var httpRegex = regexp.MustCompile("^http(s)?://")
 
 type RPC interface {
 	Close()
-	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	CallContext(ctx context.Context, result any, method string, args ...any) error
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
-	EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error)
+	EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error)
 }
 
 // NewRPC returns the correct client.RPC instance for a given RPC url.
@@ -74,7 +74,7 @@ func (b *BaseRPCClient) Close() {
 	b.c.Close()
 }
 
-func (b *BaseRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (b *BaseRPCClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	return b.c.CallContext(ctx, result, method, args...)
 }
 
@@ -82,7 +82,7 @@ func (b *BaseRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchE
 	return b.c.BatchCallContext(ctx, batch)
 }
 
-func (b *BaseRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (b *BaseRPCClient) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	return b.c.EthSubscribe(ctx, channel, args...)
 }
 
@@ -105,7 +105,7 @@ func (ic *InstrumentedRPCClient) Close() {
 	ic.c.Close()
 }
 
-func (ic *InstrumentedRPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (ic *InstrumentedRPCClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	return instrument1(ic.m, method, func() error {
 		return ic.c.CallContext(ctx, result, method, args...)
 	})
@@ -117,7 +117,7 @@ func (ic *InstrumentedRPCClient) BatchCallContext(ctx context.Context, b []rpc.B
 	}, b)
 }
 
-func (ic *InstrumentedRPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (ic *InstrumentedRPCClient) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	return ic.c.EthSubscribe(ctx, channel, args...)
 }
 

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -173,7 +173,7 @@ var Subcommands = cli.Commands{
 	},
 }
 
-func writeGenesisFile(outfile string, input interface{}) error {
+func writeGenesisFile(outfile string, input any) error {
 	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
 	if err != nil {
 		return err

--- a/op-node/eth/account_proof.go
+++ b/op-node/eth/account_proof.go
@@ -27,7 +27,7 @@ type AccountResult struct {
 
 // Verify an account proof from the getProof RPC. See https://eips.ethereum.org/EIPS/eip-1186
 func (res *AccountResult) Verify(stateRoot common.Hash) error {
-	accountClaimed := []interface{}{uint64(res.Nonce), (*big.Int)(res.Balance).Bytes(), res.StorageHash, res.CodeHash}
+	accountClaimed := []any{uint64(res.Nonce), (*big.Int)(res.Balance).Bytes(), res.StorageHash, res.CodeHash}
 	accountClaimedValue, err := rlp.EncodeToBytes(accountClaimed)
 	if err != nil {
 		return fmt.Errorf("failed to encode account from retrieved values: %w", err)

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -155,7 +155,7 @@ func validationResultString(v pubsub.ValidationResult) string {
 func logValidationResult(self peer.ID, msg string, log log.Logger, fn pubsub.ValidatorEx) pubsub.ValidatorEx {
 	return func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
 		res := fn(ctx, id, message)
-		var src interface{}
+		var src any
 		src = id
 		if id == self {
 			src = "self"
@@ -395,10 +395,10 @@ func JoinGossip(p2pCtx context.Context, self peer.ID, ps *pubsub.PubSub, log log
 }
 
 type TopicSubscriber func(ctx context.Context, sub *pubsub.Subscription)
-type MessageHandler func(ctx context.Context, from peer.ID, msg interface{}) error
+type MessageHandler func(ctx context.Context, from peer.ID, msg any) error
 
 func BlocksHandler(onBlock func(ctx context.Context, from peer.ID, msg *eth.ExecutionPayload) error) MessageHandler {
-	return func(ctx context.Context, from peer.ID, msg interface{}) error {
+	return func(ctx context.Context, from peer.ID, msg any) error {
 		payload, ok := msg.(*eth.ExecutionPayload)
 		if !ok {
 			return fmt.Errorf("expected topic validator to parse and validate data into execution payload, but got %T", msg)

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -26,7 +26,7 @@ import (
 
 // encodeBufferPool holds temporary encoder buffers for batch encoding
 var encodeBufferPool = sync.Pool{
-	New: func() interface{} { return new(bytes.Buffer) },
+	New: func() any { return new(bytes.Buffer) },
 }
 
 const (

--- a/op-node/sources/batching_test.go
+++ b/op-node/sources/batching_test.go
@@ -43,7 +43,7 @@ func makeTestRequest(i int) (*string, rpc.BatchElem) {
 	out := new(string)
 	return out, rpc.BatchElem{
 		Method: "testing_foobar",
-		Args:   []interface{}{i},
+		Args:   []any{i},
 		Result: out,
 		Error:  nil,
 	}
@@ -94,7 +94,7 @@ func (tc *batchTestCase) Run(t *testing.T) {
 		for _, elem := range bc.elems {
 			batch = append(batch, rpc.BatchElem{
 				Method: "testing_foobar",
-				Args:   []interface{}{elem.id},
+				Args:   []any{elem.id},
 				Result: new(string),
 				Error:  nil,
 			})

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -124,7 +124,7 @@ func (s *EthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Heade
 	return s.client.EthSubscribe(ctx, ch, "newHeads")
 }
 
-func (s *EthClient) headerCall(ctx context.Context, method string, id interface{}) (*HeaderInfo, error) {
+func (s *EthClient) headerCall(ctx context.Context, method string, id any) (*HeaderInfo, error) {
 	var header *rpcHeader
 	err := s.client.CallContext(ctx, &header, method, id, false) // headers are just blocks without txs
 	if err != nil {
@@ -141,7 +141,7 @@ func (s *EthClient) headerCall(ctx context.Context, method string, id interface{
 	return info, nil
 }
 
-func (s *EthClient) blockCall(ctx context.Context, method string, id interface{}) (*HeaderInfo, types.Transactions, error) {
+func (s *EthClient) blockCall(ctx context.Context, method string, id any) (*HeaderInfo, types.Transactions, error) {
 	var block *rpcBlock
 	err := s.client.CallContext(ctx, &block, method, id, true)
 	if err != nil {
@@ -159,7 +159,7 @@ func (s *EthClient) blockCall(ctx context.Context, method string, id interface{}
 	return info, txs, nil
 }
 
-func (s *EthClient) payloadCall(ctx context.Context, method string, id interface{}) (*eth.ExecutionPayload, error) {
+func (s *EthClient) payloadCall(ctx context.Context, method string, id any) (*eth.ExecutionPayload, error) {
 	var block *rpcBlock
 	err := s.client.CallContext(ctx, &block, method, id, true)
 	if err != nil {

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -27,11 +27,11 @@ func (m *mockRPC) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	return m.MethodCalled("BatchCallContext", ctx, b).Get(0).([]error)[0]
 }
 
-func (m *mockRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (m *mockRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	return m.MethodCalled("CallContext", ctx, result, method, args).Get(0).([]error)[0]
 }
 
-func (m *mockRPC) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (m *mockRPC) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	called := m.MethodCalled("EthSubscribe", channel, args)
 	return called.Get(0).(*rpc.ClientSubscription), called.Get(1).([]error)[0]
 }
@@ -105,7 +105,7 @@ func TestEthClient_InfoByHash(t *testing.T) {
 	expectedInfo, _ := rhdr.Info(true, false)
 	ctx := context.Background()
 	m.On("CallContext", ctx, new(*rpcHeader),
-		"eth_getBlockByHash", []interface{}{rhdr.Hash, false}).Run(func(args mock.Arguments) {
+		"eth_getBlockByHash", []any{rhdr.Hash, false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
 	s, err := NewEthClient(m, nil, nil, testEthClientConfig)
@@ -128,7 +128,7 @@ func TestEthClient_InfoByNumber(t *testing.T) {
 	n := rhdr.Number
 	ctx := context.Background()
 	m.On("CallContext", ctx, new(*rpcHeader),
-		"eth_getBlockByNumber", []interface{}{n.String(), false}).Run(func(args mock.Arguments) {
+		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
 	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true))

--- a/op-node/sources/limit.go
+++ b/op-node/sources/limit.go
@@ -32,7 +32,7 @@ func (lc *limitClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) 
 	return lc.c.BatchCallContext(ctx, b)
 }
 
-func (lc *limitClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (lc *limitClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	lc.wg.Add(1)
 	defer lc.wg.Done()
 	lc.sema <- struct{}{}
@@ -40,7 +40,7 @@ func (lc *limitClient) CallContext(ctx context.Context, result interface{}, meth
 	return lc.c.CallContext(ctx, result, method, args...)
 }
 
-func (lc *limitClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (lc *limitClient) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	// subscription doesn't count towards request limit
 	return lc.c.EthSubscribe(ctx, channel, args...)
 }

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -77,7 +77,7 @@ func makeReceiptRequest(txHash common.Hash) (*types.Receipt, rpc.BatchElem) {
 	out := new(types.Receipt)
 	return out, rpc.BatchElem{
 		Method: "eth_getTransactionReceipt",
-		Args:   []interface{}{txHash},
+		Args:   []any{txHash},
 		Result: &out, // receipt may become nil, double pointer is intentional
 	}
 }

--- a/op-node/testlog/testlog.go
+++ b/op-node/testlog/testlog.go
@@ -90,7 +90,7 @@ func Logger(t Testing, level log.Lvl) log.Logger {
 	return l
 }
 
-func (l *logger) Trace(msg string, ctx ...interface{}) {
+func (l *logger) Trace(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -98,7 +98,7 @@ func (l *logger) Trace(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Debug(msg string, ctx ...interface{}) {
+func (l *logger) Debug(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -106,7 +106,7 @@ func (l *logger) Debug(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Info(msg string, ctx ...interface{}) {
+func (l *logger) Info(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -114,7 +114,7 @@ func (l *logger) Info(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Warn(msg string, ctx ...interface{}) {
+func (l *logger) Warn(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -122,7 +122,7 @@ func (l *logger) Warn(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Error(msg string, ctx ...interface{}) {
+func (l *logger) Error(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -130,7 +130,7 @@ func (l *logger) Error(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) Crit(msg string, ctx ...interface{}) {
+func (l *logger) Crit(msg string, ctx ...any) {
 	l.t.Helper()
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -138,7 +138,7 @@ func (l *logger) Crit(msg string, ctx ...interface{}) {
 	l.flush()
 }
 
-func (l *logger) New(ctx ...interface{}) log.Logger {
+func (l *logger) New(ctx ...any) log.Logger {
 	return &logger{l.t, l.l.New(ctx...), l.mu, l.h}
 }
 

--- a/op-node/testutils/rpc_err_faker.go
+++ b/op-node/testutils/rpc_err_faker.go
@@ -22,7 +22,7 @@ func (r RPCErrFaker) Close() {
 	r.RPC.Close()
 }
 
-func (r RPCErrFaker) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+func (r RPCErrFaker) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	if r.ErrFn != nil {
 		if err := r.ErrFn(); err != nil {
 			return err
@@ -40,7 +40,7 @@ func (r RPCErrFaker) BatchCallContext(ctx context.Context, b []rpc.BatchElem) er
 	return r.RPC.BatchCallContext(ctx, b)
 }
 
-func (r RPCErrFaker) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (ethereum.Subscription, error) {
+func (r RPCErrFaker) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
 	if r.ErrFn != nil {
 		if err := r.ErrFn(); err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Replace interface{} with any to make code more readable. Shorter lines is nice too!

**Additional context**

Go itself [did this a while back](https://github.com/golang/go/commit/2580d0e08d5e9f979b943758d3c49877fb2324cb)