### PR TITLE
ci-builder: add changeset

### DIFF
--- a/.changeset/fifty-schools-think.md
+++ b/.changeset/fifty-schools-think.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ci-builder': patch
+---
+
+Bump foundry to edf15abd648bb96e2bcee342c1d72ec7d1066cd1


### PR DESCRIPTION
**Description**

The next time that a release is triggered, build and publish the `ci-builder` docker image. This will cause it to be used in CI for builds, meaning that we will need to update our foundry versions for local development.

This can be done with the following command:

```bash
foundryup -C edf15abd648bb96e2bcee342c1d72ec7d1066cd1
```

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
