### PR TITLE
ci: Update slither version to 0.9.1

### DIFF
--- a/.changeset/odd-parents-cheer.md
+++ b/.changeset/odd-parents-cheer.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Update the slither version to fix echidna tests

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && \
   apt-get install -y nodejs && \
   npm i -g yarn && \
   npm i -g depcheck && \
-  pip install slither-analyzer==0.9.0 && \
+  pip install slither-analyzer==0.9.1 && \
   go install gotest.tools/gotestsum@latest && \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0 && \
   curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash && \


### PR DESCRIPTION
Updates the version of slither in the CI builder. 

Should fix the echidna tests which were failing in CI once the docker image is updated.