### PR TITLE
feat(ctb): Print tenderly simulation URLs during deployment

### DIFF
--- a/.changeset/wicked-ads-pump.md
+++ b/.changeset/wicked-ads-pump.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Print tenderly simulation links during deployment

--- a/packages/contracts-bedrock/.env.example
+++ b/packages/contracts-bedrock/.env.example
@@ -3,3 +3,7 @@ L1_RPC=
 
 # Private key for the deployer account
 PRIVATE_KEY_DEPLOYER=
+
+# Optional Tenderly details for a simulation link during deployment
+TENDERLY_PROJECT=
+TENDERLY_USERNAME=

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -13,6 +13,7 @@ import {
   getDeploymentAddress,
   doStep,
   jsonifyTransaction,
+  getTenderlySimulationLink,
 } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -97,6 +98,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
     // Wait for the ownership transfer to complete.
@@ -133,6 +135,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
     // Wait for the ownership transfer to complete.
@@ -169,6 +172,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
     // Wait for the ownership transfer to complete.

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -13,6 +13,7 @@ import {
   jsonifyTransaction,
   isStep,
   doStep,
+  getTenderlySimulationLink,
 } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -193,6 +194,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
     await awaitCondition(
@@ -303,6 +305,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`OptimismPortal address: ${OptimismPortal.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
     await awaitCondition(
@@ -331,6 +334,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
     await awaitCondition(

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import { URLSearchParams } from 'url'
 
 import { ethers, Contract } from 'ethers'
 import { Provider } from '@ethersproject/abstract-provider'
@@ -293,6 +294,7 @@ export const getDeploymentAddress = async (
 export const jsonifyTransaction = (tx: ethers.PopulatedTransaction): string => {
   return JSON.stringify(
     {
+      from: tx.from,
       to: tx.to,
       data: tx.data,
       value: tx.value,
@@ -354,6 +356,9 @@ export const doStep = async (opts: {
     console.log(`MSD address: ${opts.SystemDictator.address}`)
     console.log(`JSON:`)
     console.log(jsonifyTransaction(tx))
+    console.log(
+      await getTenderlySimulationLink(opts.SystemDictator.provider, tx)
+    )
   }
 
   // Wait for the step to complete.
@@ -367,4 +372,27 @@ export const doStep = async (opts: {
 
   // Perform post-step checks.
   await opts.checks()
+}
+
+/**
+ * Returns a direct link to a Tenderly simulation.
+ *
+ * @param provider Ethers Provider.
+ * @param tx Ethers transaction object.
+ * @returns the url of the tenderly simulation.
+ */
+export const getTenderlySimulationLink = async (
+  provider: ethers.providers.Provider,
+  tx: ethers.PopulatedTransaction
+): Promise<string> => {
+  if (process.env.TENDERLY_PROJECT && process.env.TENDERLY_USERNAME) {
+    return `https://dashboard.tenderly.co/${process.env.TENDERLY_PROJECT}/${
+      process.env.TENDERLY_USERNAME
+    }/simulator/new?${new URLSearchParams({
+      network: (await provider.getNetwork()).chainId.toString(),
+      contractAddress: tx.to,
+      rawFunctionInput: tx.data,
+      from: tx.from,
+    }).toString()}`
+  }
 }


### PR DESCRIPTION
**Description**

Facilitates deployments on Goerli and Mainnet by printing simulation page URLs.

Manually tested.