### PR TITLE
op-chain-ops: `Withdrawal` type use `hexutil.Bytes`

### DIFF
--- a/op-chain-ops/crossdomain/migrate.go
+++ b/op-chain-ops/crossdomain/migrate.go
@@ -76,7 +76,7 @@ func MigrateWithdrawal(withdrawal *LegacyWithdrawal, l1CrossDomainMessenger *com
 		withdrawal.Target,
 		value,
 		new(big.Int),
-		withdrawal.Data,
+		[]byte(withdrawal.Data),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot abi encode relayMessage: %w", err)


### PR DESCRIPTION
**Description**

Use `hexutil.Bytes` in the `Withdrawal` type so that when writing and reading from JSON, it correctly serializes the data as a 0x prefixed hex string. Without this, it will some base64 looking serialization. Be sure to cast to a byte slice before doing any abi packing, otherwise it will cause errors.

Part of breaking https://github.com/ethereum-optimism/optimism/pull/4539 into smaller pieces

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
