### PR TITLE
op-batcher: close channel RPC endpoint

### DIFF
--- a/op-batcher/rpc/api.go
+++ b/op-batcher/rpc/api.go
@@ -2,11 +2,14 @@ package rpc
 
 import (
 	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 )
 
 type batcherClient interface {
 	Start() error
 	Stop() error
+	CloseChannel(ctx context.Context, id derive.ChannelID, frameNumber uint16) error
 }
 
 type adminAPI struct {
@@ -17,6 +20,10 @@ func NewAdminAPI(dr batcherClient) *adminAPI {
 	return &adminAPI{
 		b: dr,
 	}
+}
+
+func (a *adminAPI) CloseChannel(ctx context.Context, id derive.ChannelID, frameNumber uint16) error {
+	return a.b.CloseChannel(ctx, id, frameNumber)
 }
 
 func (a *adminAPI) StartBatcher(_ context.Context) error {


### PR DESCRIPTION
Util to request batcher to close any channel, with frame-number of closing-frame as argument, to avoid having to introspect stateful channel data within the op-batcher
