### PR TITLE
Enable Regolith in getting-started network

### DIFF
--- a/packages/contracts-bedrock/deploy-config/getting-started.json
+++ b/packages/contracts-bedrock/deploy-config/getting-started.json
@@ -41,6 +41,7 @@
 
   "l2GenesisBlockGasLimit": "0x17D7840",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
+  "l2GenesisRegolithTimeOffset": "0x0",
 
   "eip1559Denominator": 50,
   "eip1559Elasticity": 10


### PR DESCRIPTION
**Description**

Updates the getting-started network to enable Regolith from genesis.