### PR TITLE
:zap: add node_modules and .vscode to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .github
+.vscode
 
 node_modules
+**/node_modules
 .env
 **/.env
 


### PR DESCRIPTION
Make docker context way smaller by ignoring node modules

