### PR TITLE
fix(spec): use correct to field for contract creation deposits

### DIFF
--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -323,7 +323,7 @@ transaction are determined by the corresponding `TransactionDeposited` event emi
 1. `from` is unchanged from the emitted value (though it may have been transformed to an alias in
    the deposit feed contract).
 2. `to` is any 20-byte address (including the zero address)
-    - In case of a contract creation (cf. `isCreation`), this address is always zero.
+    - In case of a contract creation (cf. `isCreation`), this address is set to `null`.
 3. `mint` is set to the emitted value.
 4. `value` is set to the emitted value.
 5. `gaslimit` is unchanged from the emitted value. It must be at least 21000.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The spec mistakenly defines the `to` field of user deposited transactions to be equal to zero when `isCreated` is `true`. While the emitted log must be enforced to be zero, the actual transaction produced by the derivation process must have `to` set to `null`.

I use the term `null` as that is what Ethereum RPCs will use, but would you like me to instead use `nil` to match up more nicely with go conventions and the geth implementation?