### PR TITLE
op-node: Remove duplicated word in comment.

### DIFF
--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -13,7 +13,7 @@ import (
 // Channel In Reader reads a batch from the channel
 // This does decompression and limits the max RLP size
 // This is a pure function from the channel, but each channel (or channel fragment)
-// must be tagged with an L1 inclusion block to be passed to the the batch queue.
+// must be tagged with an L1 inclusion block to be passed to the batch queue.
 
 type ChannelInReader struct {
 	log log.Logger


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Removes a duplicated word in a comment.

**Tests**

No tests as no actual code changed.
