### PR TITLE
contracts-bedrock: more strict deploy checks

### DIFF
--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -93,7 +93,7 @@ const deployFn: DeployFunction = async (hre) => {
     systemConfigConfig: {
       owner: hre.deployConfig.finalSystemOwner,
       overhead: hre.deployConfig.gasPriceOracleOverhead,
-      scalar: hre.deployConfig.gasPriceOracleDecimals,
+      scalar: hre.deployConfig.gasPriceOracleScalar,
       batcherHash: hre.ethers.utils.hexZeroPad(
         hre.deployConfig.batchSenderAddress,
         32

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps.ts
@@ -144,7 +144,7 @@ const deployFn: DeployFunction = async (hre) => {
   if (
     needsProxyTransfer &&
     (await AddressManager.getAddress('OVM_L1CrossDomainMessenger')) !==
-    ethers.constants.AddressZero &&
+      ethers.constants.AddressZero &&
     (await L1CrossDomainMessenger.owner()) !== SystemDictator.address
   ) {
     if (isLiveDeployer) {
@@ -323,7 +323,7 @@ const deployFn: DeployFunction = async (hre) => {
     checks: async () => {
       assert(
         (await AddressManager.getAddress('OVM_L1CrossDomainMessenger')) ===
-        ethers.constants.AddressZero
+          ethers.constants.AddressZero
       )
     },
   })
@@ -359,7 +359,7 @@ const deployFn: DeployFunction = async (hre) => {
       for (const dead of deads) {
         assert(
           (await AddressManager.getAddress(dead)) ===
-          ethers.constants.AddressZero
+            ethers.constants.AddressZero
         )
       }
     },

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps.ts
@@ -527,7 +527,10 @@ const deployFn: DeployFunction = async (hre) => {
       await assertContractVariable(
         SystemConfigProxy,
         'batcherHash',
-        ethers.utils.hexZeroPad(hre.deployConfig.batchSenderAddress, 32)
+        ethers.utils.hexZeroPad(
+          hre.deployConfig.batchSenderAddress.toLowerCase(),
+          32
+        )
       )
 
       await assertContractVariable(


### PR DESCRIPTION
**Description**

Specifically strictly check the `SystemConfig` proxy so that the correct storage is set.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

