### PR TITLE
contracts-bedrock: remove dead config, fix misconfig

### DIFF
--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -93,7 +93,7 @@ const deployFn: DeployFunction = async (hre) => {
     systemConfigConfig: {
       owner: hre.deployConfig.finalSystemOwner,
       overhead: hre.deployConfig.gasPriceOracleOverhead,
-      scalar: hre.deployConfig.gasPriceOracleDecimals,
+      scalar: hre.deployConfig.gasPriceOracleScalar,
       batcherHash: hre.ethers.utils.hexZeroPad(
         hre.deployConfig.batchSenderAddress,
         32

--- a/packages/contracts-bedrock/src/deploy-config.ts
+++ b/packages/contracts-bedrock/src/deploy-config.ts
@@ -155,7 +155,6 @@ interface OptionalL2DeployConfig {
   l2GenesisBlockBaseFeePerGas: string
   gasPriceOracleOverhead: number
   gasPriceOracleScalar: number
-  gasPriceOracleDecimals: number
 }
 
 /**
@@ -325,10 +324,6 @@ export const deployConfigSpec: {
   gasPriceOracleScalar: {
     type: 'number',
     default: 1_000_000,
-  },
-  gasPriceOracleDecimals: {
-    type: 'number',
-    default: 6,
   },
   governanceTokenSymbol: {
     type: 'string',


### PR DESCRIPTION
**Description**

Fixes a misconfiguration in the deploy script. The decimals value was being used when the scalar should have been used. The decimals value is now a protocol constant, so it no longer needs to be configured. Remove the value from the deploy config.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

