### PR TITLE
feat: add view function to the proxied contract 

### DIFF
--- a/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
+++ b/packages/contracts/contracts/chugsplash/L1ChugSplashProxy.sol
@@ -183,12 +183,30 @@ contract L1ChugSplashProxy {
     }
 
     /**
+     * Queries the owner of the proxy contract.
+     * @return Owner address.
+     */
+    // slither-disable-next-line external-function
+    function owner() public view returns (address) {
+        return _getOwner();
+    }
+
+    /**
      * Queries the implementation address. Can only be called by the owner OR by making an
      * eth_call and setting the "from" address to address(0).
      * @return Implementation address.
      */
     // slither-disable-next-line external-function
     function getImplementation() public proxyCallIfNotOwner returns (address) {
+        return _getImplementation();
+    }
+
+    /**
+     * Queries the implementation address.
+     * @return Implementation address.
+     */
+    // slither-disable-next-line external-function
+    function implementation() public view returns (address) {
         return _getImplementation();
     }
 

--- a/packages/contracts/docs/L1ChugSplashProxy.md
+++ b/packages/contracts/docs/L1ChugSplashProxy.md
@@ -44,6 +44,40 @@ Queries the owner of the proxy contract. Can only be called by the owner OR by m
 |---|---|---|
 | _0 | address | Owner address.
 
+### implementation
+
+```solidity
+function implementation() external view returns (address)
+```
+
+Queries the implementation address.
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | Implementation address.
+
+### owner
+
+```solidity
+function owner() external view returns (address)
+```
+
+Queries the owner of the proxy contract.
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | Owner address.
+
 ### setCode
 
 ```solidity


### PR DESCRIPTION
…tation and owner

Added a view function because it was difficult to check the address and owner of the proxy on the etherscan site.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

feat: add view function to the proxied contract for checking implementation and owner

Added a view function because it was difficult to check the address and owner of the proxy on the etherscan site.

**Tests**


**Invariants**
 

**Additional context**
 

**Metadata**
- Fixes #[Link to Issue]
