### PR TITLE
feat(ci-builder/ctb): Update foundry & `forge-std`

### DIFF
--- a/.changeset/weak-onions-think.md
+++ b/.changeset/weak-onions-think.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/ci-builder': minor
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Update foundry

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /opt/foundry
 # Only diff from upstream docker image is this clone instead
 # of COPY. We select a specific commit to use.
 RUN git clone https://github.com/foundry-rs/foundry.git . \
-    && git checkout edf15abd648bb96e2bcee342c1d72ec7d1066cd1
+    && git checkout 8f3fca9c608d58981daaffe11e7f8076644cb753
 
 RUN source $HOME/.profile && \
     cargo build --release && \

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -79,7 +79,7 @@
     "dotenv": "^16.0.0",
     "ds-test": "https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5",
     "ethereum-waffle": "^3.0.0",
-    "forge-std": "https://github.com/foundry-rs/forge-std.git#a2edd39db95df7e9dd3f9ef9edc8c55fefddb6df",
+    "forge-std": "https://github.com/foundry-rs/forge-std.git#fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0",
     "glob": "^7.1.6",
     "hardhat-deploy": "^0.11.4",
     "solhint": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9518,9 +9518,9 @@ forever-agent@~0.6.1:
   version "1.2.0"
   resolved "https://github.com/foundry-rs/forge-std.git#53331f4cb2e313466f72440f3e73af048c454d02"
 
-"forge-std@https://github.com/foundry-rs/forge-std.git#a2edd39db95df7e9dd3f9ef9edc8c55fefddb6df":
+"forge-std@https://github.com/foundry-rs/forge-std.git#fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0":
   version "1.4.0"
-  resolved "https://github.com/foundry-rs/forge-std.git#a2edd39db95df7e9dd3f9ef9edc8c55fefddb6df"
+  resolved "https://github.com/foundry-rs/forge-std.git#fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0"
 
 form-data@^2.2.0:
   version "2.5.1"


### PR DESCRIPTION
# Overview

Updates:
- Foundry version in the ci-builder to: `8f3fca9c608d58981daaffe11e7f8076644cb753`
- `forge-std` version in `contracts-bedrock` dependencies to: `fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0`

Includes two new variants of the `expectCall` cheatcode that are necessary to properly test #4954 ++ Includes a changeset for a new release of the `ci-builder` package.