### PR TITLE
op-bindings: add test coverage of the L1 fee constants

### DIFF
--- a/op-bindings/predeploys/addresses_test.go
+++ b/op-bindings/predeploys/addresses_test.go
@@ -1,8 +1,11 @@
 package predeploys
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
@@ -11,4 +14,27 @@ func TestGethAddresses(t *testing.T) {
 	// We test if the addresses in geth match those in op-bindings, to avoid an import-cycle:
 	// we import geth in the monorepo, and do not want to import op-bindings into geth.
 	require.Equal(t, L1BlockAddr, types.L1BlockAddr)
+}
+
+// TestL1BlockSlots ensures that the storage layout of the L1Block
+// contract matches the hardcoded values in `op-geth`.
+func TestL1BlockSlots(t *testing.T) {
+	layout, err := bindings.GetStorageLayout("L1Block")
+	require.NoError(t, err)
+
+	var l1BaseFeeSlot, overHeadSlot, scalarSlot common.Hash
+	for _, entry := range layout.Storage {
+		switch entry.Label {
+		case "l1FeeOverhead":
+			overHeadSlot = common.BigToHash(big.NewInt(int64(entry.Slot)))
+		case "l1FeeScalar":
+			scalarSlot = common.BigToHash(big.NewInt(int64(entry.Slot)))
+		case "basefee":
+			l1BaseFeeSlot = common.BigToHash(big.NewInt(int64(entry.Slot)))
+		}
+	}
+
+	require.Equal(t, types.OverheadSlot, overHeadSlot)
+	require.Equal(t, types.ScalarSlot, scalarSlot)
+	require.Equal(t, types.L1BaseFeeSlot, l1BaseFeeSlot)
 }


### PR DESCRIPTION
**Description**

`TestL1BlockSlots` will ensure that the values in the committed storage layout matches the values that are hard coded in `op-geth`. This is important to handle because the storage layout may accidentally change in the future. This will make it very obvious is there are issues with the storage layout changing.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

