### PR TITLE
ci: Combine release jobs, add release approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ jobs:
             docker build \
             $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
             -f <<parameters.docker_file>> \
+            --build-arg VERSION=$CIRCLE_TAG \ 
             <<parameters.docker_context>>
       - run:
           name: Configure Docker
@@ -1152,6 +1153,11 @@ workflows:
       - hold:
           type: approval
           context: oplabs-gcr-release
+          filters:
+            tags:
+              only: /^op-node\/v.*/
+            branches:
+              ignore: /.*/
       - docker-release:
           name: op-node-docker-release
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,8 +189,22 @@ jobs:
             DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|${IMAGE_BASE}:|")
             echo -ne $DOCKER_TAGS | tr ' ' '\n' | xargs -L1 docker push
 
-  docker-tag-op-stack-release:
+  docker-release:
+    environment:
+      DOCKER_BUILDKIT: 1
     parameters:
+      docker_name:
+        description: Docker image name
+        type: string
+      docker_tags:
+        description: Docker image tags as csv
+        type: string
+      docker_file:
+        description: Path to Dockerfile
+        type: string
+      docker_context:
+        description: Docker build context
+        type: string
       registry:
         description: Docker registry
         type: string
@@ -199,17 +213,35 @@ jobs:
         description: Docker repo
         type: string
         default: "oplabs-tools-artifacts/images"
-    docker:
-      - image: cimg/python:3.7
-    resource_class: small
+    machine:
+      image: ubuntu-2204:2022.07.1
+      resource_class: xlarge
     steps:
       - gcp-cli/install
       - gcp-oidc-authenticate
       - checkout
       - run:
-          name: Tag
+          name: Build
+          command: |
+            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
+            DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
+            docker build \
+            $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
+            -f <<parameters.docker_file>> \
+            <<parameters.docker_context>>
+      - run:
+          name: Configure Docker
           command: |
             gcloud auth configure-docker <<parameters.registry>>
+      - run:
+          name: Publish
+          command: |
+            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
+            DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|${IMAGE_BASE}:|")
+            echo -ne $DOCKER_TAGS | tr ' ' '\n' | xargs -L1 docker push
+      - run:
+          name: Tag
+          command: |
             ./ops/scripts/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
 
   contracts-bedrock-tests:
@@ -1117,113 +1149,66 @@ workflows:
             - op-proposer-docker-build
   release:
     jobs:
-      - docker-build:
-          name: op-node-docker-build
+      - hold:
+          type: approval
+          context: oplabs-gcr-release
+      - docker-release:
+          name: op-node-docker-release
           filters:
             tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
+              only: /^op-node\/v.*/
             branches:
               ignore: /.*/
           docker_file: op-node/Dockerfile
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-      - docker-publish:
-          name: op-node-docker-publish
-          filters:
-            tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
-            branches:
-              ignore: /.*/
-          docker_name: op-node
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - oplabs-gcr
+            - oplabs-gcr-release
           requires:
-            - op-node-docker-build
-      - docker-build:
-          name: op-batcher-docker-build
+            - hold
+      - docker-release:
+          name: op-batcher-docker-release
           filters:
             tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
+              only: /^op-batcher\/v.*/
             branches:
               ignore: /.*/
           docker_file: op-batcher/Dockerfile
           docker_name: op-batcher
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-      - docker-publish:
-          name: op-batcher-docker-publish
-          filters:
-            tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
-            branches:
-              ignore: /.*/
-          docker_name: op-batcher
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - oplabs-gcr
+            - oplabs-gcr-release
           requires:
-            - op-batcher-docker-build
-      - docker-build:
-          name: op-proposer-docker-build
+            - hold
+      - docker-release:
+          name: op-proposer-docker-release
           filters:
             tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
+              only: /^op-proposer\/v.*/
             branches:
               ignore: /.*/
           docker_file: op-proposer/Dockerfile
           docker_name: op-proposer
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-      - docker-publish:
-          name: op-proposer-docker-publish
-          filters:
-            tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
-            branches:
-              ignore: /.*/
-          docker_name: op-proposer
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           context:
-            - oplabs-gcr
+            - oplabs-gcr-release
           requires:
-            - op-proposer-docker-build
+            - hold
       - docker-build:
-          name: op-migrate-docker-build
+          name: op-migrate-docker-release
           filters:
             tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
+              only: /^op-migrate\/v.*/
             branches:
               ignore: /.*/
           docker_file: op-chain-ops/Dockerfile
           docker_name: op-migrate
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           docker_context: .
-      - docker-publish:
-          name: op-migrate-docker-publish
-          filters:
-            tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
-            branches:
-              ignore: /.*/
-          docker_name: op-migrate
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          context:
-            - oplabs-gcr
-          requires:
-            - op-migrate-docker-build
-      - docker-tag-op-stack-release:
-          name: docker-tag-op-stack-release
-          filters:
-            tags:
-              only: /^op-[a-z0-9\-]*\/v.*/
-            branches:
-              ignore: /.*/
-          requires:
-            - op-node-docker-publish
-            - op-proposer-docker-publish
-            - op-batcher-docker-publish
-            - op-migrate-docker-publish
           context:
             - oplabs-gcr-release
+          requires:
+            - hold

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.18.0-alpine3.15 as builder
 
+ARG VERSION=v0.0.0
+
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # build op-batcher with the shared go.mod & go.sum files
@@ -15,7 +17,7 @@ COPY ./.git /app/.git
 
 WORKDIR /app/op-batcher
 
-RUN make op-batcher
+RUN make op-batcher VERSION="$VERSION"
 
 FROM alpine:3.15
 

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.18.0-alpine3.15 as builder
 
+ARG VERSION=v0.0.0
+
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # build op-node with the shared go.mod & go.sum files
@@ -13,7 +15,7 @@ COPY ./.git /app/.git
 
 WORKDIR /app/op-node
 
-RUN make op-node
+RUN make op-node VERSION="$VERSION"
 
 FROM alpine:3.15
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.18.0-alpine3.15 as builder
 
+ARG VERSION=v0.0.0
+
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # build op-proposer with the shared go.mod & go.sum files
@@ -14,7 +16,7 @@ COPY ./.git /app/.git
 
 WORKDIR /app/op-proposer
 
-RUN make op-proposer
+RUN make op-proposer VERSION="$VERSION"
 
 FROM alpine:3.15
 

--- a/ops/scripts/ci-docker-tag-op-stack-release.sh
+++ b/ops/scripts/ci-docker-tag-op-stack-release.sh
@@ -35,5 +35,11 @@ fi
 echo "Tagging $SOURCE_IMAGE_TAG with '$IMAGE_TAG'"
 gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG"
 
+# Do not tag with latest if the release is a release candidate.
+if [[ "$IMAGE_TAG" == *"rc"* ]]; then
+  echo "Not tagging with 'latest' because the release is a release candidate."
+  exit 0
+fi
+
 echo "Tagging $SOURCE_IMAGE_TAG with 'latest'"
 gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG_LATEST"


### PR DESCRIPTION
Combines the Docker build/publish jobs into one, and makes them all depend on a `hold` job that asks for approval. The `hold` step allows someone from the `release-managers` security group to approve the build before it is released. Without this step, tags created by automation tools like GitHub Actions will not be pushed.

I also added automatic release tags to each Docker build.