### PR TITLE
ci: fix slither

### DIFF
--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -6,6 +6,6 @@ rm -rf artifacts forge-artifacts
 TEMP=$(mktemp -d)
 mv contracts/test $TEMP/test
 
-slither .
+slither . --foundry-out-directory artifacts
 
 mv $TEMP/test contracts/test


### PR DESCRIPTION
**Description**

It was looking in the wrong directory for the `build-info` file directory.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
