### PR TITLE
op-node/cmd/batch_decoder: Fetch batches

### DIFF
--- a/op-node/cmd/batch_decoder/fetch/fetch.go
+++ b/op-node/cmd/batch_decoder/fetch/fetch.go
@@ -1,0 +1,98 @@
+package fetch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"path"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type TransactionWithMeta struct {
+	TxIndex     uint64             `json:"tx_index"`
+	InboxAddr   common.Address     `json:"inbox_address"`
+	BlockNumber uint64             `json:"block_number"`
+	BlockHash   common.Hash        `json:"block_hash"`
+	ChainId     uint64             `json:"chain_id"`
+	Sender      common.Address     `json:"sender"`
+	ValidSender bool               `json:"valid_sender"`
+	Tx          *types.Transaction `json:"tx"`
+}
+
+type Config struct {
+	Start, End   uint64
+	ChainID      *big.Int
+	BatchInbox   common.Address
+	BatchSenders map[common.Address]struct{}
+	OutDirectory string
+}
+
+func Batches(client *ethclient.Client, config Config) (totalValid, totalInvalid int) {
+	if err := os.MkdirAll(config.OutDirectory, 0750); err != nil {
+		log.Fatal(err)
+	}
+	number := new(big.Int).SetUint64(config.Start)
+	signer := types.LatestSignerForChainID(config.ChainID)
+	for i := config.Start; i < config.End; i++ {
+		valid, invalid := fetchBatchesPerBlock(client, number, signer, config)
+		totalValid += valid
+		totalInvalid += invalid
+		number = number.Add(number, common.Big1)
+	}
+	return
+}
+
+func fetchBatchesPerBlock(client *ethclient.Client, number *big.Int, signer types.Signer, config Config) (validBatchCount, invalidBatchCount int) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	block, err := client.BlockByNumber(ctx, number)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for i, tx := range block.Transactions() {
+		if tx.To() != nil && *tx.To() == config.BatchInbox {
+			sender, err := signer.Sender(tx)
+			if err != nil {
+				log.Fatal(err)
+			}
+			var validSender bool
+			if _, ok := config.BatchSenders[sender]; !ok {
+				fmt.Printf("Found a transaction (%s) from an invalid sender (%s)\n", tx.Hash().String(), sender.String())
+				invalidBatchCount += 1
+				validSender = false
+			} else {
+				validBatchCount += 1
+				validSender = true
+			}
+
+			txm := &TransactionWithMeta{
+				Tx:          tx,
+				Sender:      sender,
+				ValidSender: validSender,
+				TxIndex:     uint64(i),
+				BlockNumber: block.NumberU64(),
+				BlockHash:   block.Hash(),
+				ChainId:     config.ChainID.Uint64(),
+				InboxAddr:   config.BatchInbox,
+			}
+			filename := path.Join(config.OutDirectory, fmt.Sprintf("%s.json", tx.Hash().String()))
+			file, err := os.Create(filename)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer file.Close()
+			enc := json.NewEncoder(file)
+			if err := enc.Encode(txm); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+	return
+}

--- a/op-node/cmd/batch_decoder/main.go
+++ b/op-node/cmd/batch_decoder/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/cmd/batch_decoder/fetch"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "batch-decoder"
+	app.Usage = "Optimism Batch Decoding Utility"
+	app.Commands = []cli.Command{
+		{
+			Name:  "fetch",
+			Usage: "Fetches batches in the specified range",
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:     "start",
+					Required: true,
+					Usage:    "First block (inclusive) to fetch",
+				},
+				cli.IntFlag{
+					Name:     "end",
+					Required: true,
+					Usage:    "Last block (exclusive) to fetch",
+				},
+				cli.StringFlag{
+					Name:     "inbox",
+					Required: true,
+					Usage:    "Batch Inbox Address",
+				},
+				cli.StringFlag{
+					Name:     "sender",
+					Required: true,
+					Usage:    "Batch Sender Address",
+				},
+				cli.StringFlag{
+					Name:  "out",
+					Value: "/tmp/batch_decoder/transactions_cache",
+					Usage: "Cache directory for the found transactions",
+				},
+				cli.StringFlag{
+					Name:     "l1",
+					Required: true,
+					Usage:    "L1 RPC URL",
+					EnvVar:   "L1_RPC",
+				},
+			},
+			Action: func(cliCtx *cli.Context) error {
+				client, err := ethclient.Dial(cliCtx.String("l1"))
+				if err != nil {
+					log.Fatal(err)
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+				defer cancel()
+				chainID, err := client.ChainID(ctx)
+				if err != nil {
+					log.Fatal(err)
+				}
+				config := fetch.Config{
+					Start:   uint64(cliCtx.Int("start")),
+					End:     uint64(cliCtx.Int("end")),
+					ChainID: chainID,
+					BatchSenders: map[common.Address]struct{}{
+						common.HexToAddress(cliCtx.String("sender")): struct{}{},
+					},
+					BatchInbox:   common.HexToAddress(cliCtx.String("inbox")),
+					OutDirectory: cliCtx.String("out"),
+				}
+				totalValid, totalInvalid := fetch.Batches(client, config)
+				fmt.Printf("Fetched batches in range [%v,%v). Found %v valid & %v invalid batches\n", config.Start, config.End, totalValid, totalInvalid)
+				fmt.Printf("Fetch Config: Chain ID: %v. Inbox Address: %v. Valid Senders: %v.\n", config.ChainID, config.BatchInbox, config.BatchSenders)
+				fmt.Printf("Wrote transactions with batches to %v\n", config.OutDirectory)
+				return nil
+			},
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -43,4 +44,8 @@ func (id ChannelID) String() string {
 // TerminalString implements log.TerminalStringer, formatting a string for console output during logging.
 func (id ChannelID) TerminalString() string {
 	return fmt.Sprintf("%x..%x", id[:3], id[13:])
+}
+
+func (id ChannelID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(id.String())
 }


### PR DESCRIPTION
**Description**

Provides a utility for fetching batches. It downloads all transactions sent to the batch inbox & stores them for later inspection. It logs transaction hashes that do not come from the authorized senders.

**Tests**

Manually tested.

**Additional context**

This is part of a series of patches to build out this tool to help debug batches.

**Metadata**
- Fixes CLI-3557