### PR TITLE
op-chain-ops: add in json struct tags to cdm

### DIFF
--- a/op-chain-ops/crossdomain/message.go
+++ b/op-chain-ops/crossdomain/message.go
@@ -14,12 +14,12 @@ import (
 // version 1 messages have a value and the most significant
 // byte of the nonce is a 1
 type CrossDomainMessage struct {
-	Nonce    *big.Int
-	Sender   *common.Address
-	Target   *common.Address
-	Value    *big.Int
-	GasLimit *big.Int
-	Data     []byte
+	Nonce    *big.Int        `json:"nonce"`
+	Sender   *common.Address `json:"sender"`
+	Target   *common.Address `json:"target"`
+	Value    *big.Int        `json:"value"`
+	GasLimit *big.Int        `json:"gasLimit"`
+	Data     []byte          `json:"data"`
 }
 
 // NewCrossDomainMessage creates a CrossDomainMessage.


### PR DESCRIPTION
**Description**

Adds json struct tags to the `CrossDomainMessage` type. This is useful for reading and writing this type to a file. The `Data` field must be updated to a `hexutil.Bytes` in a subsequent PR.

Part of breaking up https://github.com/ethereum-optimism/optimism/pull/4539

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

