### PR TITLE
fix(ci): better lint check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
             fi
       - run:
           name: Lint
-          command: yarn lint:check
+          command: yarn lint && git diff --exit-code
           working_directory: packages/<<parameters.package_name>>
       - run:
           name: Test


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates the lint check in CI. Since lint calls both lint:fix and lint:check under the hood, this will catch issues in the case that the linter and lint:fix aren't using exactly the same rules.