### PR TITLE
fix(fd): use correct fn for getTotalElements

### DIFF
--- a/.changeset/three-apes-study.md
+++ b/.changeset/three-apes-study.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': patch
+---
+
+Fixes a bug that would cause the fault detector to error out if no outputs had been proposed yet.

--- a/packages/fault-detector/src/service.ts
+++ b/packages/fault-detector/src/service.ts
@@ -124,7 +124,7 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
       this.state.oo = {
         contract: oo,
         filter: oo.filters.OutputProposed(),
-        getTotalElements: async () => oo.latestOutputIndex(),
+        getTotalElements: async () => oo.nextOutputIndex(),
         getEventIndex: (args) => args.l2OutputIndex,
       }
     } else {


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Fault detector was using L2OutputOracle.latestOutputIndex() to query the total number of outputs submitted, which was off by one. Correct function is L2OutputOracle.nextOutputIndex(). Caused crashes of the fault detector on startup if no outputs had been submitted to the L2OO yet.
