### PR TITLE
fix batcher push back frame when tx failed

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -308,13 +308,13 @@ func (c *channelBuilder) NextFrame() (txID, []byte) {
 	return f.id, f.data
 }
 
-// PushFrame adds the frame back to the internal frames queue. Panics if not of
+// ReassembleFrame adds the frame back to the internal frames queue. Panics if not of
 // the same channel.
-func (c *channelBuilder) PushFrame(id txID, frame []byte) {
+func (c *channelBuilder) ReassembleFrame(id txID, frame []byte) {
 	if id.chID != c.ID() {
 		panic("wrong channel")
 	}
-	c.frames = append(c.frames, taggedData{id: id, data: frame})
+	c.frames = append([]taggedData{{id: id, data: frame}}, c.frames...)
 }
 
 var (

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -87,7 +87,7 @@ func (s *channelManager) Clear() {
 func (s *channelManager) TxFailed(id txID) {
 	if data, ok := s.pendingTransactions[id]; ok {
 		s.log.Trace("marked transaction as failed", "id", id)
-		s.pendingChannel.PushFrame(id, data)
+		s.pendingChannel.ReassembleFrame(id, data)
 		delete(s.pendingTransactions, id)
 	} else {
 		s.log.Warn("unknown transaction marked as failed", "id", id)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When Batcher fails to submit a frame, it should add the failed frame back to `channelBuilder.frames`. Failure frames have the lowest index, so they should be put at the beginning, not the end, of `channelBuilder.frames`. Batcher will then retry sending the failed frame.

**Tests**

If there are any tests I need to add, please let me know.