### PR TITLE
fix(ctb): Fix empty block calculation

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/contracts/L1/ResourceMetering.sol
@@ -103,15 +103,16 @@ abstract contract ResourceMetering is Initializable {
             // Empty block means there was no demand for deposits in that block, so we should
             // reflect this lack of demand in the fee.
             if (blockDiff > 1) {
-                // Update the base fee by repeatedly applying the exponent 1-(1/change_denominator)
+                // Update the base fee by multiplying by 1-(1/change_denominator)
                 // blockDiff - 1 times. Simulates multiple empty blocks. Clamp the resulting value
                 // between min and max.
                 newBaseFee = Arithmetic.clamp(
-                    Arithmetic.cdexp(
-                        newBaseFee,
-                        BASE_FEE_MAX_CHANGE_DENOMINATOR,
-                        int256(blockDiff - 1)
-                    ),
+                    newBaseFee *
+                        Arithmetic.cdexp(
+                            (BASE_FEE_MAX_CHANGE_DENOMINATOR - 1),
+                            BASE_FEE_MAX_CHANGE_DENOMINATOR,
+                            int256(blockDiff - 1)
+                        ),
                     MINIMUM_BASE_FEE,
                     MAXIMUM_BASE_FEE
                 );


### PR DESCRIPTION
**Description**

The math looked off to me, here's my attempt to fix it to match the spec and comments (I also tweaked the comment slightly). 

Based on the spec, especially lines 100 and 101 here:

https://github.com/ethereum-optimism/optimism/blob/dfdf9732d8d558c2c873ee267d625616f0fbc220/specs/guaranteed-gas-market.md?plain=1#L94-L102



**Tests**

I have not added or updated any. If we agree that this change is correct I will do so.

**Invariants**

For each empty block, the baseFee should be multiplied by `1 - 1/BASE_FEE_MAX_CHANGE_DENOMINATOR`
