### PR TITLE
ci: Add a ci-builder changeset to cause a release

### DIFF
--- a/.changeset/mean-worms-doubt.md
+++ b/.changeset/mean-worms-doubt.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Add a changeset to trigger a new release of ci-builder


### PR DESCRIPTION
The [ci-builder image is outdated](https://hub.docker.com/r/ethereumoptimism/ci-builder) due to the release workflow having been broken for a period of time. 

Adding a changeset should cause it to update.