### PR TITLE
ops-bedrock: Fix docker-compose file for MacOS

### DIFF
--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -20,8 +20,14 @@ services:
       - "7060:6060"
     volumes:
       - "l1_data:/db"
-      - "${PWD}/../.devnet/genesis-l1.json:/genesis.json"
-      - "${PWD}/test-jwt-secret.txt:/config/test-jwt-secret.txt"
+      - type: bind
+        source: ${PWD}/../.devnet/genesis-l1.json
+        target: /genesis.json
+        read_only: true
+      - type: bind
+        source: ${PWD}/test-jwt-secret.txt
+        target: /config/test-jwt-secret.txt
+        read_only: true
 
   l2:
     build:
@@ -32,8 +38,14 @@ services:
       - "8060:6060"
     volumes:
       - "l2_data:/db"
-      - "${PWD}/../.devnet/genesis-l2.json:/genesis.json"
-      - "${PWD}/test-jwt-secret.txt:/config/test-jwt-secret.txt"
+      - type: bind
+        source: ${PWD}/../.devnet/genesis-l2.json
+        target: /genesis.json
+        read_only: true
+      - type: bind
+        source: ${PWD}/test-jwt-secret.txt
+        target: /config/test-jwt-secret.txt
+        read_only: true
     entrypoint:  # pass the L2 specific flags by overriding the entry-point and adding extra arguments
       - "/bin/sh"
       - "/entrypoint.sh"
@@ -74,10 +86,20 @@ services:
       - "7300:7300"
       - "6060:6060"
     volumes:
-      - "${PWD}/p2p-sequencer-key.txt:/config/p2p-sequencer-key.txt"
-      - "${PWD}/p2p-node-key.txt:/config/p2p-node-key.txt"
-      - "${PWD}/test-jwt-secret.txt:/config/test-jwt-secret.txt"
-      - "${PWD}/../.devnet/rollup.json:/rollup.json"
+      - type: bind
+        source: ${PWD}/p2p-sequencer-key.txt
+        target: /config/p2p-sequencer-key.txt
+        read_only: true
+      - type: bind
+        source: ${PWD}/p2p-node-key.txt
+        target: /config/p2p-node-key.txt
+        read_only: true
+      - type: bind
+        source: ${PWD}/test-jwt-secret.txt
+        target: /config/test-jwt-secret.txt
+      - type: bind
+        source: ${PWD}/../.devnet/rollup.json
+        target: /rollup.json
       - op_log:/op_log
 
   op-proposer:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Use the "bind" mode when mounting files (not directories) from the host OS into the ops-bedrock containers. This fixes an issue with docker for Mac where the default volume mount always creates a directory on the container side, even when the path points to a file on the host.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
