### PR TITLE
op-node: delay creating blocks when safe lag exceeds limit

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -100,6 +100,13 @@ var (
 		Usage:  "Initialize the sequencer in a stopped state. The sequencer can be started using the admin_startSequencer RPC",
 		EnvVar: prefixEnvVar("SEQUENCER_STOPPED"),
 	}
+	SequencerMaxSafeLagFlag = cli.Uint64Flag{
+		Name:     "sequencer.max-safe-lag",
+		Usage:    "Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe. Disabled if 0.",
+		EnvVar:   prefixEnvVar("SEQUENCER_MAX_SAFE_LAG"),
+		Required: false,
+		Value:    0,
+	}
 	SequencerL1Confs = cli.Uint64Flag{
 		Name:     "sequencer.l1-confs",
 		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
@@ -193,6 +200,7 @@ var optionalFlags = []cli.Flag{
 	VerifierL1Confs,
 	SequencerEnabledFlag,
 	SequencerStoppedFlag,
+	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
 	L1EpochPollIntervalFlag,
 	RPCEnableAdmin,

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -16,4 +16,8 @@ type Config struct {
 
 	// SequencerStopped is false when the driver should sequence new blocks.
 	SequencerStopped bool `json:"sequencer_stopped"`
+
+	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
+	// Disabled if 0.
+	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
 }

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -141,10 +141,11 @@ func NewL2SyncEndpointConfig(ctx *cli.Context) *node.L2SyncEndpointConfig {
 
 func NewDriverConfig(ctx *cli.Context) *driver.Config {
 	return &driver.Config{
-		VerifierConfDepth:  ctx.GlobalUint64(flags.VerifierL1Confs.Name),
-		SequencerConfDepth: ctx.GlobalUint64(flags.SequencerL1Confs.Name),
-		SequencerEnabled:   ctx.GlobalBool(flags.SequencerEnabledFlag.Name),
-		SequencerStopped:   ctx.GlobalBool(flags.SequencerStoppedFlag.Name),
+		VerifierConfDepth:   ctx.GlobalUint64(flags.VerifierL1Confs.Name),
+		SequencerConfDepth:  ctx.GlobalUint64(flags.SequencerL1Confs.Name),
+		SequencerEnabled:    ctx.GlobalBool(flags.SequencerEnabledFlag.Name),
+		SequencerStopped:    ctx.GlobalBool(flags.SequencerStoppedFlag.Name),
+		SequencerMaxSafeLag: ctx.GlobalUint64(flags.SequencerMaxSafeLagFlag.Name),
 	}
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Some OP chains are sensitive to reorg, specifically, these chains may have an upper threshold beyond which a reorg can occur. This PR comes for reorg-sensitive OP chains.

In order to prevent deep reorgs, this PR propose a new configuration parameter called `cfg.SequencerMaxSafeLag` to OP-Node. Before block generation, OP-Node will check the difference between `l2Unsafe.Number` and `l2Safe.Number`, and if the result is greater than `cfg.SequencerMaxSafeLag`, it will cancel the current block-generation plan and wait for the next ticker.

By default, this flag is disabled.

**Tests**

I have tested it manually. If you believe that additional test cases should be included, please let me know.


**Metadata**
- Resolve #5059
