### PR TITLE
deps: update foundry

### DIFF
--- a/.changeset/weak-pianos-repair.md
+++ b/.changeset/weak-pianos-repair.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/ci-builder': minor
+'@eth-optimism/foundry': minor
+---
+
+Bump foundry to 2ff99025abade470a795724c10648c800a41025e

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /opt/foundry
 # Only diff from upstream docker image is this clone instead
 # of COPY. We select a specific commit to use.
 RUN git clone https://github.com/foundry-rs/foundry.git . \
-    && git checkout c06b53287dc23c4e5b1b3e57c937a90114bbe166
+    && git checkout 2ff99025abade470a795724c10648c800a41025e
 
 RUN source $HOME/.profile && \
     cargo build --release && \

--- a/ops/docker/foundry/Dockerfile
+++ b/ops/docker/foundry/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /opt/foundry
 # Only diff from upstream docker image is this clone instead
 # of COPY. We select a specific commit to use.
 RUN git clone https://github.com/foundry-rs/foundry.git . \
-    && git checkout f540aa9ebde88dce720140b332412089c2ee85b6
+    && git checkout 2ff99025abade470a795724c10648c800a41025e
 
 RUN source $HOME/.profile && cargo build --release \
     && strip /opt/foundry/target/release/forge \

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -57,7 +57,7 @@ We work on this repository with a combination of [Hardhat](https://hardhat.org) 
 1. Install Foundry by following [the instructions located here](https://getfoundry.sh/).
    A specific version must be used.
    ```shell
-   foundryup -C c06b53287dc23c4e5b1b3e57c937a90114bbe166
+   foundryup -C 2ff99025abade470a795724c10648c800a41025e
    ```
 2. Install node modules with yarn (v1) and Node.js (16+):
 


### PR DESCRIPTION
**Description**

Updates foundry to 2ff99025abade470a795724c10648c800a41025e https://github.com/foundry-rs/foundry/tree/2ff99025abade470a795724c10648c800a41025e


This update is specifically for fixing a bug with contract verification with forge. After updating to this version, contract verification just worked.

To install this version, run the command:

```bash
$ foundryup -C 2ff99025abade470a795724c10648c800a41025e
```

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

