### PR TITLE
feat(base-service-v2): Add trpc servers to base service v2

### DIFF
--- a/.changeset/chatty-cougars-explain.md
+++ b/.changeset/chatty-cougars-explain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': minor
+---
+
+Add trpc routes as an option to bsv2

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -49,7 +49,10 @@
     "pino-multi-stream": "^5.3.0",
     "pino-sentry": "^0.7.0",
     "prom-client": "^13.1.0",
-    "qs": "^6.10.5"
+    "qs": "^6.10.5",
+    "@trpc/server": "^10.4.3",
+    "superjson": "^1.10.1",
+    "zod": "^3.19.1"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5.7.0",

--- a/packages/common-ts/src/base-service/trpc.ts
+++ b/packages/common-ts/src/base-service/trpc.ts
@@ -1,0 +1,133 @@
+import { BuildProcedure, CreateRouterInner, initTRPC } from '@trpc/server'
+import superjson from 'superjson'
+import { z } from 'zod'
+import * as trpcExpress from '@trpc/server/adapters/express'
+
+import { Logger } from '../common'
+import { MetricsV2 } from './base-service-v2'
+
+/**
+ * Extend this class to create a new trpc server
+ *
+ * @see https://trpc.io/docs/v10/quick-start
+ * @example
+ * class TrpcApi extends Trpc<Metrics> {
+ *   public readonly metadataController = this.trpc.procedure
+ *     .input(
+ *       z.object({
+ *         address: ZodHelpers.ethereumAddress,
+ *       }),
+ *     )
+ *     .query(async (req) => {
+ *       return this.keyValueStorage.get(createMetadataKey(req.input.address))
+ *     })
+ *
+ *  routes = this.router({
+ *    metadata: this.trpc.procedure
+ *      .input(
+ *       z.object({
+ *        address: this.z.string().refine(ethers.utils.isAddress),
+ *      }),
+ *    )
+ *   .query(async (req) => {
+ *      return this.keyValueStorage.get(createMetadataKey(req.input.address))
+ *    }),
+ *  })
+ * }
+ *
+ * @important - You can then create a typesafe client for vanillajs, react, and more
+ * @see https://trpc.io/docs/v10/client
+ * @important - See vanilla js examples in trpc documentation if not using react
+ * @example - react example
+ * // import only the type so you don't have to import any actual code
+ * import type {Api} from '../backend/api'
+ * import { createTRPCReact, httpBatchLink } from '@trpc/react'
+ *
+ * // the client can infer the api types from the routes
+ * export const apiClient = createTRPCReact<Api['routes']>()
+ *
+ * // you can then use it in a typesafe way in your client code
+ * apiClient.metadata.useQuery({address: userAddress})
+ */
+export abstract class TrpcApi<TMetrics extends MetricsV2> {
+  /**
+   * Turns an trpc server into express middleware
+   *
+   * @see https://trpc.io/docs/v10/express
+   * @example
+   * app.use('/', api.createExpressMiddleware())
+   */
+  public readonly createExpressMiddleware = () =>
+    trpcExpress.createExpressMiddleware({
+      router: this.routes,
+    })
+
+  /**
+   * quality of life property.  Zod is used to validate input in a
+   * typesafe way.
+   * Can be used by `import {z} from 'zod' as well.
+   *
+   * @see https://github.com/colinhacks/zod
+   */
+  protected readonly z = z
+  /**
+   * @see https://trpc.io/docs/v10/router
+   */
+  protected readonly router = this.trpc.router
+  /**
+   * @see https://trpc.io/docs/v10/merging-routers
+   */
+  protected readonly mergeRouters = this.trpc.mergeRouters
+  /**
+   * @see https://trpc.io/docs/v10/procedures
+   **/
+  protected readonly procedure = this.trpc.procedure
+  /**
+   * @see https://trpc.io/docs/v10/middlewares
+   */
+  protected readonly middleware = this.trpc.middleware
+
+  /**
+   * Routes are objects of route names to route handlers
+   * You can also recursively set other routes as route
+   * handlers to create nested routes
+   *
+   * @see https://trpc.io/docs/v10/procedures
+   * @example typescript
+   *   public readonly metadataController = this.trpc.procedure
+   *     .input(
+   *       z.object({
+   *         address: ZodHelpers.ethereumAddress,
+   *       }),
+   *     )
+   *     .query(async (req) => {
+   *       return this.keyValueStorage.get(createMetadataKey(req.input.address))
+   *     })
+   *
+   *  routes = this.router({
+   *     metadata: this.metadataController,
+   *     nestedroute: this.router({
+   *        nestedRoute: this.nestedRouteHandler
+   *     })
+   *  })
+   *
+   */
+  public abstract readonly routes:
+    | BuildProcedure<any, any, any>
+    | CreateRouterInner<any, any>
+
+  /**
+   * Class is not meant to be instantiated directly
+   * but rather extended
+   */
+  constructor(
+    protected metrics: TMetrics,
+    protected logger: Logger,
+    private readonly trpc = initTRPC.create({
+      /**
+       * @see https://trpc.io/docs/v10/data-transformers
+       */
+      transformer: superjson,
+    })
+  ) {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,11 +3207,6 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz#f1d606e2827d409053f3e908ba4eb8adb1dd6995"
   integrity sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==
 
-"@openzeppelin/contracts-upgradeable@4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.0.tgz#26688982f46969018e3ed3199e72a07c8d114275"
-  integrity sha512-5GeFgqMiDlqGT8EdORadp1ntGF0qzWZLmEY7Wbp/yVhN7/B3NNzCxujuI77ktlyG81N3CUZP8cZe3ZAQ/cW10w==
-
 "@openzeppelin/contracts@3.4.1-solc-0.7-2":
   version "3.4.1-solc-0.7-2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
@@ -3516,6 +3511,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@trpc/server@^10.4.3":
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/@trpc/server/-/server-10.4.3.tgz#8db5dc9a5082feea593d58b845ceef6a1adaf3d9"
+  integrity sha512-U+TVFtMUnySUfKHXjdpdZdFS268naGafbjQiG/H7t0OKpiLnbJ4IhgyYzj82Hvghb6Ow9E+UTNt6ALP7KoN4/g==
 
 "@truffle/error@^0.0.14":
   version "0.0.14"
@@ -6724,6 +6724,13 @@ cookiejar@^2.1.1, cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
+
+copy-anything@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.3.tgz#206767156f08da0e02efd392f71abcdf79643559"
+  integrity sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==
+  dependencies:
+    is-what "^4.1.8"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -11102,6 +11109,11 @@ is-weakref@^1.0.2:
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-what@^4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.8.tgz#0e2a8807fda30980ddb2571c79db3d209b14cbe4"
+  integrity sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==
 
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
@@ -16889,6 +16901,13 @@ superagent@^6.1.0:
     readable-stream "^3.6.0"
     semver "^7.3.2"
 
+superjson@^1.10.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.12.0.tgz#7b314b982bfebc5b8e56054b8528813fdda8fc7a"
+  integrity sha512-B4tefmFqj8KDShHi2br2rz0kBlUJuQHtxMCydEuHvooL+6EscROTNWRfOLMDxW1dS/daK2zZr3C3N9DU+jXATQ==
+  dependencies:
+    copy-anything "^3.0.2"
+
 supertest@^6.1.4:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.6.tgz#6151c518f4c5ced2ac2aadb9f96f1bf8198174c8"
@@ -19147,6 +19166,11 @@ zksync-web3@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.4.0.tgz#9ab3e8648a6ab11d42b649b3458a0383d6c41bab"
   integrity sha512-LmrjkQlg2YSR+P0J1NQKtkraCN2ESKfVoMxole3NxesrASQTsk6fR5+ph/8Vucq/Xh8EoAafp07+Q6TavP/TTw==
+
+zod@^3.19.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
+  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Currently being used in the gateway backend: https://github.com/ethereum-optimism/gateway/tree/develop/packages/backend/src/routes

And it is also being used on the gateway frontend: https://github.com/ethereum-optimism/gateway/search?q=apiReact

TRPC allows a really easy api for creating full typesafe apis for typescript consumers.   It's the best way in terms of developer velocity safety to connect typescript services.  The typesafety does not require a build step.  https://trpc.io/

I added trpc as an option to base service v2 because for some use cases express would be better.

**Testing**

This had 100% test coverage in gateway repo but the tests were written in jest not mocha.  Won't have time to translate them here anytime soon.  This will get implicitly tested though via the gateway repo using it in it's tests