### PR TITLE
[op-node] Fix ReadStorageAt for 0-prefixed values

### DIFF
--- a/op-node/eth/account_proof.go
+++ b/op-node/eth/account_proof.go
@@ -15,7 +15,7 @@ import (
 
 type StorageProofEntry struct {
 	Key   common.Hash     `json:"key"`
-	Value hexutil.Bytes   `json:"value"`
+	Value hexutil.Big     `json:"value"`
 	Proof []hexutil.Bytes `json:"proof"`
 }
 

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -359,7 +359,8 @@ func (s *EthClient) ReadStorageAt(ctx context.Context, address common.Address, s
 	if err := result.Verify(block.Root()); err != nil {
 		return common.Hash{}, fmt.Errorf("failed to verify retrieved proof against state root: %w", err)
 	}
-	return common.BytesToHash(result.StorageProof[0].Value), nil
+	value := big.Int(result.StorageProof[0].Value)
+	return common.BytesToHash((&value).Bytes()), nil
 }
 
 func (s *EthClient) Close() {

--- a/op-node/sources/eth_client.go
+++ b/op-node/sources/eth_client.go
@@ -359,8 +359,8 @@ func (s *EthClient) ReadStorageAt(ctx context.Context, address common.Address, s
 	if err := result.Verify(block.Root()); err != nil {
 		return common.Hash{}, fmt.Errorf("failed to verify retrieved proof against state root: %w", err)
 	}
-	value := big.Int(result.StorageProof[0].Value)
-	return common.BytesToHash((&value).Bytes()), nil
+	value := result.StorageProof[0].Value.ToInt()
+	return common.BytesToHash(value.Bytes()), nil
 }
 
 func (s *EthClient) Close() {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The spec for `eth_getProof` says that the storage `value` is a `QUANTITY` type: https://eips.ethereum.org/EIPS/eip-1186. In geth this is [implemented](https://github.com/ethereum-optimism/op-geth/blob/optimism-history/ethclient/gethclient/gethclient.go#L76) as a `*big.Int`.

`op-node` uses a `hexutil.Bytes` value for unmarshaling responses from JSON. This expects `0x` prefixed hex values with even numbers of digits: https://cs.opensource.google/go/go/+/refs/tags/go1.19.5:src/encoding/hex/hex.go;l=94-100 (and translated to a different error [here](https://github.com/ethereum-optimism/op-geth/blob/985086bf2a5c61e76a8ce7c74ac029660751e260/common/hexutil/hexutil.go#L237-L239)). This causes the hex decoding to fail with errors like:
```
failed to fetch proof of storage slot 0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08 at block 0x36ba8413db2fb4db4832e3e028966dcb13f198303cb3c7730e5e565f033aabe9: json: cannot unmarshal hex string of odd length into Go struct field StorageProofEntry.storageProof.value of type hexutil.Bytes"
```

This PR switches the struct value to a `hexutil.Big` type, which can handle storage values with odd numbers of hex digits.

An example of where this might fail: using a `p2pSequencerAddress` like `0x09D5fEdb4bb6105A8420cDd31c87867216013C26`, which is `0` prefixed, causes `eth_getProof` return `0x9D5fEdb4bb6105A8420cDd31c87867216013C26` for the `value`, which fails to parse in `op-node`.

**Tests**

I tested this locally. I can also write tests for `ReadStorageAt` if required, but there don't seem to be any existing ones yet.

One can repro the issue with:
```
client.ReadStorageAt(context.Background(),
	common.HexToAddress("0xb15eea247eCE011C68a614e4a77AD648ff495bc1"),
	common.HexToHash("0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08"),
	common.HexToHash("0xe2041c8b04b9a89b0de852ad5797d16b3a269a5e8a1aef80caf5c94eab4f5f9a")
)
```
or `curl`:
```
curl -H "Content-Type: application/json" https://goerli-node -d '{"id":0,"jsonrpc":"2.0","method":"eth_getProof","params":["0xb15eea247eCE011C68a614e4a77AD648ff495bc1",["0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08"],"0xe2041c8b04b9a89b0de852ad5797d16b3a269a5e8a1aef80caf5c94eab4f5f9a"]}'
```