### PR TITLE
op-chain-ops: wipe predeploy storage

### DIFF
--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -138,6 +138,12 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 	// actual migration process. This involves modifying parts of the legacy database and inserting
 	// a transition block.
 
+	// The predeploy storage must be wiped before anything else,
+	// otherwise the ERC-1967 proxy storage slots will be removed.
+	if err := WipePredeployStorage(db); err != nil {
+		return nil, fmt.Errorf("cannot wipe storage: %w", err)
+	}
+
 	// First order of business is to convert all predeployed smart contracts into proxies so they
 	// can be easily upgraded later on. In the legacy system, all upgrades to predeployed contracts
 	// required hard forks which was a huge pain. Note that we do NOT put the GovernanceToken or

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -14,27 +14,44 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// UntouchablePredeploys are addresses in the predeploy namespace
-// that should not be touched by the migration process.
-var UntouchablePredeploys = map[common.Address]bool{
-	predeploys.GovernanceTokenAddr: true,
-	predeploys.WETH9Addr:           true,
-}
-
 // UntouchableCodeHashes contains code hashes of all the contracts
 // that should not be touched by the migration process.
 type ChainHashMap map[uint64]common.Hash
 
-var UntouchableCodeHashes = map[common.Address]ChainHashMap{
-	predeploys.GovernanceTokenAddr: {
-		1: common.HexToHash("0x8551d935f4e67ad3c98609f0d9f0f234740c4c4599f82674633b55204393e07f"),
-		5: common.HexToHash("0xc4a213cf5f06418533e5168d8d82f7ccbcc97f27ab90197c2c051af6a4941cf9"),
-	},
-	predeploys.WETH9Addr: {
-		1: common.HexToHash("0x779bbf2a738ef09d961c945116197e2ac764c1b39304b2b4418cd4e42668b173"),
-		5: common.HexToHash("0x779bbf2a738ef09d961c945116197e2ac764c1b39304b2b4418cd4e42668b173"),
-	},
-}
+var (
+	// UntouchablePredeploys are addresses in the predeploy namespace
+	// that should not be touched by the migration process.
+	UntouchablePredeploys = map[common.Address]bool{
+		predeploys.GovernanceTokenAddr: true,
+		predeploys.WETH9Addr:           true,
+	}
+
+	// UntouchableCodeHashes represent the bytecode hashes of contracts
+	// that should not be touched by the migration process.
+	UntouchableCodeHashes = map[common.Address]ChainHashMap{
+		predeploys.GovernanceTokenAddr: {
+			1: common.HexToHash("0x8551d935f4e67ad3c98609f0d9f0f234740c4c4599f82674633b55204393e07f"),
+			5: common.HexToHash("0xc4a213cf5f06418533e5168d8d82f7ccbcc97f27ab90197c2c051af6a4941cf9"),
+		},
+		predeploys.WETH9Addr: {
+			1: common.HexToHash("0x779bbf2a738ef09d961c945116197e2ac764c1b39304b2b4418cd4e42668b173"),
+			5: common.HexToHash("0x779bbf2a738ef09d961c945116197e2ac764c1b39304b2b4418cd4e42668b173"),
+		},
+	}
+
+	// FrozenStoragePredeploys represents the set of predeploys that
+	// will not have their storage wiped during the migration process.
+	// It is very explicitly set in its own mapping to ensure that
+	// changes elsewhere in the codebase do no alter the predeploys
+	// that do not have their storage wiped. It is safe for all other
+	// predeploys to have their storage wiped.
+	FrozenStoragePredeploys = map[common.Address]bool{
+		predeploys.GovernanceTokenAddr:     true,
+		predeploys.WETH9Addr:               true,
+		predeploys.LegacyMessagePasserAddr: true,
+		predeploys.LegacyERC20ETHAddr:      true,
+	}
+)
 
 // FundDevAccounts will fund each of the development accounts.
 func FundDevAccounts(db vm.StateDB) {
@@ -77,7 +94,7 @@ func WipePredeployStorage(db vm.StateDB) error {
 			return fmt.Errorf("nil address in predeploys mapping for %s", name)
 		}
 
-		if UntouchablePredeploys[*addr] || *addr == predeploys.LegacyMessagePasserAddr || *addr == predeploys.LegacyERC20ETHAddr {
+		if FrozenStoragePredeploys[*addr] {
 			log.Trace("skipping wiping of storage", "name", name, "address", *addr)
 			continue
 		}

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -77,7 +77,7 @@ func WipePredeployStorage(db vm.StateDB) error {
 			return fmt.Errorf("nil address in predeploys mapping for %s", name)
 		}
 
-		if UntouchablePredeploys[*addr] || *addr == predeploys.LegacyMessagePasserAddr {
+		if UntouchablePredeploys[*addr] || *addr == predeploys.LegacyMessagePasserAddr || *addr == predeploys.LegacyERC20ETHAddr {
 			log.Trace("skipping wiping of storage", "name", name, "address", *addr)
 			continue
 		}

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -50,6 +50,7 @@ var (
 		predeploys.WETH9Addr:               true,
 		predeploys.LegacyMessagePasserAddr: true,
 		predeploys.LegacyERC20ETHAddr:      true,
+		predeploys.DeployerWhitelistAddr:   true,
 	}
 )
 

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -78,15 +78,6 @@ func SetL1Proxies(db vm.StateDB, proxyAdminAddr common.Address) error {
 	return setProxies(db, proxyAdminAddr, bigL1PredeployNamespace, 2048)
 }
 
-// WipeStorage will set every storage variable that is set to `bytes32(0)`.
-func WipeStorage(db vm.StateDB, addr common.Address) error {
-	err := db.ForEachStorage(addr, func(key, _ common.Hash) bool {
-		db.SetState(addr, key, common.Hash{})
-		return true
-	})
-	return err
-}
-
 // WipePredeployStorage will wipe the storage of all L2 predeploys expect
 // for predeploys that must not have their storage altered.
 func WipePredeployStorage(db vm.StateDB) error {
@@ -101,9 +92,7 @@ func WipePredeployStorage(db vm.StateDB) error {
 		}
 
 		log.Info("wiping storage", "name", name, "address", *addr)
-		if err := WipeStorage(db, *addr); err != nil {
-			return err
-		}
+		db.CreateAccount(*addr)
 	}
 
 	return nil


### PR DESCRIPTION
**Description**

Makes the spec for the migration process much more simple by wiping the storage of the predeploys expect for special cases. The contracts that do not have their storage wiped are:

- GovernanceToken
- WETH9
- LegacyMessagePasser
- LegacyERC20ETH
- DeployerWhitelist

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

