### PR TITLE
da: refactor to use abstract da interface

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -111,6 +111,10 @@ def main():
     })
     wait_up(9545)
 
+    log.info('Bringing up DA')
+    run_command(['docker-compose', 'up', '-d', 'da'], cwd=ops_bedrock_dir, env={
+      'PWD': ops_bedrock_dir,
+    })
     log.info('Bringing up everything else.')
     run_command(['docker-compose', 'up', '-d', 'op-node', 'op-proposer', 'op-batcher'], cwd=ops_bedrock_dir, env={
         'PWD': ops_bedrock_dir,

--- a/go.work.sum
+++ b/go.work.sum
@@ -57,6 +57,7 @@ github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af h1:wVe6/Ea46ZMeNkQjj
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db h1:nxAtV4VajJDhKysp2kdcJZsq8Ss1xSA0vZTkVHHJd0E=
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
@@ -106,8 +107,13 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec h1:EdRZT3IeKQmfCSrgo
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
@@ -146,9 +152,11 @@ github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaI
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633 h1:H2pdYOb3KQ1/YsqVWoWNLQO+fusocsw354rqGTZtAgw=
 github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELBIYWeBVh6wn+E=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0 h1:dulLQAYQFYtG5MTplgNGHWuV2D+OBD+Z8lmDBmbLg+s=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/etcd-io/bbolt v1.3.3 h1:gSJmxrs37LgTqR/oyJBWok6k6SvXEUerFTbltIhXkBM=
 github.com/ethereum-optimism/op-geth v0.0.0-20220904174542-4311f9d2cead/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
@@ -207,6 +215,7 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF0
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec h1:lJwO/92dFXWeXOZdoGXgptLmNLwynMSHUmU6besqtiw=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7 h1:2hRPrmiwPrp3fQX967rNJIhQPtiGXdlQWAxKbKw3VHA=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
@@ -243,6 +252,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5 h1:UImYN5qQ8tuGpGE16ZmjvcTtTw24zw1QAp/SlnNrZhI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gxed/hashland/keccakpg v0.0.1 h1:wrk3uMNaMxbXiHibbPO4S0ymqJMm41WiudyFSs7UnsU=
 github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJu4ZbSc=
 github.com/hashicorp/consul/api v1.3.0 h1:HXNYlRkkM/t+Y/Yhxtwcy02dlYwIaoxzvxPnS+cqy78=
@@ -436,6 +446,8 @@ github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je4
 github.com/onsi/gomega v1.20.1/go.mod h1:DtrZpjmvpn2mPm4YWQa0/ALMDj9v4YxLgojwPeREyVo=
 github.com/onsi/gomega v1.24.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
+github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 h1:rc3tiVYb5z54aKaDfakKn0dDjIyPpTtszkjuMzyt7ec=
+github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=
 github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7lZWlQw5UXuoo=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5 h1:ZCnq+JUrvXcDVhX/xRolRBZifmabN1HcS1wrPSvxhrU=
@@ -459,6 +471,7 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhD
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52 h1:RnWNS9Hlm8BIkjr6wx8li5abe0fr73jljLycdfemTp0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af h1:gu+uRPtBe88sKxUCEXRoeCvVG90TJmwhiqRpvdhQFng=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/ryanuber/columnize v2.1.0+incompatible h1:j1Wcmh8OrK4Q7GXY+V7SVSY8nUWQxHW5TkBe7YUl+2s=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da h1:p3Vo3i64TCLY7gIfzeQaUJ+kppEO5WQG3cL8iE8tGHU=
 github.com/schollz/closestmatch v2.1.0+incompatible h1:Uel2GXEpJqOWBrlyI+oY9LTiyyjYS17cCYRqP13/SHk=
@@ -541,6 +554,7 @@ go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/proto/otlp v0.7.0 h1:rwOQPCuKAKmwGKq2aVNnYIibI6wnV7EvzgfTCzcdGg8=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/dig v1.15.0/go.mod h1:pKHs0wMynzL6brANhB2hLMro+zalv1osARTviTcqHLM=
 go.uber.org/fx v1.18.2/go.mod h1:g0V1KMQ66zIRk8bLu3Ea5Jt2w/cHlOIp4wdRsgh0JaY=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
@@ -691,6 +705,7 @@ google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
@@ -707,6 +722,7 @@ google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/cheggaaa/pb.v1 v1.0.25 h1:Ev7yu1/f6+d+b3pi5vPdRPc6nNtP1umSfcWiEfRqv6I=

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	TxManagerConfig txmgr.Config
 	From            common.Address
 	SignerFnFactory opcrypto.SignerFactory
+	DaRpc           string
+	NamespaceId     string
 
 	// RollupConfig is queried at startup
 	Rollup *rollup.Config
@@ -53,6 +55,12 @@ type CLIConfig struct {
 	// a channel's timeout and sequencing window, to guarantee safe inclusion of
 	// a channel on L1.
 	SubSafetyMargin uint64
+
+	// DaRpc is the HTTP provider URL for the Data Availability node.
+	DaRpc string
+
+	// NamespaceId is the id of the namespace of the Data Availability node.
+	NamespaceId string
 
 	// PollInterval is the delay between querying L2 for more transaction
 	// and creating a new batch.
@@ -136,6 +144,8 @@ func NewConfig(ctx *cli.Context) CLIConfig {
 		L1EthRpc:                  ctx.GlobalString(flags.L1EthRpcFlag.Name),
 		L2EthRpc:                  ctx.GlobalString(flags.L2EthRpcFlag.Name),
 		RollupRpc:                 ctx.GlobalString(flags.RollupRpcFlag.Name),
+		DaRpc:                     ctx.GlobalString(flags.DaRpcFlag.Name),
+		NamespaceId:               ctx.GlobalString(flags.NamespaceIdFlag.Name),
 		SubSafetyMargin:           ctx.GlobalUint64(flags.SubSafetyMarginFlag.Name),
 		PollInterval:              ctx.GlobalDuration(flags.PollIntervalFlag.Name),
 		NumConfirmations:          ctx.GlobalUint64(flags.NumConfirmationsFlag.Name),

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -34,11 +34,27 @@ var (
 		Required: true,
 		EnvVar:   opservice.PrefixEnvVar(envVarPrefix, "ROLLUP_RPC"),
 	}
+	DaRpcFlag = cli.StringFlag{
+		Name:     "da-rpc",
+		Usage:    "HTTP provider URL for DA node",
+		Required: true,
+		EnvVar:   opservice.PrefixEnvVar(envVarPrefix, "DA_RPC"),
+	}
+	NamespaceIdFlag = cli.StringFlag{
+		Name:     "namespace-id",
+		Usage:    "Namespace ID for DA node",
+		Required: true,
+		EnvVar:   opservice.PrefixEnvVar(envVarPrefix, "NAMESPACE_ID"),
+	}
 	SubSafetyMarginFlag = cli.Uint64Flag{
 		Name: "sub-safety-margin",
 		Usage: "The batcher tx submission safety margin (in #L1-blocks) to subtract " +
 			"from a channel's timeout and sequencing window, to guarantee safe inclusion " +
 			"of a channel on L1.",
+	}
+	MinL1TxSizeBytesFlag = cli.Uint64Flag{
+		Name:     "min-l1-tx-size-bytes",
+		Usage:    "The minimum size of a batch tx submitted to L1.",
 		Required: true,
 		EnvVar:   opservice.PrefixEnvVar(envVarPrefix, "SUB_SAFETY_MARGIN"),
 	}
@@ -121,6 +137,8 @@ var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	L2EthRpcFlag,
 	RollupRpcFlag,
+	DaRpcFlag,
+	NamespaceIdFlag,
 	SubSafetyMarginFlag,
 	PollIntervalFlag,
 	NumConfirmationsFlag,

--- a/op-batcher/go.mod
+++ b/op-batcher/go.mod
@@ -3,6 +3,8 @@ module github.com/ethereum-optimism/optimism/op-batcher
 go 1.18
 
 require (
+	github.com/celestiaorg/go-cnc v0.2.0
+	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
 	github.com/ethereum-optimism/optimism/op-node v0.10.13
 	github.com/ethereum-optimism/optimism/op-service v0.10.13
 	github.com/ethereum-optimism/optimism/op-signer v0.1.0
@@ -23,11 +25,11 @@ require (
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dyson/certman v0.3.0 // indirect
-	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 // indirect
 	github.com/ethereum-optimism/optimism/op-bindings v0.10.13 // indirect
 	github.com/fjl/memsize v0.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
@@ -89,6 +91,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
+	golang.org/x/net v0.0.0-20220920183852-bf014ff85ad5 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect

--- a/op-batcher/go.sum
+++ b/op-batcher/go.sum
@@ -71,6 +71,8 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/celestiaorg/go-cnc v0.2.0 h1:QBcWz1v6341r+5Urbr/eaCm9S8D2wwEwielKcwBc1Z4=
+github.com/celestiaorg/go-cnc v0.2.0/go.mod h1:CZBVUhQnJnAVcfQnnEAqREF+PNWr97m/BhJ5fp1K44Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -140,6 +142,8 @@ github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNV
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
@@ -502,10 +506,12 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220920183852-bf014ff85ad5 h1:KafLifaRFIuSJ5C+7CyFJOF9haxKNC1CEIDk8GX6X0k=
+golang.org/x/net v0.0.0-20220920183852-bf014ff85ad5/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -57,7 +57,9 @@ type L2API interface {
 
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, cfg *rollup.Config) *L2Verifier {
 	metrics := &testutils.TestDerivationMetrics{}
-	pipeline := derive.NewDerivationPipeline(log, cfg, l1, eng, metrics)
+	daConfig, err := rollup.NewDAConfig("http://localhost:26659", "e8e5f679bf7116cb")
+	require.NoError(t, err)
+	pipeline := derive.NewDerivationPipeline(log, cfg, l1, eng, daConfig, metrics)
 	pipeline.Reset()
 
 	rollupNode := &L2Verifier{

--- a/op-node/da/da_celestia.go
+++ b/op-node/da/da_celestia.go
@@ -1,0 +1,50 @@
+package da
+
+import (
+	"context"
+	"time"
+
+	"github.com/celestiaorg/go-cnc"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// CelestiaDA satisfies DAChain interface
+type CelestiaDA struct {
+	cfg    *rollup.DAConfig
+	client *cnc.Client
+}
+
+func (c CelestiaDA) FetchFrame(ctx context.Context, ref FrameRef) (Frame, error) {
+	tx, err := c.client.NamespacedData(ctx, c.cfg.NamespaceId, ref.Number)
+	if err != nil {
+		return Frame{}, err
+	}
+	return Frame{tx[ref.Index], &FrameRef{
+		Number: ref.Number,
+		Index:  ref.Index,
+	}}, nil
+}
+
+func (c CelestiaDA) WriteFrame(ctx context.Context, data []byte) (FrameRef, error) {
+	return FrameRef{}, nil
+}
+
+func (c CelestiaDA) TxsByNumber(ctx context.Context, number uint64) (types.Transactions, error) {
+	return nil, nil
+}
+
+var _ DAChain = (&CelestiaDA{})
+
+// NewCelestiaDA creates a new Celestia client
+func NewCelestiaDA(cfg *rollup.DAConfig, log log.Logger) (*CelestiaDA, error) {
+	client, err := cnc.NewClient(cfg.Rpc, cnc.WithTimeout(90*time.Second))
+	if err != nil {
+		return nil, err
+	}
+	return &CelestiaDA{
+		cfg:    cfg,
+		client: client,
+	}, nil
+}

--- a/op-node/da/da_chain.go
+++ b/op-node/da/da_chain.go
@@ -1,0 +1,65 @@
+package da
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type L1TransactionFetcher interface {
+	TxsByNumber(ctx context.Context, number uint64) (types.Transactions, error)
+}
+
+// FrameRef contains data to lookup a frame by its reference
+type FrameRef struct {
+	Number uint64
+	Index  uint64
+}
+
+// Frame contains the frame data and it's reference
+// Frame needs to contain FrameRef because each implementation decides if
+// it's writing the entire frame to calldata or just the reference
+type Frame struct {
+	Data []byte
+	Ref  *FrameRef // nil if not yet confirmed on DAChain
+}
+
+// Encode serializes the frame for writing to the DASource
+// Optimism encode -> encodes the whole frame
+// Celestia encode -> encodes only the FrameRef, fails if FrameRef is nil
+func (f FrameRef) Encode() []byte { return nil }
+
+// Decode deserializes the frame data back from the DASource
+func (f FrameRef) Decode(data []byte) {}
+
+// FrameFetcher returns a Frame by it's reference
+type FrameFetcher interface {
+	FetchFrame(ctx context.Context, ref FrameRef) (Frame, error)
+}
+
+// FrameWriter writes a FrameRef to the DASource
+type FrameWriter interface {
+	WriteFrame(context.Context, []byte) (FrameRef, error)
+}
+
+// DAChain satisifes both read/write on the DASource
+type DAChain interface {
+	FrameFetcher
+	FrameWriter
+	L1TransactionFetcher
+}
+
+func DataFromDASource(ctx context.Context, block eth.BlockID, daSource DAChain, log log.Logger) []Frame {
+	refs, _ := daSource.TxsByNumber(ctx, block.Number)
+	var frames []Frame
+	for index := range refs {
+		frame, _ := daSource.FetchFrame(ctx, FrameRef{
+			Number: block.Number,
+			Index:  uint64(index),
+		})
+		frames = append(frames, frame)
+	}
+	return frames
+}

--- a/op-node/da/da_source_test.go
+++ b/op-node/da/da_source_test.go
@@ -1,0 +1,291 @@
+package da_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/da"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+)
+
+type calldataTest struct {
+	name string
+	txs  []testTx
+}
+
+type testTx struct {
+	to      *common.Address
+	dataLen int
+	author  *ecdsa.PrivateKey
+	good    bool
+	value   int
+}
+
+func (tx *testTx) Create(t *testing.T, signer types.Signer, rng *rand.Rand) *types.Transaction {
+	t.Helper()
+	out, err := types.SignNewTx(tx.author, signer, &types.DynamicFeeTx{
+		ChainID:   signer.ChainID(),
+		Nonce:     0,
+		GasTipCap: big.NewInt(2 * params.GWei),
+		GasFeeCap: big.NewInt(30 * params.GWei),
+		Gas:       100_000,
+		To:        tx.to,
+		Value:     big.NewInt(int64(tx.value)),
+		Data:      testutils.RandomData(rng, tx.dataLen),
+	})
+	require.NoError(t, err)
+	return out
+}
+
+type rpcHeader struct {
+	ParentHash  common.Hash      `json:"parentHash"`
+	UncleHash   common.Hash      `json:"sha3Uncles"`
+	Coinbase    common.Address   `json:"miner"`
+	Root        common.Hash      `json:"stateRoot"`
+	TxHash      common.Hash      `json:"transactionsRoot"`
+	ReceiptHash common.Hash      `json:"receiptsRoot"`
+	Bloom       eth.Bytes256     `json:"logsBloom"`
+	Difficulty  hexutil.Big      `json:"difficulty"`
+	Number      hexutil.Uint64   `json:"number"`
+	GasLimit    hexutil.Uint64   `json:"gasLimit"`
+	GasUsed     hexutil.Uint64   `json:"gasUsed"`
+	Time        hexutil.Uint64   `json:"timestamp"`
+	Extra       hexutil.Bytes    `json:"extraData"`
+	MixDigest   common.Hash      `json:"mixHash"`
+	Nonce       types.BlockNonce `json:"nonce"`
+
+	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
+	BaseFee *hexutil.Big `json:"baseFeePerGas" rlp:"optional"`
+
+	// untrusted info included by RPC, may have to be checked
+	Hash common.Hash `json:"hash"`
+}
+
+type rpcBlock struct {
+	rpcHeader
+	Transactions []*types.Transaction `json:"transactions"`
+}
+
+func randHash() (out common.Hash) {
+	rand.Read(out[:])
+	return out
+}
+
+func randBlock() *rpcBlock {
+	hdr := &types.Header{
+		ParentHash:  randHash(),
+		UncleHash:   randHash(),
+		Coinbase:    common.Address{},
+		Root:        randHash(),
+		TxHash:      randHash(),
+		ReceiptHash: randHash(),
+		Bloom:       types.Bloom{},
+		Difficulty:  big.NewInt(42),
+		Number:      big.NewInt(1234),
+		GasLimit:    0,
+		GasUsed:     0,
+		Time:        123456,
+		Extra:       make([]byte, 0),
+		MixDigest:   randHash(),
+		Nonce:       types.BlockNonce{},
+		BaseFee:     big.NewInt(100),
+	}
+	block := &rpcBlock{
+		rpcHeader: rpcHeader{
+			ParentHash:  hdr.ParentHash,
+			UncleHash:   hdr.UncleHash,
+			Coinbase:    hdr.Coinbase,
+			Root:        hdr.Root,
+			TxHash:      hdr.TxHash,
+			ReceiptHash: hdr.ReceiptHash,
+			Bloom:       eth.Bytes256(hdr.Bloom),
+			Difficulty:  *(*hexutil.Big)(hdr.Difficulty),
+			Number:      hexutil.Uint64(hdr.Number.Uint64()),
+			GasLimit:    hexutil.Uint64(hdr.GasLimit),
+			GasUsed:     hexutil.Uint64(hdr.GasUsed),
+			Time:        hexutil.Uint64(hdr.Time),
+			Extra:       hdr.Extra,
+			MixDigest:   hdr.MixDigest,
+			Nonce:       hdr.Nonce,
+			BaseFee:     (*hexutil.Big)(hdr.BaseFee),
+			Hash:        hdr.Hash(),
+		},
+		Transactions: []*types.Transaction{},
+	}
+	return block
+}
+
+type mockRPC struct {
+	mock.Mock
+}
+
+func (m *mockRPC) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	return m.MethodCalled("BatchCallContext", ctx, b).Get(0).([]error)[0]
+}
+
+func (m *mockRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
+	called := m.MethodCalled("CallContext", ctx, result, method, args)
+	err, ok := called.Get(0).(*error)
+	if !ok {
+		return nil
+	}
+	return *err
+}
+
+func (m *mockRPC) ExpectCallContext(t *testing.T, ctx context.Context, block *rpcBlock, err error, args ...any) {
+	m.Mock.On("CallContext", ctx, new(*rpcBlock),
+		"eth_getBlockByNumber", []any{block.Number.String(), true}).Run(func(args mock.Arguments) {
+		*args[1].(**rpcBlock) = block
+	}).Return([]error{nil})
+}
+
+func (m *mockRPC) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
+	called := m.MethodCalled("EthSubscribe", channel, args)
+	return called.Get(0).(*rpc.ClientSubscription), called.Get(1).([]error)[0]
+}
+
+func (m *mockRPC) Close() {
+	m.MethodCalled("Close")
+}
+
+var _ client.RPC = (*mockRPC)(nil)
+
+var testEthClientConfig = &sources.EthClientConfig{
+	ReceiptsCacheSize:     10,
+	TransactionsCacheSize: 10,
+	HeadersCacheSize:      10,
+	PayloadsCacheSize:     10,
+	MaxRequestsPerBatch:   20,
+	MaxConcurrentRequests: 10,
+	TrustRPC:              false,
+	MustBePostMerge:       false,
+	RPCProviderKind:       sources.RPCKindBasic,
+}
+
+// TestDataFromDASource creates some transactions from a specified template and asserts
+// that DataFromEVMTransactions properly filters and returns the data from the authorized transactions
+// inside the transaction set.
+func TestDataFromDASource(t *testing.T) {
+	inboxPriv := testutils.RandomKey()
+	batcherPriv := testutils.RandomKey()
+	rng := rand.New(rand.NewSource(1234))
+	cfg := &rollup.Config{
+		L1ChainID:         big.NewInt(100),
+		BatchInboxAddress: crypto.PubkeyToAddress(inboxPriv.PublicKey),
+	}
+	block := randBlock()
+	blockId := eth.BlockID{
+		Hash:   block.Hash,
+		Number: uint64(block.Number),
+	}
+	batcherAddr := crypto.PubkeyToAddress(batcherPriv.PublicKey)
+
+	altInbox := testutils.RandomAddress(rand.New(rand.NewSource(1234)))
+	altAuthor := testutils.RandomKey()
+
+	testCases := []calldataTest{
+		{
+			name: "simple",
+			txs:  []testTx{{to: &cfg.BatchInboxAddress, dataLen: 1234, author: batcherPriv, good: true}},
+		},
+		{
+			name: "other inbox",
+			txs:  []testTx{{to: &altInbox, dataLen: 1234, author: batcherPriv, good: false}}},
+		{
+			name: "other author",
+			txs:  []testTx{{to: &cfg.BatchInboxAddress, dataLen: 1234, author: altAuthor, good: false}}},
+		{
+			name: "inbox is author",
+			txs:  []testTx{{to: &cfg.BatchInboxAddress, dataLen: 1234, author: inboxPriv, good: false}}},
+		{
+			name: "author is inbox",
+			txs:  []testTx{{to: &batcherAddr, dataLen: 1234, author: batcherPriv, good: false}}},
+		{
+			name: "unrelated",
+			txs:  []testTx{{to: &altInbox, dataLen: 1234, author: altAuthor, good: false}}},
+		{
+			name: "contract creation",
+			txs:  []testTx{{to: nil, dataLen: 1234, author: batcherPriv, good: false}}},
+		{
+			name: "empty tx",
+			txs:  []testTx{{to: &cfg.BatchInboxAddress, dataLen: 0, author: batcherPriv, good: true}}},
+		{
+			name: "value tx",
+			txs:  []testTx{{to: &cfg.BatchInboxAddress, dataLen: 1234, value: 42, author: batcherPriv, good: true}}},
+		{
+			name: "empty block", txs: []testTx{},
+		},
+		{
+			name: "mixed txs",
+			txs: []testTx{
+				{to: &cfg.BatchInboxAddress, dataLen: 1234, value: 42, author: batcherPriv, good: true},
+				{to: &cfg.BatchInboxAddress, dataLen: 3333, value: 32, author: altAuthor, good: false},
+				{to: &cfg.BatchInboxAddress, dataLen: 2000, value: 22, author: batcherPriv, good: true},
+				{to: &altInbox, dataLen: 2020, value: 12, author: batcherPriv, good: false},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range testCases {
+		signer := cfg.L1Signer()
+		var expectedData []da.Frame
+		var txs []*types.Transaction
+		for i, tx := range tc.txs {
+			txs = append(txs, tx.Create(t, signer, rng))
+			if tx.good {
+				expectedData = append(expectedData, da.Frame{
+					Data: txs[i].Data(),
+					Ref: &da.FrameRef{
+						Number: blockId.Number,
+						Index:  uint64(len(block.Transactions)),
+					}})
+			}
+		}
+		block.Transactions = txs
+
+		m := new(mockRPC)
+		m.ExpectCallContext(
+			t,
+			ctx,
+			block,
+			nil,
+			[]any{
+				ctx,
+				&block,
+				"eth_getBlockByNumber",
+				[]any{
+					0,
+					true,
+				},
+			}...,
+		)
+
+		dab, err := sources.NewEthereumDA(testlog.Logger(t, log.LvlCrit), m, nil)
+		require.NoError(t, err)
+
+		out := da.DataFromDASource(ctx, blockId, dab, testlog.Logger(t, log.LvlCrit))
+		require.ElementsMatch(t, expectedData, out)
+	}
+}

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -37,6 +37,12 @@ var (
 		Usage:  "Rollup chain parameters",
 		EnvVar: prefixEnvVar("ROLLUP_CONFIG"),
 	}
+	NamespaceId = cli.StringFlag{
+		Name:   "namespace-id",
+		Usage:  "Namespace ID for DA node",
+		Value:  "e8e5f679bf7116cb",
+		EnvVar: prefixEnvVar("NAMESPACE_ID"),
+	}
 	Network = cli.StringFlag{
 		Name:   "network",
 		Usage:  fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
@@ -46,6 +52,12 @@ var (
 		Name:   "rpc.addr",
 		Usage:  "RPC listening address",
 		EnvVar: prefixEnvVar("RPC_ADDR"),
+	}
+	DaRPC = cli.StringFlag{
+		Name:   "da-rpc",
+		Usage:  "Data Availability RPC",
+		Value:  "http://da:26659",
+		EnvVar: prefixEnvVar("DA_RPC"),
 	}
 	RPCListenPort = cli.IntFlag{
 		Name:   "rpc.port",
@@ -196,6 +208,8 @@ var requiredFlags = []cli.Flag{
 
 var optionalFlags = append([]cli.Flag{
 	RollupConfig,
+	DaRPC,
+	NamespaceId,
 	Network,
 	L1TrustRPC,
 	L1RPCProviderKind,

--- a/op-node/go.mod
+++ b/op-node/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
+	github.com/celestiaorg/go-cnc v0.2.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/ethereum-optimism/optimism/op-bindings v0.10.13
 	github.com/ethereum-optimism/optimism/op-chain-ops v0.10.13
@@ -54,6 +55,7 @@ require (
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/op-node/go.sum
+++ b/op-node/go.sum
@@ -85,6 +85,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/celestiaorg/go-cnc v0.2.0 h1:QBcWz1v6341r+5Urbr/eaCm9S8D2wwEwielKcwBc1Z4=
+github.com/celestiaorg/go-cnc v0.2.0/go.mod h1:CZBVUhQnJnAVcfQnnEAqREF+PNWr97m/BhJ5fp1K44Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -182,6 +184,8 @@ github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNV
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
@@ -748,6 +752,7 @@ golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -20,6 +20,8 @@ type Config struct {
 
 	Rollup rollup.Config
 
+	DAConfig rollup.DAConfig
+
 	// P2PSigner will be used for signing off on published content
 	// if the node is sequencing and if the p2p stack is enabled
 	P2PSigner p2p.SignerSetup

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -38,7 +39,7 @@ type OpNode struct {
 	p2pSigner p2p.Signer            // p2p gogssip application messages will be signed with this signer
 	tracer    Tracer                // tracer to get events for testing/debugging
 	runCfg    *RuntimeConfig        // runtime configurables
-
+	DaCfg     *rollup.DAConfig      // Rpc for DA node
 	// some resources cannot be stopped directly, like the p2p gossipsub router (not our design),
 	// and depend on this ctx to be closed.
 	resourcesCtx   context.Context
@@ -74,6 +75,9 @@ func New(ctx context.Context, cfg *Config, log log.Logger, snapshotLog log.Logge
 }
 
 func (n *OpNode) init(ctx context.Context, cfg *Config, snapshotLog log.Logger) error {
+	if err := n.initDA(ctx, cfg); err != nil {
+		return err
+	}
 	if err := n.initTracer(ctx, cfg); err != nil {
 		return err
 	}
@@ -99,6 +103,11 @@ func (n *OpNode) init(ctx context.Context, cfg *Config, snapshotLog log.Logger) 
 	if err := n.initMetricsServer(ctx, cfg); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (n *OpNode) initDA(ctx context.Context, cfg *Config) error {
+	n.DaCfg = &cfg.DAConfig
 	return nil
 }
 
@@ -197,7 +206,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n.log, snapshotLog, n.metrics)
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.DaCfg, n.l2Source, n.l1Source, n, n.log, snapshotLog, n.metrics)
 
 	return nil
 }

--- a/op-node/rollup/da_config.go
+++ b/op-node/rollup/da_config.go
@@ -1,0 +1,32 @@
+package rollup
+
+import (
+	"encoding/hex"
+	"github.com/celestiaorg/go-cnc"
+	"time"
+)
+
+type DAConfig struct {
+	Rpc         string
+	NamespaceId [8]byte
+	Client      *cnc.Client
+}
+
+func NewDAConfig(rpc string, namespaceId string) (*DAConfig, error) {
+	var nid [8]byte
+	n, err := hex.DecodeString(namespaceId)
+	if err != nil {
+		return &DAConfig{}, err
+	}
+	copy(nid[:], n)
+	daClient, err := cnc.NewClient(rpc, cnc.WithTimeout(30*time.Second))
+	if err != nil {
+		return &DAConfig{}, err
+	}
+
+	return &DAConfig{
+		NamespaceId: nid,
+		Rpc:         rpc,
+		Client:      daClient,
+	}, nil
+}

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -1,7 +1,9 @@
 package derive
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -30,15 +32,16 @@ type DataSourceFactory struct {
 	log     log.Logger
 	cfg     *rollup.Config
 	fetcher L1TransactionFetcher
+	da      *rollup.DAConfig
 }
 
-func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1TransactionFetcher) *DataSourceFactory {
-	return &DataSourceFactory{log: log, cfg: cfg, fetcher: fetcher}
+func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1TransactionFetcher, da *rollup.DAConfig) *DataSourceFactory {
+	return &DataSourceFactory{log: log, cfg: cfg, fetcher: fetcher, da: da}
 }
 
 // OpenData returns a CalldataSourceImpl. This struct implements the `Next` function.
 func (ds *DataSourceFactory) OpenData(ctx context.Context, id eth.BlockID, batcherAddr common.Address) DataIter {
-	return NewDataSource(ctx, ds.log, ds.cfg, ds.fetcher, id, batcherAddr)
+	return NewDataSource(ctx, ds.log, ds.cfg, ds.fetcher, id, batcherAddr, ds.da)
 }
 
 // DataSource is a fault tolerant approach to fetching data.
@@ -53,13 +56,14 @@ type DataSource struct {
 	cfg     *rollup.Config // TODO: `DataFromEVMTransactions` should probably not take the full config
 	fetcher L1TransactionFetcher
 	log     log.Logger
+	da      *rollup.DAConfig
 
 	batcherAddr common.Address
 }
 
 // NewDataSource creates a new calldata source. It suppresses errors in fetching the L1 block if they occur.
 // If there is an error, it will attempt to fetch the result on the next call to `Next`.
-func NewDataSource(ctx context.Context, log log.Logger, cfg *rollup.Config, fetcher L1TransactionFetcher, block eth.BlockID, batcherAddr common.Address) DataIter {
+func NewDataSource(ctx context.Context, log log.Logger, cfg *rollup.Config, fetcher L1TransactionFetcher, block eth.BlockID, batcherAddr common.Address, da *rollup.DAConfig) DataIter {
 	_, txs, err := fetcher.InfoAndTxsByHash(ctx, block.Hash)
 	if err != nil {
 		return &DataSource{
@@ -73,7 +77,7 @@ func NewDataSource(ctx context.Context, log log.Logger, cfg *rollup.Config, fetc
 	} else {
 		return &DataSource{
 			open: true,
-			data: DataFromEVMTransactions(cfg, batcherAddr, txs, log.New("origin", block)),
+			data: DataFromEVMTransactions(cfg, da, batcherAddr, txs, log.New("origin", block)),
 		}
 	}
 }
@@ -85,7 +89,7 @@ func (ds *DataSource) Next(ctx context.Context) (eth.Data, error) {
 	if !ds.open {
 		if _, txs, err := ds.fetcher.InfoAndTxsByHash(ctx, ds.id.Hash); err == nil {
 			ds.open = true
-			ds.data = DataFromEVMTransactions(ds.cfg, ds.batcherAddr, txs, log.New("origin", ds.id))
+			ds.data = DataFromEVMTransactions(ds.cfg, ds.da, ds.batcherAddr, txs, log.New("origin", ds.id))
 		} else if errors.Is(err, ethereum.NotFound) {
 			return nil, NewResetError(fmt.Errorf("failed to open calldata source: %w", err))
 		} else {
@@ -104,8 +108,9 @@ func (ds *DataSource) Next(ctx context.Context) (eth.Data, error) {
 // DataFromEVMTransactions filters all of the transactions and returns the calldata from transactions
 // that are sent to the batch inbox address from the batch sender address.
 // This will return an empty array if no valid transactions are found.
-func DataFromEVMTransactions(config *rollup.Config, batcherAddr common.Address, txs types.Transactions, log log.Logger) []eth.Data {
+func DataFromEVMTransactions(config *rollup.Config, daConfig *rollup.DAConfig, batcherAddr common.Address, txs types.Transactions, log log.Logger) []eth.Data {
 	var out []eth.Data
+
 	l1Signer := config.L1Signer()
 	for j, tx := range txs {
 		if to := tx.To(); to != nil && *to == config.BatchInboxAddress {
@@ -119,8 +124,36 @@ func DataFromEVMTransactions(config *rollup.Config, batcherAddr common.Address, 
 				log.Warn("tx in inbox with unauthorized submitter", "index", j, "err", err)
 				continue // not an authorized batch submitter, ignore
 			}
-			out = append(out, tx.Data())
+
+			height, index, err := decodeETHData(tx.Data())
+			if err != nil {
+				log.Warn("unable to decode data pointer", "index", j, "err", err)
+				continue
+			}
+			data, err := daConfig.Client.NamespacedData(context.Background(), daConfig.NamespaceId, uint64(height))
+			if err != nil {
+				log.Warn("unable to retrieve data from da", "err", err)
+			}
+			out = append(out, data[index])
 		}
 	}
 	return out
+}
+
+// decodeETHData will decode the data retrieved from the EVM, this data
+// was previously posted from op-batcher and contains the block height
+// with transaction index of the SubmitPFD transaction to the DA.
+func decodeETHData(celestiaData []byte) (int64, int64, error) {
+	buf := bytes.NewBuffer(celestiaData)
+	var height int64
+	err := binary.Read(buf, binary.BigEndian, &height)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error deserializing height: %w", err)
+	}
+	var index int64
+	err = binary.Read(buf, binary.BigEndian, &index)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error deserializing index: %w", err)
+	}
+	return height, index, nil
 }

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -56,8 +56,8 @@ func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
 		l1r.datas = l1r.dataSrc.OpenData(ctx, next.ID(), l1r.prev.SystemConfig().BatcherAddr)
 	}
 
-	l1r.log.Debug("fetching next piece of data")
 	data, err := l1r.datas.Next(ctx)
+	l1r.log.Debug("fetching next piece of data", "data", data, "err", err)
 	if err == io.EOF {
 		l1r.datas = nil
 		return nil, io.EOF

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -66,11 +66,11 @@ type DerivationPipeline struct {
 }
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.
-func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetcher, engine Engine, metrics Metrics) *DerivationPipeline {
+func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetcher, engine Engine, da *rollup.DAConfig, metrics Metrics) *DerivationPipeline {
 
 	// Pull stages
 	l1Traversal := NewL1Traversal(log, cfg, l1Fetcher)
-	dataSrc := NewDataSourceFactory(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
+	dataSrc := NewDataSourceFactory(log, cfg, l1Fetcher, da) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -79,12 +79,12 @@ type Network interface {
 }
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
-func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
+func NewDriver(driverCfg *Config, cfg *rollup.Config, da *rollup.DAConfig, l2 L2Chain, l1 L1Chain, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
 	verifConfDepth := NewConfDepth(driverCfg.VerifierConfDepth, l1State.L1Head, l1)
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l2, metrics)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l2, da, metrics)
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	engine := derivationPipeline
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 )

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -61,11 +61,17 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, fmt.Errorf("failed to load l2 endpoints info: %w", err)
 	}
 
+	daCfg, err := rollup.NewDAConfig(flags.DaRPC.Value, flags.NamespaceId.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load da config: %w", err)
+	}
+
 	cfg := &node.Config{
-		L1:     l1Endpoint,
-		L2:     l2Endpoint,
-		Rollup: *rollupConfig,
-		Driver: *driverConfig,
+		L1:       l1Endpoint,
+		L2:       l2Endpoint,
+		Rollup:   *rollupConfig,
+		DAConfig: *daCfg,
+		Driver:   *driverConfig,
 		RPC: node.RPCConfig{
 			ListenAddr:  ctx.GlobalString(flags.RPCListenAddr.Name),
 			ListenPort:  ctx.GlobalInt(flags.RPCListenPort.Name),

--- a/op-node/sources/da_eth.go
+++ b/op-node/sources/da_eth.go
@@ -1,0 +1,65 @@
+package sources
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/sources/caching"
+
+	"github.com/ethereum-optimism/optimism/op-node/da"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// EthereumDA satisfies DAChain interface
+type EthereumDA struct {
+	client *L1Client
+}
+
+func (e EthereumDA) TxByBlockNumberAndIndex(ctx context.Context, number uint64, index uint64) (*types.Transaction, error) {
+	txs, err := e.TxsByNumber(ctx, number)
+	if err != nil {
+		return &types.Transaction{}, err
+	}
+	return txs[index], nil
+}
+
+func (e EthereumDA) FetchFrame(ctx context.Context, ref da.FrameRef) (da.Frame, error) {
+	// fetching the tx not from API or db - it will just be fetching from the
+	// existing types.Transactions by index
+	// return types.Transactions[index]
+	tx, err := e.TxByBlockNumberAndIndex(ctx, ref.Number, ref.Index)
+	if err != nil {
+		return da.Frame{}, err
+	}
+	return da.Frame{tx.Data(), &da.FrameRef{
+		Number: ref.Number,
+		Index:  ref.Index,
+	}}, nil
+}
+
+func (e EthereumDA) WriteFrame(ctx context.Context, data []byte) (da.FrameRef, error) {
+	return da.FrameRef{}, nil
+}
+
+func (e EthereumDA) TxsByNumber(ctx context.Context, number uint64) (types.Transactions, error) {
+	// TODO: caching
+	_, txs, err := e.client.InfoAndTxsByNumber(ctx, number)
+	return txs, err
+}
+
+var _ da.DAChain = (&EthereumDA{})
+
+// NewEthereumDA creates a new Ethereum DA
+func NewEthereumDA(log log.Logger, client client.RPC, metrics caching.Metrics) (*EthereumDA, error) {
+	ethClient, err := NewL1Client(
+		client, log, metrics, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindBasic),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &EthereumDA{
+		client: ethClient,
+	}, nil
+}

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -11,6 +11,13 @@ volumes:
 
 
 services:
+  da:
+    container_name: da
+    image: "celestia-local-devnet"
+    ports:
+      - "26657:26657"
+      - "26659:26659"
+
   l1:
     build:
       context: .
@@ -66,6 +73,8 @@ services:
       --metrics.port=7300
       --pprof.enabled
       --rpc.enable-admin
+      --da-rpc=http://da:26659
+      --namespace-id=e8e5f679bf7116cb
     ports:
       - "7545:8545"
       - "9003:9003"
@@ -134,6 +143,8 @@ services:
       OP_BATCHER_LOG_TERMINAL: "true"
       OP_BATCHER_PPROF_ENABLED: "true"
       OP_BATCHER_METRICS_ENABLED: "true"
+      OP_BATCHER_NAMESPACE_ID: "e8e5f679bf7116cb"
+      OP_BATCHER_DA_RPC: http://da:26659
 
   stateviz:
     build:


### PR DESCRIPTION
**Description**

This PR adds a new `pkg da`, which abstracts the Data Availability layer so that it be customized without changing the implementation a lot.

**Tests**

Existing tests for e.g. `calldata_source_test.go` have been updated to work with new pkg.

**Invariants**

No new assumptions are made, the changes are purely cosmetic in terms of the architecture.

**Additional context**

There is still work to be done to integrate the new pkg with the older changes related to changing the data layer to celestia.