### PR TITLE
contracts-bedrock: require dynamic config set at correct time

### DIFF
--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -175,6 +175,9 @@ contract SystemDictator is OwnableUpgradeable {
      * @notice Configures the ProxyAdmin contract.
      */
     function step1() external onlyOwner step(1) {
+        // Dynamic config must be set before we can initialize the L2OutputOracle.
+        require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
+
         // Set the AddressManager in the ProxyAdmin.
         config.globalConfig.proxyAdmin.setAddressManager(config.globalConfig.addressManager);
 
@@ -307,9 +310,6 @@ contract SystemDictator is OwnableUpgradeable {
      * @notice Upgrades and initializes proxy contracts.
      */
     function step5() external onlyOwner step(5) {
-        // Dynamic config must be set before we can initialize the L2OutputOracle.
-        require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
-
         // Upgrade and initialize the OptimismPortal.
         config.globalConfig.proxyAdmin.upgradeAndCall(
             payable(config.proxyAddressConfig.optimismPortalProxy),


### PR DESCRIPTION
The initialization of the L2OutputOracle must happen after the dynamic config is set.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixes a bug introduced in https://github.com/ethereum-optimism/optimism/commit/654ea9598100dd5823645ad3b70d5e13afcf910a

The L2OO would be initialized with null data

This is going to need changes to the deploy scripts to pass CI