### PR TITLE
ops: Remove speculative checks, add multiple-reviewers label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,5 @@
 queue_rules:
   - name: default
-    speculative_checks: 3
     conditions: []
 
 pull_request_rules:
@@ -11,6 +10,7 @@ pull_request_rules:
         - "#approved-reviews-by>=1"
         - "#changes-requested-reviews-by=0"
         - "label!=do-not-merge"
+        - "label!=multiple-reviewers"
         - "label!=mergify-ignore"
         - "base=develop"
         - or:


### PR DESCRIPTION
Removes speculative checks since they are increasing CI costs significantly and haven't provided much value. Also adds a new `multiple-reviewers` label to block auto-merge if review from multiple people is required.