### PR TITLE
feat(cmn): make logLevel a default option

### DIFF
--- a/.changeset/sharp-colts-yawn.md
+++ b/.changeset/sharp-colts-yawn.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Make logLevel a default option of BaseServiceV2

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -11,7 +11,7 @@ import promBundle from 'express-prom-bundle'
 import bodyParser from 'body-parser'
 import morgan from 'morgan'
 
-import { Logger } from '../common/logger'
+import { Logger, LogLevel } from '../common/logger'
 import { Metric, Gauge, Counter } from './metrics'
 import { validators } from './validators'
 
@@ -23,6 +23,7 @@ export type StandardOptions = {
   loopIntervalMs?: number
   port?: number
   hostname?: string
+  logLevel?: LogLevel
 }
 
 export type OptionsSpec<TOptions extends Options> = {
@@ -155,6 +156,7 @@ export abstract class BaseServiceV2<
       loopIntervalMs?: number
       port?: number
       hostname?: string
+      logLevel?: LogLevel
     }
   ) {
     this.loop = params.loop !== undefined ? params.loop : true
@@ -175,6 +177,11 @@ export abstract class BaseServiceV2<
         validator: validators.str,
         desc: 'Hostname for the app server',
         default: params.hostname || '0.0.0.0',
+      },
+      logLevel: {
+        validator: validators.logLevel,
+        desc: 'Log level',
+        default: params.logLevel || 'debug',
       },
     }
 
@@ -322,7 +329,10 @@ export abstract class BaseServiceV2<
 
     // Set up everything else.
     this.loopIntervalMs = this.options.loopIntervalMs
-    this.logger = new Logger({ name: params.name })
+    this.logger = new Logger({
+      name: params.name,
+      level: this.options.logLevel,
+    })
     this.healthy = true
 
     // Gracefully handle stop signals.

--- a/packages/common-ts/src/base-service/validators.ts
+++ b/packages/common-ts/src/base-service/validators.ts
@@ -13,6 +13,8 @@ import { Provider } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
 import { ethers } from 'ethers'
 
+import { LogLevel, logLevels } from '../common'
+
 const provider = makeValidator<Provider>((input) => {
   const parsed = url()._parse(input)
   return new ethers.providers.JsonRpcProvider(parsed)
@@ -39,6 +41,14 @@ const wallet = makeValidator<Signer>((input) => {
   }
 })
 
+const logLevel = makeValidator<LogLevel>((input) => {
+  if (!logLevels.includes(input as LogLevel)) {
+    throw new Error(`expected log level to be one of ${logLevels.join(', ')}`)
+  } else {
+    return input as LogLevel
+  }
+})
+
 export const validators = {
   str,
   bool,
@@ -52,4 +62,5 @@ export const validators = {
   provider,
   jsonRpcProvider,
   staticJsonRpcProvider,
+  logLevel,
 }

--- a/packages/common-ts/src/common/logger.ts
+++ b/packages/common-ts/src/common/logger.ts
@@ -3,7 +3,15 @@ import pinoms, { Streams } from 'pino-multi-stream'
 import { createWriteStream } from 'pino-sentry'
 import { NodeOptions } from '@sentry/node'
 
-export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+export const logLevels = [
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+] as const
+export type LogLevel = typeof logLevels[number]
 
 export interface LoggerOptions {
   name: string


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates BaseServiceV2 so that logLevel is a default option to any new instantiation of BaseServiceV2. Avoids people having to include hacky code to set the log level.