### PR TITLE
docs: updating Optimism's org structure

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -44,5 +44,5 @@ Our aim is to design a protocol specification that is:
 - **Secure:** This is self-evident. We cannot lose money and in a system where even a bit of
   downtime can result in loss of funds this means everything we build must be incredibly secure.
 - **Decentralizable:** Everything we build must have a clear path towards decentralization. Today
-  Optimism relies on the Optimism Foundation and OP Labs to function, but eventually it will be managed by a DAO and even in
-  that decentralized future our system must thrive.
+  Optimism relies on the Optimism Foundation and OP Labs to function, but eventually it will be
+  managed by a DAO and even in that decentralized future our system must thrive.

--- a/specs/README.md
+++ b/specs/README.md
@@ -43,6 +43,5 @@ Our aim is to design a protocol specification that is:
   systems team consuming the spec is also key!
 - **Secure:** This is self-evident. We cannot lose money and in a system where even a bit of
   downtime can result in loss of funds this means everything we build must be incredibly secure.
-- **Decentralizable:** Everything we build must have a clear path towards decentralization. Today
-  Optimism relies on the Optimism Foundation and OP Labs to function, but eventually it will be
-  managed by a DAO and even in that decentralized future our system must thrive.
+- **Decentralizable:** Everything we build must have a clear path towards decentralization so the
+  system can be fully managed by a DAO.

--- a/specs/README.md
+++ b/specs/README.md
@@ -44,5 +44,5 @@ Our aim is to design a protocol specification that is:
 - **Secure:** This is self-evident. We cannot lose money and in a system where even a bit of
   downtime can result in loss of funds this means everything we build must be incredibly secure.
 - **Decentralizable:** Everything we build must have a clear path towards decentralization. Today
-  Optimism relies on OptimismPBC to function, but eventually it will be managed by a DAO and even in
+  Optimism relies on the Optimism Foundation and OP Labs to function, but eventually it will be managed by a DAO and even in
   that decentralized future our system must thrive.


### PR DESCRIPTION
**Description**

From what I understand the Optimism organization moved from OptimismPBC to Optimism Foundation and OP Labs. I updated the `specs` `README` doc to reflect that.

**Tests**

n/a - documentation 

**Invariants**

n/a - documentation

**Additional context**

n/a
