### PR TITLE
ci, ctb: Reduce devnet sequencer drift

### DIFF
--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -2,7 +2,7 @@
   "l1ChainID": 900,
   "l2ChainID": 901,
   "l2BlockTime": 2,
-  "maxSequencerDrift": 300,
+  "maxSequencerDrift": 10,
   "sequencerWindowSize": 15,
   "channelTimeout": 40,
   "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",


### PR DESCRIPTION
The sequencer drift was larger than the sequencing window. This can cause reorgs. To fix I reduced the drift to 10s, which is lower than the 45 second sequencing window specified via the L1 block time and the window size.
