### PR TITLE
contracts-bedrock: relax semver solidity version

### DIFF
--- a/packages/contracts-bedrock/contracts/universal/Semver.sol
+++ b/packages/contracts-bedrock/contracts/universal/Semver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.0;
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 


### PR DESCRIPTION
**Description**

Allows contracts to import semver that are at least solidity version 0.8.0. This allows a wider range of contracts to be able to use the `Semver` contract, which doesn't need to be strictly at a higher version.

Fixes build issues in https://github.com/ethereum-optimism/optimism/pull/4879

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

