### PR TITLE
feat(ctb): `L2OutputOracle` monotonic block number increase invariant

### DIFF
--- a/.changeset/purple-knives-carry.md
+++ b/.changeset/purple-knives-carry.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Add an echidna test for the monotonic increase of `L2OutputOracle` output proposal block numbers.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,6 +869,11 @@ workflows:
           echidna_target: portal
           requires:
             - bedrock-echidna-build
+      - bedrock-echidna-run:
+          name: Bedrock Echidna L2OutputOracle Test
+          echidna_target: oracle
+          requires:
+            - bedrock-echidna-build
       - op-bindings-build:
           requires:
             - yarn-monorepo

--- a/packages/contracts-bedrock/contracts/echidna/FuzzOracle.sol
+++ b/packages/contracts-bedrock/contracts/echidna/FuzzOracle.sol
@@ -1,0 +1,113 @@
+pragma solidity 0.8.15;
+
+import { L2OutputOracle } from "../L1/L2OutputOracle.sol";
+import { Types } from "../libraries/Types.sol";
+
+/**
+ * @dev Modified version of `L2OutputOracle` that contains a less restrictive
+ * version `proposeL2Output` for use with echidna.
+ */
+contract ModL2OutputOracle is L2OutputOracle {
+    constructor(
+        uint256 _submissionInterval,
+        uint256 _l2BlockTime,
+        uint256 _startingBlockNumber,
+        uint256 _startingTimestamp,
+        address _proposer,
+        address _challenger
+    ) L2OutputOracle(
+        _submissionInterval,
+        _l2BlockTime,
+        _startingBlockNumber,
+        _startingTimestamp,
+        _proposer,
+        _challenger
+    ) {
+        // ...
+    }
+
+    /**
+     * @dev This function is a modified version of `proposeL2Output` that removes
+     * several checks which limit echidna.
+     *
+     * Because the purpose of this test is to check that the block number of the
+     * proposed outputs must monotonically increase, these checks are safe to remove.
+     */
+    function proposeLessChecks(
+        bytes32 _outputRoot,
+        uint256 _l2BlockNumber
+    ) external {
+        require(
+            _l2BlockNumber == nextBlockNumber(),
+            "L2OutputOracle: block number must be equal to next expected block number"
+        );
+
+        emit OutputProposed(_outputRoot, nextOutputIndex(), block.timestamp, _l2BlockNumber);
+
+        l2Outputs.push(
+            Types.OutputProposal({
+                outputRoot: _outputRoot,
+                timestamp: uint128(block.timestamp),
+                l2BlockNumber: uint128(_l2BlockNumber)
+            })
+        );
+    }
+}
+
+contract EchidnaFuzzL2OutputOracle {
+    // ENV
+    uint256 internal immutable submissionInterval = 1800;
+    uint256 internal immutable l2BlockTime = 2;
+    uint256 internal immutable startingBlockNumber = 200;
+    uint256 internal immutable startingTimestamp = 1000;
+    ModL2OutputOracle public immutable oracle;
+
+    // STATE
+    bool internal blockNumberMonotonicallyIncreases = true;
+
+    constructor() {
+        // Create a new modified L2 Output Oracle
+        oracle = new ModL2OutputOracle(
+            submissionInterval,
+            l2BlockTime,
+            startingBlockNumber,
+            startingTimestamp,
+            address(this),
+            address(this)
+        );
+    }
+
+    /**
+     * @dev Propose an l2 output root using `ModL2OutputOracle`'s less restrictive
+     * `proposeLessChecks` function.
+     */
+    function propose(
+        bytes32 _outputRoot,
+        uint256 _l2BlockNumber
+    ) external {
+        // Grab the previous latest block number
+        uint256 previousLatestBlock = oracle.latestBlockNumber();
+
+        // Attempt to propose a new output
+        oracle.proposeLessChecks(_outputRoot, _l2BlockNumber);
+
+        // Ensure that the block number monotonically increased
+        if (oracle.latestBlockNumber() < previousLatestBlock) {
+            blockNumberMonotonicallyIncreases = false;
+        }
+    }
+
+    /**
+     * @dev Delete one or multiple L2 outputs from the L2 Output Oracle.
+     */
+    function deleteL2Output(uint256 _index) external {
+        oracle.deleteL2Outputs(_index);
+    }
+
+    /**
+     * Invariant: The block number of output root proposals should monotonically increase.
+     */
+    function echidna_blockNumberMonotonicallyIncreases() public view returns (bool) {
+        return blockNumberMonotonicallyIncreases;
+    }
+}

--- a/packages/contracts-bedrock/contracts/echidna/FuzzOracle.sol
+++ b/packages/contracts-bedrock/contracts/echidna/FuzzOracle.sol
@@ -15,14 +15,16 @@ contract ModL2OutputOracle is L2OutputOracle {
         uint256 _startingTimestamp,
         address _proposer,
         address _challenger
-    ) L2OutputOracle(
-        _submissionInterval,
-        _l2BlockTime,
-        _startingBlockNumber,
-        _startingTimestamp,
-        _proposer,
-        _challenger
-    ) {
+    )
+        L2OutputOracle(
+            _submissionInterval,
+            _l2BlockTime,
+            _startingBlockNumber,
+            _startingTimestamp,
+            _proposer,
+            _challenger
+        )
+    {
         // ...
     }
 
@@ -33,10 +35,7 @@ contract ModL2OutputOracle is L2OutputOracle {
      * Because the purpose of this test is to check that the block number of the
      * proposed outputs must monotonically increase, these checks are safe to remove.
      */
-    function proposeLessChecks(
-        bytes32 _outputRoot,
-        uint256 _l2BlockNumber
-    ) external {
+    function proposeLessChecks(bytes32 _outputRoot, uint256 _l2BlockNumber) external {
         require(
             _l2BlockNumber == nextBlockNumber(),
             "L2OutputOracle: block number must be equal to next expected block number"
@@ -56,10 +55,10 @@ contract ModL2OutputOracle is L2OutputOracle {
 
 contract EchidnaFuzzL2OutputOracle {
     // ENV
-    uint256 internal immutable submissionInterval = 1800;
-    uint256 internal immutable l2BlockTime = 2;
-    uint256 internal immutable startingBlockNumber = 200;
-    uint256 internal immutable startingTimestamp = 1000;
+    uint256 internal constant submissionInterval = 1800;
+    uint256 internal constant l2BlockTime = 2;
+    uint256 internal constant startingBlockNumber = 200;
+    uint256 internal constant startingTimestamp = 1000;
     ModL2OutputOracle public immutable oracle;
 
     // STATE
@@ -81,10 +80,7 @@ contract EchidnaFuzzL2OutputOracle {
      * @dev Propose an l2 output root using `ModL2OutputOracle`'s less restrictive
      * `proposeLessChecks` function.
      */
-    function propose(
-        bytes32 _outputRoot,
-        uint256 _l2BlockNumber
-    ) external {
+    function propose(bytes32 _outputRoot, uint256 _l2BlockNumber) external {
         // Grab the previous latest block number
         uint256 previousLatestBlock = oracle.latestBlockNumber();
 

--- a/packages/contracts-bedrock/contracts/echidna/FuzzOracle.sol
+++ b/packages/contracts-bedrock/contracts/echidna/FuzzOracle.sol
@@ -24,9 +24,7 @@ contract ModL2OutputOracle is L2OutputOracle {
             _proposer,
             _challenger
         )
-    {
-        // ...
-    }
+    {}
 
     /**
      * @dev This function is a modified version of `proposeL2Output` that removes
@@ -39,6 +37,14 @@ contract ModL2OutputOracle is L2OutputOracle {
         require(
             _l2BlockNumber == nextBlockNumber(),
             "L2OutputOracle: block number must be equal to next expected block number"
+        );
+        require(
+            computeL2Timestamp(_l2BlockNumber) < block.timestamp,
+            "L2OutputOracle: cannot propose L2 output in the future"
+        );
+        require(
+            _outputRoot != bytes32(0),
+            "L2OutputOracle: L2 output proposal cannot be the zero hash"
         );
 
         emit OutputProposed(_outputRoot, nextOutputIndex(), block.timestamp, _l2BlockNumber);

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -46,7 +46,8 @@
     "echidna:encoding": "echidna-test --contract EchidnaFuzzEncoding --config ./echidna.yaml .",
     "echidna:portal": "echidna-test --contract EchidnaFuzzOptimismPortal --config ./echidna.yaml .",
     "echidna:hashing": "echidna-test --contract EchidnaFuzzHashing --config ./echidna.yaml .",
-    "echidna:metering": "echidna-test --contract EchidnaFuzzResourceMetering --config ./echidna.yaml ."
+    "echidna:metering": "echidna-test --contract EchidnaFuzzResourceMetering --config ./echidna.yaml .",
+    "echidna:oracle": "echidna-test --contract EchidnaFuzzL2OutputOracle --config ./echidna.yaml ."
   },
   "dependencies": {
     "@eth-optimism/core-utils": "^0.12.0",

--- a/packages/contracts-bedrock/slither.config.json
+++ b/packages/contracts-bedrock/slither.config.json
@@ -8,5 +8,6 @@
   "hardhat_ignore_compile": false,
   "disable_color": false,
   "exclude_dependencies": false,
-  "filter_paths": "contracts/test|lib"
+  "filter_paths": "contracts/test|lib",
+  "compile_force_framework": "hardhat"
 }


### PR DESCRIPTION
# Overview

Adds an echidna invariant test for the `L2OutputOracle` that ensures that the L2 block number of output root proposals monotonically increases.
