### PR TITLE
feat(op-e2e): Peer Scoring Test with Malleable Nodes

### DIFF
--- a/op-e2e/malleable/common.go
+++ b/op-e2e/malleable/common.go
@@ -1,0 +1,75 @@
+package malleable
+
+import (
+	"testing"
+
+	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	predeploys "github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	genesis "github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	e2eutils "github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	eth "github.com/ethereum-optimism/optimism/op-node/eth"
+
+	// rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
+	rollup "github.com/ethereum-optimism/optimism/op-node/rollup"
+	crypto "github.com/libp2p/go-libp2p/core/crypto"
+)
+
+// DefaultConfig returns a default [p2p.Config] for the malleable package.
+func DefaultConfig() (*p2p.Config, error) {
+	blockTime := uint64(2)
+	params, err := p2p.GetPeerScoreParams("light", blockTime)
+	if err != nil {
+		return nil, err
+	}
+	topicScores, err := p2p.GetTopicScoreParams("light", blockTime)
+	if err != nil {
+		return nil, err
+	}
+	bandScoreThresholds, err := p2p.NewBandScorer("-40:graylist;-20:restricted;0:nopx;20:friend;")
+	if err != nil {
+		return nil, err
+	}
+	p2pPrivKey := secp256k1.NewPrivateKey(&secp256k1.ModNScalar{})
+	return &p2p.Config{
+		Priv:                (*crypto.Secp256k1PrivateKey)(p2pPrivKey),
+		PeerScoring:         params,
+		BanningEnabled:      false,
+		BandScoreThresholds: *bandScoreThresholds,
+		TopicScoring:        topicScores,
+	}, nil
+}
+
+// GetRollupConfig returns a [rollup.Config] for the [MalleableNode].
+func GetRollupConfig(t *testing.T) rollup.Config {
+	defaultConfig := e2e.DefaultSystemConfig(t)
+	defaultConfig.DeployConfig.L1BlockTime = 10
+	l1Genesis, _ := genesis.BuildL1DeveloperGenesis(defaultConfig.DeployConfig)
+	l1Block := l1Genesis.ToBlock()
+	l2Genesis, _ := genesis.BuildL2DeveloperGenesis(defaultConfig.DeployConfig, l1Block)
+	return rollup.Config{
+		Genesis: rollup.Genesis{
+			L1: eth.BlockID{
+				Hash:   l1Block.Hash(),
+				Number: 0,
+			},
+			L2: eth.BlockID{
+				Hash:   l2Genesis.ToBlock().Hash(),
+				Number: 0,
+			},
+			L2Time:       uint64(defaultConfig.DeployConfig.L1GenesisBlockTimestamp),
+			SystemConfig: e2eutils.SystemConfigFromDeployConfig(defaultConfig.DeployConfig),
+		},
+		BlockTime:              defaultConfig.DeployConfig.L2BlockTime,
+		MaxSequencerDrift:      defaultConfig.DeployConfig.MaxSequencerDrift,
+		SeqWindowSize:          defaultConfig.DeployConfig.SequencerWindowSize,
+		ChannelTimeout:         defaultConfig.DeployConfig.ChannelTimeout,
+		L1ChainID:              defaultConfig.L1ChainIDBig(),
+		L2ChainID:              defaultConfig.L2ChainIDBig(),
+		BatchInboxAddress:      defaultConfig.DeployConfig.BatchInboxAddress,
+		DepositContractAddress: predeploys.DevOptimismPortalAddr,
+		L1SystemConfigAddress:  predeploys.DevSystemConfigAddr,
+		RegolithTime:           defaultConfig.DeployConfig.RegolithTime(uint64(defaultConfig.DeployConfig.L1GenesisBlockTimestamp)),
+	}
+}

--- a/op-e2e/malleable/gossip.go
+++ b/op-e2e/malleable/gossip.go
@@ -1,0 +1,107 @@
+package malleable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
+	rollup "github.com/ethereum-optimism/optimism/op-node/rollup"
+	log "github.com/ethereum/go-ethereum/log"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	peer "github.com/libp2p/go-libp2p/core/peer"
+)
+
+// SetupGossip sets up gossip for the [MalleableNode].
+func (m *MalleableNode) SetupGossip(t *testing.T, conf *p2p.Config, snapLog log.Logger) error {
+	rollupCfg := GetRollupConfig(t)
+
+	// Enable extra features, if any. During testing we don't setup the most advanced host all the time.
+	if extra, ok := m.innerHost.(p2p.ExtraHostFeatures); ok {
+		m.gater = extra.ConnectionGater()
+		m.connMgr = extra.ConnectionManager()
+	}
+
+	// Setup the host network
+	notifiee := p2p.NewNetworkNotifier(snapLog, nil)
+	m.innerHost.Network().Notify(notifiee)
+
+	// Construct the pubsub instance with a GossipSub router internally
+	var err error
+	m.gs, err = p2p.NewGossipSub(context.Background(), m.innerHost, m.gater, &rollupCfg, conf, nil, snapLog)
+	if err != nil {
+		return fmt.Errorf("failed to start gossipsub router: %w", err)
+	}
+
+	// Register to the associated gossip
+	m.gsOut, err = JoinGossip(context.Background(), m.innerHost.ID(), conf.TopicScoringParams(), m.gs, snapLog, &rollupCfg, nil, m)
+	if err != nil {
+		return fmt.Errorf("failed to join blocks gossip topic: %w", err)
+	}
+
+	return nil
+}
+
+func guardGossipValidator(log log.Logger, fn pubsub.ValidatorEx) pubsub.ValidatorEx {
+	return func(ctx context.Context, id peer.ID, message *pubsub.Message) (result pubsub.ValidationResult) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Error("gossip validation panic", "err", err, "peer", id)
+				result = pubsub.ValidationReject
+			}
+		}()
+		return fn(ctx, id, message)
+	}
+}
+
+// JoinGossip joins the gossip network for the peer's given topic parameters.
+func JoinGossip(
+	p2pCtx context.Context,
+	self peer.ID,
+	topicScoreParams *pubsub.TopicScoreParams,
+	ps *pubsub.PubSub,
+	log log.Logger,
+	cfg *rollup.Config,
+	runCfg p2p.GossipRuntimeConfig,
+	gossipIn p2p.GossipIn,
+) (p2p.GossipOut, error) {
+	val := guardGossipValidator(log, p2p.BuildBlocksValidator(log, cfg, runCfg))
+	blocksTopicName := fmt.Sprintf("/optimism/%s/0/blocks", cfg.L2ChainID.String())
+	err := ps.RegisterTopicValidator(blocksTopicName,
+		val,
+		pubsub.WithValidatorTimeout(3*time.Second),
+		pubsub.WithValidatorConcurrency(4),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register blocks gossip topic: %w", err)
+	}
+	blocksTopic, err := ps.Join(blocksTopicName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to join blocks gossip topic: %w", err)
+	}
+	blocksTopicEvents, err := blocksTopic.EventHandler()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create blocks gossip topic handler: %w", err)
+	}
+	go p2p.LogTopicEvents(p2pCtx, log.New("topic", "blocks"), blocksTopicEvents)
+
+	// A [TimeInMeshQuantum] value of 0 means the topic score is disabled.
+	// If we passed a topicScoreParams with [TimeInMeshQuantum] set to 0,
+	// libp2p errors since the params will be rejected.
+	if topicScoreParams != nil && topicScoreParams.TimeInMeshQuantum != 0 {
+		if err = blocksTopic.SetScoreParams(topicScoreParams); err != nil {
+			return nil, fmt.Errorf("failed to set topic score params: %w", err)
+		}
+	}
+
+	subscription, err := blocksTopic.Subscribe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to blocks gossip topic: %w", err)
+	}
+
+	subscriber := p2p.MakeSubscriber(log, p2p.BlocksHandler(gossipIn.OnUnsafeL2Payload))
+	go subscriber(p2pCtx, subscription)
+
+	return &malpub{cfg: cfg, blocksTopic: blocksTopic}, nil
+}

--- a/op-e2e/malleable/host.go
+++ b/op-e2e/malleable/host.go
@@ -1,0 +1,134 @@
+package malleable
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
+	log "github.com/ethereum/go-ethereum/log"
+	"github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p/core/connmgr"
+	host "github.com/libp2p/go-libp2p/core/host"
+	metrics "github.com/libp2p/go-libp2p/core/metrics"
+	peer "github.com/libp2p/go-libp2p/core/peer"
+	insecure "github.com/libp2p/go-libp2p/core/sec/insecure"
+	pstoreds "github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	tcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	ma "github.com/multiformats/go-multiaddr"
+	madns "github.com/multiformats/go-multiaddr-dns"
+)
+
+// hostWrapper is a wrapper around the [host.Host] interface
+// with a [p2p.ConnectionGater] and [connmgr.ConnManager].
+type hostWrapper struct {
+	host.Host
+	gater   p2p.ConnectionGater
+	connMgr connmgr.ConnManager
+}
+
+// ConnectionGater returns the [hostWrapper]'s [p2p.ConnectionGater].
+func (h *hostWrapper) ConnectionGater() p2p.ConnectionGater {
+	return h.gater
+}
+
+// ConnectionManager returns the [hostWrapper]'s [connmgr.ConnManager].
+func (h *hostWrapper) ConnectionManager() connmgr.ConnManager {
+	return h.connMgr
+}
+
+// Close closes the [hostWrapper].
+func (h *hostWrapper) Close() error {
+	return h.Host.Close()
+}
+
+// CreateMultiaddr creates an [ma.Multiaddr] to bind to.
+// Does not contain a PeerID component (required for usage by external peers).
+func CreateMultiaddr(ip net.IP, port uint16) (ma.Multiaddr, error) {
+	ipScheme := "ip4"
+	if ip4 := ip.To4(); ip4 == nil {
+		ipScheme = "ip6"
+	} else {
+		ip = ip4
+	}
+	return ma.NewMultiaddr(fmt.Sprintf("/%s/%s/tcp/%d", ipScheme, ip.String(), port))
+}
+
+// BuildHost creates a new [host.Host] for the [MalleableNode].
+func (m *MalleableNode) BuildHost(
+	conf *p2p.Config,
+	log log.Logger,
+	reporter metrics.Reporter,
+) (host.Host, error) {
+	pub := conf.Priv.GetPublic()
+	pid, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive pubkey from network priv key: %w", err)
+	}
+
+	ps, err := pstoreds.NewPeerstore(context.Background(), conf.Store, pstoreds.DefaultOpts())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open peerstore: %w", err)
+	}
+
+	if err := ps.AddPrivKey(pid, conf.Priv); err != nil {
+		return nil, fmt.Errorf("failed to set up peerstore with priv key: %w", err)
+	}
+	if err := ps.AddPubKey(pid, pub); err != nil {
+		return nil, fmt.Errorf("failed to set up peerstore with pub key: %w", err)
+	}
+
+	listenAddr, err := CreateMultiaddr(conf.ListenIP, conf.ListenTCPPort)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make listen addr: %w", err)
+	}
+	tcpTransport := libp2p.Transport(
+		tcp.NewTCPTransport,
+		tcp.WithConnectionTimeout(time.Minute*60)) // break unused connections
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TCP transport: %w", err)
+	}
+
+	opts := []libp2p.Option{
+		libp2p.Identity(conf.Priv),
+		// Explicitly set the user-agent, so we can differentiate from other Go libp2p users.
+		libp2p.UserAgent(conf.UserAgent),
+		tcpTransport,
+		libp2p.WithDialTimeout(conf.TimeoutDial),
+		// No relay services, direct connections between peers only.
+		libp2p.DisableRelay(),
+		// host will start and listen to network directly after construction from config.
+		libp2p.ListenAddrs(listenAddr),
+		libp2p.ConnectionGater(m.gater),
+		libp2p.ConnectionManager(m.connMgr),
+		//libp2p.ResourceManager(nil),
+		// libp2p.NATManager(nat),
+		libp2p.Peerstore(ps),
+		libp2p.BandwidthReporter(reporter), // may be nil if disabled
+		libp2p.MultiaddrResolver(madns.DefaultResolver),
+		// Ping is a small built-in libp2p protocol that helps us check/debug latency between peers.
+		libp2p.Ping(true),
+		// Help peers with their NAT reachability status, but throttle to avoid too much work.
+		libp2p.EnableNATService(),
+		libp2p.AutoNATServiceRateLimit(10, 5, time.Second*60),
+	}
+	opts = append(opts, conf.HostMux...)
+	if conf.NoTransportSecurity {
+		opts = append(opts, libp2p.Security(insecure.ID, insecure.NewWithIdentity))
+	} else {
+		opts = append(opts, conf.HostSecurity...)
+	}
+	h, err := libp2p.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &hostWrapper{
+		Host:    h,
+		connMgr: m.connMgr,
+		gater:   m.gater,
+	}
+
+	return out, nil
+}

--- a/op-e2e/malleable/node.go
+++ b/op-e2e/malleable/node.go
@@ -1,0 +1,84 @@
+package malleable
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	log "github.com/ethereum/go-ethereum/log"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	connmgr "github.com/libp2p/go-libp2p/core/connmgr"
+	host "github.com/libp2p/go-libp2p/core/host"
+	p2pmetrics "github.com/libp2p/go-libp2p/core/metrics"
+	peer "github.com/libp2p/go-libp2p/core/peer"
+
+	eth "github.com/ethereum-optimism/optimism/op-node/eth"
+	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
+)
+
+// MalleableNode is a slimmed down [opNode.NodeP2P] with configurable gossip.
+// Discovery is not enabled for simplicity.
+type MalleableNode struct {
+	innerHost host.Host
+
+	// p2p parameters
+	gater   p2p.ConnectionGater
+	connMgr connmgr.ConnManager
+
+	// Gossip parameters
+	gs    *pubsub.PubSub
+	gsOut p2p.GossipOut
+}
+
+// NewMalleableNode creates a new [MalleableNode].
+func NewMalleableNode(t *testing.T) (*MalleableNode, error) {
+	var m MalleableNode
+	if err := m.Init(t); err != nil {
+		return nil, err
+	}
+	if err := m.Start(context.Background()); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// Init builds a [MalleableNode].
+func (m *MalleableNode) Init(t *testing.T) error {
+	bwc := p2pmetrics.NewBandwidthCounter()
+
+	snapLog := log.New()
+	snapLog.SetHandler(log.DiscardHandler())
+
+	conf, err := DefaultConfig()
+	if err != nil {
+		return err
+	}
+
+	// Build the inner host
+	m.innerHost, err = m.BuildHost(conf, snapLog, bwc)
+	if err != nil {
+		return fmt.Errorf("failed to start p2p host: %w", err)
+	}
+
+	if err := m.SetupGossip(t, conf, snapLog); err != nil {
+		return fmt.Errorf("failed to setup gossip: %w", err)
+	}
+
+	return nil
+}
+
+// Start starts the [MalleableNode].
+func (m *MalleableNode) Start(ctx context.Context) error {
+
+	// TODO: start the malleable node
+
+	return nil
+}
+
+// OnUnsafeL1Payload implements the [p2p.GossipIn] interface.
+func (m *MalleableNode) OnUnsafeL2Payload(ctx context.Context, from peer.ID, msg *eth.ExecutionPayload) error {
+
+	// TODO: Implement this
+
+	return nil
+}

--- a/op-e2e/malleable/publisher.go
+++ b/op-e2e/malleable/publisher.go
@@ -1,0 +1,69 @@
+package malleable
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+
+	snappy "github.com/golang/snappy"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	peer "github.com/libp2p/go-libp2p/core/peer"
+
+	eth "github.com/ethereum-optimism/optimism/op-node/eth"
+	p2p "github.com/ethereum-optimism/optimism/op-node/p2p"
+	rollup "github.com/ethereum-optimism/optimism/op-node/rollup"
+)
+
+// malpub is a malleable publisher for gossip.
+type malpub struct {
+	cfg         *rollup.Config
+	blocksTopic *pubsub.Topic
+}
+
+// BlocksTopicPeers returns the list of peers subscribed to the blocks topic.
+func (m *malpub) BlocksTopicPeers() []peer.ID {
+	return m.blocksTopic.ListPeers()
+}
+
+// Close shuts down the [malpub], closing the pubsub topic.
+func (m *malpub) Close() error {
+	return m.blocksTopic.Close()
+}
+
+const maxGossipSize = 10 * (1 << 20)
+
+var msgBufPool = sync.Pool{New: func() any {
+	// note: the topic validator concurrency is limited, so pool won't blow up, even with large pre-allocation.
+	x := make([]byte, 0, maxGossipSize)
+	return &x
+}}
+
+// PublishL2Payload publishes an L2 payload to the gossip network.
+func (m *malpub) PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayload, signer p2p.Signer) error {
+	res := msgBufPool.Get().(*[]byte)
+	buf := bytes.NewBuffer((*res)[:0])
+	defer func() {
+		*res = buf.Bytes()
+		defer msgBufPool.Put(res)
+	}()
+
+	buf.Write(make([]byte, 65))
+	if _, err := payload.MarshalSSZ(buf); err != nil {
+		return fmt.Errorf("failed to encoded execution payload to publish: %w", err)
+	}
+	data := buf.Bytes()
+	payloadData := data[65:]
+	sig, err := signer.Sign(ctx, p2p.SigningDomainBlocksV1, m.cfg.L2ChainID, payloadData)
+	if err != nil {
+		return fmt.Errorf("failed to sign execution payload with signer: %w", err)
+	}
+	copy(data[:65], sig[:])
+
+	// compress the full message
+	// This also copies the data, freeing up the original buffer to go back into the pool
+	out := snappy.Encode(nil, data)
+
+	return m.blocksTopic.Publish(ctx, out)
+}

--- a/op-e2e/peer_scoring_test.go
+++ b/op-e2e/peer_scoring_test.go
@@ -1,0 +1,422 @@
+package op_e2e
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	rollupNode "github.com/ethereum-optimism/optimism/op-node/node"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	geth_eth "github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystem_PeerScoring tests that the peer scoring system works as expected.
+func TestSystem_PeerScoring(t *testing.T) {
+	parallel(t)
+	if !verboseGethNodes {
+		log.Root().SetHandler(log.DiscardHandler())
+	}
+
+	cfg := DefaultSystemConfig(t)
+
+	// Slow down L1 blocks so we can see the L2 blocks arrive before L1 blocks
+	cfg.DeployConfig.L1BlockTime = 10
+
+	// Dial the nodes to each other
+	cfg.P2PTopology = map[string][]string{"verifier":  {"sequencer"}}
+
+	// Set peer scoring for each node, but without banning
+	for _, node := range cfg.Nodes {
+		params, err := p2p.GetPeerScoreParams("light", 2)
+		require.NoError(t, err)
+		bandScoreThresholds, err := p2p.NewBandScorer("-40:graylist;-20:restricted;0:nopx;20:friend;")
+		require.NoError(t, err)
+		p2pPrivKey := secp256k1.NewPrivateKey(&secp256k1.ModNScalar{})
+		node.P2P = &p2p.Config{
+			Priv:                (*crypto.Secp256k1PrivateKey)(p2pPrivKey),
+			PeerScoring:         params,
+			BanningEnabled:      false,
+			BandScoreThresholds: *bandScoreThresholds,
+		}
+		// We only want to set the signer of the first verifier
+		// if name == "verifier" {
+		// 	node.P2PSigner = &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(cfg.Secrets.Alice)}
+		// }
+	}
+
+	var published, received []common.Hash
+	seqTracer, verifTracer := new(FnTracer), new(FnTracer)
+	seqTracer.OnPublishL2PayloadFn = func(ctx context.Context, payload *eth.ExecutionPayload) {
+		published = append(published, payload.BlockHash)
+	}
+	verifTracer.OnUnsafeL2PayloadFn = func(ctx context.Context, from peer.ID, payload *eth.ExecutionPayload) {
+		received = append(received, payload.BlockHash)
+	}
+	cfg.Nodes["sequencer"].Tracer = seqTracer
+	cfg.Nodes["verifier"].Tracer = verifTracer
+
+
+	sys, err := startConfig(cfg)
+	require.NoError(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l2Seq := sys.Clients["sequencer"]
+	l2Verif := sys.Clients["verifier"]
+
+	// Transactor Account
+	ethPrivKey := cfg.Secrets.Alice
+
+	// Create a malicious node
+
+	// Connect the malicious verifier node to the mocknet
+	_, err = sys.Mocknet.ConnectPeers(peerA.HostP2P.ID(), cfg.Nodes["verifier"]..HostP2P.ID());
+	require.NoError(t, err, "failed to setup mocknet connection between %s and %s", k, v)
+
+	// TODO: Have the malicious verifier node broadcast a tx to the second verifier node
+
+	// Submit TX to L2 sequencer node
+	toAddr := common.Address{0xff, 0xff}
+	tx := types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L2ChainIDBig()), &types.DynamicFeeTx{
+		ChainID:   cfg.L2ChainIDBig(),
+		Nonce:     0,
+		To:        &toAddr,
+		Value:     big.NewInt(1_000_000_000),
+		GasTipCap: big.NewInt(10),
+		GasFeeCap: big.NewInt(200),
+		Gas:       21000,
+	})
+	err = l2Seq.SendTransaction(context.Background(), tx)
+	require.NoError(t, err, "Sending L2 tx to sequencer")
+
+	// Wait for tx to be mined on the L2 sequencer chain
+	receiptSeq, err := waitForTransaction(tx.Hash(), l2Seq, 10*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.NoError(t, err, "Waiting for L2 tx on sequencer")
+
+	// Wait until the block it was first included in shows up in the safe chain on the verifier
+	receiptVerif, err := waitForTransaction(tx.Hash(), l2Verif, 10*time.Duration(sys.RollupConfig.BlockTime)*time.Second)
+	require.NoError(t, err, "Waiting for L2 tx on verifier")
+	require.Equal(t, receiptSeq, receiptVerif)
+
+	// Verify that everything that was received was published
+	require.GreaterOrEqual(t, len(published), len(received))
+	require.ElementsMatch(t, published, received[:len(published)])
+
+	// Verify that the tx was received via p2p
+	require.Contains(t, received, receiptVerif.BlockHash)
+
+
+	// fmt.Printf("Publishing L2 payload to the first verifier rollup node...")
+	// require.NoError(t, sys.RollupNodes["verifier"].PublishL2Payload(context.Background(), &eth.ExecutionPayload{
+	// 	BlockHash: common.HexToHash("0xdeadbeef"),
+	// 	From
+	// }))
+}
+
+
+func startConfig(cfg *SystemConfig) (*System, error) {
+	opts, err := NewSystemConfigOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	sys := &System{
+		cfg:         cfg,
+		Nodes:       make(map[string]*node.Node),
+		Backends:    make(map[string]*geth_eth.Ethereum),
+		Clients:     make(map[string]*ethclient.Client),
+		RollupNodes: make(map[string]*rollupNode.OpNode),
+	}
+	didErrAfterStart := false
+	defer func() {
+		if didErrAfterStart {
+			for _, node := range sys.RollupNodes {
+				node.Close()
+			}
+			for _, node := range sys.Nodes {
+				node.Close()
+			}
+		}
+	}()
+
+	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for addr, amount := range cfg.Premine {
+		if existing, ok := l1Genesis.Alloc[addr]; ok {
+			l1Genesis.Alloc[addr] = core.GenesisAccount{
+				Code:    existing.Code,
+				Storage: existing.Storage,
+				Balance: amount,
+				Nonce:   existing.Nonce,
+			}
+		} else {
+			l1Genesis.Alloc[addr] = core.GenesisAccount{
+				Balance: amount,
+				Nonce:   0,
+			}
+		}
+	}
+
+	l1Block := l1Genesis.ToBlock()
+	l2Genesis, err := genesis.BuildL2DeveloperGenesis(cfg.DeployConfig, l1Block)
+	if err != nil {
+		return nil, err
+	}
+	for addr, amount := range cfg.Premine {
+		if existing, ok := l2Genesis.Alloc[addr]; ok {
+			l2Genesis.Alloc[addr] = core.GenesisAccount{
+				Code:    existing.Code,
+				Storage: existing.Storage,
+				Balance: amount,
+				Nonce:   existing.Nonce,
+			}
+		} else {
+			l2Genesis.Alloc[addr] = core.GenesisAccount{
+				Balance: amount,
+				Nonce:   0,
+			}
+		}
+	}
+
+	makeRollupConfig := func() rollup.Config {
+		return rollup.Config{
+			Genesis: rollup.Genesis{
+				L1: eth.BlockID{
+					Hash:   l1Block.Hash(),
+					Number: 0,
+				},
+				L2: eth.BlockID{
+					Hash:   l2Genesis.ToBlock().Hash(),
+					Number: 0,
+				},
+				L2Time:       uint64(cfg.DeployConfig.L1GenesisBlockTimestamp),
+				SystemConfig: e2eutils.SystemConfigFromDeployConfig(cfg.DeployConfig),
+			},
+			BlockTime:              cfg.DeployConfig.L2BlockTime,
+			MaxSequencerDrift:      cfg.DeployConfig.MaxSequencerDrift,
+			SeqWindowSize:          cfg.DeployConfig.SequencerWindowSize,
+			ChannelTimeout:         cfg.DeployConfig.ChannelTimeout,
+			L1ChainID:              cfg.L1ChainIDBig(),
+			L2ChainID:              cfg.L2ChainIDBig(),
+			BatchInboxAddress:      cfg.DeployConfig.BatchInboxAddress,
+			DepositContractAddress: predeploys.DevOptimismPortalAddr,
+			L1SystemConfigAddress:  predeploys.DevSystemConfigAddr,
+			RegolithTime:           cfg.DeployConfig.RegolithTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
+		}
+	}
+	defaultConfig := makeRollupConfig()
+	sys.RollupConfig = &defaultConfig
+
+	// Initialize nodes
+	l1Node, l1Backend, err := initL1Geth(&cfg, l1Genesis, cfg.GethOptions["l1"]...)
+	if err != nil {
+		return nil, err
+	}
+	sys.Nodes["l1"] = l1Node
+	sys.Backends["l1"] = l1Backend
+
+	for name := range cfg.Nodes {
+		node, backend, err := initL2Geth(name, big.NewInt(int64(cfg.DeployConfig.L2ChainID)), l2Genesis, cfg.JWTFilePath, cfg.GethOptions[name]...)
+		if err != nil {
+			return nil, err
+		}
+		sys.Nodes[name] = node
+		sys.Backends[name] = backend
+	}
+
+	// Start
+	err = l1Node.Start()
+	if err != nil {
+		didErrAfterStart = true
+		return nil, err
+	}
+	err = l1Backend.StartMining(1)
+	if err != nil {
+		didErrAfterStart = true
+		return nil, err
+	}
+	for name, node := range sys.Nodes {
+		if name == "l1" {
+			continue
+		}
+		err = node.Start()
+		if err != nil {
+			didErrAfterStart = true
+			return nil, err
+		}
+	}
+
+	// Configure connections to L1 and L2 for rollup nodes.
+	l1EndpointConfig := l1Node.WSEndpoint()
+	useHTTP := os.Getenv("OP_E2E_USE_HTTP") == "true"
+	if useHTTP {
+		log.Info("using HTTP client")
+		l1EndpointConfig = l1Node.HTTPEndpoint()
+	}
+
+	for name, rollupCfg := range cfg.Nodes {
+		l2EndpointConfig := sys.Nodes[name].WSAuthEndpoint()
+		if useHTTP {
+			l2EndpointConfig = sys.Nodes[name].HTTPAuthEndpoint()
+		}
+		rollupCfg.L1 = &rollupNode.L1EndpointConfig{
+			L1NodeAddr: l1EndpointConfig,
+			L1TrustRPC: false,
+			L1RPCKind:  sources.RPCKindBasic,
+		}
+		rollupCfg.L2 = &rollupNode.L2EndpointConfig{
+			L2EngineAddr:      l2EndpointConfig,
+			L2EngineJWTSecret: cfg.JWTSecret,
+		}
+		rollupCfg.L2Sync = &rollupNode.PreparedL2SyncEndpoint{
+			Client:   nil,
+			TrustRPC: false,
+		}
+	}
+
+	// Geth Clients
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	l1Srv, err := l1Node.RPCHandler()
+	if err != nil {
+		didErrAfterStart = true
+		return nil, err
+	}
+	l1Client := ethclient.NewClient(rpc.DialInProc(l1Srv))
+	sys.Clients["l1"] = l1Client
+	for name, node := range sys.Nodes {
+		client, err := ethclient.DialContext(ctx, node.WSEndpoint())
+		if err != nil {
+			didErrAfterStart = true
+			return nil, err
+		}
+		sys.Clients[name] = client
+	}
+
+	_, err = waitForBlock(big.NewInt(2), l1Client, 6*time.Second*time.Duration(cfg.DeployConfig.L1BlockTime))
+	if err != nil {
+		return nil, fmt.Errorf("waiting for blocks: %w", err)
+	}
+
+	// Create the custom mocknet
+	sys.Mocknet = mocknet.New()
+	p2pNodes := make(map[string]*p2p.Prepared)
+
+	// Helper function to initialize a mocknet host
+	initHostMaybe := func(name string) (*p2p.Prepared, error) {
+		if p, ok := p2pNodes[name]; ok {
+			return p, nil
+		}
+		h, err := sys.Mocknet.GenPeer()
+		if err != nil {
+			return nil, fmt.Errorf("failed to init p2p host for node %s", name)
+		}
+		h.Network()
+		_, ok := cfg.Nodes[name]
+		if !ok {
+			return nil, fmt.Errorf("node %s from p2p topology not found in actual nodes map", name)
+		}
+		p := &p2p.Prepared{
+			HostP2P:   h,
+			LocalNode: nil,
+			UDPv5:     nil,
+		}
+		p2pNodes[name] = p
+		return p, nil
+	}
+
+	// Create the verifier and sequencer hosts
+	verifierHost, err := initHostMaybe("verifier")
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup mocknet peer %s", k)
+	}
+	sequencerHost, err := initHostMaybe("sequencer")
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup mocknet peer %s (peer of %s)", v, k)
+	}
+	if _, err := sys.Mocknet.LinkPeers(verifierHost.HostP2P.ID(), sequencerHost.HostP2P.ID()); err != nil {
+		return nil, fmt.Errorf("failed to setup mocknet link between %s and %s", k, v)
+	}
+
+	// Start the nodes
+	sys.RollupNodes["sequencer"], err = startNode(cfg, "sequencer", p2pNodes)
+	require.NoError(t, err)
+	sys.RollupNodes["verifier"], err = startNode(cfg, "verifier", p2pNodes)
+	require.NoError(t, err)
+
+
+	// Node topology:
+	//
+	//		 sequencer
+	//  	 / /
+	//	verifier = malicious
+
+	require.NoError(t, connectNodes(p2pNodes["sequencer"], p2pNodes["verifier"]))
+	require.NoError(t, connectNodes(p2pNodes["verifier"], p2pNodes["sequencer"]))
+	require.NoError(t, connectNodes(p2pNodes["verifier"], p2pNodes["malicious"]))
+	require.NoError(t, connectNodes(p2pNodes["malicious"], p2pNodes["verifier"]))
+
+
+
+}
+
+func connectNodes(nodeA *p2p.Prepared, nodeB *p2p.Prepared) error {
+	return sys.Mocknet.ConnectPeers(nodeA.HostP2P.ID(), nodeB.HostP2P.ID())
+}
+
+func startNode(cfg *SystemConfig, name string, p2pNodes *map[string]*p2p.Prepared) (*rollupNode.OpNode, error) {
+	fmt.Printf("Starting node: %s with config: %+v\n", name, cfg.Nodes[name])
+	nodeConfig := cfg.Nodes[name]
+	c := *nodeConfig
+	c.Rollup = makeRollupConfig()
+
+	if p, ok := p2pNodes[name]; ok {
+		c.P2P = p
+
+		if c.Driver.SequencerEnabled && c.P2PSigner == nil {
+			c.P2PSigner = &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(cfg.Secrets.SequencerP2P)}
+		}
+	}
+
+	c.Rollup.LogDescription(cfg.Loggers[name], chaincfg.L2ChainIDToNetworkName)
+
+	snapLog := log.New()
+	snapLog.SetHandler(log.DiscardHandler())
+	node, err := rollupNode.New(context.Background(), &c, cfg.Loggers[name], snapLog, "", metrics.NewMetrics(""))
+	if err != nil {
+		didErrAfterStart = true
+		return nil, err
+	}
+	err = node.Start(context.Background())
+	if err != nil {
+		didErrAfterStart = true
+		return nil, err
+	}
+
+	return node, nil
+}

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -513,6 +513,7 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 	sort.Strings(ks)
 
 	for _, name := range ks {
+		fmt.Printf("Starting node: %s with config: %+v\n", name, cfg.Nodes[name])
 		nodeConfig := cfg.Nodes[name]
 		c := *nodeConfig // copy
 		c.Rollup = makeRollupConfig()

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -433,6 +433,8 @@ func (p *publisher) PublishL2Payload(ctx context.Context, payload *eth.Execution
 	// This also copies the data, freeing up the original buffer to go back into the pool
 	out := snappy.Encode(nil, data)
 
+	fmt.Printf("Inside p2p/gossip.go: publishing %d bytes\n", len(out))
+
 	return p.blocksTopic.Publish(ctx, out)
 }
 


### PR DESCRIPTION
**Description**

Introduces an `op-e2e` end to end test composed of a system with a `verifier`, `sequencer`, and "`malleable`" nodes. The `malleable` node is a new system entrant that allows publishing invalid L2 blocks through libp2p gossip channels. This is intended to test that it's peer scoring will decrease from the perspective of the `verifier` and `sequencer` nodes.

**Metadata**

Fixes CLI-3603
