### PR TITLE
op-node: Set timeouts on http servers

### DIFF
--- a/op-node/cmd/stateviz/main.go
+++ b/op-node/cmd/stateviz/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/server"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -161,7 +162,8 @@ func runServer() {
 	mux.HandleFunc("/logs", makeGzipHandler(logsHandler))
 
 	log.Info("running webserver...")
-	if err := http.Serve(l, mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	httpServer := server.NewHttpServer(mux)
+	if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Crit("http server failed", "message", err)
 	}
 }

--- a/op-node/cmd/stateviz/main.go
+++ b/op-node/cmd/stateviz/main.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-	"github.com/ethereum-optimism/optimism/op-node/server"
+	ophttp "github.com/ethereum-optimism/optimism/op-node/http"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -162,7 +162,7 @@ func runServer() {
 	mux.HandleFunc("/logs", makeGzipHandler(logsHandler))
 
 	log.Info("running webserver...")
-	httpServer := server.NewHttpServer(mux)
+	httpServer := ophttp.NewHttpServer(mux)
 	if err := httpServer.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Crit("http server failed", "message", err)
 	}

--- a/op-node/http/http.go
+++ b/op-node/http/http.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"net/http"

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-node/server"
+	ophttp "github.com/ethereum-optimism/optimism/op-node/http"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -528,7 +528,7 @@ func (m *Metrics) RecordSequencerSealingTime(duration time.Duration) {
 // The server will be closed when the passed-in context is cancelled.
 func (m *Metrics) Serve(ctx context.Context, hostname string, port int) error {
 	addr := net.JoinHostPort(hostname, strconv.Itoa(port))
-	server := server.NewHttpServer(promhttp.InstrumentMetricHandler(
+	server := ophttp.NewHttpServer(promhttp.InstrumentMetricHandler(
 		m.registry, promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}),
 	))
 	server.Addr = addr

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/server"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -528,12 +528,10 @@ func (m *Metrics) RecordSequencerSealingTime(duration time.Duration) {
 // The server will be closed when the passed-in context is cancelled.
 func (m *Metrics) Serve(ctx context.Context, hostname string, port int) error {
 	addr := net.JoinHostPort(hostname, strconv.Itoa(port))
-	server := &http.Server{
-		Addr: addr,
-		Handler: promhttp.InstrumentMetricHandler(
-			m.registry, promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}),
-		),
-	}
+	server := server.NewHttpServer(promhttp.InstrumentMetricHandler(
+		m.registry, promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}),
+	))
+	server.Addr = addr
 	go func() {
 		<-ctx.Done()
 		server.Close()

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/ethereum-optimism/optimism/op-node/server"
+	ophttp "github.com/ethereum-optimism/optimism/op-node/http"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -88,7 +88,7 @@ func (s *rpcServer) Start() error {
 	}
 	s.listenAddr = listener.Addr()
 
-	s.httpServer = server.NewHttpServer(mux)
+	s.httpServer = ophttp.NewHttpServer(mux)
 	go func() {
 		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) { // todo improve error handling
 			s.log.Error("http server failed", "err", err)

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/ethereum-optimism/optimism/op-node/server"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -87,7 +88,7 @@ func (s *rpcServer) Start() error {
 	}
 	s.listenAddr = listener.Addr()
 
-	s.httpServer = &http.Server{Handler: mux}
+	s.httpServer = server.NewHttpServer(mux)
 	go func() {
 		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) { // todo improve error handling
 			s.log.Error("http server failed", "err", err)

--- a/op-node/server/http.go
+++ b/op-node/server/http.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Use default timeouts from Geth as battle tested default values
+var timeouts = rpc.DefaultHTTPTimeouts
+
+func NewHttpServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Handler:           handler,
+		ReadTimeout:       timeouts.ReadTimeout,
+		ReadHeaderTimeout: timeouts.ReadHeaderTimeout,
+		WriteTimeout:      timeouts.WriteTimeout,
+		IdleTimeout:       timeouts.IdleTimeout,
+	}
+}


### PR DESCRIPTION
**Description**

Sets reasonable timeouts on ppc, metrics and stateviz servers.

Used the default timeouts from Geth RPC since they seem reasonable and are battle-tested.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3345/sherlock-261-http-services-dont-set-timeouts
