### PR TITLE
feat(cmn): better config parsing for BSV2

### DIFF
--- a/.changeset/old-parrots-watch.md
+++ b/.changeset/old-parrots-watch.md
@@ -1,0 +1,9 @@
+---
+'@eth-optimism/replica-healthcheck': patch
+'@eth-optimism/message-relayer': patch
+'@eth-optimism/fault-detector': patch
+'@eth-optimism/chain-mon': patch
+'@eth-optimism/common-ts': minor
+---
+
+Updates BaseServiceV2 to have more flexible config parsing.

--- a/packages/chain-mon/src/drippie-mon/service.ts
+++ b/packages/chain-mon/src/drippie-mon/service.ts
@@ -42,7 +42,7 @@ export class DrippieMonService extends BaseServiceV2<
       },
       optionsSpec: {
         rpc: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for network where Drippie is deployed',
         },
         drippieAddress: {

--- a/packages/chain-mon/src/wd-mon/service.ts
+++ b/packages/chain-mon/src/wd-mon/service.ts
@@ -46,11 +46,11 @@ export class WithdrawalMonitor extends BaseServiceV2<Options, Metrics, State> {
       },
       optionsSpec: {
         l1RpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L1',
         },
         l2RpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L2',
         },
         startBlockNumber: {

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "yarn lint:check --fix",
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",
-    "test": "ts-mocha test/*.spec.ts",
+    "test": "ts-mocha test/**/*.spec.ts",
     "test:coverage": "echo 'no coverage'"
   },
   "keywords": [

--- a/packages/common-ts/src/base-service/config.ts
+++ b/packages/common-ts/src/base-service/config.ts
@@ -1,0 +1,24 @@
+import { Validator } from './validators'
+
+/**
+ * Cleans a configuration object.
+ *
+ * @param config Configuration object to clean.
+ * @param validators Mapping of config keys to validators.
+ * @returns Cleaned configuration object.
+ */
+export const cleanConfig = (
+  config: { [key: string]: any },
+  validators: { [key: string]: Validator<any> }
+) => {
+  const cleaned = {}
+  for (const [key, value] of Object.entries(config)) {
+    const validator = validators[key] || validators[key.toLowerCase()]
+    if (validator) {
+      cleaned[key] = validator(value)
+    } else {
+      cleaned[key] = value
+    }
+  }
+  return cleaned
+}

--- a/packages/common-ts/src/base-service/options.ts
+++ b/packages/common-ts/src/base-service/options.ts
@@ -1,7 +1,5 @@
-import { ValidatorSpec, Spec } from 'envalid'
-
 import { LogLevel } from '../common/logger'
-import { validators } from './validators'
+import { Validator, validators } from './validators'
 
 /**
  * Options for a service.
@@ -15,7 +13,7 @@ export type Options = {
  */
 export type OptionsSpec<TOptions extends Options> = {
   [P in keyof Required<TOptions>]: {
-    validator: (spec?: Spec<TOptions[P]>) => ValidatorSpec<TOptions[P]>
+    validator: Validator<TOptions[P]>
     desc: string
     default?: TOptions[P]
     public?: boolean
@@ -57,7 +55,7 @@ export const stdOptionsSpec: OptionsSpec<StandardOptions> = {
     public: true,
   },
   logLevel: {
-    validator: validators.logLevel,
+    validator: validators.LogLevel,
     desc: 'Log level',
     default: 'debug',
     public: true,

--- a/packages/common-ts/src/base-service/validators.ts
+++ b/packages/common-ts/src/base-service/validators.ts
@@ -1,66 +1,91 @@
-import {
-  str,
-  bool,
-  num,
-  email,
-  host,
-  port,
-  url,
-  json,
-  makeValidator,
-} from 'envalid'
+import { str, bool, num, email, host, port, url, json } from 'envalid'
 import { Provider } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
 import { ethers } from 'ethers'
 
 import { LogLevel, logLevels } from '../common'
 
-const provider = makeValidator<Provider>((input) => {
-  const parsed = url()._parse(input)
-  return new ethers.providers.JsonRpcProvider(parsed)
-})
-
-const jsonRpcProvider = makeValidator<ethers.providers.JsonRpcProvider>(
-  (input) => {
-    const parsed = url()._parse(input)
-    return new ethers.providers.JsonRpcProvider(parsed)
-  }
-)
-
-const staticJsonRpcProvider =
-  makeValidator<ethers.providers.StaticJsonRpcProvider>((input) => {
-    const parsed = url()._parse(input)
-    return new ethers.providers.StaticJsonRpcProvider(parsed)
-  })
-
-const wallet = makeValidator<Signer>((input) => {
-  if (!ethers.utils.isHexString(input)) {
-    throw new Error(`expected wallet to be a hex string`)
-  } else {
-    return new ethers.Wallet(input)
-  }
-})
-
-const logLevel = makeValidator<LogLevel>((input) => {
-  if (!logLevels.includes(input as LogLevel)) {
-    throw new Error(`expected log level to be one of ${logLevels.join(', ')}`)
-  } else {
-    return input as LogLevel
-  }
-})
+export type Validator<T> = (input: string | T) => T
 
 export const validators = {
-  str,
-  bool,
-  num,
-  email,
-  host,
-  port,
-  url,
-  json,
-  wallet,
-  provider,
-  jsonRpcProvider,
-  staticJsonRpcProvider,
-  logLevel,
+  str: (input: string) => {
+    return str()._parse(input)
+  },
+  bool: (input: string | boolean) => {
+    if (typeof input === 'boolean') {
+      return input
+    } else {
+      return bool()._parse(input)
+    }
+  },
+  num: (input: string | number) => {
+    if (typeof input === 'number') {
+      return input
+    } else {
+      return num()._parse(input)
+    }
+  },
+  email: (input: string) => {
+    return email()._parse(input)
+  },
+  host: (input: string) => {
+    return host()._parse(input)
+  },
+  port: (input: string) => {
+    return port()._parse(input)
+  },
+  url: (input: string) => {
+    return url()._parse(input)
+  },
+  json: (input: string | object) => {
+    if (typeof input === 'object') {
+      return input
+    } else {
+      return json()._parse(input)
+    }
+  },
+  Provider: (input: string | Provider) => {
+    if (typeof input === 'string') {
+      const parsed = url()._parse(input)
+      return new ethers.providers.JsonRpcProvider(parsed)
+    } else {
+      return input
+    }
+  },
+  JsonRpcProvider: (input: string | ethers.providers.JsonRpcProvider) => {
+    if (typeof input === 'string') {
+      const parsed = url()._parse(input)
+      return new ethers.providers.JsonRpcProvider(parsed)
+    } else {
+      return input
+    }
+  },
+  StaticJsonRpcProvider: (
+    input: string | ethers.providers.StaticJsonRpcProvider
+  ) => {
+    if (typeof input === 'string') {
+      const parsed = url()._parse(input)
+      return new ethers.providers.StaticJsonRpcProvider(parsed)
+    } else {
+      return input
+    }
+  },
+  Wallet: (input: string | Signer) => {
+    if (typeof input === 'string') {
+      if (!ethers.utils.isHexString(input)) {
+        throw new Error(`expected wallet to be a hex string`)
+      } else {
+        return new ethers.Wallet(input)
+      }
+    } else {
+      return input
+    }
+  },
+  LogLevel: (input: LogLevel) => {
+    if (!logLevels.includes(input as LogLevel)) {
+      throw new Error(`expected log level to be one of ${logLevels.join(', ')}`)
+    } else {
+      return input as LogLevel
+    }
+  },
 }

--- a/packages/common-ts/test/base-service/base-service-v2.spec.ts
+++ b/packages/common-ts/test/base-service/base-service-v2.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from '../setup'
+import { BaseServiceV2, StandardOptions, validators } from '../../src'
+
+interface TestServiceOptions {
+  foo: string
+  bar: number
+}
+
+class TestService extends BaseServiceV2<TestServiceOptions, any, any> {
+  constructor(options: Partial<TestServiceOptions & StandardOptions>) {
+    super({
+      name: 'test-service',
+      version: '1.0.0',
+      options,
+      optionsSpec: {
+        foo: {
+          validator: validators.str,
+          desc: 'a string value',
+        },
+        bar: {
+          validator: validators.num,
+          desc: 'a number value',
+        },
+      },
+      metricsSpec: {},
+    })
+  }
+
+  async main() {
+    // No-op
+  }
+}
+
+describe('BaseServiceV2', () => {
+  describe('constructor', () => {
+    describe('validation', () => {
+      it('should parse when all configuration is valid', () => {
+        const service = new TestService({
+          foo: 'abc',
+          bar: 123,
+        })
+
+        expect(service.options.foo).to.equal('abc')
+        expect(service.options.bar).to.equal(123)
+      })
+
+      it('should throw an error when a value is invalid', () => {
+        expect(() => {
+          new TestService({
+            foo: 'abc',
+            bar: '123' as any,
+          })
+        }).to.throw()
+      })
+
+      it('should throw an error when more than one value is invalid', () => {
+        expect(() => {
+          new TestService({
+            foo: 123 as any,
+            bar: '123' as any,
+          })
+        }).to.throw()
+      })
+
+      it('should throw an error when a value is missing', () => {
+        expect(() => {
+          new TestService({
+            bar: 123,
+          })
+        }).to.throw()
+      })
+
+      it('should throw an error when an extra value is given', () => {
+        expect(() => {
+          new TestService({
+            foo: 'abc',
+            bar: 123,
+            baz: 'xyz',
+          } as any)
+        }).to.throw()
+      })
+    })
+  })
+})

--- a/packages/common-ts/test/common/metrics.spec.ts
+++ b/packages/common-ts/test/common/metrics.spec.ts
@@ -1,13 +1,11 @@
 import request from 'supertest'
-// Setup
-import chai = require('chai')
-const expect = chai.expect
 
-import { Logger, Metrics, createMetricsServer } from '../src'
+import { expect } from '../setup'
+import { Logger, LegacyMetrics, createMetricsServer } from '../../src'
 
 describe('Metrics', () => {
   it('shoud serve metrics', async () => {
-    const metrics = new Metrics({
+    const metrics = new LegacyMetrics({
       prefix: 'test_metrics',
     })
     const registry = metrics.registry

--- a/packages/common-ts/test/setup.ts
+++ b/packages/common-ts/test/setup.ts
@@ -1,0 +1,3 @@
+// Setup
+import chai = require('chai')
+export const expect = chai.expect

--- a/packages/fault-detector/src/service.ts
+++ b/packages/fault-detector/src/service.ts
@@ -52,11 +52,11 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
       },
       optionsSpec: {
         l1RpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L1',
         },
         l2RpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L2',
         },
         startBatchIndex: {

--- a/packages/message-relayer/src/service.ts
+++ b/packages/message-relayer/src/service.ts
@@ -44,15 +44,15 @@ export class MessageRelayerService extends BaseServiceV2<
       options,
       optionsSpec: {
         l1RpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L1.',
         },
         l2RpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L2.',
         },
         l1Wallet: {
-          validator: validators.wallet,
+          validator: validators.Wallet,
           desc: 'Wallet used to interact with L1.',
         },
         fromL2TransactionIndex: {

--- a/packages/replica-healthcheck/src/service.ts
+++ b/packages/replica-healthcheck/src/service.ts
@@ -43,11 +43,11 @@ export class HealthcheckService extends BaseServiceV2<
       },
       optionsSpec: {
         referenceRpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L1',
         },
         targetRpcProvider: {
-          validator: validators.provider,
+          validator: validators.Provider,
           desc: 'Provider for interacting with L2',
         },
         onDivergenceWaitMs: {


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates config parsing for BaseServiceV2 to be more flexible and to allow for non-string input types. Makes it much easier to use BaseServiceV2 programmatically where you may want to supply the actual type instead of a string representation.