### PR TITLE
Update docker publish target to oplabs-tools-artifacts/images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,11 +109,11 @@ jobs:
       registry:
         description: Docker registry
         type: string
-        default: "us-central1-docker.pkg.dev"
+        default: "us-docker.pkg.dev"
       repo:
         description: Docker repo
         type: string
-        default: "bedrock-goerli-development/images"
+        default: "oplabs-tools-artifacts/images"
     machine:
       image: ubuntu-2204:2022.07.1
       resource_class: xlarge
@@ -157,11 +157,11 @@ jobs:
       registry:
         description: Docker registry
         type: string
-        default: "us-central1-docker.pkg.dev"
+        default: "us-docker.pkg.dev"
       repo:
         description: Docker repo
         type: string
-        default: "bedrock-goerli-development/images"
+        default: "oplabs-tools-artifacts/images"
     machine:
       image: ubuntu-2204:2022.07.1
       resource_class: xlarge
@@ -194,11 +194,11 @@ jobs:
       registry:
         description: Docker registry
         type: string
-        default: "us-central1-docker.pkg.dev"
+        default: "us-docker.pkg.dev"
       repo:
         description: Docker repo
         type: string
-        default: "bedrock-goerli-development/images"
+        default: "oplabs-tools-artifacts/images"
     docker:
       - image: cimg/python:3.7
     resource_class: small
@@ -990,7 +990,7 @@ workflows:
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-node-docker-build
       - docker-build:
@@ -1004,7 +1004,7 @@ workflows:
           docker_name: op-batcher
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-batcher-docker-build
       - docker-build:
@@ -1018,7 +1018,7 @@ workflows:
           docker_name: op-proposer
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-proposer-docker-build
       - docker-build:
@@ -1032,7 +1032,7 @@ workflows:
           docker_name: op-heartbeat
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-heartbeat-docker-build
       - hive-test:
@@ -1063,6 +1063,11 @@ workflows:
     jobs:
       - docker-build:
           name: op-node-docker-build
+          filters:
+            tags:
+              only: /^op-[a-z0-9\-]*\/v.*/
+            branches:
+              ignore: /.*/
           docker_file: op-node/Dockerfile
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
@@ -1072,11 +1077,16 @@ workflows:
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-node-docker-build
       - docker-build:
           name: op-batcher-docker-build
+          filters:
+            tags:
+              only: /^op-[a-z0-9\-]*\/v.*/
+            branches:
+              ignore: /.*/
           docker_file: op-batcher/Dockerfile
           docker_name: op-batcher
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
@@ -1086,11 +1096,16 @@ workflows:
           docker_name: op-batcher
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-batcher-docker-build
       - docker-build:
           name: op-proposer-docker-build
+          filters:
+            tags:
+              only: /^op-[a-z0-9\-]*\/v.*/
+            branches:
+              ignore: /.*/
           docker_file: op-proposer/Dockerfile
           docker_name: op-proposer
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
@@ -1100,11 +1115,16 @@ workflows:
           docker_name: op-proposer
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-proposer-docker-build
       - docker-build:
           name: op-migrate-docker-build
+          filters:
+            tags:
+              only: /^op-[a-z0-9\-]*\/v.*/
+            branches:
+              ignore: /.*/
           docker_file: op-chain-ops/Dockerfile
           docker_name: op-migrate
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
@@ -1114,7 +1134,7 @@ workflows:
           docker_name: op-migrate
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - gcr
+            - oplabs-gcr
           requires:
             - op-migrate-docker-build
       - docker-tag-op-stack-release:
@@ -1129,4 +1149,4 @@ workflows:
             - op-proposer-docker-publish
             - op-batcher-docker-publish
           context:
-            - gcr-release
+            - oplabs-gcr-release


### PR DESCRIPTION
**Description**

Moving away from publishing images to bedrock-goerli-development to the new oplabs-tools-artifacts GAR repo.