### PR TITLE
op-node: Add default boot nodes

### DIFF
--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -38,6 +38,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
+var DefaultBootnodes = []*enode.Node{
+	enode.MustParse("enode://869d07b5932f17e8490990f75a3f94195e9504ddb6b85f7189e5a9c0a8fff8b00aecf6f3ac450ecba6cdabdb5858788a94bde2b613e0f2d82e9b395355f76d1a@34.65.67.101:0?discport=30305"),
+	enode.MustParse("enode://2d4e7e9d48f4dd4efe9342706dd1b0024681bd4c3300d021f86fc75eab7865d4e0cbec6fbc883f011cfd6a57423e7e2f6e104baad2b744c3cafaec6bc7dc92c1@34.65.43.171:0?discport=30305"),
+	enode.MustParse("enode://9d7a3efefe442351217e73b3a593bcb8efffb55b4807699972145324eab5e6b382152f8d24f6301baebbfb5ecd4127bd3faab2842c04cd432bdf50ba092f6645@34.65.109.126:0?discport=30305"),
+}
+
 // SetupP2P provides a host and discovery service for usage in the rollup node.
 type SetupP2P interface {
 	Check() error
@@ -242,6 +248,7 @@ func (conf *Config) loadDiscoveryOpts(ctx *cli.Context) error {
 		return fmt.Errorf("failed to open discovery db: %w", err)
 	}
 
+	conf.Bootnodes = DefaultBootnodes
 	records := strings.Split(ctx.GlobalString(flags.Bootnodes.Name), ",")
 	for i, recordB64 := range records {
 		recordB64 = strings.TrimSpace(recordB64)


### PR DESCRIPTION
Adds default boot nodes. Specifiying `--bootnodes` will override them.
