### PR TITLE
op-node: ensure sequencer selects L1 origin within sequencer time drift and use conf depth util

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -66,10 +66,10 @@ type L1StateIface interface {
 }
 
 type SequencerIface interface {
-	StartBuildingBlock(ctx context.Context, l1Head eth.L1BlockRef) error
+	StartBuildingBlock(ctx context.Context) error
 	CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayload, error)
 	PlanNextSequencerAction() time.Duration
-	RunNextSequencerAction(ctx context.Context, l1Head eth.L1BlockRef) *eth.ExecutionPayload
+	RunNextSequencerAction(ctx context.Context) *eth.ExecutionPayload
 	BuildingOnto() eth.L2BlockRef
 }
 
@@ -81,7 +81,8 @@ type Network interface {
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
 func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
 	l1State := NewL1State(log, metrics)
-	findL1Origin := NewL1OriginSelector(log, cfg, l1, driverCfg.SequencerConfDepth)
+	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
+	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
 	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l2, metrics)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)

--- a/op-node/rollup/driver/origin_selector_test.go
+++ b/op-node/rollup/driver/origin_selector_test.go
@@ -27,6 +27,7 @@ func TestOriginSelectorAdvances(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -46,9 +47,8 @@ func TestOriginSelectorAdvances(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 0)
-
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	s := NewL1OriginSelector(log, cfg, l1)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, b, next)
 }
@@ -68,6 +68,7 @@ func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -87,15 +88,14 @@ func TestOriginSelectorRespectsOriginTiming(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 0)
-
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	s := NewL1OriginSelector(log, cfg, l1)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
 
 // TestOriginSelectorRespectsConfDepth ensures that the origin selector
-// will respects the confirmation depth requirement
+// will respect the confirmation depth requirement
 //
 // There are 2 L1 blocks at time 20 & 25. The L2 Head is at time 27.
 // The next L2 time is 29 which enough to normally select block `b`
@@ -108,6 +108,7 @@ func TestOriginSelectorRespectsConfDepth(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -125,33 +126,32 @@ func TestOriginSelectorRespectsConfDepth(t *testing.T) {
 	}
 
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
-	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
+	confDepthL1 := NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
+	s := NewL1OriginSelector(log, cfg, confDepthL1)
 
-	s := NewL1OriginSelector(log, cfg, l1, 10)
-
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
 }
 
-// TestOriginSelectorRespectsMaxSeqDrift ensures that the origin selector
-// will advance if the time delta between the current L1 origin and the next
-// L2 block is greater than the sequencer drift. This needs to occur even
-// if conf depth needs to be ignored
+// TestOriginSelectorStrictConfDepth ensures that the origin selector will maintain the sequencer conf depth,
+// even while the time delta between the current L1 origin and the next
+// L2 block is greater than the sequencer drift.
+// It's more important to maintain safety with an empty block than to maintain liveness with poor conf depth.
 //
 // There are 2 L1 blocks at time 20 & 25. The L2 Head is at time 27.
 // The next L2 time is 29. The sequencer drift is 8 so the L2 head is
 // valid with origin `a`, but the next L2 block is not valid with origin `b.`
 // This is because 29 (next L2 time) > 20 (origin) + 8 (seq drift) => invalid block.
-// Even though the LOS would normally refuse to advance because block `b` does not
-// have enough confirmations, it should in this instance.
-func TestOriginSelectorRespectsMaxSeqDrift(t *testing.T) {
+// We maintain confirmation distance, even though we would shift to the next origin if we could.
+func TestOriginSelectorStrictConfDepth(t *testing.T) {
 	log := testlog.Logger(t, log.LvlCrit)
 	cfg := &rollup.Config{
 		MaxSequencerDrift: 8,
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -169,13 +169,11 @@ func TestOriginSelectorRespectsMaxSeqDrift(t *testing.T) {
 	}
 
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
-	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
+	confDepthL1 := NewConfDepth(10, func() eth.L1BlockRef { return b }, l1)
+	s := NewL1OriginSelector(log, cfg, confDepthL1)
 
-	s := NewL1OriginSelector(log, cfg, l1, 10)
-
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
-	require.Nil(t, err)
-	require.Equal(t, b, next)
+	_, err := s.FindL1Origin(context.Background(), l2Head)
+	require.ErrorContains(t, err, "sequencer time drift")
 }
 
 // TestOriginSelectorSeqDriftRespectsNextOriginTime
@@ -191,6 +189,7 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTime(t *testing.T) {
 		BlockTime:         2,
 	}
 	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
 	a := eth.L1BlockRef{
 		Hash:   common.Hash{'a'},
 		Number: 10,
@@ -210,9 +209,76 @@ func TestOriginSelectorSeqDriftRespectsNextOriginTime(t *testing.T) {
 	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
 	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
 
-	s := NewL1OriginSelector(log, cfg, l1, 10)
-
-	next, err := s.FindL1Origin(context.Background(), b, l2Head)
+	s := NewL1OriginSelector(log, cfg, l1)
+	next, err := s.FindL1Origin(context.Background(), l2Head)
 	require.Nil(t, err)
 	require.Equal(t, a, next)
+}
+
+// TestOriginSelectorHandlesLateL1Blocks tests the forced repeat of the previous origin,
+// but with a conf depth that first prevents it from learning about the need to repeat.
+//
+// There are 2 L1 blocks at time 20 & 100. The L2 Head is at time 27.
+// The next L2 time is 29. Even though the next L2 time is past the seq
+// drift, the origin should remain on block `a` because the next origin's
+// time is greater than the next L2 time.
+// Due to a conf depth of 2, block `b` is not immediately visible,
+// and the origin selection should fail until it is visible, by waiting for block `c`.
+func TestOriginSelectorHandlesLateL1Blocks(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+	cfg := &rollup.Config{
+		MaxSequencerDrift: 8,
+		BlockTime:         2,
+	}
+	l1 := &testutils.MockL1Source{}
+	defer l1.AssertExpectations(t)
+	a := eth.L1BlockRef{
+		Hash:   common.Hash{'a'},
+		Number: 10,
+		Time:   20,
+	}
+	b := eth.L1BlockRef{
+		Hash:       common.Hash{'b'},
+		Number:     11,
+		Time:       100,
+		ParentHash: a.Hash,
+	}
+	c := eth.L1BlockRef{
+		Hash:       common.Hash{'c'},
+		Number:     12,
+		Time:       150,
+		ParentHash: b.Hash,
+	}
+	d := eth.L1BlockRef{
+		Hash:       common.Hash{'d'},
+		Number:     13,
+		Time:       200,
+		ParentHash: c.Hash,
+	}
+	l2Head := eth.L2BlockRef{
+		L1Origin: a.ID(),
+		Time:     27,
+	}
+
+	// l2 head does not change, so we start at the same origin again and again until we meet the conf depth
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByHash(a.Hash, a, nil)
+	l1.ExpectL1BlockRefByNumber(b.Number, b, nil)
+
+	l1Head := b
+	confDepthL1 := NewConfDepth(2, func() eth.L1BlockRef { return l1Head }, l1)
+	s := NewL1OriginSelector(log, cfg, confDepthL1)
+
+	_, err := s.FindL1Origin(context.Background(), l2Head)
+	require.ErrorContains(t, err, "sequencer time drift")
+
+	l1Head = c
+	_, err = s.FindL1Origin(context.Background(), l2Head)
+	require.ErrorContains(t, err, "sequencer time drift")
+
+	l1Head = d
+	next, err := s.FindL1Origin(context.Background(), l2Head)
+	require.Nil(t, err)
+	require.Equal(t, a, next, "must stay on a because the L1 time may not be higher than the L2 time")
 }

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -212,7 +212,7 @@ func (s *Driver) eventLoop() {
 
 		select {
 		case <-sequencerCh:
-			payload := s.sequencer.RunNextSequencerAction(ctx, s.l1State.L1Head())
+			payload := s.sequencer.RunNextSequencerAction(ctx)
 			if s.network != nil && payload != nil {
 				// Publishing of unsafe data via p2p is optional.
 				// Errors are not severe enough to change/halt sequencing but should be logged and metered.


### PR DESCRIPTION
**Description**

Subset of original #4758

As sequencer it didn't follow the safety-over-liveness priority, and ignored the sequencer conf depth to try and handle sequencer time drift.

This however is dangerous because of the recent verifier "fix" in (good fix, but incomplete):
- When the max time drift is exceeded and the next origin cannot be found, then old origin would be used, causing the batch to be dropped.
- But the sequencer still produces blocks after this, which can have later origins & include transactions again, building on top of the empty block with old origin.

This means that as a verifier you end up dropping the empty batch with old origin, causing a halt (of safe blocks) until the sequencer window forces an empty block to be created. *This already went wrong once due to a L1 RPC outage on Goerli*

And aside from halting as such, it risks adopting the next L1 origin differently than the sequencer, causing a reorg of the unsafe chain.


**Tests**

- Modified `TestOriginSelectorRespectsMaxSeqDrift` into `TestOriginSelectorStrictConfDepth` to enforce conf depth.
- Added `TestOriginSelectorHandlesLateL1Blocks` to cover the case when the L1 block time gap is larger than the sequencer time drift. It preserves the time invariant in favor of the timedrift invariant. **Note: the safe-head progress would be bricked after this (assuming L1 does not reorg out the gap)**, as one of the two invariants breaks. We need some sort of derivation change like in the original PR.

**Invariants**

- Ensure that the sequencer conf depth is maintained
- Ensure that the sequencer never produces a block that exceeds sequencer time drift w.r.t. selected origin.
  - The exception here is if the block *has* to exceed the sequencer time drift to maintain the `L2 timestamp >= L1 origin timestamp` invariant. This can happen if L1 blocks have a huge time gap, larger than the sequencer time drift. This was fixed in #4758 but will now be split into a different PR because it affects derivation. In such case I believe it's best to allow the sequencer to continue, but only until the L1 origin can be introduced without breaking the (L2 timestamp >= L1 origin timestamp` invariant, and disable tx inclusion by sequencer to avoid L2 activity that has to be submitted in such risky L1 situation (large L1 gaps = likely trouble including batch data). 

**Additional context**

See #4758 and #3861 (comments too) for additional context.

**Metadata**
- Fixes #[Link to Issue]
