### PR TITLE
op-node: fix sequencer time drift edge case, strictly enforce sequencer conf depth

### DIFF
--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -100,11 +100,31 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 		return BatchDrop
 	}
 
-	// If we ran out of sequencer time drift, then we drop the batch and produce an empty batch instead,
-	// as the sequencer is not allowed to include anything past this point without moving to the next epoch.
+	// Check if we ran out of sequencer time drift
 	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Batch.Timestamp > max {
-		log.Warn("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again", "max_time", max)
-		return BatchDrop
+		if len(batch.Batch.Transactions) == 0 {
+			// If the sequencer is co-operating by producing an empty batch,
+			// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.
+			// We only check batches that do not advance the epoch, to ensure epoch advancement regardless of time drift is allowed.
+			if epoch.Number >= batchOrigin.Number {
+				if len(l1Blocks) < 2 {
+					log.Info("without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid")
+					return BatchUndecided
+				}
+				nextOrigin := l1Blocks[1]
+				if batch.Batch.Timestamp >= nextOrigin.Time { // check if the next L1 origin could have been adopted
+					log.Info("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid")
+					return BatchDrop
+				} else {
+					log.Info("continuing with empty batch before late L1 block to preserve L2 time invariant")
+				}
+			}
+		} else {
+			// If the sequencer is ignoring the time drift rule, then drop the batch and force an empty batch instead,
+			// as the sequencer is not allowed to include anything past this point without moving to the next epoch.
+			log.Warn("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again", "max_time", max)
+			return BatchDrop
+		}
 	}
 
 	// We can do this check earlier, but it's a more intensive one, so we do this last.

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -66,10 +66,10 @@ type L1StateIface interface {
 }
 
 type SequencerIface interface {
-	StartBuildingBlock(ctx context.Context, l1Head eth.L1BlockRef) error
+	StartBuildingBlock(ctx context.Context) error
 	CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayload, error)
 	PlanNextSequencerAction() time.Duration
-	RunNextSequencerAction(ctx context.Context, l1Head eth.L1BlockRef) *eth.ExecutionPayload
+	RunNextSequencerAction(ctx context.Context) *eth.ExecutionPayload
 	BuildingOnto() eth.L2BlockRef
 }
 
@@ -81,7 +81,8 @@ type Network interface {
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
 func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
 	l1State := NewL1State(log, metrics)
-	findL1Origin := NewL1OriginSelector(log, cfg, l1, driverCfg.SequencerConfDepth)
+	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
+	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l2, metrics)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)

--- a/op-node/rollup/driver/origin_selector_test.go
+++ b/op-node/rollup/driver/origin_selector_test.go
@@ -27,6 +27,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -46,9 +47,9 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 0)
+	s := NewL1OriginSelector(log, cfg, l1)
 
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, b, next)
 }
@@ -68,6 +69,7 @@ func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -87,15 +89,15 @@ func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 0)
+	s := NewL1OriginSelector(log, cfg, l1)
 
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
 
 // TestOriginSelectorRespectsConfDepth ensures that the origin selector
-// will respects the confirmation depth requirement
+// will respect the confirmation depth requirement
 //
 // There are 2 L1 blocks at time 20 & 25. The L2 Head is at time 27.
 // The next L2 time is 29 which enough to normally select block `b`
@@ -108,6 +110,7 @@ func TestOriginSelectorRespectsConfDepth(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -125,33 +128,32 @@ func TestOriginSelectorRespectsConfDepth(t *testing.T) {
 	}
 
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
-	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
+	confDepthL1 := NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
+	s := NewL1OriginSelector(log, cfg, confDepthL1)
 
-	s := NewL1OriginSelector(log, cfg, l1, 10)
-
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
 
-// TestOriginSelectorRespectsMaxSeqDrift ensures that the origin selector
-// will advance if the time delta between the current L1 origin and the next
-// L2 block is greater than the sequencer drift. This needs to occur even
-// if conf depth needs to be ignored
+// TestOriginSelectorStrictConfDepth ensures that the origin selector will maintain the sequencer conf depth,
+// even while the time delta between the current L1 origin and the next
+// L2 block is greater than the sequencer drift.
+// It's more important to maintain safety with an empty block than to maintain liveness with poor conf depth.
 //
 // There are 2 L1 blocks at time 20 & 25. The L2 Head is at time 27.
 // The next L2 time is 29. The sequencer drift is 8 so the L2 head is
 // valid with origin `a`, but the next L2 block is not valid with origin `b.`
 // This is because 29 (next L2 time) > 20 (origin) + 8 (seq drift) => invalid block.
-// Even though the LOS would normally refuse to advance because block `b` does not
-// have enough confirmations, it should in this instance.
-func TestOriginSelectorRespectsMaxSeqDrift(t *testing.T) {
+// We maintain confirmation distance, even though we would shift to the next origin if we could.
+func TestOriginSelectorStrictConfDepth(t *testing.T) {
 	log := testlog.Logger(t, log.LvlCrit)
 	cfg := &rollup.Config{
 		MaxSequencerDrift: 8,
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -169,13 +171,12 @@ func TestOriginSelectorRespectsMaxSeqDrift(t *testing.T) {
 	}
 
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
-	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 10)
+	confDepthL1 := NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
+	s := NewL1OriginSelector(log, cfg, confDepthL1)
 
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
-	require.Nil(t, err)
-	require.Equal(t, b, next)
+	_, err := s.FindL1Origin(context.Background(), l2Head)
+	require.ErrorContains(t, err, "sequencer time drift")
 }
 
 // TestOriginSelectorSeqDriftRespectsNextOriginTime
@@ -191,6 +192,7 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTime(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -210,9 +212,77 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTime(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 10)
+	s := NewL1OriginSelector(log, cfg, l1)
 
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
+}
+
+// TestOriginSelectorHandlesLateL1Blocks tests the forced repeat of the previous origin,
+// but with a conf depth that first prevents it from learning about the need to repeat.
+//
+// There are 2 L1 blocks at time 20 & 100. The L2 Head is at time 27.
+// The next L2 time is 29. Even though the next L2 time is past the seq
+// drift, the origin should remain on block `a` because the next origin's
+// time is greater than the next L2 time.
+// Due to a conf depth of 2, block `b` is not immediately visible,
+// and the origin selection should fail until it is visible, by waiting for block `c`.
+func TestOriginSelectorHandlesLateL1Blocks(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+	cfg := &rollup.Config{
+		MaxSequencerDrift: 8,
+		BlockTime:         2,
+	}
+	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
+	a := eth.L1BlockRef{
+		Hash:   common.Hash{'a'},
+		Number: 10,
+		Time:   20,
+	}
+	b := eth.L1BlockRef{
+		Hash:       common.Hash{'b'},
+		Number:     11,
+		Time:       100,
+		ParentHash: a.Hash,
+	}
+	c := eth.L1BlockRef{
+		Hash:       common.Hash{'c'},
+		Number:     12,
+		Time:       150,
+		ParentHash: b.Hash,
+	}
+	d := eth.L1BlockRef{
+		Hash:       common.Hash{'d'},
+		Number:     13,
+		Time:       200,
+		ParentHash: c.Hash,
+	}
+	l2Head := eth.L2BlockRef{
+		L1Origin: a.ID(),
+		Time:     27,
+	}
+
+	// l2 head does not change, so we start at the same origin again and again until we meet the conf depth
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
+
+	head := b
+	confDepthL1 := NewConfDepth(2, func() eth.L1BlockRef { return head }, l1)
+	s := NewL1OriginSelector(log, cfg, confDepthL1)
+
+	_, err := s.FindL1Origin(context.Background(), l2Head)
+	require.ErrorContains(t, err, "sequencer time drift")
+
+	head = c
+	_, err = s.FindL1Origin(context.Background(), l2Head)
+	require.ErrorContains(t, err, "sequencer time drift")
+
+	head = d
+	next, err := s.FindL1Origin(context.Background(), l2Head)
+	require.Nil(t, err)
+	require.Equal(t, a, next, "must stay on a because the L1 time may not be higher than the L2 time")
 }

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -212,7 +212,7 @@ func (s *Driver) eventLoop() {
 
 		select {
 		case <-sequencerCh:
-			payload := s.sequencer.RunNextSequencerAction(ctx, s.l1State.L1Head())
+			payload := s.sequencer.RunNextSequencerAction(ctx)
 			if s.network != nil && payload != nil {
 				// Publishing of unsafe data via p2p is optional.
 				// Errors are not severe enough to change/halt sequencing but should be logged and metered.


### PR DESCRIPTION
**Description**

L1 Origin selection had related problems in both sequencer and verifier areas. This PR fixes those.

As sequencer it didn't follow the safety-over-liveness priority, and ignored the sequencer conf depth to try and handle sequencer time drift.
This however is dangerous because of the recent verifier "fix" (good fix, but incomplete):
- When the max time drift is exceeded and the next origin cannot be found, then old origin would be used, causing the batch to be dropped.
- But the sequencer still produces blocks after this, which can have later origins & include transactions again, building on top of the empty block with old origin.

This means that as a verifier you end up dropping the empty batch with old origin, causing a halt (of safe blocks) until the sequencer window forces an empty block to be created.
And aside from halting as such, it risks adopting the next L1 origin differently than the sequencer, causing a reorg of the unsafe chain.

Meanwhile we still want deposits to be processed as soon as the sequencer time drift, so we should not give the sequencer too much leeway either,
and force them to adopt the next L1 origin when they theoretically can.

This also means that we need to accept batches with an old origin if the batches hit sequencer time drift edge cases
where it is just not possible to adopt the next L1 origin without breaking the `L2 time >= L1 origin time` invariant.

And while we are at it, we might as well solve the "what if L1 block time is smaller than L2 block time" edge case:
we can ignore the sequencer time drift check if the other checks pass & the batch advances the L1 origin forward.
Advancing the L1 origin is exactly what the sequencer time drift is specified for, so we should not disallow advancing
to a later L1 origin that we still exceed the L2 sequencer time drift of.

In the sequencer we should be strict, and avoid sequencing if we ever doubt about the validity of staying on the current L1 origin:
i.e. if we are over the sequencer time drift, and can't find the next L1 origin, and then wait until we see the L1 origin,
instead of creating a L2 block that could be dropped/reorged out.

With such a sequencer, we can also clean up the conf-depth approach:
the L1 head should not have to leak into the l1 origin selection logic if the logic already has accesses L1 through a limited by-number view.
Like the verifier conf depth, we can re-use the exact same tested code to enforce the conf depth for L1 origin selection.

Changes:
- Fix `L1OriginSelector` to implement the stricter sequencer origin selection as described above
- Update `Driver` to use `L1OriginSelector` with conf-depth util that we also use for verifier conf depth, and simplify the origin selection.
- Fix sequencer time drift section in `CheckBatch` to handle edge cases
- Fix derivation batch filtering spec to define the edge case filtering conditions in the sequencer time drift check case.
- testing, see below

**Tests**

- Updated and extended `driver/origin_selector_test.go` to cover the new strict sequencer behavior.
- Updated and extended `derive/batches_test.go` with cases that cover the (new) different branches you can take.
  - 96% filtering coverage at first. We were missing `uint64(batch.Batch.EpochNum) < epoch.Number`,
   so I fixed the `epoch too old` case to get 100% coverage.

**Invariants**

- Ensure `L2 time >= L1 origin time` at all times
- Ensure max sequencer time drift is respected, but make exception to always preserve L1 Origin advancement and above invariant.

**Additional context**

Note that the sequencer origin selection got stricter (shouldn't produce invalid cases anymore) and the verifier filtering got more relaxed (shouldn't drop the exceptions to the sequencer time drift rule anymore).

Goerli users who don't update are likely risk of halting their view of the chain upon highly irregular L1 chain advancement or very delayed L1 origin inclusion.
This, together with these events already being ultra-rare (especially with the quite high sequencer time drift of 10 minutes),
means that I think we can safely roll this out to Goerli & encourage updating.

Fix ENG-3255

Stacked on #4757 and draft until that is merged.

Full PR stack:
- #4755
- #4756
- #4757
- #4758
