### PR TITLE
ci: Reduce block time in devnet tests

### DIFF
--- a/bedrock-devnet/devnet/genesis.py
+++ b/bedrock-devnet/devnet/genesis.py
@@ -26,7 +26,7 @@ GENESIS_TMPL = {
         "shanghaiBlock": None,
         "cancunBlock": None,
         'clique': {
-            'period': 15,
+            'period': 3,
             'epoch': 30000
         }
     },

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -13,7 +13,7 @@
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
   "l2GenesisBlockGasLimit": "0xE4E1C0",
-  "l1BlockTime": 15,
+  "l1BlockTime": 3,
   "cliqueSignerAddress": "0xca062b0fd91172d89bcd4bb084ac4e21972cc467",
   "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",


### PR DESCRIPTION
Reduces the block time in devnet tests to 3s from 15. This cuts the deployed contracts test runtime down to 12m from 20m, and the genesis contracts test down from 12m to 9m.