### PR TITLE
feat(cmn): allow BSv2 to ignore env/argv

### DIFF
--- a/.changeset/two-taxis-fix.md
+++ b/.changeset/two-taxis-fix.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Adds new standard options to disable parsing variables from environment and command line.

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -158,6 +158,11 @@ export abstract class BaseServiceV2<
     // commander for anything besides the ability to run `ts-node ./service.ts --help`.
     const program = new Command()
     for (const [optionName, optionSpec] of Object.entries(params.optionsSpec)) {
+      // Skip options that are not meant to be used by the user.
+      if (['useEnv', 'useArgv'].includes(optionName)) {
+        continue
+      }
+
       program.addOption(
         new Option(`--${optionName.toLowerCase()}`, `${optionSpec.desc}`).env(
           `${opSnakeCase(
@@ -197,8 +202,8 @@ export abstract class BaseServiceV2<
     dotenv.config()
     const config = new Config(params.name)
     config.load({
-      env: true,
-      argv: true,
+      env: params.options?.useEnv ?? true,
+      argv: params.options?.useEnv ?? true,
     })
 
     // Clean configuration values using the options spec.

--- a/packages/common-ts/src/base-service/options.ts
+++ b/packages/common-ts/src/base-service/options.ts
@@ -30,6 +30,8 @@ export type StandardOptions = {
   port?: number
   hostname?: string
   logLevel?: LogLevel
+  useEnv?: boolean
+  useArgv?: boolean
 }
 
 /**
@@ -58,6 +60,18 @@ export const stdOptionsSpec: OptionsSpec<StandardOptions> = {
     validator: validators.logLevel,
     desc: 'Log level',
     default: 'debug',
+    public: true,
+  },
+  useEnv: {
+    validator: validators.bool,
+    desc: 'For programmatic use, whether to use environment variables',
+    default: true,
+    public: true,
+  },
+  useArgv: {
+    validator: validators.bool,
+    desc: 'For programmatic use, whether to use command line arguments',
+    default: true,
     public: true,
   },
 }


### PR DESCRIPTION
Introduces new standard options that allow users to ignore variables
from the environment or the command line. Useful for programmatic usage
where there may be unrelated environment variables or command line
arguments that get parsed by BSv2 by accident.