### PR TITLE
op-chain-ops: Fix validation logic

### DIFF
--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-chain-ops/ether"
+
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/crossdomain"
-	"github.com/ethereum-optimism/optimism/op-chain-ops/ether"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis/migration"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"


### PR DESCRIPTION
Updaets `op-chain-ops` to correctly check for predeploy address implementations. Previously, every predeploy address in the namespace was being checked for an implementation. Only a select few of these will have implementations at genesis, so I pulled that logic out and instead iterated over the known predeploys to make sure _those_ have impementations. 
Additionally, I updated the logic to exclude certain checks for "special" predeploys like OVM ETH, the proxy admin, and the governance token.
