### PR TITLE
contracts-bedrock: add gov token to predeploys contract

### DIFF
--- a/packages/contracts-bedrock/contracts/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Predeploys.sol
@@ -104,4 +104,9 @@ library Predeploys {
      * @notice Address of the L1FeeVault predeploy.
      */
     address internal constant L1_FEE_VAULT = 0x420000000000000000000000000000000000001A;
+
+    /**
+     * @notice Address of the GovernanceToken predeploy.
+     */
+    address internal constant GOVERNANCE_TOKEN = 0x4200000000000000000000000000000000000042;
 }


### PR DESCRIPTION
**Description**

The `GovernanceToken` never had a field in the `Predeploys` contract, this commit adds it.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

