### PR TITLE
contracts-periphery: run foundry tests in CI

### DIFF
--- a/packages/contracts-periphery/contracts/foundry-tests/Transactor.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/Transactor.t.sol
@@ -50,7 +50,7 @@ contract TransactorTest is Transactor_Initializer {
         // Run CALL
         vm.prank(alice);
         vm.expectCall(address(callRecorded), data);
-        transactor.CALL(address(callRecorded), data, 200_000 wei, 420);
+        transactor.CALL(address(callRecorded), data, 200_000 wei);
     }
 
     // It should revert if called by non-owner
@@ -59,7 +59,7 @@ contract TransactorTest is Transactor_Initializer {
         bytes memory data = abi.encodeWithSelector(callRecorded.record.selector);
         // Run CALL
         vm.prank(bob);
-        transactor.CALL(address(callRecorded), data, 200_000 wei, 420);
+        transactor.CALL(address(callRecorded), data, 200_000 wei);
         vm.expectRevert("UNAUTHORIZED");
     }
 
@@ -69,7 +69,7 @@ contract TransactorTest is Transactor_Initializer {
         // Run CALL
         vm.prank(alice);
         vm.expectCall(address(reverter), data);
-        transactor.DELEGATECALL(address(reverter), data, 200_000 wei);
+        transactor.DELEGATECALL(address(reverter), data);
     }
 
     // It should revert if called by non-owner
@@ -78,7 +78,7 @@ contract TransactorTest is Transactor_Initializer {
         bytes memory data = abi.encodeWithSelector(reverter.doRevert.selector);
         // Run CALL
         vm.prank(bob);
-        transactor.DELEGATECALL(address(reverter), data, 200_000 wei);
+        transactor.DELEGATECALL(address(reverter), data);
         vm.expectRevert("UNAUTHORIZED");
     }
 }

--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -19,7 +19,7 @@
     "test": "yarn test:contracts",
     "test:contracts": "hardhat test --show-stack-traces",
     "test:forge": "forge test",
-    "test:coverage": "NODE_OPTIONS=--max_old_space_size=8192 hardhat coverage",
+    "test:coverage": "NODE_OPTIONS=--max_old_space_size=8192 hardhat coverage && yarn test:coverage:forge",
     "test:coverage:forge": "forge coverage",
     "test:slither": "slither .",
     "gas-snapshot": "forge snapshot",


### PR DESCRIPTION
**Description**

The `yarn:coverage` command is ran in CI so add
`forge coverage` to that command so the foundry tests also run.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

