### PR TITLE
l2geth: default gascap

### DIFF
--- a/.changeset/good-paws-deliver.md
+++ b/.changeset/good-paws-deliver.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/l2geth': patch
+---
+
+Use default cas gap of 25 million

--- a/l2geth/cmd/utils/flags.go
+++ b/l2geth/cmd/utils/flags.go
@@ -516,6 +516,7 @@ var (
 	}
 	RPCGlobalGasCap = cli.Uint64Flag{
 		Name:  "rpc.gascap",
+		Value: eth.DefaultConfig.RPCGasCap.Uint64(),
 		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas",
 	}
 	RPCGlobalEVMTimeoutFlag = &cli.DurationFlag{

--- a/l2geth/eth/config.go
+++ b/l2geth/eth/config.go
@@ -58,6 +58,7 @@ var DefaultConfig = Config{
 		Recommit: 3 * time.Second,
 	},
 	TxPool:        core.DefaultTxPoolConfig,
+	RPCGasCap:     new(big.Int).SetUint64(25_000_000),
 	RPCEVMTimeout: 5 * time.Second,
 	GPO: gasprice.Config{
 		Blocks:     20,


### PR DESCRIPTION
**Description**

Follows upstream by setting a default gascap for rpc

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

