### PR TITLE
sdk: allow `deposit-eth` task to work with artifacts

### DIFF
--- a/packages/sdk/hardhat.config.ts
+++ b/packages/sdk/hardhat.config.ts
@@ -29,6 +29,12 @@ const config: HardhatUserConfig = {
       url: process.env.L1_RPC || '',
       accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
     },
+    'final-migration-rehearsal': {
+      chainId: 5,
+      url: process.env.L1_RPC || '',
+      accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
+      live: true,
+    },
   },
   external: {
     contracts: [
@@ -42,6 +48,11 @@ const config: HardhatUserConfig = {
       goerli: [
         '../contracts-bedrock/deployments/goerli',
         '../contracts/deployments/goerli',
+      ],
+      'final-migration-rehearsal': [
+        '../contracts-bedrock/deployments/final-migration-rehearsal',
+        '../contracts/deployments/goerli',
+        '../contracts-periphery/deployments/goerli',
       ],
     },
   },

--- a/packages/sdk/tasks/deposit-eth.ts
+++ b/packages/sdk/tasks/deposit-eth.ts
@@ -3,11 +3,12 @@ import { promises as fs } from 'fs'
 import { task, types } from 'hardhat/config'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
+import { Deployment } from 'hardhat-deploy/types'
 import {
   predeploys,
   getContractDefinition,
 } from '@eth-optimism/contracts-bedrock'
-import { providers, utils } from 'ethers'
+import { providers, utils, ethers } from 'ethers'
 
 import {
   CrossChainMessenger,
@@ -17,7 +18,7 @@ import {
   DEFAULT_L2_CONTRACT_ADDRESSES,
 } from '../src'
 
-task('deposit-eth', 'Deposits WETH9 onto L2.')
+task('deposit-eth', 'Deposits ether to L2.')
   .addParam(
     'l2ProviderUrl',
     'L2 provider URL.',
@@ -66,6 +67,7 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
     if (balance.eq(0)) {
       throw new Error('Signer has no balance')
     }
+    console.log(`Signer balance: ${utils.formatEther(balance.toString())}`)
 
     const l2Provider = new providers.StaticJsonRpcProvider(args.l2ProviderUrl)
 
@@ -91,6 +93,57 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
         l1: JSON.parse(data.toString()),
         l2: DEFAULT_L2_CONTRACT_ADDRESSES,
       } as OEContractsLike
+    } else if (!contractAddrs) {
+      // If the contract addresses have not been hardcoded,
+      // attempt to read them from deployment artifacts
+      let Deployment__AddressManager: Deployment
+      try {
+        Deployment__AddressManager = await hre.deployments.get('AddressManager')
+      } catch (e) {
+        Deployment__AddressManager = await hre.deployments.get(
+          'Lib_AddressManager'
+        )
+      }
+      let Deployment__L1CrossDomainMessenger: Deployment
+      try {
+        Deployment__L1CrossDomainMessenger = await hre.deployments.get(
+          'L1CrossDomainMessengerProxy'
+        )
+      } catch (e) {
+        Deployment__L1CrossDomainMessenger = await hre.deployments.get(
+          'Proxy__OVM_L1CrossDomainMessenger'
+        )
+      }
+      let Deployment__L1StandardBridge: Deployment
+      try {
+        Deployment__L1StandardBridge = await hre.deployments.get(
+          'L1StandardBridgeProxy'
+        )
+      } catch (e) {
+        Deployment__L1StandardBridge = await hre.deployments.get(
+          'Proxy__OVM_L1StandardBridge'
+        )
+      }
+
+      const Deployment__OptimismPortal = await hre.deployments.get(
+        'OptimismPortalProxy'
+      )
+      const Deployment__L2OutputOracle = await hre.deployments.get(
+        'L2OutputOracleProxy'
+      )
+      contractAddrs = {
+        l1: {
+          AddressManager: Deployment__AddressManager.address,
+          L1CrossDomainMessenger: Deployment__L1CrossDomainMessenger,
+          L1StandardBridge: Deployment__L1StandardBridge,
+          StateCommitmentChain: ethers.constants.AddressZero,
+          CanonicalTransactionChain: ethers.constants.AddressZero,
+          BondManager: ethers.constants.AddressZero,
+          OptimismPortal: Deployment__OptimismPortal.address,
+          L2OutputOracle: Deployment__L2OutputOracle.address,
+        },
+        l2: DEFAULT_L2_CONTRACT_ADDRESSES,
+      }
     }
 
     const Artifact__L2ToL1MessagePasser = await getContractDefinition(
@@ -166,6 +219,7 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
     // Deposit ETH
     console.log('Depositing ETH through StandardBridge')
     const ethDeposit = await messenger.depositETH(amount, { recipient: to })
+    console.log(`Transaction hash: ${ethDeposit.hash}`)
     const depositMessageReceipt = await messenger.waitForMessageReceipt(
       ethDeposit
     )
@@ -173,7 +227,7 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
       throw new Error('deposit failed')
     }
     console.log(
-      `Deposit complete - ${depositMessageReceipt.transactionReceipt.transactionHash}`
+      `Deposit complete - included in block ${depositMessageReceipt.transactionReceipt.blockNumber}`
     )
 
     const opBalanceAfter = await signer.provider.getBalance(
@@ -184,14 +238,24 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
       throw new Error(`OptimismPortal balance mismatch`)
     }
 
+    const l2Balance = await l2Provider.getBalance(to)
+    console.log(
+      `L2 balance of deposit recipient: ${utils.formatEther(
+        l2Balance.toString()
+      )}`
+    )
+
     if (!args.withdraw) {
       return
     }
 
     console.log('Withdrawing ETH')
     const ethWithdraw = await messenger.withdrawETH(withdrawAmount)
+    console.log(`Transaction hash: ${ethWithdraw.hash}`)
     const ethWithdrawReceipt = await ethWithdraw.wait()
-    console.log(`ETH withdrawn on L2 - ${ethWithdrawReceipt.transactionHash}`)
+    console.log(
+      `ETH withdrawn on L2 - included in block ${ethWithdrawReceipt.blockNumber}`
+    )
 
     {
       // check the logs
@@ -225,11 +289,8 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
       }
     }
 
-    console.log(
-      `Withdrawal on L2 complete: ${ethWithdrawReceipt.transactionHash}`
-    )
-
     console.log('Waiting to be able to prove withdrawal')
+
     const proveInterval = setInterval(async () => {
       const currentStatus = await messenger.getMessageStatus(ethWithdrawReceipt)
       console.log(`Message status: ${MessageStatus[currentStatus]}`)
@@ -246,12 +307,15 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
 
     console.log('Proving eth withdrawal...')
     const ethProve = await messenger.proveMessage(ethWithdrawReceipt)
+    console.log(`Transaction hash: ${ethProve.hash}`)
     const ethProveReceipt = await ethProve.wait()
     if (ethProveReceipt.status !== 1) {
       throw new Error('Prove withdrawal transaction reverted')
     }
+    console.log('Successfully proved withdrawal')
 
     console.log('Waiting to be able to finalize withdrawal')
+
     const finalizeInterval = setInterval(async () => {
       const currentStatus = await messenger.getMessageStatus(ethWithdrawReceipt)
       console.log(`Message status: ${MessageStatus[currentStatus]}`)
@@ -268,13 +332,14 @@ task('deposit-eth', 'Deposits WETH9 onto L2.')
 
     console.log('Finalizing eth withdrawal...')
     const ethFinalize = await messenger.finalizeMessage(ethWithdrawReceipt)
+    console.log(`Transaction hash: ${ethFinalize.hash}`)
     const ethFinalizeReceipt = await ethFinalize.wait()
     if (ethFinalizeReceipt.status !== 1) {
       throw new Error('Finalize withdrawal reverted')
     }
 
     console.log(
-      `ETH withdrawal complete: ${ethFinalizeReceipt.transactionHash}`
+      `ETH withdrawal complete - included in block ${ethFinalizeReceipt.blockNumber}`
     )
     {
       // Check that the logs are correct


### PR DESCRIPTION
**Description**

This allows the script to be able to be used with
test networks more easily.

Usage:

```bash
export L1_RPC=...
export PRIVATE_KEY_DEPLOYER=0x...

npx hardhat deposit-eth \
    --l2-provider-url ... \
    --to 0x9C822C992b56A3bd35d16A089d99AEc870eF8d37 \
    --amount 0.0001 \
    --network final-migration-rehearsal
```

The following transactions were created using this commit on the `final-migration-rehearsal` network:

L1 Deposit Transaction hash: 0x23f42a9d18b41bd32d90026b2324dbab64a45e942fe3897dd67a56989b940e11

L2 Withdrawing Transaction hash: 0x5b1108b61b7ec97f99c3c5c312913d465e87feaec2ab805087be55d342d5e17d

L1 Proving Withdrawal Transaction hash: 0xfe8c8beae69bdca1af35f04cfa635ea7d959abf0270f082a4ab41d680d7fe35b

L1 Finalizing Withdrawal Transaction hash: 0xcab6550b4a388e0c6fbb4b3e1604b42e2ca228aed8c5a1a8601e596f4a939e56

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

cc @K-Ho 