### PR TITLE
feat(fd): add support for custom networks

### DIFF
--- a/.changeset/fair-boats-prove.md
+++ b/.changeset/fair-boats-prove.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': patch
+---
+
+Adds custom network support in the fault-detector via a new optional input parameter.

--- a/packages/fault-detector/package.json
+++ b/packages/fault-detector/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@eth-optimism/common-ts": "^0.8.0",
     "@eth-optimism/contracts": "^0.5.40",
+    "@eth-optimism/contracts-bedrock": "^0.13.0",
     "@eth-optimism/core-utils": "^0.12.0",
     "@eth-optimism/sdk": "^2.0.0",
     "@ethersproject/abstract-provider": "^5.7.0"


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Updates the fault detector to add support for custom networks. When you want to use a custom network, you need to supply the FAULT_DETECTOR__ORACLE_ADDRESS environment variable (the oracleAddress parameter to the service).