### PR TITLE
maint: add Go to dependency list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ You'll need the following:
 * [Yarn](https://classic.yarnpkg.com/en/docs/install)
 * [Docker](https://docs.docker.com/get-docker/)
 * [Docker Compose](https://docs.docker.com/compose/install/)
+* [Go](https://go.dev/dl/)
 * [Foundry](https://getfoundry.sh)
 
 ### Setup


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Adds Go to the list of dependencies in the CONTRIBUTING guide.

A clear and concise description of the features you're adding in this pull request.
