### PR TITLE
Fix `channelTimeout` docs

### DIFF
--- a/packages/contracts-bedrock/src/deploy-config.ts
+++ b/packages/contracts-bedrock/src/deploy-config.ts
@@ -56,7 +56,7 @@ interface RequiredDeployConfig {
   sequencerWindowSize: number
 
   /**
-   * Number of seconds (w.r.t. L1 time) that a frame can be valid when included in L1.
+   * Number of L1 blocks that a frame stays valid when included in L1.
    */
   channelTimeout: number
 

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -479,7 +479,7 @@ transaction must also be signed by a recognized batch submitter account.
 
 [channel-timeout]: glossary.md#channel-timeout
 
-The channel timeout is a duration (in seconds) during which [channel frames][channel-frame may land on L1 within
+The channel timeout is a duration (in L1 blocks) during which [channel frames][channel-frame] may land on L1 within
 [batcher transactions][batcher-transaction].
 
 The acceptable time range for the frames of a [channel][channel] is `[channel_id.timestamp, channel_id.timestamp +


### PR DESCRIPTION
Channel timeouts used to be given in seconds, now they're given in number of L1 blocks. This PR fixes two places where the old description was still present.
