### PR TITLE
fix(cmn): BaseServiceV2 options parsing bug

### DIFF
--- a/.changeset/cool-bears-return.md
+++ b/.changeset/cool-bears-return.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Fixes a bug in BaseServiceV2 where options were not being parsed correctly when passed into the constructor rather than via environment variables or command line arguments

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -274,16 +274,12 @@ export abstract class BaseServiceV2<
     // names into lower case for the validation step. We'll turn the names back into their original
     // names when we're done.
     const cleaned = cleanEnv<TOptions>(
-      { ...config.env, ...config.args },
+      { ...config.env, ...config.args, ...(params.options || {}) },
       Object.entries(params.optionsSpec || {}).reduce((acc, [key, val]) => {
         acc[key.toLowerCase()] = val.validator({
           desc: val.desc,
           default: val.default,
         })
-        return acc
-      }, {}) as any,
-      Object.entries(params.options || {}).reduce((acc, [key, val]) => {
-        acc[key.toLowerCase()] = val
         return acc
       }, {}) as any
     )


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Fixes a bug in BaseServiceV2 where options would not be parsed correctly when passed directly into the constructor rather than via the environment or command line arguments.
