### PR TITLE
op-chain-ops: single database commit

### DIFF
--- a/op-chain-ops/ether/cli.go
+++ b/op-chain-ops/ether/cli.go
@@ -21,6 +21,10 @@ func getOVMETHTotalSupplySlot() common.Hash {
 	return key
 }
 
+func GetOVMETHTotalSupplySlot() common.Hash {
+	return getOVMETHTotalSupplySlot()
+}
+
 // getOVMETHBalance gets a user's OVM ETH balance from state by querying the
 // appropriate storage slot directly.
 func getOVMETHBalance(db *state.StateDB, addr common.Address) *big.Int {

--- a/op-chain-ops/genesis/check.go
+++ b/op-chain-ops/genesis/check.go
@@ -1,0 +1,80 @@
+package genesis
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// CheckMigratedDB will check that the migration was performed correctly
+func CheckMigratedDB(ldb ethdb.Database) error {
+	log.Info("Validating database migration")
+
+	hash := rawdb.ReadHeadHeaderHash(ldb)
+	log.Info("Reading chain tip from database", "hash", hash)
+	num := rawdb.ReadHeaderNumber(ldb, hash)
+	if num == nil {
+		return fmt.Errorf("cannot find header number for %s", hash)
+	}
+
+	header := rawdb.ReadHeader(ldb, hash, *num)
+	log.Info("Read header from database", "number", *num)
+
+	underlyingDB := state.NewDatabaseWithConfig(ldb, &trie.Config{
+		Preimages: true,
+	})
+
+	db, err := state.New(header.Root, underlyingDB, nil)
+	if err != nil {
+		return fmt.Errorf("cannot open StateDB: %w", err)
+	}
+
+	if err := CheckPredeploys(db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CheckPredeploys will check that there is code at each predeploy
+// address
+func CheckPredeploys(db vm.StateDB) error {
+	for i := uint64(0); i <= 2048; i++ {
+		// Compute the predeploy address
+		bigAddr := new(big.Int).Or(bigL2PredeployNamespace, new(big.Int).SetUint64(i))
+		addr := common.BigToAddress(bigAddr)
+		// Get the code for the predeploy
+		code := db.GetCode(addr)
+		// There must be code for the predeploy
+		if len(code) == 0 {
+			return fmt.Errorf("no code found at predeploy %s", addr)
+		}
+
+		// There must be an implementation
+		impl := db.GetState(addr, ImplementationSlot)
+		implAddr := common.BytesToAddress(impl.Bytes())
+		if implAddr == (common.Address{}) {
+			return fmt.Errorf("no implementation for %s", addr)
+		}
+		implCode := db.GetCode(implAddr)
+		if len(implCode) == 0 {
+			return fmt.Errorf("no code found at predeploy impl %s", addr)
+		}
+
+		// There must be an admin
+		admin := db.GetState(addr, AdminSlot)
+		adminAddr := common.BytesToAddress(admin.Bytes())
+		if adminAddr != predeploys.ProxyAdminAddr {
+			return fmt.Errorf("admin is %s when it should be % for %s", adminAddr, predeploys.ProxyAdminAddr, addr)
+		}
+	}
+	return nil
+}

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -227,30 +227,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		"hash", bedrockHeader.Hash().String(),
 	)
 
-	postDB, err := state.New(newRoot, underlyingDB, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := CheckPredeploys(postDB); err != nil {
-		return nil, err
-	}
-
 	return res, nil
-}
-
-// CheckPredeploys will check that there is code at each predeploy
-// address
-func CheckPredeploys(db vm.StateDB) error {
-	for i := uint64(0); i <= 2048; i++ {
-		bigAddr := new(big.Int).Or(bigL2PredeployNamespace, new(big.Int).SetUint64(i))
-		addr := common.BigToAddress(bigAddr)
-		code := db.GetCode(addr)
-		if len(code) == 0 {
-			return fmt.Errorf("no code found at %s", addr)
-		}
-	}
-	return nil
 }
 
 // CheckWithdrawals will ensure that the entire list of withdrawals is being


### PR DESCRIPTION
**Description**

Instead of having multiple statedbs created,
use a single statedb and make sure that it is
only committed once. Various APIs are required
for the full migration which wrap the low level
LevelDB at various abstractions. This will ensure
that changes to the statedb are committed to disk.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


