### PR TITLE
fix(contracts-periphery): Fix initial check in foundry test

### DIFF
--- a/.changeset/brown-beans-hunt.md
+++ b/.changeset/brown-beans-hunt.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-periphery': patch
+---
+
+Minor fix to AttestationStation test

--- a/packages/contracts-periphery/contracts/foundry-tests/AttestationStation.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/AttestationStation.t.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.15;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";
-import { TestERC20 } from "../testing/helpers/TestERC20.sol";
-import { TestERC721 } from "../testing/helpers/TestERC721.sol";
 import { AssetReceiver } from "../universal/AssetReceiver.sol";
 import { AttestationStation } from "../universal/op-nft/AttestationStation.sol";
 
@@ -45,9 +43,9 @@ contract AssetReceiverTest is AssetReceiver_Initializer {
         // assert the attestation starts empty
         assertEq(
             attestationStation.attestations(
+                alice_attestor,
                 attestationData.about,
-                attestationData.key,
-                attestationData.val
+                attestationData.key
             ),
             ""
         );


### PR DESCRIPTION
- Fix the initial check that is checking that attestation starts empty to correct value
- remove unused imports