### PR TITLE
Fix backwards log in op-node

### DIFF
--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -157,7 +157,7 @@ func (cfg *Config) CheckL2ChainID(ctx context.Context, client L2Client) error {
 		return err
 	}
 	if cfg.L2ChainID.Cmp(id) != 0 {
-		return fmt.Errorf("incorrect L2 RPC chain id %d, expected %d", cfg.L2ChainID, id)
+		return fmt.Errorf("incorrect L2 RPC chain id, expected from config %d, obtained from client %d", cfg.L2ChainID, id)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fixes the order of checked chain ids in error message and aims to make clear where each of the compared ids comes from. 

**Metadata**
- Fixes #4892
