### PR TITLE
feat(ctb): make owner and controller required

### DIFF
--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -21,6 +21,7 @@
   "sequencerFeeVaultRecipient": "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",
   "proxyAdminOwner": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "finalSystemOwner": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
+  "controller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "finalizationPeriodSeconds": 2,
   "deploymentWaitConfirmations": 1,
   "fundDevAccounts": true,

--- a/packages/contracts-bedrock/deploy-config/goerli-forked.json
+++ b/packages/contracts-bedrock/deploy-config/goerli-forked.json
@@ -1,5 +1,6 @@
 {
   "finalSystemOwner": "0x62790eFcB3a5f3A5D398F95B47930A9Addd83807",
+  "controller": "0x62790eFcB3a5f3A5D398F95B47930A9Addd83807",
 
   "l1StartingBlockTag": "0xcbcbf93fa6ef953a491466311fce85846252a808aa3cc6a8fd432afc5ea4487b",
   "l1ChainID": 5,

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -1,5 +1,6 @@
 {
   "finalSystemOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+  "controller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
 
   "l1StartingBlockTag": "earliest",
   "l1ChainID": 900,

--- a/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
+++ b/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
@@ -1,28 +1,9 @@
-import { ethers } from 'ethers'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import '@eth-optimism/hardhat-deploy-config'
 
 import { assertContractVariable, deploy } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
-  const { deployer } = await hre.getNamedAccounts()
-
-  let finalOwner = hre.deployConfig.finalSystemOwner
-  if (finalOwner === ethers.constants.AddressZero) {
-    if (hre.network.config.live === false) {
-      console.log(`WARNING!!!`)
-      console.log(`WARNING!!!`)
-      console.log(`WARNING!!!`)
-      console.log(`WARNING!!! A proxy admin owner address was not provided.`)
-      console.log(
-        `WARNING!!! Make sure you are ONLY doing this on a test network.`
-      )
-      finalOwner = deployer
-    } else {
-      throw new Error(`must specify the finalSystemOwner on live networks`)
-    }
-  }
-
   const batcherHash = hre.ethers.utils.hexZeroPad(
     hre.deployConfig.batchSenderAddress,
     32
@@ -32,14 +13,18 @@ const deployFn: DeployFunction = async (hre) => {
     hre,
     name: 'SystemConfig',
     args: [
-      finalOwner,
+      hre.deployConfig.finalSystemOwner,
       hre.deployConfig.gasPriceOracleOverhead,
       hre.deployConfig.gasPriceOracleScalar,
       batcherHash,
       hre.deployConfig.l2GenesisBlockGasLimit,
     ],
     postDeployAction: async (contract) => {
-      await assertContractVariable(contract, 'owner', finalOwner)
+      await assertContractVariable(
+        contract,
+        'owner',
+        hre.deployConfig.finalSystemOwner
+      )
       await assertContractVariable(
         contract,
         'overhead',

--- a/packages/contracts-bedrock/src/deploy-config.ts
+++ b/packages/contracts-bedrock/src/deploy-config.ts
@@ -165,11 +165,9 @@ export const deployConfigSpec: {
   },
   finalSystemOwner: {
     type: 'address',
-    default: ethers.constants.AddressZero,
   },
   controller: {
     type: 'address',
-    default: ethers.constants.AddressZero,
   },
   l1StartingBlockTag: {
     type: 'string',


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Makes the finalSystemOwner and controller configuration values required. By making these required, we avoid the massive warnings that come with not setting the values. Much easier than repeating the warnings everywhere.
