### PR TITLE
feat(ctb): break out token interfaces

### DIFF
--- a/packages/contracts-bedrock/contracts/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2ERC721Bridge.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import { ERC721Bridge } from "../universal/ERC721Bridge.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { L1ERC721Bridge } from "../L1/L1ERC721Bridge.sol";
-import { IOptimismMintableERC721 } from "../universal/SupportedInterfaces.sol";
+import { IOptimismMintableERC721 } from "../universal/IOptimismMintableERC721.sol";
 import { Semver } from "../universal/Semver.sol";
 
 /**

--- a/packages/contracts-bedrock/contracts/test/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismMintableERC20.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Bridge_Initializer } from "./CommonTest.t.sol";
-import { ILegacyMintableERC20, IOptimismMintableERC20 } from "../universal/SupportedInterfaces.sol";
+import { ILegacyMintableERC20, IOptimismMintableERC20 } from "../universal/IOptimismMintableERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract OptimismMintableERC20_Test is Bridge_Initializer {

--- a/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC20.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * @title IOptimismMintableERC20
+ * @notice This interface is available on the OptimismMintableERC20 contract. We declare it as a
+ *         separate interface so that it can be used in custom implementations of
+ *         OptimismMintableERC20.
+ */
+interface IOptimismMintableERC20 {
+    function remoteToken() external returns (address);
+
+    function bridge() external returns (address);
+
+    function mint(address _to, uint256 _amount) external;
+
+    function burn(address _from, uint256 _amount) external;
+}
+
+/**
+ * @custom:legacy
+ * @title ILegacyMintableERC20
+ * @notice This interface was available on the legacy L2StandardERC20 contract. It remains available
+ *         on the OptimismMintableERC20 contract for backwards compatibility.
+ */
+interface ILegacyMintableERC20 is IERC165 {
+    function l1Token() external returns (address);
+
+    function mint(address _to, uint256 _amount) external;
+
+    function burn(address _from, uint256 _amount) external;
+}

--- a/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC721.sol
@@ -1,41 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// Import this here to make it available just by importing this file
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {
     IERC721Enumerable
 } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
-
-/**
- * @title IOptimismMintableERC20
- * @notice This interface is available on the OptimismMintableERC20 contract. We declare it as a
- *         separate interface so that it can be used in custom implementations of
- *         OptimismMintableERC20.
- */
-interface IOptimismMintableERC20 {
-    function remoteToken() external returns (address);
-
-    function bridge() external returns (address);
-
-    function mint(address _to, uint256 _amount) external;
-
-    function burn(address _from, uint256 _amount) external;
-}
-
-/**
- * @custom:legacy
- * @title ILegacyMintableERC20
- * @notice This interface was available on the legacy L2StandardERC20 contract. It remains available
- *         on the OptimismMintableERC20 contract for backwards compatibility.
- */
-interface ILegacyMintableERC20 {
-    function l1Token() external returns (address);
-
-    function mint(address _to, uint256 _amount) external;
-
-    function burn(address _from, uint256 _amount) external;
-}
 
 /**
  * @title IOptimismMintableERC721

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.15;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { IERC165, ILegacyMintableERC20, IOptimismMintableERC20 } from "./SupportedInterfaces.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { ILegacyMintableERC20, IOptimismMintableERC20 } from "./IOptimismMintableERC20.sol";
 
 /**
  * @title OptimismMintableERC20

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721.sol
@@ -7,7 +7,7 @@ import {
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { IOptimismMintableERC721 } from "./SupportedInterfaces.sol";
+import { IOptimismMintableERC721 } from "./IOptimismMintableERC721.sol";
 
 /**
  * @title OptimismMintableERC721

--- a/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
@@ -6,7 +6,7 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { SafeCall } from "../libraries/SafeCall.sol";
-import { IOptimismMintableERC20, ILegacyMintableERC20 } from "./SupportedInterfaces.sol";
+import { IOptimismMintableERC20, ILegacyMintableERC20 } from "./IOptimismMintableERC20.sol";
 import { CrossDomainMessenger } from "./CrossDomainMessenger.sol";
 import { OptimismMintableERC20 } from "./OptimismMintableERC20.sol";
 


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Breaks the OptimismMintableERC20 and OptimismMintableERC721 token interfaces into their own files instead of having one joint file for supported interfaces. This is in preparation for portings tests for the OptimismMintableERC721 and its factory.