### PR TITLE
op-chain-ops: better migration handling of legacy withdrawals

### DIFF
--- a/op-chain-ops/cmd/withdrawals/main.go
+++ b/op-chain-ops/cmd/withdrawals/main.go
@@ -790,7 +790,8 @@ func newWithdrawals(ctx *cli.Context, l1ChainID *big.Int) ([]*crossdomain.Legacy
 		EvmMessages: evmMessages,
 	}
 
-	wds, err := migrationData.ToWithdrawals()
+	// Filter for withdrawals coming from the L2CrossDomainMessenger
+	wds, err := migrationData.ToWithdrawals(true)
 	if err != nil {
 		return nil, err
 	}

--- a/op-chain-ops/genesis/check.go
+++ b/op-chain-ops/genesis/check.go
@@ -452,8 +452,12 @@ func PostCheckL1Block(db vm.StateDB, info *derive.L1BlockInfo) error {
 	return nil
 }
 
+// CheckWithdrawalsAfter checks that all of the legacy withdrawals were migrated
+// correctly. It calls `ToWithdrawals()` with strict mode enabled so that only
+// the LegacyWithdrawals that came from the L2CrossDomainMessenger will be
+// included.
 func CheckWithdrawalsAfter(db vm.StateDB, data migration.MigrationData, l1CrossDomainMessenger *common.Address) error {
-	wds, err := data.ToWithdrawals()
+	wds, err := data.ToWithdrawals(true)
 	if err != nil {
 		return err
 	}

--- a/op-chain-ops/genesis/db_migration.go
+++ b/op-chain-ops/genesis/db_migration.go
@@ -113,7 +113,7 @@ func MigrateDB(ldb ethdb.Database, config *DeployConfig, l1Block *types.Block, m
 
 	// Convert all input messages into legacy messages. Note that this list is not yet filtered and
 	// may be missing some messages or have some extra messages.
-	unfilteredWithdrawals, err := migrationData.ToWithdrawals()
+	unfilteredWithdrawals, err := migrationData.ToWithdrawals(false)
 	if err != nil {
 		return nil, fmt.Errorf("cannot serialize withdrawals: %w", err)
 	}


### PR DESCRIPTION
**Description**

Fixes an issue where permissionless calls of the `LegacyMessagePasser` could cause the migration process to halt due to strict checking of data. It is permissionless to cal the `LegacyMessagePasser`, we want to filter out the other senders and not error on the other senders.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
