### PR TITLE
bedrock: hardcode L2 genesis coinbase

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -62,7 +62,6 @@ type DeployConfig struct {
 	L2GenesisBlockGasLimit      hexutil.Uint64 `json:"l2GenesisBlockGasLimit"`
 	L2GenesisBlockDifficulty    *hexutil.Big   `json:"l2GenesisBlockDifficulty"`
 	L2GenesisBlockMixHash       common.Hash    `json:"l2GenesisBlockMixHash"`
-	L2GenesisBlockCoinbase      common.Address `json:"l2GenesisBlockCoinbase"`
 	L2GenesisBlockNumber        hexutil.Uint64 `json:"l2GenesisBlockNumber"`
 	L2GenesisBlockGasUsed       hexutil.Uint64 `json:"l2GenesisBlockGasUsed"`
 	L2GenesisBlockParentHash    common.Hash    `json:"l2GenesisBlockParentHash"`

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -147,7 +147,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 	bedrockHeader := &types.Header{
 		ParentHash:  header.Hash(),
 		UncleHash:   types.EmptyUncleHash,
-		Coinbase:    config.L2GenesisBlockCoinbase,
+		Coinbase:    predeploys.SequencerFeeVaultAddr,
 		Root:        newRoot,
 		TxHash:      types.EmptyRootHash,
 		ReceiptHash: types.EmptyRootHash,

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -85,7 +86,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		GasLimit:   uint64(gasLimit),
 		Difficulty: difficulty.ToInt(),
 		Mixhash:    config.L2GenesisBlockMixHash,
-		Coinbase:   config.L2GenesisBlockCoinbase,
+		Coinbase:   predeploys.SequencerFeeVaultAddr,
 		Number:     uint64(config.L2GenesisBlockNumber),
 		GasUsed:    uint64(config.L2GenesisBlockGasUsed),
 		ParentHash: config.L2GenesisBlockParentHash,

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -32,7 +32,6 @@
   "l2GenesisBlockGasLimit": "0xe4e1c0",
   "l2GenesisBlockDifficulty": "0x1",
   "l2GenesisBlockMixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "l2GenesisBlockCoinbase": "0x42000000000000000000000000000000000000f0",
   "l2GenesisBlockNumber": "0x0",
   "l2GenesisBlockGasUsed": "0x0",
   "l2GenesisBlockParentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -93,7 +93,6 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 		L2GenesisBlockGasLimit:      15_000_000,
 		L2GenesisBlockDifficulty:    uint64ToBig(0),
 		L2GenesisBlockMixHash:       common.Hash{},
-		L2GenesisBlockCoinbase:      predeploys.SequencerFeeVaultAddr,
 		L2GenesisBlockNumber:        0,
 		L2GenesisBlockGasUsed:       0,
 		L2GenesisBlockParentHash:    common.Hash{},
@@ -264,7 +263,6 @@ func ForkedDeployConfig(t require.TestingT, mnemonicCfg *MnemonicConfig, startBl
 		L2OutputOracleStartingTimestamp:  int(startBlock.Time()),
 		L2OutputOracleProposer:           addrs.Proposer,
 		L2OutputOracleChallenger:         addrs.Deployer,
-		L2GenesisBlockCoinbase:           common.HexToAddress("0x42000000000000000000000000000000000000f0"),
 		L2GenesisBlockGasLimit:           hexutil.Uint64(15_000_000),
 		// taken from devnet, need to check this
 		L2GenesisBlockBaseFeePerGas: uint64ToBig(0x3B9ACA00),

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -85,7 +85,6 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 		L2GenesisBlockGasLimit:      8_000_000,
 		L2GenesisBlockDifficulty:    uint642big(1),
 		L2GenesisBlockMixHash:       common.Hash{},
-		L2GenesisBlockCoinbase:      common.Address{0: 0x12},
 		L2GenesisBlockNumber:        0,
 		L2GenesisBlockGasUsed:       0,
 		L2GenesisBlockParentHash:    common.Hash{},

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -12,7 +12,6 @@
   "l2OutputOracleStartingTimestamp": -1,
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
-  "l2GenesisBlockCoinbase": "0x42000000000000000000000000000000000000f0",
   "l2GenesisBlockGasLimit": "0xE4E1C0",
   "l1BlockTime": 15,
   "cliqueSignerAddress": "0xca062b0fd91172d89bcd4bb084ac4e21972cc467",

--- a/packages/contracts-bedrock/deploy-config/goerli-forked.json
+++ b/packages/contracts-bedrock/deploy-config/goerli-forked.json
@@ -28,7 +28,6 @@
   "governanceTokenOwner": "0x038a8825A3C3B0c08d52Cc76E5E361953Cf6Dc76",
 
   "l2GenesisBlockGasLimit": "0x17D7840",
-  "l2GenesisBlockCoinbase": "0x4200000000000000000000000000000000000011",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
 
 

--- a/packages/contracts-bedrock/deploy-config/goerli.json
+++ b/packages/contracts-bedrock/deploy-config/goerli.json
@@ -21,7 +21,6 @@
   "finalizationPeriodSeconds": 2,
 
   "l2GenesisBlockGasLimit": "0x17D7840",
-  "l2GenesisBlockCoinbase": "0x4200000000000000000000000000000000000011",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
 
   "l2CrossDomainMessengerOwner": "DUMMY",

--- a/packages/contracts-bedrock/src/deploy-config.ts
+++ b/packages/contracts-bedrock/src/deploy-config.ts
@@ -151,7 +151,6 @@ interface OptionalL2DeployConfig {
   l2GenesisBlockGasLimit: string
   l2GenesisBlockDifficulty: string
   l2GenesisBlockMixHash: string
-  l2GenesisBlockCoinbase: string
   l2GenesisBlockNumber: string
   l2GenesisBlockGasUsed: string
   l2GenesisBlockParentHash: string
@@ -299,10 +298,6 @@ export const deployConfigSpec: {
   l2GenesisBlockMixHash: {
     type: 'string', // bytes32
     default: ethers.constants.HashZero,
-  },
-  l2GenesisBlockCoinbase: {
-    type: 'address',
-    default: ethers.constants.AddressZero,
   },
   l2GenesisBlockNumber: {
     type: 'string', // uint64


### PR DESCRIPTION
**Description**

Removes the config option for being able to set
the coinbase of the bedrock transition block.
It is now always set to the sequencer fee vault
predeploy. This is one less config option that needs to be set correctly. The coinbase is always set to the sequencer fee vault in bedrock blocks.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
