### PR TITLE
l2geth: Skip flaky console test

### DIFF
--- a/l2geth/cmd/geth/consolecmd_test.go
+++ b/l2geth/cmd/geth/consolecmd_test.go
@@ -38,6 +38,7 @@ const (
 // Tests that a node embedded within a console can be started up properly and
 // then terminated by closing the input stream.
 func TestConsoleWelcome(t *testing.T) {
+	t.Skip()
 	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
 
 	// Start a geth console, make sure it's cleaned up and terminate the console


### PR DESCRIPTION
Skips a flaky console test. We won't be modifying this code, and it's not consensus-critical.
