### PR TITLE
fix(ci): reintroduce changesets patch

### DIFF
--- a/patches/@changesets+cli+2.26.0.patch
+++ b/patches/@changesets+cli+2.26.0.patch
@@ -1,0 +1,66 @@
+diff --git a/node_modules/@changesets/cli/dist/cli.cjs.dev.js b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
+index b158219..6fdfb6e 100644
+--- a/node_modules/@changesets/cli/dist/cli.cjs.dev.js
++++ b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
+@@ -937,7 +937,7 @@ async function publishPackages({
+ }) {
+   const packagesByName = new Map(packages.map(x => [x.packageJson.name, x]));
+   const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
+-  const unpublishedPackagesInfo = await getUnpublishedPackages(publicPackages, preState);
++  const unpublishedPackagesInfo = await getUnpublishedPackages(packages, preState);
+
+   if (unpublishedPackagesInfo.length === 0) {
+     return [];
+@@ -957,20 +957,27 @@ async function publishAPackage(pkg, access, twoFactorState, tag) {
+   const {
+     name,
+     version,
+-    publishConfig
++    publishConfig,
++    private: isPrivate
+   } = pkg.packageJson;
+   const localAccess = publishConfig === null || publishConfig === void 0 ? void 0 : publishConfig.access;
+-  logger.info(`Publishing ${chalk__default['default'].cyan(`"${name}"`)} at ${chalk__default['default'].green(`"${version}"`)}`);
+-  const publishDir = publishConfig !== null && publishConfig !== void 0 && publishConfig.directory ? path.join(pkg.dir, publishConfig.directory) : pkg.dir;
+-  const publishConfirmation = await publish(name, {
+-    cwd: publishDir,
+-    access: localAccess || access,
+-    tag
+-  }, twoFactorState);
++  let published;
++  if (!isPrivate) {
++    logger.info(`Publishing ${chalk__default['default'].cyan(`"${name}"`)} at ${chalk__default['default'].green(`"${version}"`)}`);
++    const publishDir = publishConfig !== null && publishConfig !== void 0 && publishConfig.directory ? path.join(pkg.dir, publishConfig.directory) : pkg.dir;
++    const publishConfirmation = await publish(name, {
++      cwd: publishDir,
++      access: localAccess || access,
++      tag
++    }, twoFactorState);
++    published = publishConfirmation.published;
++  } else {
++    published = true;
++  }
+   return {
+     name,
+     newVersion: version,
+-    published: publishConfirmation.published
++    published
+   };
+ }
+
+@@ -1140,8 +1147,13 @@ async function tagPublish(tool, packageReleases, cwd) {
+   if (tool !== "root") {
+     for (const pkg of packageReleases) {
+       const tag = `${pkg.name}@${pkg.newVersion}`;
+-      logger.log("New tag: ", tag);
+-      await git.tag(tag, cwd);
++      const allTags = await git.getAllTags(cwd);
++      if (allTags.has(tag)) {
++        logger.log("Skipping existing tag: ", tag);
++      } else {
++        logger.log("New tag: ", tag);
++        await git.tag(tag, cwd);
++      }
+     }
+   } else {
+     const tag = `v${packageReleases[0].newVersion}`;


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Reintroduces a patch to the changesets cli that was required for private packages to be released and tagged properly.