### PR TITLE
fixes op-service's log handler level filtering

### DIFF
--- a/op-service/log/cli.go
+++ b/op-service/log/cli.go
@@ -64,7 +64,7 @@ func (cfg CLIConfig) Check() error {
 func NewLogger(cfg CLIConfig) log.Logger {
 	handler := log.StreamHandler(os.Stdout, Format(cfg.Format, cfg.Color))
 	handler = log.SyncHandler(handler)
-	log.LvlFilterHandler(Level(cfg.Level), handler)
+	handler = log.LvlFilterHandler(Level(cfg.Level), handler)
 	logger := log.New()
 	logger.SetHandler(handler)
 	return logger


### PR DESCRIPTION
**Description**
Fixes typo in op-service log handler setup that was causing the level filter to not be applied