### PR TITLE
op-node/p2p: Fix logging when a peer fails to be blocked or unblocked

### DIFF
--- a/op-node/p2p/peer_gater.go
+++ b/op-node/p2p/peer_gater.go
@@ -43,11 +43,15 @@ func (s *gater) Update(id peer.ID, score float64) {
 	if score < PeerScoreThreshold && s.banEnabled {
 		s.log.Warn("peer blocking enabled, blocking peer", "id", id.String(), "score", score)
 		err := s.connGater.BlockPeer(id)
-		s.log.Warn("connection gater failed to block peer", id.String(), "err", err)
+		if err != nil {
+			s.log.Warn("connection gater failed to block peer", "id", id.String(), "err", err)
+		}
 	}
 	// Unblock peers whose score has recovered to an acceptable level
 	if (score > PeerScoreThreshold) && slices.Contains(s.connGater.ListBlockedPeers(), id) {
 		err := s.connGater.UnblockPeer(id)
-		s.log.Warn("connection gater failed to unblock peer", id.String(), "err", err)
+		if err != nil {
+			s.log.Warn("connection gater failed to unblock peer", "id", id.String(), "err", err)
+		}
 	}
 }


### PR DESCRIPTION
**Description**

Previously a warning was logged that the peer failed to block/unblock on every attempt, even when it succeeded.  Was also missing a label for the peer ID.


**Metadata**

- https://linear.app/optimism/issue/CLI-3646/peer-scoring-not-working

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
