### PR TITLE
fix: Allow unknown options in base service v2

### DIFF
--- a/.changeset/rich-trains-exist.md
+++ b/.changeset/rich-trains-exist.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Fix unknown option error in base service v2

--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -156,7 +156,7 @@ export abstract class BaseServiceV2<
 
     // Use commander as a way to communicate info about the service. We don't actually *use*
     // commander for anything besides the ability to run `ts-node ./service.ts --help`.
-    const program = new Command()
+    const program = new Command().allowUnknownOption(true)
     for (const [optionName, optionSpec] of Object.entries(params.optionsSpec)) {
       // Skip options that are not meant to be used by the user.
       if (['useEnv', 'useArgv'].includes(optionName)) {


### PR DESCRIPTION
This changes base service v2 to not throw an error if an unknown command argument is passed in.

why:

When we use base service v2 in tests we can't pass flags into jest such as --watch or --update because
base service v2 will throw an error

