### PR TITLE
Develop -> Master

### DIFF
--- a/.changeset/kind-dodos-rest.md
+++ b/.changeset/kind-dodos-rest.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/common-ts': patch
----
-
-Fixes a minor bug where the provider name was incorrectly logged when using waitForProvider

--- a/.changeset/late-radios-suffer.md
+++ b/.changeset/late-radios-suffer.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': patch
----
-
-proxyd: Add req_id to log

--- a/.changeset/mean-dingos-shake.md
+++ b/.changeset/mean-dingos-shake.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
----
-
-Loosens the requirements for re-proving a withdrawal transaction in the `OptimismPortal`

--- a/.changeset/nervous-years-explain.md
+++ b/.changeset/nervous-years-explain.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/fault-detector': minor
----
-
-Updates the fault detector to support Bedrock networks.

--- a/.changeset/orange-panthers-impress.md
+++ b/.changeset/orange-panthers-impress.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': minor
----
-
-Add support for global method override rate limit

--- a/.changeset/quick-crabs-argue.md
+++ b/.changeset/quick-crabs-argue.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/sdk': patch
----
-
-Remove assert node builtin from sdk

--- a/.changeset/tame-lions-build.md
+++ b/.changeset/tame-lions-build.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/proxyd': minor
----
-
-Include nonce in sender rate limit

--- a/.changeset/tasty-adults-design.md
+++ b/.changeset/tasty-adults-design.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/common-ts': minor
----
-
-Add option to configure body parser

--- a/.changeset/thin-toes-remember.md
+++ b/.changeset/thin-toes-remember.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/l2geth': patch
----
-
-Has l2geth return a NonceToHigh response if the txn nonce is greater than the expected nonce.

--- a/.changeset/wet-files-knock.md
+++ b/.changeset/wet-files-knock.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/chain-mon': patch
----
-
-Added withdrawal monitoring to identify proven withdrawals not included in the L2ToL1MessagePasser's sentMessages mapping

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -30,10 +30,10 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.5.4",
     "@eth-optimism/contracts": "^0.5.40",
-    "@eth-optimism/contracts-bedrock": "0.11.3",
+    "@eth-optimism/contracts-bedrock": "0.11.4",
     "@eth-optimism/contracts-periphery": "^1.0.7",
     "@eth-optimism/core-utils": "0.12.0",
-    "@eth-optimism/sdk": "1.10.1",
+    "@eth-optimism/sdk": "1.10.2",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",

--- a/l2geth/CHANGELOG.md
+++ b/l2geth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.33
+
+### Patch Changes
+
+- 33acb7c6a: Has l2geth return a NonceToHigh response if the txn nonce is greater than the expected nonce.
+
 ## 0.5.32
 
 ### Patch Changes

--- a/l2geth/package.json
+++ b/l2geth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/l2geth",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "private": true,
   "devDependencies": {}
 }

--- a/op-node/rollup/derive/frame_test.go
+++ b/op-node/rollup/derive/frame_test.go
@@ -2,7 +2,15 @@ package derive
 
 import (
 	"bytes"
+	"io"
+	"math"
+	"math/rand"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func FuzzFrameUnmarshalBinary(f *testing.F) {
@@ -22,4 +30,218 @@ func FuzzParseFrames(f *testing.F) {
 			t.Fatal("must return data with a non-nil error")
 		}
 	})
+}
+
+func TestFrameMarshaling(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 16; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			frame := randomFrame(rng)
+			var data bytes.Buffer
+			require.NoError(t, frame.MarshalBinary(&data))
+
+			frame0 := new(Frame)
+			require.NoError(t, frame0.UnmarshalBinary(&data))
+			require.Equal(t, frame, frame0)
+		})
+	}
+}
+
+func TestFrameUnmarshalNoData(t *testing.T) {
+	frame0 := new(Frame)
+	err := frame0.UnmarshalBinary(bytes.NewReader([]byte{}))
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestFrameUnmarshalTruncated(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// 16 (channel_id) ++ 2 (frame_number) ++ 4 (frame_data_length) ++
+	// frame_data_length (frame_data) ++ 1 (is_last)
+	for _, tr := range []struct {
+		desc     string
+		truncate func([]byte) []byte
+		genData  bool // whether data should be generated
+	}{
+		{
+			desc: "truncate-channel_id-half",
+			truncate: func(data []byte) []byte {
+				return data[:8]
+			},
+		},
+		{
+			desc: "truncate-frame_number-full",
+			truncate: func(data []byte) []byte {
+				return data[:16]
+			},
+		},
+		{
+			desc: "truncate-frame_number-half",
+			truncate: func(data []byte) []byte {
+				return data[:17]
+			},
+		},
+		{
+			desc: "truncate-frame_data_length-full",
+			truncate: func(data []byte) []byte {
+				return data[:18]
+			},
+		},
+		{
+			desc: "truncate-frame_data_length-half",
+			truncate: func(data []byte) []byte {
+				return data[:20]
+			},
+			genData: true, // for non-zero frame_data_length
+		},
+		{
+			desc: "truncate-frame_data-full",
+			truncate: func(data []byte) []byte {
+				return data[:22]
+			},
+			genData: true, // for non-zero frame_data_length
+		},
+		{
+			desc: "truncate-frame_data-last-byte",
+			truncate: func(data []byte) []byte {
+				return data[:len(data)-2]
+			},
+			genData: true,
+		},
+		{
+			desc: "truncate-is_last",
+			truncate: func(data []byte) []byte {
+				return data[:len(data)-1]
+			},
+			genData: true,
+		},
+	} {
+		t.Run(tr.desc, func(t *testing.T) {
+			var opts []frameOpt
+			if !tr.genData {
+				opts = []frameOpt{frameWithDataLen(0)}
+			}
+			frame := randomFrame(rng, opts...)
+			var data bytes.Buffer
+			require.NoError(t, frame.MarshalBinary(&data))
+
+			tdata := tr.truncate(data.Bytes())
+
+			frame0 := new(Frame)
+			err := frame0.UnmarshalBinary(bytes.NewReader(tdata))
+			require.Error(t, err)
+			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		})
+	}
+}
+
+func TestFrameUnmarshalInvalidIsLast(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	frame := randomFrame(rng, frameWithDataLen(16))
+	var data bytes.Buffer
+	require.NoError(t, frame.MarshalBinary(&data))
+
+	idata := data.Bytes()
+	idata[len(idata)-1] = 2 // invalid is_last
+
+	frame0 := new(Frame)
+	err := frame0.UnmarshalBinary(bytes.NewReader(idata))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid byte")
+}
+
+func TestParseFramesNoData(t *testing.T) {
+	frames, err := ParseFrames(nil)
+	require.Empty(t, frames)
+	require.Error(t, err)
+}
+
+func TestParseFramesInvalidVer(t *testing.T) {
+	frames, err := ParseFrames([]byte{42})
+	require.Empty(t, frames)
+	require.Error(t, err)
+}
+
+func TestParseFrames(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	numFrames := rng.Intn(16) + 1
+	frames := make([]Frame, 0, numFrames)
+	for i := 0; i < numFrames; i++ {
+		frames = append(frames, *randomFrame(rng))
+	}
+	data, err := txMarshalFrames(frames)
+	require.NoError(t, err)
+
+	frames0, err := ParseFrames(data)
+	require.NoError(t, err)
+	require.Equal(t, frames, frames0)
+}
+
+func TestParseFramesTruncated(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	numFrames := rng.Intn(16) + 1
+	frames := make([]Frame, 0, numFrames)
+	for i := 0; i < numFrames; i++ {
+		frames = append(frames, *randomFrame(rng))
+	}
+	data, err := txMarshalFrames(frames)
+	require.NoError(t, err)
+	data = data[:len(data)-2] // truncate last 2 bytes
+
+	frames0, err := ParseFrames(data)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Empty(t, frames0)
+}
+
+// txMarshalFrames creates the tx payload for the given frames, i.e., it first
+// writes the version byte to a buffer and then appends all binary-marshaled
+// frames.
+func txMarshalFrames(frames []Frame) ([]byte, error) {
+	var data bytes.Buffer
+	if err := data.WriteByte(DerivationVersion0); err != nil {
+		return nil, err
+	}
+	for _, frame := range frames {
+		if err := frame.MarshalBinary(&data); err != nil {
+			return nil, err
+		}
+	}
+	return data.Bytes(), nil
+}
+
+func randomFrame(rng *rand.Rand, opts ...frameOpt) *Frame {
+	var id ChannelID
+	_, err := rng.Read(id[:])
+	if err != nil {
+		panic(err)
+	}
+
+	frame := &Frame{
+		ID:          id,
+		FrameNumber: uint16(rng.Int31n(math.MaxUint16 + 1)),
+		IsLast:      testutils.RandomBool(rng),
+	}
+
+	// evaulaute options
+	for _, opt := range opts {
+		opt(rng, frame)
+	}
+
+	// default if no option set field
+	if frame.Data == nil {
+		datalen := int(rng.Intn(MaxFrameLen + 1))
+		frame.Data = testutils.RandomData(rng, datalen)
+	}
+
+	return frame
+}
+
+type frameOpt func(*rand.Rand, *Frame)
+
+func frameWithDataLen(l int) frameOpt {
+	return func(rng *rand.Rand, frame *Frame) {
+		frame.Data = testutils.RandomData(rng, l)
+	}
 }

--- a/op-node/testutils/random.go
+++ b/op-node/testutils/random.go
@@ -14,6 +14,13 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+func RandomBool(rng *rand.Rand) bool {
+	if b := rng.Intn(2); b == 0 {
+		return false
+	}
+	return true
+}
+
 func RandomHash(rng *rand.Rand) (out common.Hash) {
 	rng.Read(out[:])
 	return

--- a/packages/actor-tests/CHANGELOG.md
+++ b/packages/actor-tests/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @eth-optimism/actor-tests
 
+## 0.0.19
+
+### Patch Changes
+
+- Updated dependencies [3c22333b8]
+- Updated dependencies [5372c9f5b]
+  - @eth-optimism/contracts-bedrock@0.11.4
+  - @eth-optimism/sdk@1.10.2
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/actor-tests/package.json
+++ b/packages/actor-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/actor-tests",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A library and suite of tests to stress test Optimism Bedrock.",
   "license": "MIT",
   "author": "",
@@ -18,9 +18,9 @@
     "test:coverage": "yarn test"
   },
   "dependencies": {
-    "@eth-optimism/contracts-bedrock": "0.11.3",
+    "@eth-optimism/contracts-bedrock": "0.11.4",
     "@eth-optimism/core-utils": "^0.12.0",
-    "@eth-optimism/sdk": "^1.10.1",
+    "@eth-optimism/sdk": "^1.10.2",
     "@types/chai": "^4.2.18",
     "@types/chai-as-promised": "^7.1.4",
     "async-mutex": "^0.3.2",

--- a/packages/chain-mon/CHANGELOG.md
+++ b/packages/chain-mon/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @eth-optimism/drippie-mon
 
+## 0.1.1
+
+### Patch Changes
+
+- 0515a7841: Added withdrawal monitoring to identify proven withdrawals not included in the L2ToL1MessagePasser's sentMessages mapping
+- Updated dependencies [0e179781b]
+- Updated dependencies [5372c9f5b]
+- Updated dependencies [4ae94b412]
+  - @eth-optimism/common-ts@0.8.0
+  - @eth-optimism/sdk@1.10.2
+
 ## 0.4.3
 
 ### Patch Changes

--- a/packages/chain-mon/package.json
+++ b/packages/chain-mon/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/chain-mon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "[Optimism] Chain monitoring services",
   "main": "dist/index",
   "types": "dist/index",
@@ -32,10 +32,10 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.7.1",
+    "@eth-optimism/common-ts": "0.8.0",
     "@eth-optimism/contracts-periphery": "1.0.7",
     "@eth-optimism/core-utils": "0.12.0",
-    "@eth-optimism/sdk": "1.10.1",
+    "@eth-optimism/sdk": "1.10.2",
     "ethers": "^5.7.0",
     "@types/dateformat": "^5.0.0",
     "chai-as-promised": "^7.1.1",

--- a/packages/common-ts/CHANGELOG.md
+++ b/packages/common-ts/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @eth-optimism/common-ts
 
+## 0.8.0
+
+### Minor Changes
+
+- 4ae94b412: Add option to configure body parser
+
+### Patch Changes
+
+- 0e179781b: Fixes a minor bug where the provider name was incorrectly logged when using waitForProvider
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/common-ts",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "[Optimism] Advanced typescript tooling used by various services",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/contracts-bedrock/CHANGELOG.md
+++ b/packages/contracts-bedrock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @eth-optimism/contracts-bedrock
 
+## 0.11.4
+
+### Patch Changes
+
+- 3c22333b8: Loosens the requirements for re-proving a withdrawal transaction in the `OptimismPortal`
+
 ## 0.11.3
 
 ### Patch Changes

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/contracts-bedrock",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Contracts for Optimism Specs",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "devDependencies": {
-    "@eth-optimism/contracts-bedrock": "0.11.3",
+    "@eth-optimism/contracts-bedrock": "0.11.4",
     "@eth-optimism/core-utils": "^0.12.0",
     "@eth-optimism/hardhat-deploy-config": "^0.2.5",
     "@ethersproject/hardware-wallets": "^5.7.0",

--- a/packages/data-transport-layer/CHANGELOG.md
+++ b/packages/data-transport-layer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # data transport layer
 
+## 0.5.53
+
+### Patch Changes
+
+- Updated dependencies [0e179781b]
+- Updated dependencies [4ae94b412]
+  - @eth-optimism/common-ts@0.8.0
+
 ## 0.5.52
 
 ### Patch Changes

--- a/packages/data-transport-layer/package.json
+++ b/packages/data-transport-layer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/data-transport-layer",
-  "version": "0.5.52",
+  "version": "0.5.53",
   "description": "[Optimism] Service for shuttling data from L1 into L2",
   "main": "dist/index",
   "types": "dist/index",
@@ -36,7 +36,7 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.7.1",
+    "@eth-optimism/common-ts": "0.8.0",
     "@eth-optimism/contracts": "0.5.40",
     "@eth-optimism/core-utils": "0.12.0",
     "@ethersproject/providers": "^5.7.0",

--- a/packages/fault-detector/CHANGELOG.md
+++ b/packages/fault-detector/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @eth-optimism/fault-detector
 
+## 0.6.0
+
+### Minor Changes
+
+- b004d1ad4: Updates the fault detector to support Bedrock networks.
+
+### Patch Changes
+
+- Updated dependencies [0e179781b]
+- Updated dependencies [5372c9f5b]
+- Updated dependencies [4ae94b412]
+  - @eth-optimism/common-ts@0.8.0
+  - @eth-optimism/sdk@1.10.2
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/fault-detector/package.json
+++ b/packages/fault-detector/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/fault-detector",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "[Optimism] Service for detecting faulty L2 output proposals",
   "main": "dist/index",
   "types": "dist/index",
@@ -47,10 +47,10 @@
     "ts-node": "^10.9.1"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "^0.7.0",
+    "@eth-optimism/common-ts": "^0.8.0",
     "@eth-optimism/contracts": "^0.5.40",
     "@eth-optimism/core-utils": "^0.12.0",
-    "@eth-optimism/sdk": "^1.9.0",
+    "@eth-optimism/sdk": "^1.10.2",
     "@ethersproject/abstract-provider": "^5.7.0"
   }
 }

--- a/packages/message-relayer/CHANGELOG.md
+++ b/packages/message-relayer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @eth-optimism/message-relayer
 
+## 0.5.28
+
+### Patch Changes
+
+- Updated dependencies [0e179781b]
+- Updated dependencies [5372c9f5b]
+- Updated dependencies [4ae94b412]
+  - @eth-optimism/common-ts@0.8.0
+  - @eth-optimism/sdk@1.10.2
+
 ## 0.5.27
 
 ### Patch Changes

--- a/packages/message-relayer/package.json
+++ b/packages/message-relayer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/message-relayer",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "[Optimism] Service for automatically relaying L2 to L1 transactions",
   "main": "dist/index",
   "types": "dist/index",
@@ -31,9 +31,9 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.7.1",
+    "@eth-optimism/common-ts": "0.8.0",
     "@eth-optimism/core-utils": "0.12.0",
-    "@eth-optimism/sdk": "1.10.1",
+    "@eth-optimism/sdk": "1.10.2",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/replica-healthcheck/CHANGELOG.md
+++ b/packages/replica-healthcheck/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @eth-optimism/replica-healthcheck
 
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [0e179781b]
+- Updated dependencies [4ae94b412]
+  - @eth-optimism/common-ts@0.8.0
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/replica-healthcheck",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "[Optimism] Service for monitoring the health of replica nodes",
   "main": "dist/index",
   "types": "dist/index",
@@ -32,7 +32,7 @@
     "url": "https://github.com/ethereum-optimism/optimism.git"
   },
   "dependencies": {
-    "@eth-optimism/common-ts": "0.7.1",
+    "@eth-optimism/common-ts": "0.8.0",
     "@eth-optimism/core-utils": "0.12.0",
     "@ethersproject/abstract-provider": "^5.7.0"
   },

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @eth-optimism/sdk
 
+## 1.10.2
+
+### Patch Changes
+
+- 5372c9f5b: Remove assert node builtin from sdk
+- Updated dependencies [3c22333b8]
+  - @eth-optimism/contracts-bedrock@0.11.4
+
 ## 1.10.1
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",
@@ -50,7 +50,7 @@
   "dependencies": {
     "@eth-optimism/contracts": "0.5.40",
     "@eth-optimism/core-utils": "0.12.0",
-    "@eth-optimism/contracts-bedrock": "0.11.3",
+    "@eth-optimism/contracts-bedrock": "0.11.4",
     "lodash": "^4.17.21",
     "merkletreejs": "^0.2.27",
     "rlp": "^2.2.7"

--- a/proxyd/CHANGELOG.md
+++ b/proxyd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @eth-optimism/proxyd
 
+## 3.14.0
+
+### Minor Changes
+
+- 9cc39bcfa: Add support for global method override rate limit
+- 30db32862: Include nonce in sender rate limit
+
+### Patch Changes
+
+- b9bb1a98a: proxyd: Add req_id to log
+
 ## 3.13.0
 
 ### Minor Changes

--- a/proxyd/package.json
+++ b/proxyd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/proxyd",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "private": true,
   "dependencies": {}
 }


### PR DESCRIPTION
- op-node: implement EngineControl interface
- op-node: implement metered EngineControl, a wrapper to capture engine building metrics
- op-node: refactor sequencer to use EngineControl, test sequencing with chaos-monkey-like test
- feat: l1 and l2 source validation
- fix(cmn): waitForProvider logging bug
- ctb: Regenesis internal devnet
- INF-22 explicity set chainId in op-signer SendTransaction
- INF-22 updates batcher and proposer to pass in chainId to signer client
- fix: separation of concerns
- fix: tests and nits :test_tube:
- fix: more nits :bug:
- Draft garbage batch test
- Add random bytes `GarbageKind`; Remove `MALFORM_RLP` & `INVALID_COMPRESSION` are WIP
- chore: `math/rand` -> `crypto/rand` per Semgrep
- Add `GarbageChannelOut` test harness; Invalid compression & malformed block RLP tests
- Specify `derive.BatchData` key for linter
- Add `eof-crawler` CLI
- Follow Go doc comment conventions
- fix: hex big util
- Use `geth dump` rather than `geth snapshot dump`
- Edit usage to instruct user to run the binary with a higher `opt-level`
- semgrep
- Go with geth snapshot method; prune deps for old IPC method
- Address Mark's feedback
- Compile time checks for `ChannelOutApi` interface implementation
- nit: Change interface names
- fix engine_executePayloadV1 -> engine_newPayloadV1
- Move `ChannelOutIface` to `op-e2e/actions` package
- fix: comment nit :sparkles:
- op-service: Migrate tx manager package
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- go mod tidy
- fix batch-deriv-chain.svg
- op-proposer: Move to shared signer setup & simplified init
- op-node: Fix maxDataSize calculation in ChannelOut.OutputFrame
- op-node: Let ChannelOut.AddBlock, OutputFrame return size, frame number
- op-batcher,e2e: Add config parameters for improved batcher txs
- op-batcher: Rework batcher to fill up txs
- Make ferris sad; Iterate over Geth DB directly
- Semgrep + README
- op-batcher: Improve documentation regarding full channels
- op-e2e: Update GarbageChannelOut to new ChannelOut interface
- op-batcher: Improve logging
- Remove old gitignore
- op-e2e: Increase TestFees timeout from 3->4 L1 blocks
- test(ctb): Test for both legacy and new events together
- ci: Bump the timeout on testing and coverage generation
- Break out binary / indexing logic into separate packages
- Bubble up errors
- op-chain-ops: update script to submit pending withdrawals
- op-chain-ops: more withdrawals development
- op-chain-ops: go mod tidy
- feat(ctp): audited Drippie mainnet deployment
- op-chain-ops: cleanup
- op-chain-ops: cleanup
- op-chain-ops: more fixes
- op-chain-ops: update go.sum
- op-chain-ops: lint fix
- op-chain-ops: refactor, better comments
- op-chain-ops: fix test
- op-batcher: Track latest block hash for reorg detection
- op-batcher: Fix channelBuilder.OutputFrames to check for full channel
- ops-bedrock: Add new batcher env vars to docker-compose.yml
- gomods: fix
- gomod: commit
- op-batcher: better error handling logic
- op-batcher: use default 2gwei instead of error
- op-node: Fix disable p2p
- feat(l2g): properly return NonceTooHigh
- op-node: Add ChannelOut.InputBytes
- op-batcher: channelBuilder: Use ChannelOut.InputBytes
- op-e2e: Bump timeouts of TestWithdrawals
- op-batcher: Improve code doc of channel builder & manager
- op-batcher: Fix channelManager.Clean - set tip to zero
- feat(ctp): ATST 1.1.0 artifacts
- op-node: ChannelOut.Reset: simplify logic
- op-batcher: Add channelBuilder.InputBytes and improve docs
- op-batcher: Fix channelManager.addBlocks
- ops-bedrock: Set batcher target tx size to 624 bytes
- op-batcher: Fix typo in driver.go
- test(ctb): Add check for address in expectEmit
- test(ctb): Add bridge tests for the new bridge interface
- proxyd: Add missing req_id to log entry
- op-batcher: Fix channelManager.nextTxData, always prepend 0
- proxyd: Add nonce to sender-based rate limit
- migrate: clean up
- Typo
- doc: fix mismatched parenthesis
- maint(ctb): clean up Alias and Bytes tests
- maint(ctb): clean up Hashing tests
- maint(ctb): clean up various test files
- op-batcher: Simplify configs, dedup init, & simplify init code
- ctp: add foundry tests for Drippie
- contracts-periphery: address review
- contracts-periphery: clean up foundry tests
- allow body parser options to be passed in
- op-node: ensure sequencer selects L1 origin within sequencer time drift and use conf depth util
- feat(mon): set up chain-mon package
- Update packages/common-ts/src/base-service/base-service-v2.ts
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- contracts-bedrock: standardize internal function naming
- ctp: delete hardhat drippie tests
- contracts-periphery: foundry tests for drip checks
- ctp: remove hh dripcheck tests
- ctp: remove unused deps
- contracts-bedrock: fix function name
- :zap: add node_modules and .vscode to dockerignore
- feat(specs): language changes
- fix(specs): Lint
- fix(specs): Lint is still not happy :-(
- ctp: remove final hh tests
- ctp: cleanup foundry test setUp
- ctp: more strict assertions on expect emit
- txmgr: Flatten + simplify
- ctp: fix depcheck
- fix(ctb): Add _emit functions to support legacy events
- fix(ctb): Refactor and fix L1 bridge tests
- chore: make bindings
- fix(sdk): Accept legacy event on deposit-eth test
- sdk: Improve readability of deposit-erc20 output
- test(sdk): bump gas limit up to fix failed message
- Fix ReadStorageAt for 0-prefixed values
- Switch to ToInt
- op-heartbeat: allow more versions in heartbeat service
- chore(op-node): Remove duplicated word in comment.
- op-heartbeat: fix formatting
- feat(mon): Add withdrawal monitor to chain-mon
- chore(deps): bump http-cache-semantics from 4.1.0 to 4.1.1
- contracts-bedrock: add gov token to predeploys contract
- fix(spec): Withdrawal calls are not forwarded during the proof verification call.
- fix(spec): Add missing call to engine_newPayload
- Remove node built in from sdk
- chore(op-node): Fix two typos
- specs: Fix typo & link in withdrawals section
- op-node: Add L1BlockRefFromHeader
- op-batcher: Pass L1BlockRef to TxData in batcher loop
- op-batcher: Watch channel timeout
- op-batcher: Add channel submission timeout parameter
- op-batcher: Add timeout trigger logging to channelManager
- op-batcher: Add data size logging to tx manager
- op-batcher: Fix BatchSubmitter after rebase
- op-batcher: channelManager: Rename addBlocks -> processBlocks
- op-node: Export BlockToBatch and add ChannelOut.AddBatch
- op-batcher: Start SequencerWindow timeout tracking (WIP)
- op-batcher: Add rollup cfg to Config and query during startup
- op-batcher: Remove unused parseAddress
- op-batcher: Rework batcher to use submission safety margin
- op-batcher: Remove now-unused BatchSubmitter methods
- op-2e2: Bump timeout in TestMixedWithdrawalValidity
- op-batcher: Remove unused lastKnownL1Time
- ops-bedrock: Remove unused env var SEQUENCER_BATCH_INBOX_ADDRESS
- changeset
- op-node: Add eth.HeaderBlockInfo
- op-node: Remove L1BlockRefFromHeader
- op-batcher: Rename TriggerTimeout -> CheckTimeout
- op-batcher: Reorder channel builder types
- Update bridges.md
- maint: add CITATION file
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- op-node: Log on L1 Info deposit mismatch
- feat(fd): support Bedrock networks
- adds certman package with k8s volume reload fixes
- update op-signer to use internal certman
- updates op-service with new op-signer client version
- fix(specs): Use alias syntax to address long lines
- contracts-bedrock: add TransferOnion contract
- ci, ctb: Reduce devnet sequencer drift
- docs: Add note about small contributions
- op-chain-ops: Ignore messages from sources other than the L2XDM
- fix: wrong arg name
- fix: remove an 'h' to fix arg name
- op-node: Monitor static peers in a background process
- op-node: Properly check storage proof
- Loosen re-prove requirements in the `OptimismPortal`
- Add test for re-proving with a different `l2OutputIndex` + a changed output root at the prior index
- Add changeset
- Run prettier
- Update op-node/p2p/host.go
- Return on error
- Fix typo
- chore: Upgrade op-chain-ops dependencies
- chore: Upgrade op-node dependencies
- chore: Upgrade op-proposer dependencies
- chore: Upgrade op-batcher dependencies
- chore: Upgrade op-e2e dependencies
- go: Remove individual versions for bedrock code
- Fix the docker file builds
- Fix non-bedrock dockerfiles
- fix(op-node): Include chainID in p2p signing hash
- fix(op-node): Accept gossip signed with either the legacy or fixed hash function
- Run go mod tidy
- fix(op-node): Require chain IDs to be positive
- fix(op-node): Increase seenMessagesTTL to cover the entire period block gossip is valid for
- fix(op-node): Increase blockHeightLRU size for better application layer duplicate detection.
- txmgr: Simplify resubmit logic and scaffolding
- Add creation time check for `SUBMISSION_INTERVAL` > `L2_BLOCK_TIME` in the `L2OutputOracle`
- Lint
- op-node: Add RandomBool to testutils
- op-node: Fix Frame parsing
- op-node: Improve Frame.UnmarshalBinary implementation
- op-node: Add more test cases for Frame.UnmarshalBinary
- op-node: Add tests for ParseFrames
- txmgr: Don't submit underpriced replacements
- Add check to deployment script
- Lint deployment script
- txmgr: Don't enforce price bump if new price is not larger
- Bump `L2OutputOracle` semver
- op-chain-ops: more strict checks for config validity
- Use variables for errors. Improve error wording
- Gas snapshot on correct forge version
- op-e2e: include required config
- feat(opn): expose GasUsed in BlockInfo type
- Update to latest opgeth build Update the update-op-geth script to account for removal of go.work
- Also update op-geth in indexer
- feat(ctb): add getting-started network
- Don't log warnings when legacy block gossip validation fails
- proxyd: Add global flag to method overrides
- op-node: Remove obsolete comment in Frame test
