### PR TITLE
op-node/p2p: Extend time out for discovery test

### DIFF
--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -315,7 +315,7 @@ func TestDiscovery(t *testing.T) {
 
 	// B and C don't know each other yet, but both have A as a bootnode.
 	// It should only be a matter of time for them to connect, if they discover each other via A.
-	timeout := time.After(time.Second * 10)
+	timeout := time.After(time.Second * 60)
 	var peersOfB []peer.ID
 	// B should be connected to the bootnode (A) it used (it's a valid optimism node to connect to here)
 	// C should also be connected, although this one might take more time to discover


### PR DESCRIPTION
**Description**

`TestDiscovery` timeout had been incorrectly reduced from 60 seconds to just 10 seconds as part of an attempt to fix intermittency.  That timeout is too short to pass reliably so return it to a 60 second total timeout.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3133/fix-testdiscovery-in-op-node
