### PR TITLE
INF-23 tls and custom middleware support for op-service/rpc

### DIFF
--- a/op-service/tls/cli.go
+++ b/op-service/tls/cli.go
@@ -1,0 +1,65 @@
+// This file contains CLI and env TLS configurations that can be used by clients or servers
+package tls
+
+import (
+	"errors"
+
+	"github.com/urfave/cli"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+)
+
+const (
+	TLSCaCertFlagName = "tls.ca"
+	TLSCertFlagName   = "tls.cert"
+	TLSKeyFlagName    = "tls.key"
+)
+
+func CLIFlags(envPrefix string) []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   TLSCaCertFlagName,
+			Usage:  "tls ca cert path",
+			Value:  "tls/ca.crt",
+			EnvVar: opservice.PrefixEnvVar(envPrefix, "TLS_CA"),
+		},
+		cli.StringFlag{
+			Name:   TLSCertFlagName,
+			Usage:  "tls cert path",
+			Value:  "tls/tls.crt",
+			EnvVar: opservice.PrefixEnvVar(envPrefix, "TLS_CERT"),
+		},
+		cli.StringFlag{
+			Name:   TLSKeyFlagName,
+			Usage:  "tls key",
+			Value:  "tls/tls.key",
+			EnvVar: opservice.PrefixEnvVar(envPrefix, "TLS_KEY"),
+		},
+	}
+}
+
+type CLIConfig struct {
+	TLSCaCert string
+	TLSCert   string
+	TLSKey    string
+}
+
+func (c CLIConfig) Check() error {
+	if c.TLSEnabled() && (c.TLSCaCert == "" || c.TLSCert == "" || c.TLSKey == "") {
+		return errors.New("all tls flags must be set if at least one is set")
+	}
+
+	return nil
+}
+
+func (c CLIConfig) TLSEnabled() bool {
+	return !(c.TLSCaCert == "" && c.TLSCert == "" && c.TLSKey == "")
+}
+
+func ReadCLIConfig(ctx *cli.Context) CLIConfig {
+	return CLIConfig{
+		TLSCaCert: ctx.GlobalString(TLSCaCertFlagName),
+		TLSCert:   ctx.GlobalString(TLSCertFlagName),
+		TLSKey:    ctx.GlobalString(TLSKeyFlagName),
+	}
+}

--- a/op-service/tls/tlsinfo.go
+++ b/op-service/tls/tlsinfo.go
@@ -1,0 +1,36 @@
+package tls
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+)
+
+// PeerTLSInfo contains request-scoped peer certificate data
+// It can be used by downstream http.Handlers to authorize access for TLS-authenticated clients
+type PeerTLSInfo struct {
+	LeafCertificate *x509.Certificate
+}
+
+type peerTLSInfoContextKey struct{}
+
+// NewPeerTLSMiddleware returns an http.Handler that extracts the peer's certificate data into PeerTLSInfo and attaches it to the request-scoped context.
+// PeerTLSInfo will only be populated if the http.Server is listening with ListenAndServeTLS
+// This is useful for ethereum-go/rpc endpoints because the http.Request object isn't accessible in the registered service.
+func NewPeerTLSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerTlsInfo := PeerTLSInfo{}
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			peerTlsInfo.LeafCertificate = r.TLS.PeerCertificates[0]
+		}
+		ctx := context.WithValue(r.Context(), peerTLSInfoContextKey{}, peerTlsInfo)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// PeerTLSInfoFromContext extracts PeerTLSInfo from the context
+// Result will only be populated if NewPeerTLSMiddleware has been added to the handler stack.
+func PeerTLSInfoFromContext(ctx context.Context) PeerTLSInfo {
+	info, _ := ctx.Value(peerTLSInfoContextKey{}).(PeerTLSInfo)
+	return info
+}


### PR DESCRIPTION
**Description**

New features for op-service
* adds TLS configuration and https serving support
* adds TLS peer leaf certificate middleware
* adds support for custom http middleware for rpc endpoints

**Tests**

* made sure that PeerTLSMiddleware doesn't break non-https servers
* tested middleware stack manually

**Invariants**

**Additional context**
Used by following implementation:
* https://github.com/ethereum-optimism/infrastructure-services/pull/5
