### PR TITLE
op-node/rollup/derive: Check origin of L2 unsafe head match new L1 origin

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -224,7 +224,12 @@ func (eq *EngineQueue) Step(ctx context.Context) error {
 	}
 	outOfData := false
 	if len(eq.safeAttributes) == 0 {
-		eq.origin = eq.prev.Origin()
+		newOrigin := eq.prev.Origin()
+		// Check if the L2 unsafe head origin is consistent with the new origin
+		if err := eq.verifyNewL1Origin(ctx, newOrigin); err != nil {
+			return err
+		}
+		eq.origin = newOrigin
 		eq.postProcessSafeL2() // make sure we track the last L2 safe head for every new L1 block
 		if next, err := eq.prev.NextAttributes(ctx, eq.safeHead); err == io.EOF {
 			outOfData = true
@@ -244,6 +249,38 @@ func (eq *EngineQueue) Step(ctx context.Context) error {
 	} else {
 		return nil
 	}
+}
+
+// verifyNewL1Origin checks that the L2 unsafe head still has a L1 origin that is on the canonical chain.
+// If the unsafe head origin is after the new L1 origin it is assumed to still be canonical.
+// The check is only required when moving to a new L1 origin.
+func (eq *EngineQueue) verifyNewL1Origin(ctx context.Context, newOrigin eth.L1BlockRef) error {
+	if newOrigin == eq.origin {
+		return nil
+	}
+	unsafeOrigin := eq.unsafeHead.L1Origin
+	if newOrigin.Number == unsafeOrigin.Number && newOrigin.ID() != unsafeOrigin {
+		return NewResetError(fmt.Errorf("l1 origin was inconsistent with l2 unsafe head origin, need reset to resolve: l1 origin: %v; unsafe origin: %v",
+			newOrigin.ID(), unsafeOrigin))
+	}
+	// Avoid requesting an older block by checking against the parent hash
+	if newOrigin.Number == unsafeOrigin.Number+1 && newOrigin.ParentHash != unsafeOrigin.Hash {
+		return NewResetError(fmt.Errorf("l2 unsafe head origin is no longer canonical, need reset to resolve: canonical hash: %v; unsafe origin hash: %v",
+			newOrigin.ParentHash, unsafeOrigin.Hash))
+	}
+	if newOrigin.Number > unsafeOrigin.Number+1 {
+		// If unsafe origin is further behind new origin, check it's still on the canonical chain.
+		canonical, err := eq.l1Fetcher.L1BlockRefByNumber(ctx, unsafeOrigin.Number)
+		if err != nil {
+			return NewTemporaryError(fmt.Errorf("failed to fetch canonical L1 block at slot: %v; err: %w", unsafeOrigin.Number, err))
+		}
+		if canonical.ID() != unsafeOrigin {
+			eq.log.Error("Resetting due to origin mismatch")
+			return NewResetError(fmt.Errorf("l2 unsafe head origin is no longer canonical, need reset to resolve: canonical: %v; unsafe origin: %v",
+				canonical, unsafeOrigin))
+		}
+	}
+	return nil
 }
 
 // tryFinalizeL2 traverses the past L1 blocks, checks if any has been finalized,

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -265,3 +265,575 @@ func TestEngineQueue_Finalize(t *testing.T) {
 	l1F.AssertExpectations(t)
 	eng.AssertExpectations(t)
 }
+func TestEngineQueue_ResetWhenUnsafeOriginNotCanonical(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	rng := rand.New(rand.NewSource(1234))
+
+	l1Time := uint64(2)
+	refA := testutils.RandomBlockRef(rng)
+
+	refB := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refA.Number + 1,
+		ParentHash: refA.Hash,
+		Time:       refA.Time + l1Time,
+	}
+	refC := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refB.Number + 1,
+		ParentHash: refB.Hash,
+		Time:       refB.Time + l1Time,
+	}
+	refD := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refC.Number + 1,
+		ParentHash: refC.Hash,
+		Time:       refC.Time + l1Time,
+	}
+	refE := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refD.Number + 1,
+		ParentHash: refD.Hash,
+		Time:       refD.Time + l1Time,
+	}
+	refF := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refE.Number + 1,
+		ParentHash: refE.Hash,
+		Time:       refE.Time + l1Time,
+	}
+
+	refA0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           refA.Time,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     refA.ID(),
+			L2:     refA0.ID(),
+			L2Time: refA0.Time,
+		},
+		BlockTime:     1,
+		SeqWindowSize: 2,
+	}
+	refA1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refA0.Number + 1,
+		ParentHash:     refA0.Hash,
+		Time:           refA0.Time + cfg.BlockTime,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 1,
+	}
+	refB0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refA1.Number + 1,
+		ParentHash:     refA1.Hash,
+		Time:           refA1.Time + cfg.BlockTime,
+		L1Origin:       refB.ID(),
+		SequenceNumber: 0,
+	}
+	refB1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refB0.Number + 1,
+		ParentHash:     refB0.Hash,
+		Time:           refB0.Time + cfg.BlockTime,
+		L1Origin:       refB.ID(),
+		SequenceNumber: 1,
+	}
+	refC0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refB1.Number + 1,
+		ParentHash:     refB1.Hash,
+		Time:           refB1.Time + cfg.BlockTime,
+		L1Origin:       refC.ID(),
+		SequenceNumber: 0,
+	}
+	refC1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refC0.Number + 1,
+		ParentHash:     refC0.Hash,
+		Time:           refC0.Time + cfg.BlockTime,
+		L1Origin:       refC.ID(),
+		SequenceNumber: 1,
+	}
+	refD0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refC1.Number + 1,
+		ParentHash:     refC1.Hash,
+		Time:           refC1.Time + cfg.BlockTime,
+		L1Origin:       refD.ID(),
+		SequenceNumber: 0,
+	}
+	refD1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refD0.Number + 1,
+		ParentHash:     refD0.Hash,
+		Time:           refD0.Time + cfg.BlockTime,
+		L1Origin:       refD.ID(),
+		SequenceNumber: 1,
+	}
+	refE0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refD1.Number + 1,
+		ParentHash:     refD1.Hash,
+		Time:           refD1.Time + cfg.BlockTime,
+		L1Origin:       refE.ID(),
+		SequenceNumber: 0,
+	}
+	refE1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refE0.Number + 1,
+		ParentHash:     refE0.Hash,
+		Time:           refE0.Time + cfg.BlockTime,
+		L1Origin:       refE.ID(),
+		SequenceNumber: 1,
+	}
+	refF0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refE1.Number + 1,
+		ParentHash:     refE1.Hash,
+		Time:           refE1.Time + cfg.BlockTime,
+		L1Origin:       refF.ID(),
+		SequenceNumber: 0,
+	}
+	refF1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refF0.Number + 1,
+		ParentHash:     refF0.Hash,
+		Time:           refF0.Time + cfg.BlockTime,
+		L1Origin:       refF.ID(),
+		SequenceNumber: 1,
+	}
+	t.Log("refA", refA.Hash)
+	t.Log("refB", refB.Hash)
+	t.Log("refC", refC.Hash)
+	t.Log("refD", refD.Hash)
+	t.Log("refE", refE.Hash)
+	t.Log("refF", refF.Hash)
+	t.Log("refA0", refA0.Hash)
+	t.Log("refA1", refA1.Hash)
+	t.Log("refB0", refB0.Hash)
+	t.Log("refB1", refB1.Hash)
+	t.Log("refC0", refC0.Hash)
+	t.Log("refC1", refC1.Hash)
+	t.Log("refD0", refD0.Hash)
+	t.Log("refD1", refD1.Hash)
+	t.Log("refE0", refE0.Hash)
+	t.Log("refE1", refE1.Hash)
+	t.Log("refF0", refF0.Hash)
+	t.Log("refF1", refF1.Hash)
+
+	metrics := &testutils.TestDerivationMetrics{}
+	eng := &testutils.MockEngine{}
+	// we find the common point to initialize to by comparing the L1 origins in the L2 chain with the L1 chain
+	l1F := &testutils.MockL1Source{}
+
+	eng.ExpectL2BlockRefByLabel(eth.Finalized, refA1, nil)
+	eng.ExpectL2BlockRefByLabel(eth.Safe, refE0, nil)
+	eng.ExpectL2BlockRefByLabel(eth.Unsafe, refF1, nil)
+
+	// unsafe
+	l1F.ExpectL1BlockRefByNumber(refF.Number, refF, nil)
+	eng.ExpectL2BlockRefByHash(refF1.ParentHash, refF0, nil)
+	eng.ExpectL2BlockRefByHash(refF0.ParentHash, refE1, nil)
+
+	// meet previous safe, counts 1/2
+	l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
+	eng.ExpectL2BlockRefByHash(refE1.ParentHash, refE0, nil)
+	eng.ExpectL2BlockRefByHash(refE0.ParentHash, refD1, nil)
+
+	// now full seq window, inclusive
+	l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+	eng.ExpectL2BlockRefByHash(refD1.ParentHash, refD0, nil)
+	eng.ExpectL2BlockRefByHash(refD0.ParentHash, refC1, nil)
+
+	// now one more L1 origin
+	l1F.ExpectL1BlockRefByNumber(refC.Number, refC, nil)
+	eng.ExpectL2BlockRefByHash(refC1.ParentHash, refC0, nil)
+	// parent of that origin will be considered safe
+	eng.ExpectL2BlockRefByHash(refC0.ParentHash, refB1, nil)
+
+	// and we fetch the L1 origin of that as starting point for engine queue
+	l1F.ExpectL1BlockRefByHash(refB.Hash, refB, nil)
+	l1F.ExpectL1BlockRefByHash(refB.Hash, refB, nil)
+
+	// and mock a L1 config for the last L2 block that references the L1 starting point
+	eng.ExpectSystemConfigByL2Hash(refB1.Hash, eth.SystemConfig{
+		BatcherAddr: common.Address{42},
+		Overhead:    [32]byte{123},
+		Scalar:      [32]byte{42},
+		GasLimit:    20_000_000,
+	}, nil)
+
+	prev := &fakeAttributesQueue{origin: refE}
+
+	eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F)
+	require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
+
+	require.Equal(t, refB1, eq.SafeL2Head(), "L2 reset should go back to sequence window ago: blocks with origin E and D are not safe until we reconcile, C is extra, and B1 is the end we look for")
+	require.Equal(t, refB, eq.Origin(), "Expecting to be set back derivation L1 progress to B")
+	require.Equal(t, refA1, eq.Finalized(), "A1 is recognized as finalized before we run any steps")
+
+	// First step after reset will do a fork choice update
+	require.True(t, eq.needForkchoiceUpdate)
+	eng.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+		HeadBlockHash:      eq.unsafeHead.Hash,
+		SafeBlockHash:      eq.safeHead.Hash,
+		FinalizedBlockHash: eq.finalized.Hash,
+	}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil)
+	err := eq.Step(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, refF.ID(), eq.unsafeHead.L1Origin, "should have refF as unsafe head origin")
+
+	// L1 chain reorgs so new origin is at same slot as refF but on a different fork
+	prev.origin = eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refF.Number,
+		ParentHash: refE.Hash,
+		Time:       refF.Time,
+	}
+	eq.UnsafeL2Head()
+	err = eq.Step(context.Background())
+	require.ErrorIs(t, err, ErrReset, "should reset pipeline due to mismatched origin")
+
+	l1F.AssertExpectations(t)
+	eng.AssertExpectations(t)
+}
+
+func TestVerifyNewL1Origin(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	rng := rand.New(rand.NewSource(1234))
+
+	l1Time := uint64(2)
+	refA := testutils.RandomBlockRef(rng)
+
+	refB := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refA.Number + 1,
+		ParentHash: refA.Hash,
+		Time:       refA.Time + l1Time,
+	}
+	refC := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refB.Number + 1,
+		ParentHash: refB.Hash,
+		Time:       refB.Time + l1Time,
+	}
+	refD := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refC.Number + 1,
+		ParentHash: refC.Hash,
+		Time:       refC.Time + l1Time,
+	}
+	refE := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refD.Number + 1,
+		ParentHash: refD.Hash,
+		Time:       refD.Time + l1Time,
+	}
+	refF := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refE.Number + 1,
+		ParentHash: refE.Hash,
+		Time:       refE.Time + l1Time,
+	}
+	refG := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refF.Number + 1,
+		ParentHash: refF.Hash,
+		Time:       refF.Time + l1Time,
+	}
+	refH := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     refG.Number + 1,
+		ParentHash: refG.Hash,
+		Time:       refG.Time + l1Time,
+	}
+
+	refA0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           refA.Time,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L1:     refA.ID(),
+			L2:     refA0.ID(),
+			L2Time: refA0.Time,
+		},
+		BlockTime:     1,
+		SeqWindowSize: 2,
+	}
+	refA1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refA0.Number + 1,
+		ParentHash:     refA0.Hash,
+		Time:           refA0.Time + cfg.BlockTime,
+		L1Origin:       refA.ID(),
+		SequenceNumber: 1,
+	}
+	refB0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refA1.Number + 1,
+		ParentHash:     refA1.Hash,
+		Time:           refA1.Time + cfg.BlockTime,
+		L1Origin:       refB.ID(),
+		SequenceNumber: 0,
+	}
+	refB1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refB0.Number + 1,
+		ParentHash:     refB0.Hash,
+		Time:           refB0.Time + cfg.BlockTime,
+		L1Origin:       refB.ID(),
+		SequenceNumber: 1,
+	}
+	refC0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refB1.Number + 1,
+		ParentHash:     refB1.Hash,
+		Time:           refB1.Time + cfg.BlockTime,
+		L1Origin:       refC.ID(),
+		SequenceNumber: 0,
+	}
+	refC1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refC0.Number + 1,
+		ParentHash:     refC0.Hash,
+		Time:           refC0.Time + cfg.BlockTime,
+		L1Origin:       refC.ID(),
+		SequenceNumber: 1,
+	}
+	refD0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refC1.Number + 1,
+		ParentHash:     refC1.Hash,
+		Time:           refC1.Time + cfg.BlockTime,
+		L1Origin:       refD.ID(),
+		SequenceNumber: 0,
+	}
+	refD1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refD0.Number + 1,
+		ParentHash:     refD0.Hash,
+		Time:           refD0.Time + cfg.BlockTime,
+		L1Origin:       refD.ID(),
+		SequenceNumber: 1,
+	}
+	refE0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refD1.Number + 1,
+		ParentHash:     refD1.Hash,
+		Time:           refD1.Time + cfg.BlockTime,
+		L1Origin:       refE.ID(),
+		SequenceNumber: 0,
+	}
+	refE1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refE0.Number + 1,
+		ParentHash:     refE0.Hash,
+		Time:           refE0.Time + cfg.BlockTime,
+		L1Origin:       refE.ID(),
+		SequenceNumber: 1,
+	}
+	refF0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refE1.Number + 1,
+		ParentHash:     refE1.Hash,
+		Time:           refE1.Time + cfg.BlockTime,
+		L1Origin:       refF.ID(),
+		SequenceNumber: 0,
+	}
+	refF1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         refF0.Number + 1,
+		ParentHash:     refF0.Hash,
+		Time:           refF0.Time + cfg.BlockTime,
+		L1Origin:       refF.ID(),
+		SequenceNumber: 1,
+	}
+	t.Log("refA", refA.Hash)
+	t.Log("refB", refB.Hash)
+	t.Log("refC", refC.Hash)
+	t.Log("refD", refD.Hash)
+	t.Log("refE", refE.Hash)
+	t.Log("refF", refF.Hash)
+	t.Log("refG", refG.Hash)
+	t.Log("refH", refH.Hash)
+	t.Log("refA0", refA0.Hash)
+	t.Log("refA1", refA1.Hash)
+	t.Log("refB0", refB0.Hash)
+	t.Log("refB1", refB1.Hash)
+	t.Log("refC0", refC0.Hash)
+	t.Log("refC1", refC1.Hash)
+	t.Log("refD0", refD0.Hash)
+	t.Log("refD1", refD1.Hash)
+	t.Log("refE0", refE0.Hash)
+	t.Log("refE1", refE1.Hash)
+	t.Log("refF0", refF0.Hash)
+	t.Log("refF1", refF1.Hash)
+
+	metrics := &testutils.TestDerivationMetrics{}
+
+	tests := []struct {
+		name                string
+		newOrigin           eth.L1BlockRef
+		expectReset         bool
+		expectedFetchBlocks map[uint64]eth.L1BlockRef
+	}{
+		{
+			name:        "L1OriginBeforeUnsafeOrigin",
+			newOrigin:   refD,
+			expectReset: false,
+		},
+		{
+			name:        "Matching",
+			newOrigin:   refF,
+			expectReset: false,
+		},
+		{
+			name: "BlockNumberEqualDifferentHash",
+			newOrigin: eth.L1BlockRef{
+				Hash:       testutils.RandomHash(rng),
+				Number:     refF.Number,
+				ParentHash: refE.Hash,
+				Time:       refF.Time,
+			},
+			expectReset: true,
+		},
+		{
+			name:        "UnsafeIsParent",
+			newOrigin:   refG,
+			expectReset: false,
+		},
+		{
+			name: "UnsafeIsParentNumberDifferentHash",
+			newOrigin: eth.L1BlockRef{
+				Hash:       testutils.RandomHash(rng),
+				Number:     refG.Number,
+				ParentHash: testutils.RandomHash(rng),
+				Time:       refG.Time,
+			},
+			expectReset: true,
+		},
+		{
+			name:        "UnsafeIsOlderCanonical",
+			newOrigin:   refH,
+			expectReset: false,
+			expectedFetchBlocks: map[uint64]eth.L1BlockRef{
+				refF.Number: refF,
+			},
+		},
+		{
+			name: "UnsafeIsOlderNonCanonical",
+			newOrigin: eth.L1BlockRef{
+				Hash:       testutils.RandomHash(rng),
+				Number:     refH.Number,
+				ParentHash: testutils.RandomHash(rng),
+				Time:       refH.Time,
+			},
+			expectReset: true,
+			expectedFetchBlocks: map[uint64]eth.L1BlockRef{
+				// Second look up gets a different block in F's block number due to a reorg
+				refF.Number: {
+					Hash:       testutils.RandomHash(rng),
+					Number:     refF.Number,
+					ParentHash: refE.Hash,
+					Time:       refF.Time,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			eng := &testutils.MockEngine{}
+			// we find the common point to initialize to by comparing the L1 origins in the L2 chain with the L1 chain
+			l1F := &testutils.MockL1Source{}
+
+			eng.ExpectL2BlockRefByLabel(eth.Finalized, refA1, nil)
+			eng.ExpectL2BlockRefByLabel(eth.Safe, refE0, nil)
+			eng.ExpectL2BlockRefByLabel(eth.Unsafe, refF1, nil)
+
+			// unsafe
+			l1F.ExpectL1BlockRefByNumber(refF.Number, refF, nil)
+			eng.ExpectL2BlockRefByHash(refF1.ParentHash, refF0, nil)
+			eng.ExpectL2BlockRefByHash(refF0.ParentHash, refE1, nil)
+
+			for blockNum, block := range test.expectedFetchBlocks {
+				l1F.ExpectL1BlockRefByNumber(blockNum, block, nil)
+			}
+
+			// meet previous safe, counts 1/2
+			l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
+			eng.ExpectL2BlockRefByHash(refE1.ParentHash, refE0, nil)
+			eng.ExpectL2BlockRefByHash(refE0.ParentHash, refD1, nil)
+
+			// now full seq window, inclusive
+			l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+			eng.ExpectL2BlockRefByHash(refD1.ParentHash, refD0, nil)
+			eng.ExpectL2BlockRefByHash(refD0.ParentHash, refC1, nil)
+
+			// now one more L1 origin
+			l1F.ExpectL1BlockRefByNumber(refC.Number, refC, nil)
+			eng.ExpectL2BlockRefByHash(refC1.ParentHash, refC0, nil)
+			// parent of that origin will be considered safe
+			eng.ExpectL2BlockRefByHash(refC0.ParentHash, refB1, nil)
+
+			// and we fetch the L1 origin of that as starting point for engine queue
+			l1F.ExpectL1BlockRefByHash(refB.Hash, refB, nil)
+			l1F.ExpectL1BlockRefByHash(refB.Hash, refB, nil)
+
+			// and mock a L1 config for the last L2 block that references the L1 starting point
+			eng.ExpectSystemConfigByL2Hash(refB1.Hash, eth.SystemConfig{
+				BatcherAddr: common.Address{42},
+				Overhead:    [32]byte{123},
+				Scalar:      [32]byte{42},
+				GasLimit:    20_000_000,
+			}, nil)
+
+			prev := &fakeAttributesQueue{origin: refE}
+			eq := NewEngineQueue(logger, cfg, eng, metrics, prev, l1F)
+			require.ErrorIs(t, eq.Reset(context.Background(), eth.L1BlockRef{}, eth.SystemConfig{}), io.EOF)
+
+			require.Equal(t, refB1, eq.SafeL2Head(), "L2 reset should go back to sequence window ago: blocks with origin E and D are not safe until we reconcile, C is extra, and B1 is the end we look for")
+			require.Equal(t, refB, eq.Origin(), "Expecting to be set back derivation L1 progress to B")
+			require.Equal(t, refA1, eq.Finalized(), "A1 is recognized as finalized before we run any steps")
+
+			// First step after reset will do a fork choice update
+			require.True(t, eq.needForkchoiceUpdate)
+			eng.ExpectForkchoiceUpdate(&eth.ForkchoiceState{
+				HeadBlockHash:      eq.unsafeHead.Hash,
+				SafeBlockHash:      eq.safeHead.Hash,
+				FinalizedBlockHash: eq.finalized.Hash,
+			}, nil, &eth.ForkchoiceUpdatedResult{PayloadStatus: eth.PayloadStatusV1{Status: eth.ExecutionValid}}, nil)
+			err := eq.Step(context.Background())
+			require.NoError(t, err)
+
+			require.Equal(t, refF.ID(), eq.unsafeHead.L1Origin, "should have refF as unsafe head origin")
+
+			// L1 chain reorgs so new origin is at same slot as refF but on a different fork
+			prev.origin = test.newOrigin
+			eq.UnsafeL2Head()
+			err = eq.Step(context.Background())
+			if test.expectReset {
+				require.ErrorIs(t, err, ErrReset, "should reset pipeline due to mismatched origin")
+			} else {
+				require.ErrorIs(t, err, io.EOF, "should not reset pipeline")
+			}
+
+			l1F.AssertExpectations(t)
+			eng.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Each time we reach a new L1 origin in the EngineQueue stage, check it indicates the L2 block is non-canonical and reset if so.

**Tests**

Add tests that drive the engine queue stage and advance the L1 origin to cover each case being checked.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3405/check-l1-origin-of-unsafe-head-when-we-traverse-in-engine-queue-stage
