### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 /op-chain-ops   @ethereum-optimism/go-reviewers
 /op-e2e         @ethereum-optimism/go-reviewers
 /op-node        @ethereum-optimism/go-reviewers
+/op-node/rollup @protolambda @trianglesphere
 /op-proposer    @ethereum-optimism/go-reviewers
 /op-service     @ethereum-optimism/go-reviewers
 


### PR DESCRIPTION
**Description**


Set proto & I to be code owners for the rollup package in the op-node. This is intended to override the `go-reviewers` group for this specific package. This code is consensus critical and tricky to work with.