### PR TITLE
fix(op-batcher): MaxFrameSize Validation

### DIFF
--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	ErrInvalidMaxFrameSize   = errors.New("max frame size cannot be zero")
+	ErrZeroMaxFrameSize      = errors.New("max frame size cannot be zero")
+	ErrSmallMaxFrameSize     = errors.New("max frame size cannot be less than 23")
 	ErrInvalidChannelTimeout = errors.New("channel timeout is less than the safety margin")
 	ErrInputTargetReached    = errors.New("target amount of input data reached")
 	ErrMaxFrameIndex         = errors.New("max frame index reached (uint16)")
@@ -82,7 +83,15 @@ func (cc *ChannelConfig) Check() error {
 	// will infinitely loop when trying to create frames in the
 	// [channelBuilder.OutputFrames] function.
 	if cc.MaxFrameSize == 0 {
-		return ErrInvalidMaxFrameSize
+		return ErrZeroMaxFrameSize
+	}
+
+	// If the [MaxFrameSize] is set to < 23, the channel out
+	// will underflow the maxSize variable in the [derive.ChannelOut].
+	// Since it is of type uint64, it will wrap around to a very large
+	// number, making the frame size extremely large.
+	if cc.MaxFrameSize < 23 {
+		return ErrSmallMaxFrameSize
 	}
 
 	return nil

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -37,7 +37,11 @@ func TestConfigValidation(t *testing.T) {
 
 	// Set the config to have a zero max frame size.
 	validChannelConfig.MaxFrameSize = 0
-	require.ErrorIs(t, validChannelConfig.Check(), ErrInvalidMaxFrameSize)
+	require.ErrorIs(t, validChannelConfig.Check(), ErrZeroMaxFrameSize)
+
+	// Set the config to have a max frame size less than 23.
+	validChannelConfig.MaxFrameSize = 22
+	require.ErrorIs(t, validChannelConfig.Check(), ErrSmallMaxFrameSize)
 
 	// Reset the config and test the Timeout error.
 	// NOTE: We should be fuzzing these values with the constraint that


### PR DESCRIPTION
**Description**

Fixes CLI-3648

**Context**

If the `MaxFrameSize` is configured to be greater than 0 and less than 23, unexpected behavior will occur where the channel builder will call it's channel out `OutputFrame` function, passing in the `MaxFrameSize` as the max frame size. Inside the channel out `OutputFrame` function though, a frame overhead of 23 is subtracted from the passed in max size. If this is less than 23, this operation will underflow, causing the frame to be filled to a nearly unbounded `uint64`. The `OutputFrame` function will then return an unexpected, extremely large frame.

**Solution**

This pr validates that the configured `MaxFrameSize` is **not** less than 23, erroring with a `ErrSmallMaxFrameSize`.

**Additional Info**

Another PR will properly fix the channel out `OutputFrame` function to error on `maxSize` underflow as tracked in CLI-3649

