### PR TITLE
specs: Defines an explicit expiry time for channels

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -517,23 +517,30 @@ New frames for timed-out channels are dropped instead of buffered.
 
 The channel-bank can only output data from the first opened channel.
 
-Upon reading, first all timed-out channels are dropped.
+Upon reading, first all expired channels are removed from the known complete channels.
+
+A channel is expired if:
+`current_l1_block.number > channel.open_l1_block.number + max(SEQUENCING_WINDOW_SIZE, CHANNEL_TIMEOUT)`
+
+After expiring known channels, all timed-out channels are moved to the set of known complete channels.
 
 After pruning timed-out channels, the first remaining channel, if any, is read if it is ready:
 
 - The channel must be closed
 - The channel must have a contiguous sequence of frames until the closing frame
 
+After being read, the channel is moved to the set of known complete channels.
+
 If no channel is ready, the next frame is read and ingested into the channel bank.
 
 #### Loading frames
 
-When a channel ID referenced by a frame is not already present in the Channel Bank,
+When a channel ID referenced by a frame is not already present in the Channel Bank, or in the known complete channels,
 a new channel is opened, tagged with the current L1 block, and appended to the channel-queue.
 
 Frame insertion conditions:
 
-- New frames matching existing timed-out channels are dropped.
+- New frames matching known complete channels are dropped.
 - Duplicate frames (by frame number) are dropped.
 - Duplicate closes (new frame `is_last == 1`, but the channel has already seen a closing frame) are dropped.
 


### PR DESCRIPTION
**Description**

Previously it was expected that seen channels were tracked indefinitely so later frames from that channel could be ignored. Setting an explicit timeframe for expiry provides an upper bound on the length of time that such channels need to be tracked.

**Invariants**

For a channel to be valid:
* All frames of a channel must be included within `CHANNEL_TIMEOUT` blocks of the first frame
* No channel expires before it would have timed out or been completed

**Additional context**

Putting this up as draft just for visibility. There needs to be further investigation done on the risks of this change causing a chain split compared to both the current spec and the actual implementation.

Already known is that the current implementation would differ from both the existing and updated spec, in the case where a channel is validly submitted and then, at any point after the frames for that channel is read or times out and within the sequence window of the first block it had a frame in,  the same channel ID is reused for a second, valid, channel. The existing implementation would have pruned the first channel when it timed out or was read and then considered the second channel valid even though it reused the ID. With this change implemented it would consider that second channel invalid because of the channel ID reuse.

Not that even with this change, safe head will still be unable to advance if there is a channel left incomplete until the channel timeout is reached. It does however prevent the case noted in https://github.com/ethereum-optimism/optimism/pull/5107 where an invalid extra frame was included the last frame of a channel within the sequencing window.

The sequencing window was used for the expiry timeline on the assumption that the node would already need to scan blocks at least that far before it's safe head at startup in order to guarantee it can find the data for the next batch on-chain.


**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3600/review-spec-duplicate-channel-rules
