### PR TITLE
tests(ctb): Add invariant test for `minGasLimit`s in the L1 XDM's `relayMessage` fn

### DIFF
--- a/.changeset/orange-penguins-reply.md
+++ b/.changeset/orange-penguins-reply.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Add invariant test for the L1 XDM's `relayMessage` minimum gas limits.

--- a/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
@@ -116,6 +116,7 @@ contract XDM_MinGasLimits is Messenger_Initializer, InvariantTest {
      * gas limits are supplied.
      *
      * There are two minimum gas limits here:
+     *
      * - The outer min gas limit is for the call from the `OptimismPortal` to the
      * `L1CrossDomainMessenger`,  and it can be retrieved by calling the xdm's `baseGas` function
      * with the `message` and inner limit.

--- a/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
@@ -125,6 +125,6 @@ contract XDM_MinGasLimits is Messenger_Initializer, InvariantTest {
             // it is not in the received messages mapping
             assertFalse(L1Messenger.failedMessages(hash));
         }
-        assertTrue(!actor.outOfGas());
+        assertFalse(actor.outOfGas());
     }
 }

--- a/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
@@ -1,16 +1,17 @@
 pragma solidity 0.8.15;
 
 import { InvariantTest } from "forge-std/InvariantTest.sol";
-import { Test } from "forge-std/Test.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { OptimismPortal } from "../../L1/OptimismPortal.sol";
+import { L1CrossDomainMessenger } from "../../L1/L1CrossDomainMessenger.sol";
 import { Messenger_Initializer } from "../CommonTest.t.sol";
 import { Types } from "../../libraries/Types.sol";
 import { Predeploys } from "../../libraries/Predeploys.sol";
 import { Encoding } from "../../libraries/Encoding.sol";
 import { Hashing } from "../../libraries/Hashing.sol";
-import { OptimismPortal } from "../../L1/OptimismPortal.sol";
-import { L1CrossDomainMessenger } from "../../L1/L1CrossDomainMessenger.sol";
 
-contract RelayActor is Test {
+contract RelayActor is StdUtils {
     // Storage slot of the l2Sender
     uint256 constant senderSlotIndex = 50;
 
@@ -20,10 +21,16 @@ contract RelayActor is Test {
 
     OptimismPortal op;
     L1CrossDomainMessenger xdm;
+    Vm vm;
 
-    constructor(OptimismPortal _op, L1CrossDomainMessenger _xdm) {
+    constructor(
+        OptimismPortal _op,
+        L1CrossDomainMessenger _xdm,
+        Vm _vm
+    ) {
         op = _op;
         xdm = _xdm;
+        vm = _vm;
     }
 
     /**
@@ -93,7 +100,7 @@ contract XDM_MinGasLimits is Messenger_Initializer, InvariantTest {
         super.setUp();
 
         // Deploy a relay actor
-        actor = new RelayActor(op, L1Messenger);
+        actor = new RelayActor(op, L1Messenger, vm);
 
         // Target the `RelayActor` contract
         targetContract(address(actor));

--- a/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
@@ -17,7 +17,7 @@ contract RelayActor is StdUtils {
 
     uint256 public numHashes;
     bytes32[] public hashes;
-    bool public outOfGas = false;
+    bool public reverted = false;
 
     OptimismPortal op;
     L1CrossDomainMessenger xdm;
@@ -80,10 +80,10 @@ contract RelayActor is StdUtils {
                 _message
             )
         {} catch {
-            // If any of these calls revert, set `outOfGas` to true to fail the invariant test.
+            // If any of these calls revert, set `reverted` to true to fail the invariant test.
             // NOTE: This is to get around forge's invariant fuzzer ignoring reverted calls
             // to this function.
-            outOfGas = true;
+            reverted = true;
         }
         vm.stopPrank();
 
@@ -132,6 +132,6 @@ contract XDM_MinGasLimits is Messenger_Initializer, InvariantTest {
             // it is not in the received messages mapping
             assertFalse(L1Messenger.failedMessages(hash));
         }
-        assertFalse(actor.outOfGas());
+        assertFalse(actor.reverted());
     }
 }

--- a/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
@@ -1,0 +1,130 @@
+pragma solidity 0.8.15;
+
+import { InvariantTest } from "forge-std/InvariantTest.sol";
+import { Test } from "forge-std/Test.sol";
+import { Messenger_Initializer } from "../CommonTest.t.sol";
+import { Types } from "../../libraries/Types.sol";
+import { Predeploys } from "../../libraries/Predeploys.sol";
+import { Encoding } from "../../libraries/Encoding.sol";
+import { Hashing } from "../../libraries/Hashing.sol";
+import { OptimismPortal } from "../../L1/OptimismPortal.sol";
+import { L1CrossDomainMessenger } from "../../L1/L1CrossDomainMessenger.sol";
+
+contract RelayActor is Test {
+    // Storage slot of the l2Sender
+    uint256 constant senderSlotIndex = 50;
+
+    uint256 public numHashes;
+    bytes32[] public hashes;
+    bool public outOfGas = false;
+
+    OptimismPortal op;
+    L1CrossDomainMessenger xdm;
+
+    constructor(OptimismPortal _op, L1CrossDomainMessenger _xdm) {
+        op = _op;
+        xdm = _xdm;
+    }
+
+    /**
+     * Relays a message to the `L1CrossDomainMessenger` with a random `version`, `_minGasLimit`
+     * and `_message`.
+     */
+    function relay(
+        uint16 _version,
+        uint32 _minGasLimit,
+        bytes memory _message
+    ) external {
+        address target = address(0x04); // ID precompile
+        address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
+
+        // set the value of op.l2Sender() to be the L2 Cross Domain Messenger.
+        vm.store(address(op), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
+
+        // Restrict `_minGasLimit` to a number in the range of the block gas limit.
+        _minGasLimit = uint32(bound(_minGasLimit, 0, block.gaslimit));
+
+        // Restrict version to the range of [0, 1]
+        _version = _version % 2;
+
+        // Compute the cross domain message hash and store it in `hashes`.
+        // The `relayMessage` function will always encode the message as a version 1
+        // message after checking that the V0 hash has not already been relayed.
+        bytes32 _hash = Hashing.hashCrossDomainMessageV1(
+            Encoding.encodeVersionedNonce(0, _version),
+            sender,
+            target,
+            0, // value
+            _minGasLimit,
+            _message
+        );
+
+        // Act as the optimism portal and call `relayMessage` on the `L1CrossDomainMessenger` with
+        // the outer min gas limit.
+        vm.startPrank(address(op));
+        vm.expectCall(target, _message);
+        try
+            xdm.relayMessage{ gas: xdm.baseGas(_message, _minGasLimit) }(
+                Encoding.encodeVersionedNonce(0, _version),
+                sender,
+                target,
+                0, // value
+                _minGasLimit,
+                _message
+            )
+        {} catch {
+            // If any of these calls revert, set `outOfGas` to true to fail the invariant test.
+            // NOTE: This is to get around forge's invariant fuzzer ignoring reverted calls
+            // to this function.
+            outOfGas = true;
+        }
+        vm.stopPrank();
+
+        hashes.push(_hash);
+        numHashes += 1;
+    }
+}
+
+contract XDM_MinGasLimits is Messenger_Initializer, InvariantTest {
+    RelayActor actor;
+
+    function setUp() public override {
+        // Set up the `L1CrossDomainMessenger` and `OptimismPortal` contracts.
+        super.setUp();
+
+        // Deploy a relay actor
+        actor = new RelayActor(op, L1Messenger);
+
+        // Target the `RelayActor` contract
+        targetContract(address(actor));
+
+        // Target the actor's `relay` function
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = actor.relay.selector;
+        targetSelector(FuzzSelector({ addr: address(actor), selectors: selectors }));
+    }
+
+    /**
+     * @custom:invariant A call to `relayMessage` should never revert if at least the proper minimum
+     * gas limits are supplied.
+     *
+     * There are two minimum gas limits here:
+     * - The outer min gas limit is for the call from the `OptimismPortal` to the
+     * `L1CrossDomainMessenger`,  and it can be retrieved by calling the xdm's `baseGas` function
+     * with the `message` and inner limit.
+     *
+     * - The inner min gas limit is for the call from the `L1CrossDomainMessenger` to the target
+     * contract.
+     */
+    function invariant_minGasLimits() public {
+        uint256 length = actor.numHashes();
+        for (uint256 i = 0; i < length; ++i) {
+            bytes32 hash = actor.hashes(i);
+            // the message hash is in the successfulMessages mapping
+            assertTrue(L1Messenger.successfulMessages(hash));
+            // it is not in the received messages mapping
+            assertFalse(L1Messenger.failedMessages(hash));
+        }
+        assertTrue(!actor.outOfGas());
+    }
+}

--- a/packages/contracts-bedrock/invariant-docs/CrossDomainMessenger.md
+++ b/packages/contracts-bedrock/invariant-docs/CrossDomainMessenger.md
@@ -1,0 +1,8 @@
+# `CrossDomainMessenger` Invariants
+
+## A call to `relayMessage` should never revert if at least the proper minimum gas limits are supplied.
+**Test:** [`CrossDomainMessenger.t.sol#L127`](../contracts/test/invariants/CrossDomainMessenger.t.sol#L127)
+
+There are two minimum gas limits here: 
+- The outer min gas limit is for the call from the `OptimismPortal` to the `L1CrossDomainMessenger`,  and it can be retrieved by calling the xdm's `baseGas` function with the `message` and inner limit. 
+- The inner min gas limit is for the call from the `L1CrossDomainMessenger` to the target contract. 

--- a/packages/contracts-bedrock/invariant-docs/README.md
+++ b/packages/contracts-bedrock/invariant-docs/README.md
@@ -8,6 +8,7 @@ This directory contains documentation for all defined invariant tests within `co
 ## Table of Contents
 - [AddressAliasing](./AddressAliasing.md)
 - [Burn](./Burn.md)
+- [CrossDomainMessenger](./CrossDomainMessenger.md)
 - [Encoding](./Encoding.md)
 - [Hashing](./Hashing.md)
 - [L2OutputOracle](./L2OutputOracle.md)


### PR DESCRIPTION
# Overview

Adds an actor-based invariant test for the L1 XDM requested by @smartcontracts.

**Invariant**

A call from the `OptimismPortal` to the `L1CrossDomainMessenger`'s `relayMessage` function can never revert if the proper minimum gas limits are supplied.

There are two minimum gas limits we need to worry about:
* **[OUTER]** - Minimum gas required for the call from the `OptimismPortal` to the L1 XDM's `relayMessage` function. This is found by calling the L1 XDM's `baseGas` function with the message payload + the inner min gas limit.
* **[INNER]** - Minimum gas required for the call from the L1 XDM to the `target` contract.

**Tests**

Added `invariants/CrossDomainMessenger.t.sol`

**Metadata**
Closes ENG-3172
