### PR TITLE
op-e2e: Run CI in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,7 +538,7 @@ jobs:
           command: |
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
-            OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=true OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
+            OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
             --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>_http_<<parameters.use_http>>.xml \
             -- -timeout=20m ./...
           working_directory: <<parameters.module>>

--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -415,6 +415,7 @@ func TestMixedDepositValidity(t *testing.T) {
 // TestMixedWithdrawalValidity makes a number of withdrawal transactions and ensures ones with modified parameters are
 // rejected while unmodified ones are accepted. This runs test cases in different systems.
 func TestMixedWithdrawalValidity(t *testing.T) {
+	parallel(t)
 	// Setup our logger handler
 	if !verboseGethNodes {
 		log.Root().SetHandler(log.DiscardHandler())
@@ -424,7 +425,6 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 	for i := 0; i <= 8; i++ {
 		i := i // avoid loop var capture
 		t.Run(fmt.Sprintf("withdrawal test#%d", i+1), func(t *testing.T) {
-			parallel(t)
 			// Create our system configuration, funding all accounts we created for L1/L2, and start it
 			cfg := DefaultSystemConfig(t)
 			cfg.DeployConfig.FinalizationPeriodSeconds = 6


### PR DESCRIPTION
 **Description**

This gains about a 2x increase in the op-e2e test speed (16 mins -> 8 mins).
I needed to roll back a change I made to how TestMixedWithdrawalValidity was
being ran because that test did not handle the subtests being ran in parallel.
