### PR TITLE
differential-testing: fix lint issue in diff testing

### DIFF
--- a/packages/contracts-bedrock/scripts/differential-testing/utils.go
+++ b/packages/contracts-bedrock/scripts/differential-testing/utils.go
@@ -27,7 +27,7 @@ func checkOk(ok bool) {
 // Shorthand to ease go's god awful error handling
 func checkErr(err error, failReason string) {
 	if err != nil {
-		panic(fmt.Errorf("%s: %s", failReason, err))
+		panic(fmt.Errorf("%s: %w", failReason, err))
 	}
 }
 


### PR DESCRIPTION
Fixes minor lint issue that kept being picked up locally, but not in CI, since the small Go program used in JS isn't part of the linted modules.
```
golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...
```
