### PR TITLE
op-node: Enforce min L2 timestamp

### DIFF
--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -95,6 +95,11 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 		return BatchDrop
 	}
 
+	if batch.Batch.Timestamp < batchOrigin.Time {
+		log.Warn("batch timestamp is less than L1 origin timestamp", "l2_timestamp", batch.Batch.Timestamp, "l1_timestamp", batchOrigin.Time, "origin", batchOrigin.ID())
+		return BatchDrop
+	}
+
 	// If we ran out of sequencer time drift, then we drop the batch and produce an empty batch instead,
 	// as the sequencer is not allowed to include anything past this point without moving to the next epoch.
 	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Batch.Timestamp > max {

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -418,6 +418,22 @@ func TestValidBatch(t *testing.T) {
 			},
 			Expected: BatchAccept,
 		},
+		{
+			Name:       "batch with L2 time before L1 time",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV1{ // we build l2B0', which starts a new epoch too early
+					ParentHash:   l2A2.Hash,
+					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:    l2B0.L1Origin.Hash,
+					Timestamp:    l2A2.Time + conf.BlockTime,
+					Transactions: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
 	}
 
 	// Log level can be increased for debugging purposes


### PR DESCRIPTION
**Description**

This adds a check to the batch queue to verify that supplied batches have a timestamp that is greater than or equal to the L1 origin timestamp. The sequencer should not sequence batches like this, but it was not being enforced in the derivation process.

**Tests**

I added a unit test for this & manually confirmed that the unit test will fail if the fix is not included.

**Metadata**

- Fixes ENG-3156