### PR TITLE
contracts-periphery: update version on test contracts

### DIFF
--- a/packages/contracts-periphery/contracts/testing/helpers/CallRecorder.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/CallRecorder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 contract CallRecorder {
     struct CallInfo {

--- a/packages/contracts-periphery/contracts/testing/helpers/ExternalContractCompiler.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/ExternalContractCompiler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { ProxyAdmin } from "@eth-optimism/contracts-bedrock/contracts/universal/ProxyAdmin.sol";
 import { Proxy } from "@eth-optimism/contracts-bedrock/contracts/universal/Proxy.sol";

--- a/packages/contracts-periphery/contracts/testing/helpers/FailingReceiver.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/FailingReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 contract FailingReceiver {
     receive() external payable {

--- a/packages/contracts-periphery/contracts/testing/helpers/Reverter.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/Reverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 contract Reverter {
     function doRevert() public pure {

--- a/packages/contracts-periphery/contracts/testing/helpers/SimpleStorage.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/SimpleStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 contract SimpleStorage {
     mapping(bytes32 => bytes32) public db;

--- a/packages/contracts-periphery/contracts/testing/helpers/TestERC20.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 

--- a/packages/contracts-periphery/contracts/testing/helpers/TestERC721.sol
+++ b/packages/contracts-periphery/contracts/testing/helpers/TestERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
 


### PR DESCRIPTION
**Description**

Makes the contracts more lenient in the version
of solc that they can compile with, makes it easier to begin porting the hardhat based tests to `foundry`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
