### PR TITLE
feat(ctb): Optionally print cast commands during migration

### DIFF
--- a/.changeset/chilled-melons-speak.md
+++ b/.changeset/chilled-melons-speak.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Optionally print cast commands during migration

--- a/packages/contracts-bedrock/.env.example
+++ b/packages/contracts-bedrock/.env.example
@@ -7,3 +7,7 @@ PRIVATE_KEY_DEPLOYER=
 # Optional Tenderly details for a simulation link during deployment
 TENDERLY_PROJECT=
 TENDERLY_USERNAME=
+
+# Optional boolean to define if cast commands should be printed.
+# Useful during migration testing
+CAST_COMMANDS=1

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -14,6 +14,7 @@ import {
   doStep,
   jsonifyTransaction,
   getTenderlySimulationLink,
+  getCastCommand,
 } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -98,6 +99,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(getCastCommand(tx))
       console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
@@ -135,6 +137,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(getCastCommand(tx))
       console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
@@ -172,6 +175,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(getCastCommand(tx))
       console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -14,6 +14,7 @@ import {
   isStep,
   doStep,
   getTenderlySimulationLink,
+  getCastCommand,
 } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
@@ -194,6 +195,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(getCastCommand(tx))
       console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
@@ -305,6 +307,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`OptimismPortal address: ${OptimismPortal.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(getCastCommand(tx))
       console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 
@@ -334,6 +337,7 @@ const deployFn: DeployFunction = async (hre) => {
       console.log(`MSD address: ${SystemDictator.address}`)
       console.log(`JSON:`)
       console.log(jsonifyTransaction(tx))
+      console.log(getCastCommand(tx))
       console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
     }
 

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -395,3 +395,15 @@ export const getTenderlySimulationLink = async (
     }).toString()}`
   }
 }
+
+/**
+ * Returns a cast commmand for submitting a given transaction.
+ *
+ * @param tx Ethers transaction object.
+ * @returns the cast command
+ */
+export const getCastCommand = (tx: ethers.PopulatedTransaction): string => {
+  if (process.env.CAST_COMMANDS) {
+    return `cast send ${tx.to} ${tx.data} --from ${tx.from} --value ${tx.value}`
+  }
+}


### PR DESCRIPTION
**Description**

Allows adding an env var, `CAST_COMMANDS` which when set will print the cast command that should be run to cause the awaited action.