### PR TITLE
maint(ctb): comments for structs

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -20,7 +20,11 @@ import { Semver } from "../universal/Semver.sol";
  */
 contract OptimismPortal is Initializable, ResourceMetering, Semver {
     /**
-     * @notice Represents a proven withdrawal
+     * @notice Represents a proven withdrawal.
+     *
+     * @custom:field outputRoot    Root of the L2 output this was proven against.
+     * @custom:field timestamp     Timestamp at whcih the withdrawal was proven.
+     * @custom:field l2OutputIndex Index of the output this was proven against.
      */
     struct ProvenWithdrawal {
         bytes32 outputRoot;

--- a/packages/contracts-bedrock/contracts/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/contracts/L1/ResourceMetering.sol
@@ -16,6 +16,10 @@ abstract contract ResourceMetering is Initializable {
     /**
      * @notice Represents the various parameters that control the way in which resources are
      *         metered. Corresponds to the EIP-1559 resource metering system.
+     *
+     * @custom:field prevBaseFee   Base fee from the previous block(s).
+     * @custom:field prevBoughtGas Amount of gas bought so far in the current block.
+     * @custom:field prevBlockNum  Last block number that the base fee was updated.
      */
     struct ResourceParams {
         uint128 prevBaseFee;

--- a/packages/contracts-bedrock/contracts/libraries/rlp/RLPReader.sol
+++ b/packages/contracts-bedrock/contracts/libraries/rlp/RLPReader.sol
@@ -27,6 +27,9 @@ library RLPReader {
 
     /**
      * @notice Struct representing an RLP item.
+     *
+     * @custom:field length Length of the RLP item.
+     * @custom:field ptr    Pointer to the RLP item in memory.
      */
     struct RLPItem {
         uint256 length;

--- a/packages/contracts-bedrock/contracts/libraries/trie/MerkleTrie.sol
+++ b/packages/contracts-bedrock/contracts/libraries/trie/MerkleTrie.sol
@@ -13,6 +13,9 @@ import { RLPReader } from "../rlp/RLPReader.sol";
 library MerkleTrie {
     /**
      * @notice Struct representing a node in the trie.
+     *
+     * @custom:field encoded The RLP-encoded node.
+     * @custom:field decoded The RLP-decoded node.
      */
     struct TrieNode {
         bytes encoded;


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds comments for all structs in the current codebase, except the SystemDictator which is going to be separately documented in the README of contracts-bedrock.