### PR TITLE
fix(ci): add changesets for packages to rerelease

### DIFF
--- a/.changeset/tricky-donkeys-lick.md
+++ b/.changeset/tricky-donkeys-lick.md
@@ -1,0 +1,9 @@
+---
+'@eth-optimism/chain-mon': patch
+'@eth-optimism/data-transport-layer': patch
+'@eth-optimism/fault-detector': patch
+'@eth-optimism/message-relayer': patch
+'@eth-optimism/replica-healthcheck': patch
+---
+
+Empty patch release to re-release packages that failed to be released by a bug in the release process.


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds changesets for several packages that need to be re-released because they were incorrectly not released due to a bug in the release process.
