### PR TITLE
ci: Add Dockerfile and build in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,6 +482,33 @@ jobs:
           push: true
           tags: ethereumoptimism/deployer-bedrock:${{ needs.release.outputs.contracts-bedrock }},ethereumoptimism/deployer-bedrock:latest
 
+  balance-monitor:
+    name: Publish balance-monitor Version ${{ needs.release.outputs.balance-monitor }}
+    needs: release
+    if: needs.release.outputs.balance-monitor != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./ops/docker/Dockerfile.packages
+          target: balance-monitor
+          push: true
+          tags: ethereumoptimism/balance-monitor:${{ needs.release.outputs.balance-monitor }},ethereumoptimism/balance-monitor:latest
+
   integration_tests:
     name: Publish Integration tests ${{ needs.release.outputs.integration-tests }}
     needs: release

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -47,6 +47,7 @@ COPY packages/message-relayer/package.json ./packages/message-relayer/package.js
 COPY packages/fault-detector/package.json ./packages/fault-detector/package.json
 COPY packages/replica-healthcheck/package.json ./packages/replica-healthcheck/package.json
 COPY packages/drippie-mon/package.json ./packages/drippie-mon/package.json
+COPY packages/balance-monitor/package.json ./packages/balance-monitor/package.json
 COPY integration-tests/package.json ./integration-tests/package.json
 
 RUN yarn install --frozen-lockfile && yarn cache clean
@@ -81,7 +82,6 @@ WORKDIR /opt/optimism/packages/data-transport-layer
 COPY ./ops/scripts/dtl.sh .
 CMD ["node", "dist/src/services/run.js"]
 
-
 FROM base as integration-tests
 WORKDIR /opt/optimism/integration-tests
 COPY ./ops/scripts/integration-tests.sh ./
@@ -107,3 +107,7 @@ ENTRYPOINT ["npm", "run", "start"]
 FROM base as drippie-mon
 WORKDIR /opt/optimism/packages/drippie-mon
 ENTRYPOINT ["npm", "run", "start"]
+
+FROM base as drippie-mon
+WORKDIR /opt/optimism/packages/balance-monitor
+ENTRYPOINT ["yarn", "run", "start:prod"]


### PR DESCRIPTION
**Description**

Adds `balance-monitor` to docker build and publish steps. 

It uses the `Dockerfile.packages` file, and GHA per @mslipper's guidance.