### PR TITLE
contracts-bedrock: add changeset

### DIFF
--- a/.changeset/soft-poets-juggle.md
+++ b/.changeset/soft-poets-juggle.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Trigger a release including CrossDomainOwnable3


### PR DESCRIPTION
**Description**

A changeset was not included in the PR that added
`CrossDomainOwnable3`, so adding a changeset now.

https://github.com/ethereum-optimism/optimism/pull/4882

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

