### PR TITLE
op-chain-ops: make the migrated withdrawals version 0

### DIFF
--- a/op-chain-ops/crossdomain/migrate.go
+++ b/op-chain-ops/crossdomain/migrate.go
@@ -63,7 +63,9 @@ func MigrateWithdrawal(withdrawal *LegacyWithdrawal, l1CrossDomainMessenger *com
 		return nil, err
 	}
 
-	// Migrated withdrawals are specified as version 0
+	// Migrated withdrawals are specified as version 0. Both the
+	// L2ToL1MessagePasser and the CrossDomainMessenger use the same
+	// versioning scheme. Both should be set to version 0
 	versionedNonce := EncodeVersionedNonce(withdrawal.Nonce, new(big.Int))
 	// Encode the call to `relayMessage` on the `CrossDomainMessenger`.
 	// The minGasLimit can safely be 0 here.
@@ -84,7 +86,7 @@ func MigrateWithdrawal(withdrawal *LegacyWithdrawal, l1CrossDomainMessenger *com
 	gasLimit := uint64(len(data)*16 + 200_000)
 
 	w := NewWithdrawal(
-		withdrawal.Nonce,
+		versionedNonce,
 		&predeploys.L2CrossDomainMessengerAddr,
 		l1CrossDomainMessenger,
 		value,

--- a/op-chain-ops/crossdomain/migrate.go
+++ b/op-chain-ops/crossdomain/migrate.go
@@ -63,7 +63,8 @@ func MigrateWithdrawal(withdrawal *LegacyWithdrawal, l1CrossDomainMessenger *com
 		return nil, err
 	}
 
-	versionedNonce := EncodeVersionedNonce(withdrawal.Nonce, common.Big1)
+	// Migrated withdrawals are specified as version 0
+	versionedNonce := EncodeVersionedNonce(withdrawal.Nonce, new(big.Int))
 	// Encode the call to `relayMessage` on the `CrossDomainMessenger`.
 	// The minGasLimit can safely be 0 here.
 	data, err := abi.Pack(


### PR DESCRIPTION
**Description**

Update the migrated withdrawals to be version 0 based on the new scheme that is introduced in https://github.com/ethereum-optimism/optimism/pull/4562. This is a safety measure to ensure that withdrawals cannot be double withdrawn and that ether stuck in the L1xdm cannot be stolen in the case of a withdrawal with value reverting.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

