### PR TITLE
proxyd: Add global flag to method overrides

### DIFF
--- a/.changeset/orange-panthers-impress.md
+++ b/.changeset/orange-panthers-impress.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/proxyd': minor
+---
+
+Add support for global method override rate limit

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -55,6 +55,7 @@ type RateLimitConfig struct {
 type RateLimitMethodOverride struct {
 	Limit    int          `toml:"limit"`
 	Interval TOMLDuration `toml:"interval"`
+	Global   bool         `toml:"global"`
 }
 
 type TOMLDuration time.Duration

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rs/cors v1.8.2
-	github.com/sethvargo/go-limiter v0.7.2
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/proxyd/go.sum
+++ b/proxyd/go.sum
@@ -451,8 +451,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sethvargo/go-limiter v0.7.2 h1:FgC4N7RMpV5gMrUdda15FaFTkQ/L4fEqM7seXMs4oO8=
-github.com/sethvargo/go-limiter v0.7.2/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/proxyd/integration_tests/testdata/frontend_rate_limit.toml
+++ b/proxyd/integration_tests/testdata/frontend_rate_limit.toml
@@ -16,6 +16,7 @@ backends = ["good"]
 [rpc_method_mappings]
 eth_chainId = "main"
 eth_foobar = "main"
+eth_baz = "main"
 
 [rate_limit]
 base_rate = 2
@@ -27,3 +28,8 @@ error_message = "over rate limit with special message"
 [rate_limit.method_overrides.eth_foobar]
 limit = 1
 interval = "1s"
+
+[rate_limit.method_overrides.eth_baz]
+limit = 1
+interval = "1s"
+global = true


### PR DESCRIPTION
This allows us to set global limits on individual RPCs that ignore any origin/user agent exemption.
