### PR TITLE
fix(ctp): Downgrade `contracts-bedrock` dep to fix CI

### DIFF
--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.0.7",
-    "@eth-optimism/contracts-bedrock": "0.11.1",
+    "@eth-optimism/contracts-bedrock": "0.11.0",
     "@eth-optimism/core-utils": "^0.12.0",
     "@eth-optimism/hardhat-deploy-config": "^0.2.5",
     "@ethersproject/hardware-wallets": "^5.7.0",


### PR DESCRIPTION
# Overview

In the latest [version action](https://github.com/ethereum-optimism/optimism/commit/a17b49fafa8b0141ae45c2b979f432f2468fd7ba), `contracts-bedrock` was updated to `v0.11.1`, which broke `contracts-periphery`'s CI. Temporarily downgrades `contracts-periphery`'s `contracts-bedrock` dependency to `v0.11.0` so that it will build.
