### PR TITLE
Revert "fix(ctb): initialize L2OO in dictator step 1"

### DIFF
--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -212,19 +212,6 @@ contract SystemDictator is OwnableUpgradeable {
                 )
             )
         );
-
-        // Upgrade and initialize the L2OutputOracle so the Proposer can start up.
-        config.globalConfig.proxyAdmin.upgradeAndCall(
-            payable(config.proxyAddressConfig.l2OutputOracleProxy),
-            address(config.implementationAddressConfig.l2OutputOracleImpl),
-            abi.encodeCall(
-                L2OutputOracle.initialize,
-                (
-                    l2OutputOracleDynamicConfig.l2OutputOracleStartingBlockNumber,
-                    l2OutputOracleDynamicConfig.l2OutputOracleStartingTimestamp
-                )
-            )
-        );
     }
 
     /**
@@ -309,6 +296,19 @@ contract SystemDictator is OwnableUpgradeable {
     function step5() external onlyOwner step(5) {
         // Dynamic config must be set before we can initialize the L2OutputOracle.
         require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
+
+        // Upgrade and initialize the L2OutputOracle.
+        config.globalConfig.proxyAdmin.upgradeAndCall(
+            payable(config.proxyAddressConfig.l2OutputOracleProxy),
+            address(config.implementationAddressConfig.l2OutputOracleImpl),
+            abi.encodeCall(
+                L2OutputOracle.initialize,
+                (
+                    l2OutputOracleDynamicConfig.l2OutputOracleStartingBlockNumber,
+                    l2OutputOracleDynamicConfig.l2OutputOracleStartingTimestamp
+                )
+            )
+        );
 
         // Upgrade and initialize the OptimismPortal.
         config.globalConfig.proxyAdmin.upgradeAndCall(

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -29,7 +29,6 @@ const deployFn: DeployFunction = async (hre) => {
     L1ERC721BridgeProxy,
     L1ERC721BridgeProxyWithSigner,
     SystemConfigProxy,
-    L2OutputOracleProxy,
   ] = await getContractsFromArtifacts(hre, [
     {
       name: 'SystemDictatorProxy',
@@ -66,11 +65,6 @@ const deployFn: DeployFunction = async (hre) => {
     {
       name: 'SystemConfigProxy',
       iface: 'SystemConfig',
-      signerOrProvider: deployer,
-    },
-    {
-      name: 'L2OutputOracleProxy',
-      iface: 'L2OutputOracle',
       signerOrProvider: deployer,
     },
   ])
@@ -292,13 +286,6 @@ const deployFn: DeployFunction = async (hre) => {
         SystemConfigProxy,
         'gasLimit',
         hre.deployConfig.l2GenesisBlockGasLimit
-      )
-
-      // Check L2OutputOracle was initialized properly.
-      await assertContractVariable(
-        L2OutputOracleProxy,
-        'latestBlockNumber',
-        hre.deployConfig.l2OutputOracleStartingBlockNumber
       )
     },
   })

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -26,6 +26,7 @@ const deployFn: DeployFunction = async (hre) => {
     L1CrossDomainMessenger,
     L1StandardBridgeProxy,
     L1StandardBridge,
+    L2OutputOracle,
     OptimismPortal,
     OptimismMintableERC20Factory,
     L1ERC721Bridge,
@@ -54,6 +55,11 @@ const deployFn: DeployFunction = async (hre) => {
     {
       name: 'Proxy__OVM_L1StandardBridge',
       iface: 'L1StandardBridge',
+      signerOrProvider: deployer,
+    },
+    {
+      name: 'L2OutputOracleProxy',
+      iface: 'L2OutputOracle',
       signerOrProvider: deployer,
     },
     {
@@ -207,6 +213,13 @@ const deployFn: DeployFunction = async (hre) => {
       submit L2 outputs to the L2OutputOracle.
     `,
     checks: async () => {
+      // Check L2OutputOracle was initialized properly.
+      await assertContractVariable(
+        L2OutputOracle,
+        'latestBlockNumber',
+        hre.deployConfig.l2OutputOracleStartingBlockNumber
+      )
+
       // Check OptimismPortal was initialized properly.
       await assertContractVariable(
         OptimismPortal,


### PR DESCRIPTION
**Description**

This reverts commit 654ea9598100dd5823645ad3b70d5e13afcf910a.

I recommend we redo this commit as another PR that ensures that the dynamic config is set at the right time

You can see that this moves the initialization of the `L2OutputOracle` back to `step5`. There is an assertion at the top of step five

```
require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
```

This ensures that the dynamic config is set for the `L2OutputOracle` before it is initialized.
This check was not moved to `step1`, meaning that its possible to initialize the oracle with null config

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

https://github.com/ethereum-optimism/optimism/pull/4940 is a start at fixing the problem
