### PR TITLE
ci: change Go lint timeout from 1m (default) to 2m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,7 +439,7 @@ jobs:
       - run:
           name: run lint
           command: |
-            golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint -e "errors.As" -e "errors.Is" ./...
+            golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...
           working_directory: <<parameters.module>>
 
   go-test:
@@ -523,7 +523,7 @@ jobs:
           patterns: <<parameters.working_directory>>,<<parameters.dependencies>>
       - run:
           name: Lint
-          command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint -e "errors.As" -e "errors.Is" ./...
+          command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...
           working_directory: <<parameters.working_directory>>
       - store_test_results:
           path: /test-results

--- a/specs/meta/linting.md
+++ b/specs/meta/linting.md
@@ -64,5 +64,5 @@ Justification for linting rules:
 # Install linter globally (should not affect go.mod)
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
 # run linter, add --fix option to fix problems (where supported)
-golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell
+golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...
 ```


### PR DESCRIPTION
**Description**

Since we have merged the Bedrock Go modules it seems to take longer to run the Go linter, resulting in CI failures. I suspect because every `op-...` package is linted separately, but it still compiles/analyzes the module as a whole.

This PR increases the timeout from the default 1 minute to 2 minutes, as well as updating the linting docs to reflect the exact command we use in CI.
