### PR TITLE
fix(atst): return correct typescript types for bytes

### DIFF
--- a/.changeset/nasty-chairs-agree.md
+++ b/.changeset/nasty-chairs-agree.md
@@ -2,4 +2,4 @@
 '@eth-optimism/atst': minor
 ---
 
-Fix types
+Fix string type that should be `0x${string}`

--- a/.changeset/nasty-chairs-agree.md
+++ b/.changeset/nasty-chairs-agree.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/atst': minor
+---
+
+Fix types

--- a/packages/atst/src/cli.ts
+++ b/packages/atst/src/cli.ts
@@ -26,6 +26,7 @@ cli
   })
   .example(
     () =>
+      // note: private key is just the first testing address when running anvil
       `atst read --key "optimist.base-uri" --about 0x2335022c740d17c2837f9C884Bfe4fFdbf0A95D5 --creator 0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3`
   )
   .action(async (options: ReadOptions) => {
@@ -72,6 +73,8 @@ cli
       `atst write --key "optimist.base-uri" --about 0x2335022c740d17c2837f9C884Bfe4fFdbf0A95D5 --value "my attestation" --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-url http://localhost:8545`
   )
   .action(async (options: WriteOptions) => {
+    const spinner = logger.spinner()
+    spinner.start('Writing attestation...')
     const { write } = await import('./commands/write')
 
     // TODO use the native api to do this instead of parsing the raw args
@@ -86,9 +89,16 @@ cli
       : options.contract
 
     await write({ ...options, about, privateKey, contract })
+      .then((res) => {
+        spinner.succeed('Attestation written!')
+        logger.info(`Attestation hash: ${res}`)
+      })
+      .catch((e) => {
+        logger.error(e)
+        spinner.fail('Attestation failed!')
+      })
   })
 
-cli.help()
 cli.version(packageJson.version)
 
 void (async () => {

--- a/packages/atst/src/index.ts
+++ b/packages/atst/src/index.ts
@@ -28,3 +28,5 @@ export type { AttestationCreatedEvent } from './types/AttestationCreatedEvent'
 export type { AttestationReadParams } from './types/AttestationReadParams'
 export type { DataTypeOption } from './types/DataTypeOption'
 export type { WagmiBytes } from './types/WagmiBytes'
+// react
+export * from './react'

--- a/packages/atst/src/lib/encodeRawKey.ts
+++ b/packages/atst/src/lib/encodeRawKey.ts
@@ -1,9 +1,11 @@
 import { ethers } from 'ethers'
 
-export const encodeRawKey = (rawKey: string) => {
+import { WagmiBytes } from '../types/WagmiBytes'
+
+export const encodeRawKey = (rawKey: string): WagmiBytes => {
   if (rawKey.length < 32) {
-    return ethers.utils.formatBytes32String(rawKey)
+    return ethers.utils.formatBytes32String(rawKey) as WagmiBytes
   }
   const hash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(rawKey))
-  return hash.slice(0, 64) + 'ff'
+  return (hash.slice(0, 64) + 'ff') as WagmiBytes
 }

--- a/packages/atst/src/lib/parseAttestationBytes.spec.ts
+++ b/packages/atst/src/lib/parseAttestationBytes.spec.ts
@@ -41,8 +41,11 @@ describe(parseAttestationBytes.name, () => {
   })
 
   it('should work for raw bytes', () => {
-    const bytes = '0x420'
-    expect(parseAttestationBytes(bytes, 'bytes')).toBe(bytes)
+    expect(parseAttestationBytes('0x420', 'bytes')).toMatchInlineSnapshot(
+      '"0x420"'
+    )
+    expect(parseAttestationBytes('0x', 'string')).toMatchInlineSnapshot('""')
+    expect(parseAttestationBytes('0x0', 'string')).toMatchInlineSnapshot('""')
   })
 
   it('should return raw bytes for invalid type', () => {
@@ -57,12 +60,16 @@ describe('parseFoo', () => {
     const str = 'Hello World'
     const bytes = BigNumber.from(toUtf8Bytes(str)).toHexString() as WagmiBytes
     expect(parseString(bytes)).toBe(str)
+    expect(parseString('0x')).toMatchInlineSnapshot('""')
+    expect(parseString('0x0')).toMatchInlineSnapshot('""')
+    expect(parseString('0x0')).toMatchInlineSnapshot('""')
   })
 
   it('works for numbers', () => {
     const num = 123
     const bytes = BigNumber.from(num).toHexString() as WagmiBytes
     expect(parseNumber(bytes)).toEqual(BigNumber.from(num))
+    expect(parseNumber('0x')).toEqual(BigNumber.from(0))
   })
 
   it('works for addresses', () => {
@@ -74,5 +81,8 @@ describe('parseFoo', () => {
   it('works for booleans', () => {
     const bytes = BigNumber.from(1).toHexString() as WagmiBytes
     expect(parseBool(bytes)).toBe(true)
+    expect(parseBool('0x')).toBe(false)
+    expect(parseBool('0x0')).toBe(false)
+    expect(parseBool('0x00000')).toBe(false)
   })
 })

--- a/packages/atst/src/lib/parseAttestationBytes.ts
+++ b/packages/atst/src/lib/parseAttestationBytes.ts
@@ -10,7 +10,7 @@ import { ParseBytesReturn } from '../types/ParseBytesReturn'
  * Parses a string attestion
  */
 export const parseString = (rawAttestation: WagmiBytes): string => {
-  rawAttestation = rawAttestation === '0x' ? '0x0' : rawAttestation
+  rawAttestation = rawAttestation === '0x0' ? '0x' : rawAttestation
   return rawAttestation ? toUtf8String(rawAttestation) : ''
 }
 

--- a/packages/atst/src/lib/readAttestation.spec.ts
+++ b/packages/atst/src/lib/readAttestation.spec.ts
@@ -39,4 +39,3 @@ describe(readAttestation.name, () => {
     )
   })
 })
-

--- a/packages/atst/src/lib/stringifyAttestationBytes.ts
+++ b/packages/atst/src/lib/stringifyAttestationBytes.ts
@@ -6,13 +6,13 @@ import { WagmiBytes } from '../types/WagmiBytes'
 
 export const stringifyAttestationBytes = (
   bytes: WagmiBytes | string | Address | number | boolean | BigNumber
-) => {
+): WagmiBytes => {
   bytes = bytes === '0x' ? '0x0' : bytes
   if (BigNumber.isBigNumber(bytes)) {
-    return bytes.toHexString()
+    return bytes.toHexString() as WagmiBytes
   }
   if (typeof bytes === 'number') {
-    return BigNumber.from(bytes).toHexString()
+    return BigNumber.from(bytes).toHexString() as WagmiBytes
   }
   if (typeof bytes === 'boolean') {
     return bytes ? '0x1' : '0x0'
@@ -21,10 +21,10 @@ export const stringifyAttestationBytes = (
     return bytes
   }
   if (isHexString(bytes)) {
-    return bytes
+    return bytes as WagmiBytes
   }
   if (typeof bytes === 'string') {
-    return toUtf8Bytes(bytes)
+    return BigNumber.from(toUtf8Bytes(bytes)).toHexString() as WagmiBytes
   }
   throw new Error(`unrecognized bytes type ${bytes satisfies never}`)
 }

--- a/packages/atst/src/lib/stringifyAttestationBytes.ts
+++ b/packages/atst/src/lib/stringifyAttestationBytes.ts
@@ -1,6 +1,11 @@
 import { Address } from '@wagmi/core'
 import { BigNumber } from 'ethers'
-import { isAddress, isHexString, toUtf8Bytes } from 'ethers/lib/utils.js'
+import {
+  hexlify,
+  isAddress,
+  isHexString,
+  toUtf8Bytes,
+} from 'ethers/lib/utils.js'
 
 import { WagmiBytes } from '../types/WagmiBytes'
 
@@ -24,7 +29,7 @@ export const stringifyAttestationBytes = (
     return bytes as WagmiBytes
   }
   if (typeof bytes === 'string') {
-    return BigNumber.from(toUtf8Bytes(bytes)).toHexString() as WagmiBytes
+    return hexlify(toUtf8Bytes(bytes)) as WagmiBytes
   }
   throw new Error(`unrecognized bytes type ${bytes satisfies never}`)
 }


### PR DESCRIPTION
- was returning a string when we should return `0x${string}`
- Makes it so users have to cast it when using it with wagmi
