### PR TITLE
fix(cmn): waitForProvider logging bug

### DIFF
--- a/.changeset/kind-dodos-rest.md
+++ b/.changeset/kind-dodos-rest.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/common-ts': patch
+---
+
+Fixes a minor bug where the provider name was incorrectly logged when using waitForProvider

--- a/packages/common-ts/src/common/provider.ts
+++ b/packages/common-ts/src/common/provider.ts
@@ -20,20 +20,17 @@ export const waitForProvider = async (
     name?: string
   }
 ) => {
-  opts?.logger?.info(`waiting for ${opts?.name || 'target'} provider...`)
-
+  const name = opts?.name || 'target'
+  opts?.logger?.info(`waiting for ${name} provider...`)
   let connected = false
   while (!connected) {
     try {
       await provider.getBlockNumber()
       connected = true
     } catch (e) {
-      opts?.logger?.info(`${provider} provider not connected, retrying...`)
-
-      // Don't spam requests
+      opts?.logger?.info(`${name} provider not connected, retrying...`)
       await sleep(opts?.intervalMs || 15000)
     }
   }
-
-  opts?.logger?.info(`${opts?.name || 'target'} provider connected`)
+  opts?.logger?.info(`${name} provider connected`)
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Fixes a small bug in waitForProvider where the name of the provider was being incorrectly logged.

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
