### PR TITLE
op-heartbeat: allow more versions in heartbeat service

### DIFF
--- a/op-heartbeat/whitelists.go
+++ b/op-heartbeat/whitelists.go
@@ -10,4 +10,11 @@ var AllowedVersions = map[string]bool{
 	"":                          true,
 	"v0.1.0-beta.1":             true,
 	"v0.1.0-goerli-rehearsal.1": true,
+	"v0.10.9": true,
+	"v0.10.10": true,
+	"v0.10.11": true,
+	"v0.10.12": true,
+	"v0.10.13": true,
+	"v0.10.14": true,
+	"v0.11.0": true,
 }


### PR DESCRIPTION
Add past versions, and some possible near future versions, to get more detailed version metrics.
