### PR TITLE
maint(ctb): remove unnecessary deploy vars

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -44,8 +44,6 @@ type DeployConfig struct {
 	L2OutputOracleProposer           common.Address `json:"l2OutputOracleProposer"`
 	L2OutputOracleChallenger         common.Address `json:"l2OutputOracleChallenger"`
 
-	SystemConfigOwner common.Address `json:"systemConfigOwner"`
-
 	L1BlockTime                 uint64         `json:"l1BlockTime"`
 	L1GenesisBlockTimestamp     hexutil.Uint64 `json:"l1GenesisBlockTimestamp"`
 	L1GenesisBlockNonce         hexutil.Uint64 `json:"l1GenesisBlockNonce"`
@@ -145,9 +143,6 @@ func (d *DeployConfig) Check() error {
 	}
 	if d.L2OutputOracleChallenger == (common.Address{}) {
 		return fmt.Errorf("%w: L2OutputOracleChallenger cannot be address(0)", ErrInvalidDeployConfig)
-	}
-	if d.SystemConfigOwner == (common.Address{}) {
-		return fmt.Errorf("%w: SystemConfigOwner cannot be address(0)", ErrInvalidDeployConfig)
 	}
 	if d.FinalSystemOwner == (common.Address{}) {
 		return fmt.Errorf("%w: FinalSystemOwner cannot be address(0)", ErrInvalidDeployConfig)

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -77,7 +77,7 @@ func BuildL1DeveloperGenesis(config *DeployConfig) (*core.Genesis, error) {
 	}
 	data, err := sysCfgABI.Pack(
 		"initialize",
-		config.SystemConfigOwner,
+		config.FinalSystemOwner,
 		uint642Big(config.GasPriceOracleOverhead),
 		uint642Big(config.GasPriceOracleScalar),
 		config.BatchSenderAddress.Hash(),
@@ -263,7 +263,7 @@ func deployL1Contracts(config *DeployConfig, backend *backends.SimulatedBackend)
 		{
 			Name: "SystemConfig",
 			Args: []interface{}{
-				config.SystemConfigOwner,
+				config.FinalSystemOwner,
 				uint642Big(config.GasPriceOracleOverhead),
 				uint642Big(config.GasPriceOracleScalar),
 				config.BatchSenderAddress.Hash(), // left-padded 32 bytes value, version is zero anyway

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -13,7 +13,6 @@
   "l2OutputOracleStartingTimestamp": -1,
   "l2OutputOracleProposer": "0x7770000000000000000000000000000000000001",
   "l2OutputOracleChallenger": "0x7770000000000000000000000000000000000002",
-  "systemConfigOwner": "0x7770000000000000000000000000000000000003",
   "l1BlockTime": 15,
   "l1GenesisBlockNonce": "0x0",
   "cliqueSignerAddress": "0x0000000000000000000000000000000000000000",

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -71,7 +71,7 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 		L2OutputOracleProposer:           addresses.Proposer,
 		L2OutputOracleChallenger:         common.Address{}, // tbd
 
-		SystemConfigOwner: addresses.SysCfgOwner,
+		FinalSystemOwner: addresses.SysCfgOwner,
 
 		L1BlockTime:                 15,
 		L1GenesisBlockNonce:         0,
@@ -257,7 +257,7 @@ func ForkedDeployConfig(t require.TestingT, mnemonicCfg *MnemonicConfig, startBl
 		P2PSequencerAddress:              addrs.SequencerP2P,
 		BatchInboxAddress:                common.HexToAddress("0xff00000000000000000000000000000000000000"),
 		BatchSenderAddress:               addrs.Batcher,
-		SystemConfigOwner:                addrs.SysCfgOwner,
+		FinalSystemOwner:                 addrs.SysCfgOwner,
 		L1GenesisBlockDifficulty:         uint64ToBig(0),
 		L1GenesisBlockBaseFeePerGas:      uint64ToBig(0),
 		L2OutputOracleSubmissionInterval: 10,

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -64,7 +64,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 		L2OutputOracleProposer:           addresses.Proposer,
 		L2OutputOracleChallenger:         common.Address{}, // tbd
 
-		SystemConfigOwner: addresses.SysCfgOwner,
+		FinalSystemOwner: addresses.SysCfgOwner,
 
 		L1BlockTime:                 2,
 		L1GenesisBlockNonce:         4660,

--- a/packages/contracts-bedrock/contracts/test/CrossDomainOwnable2.t.sol
+++ b/packages/contracts-bedrock/contracts/test/CrossDomainOwnable2.t.sol
@@ -41,7 +41,6 @@ contract CrossDomainOwnable2_Test is Messenger_Initializer {
         setter.set(1);
     }
 
-
     function test_onlyOwner_notOwner2_reverts() external {
         uint240 nonce = 0;
         address sender = bob;

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -8,7 +8,6 @@
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
-  "systemConfigOwner": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
   "l2OutputOracleSubmissionInterval": 20,
   "l2OutputOracleStartingTimestamp": -1,
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",

--- a/packages/contracts-bedrock/deploy-config/goerli-forked.json
+++ b/packages/contracts-bedrock/deploy-config/goerli-forked.json
@@ -19,7 +19,6 @@
   "l2OutputOracleChallenger": "0x88BCa4Af3d950625752867f826E073E337076581",
   "finalizationPeriodSeconds": 2,
 
-  "systemConfigOwner": "0x62790eFcB3a5f3A5D398F95B47930A9Addd83807",
   "proxyAdminOwner": "0x62790eFcB3a5f3A5D398F95B47930A9Addd83807",
 
   "l2GenesisBlockGasLimit": "0x17D7840",

--- a/packages/contracts-bedrock/deploy-config/goerli.json
+++ b/packages/contracts-bedrock/deploy-config/goerli.json
@@ -20,8 +20,6 @@
   "l2OutputOracleChallenger": "DUMMY",
   "finalizationPeriodSeconds": 2,
 
-  "systemConfigOwner": "DUMMY",
-
   "l2GenesisBlockGasLimit": "0x17D7840",
   "l2GenesisBlockCoinbase": "0x4200000000000000000000000000000000000011",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -13,8 +13,6 @@
   "batchInboxAddress": "0xff00000000000000000000000000000000000000",
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
 
-  "systemConfigOwner": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
-
   "l2OutputOracleSubmissionInterval": 6,
   "l2OutputOracleStartingTimestamp": -1,
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",

--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -125,7 +125,7 @@ const deployFn: DeployFunction = async (hre) => {
       systemConfigImpl: await getDeploymentAddress(hre, 'SystemConfig'),
     },
     systemConfigConfig: {
-      owner: hre.deployConfig.systemConfigOwner,
+      owner: finalOwner,
       overhead: hre.deployConfig.gasPriceOracleOverhead,
       scalar: hre.deployConfig.gasPriceOracleDecimals,
       batcherHash: hre.ethers.utils.hexZeroPad(

--- a/packages/contracts-bedrock/src/deploy-config.ts
+++ b/packages/contracts-bedrock/src/deploy-config.ts
@@ -5,6 +5,11 @@ import { ethers } from 'ethers'
  */
 interface RequiredDeployConfig {
   /**
+   * Number of confirmations to wait when deploying contracts.
+   */
+  numDeployConfirmations: number
+
+  /**
    * Address that will own the entire system on L1 when the deploy is complete.
    */
   finalSystemOwner: string
@@ -100,20 +105,15 @@ interface RequiredDeployConfig {
    * Output finalization period in seconds.
    */
   finalizationPeriodSeconds: number
-
-  /**
-   * Owner of the SystemConfig contract.
-   */
-  systemConfigOwner: string
 }
 
 /**
  * Optional deployment configuration when spinning up an L1 network as part of the deployment.
  */
 interface OptionalL1DeployConfig {
+  cliqueSignerAddress: string
   l1BlockTime: number
   l1GenesisBlockNonce: string
-  cliqueSignerAddress: string
   l1GenesisBlockGasLimit: string
   l1GenesisBlockDifficulty: string
   l1GenesisBlockMixHash: string
@@ -138,13 +138,9 @@ interface OptionalL2DeployConfig {
   l2GenesisBlockGasUsed: string
   l2GenesisBlockParentHash: string
   l2GenesisBlockBaseFeePerGas: string
-  optimismBaseFeeRecipient: string
-  optimismL1FeeRecipient: string
-  l2CrossDomainMessengerOwner: string
   gasPriceOracleOverhead: number
   gasPriceOracleScalar: number
   gasPriceOracleDecimals: number
-  numDeployConfirmations: number
 }
 
 /**
@@ -163,6 +159,10 @@ export const deployConfigSpec: {
     default?: any
   }
 } = {
+  numDeployConfirmations: {
+    type: 'number',
+    default: 1,
+  },
   finalSystemOwner: {
     type: 'address',
     default: ethers.constants.AddressZero,
@@ -221,8 +221,9 @@ export const deployConfigSpec: {
     type: 'number',
     default: 2,
   },
-  systemConfigOwner: {
+  cliqueSignerAddress: {
     type: 'address',
+    default: ethers.constants.AddressZero,
   },
   l1BlockTime: {
     type: 'number',
@@ -231,10 +232,6 @@ export const deployConfigSpec: {
   l1GenesisBlockNonce: {
     type: 'string', // uint64
     default: '0x0',
-  },
-  cliqueSignerAddress: {
-    type: 'address',
-    default: ethers.constants.AddressZero,
   },
   l1GenesisBlockGasLimit: {
     type: 'string',
@@ -308,18 +305,6 @@ export const deployConfigSpec: {
     type: 'string', // uint256
     default: ethers.BigNumber.from(1000_000_000).toHexString(), // 1 gwei
   },
-  optimismBaseFeeRecipient: {
-    type: 'address',
-    default: ethers.constants.AddressZero,
-  },
-  optimismL1FeeRecipient: {
-    type: 'address',
-    default: ethers.constants.AddressZero,
-  },
-  l2CrossDomainMessengerOwner: {
-    type: 'address',
-    default: ethers.constants.AddressZero,
-  },
   gasPriceOracleOverhead: {
     type: 'number',
     default: 2100,
@@ -331,9 +316,5 @@ export const deployConfigSpec: {
   gasPriceOracleDecimals: {
     type: 'number',
     default: 6,
-  },
-  numDeployConfirmations: {
-    type: 'number',
-    default: 1,
   },
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Removes several unused deployment configuration variables and shifts a few things around. Also removes the systemConfigOwner variable by replacing it with the single unified finalSystemOwner variable.