### PR TITLE
op-node: guard against panics in the p2p gossip validator

### DIFF
--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -1,0 +1,34 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+)
+
+func TestGuardGossipValidator(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlCrit)
+	val := guardGossipValidator(logger, func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
+		if id == "mallory" {
+			panic("mallory was here")
+		}
+		if id == "bob" {
+			return pubsub.ValidationIgnore
+		}
+		return pubsub.ValidationAccept
+	})
+	// Test that panics from mallory are recovered and rejected,
+	// and test that we can continue to ignore bob and accept alice.
+	require.Equal(t, pubsub.ValidationAccept, val(context.Background(), "alice", nil))
+	require.Equal(t, pubsub.ValidationReject, val(context.Background(), "mallory", nil))
+	require.Equal(t, pubsub.ValidationIgnore, val(context.Background(), "bob", nil))
+	require.Equal(t, pubsub.ValidationReject, val(context.Background(), "mallory", nil))
+	require.Equal(t, pubsub.ValidationAccept, val(context.Background(), "alice", nil))
+	require.Equal(t, pubsub.ValidationIgnore, val(context.Background(), "bob", nil))
+}


### PR DESCRIPTION
**Description**

Add a simple util function to wrap a gossip validator function  with a guard that can recover from panics, log them, and reject the messages that caused them.

**Tests**

Added a test case to cover the new util function.

**Invariants**

Gossip validation should never unexpectedly panic, but if it does, we want to reject the message from the peer that caused the panic.

**Additional context**

This prevents the node from falling over in case of an unexpected problem in the gossip validation pipeline.

**Metadata**

Fix ENG-3114
