### PR TITLE
feat(cmn): BSv2 private options by default

### DIFF
--- a/.changeset/nervous-moose-bake.md
+++ b/.changeset/nervous-moose-bake.md
@@ -1,0 +1,8 @@
+---
+'@eth-optimism/common-ts': minor
+'@eth-optimism/drippie-mon': patch
+'@eth-optimism/fault-detector': patch
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Updates BaseServiceV2 so that options are secret by default. Services will have to explicitly mark options as "public" for those options to be logged and included in the metadata metric.

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -31,7 +31,7 @@ export type OptionsSpec<TOptions extends Options> = {
     validator: (spec?: Spec<TOptions[P]>) => ValidatorSpec<TOptions[P]>
     desc: string
     default?: TOptions[P]
-    secret?: boolean
+    public?: boolean
   }
 }
 
@@ -167,21 +167,25 @@ export abstract class BaseServiceV2<
         validator: validators.num,
         desc: 'Loop interval in milliseconds',
         default: params.loopIntervalMs || 0,
+        public: true,
       },
       port: {
         validator: validators.num,
         desc: 'Port for the app server',
         default: params.port || 7300,
+        public: true,
       },
       hostname: {
         validator: validators.str,
         desc: 'Hostname for the app server',
         default: params.hostname || '0.0.0.0',
+        public: true,
       },
       logLevel: {
         validator: validators.logLevel,
         desc: 'Log level',
         default: params.logLevel || 'debug',
+        public: true,
       },
     }
 
@@ -194,7 +198,7 @@ export abstract class BaseServiceV2<
     // List of options that can safely be logged.
     const publicOptionNames = Object.entries(params.optionsSpec)
       .filter(([, spec]) => {
-        return spec.secret !== true
+        return spec.public
       })
       .map(([key]) => {
         return key

--- a/packages/drippie-mon/src/service.ts
+++ b/packages/drippie-mon/src/service.ts
@@ -41,11 +41,11 @@ export class DrippieMonService extends BaseServiceV2<
         rpc: {
           validator: validators.provider,
           desc: 'Provider for network where Drippie is deployed',
-          secret: true,
         },
         drippieAddress: {
           validator: validators.str,
           desc: 'Address of Drippie contract',
+          public: true,
         },
       },
       metricsSpec: {

--- a/packages/fault-detector/src/service.ts
+++ b/packages/fault-detector/src/service.ts
@@ -50,17 +50,16 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
         l1RpcProvider: {
           validator: validators.provider,
           desc: 'Provider for interacting with L1',
-          secret: true,
         },
         l2RpcProvider: {
           validator: validators.provider,
           desc: 'Provider for interacting with L2',
-          secret: true,
         },
         startBatchIndex: {
           validator: validators.num,
           default: -1,
           desc: 'Batch index to start checking from',
+          public: true,
         },
       },
       metricsSpec: {

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -46,22 +46,20 @@ export class MessageRelayerService extends BaseServiceV2<
         l1RpcProvider: {
           validator: validators.provider,
           desc: 'Provider for interacting with L1.',
-          secret: true,
         },
         l2RpcProvider: {
           validator: validators.provider,
           desc: 'Provider for interacting with L2.',
-          secret: true,
         },
         l1Wallet: {
           validator: validators.wallet,
           desc: 'Wallet used to interact with L1.',
-          secret: true,
         },
         fromL2TransactionIndex: {
           validator: validators.num,
           desc: 'Index of the first L2 transaction to start processing from.',
           default: 0,
+          public: true,
         },
       },
       metricsSpec: {

--- a/packages/replica-healthcheck/src/service.ts
+++ b/packages/replica-healthcheck/src/service.ts
@@ -42,17 +42,16 @@ export class HealthcheckService extends BaseServiceV2<
         referenceRpcProvider: {
           validator: validators.provider,
           desc: 'Provider for interacting with L1',
-          secret: true,
         },
         targetRpcProvider: {
           validator: validators.provider,
           desc: 'Provider for interacting with L2',
-          secret: true,
         },
         onDivergenceWaitMs: {
           validator: validators.num,
           desc: 'Waiting time in ms per loop when divergence is detected',
           default: 60_000,
+          public: true,
         },
       },
       metricsSpec: {


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Makes BaseServiceV2 options "secret" by default. Services will have to explicitly mark options as "public" for those options to be logged and included in metrics. Much more sane than logging everything, especially for anyone using BaseServiceV2 who might not know that this happens under the hood.