### PR TITLE
feat(ctb): Add larger phases containing migration steps to MSD

### DIFF
--- a/.changeset/great-papayas-pull.md
+++ b/.changeset/great-papayas-pull.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Add larger phases containing migration steps to MSD

--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -411,26 +411,9 @@ contract SystemDictator is OwnableUpgradeable {
     }
 
     /**
-     * @notice Calls the first 2 steps of the migration process.
-     */
-    function phase1() external onlyOwner {
-        step1();
-        step2();
-    }
-
-    /**
-     * @notice Calls the remaining steps of the migration process.
-     */
-    function phase2() external onlyOwner {
-        step3();
-        step4();
-        step5();
-    }
-
-    /**
      * @notice Tranfers admin ownership to the final owner.
      */
-    function finalize() external onlyOwner {
+    function finalize() public onlyOwner {
         // Transfer ownership of the ProxyAdmin to the final owner.
         config.globalConfig.proxyAdmin.transferOwnership(config.globalConfig.finalOwner);
 
@@ -455,6 +438,24 @@ contract SystemDictator is OwnableUpgradeable {
 
         // Mark the deployment as finalized.
         finalized = true;
+    }
+
+    /**
+     * @notice Calls the first 2 steps of the migration process.
+     */
+    function phase1() external onlyOwner {
+        step1();
+        step2();
+    }
+
+    /**
+     * @notice Calls the remaining steps of the migration process.
+     */
+    function phase2() external onlyOwner {
+        step3();
+        step4();
+        step5();
+        finalize();
     }
 
     /**

--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -215,7 +215,7 @@ contract SystemDictator is OwnableUpgradeable {
     /**
      * @notice Configures the ProxyAdmin contract.
      */
-    function step1() external onlyOwner step(1) {
+    function step1() public onlyOwner step(1) {
         // Set the AddressManager in the ProxyAdmin.
         config.globalConfig.proxyAdmin.setAddressManager(config.globalConfig.addressManager);
 
@@ -260,7 +260,7 @@ contract SystemDictator is OwnableUpgradeable {
      * @notice Pauses the system by shutting down the L1CrossDomainMessenger and setting the
      *         deposit halt flag to tell the Sequencer's DTL to stop accepting deposits.
      */
-    function step2() external onlyOwner step(2) {
+    function step2() public onlyOwner step(2) {
         // Store the address of the old L1CrossDomainMessenger implementation. We will need this
         // address in the case that we have to exit early.
         oldL1CrossDomainMessenger = config.globalConfig.addressManager.getAddress(
@@ -285,7 +285,7 @@ contract SystemDictator is OwnableUpgradeable {
     /**
      * @notice Removes deprecated addresses from the AddressManager.
      */
-    function step3() external onlyOwner step(EXIT_1_NO_RETURN_STEP) {
+    function step3() public onlyOwner step(EXIT_1_NO_RETURN_STEP) {
         // Remove all deprecated addresses from the AddressManager
         string[17] memory deprecated = [
             "OVM_CanonicalTransactionChain",
@@ -315,7 +315,7 @@ contract SystemDictator is OwnableUpgradeable {
     /**
      * @notice Transfers system ownership to the ProxyAdmin.
      */
-    function step4() external onlyOwner step(PROXY_TRANSFER_STEP) {
+    function step4() public onlyOwner step(PROXY_TRANSFER_STEP) {
         // Transfer ownership of the AddressManager to the ProxyAdmin.
         config.globalConfig.addressManager.transferOwnership(
             address(config.globalConfig.proxyAdmin)
@@ -335,7 +335,7 @@ contract SystemDictator is OwnableUpgradeable {
     /**
      * @notice Upgrades and initializes proxy contracts.
      */
-    function step5() external onlyOwner step(5) {
+    function step5() public onlyOwner step(5) {
         // Dynamic config must be set before we can initialize the L2OutputOracle.
         require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
 
@@ -408,6 +408,23 @@ contract SystemDictator is OwnableUpgradeable {
             payable(config.proxyAddressConfig.l1ERC721BridgeProxy),
             address(config.implementationAddressConfig.l1ERC721BridgeImpl)
         );
+    }
+
+    /**
+     * @notice Calls the first 2 steps of the migration process.
+     */
+    function phase1() external onlyOwner {
+        step1();
+        step2();
+    }
+
+    /**
+     * @notice Calls the remaining steps of the migration process.
+     */
+    function phase2() external onlyOwner {
+        step3();
+        step4();
+        step5();
     }
 
     /**

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -2,6 +2,7 @@
   "finalSystemOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "portalGuardian": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "controller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+  "proxyAdminOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
 
   "l1StartingBlockTag": "earliest",
   "l1ChainID": 900,
@@ -16,12 +17,22 @@
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
 
   "l2OutputOracleSubmissionInterval": 6,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 0,
+  "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x6925B8704Ff96DEe942623d6FB5e946EF5884b63",
 
   "l2GenesisBlockBaseFeePerGas": "0x3B9ACA00",
-  "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
+  "l2GenesisBlockGasLimit": "0x17D7840",
+
+  "baseFeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+  "l1FeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+  "sequencerFeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+
+  "governanceTokenName": "Optimism",
+  "governanceTokenSymbol": "OP",
+  "governanceTokenOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
   "sequencerFeeVaultRecipient": "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",
 

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -86,7 +86,6 @@ const deployFn: DeployFunction = async (hre) => {
   const isLiveDeployer =
     deployer.toLowerCase() === hre.deployConfig.controller.toLowerCase()
 
-
   // Make sure the dynamic system configuration has been set.
   if (
     (await isStartOfPhase(SystemDictator, 2)) &&
@@ -166,7 +165,6 @@ const deployFn: DeployFunction = async (hre) => {
       1000
     )
   }
-
 
   await doPhase({
     isLiveDeployer,
@@ -288,6 +286,8 @@ const deployFn: DeployFunction = async (hre) => {
         'messenger',
         L1CrossDomainMessenger.address
       )
+
+      await assertContractVariable(SystemDictator, 'finalized', true)
     },
   })
 
@@ -323,33 +323,6 @@ const deployFn: DeployFunction = async (hre) => {
     )
 
     await assertContractVariable(OptimismPortal, 'paused', false)
-
-    console.log(`
-      You must now finalize the upgrade by calling finalize() on the SystemDictator. This will
-      transfer ownership of the ProxyAdmin to the final system owner as specified in the deployment
-      configuration.
-    `)
-
-    if (isLiveDeployer) {
-      console.log(`Finalizing deployment...`)
-      await SystemDictator.finalize()
-    } else {
-      const tx = await SystemDictator.populateTransaction.finalize()
-      console.log(`Please finalize deployment...`)
-      console.log(`MSD address: ${SystemDictator.address}`)
-      console.log(`JSON:`)
-      console.log(jsonifyTransaction(tx))
-      console.log(getCastCommand(tx))
-      console.log(await getTenderlySimulationLink(SystemDictator.provider, tx))
-    }
-
-    await awaitCondition(
-      async () => {
-        return SystemDictator.finalized()
-      },
-      5000,
-      1000
-    )
 
     await assertContractVariable(
       ProxyAdmin,

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -329,6 +329,8 @@ export const isStartOfPhase = async (
   dictator: ethers.Contract,
   phase: number
 ): Promise<boolean> => {
+  // These values map the phase to the first step in that phase.
+  // There is no phase 3, but we use it to check if we phase 2 is complete.
   const phaseToStep = {
     1: 1,
     2: 3,


### PR DESCRIPTION
Adds `phase1()` and `phase2()` methods to the MSD which consolidates the various `stepN()` methods into two groups. 

This will significantly reduce the number of multisig transactions which need to be executed.

I tested this primarily by running `npx hardhat deploy` scripts locally.

Converted to draft. I'd still like feedback on this, but we should be careful about deciding whether or not to make the change.