### PR TITLE
feat(fd): support Bedrock networks

### DIFF
--- a/.changeset/nervous-years-explain.md
+++ b/.changeset/nervous-years-explain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': minor
+---
+
+Updates the fault detector to support Bedrock networks.

--- a/packages/data-transport-layer/.depcheckrc
+++ b/packages/data-transport-layer/.depcheckrc
@@ -1,5 +1,6 @@
 ignores: [
   "@babel/eslint-parser",
+  "@types/level",
   "@typescript-eslint/parser",
   "eslint-plugin-import",
   "eslint-plugin-unicorn",

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -52,7 +52,7 @@
     "ethers": "^5.7.0",
     "express": "^4.17.1",
     "express-prom-bundle": "^6.3.6",
-    "level": "^6.0.1",
+    "level6": "npm:level@^6.0.1",
     "levelup": "^4.4.0"
   },
   "devDependencies": {

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -1,7 +1,7 @@
 /* Imports: External */
 import { BaseService, LegacyMetrics } from '@eth-optimism/common-ts'
 import { LevelUp } from 'levelup'
-import level from 'level'
+import level from 'level6'
 import { Counter } from 'prom-client'
 
 /* Imports: Internal */

--- a/packages/fault-detector/src/helpers.ts
+++ b/packages/fault-detector/src/helpers.ts
@@ -1,4 +1,11 @@
-import { Contract } from 'ethers'
+import { Contract, BigNumber } from 'ethers'
+
+export interface OutputOracle<TSubmissionEventArgs> {
+  contract: Contract
+  filter: any
+  getTotalElements: () => Promise<BigNumber>
+  getEventIndex: (args: TSubmissionEventArgs) => BigNumber
+}
 
 /**
  * Partial event interface, meant to reduce the size of the event cache to avoid
@@ -41,27 +48,32 @@ const getCache = (
 }
 
 /**
- * Updates the event cache for the SCC.
+ * Updates the event cache for a contract and event.
  *
- * @param scc The State Commitment Chain contract.
+ * @param contract Contract to update cache for.
+ * @param filter Event filter to use.
  */
-export const updateStateBatchEventCache = async (
-  scc: Contract
+export const updateOracleCache = async <TSubmissionEventArgs>(
+  oracle: OutputOracle<TSubmissionEventArgs>
 ): Promise<void> => {
-  const cache = getCache(scc.address)
+  const cache = getCache(oracle.contract.address)
   let currentBlock = cache.highestBlock
-  const endingBlock = await scc.provider.getBlockNumber()
+  const endingBlock = await oracle.contract.provider.getBlockNumber()
   let step = endingBlock - currentBlock
   let failures = 0
   while (currentBlock < endingBlock) {
     try {
-      const events = await scc.queryFilter(
-        scc.filters.StateBatchAppended(),
+      const events = await oracle.contract.queryFilter(
+        oracle.filter,
         currentBlock,
         currentBlock + step
       )
+
+      // Throw the events into the cache.
       for (const event of events) {
-        cache.eventCache[event.args._batchIndex.toNumber()] = {
+        cache.eventCache[
+          oracle.getEventIndex(event.args as TSubmissionEventArgs).toNumber()
+        ] = {
           blockNumber: event.blockNumber,
           transactionHash: event.transactionHash,
           args: event.args,
@@ -97,15 +109,15 @@ export const updateStateBatchEventCache = async (
 /**
  * Finds the Event that corresponds to a given state batch by index.
  *
- * @param scc StateCommitmentChain contract.
+ * @param oracle Output oracle contract
  * @param index State batch index to search for.
  * @returns Event corresponding to the batch.
  */
-export const findEventForStateBatch = async (
-  scc: Contract,
+export const findEventForStateBatch = async <TSubmissionEventArgs>(
+  oracle: OutputOracle<TSubmissionEventArgs>,
   index: number
 ): Promise<PartialEvent> => {
-  const cache = getCache(scc.address)
+  const cache = getCache(oracle.contract.address)
 
   // Try to find the event in cache first.
   if (cache.eventCache[index]) {
@@ -113,7 +125,7 @@ export const findEventForStateBatch = async (
   }
 
   // Update the event cache if we don't have the event.
-  await updateStateBatchEventCache(scc)
+  await updateOracleCache(oracle)
 
   // Event better be in cache now!
   if (cache.eventCache[index] === undefined) {
@@ -126,23 +138,23 @@ export const findEventForStateBatch = async (
 /**
  * Finds the first state batch index that has not yet passed the fault proof window.
  *
- * @param scc StateCommitmentChain contract.
+ * @param oracle Output oracle contract.
  * @returns Starting state root batch index.
  */
-export const findFirstUnfinalizedStateBatchIndex = async (
-  scc: Contract
+export const findFirstUnfinalizedStateBatchIndex = async <TSubmissionEventArgs>(
+  oracle: OutputOracle<TSubmissionEventArgs>,
+  fpw: number
 ): Promise<number> => {
-  const fpw = (await scc.FRAUD_PROOF_WINDOW()).toNumber()
-  const latestBlock = await scc.provider.getBlock('latest')
-  const totalBatches = (await scc.getTotalBatches()).toNumber()
+  const latestBlock = await oracle.contract.provider.getBlock('latest')
+  const totalBatches = (await oracle.getTotalElements()).toNumber()
 
   // Perform a binary search to find the next batch that will pass the challenge period.
   let lo = 0
   let hi = totalBatches
   while (lo !== hi) {
     const mid = Math.floor((lo + hi) / 2)
-    const event = await findEventForStateBatch(scc, mid)
-    const block = await scc.provider.getBlock(event.blockNumber)
+    const event = await findEventForStateBatch(oracle, mid)
+    const block = await oracle.contract.provider.getBlock(event.blockNumber)
 
     if (block.timestamp + fpw < latestBlock.timestamp) {
       lo = mid + 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -12090,7 +12090,7 @@ level-ws@^2.0.0:
     readable-stream "^3.1.0"
     xtend "^4.0.1"
 
-level@^6.0.1:
+"level6@npm:level@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/level/-/level-6.0.1.tgz#dc34c5edb81846a6de5079eac15706334b0d7cd6"
   integrity sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates the fault detector to support Bedrock networks. Bedrock support is slightly hacky because we still also need to support the legacy system until mainnet has been upgraded to Bedrock. We will want to update the fault detector again once mainnet is upgraded to simplify the service and remove the legacy components.

Closes #4652 