### PR TITLE
Add e2e tests for Regolith op-geth changes

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -69,6 +69,9 @@ type DeployConfig struct {
 	L2GenesisBlockParentHash    common.Hash    `json:"l2GenesisBlockParentHash"`
 	L2GenesisBlockBaseFeePerGas *hexutil.Big   `json:"l2GenesisBlockBaseFeePerGas"`
 
+	// Seconds after genesis block that Regolith hard fork activates. 0 to activate at genesis. Nil to disable regolith
+	L2GenesisRegolithTimeOffset *uint64 `json:"l2GenesisRegolithTimeOffset"`
+
 	// Owner of the ProxyAdmin predeploy
 	ProxyAdminOwner common.Address `json:"proxyAdminOwner"`
 	// Owner of the system on L1

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -70,7 +70,7 @@ type DeployConfig struct {
 	L2GenesisBlockBaseFeePerGas *hexutil.Big   `json:"l2GenesisBlockBaseFeePerGas"`
 
 	// Seconds after genesis block that Regolith hard fork activates. 0 to activate at genesis. Nil to disable regolith
-	L2GenesisRegolithTimeOffset *hexutil.Uint64 `json:"l2GenesisRegolithTimeOffset"`
+	L2GenesisRegolithTimeOffset *hexutil.Uint64 `json:"l2GenesisRegolithTimeOffset,omitempty"`
 
 	// Owner of the ProxyAdmin predeploy
 	ProxyAdminOwner common.Address `json:"proxyAdminOwner"`
@@ -285,6 +285,17 @@ func (d *DeployConfig) InitDeveloperDeployedAddresses() error {
 	d.OptimismPortalProxy = predeploys.DevOptimismPortalAddr
 	d.SystemConfigProxy = predeploys.DevSystemConfigAddr
 	return nil
+}
+
+func (d *DeployConfig) RegolithTime(block *types.Block) *uint64 {
+	if d.L2GenesisRegolithTimeOffset == nil {
+		return nil
+	}
+	v := uint64(0)
+	if *d.L2GenesisRegolithTimeOffset > 0 {
+		v = block.Time() + uint64(*d.L2GenesisRegolithTimeOffset)
+	}
+	return &v
 }
 
 // RollupConfig converts a DeployConfig to a rollup.Config

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -70,7 +70,7 @@ type DeployConfig struct {
 	L2GenesisBlockBaseFeePerGas *hexutil.Big   `json:"l2GenesisBlockBaseFeePerGas"`
 
 	// Seconds after genesis block that Regolith hard fork activates. 0 to activate at genesis. Nil to disable regolith
-	L2GenesisRegolithTimeOffset *uint64 `json:"l2GenesisRegolithTimeOffset"`
+	L2GenesisRegolithTimeOffset *hexutil.Uint64 `json:"l2GenesisRegolithTimeOffset"`
 
 	// Owner of the ProxyAdmin predeploy
 	ProxyAdminOwner common.Address `json:"proxyAdminOwner"`

--- a/op-chain-ops/genesis/config_test.go
+++ b/op-chain-ops/genesis/config_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/stretchr/testify/require"
@@ -32,4 +34,18 @@ func TestUnmarshalL1StartingBlockTag(t *testing.T) {
 	h := "0x86c7263d87140ca7cd9bf1bc9e95a435a7a0efc0ae2afaf64920c5b59a6393d4"
 	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{"l1StartingBlockTag": "%s"}`, h)), decoded))
 	require.EqualValues(t, common.HexToHash(h), *decoded.L1StartingBlockTag.BlockHash)
+}
+
+func TestRegolithTimeZero(t *testing.T) {
+	regolithOffset := hexutil.Uint64(0)
+	config := &DeployConfig{L2GenesisRegolithTimeOffset: &regolithOffset}
+	block := types.NewBlockWithHeader(&types.Header{Time: 1234})
+	require.Equal(t, uint64(0), *config.RegolithTime(block))
+}
+
+func TestRegolithTimeAsOffset(t *testing.T) {
+	regolithOffset := hexutil.Uint64(1500)
+	config := &DeployConfig{L2GenesisRegolithTimeOffset: &regolithOffset}
+	block := types.NewBlockWithHeader(&types.Header{Time: 5000})
+	require.Equal(t, uint64(1500+5000), *config.RegolithTime(block))
 }

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -54,7 +54,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 		BedrockBlock:                  new(big.Int).SetUint64(uint64(config.L2GenesisBlockNumber)),
-		RegolithTime:                  regolithTime(config, block),
+		RegolithTime:                  config.RegolithTime(block),
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator: eip1559Denom,
 			EIP1559Elasticity:  eip1559Elasticity,
@@ -94,17 +94,6 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		BaseFee:    baseFee.ToInt(),
 		Alloc:      map[common.Address]core.GenesisAccount{},
 	}, nil
-}
-
-func regolithTime(config *DeployConfig, block *types.Block) *uint64 {
-	if config.L2GenesisRegolithTimeOffset == nil {
-		return nil
-	}
-	v := uint64(0)
-	if *config.L2GenesisRegolithTimeOffset > 0 {
-		v = block.Time() + uint64(*config.L2GenesisRegolithTimeOffset)
-	}
-	return &v
 }
 
 // NewL1Genesis will create a new L1 genesis config

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -102,7 +102,7 @@ func regolithTime(config *DeployConfig, block *types.Block) *uint64 {
 	}
 	v := uint64(0)
 	if *config.L2GenesisRegolithTimeOffset > 0 {
-		v = block.Time() + *config.L2GenesisRegolithTimeOffset
+		v = block.Time() + uint64(*config.L2GenesisRegolithTimeOffset)
 	}
 	return &v
 }

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -54,6 +54,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		TerminalTotalDifficulty:       big.NewInt(0),
 		TerminalTotalDifficultyPassed: true,
 		BedrockBlock:                  new(big.Int).SetUint64(uint64(config.L2GenesisBlockNumber)),
+		RegolithTime:                  regolithTime(config, block),
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator: eip1559Denom,
 			EIP1559Elasticity:  eip1559Elasticity,
@@ -93,6 +94,17 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		BaseFee:    baseFee.ToInt(),
 		Alloc:      map[common.Address]core.GenesisAccount{},
 	}, nil
+}
+
+func regolithTime(config *DeployConfig, block *types.Block) *uint64 {
+	if config.L2GenesisRegolithTimeOffset == nil {
+		return nil
+	}
+	v := uint64(0)
+	if *config.L2GenesisRegolithTimeOffset > 0 {
+		v = block.Time() + *config.L2GenesisRegolithTimeOffset
+	}
+	return &v
 }
 
 // NewL1Genesis will create a new L1 genesis config

--- a/op-e2e/devnet.go
+++ b/op-e2e/devnet.go
@@ -27,6 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	ErrForkChoiceUpdatedNotValid = errors.New("forkChoiceUpdated status was not valid")
+	ErrNewPayloadNotValid        = errors.New("newPayload status was not valid")
+)
+
 type Devnet struct {
 	node          *gn.Node
 	cancel        context.CancelFunc
@@ -122,7 +127,7 @@ func (d *Devnet) AddL2Block(ctx context.Context, txs ...*types.Transaction) (*et
 		return nil, err
 	}
 	if res.PayloadStatus.Status != eth.ExecutionValid {
-		return nil, fmt.Errorf("forkChoiceUpdated gave unexpected status: %s", res.PayloadStatus.Status)
+		return nil, fmt.Errorf("%w: %s", ErrForkChoiceUpdatedNotValid, res.PayloadStatus.Status)
 	}
 	if res.PayloadID == nil {
 		return nil, errors.New("forkChoiceUpdated returned nil PayloadID")
@@ -141,7 +146,7 @@ func (d *Devnet) AddL2Block(ctx context.Context, txs ...*types.Transaction) (*et
 		return nil, err
 	}
 	if status.Status != eth.ExecutionValid {
-		return nil, fmt.Errorf("newPayload returned unexpected status: %s", status.Status)
+		return nil, fmt.Errorf("%w: %s", ErrNewPayloadNotValid, status.Status)
 	}
 
 	fc.HeadBlockHash = payload.BlockHash
@@ -150,7 +155,7 @@ func (d *Devnet) AddL2Block(ctx context.Context, txs ...*types.Transaction) (*et
 		return nil, err
 	}
 	if res.PayloadStatus.Status != eth.ExecutionValid {
-		return nil, fmt.Errorf("forkChoiceUpdated gave unexpected status: %s", res.PayloadStatus.Status)
+		return nil, fmt.Errorf("%w: %s", ErrForkChoiceUpdatedNotValid, res.PayloadStatus.Status)
 	}
 	d.L2Head = payload
 	d.sequenceNum = d.sequenceNum + 1

--- a/op-e2e/devnet.go
+++ b/op-e2e/devnet.go
@@ -1,0 +1,182 @@
+package op_e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/client"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	gn "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+type Devnet struct {
+	node          *gn.Node
+	cancel        context.CancelFunc
+	l2Engine      *sources.EngineClient
+	L2Client      *ethclient.Client
+	SystemConfig  eth.SystemConfig
+	L1ChainConfig *params.ChainConfig
+	L2ChainConfig *params.ChainConfig
+	L1Head        *types.Block
+	L2Head        *eth.ExecutionPayload
+	sequenceNum   uint64
+}
+
+func NewDevnet(t *testing.T, cfg *genesis.DeployConfig) (*Devnet, error) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg)
+	require.Nil(t, err)
+	l1Block := l1Genesis.ToBlock()
+
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg, l1Block)
+	require.Nil(t, err)
+	l2GenesisBlock := l2Genesis.ToBlock()
+
+	rollupGenesis := rollup.Genesis{
+		L1: eth.BlockID{
+			Hash:   l1Block.Hash(),
+			Number: l1Block.NumberU64(),
+		},
+		L2: eth.BlockID{
+			Hash:   l2GenesisBlock.Hash(),
+			Number: l2GenesisBlock.NumberU64(),
+		},
+		L2Time:       l2GenesisBlock.Time(),
+		SystemConfig: e2eutils.SystemConfigFromDeployConfig(cfg),
+	}
+
+	node, _, err := initL2Geth("l2", big.NewInt(int64(cfg.L2ChainID)), l2Genesis, writeDefaultJWT(t))
+	require.Nil(t, err)
+	require.Nil(t, node.Start())
+
+	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(testingJWTSecret))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	l2Node, err := client.NewRPC(ctx, log, node.WSAuthEndpoint(), auth)
+	require.Nil(t, err)
+
+	// Finally create the engine client
+	l2Engine, err := sources.NewEngineClient(
+		l2Node,
+		log,
+		nil,
+		sources.EngineClientDefaultConfig(&rollup.Config{Genesis: rollupGenesis}),
+	)
+	require.Nil(t, err)
+
+	l2Client, err := ethclient.Dial(node.HTTPEndpoint())
+	require.Nil(t, err)
+
+	genesisPayload, err := eth.BlockAsPayload(l2GenesisBlock)
+
+	require.Nil(t, err)
+	return &Devnet{
+		cancel:        cancel,
+		node:          node,
+		L2Client:      l2Client,
+		l2Engine:      l2Engine,
+		SystemConfig:  rollupGenesis.SystemConfig,
+		L1ChainConfig: l1Genesis.Config,
+		L2ChainConfig: l2Genesis.Config,
+		L1Head:        l1Block,
+		L2Head:        genesisPayload,
+	}, nil
+}
+
+func (d *Devnet) Close() {
+	d.node.Close()
+	d.cancel()
+	d.l2Engine.Close()
+	d.L2Client.Close()
+}
+
+func (d *Devnet) AddL2Block(ctx context.Context, txs ...*types.Transaction) (*eth.ExecutionPayload, error) {
+	attrs, err := d.CreatePayloadAttributes(txs)
+	if err != nil {
+		return nil, err
+	}
+	parentHash := d.L2Head.BlockHash
+	fc := eth.ForkchoiceState{
+		HeadBlockHash: parentHash,
+		SafeBlockHash: parentHash,
+	}
+	res, err := d.l2Engine.ForkchoiceUpdate(ctx, &fc, attrs)
+	if err != nil {
+		return nil, err
+	}
+	if res.PayloadStatus.Status != eth.ExecutionValid {
+		return nil, fmt.Errorf("forkChoiceUpdated gave unexpected status: %s", res.PayloadStatus.Status)
+	}
+	if res.PayloadID == nil {
+		return nil, errors.New("forkChoiceUpdated returned nil PayloadID")
+	}
+
+	payload, err := d.l2Engine.GetPayload(ctx, *res.PayloadID)
+	if err != nil {
+		return nil, err
+	}
+	if !reflect.DeepEqual(payload.Transactions, attrs.Transactions) {
+		return nil, errors.New("required transactions were not included")
+	}
+
+	status, err := d.l2Engine.NewPayload(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+	if status.Status != eth.ExecutionValid {
+		return nil, fmt.Errorf("newPayload returned unexpected status: %s", status.Status)
+	}
+
+	fc.HeadBlockHash = payload.BlockHash
+	res, err = d.l2Engine.ForkchoiceUpdate(ctx, &fc, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res.PayloadStatus.Status != eth.ExecutionValid {
+		return nil, fmt.Errorf("forkChoiceUpdated gave unexpected status: %s", res.PayloadStatus.Status)
+	}
+	d.L2Head = payload
+	d.sequenceNum = d.sequenceNum + 1
+	return payload, nil
+}
+
+func (d *Devnet) CreatePayloadAttributes(txs []*types.Transaction) (*eth.PayloadAttributes, error) {
+	l1Info, err := derive.L1InfoDepositBytes(d.sequenceNum, d.L1Head, d.SystemConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var txBytes []hexutil.Bytes
+	txBytes = append(txBytes, l1Info)
+	for _, tx := range txs {
+		bin, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("tx marshalling failed: %w", err)
+		}
+		txBytes = append(txBytes, bin)
+	}
+	attrs := eth.PayloadAttributes{
+		Timestamp:    d.L2Head.Timestamp + 2,
+		Transactions: txBytes,
+		NoTxPool:     true,
+		GasLimit:     (*eth.Uint64Quantity)(&d.SystemConfig.GasLimit),
+	}
+	return &attrs, nil
+}

--- a/op-e2e/l2_geth.go
+++ b/op-e2e/l2_geth.go
@@ -172,7 +172,9 @@ func (d *L2Geth) StartBlockBuilding(ctx context.Context, attrs *eth.PayloadAttri
 }
 
 func (d *L2Geth) CreatePayloadAttributes(txs ...*types.Transaction) (*eth.PayloadAttributes, error) {
-	l1Info, err := derive.L1InfoDepositBytes(d.sequenceNum, d.L1Head, d.SystemConfig)
+	timestamp := d.L2Head.Timestamp + 2
+	isRegolith := d.L2ChainConfig.RegolithTime != nil && (uint64)(timestamp) >= *d.L2ChainConfig.RegolithTime
+	l1Info, err := derive.L1InfoDepositBytes(d.sequenceNum, d.L1Head, d.SystemConfig, isRegolith)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +189,7 @@ func (d *L2Geth) CreatePayloadAttributes(txs ...*types.Transaction) (*eth.Payloa
 		txBytes = append(txBytes, bin)
 	}
 	attrs := eth.PayloadAttributes{
-		Timestamp:    d.L2Head.Timestamp + 2,
+		Timestamp:    timestamp,
 		Transactions: txBytes,
 		NoTxPool:     true,
 		GasLimit:     (*eth.Uint64Quantity)(&d.SystemConfig.GasLimit),

--- a/op-e2e/l2_geth.go
+++ b/op-e2e/l2_geth.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
@@ -36,7 +35,6 @@ var (
 // It provides useful functions for advancing and querying the chain
 type L2Geth struct {
 	node          *gn.Node
-	cancel        context.CancelFunc
 	l2Engine      *sources.EngineClient
 	L2Client      *ethclient.Client
 	SystemConfig  eth.SystemConfig
@@ -47,7 +45,7 @@ type L2Geth struct {
 	sequenceNum   uint64
 }
 
-func NewL2Geth(t *testing.T, cfg *SystemConfig) (*L2Geth, error) {
+func NewL2Geth(t *testing.T, ctx context.Context, cfg *SystemConfig) (*L2Geth, error) {
 	logger := testlog.Logger(t, log.LvlCrit)
 	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig)
 	require.Nil(t, err)
@@ -75,7 +73,6 @@ func NewL2Geth(t *testing.T, cfg *SystemConfig) (*L2Geth, error) {
 	require.Nil(t, node.Start())
 
 	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(cfg.JWTSecret))
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	l2Node, err := client.NewRPC(ctx, logger, node.WSAuthEndpoint(), auth)
 	require.Nil(t, err)
 
@@ -95,7 +92,6 @@ func NewL2Geth(t *testing.T, cfg *SystemConfig) (*L2Geth, error) {
 
 	require.Nil(t, err)
 	return &L2Geth{
-		cancel:        cancel,
 		node:          node,
 		L2Client:      l2Client,
 		l2Engine:      l2Engine,
@@ -109,7 +105,6 @@ func NewL2Geth(t *testing.T, cfg *SystemConfig) (*L2Geth, error) {
 
 func (d *L2Geth) Close() {
 	d.node.Close()
-	d.cancel()
 	d.l2Engine.Close()
 	d.L2Client.Close()
 }

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	gn "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
@@ -98,111 +97,38 @@ func TestMissingGasLimit(t *testing.T) {
 // TestInvalidDepositInFCU runs an invalid deposit through a FCU/GetPayload/NewPayload/FCU set of calls.
 // This tests that deposits must always allow the block to be built even if they are invalid.
 func TestInvalidDepositInFCU(t *testing.T) {
-	// Setup an L2 EE and create a client connection to the engine.
-	// We also need to setup a L1 Genesis to create the rollup genesis.
-	log := testlog.Logger(t, log.LvlCrit)
 	cfg := DefaultSystemConfig(t)
 	cfg.DeployConfig.FundDevAccounts = false
+	l2Geth, err := NewL2Geth(t, &cfg)
+	require.NoError(t, err)
 
-	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig)
-	require.Nil(t, err)
-	l1Block := l1Genesis.ToBlock()
-
-	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block)
-	require.Nil(t, err)
-	l2GenesisBlock := l2Genesis.ToBlock()
-
-	rollupGenesis := rollup.Genesis{
-		L1: eth.BlockID{
-			Hash:   l1Block.Hash(),
-			Number: l1Block.NumberU64(),
-		},
-		L2: eth.BlockID{
-			Hash:   l2GenesisBlock.Hash(),
-			Number: l2GenesisBlock.NumberU64(),
-		},
-		L2Time:       l2GenesisBlock.Time(),
-		SystemConfig: e2eutils.SystemConfigFromDeployConfig(cfg.DeployConfig),
-	}
-
-	node, _, err := initL2Geth("l2", big.NewInt(int64(cfg.DeployConfig.L2ChainID)), l2Genesis, writeDefaultJWT(t))
-	require.Nil(t, err)
-	require.Nil(t, node.Start())
-	defer node.Close()
-
-	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(testingJWTSecret))
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	l2Node, err := client.NewRPC(ctx, log, node.WSAuthEndpoint(), auth)
-	require.Nil(t, err)
-
-	// Finally create the engine client
-	client, err := sources.NewEngineClient(
-		l2Node,
-		log,
-		nil,
-		sources.EngineClientDefaultConfig(&rollup.Config{Genesis: rollupGenesis}),
-	)
-	require.Nil(t, err)
-
-	// Create the test data (L1 Info Tx and then always failing deposit)
-	l1Info, err := derive.L1InfoDepositBytes(1, l1Block, rollupGenesis.SystemConfig)
-	require.Nil(t, err)
 
 	// Create a deposit from alice that will always fail (not enough funds)
 	fromAddr := cfg.Secrets.Addresses().Alice
-	l2Client, err := ethclient.Dial(node.HTTPEndpoint())
-	require.Nil(t, err)
-	balance, err := l2Client.BalanceAt(ctx, fromAddr, nil)
+	balance, err := l2Geth.L2Client.BalanceAt(ctx, fromAddr, nil)
 	require.Nil(t, err)
 	require.Equal(t, 0, balance.Cmp(common.Big0))
 
 	badDepositTx := types.NewTx(&types.DepositTx{
-		// TODO: Source Hash
+		SourceHash:          l2Geth.L1Head.Hash(),
 		From:                fromAddr,
 		To:                  &fromAddr, // send it to ourselves
 		Value:               big.NewInt(params.Ether),
 		Gas:                 25000,
 		IsSystemTransaction: false,
 	})
-	badDeposit, err := badDepositTx.MarshalBinary()
-	require.Nil(t, err)
 
-	attrs := eth.PayloadAttributes{
-		Timestamp:    hexutil.Uint64(l2GenesisBlock.Time() + 2),
-		Transactions: []hexutil.Bytes{l1Info, badDeposit},
-		NoTxPool:     true,
-		GasLimit:     (*eth.Uint64Quantity)(&rollupGenesis.SystemConfig.GasLimit),
-	}
-
-	// Go through the flow of FCU, GetPayload, NewPayload, FCU
 	// We are inserting a block with an invalid deposit.
 	// The invalid deposit should still remain in the block.
-	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	_, err = l2Geth.AddL2Block(ctx, badDepositTx)
+	require.NoError(t, err)
 
-	fc := eth.ForkchoiceState{
-		HeadBlockHash: l2GenesisBlock.Hash(),
-		SafeBlockHash: l2GenesisBlock.Hash(),
-	}
-	res, err := client.ForkchoiceUpdate(ctx, &fc, &attrs)
+	// Deposit tx was included, but Alice still shouldn't have any ETH
+	balance, err = l2Geth.L2Client.BalanceAt(ctx, fromAddr, nil)
 	require.Nil(t, err)
-	require.Equal(t, eth.ExecutionValid, res.PayloadStatus.Status)
-	require.NotNil(t, res.PayloadID)
-
-	payload, err := client.GetPayload(ctx, *res.PayloadID)
-	require.Nil(t, err)
-	require.NotNil(t, payload)
-	require.Equal(t, payload.Transactions, attrs.Transactions) // Ensure we don't drop the transactions
-
-	status, err := client.NewPayload(ctx, payload)
-	require.Nil(t, err)
-	require.Equal(t, eth.ExecutionValid, status.Status)
-
-	fc.HeadBlockHash = payload.BlockHash
-	res, err = client.ForkchoiceUpdate(ctx, &fc, nil)
-	require.Nil(t, err)
-	require.Equal(t, eth.ExecutionValid, res.PayloadStatus.Status)
+	require.Equal(t, 0, balance.Cmp(common.Big0))
 }
 
 // TestActivateRegolithAtGenesis runs deposit transactions on a chain with Regolith enabled at genesis

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -20,11 +20,10 @@ import (
 func TestMissingGasLimit(t *testing.T) {
 	cfg := DefaultSystemConfig(t)
 	cfg.DeployConfig.FundDevAccounts = false
-	l2Geth, err := NewL2Geth(t, &cfg)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	l2Geth, err := NewL2Geth(t, ctx, &cfg)
+	require.NoError(t, err)
 
 	attrs, err := l2Geth.CreatePayloadAttributes()
 	require.NoError(t, err)
@@ -42,11 +41,10 @@ func TestMissingGasLimit(t *testing.T) {
 func TestInvalidDepositInFCU(t *testing.T) {
 	cfg := DefaultSystemConfig(t)
 	cfg.DeployConfig.FundDevAccounts = false
-	l2Geth, err := NewL2Geth(t, &cfg)
-	require.NoError(t, err)
-
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	l2Geth, err := NewL2Geth(t, ctx, &cfg)
+	require.NoError(t, err)
 
 	// Create a deposit from alice that will always fail (not enough funds)
 	fromAddr := cfg.Secrets.Addresses().Alice
@@ -82,7 +80,10 @@ func TestActivateRegolithAtGenesis(t *testing.T) {
 	regolithTime := hexutil.Uint64(0)
 	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
 
-	l2Geth, err := NewL2Geth(t, &cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	l2Geth, err := NewL2Geth(t, ctx, &cfg)
 	require.NoError(t, err)
 	defer l2Geth.Close()
 
@@ -107,10 +108,6 @@ func TestActivateRegolithAtGenesis(t *testing.T) {
 		Data:                []byte{},
 		IsSystemTransaction: false,
 	})
-
-	// Add a new block with these transactions
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
 
 	payload, err := l2Geth.AddL2Block(ctx, depositTx, contractCreateTx)
 	require.NoError(t, err)
@@ -144,7 +141,10 @@ func TestActivateRegolithAfterGenesis(t *testing.T) {
 	regolithTime := hexutil.Uint64(4)
 	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
 
-	l2Geth, err := NewL2Geth(t, &cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	l2Geth, err := NewL2Geth(t, ctx, &cfg)
 	require.NoError(t, err)
 	defer l2Geth.Close()
 
@@ -169,10 +169,6 @@ func TestActivateRegolithAfterGenesis(t *testing.T) {
 		Data:                []byte{},
 		IsSystemTransaction: false,
 	})
-
-	// Add a new block with these transactions
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
 
 	// First block is still in bedrock
 	payload, err := l2Geth.AddL2Block(ctx, depositTx, contractCreateTx)
@@ -251,12 +247,12 @@ func TestRegolithDepositTxUnusedGas(t *testing.T) {
 	regolithTime := hexutil.Uint64(0)
 	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
 
-	l2Geth, err := NewL2Geth(t, &cfg)
-	require.NoError(t, err)
-	defer l2Geth.Close()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	l2Geth, err := NewL2Geth(t, ctx, &cfg)
+	require.NoError(t, err)
+	defer l2Geth.Close()
 
 	fromAddr := cfg.Secrets.Addresses().Alice
 
@@ -301,12 +297,12 @@ func TestRegolithRejectsSystemTx(t *testing.T) {
 	regolithTime := hexutil.Uint64(0)
 	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
 
-	l2Geth, err := NewL2Geth(t, &cfg)
-	require.NoError(t, err)
-	defer l2Geth.Close()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	l2Geth, err := NewL2Geth(t, ctx, &cfg)
+	require.NoError(t, err)
+	defer l2Geth.Close()
 
 	systemTx, err := derive.L1InfoDeposit(1, l2Geth.L1Head, l2Geth.SystemConfig)
 	systemTx.IsSystemTransaction = true

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -251,6 +251,7 @@ func TestActivateRegolithAtGenesis(t *testing.T) {
 	receipt, err := devnet.L2Client.TransactionReceipt(ctx, depositTx.Hash())
 	require.NoError(t, err)
 	require.NotEqual(t, depositTx.Gas(), receipt.GasUsed)
+	require.Equal(t, uint64(0), *receipt.DepositNonce)
 
 	infoTx, err := devnet.L2Client.TransactionInBlock(ctx, payload.BlockHash, 0)
 	require.NoError(t, err)
@@ -263,7 +264,7 @@ func TestActivateRegolithAtGenesis(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, createRcpt.Status)
 	require.Equal(t, expectedContractAddress, createRcpt.ContractAddress)
-
+	require.Equal(t, uint64(1), *createRcpt.DepositNonce)
 	contractBalance, err := devnet.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
 	require.NoError(t, err)
 	require.Equal(t, contractCreateTx.Value(), contractBalance)

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -181,6 +181,7 @@ func TestActivateRegolithAfterGenesis(t *testing.T) {
 
 	infoTx, err := l2Geth.L2Client.TransactionInBlock(ctx, payload.BlockHash, 0)
 	require.NoError(t, err)
+	require.True(t, infoTx.IsSystemTx(), "should use system tx in bedrock")
 	infoRcpt, err := l2Geth.L2Client.TransactionReceipt(ctx, infoTx.Hash())
 	require.NoError(t, err)
 	require.Zero(t, infoRcpt.GasUsed)
@@ -238,6 +239,11 @@ func TestActivateRegolithAfterGenesis(t *testing.T) {
 	contractBalance, err = l2Geth.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
 	require.NoError(t, err)
 	require.Equal(t, contractCreateTx.Value(), contractBalance)
+
+	// TODO: Check nonce is returned in deposit transaction
+	//tx, _, err := l2Geth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())
+	//require.NoError(t, err)
+	//require.Equal(t, uint64(3), tx.Nonce())
 }
 
 // TestRegolithDepositTxUnusedGas checks that unused gas from deposit transactions is returned to the block gas pool
@@ -292,7 +298,6 @@ func TestRegolithDepositTxUnusedGas(t *testing.T) {
 
 // TestRegolithRejectsSystemTx checks that IsSystemTx must be false after Regolith
 func TestRegolithRejectsSystemTx(t *testing.T) {
-	t.Skip("Need to wait for op-node to have Regolith support before this requirement can be enforced")
 	cfg := DefaultSystemConfig(t)
 	regolithTime := hexutil.Uint64(0)
 	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
@@ -311,3 +316,5 @@ func TestRegolithRejectsSystemTx(t *testing.T) {
 	_, err = l2Geth.AddL2Block(ctx, types.NewTx(systemTx))
 	require.ErrorIs(t, err, ErrNewPayloadNotValid)
 }
+
+// TODO: Need a test to check that gas refunds (eg for selfdestruct) are included in the receipt gasUsed

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	gn "github.com/ethereum/go-ethereum/node"
@@ -204,4 +204,223 @@ func TestInvalidDepositInFCU(t *testing.T) {
 	res, err = client.ForkchoiceUpdate(ctx, &fc, nil)
 	require.Nil(t, err)
 	require.Equal(t, eth.ExecutionValid, res.PayloadStatus.Status)
+}
+
+// TestActivateRegolithAtGenesis runs deposit transactions on a chain with Regolith enabled at genesis
+func TestActivateRegolithAtGenesis(t *testing.T) {
+	// Setup an L2 EE and create a client connection to the engine.
+	// We also need to setup a L1 Genesis to create the rollup genesis.
+	cfg := DefaultSystemConfig(t)
+	regolithTime := uint64(0)
+	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
+
+	devnet, err := NewDevnet(t, cfg.DeployConfig)
+	require.NoError(t, err)
+	defer devnet.Close()
+
+	fromAddr := cfg.Secrets.Addresses().Alice
+
+	// Simple transfer deposit tx
+	depositTx := types.NewTx(&types.DepositTx{
+		SourceHash:          devnet.L1Head.Hash(),
+		From:                fromAddr,
+		To:                  &fromAddr, // send it to ourselves
+		Value:               big.NewInt(params.Ether),
+		Gas:                 25000,
+		IsSystemTransaction: false,
+	})
+
+	// Contract creation deposit tx
+	contractCreateTx := types.NewTx(&types.DepositTx{
+		SourceHash:          devnet.L1Head.Hash(),
+		From:                fromAddr,
+		Value:               big.NewInt(params.Ether),
+		Gas:                 1000000,
+		Data:                []byte{},
+		IsSystemTransaction: false,
+	})
+
+	// Add a new block with these transactions
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	payload, err := devnet.AddL2Block(ctx, depositTx, contractCreateTx)
+	require.NoError(t, err)
+
+	// Check the deposit tx show actual gas used, not gas limit
+	receipt, err := devnet.L2Client.TransactionReceipt(ctx, depositTx.Hash())
+	require.NoError(t, err)
+	require.NotEqual(t, depositTx.Gas(), receipt.GasUsed)
+
+	infoTx, err := devnet.L2Client.TransactionInBlock(ctx, payload.BlockHash, 0)
+	require.NoError(t, err)
+	infoRcpt, err := devnet.L2Client.TransactionReceipt(ctx, infoTx.Hash())
+	require.NoError(t, err)
+	require.NotZero(t, infoRcpt.GasUsed)
+
+	expectedContractAddress := crypto.CreateAddress(fromAddr, uint64(1))
+	createRcpt, err := devnet.L2Client.TransactionReceipt(ctx, contractCreateTx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, createRcpt.Status)
+	require.Equal(t, expectedContractAddress, createRcpt.ContractAddress)
+
+	contractBalance, err := devnet.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
+	require.NoError(t, err)
+	require.Equal(t, contractCreateTx.Value(), contractBalance)
+}
+
+// TestActivateRegolithAtGenesis runs deposit transactions on a chain with Regolith enabled from block 2
+func TestActivateRegolithAfterGenesis(t *testing.T) {
+	cfg := DefaultSystemConfig(t)
+	regolithTime := uint64(4)
+	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
+
+	devnet, err := NewDevnet(t, cfg.DeployConfig)
+	require.NoError(t, err)
+	defer devnet.Close()
+
+	fromAddr := cfg.Secrets.Addresses().Alice
+
+	// Simple transfer deposit tx
+	depositTx := types.NewTx(&types.DepositTx{
+		SourceHash:          devnet.L1Head.Hash(),
+		From:                fromAddr,
+		To:                  &fromAddr, // send it to ourselves
+		Value:               big.NewInt(params.Ether),
+		Gas:                 25000,
+		IsSystemTransaction: false,
+	})
+
+	// Contract creation deposit tx
+	contractCreateTx := types.NewTx(&types.DepositTx{
+		SourceHash:          devnet.L1Head.Hash(),
+		From:                fromAddr,
+		Value:               big.NewInt(params.Ether),
+		Gas:                 1000000,
+		Data:                []byte{},
+		IsSystemTransaction: false,
+	})
+
+	// Add a new block with these transactions
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// First block is still in bedrock
+	payload, err := devnet.AddL2Block(ctx, depositTx, contractCreateTx)
+	require.NoError(t, err)
+
+	// Check the deposit tx show actual gas used, not gas limit
+	receipt, err := devnet.L2Client.TransactionReceipt(ctx, depositTx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, depositTx.Gas(), receipt.GasUsed)
+
+	infoTx, err := devnet.L2Client.TransactionInBlock(ctx, payload.BlockHash, 0)
+	require.NoError(t, err)
+	infoRcpt, err := devnet.L2Client.TransactionReceipt(ctx, infoTx.Hash())
+	require.NoError(t, err)
+	require.Zero(t, infoRcpt.GasUsed)
+
+	expectedContractAddress := crypto.CreateAddress(fromAddr, uint64(0)) // Expected to be wrong
+	createRcpt, err := devnet.L2Client.TransactionReceipt(ctx, contractCreateTx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, createRcpt.Status)
+	require.Equal(t, expectedContractAddress, createRcpt.ContractAddress)
+
+	contractBalance, err := devnet.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), contractBalance.Uint64())
+
+	// Second block is in regolith
+	// Simple transfer deposit tx
+	depositTx = types.NewTx(&types.DepositTx{
+		SourceHash:          devnet.L1Head.Hash(),
+		From:                fromAddr,
+		To:                  &fromAddr, // send it to ourselves
+		Value:               big.NewInt(params.Ether),
+		Gas:                 25001,
+		IsSystemTransaction: false,
+	})
+
+	// Contract creation deposit tx
+	contractCreateTx = types.NewTx(&types.DepositTx{
+		SourceHash:          devnet.L1Head.Hash(),
+		From:                fromAddr,
+		Value:               big.NewInt(params.Ether),
+		Gas:                 1000001,
+		Data:                []byte{},
+		IsSystemTransaction: false,
+	})
+	payload, err = devnet.AddL2Block(ctx, depositTx, contractCreateTx)
+	require.NoError(t, err)
+
+	// Check the deposit tx show actual gas used, not gas limit
+	receipt, err = devnet.L2Client.TransactionReceipt(ctx, depositTx.Hash())
+	require.NoError(t, err)
+	require.NotEqual(t, depositTx.Gas(), receipt.GasUsed)
+
+	infoTx, err = devnet.L2Client.TransactionInBlock(ctx, payload.BlockHash, 0)
+	require.NoError(t, err)
+	infoRcpt, err = devnet.L2Client.TransactionReceipt(ctx, infoTx.Hash())
+	require.NoError(t, err)
+	require.NotZero(t, infoRcpt.GasUsed)
+
+	expectedContractAddress = crypto.CreateAddress(fromAddr, uint64(3))
+	createRcpt, err = devnet.L2Client.TransactionReceipt(ctx, contractCreateTx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, createRcpt.Status)
+	require.Equal(t, expectedContractAddress, createRcpt.ContractAddress)
+
+	contractBalance, err = devnet.L2Client.BalanceAt(ctx, createRcpt.ContractAddress, nil)
+	require.NoError(t, err)
+	require.Equal(t, contractCreateTx.Value(), contractBalance)
+}
+
+// TestRegolithDepositTxUnusedGas checks that unused gas from deposit transactions is returned to the block gas pool
+// Also checks the user is not refunded for unused gas.
+func TestRegolithDepositTxUnusedGas(t *testing.T) {
+	cfg := DefaultSystemConfig(t)
+	regolithTime := uint64(0)
+	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
+
+	devnet, err := NewDevnet(t, cfg.DeployConfig)
+	require.NoError(t, err)
+	defer devnet.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	fromAddr := cfg.Secrets.Addresses().Alice
+
+	aliceBalance, err := devnet.L2Client.BalanceAt(ctx, fromAddr, nil)
+	require.NoError(t, err)
+
+	// Deposit TX with a high gas limit but using very little actual gas
+	depositTx := types.NewTx(&types.DepositTx{
+		SourceHash: devnet.L1Head.Hash(),
+		From:       fromAddr,
+		To:         &fromAddr, // send it to ourselves
+		Value:      big.NewInt(params.Ether),
+		// SystemTx is assigned 1M gas limit
+		Gas:                 uint64(cfg.DeployConfig.L2GenesisBlockGasLimit) - 1_000_000,
+		IsSystemTransaction: false,
+	})
+
+	signer := types.LatestSigner(devnet.L2ChainConfig)
+	// Second deposit tx with a gas limit that will fit in regolith but not bedrock
+	tx := types.MustSignNewTx(cfg.Secrets.Bob, signer, &types.DynamicFeeTx{
+		ChainID:   big.NewInt(int64(cfg.DeployConfig.L2ChainID)),
+		Nonce:     0,
+		GasTipCap: big.NewInt(100),
+		GasFeeCap: big.NewInt(100000),
+		Gas:       1_000_001,
+		To:        &cfg.Secrets.Addresses().Alice,
+		Value:     big.NewInt(0),
+		Data:      nil,
+	})
+
+	_, err = devnet.AddL2Block(ctx, depositTx, tx)
+	require.NoError(t, err)
+
+	newAliceBalance, err := devnet.L2Client.BalanceAt(ctx, fromAddr, nil)
+	require.Equal(t, aliceBalance, newAliceBalance, "should not refund fee for unused gas")
 }

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -23,7 +23,6 @@ import (
 	gn "github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -212,7 +211,7 @@ func TestActivateRegolithAtGenesis(t *testing.T) {
 	// We also need to setup a L1 Genesis to create the rollup genesis.
 	cfg := DefaultSystemConfig(t)
 	regolithTime := uint64(0)
-	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
+	cfg.DeployConfig.L2GenesisRegolithTimeOffset = (*hexutil.Uint64)(&regolithTime)
 
 	devnet, err := NewDevnet(t, cfg.DeployConfig)
 	require.NoError(t, err)
@@ -274,7 +273,7 @@ func TestActivateRegolithAtGenesis(t *testing.T) {
 func TestActivateRegolithAfterGenesis(t *testing.T) {
 	cfg := DefaultSystemConfig(t)
 	regolithTime := uint64(4)
-	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
+	cfg.DeployConfig.L2GenesisRegolithTimeOffset = (*hexutil.Uint64)(&regolithTime)
 
 	devnet, err := NewDevnet(t, cfg.DeployConfig)
 	require.NoError(t, err)
@@ -381,7 +380,7 @@ func TestActivateRegolithAfterGenesis(t *testing.T) {
 func TestRegolithDepositTxUnusedGas(t *testing.T) {
 	cfg := DefaultSystemConfig(t)
 	regolithTime := uint64(0)
-	cfg.DeployConfig.L2GenesisRegolithTimeOffset = &regolithTime
+	cfg.DeployConfig.L2GenesisRegolithTimeOffset = (*hexutil.Uint64)(&regolithTime)
 
 	devnet, err := NewDevnet(t, cfg.DeployConfig)
 	require.NoError(t, err)

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -240,10 +240,9 @@ func TestActivateRegolithAfterGenesis(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, contractCreateTx.Value(), contractBalance)
 
-	// TODO: Check nonce is returned in deposit transaction
-	//tx, _, err := l2Geth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())
-	//require.NoError(t, err)
-	//require.Equal(t, uint64(3), tx.Nonce())
+	tx, _, err := l2Geth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), tx.Nonce())
 }
 
 // TestRegolithDepositTxUnusedGas checks that unused gas from deposit transactions is returned to the block gas pool

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -100,7 +100,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 			l2Parent, nextL2Time, eth.ToBlockID(l1Info), l1Info.Time()))
 	}
 
-	l1InfoTx, err := L1InfoDepositBytes(seqNumber, l1Info, sysConfig)
+	l1InfoTx, err := L1InfoDepositBytes(seqNumber, l1Info, sysConfig, false)
 	if err != nil {
 		return nil, NewCriticalError(fmt.Errorf("failed to create l1InfoTx: %w", err))
 	}

--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -145,10 +145,16 @@ func L1InfoDeposit(seqNumber uint64, block eth.BlockInfo, sysCfg eth.SystemConfi
 }
 
 // L1InfoDepositBytes returns a serialized L1-info attributes transaction.
-func L1InfoDepositBytes(seqNumber uint64, l1Info eth.BlockInfo, sysCfg eth.SystemConfig) ([]byte, error) {
+func L1InfoDepositBytes(seqNumber uint64, l1Info eth.BlockInfo, sysCfg eth.SystemConfig, isRegolith bool) ([]byte, error) {
 	dep, err := L1InfoDeposit(seqNumber, l1Info, sysCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create L1 info tx: %w", err)
+	}
+
+	// TODO: Passing a isRegolith bool here is nasty, but is a quick way to keep e2e tests passing before op-node is updated properly
+	if isRegolith {
+		dep.IsSystemTransaction = false
+		dep.Gas = 1_000_000
 	}
 	l1Tx := types.NewTx(dep)
 	opaqueL1Tx, err := l1Tx.MarshalBinary()


### PR DESCRIPTION
**Description**

Adds e2e tests for the op-geth changes from Regolith.

Also introduces a e2e test util `devnet` to avoid needing so much boilerplate code in each e2e test to create the L1 and L2 chains and go through the block creation process.

**Tests**

* Starting regolith at genesis
* Starting regolith after genesis
* Correct gasUsed reported for deposit tx
* Correct ContractAddress for deposit tx that create contracts
* Unused gas from deposit tx can be used by other transactions
* User is not paid ETH for unused deposit tx gas

**Metadata**
- Part of https://linear.app/optimism/issue/CLI-3384/implement-deposits-hf-regolith-op-geth-changes
