### PR TITLE
fix(l2g): sequencer historical sync bug

### DIFF
--- a/.changeset/purple-falcons-teach.md
+++ b/.changeset/purple-falcons-teach.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Fixes a bug when re-syncing Sequencers

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -622,8 +622,8 @@ func (s *SyncService) GasPriceOracleOwnerAddress() *common.Address {
 	return &s.gasPriceOracleOwnerAddress
 }
 
-/// Update the execution context's timestamp and blocknumber
-/// over time. This is only necessary for the sequencer.
+// Update the execution context's timestamp and blocknumber
+// over time. This is only necessary for the sequencer.
 func (s *SyncService) updateL1BlockNumber() error {
 	context, err := s.client.GetLatestEthContext()
 	if err != nil {
@@ -838,7 +838,7 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
 	// network split.
 	// Note that it should never be possible for the timestamp to be set to
 	// 0 when running as a verifier.
-	shouldMalleateTimestamp := !s.verifier && tx.QueueOrigin() == types.QueueOriginL1ToL2
+	shouldMalleateTimestamp := !s.verifier && !s.IsSyncing() && tx.QueueOrigin() == types.QueueOriginL1ToL2
 	if tx.L1Timestamp() == 0 || shouldMalleateTimestamp {
 		// Get the latest known timestamp
 		current := time.Unix(int64(ts), 0)


### PR DESCRIPTION
Fixes a bug that prevented Sequencers from syncing historical transactions.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
