### PR TITLE
prototype: more config in system config

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -11,6 +11,7 @@ import { SecureMerkleTrie } from "../libraries/trie/SecureMerkleTrie.sol";
 import { AddressAliasHelper } from "../vendor/AddressAliasHelper.sol";
 import { ResourceMetering } from "./ResourceMetering.sol";
 import { Semver } from "../universal/Semver.sol";
+import { SystemConfig } from "../L1/SystemConfig.sol";
 
 /**
  * @custom:proxied
@@ -144,8 +145,9 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     constructor(
         L2OutputOracle _l2Oracle,
         address _guardian,
-        bool _paused
-    ) Semver(1, 2, 0) {
+        bool _paused,
+        SystemConfig _systemConfig
+    ) Semver(1, 2, 0) ResourceMetering(_systemConfig) {
         L2_ORACLE = _l2Oracle;
         GUARDIAN = _guardian;
         initialize(_paused);

--- a/packages/contracts-bedrock/contracts/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/contracts/L1/SystemConfig.sol
@@ -48,6 +48,8 @@ contract SystemConfig is OwnableUpgradeable, Semver {
      */
     uint256 public immutable SYSTEM_TRANSACTION_MAX_GAS;
 
+    int256 public immutable MAX_RESOURCE_LIMIT;
+
     /**
      * @notice Address of the OptimismPortal.
      */
@@ -97,7 +99,8 @@ contract SystemConfig is OwnableUpgradeable, Semver {
      * @param _batcherHash       Initial batcher hash.
      * @param _gasLimit          Initial gas limit.
      * @param _unsafeBlockSigner Initial unsafe block signer address.
-     * @param _portal            Address of the OptimismPortal
+     * @param _maxResourceLimit  Maximum amount of deposit tx gas per block.
+     * @param _systemTxMaxGas    Maximum amount of gas the system tx can consume.
      */
     constructor(
         address _owner,
@@ -106,10 +109,10 @@ contract SystemConfig is OwnableUpgradeable, Semver {
         bytes32 _batcherHash,
         uint64 _gasLimit,
         address _unsafeBlockSigner,
-        address _portal,
+        int256 _maxResourceLimit,
         uint64 _systemTxMaxGas
     ) Semver(1, 1, 0) {
-        PORTAL = _portal;
+        MAX_RESOURCE_LIMIT = _maxResourceLimit;
         SYSTEM_TRANSACTION_MAX_GAS = _systemTxMaxGas;
         initialize(_owner, _overhead, _scalar, _batcherHash, _gasLimit, _unsafeBlockSigner);
     }
@@ -232,7 +235,8 @@ contract SystemConfig is OwnableUpgradeable, Semver {
      *         gas the system transaction can consume in a block.
      */
     function minimumGasLimit() public view returns (uint256) {
-        uint256 maxResourceLimit = uint256(ResourceMetering(PORTAL).MAX_RESOURCE_LIMIT());
-        return maxResourceLimit + SYSTEM_TRANSACTION_MAX_GAS;
+        // we can technically not break this up into 2 variables. It
+        // is a bit more explicit with 2 variables but more complex.
+        return uint256(MAX_RESOURCE_LIMIT) + SYSTEM_TRANSACTION_MAX_GAS;
     }
 }

--- a/packages/contracts-bedrock/contracts/test/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/contracts/test/ResourceMetering.t.sol
@@ -4,9 +4,10 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 import { ResourceMetering } from "../L1/ResourceMetering.sol";
 import { Proxy } from "../universal/Proxy.sol";
+import { SystemConfig } from "../L1/SystemConfig.sol";
 
 contract MeterUser is ResourceMetering {
-    constructor() {
+    constructor() ResourceMetering(SystemConfig(address(0))) {
         initialize();
     }
 
@@ -174,7 +175,7 @@ contract CustomMeterUser is ResourceMetering {
         uint128 _prevBaseFee,
         uint64 _prevBoughtGas,
         uint64 _prevBlockNum
-    ) {
+    ) ResourceMetering(SystemConfig(address(0))) {
         params = ResourceMetering.ResourceParams({
             prevBaseFee: _prevBaseFee,
             prevBoughtGas: _prevBoughtGas,

--- a/packages/contracts-bedrock/contracts/test/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/contracts/test/SystemConfig.t.sol
@@ -17,7 +17,7 @@ contract SystemConfig_Init is Portal_Initializer {
             _batcherHash: bytes32(hex"abcd"),
             _gasLimit: 30_000_000,
             _unsafeBlockSigner: address(1),
-            _portal: address(op),
+            _maxResourceLimit: 20_000_000,
             _systemTxMaxGas: 1_000_000
         });
     }

--- a/packages/contracts-bedrock/contracts/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/SystemConfig.t.sol
@@ -23,7 +23,7 @@ contract SystemConfig_GasLimitLowerBound_Invariant is Test {
             _batcherHash: bytes32(hex"abcd"),
             _gasLimit: 30_000_000,
             _unsafeBlockSigner: address(1),
-            _portal: address(portal),
+            _maxResourceLimit: 20_000_000,
             _systemTxMaxGas: 1_000_000
         });
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Quick prototype to see what the code would look like if we moved some config values out of the resource metering contract and into the system config contract.

Some problems:
- Things that were previously constants are no longer constants
- Now the portal needs a pointer to the system config, maybe this was inevitable
- Tests have more deps

Good things:
- More centralized config
