### PR TITLE
chore(ctb): Bump `forge` & `forge-std`

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /opt/foundry
 # Only diff from upstream docker image is this clone instead
 # of COPY. We select a specific commit to use.
 RUN git clone https://github.com/foundry-rs/foundry.git . \
-    && git checkout 8f3fca9c608d58981daaffe11e7f8076644cb753
+    && git checkout da2392e58bb8a7fefeba46b40c4df1afad8ccd22
 
 RUN source $HOME/.profile && \
     cargo build --release && \

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -77,7 +77,7 @@
     "dotenv": "^16.0.0",
     "ds-test": "https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5",
     "ethereum-waffle": "^3.0.0",
-    "forge-std": "https://github.com/foundry-rs/forge-std.git#fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0",
+    "forge-std": "https://github.com/foundry-rs/forge-std.git#46264e9788017fc74f9f58b7efa0bc6e1df6d410",
     "glob": "^7.1.6",
     "hardhat-deploy": "^0.11.4",
     "solhint": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11471,13 +11471,13 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+"forge-std@https://github.com/foundry-rs/forge-std.git#46264e9788017fc74f9f58b7efa0bc6e1df6d410":
+  version "1.5.2"
+  resolved "https://github.com/foundry-rs/forge-std.git#46264e9788017fc74f9f58b7efa0bc6e1df6d410"
+
 "forge-std@https://github.com/foundry-rs/forge-std.git#53331f4cb2e313466f72440f3e73af048c454d02":
   version "1.2.0"
   resolved "https://github.com/foundry-rs/forge-std.git#53331f4cb2e313466f72440f3e73af048c454d02"
-
-"forge-std@https://github.com/foundry-rs/forge-std.git#fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0":
-  version "1.4.0"
-  resolved "https://github.com/foundry-rs/forge-std.git#fd86115ed6aba8e234ee0fb86c12fe35eff0b2a0"
 
 form-data@^2.2.0:
   version "2.5.1"


### PR DESCRIPTION
# Overview

Bumps:
`forge`: `8f3fca9c608d58981daaffe11e7f8076644cb753` -> `da2392e58bb8a7fefeba46b40c4df1afad8ccd22`
`forge-std`: `1.4.0` -> `1.5.2`

and uses the new `expectSafeMemory` cheatcode for our `Bytes.slice` memory safety test.