### PR TITLE
op-node/p2p: Use the new block signing hash when producing gossip

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -464,7 +464,7 @@ func (cfg SystemConfig) Start() (*System, error) {
 			c.P2P = p
 
 			if c.Driver.SequencerEnabled {
-				c.P2PSigner = &p2p.PreparedSigner{Signer: p2p.NewLegacyLocalSigner(cfg.Secrets.SequencerP2P)}
+				c.P2PSigner = &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(cfg.Secrets.SequencerP2P)}
 			}
 		}
 

--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -24,7 +24,7 @@ func LoadSignerSetup(ctx *cli.Context) (p2p.SignerSetup, error) {
 			return nil, fmt.Errorf("failed to read batch submitter key: %w", err)
 		}
 
-		return &p2p.PreparedSigner{Signer: p2p.NewLegacyLocalSigner(priv)}, nil
+		return &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(priv)}, nil
 	}
 
 	// TODO: create remote signer

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -49,7 +49,7 @@ func TestVerifyBlockSignature(t *testing.T) {
 	}{
 		{
 			name:      "Legacy",
-			newSigner: NewLegacyLocalSigner,
+			newSigner: newLegacyLocalSigner,
 		},
 		{
 			name:      "Updated",
@@ -101,4 +101,8 @@ func TestVerifyBlockSignature(t *testing.T) {
 			require.Equal(t, pubsub.ValidationIgnore, result)
 		})
 	}
+}
+
+func newLegacyLocalSigner(priv *ecdsa.PrivateKey) *LocalSigner {
+	return &LocalSigner{priv: priv, hasher: LegacySigningHash}
 }

--- a/op-node/p2p/signer.go
+++ b/op-node/p2p/signer.go
@@ -64,10 +64,6 @@ type LocalSigner struct {
 	hasher func(domain [32]byte, chainID *big.Int, payloadBytes []byte) (common.Hash, error)
 }
 
-func NewLegacyLocalSigner(priv *ecdsa.PrivateKey) *LocalSigner {
-	return &LocalSigner{priv: priv, hasher: LegacySigningHash}
-}
-
 func NewLocalSigner(priv *ecdsa.PrivateKey) *LocalSigner {
 	return &LocalSigner{priv: priv, hasher: SigningHash}
 }


### PR DESCRIPTION
**Description**

Both legacy and new hashes are still accepted to avoid incompatibility if other nodes upgrade before the sequencer is upgraded.

**Metadata**
- Second step for https://linear.app/optimism/issue/CLI-3341/sherlock-067-125-chain-id-is-clobbered-in-p2p-signing-hash
