### PR TITLE
op-batcher: Refactor frame & tx data handling

### DIFF
--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -77,9 +77,9 @@ func TestChannelManagerReturnsErrReorgWhenDrained(t *testing.T) {
 	err = m.AddL2Block(a)
 	require.NoError(t, err)
 
-	_, _, err = m.TxData(eth.BlockID{})
+	_, err = m.TxData(eth.BlockID{})
 	require.NoError(t, err)
-	_, _, err = m.TxData(eth.BlockID{})
+	_, err = m.TxData(eth.BlockID{})
 	require.ErrorIs(t, err, io.EOF)
 	err = m.AddL2Block(x)
 	require.ErrorIs(t, err, batcher.ErrReorg)

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -3,11 +3,14 @@ package batcher_test
 import (
 	"io"
 	"math/big"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	derivetest "github.com/ethereum-optimism/optimism/op-node/rollup/derive/test"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -54,15 +57,15 @@ func TestChannelManagerReturnsErrReorgWhenDrained(t *testing.T) {
 	log := testlog.Logger(t, log.LvlCrit)
 	m := batcher.NewChannelManager(log, batcher.ChannelConfig{
 		TargetFrameSize:  0,
-		MaxFrameSize:     100,
+		MaxFrameSize:     120_000,
 		ApproxComprRatio: 1.0,
 	})
-	lBlock := types.NewBlock(&types.Header{
+	l1Block := types.NewBlock(&types.Header{
 		BaseFee:    big.NewInt(10),
 		Difficulty: common.Big0,
 		Number:     big.NewInt(100),
 	}, nil, nil, nil, trie.NewStackTrie(nil))
-	l1InfoTx, err := derive.L1InfoDeposit(0, lBlock, eth.SystemConfig{}, false)
+	l1InfoTx, err := derive.L1InfoDeposit(0, l1Block, eth.SystemConfig{}, false)
 	require.NoError(t, err)
 	txs := []*types.Transaction{types.NewTx(l1InfoTx)}
 
@@ -81,6 +84,46 @@ func TestChannelManagerReturnsErrReorgWhenDrained(t *testing.T) {
 	require.NoError(t, err)
 	_, err = m.TxData(eth.BlockID{})
 	require.ErrorIs(t, err, io.EOF)
+
 	err = m.AddL2Block(x)
 	require.ErrorIs(t, err, batcher.ErrReorg)
+}
+
+func TestChannelManager_TxResend(t *testing.T) {
+	require := require.New(t)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	log := testlog.Logger(t, log.LvlError)
+	m := batcher.NewChannelManager(log, batcher.ChannelConfig{
+		TargetFrameSize:  0,
+		MaxFrameSize:     120_000,
+		ApproxComprRatio: 1.0,
+	})
+
+	a, _ := derivetest.RandomL2Block(rng, 4)
+
+	err := m.AddL2Block(a)
+	require.NoError(err)
+
+	txdata0, err := m.TxData(eth.BlockID{})
+	require.NoError(err)
+	txdata0bytes := txdata0.Bytes()
+	data0 := make([]byte, len(txdata0bytes))
+	// make sure we have a clone for later comparison
+	copy(data0, txdata0bytes)
+
+	// ensure channel is drained
+	_, err = m.TxData(eth.BlockID{})
+	require.ErrorIs(err, io.EOF)
+
+	// requeue frame
+	m.TxFailed(txdata0.ID())
+
+	txdata1, err := m.TxData(eth.BlockID{})
+	require.NoError(err)
+
+	data1 := txdata1.Bytes()
+	require.Equal(data1, data0)
+	fs, err := derive.ParseFrames(data1)
+	require.NoError(err)
+	require.Len(fs, 1)
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -280,7 +280,7 @@ func (l *BatchSubmitter) loop() {
 				}
 
 				// Collect next transaction data
-				data, id, err := l.state.TxData(l1tip.ID())
+				txdata, err := l.state.TxData(l1tip.ID())
 				if err == io.EOF {
 					l.log.Trace("no transaction data available")
 					break // local for loop
@@ -289,10 +289,10 @@ func (l *BatchSubmitter) loop() {
 					break
 				}
 				// Record TX Status
-				if receipt, err := l.txMgr.SendTransaction(l.ctx, data); err != nil {
-					l.recordFailedTx(id, err)
+				if receipt, err := l.txMgr.SendTransaction(l.ctx, txdata.Bytes()); err != nil {
+					l.recordFailedTx(txdata.ID(), err)
 				} else {
-					l.recordConfirmedTx(id, receipt)
+					l.recordConfirmedTx(txdata.ID(), receipt)
 				}
 
 				// hack to exit this loop. Proper fix is to do request another send tx or parallel tx sending

--- a/op-batcher/batcher/tx_data.go
+++ b/op-batcher/batcher/tx_data.go
@@ -1,0 +1,54 @@
+package batcher
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+// txData represents the data for a single transaction.
+//
+// Note: The batcher currently sends exactly one frame per transaction. This
+// might change in the future to allow for multiple frames from possibly
+// different channels.
+type txData struct {
+	frame frameData
+}
+
+// ID returns the id for this transaction data. It can be used as a map key.
+func (td *txData) ID() txID {
+	return td.frame.id
+}
+
+// Bytes returns the transaction data. It's a version byte (0) followed by the
+// concatenated frames for this transaction.
+func (td *txData) Bytes() []byte {
+	return append([]byte{derive.DerivationVersion0}, td.frame.data...)
+}
+
+// Frame returns the single frame of this tx data.
+//
+// Note: when the batcher is changed to possibly send multiple frames per tx,
+// this should be changed to a func Frames() []frameData.
+func (td *txData) Frame() frameData {
+	return td.frame
+}
+
+// txID is an opaque identifier for a transaction.
+// It's internal fields should not be inspected after creation & are subject to change.
+// This ID must be trivially comparable & work as a map key.
+//
+// Note: transactions currently only hold a single frame, so it can be
+// identified by the frame. This needs to be changed once the batcher is changed
+// to send multiple frames per tx.
+type txID = frameID
+
+func (id txID) String() string {
+	return fmt.Sprintf("%s:%d", id.chID.String(), id.frameNumber)
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (id txID) TerminalString() string {
+	return fmt.Sprintf("%s:%d", id.chID.TerminalString(), id.frameNumber)
+}

--- a/op-node/rollup/derive/test/random.go
+++ b/op-node/rollup/derive/test/random.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// RandomL2Block returns a random block whose first transaction is a random
+// L1 Info Deposit transaction.
+func RandomL2Block(rng *rand.Rand, txCount int) (*types.Block, []*types.Receipt) {
+	l1Block := types.NewBlock(testutils.RandomHeader(rng),
+		nil, nil, nil, trie.NewStackTrie(nil))
+	l1InfoTx, err := derive.L1InfoDeposit(0, l1Block, eth.SystemConfig{}, testutils.RandomBool(rng))
+	if err != nil {
+		panic("L1InfoDeposit: " + err.Error())
+	}
+	return testutils.RandomBlockPrependTxs(rng, txCount, types.NewTx(l1InfoTx))
+}

--- a/op-node/testutils/random.go
+++ b/op-node/testutils/random.go
@@ -206,13 +206,21 @@ func RandomHeader(rng *rand.Rand) *types.Header {
 }
 
 func RandomBlock(rng *rand.Rand, txCount uint64) (*types.Block, []*types.Receipt) {
+	return RandomBlockPrependTxs(rng, int(txCount))
+}
+
+// RandomBlockPrependTxs returns a random block with txCount randomly generated
+// transactions and additionally the transactions ptxs prepended. So the total
+// number of transactions is len(ptxs) + txCount.
+func RandomBlockPrependTxs(rng *rand.Rand, txCount int, ptxs ...*types.Transaction) (*types.Block, []*types.Receipt) {
 	header := RandomHeader(rng)
 	signer := types.NewLondonSigner(big.NewInt(rng.Int63n(1000)))
-	txs := make([]*types.Transaction, 0, txCount)
-	for i := uint64(0); i < txCount; i++ {
+	txs := make([]*types.Transaction, 0, txCount+len(ptxs))
+	txs = append(txs, ptxs...)
+	for i := 0; i < txCount; i++ {
 		txs = append(txs, RandomTx(rng, header.BaseFee, signer))
 	}
-	receipts := make([]*types.Receipt, 0, txCount)
+	receipts := make([]*types.Receipt, 0, len(txs))
 	cumulativeGasUsed := uint64(0)
 	for i, tx := range txs {
 		r := RandomReceipt(rng, signer, tx, uint64(i), cumulativeGasUsed)


### PR DESCRIPTION
**Description**

Introduces two separate types for frame data and tx data to make a clear
distinction between the two. Also prepares the batcher for future changes
when it will support sending multiple frames per tx.

**Tests**

Added a regression test to validate that requeued transactions have the same data (and don't prepend 0 version bytes) and that transaction data can be parsed correctly.

I added a random L2 block generator. Because of dependency cycles, I couldn't put it into package `op-node/testutils` since it uses a function from the `derive` package. Hence added the random generator to a new package `op-node/rollup/derive/test`, following the pattern to create testing code dependent on a package in a `.../test` sub-package.

**Additional context**

Cleaner solution of #5050 