### PR TITLE
indexer: Add changeset

### DIFF
--- a/.changeset/afraid-roses-type.md
+++ b/.changeset/afraid-roses-type.md
@@ -1,5 +1,5 @@
 ---
-'@eth-optimism/indexer': minor
+'@eth-optimism/indexer': major
 ---
 
 Add support for two-phase withdrawals

--- a/.changeset/afraid-roses-type.md
+++ b/.changeset/afraid-roses-type.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/indexer': minor
+---
+
+Add support for two-phase withdrawals


### PR DESCRIPTION
The indexer hasn't been released yet to include two-phase withdrawals. This PR adds a changeset in order to do that.