### PR TITLE
op-node: make find-sync-start more resilient against errors by improving cache usage

### DIFF
--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -216,17 +216,17 @@ func TestEngineQueue_Finalize(t *testing.T) {
 	eng.ExpectL2BlockRefByHash(refF0.ParentHash, refE1, nil)
 
 	// meet previous safe, counts 1/2
-	l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
+	l1F.ExpectL1BlockRefByHash(refE.Hash, refE, nil)
 	eng.ExpectL2BlockRefByHash(refE1.ParentHash, refE0, nil)
 	eng.ExpectL2BlockRefByHash(refE0.ParentHash, refD1, nil)
 
 	// now full seq window, inclusive
-	l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+	l1F.ExpectL1BlockRefByHash(refD.Hash, refD, nil)
 	eng.ExpectL2BlockRefByHash(refD1.ParentHash, refD0, nil)
 	eng.ExpectL2BlockRefByHash(refD0.ParentHash, refC1, nil)
 
 	// now one more L1 origin
-	l1F.ExpectL1BlockRefByNumber(refC.Number, refC, nil)
+	l1F.ExpectL1BlockRefByHash(refC.Hash, refC, nil)
 	eng.ExpectL2BlockRefByHash(refC1.ParentHash, refC0, nil)
 	// parent of that origin will be considered safe
 	eng.ExpectL2BlockRefByHash(refC0.ParentHash, refB1, nil)
@@ -450,17 +450,17 @@ func TestEngineQueue_ResetWhenUnsafeOriginNotCanonical(t *testing.T) {
 	eng.ExpectL2BlockRefByHash(refF0.ParentHash, refE1, nil)
 
 	// meet previous safe, counts 1/2
-	l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
+	l1F.ExpectL1BlockRefByHash(refE.Hash, refE, nil)
 	eng.ExpectL2BlockRefByHash(refE1.ParentHash, refE0, nil)
 	eng.ExpectL2BlockRefByHash(refE0.ParentHash, refD1, nil)
 
 	// now full seq window, inclusive
-	l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+	l1F.ExpectL1BlockRefByHash(refD.Hash, refD, nil)
 	eng.ExpectL2BlockRefByHash(refD1.ParentHash, refD0, nil)
 	eng.ExpectL2BlockRefByHash(refD0.ParentHash, refC1, nil)
 
 	// now one more L1 origin
-	l1F.ExpectL1BlockRefByNumber(refC.Number, refC, nil)
+	l1F.ExpectL1BlockRefByHash(refC.Hash, refC, nil)
 	eng.ExpectL2BlockRefByHash(refC1.ParentHash, refC0, nil)
 	// parent of that origin will be considered safe
 	eng.ExpectL2BlockRefByHash(refC0.ParentHash, refB1, nil)
@@ -782,17 +782,17 @@ func TestVerifyNewL1Origin(t *testing.T) {
 			}
 
 			// meet previous safe, counts 1/2
-			l1F.ExpectL1BlockRefByNumber(refE.Number, refE, nil)
+			l1F.ExpectL1BlockRefByHash(refE.Hash, refE, nil)
 			eng.ExpectL2BlockRefByHash(refE1.ParentHash, refE0, nil)
 			eng.ExpectL2BlockRefByHash(refE0.ParentHash, refD1, nil)
 
 			// now full seq window, inclusive
-			l1F.ExpectL1BlockRefByNumber(refD.Number, refD, nil)
+			l1F.ExpectL1BlockRefByHash(refD.Hash, refD, nil)
 			eng.ExpectL2BlockRefByHash(refD1.ParentHash, refD0, nil)
 			eng.ExpectL2BlockRefByHash(refD0.ParentHash, refC1, nil)
 
 			// now one more L1 origin
-			l1F.ExpectL1BlockRefByNumber(refC.Number, refC, nil)
+			l1F.ExpectL1BlockRefByHash(refC.Hash, refC, nil)
 			eng.ExpectL2BlockRefByHash(refC1.ParentHash, refC0, nil)
 			// parent of that origin will be considered safe
 			eng.ExpectL2BlockRefByHash(refC0.ParentHash, refB1, nil)

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -24,6 +24,7 @@ type L1ClientConfig struct {
 func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProviderKind) *L1ClientConfig {
 	// Cache 3/2 worth of sequencing window of receipts and txs
 	span := int(config.SeqWindowSize) * 3 / 2
+	fullSpan := span
 	if span > 1000 { // sanity cap. If a large sequencing window is configured, do not make the cache too large
 		span = 1000
 	}
@@ -40,7 +41,8 @@ func L1ClientDefaultConfig(config *rollup.Config, trustRPC bool, kind RPCProvide
 			MustBePostMerge:       false,
 			RPCProviderKind:       kind,
 		},
-		L1BlockRefsCacheSize: span,
+		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
+		L1BlockRefsCacheSize: fullSpan,
 	}
 }
 

--- a/op-node/sources/l2_client.go
+++ b/op-node/sources/l2_client.go
@@ -34,6 +34,7 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 		span *= 12
 		span /= int(config.BlockTime)
 	}
+	fullSpan := span
 	if span > 1000 { // sanity cap. If a large sequencing window is configured, do not make the cache too large
 		span = 1000
 	}
@@ -50,7 +51,8 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 			MustBePostMerge:       true,
 			RPCProviderKind:       RPCKindBasic,
 		},
-		L2BlockRefsCacheSize: span,
+		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
+		L2BlockRefsCacheSize: fullSpan,
 		L1ConfigsCacheSize:   span,
 		RollupCfg:            config,
 	}


### PR DESCRIPTION
**Description**

This improves find-sync-start by improving L1 and L2 rpc caches to include full ranges of block-ref info, and adjusting the code to hit L1 block ref cache when possible.

So when it does hit an error, it'll recover more quickly using the cached data, avoiding a cascade of additional already executed RPC requests following a rate limit hit.
See the notion doc regarding problem & other long term ideas of improving this.

**Tests**

No change in behavior other than utilizing the L1 cache when possible. Existing find-sync start and op-e2e tests cover this new code.

**Metadata**

Fix CLI-3650