### PR TITLE
op-chain-ops: do not allow 0 scalar

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -170,7 +170,7 @@ func (d *DeployConfig) Check() error {
 		log.Warn("GasPriceOracleOverhead is 0")
 	}
 	if d.GasPriceOracleScalar == 0 {
-		log.Warn("GasPriceOracleScalar is 0")
+		return fmt.Errorf("%w: GasPriceOracleScalar cannot be 0", ErrInvalidDeployConfig)
 	}
 	if d.L1StandardBridgeProxy == (common.Address{}) {
 		return fmt.Errorf("%w: L1StandardBridgeProxy cannot be address(0)", ErrInvalidDeployConfig)


### PR DESCRIPTION
**Description**

The `DeployConfig` value for the `GasPriceOracleScalar` should not be allowed to be set to 0. If it is set to 0, it would effectively make the L1 portion of the fee nothing. This isn't useful since eip1559 is enabled which required ether to be burnt with execution, meaning that free transactions are not allowed on the network.

If this value is set to 0, it is most likely a bug in the config and we do not want to lose money by charging no L1 portion of the fee.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


