### PR TITLE
ci: parallel e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ jobs:
           command: |
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
-            OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=true OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
+            OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
             --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>_http_<<parameters.use_http>>.xml \
             -- -timeout=20m ./...
           working_directory: <<parameters.module>>


### PR DESCRIPTION
**Description**

Makes the op-e2e tests parallel in CI.
Because of `gotestsum` the output is collected into a per test file & mostly readable.
There are a lot of `CONT` lines, but it does stitch together the logs.

Note: This may have made TestWithdrawals more flaky.
