### PR TITLE
maint(ctb): remove unnecessary deploy utils

### DIFF
--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -3,46 +3,11 @@ import assert from 'assert'
 import { ethers, Contract } from 'ethers'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
-import { sleep, getChainId } from '@eth-optimism/core-utils'
+import { sleep } from '@eth-optimism/core-utils'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import 'hardhat-deploy'
 import '@eth-optimism/hardhat-deploy-config'
 import '@nomiclabs/hardhat-ethers'
-
-export interface DictatorConfig {
-  globalConfig: {
-    proxyAdmin: string
-    controller: string
-    finalOwner: string
-    addressManager: string
-  }
-  proxyAddressConfig: {
-    l2OutputOracleProxy: string
-    optimismPortalProxy: string
-    l1CrossDomainMessengerProxy: string
-    l1StandardBridgeProxy: string
-    optimismMintableERC20FactoryProxy: string
-    l1ERC721BridgeProxy: string
-    systemConfigProxy: string
-  }
-  implementationAddressConfig: {
-    l2OutputOracleImpl: string
-    optimismPortalImpl: string
-    l1CrossDomainMessengerImpl: string
-    l1StandardBridgeImpl: string
-    optimismMintableERC20FactoryImpl: string
-    l1ERC721BridgeImpl: string
-    portalSenderImpl: string
-    systemConfigImpl: string
-  }
-  systemConfigConfig: {
-    owner: string
-    overhead: number
-    scalar: number
-    batcherHash: string
-    gasLimit: number
-  }
-}
 
 export const deployAndVerifyAndThen = async ({
   hre,
@@ -234,10 +199,6 @@ export const getContractsFromArtifacts = async (
   return contracts
 }
 
-export const isHardhatNode = async (hre) => {
-  return (await getChainId(hre.ethers.provider)) === 31337
-}
-
 export const assertContractVariable = async (
   contract: ethers.Contract,
   variable: string,
@@ -275,110 +236,4 @@ export const getDeploymentAddress = async (
 ): Promise<string> => {
   const deployment = await hre.deployments.get(name)
   return deployment.address
-}
-
-export const makeDictatorConfig = async (
-  hre: any,
-  controller: string,
-  finalOwner: string,
-  fresh: boolean
-): Promise<DictatorConfig> => {
-  return {
-    globalConfig: {
-      proxyAdmin: await getDeploymentAddress(hre, 'ProxyAdmin'),
-      controller,
-      finalOwner,
-      addressManager: fresh
-        ? ethers.constants.AddressZero
-        : await getDeploymentAddress(hre, 'Lib_AddressManager'),
-    },
-    proxyAddressConfig: {
-      l2OutputOracleProxy: await getDeploymentAddress(
-        hre,
-        'L2OutputOracleProxy'
-      ),
-      optimismPortalProxy: await getDeploymentAddress(
-        hre,
-        'OptimismPortalProxy'
-      ),
-      l1CrossDomainMessengerProxy: await getDeploymentAddress(
-        hre,
-        fresh
-          ? 'L1CrossDomainMessengerProxy'
-          : 'Proxy__OVM_L1CrossDomainMessenger'
-      ),
-      l1StandardBridgeProxy: await getDeploymentAddress(
-        hre,
-        fresh ? 'L1StandardBridgeProxy' : 'Proxy__OVM_L1StandardBridge'
-      ),
-      optimismMintableERC20FactoryProxy: await getDeploymentAddress(
-        hre,
-        'OptimismMintableERC20FactoryProxy'
-      ),
-      l1ERC721BridgeProxy: await getDeploymentAddress(
-        hre,
-        'L1ERC721BridgeProxy'
-      ),
-      systemConfigProxy: await getDeploymentAddress(hre, 'SystemConfigProxy'),
-    },
-    implementationAddressConfig: {
-      l2OutputOracleImpl: await getDeploymentAddress(hre, 'L2OutputOracle'),
-      optimismPortalImpl: await getDeploymentAddress(hre, 'OptimismPortal'),
-      l1CrossDomainMessengerImpl: await getDeploymentAddress(
-        hre,
-        'L1CrossDomainMessenger'
-      ),
-      l1StandardBridgeImpl: await getDeploymentAddress(hre, 'L1StandardBridge'),
-      optimismMintableERC20FactoryImpl: await getDeploymentAddress(
-        hre,
-        'OptimismMintableERC20Factory'
-      ),
-      l1ERC721BridgeImpl: await getDeploymentAddress(hre, 'L1ERC721Bridge'),
-      portalSenderImpl: await getDeploymentAddress(hre, 'PortalSender'),
-      systemConfigImpl: await getDeploymentAddress(hre, 'SystemConfig'),
-    },
-    systemConfigConfig: {
-      owner: hre.deployConfig.systemConfigOwner,
-      overhead: hre.deployConfig.gasPriceOracleOverhead,
-      scalar: hre.deployConfig.gasPriceOracleDecimals,
-      batcherHash: hre.ethers.utils.hexZeroPad(
-        hre.deployConfig.batchSenderAddress,
-        32
-      ),
-      gasLimit: hre.deployConfig.l2GenesisBlockGasLimit,
-    },
-  }
-}
-
-export const assertDictatorConfig = async (
-  dictator: Contract,
-  config: DictatorConfig
-) => {
-  const dictatorConfig = await dictator.config()
-  for (const [outerConfigKey, outerConfigValue] of Object.entries(config)) {
-    for (const [innerConfigKey, innerConfigValue] of Object.entries(
-      outerConfigValue
-    )) {
-      let have = dictatorConfig[outerConfigKey][innerConfigKey]
-      let want = innerConfigValue as any
-
-      if (ethers.utils.isAddress(want)) {
-        want = want.toLowerCase()
-        have = have.toLowerCase()
-      } else if (typeof want === 'number') {
-        want = ethers.BigNumber.from(want)
-        have = ethers.BigNumber.from(have)
-        assert(
-          want.eq(have),
-          `incorrect config for ${outerConfigKey}.${innerConfigKey}. Want: ${want}, have: ${have}`
-        )
-        return
-      }
-
-      assert(
-        want === have,
-        `incorrect config for ${outerConfigKey}.${innerConfigKey}. Want: ${want}, have: ${have}`
-      )
-    }
-  }
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Removes some unnecessary deploy utils related to the SystemDictator. These utils were originally used because there were two different SystemDictator contracts and both needed to use the same logic. Now that there's only one SystemDictator, there's no need to break the code out into a separate function.