### PR TITLE
fix(spec): Withdrawal calls are not forwarded during the proof verification call

### DIFF
--- a/specs/withdrawals.md
+++ b/specs/withdrawals.md
@@ -65,9 +65,8 @@ This is a very simple contract that stores the hash of the withdrawal data.
    must be one for which an L2 output root exists, which commits to the withdrawal as registered on L2.
 1. The `OptimismPortal` contract retrieves the output root for the given block number from the `L2OutputOracle`'s
    `getL2OutputAfter()` function, and performs the remainder of the verification process internally.
-1. If proof verification fails, the call reverts. Otherwise the call is forwarded, and the hash is recorded to
-   prevent it from being re-proven. Note that the withdrawal can be proven more than once if the corresponding
-   output root changes.
+1. If proof verification fails, the call reverts. Otherwise the hash is recorded to prevent it from being re-proven.
+   Note that the withdrawal can be proven more than once if the corresponding output root changes.
 1. After the withdrawal is proven, it enters a 7 day challenge period, allowing time for other network participants
    to challenge the integrity of the corresponding output root.
 1. Once the challenge period has passed, a relayer submits the withdrawal transaction once again to the


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The spec incorrectly stated that the call was forwarded at both the proof verification call and during the finalization call. They are actually only forwarded once the finalisation call completes, so remove the mention of forwarding from the proof verification step.

