### PR TITLE
op-heartbeat: Add CI, clean up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,6 +954,10 @@ workflows:
           binary_name: bss-core
           working_directory: bss-core
           build: false
+      - go-lint-test-build:
+          name: op-heartbeat tests
+          binary_name: op-heartbeat
+          working_directory: op-heartbeat
       - geth-tests
       - integration-tests
       - semgrep-scan
@@ -1067,6 +1071,20 @@ workflows:
             - gcr
           requires:
             - op-proposer-docker-build
+      - docker-build:
+          name: op-heartbeat-docker-build
+          docker_file: op-heartbeat/Dockerfile
+          docker_name: op-heartbeat
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+      - docker-publish:
+          name: op-heartbeat-docker-publish
+          docker_name: op-heartbeat
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          context:
+            - gcr
+          requires:
+            - op-heartbeat-docker-build
       - hive-test:
           name: hive-test-rpc
           version: <<pipeline.git.revision>>

--- a/op-heartbeat/Dockerfile
+++ b/op-heartbeat/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.18.0-alpine3.15 as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
+
+# build op-heartbeat with local monorepo go modules
+COPY ./op-heartbeat/docker.go.work /app/go.work
+COPY ./op-heartbeat /app/op-heartbeat
+COPY ./op-node /app/op-node
+COPY ./op-service /app/op-service
+COPY ./.git /app/.git
+
+WORKDIR /app/op-heartbeat
+
+RUN make op-heartbeat
+
+FROM alpine:3.15
+
+COPY --from=builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin
+
+CMD ["op-heartbeat"]

--- a/op-heartbeat/docker.go.work
+++ b/op-heartbeat/docker.go.work
@@ -1,6 +1,7 @@
 go 1.18
 
 use (
+	./op-heartbeat
 	./op-node
 	./op-service
 )

--- a/op-heartbeat/flags/flags.go
+++ b/op-heartbeat/flags/flags.go
@@ -10,10 +10,8 @@ import (
 const envPrefix = "OP_HEARTBEAT"
 
 const (
-	HTTPAddrFlagName        = "http.addr"
-	HTTPPortFlagName        = "http.port"
-	HTTPMaxBodySizeFlagName = "http.max-body-size"
-	AllowedChainIDsFlagName = "allowed-chain-ids"
+	HTTPAddrFlagName = "http.addr"
+	HTTPPortFlagName = "http.port"
 )
 
 var (

--- a/op-heartbeat/service_test.go
+++ b/op-heartbeat/service_test.go
@@ -5,24 +5,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/ethereum-optimism/optimism/op-node/heartbeat"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
-	"io"
-	"net/http"
-	"testing"
 )
 
 func TestService(t *testing.T) {
+	httpPort := freePort(t)
+	metricsPort := freePort(t)
 	cfg := Config{
-		HTTPAddr:        "127.0.0.1",
-		HTTPPort:        8080,
-		HTTPMaxBodySize: 1024 * 1024,
+		HTTPAddr: "127.0.0.1",
+		HTTPPort: httpPort,
 		Metrics: opmetrics.CLIConfig{
 			Enabled:    true,
 			ListenAddr: "127.0.0.1",
-			ListenPort: 7300,
+			ListenPort: metricsPort,
 		},
 	}
 
@@ -31,6 +35,14 @@ func TestService(t *testing.T) {
 	go func() {
 		exitC <- Start(ctx, log.New(), cfg, "foobar")
 	}()
+
+	// Make sure that the service properly starts
+	select {
+	case <-time.NewTimer(100 * time.Millisecond).C:
+		// pass
+	case err := <-exitC:
+		t.Fatalf("unexpected error on startup: %v", err)
+	}
 
 	tests := []struct {
 		name        string
@@ -79,13 +91,15 @@ func TestService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := json.Marshal(tt.hb)
 			require.NoError(t, err)
-			req, err := http.NewRequestWithContext(ctx, "POST", "http://127.0.0.1:8080", bytes.NewReader(data))
+			req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("http://127.0.0.1:%d", httpPort), bytes.NewReader(data))
 			require.NoError(t, err)
 			res, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
+			defer res.Body.Close()
 			require.Equal(t, res.StatusCode, 204)
 
-			metricsRes, err := http.Get("http://127.0.0.1:7300")
+			metricsRes, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d", metricsPort))
+			require.NoError(t, err)
 			defer metricsRes.Body.Close()
 			require.NoError(t, err)
 			metricsBody, err := io.ReadAll(metricsRes.Body)
@@ -96,4 +110,13 @@ func TestService(t *testing.T) {
 
 	cancel()
 	require.NoError(t, <-exitC)
+}
+
+func freePort(t *testing.T) int {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	require.NoError(t, err)
+	l, err := net.ListenTCP("tcp", addr)
+	require.NoError(t, err)
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
 }


### PR DESCRIPTION
- Adds CI for `op-heartbeat`.
- Adds a healthz endpoint
- Cleans up tests + lint