### PR TITLE
Fix one grammatical error, update Discord link in README.md, and update License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright 2020-2022 Optimism
+Copyright 2020-2023 Optimism
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to build Optimism, check out the [Protocol Specs](./specs/).
 
 ## Community
 
-General discussion happens most frequently on the [Optimism discord](https://discord-gateway.optimism.io/).
+General discussion happens most frequently on the [Optimism discord](https://discord-gateway.optimism.io).
 Governance discussion can also be found on the [Optimism Governance Forum](https://gov.optimism.io/).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to build Optimism, check out the [Protocol Specs](./specs/).
 
 ## Community
 
-General discussion happens most frequently on the [Optimism discord](https://discord.optimism.io).
+General discussion happens most frequently on the [Optimism discord](https://discord-gateway.optimism.io/).
 Governance discussion can also be found on the [Optimism Governance Forum](https://gov.optimism.io/).
 
 ## Contributing
@@ -138,7 +138,7 @@ When merging commits to the `develop` branch you MUST include a changeset file i
 
 To add a changeset, run the command `yarn changeset` in the root of this monorepo.
 You will be presented with a small prompt to select the packages to be released, the scope of the release (major, minor, or patch), and the reason for the release.
-Comments with in changeset files will be automatically included in the changelog of the package.
+Comments within changeset files will be automatically included in the changelog of the package.
 
 ### Triggering Releases
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixes one grammatical error

Updates the Discord link in the README.md file to be consistent with the Discord link within the community-hub repository's README.md file (https://github.com/ethereum-optimism/community-hub). This change improves consistency and reduces the risk of confusion for users. 

Updates License to reflect current year

**Tests**

discord-gateway.optimism.io directs to the correct webpage. 

**Additional context**

Per my previous pull request (https://github.com/ethereum-optimism/community-hub/pull/679), discord-gateway.optimism.io is preferred.  



