### PR TITLE
feat(ctb): set up SystemConfig in step 1

### DIFF
--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -188,6 +188,23 @@ contract SystemDictator is OwnableUpgradeable {
             config.proxyAddressConfig.l1StandardBridgeProxy,
             ProxyAdmin.ProxyType.CHUGSPLASH
         );
+
+        // Upgrade and initialize the SystemConfig so the Sequencer can start up.
+        config.globalConfig.proxyAdmin.upgradeAndCall(
+            payable(config.proxyAddressConfig.systemConfigProxy),
+            address(config.implementationAddressConfig.systemConfigImpl),
+            abi.encodeCall(
+                SystemConfig.initialize,
+                (
+                    config.systemConfigConfig.owner,
+                    config.systemConfigConfig.overhead,
+                    config.systemConfigConfig.scalar,
+                    config.systemConfigConfig.batcherHash,
+                    config.systemConfigConfig.gasLimit,
+                    config.systemConfigConfig.unsafeBlockSigner
+                )
+            )
+        );
     }
 
     /**
@@ -341,23 +358,6 @@ contract SystemDictator is OwnableUpgradeable {
         config.globalConfig.proxyAdmin.upgrade(
             payable(config.proxyAddressConfig.l1ERC721BridgeProxy),
             address(config.implementationAddressConfig.l1ERC721BridgeImpl)
-        );
-
-        // Upgrade and initialize the SystemConfig.
-        config.globalConfig.proxyAdmin.upgradeAndCall(
-            payable(config.proxyAddressConfig.systemConfigProxy),
-            address(config.implementationAddressConfig.systemConfigImpl),
-            abi.encodeCall(
-                SystemConfig.initialize,
-                (
-                    config.systemConfigConfig.owner,
-                    config.systemConfigConfig.overhead,
-                    config.systemConfigConfig.scalar,
-                    config.systemConfigConfig.batcherHash,
-                    config.systemConfigConfig.gasLimit,
-                    config.systemConfigConfig.unsafeBlockSigner
-                )
-            )
         );
 
         // Pause the L1CrossDomainMessenger, chance to check that everything is OK.

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -28,6 +28,7 @@ const deployFn: DeployFunction = async (hre) => {
     L1StandardBridgeProxyWithSigner,
     L1ERC721BridgeProxy,
     L1ERC721BridgeProxyWithSigner,
+    SystemConfigProxy,
   ] = await getContractsFromArtifacts(hre, [
     {
       name: 'SystemDictatorProxy',
@@ -59,6 +60,11 @@ const deployFn: DeployFunction = async (hre) => {
     },
     {
       name: 'L1ERC721BridgeProxy',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'SystemConfigProxy',
+      iface: 'SystemConfig',
       signerOrProvider: deployer,
     },
   ])
@@ -250,6 +256,36 @@ const deployFn: DeployFunction = async (hre) => {
         (await ProxyAdmin.proxyType(
           getDeploymentAddress(hre, 'Proxy__OVM_L1StandardBridge')
         )) === 1
+      )
+
+      // Check the SystemConfig was initialized properly.
+      await assertContractVariable(
+        SystemConfigProxy,
+        'owner',
+        hre.deployConfig.finalSystemOwner
+      )
+      await assertContractVariable(
+        SystemConfigProxy,
+        'overhead',
+        hre.deployConfig.gasPriceOracleOverhead
+      )
+      await assertContractVariable(
+        SystemConfigProxy,
+        'scalar',
+        hre.deployConfig.gasPriceOracleScalar
+      )
+      await assertContractVariable(
+        SystemConfigProxy,
+        'batcherHash',
+        ethers.utils.hexZeroPad(
+          hre.deployConfig.batchSenderAddress.toLowerCase(),
+          32
+        )
+      )
+      await assertContractVariable(
+        SystemConfigProxy,
+        'gasLimit',
+        hre.deployConfig.l2GenesisBlockGasLimit
       )
     },
   })

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -30,7 +30,6 @@ const deployFn: DeployFunction = async (hre) => {
     OptimismPortal,
     OptimismMintableERC20Factory,
     L1ERC721Bridge,
-    SystemConfigProxy,
   ] = await getContractsFromArtifacts(hre, [
     {
       name: 'SystemDictatorProxy',
@@ -76,11 +75,6 @@ const deployFn: DeployFunction = async (hre) => {
     {
       name: 'L1ERC721BridgeProxy',
       iface: 'L1ERC721Bridge',
-      signerOrProvider: deployer,
-    },
-    {
-      name: 'SystemConfigProxy',
-      iface: 'SystemConfig',
       signerOrProvider: deployer,
     },
   ])
@@ -285,40 +279,6 @@ const deployFn: DeployFunction = async (hre) => {
         L1ERC721Bridge,
         'messenger',
         L1CrossDomainMessenger.address
-      )
-
-      // Check the SystemConfig was initialized properly.
-      await assertContractVariable(
-        SystemConfigProxy,
-        'owner',
-        hre.deployConfig.finalSystemOwner
-      )
-
-      await assertContractVariable(
-        SystemConfigProxy,
-        'overhead',
-        hre.deployConfig.gasPriceOracleOverhead
-      )
-
-      await assertContractVariable(
-        SystemConfigProxy,
-        'scalar',
-        hre.deployConfig.gasPriceOracleScalar
-      )
-
-      await assertContractVariable(
-        SystemConfigProxy,
-        'batcherHash',
-        ethers.utils.hexZeroPad(
-          hre.deployConfig.batchSenderAddress.toLowerCase(),
-          32
-        )
-      )
-
-      await assertContractVariable(
-        SystemConfigProxy,
-        'gasLimit',
-        hre.deployConfig.l2GenesisBlockGasLimit
       )
     },
   })


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Moves the SystemConfig upgrade/initialization logic into Step 1 of the SystemDictator contract. This means that the Sequencer is correctly able to spin up between steps 2 and 3.