### PR TITLE
make build fail on frozen lockfile

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -58,7 +58,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: yarn install:ci
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: yarn install:ci
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint:specs:fix": "yarn run markdownlint-cli2-fix \"./specs/**/*.md\"",
     "lint:specs:check": "yarn run markdownlint-cli2  \"./specs/**/*.md\"",
     "lint:specs:toc": "yarn run doctoc '--title=**Table of Contents**' ./specs",
+    "install:ci": "./scripts/yarn-install.sh",
     "postinstall": "patch-package",
     "ready": "yarn lint && yarn test",
     "prepare": "husky install",

--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -25,7 +25,6 @@
     "gas-snapshot": "forge snapshot",
     "pretest:slither": "rm -f @openzeppelin && rm -f hardhat && ln -s node_modules/@openzeppelin @openzeppelin && ln -s ../../node_modules/hardhat hardhat",
     "posttest:slither": "rm -f @openzeppelin && rm -f hardhat",
-    "install:ci": "./scripts/yarn-lock-file.sh",
     "lint:ts:check": "eslint . --max-warnings=0",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol'",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",

--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -25,6 +25,7 @@
     "gas-snapshot": "forge snapshot",
     "pretest:slither": "rm -f @openzeppelin && rm -f hardhat && ln -s node_modules/@openzeppelin @openzeppelin && ln -s ../../node_modules/hardhat hardhat",
     "posttest:slither": "rm -f @openzeppelin && rm -f hardhat",
+    "install:ci": "./scripts/yarn-lock-file.sh",
     "lint:ts:check": "eslint . --max-warnings=0",
     "lint:contracts:check": "yarn solhint -f table 'contracts/**/*.sol'",
     "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",

--- a/scripts/yarn-install.sh
+++ b/scripts/yarn-install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This file exists because as of yarn@1.12.3, --frozen-lockfile is completely
+# broken when combined with Yarn workspaces. See https://github.com/yarnpkg/yarn/issues/6291
+# This runs on CI to make sure yarn lockfile is up to date before merging a pr
+
+CKSUM_BEFORE=$(cksum yarn.lock)
+yarn install
+CKSUM_AFTER=$(cksum yarn.lock)
+
+
+if [[ $CKSUM_BEFORE != $CKSUM_AFTER ]]; then
+  echo "yarn_frozen_lockfile.sh: yarn.lock was modified unexpectedly - terminating"
+  exit 1
+fi


### PR DESCRIPTION
Resurrecting #4481

I tried to achieve this by just adding `git diff --exit-code` to the ci config file in #4607, but for reasons unclear to me it is not working. [This job](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/12400/workflows/3cd42a84-329e-484b-966c-7ef4bb37b696/jobs/378384) on that PR should fail due to the existing dirty lockfile, but it does not. 

This approach should work.