### PR TITLE
feat(ctb): deploy setup tag

### DIFF
--- a/packages/contracts-bedrock/deploy/000-ProxyAdmin.ts
+++ b/packages/contracts-bedrock/deploy/000-ProxyAdmin.ts
@@ -17,6 +17,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['ProxyAdmin']
+deployFn.tags = ['ProxyAdmin', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/001-AddressManager.ts
+++ b/packages/contracts-bedrock/deploy/001-AddressManager.ts
@@ -17,6 +17,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['AddressManager']
+deployFn.tags = ['AddressManager', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/002-L1StandardBridgeProxy.ts
+++ b/packages/contracts-bedrock/deploy/002-L1StandardBridgeProxy.ts
@@ -16,6 +16,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1StandardBridgeProxy']
+deployFn.tags = ['L1StandardBridgeProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/003-L2OutputOracleProxy.ts
+++ b/packages/contracts-bedrock/deploy/003-L2OutputOracleProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L2OutputOracleProxy']
+deployFn.tags = ['L2OutputOracleProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/004-L1CrossDomainMessengerProxy.ts
+++ b/packages/contracts-bedrock/deploy/004-L1CrossDomainMessengerProxy.ts
@@ -13,6 +13,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1CrossDomainMessengerProxy']
+deployFn.tags = ['L1CrossDomainMessengerProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/005-OptimismPortalProxy.ts
+++ b/packages/contracts-bedrock/deploy/005-OptimismPortalProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismPortalProxy']
+deployFn.tags = ['OptimismPortalProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/006-OptimismMintableERC20FactoryProxy.ts
+++ b/packages/contracts-bedrock/deploy/006-OptimismMintableERC20FactoryProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismMintableERC20FactoryProxy']
+deployFn.tags = ['OptimismMintableERC20FactoryProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/007-L1ERC721BridgeProxy.ts
+++ b/packages/contracts-bedrock/deploy/007-L1ERC721BridgeProxy.ts
@@ -16,6 +16,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1ERC721BridgeProxy']
+deployFn.tags = ['L1ERC721BridgeProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/008-SystemConfigProxy.ts
+++ b/packages/contracts-bedrock/deploy/008-SystemConfigProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemConfigProxy']
+deployFn.tags = ['SystemConfigProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/009-SystemDictatorProxy.ts
+++ b/packages/contracts-bedrock/deploy/009-SystemDictatorProxy.ts
@@ -16,6 +16,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemDictatorProxy']
+deployFn.tags = ['SystemDictatorProxy', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/010-L1CrossDomainMessengerImpl.ts
+++ b/packages/contracts-bedrock/deploy/010-L1CrossDomainMessengerImpl.ts
@@ -32,6 +32,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1CrossDomainMessengerImpl']
+deployFn.tags = ['L1CrossDomainMessengerImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/011-L1StandardBridgeImpl.ts
+++ b/packages/contracts-bedrock/deploy/011-L1StandardBridgeImpl.ts
@@ -32,6 +32,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1StandardBridgeImpl']
+deployFn.tags = ['L1StandardBridgeImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/012-L2OutputOracleImpl.ts
+++ b/packages/contracts-bedrock/deploy/012-L2OutputOracleImpl.ts
@@ -41,6 +41,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L2OutputOracleImpl']
+deployFn.tags = ['L2OutputOracleImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/013-OptimismPortalImpl.ts
+++ b/packages/contracts-bedrock/deploy/013-OptimismPortalImpl.ts
@@ -35,6 +35,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismPortalImpl']
+deployFn.tags = ['OptimismPortalImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/014-OptimismMintableERC20FactoryImpl.ts
+++ b/packages/contracts-bedrock/deploy/014-OptimismMintableERC20FactoryImpl.ts
@@ -26,6 +26,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismMintableERC20FactoryImpl']
+deployFn.tags = ['OptimismMintableERC20FactoryImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/015-L1ERC721BridgeImpl.ts
+++ b/packages/contracts-bedrock/deploy/015-L1ERC721BridgeImpl.ts
@@ -27,6 +27,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1ERC721BridgeImpl']
+deployFn.tags = ['L1ERC721BridgeImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/016-PortalSenderImpl.ts
+++ b/packages/contracts-bedrock/deploy/016-PortalSenderImpl.ts
@@ -26,6 +26,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['PortalSenderImpl']
+deployFn.tags = ['PortalSenderImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
+++ b/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
@@ -45,6 +45,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemConfigImpl']
+deployFn.tags = ['SystemConfigImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/018-SystemDictatorImpl.ts
+++ b/packages/contracts-bedrock/deploy/018-SystemDictatorImpl.ts
@@ -12,6 +12,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemDictatorImpl']
+deployFn.tags = ['SystemDictatorImpl', 'setup']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -188,6 +188,6 @@ const deployFn: DeployFunction = async (hre) => {
   }
 }
 
-deployFn.tags = ['SystemDictatorImpl']
+deployFn.tags = ['SystemDictatorImpl', 'setup']
 
 export default deployFn


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds a new "setup" tag to deploy steps that can be executed ahead of the Bedrock migration. Runs everything except the SystemDictator steps.