### PR TITLE
hive: Update op-geth image used for hive tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,7 +849,7 @@ jobs:
             ./hive \
             -sim=<<parameters.sim>> \
             -sim.loglevel=5 \
-            -client=go-ethereum,op-geth_optimism-history,op-proposer_<<parameters.version>>,op-batcher_<<parameters.version>>,op-node_<<parameters.version>> |& tee /tmp/hive.log || echo "failed."
+            -client=go-ethereum,op-geth_optimism,op-proposer_<<parameters.version>>,op-batcher_<<parameters.version>>,op-node_<<parameters.version>> |& tee /tmp/hive.log || echo "failed."
       - run:
           command: |
             tar -cvf /tmp/workspace.tgz -C /home/circleci/project /home/circleci/project/workspace


### PR DESCRIPTION
**Description**

Updates CI config for hive to run the op-geth optimism branch, not the old optimism-history branch.