### PR TITLE
op-chain-ops: export bedrock transition block extradata

### DIFF
--- a/op-chain-ops/genesis/check.go
+++ b/op-chain-ops/genesis/check.go
@@ -51,8 +51,8 @@ func PostCheckMigratedDB(ldb ethdb.Database, migrationData migration.MigrationDa
 	header := rawdb.ReadHeader(ldb, hash, *num)
 	log.Info("Read header from database", "number", *num)
 
-	if !bytes.Equal(header.Extra, bedrockTransitionBlockExtraData) {
-		return fmt.Errorf("expected extra data to be %x, but got %x", bedrockTransitionBlockExtraData, header.Extra)
+	if !bytes.Equal(header.Extra, BedrockTransitionBlockExtraData) {
+		return fmt.Errorf("expected extra data to be %x, but got %x", BedrockTransitionBlockExtraData, header.Extra)
 	}
 
 	prevHeader := rawdb.ReadHeader(ldb, header.ParentHash, *num-1)

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	abiTrue                         = common.Hash{31: 0x01}
-	bedrockTransitionBlockExtraData = []byte("BEDROCK")
+	BedrockTransitionBlockExtraData = []byte("BEDROCK")
 )
 
 type MigrationResult struct {
@@ -42,7 +42,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 	header := rawdb.ReadHeader(ldb, hash, *num)
 	log.Info("Read header from database", "number", *num)
 
-	if bytes.Equal(header.Extra, bedrockTransitionBlockExtraData) {
+	if bytes.Equal(header.Extra, BedrockTransitionBlockExtraData) {
 		log.Info("Detected migration already happened", "root", header.Root, "blockhash", header.Hash())
 
 		return &MigrationResult{
@@ -157,7 +157,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 		GasLimit:    (uint64)(config.L2GenesisBlockGasLimit),
 		GasUsed:     gasUsed,
 		Time:        uint64(config.L2OutputOracleStartingTimestamp),
-		Extra:       bedrockTransitionBlockExtraData,
+		Extra:       BedrockTransitionBlockExtraData,
 		MixDigest:   common.Hash{},
 		Nonce:       types.BlockNonce{},
 		BaseFee:     big.NewInt(params.InitialBaseFee),

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -20,7 +20,10 @@ import (
 )
 
 var (
-	abiTrue                         = common.Hash{31: 0x01}
+	abiTrue = common.Hash{31: 0x01}
+	// BedrockTransitionBlockExtraData represents the extradata
+	// set in the very first bedrock block. This value must be
+	// less than 32 bytes long or it will create an invalid block.
 	BedrockTransitionBlockExtraData = []byte("BEDROCK")
 )
 
@@ -142,6 +145,11 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 
 	// Set the amount of gas used so that EIP 1559 starts off stable
 	gasUsed := (uint64)(config.L2GenesisBlockGasLimit) * config.EIP1559Elasticity
+
+	// Ensure that the extradata is valid
+	if size := len(BedrockTransitionBlockExtraData); size > 32 {
+		return nil, fmt.Errorf("transition block extradata too long: %d", size)
+	}
 
 	// Create the bedrock transition block
 	bedrockHeader := &types.Header{


### PR DESCRIPTION
**Description**

Makes the extradata for the bedrock transition block a public variable. This is useful for exporting the value to be imported in other packages where assertions can be made to ensure that the extradata is correct.

When fetching the `L2OutputOracle`'s configured starting block number, the L2 block with that number can be fetched and then we can assert that it has the magic extradata.

```bash
$ cast call 0x02Ac1923480E7fd234e7F2Fd11596b9F20372374 'startingBlockNumber()(uint256)'
3855343
```

```bash
$ cast block 3855343 --json | jq -r .extraData
0x424544524f434b
```

Now check like so:

```bash
$ cast --to-ascii 0x424544524f434b
BEDROCK
```

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

