### PR TITLE
ci: Add more codeowners to specs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,5 +39,5 @@
 /proxyd           @mslipper @Inphi @tynes
 /indexer          @mslipper @nickbalestra @roninjin10
 /infra            @mslipper @zhwrd
-/specs            @norswap @trianglesphere @tynes
+/specs            @trianglesphere @tynes @protolambda @smartcontracts @maurelian
 /endpoint-monitor @zhwrd


### PR DESCRIPTION
**Description**

The specs are likely to be under a lot of scrutiny in the coming weeks, and many changes will be needed. More codeowners will facilitate this.