### PR TITLE
op-node: Return error when unmarshaling L1Info txs with invalid function selectors

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -74,6 +74,11 @@ func (info *L1BlockInfo) UnmarshalBinary(data []byte) error {
 	}
 	var padding [24]byte
 	offset := 4
+
+	if !bytes.Equal(data[0:offset], L1InfoFuncBytes4) {
+		return fmt.Errorf("data does not match L1 info function signature: 0x%x", data[offset:4])
+	}
+
 	info.Number = binary.BigEndian.Uint64(data[offset+24 : offset+32])
 	if !bytes.Equal(data[offset:offset+24], padding[:]) {
 		return fmt.Errorf("l1 info number exceeds uint64 bounds: %x", data[offset:offset+32])

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -92,4 +92,14 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		_, err := L1InfoDepositTxData(make([]byte, 4+32+32+32+32+32+1))
 		assert.Error(t, err)
 	})
+	t.Run("invalid selector", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(1234))
+		info := testutils.MakeBlockInfo(nil)(rng)
+		depTx, err := L1InfoDeposit(randomSeqNr(rng), info, randomL1Cfg(rng, info))
+		require.NoError(t, err)
+		_, err = rand.Read(depTx.Data[0:4])
+		require.NoError(t, err)
+		_, err = L1InfoDepositTxData(depTx.Data)
+		require.ErrorContains(t, err, "function signature")
+	})
 }


### PR DESCRIPTION
The function selector was not being checked on unmarshal, which allows for invalid block data to pass validation.

Fixes CLI-3389
