### PR TITLE
op-batcher/batcher/channel_manager: when send tx failed, the frame should strip the version

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -87,7 +87,7 @@ func (s *channelManager) Clear() {
 func (s *channelManager) TxFailed(id txID) {
 	if data, ok := s.pendingTransactions[id]; ok {
 		s.log.Trace("marked transaction as failed", "id", id)
-		s.pendingChannel.PushFrame(id, data)
+		s.pendingChannel.PushFrame(id, data[1:]) // strip the version byte
 		delete(s.pendingTransactions, id)
 	} else {
 		s.log.Warn("unknown transaction marked as failed", "id", id)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When send tx failed, the frame should strip the version. fix #4937 

**Metadata**
- Fixes #4937 
- Fixes CLI-3428
