### PR TITLE
op-proposer: add L1 fee metrics

### DIFF
--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type noopMetrics struct{ opmetrics.NoopRefMetrics }
@@ -13,3 +14,5 @@ func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
 func (*noopMetrics) RecordL2BlocksProposed(l2ref eth.L2BlockRef) {}
+func (*noopMetrics) RecordL1GasFee(receipt *types.Receipt) {
+}

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -359,6 +359,7 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 	if err != nil {
 		return err
 	}
+	l.metr.RecordL1GasFee(receipt)
 	l.log.Info("proposer tx successfully published", "tx_hash", receipt.TxHash)
 	return nil
 }

--- a/op-service/metrics/ref_metrics.go
+++ b/op-service/metrics/ref_metrics.go
@@ -2,10 +2,10 @@ package metrics
 
 import (
 	"encoding/binary"
+
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 )


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- We want to add metrics to emit L1 gas fee for proposer and batcher

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
