### PR TITLE
specs: Update derivation spec to process the first ready frame

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -515,14 +515,15 @@ New frames for timed-out channels are dropped instead of buffered.
 
 #### Reading
 
-The channel-bank can only output data from the first opened channel.
+Upon reading, process each channel in the order they were added to the channel bank. For each frame:
 
-Upon reading, first all timed-out channels are dropped.
+- if the channel is timed out, remove it from the channel-bank
+- otherwise, if the channel is ready, then read it, remove it from the channel bank and stop processing further channels
 
-After pruning timed-out channels, the first remaining channel, if any, is read if it is ready:
+A channel is ready if:
 
-- The channel must be closed
-- The channel must have a contiguous sequence of frames until the closing frame
+- The channel is closed
+- The channel has a contiguous sequence of frames until the closing frame
 
 If no channel is ready, the next frame is read and ingested into the channel bank.
 
@@ -533,9 +534,10 @@ a new channel is opened, tagged with the current L1 block, and appended to the c
 
 Frame insertion conditions:
 
-- New frames matching existing timed-out channels are dropped.
-- Duplicate frames (by frame number) are dropped.
-- Duplicate closes (new frame `is_last == 1`, but the channel has already seen a closing frame) are dropped.
+- New frames matching timed-out channels that have not yet been pruned from the channel-bank are dropped.
+- Duplicate frames (by frame number) for frames that have not been pruned from the channel-bank are dropped.
+- Duplicate closes (new frame `is_last == 1`, but the channel has already seen a closing frame and has not yet been
+    pruned from the channel-bank) are dropped.
 
 If a frame is closing (`is_last == 1`) any existing higher-numbered frames are removed from the channel.
 


### PR DESCRIPTION
**Description**
Updates the derivation spec channel handling so that it will skip over incomplete and not timed out channels to find a frame that is ready to read. As frames are ingested one at a time and only when there are no channels ready to read, this results in  channels being read in the order that they become ready, instead of the order of their first frame. In turn, this prevents unclosed frames from delaying the progression of the safe head until they time out if valid data is submitted in another channel.

Other changes to make the spec match the current implementation:
* Dropping frames due to timed out channels or duplication is only done for channels that have not yet been pruned from the channel bank.
* Timed out channels are only pruned from the channel-bank if they are prior to a readable channel.
* Explicitly state that channels are removed from the channel-bank when they are read.

**Additional context**

This is technically a breaking consensus change. Suppose there are two valid channels A and B containing attributes for the same L2 block numbers where the first frame of A is included on L1 before the first frame of B, but the last frame of A is included on L1 _after_ the last frame of B. In this case the old spec would have processed A and ignored B, but the new code will process B and ignore A.

An analysis of channels submitted for Optimism Goerli confirmed there are no complete channels that would be processed in a different order because of this change.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3600/review-spec-duplicate-channel-rules
- See also #5107 
