### PR TITLE
fix(specs): Use alias syntax to address long lines

### DIFF
--- a/specs/withdrawals.md
+++ b/specs/withdrawals.md
@@ -133,8 +133,8 @@ The Optimism Portal serves as both the entry and exit point to the Optimism L2. 
 the [DepositFeed](./deposits.md#deposit-contract) contract, and in addition provides the following interface for
 withdrawals:
 
-- [`WithdrawalTransaction` type](https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/contracts/libraries/Types.sol#L76-L83)
-- [`OutputRootProof` type](https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/contracts/libraries/Types.sol#L33-L38)
+- [`WithdrawalTransaction` type]
+- [`OutputRootProof` type]
 
 ```js
 interface OptimismPortal {
@@ -217,3 +217,6 @@ contracts if desired.
 | `FINALIZATION_PERIOD` | `604_800` | seconds |
 
 This `FINALIZATION_PERIOD` value is equivalent to 7 days.
+
+[`WithdrawalTransaction` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/contracts/libraries/Types.sol#L76-L83
+[`OutputRootProof` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/contracts/libraries/Types.sol#L33-L38


### PR DESCRIPTION
Fixes the linter error in [CI](https://circleci.com/gh/ethereum-optimism/optimism/440180).