### PR TITLE
op-node: ComputeL2OutputRoot cleanup

### DIFF
--- a/op-node/rollup/output_root.go
+++ b/op-node/rollup/output_root.go
@@ -1,11 +1,13 @@
 package rollup
 
 import (
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+// ComputeL2OutputRoot computes the L2 output root
 func ComputeL2OutputRoot(l2OutputRootVersion eth.Bytes32, blockHash common.Hash, blockRoot common.Hash, storageRoot common.Hash) eth.Bytes32 {
 	digest := crypto.Keccak256Hash(
 		l2OutputRootVersion[:],
@@ -14,4 +16,14 @@ func ComputeL2OutputRoot(l2OutputRootVersion eth.Bytes32, blockHash common.Hash,
 		blockHash.Bytes(),
 	)
 	return eth.Bytes32(digest)
+}
+
+// HashOutputRootProof computes the hash of the output root proof
+func HashOutputRootProof(proof *bindings.TypesOutputRootProof) eth.Bytes32 {
+	return ComputeL2OutputRoot(
+		proof.Version,
+		proof.StateRoot,
+		proof.MessagePasserStorageRoot,
+		proof.LatestBlockhash,
+	)
 }

--- a/op-node/rollup/output_root.go
+++ b/op-node/rollup/output_root.go
@@ -1,18 +1,17 @@
 package rollup
 
 import (
-	"bytes"
-
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
 func ComputeL2OutputRoot(l2OutputRootVersion eth.Bytes32, blockHash common.Hash, blockRoot common.Hash, storageRoot common.Hash) eth.Bytes32 {
-	var buf bytes.Buffer
-	buf.Write(l2OutputRootVersion[:])
-	buf.Write(blockRoot.Bytes())
-	buf.Write(storageRoot[:])
-	buf.Write(blockHash.Bytes())
-	return eth.Bytes32(crypto.Keccak256Hash(buf.Bytes()))
+	digest := crypto.Keccak256Hash(
+		l2OutputRootVersion[:],
+		blockRoot.Bytes(),
+		storageRoot[:],
+		blockHash.Bytes(),
+	)
+	return eth.Bytes32(digest)
 }


### PR DESCRIPTION
**Description**

Cleans up the implementation of the `ComputeL2OutputRoot` function. No need for the intermediate `bytes.Buffer`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

cc @protolambda 