### PR TITLE
fix(dtl): sync beyond deposit shutoff block

### DIFF
--- a/.changeset/unlucky-rats-sit.md
+++ b/.changeset/unlucky-rats-sit.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Fixes a bug in the DTL that would cause it to not be able to sync beyond the deposit shutoff block.

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -268,16 +268,16 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           )
         }
 
-        // I prefer to do this in serial to avoid non-determinism. We could have a discussion about
-        // using Promise.all if necessary, but I don't see a good reason to do so unless parsing is
-        // really, really slow for all event types.
-        await this._syncEvents(
-          'CanonicalTransactionChain',
-          'TransactionEnqueued',
-          highestSyncedL1Block,
-          depositTargetL1Block,
-          handleEventsTransactionEnqueued
-        )
+        // We should not sync TransactionEnqueued events beyond the deposit shutoff block.
+        if (depositTargetL1Block >= highestSyncedL1Block) {
+          await this._syncEvents(
+            'CanonicalTransactionChain',
+            'TransactionEnqueued',
+            highestSyncedL1Block,
+            depositTargetL1Block,
+            handleEventsTransactionEnqueued
+          )
+        }
 
         await this._syncEvents(
           'CanonicalTransactionChain',


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Fixes a bug in the DTL that caused it to not be able to sync beyond the deposit shutoff block. This would happen because the TO block would be less than the FROM block which would cause certain providers to throw an error.