### PR TITLE
feat(ctb): add getting-started network

### DIFF
--- a/packages/contracts-bedrock/deploy-config/getting-started.json
+++ b/packages/contracts-bedrock/deploy-config/getting-started.json
@@ -1,0 +1,47 @@
+{
+  "numDeployConfirmations": 1,
+
+  "finalSystemOwner": "ADMIN",
+  "controller": "ADMIN",
+
+  "l1StartingBlockTag": "BLOCKHASH",
+
+  "l1ChainID": 5,
+  "l2ChainID": 42069,
+  "l2BlockTime": 2,
+
+  "maxSequencerDrift": 600,
+  "sequencerWindowSize": 3600,
+  "channelTimeout": 300,
+
+  "p2pSequencerAddress": "SEQUENCER",
+  "batchInboxAddress": "0xff00000000000000000000000000000000042069",
+  "batchSenderAddress": "BATCHER",
+
+  "l2OutputOracleSubmissionInterval": 120,
+  "l2OutputOracleStartingBlockNumber": 0,
+  "l2OutputOracleStartingTimestamp": "TIMESTAMP",
+
+  "l2OutputOracleProposer": "PROPOSER",
+  "l2OutputOracleChallenger": "ADMIN",
+
+  "finalizationPeriodSeconds": 12,
+
+  "proxyAdminOwner": "ADMIN",
+  "baseFeeVaultRecipient": "ADMIN",
+  "l1FeeVaultRecipient": "ADMIN",
+  "sequencerFeeVaultRecipient": "ADMIN",
+
+  "gasPriceOracleOverhead": 2100,
+  "gasPriceOracleScalar": 1000000,
+
+  "governanceTokenSymbol": "OP",
+  "governanceTokenName": "Optimism",
+  "governanceTokenOwner": "ADMIN",
+
+  "l2GenesisBlockGasLimit": "0x17D7840",
+  "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
+
+  "eip1559Denominator": 50,
+  "eip1559Elasticity": 10
+}

--- a/packages/contracts-bedrock/deploy-config/getting-started.ts
+++ b/packages/contracts-bedrock/deploy-config/getting-started.ts
@@ -1,0 +1,4 @@
+import { DeployConfig } from '../src/deploy-config'
+import config from './getting-started.json'
+
+export default config satisfies DeployConfig

--- a/packages/contracts-bedrock/hardhat.config.ts
+++ b/packages/contracts-bedrock/hardhat.config.ts
@@ -84,6 +84,12 @@ const config: HardhatUserConfig = {
       accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
       live: true,
     },
+    'getting-started': {
+      chainId: 5,
+      url: process.env.L1_RPC || '',
+      accounts: [process.env.PRIVATE_KEY_DEPLOYER || ethers.constants.HashZero],
+      live: true,
+    },
   },
   foundry: {
     buildInfo: true,


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds the getting-started network and configuration for the OP Stack Getting Started guide.