### PR TITLE
feat(fd): have fault detector wait for providers

### DIFF
--- a/.changeset/proud-socks-sip.md
+++ b/.changeset/proud-socks-sip.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Adds a function for waiting for ethers providers

--- a/.changeset/silver-kids-search.md
+++ b/.changeset/silver-kids-search.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': patch
+---
+
+Fault detector will now wait for providers to be connected

--- a/packages/common-ts/src/common/index.ts
+++ b/packages/common-ts/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './logger'
 export * from './metrics'
+export * from './provider'

--- a/packages/common-ts/src/common/provider.ts
+++ b/packages/common-ts/src/common/provider.ts
@@ -1,0 +1,39 @@
+import { Provider } from '@ethersproject/abstract-provider'
+import { sleep } from '@eth-optimism/core-utils'
+
+import { Logger } from './logger'
+
+/**
+ * Waits for an Ethers provider to be connected.
+ *
+ * @param provider Ethers provider to check.
+ * @param opts Options for the function.
+ * @param opts.logger Logger to use.
+ * @param opts.intervalMs Interval to wait between checks.
+ * @param opts.name Name of the provider for logs.
+ */
+export const waitForProvider = async (
+  provider: Provider,
+  opts?: {
+    logger?: Logger
+    intervalMs?: number
+    name?: string
+  }
+) => {
+  opts?.logger?.info(`waiting for ${opts?.name || 'target'} provider...`)
+
+  let connected = false
+  while (!connected) {
+    try {
+      await provider.getBlockNumber()
+      connected = true
+    } catch (e) {
+      opts?.logger?.info(`${provider} provider not connected, retrying...`)
+
+      // Don't spam requests
+      await sleep(opts?.intervalMs || 15000)
+    }
+  }
+
+  opts?.logger?.info(`${opts?.name || 'target'} provider connected`)
+}

--- a/packages/fault-detector/src/service.ts
+++ b/packages/fault-detector/src/service.ts
@@ -4,6 +4,7 @@ import {
   ExpressRouter,
   Gauge,
   validators,
+  waitForProvider,
 } from '@eth-optimism/common-ts'
 import { getChainId, sleep, toRpcHexString } from '@eth-optimism/core-utils'
 import { CrossChainMessenger } from '@eth-optimism/sdk'
@@ -85,6 +86,18 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
   }
 
   async init(): Promise<void> {
+    // Connect to L1.
+    await waitForProvider(this.options.l1RpcProvider, {
+      logger: this.logger,
+      name: 'L1',
+    })
+
+    // Connect to L2.
+    await waitForProvider(this.options.l2RpcProvider, {
+      logger: this.logger,
+      name: 'L2',
+    })
+
     this.state.messenger = new CrossChainMessenger({
       l1SignerOrProvider: this.options.l1RpcProvider,
       l2SignerOrProvider: this.options.l2RpcProvider,


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates the fault detector to wait for its L1 and L2 RPC providers using a new utility function in common-ts. This will prevent errors that users currently experience with the fault detector.