### PR TITLE
[RFC] Bedrock: rename "optimism" ENR key to "opstack"

### DIFF
--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -216,7 +216,7 @@ func FilterEnodes(log log.Logger, cfg *rollup.Config) func(node *enode.Node) boo
 		err := node.Load(&dat)
 		// if the entry does not exist, or if it is invalid, then ignore the node
 		if err != nil {
-			log.Debug("discovered node record has no optimism info", "node", node.ID(), "err", err)
+			log.Debug("discovered node record has no chain info", "node", node.ID(), "err", err)
 			return false
 		}
 		// check chain ID matches

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -75,7 +75,7 @@ func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort 
 	} else {
 		return nil, nil, fmt.Errorf("no TCP port to put in discovery record")
 	}
-	dat := ChainENRData{
+	dat := OpStackENRData{
 		chainID: rollupCfg.L2ChainID.Uint64(),
 		version: 0,
 	}
@@ -167,18 +167,18 @@ func enrToAddrInfo(r *enode.Node) (*peer.AddrInfo, *crypto.Secp256k1PublicKey, e
 	}, pub, nil
 }
 
-// The discovery ENRs are just key-value lists, and we filter them by records tagged with the "chain" key,
+// The discovery ENRs are just key-value lists, and we filter them by records tagged with the "opstack" key,
 // and then check the chain ID and version.
-type ChainENRData struct {
+type OpStackENRData struct {
 	chainID uint64
 	version uint64
 }
 
-func (o *ChainENRData) ENRKey() string {
-	return "chain"
+func (o *OpStackENRData) ENRKey() string {
+	return "opstack"
 }
 
-func (o *ChainENRData) EncodeRLP(w io.Writer) error {
+func (o *OpStackENRData) EncodeRLP(w io.Writer) error {
 	out := make([]byte, 2*binary.MaxVarintLen64)
 	offset := binary.PutUvarint(out, o.chainID)
 	offset += binary.PutUvarint(out[offset:], o.version)
@@ -187,13 +187,13 @@ func (o *ChainENRData) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, out)
 }
 
-func (o *ChainENRData) DecodeRLP(s *rlp.Stream) error {
+func (o *OpStackENRData) DecodeRLP(s *rlp.Stream) error {
 	b, err := s.Bytes()
 	if err != nil {
 		return fmt.Errorf("failed to decode outer ENR entry: %w", err)
 	}
 	// We don't check the byte length: the below readers are limited, and the ENR itself has size limits.
-	// Future "optimism" entries may contain additional data, and will be tagged with a newer version etc.
+	// Future "opstack" entries may contain additional data, and will be tagged with a newer version etc.
 	r := bytes.NewReader(b)
 	chainID, err := binary.ReadUvarint(r)
 	if err != nil {
@@ -208,15 +208,15 @@ func (o *ChainENRData) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-var _ enr.Entry = (*ChainENRData)(nil)
+var _ enr.Entry = (*OpStackENRData)(nil)
 
 func FilterEnodes(log log.Logger, cfg *rollup.Config) func(node *enode.Node) bool {
 	return func(node *enode.Node) bool {
-		var dat ChainENRData
+		var dat OpStackENRData
 		err := node.Load(&dat)
 		// if the entry does not exist, or if it is invalid, then ignore the node
 		if err != nil {
-			log.Debug("discovered node record has no chain info", "node", node.ID(), "err", err)
+			log.Debug("discovered node record has no opstack info", "node", node.ID(), "err", err)
 			return false
 		}
 		// check chain ID matches
@@ -347,7 +347,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 			log.Info("stopped peer discovery")
 			return // no ctx error, expected close
 		case found := <-randomNodesCh:
-			var dat ChainENRData
+			var dat OpStackENRData
 			if err := found.Load(&dat); err != nil { // we already filtered on chain ID and version
 				continue
 			}
@@ -362,7 +362,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 			// Tag the peer, we'd rather have the connection manager prune away old peers,
 			// or peers on different chains, or anyone we have not seen via discovery.
 			// There is no tag score decay yet, so just set it to 42.
-			n.ConnectionManager().TagPeer(info.ID, fmt.Sprintf("chain-%d-%d", dat.chainID, dat.version), 42)
+			n.ConnectionManager().TagPeer(info.ID, fmt.Sprintf("opstack-%d-%d", dat.chainID, dat.version), 42)
 			log.Debug("discovered peer", "peer", info.ID, "nodeID", found.ID(), "addr", info.Addrs[0])
 		case <-connectTicker.C:
 			connected := n.Host().Network().Peers()

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -47,7 +47,7 @@ func (p *Prepared) Host(log log.Logger, reporter metrics.Reporter) (host.Host, e
 // Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
 func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
 	if p.LocalNode != nil {
-		dat := ChainENRData{
+		dat := OpStackENRData{
 			chainID: rollupCfg.L2ChainID.Uint64(),
 			version: 0,
 		}

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -47,7 +47,7 @@ func (p *Prepared) Host(log log.Logger, reporter metrics.Reporter) (host.Host, e
 // Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
 func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort uint16) (*enode.LocalNode, *discover.UDPv5, error) {
 	if p.LocalNode != nil {
-		dat := OptimismENRData{
+		dat := ChainENRData{
 			chainID: rollupCfg.L2ChainID.Uint64(),
 			version: 0,
 		}

--- a/specs/rollup-node-p2p.md
+++ b/specs/rollup-node-p2p.md
@@ -84,9 +84,9 @@ The Ethereum Node Record (ENR) for an Optimism rollup node must contain the foll
 - An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
 - A TCP port (`tcp` field) representing the local libp2p listening port.
 - A UDP port (`udp` field) representing the local discv5 listening port.
-- An Optimism (`optimism` field) L2 network identifier
+- An OpStack (`opstack` field) L2 network identifier
 
-The `optimism` value is encoded as a single RLP `bytes` value, the concatenation of:
+The `opstack` value is encoded as a single RLP `bytes` value, the concatenation of:
 
 - chain ID (`unsigned varint`)
 - fork ID (`unsigned varint`)
@@ -101,7 +101,7 @@ The discovery process in Optimism is a pipeline of node records:
 2. Pull additional records with searches to random Node IDs if necessary
    (e.g. iterate [`RandomNodes()`][discv5-random-nodes] in Go implementation)
 3. Pull records from the DiscV5 module when looking for peers
-4. Check if the record contains the `optimism` entry, verify it matches the chain ID and current or future fork number
+4. Check if the record contains the `opstack` entry, verify it matches the chain ID and current or future fork number
 5. If not already connected, and not recently disconnected or put on deny-list, attempt to dial.
 
 ### LibP2P


### PR DESCRIPTION
**Description**

Currently `op-node`'s P2P implementation uses a key called `optimism` to store the node's chain ID and version in its ENR address. However, there's nothing specific about optimism in this key to warrant the key name.

This PR genericizes the key to `opstack`.

**Tests**

This is an RFC; happy to add tests if there is alignment on this.

**Additional context**

This is primarily to make Bedrock more forkable / configurable. Some other ideas: make this key configurable via an op-node CLI parameter, or split into two separate ENR keys: `chainid` and `version`.

Some other potential areas for more generic naming are:
 - The `optimism` key used in the [L2 genesis configuration](https://github.com/ethereum-optimism/op-geth/commit/68bfa8b473bb8770216517f007b521fab41c5afa#diff-10ff00a15ef58da7485fedeca3906c73cb236fde4b143a9d61601c63cbf1ffe8R422). Perhaps could be `rollup` or similar.
 - The `optimism` key used in as the [prefix for the RPCs](https://github.com/ethereum-optimism/optimism/blob/8b70a0f3f51dc25af59ef500a4b138c9314ae02d/op-node/node/server.go#L38) on `op-node`. Could be made configurable, with `optimism` as the default.