### PR TITLE
[op-node] Fix bug in batching retries

### DIFF
--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -73,6 +73,7 @@ func (ibc *IterativeBatchCall[K, V, O]) Reset() {
 		scheduled <- r
 	}
 
+	atomic.StoreUint32(&ibc.completed, 0)
 	ibc.requestsValues = requestsValues
 	ibc.scheduled = scheduled
 	if len(ibc.requestsKeys) == 0 {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
I noticed the sequencer would halt block production, spitting out the following "temp" message over and over which turned out not to be temporary at all:
```
ERROR[12-19|08:49:49.706] sequencing error      err="temp: failed to fetch L1 block info and receipts: receipt 20 has unexpected tx index 0"
```
The `20` index was curious as it is the default batch size for the batcher. After some debugging, found that the `completed` counter was increasing without being reset, which meant that, upon calling `Reset`, only the first batch would be retried, causing the remainder to be cached in an erroneous state.

This PR resets the `completed` counter to zero in the `Reset` method.

**Tests**
I tested the fix in a testnet environment, and checked that the reproducible error had gone away.
