### PR TITLE
Version binaries

### DIFF
--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -9,6 +9,7 @@ COPY ./op-node /app/op-node
 COPY ./op-proposer /app/op-proposer
 COPY ./op-service /app/op-service
 COPY ./op-batcher /app/op-batcher
+COPY ./.git /app/.git
 
 WORKDIR /app/op-batcher
 

--- a/op-chain-ops/Dockerfile
+++ b/op-chain-ops/Dockerfile
@@ -6,6 +6,7 @@ COPY ./op-chain-ops/docker.go.work /app/go.work
 COPY ./op-chain-ops /app/op-chain-ops
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
+COPY ./.git /app/.git
 
 WORKDIR /app/op-chain-ops
 

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -8,6 +8,7 @@ COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-chain-ops /app/op-chain-ops
 COPY ./op-service /app/op-service
+COPY ./.git /app/.git
 
 WORKDIR /app/op-node
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -8,6 +8,7 @@ COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-proposer /app/op-proposer
 COPY ./op-service /app/op-service
+COPY ./.git /app/.git
 
 WORKDIR /app/op-proposer
 

--- a/ops/scripts/tag-bedrock-go-modules.sh
+++ b/ops/scripts/tag-bedrock-go-modules.sh
@@ -36,6 +36,9 @@ go get github.com/ethereum-optimism/optimism/op-service@$VERSION
 go get github.com/ethereum-optimism/optimism/op-chain-ops@$VERSION
 go mod tidy
 
+echo Please update the version to ${VERSION} in op-node/version/version.go
+read -p "Press [Enter] key to continue"
+
 git add .
 git commit -am 'chore: Upgrade op-node dependencies'
 git push $BEDROCK_TAGS_REMOTE
@@ -47,6 +50,9 @@ go get github.com/ethereum-optimism/optimism/op-bindings@$VERSION
 go get github.com/ethereum-optimism/optimism/op-service@$VERSION
 go get github.com/ethereum-optimism/optimism/op-node@$VERSION
 go mod tidy
+
+echo Please update the version to ${VERSION} in op-proposer/cmd/main.go
+read -p "Press [Enter] key to continue"
 
 git add .
 git commit -am 'chore: Upgrade op-proposer dependencies'
@@ -60,6 +66,9 @@ go get github.com/ethereum-optimism/optimism/op-service@$VERSION
 go get github.com/ethereum-optimism/optimism/op-node@$VERSION
 go get github.com/ethereum-optimism/optimism/op-proposer@$VERSION
 go mod tidy
+
+echo Please update the version to ${VERSION} in op-batcher/cmd/main.go
+read -p "Press [Enter] key to continue"
 
 git add .
 git commit -am 'chore: Upgrade op-batcher dependencies'


### PR DESCRIPTION
**Description**

This adds two layers of versioning to builds. The first is providing git information to docker builds. We already pulled the information into the build via make & ldflags, but did not have it available because we did not have the `.git` folder inside docker.

The second is setting a reminder in the `tag-bedrock-go-modules.sh` script to set the version in the `op-node`, `op-batcher`, & `op-proposer`. This should try to correspond to the tag version. This might be able to be scripted, but scripting it is hard, so I chose to prompt the developer.

**Metadata**
- Fixes ENG-3081
