### PR TITLE
config: set the L2 gaslimit to 30 million in config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -12,7 +12,7 @@
   "l2OutputOracleStartingTimestamp": -1,
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
-  "l2GenesisBlockGasLimit": "0xE4E1C0",
+  "l2GenesisBlockGasLimit": "0x1c9c380",
   "l1BlockTime": 3,
   "cliqueSignerAddress": "0xca062b0fd91172d89bcd4bb084ac4e21972cc467",
   "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",

--- a/packages/contracts-bedrock/deploy-config/final-migration-rehearsal.json
+++ b/packages/contracts-bedrock/deploy-config/final-migration-rehearsal.json
@@ -28,7 +28,7 @@
   "governanceTokenSymbol": "OP",
   "governanceTokenOwner": "0x038a8825A3C3B0c08d52Cc76E5E361953Cf6Dc76",
 
-  "l2GenesisBlockGasLimit": "0x17D7840",
+  "l2GenesisBlockGasLimit": "0x1c9c380",
   "l2GenesisBlockCoinbase": "0x4200000000000000000000000000000000000011",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
 

--- a/packages/contracts-bedrock/deploy-config/getting-started.json
+++ b/packages/contracts-bedrock/deploy-config/getting-started.json
@@ -40,7 +40,7 @@
   "governanceTokenName": "Optimism",
   "governanceTokenOwner": "ADMIN",
 
-  "l2GenesisBlockGasLimit": "0x17D7840",
+  "l2GenesisBlockGasLimit": "0x1c9c380",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
   "l2GenesisRegolithTimeOffset": "0x0",
 


### PR DESCRIPTION
**Description**

Ensures that things are smooth once https://github.com/ethereum-optimism/optimism/pull/5112 is merged. A too small of gas limit will break things after that PR is merged. We will run with 30 million limit on mainnet, so we should ensure that our devnet config reflects that.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
