### PR TITLE
op-chain-ops: fix merge conflict issue

### DIFF
--- a/op-chain-ops/crossdomain/precheck_test.go
+++ b/op-chain-ops/crossdomain/precheck_test.go
@@ -68,7 +68,7 @@ func TestPreCheckWithdrawals_InvalidSlotInStorage(t *testing.T) {
 	root, err := stateDB.Commit(false)
 	require.NoError(t, err)
 
-	err = stateDB.Database().TrieDB().Commit(root, true, nil)
+	err = stateDB.Database().TrieDB().Commit(root, true)
 	require.NoError(t, err)
 
 	_, err = PreCheckWithdrawals(stateDB, nil)
@@ -127,7 +127,7 @@ func runPrecheck(t *testing.T, dbWds []*LegacyWithdrawal, witnessWds []*LegacyWi
 	root, err := stateDB.Commit(false)
 	require.NoError(t, err)
 
-	err = stateDB.Database().TrieDB().Commit(root, true, nil)
+	err = stateDB.Database().TrieDB().Commit(root, true)
 	require.NoError(t, err)
 
 	return PreCheckWithdrawals(stateDB, witnessWds)


### PR DESCRIPTION
**Description**

Update to op-geth version changes the function signature, this commit fixes it so that the correct function signature is used.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

