### PR TITLE
[op-batcher / op-proposer] Provide context to signer function

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -84,7 +84,7 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 
 	signer := func(chainID *big.Int) SignerFn {
 		s := types.LatestSignerForChainID(chainID)
-		return func(rawTx types.TxData) (*types.Transaction, error) {
+		return func(_ context.Context, rawTx types.TxData) (*types.Transaction, error) {
 			return types.SignNewTx(sequencerPrivKey, s, rawTx)
 		}
 	}

--- a/op-batcher/batcher/txmgr.go
+++ b/op-batcher/batcher/txmgr.go
@@ -16,7 +16,7 @@ import (
 
 const networkTimeout = 2 * time.Second // How long a single network request can take. TODO: put in a config somewhere
 
-type SignerFn func(rawTx types.TxData) (*types.Transaction, error)
+type SignerFn func(ctx context.Context, rawTx types.TxData) (*types.Transaction, error)
 
 // TransactionManager wraps the simple txmgr package to make it easy to send & wait for transactions
 type TransactionManager struct {
@@ -121,7 +121,7 @@ func (t *TransactionManager) CraftTx(ctx context.Context, data []byte) (*types.T
 	}
 	rawTx.Gas = gas
 
-	return t.signerFn(rawTx)
+	return t.signerFn(ctx, rawTx)
 }
 
 // UpdateGasPrice signs an otherwise identical txn to the one provided but with
@@ -146,5 +146,5 @@ func (t *TransactionManager) UpdateGasPrice(ctx context.Context, tx *types.Trans
 	// Only log the new tip/fee cap because the updateGasPrice closure reuses the same initial transaction
 	t.log.Trace("updating gas price", "tip_cap", gasTipCap, "fee_cap", gasFeeCap)
 
-	return t.signerFn(rawTx)
+	return t.signerFn(ctx, rawTx)
 }

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -15,8 +15,8 @@ import (
 
 	hdwallet "github.com/ethereum-optimism/go-ethereum-hdwallet"
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -161,13 +161,16 @@ func NewL2OutputSubmitter(
 		}
 	}
 
-	signer := func(chainID *big.Int) bind.SignerFn {
-		return opcrypto.PrivateKeySignerFn(l2OutputPrivKey, chainID)
+	signer := func(chainID *big.Int) SignerFn {
+		s := opcrypto.PrivateKeySignerFn(l2OutputPrivKey, chainID)
+		return func(_ context.Context, addr common.Address, tx *types.Transaction) (*types.Transaction, error) {
+			return s(addr, tx)
+		}
 	}
 	return NewL2OutputSubmitterWithSigner(cfg, crypto.PubkeyToAddress(l2OutputPrivKey.PublicKey), signer, gitVersion, l)
 }
 
-type SignerFactory func(chainID *big.Int) bind.SignerFn
+type SignerFactory func(chainID *big.Int) SignerFn
 
 func NewL2OutputSubmitterWithSigner(
 	cfg Config,


### PR DESCRIPTION
**Description**
Passes the `context.Context` from the op-batcher / op-proposer into the `SignerFn`. This allows the SignerFn to make remote requests to external tx-signing services, and gives the ability for the caller to cancel those requests if needed.

**Tests**
No logic changes implemented, just passing the context through.