### PR TITLE
[op-node: derivation pipeline] Don't allow a channel to be reopened

### DIFF
--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -58,6 +58,9 @@ func (p *ProcessedChannels) Seen(id ChannelID) bool {
 }
 
 func (p *ProcessedChannels) Add(id ChannelID) {
+	if p.Seen(id) {
+		return
+	}
 	p.m[id] = true
 	p.a = append(p.a, id)
 	if len(p.a) > MaxProcessedChannelsSize {

--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -34,7 +34,7 @@ type ChannelBank struct {
 
 	channels          map[ChannelID]*Channel // channels by ID
 	channelQueue      []ChannelID            // channels in FIFO order
-	processedChannels ProcessedChannels      // processed channels by ID
+	processedChannels ProcessedChannels
 
 	prev NextFrameProvider
 }
@@ -43,8 +43,8 @@ type ChannelBank struct {
 // This is to ensure if a new frame arrives for a completed channel, we don't create a new
 // channel for that frame.
 type ProcessedChannels struct {
-	m map[ChannelID]bool
-	a []ChannelID
+	m map[ChannelID]bool // channels by ID
+	a []ChannelID        // channels in FIFO order
 }
 
 func NewProcessedChannels() ProcessedChannels {

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -24,6 +24,9 @@ const DerivationVersion0 = 0
 // starting with the oldest channel.
 const MaxChannelBankSize = 100_000_000
 
+// MaxProcessedChannelsSize is the maximum amount of processed channels to track.
+const MaxProcessedChannelsSize = 100_000
+
 // MaxRLPBytesPerChannel is the maximum amount of bytes that will be read from
 // a channel. This limit is set when decoding the RLP.
 const MaxRLPBytesPerChannel = 10_000_000

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -81,7 +81,7 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	dataSrc := NewDataSourceFactory(log, cfg, l1Fetcher) // auxiliary stage for L1Retrieval
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, l1Src)
-	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher)
+	bank := NewChannelBank(log, cfg, frameQueue)
 	chInReader := NewChannelInReader(log, bank)
 	batchQueue := NewBatchQueue(log, cfg, chInReader)
 	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, engine)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Base had a safe-block halt for a number of hours last night. After downloading the L1 data and simulating the derivation pipeline, I found a number of duplicate `frame_number>0 IsLast=true` frames.

Currently the derivation pipeline will open a new channel with the same ID for channels that have completed (timed out or read) if a new frame is submitted for that channel. I believe according to the [spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#loading-frames), this is a bug:
```
 - Duplicate closes (new frame is_last == 1, but the channel has already seen a closing frame) are dropped.
 - If a frame is closing (is_last == 1) any existing higher-numbered frames are removed from the channel.
```

**Tests**

I added a new regression test that reproduces the issue.

**Invariants**

This may change the chain derivation and may require a hard fork.

**Additional context**

Safe block derivation before the fix:
![Screenshot 2023-03-09 at 10 16 37 PM](https://user-images.githubusercontent.com/1538523/224237194-434a75ab-fcb0-4703-9c27-047be51dd830.png)

After:
![Screenshot 2023-03-09 at 11 50 21 PM](https://user-images.githubusercontent.com/1538523/224237212-dff8f048-8147-4e54-b657-39b3c75a9381.png)

(there was still a halt with the fix, this is due to a dangling unclosed channel from restarting the batcher as an attempt to fix the initial chain halt)