### PR TITLE
op-wheel: Updates to make cheats work

### DIFF
--- a/op-wheel/Dockerfile
+++ b/op-wheel/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.18.0-alpine3.15 as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers
+
+COPY ./op-wheel/docker.go.work /app/go.work
+COPY ./op-node /app/op-node
+COPY ./op-service /app/op-service
+COPY ./op-wheel /app/op-wheel
+
+WORKDIR /app/op-wheel
+
+RUN go build -o op-wheel ./cmd/main.go
+
+FROM alpine:3.15
+
+COPY --from=builder /app/op-wheel/op-wheel /usr/local/bin
+
+CMD ["op-wheel"]

--- a/op-wheel/docker.go.work
+++ b/op-wheel/docker.go.work
@@ -1,0 +1,7 @@
+go 1.18
+
+use (
+	./op-node
+	./op-service
+	./op-wheel
+)


### PR DESCRIPTION
With these changes I was able to successfully run the `ovm-owners` cheats against a Goerli datadir, run the engine, and execute the L1 migration. The specifics of what I did are in comments.

Note that there's one outstanding issue I didn't fix as part of this PR. The `head-block` command returns garbage, since the `types.Block` structure isn't directly JSON serializable. I figured we could fix that separately since it doesn't touch critical code paths.

Also adds a `Dockerfile` + assorted `go.work` files so that we can deploy this on k8s.