### PR TITLE
ci: Add op-e2e to codecov's ignored paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,7 @@ comment:
   require_changes: true    # only post the comment if coverage changes
 ignore:
   - "l2geth"
+  - "op-e2e"
   - "**/*.t.sol"
   - "op-bindings/bindings/*.go"
   - "packages/contracts-bedrock/contracts/vendor/WETH9.sol"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

@trianglesphere requested this as the coverage behavior of this package seems to be erratic.

