### PR TITLE
op-chain-ops: always use magic for transition/genesis block

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -58,7 +58,6 @@ type DeployConfig struct {
 	L1GenesisBlockBaseFeePerGas *hexutil.Big   `json:"l1GenesisBlockBaseFeePerGas"`
 
 	L2GenesisBlockNonce         hexutil.Uint64 `json:"l2GenesisBlockNonce"`
-	L2GenesisBlockExtraData     hexutil.Bytes  `json:"l2GenesisBlockExtraData"`
 	L2GenesisBlockGasLimit      hexutil.Uint64 `json:"l2GenesisBlockGasLimit"`
 	L2GenesisBlockDifficulty    *hexutil.Big   `json:"l2GenesisBlockDifficulty"`
 	L2GenesisBlockMixHash       common.Hash    `json:"l2GenesisBlockMixHash"`

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -2,6 +2,7 @@ package genesis
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -61,10 +62,6 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		},
 	}
 
-	extraData := config.L2GenesisBlockExtraData
-	if len(extraData) == 0 {
-		extraData = common.Hash{}.Bytes()
-	}
 	gasLimit := config.L2GenesisBlockGasLimit
 	if gasLimit == 0 {
 		gasLimit = defaultL2GasLimit
@@ -78,11 +75,16 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		difficulty = newHexBig(0)
 	}
 
+	// Ensure that the extradata is valid
+	if size := len(BedrockTransitionBlockExtraData); size > 32 {
+		return nil, fmt.Errorf("transition block extradata too long: %d", size)
+	}
+
 	return &core.Genesis{
 		Config:     &optimismChainConfig,
 		Nonce:      uint64(config.L2GenesisBlockNonce),
 		Timestamp:  block.Time(),
-		ExtraData:  extraData,
+		ExtraData:  BedrockTransitionBlockExtraData,
 		GasLimit:   uint64(gasLimit),
 		Difficulty: difficulty.ToInt(),
 		Mixhash:    config.L2GenesisBlockMixHash,

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -28,7 +28,6 @@
   "l1GenesisBlockTimestamp": "0x0",
   "l1GenesisBlockBaseFeePerGas": "0x3b9aca00",
   "l2GenesisBlockNonce": "0x0",
-  "l2GenesisBlockExtraData": "0x",
   "l2GenesisBlockGasLimit": "0xe4e1c0",
   "l2GenesisBlockDifficulty": "0x1",
   "l2GenesisBlockMixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -89,7 +89,6 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 		FinalizationPeriodSeconds:   12,
 
 		L2GenesisBlockNonce:         0,
-		L2GenesisBlockExtraData:     []byte{},
 		L2GenesisBlockGasLimit:      15_000_000,
 		L2GenesisBlockDifficulty:    uint64ToBig(0),
 		L2GenesisBlockMixHash:       common.Hash{},

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -81,7 +81,6 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 		L1GenesisBlockBaseFeePerGas: uint642big(7),
 
 		L2GenesisBlockNonce:         0,
-		L2GenesisBlockExtraData:     []byte{},
 		L2GenesisBlockGasLimit:      8_000_000,
 		L2GenesisBlockDifficulty:    uint642big(1),
 		L2GenesisBlockMixHash:       common.Hash{},

--- a/packages/contracts-bedrock/src/deploy-config.ts
+++ b/packages/contracts-bedrock/src/deploy-config.ts
@@ -147,7 +147,6 @@ interface OptionalL1DeployConfig {
  */
 interface OptionalL2DeployConfig {
   l2GenesisBlockNonce: string
-  l2GenesisBlockExtraData: string
   l2GenesisBlockGasLimit: string
   l2GenesisBlockDifficulty: string
   l2GenesisBlockMixHash: string
@@ -282,10 +281,6 @@ export const deployConfigSpec: {
   l2GenesisBlockNonce: {
     type: 'string', // uint64
     default: '0x0',
-  },
-  l2GenesisBlockExtraData: {
-    type: 'string', // important: in the case of L2, which uses post-Merge Ethereum rules, this must be <= 32 bytes.
-    default: ethers.constants.HashZero,
   },
   l2GenesisBlockGasLimit: {
     type: 'string',


### PR DESCRIPTION
**Description**

No longer allow for a configurable L2 genesis/transition block extradata. The extradata will always be set to `BEDROCK`. This allows us to have automation to ensure that the value set as the `L2OutputOracle.startingBlockNumber` matches the actual L2 genesis/transition block.

Note that the term genesis block and transition block are used interchangably, the term transition block is used for upgraded networks.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Builds on top of https://github.com/ethereum-optimism/optimism/pull/4613

