### PR TITLE
fix(op-e2e): Flaky Peering Score Test

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -684,29 +684,29 @@ func TestSystemMockPeerScoring(t *testing.T) {
 
 	// Construct a new sequencer with an invalid privkey to produce invalid gossip
 	// We can then test that the peer scoring system will ban the node
-	sequencer2PrivateKey := cfg.Secrets.Mallory
-	cfg.Nodes["sequencer2"] = &rollupNode.Config{
-		Driver: driver.Config{
-			VerifierConfDepth:  0,
-			SequencerConfDepth: 0,
-			SequencerEnabled:   true,
-		},
-		// Submitter PrivKey is set in system start for rollup nodes where sequencer = true
-		RPC: rollupNode.RPCConfig{
-			ListenAddr:  "127.0.0.1",
-			ListenPort:  0,
-			EnableAdmin: true,
-		},
-		L1EpochPollInterval: time.Second * 4,
-		P2PSigner:           &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(sequencer2PrivateKey)},
-	}
-	cfg.Loggers["sequencer2"] = testlog.Logger(t, log.LvlInfo).New("role", "sequencer")
+	// sequencer2PrivateKey := cfg.Secrets.Mallory
+	// cfg.Nodes["sequencer2"] = &rollupNode.Config{
+	// 	Driver: driver.Config{
+	// 		VerifierConfDepth:  0,
+	// 		SequencerConfDepth: 0,
+	// 		SequencerEnabled:   true,
+	// 	},
+	// 	// Submitter PrivKey is set in system start for rollup nodes where sequencer = true
+	// 	RPC: rollupNode.RPCConfig{
+	// 		ListenAddr:  "127.0.0.1",
+	// 		ListenPort:  0,
+	// 		EnableAdmin: true,
+	// 	},
+	// 	L1EpochPollInterval: time.Second * 4,
+	// 	P2PSigner:           &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(sequencer2PrivateKey)},
+	// }
+	// cfg.Loggers["sequencer2"] = testlog.Logger(t, log.LvlInfo).New("role", "sequencer")
 
 	// connect the nodes
 	cfg.P2PTopology = map[string][]string{
-		"verifier":  {"sequencer", "sequencer2", "verifier2", "verifier3"},
-		"verifier2": {"sequencer", "sequencer2", "verifier", "verifier3"},
-		"verifier3": {"sequencer", "sequencer2", "verifier", "verifier2"},
+		"verifier":  {"sequencer", "verifier2", "verifier3"},
+		"verifier2": {"sequencer", "verifier", "verifier3"},
+		"verifier3": {"sequencer", "verifier", "verifier2"},
 	}
 
 	// Set peer scoring for each node, but without banning
@@ -719,15 +719,16 @@ func TestSystemMockPeerScoring(t *testing.T) {
 		}
 	}
 
-	var published, published2, received1, received2, received3 []common.Hash
+	var published, received1, received2, received3 []common.Hash
+	// var published2 []common.Hash
 	seqTracer, verifTracer, verifTracer2, verifTracer3 := new(FnTracer), new(FnTracer), new(FnTracer), new(FnTracer)
-	seq2Tracer := new(FnTracer)
+	// seq2Tracer := new(FnTracer)
 	seqTracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
 		published = append(published, payload.BlockHash)
 	}
-	seq2Tracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
-		published2 = append(published2, payload.BlockHash)
-	}
+	// seq2Tracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
+	// 	published2 = append(published2, payload.BlockHash)
+	// }
 	verifTracer.OnUnsafeL2PayloadFn = func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayload) {
 		received1 = append(received1, payload.BlockHash)
 	}
@@ -738,7 +739,7 @@ func TestSystemMockPeerScoring(t *testing.T) {
 		received3 = append(received3, payload.BlockHash)
 	}
 	cfg.Nodes["sequencer"].Tracer = seqTracer
-	cfg.Nodes["sequencer2"].Tracer = seq2Tracer
+	// cfg.Nodes["sequencer2"].Tracer = seq2Tracer
 	cfg.Nodes["verifier"].Tracer = verifTracer
 	cfg.Nodes["verifier2"].Tracer = verifTracer2
 	cfg.Nodes["verifier3"].Tracer = verifTracer3
@@ -768,23 +769,23 @@ func TestSystemMockPeerScoring(t *testing.T) {
 		Gas:       21000,
 	})
 	err = l2Seq.SendTransaction(context.Background(), tx)
-	require.Nil(t, err, "Sending L2 tx to sequencer")
+	require.NoError(t, err, "Sending L2 tx to sequencer")
 
 	// Wait for tx to be mined on the L2 sequencer chain
-	receiptSeq, err := waitForTransaction(tx.Hash(), l2Seq, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx on sequencer")
+	receiptSeq, err := waitForTransaction(tx.Hash(), l2Seq, 10*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.NoError(t, err, "Waiting for L2 tx on sequencer")
 
 	// Wait until the block it was first included in shows up in the safe chain on the verifier
-	receiptVerif, err := waitForTransaction(tx.Hash(), l2Verif, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx on verifier")
+	receiptVerif, err := waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.NoError(t, err, "Waiting for L2 tx on verifier")
 	require.Equal(t, receiptSeq, receiptVerif)
 
-	receiptVerif, err = waitForTransaction(tx.Hash(), l2Verif2, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx on verifier2")
+	receiptVerif, err = waitForTransaction(tx.Hash(), l2Verif2, 10*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.NoError(t, err, "Waiting for L2 tx on verifier2")
 	require.Equal(t, receiptSeq, receiptVerif)
 
-	receiptVerif, err = waitForTransaction(tx.Hash(), l2Verif3, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx on verifier3")
+	receiptVerif, err = waitForTransaction(tx.Hash(), l2Verif3, 10*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.NoError(t, err, "Waiting for L2 tx on verifier3")
 	require.Equal(t, receiptSeq, receiptVerif)
 
 	// Verify that everything that was received was published

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -649,9 +649,8 @@ func TestSystemMockP2P(t *testing.T) {
 	require.Contains(t, received, receiptVerif.BlockHash)
 }
 
-// TestSystemMockPeerScoring sets up a L1 Geth node, a rollup node, and a L2 geth node and then confirms that
-// the nodes can sync L2 blocks before they are confirmed on L1.
-func TestSystemMockPeerScoring(t *testing.T) {
+// TestSystemDenseTopology sets up a dense p2p topology with 3 verifier nodes and 1 sequencer node.
+func TestSystemDenseTopology(t *testing.T) {
 	parallel(t)
 	if !verboseGethNodes {
 		log.Root().SetHandler(log.DiscardHandler())
@@ -682,26 +681,6 @@ func TestSystemMockPeerScoring(t *testing.T) {
 	cfg.Loggers["verifier2"] = testlog.Logger(t, log.LvlInfo).New("role", "verifier")
 	cfg.Loggers["verifier3"] = testlog.Logger(t, log.LvlInfo).New("role", "verifier")
 
-	// Construct a new sequencer with an invalid privkey to produce invalid gossip
-	// We can then test that the peer scoring system will ban the node
-	// sequencer2PrivateKey := cfg.Secrets.Mallory
-	// cfg.Nodes["sequencer2"] = &rollupNode.Config{
-	// 	Driver: driver.Config{
-	// 		VerifierConfDepth:  0,
-	// 		SequencerConfDepth: 0,
-	// 		SequencerEnabled:   true,
-	// 	},
-	// 	// Submitter PrivKey is set in system start for rollup nodes where sequencer = true
-	// 	RPC: rollupNode.RPCConfig{
-	// 		ListenAddr:  "127.0.0.1",
-	// 		ListenPort:  0,
-	// 		EnableAdmin: true,
-	// 	},
-	// 	L1EpochPollInterval: time.Second * 4,
-	// 	P2PSigner:           &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(sequencer2PrivateKey)},
-	// }
-	// cfg.Loggers["sequencer2"] = testlog.Logger(t, log.LvlInfo).New("role", "sequencer")
-
 	// connect the nodes
 	cfg.P2PTopology = map[string][]string{
 		"verifier":  {"sequencer", "verifier2", "verifier3"},
@@ -720,15 +699,10 @@ func TestSystemMockPeerScoring(t *testing.T) {
 	}
 
 	var published, received1, received2, received3 []common.Hash
-	// var published2 []common.Hash
 	seqTracer, verifTracer, verifTracer2, verifTracer3 := new(FnTracer), new(FnTracer), new(FnTracer), new(FnTracer)
-	// seq2Tracer := new(FnTracer)
 	seqTracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
 		published = append(published, payload.BlockHash)
 	}
-	// seq2Tracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
-	// 	published2 = append(published2, payload.BlockHash)
-	// }
 	verifTracer.OnUnsafeL2PayloadFn = func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayload) {
 		received1 = append(received1, payload.BlockHash)
 	}
@@ -739,7 +713,6 @@ func TestSystemMockPeerScoring(t *testing.T) {
 		received3 = append(received3, payload.BlockHash)
 	}
 	cfg.Nodes["sequencer"].Tracer = seqTracer
-	// cfg.Nodes["sequencer2"].Tracer = seq2Tracer
 	cfg.Nodes["verifier"].Tracer = verifTracer
 	cfg.Nodes["verifier2"].Tracer = verifTracer2
 	cfg.Nodes["verifier3"].Tracer = verifTracer3
@@ -749,7 +722,6 @@ func TestSystemMockPeerScoring(t *testing.T) {
 	defer sys.Close()
 
 	l2Seq := sys.Clients["sequencer"]
-	// l2Seq2 := sys.Clients["sequencer2"]
 	l2Verif := sys.Clients["verifier"]
 	l2Verif2 := sys.Clients["verifier2"]
 	l2Verif3 := sys.Clients["verifier3"]
@@ -800,37 +772,6 @@ func TestSystemMockPeerScoring(t *testing.T) {
 	require.Contains(t, received1, receiptVerif.BlockHash)
 	require.Contains(t, received2, receiptVerif.BlockHash)
 	require.Contains(t, received3, receiptVerif.BlockHash)
-
-	// Submit TX to the second (malicious) sequencer node
-	// toAddr = common.Address{0xff, 0xff}
-	// maliciousTx := types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L2ChainIDBig()), &types.DynamicFeeTx{
-	// 	ChainID:   cfg.L2ChainIDBig(),
-	// 	Nonce:     1,
-	// 	To:        &toAddr,
-	// 	Value:     big.NewInt(1_000_000_000),
-	// 	GasTipCap: big.NewInt(10),
-	// 	GasFeeCap: big.NewInt(200),
-	// 	Gas:       21000,
-	// })
-	// err = l2Seq2.SendTransaction(context.Background(), maliciousTx)
-	// require.Nil(t, err, "Sending L2 tx to sequencer")
-
-	// Wait for tx to be mined on the L2 sequencer chain
-	// receiptSeq, err = waitForTransaction(maliciousTx.Hash(), l2Seq2, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	// require.Nil(t, err, "Waiting for L2 tx on sequencer")
-
-	// Wait until the block it was first included in shows up in the safe chain on the verifier
-	// receiptVerif, err = waitForTransaction(maliciousTx.Hash(), l2Verif, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	// require.Nil(t, err, "Waiting for L2 tx on verifier")
-	// require.Equal(t, receiptSeq, receiptVerif)
-
-	// receiptVerif, err = waitForTransaction(tx.Hash(), l2Verif2, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	// require.Nil(t, err, "Waiting for L2 tx on verifier2")
-	// require.Equal(t, receiptSeq, receiptVerif)
-
-	// receiptVerif, err = waitForTransaction(tx.Hash(), l2Verif3, 6*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
-	// require.Nil(t, err, "Waiting for L2 tx on verifier3")
-	// require.Equal(t, receiptSeq, receiptVerif)
 }
 
 func TestL1InfoContract(t *testing.T) {


### PR DESCRIPTION
**Description**

Fixes a flaky `op-e2e` system test introduced by peer scoring. Added sequencer is likely eating bandwidth, timing out the test.