### PR TITLE
Example of spec mismatch

### DIFF
--- a/op-e2e/actions/blocktime_test.go
+++ b/op-e2e/actions/blocktime_test.go
@@ -279,6 +279,8 @@ func TestL1BlockTimeShorterThanL2Time(gt *testing.T) {
 
 	sd, miner, sequencer, sequencerEngine, _, _, batcher := setupReorgTestActors(t, dp, sd, log)
 
+	batchSubmit := true
+
 	miner.ActL1StartBlock(2)(t)
 	miner.ActL1EndBlock(t)
 	sequencer.ActL1HeadSignal(t)
@@ -286,9 +288,13 @@ func TestL1BlockTimeShorterThanL2Time(gt *testing.T) {
 	sequencer.ActBuildToL1Head(t)
 
 	for i := 0; i < 25; i++ {
-		batcher.ActSubmitAll(t)
+		if batchSubmit {
+			batcher.ActSubmitAll(t)
+		}
 		miner.ActL1StartBlock(2)(t)
-		miner.ActL1IncludeTx(sd.RollupCfg.Genesis.SystemConfig.BatcherAddr)(t)
+		if batchSubmit {
+			miner.ActL1IncludeTx(sd.RollupCfg.Genesis.SystemConfig.BatcherAddr)(t)
+		}
 		miner.ActL1EndBlock(t)
 		sequencer.ActL1HeadSignal(t)
 		sequencer.ActL2PipelineFull(t)

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -234,7 +234,7 @@ batchLoop:
 	nextEpoch := bq.l1Blocks[1]
 	// Fill with empty L2 blocks of the same epoch until we meet the time of the next L1 origin,
 	// to preserve that L2 time >= L1 time
-	if nextTimestamp < nextEpoch.Time {
+	if nextTimestamp < nextEpoch.Time || l2SafeHead.L1Origin.Number != epoch.Number {
 		return &BatchData{
 			BatchV1{
 				ParentHash:   l2SafeHead.Hash,

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -97,7 +97,11 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 
 	// If we ran out of sequencer time drift, then we drop the batch and produce an empty batch instead,
 	// as the sequencer is not allowed to include anything past this point without moving to the next epoch.
-	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Batch.Timestamp > max {
+	max := batchOrigin.Time + cfg.MaxSequencerDrift
+	if max < nextTimestamp {
+		max = nextTimestamp + 1
+	}
+	if batch.Batch.Timestamp > max {
 		log.Warn("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again", "max_time", max)
 		return BatchDrop
 	}


### PR DESCRIPTION
This shows the conflict in the specs between the logic laid out in the [batch validity rules](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#batch-buffering) is in conflict with [rules just below the overview](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#overview).

This includes example fixes for both the batch submission case and the no batch submission case. If the fix is not applied, the test times out (can observe a livelock in the logs).