### PR TITLE
contracts-bedrock: be explicit with mintable erc721 token version

### DIFF
--- a/integration-tests/hardhat.config.ts
+++ b/integration-tests/hardhat.config.ts
@@ -39,6 +39,20 @@ const config: HardhatUserConfig = {
           },
         },
       },
+      {
+        version: '0.8.15',
+        settings: {
+          optimizer: { enabled: true, runs: 200 },
+          metadata: {
+            bytecodeHash: 'none',
+          },
+          outputSelection: {
+            '*': {
+              '*': ['storageLayout'],
+            },
+          },
+        },
+      },
     ],
   },
   gasReporter: {

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.15;
 
 import {
     ERC721Enumerable


### PR DESCRIPTION
**Description**

Previously any solidity version greater than or equal to 0.8.15 was allowed, this updates it such that exactly 0.8.15 is allowed. This matches the style of the other contracts in the system.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

