### PR TITLE
fix(ci): run tests for common-ts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,10 @@ jobs:
       # Note: The below needs to be manually configured whenever we
       # add a new package to CI.
       - run:
+          name: Check common-ts
+          command: npx depcheck
+          working_directory: packages/common-ts
+      - run:
           name: Check contracts
           command: npx depcheck
           working_directory: packages/contracts

--- a/packages/common-ts/.depcheckrc
+++ b/packages/common-ts/.depcheckrc
@@ -1,0 +1,12 @@
+ignores: [
+  "@babel/eslint-parser",
+  "@typescript-eslint/parser",
+  "eslint-plugin-import",
+  "eslint-plugin-unicorn",
+  "eslint-plugin-jsdoc",
+  "eslint-plugin-prefer-arrow",
+  "eslint-plugin-react",
+  "@typescript-eslint/eslint-plugin",
+  "eslint-config-prettier",
+  "eslint-plugin-prettier"
+]

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -17,7 +17,7 @@
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",
     "test": "ts-mocha test/*.spec.ts",
-    "test:coverage": "echo 'no coverage'"
+    "test:coverage": "nyc ts-mocha test/*.spec.ts && nyc merge .nyc_output coverage.json"
   },
   "keywords": [
     "optimism",
@@ -48,8 +48,7 @@
     "pino": "^6.11.3",
     "pino-multi-stream": "^5.3.0",
     "pino-sentry": "^0.7.0",
-    "prom-client": "^13.1.0",
-    "qs": "^6.10.5"
+    "prom-client": "^13.1.0"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5.7.0",

--- a/packages/common-ts/test/metrics.spec.ts
+++ b/packages/common-ts/test/metrics.spec.ts
@@ -3,11 +3,11 @@ import request from 'supertest'
 import chai = require('chai')
 const expect = chai.expect
 
-import { Logger, Metrics, createMetricsServer } from '../src'
+import { Logger, LegacyMetrics, createMetricsServer } from '../src'
 
 describe('Metrics', () => {
   it('shoud serve metrics', async () => {
-    const metrics = new Metrics({
+    const metrics = new LegacyMetrics({
       prefix: 'test_metrics',
     })
     const registry = metrics.registry

--- a/yarn.lock
+++ b/yarn.lock
@@ -17871,13 +17871,6 @@ qs@^6.10.3, qs@^6.9.4:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.10.5:
-  version "6.10.5"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.5.tgz#974715920a80ff6a262264acd2c7e6c2a53282b4"
-  integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
-  dependencies:
-    side-channel "^1.0.4"
-
 qs@^6.4.0, qs@^6.7.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Tests for common-ts were not being executed in CI because the command being triggered was "yarn test:coverage" and this command was a noop for common-ts. Also fixes a bug in the tests that wasn't caught by CI because of this.

**Metadata**
- Fixes #5214
