### PR TITLE
contracts-bedrock: deploy log

### DIFF
--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -53,6 +53,7 @@ export const deploy = async ({
       log: true,
       waitConfirmations: hre.deployConfig.numDeployConfirmations,
     })
+    console.log(`Deployed ${name} at ${result.address}`)
   }
 
   // Always wait for the transaction to be mined, just in case.


### PR DESCRIPTION
**Description**

Adds a logline that logs the deployed contract name and address when doing a deployment. This will give better visual feedback when doing deployments.
It matches the logline that happens when a deployment is skipped.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
