### PR TITLE
op-service/txmgr : add tx manager metrics

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -73,7 +73,7 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 	if err != nil {
 		return nil, err
 	}
-	txManager := txmgr.NewSimpleTxManager("batcher", l, txManagerConfig)
+	txManager := txmgr.NewSimpleTxManager("batcher", l, m, txManagerConfig)
 
 	batcherCfg := Config{
 		L1Client:       l1Client,

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
 const Namespace = "op_batcher"
@@ -21,6 +22,9 @@ type Metricer interface {
 
 	// Records all L1 and L2 block events
 	opmetrics.RefMetricer
+
+	// Record Tx metrics
+	txmetrics.TxMetricer
 
 	RecordLatestL1Block(l1ref eth.L1BlockRef)
 	RecordL2BlocksLoaded(l2ref eth.L2BlockRef)
@@ -43,6 +47,7 @@ type Metrics struct {
 	factory  opmetrics.Factory
 
 	opmetrics.RefMetrics
+	txmetrics.TxMetrics
 
 	Info prometheus.GaugeVec
 	Up   prometheus.Gauge
@@ -80,6 +85,7 @@ func NewMetrics(procName string) *Metrics {
 		factory:  factory,
 
 		RefMetrics: opmetrics.MakeRefMetrics(ns, factory),
+		TxMetrics:  txmetrics.MakeTxMetrics(ns, factory),
 
 		Info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -4,9 +4,13 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
-type noopMetrics struct{ opmetrics.NoopRefMetrics }
+type noopMetrics struct {
+	opmetrics.NoopRefMetrics
+	txmetrics.NoopTxMetrics
+}
 
 var NoopMetrics Metricer = new(noopMetrics)
 

--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
 const Namespace = "op_proposer"
@@ -22,6 +23,9 @@ type Metricer interface {
 	// Records all L1 and L2 block events
 	opmetrics.RefMetricer
 
+	// Record Tx metrics
+	txmetrics.TxMetricer
+
 	RecordL2BlocksProposed(l2ref eth.L2BlockRef)
 }
 
@@ -31,6 +35,7 @@ type Metrics struct {
 	factory  opmetrics.Factory
 
 	opmetrics.RefMetrics
+	txmetrics.TxMetrics
 
 	Info prometheus.GaugeVec
 	Up   prometheus.Gauge
@@ -53,6 +58,7 @@ func NewMetrics(procName string) *Metrics {
 		factory:  factory,
 
 		RefMetrics: opmetrics.MakeRefMetrics(ns, factory),
+		TxMetrics:  txmetrics.MakeTxMetrics(ns, factory),
 
 		Info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-proposer/metrics/noop.go
+++ b/op-proposer/metrics/noop.go
@@ -3,9 +3,13 @@ package metrics
 import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
-type noopMetrics struct{ opmetrics.NoopRefMetrics }
+type noopMetrics struct {
+	opmetrics.NoopRefMetrics
+	txmetrics.NoopTxMetrics
+}
 
 var NoopMetrics Metricer = new(noopMetrics)
 

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -42,7 +42,7 @@ func Main(version string, cliCtx *cli.Context) error {
 	m := metrics.NewMetrics("default")
 	l.Info("Initializing L2 Output Submitter")
 
-	proposerConfig, err := NewL2OutputSubmitterConfigFromCLIConfig(cfg, l)
+	proposerConfig, err := NewL2OutputSubmitterConfigFromCLIConfig(cfg, l, m)
 	if err != nil {
 		l.Error("Unable to create the L2 Output Submitter", "error", err)
 		return err
@@ -138,7 +138,7 @@ type L2OutputSubmitter struct {
 
 // NewL2OutputSubmitterFromCLIConfig creates a new L2 Output Submitter given the CLI Config
 func NewL2OutputSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metricer) (*L2OutputSubmitter, error) {
-	proposerConfig, err := NewL2OutputSubmitterConfigFromCLIConfig(cfg, l)
+	proposerConfig, err := NewL2OutputSubmitterConfigFromCLIConfig(cfg, l, m)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func NewL2OutputSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Me
 }
 
 // NewL2OutputSubmitterConfigFromCLIConfig creates the proposer config from the CLI config.
-func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger) (*Config, error) {
+func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metricer) (*Config, error) {
 	l2ooAddress, err := parseAddress(cfg.L2OOAddress)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger) (*Conf
 	if err != nil {
 		return nil, err
 	}
-	txManager := txmgr.NewSimpleTxManager("proposer", l, txManagerConfig)
+	txManager := txmgr.NewSimpleTxManager("proposer", l, m, txManagerConfig)
 
 	// Connect to L1 and L2 providers. Perform these last since they are the most expensive.
 	ctx := context.Background()

--- a/op-service/txmgr/metrics/noop.go
+++ b/op-service/txmgr/metrics/noop.go
@@ -1,0 +1,7 @@
+package metrics
+
+import "github.com/ethereum/go-ethereum/core/types"
+
+type NoopTxMetrics struct{}
+
+func (*NoopTxMetrics) RecordL1GasFee(*types.Receipt) {}

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -1,0 +1,34 @@
+package metrics
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type TxMetricer interface {
+	RecordL1GasFee(receipt *types.Receipt)
+}
+
+type TxMetrics struct {
+	TxL1GasFee prometheus.Gauge
+}
+
+var _ TxMetricer = (*TxMetrics)(nil)
+
+func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
+	return TxMetrics{
+		TxL1GasFee: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "tx_fee_gwei",
+			Help:      "L1 gas fee for transactions in GWEI",
+			Subsystem: "txmgr",
+		}),
+	}
+}
+
+func (t *TxMetrics) RecordL1GasFee(receipt *types.Receipt) {
+	t.TxL1GasFee.Set(float64(receipt.EffectiveGasPrice.Uint64() * receipt.GasUsed / params.GWei))
+}

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -39,7 +41,7 @@ func newTestHarnessWithConfig(t *testing.T, cfg Config) *testHarness {
 	g := newGasPricer(3)
 	backend := newMockBackend(g)
 	cfg.Backend = backend
-	mgr := NewSimpleTxManager("TEST", testlog.Logger(t, log.LvlCrit), cfg)
+	mgr := NewSimpleTxManager("TEST", testlog.Logger(t, log.LvlCrit), &metrics.NoopTxMetrics{}, cfg)
 
 	return &testHarness{
 		cfg:       cfg,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

- 1/n PR for #5291 
- Adding metrics for transaction manager
- Embed and initialize from `op-proposer` and `op-batcher`
- Add L1 Gas fee metrics

- [x] Test L1 gas metrics using `devnet`
```
 HELP op_proposer_default_txmgr_tx_fee L1 gas fee for a transaction in GWEI
# TYPE op_proposer_default_txmgr_tx_fee gauge
op_proposer_default_txmgr_tx_fee 89488
```

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
