### PR TITLE
op-chain-ops: Fix data race in error handling

### DIFF
--- a/op-chain-ops/ether/migrate_test.go
+++ b/op-chain-ops/ether/migrate_test.go
@@ -228,35 +228,12 @@ func makeLegacyETH(t *testing.T, totalSupply *big.Int, balances map[common.Addre
 	}
 }
 
-// TestMigrateBalancesRandom tests that the pre-check balances function works
+// TestMigrateBalancesRandomOK tests that the pre-check balances function works
 // with random addresses. This test makes sure that the partition logic doesn't
-// miss anything.
-func TestMigrateBalancesRandom(t *testing.T) {
+// miss anything, and helps detect concurrency errors.
+func TestMigrateBalancesRandomOK(t *testing.T) {
 	for i := 0; i < 100; i++ {
-		addresses := make([]common.Address, 0)
-		stateBalances := make(map[common.Address]*big.Int)
-
-		allowances := make([]*crossdomain.Allowance, 0)
-		stateAllowances := make(map[common.Address]common.Address)
-
-		totalSupply := big.NewInt(0)
-
-		for j := 0; j < rand.Intn(10000); j++ {
-			addr := randAddr(t)
-			addresses = append(addresses, addr)
-			stateBalances[addr] = big.NewInt(int64(rand.Intn(1_000_000)))
-			totalSupply = new(big.Int).Add(totalSupply, stateBalances[addr])
-		}
-
-		for j := 0; j < rand.Intn(1000); j++ {
-			addr := randAddr(t)
-			to := randAddr(t)
-			allowances = append(allowances, &crossdomain.Allowance{
-				From: addr,
-				To:   to,
-			})
-			stateAllowances[addr] = to
-		}
+		addresses, stateBalances, allowances, stateAllowances, totalSupply := setupRandTest(t)
 
 		db, factory := makeLegacyETH(t, totalSupply, stateBalances, stateAllowances)
 		err := doMigration(db, factory, addresses, allowances, big.NewInt(0), false)
@@ -266,6 +243,43 @@ func TestMigrateBalancesRandom(t *testing.T) {
 			actBal := db.GetBalance(addr)
 			require.EqualValues(t, expBal, actBal)
 		}
+	}
+}
+
+// TestMigrateBalancesRandomMissing tests that the pre-check balances function works
+// with random addresses when some of them are missing. This helps make sure that the
+// partition logic doesn't miss anything, and helps detect concurrency errors.
+func TestMigrateBalancesRandomMissing(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		addresses, stateBalances, allowances, stateAllowances, totalSupply := setupRandTest(t)
+
+		if len(addresses) == 0 {
+			continue
+		}
+
+		// Remove a random address from the list of witnesses
+		idx := rand.Intn(len(addresses))
+		addresses = append(addresses[:idx], addresses[idx+1:]...)
+
+		db, factory := makeLegacyETH(t, totalSupply, stateBalances, stateAllowances)
+		err := doMigration(db, factory, addresses, allowances, big.NewInt(0), false)
+		require.ErrorContains(t, err, "unknown storage slot")
+	}
+
+	for i := 0; i < 100; i++ {
+		addresses, stateBalances, allowances, stateAllowances, totalSupply := setupRandTest(t)
+
+		if len(allowances) == 0 {
+			continue
+		}
+
+		// Remove a random allowance from the list of witnesses
+		idx := rand.Intn(len(allowances))
+		allowances = append(allowances[:idx], allowances[idx+1:]...)
+
+		db, factory := makeLegacyETH(t, totalSupply, stateBalances, stateAllowances)
+		err := doMigration(db, factory, addresses, allowances, big.NewInt(0), false)
+		require.ErrorContains(t, err, "unknown storage slot")
 	}
 }
 
@@ -353,4 +367,33 @@ func randAddr(t *testing.T) common.Address {
 	_, err := rand.Read(addr[:])
 	require.NoError(t, err)
 	return addr
+}
+
+func setupRandTest(t *testing.T) ([]common.Address, map[common.Address]*big.Int, []*crossdomain.Allowance, map[common.Address]common.Address, *big.Int) {
+	addresses := make([]common.Address, 0)
+	stateBalances := make(map[common.Address]*big.Int)
+
+	allowances := make([]*crossdomain.Allowance, 0)
+	stateAllowances := make(map[common.Address]common.Address)
+
+	totalSupply := big.NewInt(0)
+
+	for j := 0; j < rand.Intn(10000); j++ {
+		addr := randAddr(t)
+		addresses = append(addresses, addr)
+		stateBalances[addr] = big.NewInt(int64(rand.Intn(1_000_000)))
+		totalSupply = new(big.Int).Add(totalSupply, stateBalances[addr])
+	}
+
+	for j := 0; j < rand.Intn(1000); j++ {
+		addr := randAddr(t)
+		to := randAddr(t)
+		allowances = append(allowances, &crossdomain.Allowance{
+			From: addr,
+			To:   to,
+		})
+		stateAllowances[addr] = to
+	}
+
+	return addresses, stateBalances, allowances, stateAllowances, totalSupply
 }


### PR DESCRIPTION
The error channel in the OVM_ETH migration is buffered. In rare cases, errors were written to this channel in such a way that they were not processed by the collector goroutine. This meant that errors were not being caught by the `lastErr != nil` check, and were instead triggering the total supply check below.

This error reliably reproduces when running the new TestMigrateBalancesRandomMissing test. This test generates a random state, and randomly removes an address/allowance from the witness data. It runs this 100 times per test. We didn't catch this with the other random test because it doesn't exercise the error handling codepath.
