### PR TITLE
op-proposer: log L2OutputOracle version + address

### DIFF
--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -208,6 +208,13 @@ func NewL2OutputSubmitter(cfg Config, l log.Logger) (*L2OutputSubmitter, error) 
 		return nil, err
 	}
 
+	version, err := l2ooContract.Version(&bind.CallOpts{})
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	log.Info("Connected to L2OutputOracle", "address", cfg.L2OutputOracleAddr, "version", version)
+
 	parsed, err := abi.JSON(strings.NewReader(bindings.L2OutputOracleMetaData.ABI))
 	if err != nil {
 		cancel()


### PR DESCRIPTION
**Description**

Logs the L2OutputOracle version and address after building a client to call it. This is generally useful information to have and future implementations of the `op-proposer` will need to function differently depending on the version to keep the software compatible with both permissioned and permissionless output proposal submission.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

