### PR TITLE
Directly test bedrock v0 encoding and hashing against legacy implementations

### DIFF
--- a/packages/contracts-bedrock/contracts/libraries/LegacyCrossDomainUtils.sol
+++ b/packages/contracts-bedrock/contracts/libraries/LegacyCrossDomainUtils.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+// Importing from the legacy contracts package causes issues with the build of the contract bindings
+// so we just copy the library here from
+// /packages/contracts/contracts/libraries/bridge/Lib_CrossDomainUtils.sol at commit
+// 7866168c
+/**
+ * @title LegacyCrossDomainUtils
+ */
+library LegacyCrossDomainUtils {
+    /**
+     * Generates the correct cross domain calldata for a message.
+     * @param _target Target contract address.
+     * @param _sender Message sender address.
+     * @param _message Message to send to the target.
+     * @param _messageNonce Nonce for the provided message.
+     * @return ABI encoded cross domain calldata.
+     */
+    function encodeXDomainCalldata(
+        address _target,
+        address _sender,
+        bytes memory _message,
+        uint256 _messageNonce
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodeWithSignature(
+                "relayMessage(address,address,bytes,uint256)",
+                _target,
+                _sender,
+                _message,
+                _messageNonce
+            );
+    }
+}

--- a/packages/contracts-bedrock/contracts/test/Encoding.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Encoding.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import { CommonTest } from "./CommonTest.t.sol";
 import { Types } from "../libraries/Types.sol";
 import { Encoding } from "../libraries/Encoding.sol";
+import { LegacyCrossDomainUtils } from "../libraries/LegacyCrossDomainUtils.sol";
 
 contract Encoding_Test is CommonTest {
     function testFuzz_nonceVersioning_succeeds(uint240 _nonce, uint16 _version) external {
@@ -54,6 +55,32 @@ contract Encoding_Test is CommonTest {
         );
 
         assertEq(encoding, _encoding);
+    }
+
+    function testFuzz_encodeCrossDomainMessageV0_matchesLegacy_succeeds(
+        uint240 _nonce,
+        address _sender,
+        address _target,
+        bytes memory _data
+    ) external {
+        uint8 version = 0;
+        uint256 nonce = Encoding.encodeVersionedNonce(_nonce, version);
+
+        bytes memory legacyEncoding = LegacyCrossDomainUtils.encodeXDomainCalldata(
+            _target,
+            _sender,
+            _data,
+            nonce
+        );
+
+        bytes memory bedrockEncoding = Encoding.encodeCrossDomainMessageV0(
+            _target,
+            _sender,
+            _data,
+            nonce
+        );
+
+        assertEq(legacyEncoding, bedrockEncoding);
     }
 
     function testDiff_encodeDepositTransaction_succeeds(

--- a/packages/contracts-bedrock/contracts/test/Hashing.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Hashing.t.sol
@@ -5,6 +5,7 @@ import { CommonTest } from "./CommonTest.t.sol";
 import { Types } from "../libraries/Types.sol";
 import { Hashing } from "../libraries/Hashing.sol";
 import { Encoding } from "../libraries/Encoding.sol";
+import { LegacyCrossDomainUtils } from "../libraries/LegacyCrossDomainUtils.sol";
 
 contract Hashing_hashDepositSource_Test is CommonTest {
     /**
@@ -41,6 +42,28 @@ contract Hashing_hashCrossDomainMessage_Test is CommonTest {
         assertEq(
             Hashing.hashCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data),
             ffi.hashCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data)
+        );
+    }
+
+    /**
+     * @notice Tests that hashCrossDomainMessageV0 matches the hash of the legacy encoding.
+     */
+    function testFuzz_hashCrossDomainMessageV0_matchesLegacy_succeeds(
+        address _target,
+        address _sender,
+        bytes memory _message,
+        uint256 _messageNonce
+    ) external {
+        assertEq(
+            keccak256(
+                LegacyCrossDomainUtils.encodeXDomainCalldata(
+                    _target,
+                    _sender,
+                    _message,
+                    _messageNonce
+                )
+            ),
+            Hashing.hashCrossDomainMessageV0(_target, _sender, _message, _messageNonce)
         );
     }
 }


### PR DESCRIPTION
**Description**

Although it may seem obvious, we were not directly testing that Bedrock's V0 hashing and encoding schemes match those of the legacy system.

**Tests**

Two tests: 
1. `testFuzz_encodeCrossDomainMessage_matchesLegacy_succeeds`
2. `testFuzz_hashCrossDomainMessageV0_matchesLegacy_succeeds`



