### PR TITLE
contracts-bedrock: check-l2 checks for genesis magic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,7 +641,7 @@ jobs:
                   make devnet-up
             - run:
                 name: Check L2 config
-                command: npx hardhat check-l2 --network devnetL2
+                command: npx hardhat check-l2 --network devnetL1 --l2-rpc-url http://localhost:9545 --l1-rpc-url http://localhost:8545
                 working_directory: packages/contracts-bedrock
             - run:
                 name: Deposit ERC20 through the bridge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,7 +591,7 @@ jobs:
                   make devnet-up-deploy
             - run:
                 name: Check L2 config
-                command: npx hardhat check-l2 --network devnetL2
+                command: npx hardhat check-l2 --network devnetL1 --l2-rpc-url http://localhost:9545 --l1-rpc-url http://localhost:8545
                 working_directory: packages/contracts-bedrock
             - run:
                 name: Deposit ERC20 through the bridge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,7 +641,12 @@ jobs:
                   make devnet-up
             - run:
                 name: Check L2 config
-                command: npx hardhat check-l2 --network devnetL1 --l2-rpc-url http://localhost:9545 --l1-rpc-url http://localhost:8545
+                command: |
+                  npx hardhat check-l2 \
+                    --network devnetL1 \
+                    --l2-rpc-url http://localhost:9545 \
+                    --l1-rpc-url http://localhost:8545 \
+                    --l2-output-oracle-address 0x6900000000000000000000000000000000000000
                 working_directory: packages/contracts-bedrock
             - run:
                 name: Deposit ERC20 through the bridge

--- a/packages/contracts-bedrock/tasks/check-l2.ts
+++ b/packages/contracts-bedrock/tasks/check-l2.ts
@@ -131,6 +131,22 @@ const assertProxy = async (
   }
 }
 
+// checks to make sure that the genesis magic value
+// was set correctly
+const checkGenesisMagic = async (
+  hre: HardhatRuntimeEnvironment,
+  provider: providers.Provider
+) => {
+  const start = hre.deployConfig.l2OutputOracleStartingBlockNumber
+  const block = await provider.getBlock(start)
+  const extradata = block.extraData
+  const magic = '0x' + Buffer.from('BEDROCK').toString('hex')
+
+  if (extradata !== magic) {
+    throw new Error('magic value in extradata does not match')
+  }
+}
+
 const check = {
   // LegacyMessagePasser
   // - check version
@@ -631,6 +647,8 @@ task('check-l2', 'Checks a freshly migrated L2 system for correct migration')
     if (!args.skipPredeployCheck) {
       await checkPredeploys(hre, signer.provider)
     }
+
+    await checkGenesisMagic(hre, signer.provider)
 
     console.log()
     // Check the currently configured predeploys

--- a/packages/contracts-bedrock/tasks/check-l2.ts
+++ b/packages/contracts-bedrock/tasks/check-l2.ts
@@ -4,7 +4,7 @@ import { task, types } from 'hardhat/config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
-import { Contract, providers, Wallet, Signer } from 'ethers'
+import { Contract, providers, Wallet, Signer, BigNumber } from 'ethers'
 
 import { predeploys } from '../src'
 
@@ -161,6 +161,9 @@ const checkGenesisMagic = async (
     // The `--network` flag must be set to the L1 network
     startingBlockNumber = hre.deployConfig.l2OutputOracleStartingBlockNumber
   }
+
+  // ensure that the starting block number is a number
+  startingBlockNumber = BigNumber.from(startingBlockNumber).toNumber()
 
   const block = await l2Provider.getBlock(startingBlockNumber)
   const extradata = block.extraData


### PR DESCRIPTION
**Description**

Add additional check for the genesis magic value.
This ensures that the L2OutputOracle's starting
block number is set correctly.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
