### PR TITLE
CI: Check if we should run in bedrock-echidna-run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,14 @@ jobs:
       - checkout
       - attach_workspace: {at: "."}
       - run:
+          name: Check if we should run
+          command: |
+            shopt -s inherit_errexit
+            CHANGED=$(check-changed "(contracts-bedrock/contracts)" || echo "TRUE")
+            if [[ "$CHANGED" = "FALSE" ]]; then
+              circleci step halt
+            fi
+      - run:
           name: Echidna Fuzz <<parameters.echidna_target>>
           command: yarn echidna:<<parameters.echidna_target>>
           working_directory: packages/contracts-bedrock


### PR DESCRIPTION
**Description**

The previous steps (required for this one) had the check changed script. This means that the required build artifacts were not being created and then cause this step to fail.

