### PR TITLE
contracts-bedrock: fix the solc version for Types

### DIFF
--- a/packages/contracts-bedrock/contracts/libraries/Types.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 /**
  * @title Types


### PR DESCRIPTION
**Description**

This standardizes the solidity pragma to be `^0.8.0` for `Types`. All of the other libraries are set to this version, and it makes the code more portable for projects that want to import it. It will have no impact on the deployed bytecode.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

