### PR TITLE
fix(atst): Explicitly warn user if they need to pass in a data type

### DIFF
--- a/packages/atst/src/commands/read.spec.ts
+++ b/packages/atst/src/commands/read.spec.ts
@@ -22,7 +22,10 @@ describe(`cli:${read.name}`, () => {
       rpcUrl: 'http://localhost:8545',
     })
     expect(consoleUtil.formatted).toMatchInlineSnapshot(
-      '"[37mhttps://assets.optimism.io/4a609661-6774-441f-9fdb-453fdbb89931-bucket/optimist-nft/attributes[39m"'
+      `
+      "https://assets.optimism.io/4a609661-6774-441f-9fdb-453fdbb89931-bucket/optimist-nft/attributes
+      [37mhttps://assets.optimism.io/4a609661-6774-441f-9fdb-453fdbb89931-bucket/optimist-nft/attributes[39m"
+    `
     )
   })
 })

--- a/packages/atst/src/commands/read.ts
+++ b/packages/atst/src/commands/read.ts
@@ -64,8 +64,18 @@ export const read = async (options: ReadOptions) => {
       parsedOptions.dataType,
       parsedOptions.contract
     )
-    logger.log(result?.toString())
-    return result?.toString()
+    const strResult = result?.toString()
+    console.log(strResult.trim())
+    if (!strResult.replace(/[\u0000-\u001F\u007F-\u009F]/g, '').trim()) {
+      logger.warn(
+        `Unable to parse as string.  Pass in --dataType to specify the type of the data`
+      )
+      logger.log(result)
+      return result
+    } else {
+      logger.log(strResult)
+      return result?.toString()
+    }
   } catch (e) {
     logger.error('Unable to read attestation', e)
     process.exit(1)


### PR DESCRIPTION
- check to see if attestation is all whitespace
- if it's all whitespace warn user they might need --data-type option
