### PR TITLE
op-node: Restructure the derive package

### DIFF
--- a/op-node/rollup/driver/conf_depth.go
+++ b/op-node/rollup/driver/conf_depth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
 	"github.com/ethereum/go-ethereum"
 )
 
@@ -14,12 +14,12 @@ import (
 // At 0 depth the l1 head is completely ignored.
 type confDepth struct {
 	// everything fetched by hash is trusted already, so we implement those by embedding the fetcher
-	derive.L1Fetcher
+	stages.L1Fetcher
 	l1Head func() eth.L1BlockRef
 	depth  uint64
 }
 
-func NewConfDepth(depth uint64, l1Head func() eth.L1BlockRef, fetcher derive.L1Fetcher) *confDepth {
+func NewConfDepth(depth uint64, l1Head func() eth.L1BlockRef, fetcher stages.L1Fetcher) *confDepth {
 	return &confDepth{L1Fetcher: fetcher, l1Head: l1Head, depth: depth}
 }
 
@@ -41,4 +41,4 @@ func (c *confDepth) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1B
 	return eth.L1BlockRef{}, ethereum.NotFound
 }
 
-var _ derive.L1Fetcher = (*confDepth)(nil)
+var _ stages.L1Fetcher = (*confDepth)(nil)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
 )
 
 type Metrics interface {
@@ -34,12 +34,12 @@ type Metrics interface {
 }
 
 type L1Chain interface {
-	derive.L1Fetcher
+	stages.L1Fetcher
 	L1BlockRefByLabel(context.Context, eth.BlockLabel) (eth.L1BlockRef, error)
 }
 
 type L2Chain interface {
-	derive.Engine
+	stages.Engine
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
@@ -88,7 +88,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, ne
 	l1State := NewL1State(log, metrics)
 	findL1Origin := NewL1OriginSelector(log, cfg, l1, driverCfg.SequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l2, metrics)
+	derivationPipeline := stages.NewDerivationPipeline(log, cfg, verifConfDepth, l2, metrics)
 	sequencer := NewSequencer(log, cfg, l1, l2, derivationPipeline, metrics)
 
 	return &Driver{

--- a/op-node/rollup/driver/origin_selector.go
+++ b/op-node/rollup/driver/origin_selector.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/stages"
 )
 
 type L1Blocks interface {
-	derive.L1BlockRefByHashFetcher
-	derive.L1BlockRefByNumberFetcher
+	stages.L1BlockRefByHashFetcher
+	stages.L1BlockRefByNumberFetcher
 }
 
 type L1OriginSelector struct {

--- a/op-node/rollup/stages/attributes_queue_test.go
+++ b/op-node/rollup/stages/attributes_queue_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 )
@@ -41,7 +42,7 @@ func TestAttributesQueue(t *testing.T) {
 	safeHead := testutils.RandomL2BlockRef(rng)
 	safeHead.L1Origin = l1Info.ID()
 
-	batch := &BatchData{BatchV1{
+	batch := &derive.BatchData{BatchV1: derive.BatchV1{
 		ParentHash:   safeHead.Hash,
 		EpochNum:     rollup.Epoch(l1Info.InfoNum),
 		EpochHash:    l1Info.InfoHash,
@@ -65,7 +66,7 @@ func TestAttributesQueue(t *testing.T) {
 	l2Fetcher := &testutils.MockL2Client{}
 	l2Fetcher.ExpectSystemConfigByL2Hash(safeHead.Hash, parentL1Cfg, nil)
 
-	l1InfoTx, err := L1InfoDepositBytes(safeHead.SequenceNumber+1, l1Info, expectedL1Cfg)
+	l1InfoTx, err := derive.L1InfoDepositBytes(safeHead.SequenceNumber+1, l1Info, expectedL1Cfg)
 	require.NoError(t, err)
 	attrs := eth.PayloadAttributes{
 		Timestamp:             eth.Uint64Quantity(safeHead.Time + cfg.BlockTime),

--- a/op-node/rollup/stages/batch_queue.go
+++ b/op-node/rollup/stages/batch_queue.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
 
 // The batch queue is responsible for ordering unordered batches & generating empty batches
@@ -29,7 +30,7 @@ import (
 
 type NextBatchProvider interface {
 	Origin() eth.L1BlockRef
-	NextBatch(ctx context.Context) (*BatchData, error)
+	NextBatch(ctx context.Context) (*derive.BatchData, error)
 }
 
 // BatchQueue contains a set of batches for every L1 block.
@@ -43,7 +44,7 @@ type BatchQueue struct {
 	l1Blocks []eth.L1BlockRef
 
 	// batches in order of when we've first seen them, grouped by L2 timestamp
-	batches map[uint64][]*BatchWithL1InclusionBlock
+	batches map[uint64][]*derive.BatchWithL1InclusionBlock
 }
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.
@@ -59,7 +60,7 @@ func (bq *BatchQueue) Origin() eth.L1BlockRef {
 	return bq.prev.Origin()
 }
 
-func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) (*BatchData, error) {
+func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) (*derive.BatchData, error) {
 	// Note: We use the origin that we will have to determine if it's behind. This is important
 	// because it's the future origin that gets saved into the l1Blocks array.
 	// We always update the origin of this stage if it is not the same so after the update code
@@ -98,7 +99,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 		if outOfData {
 			return nil, io.EOF
 		} else {
-			return nil, NotEnoughData
+			return nil, derive.NotEnoughData
 		}
 	}
 
@@ -107,7 +108,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 	if err == io.EOF && outOfData {
 		return nil, io.EOF
 	} else if err == io.EOF {
-		return nil, NotEnoughData
+		return nil, derive.NotEnoughData
 	} else if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func (bq *BatchQueue) Reset(ctx context.Context, base eth.L1BlockRef, _ eth.Syst
 	// Copy over the Origin from the next stage
 	// It is set in the engine queue (two stages away) such that the L2 Safe Head origin is the progress
 	bq.origin = base
-	bq.batches = make(map[uint64][]*BatchWithL1InclusionBlock)
+	bq.batches = make(map[uint64][]*derive.BatchWithL1InclusionBlock)
 	// Include the new origin as an origin to build on
 	// Note: This is only for the initialization case. During normal resets we will later
 	// throw out this block.
@@ -127,16 +128,16 @@ func (bq *BatchQueue) Reset(ctx context.Context, base eth.L1BlockRef, _ eth.Syst
 	return io.EOF
 }
 
-func (bq *BatchQueue) AddBatch(batch *BatchData, l2SafeHead eth.L2BlockRef) {
+func (bq *BatchQueue) AddBatch(batch *derive.BatchData, l2SafeHead eth.L2BlockRef) {
 	if len(bq.l1Blocks) == 0 {
 		panic(fmt.Errorf("cannot add batch with timestamp %d, no origin was prepared", batch.Timestamp))
 	}
-	data := BatchWithL1InclusionBlock{
+	data := derive.BatchWithL1InclusionBlock{
 		L1InclusionBlock: bq.origin,
 		Batch:            batch,
 	}
-	validity := CheckBatch(bq.config, bq.log, bq.l1Blocks, l2SafeHead, &data)
-	if validity == BatchDrop {
+	validity := derive.CheckBatch(bq.config, bq.log, bq.l1Blocks, l2SafeHead, &data)
+	if validity == derive.BatchDrop {
 		return // if we do drop the batch, CheckBatch will log the drop reason with WARN level.
 	}
 	bq.batches[batch.Timestamp] = append(bq.batches[batch.Timestamp], &data)
@@ -146,33 +147,33 @@ func (bq *BatchQueue) AddBatch(batch *BatchData, l2SafeHead eth.L2BlockRef) {
 // following the validity rules imposed on consecutive batches,
 // based on currently available buffered batch and L1 origin information.
 // If no batch can be derived yet, then (nil, io.EOF) is returned.
-func (bq *BatchQueue) deriveNextBatch(ctx context.Context, outOfData bool, l2SafeHead eth.L2BlockRef) (*BatchData, error) {
+func (bq *BatchQueue) deriveNextBatch(ctx context.Context, outOfData bool, l2SafeHead eth.L2BlockRef) (*derive.BatchData, error) {
 	if len(bq.l1Blocks) == 0 {
-		return nil, NewCriticalError(errors.New("cannot derive next batch, no origin was prepared"))
+		return nil, derive.NewCriticalError(errors.New("cannot derive next batch, no origin was prepared"))
 	}
 	epoch := bq.l1Blocks[0]
 
 	if l2SafeHead.L1Origin != epoch.ID() {
-		return nil, NewResetError(fmt.Errorf("buffered L1 chain epoch %s in batch queue does not match safe head origin %s", epoch, l2SafeHead.L1Origin))
+		return nil, derive.NewResetError(fmt.Errorf("buffered L1 chain epoch %s in batch queue does not match safe head origin %s", epoch, l2SafeHead.L1Origin))
 	}
 
 	// Find the first-seen batch that matches all validity conditions.
 	// We may not have sufficient information to proceed filtering, and then we stop.
 	// There may be none: in that case we force-create an empty batch
 	nextTimestamp := l2SafeHead.Time + bq.config.BlockTime
-	var nextBatch *BatchWithL1InclusionBlock
+	var nextBatch *derive.BatchWithL1InclusionBlock
 
 	// Go over all batches, in order of inclusion, and find the first batch we can accept.
 	// We filter in-place by only remembering the batches that may be processed in the future, or those we are undecided on.
-	var remaining []*BatchWithL1InclusionBlock
+	var remaining []*derive.BatchWithL1InclusionBlock
 	candidates := bq.batches[nextTimestamp]
 batchLoop:
 	for i, batch := range candidates {
-		validity := CheckBatch(bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch)
+		validity := derive.CheckBatch(bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch)
 		switch validity {
-		case BatchFuture:
-			return nil, NewCriticalError(fmt.Errorf("found batch with timestamp %d marked as future batch, but expected timestamp %d", batch.Batch.Timestamp, nextTimestamp))
-		case BatchDrop:
+		case derive.BatchFuture:
+			return nil, derive.NewCriticalError(fmt.Errorf("found batch with timestamp %d marked as future batch, but expected timestamp %d", batch.Batch.Timestamp, nextTimestamp))
+		case derive.BatchDrop:
 			bq.log.Warn("dropping batch",
 				"batch_timestamp", batch.Batch.Timestamp,
 				"parent_hash", batch.Batch.ParentHash,
@@ -182,18 +183,18 @@ batchLoop:
 				"l2_safe_head_time", l2SafeHead.Time,
 			)
 			continue
-		case BatchAccept:
+		case derive.BatchAccept:
 			nextBatch = batch
 			// don't keep the current batch in the remaining items since we are processing it now,
 			// but retain every batch we didn't get to yet.
 			remaining = append(remaining, candidates[i+1:]...)
 			break batchLoop
-		case BatchUndecided:
+		case derive.BatchUndecided:
 			remaining = append(remaining, batch)
 			bq.batches[nextTimestamp] = remaining
 			return nil, io.EOF
 		default:
-			return nil, NewCriticalError(fmt.Errorf("unknown batch validity type: %d", validity))
+			return nil, derive.NewCriticalError(fmt.Errorf("unknown batch validity type: %d", validity))
 		}
 	}
 	// clean up if we remove the final batch for this timestamp
@@ -232,8 +233,8 @@ batchLoop:
 	// Fill with empty L2 blocks of the same epoch until we meet the time of the next L1 origin,
 	// to preserve that L2 time >= L1 time
 	if nextTimestamp < nextEpoch.Time {
-		return &BatchData{
-			BatchV1{
+		return &derive.BatchData{
+			BatchV1: derive.BatchV1{
 				ParentHash:   l2SafeHead.Hash,
 				EpochNum:     rollup.Epoch(epoch.Number),
 				EpochHash:    epoch.Hash,
@@ -244,8 +245,8 @@ batchLoop:
 	}
 	// As we move the safe head origin forward, we also drop the old L1 block reference
 	bq.l1Blocks = bq.l1Blocks[1:]
-	return &BatchData{
-		BatchV1{
+	return &derive.BatchData{
+		BatchV1: derive.BatchV1{
 			ParentHash:   l2SafeHead.Hash,
 			EpochNum:     rollup.Epoch(nextEpoch.Number),
 			EpochHash:    nextEpoch.Hash,

--- a/op-node/rollup/stages/calldata_source.go
+++ b/op-node/rollup/stages/calldata_source.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
 
 type DataIter interface {
@@ -87,9 +88,9 @@ func (ds *DataSource) Next(ctx context.Context) (eth.Data, error) {
 			ds.open = true
 			ds.data = DataFromEVMTransactions(ds.cfg, ds.batcherAddr, txs, log.New("origin", ds.id))
 		} else if errors.Is(err, ethereum.NotFound) {
-			return nil, NewResetError(fmt.Errorf("failed to open calldata source: %w", err))
+			return nil, derive.NewResetError(fmt.Errorf("failed to open calldata source: %w", err))
 		} else {
-			return nil, NewTemporaryError(fmt.Errorf("failed to open calldata source: %w", err))
+			return nil, derive.NewTemporaryError(fmt.Errorf("failed to open calldata source: %w", err))
 		}
 	}
 	if len(ds.data) == 0 {

--- a/op-node/rollup/stages/calldata_source_test.go
+++ b/op-node/rollup/stages/calldata_source_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"crypto/ecdsa"

--- a/op-node/rollup/stages/engine_consolidate.go
+++ b/op-node/rollup/stages/engine_consolidate.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"bytes"

--- a/op-node/rollup/stages/engine_queue_test.go
+++ b/op-node/rollup/stages/engine_queue_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"

--- a/op-node/rollup/stages/engine_update.go
+++ b/op-node/rollup/stages/engine_update.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"

--- a/op-node/rollup/stages/l1_retrieval.go
+++ b/op-node/rollup/stages/l1_retrieval.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"

--- a/op-node/rollup/stages/l1_retrieval_test.go
+++ b/op-node/rollup/stages/l1_retrieval_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 )
@@ -137,8 +138,8 @@ func TestL1RetrievalNextData(t *testing.T) {
 			prevErr:      nil,
 			openErr:      nil,
 			datas:        []eth.Data{nil},
-			datasErrs:    []error{NewCriticalError(ethereum.NotFound)},
-			expectedErrs: []error{ErrCritical},
+			datasErrs:    []error{derive.NewCriticalError(ethereum.NotFound)},
+			expectedErrs: []error{derive.ErrCritical},
 		},
 	}
 

--- a/op-node/rollup/stages/l1_traversal_test.go
+++ b/op-node/rollup/stages/l1_traversal_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 )
@@ -94,7 +95,7 @@ func TestL1TraversalAdvance(t *testing.T) {
 			startBlock:  a,
 			nextBlock:   x,
 			fetcherErr:  nil,
-			expectedErr: ErrReset,
+			expectedErr: derive.ErrReset,
 		},
 		{
 			name:        "not found",
@@ -108,7 +109,7 @@ func TestL1TraversalAdvance(t *testing.T) {
 			startBlock:  a,
 			nextBlock:   eth.L1BlockRef{},
 			fetcherErr:  errors.New("interrupted connection"),
-			expectedErr: ErrTemporary,
+			expectedErr: derive.ErrTemporary,
 		},
 		// TODO: add tests that cover the receipts to config data updates
 	}

--- a/op-node/rollup/stages/payloads_queue.go
+++ b/op-node/rollup/stages/payloads_queue.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"container/heap"

--- a/op-node/rollup/stages/payloads_queue_test.go
+++ b/op-node/rollup/stages/payloads_queue_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"container/heap"

--- a/op-node/rollup/stages/pipeline.go
+++ b/op-node/rollup/stages/pipeline.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
 
 type Metrics interface {
@@ -21,7 +22,7 @@ type L1Fetcher interface {
 	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
 	L1BlockRefByNumberFetcher
 	L1BlockRefByHashFetcher
-	L1ReceiptsFetcher
+	derive.L1ReceiptsFetcher
 	L1TransactionFetcher
 }
 

--- a/op-node/rollup/stages/pipeline_test.go
+++ b/op-node/rollup/stages/pipeline_test.go
@@ -1,4 +1,4 @@
-package derive
+package stages
 
 import "github.com/ethereum-optimism/optimism/op-node/testutils"
 


### PR DESCRIPTION
**Description**

This pulls out the derivation pipeline into a new package called stages which depends upon the derive package. This is to split up the derive folder into two folders in order to make each package have a more manageable number of files.

**Tests**

No behavior changes. Lint + tests pass (except for op-e2e)

**Metadata**
- Fixes ENG-3121
