### PR TITLE
chore(op-node): Fix two typos

### DIFF
--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -20,7 +20,7 @@ import (
 // It also buffers batches that have been output because multiple batches can
 // be created at once.
 //
-// This stage can be reset by clearing it's batch buffer.
+// This stage can be reset by clearing its batch buffer.
 // This stage does not need to retain any references to L1 blocks.
 
 type AttributesBuilder interface {

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -517,7 +517,7 @@ func (eq *EngineQueue) ConfirmPayload(ctx context.Context) (out *eth.ExecutionPa
 		return nil, BlockInsertPrestateErr, fmt.Errorf("cannot complete payload building: not currently building a payload")
 	}
 	if eq.buildingOnto.Hash != eq.unsafeHead.Hash { // E.g. when safe-attributes consolidation fails, it will drop the existing work.
-		eq.log.Warn("engine is building block that reorgs previous usafe head", "onto", eq.buildingOnto, "unsafe", eq.unsafeHead)
+		eq.log.Warn("engine is building block that reorgs previous unsafe head", "onto", eq.buildingOnto, "unsafe", eq.unsafeHead)
 	}
 	fc := eth.ForkchoiceState{
 		HeadBlockHash:      common.Hash{}, // gets overridden


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixes two minor typos discovered while reading through the codebase. Note that the second one is actually in a warning log so will change user visible behaviour.