### PR TITLE
feat(op-node): Add alternative backup sync method via RPC

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -649,6 +649,90 @@ func TestSystemMockP2P(t *testing.T) {
 	require.Contains(t, received, receiptVerif.BlockHash)
 }
 
+// TestSystemMockP2P sets up a L1 Geth node, a rollup node, and a L2 geth node and then confirms that
+// the nodes can sync L2 blocks before they are confirmed on L1.
+//
+// Test steps:
+// 1. Spin up the nodes (P2P is disabled on the verifier)
+// 2. Send a transaction to the sequencer.
+// 3. Wait for the TX to be mined on the sequencer chain.
+// 5. Wait for the verifier to detect a gap in the payload queue vs. the unsafe head
+// 6. Wait for the RPC sync method to grab the block from the sequencer over RPC and insert it into the verifier's unsafe chain.
+// 7. Wait for the verifier to sync the unsafe chain into the safe chain.
+// 8. Verify that the TX is included in the verifier's safe chain.
+func TestSystemMockAltSync(t *testing.T) {
+	parallel(t)
+	if !verboseGethNodes {
+		log.Root().SetHandler(log.DiscardHandler())
+	}
+
+	cfg := DefaultSystemConfig(t)
+	// slow down L1 blocks so we can see the L2 blocks arrive well before the L1 blocks do.
+	// Keep the seq window small so the L2 chain is started quick
+	cfg.DeployConfig.L1BlockTime = 10
+
+	var published, received []common.Hash
+	seqTracer, verifTracer := new(FnTracer), new(FnTracer)
+	seqTracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
+		published = append(published, payload.BlockHash)
+	}
+	verifTracer.OnUnsafeL2PayloadFn = func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayload) {
+		received = append(received, payload.BlockHash)
+	}
+	cfg.Nodes["sequencer"].Tracer = seqTracer
+	cfg.Nodes["verifier"].Tracer = verifTracer
+
+	sys, err := cfg.Start(SystemConfigOption{
+		key:  "afterRollupNodeStart",
+		role: "sequencer",
+		action: func(sCfg *SystemConfig, system *System) {
+			rpc, _ := system.Nodes["sequencer"].Attach() // never errors
+			cfg.Nodes["verifier"].L2Sync = &rollupNode.L2SyncRPCConfig{
+				Rpc: client.NewBaseRPCClient(rpc),
+			}
+		},
+	})
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+	l2Verif := sys.Clients["verifier"]
+
+	// Transactor Account
+	ethPrivKey := cfg.Secrets.Alice
+
+	// Submit a TX to L2 sequencer node
+	toAddr := common.Address{0xff, 0xff}
+	tx := types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L2ChainIDBig()), &types.DynamicFeeTx{
+		ChainID:   cfg.L2ChainIDBig(),
+		Nonce:     0,
+		To:        &toAddr,
+		Value:     big.NewInt(1_000_000_000),
+		GasTipCap: big.NewInt(10),
+		GasFeeCap: big.NewInt(200),
+		Gas:       21000,
+	})
+	err = l2Seq.SendTransaction(context.Background(), tx)
+	require.Nil(t, err, "Sending L2 tx to sequencer")
+
+	// Wait for tx to be mined on the L2 sequencer chain
+	receiptSeq, err := waitForTransaction(tx.Hash(), l2Seq, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.Nil(t, err, "Waiting for L2 tx on sequencer")
+
+	// Wait for alt RPC sync to pick up the blocks on the sequencer chain
+	receiptVerif, err := waitForTransaction(tx.Hash(), l2Verif, 12*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.Nil(t, err, "Waiting for L2 tx on verifier")
+
+	require.Equal(t, receiptSeq, receiptVerif)
+
+	// Verify that the tx was received via RPC sync (P2P is disabled)
+	require.Contains(t, received, receiptVerif.BlockHash)
+
+	// Verify that everything that was received was published
+	require.GreaterOrEqual(t, len(published), len(received))
+	require.ElementsMatch(t, received, published[:len(received)])
+}
+
 // TestSystemDenseTopology sets up a dense p2p topology with 3 verifier nodes and 1 sequencer node.
 func TestSystemDenseTopology(t *testing.T) {
 	parallel(t)

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -185,6 +185,12 @@ var (
 		EnvVar: prefixEnvVar("HEARTBEAT_URL"),
 		Value:  "https://heartbeat.optimism.io",
 	}
+	BackupL2UnsafeSyncRPC = cli.StringFlag{
+		Name:     "l2.backup-unsafe-sync-rpc",
+		Usage:    "Set the backup L2 unsafe sync RPC endpoint.",
+		EnvVar:   prefixEnvVar("L2_BACKUP_UNSAFE_SYNC_RPC"),
+		Required: false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -219,6 +225,7 @@ var optionalFlags = append([]cli.Flag{
 	HeartbeatEnabledFlag,
 	HeartbeatMonikerFlag,
 	HeartbeatURLFlag,
+	BackupL2UnsafeSyncRPC,
 }, p2pFlags...)
 
 // Flags contains the list of configuration options available to the binary.

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -19,6 +19,11 @@ type L2EndpointSetup interface {
 	Check() error
 }
 
+type L2SyncEndpointSetup interface {
+	Setup(ctx context.Context, log log.Logger) (cl client.RPC, err error)
+	Check() error
+}
+
 type L1EndpointSetup interface {
 	// Setup a RPC client to a L1 node to pull rollup input-data from.
 	// The results of the RPC client may be trusted for faster processing, or strictly validated.
@@ -73,6 +78,31 @@ var _ L2EndpointSetup = (*PreparedL2Endpoints)(nil)
 
 func (p *PreparedL2Endpoints) Setup(ctx context.Context, log log.Logger) (client.RPC, error) {
 	return p.Client, nil
+}
+
+// L2SyncEndpointConfig contains configuration for the fallback sync endpoint
+type L2SyncEndpointConfig struct {
+	// HTTP Address of the L2 RPC to use for backup sync
+	L2NodeAddr string
+}
+
+var _ L2SyncEndpointSetup = (*L2SyncEndpointConfig)(nil)
+
+func (cfg *L2SyncEndpointConfig) Setup(ctx context.Context, log log.Logger) (client.RPC, error) {
+	l2Node, err := client.NewRPC(ctx, log, cfg.L2NodeAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return l2Node, nil
+}
+
+func (cfg *L2SyncEndpointConfig) Check() error {
+	if cfg.L2NodeAddr == "" {
+		return errors.New("empty L2 Node Address")
+	}
+
+	return nil
 }
 
 type L1EndpointConfig struct {

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -82,7 +82,7 @@ func (p *PreparedL2Endpoints) Setup(ctx context.Context, log log.Logger) (client
 
 // L2SyncEndpointConfig contains configuration for the fallback sync endpoint
 type L2SyncEndpointConfig struct {
-	// HTTP Address of the L2 RPC to use for backup sync
+	// Address of the L2 RPC to use for backup sync
 	L2NodeAddr string
 }
 
@@ -100,6 +100,25 @@ func (cfg *L2SyncEndpointConfig) Setup(ctx context.Context, log log.Logger) (cli
 func (cfg *L2SyncEndpointConfig) Check() error {
 	if cfg.L2NodeAddr == "" {
 		return errors.New("empty L2 Node Address")
+	}
+
+	return nil
+}
+
+type L2SyncRPCConfig struct {
+	// RPC endpoint to use for syncing
+	Rpc client.RPC
+}
+
+var _ L2SyncEndpointSetup = (*L2SyncRPCConfig)(nil)
+
+func (cfg *L2SyncRPCConfig) Setup(ctx context.Context, log log.Logger) (client.RPC, error) {
+	return cfg.Rpc, nil
+}
+
+func (cfg *L2SyncRPCConfig) Check() error {
+	if cfg.Rpc == nil {
+		return errors.New("rpc cannot be nil")
 	}
 
 	return nil

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -13,8 +13,9 @@ import (
 )
 
 type Config struct {
-	L1 L1EndpointSetup
-	L2 L2EndpointSetup
+	L1     L1EndpointSetup
+	L2     L2EndpointSetup
+	L2Sync L2SyncEndpointSetup
 
 	Driver driver.Config
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -197,7 +197,24 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n.log, snapshotLog, n.metrics)
+	var syncClient *sources.SyncClient
+	// If there is an RPC url present in the config, create a sync client
+	if err := cfg.L2Sync.Check(); err == nil {
+		rpcSyncClient, err := cfg.L2Sync.Setup(ctx, n.log)
+		if err != nil {
+			return fmt.Errorf("failed to setup L2 execution-engine RPC client for backup sync: %w", err)
+		}
+
+		// The sync client's RPC is always trusted
+		config := sources.SyncClientDefaultConfig(&cfg.Rollup, true)
+
+		syncClient, err = sources.NewSyncClient(rpcSyncClient, n.log, n.metrics.L2SourceCache, config)
+		if err != nil {
+			return fmt.Errorf("failed to create sync client: %w", err)
+		}
+	}
+
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, syncClient, n, n.log, snapshotLog, n.metrics)
 
 	return nil
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -198,19 +198,23 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 	}
 
 	var syncClient *sources.SyncClient
-	// If there is an RPC url present in the config, create a sync client
-	if err := cfg.L2Sync.Check(); err == nil {
-		rpcSyncClient, err := cfg.L2Sync.Setup(ctx, n.log)
-		if err != nil {
-			return fmt.Errorf("failed to setup L2 execution-engine RPC client for backup sync: %w", err)
-		}
+	// If the L2 sync config is present, use it to create a sync client
+	if cfg.L2Sync != nil {
+		if err := cfg.L2Sync.Check(); err != nil {
+			log.Info("L2 sync config is not present, skipping L2 sync client setup", "err", err)
+		} else {
+			rpcSyncClient, err := cfg.L2Sync.Setup(ctx, n.log)
+			if err != nil {
+				return fmt.Errorf("failed to setup L2 execution-engine RPC client for backup sync: %w", err)
+			}
 
-		// The sync client's RPC is always trusted
-		config := sources.SyncClientDefaultConfig(&cfg.Rollup, true)
+			// The sync client's RPC is always trusted
+			config := sources.SyncClientDefaultConfig(&cfg.Rollup, true)
 
-		syncClient, err = sources.NewSyncClient(rpcSyncClient, n.log, n.metrics.L2SourceCache, config)
-		if err != nil {
-			return fmt.Errorf("failed to create sync client: %w", err)
+			syncClient, err = sources.NewSyncClient(n.OnUnsafeL2Payload, rpcSyncClient, n.log, n.metrics.L2SourceCache, config)
+			if err != nil {
+				return fmt.Errorf("failed to create sync client: %w", err)
+			}
 		}
 	}
 
@@ -289,7 +293,7 @@ func (n *OpNode) Start(ctx context.Context) error {
 
 	// If the backup unsafe sync client is enabled, start its event loop
 	if n.l2Driver.L2SyncCl != nil {
-		if err := n.l2Driver.L2SyncCl.Start(n.l2Driver.UnsafeL2Payloads); err != nil {
+		if err := n.l2Driver.L2SyncCl.Start(); err != nil {
 			n.log.Error("Could not start the backup sync client", "err", err)
 			return err
 		}

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -666,10 +666,8 @@ func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.System
 // GetUnsafeQueueGap retrieves the current [start, end) range of the gap between the tip of the unsafe priority queue and the unsafe head.
 // If there is no gap, the start and end will be 0.
 func (eq *EngineQueue) GetUnsafeQueueGap() (start uint64, end uint64) {
-	first := eq.unsafePayloads.Peek()
-
 	// If the parent hash of the first unsafe payload does not match the current unsafe head, then there is a gap.
-	if first.ParentHash != eq.unsafeHead.Hash {
+	if first := eq.unsafePayloads.Peek(); first != nil && first.ParentHash != eq.unsafeHead.Hash {
 		// The gap starts at the unsafe head + 1
 		start = eq.unsafeHead.Number + 1
 		// The gap ends at the parent block of the first unsafe payload in the priority queue, but we return the exclusive bound.

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -371,54 +370,6 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 			eq.log.Info("skipping unsafe payload, since it does not build onto the existing unsafe chain", "safe", eq.safeHead.ID(), "unsafe", first.ID(), "payload", first.ID())
 			eq.unsafePayloads.Pop()
 		}
-
-		// Request the payload that builds upon the current unsafe head from the fallback RPC.
-		// This is a temporary alternative sync method- in the future, this will be done over the p2p network.
-		if eq.cfg.BackupL2UnsafeSyncRPC != "" {
-			eq.log.Info("requesting unsafe payload from backup RPC", "unsafe head", eq.unsafeHead.ID(), "first unsafe payload", first.ID(), "backup rpc", eq.cfg.BackupL2UnsafeSyncRPC)
-			// TODO: Create a client for the backup RPC and request the payload from the backup sync RPC via the `eth_getBlockByNumber` method.
-			// Once the payload has been received, verify its integrity and push it into the priority queue.
-
-			// TODO: Post Shanghai hardfork, the engine API's `PayloadBodiesByRange` method will be much more efficient, but for now,
-			// the `eth_getBlockByNumber` method is more widely available.
-
-			// Dial the backup unsafe sync RPC.
-			// TODO: Should this request block this thread (with a reasonable timeout) so that we can attempt to continue when the payload
-			// has been received and pushed into the priority queue? Or should it be made concurrently?
-			client, err := rpc.DialHTTP(eq.cfg.BackupL2UnsafeSyncRPC)
-			if err != nil {
-				return NewTemporaryError(fmt.Errorf("failed to dial backup unsafe sync RPC: %w", err))
-			}
-
-			// Fetch the next unsafe block from the backup unsafe sync RPC.
-			var block *types.Block
-			timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-			defer cancel()
-			if err = client.CallContext(timeoutCtx, &block, "eth_getBlockByNumber", eq.unsafeHead.Number+1); err != nil {
-				return NewTemporaryError(fmt.Errorf("failed to get next unsafe block from backup unsafe sync RPC: %w", err))
-			}
-
-			// Convert the received block to a `eth.ExecutionPayload`.
-			payload, err := eth.BlockAsPayload(block)
-			if err != nil {
-				return NewTemporaryError(fmt.Errorf("failed to convert block to execution payload: %w", err))
-			}
-
-			// TODO: Validate the integrity of the payload.
-			if _, ok := payload.CheckBlockHash(); !ok {
-				return NewTemporaryError(fmt.Errorf("received invalid payload from backup unsafe sync RPC; invalid block hash"))
-			}
-
-			eq.log.Info("received unsafe payload from backup RPC", "payload", payload.ID(), "backup rpc", eq.cfg.BackupL2UnsafeSyncRPC)
-
-			// Add the received execution payload to the unsafe payload priority queue.
-			eq.AddUnsafePayload(payload)
-
-			eq.log.Info("inserted received unsafe payload into priority queue", "payload", payload.ID(), "backup rpc", eq.cfg.BackupL2UnsafeSyncRPC)
-
-			// TODO: Should we attempt to continue here, or wait for the next iteration of the state loop and still return EOF?
-		}
-
 		return io.EOF // time to go to next stage if we cannot process the first unsafe payload
 	}
 
@@ -710,4 +661,25 @@ func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.System
 	eq.metrics.RecordL2Ref("l2_unsafe", unsafe)
 	eq.logSyncProgress("reset derivation work")
 	return io.EOF
+}
+
+// GetUnsafeQueueGap retrieves the current size, start, and end of the gap between the tip of the unsafe priority queue and the unsafe head.
+// If there is no gap, all values will be 0.
+// Note: The range returned by this function is *inclusive*.
+func (eq *EngineQueue) GetUnsafeQueueGap() (size uint64, start uint64, end uint64) {
+	first := eq.unsafePayloads.Peek()
+
+	// If the parent hash of the first unsafe payload does not match the current unsafe head, then there is a gap.
+	if first.ParentHash != eq.unsafeHead.Hash {
+		// The gap starts at the unsafe head + 1
+		start = eq.unsafeHead.Number + 1
+		// The gap ends at the parent block of the first unsafe payload in the priority queue.
+		end = first.ID().Number - 1
+		// The size of the gap is the difference between the exclusive end and inclusive start.
+		size = first.ID().Number - start
+
+		return size, start, end
+	} else {
+		return 0, 0, 0
+	}
 }

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -370,6 +371,54 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 			eq.log.Info("skipping unsafe payload, since it does not build onto the existing unsafe chain", "safe", eq.safeHead.ID(), "unsafe", first.ID(), "payload", first.ID())
 			eq.unsafePayloads.Pop()
 		}
+
+		// Request the payload that builds upon the current unsafe head from the fallback RPC.
+		// This is a temporary alternative sync method- in the future, this will be done over the p2p network.
+		if eq.cfg.BackupL2UnsafeSyncRPC != "" {
+			eq.log.Info("requesting unsafe payload from backup RPC", "unsafe head", eq.unsafeHead.ID(), "first unsafe payload", first.ID(), "backup rpc", eq.cfg.BackupL2UnsafeSyncRPC)
+			// TODO: Create a client for the backup RPC and request the payload from the backup sync RPC via the `eth_getBlockByNumber` method.
+			// Once the payload has been received, verify its integrity and push it into the priority queue.
+
+			// TODO: Post Shanghai hardfork, the engine API's `PayloadBodiesByRange` method will be much more efficient, but for now,
+			// the `eth_getBlockByNumber` method is more widely available.
+
+			// Dial the backup unsafe sync RPC.
+			// TODO: Should this request block this thread (with a reasonable timeout) so that we can attempt to continue when the payload
+			// has been received and pushed into the priority queue? Or should it be made concurrently?
+			client, err := rpc.DialHTTP(eq.cfg.BackupL2UnsafeSyncRPC)
+			if err != nil {
+				return NewTemporaryError(fmt.Errorf("failed to dial backup unsafe sync RPC: %w", err))
+			}
+
+			// Fetch the next unsafe block from the backup unsafe sync RPC.
+			var block *types.Block
+			timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+			if err = client.CallContext(timeoutCtx, &block, "eth_getBlockByNumber", eq.unsafeHead.Number+1); err != nil {
+				return NewTemporaryError(fmt.Errorf("failed to get next unsafe block from backup unsafe sync RPC: %w", err))
+			}
+
+			// Convert the received block to a `eth.ExecutionPayload`.
+			payload, err := eth.BlockAsPayload(block)
+			if err != nil {
+				return NewTemporaryError(fmt.Errorf("failed to convert block to execution payload: %w", err))
+			}
+
+			// TODO: Validate the integrity of the payload.
+			if _, ok := payload.CheckBlockHash(); !ok {
+				return NewTemporaryError(fmt.Errorf("received invalid payload from backup unsafe sync RPC; invalid block hash"))
+			}
+
+			eq.log.Info("received unsafe payload from backup RPC", "payload", payload.ID(), "backup rpc", eq.cfg.BackupL2UnsafeSyncRPC)
+
+			// Add the received execution payload to the unsafe payload priority queue.
+			eq.AddUnsafePayload(payload)
+
+			eq.log.Info("inserted received unsafe payload into priority queue", "payload", payload.ID(), "backup rpc", eq.cfg.BackupL2UnsafeSyncRPC)
+
+			// TODO: Should we attempt to continue here, or wait for the next iteration of the state loop and still return EOF?
+		}
+
 		return io.EOF // time to go to next stage if we cannot process the first unsafe payload
 	}
 

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -663,23 +663,20 @@ func (eq *EngineQueue) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.System
 	return io.EOF
 }
 
-// GetUnsafeQueueGap retrieves the current size, start, and end of the gap between the tip of the unsafe priority queue and the unsafe head.
-// If there is no gap, all values will be 0.
-// Note: The range returned by this function is *inclusive*.
-func (eq *EngineQueue) GetUnsafeQueueGap() (size uint64, start uint64, end uint64) {
+// GetUnsafeQueueGap retrieves the current [start, end) range of the gap between the tip of the unsafe priority queue and the unsafe head.
+// If there is no gap, the start and end will be 0.
+func (eq *EngineQueue) GetUnsafeQueueGap() (start uint64, end uint64) {
 	first := eq.unsafePayloads.Peek()
 
 	// If the parent hash of the first unsafe payload does not match the current unsafe head, then there is a gap.
 	if first.ParentHash != eq.unsafeHead.Hash {
 		// The gap starts at the unsafe head + 1
 		start = eq.unsafeHead.Number + 1
-		// The gap ends at the parent block of the first unsafe payload in the priority queue.
-		end = first.ID().Number - 1
-		// The size of the gap is the difference between the exclusive end and inclusive start.
-		size = first.ID().Number - start
+		// The gap ends at the parent block of the first unsafe payload in the priority queue, but we return the exclusive bound.
+		end = first.ID().Number
 
-		return size, start, end
+		return start, end
 	} else {
-		return 0, 0, 0
+		return 0, 0
 	}
 }

--- a/op-node/rollup/derive/payloads_queue_test.go
+++ b/op-node/rollup/derive/payloads_queue_test.go
@@ -75,8 +75,9 @@ func TestPayloadMemSize(t *testing.T) {
 
 func TestPayloadsQueue(t *testing.T) {
 	pq := PayloadsQueue{
-		MaxSize: payloadMemFixedCost * 3,
-		SizeFn:  payloadMemSize,
+		MaxSize:  payloadMemFixedCost * 3,
+		SizeFn:   payloadMemSize,
+		blockNos: make(map[uint64]bool),
 	}
 	require.Equal(t, 0, pq.Len())
 	require.Equal(t, (*eth.ExecutionPayload)(nil), pq.Peek())
@@ -85,6 +86,7 @@ func TestPayloadsQueue(t *testing.T) {
 	a := &eth.ExecutionPayload{BlockNumber: 3}
 	b := &eth.ExecutionPayload{BlockNumber: 4}
 	c := &eth.ExecutionPayload{BlockNumber: 5}
+	d := &eth.ExecutionPayload{BlockNumber: 6}
 	bAlt := &eth.ExecutionPayload{BlockNumber: 4}
 	require.NoError(t, pq.Push(b))
 	require.Equal(t, pq.Len(), 1)
@@ -105,28 +107,33 @@ func TestPayloadsQueue(t *testing.T) {
 	require.Equal(t, pq.Pop(), a)
 	require.Equal(t, pq.Len(), 2, "expecting to pop the lowest")
 
-	require.NoError(t, pq.Push(bAlt))
-	require.Equal(t, pq.Len(), 3)
-	require.Equal(t, pq.Peek(), b, "expecting b to be lowest, compared to bAlt and c")
+	require.Equal(t, pq.Peek(), b, "expecting b to be lowest, compared to c")
 
 	require.Equal(t, pq.Pop(), b)
-	require.Equal(t, pq.Len(), 2)
-	require.Equal(t, pq.MemSize(), 2*payloadMemFixedCost)
-
-	require.Equal(t, pq.Pop(), bAlt)
 	require.Equal(t, pq.Len(), 1)
-	require.Equal(t, pq.Peek(), c, "expecting c to only remain")
+	require.Equal(t, pq.MemSize(), payloadMemFixedCost)
 
-	d := &eth.ExecutionPayload{BlockNumber: 5, Transactions: []eth.Data{make([]byte, payloadMemFixedCost*3+1)}}
-	require.Error(t, pq.Push(d), "cannot add payloads that are too large")
+	require.Equal(t, pq.Pop(), c)
+	require.Equal(t, pq.Len(), 0, "expecting no items to remain")
+
+	e := &eth.ExecutionPayload{BlockNumber: 5, Transactions: []eth.Data{make([]byte, payloadMemFixedCost*3+1)}}
+	require.Error(t, pq.Push(e), "cannot add payloads that are too large")
 
 	require.NoError(t, pq.Push(b))
+	require.Equal(t, pq.Len(), 1, "expecting b")
+	require.Equal(t, pq.Peek(), b)
+	require.NoError(t, pq.Push(c))
 	require.Equal(t, pq.Len(), 2, "expecting b, c")
 	require.Equal(t, pq.Peek(), b)
 	require.NoError(t, pq.Push(a))
 	require.Equal(t, pq.Len(), 3, "expecting a, b, c")
 	require.Equal(t, pq.Peek(), a)
-	require.NoError(t, pq.Push(bAlt))
-	require.Equal(t, pq.Len(), 3, "expecting b, bAlt, c")
+
+	// No duplicates allowed
+	require.Error(t, pq.Push(bAlt))
+
+	require.NoError(t, pq.Push(d))
+	require.Equal(t, pq.Len(), 3)
+	require.Equal(t, pq.Peek(), b, "expecting b, c, d")
 	require.NotContainsf(t, pq.pq[:], a, "a should be dropped after 3 items already exist under max size constraint")
 }

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -51,6 +51,7 @@ type EngineQueueStage interface {
 
 	Finalize(l1Origin eth.L1BlockRef)
 	AddUnsafePayload(payload *eth.ExecutionPayload)
+	GetUnsafeQueueGap() (uint64, uint64, uint64)
 	Step(context.Context) error
 }
 
@@ -158,6 +159,12 @@ func (dp *DerivationPipeline) BuildingPayload() (onto eth.L2BlockRef, id eth.Pay
 // AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1
 func (dp *DerivationPipeline) AddUnsafePayload(payload *eth.ExecutionPayload) {
 	dp.eng.AddUnsafePayload(payload)
+}
+
+// GetUnsafeQueueGap retrieves the current size, start, and end of the gap between the tip of the unsafe priority queue and the unsafe head.
+// If there is no gap, all values will be 0.
+func (dp *DerivationPipeline) GetUnsafeQueueGap() (uint64, uint64, uint64) {
+	return dp.eng.GetUnsafeQueueGap()
 }
 
 // Step tries to progress the buffer.

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -51,7 +51,7 @@ type EngineQueueStage interface {
 
 	Finalize(l1Origin eth.L1BlockRef)
 	AddUnsafePayload(payload *eth.ExecutionPayload)
-	GetUnsafeQueueGap() (uint64, uint64, uint64)
+	GetUnsafeQueueGap() (uint64, uint64)
 	Step(context.Context) error
 }
 
@@ -161,9 +161,9 @@ func (dp *DerivationPipeline) AddUnsafePayload(payload *eth.ExecutionPayload) {
 	dp.eng.AddUnsafePayload(payload)
 }
 
-// GetUnsafeQueueGap retrieves the current size, start, and end of the gap between the tip of the unsafe priority queue and the unsafe head.
-// If there is no gap, all values will be 0.
-func (dp *DerivationPipeline) GetUnsafeQueueGap() (uint64, uint64, uint64) {
+// GetUnsafeQueueGap retrieves the current [start, end) range of the gap between the tip of the unsafe priority queue and the unsafe head.
+// If there is no gap, the start and end will be 0.
+func (dp *DerivationPipeline) GetUnsafeQueueGap() (uint64, uint64) {
 	return dp.eng.GetUnsafeQueueGap()
 }
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -51,7 +51,7 @@ type EngineQueueStage interface {
 
 	Finalize(l1Origin eth.L1BlockRef)
 	AddUnsafePayload(payload *eth.ExecutionPayload)
-	GetUnsafeQueueGap() (uint64, uint64)
+	GetUnsafeQueueGap(expectedNumber uint64) (uint64, uint64)
 	Step(context.Context) error
 }
 
@@ -161,10 +161,10 @@ func (dp *DerivationPipeline) AddUnsafePayload(payload *eth.ExecutionPayload) {
 	dp.eng.AddUnsafePayload(payload)
 }
 
-// GetUnsafeQueueGap retrieves the current [start, end) range of the gap between the tip of the unsafe priority queue and the unsafe head.
+// GetUnsafeQueueGap retrieves the current [start, end] range of the gap between the tip of the unsafe priority queue and the unsafe head.
 // If there is no gap, the start and end will be 0.
-func (dp *DerivationPipeline) GetUnsafeQueueGap() (uint64, uint64) {
-	return dp.eng.GetUnsafeQueueGap()
+func (dp *DerivationPipeline) GetUnsafeQueueGap(expectedNumber uint64) (uint64, uint64) {
+	return dp.eng.GetUnsafeQueueGap(expectedNumber)
 }
 
 // Step tries to progress the buffer.

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -107,13 +107,13 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, sy
 		snapshotLog:      snapshotLog,
 		l1:               l1,
 		l2:               l2,
-		l2SyncCl:         syncClient,
 		sequencer:        sequencer,
 		network:          network,
 		metrics:          metrics,
 		l1HeadSig:        make(chan eth.L1BlockRef, 10),
 		l1SafeSig:        make(chan eth.L1BlockRef, 10),
 		l1FinalizedSig:   make(chan eth.L1BlockRef, 10),
-		unsafeL2Payloads: make(chan *eth.ExecutionPayload, 10),
+		UnsafeL2Payloads: make(chan *eth.ExecutionPayload, 10),
+		L2SyncCl:         syncClient,
 	}
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -48,6 +48,7 @@ type DerivationPipeline interface {
 	Reset()
 	Step(ctx context.Context) error
 	AddUnsafePayload(payload *eth.ExecutionPayload)
+	GetUnsafeQueueGap() (uint64, uint64, uint64)
 	Finalize(ref eth.L1BlockRef)
 	FinalizedL1() eth.L1BlockRef
 	Finalized() eth.L2BlockRef

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
 )
 
 type Metrics interface {
@@ -81,7 +82,7 @@ type Network interface {
 }
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
-func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
+func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, syncClient *sources.SyncClient, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
@@ -106,6 +107,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, ne
 		snapshotLog:      snapshotLog,
 		l1:               l1,
 		l2:               l2,
+		l2SyncCl:         syncClient,
 		sequencer:        sequencer,
 		network:          network,
 		metrics:          metrics,

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -48,7 +48,7 @@ type DerivationPipeline interface {
 	Reset()
 	Step(ctx context.Context) error
 	AddUnsafePayload(payload *eth.ExecutionPayload)
-	GetUnsafeQueueGap() (uint64, uint64, uint64)
+	GetUnsafeQueueGap() (uint64, uint64)
 	Finalize(ref eth.L1BlockRef)
 	FinalizedL1() eth.L1BlockRef
 	Finalized() eth.L2BlockRef

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -49,7 +49,7 @@ type DerivationPipeline interface {
 	Reset()
 	Step(ctx context.Context) error
 	AddUnsafePayload(payload *eth.ExecutionPayload)
-	GetUnsafeQueueGap() (uint64, uint64)
+	GetUnsafeQueueGap(expectedNumber uint64) (uint64, uint64)
 	Finalize(ref eth.L1BlockRef)
 	FinalizedL1() eth.L1BlockRef
 	Finalized() eth.L2BlockRef
@@ -113,7 +113,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, sy
 		l1HeadSig:        make(chan eth.L1BlockRef, 10),
 		l1SafeSig:        make(chan eth.L1BlockRef, 10),
 		l1FinalizedSig:   make(chan eth.L1BlockRef, 10),
-		UnsafeL2Payloads: make(chan *eth.ExecutionPayload, 10),
+		unsafeL2Payloads: make(chan *eth.ExecutionPayload, 10),
 		L2SyncCl:         syncClient,
 	}
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -36,11 +36,6 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, err
 	}
 
-	// If the backup sync RPC flag is set, then use it over the value present in the config file.
-	if backupSyncRPC := ctx.GlobalString(flags.BackupL2UnsafeSyncRPC.Name); backupSyncRPC != "" {
-		rollupConfig.BackupL2UnsafeSyncRPC = backupSyncRPC
-	}
-
 	driverConfig, err := NewDriverConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -66,9 +61,12 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, fmt.Errorf("failed to load l2 endpoints info: %w", err)
 	}
 
+	l2SyncEndpoint := NewL2SyncEndpointConfig(ctx)
+
 	cfg := &node.Config{
 		L1:     l1Endpoint,
 		L2:     l2Endpoint,
+		L2Sync: l2SyncEndpoint,
 		Rollup: *rollupConfig,
 		Driver: *driverConfig,
 		RPC: node.RPCConfig{
@@ -137,6 +135,12 @@ func NewL2EndpointConfig(ctx *cli.Context, log log.Logger) (*node.L2EndpointConf
 		L2EngineAddr:      l2Addr,
 		L2EngineJWTSecret: secret,
 	}, nil
+}
+
+func NewL2SyncEndpointConfig(ctx *cli.Context) *node.L2SyncEndpointConfig {
+	return &node.L2SyncEndpointConfig{
+		L2NodeAddr: ctx.GlobalString(flags.BackupL2UnsafeSyncRPC.Name),
+	}
 }
 
 func NewDriverConfig(ctx *cli.Context) (*driver.Config, error) {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -36,6 +36,11 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, err
 	}
 
+	// If the backup sync RPC flag is set, then use it over the value present in the config file.
+	if backupSyncRPC := ctx.GlobalString(flags.BackupL2UnsafeSyncRPC.Name); backupSyncRPC != "" {
+		rollupConfig.BackupL2UnsafeSyncRPC = backupSyncRPC
+	}
+
 	driverConfig, err := NewDriverConfig(ctx)
 	if err != nil {
 		return nil, err

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -36,10 +36,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, err
 	}
 
-	driverConfig, err := NewDriverConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
+	driverConfig := NewDriverConfig(ctx)
 
 	p2pSignerSetup, err := p2pcli.LoadSignerSetup(ctx)
 	if err != nil {
@@ -51,10 +48,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, fmt.Errorf("failed to load p2p config: %w", err)
 	}
 
-	l1Endpoint, err := NewL1EndpointConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load l1 endpoint info: %w", err)
-	}
+	l1Endpoint := NewL1EndpointConfig(ctx)
 
 	l2Endpoint, err := NewL2EndpointConfig(ctx, log)
 	if err != nil {
@@ -99,12 +93,12 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	return cfg, nil
 }
 
-func NewL1EndpointConfig(ctx *cli.Context) (*node.L1EndpointConfig, error) {
+func NewL1EndpointConfig(ctx *cli.Context) *node.L1EndpointConfig {
 	return &node.L1EndpointConfig{
 		L1NodeAddr: ctx.GlobalString(flags.L1NodeAddr.Name),
 		L1TrustRPC: ctx.GlobalBool(flags.L1TrustRPC.Name),
 		L1RPCKind:  sources.RPCProviderKind(strings.ToLower(ctx.GlobalString(flags.L1RPCProviderKind.Name))),
-	}, nil
+	}
 }
 
 func NewL2EndpointConfig(ctx *cli.Context, log log.Logger) (*node.L2EndpointConfig, error) {
@@ -137,19 +131,21 @@ func NewL2EndpointConfig(ctx *cli.Context, log log.Logger) (*node.L2EndpointConf
 	}, nil
 }
 
+// NewL2SyncEndpointConfig returns a pointer to a L2SyncEndpointConfig if the
+// flag is set, otherwise nil.
 func NewL2SyncEndpointConfig(ctx *cli.Context) *node.L2SyncEndpointConfig {
 	return &node.L2SyncEndpointConfig{
 		L2NodeAddr: ctx.GlobalString(flags.BackupL2UnsafeSyncRPC.Name),
 	}
 }
 
-func NewDriverConfig(ctx *cli.Context) (*driver.Config, error) {
+func NewDriverConfig(ctx *cli.Context) *driver.Config {
 	return &driver.Config{
 		VerifierConfDepth:  ctx.GlobalUint64(flags.VerifierL1Confs.Name),
 		SequencerConfDepth: ctx.GlobalUint64(flags.SequencerL1Confs.Name),
 		SequencerEnabled:   ctx.GlobalBool(flags.SequencerEnabledFlag.Name),
 		SequencerStopped:   ctx.GlobalBool(flags.SequencerStoppedFlag.Name),
-	}, nil
+	}
 }
 
 func NewRollupConfig(ctx *cli.Context) (*rollup.Config, error) {

--- a/op-node/sources/sync_client.go
+++ b/op-node/sources/sync_client.go
@@ -1,15 +1,32 @@
 package sources
 
 import (
+	"context"
+	"errors"
+	"sync"
+
 	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/sources/caching"
 	"github.com/ethereum/go-ethereum/log"
 )
 
+type SyncClientInterface interface {
+	Start(unsafeL2Payloads chan *eth.ExecutionPayload) error
+	Close() error
+	fetchUnsafeBlockFromRpc(ctx context.Context, blockNumber uint64)
+}
+
 type SyncClient struct {
 	*L2Client
+	FetchUnsafeBlock chan uint64
+	done             chan struct{}
+	unsafeL2Payloads chan *eth.ExecutionPayload
+	wg               sync.WaitGroup
 }
+
+var _ SyncClientInterface = (*SyncClient)(nil)
 
 type SyncClientConfig struct {
 	L2ClientConfig
@@ -28,6 +45,72 @@ func NewSyncClient(client client.RPC, log log.Logger, metrics caching.Metrics, c
 	}
 
 	return &SyncClient{
-		L2Client: l2Client,
+		L2Client:         l2Client,
+		FetchUnsafeBlock: make(chan uint64),
+		done:             make(chan struct{}),
 	}, nil
+}
+
+// Start starts up the state loop.
+// The loop will have been started if err is not nil.
+func (s *SyncClient) Start(unsafeL2Payloads chan *eth.ExecutionPayload) error {
+	if unsafeL2Payloads == nil {
+		return errors.New("unsafeL2Payloads channel must not be nil")
+	}
+	s.unsafeL2Payloads = unsafeL2Payloads
+
+	s.wg.Add(1)
+	go s.eventLoop()
+	return nil
+}
+
+// Close sends a signal to the event loop to stop.
+func (s *SyncClient) Close() error {
+	s.done <- struct{}{}
+	s.wg.Wait()
+	return nil
+}
+
+// eventLoop is the main event loop for the sync client.
+func (s *SyncClient) eventLoop() {
+	defer s.wg.Done()
+	s.log.Info("starting sync client event loop")
+
+	for {
+		select {
+		case <-s.done:
+			return
+		case blockNumber := <-s.FetchUnsafeBlock:
+			s.fetchUnsafeBlockFromRpc(context.Background(), blockNumber)
+		}
+	}
+}
+
+// fetchUnsafeBlockFromRpc attempts to fetch an unsafe execution payload from the backup unsafe sync RPC.
+// WARNING: This function fails silently (aside from warning logs).
+func (s *SyncClient) fetchUnsafeBlockFromRpc(ctx context.Context, blockNumber uint64) {
+	s.log.Info("requesting unsafe payload from backup RPC", "block number", blockNumber)
+
+	// TODO: Post Shanghai hardfork, the engine API's `PayloadBodiesByRange` method will be much more efficient, but for now,
+	// the `eth_getBlockByNumber` method is more widely available.
+
+	payload, err := s.PayloadByNumber(ctx, blockNumber)
+	if err != nil {
+		s.log.Warn("failed to convert block to execution payload", "block number", blockNumber, "err", err)
+		return
+	}
+
+	// TODO: Validate the integrity of the payload. Is this required?
+	// Signature validation is not necessary here since the backup RPC is trusted.
+	if _, ok := payload.CheckBlockHash(); !ok {
+		s.log.Warn("received invalid payload from backup RPC; invalid block hash", "payload", payload.ID())
+		return
+	}
+
+	s.log.Info("received unsafe payload from backup RPC", "payload", payload.ID())
+
+	// Send the retrieved payload to the `unsafeL2Payloads` channel.
+	s.unsafeL2Payloads <- payload
+
+	s.log.Info("sent received payload into the driver's unsafeL2Payloads channel", "payload", payload.ID())
 }

--- a/op-node/sources/sync_client.go
+++ b/op-node/sources/sync_client.go
@@ -1,0 +1,33 @@
+package sources
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/sources/caching"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type SyncClient struct {
+	*L2Client
+}
+
+type SyncClientConfig struct {
+	L2ClientConfig
+}
+
+func SyncClientDefaultConfig(config *rollup.Config, trustRPC bool) *SyncClientConfig {
+	return &SyncClientConfig{
+		*L2ClientDefaultConfig(config, trustRPC),
+	}
+}
+
+func NewSyncClient(client client.RPC, log log.Logger, metrics caching.Metrics, config *SyncClientConfig) (*SyncClient, error) {
+	l2Client, err := NewL2Client(client, log, metrics, &config.L2ClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SyncClient{
+		L2Client: l2Client,
+	}, nil
+}


### PR DESCRIPTION
# Overview

Adds an alternative backup sync method via RPC to the `op-node`.

The new CLI flag, `l2.backup-unsafe-sync-rpc`, feeds into the new `sources.L2SyncEndpointSetup`, which lives in the node config. This flag is optional- if it is not present, alternative sync will not be enabled. 

If the flag is set, a `sources.SyncClient` is initialized alongside the driver, which spawns a new event loop that the driver's state loop can communicate back and forth with in order to fetch missing blocks from a backup RPC.

**Tests**

- `op-e2e` - `TestSystemMockAltSync`
- Modified `TestPayloadsQueue` in the `op-node` to account for the `PayloadsQueue` changes.

**Metadata**
- Closes ENG-3218
