### PR TITLE
ctb: Fix check-l2 magic check

### DIFF
--- a/packages/contracts-bedrock/tasks/check-l2.ts
+++ b/packages/contracts-bedrock/tasks/check-l2.ts
@@ -154,7 +154,7 @@ const checkGenesisMagic = async (
       address = args.l2OutputOracleAddress
     } else {
       const Deployment__L2OutputOracle = await hre.deployments.get(
-        'L2OutputOracle'
+        'L2OutputOracleProxy'
       )
       address = Deployment__L2OutputOracle.address
     }


### PR DESCRIPTION
The value needs to be read from the proxy, not the implementation.
