### PR TITLE
feat(ctb): break out system dictator steps

### DIFF
--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -1,0 +1,279 @@
+import assert from 'assert'
+
+import { ethers } from 'ethers'
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+import { awaitCondition } from '@eth-optimism/core-utils'
+import '@eth-optimism/hardhat-deploy-config'
+import 'hardhat-deploy'
+import '@nomiclabs/hardhat-ethers'
+
+import {
+  assertContractVariable,
+  getContractsFromArtifacts,
+  getDeploymentAddress,
+  doStep,
+  jsonifyTransaction,
+} from '../src/deploy-utils'
+
+const deployFn: DeployFunction = async (hre) => {
+  const { deployer } = await hre.getNamedAccounts()
+
+  // Set up required contract references.
+  const [
+    SystemDictator,
+    ProxyAdmin,
+    AddressManager,
+    L1CrossDomainMessenger,
+    L1StandardBridgeProxy,
+    L1StandardBridgeProxyWithSigner,
+    L1ERC721BridgeProxy,
+    L1ERC721BridgeProxyWithSigner,
+  ] = await getContractsFromArtifacts(hre, [
+    {
+      name: 'SystemDictatorProxy',
+      iface: 'SystemDictator',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'ProxyAdmin',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'Lib_AddressManager',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'Proxy__OVM_L1CrossDomainMessenger',
+      iface: 'L1CrossDomainMessenger',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'Proxy__OVM_L1StandardBridge',
+    },
+    {
+      name: 'Proxy__OVM_L1StandardBridge',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'L1ERC721BridgeProxy',
+    },
+    {
+      name: 'L1ERC721BridgeProxy',
+      signerOrProvider: deployer,
+    },
+  ])
+
+  // If we have the key for the controller then we don't need to wait for external txns.
+  const isLiveDeployer =
+    deployer.toLowerCase() === hre.deployConfig.controller.toLowerCase()
+
+  // Transfer ownership of the ProxyAdmin to the SystemDictator.
+  if ((await ProxyAdmin.owner()) !== SystemDictator.address) {
+    console.log(`Setting ProxyAdmin owner to MSD`)
+    await ProxyAdmin.transferOwnership(SystemDictator.address)
+  } else {
+    console.log(`Proxy admin already owned by MSD`)
+  }
+
+  // We don't need to transfer proxy addresses if we're already beyond the proxy transfer step.
+  const needsProxyTransfer =
+    (await SystemDictator.currentStep()) <=
+    (await SystemDictator.PROXY_TRANSFER_STEP())
+
+  // Transfer ownership of the AddressManager to SystemDictator.
+  if (
+    needsProxyTransfer &&
+    (await AddressManager.owner()) !== SystemDictator.address
+  ) {
+    if (isLiveDeployer) {
+      console.log(`Setting AddressManager owner to MSD`)
+      await AddressManager.transferOwnership(SystemDictator.address)
+    } else {
+      const tx = await AddressManager.populateTransaction.transferOwnership(
+        SystemDictator.address
+      )
+      console.log(`Please transfer AddressManager owner to MSD`)
+      console.log(`AddressManager address: ${AddressManager.address}`)
+      console.log(`MSD address: ${SystemDictator.address}`)
+      console.log(`JSON:`)
+      console.log(jsonifyTransaction(tx))
+    }
+
+    // Wait for the ownership transfer to complete.
+    await awaitCondition(
+      async () => {
+        const owner = await AddressManager.owner()
+        return owner === SystemDictator.address
+      },
+      30000,
+      1000
+    )
+  } else {
+    console.log(`AddressManager already owned by the SystemDictator`)
+  }
+
+  // Transfer ownership of the L1CrossDomainMessenger to SystemDictator.
+  if (
+    needsProxyTransfer &&
+    (await AddressManager.getAddress('OVM_L1CrossDomainMessenger')) !==
+      ethers.constants.AddressZero &&
+    (await L1CrossDomainMessenger.owner()) !== SystemDictator.address
+  ) {
+    if (isLiveDeployer) {
+      console.log(`Setting L1CrossDomainMessenger owner to MSD`)
+      await L1CrossDomainMessenger.transferOwnership(SystemDictator.address)
+    } else {
+      const tx =
+        await L1CrossDomainMessenger.populateTransaction.transferOwnership(
+          SystemDictator.address
+        )
+      console.log(`Please transfer L1CrossDomainMessenger owner to MSD`)
+      console.log(`L1XDM address: ${L1CrossDomainMessenger.address}`)
+      console.log(`MSD address: ${SystemDictator.address}`)
+      console.log(`JSON:`)
+      console.log(jsonifyTransaction(tx))
+    }
+
+    // Wait for the ownership transfer to complete.
+    await awaitCondition(
+      async () => {
+        const owner = await L1CrossDomainMessenger.owner()
+        return owner === SystemDictator.address
+      },
+      30000,
+      1000
+    )
+  } else {
+    console.log(`L1CrossDomainMessenger already owned by MSD`)
+  }
+
+  // Transfer ownership of the L1StandardBridge (proxy) to SystemDictator.
+  if (
+    needsProxyTransfer &&
+    (await L1StandardBridgeProxy.callStatic.getOwner({
+      from: ethers.constants.AddressZero,
+    })) !== SystemDictator.address
+  ) {
+    if (isLiveDeployer) {
+      console.log(`Setting L1StandardBridge owner to MSD`)
+      await L1StandardBridgeProxyWithSigner.setOwner(SystemDictator.address)
+    } else {
+      const tx = await L1StandardBridgeProxy.populateTransaction.setOwner(
+        SystemDictator.address
+      )
+      console.log(`Please transfer L1StandardBridge (proxy) owner to MSD`)
+      console.log(
+        `L1StandardBridgeProxy address: ${L1StandardBridgeProxy.address}`
+      )
+      console.log(`MSD address: ${SystemDictator.address}`)
+      console.log(`JSON:`)
+      console.log(jsonifyTransaction(tx))
+    }
+
+    // Wait for the ownership transfer to complete.
+    await awaitCondition(
+      async () => {
+        const owner = await L1StandardBridgeProxy.callStatic.getOwner({
+          from: ethers.constants.AddressZero,
+        })
+        return owner === SystemDictator.address
+      },
+      30000,
+      1000
+    )
+  } else {
+    console.log(`L1StandardBridge already owned by MSD`)
+  }
+
+  // Transfer ownership of the L1ERC721Bridge (proxy) to SystemDictator.
+  if (
+    needsProxyTransfer &&
+    (await L1ERC721BridgeProxy.callStatic.admin({
+      from: ethers.constants.AddressZero,
+    })) !== SystemDictator.address
+  ) {
+    if (isLiveDeployer) {
+      console.log(`Setting L1ERC721Bridge owner to MSD`)
+      await L1ERC721BridgeProxyWithSigner.changeAdmin(SystemDictator.address)
+    } else {
+      const tx = await L1ERC721BridgeProxy.populateTransaction.changeAdmin(
+        SystemDictator.address
+      )
+      console.log(`Please transfer L1ERC721Bridge (proxy) owner to MSD`)
+      console.log(`L1ERC721BridgeProxy address: ${L1ERC721BridgeProxy.address}`)
+      console.log(`MSD address: ${SystemDictator.address}`)
+      console.log(`JSON:`)
+      console.log(jsonifyTransaction(tx))
+    }
+
+    // Wait for the ownership transfer to complete.
+    await awaitCondition(
+      async () => {
+        const owner = await L1ERC721BridgeProxy.callStatic.admin({
+          from: ethers.constants.AddressZero,
+        })
+        return owner === SystemDictator.address
+      },
+      30000,
+      1000
+    )
+  } else {
+    console.log(`L1ERC721Bridge already owned by MSD`)
+  }
+
+  // Step 1 is a freebie, it doesn't impact the system.
+  await doStep({
+    isLiveDeployer,
+    SystemDictator,
+    step: 1,
+    message: `
+      Step 1 will configure the ProxyAdmin contract, you can safely execute this step at any time
+      without impacting the functionality of the rest of the system.
+    `,
+    checks: async () => {
+      await assertContractVariable(
+        ProxyAdmin,
+        'addressManager',
+        AddressManager.address
+      )
+      assert(
+        (await ProxyAdmin.implementationName(
+          getDeploymentAddress(hre, 'Proxy__OVM_L1CrossDomainMessenger')
+        )) === 'OVM_L1CrossDomainMessenger'
+      )
+      assert(
+        (await ProxyAdmin.proxyType(
+          getDeploymentAddress(hre, 'Proxy__OVM_L1CrossDomainMessenger')
+        )) === 2
+      )
+      assert(
+        (await ProxyAdmin.proxyType(
+          getDeploymentAddress(hre, 'Proxy__OVM_L1StandardBridge')
+        )) === 1
+      )
+    },
+  })
+
+  // Step 2 shuts down the system.
+  await doStep({
+    isLiveDeployer,
+    SystemDictator,
+    step: 2,
+    message: `
+      Step 2 will stop deposits and withdrawals via the L1CrossDomainMessenger and will stop the
+      DTL from syncing new deposits via the CTC, effectively shutting down the legacy system. Once
+      this step has been executed, you should immediately begin the L2 migration process. If you
+      need to restart the system, run exit1() followed by finalize().
+    `,
+    checks: async () => {
+      assert(
+        (await AddressManager.getAddress('OVM_L1CrossDomainMessenger')) ===
+          ethers.constants.AddressZero
+      )
+    },
+  })
+}
+
+deployFn.tags = ['SystemDictatorSteps', 'phase1']
+
+export default deployFn

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -3,7 +3,7 @@ import assert from 'assert'
 import { ethers, Contract } from 'ethers'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
-import { sleep } from '@eth-optimism/core-utils'
+import { awaitCondition, sleep } from '@eth-optimism/core-utils'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { Deployment, DeployResult } from 'hardhat-deploy/dist/types'
 import 'hardhat-deploy'
@@ -277,6 +277,12 @@ export const getDeploymentAddress = async (
   return deployment.address
 }
 
+/**
+ * JSON-ifies an ethers transaction object.
+ *
+ * @param tx Ethers transaction object.
+ * @returns JSON-ified transaction object.
+ */
 export const jsonifyTransaction = (tx: ethers.PopulatedTransaction): string => {
   return JSON.stringify(
     {
@@ -288,4 +294,64 @@ export const jsonifyTransaction = (tx: ethers.PopulatedTransaction): string => {
     null,
     2
   )
+}
+
+/**
+ * Mini helper for checking if the current step is a target step.
+ *
+ * @param dictator SystemDictator contract.
+ * @param step Target step.
+ * @returns True if the current step is the target step.
+ */
+export const isStep = async (
+  dictator: ethers.Contract,
+  step: number
+): Promise<boolean> => {
+  return (await dictator.currentStep()) === step
+}
+
+/**
+ * Mini helper for executing a given step.
+ *
+ * @param opts Options for executing the step.
+ * @param opts.isLiveDeployer True if the deployer is live.
+ * @param opts.SystemDictator SystemDictator contract.
+ * @param opts.step Step to execute.
+ * @param opts.message Message to print before executing the step.
+ * @param opts.checks Checks to perform after executing the step.
+ */
+export const doStep = async (opts: {
+  isLiveDeployer?: boolean
+  SystemDictator: ethers.Contract
+  step: number
+  message: string
+  checks: () => Promise<void>
+}): Promise<void> => {
+  if (!(await isStep(opts.SystemDictator, opts.step))) {
+    console.log(`Step already completed: ${opts.step}`)
+    return
+  }
+
+  // Extra message to help the user understand what's going on.
+  console.log(opts.message)
+
+  // Either automatically or manually execute the step.
+  if (opts.isLiveDeployer) {
+    console.log(`Executing step ${opts.step}...`)
+    await opts.SystemDictator[`step${opts.step}`]()
+  } else {
+    console.log(`Please execute step ${opts.step}...`)
+  }
+
+  // Wait for the step to complete.
+  await awaitCondition(
+    async () => {
+      return isStep(opts.SystemDictator, opts.step + 1)
+    },
+    30000,
+    1000
+  )
+
+  // Perform post-step checks.
+  await opts.checks()
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Breaks out the SystemDictator steps into two files so that the steps that get executed before the system is shut down can easily be separated from the steps that executed after the system gets spun back up. Idea here is that you would execute with the tag "steps1", wait for the legacy system to come down, migrate the L2, then execute with the tags "steps2" to complete the upgrade.