### PR TITLE
op-node: fix AttributesQueue Reset function

### DIFF
--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -92,5 +92,6 @@ func (aq *AttributesQueue) createNextAttributes(ctx context.Context, batch *Batc
 }
 
 func (aq *AttributesQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.SystemConfig) error {
+	aq.batch = nil
 	return io.EOF
 }


### PR DESCRIPTION
**Description**

When the pipeline is reset with a reorg just after the next attributes fail to be generated then this batch may stick in the queue, causing a potential divergence with nodes that don't have this stale batch left in their pipeline stage.

**Tests**

We already have action testing that fuzzes the RPC errors and shows it eventually syncs, but resets were not captured there yet, as they only trigger on a reorg. Will need to investigate reorg-fuzzing to catch things like this.

