### PR TITLE
fix(op-e2e): Include `action` tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,6 +484,7 @@ jobs:
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
             OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
             --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>_http_<<parameters.use_http>>.xml \
+            ./... \
             -- -timeout=20m
           working_directory: <<parameters.module>>
       - store_test_results:


### PR DESCRIPTION
# Overview

Changes the circleci config such that `op-e2e`'s action tests run in CI.
