### PR TITLE
[Bedrock] op-batcher / op-proposer: allow customization of signer function

### DIFF
--- a/op-batcher/driver.go
+++ b/op-batcher/driver.go
@@ -151,7 +151,7 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 	return &BatchSubmitter{
 		cfg:   batcherCfg,
 		addr:  addr,
-		txMgr: NewTransactionManager(l, txManagerConfig, batchInboxAddress, chainID, sequencerPrivKey, l1Client, signerFn),
+		txMgr: NewTransactionManager(l, txManagerConfig, batchInboxAddress, chainID, addr, l1Client, signerFn),
 		done:  make(chan struct{}),
 		log:   l,
 		state: NewChannelManager(l, cfg.ChannelTimeout),

--- a/op-batcher/sequencer/driver.go
+++ b/op-batcher/sequencer/driver.go
@@ -1,7 +1,6 @@
 package sequencer
 
 import (
-	"crypto/ecdsa"
 	"math/big"
 	"time"
 
@@ -38,9 +37,6 @@ type Config struct {
 
 	// Chain ID of the L1 chain to submit txs to.
 	ChainID *big.Int
-
-	// Private key to sign batch txs with
-	PrivKey *ecdsa.PrivateKey
 
 	PollInterval time.Duration
 }

--- a/op-batcher/txmgr.go
+++ b/op-batcher/txmgr.go
@@ -2,7 +2,6 @@ package op_batcher
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 	"time"
@@ -11,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -33,10 +31,10 @@ type TransactionManager struct {
 	log      log.Logger
 }
 
-func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, privKey *ecdsa.PrivateKey, l1Client *ethclient.Client, signerFn SignerFn) *TransactionManager {
+func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, senderAddress common.Address, l1Client *ethclient.Client, signerFn SignerFn) *TransactionManager {
 	t := &TransactionManager{
 		batchInboxAddress: batchInboxAddress,
-		senderAddress:     crypto.PubkeyToAddress(privKey.PublicKey),
+		senderAddress:     senderAddress,
 		chainID:           chainID,
 		txMgr:             txmgr.NewSimpleTxManager("batcher", txMgrConfg, l1Client),
 		l1Client:          l1Client,

--- a/op-batcher/txmgr.go
+++ b/op-batcher/txmgr.go
@@ -18,6 +18,8 @@ import (
 
 const networkTimeout = 2 * time.Second // How long a single network request can take. TODO: put in a config somewhere
 
+type SignerFn func(rawTx types.TxData) (*types.Transaction, error)
+
 // TransactionManager wraps the simple txmgr package to make it easy to send & wait for transactions
 type TransactionManager struct {
 	// Config
@@ -27,15 +29,11 @@ type TransactionManager struct {
 	// Outside world
 	txMgr    txmgr.TxManager
 	l1Client *ethclient.Client
-	signerFn func(types.TxData) (*types.Transaction, error)
+	signerFn SignerFn
 	log      log.Logger
 }
 
-func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, privKey *ecdsa.PrivateKey, l1Client *ethclient.Client) *TransactionManager {
-	signerFn := func(rawTx types.TxData) (*types.Transaction, error) {
-		return types.SignNewTx(privKey, types.LatestSignerForChainID(chainID), rawTx)
-	}
-
+func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, privKey *ecdsa.PrivateKey, l1Client *ethclient.Client, signerFn SignerFn) *TransactionManager {
 	t := &TransactionManager{
 		batchInboxAddress: batchInboxAddress,
 		senderAddress:     crypto.PubkeyToAddress(privKey.PublicKey),

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-proposer/drivers/l2output"
+	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 )
 
 type ProposerCfg struct {
@@ -39,7 +40,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		AllowNonFinalized: cfg.AllowNonFinalized,
 		L2OOAddr:          cfg.OutputOracleAddr,
 		From:              crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey),
-		SignerFn:          l2output.SignerFnForPrivateKey(cfg.ProposerKey, chainID),
+		SignerFn:          opcrypto.PrivateKeySignerFn(cfg.ProposerKey, chainID),
 	})
 	require.NoError(t, err)
 	return &L2Proposer{

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -38,8 +38,8 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		RollupClient:      rollupCl,
 		AllowNonFinalized: cfg.AllowNonFinalized,
 		L2OOAddr:          cfg.OutputOracleAddr,
-		ChainID:           chainID,
-		PrivKey:           cfg.ProposerKey,
+		From:              crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey),
+		SignerFn:          l2output.SignerFnForPrivateKey(cfg.ProposerKey, chainID),
 	})
 	require.NoError(t, err)
 	return &L2Proposer{

--- a/op-proposer/drivers/l2output/driver.go
+++ b/op-proposer/drivers/l2output/driver.go
@@ -2,7 +2,6 @@ package l2output
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 	"strings"
@@ -13,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -47,21 +45,6 @@ type Config struct {
 
 	// SignerFn is the function used to sign transactions
 	SignerFn bind.SignerFn
-}
-
-func SignerFnForPrivateKey(key *ecdsa.PrivateKey, chainID *big.Int) bind.SignerFn {
-	from := crypto.PubkeyToAddress(key.PublicKey)
-	signer := types.LatestSignerForChainID(chainID)
-	return func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
-		if address != from {
-			return nil, bind.ErrNotAuthorized
-		}
-		signature, err := crypto.Sign(signer.Hash(tx).Bytes(), key)
-		if err != nil {
-			return nil, err
-		}
-		return tx.WithSignature(signer, signature)
-	}
 }
 
 type Driver struct {

--- a/op-proposer/drivers/l2output/driver.go
+++ b/op-proposer/drivers/l2output/driver.go
@@ -42,11 +42,26 @@ type Config struct {
 	// L2OOAddr is the L1 contract address of the L2 Output Oracle.
 	L2OOAddr common.Address
 
-	// ChainID is the L1 chain ID used for proposal transaction signing
-	ChainID *big.Int
+	// From is the address to send transactions from
+	From common.Address
 
-	// Privkey used for proposal transaction signing
-	PrivKey *ecdsa.PrivateKey
+	// SignerFn is the function used to sign transactions
+	SignerFn bind.SignerFn
+}
+
+func SignerFnForPrivateKey(key *ecdsa.PrivateKey, chainID *big.Int) bind.SignerFn {
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	signer := types.LatestSignerForChainID(chainID)
+	return func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+		if address != from {
+			return nil, bind.ErrNotAuthorized
+		}
+		signature, err := crypto.Sign(signer.Hash(tx).Bytes(), key)
+		if err != nil {
+			return nil, err
+		}
+		return tx.WithSignature(signer, signature)
+	}
 }
 
 type Driver struct {
@@ -74,14 +89,13 @@ func NewDriver(cfg Config) (*Driver, error) {
 		cfg.L2OOAddr, parsed, cfg.L1Client, cfg.L1Client, cfg.L1Client,
 	)
 
-	walletAddr := crypto.PubkeyToAddress(cfg.PrivKey.PublicKey)
-	cfg.Log.Info("Configured driver", "wallet", walletAddr, "l2-output-contract", cfg.L2OOAddr)
+	cfg.Log.Info("Configured driver", "wallet", cfg.From, "l2-output-contract", cfg.L2OOAddr)
 
 	return &Driver{
 		cfg:             cfg,
 		l2ooContract:    l2ooContract,
 		rawL2ooContract: rawL2ooContract,
-		walletAddr:      walletAddr,
+		walletAddr:      cfg.From,
 		l:               cfg.Log,
 	}, nil
 }
@@ -184,13 +198,13 @@ func (d *Driver) CraftTx(ctx context.Context, start, end, nonce *big.Int) (*type
 		return nil, fmt.Errorf("output for L2 block %s is still unsafe", output.BlockRef)
 	}
 
-	opts, err := bind.NewKeyedTransactorWithChainID(d.cfg.PrivKey, d.cfg.ChainID)
-	if err != nil {
-		return nil, err
+	opts := &bind.TransactOpts{
+		From:    d.cfg.From,
+		Signer:  d.cfg.SignerFn,
+		Context: ctx,
+		Nonce:   nonce,
+		NoSend:  true,
 	}
-	opts.Context = ctx
-	opts.Nonce = nonce
-	opts.NoSend = true
 
 	// Note: the CurrentL1 is up to (and incl.) what the safe chain and finalized chain have been derived from,
 	// and should be a quite recent L1 block (depends on L1 conf distance applied to rollup node).
@@ -227,16 +241,13 @@ func (d *Driver) CraftTx(ctx context.Context, start, end, nonce *big.Int) (*type
 //
 // NOTE: This method SHOULD NOT publish the resulting transaction.
 func (d *Driver) UpdateGasPrice(ctx context.Context, tx *types.Transaction) (*types.Transaction, error) {
-	opts, err := bind.NewKeyedTransactorWithChainID(
-		d.cfg.PrivKey, d.cfg.ChainID,
-	)
-	if err != nil {
-		return nil, err
+	opts := &bind.TransactOpts{
+		From:    d.cfg.From,
+		Signer:  d.cfg.SignerFn,
+		Context: ctx,
+		Nonce:   new(big.Int).SetUint64(tx.Nonce()),
+		NoSend:  true,
 	}
-	opts.Context = ctx
-	opts.Nonce = new(big.Int).SetUint64(tx.Nonce())
-	opts.NoSend = true
-
 	return d.rawL2ooContract.RawTransact(opts, tx.Data())
 }
 

--- a/op-proposer/go.mod
+++ b/op-proposer/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
 	github.com/ethereum-optimism/optimism/op-bindings v0.10.3
 	github.com/ethereum-optimism/optimism/op-node v0.10.3
-	github.com/ethereum-optimism/optimism/op-service v0.10.3
+	github.com/ethereum-optimism/optimism/op-service v0.10.4-0.20221213024528-ed796b7b65ad
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.9

--- a/op-proposer/go.sum
+++ b/op-proposer/go.sum
@@ -113,6 +113,8 @@ github.com/ethereum-optimism/optimism/op-node v0.10.3 h1:96KbEtbfJTg5GXtNqLnrDPn
 github.com/ethereum-optimism/optimism/op-node v0.10.3/go.mod h1:fsRLXH68xaLhjfr67MPEtjCocCzSXGhZIre536QccIw=
 github.com/ethereum-optimism/optimism/op-service v0.10.3 h1:gr+eVq6CzxMFqo0/9n6EoUkpumtYZEzO84gti6ekj/s=
 github.com/ethereum-optimism/optimism/op-service v0.10.3/go.mod h1:hCY0nAeGYp3YqB0NpLmOzUdXV/5t9EyukHMTJL3pIUQ=
+github.com/ethereum-optimism/optimism/op-service v0.10.4-0.20221213024528-ed796b7b65ad h1:cpb0s9Ewe3jBxIS5B86KdmHeaH5Rg9R2gs6t6VjsLnQ=
+github.com/ethereum-optimism/optimism/op-service v0.10.4-0.20221213024528-ed796b7b65ad/go.mod h1:7INvNCJGwVgNT4gz9Yupx7PAEJeu+F/JtHKv1fOr+9Q=
 github.com/fjl/memsize v0.0.1 h1:+zhkb+dhUgx0/e+M8sF0QqiouvMQUiKR+QYvdxIOKcQ=
 github.com/fjl/memsize v0.0.1/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/op-proposer/l2_output_submitter.go
+++ b/op-proposer/l2_output_submitter.go
@@ -199,8 +199,8 @@ func NewL2OutputSubmitter(
 		RollupClient:      rollupClient,
 		AllowNonFinalized: cfg.AllowNonFinalized,
 		L2OOAddr:          l2ooAddress,
-		ChainID:           chainID,
-		PrivKey:           l2OutputPrivKey,
+		From:              crypto.PubkeyToAddress(l2OutputPrivKey.PublicKey),
+		SignerFn:          l2output.SignerFnForPrivateKey(l2OutputPrivKey, chainID),
 	})
 	if err != nil {
 		return nil, err

--- a/op-proposer/l2_output_submitter.go
+++ b/op-proposer/l2_output_submitter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-proposer/drivers/l2output"
 	"github.com/ethereum-optimism/optimism/op-proposer/txmgr"
+	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
@@ -200,7 +201,7 @@ func NewL2OutputSubmitter(
 		AllowNonFinalized: cfg.AllowNonFinalized,
 		L2OOAddr:          l2ooAddress,
 		From:              crypto.PubkeyToAddress(l2OutputPrivKey.PublicKey),
-		SignerFn:          l2output.SignerFnForPrivateKey(l2OutputPrivKey, chainID),
+		SignerFn:          opcrypto.PrivateKeySignerFn(l2OutputPrivKey, chainID),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Supports passing a custom transaction signer function to the batcher's transaction manager and the proposer's driver.

**Tests**

No logic changes in this PR, simply threading through some configuration.

**Additional context**

This allows plugging in different implementations for transaction signing, which paves the way for more secure management of keys.