### PR TITLE
maint(ctb): move default sender to constants

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -39,11 +39,6 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     uint256 internal constant DEPOSIT_VERSION = 0;
 
     /**
-     * @notice Value used to reset the l2Sender, this is more efficient than setting it to zero.
-     */
-    address internal constant DEFAULT_L2_SENDER = 0x000000000000000000000000000000000000dEaD;
-
-    /**
      * @notice The L2 gas limit set when eth is deposited using the receive() function.
      */
     uint64 internal constant RECEIVE_DEFAULT_GAS_LIMIT = 100_000;
@@ -131,7 +126,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
      * @notice Initializer;
      */
     function initialize() public initializer {
-        l2Sender = DEFAULT_L2_SENDER;
+        l2Sender = Constants.DEFAULT_L2_SENDER;
         __ResourceMetering_init();
     }
 
@@ -239,7 +234,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     function finalizeWithdrawalTransaction(Types.WithdrawalTransaction memory _tx) external {
         // Prevent nested withdrawals within withdrawals.
         require(
-            l2Sender == DEFAULT_L2_SENDER,
+            l2Sender == Constants.DEFAULT_L2_SENDER,
             "OptimismPortal: can only trigger one withdrawal per transaction"
         );
 
@@ -315,7 +310,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         );
 
         // Reset the l2Sender back to the default value.
-        l2Sender = DEFAULT_L2_SENDER;
+        l2Sender = Constants.DEFAULT_L2_SENDER;
 
         // All withdrawals are immediately finalized. Replayability can
         // be achieved through contracts built on top of this contract

--- a/packages/contracts-bedrock/contracts/libraries/Constants.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Constants.sol
@@ -17,4 +17,11 @@ library Constants {
      *         never have any code on any EVM chain.
      */
     address internal constant ESTIMATION_ADDRESS = address(1);
+
+    /**
+     * @notice Value used for the L2 sender storage slot in both the OptimismPortal and the
+     *         CrossDomainMessenger contracts before an actual sender is set. This value is
+     *         non-zero to reduce the gas cost of message passing transactions.
+     */
+    address internal constant DEFAULT_L2_SENDER = 0x000000000000000000000000000000000000dEaD;
 }

--- a/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
@@ -82,13 +82,6 @@ abstract contract CrossDomainMessenger is
     uint256 internal constant RELAY_GAS_BUFFER = RELAY_GAS_REQUIRED - 5000;
 
     /**
-     * @notice Initial value for the xDomainMsgSender variable. We set this to a non-zero value
-     *         because performing an SSTORE on a non-zero value is significantly cheaper than on a
-     *         zero value.
-     */
-    address internal constant DEFAULT_XDOMAIN_SENDER = 0x000000000000000000000000000000000000dEaD;
-
-    /**
      * @notice Address of the paired CrossDomainMessenger contract on the other chain.
      */
     address public immutable OTHER_MESSENGER;
@@ -322,7 +315,7 @@ abstract contract CrossDomainMessenger is
 
         xDomainMsgSender = _sender;
         bool success = SafeCall.call(_target, gasleft() - RELAY_GAS_BUFFER, _value, _message);
-        xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+        xDomainMsgSender = Constants.DEFAULT_L2_SENDER;
 
         if (success == true) {
             successfulMessages[versionedHash] = true;
@@ -351,7 +344,7 @@ abstract contract CrossDomainMessenger is
      */
     function xDomainMessageSender() external view returns (address) {
         require(
-            xDomainMsgSender != DEFAULT_XDOMAIN_SENDER,
+            xDomainMsgSender != Constants.DEFAULT_L2_SENDER,
             "CrossDomainMessenger: xDomainMessageSender is not set"
         );
 
@@ -399,7 +392,7 @@ abstract contract CrossDomainMessenger is
      */
     // solhint-disable-next-line func-name-mixedcase
     function __CrossDomainMessenger_init() internal onlyInitializing {
-        xDomainMsgSender = DEFAULT_XDOMAIN_SENDER;
+        xDomainMsgSender = Constants.DEFAULT_L2_SENDER;
         __Context_init_unchained();
         __Ownable_init_unchained();
         __Pausable_init_unchained();


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Moves the DEFAULT_L2_SENDER variable to Constants.sol since it's being shared by both CrossDomainMessenger and OptimismPortal.