### PR TITLE
ctp: bump semver to 1.0.0 for nft contracts

### DIFF
--- a/packages/contracts-periphery/contracts/foundry-tests/Optimist.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/Optimist.t.sol
@@ -56,7 +56,7 @@ contract OptimistTest is Optimist_Initializer {
         // expect attestationStation to be set
         assertEq(address(optimist.ATTESTATION_STATION()), address(attestationStation));
         assertEq(optimist.ATTESTOR(), alice_admin);
-        assertEq(optimist.version(), "0.0.1");
+        assertEq(optimist.version(), "1.0.0");
     }
 
     /**

--- a/packages/contracts-periphery/contracts/universal/op-nft/AttestationStation.sol
+++ b/packages/contracts-periphery/contracts/universal/op-nft/AttestationStation.sol
@@ -42,9 +42,9 @@ contract AttestationStation is Semver {
     );
 
     /**
-     * @custom:semver 0.0.1
+     * @custom:semver 1.0.0
      */
-    constructor() Semver(0, 0, 1) {}
+    constructor() Semver(1, 0, 0) {}
 
     /**
      * @notice Allows anyone to create attestations.

--- a/packages/contracts-periphery/contracts/universal/op-nft/Optimist.sol
+++ b/packages/contracts-periphery/contracts/universal/op-nft/Optimist.sol
@@ -29,6 +29,7 @@ contract Optimist is ERC721BurnableUpgradeable, Semver {
 
     /**
      * @notice  Initialize the Optimist contract.
+     * @custom:semver 1.0.0
      * @dev     call initialize function
      * @param   _name  The token name.
      * @param   _symbol  The token symbol.
@@ -40,7 +41,7 @@ contract Optimist is ERC721BurnableUpgradeable, Semver {
         string memory _symbol,
         address _attestor,
         AttestationStation _attestationStation
-    ) Semver(0, 0, 1) {
+    ) Semver(1, 0, 0) {
         ATTESTOR = _attestor;
         ATTESTATION_STATION = _attestationStation;
         initialize(_name, _symbol);


### PR DESCRIPTION
**Description**

The semver should be set to `1.0.0` for production deployment of the nft contracts. This needs to
be merged before prod deployment.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

