### PR TITLE
fix(specs): Add white bg to `batch-deriv-*.svg` images

### DIFF
--- a/specs/assets/batch-deriv-chain.svg
+++ b/specs/assets/batch-deriv-chain.svg
@@ -1,3 +1,726 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="10662px" height="6124px" viewBox="-0.5 -0.5 10662 6124"><defs><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-75acff-1-ff66b3-1-e-0"><stop offset="0%" style="stop-color: rgb(117, 172, 255); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(255, 102, 179); stop-opacity: 1;"/></linearGradient><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-ffe563-1-8cffb6-1-e-0"><stop offset="0%" style="stop-color: rgb(255, 229, 99); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(140, 255, 182); stop-opacity: 1;"/></linearGradient><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-75acff-1-c683d2-1-e-0"><stop offset="0%" style="stop-color: rgb(117, 172, 255); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(198, 131, 210); stop-opacity: 1;"/></linearGradient><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-ffe563-1-d8ea7c-1-e-0"><stop offset="0%" style="stop-color: rgb(255, 229, 99); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(216, 234, 124); stop-opacity: 1;"/></linearGradient><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-d8ea7c-1-b0f79c-1-e-0"><stop offset="0%" style="stop-color: rgb(216, 234, 124); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(176, 247, 156); stop-opacity: 1;"/></linearGradient><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-c683d2-1-ff66b3-1-e-0"><stop offset="0%" style="stop-color: rgb(198, 131, 210); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(255, 102, 179); stop-opacity: 1;"/></linearGradient><linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-b0f79c-1-8cffb6-1-e-0"><stop offset="0%" style="stop-color: rgb(176, 247, 156); stop-opacity: 1;"/><stop offset="100%" style="stop-color: rgb(140, 255, 182); stop-opacity: 1;"/></linearGradient></defs><g><path d="M 3900 20 L 4300 20 L 4380 100 L 4380 500 L 3980 500 L 3900 420 L 3900 20 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 3900 20 L 4300 20 L 4380 100 L 3980 100 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 3900 20 L 3980 100 L 3980 500 L 3900 420 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 3980 500 L 3980 100 L 3900 20 M 3980 100 L 4380 100" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 111px; margin-left: 1006px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="1082" y="111" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100</text></switch></g><path d="M 7420 20 L 7820 20 L 7900 100 L 7900 500 L 7500 500 L 7420 420 L 7420 20 Z" fill="#ccffff" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 7420 20 L 7820 20 L 7900 100 L 7500 100 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 7420 20 L 7500 100 L 7500 500 L 7420 420 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 7500 500 L 7500 100 L 7420 20 M 7500 100 L 7900 100" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 111px; margin-left: 1886px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">102</div></div></div></foreignObject><text x="1962" y="111" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">102</text></switch></g><path d="M 5540 20 L 5940 20 L 6020 100 L 6020 500 L 5620 500 L 5540 420 L 5540 20 Z" fill="#ffff66" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 5540 20 L 5940 20 L 6020 100 L 5620 100 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 5540 20 L 5620 100 L 5620 500 L 5540 420 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 5620 500 L 5620 100 L 5540 20 M 5620 100 L 6020 100" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 111px; margin-left: 1416px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">101</div></div></div></foreignObject><text x="1492" y="111" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">101</text></switch></g><path d="M 3600 4420 L 4000 4420 L 4080 4500 L 4080 4900 L 3680 4900 L 3600 4820 L 3600 4420 Z" fill="#ccccff" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 3600 4420 L 4000 4420 L 4080 4500 L 3680 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 3600 4420 L 3680 4500 L 3680 4900 L 3600 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 3680 4900 L 3680 4500 L 3600 4420 M 3680 4500 L 4080 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 931px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">3</div></div></div></foreignObject><text x="1007" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">3</text></switch></g><path d="M 4240 4420 L 4640 4420 L 4720 4500 L 4720 4900 L 4320 4900 L 4240 4820 L 4240 4420 Z" fill="#75acff" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 4240 4420 L 4640 4420 L 4720 4500 L 4320 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 4240 4420 L 4320 4500 L 4320 4900 L 4240 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 4320 4900 L 4320 4500 L 4240 4420 M 4320 4500 L 4720 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1091px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">4</div></div></div></foreignObject><text x="1167" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">4</text></switch></g><path d="M 4880 4420 L 5280 4420 L 5360 4500 L 5360 4900 L 4960 4900 L 4880 4820 L 4880 4420 Z" fill="#c882d1" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 4880 4420 L 5280 4420 L 5360 4500 L 4960 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 4880 4420 L 4960 4500 L 4960 4900 L 4880 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 4960 4900 L 4960 4500 L 4880 4420 M 4960 4500 L 5360 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1251px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">5</div></div></div></foreignObject><text x="1327" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">5</text></switch></g><path d="M 5520 4420 L 5920 4420 L 6000 4500 L 6000 4900 L 5600 4900 L 5520 4820 L 5520 4420 Z" fill="#ff66b3" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 5520 4420 L 5920 4420 L 6000 4500 L 5600 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 5520 4420 L 5600 4500 L 5600 4900 L 5520 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 5600 4900 L 5600 4500 L 5520 4420 M 5600 4500 L 6000 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1411px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">6</div></div></div></foreignObject><text x="1487" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">6</text></switch></g><path d="M 6160 4420 L 6560 4420 L 6640 4500 L 6640 4900 L 6240 4900 L 6160 4820 L 6160 4420 Z" fill="#ffae52" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 6160 4420 L 6560 4420 L 6640 4500 L 6240 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 6160 4420 L 6240 4500 L 6240 4900 L 6160 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 6240 4900 L 6240 4500 L 6160 4420 M 6240 4500 L 6640 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1571px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">7</div></div></div></foreignObject><text x="1647" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">7</text></switch></g><path d="M 6800 4420 L 7200 4420 L 7280 4500 L 7280 4900 L 6880 4900 L 6800 4820 L 6800 4420 Z" fill="#ffffa1" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 6800 4420 L 7200 4420 L 7280 4500 L 6880 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 6800 4420 L 6880 4500 L 6880 4900 L 6800 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 6880 4900 L 6880 4500 L 6800 4420 M 6880 4500 L 7280 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1731px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">8</div></div></div></foreignObject><text x="1807" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">8</text></switch></g><rect x="3600" y="3940" width="480" height="240" rx="36" ry="36" fill="#ccccff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="4240" y="3940" width="480" height="240" rx="36" ry="36" fill="#75acff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="4880" y="3940" width="480" height="240" rx="36" ry="36" fill="#c882d1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="5520" y="3940" width="480" height="240" rx="36" ry="36" fill="#ff66b3" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="6160" y="3940" width="480" height="240" rx="36" ry="36" fill="#ffae52" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="6800" y="3940" width="480" height="240" rx="36" ry="36" fill="#ffffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="3600" y="3500" width="2400" height="240" fill="url(#mx-gradient-75acff-1-ff66b3-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 598px; height: 1px; padding-top: 905px; margin-left: 901px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 25px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; overflow-wrap: normal;">Compressed &amp; encoded batch data</div></div></div></foreignObject><text x="1200" y="912" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="25px" text-anchor="middle" font-style="italic">Compressed &amp; encoded batch data</text></switch></g><rect x="6080" y="3500" width="3040" height="240" fill="url(#mx-gradient-ffe563-1-8cffb6-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="3600" y="3060" width="1440" height="240" fill="url(#mx-gradient-75acff-1-c683d2-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 815px; margin-left: 907px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A0</div></div></div></foreignObject><text x="1239" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A0</text></switch></g><rect x="6080" y="3060" width="480" height="240" fill="url(#mx-gradient-ffe563-1-d8ea7c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 92px; height: 1px; padding-top: 815px; margin-left: 1527px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B0</div></div></div></foreignObject><text x="1619" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B0</text></switch></g><rect x="6640" y="3060" width="1440" height="240" fill="url(#mx-gradient-d8ea7c-1-b0f79c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 815px; margin-left: 1667px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B1</div></div></div></foreignObject><text x="1999" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B1</text></switch></g><rect x="9280" y="3060" width="320" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><path d="M 7440 4420 L 7840 4420 L 7920 4500 L 7920 4900 L 7520 4900 L 7440 4820 L 7440 4420 Z" fill="#c3ffa1" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 7440 4420 L 7840 4420 L 7920 4500 L 7520 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 7440 4420 L 7520 4500 L 7520 4900 L 7440 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 7520 4900 L 7520 4500 L 7440 4420 M 7520 4500 L 7920 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1891px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">9</div></div></div></foreignObject><text x="1967" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">9</text></switch></g><path d="M 8080 4420 L 8480 4420 L 8560 4500 L 8560 4900 L 8160 4900 L 8080 4820 L 8080 4420 Z" fill="#97ff63" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 8080 4420 L 8480 4420 L 8560 4500 L 8160 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 8080 4420 L 8160 4500 L 8160 4900 L 8080 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 8160 4900 L 8160 4500 L 8080 4420 M 8160 4500 L 8560 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 2051px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">10</div></div></div></foreignObject><text x="2127" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">10</text></switch></g><path d="M 8720 4420 L 9120 4420 L 9200 4500 L 9200 4900 L 8800 4900 L 8720 4820 L 8720 4420 Z" fill="#8cffb6" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 8720 4420 L 9120 4420 L 9200 4500 L 8800 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 8720 4420 L 8800 4500 L 8800 4900 L 8720 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 8800 4900 L 8800 4500 L 8720 4420 M 8800 4500 L 9200 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 2211px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">11</div></div></div></foreignObject><text x="2287" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">11</text></switch></g><path d="M 9360 4420 L 9760 4420 L 9840 4500 L 9840 4900 L 9440 4900 L 9360 4820 L 9360 4420 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 9360 4420 L 9760 4420 L 9840 4500 L 9440 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 9360 4420 L 9440 4500 L 9440 4900 L 9360 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 9440 4900 L 9440 4500 L 9360 4420 M 9440 4500 L 9840 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><rect x="7440" y="3940" width="480" height="240" rx="36" ry="36" fill="#c3ffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="8080" y="3940" width="480" height="240" rx="36" ry="36" fill="#97ff63" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="8720" y="3940" width="480" height="240" rx="36" ry="36" fill="#8cffb6" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="9360" y="3940" width="480" height="240" rx="36" ry="36" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="5120" y="3060" width="960" height="240" fill="url(#mx-gradient-c683d2-1-ff66b3-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 212px; height: 1px; padding-top: 815px; margin-left: 1287px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A1</div></div></div></foreignObject><text x="1499" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A1</text></switch></g><rect x="8160" y="3060" width="1120" height="240" fill="url(#mx-gradient-b0f79c-1-8cffb6-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 252px; height: 1px; padding-top: 815px; margin-left: 2047px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B2</div></div></div></foreignObject><text x="2299" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B2</text></switch></g><rect x="9200" y="3500" width="760" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="9840" y="3140" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10010" y="3140" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10170" y="3140" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10090" y="3580" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10260" y="3580" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10420" y="3580" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10010" y="4020" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10180" y="4020" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10340" y="4020" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="9960" y="4620" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10130" y="4620" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="10290" y="4620" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="2600" y="3060" width="760" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 795px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">L1 Transactions,<br /> ~128 KB each</div></div></div></foreignObject><text x="838" y="801" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">L1 Transactions,...</text></switch></g><rect x="2760" y="3500" width="600" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 905px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Channels,<br />with timeout</div></div></div></foreignObject><text x="838" y="911" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Channels,...</text></switch></g><rect x="2240" y="3940" width="1120" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1015px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Batches,<br />1 batch = 1 L2 block tx list</div></div></div></foreignObject><text x="838" y="1021" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Batches,...</text></switch></g><rect x="2240" y="4520" width="1120" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1160px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">L2 Blocks<br />(a.k.a. execution payloads)</div></div></div></foreignObject><text x="838" y="1166" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">L2 Blocks...</text></switch></g><rect x="3920" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 1080px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel A, Frame 0</div></div></div></foreignObject><text x="1080" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel A, Frame 0</text></switch></g><rect x="5140" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 1385px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel A, Frame 1</div></div></div></foreignObject><text x="1385" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel A, Frame 1</text></switch></g><rect x="6100" y="2740" width="480" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 715px; margin-left: 1585px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel B,<br /> Frame 0</div></div></div></foreignObject><text x="1585" y="721" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel B,...</text></switch></g><rect x="6960" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 1840px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel B, Frame 1</div></div></div></foreignObject><text x="1840" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel B, Frame 1</text></switch></g><rect x="8300" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 2175px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel B, Frame 2</div></div></div></foreignObject><text x="2175" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel B, Frame 2</text></switch></g><rect x="9410" y="2860" width="680" height="120" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 2438px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel C, etc...</div></div></div></foreignObject><text x="2438" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel C, etc...</text></switch></g><rect x="8700" y="40" width="880" height="440" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 65px; margin-left: 2177px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">L1 Blocks,<br />These may not be as<br />frequent/consistent<br /> as L2 blocks.</div></div></div></foreignObject><text x="2177" y="71" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" font-weight="bold">L1 Blocks,...</text></switch></g><rect x="8700" y="660" width="1000" height="320" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 205px; margin-left: 2177px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Actual inclusion on L1:<br />channels are valid<br />within a timeout</div></div></div></foreignObject><text x="2177" y="211" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" font-weight="bold">Actual inclusion on L1:...</text></switch></g><rect x="8700" y="1180" width="1600" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 325px; margin-left: 2177px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Channel B was seen first,<br />and will be decoded into batches first.</div></div></div></foreignObject><text x="2177" y="331" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" font-weight="bold">Channel B was seen first,...</text></switch></g><rect x="3600" y="2020" width="480" height="240" rx="36" ry="36" fill="#ffae52" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="4240" y="2020" width="480" height="240" rx="36" ry="36" fill="#ffffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="4880" y="2020" width="480" height="240" rx="36" ry="36" fill="#c3ffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="5520" y="2020" width="480" height="240" rx="36" ry="36" fill="#97ff63" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="6160" y="2020" width="480" height="240" rx="36" ry="36" fill="#8cffb6" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="6800" y="2020" width="480" height="240" rx="36" ry="36" fill="#ccccff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="7440" y="2020" width="480" height="240" rx="36" ry="36" fill="#75acff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="8080" y="2020" width="480" height="240" rx="36" ry="36" fill="#c882d1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="8720" y="2020" width="480" height="240" rx="36" ry="36" fill="#ff66b3" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="1920" y="1980" width="1440" height="440" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 550px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Batches can be buffered<br />for up to a full sequencing window<br />worth of L1 blocks<br />to get the L2 ordering back.</div></div></div></foreignObject><text x="838" y="556" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Batches can be buffered...</text></switch></g><rect x="9220" y="5660" width="520" height="280" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1450px; margin-left: 2433px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Time</div></div></div></foreignObject><text x="2433" y="1465" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px" text-anchor="end" font-weight="bold">Time</text></switch></g><path d="M 9842 5800 L 9842 5760 L 10490 5760 L 10490 5648.91 L 10638 5780 L 10490 5911.09 L 10490 5800 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><rect x="3540" y="700" width="1440" height="240" fill="#bfbfbf" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 358px; height: 1px; padding-top: 205px; margin-left: 886px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; overflow-wrap: normal;">older L2 data</div></div></div></foreignObject><text x="1065" y="214" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle" font-style="italic">older L2 data</text></switch></g><rect x="5260" y="700" width="1440" height="240" fill="url(#mx-gradient-d8ea7c-1-b0f79c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 225px; margin-left: 1322px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B1</div></div></div></foreignObject><text x="1654" y="225" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B1</text></switch></g><rect x="6220" y="1060" width="480" height="240" fill="url(#mx-gradient-ffe563-1-d8ea7c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 92px; height: 1px; padding-top: 315px; margin-left: 1562px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B0</div></div></div></foreignObject><text x="1654" y="315" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B0</text></switch></g><rect x="5260" y="1060" width="960" height="240" fill="url(#mx-gradient-c683d2-1-ff66b3-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 212px; height: 1px; padding-top: 315px; margin-left: 1322px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A1</div></div></div></foreignObject><text x="1534" y="315" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A1</text></switch></g><rect x="8060" y="700" width="320" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><rect x="6940" y="700" width="1120" height="240" fill="url(#mx-gradient-b0f79c-1-8cffb6-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 252px; height: 1px; padding-top: 225px; margin-left: 1742px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B2</div></div></div></foreignObject><text x="1994" y="225" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B2</text></switch></g><rect x="6940" y="1060" width="1440" height="240" fill="url(#mx-gradient-75acff-1-c683d2-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 315px; margin-left: 1742px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A0</div></div></div></foreignObject><text x="2074" y="315" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A0</text></switch></g><path d="M 6160 5420 L 6240 5180 L 6640 5180 L 6560 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1551px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-0</div></div></div></foreignObject><text x="1647" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-0</text></switch></g><path d="M 6800 5420 L 6880 5180 L 7280 5180 L 7200 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1711px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-1</div></div></div></foreignObject><text x="1807" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-1</text></switch></g><path d="M 7440 5420 L 7520 5180 L 7920 5180 L 7840 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1871px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-2</div></div></div></foreignObject><text x="1967" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-2</text></switch></g><path d="M 8080 5420 L 8160 5180 L 8560 5180 L 8480 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 2031px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-3</div></div></div></foreignObject><text x="2127" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-3</text></switch></g><path d="M 8720 5420 L 8800 5180 L 9200 5180 L 9120 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 2191px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-2</div></div></div></foreignObject><text x="2287" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-2</text></switch></g><path d="M 9360 5420 L 9440 5180 L 9840 5180 L 9760 5420 Z" fill="#ffff66" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 2351px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">101-0</div></div></div></foreignObject><text x="2447" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">101-0</text></switch></g><path d="M 5520 5420 L 5600 5180 L 6000 5180 L 5920 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1391px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-5</div></div></div></foreignObject><text x="1487" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-5</text></switch></g><path d="M 4880 5420 L 4960 5180 L 5360 5180 L 5280 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1231px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-4</div></div></div></foreignObject><text x="1327" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-4</text></switch></g><path d="M 4240 5420 L 4320 5180 L 4720 5180 L 4640 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1071px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-3</div></div></div></foreignObject><text x="1167" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-3</text></switch></g><path d="M 3600 5420 L 3680 5180 L 4080 5180 L 4000 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 911px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-2</div></div></div></foreignObject><text x="1007" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-2</text></switch></g><path d="M 2400 40 L 2800 40 L 2880 120 L 2880 520 L 2480 520 L 2400 440 L 2400 40 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><path d="M 2400 40 L 2800 40 L 2880 120 L 2480 120 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all"/><path d="M 2400 40 L 2480 120 L 2480 520 L 2400 440 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all"/><path d="M 2480 520 L 2480 120 L 2400 40 M 2480 120 L 2880 120" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 116px; margin-left: 631px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99</div></div></div></foreignObject><text x="707" y="116" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99</text></switch></g><rect x="2040" y="5180" width="1320" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1325px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Each L2 block has a tx with info<br />about the "origin" L1 block</div></div></div></foreignObject><text x="838" y="1331" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Each L2 block has a tx with info...</text></switch></g><rect x="2040" y="5580" width="1320" height="320" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1435px; margin-left: 838px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">The "sequence number" <br />helps differentiate between <br />L2 blocks with the same origin.</div></div></div></foreignObject><text x="838" y="1441" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">The "sequence number"...</text></switch></g><path d="M 3900 1100 Q 4080 1172 4260 1100 Q 4440 1028 4620 1100 L 4620 1300 Q 4440 1228 4260 1300 Q 4080 1372 3900 1300 L 3900 1100 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 300px; margin-left: 976px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div></div></div></foreignObject><text x="1065" y="309" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text></switch></g><path d="M 3920 1380 Q 4100 1452 4280 1380 Q 4460 1308 4640 1380 L 4640 1580 Q 4460 1508 4280 1580 Q 4100 1652 3920 1580 L 3920 1380 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 370px; margin-left: 981px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div></div></div></foreignObject><text x="1070" y="379" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text></switch></g><rect x="2180" y="1180" width="1160" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 325px; margin-left: 833px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Deposits are L1 log events,<br />parsed from EVM receipts</div></div></div></foreignObject><text x="833" y="331" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Deposits are L1 log events,...</text></switch></g><path d="M 6100 5560 Q 6280 5632 6460 5560 Q 6640 5488 6820 5560 L 6820 5760 Q 6640 5688 6460 5760 Q 6280 5832 6100 5760 L 6100 5560 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 1415px; margin-left: 1526px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div></div></div></foreignObject><text x="1615" y="1424" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text></switch></g><path d="M 6120 5840 Q 6300 5912 6480 5840 Q 6660 5768 6840 5840 L 6840 6040 Q 6660 5968 6480 6040 Q 6300 6112 6120 6040 L 6120 5840 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 1485px; margin-left: 1531px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div></div></div></foreignObject><text x="1620" y="1494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text></switch></g><rect x="4980" y="5660" width="1000" height="440" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1470px; margin-left: 1493px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Deposits get included<br />the first L2 block that<br />adopts the L1 origin the<br />deposits were made in.</div></div></div></foreignObject><text x="1493" y="1476" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Deposits get included...</text></switch></g><rect x="20" y="2300" width="2560" height="640" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 655px; margin-left: 7px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Security types on L2:<br />- "unsafe": not submitted on L1<br />- "safe": is confirmed on L1<br />- "finalized": fully derived from finalized L1 data</div></div></div></foreignObject><text x="7" y="664" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px">Security types on L2:...</text></switch></g><rect x="60" y="3140" width="2000" height="640" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 865px; margin-left: 17px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Security types on L1:<br />- "unsafe": very new<br />- "safe": decent attestation ratio<br />- "finalized": with FFG finality gadget</div></div></div></foreignObject><text x="17" y="874" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px">Security types on L1:...</text></switch></g></g><switch><g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/><a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank"><text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text></a></switch></svg>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5331 3062" width="5331" height="3062">
+	<title>batch-deriv-chain-svg</title>
+	<defs>
+		<image  width="5331" height="3062" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAFNMAAAv2AQMAAABqgMOsAAAAAXNSR0IB2cksfwAAAANQTFRF////p8QbyAAAB9RJREFUeJztwQEBAAAAgiD/r25IQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAArwY3uQABEP0VtwAAAABJRU5ErkJggg=="/>
+		<linearGradient id="g1" x1="1800.5" y1="1750.5" x2="1441800.5" y2="1750.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#75acff"/>
+			<stop offset="1" stop-color="#ff66b3"/>
+		</linearGradient>
+		<linearGradient id="g2" x1="3040.5" y1="1750.5" x2="2313440.5" y2="1750.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#ffe563"/>
+			<stop offset="1" stop-color="#8cffb6"/>
+		</linearGradient>
+		<linearGradient id="g3" x1="1800.5" y1="1530.5" x2="520200.5" y2="1530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#75acff"/>
+			<stop offset="1" stop-color="#c683d2"/>
+		</linearGradient>
+		<linearGradient id="g4" x1="3040.5" y1="1530.5" x2="60640.5" y2="1530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#ffe563"/>
+			<stop offset="1" stop-color="#d8ea7c"/>
+		</linearGradient>
+		<linearGradient id="g5" x1="3320.5" y1="1530.5" x2="521720.5" y2="1530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#d8ea7c"/>
+			<stop offset="1" stop-color="#b0f79c"/>
+		</linearGradient>
+		<linearGradient id="g6" x1="2560.5" y1="1530.5" x2="232960.5" y2="1530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#c683d2"/>
+			<stop offset="1" stop-color="#ff66b3"/>
+		</linearGradient>
+		<linearGradient id="g7" x1="4080.5" y1="1530.5" x2="317680.5" y2="1530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#b0f79c"/>
+			<stop offset="1" stop-color="#8cffb6"/>
+		</linearGradient>
+		<linearGradient id="g8" x1="2630.5" y1="350.5" x2="521030.5" y2="350.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#d8ea7c"/>
+			<stop offset="1" stop-color="#b0f79c"/>
+		</linearGradient>
+		<linearGradient id="g9" x1="3110.5" y1="530.5" x2="60710.5" y2="530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#ffe563"/>
+			<stop offset="1" stop-color="#d8ea7c"/>
+		</linearGradient>
+		<linearGradient id="g10" x1="2630.5" y1="530.5" x2="233030.5" y2="530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#c683d2"/>
+			<stop offset="1" stop-color="#ff66b3"/>
+		</linearGradient>
+		<linearGradient id="g11" x1="3470.5" y1="350.5" x2="317070.5" y2="350.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#b0f79c"/>
+			<stop offset="1" stop-color="#8cffb6"/>
+		</linearGradient>
+		<linearGradient id="g12" x1="3470.5" y1="530.5" x2="521870.5" y2="530.5" gradientUnits="userSpaceOnUse">
+			<stop offset="0" stop-color="#75acff"/>
+			<stop offset="1" stop-color="#c683d2"/>
+		</linearGradient>
+	</defs>
+	<style>
+		tspan { white-space:pre } 
+		.s0 { fill: #ff0080;stroke: #000000;stroke-width: 2 } 
+		.s1 { opacity: .1;fill: #000000 } 
+		.s2 { fill: none;stroke: #000000;stroke-width: 2 } 
+		.t3 { font-size: 30px;fill: #000000;font-family: "Helvetica" } 
+		.s4 { fill: #ccffff;stroke: #000000;stroke-width: 2 } 
+		.s5 { fill: #ffff66;stroke: #000000;stroke-width: 2 } 
+		.s6 { fill: #ccccff;stroke: #000000;stroke-width: 2 } 
+		.s7 { fill: #75acff;stroke: #000000;stroke-width: 2 } 
+		.s8 { fill: #c882d1;stroke: #000000;stroke-width: 2 } 
+		.s9 { fill: #ff66b3;stroke: #000000;stroke-width: 2 } 
+		.s10 { fill: #ffae52;stroke: #000000;stroke-width: 2 } 
+		.s11 { fill: #ffffa1;stroke: #000000;stroke-width: 2 } 
+		.s12 { fill: url(#g1);stroke: #000000;stroke-width: 2 } 
+		.t13 { font-size: 25px;fill: #000000;font-family: "Helvetica" } 
+		.s14 { fill: url(#g2);stroke: #000000;stroke-width: 2 } 
+		.s15 { fill: url(#g3);stroke: #000000;stroke-width: 2 } 
+		.s16 { fill: url(#g4);stroke: #000000;stroke-width: 2 } 
+		.s17 { fill: url(#g5);stroke: #000000;stroke-width: 2 } 
+		.s18 { fill: #ffffff;stroke: #000000;stroke-width: 2 } 
+		.s19 { fill: #c3ffa1;stroke: #000000;stroke-width: 2 } 
+		.s20 { fill: #97ff63;stroke: #000000;stroke-width: 2 } 
+		.s21 { fill: #8cffb6;stroke: #000000;stroke-width: 2 } 
+		.s22 { fill: url(#g6);stroke: #000000;stroke-width: 2 } 
+		.s23 { fill: url(#g7);stroke: #000000;stroke-width: 2 } 
+		.s24 { fill: #000000;stroke: #000000;stroke-width: 2 } 
+		.s25 { fill: none } 
+		.t26 { font-size: 21px;fill: #000000;font-family: "Helvetica" } 
+		.t27 { font-size: 50px;fill: #000000;font-family: "Helvetica" } 
+		.s28 { fill: #bfbfbf;stroke: #000000;stroke-width: 2 } 
+		.s29 { fill: url(#g8);stroke: #000000;stroke-width: 2 } 
+		.s30 { fill: url(#g9);stroke: #000000;stroke-width: 2 } 
+		.s31 { fill: url(#g10);stroke: #000000;stroke-width: 2 } 
+		.s32 { fill: url(#g11);stroke: #000000;stroke-width: 2 } 
+		.s33 { fill: url(#g12);stroke: #000000;stroke-width: 2 } 
+		.s34 { fill: #e0e0e0;stroke: #000000;stroke-width: 2 } 
+		.s35 { fill: #fff2cc;stroke: #d6b656;stroke-width: 2 } 
+		.t36 { font-size: 10px;fill: #000000;font-weight: 400;font-family: "LiberationSans", "Liberation Sans" } 
+	</style>
+	<g id="Layer">
+		<use id="Layer 1" href="#img1" x="0" y="0"/>
+		<path id="Layer" class="s0" d="m1950.5 10.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m1950.5 10.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m1950.5 10.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m1950.5 10.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,2164.25,222.25)" >
+					<tspan x="-57.3" y="0" class="t3">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s4" d="m3710.5 10.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m3710.5 10.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m3710.5 10.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m3710.5 10.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="102" style="transform: matrix(2,0,0,2,3924.25,222.25)" >
+					<tspan x="-57.3" y="0" class="t3">102
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s5" d="m2770.5 10.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m2770.5 10.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m2770.5 10.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m2770.5 10.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="101" style="transform: matrix(2,0,0,2,2984.25,222.25)" >
+					<tspan x="-57.3" y="0" class="t3">101
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s6" d="m1800.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m1800.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m1800.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m1800.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="3" style="transform: matrix(2,0,0,2,2014.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">3
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s7" d="m2120.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m2120.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m2120.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m2120.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="4" style="transform: matrix(2,0,0,2,2334.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">4
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s8" d="m2440.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m2440.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m2440.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m2440.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="5" style="transform: matrix(2,0,0,2,2654.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">5
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m2760.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m2760.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m2760.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m2760.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="6" style="transform: matrix(2,0,0,2,2974.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">6
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s10" d="m3080.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m3080.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m3080.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m3080.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="7" style="transform: matrix(2,0,0,2,3294.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">7
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s11" d="m3400.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m3400.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m3400.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m3400.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="8" style="transform: matrix(2,0,0,2,3614.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">8
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s6" d="m1800.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s7" d="m2120.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s8" d="m2440.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s9" d="m2760.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s10" d="m3080.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s11" d="m3400.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s12" d="m1800.5 1750.5h1200v120h-1200z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Compressed &amp; encoded batch data" style="transform: matrix(2,0,0,2,2400.25,1824.25)" >
+					<tspan x="-220.5" y="0" class="t13">Compressed &amp; encoded batch data
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s14" d="m3040.5 1750.5h1520v120h-1520z"/>
+		<path id="Layer" class="s15" d="m1800.5 1530.5h720v120h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="A0" style="transform: matrix(2,0,0,2,2478.25,1630.25)" >
+					<tspan x="-39.6" y="0" class="t3">A0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s16" d="m3040.5 1530.5h240v120h-240z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="B0" style="transform: matrix(2,0,0,2,3238.25,1630.25)" >
+					<tspan x="-39.7" y="0" class="t3">B0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s17" d="m3320.5 1530.5h720v120h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="B1" style="transform: matrix(2,0,0,2,3998.25,1630.25)" >
+					<tspan x="-39.7" y="0" class="t3">B1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s18" d="m4640.5 1530.5h160v120h-160z"/>
+		<path id="Layer" class="s19" d="m3720.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m3720.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m3720.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m3720.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="9" style="transform: matrix(2,0,0,2,3934.25,2422.25)" >
+					<tspan x="-19.1" y="0" class="t3">9
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s20" d="m4040.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m4040.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m4040.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m4040.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="10" style="transform: matrix(2,0,0,2,4254.25,2422.25)" >
+					<tspan x="-38.2" y="0" class="t3">10
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s21" d="m4360.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m4360.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m4360.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m4360.5 2210.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="11" style="transform: matrix(2,0,0,2,4574.25,2422.25)" >
+					<tspan x="-38.2" y="0" class="t3">11
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s18" d="m4680.5 2210.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m4680.5 2210.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m4680.5 2210.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m4680.5 2210.5l40 40v200m0-200h200"/>
+		<path id="Layer" class="s19" d="m3720.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s20" d="m4040.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s21" d="m4360.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s18" d="m4680.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s22" d="m2560.5 1530.5h480v120h-480z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="A1" style="transform: matrix(2,0,0,2,2998.25,1630.25)" >
+					<tspan x="-39.6" y="0" class="t3">A1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s23" d="m4080.5 1530.5h560v120h-560z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="B2" style="transform: matrix(2,0,0,2,4598.25,1630.25)" >
+					<tspan x="-39.7" y="0" class="t3">B2
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s18" d="m4600.5 1750.5h380v120h-380z"/>
+		<path id="Layer" class="s24" d="m4920.5 1570.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5005.5 1570.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5085.5 1570.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5045.5 1790.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5130.5 1790.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5210.5 1790.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5005.5 2010.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5090.5 2010.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5170.5 2010.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m4980.5 2310.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5065.5 2310.5h30v40h-30z"/>
+		<path id="Layer" class="s24" d="m5145.5 2310.5h30v40h-30z"/>
+		<path id="Layer" class="s25" d="m1300.5 1530.5h380v120h-380z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Transactions,..." style="transform: matrix(2,0,0,2,1676.25,1602.25)" >
+					<tspan x="-189.5" y="0" class="t26">L1 Transactions,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1380.5 1750.5h300v120h-300z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channels,..." style="transform: matrix(2,0,0,2,1676.25,1822.25)" >
+					<tspan x="-123.9" y="0" class="t26">Channels,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1120.5 1970.5h560v120h-560z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Batches,..." style="transform: matrix(2,0,0,2,1676.25,2042.25)" >
+					<tspan x="-110.9" y="0" class="t26">Batches,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1120.5 2260.5h560v120h-560z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L2 Blocks..." style="transform: matrix(2,0,0,2,1676.25,2332.25)" >
+					<tspan x="-119.5" y="0" class="t26">L2 Blocks...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1960.5 1430.5h400v60h-400z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel A, Frame 0" style="transform: matrix(2,0,0,2,2160.25,1472.25)" >
+					<tspan x="-103" y="0" class="t26">Channel A, Frame 0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m2570.5 1430.5h400v60h-400z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel A, Frame 1" style="transform: matrix(2,0,0,2,2770.25,1472.25)" >
+					<tspan x="-103" y="0" class="t26">Channel A, Frame 1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m3050.5 1370.5h240v120h-240z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel B,..." style="transform: matrix(2,0,0,2,3170.25,1442.25)" >
+					<tspan x="-67" y="0" class="t26">Channel B,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m3480.5 1430.5h400v60h-400z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel B, Frame 1" style="transform: matrix(2,0,0,2,3680.25,1472.25)" >
+					<tspan x="-103.1" y="0" class="t26">Channel B, Frame 1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m4150.5 1430.5h400v60h-400z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel B, Frame 2" style="transform: matrix(2,0,0,2,4350.25,1472.25)" >
+					<tspan x="-103.1" y="0" class="t26">Channel B, Frame 2
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m4705.5 1430.5h340v60h-340z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel C, etc..." style="transform: matrix(2,0,0,2,4876.25,1472.25)" >
+					<tspan x="-86.8" y="0" class="t26">Channel C, etc...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m4350.5 20.5h440v220h-440z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Blocks,..." style="transform: matrix(2,0,0,2,4354.25,142.25)" >
+					<tspan x="0" y="0" class="t26">L1 Blocks,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m4350.5 330.5h500v160h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Actual inclusion on L1:..." style="transform: matrix(2,0,0,2,4354.25,422.25)" >
+					<tspan x="0" y="0" class="t26">Actual inclusion on L1:...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m4350.5 590.5h800v120h-800z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel B was seen first,..." style="transform: matrix(2,0,0,2,4354.25,662.25)" >
+					<tspan x="0" y="0" class="t26">Channel B was seen first,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s10" d="m1800.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s11" d="m2120.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s19" d="m2440.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s20" d="m2760.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s21" d="m3080.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s6" d="m3400.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s7" d="m3720.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s8" d="m4040.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s9" d="m4360.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
+		<path id="Layer" class="s25" d="m960.5 990.5h720v220h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Batches can be buffered..." style="transform: matrix(2,0,0,2,1676.25,1112.25)" >
+					<tspan x="-276.7" y="0" class="t26">Batches can be buffered...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m4610.5 2830.5h260v140h-260z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Time" style="transform: matrix(2,0,0,2,4866.25,2930.25)" >
+					<tspan x="-122.4" y="0" class="t27">Time
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s24" d="m4921.5 2900.5v-20h324v-55.5l74 65.5-74 65.5v-55.5z"/>
+		<path id="Layer" class="s28" d="m1770.5 350.5h720v120h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="older L2 data" style="transform: matrix(2,0,0,2,2130.25,428.25)" >
+					<tspan x="-99.5" y="0" class="t3">older L2 data
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s29" d="m2630.5 350.5h720v120h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="B1" style="transform: matrix(2,0,0,2,3308.25,450.25)" >
+					<tspan x="-39.7" y="0" class="t3">B1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s30" d="m3110.5 530.5h240v120h-240z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="B0" style="transform: matrix(2,0,0,2,3308.25,630.25)" >
+					<tspan x="-39.7" y="0" class="t3">B0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s31" d="m2630.5 530.5h480v120h-480z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="A1" style="transform: matrix(2,0,0,2,3068.25,630.25)" >
+					<tspan x="-39.6" y="0" class="t3">A1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s18" d="m4030.5 350.5h160v120h-160z"/>
+		<path id="Layer" class="s32" d="m3470.5 350.5h560v120h-560z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="B2" style="transform: matrix(2,0,0,2,3988.25,450.25)" >
+					<tspan x="-39.7" y="0" class="t3">B2
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s33" d="m3470.5 530.5h720v120h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="A0" style="transform: matrix(2,0,0,2,4148.25,630.25)" >
+					<tspan x="-39.6" y="0" class="t3">A0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m3080.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100-0" style="transform: matrix(2,0,0,2,3294.25,2682.25)" >
+					<tspan x="-87.2" y="0" class="t3">100-0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m3400.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100-1" style="transform: matrix(2,0,0,2,3614.25,2682.25)" >
+					<tspan x="-87.2" y="0" class="t3">100-1
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m3720.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100-2" style="transform: matrix(2,0,0,2,3934.25,2682.25)" >
+					<tspan x="-87.2" y="0" class="t3">100-2
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m4040.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100-3" style="transform: matrix(2,0,0,2,4254.25,2682.25)" >
+					<tspan x="-87.2" y="0" class="t3">100-3
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m4360.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100-2" style="transform: matrix(2,0,0,2,4574.25,2682.25)" >
+					<tspan x="-87.2" y="0" class="t3">100-2
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s5" d="m4680.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="101-0" style="transform: matrix(2,0,0,2,4894.25,2682.25)" >
+					<tspan x="-87.2" y="0" class="t3">101-0
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s34" d="m2760.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="99-5" style="transform: matrix(2,0,0,2,2974.25,2682.25)" >
+					<tspan x="-68.1" y="0" class="t3">99-5
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s34" d="m2440.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="99-4" style="transform: matrix(2,0,0,2,2654.25,2682.25)" >
+					<tspan x="-68.1" y="0" class="t3">99-4
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s34" d="m2120.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="99-3" style="transform: matrix(2,0,0,2,2334.25,2682.25)" >
+					<tspan x="-68.1" y="0" class="t3">99-3
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s34" d="m1800.5 2710.5l40-120h200l-40 120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="99-2" style="transform: matrix(2,0,0,2,2014.25,2682.25)" >
+					<tspan x="-68.1" y="0" class="t3">99-2
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s34" d="m1200.5 20.5h200l40 40v200h-200l-40-40z"/>
+		<path id="Layer" class="s1" d="m1200.5 20.5h200l40 40h-200z"/>
+		<path id="Layer" class="s1" d="m1200.5 20.5l40 40v200l-40-40z"/>
+		<path id="Layer" class="s2" d="m1200.5 20.5l40 40v200m0-200h200"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="99" style="transform: matrix(2,0,0,2,1414.25,232.25)" >
+					<tspan x="-38.2" y="0" class="t3">99
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1020.5 2590.5h660v120h-660z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Each L2 block has a tx with info..." style="transform: matrix(2,0,0,2,1676.25,2662.25)" >
+					<tspan x="-352.7" y="0" class="t26">Each L2 block has a tx with info...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1020.5 2790.5h660v160h-660z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="The &quot;sequence number&quot;..." style="transform: matrix(2,0,0,2,1676.25,2882.25)" >
+					<tspan x="-274.9" y="0" class="t26">The &quot;sequence number&quot;...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s35" d="m1950.5 550.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="deposit" style="transform: matrix(2,0,0,2,2130.25,618.25)" >
+					<tspan x="-55.3" y="0" class="t3">deposit
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s35" d="m1960.5 690.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="deposit" style="transform: matrix(2,0,0,2,2140.25,758.25)" >
+					<tspan x="-55.3" y="0" class="t3">deposit
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m1090.5 590.5h580v120h-580z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Deposits are L1 log events,..." style="transform: matrix(2,0,0,2,1666.25,662.25)" >
+					<tspan x="-306.4" y="0" class="t26">Deposits are L1 log events,...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s35" d="m3050.5 2780.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="deposit" style="transform: matrix(2,0,0,2,3230.25,2848.25)" >
+					<tspan x="-55.3" y="0" class="t3">deposit
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s35" d="m3060.5 2920.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="deposit" style="transform: matrix(2,0,0,2,3240.25,2988.25)" >
+					<tspan x="-55.3" y="0" class="t3">deposit
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m2490.5 2830.5h500v220h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Deposits get included..." style="transform: matrix(2,0,0,2,2986.25,2952.25)" >
+					<tspan x="-248.5" y="0" class="t26">Deposits get included...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m10.5 1150.5h1280v320h-1280z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Security types on L2:..." style="transform: matrix(2,0,0,2,14.25,1328.25)" >
+					<tspan x="0" y="0" class="t3">Security types on L2:...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s25" d="m30.5 1570.5h1000v320h-1000z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Security types on L1:..." style="transform: matrix(2,0,0,2,34.25,1748.25)" >
+					<tspan x="0" y="0" class="t3">Security types on L1:...
+</tspan>
+				</text>
+			</g>
+		</g>
+	</g>
+	<g id="Layer">
+		<g id="Layer">
+		</g>
+		<g id="Layer">
+			<text id="Text is not SVG - cannot display" style="transform: matrix(.5,0,0,.5,25.5,48)" >
+				<tspan x="-70.9" y="0" class="t36">Text is not SVG - cannot display
+</tspan>
+			</text>
+		</g>
+	</g>
+</svg>

--- a/specs/assets/batch-deriv-chain.svg
+++ b/specs/assets/batch-deriv-chain.svg
@@ -1,726 +1,839 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5331 3062" width="5331" height="3062">
-	<title>batch-deriv-chain-svg</title>
-	<defs>
-		<image  width="5331" height="3062" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAFNMAAAv2AQMAAABqgMOsAAAAAXNSR0IB2cksfwAAAANQTFRF////p8QbyAAAB9RJREFUeJztwQEBAAAAgiD/r25IQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAArwY3uQABEP0VtwAAAABJRU5ErkJggg=="/>
-		<linearGradient id="g1" x1="1800.5" y1="1750.5" x2="1441800.5" y2="1750.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#75acff"/>
-			<stop offset="1" stop-color="#ff66b3"/>
-		</linearGradient>
-		<linearGradient id="g2" x1="3040.5" y1="1750.5" x2="2313440.5" y2="1750.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#ffe563"/>
-			<stop offset="1" stop-color="#8cffb6"/>
-		</linearGradient>
-		<linearGradient id="g3" x1="1800.5" y1="1530.5" x2="520200.5" y2="1530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#75acff"/>
-			<stop offset="1" stop-color="#c683d2"/>
-		</linearGradient>
-		<linearGradient id="g4" x1="3040.5" y1="1530.5" x2="60640.5" y2="1530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#ffe563"/>
-			<stop offset="1" stop-color="#d8ea7c"/>
-		</linearGradient>
-		<linearGradient id="g5" x1="3320.5" y1="1530.5" x2="521720.5" y2="1530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#d8ea7c"/>
-			<stop offset="1" stop-color="#b0f79c"/>
-		</linearGradient>
-		<linearGradient id="g6" x1="2560.5" y1="1530.5" x2="232960.5" y2="1530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#c683d2"/>
-			<stop offset="1" stop-color="#ff66b3"/>
-		</linearGradient>
-		<linearGradient id="g7" x1="4080.5" y1="1530.5" x2="317680.5" y2="1530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#b0f79c"/>
-			<stop offset="1" stop-color="#8cffb6"/>
-		</linearGradient>
-		<linearGradient id="g8" x1="2630.5" y1="350.5" x2="521030.5" y2="350.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#d8ea7c"/>
-			<stop offset="1" stop-color="#b0f79c"/>
-		</linearGradient>
-		<linearGradient id="g9" x1="3110.5" y1="530.5" x2="60710.5" y2="530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#ffe563"/>
-			<stop offset="1" stop-color="#d8ea7c"/>
-		</linearGradient>
-		<linearGradient id="g10" x1="2630.5" y1="530.5" x2="233030.5" y2="530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#c683d2"/>
-			<stop offset="1" stop-color="#ff66b3"/>
-		</linearGradient>
-		<linearGradient id="g11" x1="3470.5" y1="350.5" x2="317070.5" y2="350.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#b0f79c"/>
-			<stop offset="1" stop-color="#8cffb6"/>
-		</linearGradient>
-		<linearGradient id="g12" x1="3470.5" y1="530.5" x2="521870.5" y2="530.5" gradientUnits="userSpaceOnUse">
-			<stop offset="0" stop-color="#75acff"/>
-			<stop offset="1" stop-color="#c683d2"/>
-		</linearGradient>
-	</defs>
-	<style>
-		tspan { white-space:pre } 
-		.s0 { fill: #ff0080;stroke: #000000;stroke-width: 2 } 
-		.s1 { opacity: .1;fill: #000000 } 
-		.s2 { fill: none;stroke: #000000;stroke-width: 2 } 
-		.t3 { font-size: 30px;fill: #000000;font-family: "Helvetica" } 
-		.s4 { fill: #ccffff;stroke: #000000;stroke-width: 2 } 
-		.s5 { fill: #ffff66;stroke: #000000;stroke-width: 2 } 
-		.s6 { fill: #ccccff;stroke: #000000;stroke-width: 2 } 
-		.s7 { fill: #75acff;stroke: #000000;stroke-width: 2 } 
-		.s8 { fill: #c882d1;stroke: #000000;stroke-width: 2 } 
-		.s9 { fill: #ff66b3;stroke: #000000;stroke-width: 2 } 
-		.s10 { fill: #ffae52;stroke: #000000;stroke-width: 2 } 
-		.s11 { fill: #ffffa1;stroke: #000000;stroke-width: 2 } 
-		.s12 { fill: url(#g1);stroke: #000000;stroke-width: 2 } 
-		.t13 { font-size: 25px;fill: #000000;font-family: "Helvetica" } 
-		.s14 { fill: url(#g2);stroke: #000000;stroke-width: 2 } 
-		.s15 { fill: url(#g3);stroke: #000000;stroke-width: 2 } 
-		.s16 { fill: url(#g4);stroke: #000000;stroke-width: 2 } 
-		.s17 { fill: url(#g5);stroke: #000000;stroke-width: 2 } 
-		.s18 { fill: #ffffff;stroke: #000000;stroke-width: 2 } 
-		.s19 { fill: #c3ffa1;stroke: #000000;stroke-width: 2 } 
-		.s20 { fill: #97ff63;stroke: #000000;stroke-width: 2 } 
-		.s21 { fill: #8cffb6;stroke: #000000;stroke-width: 2 } 
-		.s22 { fill: url(#g6);stroke: #000000;stroke-width: 2 } 
-		.s23 { fill: url(#g7);stroke: #000000;stroke-width: 2 } 
-		.s24 { fill: #000000;stroke: #000000;stroke-width: 2 } 
-		.s25 { fill: none } 
-		.t26 { font-size: 21px;fill: #000000;font-family: "Helvetica" } 
-		.t27 { font-size: 50px;fill: #000000;font-family: "Helvetica" } 
-		.s28 { fill: #bfbfbf;stroke: #000000;stroke-width: 2 } 
-		.s29 { fill: url(#g8);stroke: #000000;stroke-width: 2 } 
-		.s30 { fill: url(#g9);stroke: #000000;stroke-width: 2 } 
-		.s31 { fill: url(#g10);stroke: #000000;stroke-width: 2 } 
-		.s32 { fill: url(#g11);stroke: #000000;stroke-width: 2 } 
-		.s33 { fill: url(#g12);stroke: #000000;stroke-width: 2 } 
-		.s34 { fill: #e0e0e0;stroke: #000000;stroke-width: 2 } 
-		.s35 { fill: #fff2cc;stroke: #d6b656;stroke-width: 2 } 
-		.t36 { font-size: 10px;fill: #000000;font-weight: 400;font-family: "LiberationSans", "Liberation Sans" } 
-	</style>
-	<g id="Layer">
-		<use id="Layer 1" href="#img1" x="0" y="0"/>
-		<path id="Layer" class="s0" d="m1950.5 10.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m1950.5 10.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m1950.5 10.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m1950.5 10.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,2164.25,222.25)" >
-					<tspan x="-57.3" y="0" class="t3">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s4" d="m3710.5 10.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m3710.5 10.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m3710.5 10.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m3710.5 10.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="102" style="transform: matrix(2,0,0,2,3924.25,222.25)" >
-					<tspan x="-57.3" y="0" class="t3">102
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s5" d="m2770.5 10.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m2770.5 10.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m2770.5 10.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m2770.5 10.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="101" style="transform: matrix(2,0,0,2,2984.25,222.25)" >
-					<tspan x="-57.3" y="0" class="t3">101
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s6" d="m1800.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m1800.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m1800.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m1800.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="3" style="transform: matrix(2,0,0,2,2014.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">3
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s7" d="m2120.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m2120.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m2120.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m2120.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="4" style="transform: matrix(2,0,0,2,2334.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">4
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s8" d="m2440.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m2440.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m2440.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m2440.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="5" style="transform: matrix(2,0,0,2,2654.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">5
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m2760.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m2760.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m2760.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m2760.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="6" style="transform: matrix(2,0,0,2,2974.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">6
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s10" d="m3080.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m3080.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m3080.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m3080.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="7" style="transform: matrix(2,0,0,2,3294.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">7
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s11" d="m3400.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m3400.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m3400.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m3400.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="8" style="transform: matrix(2,0,0,2,3614.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">8
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s6" d="m1800.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s7" d="m2120.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s8" d="m2440.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s9" d="m2760.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s10" d="m3080.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s11" d="m3400.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s12" d="m1800.5 1750.5h1200v120h-1200z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Compressed &amp; encoded batch data" style="transform: matrix(2,0,0,2,2400.25,1824.25)" >
-					<tspan x="-220.5" y="0" class="t13">Compressed &amp; encoded batch data
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s14" d="m3040.5 1750.5h1520v120h-1520z"/>
-		<path id="Layer" class="s15" d="m1800.5 1530.5h720v120h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="A0" style="transform: matrix(2,0,0,2,2478.25,1630.25)" >
-					<tspan x="-39.6" y="0" class="t3">A0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s16" d="m3040.5 1530.5h240v120h-240z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="B0" style="transform: matrix(2,0,0,2,3238.25,1630.25)" >
-					<tspan x="-39.7" y="0" class="t3">B0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s17" d="m3320.5 1530.5h720v120h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="B1" style="transform: matrix(2,0,0,2,3998.25,1630.25)" >
-					<tspan x="-39.7" y="0" class="t3">B1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s18" d="m4640.5 1530.5h160v120h-160z"/>
-		<path id="Layer" class="s19" d="m3720.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m3720.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m3720.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m3720.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="9" style="transform: matrix(2,0,0,2,3934.25,2422.25)" >
-					<tspan x="-19.1" y="0" class="t3">9
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s20" d="m4040.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m4040.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m4040.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m4040.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="10" style="transform: matrix(2,0,0,2,4254.25,2422.25)" >
-					<tspan x="-38.2" y="0" class="t3">10
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s21" d="m4360.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m4360.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m4360.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m4360.5 2210.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="11" style="transform: matrix(2,0,0,2,4574.25,2422.25)" >
-					<tspan x="-38.2" y="0" class="t3">11
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s18" d="m4680.5 2210.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m4680.5 2210.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m4680.5 2210.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m4680.5 2210.5l40 40v200m0-200h200"/>
-		<path id="Layer" class="s19" d="m3720.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s20" d="m4040.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s21" d="m4360.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s18" d="m4680.5 1988.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s22" d="m2560.5 1530.5h480v120h-480z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="A1" style="transform: matrix(2,0,0,2,2998.25,1630.25)" >
-					<tspan x="-39.6" y="0" class="t3">A1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s23" d="m4080.5 1530.5h560v120h-560z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="B2" style="transform: matrix(2,0,0,2,4598.25,1630.25)" >
-					<tspan x="-39.7" y="0" class="t3">B2
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s18" d="m4600.5 1750.5h380v120h-380z"/>
-		<path id="Layer" class="s24" d="m4920.5 1570.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5005.5 1570.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5085.5 1570.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5045.5 1790.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5130.5 1790.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5210.5 1790.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5005.5 2010.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5090.5 2010.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5170.5 2010.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m4980.5 2310.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5065.5 2310.5h30v40h-30z"/>
-		<path id="Layer" class="s24" d="m5145.5 2310.5h30v40h-30z"/>
-		<path id="Layer" class="s25" d="m1300.5 1530.5h380v120h-380z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Transactions,..." style="transform: matrix(2,0,0,2,1676.25,1602.25)" >
-					<tspan x="-189.5" y="0" class="t26">L1 Transactions,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1380.5 1750.5h300v120h-300z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channels,..." style="transform: matrix(2,0,0,2,1676.25,1822.25)" >
-					<tspan x="-123.9" y="0" class="t26">Channels,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1120.5 1970.5h560v120h-560z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Batches,..." style="transform: matrix(2,0,0,2,1676.25,2042.25)" >
-					<tspan x="-110.9" y="0" class="t26">Batches,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1120.5 2260.5h560v120h-560z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L2 Blocks..." style="transform: matrix(2,0,0,2,1676.25,2332.25)" >
-					<tspan x="-119.5" y="0" class="t26">L2 Blocks...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1960.5 1430.5h400v60h-400z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel A, Frame 0" style="transform: matrix(2,0,0,2,2160.25,1472.25)" >
-					<tspan x="-103" y="0" class="t26">Channel A, Frame 0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m2570.5 1430.5h400v60h-400z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel A, Frame 1" style="transform: matrix(2,0,0,2,2770.25,1472.25)" >
-					<tspan x="-103" y="0" class="t26">Channel A, Frame 1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m3050.5 1370.5h240v120h-240z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel B,..." style="transform: matrix(2,0,0,2,3170.25,1442.25)" >
-					<tspan x="-67" y="0" class="t26">Channel B,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m3480.5 1430.5h400v60h-400z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel B, Frame 1" style="transform: matrix(2,0,0,2,3680.25,1472.25)" >
-					<tspan x="-103.1" y="0" class="t26">Channel B, Frame 1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m4150.5 1430.5h400v60h-400z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel B, Frame 2" style="transform: matrix(2,0,0,2,4350.25,1472.25)" >
-					<tspan x="-103.1" y="0" class="t26">Channel B, Frame 2
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m4705.5 1430.5h340v60h-340z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel C, etc..." style="transform: matrix(2,0,0,2,4876.25,1472.25)" >
-					<tspan x="-86.8" y="0" class="t26">Channel C, etc...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m4350.5 20.5h440v220h-440z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Blocks,..." style="transform: matrix(2,0,0,2,4354.25,142.25)" >
-					<tspan x="0" y="0" class="t26">L1 Blocks,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m4350.5 330.5h500v160h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Actual inclusion on L1:..." style="transform: matrix(2,0,0,2,4354.25,422.25)" >
-					<tspan x="0" y="0" class="t26">Actual inclusion on L1:...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m4350.5 590.5h800v120h-800z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel B was seen first,..." style="transform: matrix(2,0,0,2,4354.25,662.25)" >
-					<tspan x="0" y="0" class="t26">Channel B was seen first,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s10" d="m1800.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s11" d="m2120.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s19" d="m2440.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s20" d="m2760.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s21" d="m3080.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s6" d="m3400.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s7" d="m3720.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s8" d="m4040.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s9" d="m4360.5 1028.5c0-9.9 8.1-18 18-18h204c9.9 0 18 8.1 18 18v84c0 9.9-8.1 18-18 18h-204c-9.9 0-18-8.1-18-18z"/>
-		<path id="Layer" class="s25" d="m960.5 990.5h720v220h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Batches can be buffered..." style="transform: matrix(2,0,0,2,1676.25,1112.25)" >
-					<tspan x="-276.7" y="0" class="t26">Batches can be buffered...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m4610.5 2830.5h260v140h-260z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Time" style="transform: matrix(2,0,0,2,4866.25,2930.25)" >
-					<tspan x="-122.4" y="0" class="t27">Time
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s24" d="m4921.5 2900.5v-20h324v-55.5l74 65.5-74 65.5v-55.5z"/>
-		<path id="Layer" class="s28" d="m1770.5 350.5h720v120h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="older L2 data" style="transform: matrix(2,0,0,2,2130.25,428.25)" >
-					<tspan x="-99.5" y="0" class="t3">older L2 data
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s29" d="m2630.5 350.5h720v120h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="B1" style="transform: matrix(2,0,0,2,3308.25,450.25)" >
-					<tspan x="-39.7" y="0" class="t3">B1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s30" d="m3110.5 530.5h240v120h-240z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="B0" style="transform: matrix(2,0,0,2,3308.25,630.25)" >
-					<tspan x="-39.7" y="0" class="t3">B0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s31" d="m2630.5 530.5h480v120h-480z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="A1" style="transform: matrix(2,0,0,2,3068.25,630.25)" >
-					<tspan x="-39.6" y="0" class="t3">A1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s18" d="m4030.5 350.5h160v120h-160z"/>
-		<path id="Layer" class="s32" d="m3470.5 350.5h560v120h-560z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="B2" style="transform: matrix(2,0,0,2,3988.25,450.25)" >
-					<tspan x="-39.7" y="0" class="t3">B2
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s33" d="m3470.5 530.5h720v120h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="A0" style="transform: matrix(2,0,0,2,4148.25,630.25)" >
-					<tspan x="-39.6" y="0" class="t3">A0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m3080.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100-0" style="transform: matrix(2,0,0,2,3294.25,2682.25)" >
-					<tspan x="-87.2" y="0" class="t3">100-0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m3400.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100-1" style="transform: matrix(2,0,0,2,3614.25,2682.25)" >
-					<tspan x="-87.2" y="0" class="t3">100-1
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m3720.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100-2" style="transform: matrix(2,0,0,2,3934.25,2682.25)" >
-					<tspan x="-87.2" y="0" class="t3">100-2
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m4040.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100-3" style="transform: matrix(2,0,0,2,4254.25,2682.25)" >
-					<tspan x="-87.2" y="0" class="t3">100-3
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m4360.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100-2" style="transform: matrix(2,0,0,2,4574.25,2682.25)" >
-					<tspan x="-87.2" y="0" class="t3">100-2
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s5" d="m4680.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="101-0" style="transform: matrix(2,0,0,2,4894.25,2682.25)" >
-					<tspan x="-87.2" y="0" class="t3">101-0
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s34" d="m2760.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="99-5" style="transform: matrix(2,0,0,2,2974.25,2682.25)" >
-					<tspan x="-68.1" y="0" class="t3">99-5
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s34" d="m2440.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="99-4" style="transform: matrix(2,0,0,2,2654.25,2682.25)" >
-					<tspan x="-68.1" y="0" class="t3">99-4
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s34" d="m2120.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="99-3" style="transform: matrix(2,0,0,2,2334.25,2682.25)" >
-					<tspan x="-68.1" y="0" class="t3">99-3
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s34" d="m1800.5 2710.5l40-120h200l-40 120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="99-2" style="transform: matrix(2,0,0,2,2014.25,2682.25)" >
-					<tspan x="-68.1" y="0" class="t3">99-2
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s34" d="m1200.5 20.5h200l40 40v200h-200l-40-40z"/>
-		<path id="Layer" class="s1" d="m1200.5 20.5h200l40 40h-200z"/>
-		<path id="Layer" class="s1" d="m1200.5 20.5l40 40v200l-40-40z"/>
-		<path id="Layer" class="s2" d="m1200.5 20.5l40 40v200m0-200h200"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="99" style="transform: matrix(2,0,0,2,1414.25,232.25)" >
-					<tspan x="-38.2" y="0" class="t3">99
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1020.5 2590.5h660v120h-660z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Each L2 block has a tx with info..." style="transform: matrix(2,0,0,2,1676.25,2662.25)" >
-					<tspan x="-352.7" y="0" class="t26">Each L2 block has a tx with info...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1020.5 2790.5h660v160h-660z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="The &quot;sequence number&quot;..." style="transform: matrix(2,0,0,2,1676.25,2882.25)" >
-					<tspan x="-274.9" y="0" class="t26">The &quot;sequence number&quot;...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s35" d="m1950.5 550.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="deposit" style="transform: matrix(2,0,0,2,2130.25,618.25)" >
-					<tspan x="-55.3" y="0" class="t3">deposit
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s35" d="m1960.5 690.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="deposit" style="transform: matrix(2,0,0,2,2140.25,758.25)" >
-					<tspan x="-55.3" y="0" class="t3">deposit
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m1090.5 590.5h580v120h-580z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Deposits are L1 log events,..." style="transform: matrix(2,0,0,2,1666.25,662.25)" >
-					<tspan x="-306.4" y="0" class="t26">Deposits are L1 log events,...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s35" d="m3050.5 2780.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="deposit" style="transform: matrix(2,0,0,2,3230.25,2848.25)" >
-					<tspan x="-55.3" y="0" class="t3">deposit
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s35" d="m3060.5 2920.5q90 36 180 0 90-36 180 0v100q-90-36-180 0-90 36-180 0z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="deposit" style="transform: matrix(2,0,0,2,3240.25,2988.25)" >
-					<tspan x="-55.3" y="0" class="t3">deposit
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m2490.5 2830.5h500v220h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Deposits get included..." style="transform: matrix(2,0,0,2,2986.25,2952.25)" >
-					<tspan x="-248.5" y="0" class="t26">Deposits get included...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m10.5 1150.5h1280v320h-1280z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Security types on L2:..." style="transform: matrix(2,0,0,2,14.25,1328.25)" >
-					<tspan x="0" y="0" class="t3">Security types on L2:...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s25" d="m30.5 1570.5h1000v320h-1000z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Security types on L1:..." style="transform: matrix(2,0,0,2,34.25,1748.25)" >
-					<tspan x="0" y="0" class="t3">Security types on L1:...
-</tspan>
-				</text>
-			</g>
-		</g>
-	</g>
-	<g id="Layer">
-		<g id="Layer">
-		</g>
-		<g id="Layer">
-			<text id="Text is not SVG - cannot display" style="transform: matrix(.5,0,0,.5,25.5,48)" >
-				<tspan x="-70.9" y="0" class="t36">Text is not SVG - cannot display
-</tspan>
-			</text>
-		</g>
-	</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="10662px" height="6124px" viewBox="-0.5 -0.5 10662 6124">
+  <defs>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-75acff-1-ff66b3-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(117, 172, 255); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(255, 102, 179); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-ffe563-1-8cffb6-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(255, 229, 99); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(140, 255, 182); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-75acff-1-c683d2-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(117, 172, 255); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(198, 131, 210); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-ffe563-1-d8ea7c-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(255, 229, 99); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(216, 234, 124); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-d8ea7c-1-b0f79c-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(216, 234, 124); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(176, 247, 156); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-c683d2-1-ff66b3-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(198, 131, 210); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(255, 102, 179); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient x1="0%" y1="0%" x2="100%" y2="0%" id="mx-gradient-b0f79c-1-8cffb6-1-e-0">
+      <stop offset="0%" style="stop-color: rgb(176, 247, 156); stop-opacity: 1;" />
+      <stop offset="100%" style="stop-color: rgb(140, 255, 182); stop-opacity: 1;" />
+    </linearGradient>
+  </defs>
+  <rect fill="#fff" width="100%" height="100%" />
+  <g>
+    <path d="M 3900 20 L 4300 20 L 4380 100 L 4380 500 L 3980 500 L 3900 420 L 3900 20 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 3900 20 L 4300 20 L 4380 100 L 3980 100 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 3900 20 L 3980 100 L 3980 500 L 3900 420 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 3980 500 L 3980 100 L 3900 20 M 3980 100 L 4380 100" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 111px; margin-left: 1006px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="1082" y="111" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100</text>
+      </switch>
+    </g>
+    <path d="M 7420 20 L 7820 20 L 7900 100 L 7900 500 L 7500 500 L 7420 420 L 7420 20 Z" fill="#ccffff" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 7420 20 L 7820 20 L 7900 100 L 7500 100 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 7420 20 L 7500 100 L 7500 500 L 7420 420 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 7500 500 L 7500 100 L 7420 20 M 7500 100 L 7900 100" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 111px; margin-left: 1886px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">102</div>
+            </div>
+          </div>
+        </foreignObject><text x="1962" y="111" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">102</text>
+      </switch>
+    </g>
+    <path d="M 5540 20 L 5940 20 L 6020 100 L 6020 500 L 5620 500 L 5540 420 L 5540 20 Z" fill="#ffff66" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 5540 20 L 5940 20 L 6020 100 L 5620 100 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 5540 20 L 5620 100 L 5620 500 L 5540 420 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 5620 500 L 5620 100 L 5540 20 M 5620 100 L 6020 100" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 111px; margin-left: 1416px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">101</div>
+            </div>
+          </div>
+        </foreignObject><text x="1492" y="111" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">101</text>
+      </switch>
+    </g>
+    <path d="M 3600 4420 L 4000 4420 L 4080 4500 L 4080 4900 L 3680 4900 L 3600 4820 L 3600 4420 Z" fill="#ccccff" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 3600 4420 L 4000 4420 L 4080 4500 L 3680 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 3600 4420 L 3680 4500 L 3680 4900 L 3600 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 3680 4900 L 3680 4500 L 3600 4420 M 3680 4500 L 4080 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 931px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">3</div>
+            </div>
+          </div>
+        </foreignObject><text x="1007" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">3</text>
+      </switch>
+    </g>
+    <path d="M 4240 4420 L 4640 4420 L 4720 4500 L 4720 4900 L 4320 4900 L 4240 4820 L 4240 4420 Z" fill="#75acff" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 4240 4420 L 4640 4420 L 4720 4500 L 4320 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 4240 4420 L 4320 4500 L 4320 4900 L 4240 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 4320 4900 L 4320 4500 L 4240 4420 M 4320 4500 L 4720 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1091px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">4</div>
+            </div>
+          </div>
+        </foreignObject><text x="1167" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">4</text>
+      </switch>
+    </g>
+    <path d="M 4880 4420 L 5280 4420 L 5360 4500 L 5360 4900 L 4960 4900 L 4880 4820 L 4880 4420 Z" fill="#c882d1" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 4880 4420 L 5280 4420 L 5360 4500 L 4960 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 4880 4420 L 4960 4500 L 4960 4900 L 4880 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 4960 4900 L 4960 4500 L 4880 4420 M 4960 4500 L 5360 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1251px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">5</div>
+            </div>
+          </div>
+        </foreignObject><text x="1327" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">5</text>
+      </switch>
+    </g>
+    <path d="M 5520 4420 L 5920 4420 L 6000 4500 L 6000 4900 L 5600 4900 L 5520 4820 L 5520 4420 Z" fill="#ff66b3" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 5520 4420 L 5920 4420 L 6000 4500 L 5600 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 5520 4420 L 5600 4500 L 5600 4900 L 5520 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 5600 4900 L 5600 4500 L 5520 4420 M 5600 4500 L 6000 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1411px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">6</div>
+            </div>
+          </div>
+        </foreignObject><text x="1487" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">6</text>
+      </switch>
+    </g>
+    <path d="M 6160 4420 L 6560 4420 L 6640 4500 L 6640 4900 L 6240 4900 L 6160 4820 L 6160 4420 Z" fill="#ffae52" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 6160 4420 L 6560 4420 L 6640 4500 L 6240 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 6160 4420 L 6240 4500 L 6240 4900 L 6160 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 6240 4900 L 6240 4500 L 6160 4420 M 6240 4500 L 6640 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1571px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">7</div>
+            </div>
+          </div>
+        </foreignObject><text x="1647" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">7</text>
+      </switch>
+    </g>
+    <path d="M 6800 4420 L 7200 4420 L 7280 4500 L 7280 4900 L 6880 4900 L 6800 4820 L 6800 4420 Z" fill="#ffffa1" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 6800 4420 L 7200 4420 L 7280 4500 L 6880 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 6800 4420 L 6880 4500 L 6880 4900 L 6800 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 6880 4900 L 6880 4500 L 6800 4420 M 6880 4500 L 7280 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1731px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">8</div>
+            </div>
+          </div>
+        </foreignObject><text x="1807" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">8</text>
+      </switch>
+    </g>
+    <rect x="3600" y="3940" width="480" height="240" rx="36" ry="36" fill="#ccccff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="4240" y="3940" width="480" height="240" rx="36" ry="36" fill="#75acff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="4880" y="3940" width="480" height="240" rx="36" ry="36" fill="#c882d1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="5520" y="3940" width="480" height="240" rx="36" ry="36" fill="#ff66b3" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="6160" y="3940" width="480" height="240" rx="36" ry="36" fill="#ffae52" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="6800" y="3940" width="480" height="240" rx="36" ry="36" fill="#ffffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="3600" y="3500" width="2400" height="240" fill="url(#mx-gradient-75acff-1-ff66b3-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 598px; height: 1px; padding-top: 905px; margin-left: 901px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 25px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; overflow-wrap: normal;">Compressed &amp; encoded batch data</div>
+            </div>
+          </div>
+        </foreignObject><text x="1200" y="912" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="25px" text-anchor="middle" font-style="italic">Compressed &amp; encoded batch data</text>
+      </switch>
+    </g>
+    <rect x="6080" y="3500" width="3040" height="240" fill="url(#mx-gradient-ffe563-1-8cffb6-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="3600" y="3060" width="1440" height="240" fill="url(#mx-gradient-75acff-1-c683d2-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 815px; margin-left: 907px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A0</div>
+            </div>
+          </div>
+        </foreignObject><text x="1239" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A0</text>
+      </switch>
+    </g>
+    <rect x="6080" y="3060" width="480" height="240" fill="url(#mx-gradient-ffe563-1-d8ea7c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 92px; height: 1px; padding-top: 815px; margin-left: 1527px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B0</div>
+            </div>
+          </div>
+        </foreignObject><text x="1619" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B0</text>
+      </switch>
+    </g>
+    <rect x="6640" y="3060" width="1440" height="240" fill="url(#mx-gradient-d8ea7c-1-b0f79c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 815px; margin-left: 1667px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1999" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B1</text>
+      </switch>
+    </g>
+    <rect x="9280" y="3060" width="320" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <path d="M 7440 4420 L 7840 4420 L 7920 4500 L 7920 4900 L 7520 4900 L 7440 4820 L 7440 4420 Z" fill="#c3ffa1" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 7440 4420 L 7840 4420 L 7920 4500 L 7520 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 7440 4420 L 7520 4500 L 7520 4900 L 7440 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 7520 4900 L 7520 4500 L 7440 4420 M 7520 4500 L 7920 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 1891px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">9</div>
+            </div>
+          </div>
+        </foreignObject><text x="1967" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">9</text>
+      </switch>
+    </g>
+    <path d="M 8080 4420 L 8480 4420 L 8560 4500 L 8560 4900 L 8160 4900 L 8080 4820 L 8080 4420 Z" fill="#97ff63" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 8080 4420 L 8480 4420 L 8560 4500 L 8160 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 8080 4420 L 8160 4500 L 8160 4900 L 8080 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 8160 4900 L 8160 4500 L 8080 4420 M 8160 4500 L 8560 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 2051px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">10</div>
+            </div>
+          </div>
+        </foreignObject><text x="2127" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">10</text>
+      </switch>
+    </g>
+    <path d="M 8720 4420 L 9120 4420 L 9200 4500 L 9200 4900 L 8800 4900 L 8720 4820 L 8720 4420 Z" fill="#8cffb6" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 8720 4420 L 9120 4420 L 9200 4500 L 8800 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 8720 4420 L 8800 4500 L 8800 4900 L 8720 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 8800 4900 L 8800 4500 L 8720 4420 M 8800 4500 L 9200 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 1211px; margin-left: 2211px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">11</div>
+            </div>
+          </div>
+        </foreignObject><text x="2287" y="1211" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">11</text>
+      </switch>
+    </g>
+    <path d="M 9360 4420 L 9760 4420 L 9840 4500 L 9840 4900 L 9440 4900 L 9360 4820 L 9360 4420 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 9360 4420 L 9760 4420 L 9840 4500 L 9440 4500 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 9360 4420 L 9440 4500 L 9440 4900 L 9360 4820 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 9440 4900 L 9440 4500 L 9360 4420 M 9440 4500 L 9840 4500" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <rect x="7440" y="3940" width="480" height="240" rx="36" ry="36" fill="#c3ffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="8080" y="3940" width="480" height="240" rx="36" ry="36" fill="#97ff63" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="8720" y="3940" width="480" height="240" rx="36" ry="36" fill="#8cffb6" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="9360" y="3940" width="480" height="240" rx="36" ry="36" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="5120" y="3060" width="960" height="240" fill="url(#mx-gradient-c683d2-1-ff66b3-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 212px; height: 1px; padding-top: 815px; margin-left: 1287px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1499" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A1</text>
+      </switch>
+    </g>
+    <rect x="8160" y="3060" width="1120" height="240" fill="url(#mx-gradient-b0f79c-1-8cffb6-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 252px; height: 1px; padding-top: 815px; margin-left: 2047px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B2</div>
+            </div>
+          </div>
+        </foreignObject><text x="2299" y="815" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B2</text>
+      </switch>
+    </g>
+    <rect x="9200" y="3500" width="760" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="9840" y="3140" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10010" y="3140" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10170" y="3140" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10090" y="3580" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10260" y="3580" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10420" y="3580" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10010" y="4020" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10180" y="4020" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10340" y="4020" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="9960" y="4620" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10130" y="4620" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="10290" y="4620" width="60" height="80" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="2600" y="3060" width="760" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 795px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">L1 Transactions,<br /> ~128 KB each</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="801" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">L1 Transactions,...</text>
+      </switch>
+    </g>
+    <rect x="2760" y="3500" width="600" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 905px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Channels,<br />with timeout</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="911" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Channels,...</text>
+      </switch>
+    </g>
+    <rect x="2240" y="3940" width="1120" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1015px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Batches,<br />1 batch = 1 L2 block tx list</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="1021" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Batches,...</text>
+      </switch>
+    </g>
+    <rect x="2240" y="4520" width="1120" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1160px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">L2 Blocks<br />(a.k.a. execution payloads)</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="1166" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">L2 Blocks...</text>
+      </switch>
+    </g>
+    <rect x="3920" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 1080px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel A, Frame 0</div>
+            </div>
+          </div>
+        </foreignObject><text x="1080" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel A, Frame 0</text>
+      </switch>
+    </g>
+    <rect x="5140" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 1385px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel A, Frame 1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1385" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel A, Frame 1</text>
+      </switch>
+    </g>
+    <rect x="6100" y="2740" width="480" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 715px; margin-left: 1585px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel B,<br /> Frame 0</div>
+            </div>
+          </div>
+        </foreignObject><text x="1585" y="721" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel B,...</text>
+      </switch>
+    </g>
+    <rect x="6960" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 1840px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel B, Frame 1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1840" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel B, Frame 1</text>
+      </switch>
+    </g>
+    <rect x="8300" y="2860" width="800" height="120" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 2175px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel B, Frame 2</div>
+            </div>
+          </div>
+        </foreignObject><text x="2175" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel B, Frame 2</text>
+      </switch>
+    </g>
+    <rect x="9410" y="2860" width="680" height="120" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 730px; margin-left: 2438px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Channel C, etc...</div>
+            </div>
+          </div>
+        </foreignObject><text x="2438" y="736" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="middle">Channel C, etc...</text>
+      </switch>
+    </g>
+    <rect x="8700" y="40" width="880" height="440" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 65px; margin-left: 2177px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">L1 Blocks,<br />These may not be as<br />frequent/consistent<br /> as L2 blocks.</div>
+            </div>
+          </div>
+        </foreignObject><text x="2177" y="71" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" font-weight="bold">L1 Blocks,...</text>
+      </switch>
+    </g>
+    <rect x="8700" y="660" width="1000" height="320" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 205px; margin-left: 2177px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Actual inclusion on L1:<br />channels are valid<br />within a timeout</div>
+            </div>
+          </div>
+        </foreignObject><text x="2177" y="211" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" font-weight="bold">Actual inclusion on L1:...</text>
+      </switch>
+    </g>
+    <rect x="8700" y="1180" width="1600" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 325px; margin-left: 2177px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Channel B was seen first,<br />and will be decoded into batches first.</div>
+            </div>
+          </div>
+        </foreignObject><text x="2177" y="331" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" font-weight="bold">Channel B was seen first,...</text>
+      </switch>
+    </g>
+    <rect x="3600" y="2020" width="480" height="240" rx="36" ry="36" fill="#ffae52" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="4240" y="2020" width="480" height="240" rx="36" ry="36" fill="#ffffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="4880" y="2020" width="480" height="240" rx="36" ry="36" fill="#c3ffa1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="5520" y="2020" width="480" height="240" rx="36" ry="36" fill="#97ff63" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="6160" y="2020" width="480" height="240" rx="36" ry="36" fill="#8cffb6" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="6800" y="2020" width="480" height="240" rx="36" ry="36" fill="#ccccff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="7440" y="2020" width="480" height="240" rx="36" ry="36" fill="#75acff" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="8080" y="2020" width="480" height="240" rx="36" ry="36" fill="#c882d1" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="8720" y="2020" width="480" height="240" rx="36" ry="36" fill="#ff66b3" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="1920" y="1980" width="1440" height="440" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 550px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Batches can be buffered<br />for up to a full sequencing window<br />worth of L1 blocks<br />to get the L2 ordering back.</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="556" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Batches can be buffered...</text>
+      </switch>
+    </g>
+    <rect x="9220" y="5660" width="520" height="280" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1450px; margin-left: 2433px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Time</div>
+            </div>
+          </div>
+        </foreignObject><text x="2433" y="1465" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px" text-anchor="end" font-weight="bold">Time</text>
+      </switch>
+    </g>
+    <path d="M 9842 5800 L 9842 5760 L 10490 5760 L 10490 5648.91 L 10638 5780 L 10490 5911.09 L 10490 5800 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <rect x="3540" y="700" width="1440" height="240" fill="#bfbfbf" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 358px; height: 1px; padding-top: 205px; margin-left: 886px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: normal; overflow-wrap: normal;">older L2 data</div>
+            </div>
+          </div>
+        </foreignObject><text x="1065" y="214" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle" font-style="italic">older L2 data</text>
+      </switch>
+    </g>
+    <rect x="5260" y="700" width="1440" height="240" fill="url(#mx-gradient-d8ea7c-1-b0f79c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 225px; margin-left: 1322px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1654" y="225" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B1</text>
+      </switch>
+    </g>
+    <rect x="6220" y="1060" width="480" height="240" fill="url(#mx-gradient-ffe563-1-d8ea7c-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 92px; height: 1px; padding-top: 315px; margin-left: 1562px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B0</div>
+            </div>
+          </div>
+        </foreignObject><text x="1654" y="315" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B0</text>
+      </switch>
+    </g>
+    <rect x="5260" y="1060" width="960" height="240" fill="url(#mx-gradient-c683d2-1-ff66b3-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 212px; height: 1px; padding-top: 315px; margin-left: 1322px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1534" y="315" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A1</text>
+      </switch>
+    </g>
+    <rect x="8060" y="700" width="320" height="240" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <rect x="6940" y="700" width="1120" height="240" fill="url(#mx-gradient-b0f79c-1-8cffb6-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 252px; height: 1px; padding-top: 225px; margin-left: 1742px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">B2</div>
+            </div>
+          </div>
+        </foreignObject><text x="1994" y="225" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">B2</text>
+      </switch>
+    </g>
+    <rect x="6940" y="1060" width="1440" height="240" fill="url(#mx-gradient-75acff-1-c683d2-1-e-0)" stroke="rgb(0, 0, 0)" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 332px; height: 1px; padding-top: 315px; margin-left: 1742px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">A0</div>
+            </div>
+          </div>
+        </foreignObject><text x="2074" y="315" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="end">A0</text>
+      </switch>
+    </g>
+    <path d="M 6160 5420 L 6240 5180 L 6640 5180 L 6560 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1551px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-0</div>
+            </div>
+          </div>
+        </foreignObject><text x="1647" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-0</text>
+      </switch>
+    </g>
+    <path d="M 6800 5420 L 6880 5180 L 7280 5180 L 7200 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1711px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-1</div>
+            </div>
+          </div>
+        </foreignObject><text x="1807" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-1</text>
+      </switch>
+    </g>
+    <path d="M 7440 5420 L 7520 5180 L 7920 5180 L 7840 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1871px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-2</div>
+            </div>
+          </div>
+        </foreignObject><text x="1967" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-2</text>
+      </switch>
+    </g>
+    <path d="M 8080 5420 L 8160 5180 L 8560 5180 L 8480 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 2031px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-3</div>
+            </div>
+          </div>
+        </foreignObject><text x="2127" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-3</text>
+      </switch>
+    </g>
+    <path d="M 8720 5420 L 8800 5180 L 9200 5180 L 9120 5420 Z" fill="#ff0080" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 2191px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100-2</div>
+            </div>
+          </div>
+        </foreignObject><text x="2287" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">100-2</text>
+      </switch>
+    </g>
+    <path d="M 9360 5420 L 9440 5180 L 9840 5180 L 9760 5420 Z" fill="#ffff66" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 2351px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">101-0</div>
+            </div>
+          </div>
+        </foreignObject><text x="2447" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">101-0</text>
+      </switch>
+    </g>
+    <path d="M 5520 5420 L 5600 5180 L 6000 5180 L 5920 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1391px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-5</div>
+            </div>
+          </div>
+        </foreignObject><text x="1487" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-5</text>
+      </switch>
+    </g>
+    <path d="M 4880 5420 L 4960 5180 L 5360 5180 L 5280 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1231px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-4</div>
+            </div>
+          </div>
+        </foreignObject><text x="1327" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-4</text>
+      </switch>
+    </g>
+    <path d="M 4240 5420 L 4320 5180 L 4720 5180 L 4640 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 1071px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-3</div>
+            </div>
+          </div>
+        </foreignObject><text x="1167" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-3</text>
+      </switch>
+    </g>
+    <path d="M 3600 5420 L 3680 5180 L 4080 5180 L 4000 5420 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 96px; height: 1px; padding-top: 1341px; margin-left: 911px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99-2</div>
+            </div>
+          </div>
+        </foreignObject><text x="1007" y="1341" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99-2</text>
+      </switch>
+    </g>
+    <path d="M 2400 40 L 2800 40 L 2880 120 L 2880 520 L 2480 520 L 2400 440 L 2400 40 Z" fill="#e0e0e0" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 2400 40 L 2800 40 L 2880 120 L 2480 120 Z" fill-opacity="0.05" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 2400 40 L 2480 120 L 2480 520 L 2400 440 Z" fill-opacity="0.1" fill="#000000" stroke="none" pointer-events="all" />
+    <path d="M 2480 520 L 2480 120 L 2400 40 M 2480 120 L 2880 120" fill="none" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-end; width: 76px; height: 1px; padding-top: 116px; margin-left: 631px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">99</div>
+            </div>
+          </div>
+        </foreignObject><text x="707" y="116" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="end">99</text>
+      </switch>
+    </g>
+    <rect x="2040" y="5180" width="1320" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1325px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Each L2 block has a tx with info<br />about the "origin" L1 block</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="1331" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Each L2 block has a tx with info...</text>
+      </switch>
+    </g>
+    <rect x="2040" y="5580" width="1320" height="320" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1435px; margin-left: 838px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">The "sequence number" <br />helps differentiate between <br />L2 blocks with the same origin.</div>
+            </div>
+          </div>
+        </foreignObject><text x="838" y="1441" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">The "sequence number"...</text>
+      </switch>
+    </g>
+    <path d="M 3900 1100 Q 4080 1172 4260 1100 Q 4440 1028 4620 1100 L 4620 1300 Q 4440 1228 4260 1300 Q 4080 1372 3900 1300 L 3900 1100 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 300px; margin-left: 976px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div>
+            </div>
+          </div>
+        </foreignObject><text x="1065" y="309" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text>
+      </switch>
+    </g>
+    <path d="M 3920 1380 Q 4100 1452 4280 1380 Q 4460 1308 4640 1380 L 4640 1580 Q 4460 1508 4280 1580 Q 4100 1652 3920 1580 L 3920 1380 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 370px; margin-left: 981px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div>
+            </div>
+          </div>
+        </foreignObject><text x="1070" y="379" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text>
+      </switch>
+    </g>
+    <rect x="2180" y="1180" width="1160" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 325px; margin-left: 833px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Deposits are L1 log events,<br />parsed from EVM receipts</div>
+            </div>
+          </div>
+        </foreignObject><text x="833" y="331" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Deposits are L1 log events,...</text>
+      </switch>
+    </g>
+    <path d="M 6100 5560 Q 6280 5632 6460 5560 Q 6640 5488 6820 5560 L 6820 5760 Q 6640 5688 6460 5760 Q 6280 5832 6100 5760 L 6100 5560 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 1415px; margin-left: 1526px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div>
+            </div>
+          </div>
+        </foreignObject><text x="1615" y="1424" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text>
+      </switch>
+    </g>
+    <path d="M 6120 5840 Q 6300 5912 6480 5840 Q 6660 5768 6840 5840 L 6840 6040 Q 6660 5968 6480 6040 Q 6300 6112 6120 6040 L 6120 5840 Z" fill="#fff2cc" stroke="#d6b656" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 1485px; margin-left: 1531px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">deposit</div>
+            </div>
+          </div>
+        </foreignObject><text x="1620" y="1494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">deposit</text>
+      </switch>
+    </g>
+    <rect x="4980" y="5660" width="1000" height="440" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 1470px; margin-left: 1493px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 21px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">Deposits get included<br />the first L2 block that<br />adopts the L1 origin the<br />deposits were made in.</div>
+            </div>
+          </div>
+        </foreignObject><text x="1493" y="1476" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="21px" text-anchor="end" font-weight="bold">Deposits get included...</text>
+      </switch>
+    </g>
+    <rect x="20" y="2300" width="2560" height="640" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 655px; margin-left: 7px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Security types on L2:<br />- "unsafe": not submitted on L1<br />- "safe": is confirmed on L1<br />- "finalized": fully derived from finalized L1 data</div>
+            </div>
+          </div>
+        </foreignObject><text x="7" y="664" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px">Security types on L2:...</text>
+      </switch>
+    </g>
+    <rect x="60" y="3140" width="2000" height="640" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 865px; margin-left: 17px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">Security types on L1:<br />- "unsafe": very new<br />- "safe": decent attestation ratio<br />- "finalized": with FFG finality gadget</div>
+            </div>
+          </div>
+        </foreignObject><text x="17" y="874" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px">Security types on L1:...</text>
+      </switch>
+    </g>
+  </g>
+  <switch>
+    <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" /><a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank"><text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text></a>
+  </switch>
 </svg>

--- a/specs/assets/batch-deriv-pipeline.svg
+++ b/specs/assets/batch-deriv-pipeline.svg
@@ -1,3 +1,489 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="11984px" height="4564px" viewBox="-0.5 -0.5 11984 4564"><defs/><g><path d="M 4820 2900 L 5820 2900 L 5900 3000 L 5820 3100 L 4820 3100 L 4900 3000 Z" fill="#99ffcc" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 1206px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="1338" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 6900 2900 L 7900 2900 L 7980 3000 L 7900 3100 L 6900 3100 L 6980 3000 Z" fill="#a8fff6" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 1726px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="1858" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 5860 2900 L 6860 2900 L 6940 3000 L 6860 3100 L 5860 3100 L 5940 3000 Z" fill="#96ffe3" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 1466px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="1598" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 4100 3000 L 4900 3000" fill="none" stroke="rgb(0, 0, 0)" stroke-width="28" stroke-miterlimit="10" stroke-dasharray="84 84" pointer-events="stroke"/><path d="M 3780 2900 L 4020 2900 L 4100 3000 L 4020 3100 L 3780 3100 L 3860 3000 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 74px; height: 1px; padding-top: 772px; margin-left: 946px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="983" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text></switch></g><rect x="5860" y="1340" width="1000" height="560" fill="#96ffe3" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1466px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">Batch Queue</div></div></div></foreignObject><text x="1590" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Batch Queue</text></switch></g><rect x="7940" y="1340" width="1000" height="560" fill="#9ceeff" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1986px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">Engine Queue</div></div></div></foreignObject><text x="2110" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Engine Queue</text></switch></g><rect x="6900" y="1340" width="1000" height="560" fill="#a8fff6" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1726px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><div>PayloadAttributes</div><div>Queue<br /></div></div></div></div></foreignObject><text x="1850" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">PayloadAttributes...</text></switch></g><rect x="4820" y="1340" width="1000" height="560" fill="#99ffcc" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1206px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><div>Channel</div><div>Input-reader<br /></div></div></div></div></foreignObject><text x="1330" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Channel...</text></switch></g><rect x="3780" y="1340" width="1000" height="560" fill="#99ff99" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 946px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><div>Channel</div><div>Bank<br /></div></div></div></div></foreignObject><text x="1070" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Channel...</text></switch></g><rect x="1700" y="1340" width="1000" height="560" fill="#e3ff96" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 426px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Traversal</div></div></div></foreignObject><text x="550" y="414" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Traversal</text></switch></g><path d="M 1700 2900 L 2700 2900 L 2780 3000 L 2700 3100 L 1700 3100 L 1780 3000 Z" fill="#e3ff96" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 426px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="558" y="772" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text></switch></g><path d="M 8340 3000 L 8980 3000" fill="none" stroke="rgb(0, 0, 0)" stroke-width="28" stroke-miterlimit="10" stroke-dasharray="84 84" pointer-events="stroke"/><path d="M 7940 2900 L 8260 2900 L 8340 3000 L 8260 3100 L 7940 3100 L 8020 3000 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 772px; margin-left: 1986px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="2033" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 7120 540 C 6912 540 6860 700 7026.4 732 C 6860 802.4 7047.2 956 7182.4 892 C 7276 1020 7588 1020 7692 892 C 7900 892 7900 764 7770 700 C 7900 572 7692 444 7510 508 C 7380 412 7172 412 7120 540 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 258px; height: 1px; padding-top: 175px; margin-left: 1716px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Deposits</div></div></div></foreignObject><text x="1845" y="184" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Deposits</text></switch></g><path d="M 8660 1980 L 8940 1980 L 9020 2080 L 8940 2180 L 8660 2180 L 8740 2080 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 84px; height: 1px; padding-top: 542px; margin-left: 2166px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="2208" y="542" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 5860 2460 L 6900 2460 L 6980 2560 L 6900 2660 L 5860 2660 L 5940 2560 Z" fill="#96ffe3" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 274px; height: 1px; padding-top: 662px; margin-left: 1466px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="1603" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 4820 2460 L 5820 2460 L 5900 2560 L 5820 2660 L 4820 2660 L 4900 2560 Z" fill="#99ffcc" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 662px; margin-left: 1206px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="1338" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 4540 2460 L 4780 2460 L 4860 2560 L 4780 2660 L 4540 2660 L 4620 2560 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 74px; height: 1px; padding-top: 662px; margin-left: 1136px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="1173" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 1700 2660 L 2700 2660 L 2780 2760 L 2700 2860 L 1700 2860 L 1780 2760 Z" fill="#e3ff96" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 712px; margin-left: 426px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="558" y="712" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text></switch></g><path d="M 3780 2660 L 4020 2660 L 4100 2760 L 4020 2860 L 3780 2860 L 3860 2760 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 74px; height: 1px; padding-top: 712px; margin-left: 946px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="983" y="712" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text></switch></g><path d="M 4820 3300 L 5820 3300 L 5900 3400 L 5820 3500 L 4820 3500 L 4900 3400 Z" fill="#99ffcc" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1206px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="1338" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 6900 3300 L 7900 3300 L 7980 3400 L 7900 3500 L 6900 3500 L 6980 3400 Z" fill="#a8fff6" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1726px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="1858" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 5860 3300 L 6860 3300 L 6940 3400 L 6860 3500 L 5860 3500 L 5940 3400 Z" fill="#96ffe3" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1466px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="1598" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 3780 3300 L 4780 3300 L 4860 3400 L 4780 3500 L 3780 3500 L 3860 3400 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 946px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="1078" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 1700 3300 L 2700 3300 L 2780 3400 L 2700 3500 L 1700 3500 L 1780 3400 Z" fill="#e3ff96" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 426px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="558" y="872" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 7940 3300 L 8940 3300 L 9020 3400 L 8940 3500 L 7940 3500 L 8020 3400 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1986px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="2118" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><rect x="9720" y="1152" width="2160" height="520" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 353px; margin-left: 2432px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">1) find safe L2 block<br />with canonical L1 origin</div></div></div></foreignObject><text x="2432" y="368" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">1) find safe L2 block...</text></switch></g><rect x="9720" y="2472" width="2240" height="520" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 683px; margin-left: 2432px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">3) reset all stage origins,<br />traverse chain back</div></div></div></foreignObject><text x="2432" y="698" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">3) reset all stage orig...</text></switch></g><rect x="9720" y="3112" width="1880" height="520" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 843px; margin-left: 2432px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">4) dry-run pipeline<br />to heal stage buffers</div></div></div></foreignObject><text x="2432" y="858" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">4) dry-run pipeline...</text></switch></g><rect x="9720" y="3752" width="2120" height="520" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 1003px; margin-left: 2432px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">5) new L1 data<br />can now stream into L2</div></div></div></foreignObject><text x="2432" y="1018" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">5) new L1 data...</text></switch></g><rect x="9720" y="1832" width="2160" height="520" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 523px; margin-left: 2432px;"><div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">2) Stages with gaps will<br /> reconstruct buffer data</div></div></div></foreignObject><text x="2432" y="538" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">2) Stages with gaps wi...</text></switch></g><path d="M 2055.29 1022 L 2304.71 1022 L 2304.71 1116.35 L 2600.82 1116.35 L 2180 1258 L 1759.18 1116.35 L 2055.29 1116.35 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/><path d="M 8609.69 1258 L 8360.28 1258 L 8360.28 1163.65 L 8064.16 1163.65 L 8484.99 1022 L 8905.81 1163.65 L 8609.69 1163.65 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/><rect x="460" y="4140" width="1160" height="400" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1085px; margin-left: 260px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 26px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: nowrap;">Numbers for illustration,<br /> referring to L1 origin<br />block numbers</div></div></div></foreignObject><text x="260" y="1093" fill="#000000" font-family="Helvetica" font-size="26px" text-anchor="middle" font-style="italic">Numbers for illustrati...</text></switch></g><rect x="60" y="1900" width="1360" height="600" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 550px; margin-left: 185px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 40px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">"<b>ResetStep</b>":<br style="font-size: 40px" />reset stage with<br style="font-size: 40px" />distance from next</div></div></div></foreignObject><text x="185" y="562" fill="#000000" font-family="Helvetica" font-size="40px" text-anchor="middle">"ResetStep":...</text></switch></g><rect x="20" y="2940" width="1440" height="1000" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 860px; margin-left: 185px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 40px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">"<b>Step</b>":<br style="font-size: 40px" />progress pipeline.<br />Start closest to L2,<br />visit previous stage<br />for more input data.</div></div></div></foreignObject><text x="185" y="872" fill="#000000" font-family="Helvetica" font-size="40px" text-anchor="middle">"Step":...</text></switch></g><rect x="1760" y="3860" width="7080" height="240" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 995px; margin-left: 1325px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 36px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payloads</div></div></div></foreignObject><text x="1325" y="1006" fill="#000000" font-family="Helvetica" font-size="36px" text-anchor="middle">L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payl...</text></switch></g><rect x="3800" y="2100" width="680" height="560" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 595px; margin-left: 1118px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 36px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: nowrap;">Resets<br /><b>Channel</b><br /><b>timeout</b></div></div></div></foreignObject><text x="1118" y="606" fill="#000000" font-family="Helvetica" font-size="36px" text-anchor="end" font-style="italic">Resets...</text></switch></g><rect x="7620" y="1900" width="920" height="560" fill="none" stroke="none" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 545px; margin-left: 2133px;"><div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 36px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: nowrap;"><div>Resets</div><b>Sequencing</b><br /><b>window</b></div></div></div></foreignObject><text x="2133" y="556" fill="#000000" font-family="Helvetica" font-size="36px" text-anchor="end" font-style="italic">ResetsSequenc...</text></switch></g><rect x="2740" y="1340" width="1000" height="560" fill="#c9f783" stroke="#000000" stroke-width="4" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 686px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Retrieval</div></div></div></foreignObject><text x="810" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Retrieval</text></switch></g><path d="M 2740 2900 L 3740 2900 L 3820 3000 L 3740 3100 L 2740 3100 L 2820 3000 Z" fill="#c9f783" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 686px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="818" y="772" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text></switch></g><path d="M 2740 2660 L 3740 2660 L 3820 2760 L 3740 2860 L 2740 2860 L 2820 2760 Z" fill="#c9f783" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 712px; margin-left: 686px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div></div></div></foreignObject><text x="818" y="712" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text></switch></g><path d="M 2740 3300 L 3740 3300 L 3820 3400 L 3740 3500 L 2740 3500 L 2820 3400 Z" fill="#c9f783" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 686px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div></div></div></foreignObject><text x="818" y="872" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text></switch></g><path d="M 3152.45 1022 L 3401.87 1022 L 3401.87 1116.35 L 3697.98 1116.35 L 3277.16 1258 L 2856.34 1116.35 L 3152.45 1116.35 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/><path d="M 7295.29 1062 L 7544.71 1062 L 7544.71 1156.35 L 7840.82 1156.35 L 7420 1298 L 6999.18 1156.35 L 7295.29 1156.35 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all"/><path d="M 3020 500 C 2812 500 2760 660 2926.4 692 C 2760 762.4 2947.2 916 3082.4 852 C 3176 980 3488 980 3592 852 C 3800 852 3800 724 3670 660 C 3800 532 3592 404 3410 468 C 3280 372 3072 372 3020 500 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 258px; height: 1px; padding-top: 165px; margin-left: 691px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Data</div></div></div></foreignObject><text x="820" y="174" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Data</text></switch></g><path d="M 1940 500 C 1732 500 1680 660 1846.4 692 C 1680 762.4 1867.2 916 2002.4 852 C 2096 980 2408 980 2512 852 C 2720 852 2720 724 2590 660 C 2720 532 2512 404 2330 468 C 2200 372 1992 372 1940 500 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 258px; height: 1px; padding-top: 165px; margin-left: 421px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Chain</div></div></div></foreignObject><text x="550" y="174" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Chain</text></switch></g><rect x="8220" y="220" width="520" height="520" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="12" pointer-events="none"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 128px; height: 1px; padding-top: 120px; margin-left: 2056px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">L2 Exec<br style="font-size: 30px;" />Engine</div></div></div></foreignObject><text x="2120" y="129" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L2 Exec...</text></switch></g><rect x="8020" y="220" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8100" y="300" width="80" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8020" y="380" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8100" y="460" width="80" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8020" y="540" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8100" y="620" width="80" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8020" y="700" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="220" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="300" width="80" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="380" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="460" width="80" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="540" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="620" width="80" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8780" y="700" width="160" height="40" fill="#000000" stroke="none" pointer-events="none"/><rect x="8300" y="780" width="40" height="80" fill="#000000" stroke="none" pointer-events="none"/><rect x="8220" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8460" y="780" width="40" height="80" fill="#000000" stroke="none" pointer-events="none"/><rect x="8380" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8620" y="780" width="40" height="80" fill="#000000" stroke="none" pointer-events="none"/><rect x="8540" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8700" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8300" y="100" width="40" height="80" fill="#000000" stroke="none" pointer-events="none"/><rect x="8220" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8460" y="100" width="40" height="80" fill="#000000" stroke="none" pointer-events="none"/><rect x="8380" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8620" y="100" width="40" height="80" fill="#000000" stroke="none" pointer-events="none"/><rect x="8540" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><rect x="8700" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 233px; margin-left: 2535px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); "><div style="display: inline-block; font-size: 70px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">Reset:</div></div></div></foreignObject><text x="2535" y="254" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="70px" text-anchor="middle">Reset:</text></switch></g><path d="M 6940 2460 L 7900 2460 L 7980 2560 L 7900 2660 L 6940 2660 L 7020 2560 Z" fill="#a8fff6" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 254px; height: 1px; padding-top: 662px; margin-left: 1736px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;"><div>110</div></div></div></div></foreignObject><text x="1863" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g><path d="M 7940 2460 L 8260 2460 L 8340 2560 L 8260 2660 L 7940 2660 L 8020 2560 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="none"/><g transform="translate(-0.5 -0.5)scale(4)"><switch><foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 662px; margin-left: 1986px;"><div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; "><div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">110</div></div></div></foreignObject><text x="2033" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text></switch></g></g><switch><g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/><a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank"><text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text></a></switch></svg>
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5992 2282" width="5992" height="2282">
+	<title>batch-deriv-pipeline-svg</title>
+	<defs>
+		<image  width="5992" height="2282" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAF2gAAAjqAQMAAADAiA0eAAAAAXNSR0IB2cksfwAAAANQTFRF////p8QbyAAABpFJREFUeJztwQENAAAAwqD3T20ON6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHg1HxIAAY6fyO8AAAAASUVORK5CYII="/>
+	</defs>
+	<style>
+		tspan { white-space:pre } 
+		.s0 { fill: #99ffcc;stroke: #000000;stroke-width: 2 } 
+		.t1 { font-size: 30px;fill: #000000;font-family: "Helvetica" } 
+		.s2 { fill: #a8fff6;stroke: #000000;stroke-width: 2 } 
+		.s3 { fill: #96ffe3;stroke: #000000;stroke-width: 2 } 
+		.s4 { fill: none;stroke: #000000;stroke-width: 14;stroke-dasharray: 42 } 
+		.s5 { fill: #99ff99;stroke: #000000;stroke-width: 2 } 
+		.s6 { fill: #9ceeff;stroke: #000000;stroke-width: 2 } 
+		.s7 { fill: #e3ff96;stroke: #000000;stroke-width: 2 } 
+		.s8 { fill: #ffffff;stroke: #000000;stroke-width: 2 } 
+		.s9 { fill: none } 
+		.t10 { font-size: 50px;fill: #000000;font-family: "Helvetica" } 
+		.s11 { fill: #000000;stroke: #000000;stroke-linejoin: round;stroke-width: 2 } 
+		.t12 { font-size: 26px;fill: #000000;font-family: "Helvetica" } 
+		.t13 { font-size: 40px;fill: #000000;font-family: "Helvetica" } 
+		.t14 { font-size: 36px;fill: #000000;font-family: "Helvetica" } 
+		.s15 { fill: #c9f783;stroke: #000000;stroke-width: 2 } 
+		.s16 { fill: #ffffff;stroke: #000000;stroke-width: 6 } 
+		.s17 { fill: #000000 } 
+		.t18 { font-size: 70px;fill: #000000;font-family: "Helvetica" } 
+		.t19 { font-size: 10px;fill: #000000;font-weight: 400;font-family: "LiberationSans", "Liberation Sans" } 
+	</style>
+	<use id="Layer 1" href="#img1" x="0" y="0"/>
+	<g id="Layer">
+		<path id="Layer" class="s0" d="m2410.5 1450.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,2676.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s2" d="m3450.5 1450.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,3716.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s3" d="m2930.5 1450.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,3196.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s4" d="m2050.5 1500.5h400"/>
+		<path id="Layer" class="s5" d="m1890.5 1450.5h120l40 50-40 50h-120l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,1966.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s3" d="m2930.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Batch Queue" style="transform: matrix(2,0,0,2,3180.25,828.25)" >
+					<tspan x="-97.2" y="0" class="t1">Batch Queue
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s6" d="m3970.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Engine Queue" style="transform: matrix(2,0,0,2,4220.25,828.25)" >
+					<tspan x="-105.5" y="0" class="t1">Engine Queue
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s2" d="m3450.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="PayloadAttributes..." style="transform: matrix(2,0,0,2,3700.25,828.25)" >
+					<tspan x="-146.9" y="0" class="t1">PayloadAttributes...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m2410.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel..." style="transform: matrix(2,0,0,2,2660.25,828.25)" >
+					<tspan x="-75.9" y="0" class="t1">Channel...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s5" d="m1890.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Channel..." style="transform: matrix(2,0,0,2,2140.25,828.25)" >
+					<tspan x="-75.9" y="0" class="t1">Channel...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s7" d="m850.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Traversal" style="transform: matrix(2,0,0,2,1100.25,828.25)" >
+					<tspan x="-90.4" y="0" class="t1">L1 Traversal
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s7" d="m850.5 1450.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,1116.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s4" d="m4170.5 1500.5h320"/>
+		<path id="Layer" class="s6" d="m3970.5 1450.5h160l40 50-40 50h-160l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,4066.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s8" d="m3755.5 254.5c91-32 195 32 130 96 65 32 65 96-39 96-52 64-208 64-254.8 0-67.6 32-161.2-44.8-78-80-83.2-16-57.2-96 46.8-96 26-64 130-64 195-16z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Deposits" style="transform: matrix(2,0,0,2,3690.25,368.25)" >
+					<tspan x="-87.8" y="0" class="t1">L1 Deposits
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s6" d="m4330.5 990.5h140l40 50-40 50h-140l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,4416.25,1084.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s3" d="m2930.5 1230.5h520l40 50-40 50h-520l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,3206.25,1324.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m2410.5 1230.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,2676.25,1324.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s5" d="m2270.5 1230.5h120l40 50-40 50h-120l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,2346.25,1324.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s7" d="m850.5 1330.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,1116.25,1424.25)" >
+					<tspan x="-28.6" y="0" class="t1">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s5" d="m1890.5 1330.5h120l40 50-40 50h-120l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,1966.25,1424.25)" >
+					<tspan x="-28.6" y="0" class="t1">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s0" d="m2410.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,2676.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s2" d="m3450.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,3716.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s3" d="m2930.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,3196.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s5" d="m1890.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,2156.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s7" d="m850.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,1116.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s6" d="m3970.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,4236.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m4860.5 576.5h1080v260h-1080z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="1) find safe L2 block..." style="transform: matrix(2,0,0,2,4864.25,736.25)" >
+					<tspan x="0" y="0" class="t10">1) find safe L2 block...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m4860.5 1236.5h1120v260h-1120z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="3) reset all stage orig..." style="transform: matrix(2,0,0,2,4864.25,1396.25)" >
+					<tspan x="0" y="0" class="t10">3) reset all stage orig...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m4860.5 1556.5h940v260h-940z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="4) dry-run pipeline..." style="transform: matrix(2,0,0,2,4864.25,1716.25)" >
+					<tspan x="0" y="0" class="t10">4) dry-run pipeline...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m4860.5 1876.5h1060v260h-1060z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="5) new L1 data..." style="transform: matrix(2,0,0,2,4864.25,2036.25)" >
+					<tspan x="0" y="0" class="t10">5) new L1 data...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m4860.5 916.5h1080v260h-1080z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="2) Stages with gaps wi..." style="transform: matrix(2,0,0,2,4864.25,1076.25)" >
+					<tspan x="0" y="0" class="t10">2) Stages with gaps wi...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s11" d="m1028.1 511.5h124.8v47.2h148l-210.4 70.8-210.4-70.8h148z"/>
+		<path id="Layer" class="s11" d="m4305.3 629.5h-124.7v-47.2h-148l210.4-70.8 210.4 70.8h-148.1z"/>
+		<path id="Layer" class="s9" d="m230.5 2070.5h580v200h-580z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Numbers for illustrati..." style="transform: matrix(2,0,0,2,520.25,2186.25)" >
+					<tspan x="-150.5" y="0" class="t12">Numbers for illustrati...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m30.5 950.5h680v300h-680z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="&quot;ResetStep&quot;:..." style="transform: matrix(2,0,0,2,370.25,1124.25)" >
+					<tspan x="-145.6" y="0" class="t13">&quot;ResetStep&quot;:...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m10.5 1470.5h720v500h-720z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="&quot;Step&quot;:..." style="transform: matrix(2,0,0,2,370.25,1744.25)" >
+					<tspan x="-89.7" y="0" class="t13">&quot;Step&quot;:...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m880.5 1930.5h3540v120h-3540z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payl..." style="transform: matrix(2,0,0,2,2650.25,2012.25)" >
+					<tspan x="-973.5" y="0" class="t14">L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payl...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m1900.5 1050.5h340v280h-340z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Resets..." style="transform: matrix(2,0,0,2,2236.25,1212.25)" >
+					<tspan x="-153.7" y="0" class="t14">Resets...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s9" d="m3810.5 950.5h460v280h-460z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="ResetsSequenc..." style="transform: matrix(2,0,0,2,4266.25,1112.25)" >
+					<tspan x="-309.1" y="0" class="t14">ResetsSequenc...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s15" d="m1370.5 670.5h500v280h-500z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Retrieval" style="transform: matrix(2,0,0,2,1620.25,828.25)" >
+					<tspan x="-89.3" y="0" class="t1">L1 Retrieval
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s15" d="m1370.5 1450.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,1636.25,1544.25)" >
+					<tspan x="-28.6" y="0" class="t1">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s15" d="m1370.5 1330.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="100" style="transform: matrix(2,0,0,2,1636.25,1424.25)" >
+					<tspan x="-28.6" y="0" class="t1">100
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s15" d="m1370.5 1650.5h500l40 50-40 50h-500l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="130" style="transform: matrix(2,0,0,2,1636.25,1744.25)" >
+					<tspan x="-28.6" y="0" class="t1">130
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s11" d="m1576.7 511.5h124.7v47.2h148.1l-210.4 70.8-210.4-70.8h148z"/>
+		<path id="Layer" class="s11" d="m3648.1 531.5h124.8v47.2h148l-210.4 70.8-210.4-70.8h148z"/>
+		<path id="Layer" class="s8" d="m1705.5 234.5c91-32 195 32 130 96 65 32 65 96-39 96-52 64-208 64-254.8 0-67.6 32-161.2-44.8-78-80-83.2-16-57.2-96 46.8-96 26-64 130-64 195-16z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Data" style="transform: matrix(2,0,0,2,1640.25,348.25)" >
+					<tspan x="-58.5" y="0" class="t1">L1 Data
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s8" d="m1165.5 234.5c91-32 195 32 130 96 65 32 65 96-39 96-52 64-208 64-254.8 0-67.6 32-161.2-44.8-78-80-83.2-16-57.2-96 46.8-96 26-64 130-64 195-16z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L1 Chain" style="transform: matrix(2,0,0,2,1100.25,348.25)" >
+					<tspan x="-65.5" y="0" class="t1">L1 Chain
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s16" d="m4110.5 110.5h260v260h-260z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="L2 Exec..." style="transform: matrix(2,0,0,2,4240.25,258.25)" >
+					<tspan x="-72.3" y="0" class="t1">L2 Exec...
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s17" d="m4010.5 110.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4050.5 150.5h40v20h-40z"/>
+		<path id="Layer" class="s17" d="m4010.5 190.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4050.5 230.5h40v20h-40z"/>
+		<path id="Layer" class="s17" d="m4010.5 270.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4050.5 310.5h40v20h-40z"/>
+		<path id="Layer" class="s17" d="m4010.5 350.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4390.5 110.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4390.5 150.5h40v20h-40z"/>
+		<path id="Layer" class="s17" d="m4390.5 190.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4390.5 230.5h40v20h-40z"/>
+		<path id="Layer" class="s17" d="m4390.5 270.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4390.5 310.5h40v20h-40z"/>
+		<path id="Layer" class="s17" d="m4390.5 350.5h80v20h-80z"/>
+		<path id="Layer" class="s17" d="m4150.5 390.5h20v40h-20z"/>
+		<path id="Layer" class="s17" d="m4110.5 390.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4230.5 390.5h20v40h-20z"/>
+		<path id="Layer" class="s17" d="m4190.5 390.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4310.5 390.5h20v40h-20z"/>
+		<path id="Layer" class="s17" d="m4270.5 390.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4350.5 390.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4150.5 50.5h20v40h-20z"/>
+		<path id="Layer" class="s17" d="m4110.5 10.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4230.5 50.5h20v40h-20z"/>
+		<path id="Layer" class="s17" d="m4190.5 10.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4310.5 50.5h20v40h-20z"/>
+		<path id="Layer" class="s17" d="m4270.5 10.5h20v80h-20z"/>
+		<path id="Layer" class="s17" d="m4350.5 10.5h20v80h-20z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="Reset:" style="transform: matrix(2,0,0,2,5070.25,508.25)" >
+					<tspan x="-109.6" y="0" class="t18">Reset:
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s2" d="m3470.5 1230.5h480l40 50-40 50h-480l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,3726.25,1324.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+		<path id="Layer" class="s6" d="m3970.5 1230.5h160l40 50-40 50h-160l40-50z"/>
+		<g id="Layer">
+			<g id="Layer">
+				<text id="110" style="transform: matrix(2,0,0,2,4066.25,1324.25)" >
+					<tspan x="-28.6" y="0" class="t1">110
+</tspan>
+				</text>
+			</g>
+		</g>
+	</g>
+	<g id="Layer">
+		<g id="Layer">
+		</g>
+		<g id="Layer">
+			<text id="Text is not SVG - cannot display" style="transform: matrix(.5,0,0,.5,25.5,48)" >
+				<tspan x="-70.9" y="0" class="t19">Text is not SVG - cannot display
+</tspan>
+			</text>
+		</g>
+	</g>
+</svg>

--- a/specs/assets/batch-deriv-pipeline.svg
+++ b/specs/assets/batch-deriv-pipeline.svg
@@ -1,489 +1,609 @@
-<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5992 2282" width="5992" height="2282">
-	<title>batch-deriv-pipeline-svg</title>
-	<defs>
-		<image  width="5992" height="2282" id="img1" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAF2gAAAjqAQMAAADAiA0eAAAAAXNSR0IB2cksfwAAAANQTFRF////p8QbyAAABpFJREFUeJztwQENAAAAwqD3T20ON6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHg1HxIAAY6fyO8AAAAASUVORK5CYII="/>
-	</defs>
-	<style>
-		tspan { white-space:pre } 
-		.s0 { fill: #99ffcc;stroke: #000000;stroke-width: 2 } 
-		.t1 { font-size: 30px;fill: #000000;font-family: "Helvetica" } 
-		.s2 { fill: #a8fff6;stroke: #000000;stroke-width: 2 } 
-		.s3 { fill: #96ffe3;stroke: #000000;stroke-width: 2 } 
-		.s4 { fill: none;stroke: #000000;stroke-width: 14;stroke-dasharray: 42 } 
-		.s5 { fill: #99ff99;stroke: #000000;stroke-width: 2 } 
-		.s6 { fill: #9ceeff;stroke: #000000;stroke-width: 2 } 
-		.s7 { fill: #e3ff96;stroke: #000000;stroke-width: 2 } 
-		.s8 { fill: #ffffff;stroke: #000000;stroke-width: 2 } 
-		.s9 { fill: none } 
-		.t10 { font-size: 50px;fill: #000000;font-family: "Helvetica" } 
-		.s11 { fill: #000000;stroke: #000000;stroke-linejoin: round;stroke-width: 2 } 
-		.t12 { font-size: 26px;fill: #000000;font-family: "Helvetica" } 
-		.t13 { font-size: 40px;fill: #000000;font-family: "Helvetica" } 
-		.t14 { font-size: 36px;fill: #000000;font-family: "Helvetica" } 
-		.s15 { fill: #c9f783;stroke: #000000;stroke-width: 2 } 
-		.s16 { fill: #ffffff;stroke: #000000;stroke-width: 6 } 
-		.s17 { fill: #000000 } 
-		.t18 { font-size: 70px;fill: #000000;font-family: "Helvetica" } 
-		.t19 { font-size: 10px;fill: #000000;font-weight: 400;font-family: "LiberationSans", "Liberation Sans" } 
-	</style>
-	<use id="Layer 1" href="#img1" x="0" y="0"/>
-	<g id="Layer">
-		<path id="Layer" class="s0" d="m2410.5 1450.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,2676.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s2" d="m3450.5 1450.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,3716.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s3" d="m2930.5 1450.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,3196.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s4" d="m2050.5 1500.5h400"/>
-		<path id="Layer" class="s5" d="m1890.5 1450.5h120l40 50-40 50h-120l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,1966.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s3" d="m2930.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Batch Queue" style="transform: matrix(2,0,0,2,3180.25,828.25)" >
-					<tspan x="-97.2" y="0" class="t1">Batch Queue
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s6" d="m3970.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Engine Queue" style="transform: matrix(2,0,0,2,4220.25,828.25)" >
-					<tspan x="-105.5" y="0" class="t1">Engine Queue
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s2" d="m3450.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="PayloadAttributes..." style="transform: matrix(2,0,0,2,3700.25,828.25)" >
-					<tspan x="-146.9" y="0" class="t1">PayloadAttributes...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m2410.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel..." style="transform: matrix(2,0,0,2,2660.25,828.25)" >
-					<tspan x="-75.9" y="0" class="t1">Channel...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s5" d="m1890.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Channel..." style="transform: matrix(2,0,0,2,2140.25,828.25)" >
-					<tspan x="-75.9" y="0" class="t1">Channel...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s7" d="m850.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Traversal" style="transform: matrix(2,0,0,2,1100.25,828.25)" >
-					<tspan x="-90.4" y="0" class="t1">L1 Traversal
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s7" d="m850.5 1450.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,1116.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s4" d="m4170.5 1500.5h320"/>
-		<path id="Layer" class="s6" d="m3970.5 1450.5h160l40 50-40 50h-160l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,4066.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s8" d="m3755.5 254.5c91-32 195 32 130 96 65 32 65 96-39 96-52 64-208 64-254.8 0-67.6 32-161.2-44.8-78-80-83.2-16-57.2-96 46.8-96 26-64 130-64 195-16z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Deposits" style="transform: matrix(2,0,0,2,3690.25,368.25)" >
-					<tspan x="-87.8" y="0" class="t1">L1 Deposits
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s6" d="m4330.5 990.5h140l40 50-40 50h-140l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,4416.25,1084.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s3" d="m2930.5 1230.5h520l40 50-40 50h-520l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,3206.25,1324.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m2410.5 1230.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,2676.25,1324.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s5" d="m2270.5 1230.5h120l40 50-40 50h-120l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,2346.25,1324.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s7" d="m850.5 1330.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,1116.25,1424.25)" >
-					<tspan x="-28.6" y="0" class="t1">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s5" d="m1890.5 1330.5h120l40 50-40 50h-120l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,1966.25,1424.25)" >
-					<tspan x="-28.6" y="0" class="t1">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s0" d="m2410.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,2676.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s2" d="m3450.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,3716.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s3" d="m2930.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,3196.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s5" d="m1890.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,2156.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s7" d="m850.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,1116.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s6" d="m3970.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,4236.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m4860.5 576.5h1080v260h-1080z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="1) find safe L2 block..." style="transform: matrix(2,0,0,2,4864.25,736.25)" >
-					<tspan x="0" y="0" class="t10">1) find safe L2 block...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m4860.5 1236.5h1120v260h-1120z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="3) reset all stage orig..." style="transform: matrix(2,0,0,2,4864.25,1396.25)" >
-					<tspan x="0" y="0" class="t10">3) reset all stage orig...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m4860.5 1556.5h940v260h-940z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="4) dry-run pipeline..." style="transform: matrix(2,0,0,2,4864.25,1716.25)" >
-					<tspan x="0" y="0" class="t10">4) dry-run pipeline...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m4860.5 1876.5h1060v260h-1060z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="5) new L1 data..." style="transform: matrix(2,0,0,2,4864.25,2036.25)" >
-					<tspan x="0" y="0" class="t10">5) new L1 data...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m4860.5 916.5h1080v260h-1080z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="2) Stages with gaps wi..." style="transform: matrix(2,0,0,2,4864.25,1076.25)" >
-					<tspan x="0" y="0" class="t10">2) Stages with gaps wi...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s11" d="m1028.1 511.5h124.8v47.2h148l-210.4 70.8-210.4-70.8h148z"/>
-		<path id="Layer" class="s11" d="m4305.3 629.5h-124.7v-47.2h-148l210.4-70.8 210.4 70.8h-148.1z"/>
-		<path id="Layer" class="s9" d="m230.5 2070.5h580v200h-580z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Numbers for illustrati..." style="transform: matrix(2,0,0,2,520.25,2186.25)" >
-					<tspan x="-150.5" y="0" class="t12">Numbers for illustrati...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m30.5 950.5h680v300h-680z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="&quot;ResetStep&quot;:..." style="transform: matrix(2,0,0,2,370.25,1124.25)" >
-					<tspan x="-145.6" y="0" class="t13">&quot;ResetStep&quot;:...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m10.5 1470.5h720v500h-720z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="&quot;Step&quot;:..." style="transform: matrix(2,0,0,2,370.25,1744.25)" >
-					<tspan x="-89.7" y="0" class="t13">&quot;Step&quot;:...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m880.5 1930.5h3540v120h-3540z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payl..." style="transform: matrix(2,0,0,2,2650.25,2012.25)" >
-					<tspan x="-973.5" y="0" class="t14">L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payl...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m1900.5 1050.5h340v280h-340z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Resets..." style="transform: matrix(2,0,0,2,2236.25,1212.25)" >
-					<tspan x="-153.7" y="0" class="t14">Resets...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s9" d="m3810.5 950.5h460v280h-460z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="ResetsSequenc..." style="transform: matrix(2,0,0,2,4266.25,1112.25)" >
-					<tspan x="-309.1" y="0" class="t14">ResetsSequenc...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s15" d="m1370.5 670.5h500v280h-500z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Retrieval" style="transform: matrix(2,0,0,2,1620.25,828.25)" >
-					<tspan x="-89.3" y="0" class="t1">L1 Retrieval
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s15" d="m1370.5 1450.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,1636.25,1544.25)" >
-					<tspan x="-28.6" y="0" class="t1">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s15" d="m1370.5 1330.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="100" style="transform: matrix(2,0,0,2,1636.25,1424.25)" >
-					<tspan x="-28.6" y="0" class="t1">100
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s15" d="m1370.5 1650.5h500l40 50-40 50h-500l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="130" style="transform: matrix(2,0,0,2,1636.25,1744.25)" >
-					<tspan x="-28.6" y="0" class="t1">130
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s11" d="m1576.7 511.5h124.7v47.2h148.1l-210.4 70.8-210.4-70.8h148z"/>
-		<path id="Layer" class="s11" d="m3648.1 531.5h124.8v47.2h148l-210.4 70.8-210.4-70.8h148z"/>
-		<path id="Layer" class="s8" d="m1705.5 234.5c91-32 195 32 130 96 65 32 65 96-39 96-52 64-208 64-254.8 0-67.6 32-161.2-44.8-78-80-83.2-16-57.2-96 46.8-96 26-64 130-64 195-16z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Data" style="transform: matrix(2,0,0,2,1640.25,348.25)" >
-					<tspan x="-58.5" y="0" class="t1">L1 Data
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s8" d="m1165.5 234.5c91-32 195 32 130 96 65 32 65 96-39 96-52 64-208 64-254.8 0-67.6 32-161.2-44.8-78-80-83.2-16-57.2-96 46.8-96 26-64 130-64 195-16z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L1 Chain" style="transform: matrix(2,0,0,2,1100.25,348.25)" >
-					<tspan x="-65.5" y="0" class="t1">L1 Chain
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s16" d="m4110.5 110.5h260v260h-260z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="L2 Exec..." style="transform: matrix(2,0,0,2,4240.25,258.25)" >
-					<tspan x="-72.3" y="0" class="t1">L2 Exec...
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s17" d="m4010.5 110.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4050.5 150.5h40v20h-40z"/>
-		<path id="Layer" class="s17" d="m4010.5 190.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4050.5 230.5h40v20h-40z"/>
-		<path id="Layer" class="s17" d="m4010.5 270.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4050.5 310.5h40v20h-40z"/>
-		<path id="Layer" class="s17" d="m4010.5 350.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4390.5 110.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4390.5 150.5h40v20h-40z"/>
-		<path id="Layer" class="s17" d="m4390.5 190.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4390.5 230.5h40v20h-40z"/>
-		<path id="Layer" class="s17" d="m4390.5 270.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4390.5 310.5h40v20h-40z"/>
-		<path id="Layer" class="s17" d="m4390.5 350.5h80v20h-80z"/>
-		<path id="Layer" class="s17" d="m4150.5 390.5h20v40h-20z"/>
-		<path id="Layer" class="s17" d="m4110.5 390.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4230.5 390.5h20v40h-20z"/>
-		<path id="Layer" class="s17" d="m4190.5 390.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4310.5 390.5h20v40h-20z"/>
-		<path id="Layer" class="s17" d="m4270.5 390.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4350.5 390.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4150.5 50.5h20v40h-20z"/>
-		<path id="Layer" class="s17" d="m4110.5 10.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4230.5 50.5h20v40h-20z"/>
-		<path id="Layer" class="s17" d="m4190.5 10.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4310.5 50.5h20v40h-20z"/>
-		<path id="Layer" class="s17" d="m4270.5 10.5h20v80h-20z"/>
-		<path id="Layer" class="s17" d="m4350.5 10.5h20v80h-20z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="Reset:" style="transform: matrix(2,0,0,2,5070.25,508.25)" >
-					<tspan x="-109.6" y="0" class="t18">Reset:
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s2" d="m3470.5 1230.5h480l40 50-40 50h-480l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,3726.25,1324.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-		<path id="Layer" class="s6" d="m3970.5 1230.5h160l40 50-40 50h-160l40-50z"/>
-		<g id="Layer">
-			<g id="Layer">
-				<text id="110" style="transform: matrix(2,0,0,2,4066.25,1324.25)" >
-					<tspan x="-28.6" y="0" class="t1">110
-</tspan>
-				</text>
-			</g>
-		</g>
-	</g>
-	<g id="Layer">
-		<g id="Layer">
-		</g>
-		<g id="Layer">
-			<text id="Text is not SVG - cannot display" style="transform: matrix(.5,0,0,.5,25.5,48)" >
-				<tspan x="-70.9" y="0" class="t19">Text is not SVG - cannot display
-</tspan>
-			</text>
-		</g>
-	</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="11984px" height="4564px" viewBox="-0.5 -0.5 11984 4564">
+  <rect width="100%" height="100%" fill="#fff" />
+  <defs />
+  <g>
+    <path d="M 4820 2900 L 5820 2900 L 5900 3000 L 5820 3100 L 4820 3100 L 4900 3000 Z" fill="#99ffcc" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 1206px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="1338" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 6900 2900 L 7900 2900 L 7980 3000 L 7900 3100 L 6900 3100 L 6980 3000 Z" fill="#a8fff6" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 1726px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="1858" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 5860 2900 L 6860 2900 L 6940 3000 L 6860 3100 L 5860 3100 L 5940 3000 Z" fill="#96ffe3" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 1466px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="1598" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 4100 3000 L 4900 3000" fill="none" stroke="rgb(0, 0, 0)" stroke-width="28" stroke-miterlimit="10" stroke-dasharray="84 84" pointer-events="stroke" />
+    <path d="M 3780 2900 L 4020 2900 L 4100 3000 L 4020 3100 L 3780 3100 L 3860 3000 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 74px; height: 1px; padding-top: 772px; margin-left: 946px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="983" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text>
+      </switch>
+    </g>
+    <rect x="5860" y="1340" width="1000" height="560" fill="#96ffe3" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1466px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">Batch Queue</div>
+            </div>
+          </div>
+        </foreignObject><text x="1590" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Batch Queue</text>
+      </switch>
+    </g>
+    <rect x="7940" y="1340" width="1000" height="560" fill="#9ceeff" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1986px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">Engine Queue</div>
+            </div>
+          </div>
+        </foreignObject><text x="2110" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Engine Queue</text>
+      </switch>
+    </g>
+    <rect x="6900" y="1340" width="1000" height="560" fill="#a8fff6" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1726px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                <div>PayloadAttributes</div>
+                <div>Queue<br /></div>
+              </div>
+            </div>
+          </div>
+        </foreignObject><text x="1850" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">PayloadAttributes...</text>
+      </switch>
+    </g>
+    <rect x="4820" y="1340" width="1000" height="560" fill="#99ffcc" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 1206px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                <div>Channel</div>
+                <div>Input-reader<br /></div>
+              </div>
+            </div>
+          </div>
+        </foreignObject><text x="1330" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Channel...</text>
+      </switch>
+    </g>
+    <rect x="3780" y="1340" width="1000" height="560" fill="#99ff99" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 946px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                <div>Channel</div>
+                <div>Bank<br /></div>
+              </div>
+            </div>
+          </div>
+        </foreignObject><text x="1070" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">Channel...</text>
+      </switch>
+    </g>
+    <rect x="1700" y="1340" width="1000" height="560" fill="#e3ff96" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 426px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Traversal</div>
+            </div>
+          </div>
+        </foreignObject><text x="550" y="414" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Traversal</text>
+      </switch>
+    </g>
+    <path d="M 1700 2900 L 2700 2900 L 2780 3000 L 2700 3100 L 1700 3100 L 1780 3000 Z" fill="#e3ff96" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 426px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="558" y="772" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text>
+      </switch>
+    </g>
+    <path d="M 8340 3000 L 8980 3000" fill="none" stroke="rgb(0, 0, 0)" stroke-width="28" stroke-miterlimit="10" stroke-dasharray="84 84" pointer-events="stroke" />
+    <path d="M 7940 2900 L 8260 2900 L 8340 3000 L 8260 3100 L 7940 3100 L 8020 3000 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 772px; margin-left: 1986px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="2033" y="772" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 7120 540 C 6912 540 6860 700 7026.4 732 C 6860 802.4 7047.2 956 7182.4 892 C 7276 1020 7588 1020 7692 892 C 7900 892 7900 764 7770 700 C 7900 572 7692 444 7510 508 C 7380 412 7172 412 7120 540 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 258px; height: 1px; padding-top: 175px; margin-left: 1716px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Deposits</div>
+            </div>
+          </div>
+        </foreignObject><text x="1845" y="184" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Deposits</text>
+      </switch>
+    </g>
+    <path d="M 8660 1980 L 8940 1980 L 9020 2080 L 8940 2180 L 8660 2180 L 8740 2080 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 84px; height: 1px; padding-top: 542px; margin-left: 2166px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="2208" y="542" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 5860 2460 L 6900 2460 L 6980 2560 L 6900 2660 L 5860 2660 L 5940 2560 Z" fill="#96ffe3" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 274px; height: 1px; padding-top: 662px; margin-left: 1466px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="1603" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 4820 2460 L 5820 2460 L 5900 2560 L 5820 2660 L 4820 2660 L 4900 2560 Z" fill="#99ffcc" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 662px; margin-left: 1206px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="1338" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 4540 2460 L 4780 2460 L 4860 2560 L 4780 2660 L 4540 2660 L 4620 2560 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 74px; height: 1px; padding-top: 662px; margin-left: 1136px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="1173" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 1700 2660 L 2700 2660 L 2780 2760 L 2700 2860 L 1700 2860 L 1780 2760 Z" fill="#e3ff96" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 712px; margin-left: 426px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="558" y="712" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text>
+      </switch>
+    </g>
+    <path d="M 3780 2660 L 4020 2660 L 4100 2760 L 4020 2860 L 3780 2860 L 3860 2760 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 74px; height: 1px; padding-top: 712px; margin-left: 946px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="983" y="712" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text>
+      </switch>
+    </g>
+    <path d="M 4820 3300 L 5820 3300 L 5900 3400 L 5820 3500 L 4820 3500 L 4900 3400 Z" fill="#99ffcc" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1206px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="1338" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 6900 3300 L 7900 3300 L 7980 3400 L 7900 3500 L 6900 3500 L 6980 3400 Z" fill="#a8fff6" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1726px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="1858" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 5860 3300 L 6860 3300 L 6940 3400 L 6860 3500 L 5860 3500 L 5940 3400 Z" fill="#96ffe3" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1466px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="1598" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 3780 3300 L 4780 3300 L 4860 3400 L 4780 3500 L 3780 3500 L 3860 3400 Z" fill="#99ff99" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 946px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="1078" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 1700 3300 L 2700 3300 L 2780 3400 L 2700 3500 L 1700 3500 L 1780 3400 Z" fill="#e3ff96" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 426px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="558" y="872" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 7940 3300 L 8940 3300 L 9020 3400 L 8940 3500 L 7940 3500 L 8020 3400 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 1986px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="2118" y="872" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <rect x="9720" y="1152" width="2160" height="520" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 353px; margin-left: 2432px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">1) find safe L2 block<br />with canonical L1 origin</div>
+            </div>
+          </div>
+        </foreignObject><text x="2432" y="368" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">1) find safe L2 block...</text>
+      </switch>
+    </g>
+    <rect x="9720" y="2472" width="2240" height="520" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 683px; margin-left: 2432px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">3) reset all stage origins,<br />traverse chain back</div>
+            </div>
+          </div>
+        </foreignObject><text x="2432" y="698" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">3) reset all stage orig...</text>
+      </switch>
+    </g>
+    <rect x="9720" y="3112" width="1880" height="520" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 843px; margin-left: 2432px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">4) dry-run pipeline<br />to heal stage buffers</div>
+            </div>
+          </div>
+        </foreignObject><text x="2432" y="858" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">4) dry-run pipeline...</text>
+      </switch>
+    </g>
+    <rect x="9720" y="3752" width="2120" height="520" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 1003px; margin-left: 2432px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">5) new L1 data<br />can now stream into L2</div>
+            </div>
+          </div>
+        </foreignObject><text x="2432" y="1018" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">5) new L1 data...</text>
+      </switch>
+    </g>
+    <rect x="9720" y="1832" width="2160" height="520" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 523px; margin-left: 2432px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: left;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 50px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">2) Stages with gaps will<br /> reconstruct buffer data</div>
+            </div>
+          </div>
+        </foreignObject><text x="2432" y="538" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="50px">2) Stages with gaps wi...</text>
+      </switch>
+    </g>
+    <path d="M 2055.29 1022 L 2304.71 1022 L 2304.71 1116.35 L 2600.82 1116.35 L 2180 1258 L 1759.18 1116.35 L 2055.29 1116.35 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 8609.69 1258 L 8360.28 1258 L 8360.28 1163.65 L 8064.16 1163.65 L 8484.99 1022 L 8905.81 1163.65 L 8609.69 1163.65 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all" />
+    <rect x="460" y="4140" width="1160" height="400" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1085px; margin-left: 260px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 26px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: nowrap;">Numbers for illustration,<br /> referring to L1 origin<br />block numbers</div>
+            </div>
+          </div>
+        </foreignObject><text x="260" y="1093" fill="#000000" font-family="Helvetica" font-size="26px" text-anchor="middle" font-style="italic">Numbers for illustrati...</text>
+      </switch>
+    </g>
+    <rect x="60" y="1900" width="1360" height="600" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 550px; margin-left: 185px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 40px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">"<b>ResetStep</b>":<br style="font-size: 40px" />reset stage with<br style="font-size: 40px" />distance from next</div>
+            </div>
+          </div>
+        </foreignObject><text x="185" y="562" fill="#000000" font-family="Helvetica" font-size="40px" text-anchor="middle">"ResetStep":...</text>
+      </switch>
+    </g>
+    <rect x="20" y="2940" width="1440" height="1000" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 860px; margin-left: 185px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 40px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">"<b>Step</b>":<br style="font-size: 40px" />progress pipeline.<br />Start closest to L2,<br />visit previous stage<br />for more input data.</div>
+            </div>
+          </div>
+        </foreignObject><text x="185" y="872" fill="#000000" font-family="Helvetica" font-size="40px" text-anchor="middle">"Step":...</text>
+      </switch>
+    </g>
+    <rect x="1760" y="3860" width="7080" height="240" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 995px; margin-left: 1325px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 36px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payloads</div>
+            </div>
+          </div>
+        </foreignObject><text x="1325" y="1006" fill="#000000" font-family="Helvetica" font-size="36px" text-anchor="middle">L1 block hash &gt; Data TXs &gt; Channel Frames &gt; Batches &gt; Ordered batches &gt; PayloadAttributes &gt; L2 payl...</text>
+      </switch>
+    </g>
+    <rect x="3800" y="2100" width="680" height="560" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 595px; margin-left: 1118px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 36px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: nowrap;">Resets<br /><b>Channel</b><br /><b>timeout</b></div>
+            </div>
+          </div>
+        </foreignObject><text x="1118" y="606" fill="#000000" font-family="Helvetica" font-size="36px" text-anchor="end" font-style="italic">Resets...</text>
+      </switch>
+    </g>
+    <rect x="7620" y="1900" width="920" height="560" fill="none" stroke="none" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 545px; margin-left: 2133px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: right;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 36px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-style: italic; white-space: nowrap;">
+                <div>Resets</div><b>Sequencing</b><br /><b>window</b>
+              </div>
+            </div>
+          </div>
+        </foreignObject><text x="2133" y="556" fill="#000000" font-family="Helvetica" font-size="36px" text-anchor="end" font-style="italic">ResetsSequenc...</text>
+      </switch>
+    </g>
+    <rect x="2740" y="1340" width="1000" height="560" fill="#c9f783" stroke="#000000" stroke-width="4" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 405px; margin-left: 686px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Retrieval</div>
+            </div>
+          </div>
+        </foreignObject><text x="810" y="414" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Retrieval</text>
+      </switch>
+    </g>
+    <path d="M 2740 2900 L 3740 2900 L 3820 3000 L 3740 3100 L 2740 3100 L 2820 3000 Z" fill="#c9f783" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 772px; margin-left: 686px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="818" y="772" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text>
+      </switch>
+    </g>
+    <path d="M 2740 2660 L 3740 2660 L 3820 2760 L 3740 2860 L 2740 2860 L 2820 2760 Z" fill="#c9f783" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 712px; margin-left: 686px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">100</div>
+            </div>
+          </div>
+        </foreignObject><text x="818" y="712" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">100</text>
+      </switch>
+    </g>
+    <path d="M 2740 3300 L 3740 3300 L 3820 3400 L 3740 3500 L 2740 3500 L 2820 3400 Z" fill="#c9f783" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 264px; height: 1px; padding-top: 872px; margin-left: 686px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">130</div>
+            </div>
+          </div>
+        </foreignObject><text x="818" y="872" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">130</text>
+      </switch>
+    </g>
+    <path d="M 3152.45 1022 L 3401.87 1022 L 3401.87 1116.35 L 3697.98 1116.35 L 3277.16 1258 L 2856.34 1116.35 L 3152.45 1116.35 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 7295.29 1062 L 7544.71 1062 L 7544.71 1156.35 L 7840.82 1156.35 L 7420 1298 L 6999.18 1156.35 L 7295.29 1156.35 Z" fill="#000000" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" pointer-events="all" />
+    <path d="M 3020 500 C 2812 500 2760 660 2926.4 692 C 2760 762.4 2947.2 916 3082.4 852 C 3176 980 3488 980 3592 852 C 3800 852 3800 724 3670 660 C 3800 532 3592 404 3410 468 C 3280 372 3072 372 3020 500 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 258px; height: 1px; padding-top: 165px; margin-left: 691px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Data</div>
+            </div>
+          </div>
+        </foreignObject><text x="820" y="174" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Data</text>
+      </switch>
+    </g>
+    <path d="M 1940 500 C 1732 500 1680 660 1846.4 692 C 1680 762.4 1867.2 916 2002.4 852 C 2096 980 2408 980 2512 852 C 2720 852 2720 724 2590 660 C 2720 532 2512 404 2330 468 C 2200 372 1992 372 1940 500 Z" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="4" stroke-miterlimit="10" pointer-events="all" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 258px; height: 1px; padding-top: 165px; margin-left: 421px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">L1 Chain</div>
+            </div>
+          </div>
+        </foreignObject><text x="550" y="174" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L1 Chain</text>
+      </switch>
+    </g>
+    <rect x="8220" y="220" width="520" height="520" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-width="12" pointer-events="none" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 128px; height: 1px; padding-top: 120px; margin-left: 2056px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">L2 Exec<br style="font-size: 30px;" />Engine</div>
+            </div>
+          </div>
+        </foreignObject><text x="2120" y="129" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="30px" text-anchor="middle">L2 Exec...</text>
+      </switch>
+    </g>
+    <rect x="8020" y="220" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8100" y="300" width="80" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8020" y="380" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8100" y="460" width="80" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8020" y="540" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8100" y="620" width="80" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8020" y="700" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="220" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="300" width="80" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="380" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="460" width="80" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="540" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="620" width="80" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8780" y="700" width="160" height="40" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8300" y="780" width="40" height="80" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8220" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8460" y="780" width="40" height="80" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8380" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8620" y="780" width="40" height="80" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8540" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8700" y="780" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8300" y="100" width="40" height="80" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8220" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8460" y="100" width="40" height="80" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8380" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8620" y="100" width="40" height="80" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8540" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <rect x="8700" y="20" width="40" height="160" fill="#000000" stroke="none" pointer-events="none" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 233px; margin-left: 2535px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: rgb(0, 0, 0); ">
+              <div style="display: inline-block; font-size: 70px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">Reset:</div>
+            </div>
+          </div>
+        </foreignObject><text x="2535" y="254" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="70px" text-anchor="middle">Reset:</text>
+      </switch>
+    </g>
+    <path d="M 6940 2460 L 7900 2460 L 7980 2560 L 7900 2660 L 6940 2660 L 7020 2560 Z" fill="#a8fff6" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="none" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 254px; height: 1px; padding-top: 662px; margin-left: 1736px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                <div>110</div>
+              </div>
+            </div>
+          </div>
+        </foreignObject><text x="1863" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+    <path d="M 7940 2460 L 8260 2460 L 8340 2560 L 8260 2660 L 7940 2660 L 8020 2560 Z" fill="#9ceeff" stroke="#000000" stroke-width="4" stroke-miterlimit="10" pointer-events="none" />
+    <g transform="translate(-0.5 -0.5)scale(4)">
+      <switch>
+        <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe center; width: 94px; height: 1px; padding-top: 662px; margin-left: 1986px;">
+            <div style="box-sizing: border-box; font-size: 0px; text-align: center;" data-drawio-colors="color: #000000; ">
+              <div style="display: inline-block; font-size: 30px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">110</div>
+            </div>
+          </div>
+        </foreignObject><text x="2033" y="662" fill="#000000" font-family="Helvetica" font-size="30px" text-anchor="middle">110</text>
+      </switch>
+    </g>
+  </g>
+  <switch>
+    <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" /><a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank"><text text-anchor="middle" font-size="10px" x="50%" y="100%">Text is not SVG - cannot display</text></a>
+  </switch>
 </svg>


### PR DESCRIPTION
# Overview

Adds a white background to `batch-deriv-*.svg` in the specs assets.

**Rationale**

Most users view GitHub in dark mode, and the transparent backgrounds made the descriptions on these images unreadable.
