### PR TITLE
[op-batcher] Remove duplicate signer

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
-	opcrypto "github.com/ethereum-optimism/optimism/op-service/crypto"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
@@ -28,7 +27,6 @@ type Config struct {
 	PollInterval    time.Duration
 	TxManagerConfig txmgr.Config
 	From            common.Address
-	SignerFnFactory opcrypto.SignerFactory
 
 	// RollupConfig is queried at startup
 	Rollup *rollup.Config

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -83,7 +83,6 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger) (*BatchSubmitte
 		PollInterval:    cfg.PollInterval,
 		TxManagerConfig: txManagerConfig,
 		From:            fromAddress,
-		SignerFnFactory: signer,
 		Rollup:          rcfg,
 		Channel: ChannelConfig{
 			SeqWindowSize:    rcfg.SeqWindowSize,
@@ -117,7 +116,7 @@ func NewBatchSubmitter(cfg Config, l log.Logger) (*BatchSubmitter, error) {
 		Config: cfg,
 		txMgr: NewTransactionManager(l,
 			cfg.TxManagerConfig, cfg.Rollup.BatchInboxAddress, cfg.Rollup.L1ChainID,
-			cfg.From, cfg.L1Client, cfg.SignerFnFactory(cfg.Rollup.L1ChainID)),
+			cfg.From, cfg.L1Client),
 		done: make(chan struct{}),
 		// TODO: this context only exists because the event loop doesn't reach done
 		// if the tx manager is blocking forever due to e.g. insufficient balance.

--- a/op-batcher/batcher/txmgr.go
+++ b/op-batcher/batcher/txmgr.go
@@ -32,14 +32,14 @@ type TransactionManager struct {
 	log      log.Logger
 }
 
-func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, senderAddress common.Address, l1Client *ethclient.Client, signerFn opcrypto.SignerFn) *TransactionManager {
+func NewTransactionManager(log log.Logger, txMgrConfg txmgr.Config, batchInboxAddress common.Address, chainID *big.Int, senderAddress common.Address, l1Client *ethclient.Client) *TransactionManager {
 	t := &TransactionManager{
 		batchInboxAddress: batchInboxAddress,
 		senderAddress:     senderAddress,
 		chainID:           chainID,
 		txMgr:             txmgr.NewSimpleTxManager("batcher", log, txMgrConfg, l1Client),
 		l1Client:          l1Client,
-		signerFn:          signerFn,
+		signerFn:          txMgrConfg.Signer,
 		log:               log,
 	}
 	return t


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Currently the signer factory is called twice, once for creating the `txmgr.Config`, and once for passing to `NewTransactionManager`. The one in the `txmgr.Config` is available to the `NewTransactionManager` method, so we can clean up the `SignerFnFactory` from `batcher.Config` and remove the duplicate factory call.

**Tests**

No logic changes, just a cleanup.
