### PR TITLE
contracts-bedrock: move L2oo init to step1 of deploy

### DIFF
--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -254,6 +254,22 @@ contract SystemDictator is OwnableUpgradeable {
                 )
             )
         );
+
+        // Dynamic config must be set before we can initialize the L2OutputOracle.
+        require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
+
+        // Upgrade and initialize the L2OutputOracle.
+        config.globalConfig.proxyAdmin.upgradeAndCall(
+            payable(config.proxyAddressConfig.l2OutputOracleProxy),
+            address(config.implementationAddressConfig.l2OutputOracleImpl),
+            abi.encodeCall(
+                L2OutputOracle.initialize,
+                (
+                    l2OutputOracleDynamicConfig.l2OutputOracleStartingBlockNumber,
+                    l2OutputOracleDynamicConfig.l2OutputOracleStartingTimestamp
+                )
+            )
+        );
     }
 
     /**
@@ -336,21 +352,8 @@ contract SystemDictator is OwnableUpgradeable {
      * @notice Upgrades and initializes proxy contracts.
      */
     function step5() external onlyOwner step(5) {
-        // Dynamic config must be set before we can initialize the L2OutputOracle.
+        // Dynamic config must be set before we can initialize the OptimismPortal
         require(dynamicConfigSet, "SystemDictator: dynamic oracle config is not yet initialized");
-
-        // Upgrade and initialize the L2OutputOracle.
-        config.globalConfig.proxyAdmin.upgradeAndCall(
-            payable(config.proxyAddressConfig.l2OutputOracleProxy),
-            address(config.implementationAddressConfig.l2OutputOracleImpl),
-            abi.encodeCall(
-                L2OutputOracle.initialize,
-                (
-                    l2OutputOracleDynamicConfig.l2OutputOracleStartingBlockNumber,
-                    l2OutputOracleDynamicConfig.l2OutputOracleStartingTimestamp
-                )
-            )
-        );
 
         // Upgrade and initialize the OptimismPortal.
         config.globalConfig.proxyAdmin.upgradeAndCall(


### PR DESCRIPTION
**Description**

This allows the full sequencer to start up after `step1`. The dynamic config check needs to be moved to ensure that the config is set up correctly.

This PR should get close review from @maurelian and @smartcontracts before merging to ensure that it is safe.

Closes CLI-3435
Closes CLI-3670

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

