### PR TITLE
op-node: fix stale payload-ID in sequencer log

### DIFF
--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -179,7 +179,8 @@ func (d *Sequencer) RunNextSequencerAction(ctx context.Context) *eth.ExecutionPa
 			d.log.Error("sequencer failed to start building new block", "err", err)
 			d.nextAction = d.timeNow().Add(time.Second)
 		} else {
-			d.log.Info("sequencer started building new block", "payload_id", buildingID)
+			parent, buildingID, _ := d.engine.BuildingPayload() // we should have a new payload ID now that we're building a block
+			d.log.Info("sequencer started building new block", "payload_id", buildingID, "l2_parent_block", parent, "l2_parent_block_time", parent.Time)
 		}
 		return nil
 	}


### PR DESCRIPTION
**Description**

Small logging fix: It was logging a zeroed payload-ID instead of the new payload-ID when starting block-building.
This also adds the L2 parent block as log information, to get a better idea of what block is actually being built.