### PR TITLE
fix: don't cancel context before passing to signer

### DIFF
--- a/op-batcher/batcher/txmgr.go
+++ b/op-batcher/batcher/txmgr.go
@@ -98,8 +98,8 @@ func (t *TransactionManager) CraftTx(ctx context.Context, data []byte) (*types.T
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, networkTimeout)
-	nonce, err := t.l1Client.NonceAt(ctx, t.senderAddress, nil)
+	childCtx, cancel := context.WithTimeout(ctx, networkTimeout)
+	nonce, err := t.l1Client.NonceAt(childCtx, t.senderAddress, nil)
 	cancel()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nonce: %w", err)
@@ -121,6 +121,8 @@ func (t *TransactionManager) CraftTx(ctx context.Context, data []byte) (*types.T
 	}
 	rawTx.Gas = gas
 
+	ctx, cancel = context.WithTimeout(ctx, networkTimeout)
+	defer cancel()
 	return t.signerFn(ctx, rawTx)
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Since #4555, we can pass a context to the signing function for e.g. signing with a different backend. Right now the batcher's context is being early-cancelled, so fix that. 

**Tests**

Using existing tests

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
