### PR TITLE
op-node: Fix disable p2p

### DIFF
--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -123,7 +123,7 @@ func RollupNodeMain(ctx *cli.Context) error {
 
 	if cfg.Heartbeat.Enabled {
 		var peerID string
-		if cfg.P2P == nil {
+		if cfg.P2P.Disabled() {
 			peerID = "disabled"
 		} else {
 			peerID = n.P2P().Host().ID().String()

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -33,6 +33,7 @@ var DefaultBootnodes = []*enode.Node{
 // SetupP2P provides a host and discovery service for usage in the rollup node.
 type SetupP2P interface {
 	Check() error
+	Disabled() bool
 	// Host creates a libp2p host service. Returns nil, nil if p2p is disabled.
 	Host(log log.Logger, reporter metrics.Reporter) (host.Host, error)
 	// Discovery creates a disc-v5 service. Returns nil, nil, nil if discovery is disabled.
@@ -132,6 +133,10 @@ func DefaultConnManager(conf *Config) (connmgr.ConnManager, error) {
 
 func (conf *Config) TargetPeers() uint {
 	return conf.PeersLo
+}
+
+func (conf *Config) Disabled() bool {
+	return conf.DisableP2P
 }
 
 const maxMeshParam = 1000

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -63,3 +63,7 @@ func (p *Prepared) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort u
 func (p *Prepared) ConfigureGossip(params *pubsub.GossipSubParams) []pubsub.Option {
 	return nil
 }
+
+func (p *Prepared) Disabled() bool {
+	return false
+}


### PR DESCRIPTION
**Description**

This should fix the disable p2p flag which previous caused a panic.
