### PR TITLE
feat(ci): Include daisy chain tests in the monorepo CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1246,6 +1246,14 @@ workflows:
             - op-node-docker-build
             - op-batcher-docker-build
             - op-proposer-docker-build
+      - hive-test:
+          name: hive-test-daisy-chain
+          version: <<pipeline.git.revision>>
+          sim: optimism/daisy-chain
+          requires:
+            - op-node-docker-build
+            - op-batcher-docker-build
+            - op-proposer-docker-build
   release:
     jobs:
       - hold:


### PR DESCRIPTION
# Overview

Adds the new daisy chain simulator introduced in https://github.com/ethereum-optimism/hive/pull/79 to the monorepo CI.