### PR TITLE
devnet: Enable Regolith from genesis when deploying the local devnet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,6 +191,6 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-aea0402.0.20230301232322-c407b2a217b7
+replace github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8
 
 //replace github.com/ethereum/go-ethereum v1.11.2 => ../go-ethereum

--- a/go.mod
+++ b/go.mod
@@ -191,6 +191,6 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8
+replace github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230308025559-13ee9ab9153b
 
 //replace github.com/ethereum/go-ethereum v1.11.2 => ../go-ethereum

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8 h1:MVef6knR9Kk6c2EsuqClLQX6An03bP8G4Vdse9t4tUw=
-github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8/go.mod h1:/tjlXxOaovIyuF0l6+wCzr6AtDb3lYWTymmpQAQcqu8=
+github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230308025559-13ee9ab9153b h1:7RNzqCwam//7PPieblo8GSIVukwrfoPO+0xT1yMp9Zw=
+github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230308025559-13ee9ab9153b/go.mod h1:/tjlXxOaovIyuF0l6+wCzr6AtDb3lYWTymmpQAQcqu8=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.11.2-aea0402.0.20230301232322-c407b2a217b7 h1:bkttBXCRDv2Mp4VoGBglr4BjS7icIuN8HS5ZFpeKfvE=
-github.com/ethereum-optimism/op-geth v1.11.2-aea0402.0.20230301232322-c407b2a217b7/go.mod h1:/tjlXxOaovIyuF0l6+wCzr6AtDb3lYWTymmpQAQcqu8=
+github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8 h1:MVef6knR9Kk6c2EsuqClLQX6An03bP8G4Vdse9t4tUw=
+github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8/go.mod h1:/tjlXxOaovIyuF0l6+wCzr6AtDb3lYWTymmpQAQcqu8=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=

--- a/indexer/go.mod
+++ b/indexer/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace (
 	github.com/ethereum/go-ethereum v1.10.26 => github.com/ethereum-optimism/op-geth v0.0.0-20230214215134-401b7fd3309b
-	github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8
+	github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230308025559-13ee9ab9153b
 )
 
 require (

--- a/indexer/go.mod
+++ b/indexer/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace (
 	github.com/ethereum/go-ethereum v1.10.26 => github.com/ethereum-optimism/op-geth v0.0.0-20230214215134-401b7fd3309b
-	github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-aea0402.0.20230301232322-c407b2a217b7
+	github.com/ethereum/go-ethereum v1.11.2 => github.com/ethereum-optimism/op-geth v1.11.2-de8c5df46.0.20230307041648-cde669ce69f8
 )
 
 require (

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -371,6 +372,12 @@ func TestRegolith(t *testing.T) {
 			tx, _, err := opGeth.L2Client.TransactionByHash(ctx, contractCreateTx.Hash())
 			require.NoError(t, err)
 			require.Equal(t, expectedNonce, *tx.EffectiveNonce(), "should report actual tx nonce")
+
+			// Should be able to search for logs even though there are deposit transactions in blocks.
+			logs, err := opGeth.L2Client.FilterLogs(ctx, ethereum.FilterQuery{})
+			require.NoError(t, err)
+			require.NotNil(t, logs)
+			require.Empty(t, logs)
 		})
 
 		t.Run("ReturnUnusedGasToPool_"+test.name, func(t *testing.T) {

--- a/ops-bedrock/Dockerfile.l2
+++ b/ops-bedrock/Dockerfile.l2
@@ -1,4 +1,4 @@
-FROM ethereumoptimism/op-geth:optimism
+FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:optimism
 
 RUN apk add --no-cache jq
 

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -33,5 +33,6 @@
   "eip1559Denominator": 8,
   "eip1559Elasticity": 2,
   "l1GenesisBlockTimestamp": "0x638a4554",
-  "l1StartingBlockTag": "earliest"
+  "l1StartingBlockTag": "earliest",
+  "l2GenesisRegolithTimeOffset": "0x0"
 }


### PR DESCRIPTION
**Description**

op-e2e: Add test to reproduce eth_getLogs failure

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3555/error-from-eth-getlogs-when-regolith-enabled
- Fixes https://linear.app/optimism/issue/CLI-3561/eth-getlogs-fails-on-pre-bedrock-blocks
