### PR TITLE
feat: Add lcov.info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ temp
 .nyc_output
 coverage.json
 *.tsbuildinfo
+**/lcov.info
 
 yarn-error.log
 .yarn/*


### PR DESCRIPTION
- Add lcov.info to git ignore
- these files are generated by coverage reports and can be used by editor to show where coverage exists

