### PR TITLE
fix(atst): Default chainId to undefined instead of 10

### DIFF
--- a/.changeset/sixty-days-explain.md
+++ b/.changeset/sixty-days-explain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/atst': patch
+---
+
+Fixed bug with atst not defaulting to currently connected chain

--- a/packages/atst/src/lib/prepareWriteAttestation.ts
+++ b/packages/atst/src/lib/prepareWriteAttestation.ts
@@ -10,7 +10,7 @@ export const prepareWriteAttestation = async (
   about: Address,
   key: string,
   value: string | WagmiBytes | number | boolean,
-  chainId = 10,
+  chainId: number | undefined = undefined,
   contractAddress: Address = ATTESTATION_STATION_ADDRESS
 ) => {
   let formattedKey: WagmiBytes

--- a/packages/atst/src/lib/prepareWriteAttestations.ts
+++ b/packages/atst/src/lib/prepareWriteAttestations.ts
@@ -14,7 +14,7 @@ type Attestation = {
 
 export const prepareWriteAttestations = async (
   attestations: Attestation[],
-  chainId = 10,
+  chainId: number | undefined = undefined,
   contractAddress: Address = ATTESTATION_STATION_ADDRESS
 ) => {
   const formattedAttestations = attestations.map((attestation) => {
@@ -27,9 +27,7 @@ export const prepareWriteAttestations = async (
         `key is longer than 32 bytes: ${attestation.key}.  Try using a shorter key or using 'encodeRawKey' to encode the key into 32 bytes first`
       )
     }
-    const formattedValue = createValue(
-      attestation.value
-    ) as WagmiBytes
+    const formattedValue = createValue(attestation.value) as WagmiBytes
     return {
       about: attestation.about,
       key: formattedKey,

--- a/packages/atst/src/types/AttestationReadParams.ts
+++ b/packages/atst/src/types/AttestationReadParams.ts
@@ -11,4 +11,5 @@ export interface AttestationReadParams {
   key: string
   dataType?: DataTypeOption
   contractAddress?: Address
+  chainId?: number
 }


### PR DESCRIPTION
Another bug ori found
ChainId defaults to 10.  That means if using a network other than 10 user has to be explicit about chainId needlessly.

- make it so chainId defaults to undefined (aka the currently connected chain)

