### PR TITLE
Stop TestSystemMockP2P from flaking

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -577,7 +577,7 @@ func TestSystemMockP2P(t *testing.T) {
 
 	// Verify that everything that was received was published
 	require.GreaterOrEqual(t, len(published), len(received))
-	require.Equal(t, received, published[:len(received)])
+	require.ElementsMatch(t, received, published[:len(received)])
 
 	// Verify that the tx was received via p2p
 	require.Contains(t, received, receiptVerif.BlockHash)


### PR DESCRIPTION
**Description**

The root cause is that the elements were out of order. There isn't a strong reason that the order of the arrays would be the same so & the thing we care about is that the elements match so I switch the require statement to be that. In the failing test I manually verified that the elements were the same.

Last seen in https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/11438/workflows/e524ab48-9fff-445d-9813-8a4f76046012/jobs/321725.
