### PR TITLE
feat(contracts-periphery): create OptimistAllowlist contract

### DIFF
--- a/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
@@ -138,7 +138,7 @@ contract OptimistAllowlist_Initializer is Test {
 }
 
 contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
-    function test_constructor_success() external {
+    function test_constructor_succeeds() external {
         // expect attestationStation to be set
         assertEq(address(optimistAllowlist.ATTESTATION_STATION()), address(attestationStation));
         assertEq(optimistAllowlist.ALLOWLIST_ATTESTOR(), alice_allowlistAttestor);
@@ -158,7 +158,7 @@ contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
     /**
      * @notice After receiving a valid allowlist attestation, the account should be able to mint.
      */
-    function test_isAllowedToMint_fromAllowlistAttestor_success() external {
+    function test_isAllowedToMint_fromAllowlistAttestor_succeeds() external {
         attestAllowlist(bob);
         assertTrue(optimistAllowlist.isAllowedToMint(bob));
     }
@@ -167,7 +167,7 @@ contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
      * @notice After receiving a valid attestation from the Coinbase Quest attestor,
      *         the account should be able to mint.
      */
-    function test_isAllowedToMint_fromCoinbaseQuestAttestor_success() external {
+    function test_isAllowedToMint_fromCoinbaseQuestAttestor_succeeds() external {
         attestCoinbaseQuest(bob);
         assertTrue(optimistAllowlist.isAllowedToMint(bob));
     }
@@ -176,7 +176,7 @@ contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
      * @notice Account that received an attestation from the OptimistInviter contract by going
      *         through the claim invite flow should be able to mint.
      */
-    function test_isAllowedToMint_fromInvite_success() external {
+    function test_isAllowedToMint_fromInvite_succeeds() external {
         inviteAndClaim(bob);
         assertTrue(optimistAllowlist.isAllowedToMint(bob));
     }
@@ -226,7 +226,7 @@ contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
     /**
      * @notice Having multiple signals, even if one is invalid, should still allow minting.
      */
-    function test_isAllowedToMint_withMultipleAttestations_success() external {
+    function test_isAllowedToMint_withMultipleAttestations_succeeds() external {
         attestAllowlist(bob);
         attestCoinbaseQuest(bob);
         inviteAndClaim(bob);

--- a/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
@@ -1,0 +1,283 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+/* Testing utilities */
+import { Test } from "forge-std/Test.sol";
+import { AttestationStation } from "../universal/op-nft/AttestationStation.sol";
+import { OptimistAllowlist } from "../universal/op-nft/OptimistAllowlist.sol";
+import { OptimistInviter } from "../universal/op-nft/OptimistInviter.sol";
+import { OptimistInviterHelper } from "../testing/helpers/OptimistInviterHelper.sol";
+
+contract OptimistAllowlist_Initializer is Test {
+    event AttestationCreated(
+        address indexed creator,
+        address indexed about,
+        bytes32 indexed key,
+        bytes val
+    );
+    address internal alice_allowlistAttestor;
+    address internal sally_coinbaseQuestAttestor;
+    address internal ted;
+
+    uint256 internal bobPrivateKey;
+    address internal bob;
+
+    AttestationStation attestationStation;
+    OptimistAllowlist optimistAllowlist;
+    OptimistInviter optimistInviter;
+
+    // Helps with EIP-712 signature generation
+    OptimistInviterHelper optimistInviterHelper;
+
+    function setUp() public {
+        alice_allowlistAttestor = makeAddr("alice_allowlistAttestor");
+        sally_coinbaseQuestAttestor = makeAddr("sally_coinbaseQuestAttestor");
+        ted = makeAddr("ted");
+
+        bobPrivateKey = 0xB0B0B0B0;
+        bob = vm.addr(bobPrivateKey);
+        vm.label(bob, "bob");
+
+        // Give alice and bob and sally some ETH
+        vm.deal(alice_allowlistAttestor, 1 ether);
+        vm.deal(sally_coinbaseQuestAttestor, 1 ether);
+        vm.deal(bob, 1 ether);
+        vm.deal(ted, 1 ether);
+
+        _initializeContracts();
+    }
+
+    function attestAllowlist(address _about) internal {
+        AttestationStation.AttestationData[]
+            memory attestationData = new AttestationStation.AttestationData[](1);
+        // we are using true but it can be any non empty value
+        attestationData[0] = AttestationStation.AttestationData({
+            about: _about,
+            key: optimistAllowlist.OPTIMIST_CAN_MINT_ATTESTATION_KEY(),
+            val: bytes("true")
+        });
+        vm.prank(alice_allowlistAttestor);
+        attestationStation.attest(attestationData);
+    }
+
+    function attestCoinbaseQuest(address _about) internal {
+        AttestationStation.AttestationData[]
+            memory attestationData = new AttestationStation.AttestationData[](1);
+        // we are using true but it can be any non empty value
+        attestationData[0] = AttestationStation.AttestationData({
+            about: _about,
+            key: optimistAllowlist.COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY(),
+            val: bytes("true")
+        });
+        vm.prank(sally_coinbaseQuestAttestor);
+        attestationStation.attest(attestationData);
+    }
+
+    function inviteAndClaim(address claimer) internal {
+        address[] memory addresses = new address[](1);
+        addresses[0] = bob;
+
+        vm.prank(alice_allowlistAttestor);
+
+        // grant invites to Bob;
+        optimistInviter.setInviteCounts(addresses, 3);
+
+        // issue a new invite
+        OptimistInviter.ClaimableInvite memory claimableInvite = optimistInviterHelper
+            .getClaimableInviteWithNewNonce(bob);
+
+        // EIP-712 sign with Bob's private key
+        bytes memory signature = _getSignature(
+            bobPrivateKey,
+            optimistInviterHelper.getDigest(claimableInvite)
+        );
+
+        bytes32 hashedCommit = keccak256(abi.encode(claimer, signature));
+
+        // commit the invite
+        vm.prank(claimer);
+        optimistInviter.commitInvite(hashedCommit);
+
+        // wait minimum commitment period
+        vm.warp(optimistInviter.MIN_COMMITMENT_PERIOD() + block.timestamp);
+
+        // reveal and claim the invite
+        optimistInviter.claimInvite(claimer, claimableInvite, signature);
+    }
+
+    /**
+     * @notice Get signature as a bytes blob, since SignatureChecker takes arbitrary signature blobs.
+     *
+     */
+    function _getSignature(uint256 _signingPrivateKey, bytes32 _digest)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signingPrivateKey, _digest);
+
+        bytes memory signature = abi.encodePacked(r, s, v);
+        return signature;
+    }
+
+    function _initializeContracts() internal {
+        attestationStation = new AttestationStation();
+
+        optimistInviter = new OptimistInviter(alice_allowlistAttestor, attestationStation);
+        optimistInviter.initialize("OptimistInviter");
+
+        optimistAllowlist = new OptimistAllowlist(
+            attestationStation,
+            alice_allowlistAttestor,
+            sally_coinbaseQuestAttestor,
+            address(optimistInviter)
+        );
+
+        optimistInviterHelper = new OptimistInviterHelper(optimistInviter, "OptimistInviter");
+    }
+}
+
+contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
+    function test_constructor_success() external {
+        // expect attestationStation to be set
+        assertEq(address(optimistAllowlist.ATTESTATION_STATION()), address(attestationStation));
+        assertEq(optimistAllowlist.ALLOWLIST_ATTESTOR(), alice_allowlistAttestor);
+        assertEq(optimistAllowlist.COINBASE_QUEST_ATTESTOR(), sally_coinbaseQuestAttestor);
+        assertEq(address(optimistAllowlist.OPTIMIST_INVITER()), address(optimistInviter));
+
+        assertEq(optimistAllowlist.version(), "1.0.0");
+    }
+
+    /**
+     * @notice Base case, a account without any relevant attestations should not be able to mint.
+     */
+    function test_isAllowedToMint_withoutAnyAttestations_fails() external {
+        assertFalse(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice After receiving a valid allowlist attestation, the account should be able to mint.
+     */
+    function test_isAllowedToMint_fromAllowlistAttestor_success() external {
+        attestAllowlist(bob);
+        assertTrue(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice After receiving a valid attestation from the Coinbase Quest attestor,
+     *         the account should be able to mint.
+     */
+    function test_isAllowedToMint_fromCoinbaseQuestAttestor_success() external {
+        attestCoinbaseQuest(bob);
+        assertTrue(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Account that received an attestation from the OptimistInviter contract by going
+     *         through the claim invite flow should be able to mint.
+     */
+    function test_isAllowedToMint_fromInvite_success() external {
+        inviteAndClaim(bob);
+        assertTrue(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Attestation from the wrong allowlist attestor should not allow minting.
+     */
+    function test_isAllowedToMint_fromWrongAllowlistAttestor_fails() external {
+        // Ted is not the allowlist attestor
+        vm.prank(ted);
+        attestationStation.attest(
+            bob,
+            optimistAllowlist.OPTIMIST_CAN_MINT_ATTESTATION_KEY(),
+            bytes("true")
+        );
+        assertFalse(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Coinbase attestation from wrong attestor should not allow minting.
+     */
+    function test_isAllowedToMint_fromWrongCoinbaseQuestAttestor_fails() external {
+        // Ted is not the coinbase quest attestor
+        vm.prank(ted);
+        attestationStation.attest(
+            bob,
+            optimistAllowlist.COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY(),
+            bytes("true")
+        );
+        assertFalse(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Claiming an invite on the non-official OptimistInviter contract should not allow
+     *         minting.
+     */
+    function test_isAllowedToMint_fromWrongOptimistInviter_fails() external {
+        vm.prank(ted);
+        attestationStation.attest(
+            bob,
+            optimistInviter.CAN_MINT_FROM_INVITE_ATTESTATION_KEY(),
+            bytes("true")
+        );
+        assertFalse(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Having multiple signals, even if one is invalid, should still allow minting.
+     */
+    function test_isAllowedToMint_withMultipleAttestations_success() external {
+        attestAllowlist(bob);
+        attestCoinbaseQuest(bob);
+        inviteAndClaim(bob);
+
+        assertTrue(optimistAllowlist.isAllowedToMint(bob));
+
+        // A invalid attestation, as Ted is not allowlist attestor
+        vm.prank(ted);
+        attestationStation.attest(
+            bob,
+            optimistAllowlist.OPTIMIST_CAN_MINT_ATTESTATION_KEY(),
+            bytes("true")
+        );
+
+        // Since Bob has at least one valid attestation, he should be allowed to mint
+        assertTrue(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Having falsy attestation value should not allow minting.
+     */
+    function test_isAllowedToMint_fromAllowlistAttestorWithFalsyValue_fails() external {
+        // First sends correct attestation
+        attestAllowlist(bob);
+
+        bytes32 key = optimistAllowlist.OPTIMIST_CAN_MINT_ATTESTATION_KEY();
+        vm.expectEmit(true, true, true, false);
+        emit AttestationCreated(alice_allowlistAttestor, bob, key, bytes("dsafsds"));
+
+        // Invalidates existing attestation
+        vm.prank(alice_allowlistAttestor);
+        attestationStation.attest(bob, key, bytes(""));
+
+        assertFalse(optimistAllowlist.isAllowedToMint(bob));
+    }
+
+    /**
+     * @notice Having falsy attestation value from Coinbase attestor should not allow minting.
+     */
+    function test_isAllowedToMint_fromCoinbaseQuestAttestorWithFalsyValue_fails() external {
+        // First sends correct attestation
+        attestAllowlist(bob);
+
+        bytes32 key = optimistAllowlist.OPTIMIST_CAN_MINT_ATTESTATION_KEY();
+        vm.expectEmit(true, true, true, true);
+        emit AttestationCreated(alice_allowlistAttestor, bob, key, bytes(""));
+
+        // Invalidates existing attestation
+        vm.prank(alice_allowlistAttestor);
+        attestationStation.attest(bob, key, bytes(""));
+
+        assertFalse(optimistAllowlist.isAllowedToMint(bob));
+    }
+}

--- a/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
@@ -7,6 +7,7 @@ import { AttestationStation } from "../universal/op-nft/AttestationStation.sol";
 import { OptimistAllowlist } from "../universal/op-nft/OptimistAllowlist.sol";
 import { OptimistInviter } from "../universal/op-nft/OptimistInviter.sol";
 import { OptimistInviterHelper } from "../testing/helpers/OptimistInviterHelper.sol";
+import { OptimistConstants } from "../universal/op-nft/libraries/OptimistConstants.sol";
 
 contract OptimistAllowlist_Initializer is Test {
     event AttestationCreated(
@@ -217,7 +218,7 @@ contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
         vm.prank(ted);
         attestationStation.attest(
             bob,
-            optimistInviter.CAN_MINT_FROM_INVITE_ATTESTATION_KEY(),
+            OptimistConstants.OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY,
             bytes("true")
         );
         assertFalse(optimistAllowlist.isAllowedToMint(bob));

--- a/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
+++ b/packages/contracts-periphery/contracts/foundry-tests/OptimistAllowlist.t.sol
@@ -197,7 +197,7 @@ contract OptimistAllowlistTest is OptimistAllowlist_Initializer {
     }
 
     /**
-     * @notice Coinbase attestation from wrong attestor should not allow minting.
+     * @notice Coinbase quest attestation from wrong attestor should not allow minting.
      */
     function test_isAllowedToMint_fromWrongCoinbaseQuestAttestor_fails() external {
         // Ted is not the coinbase quest attestor

--- a/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
+import { AttestationStation } from "./AttestationStation.sol";
+
+/**
+ * @title  OptimistAllowlist
+ * @notice Source of truth for whether an address is able to mint an Optimist NFT.
+           isAllowedToMint function checks various signals to return boolean value for whether an
+           address is eligible or not.
+ */
+contract OptimistAllowlist is Semver {
+    /**
+     * @notice Attestation key used by the AllowlistAttestor to manually add addresses to the
+     *         allowlist.
+     */
+    bytes32 public constant OPTIMIST_CAN_MINT_ATTESTATION_KEY = bytes32("optimist.can-mint");
+
+    /**
+     * @notice Attestation key used by Coinbase to issue attestations for Quest participants.
+     */
+    bytes32 public constant COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY =
+        bytes32("coinbase.quest-eligible");
+
+    /**
+     * @notice Attestation key the OptimistInviter needs to issue to allow an address to mint.
+     */
+    bytes32 public constant OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY =
+        bytes32("optimist.can-mint-from-invite");
+
+    /**
+     * @notice Address of the AttestationStation contract.
+     */
+    AttestationStation public immutable ATTESTATION_STATION;
+
+    /**
+     * @notice Attestor that issues 'optimist.can-mint' attestations.
+     */
+    address public immutable ALLOWLIST_ATTESTOR;
+
+    /**
+     * @notice Attestor that issues 'coinbase.quest-eligible' attestations.
+     */
+    address public immutable COINBASE_QUEST_ATTESTOR;
+
+    /**
+     * @notice Address of OptimistInviter contract that issues 'optimist.can-mint-from-invite'
+     *         attestations.
+     */
+    address public immutable OPTIMIST_INVITER;
+
+    /**
+     * @custom:semver 1.0.0
+     *
+     * @param _attestationStation    Address of the AttestationStation contract.
+     * @param _allowlistAttestor     Address of the allowlist attestor.
+     * @param _coinbaseQuestAttestor Address of the Coinbase Quest attestor.
+     * @param _optimistInviter       Address of the OptimistInviter contract.
+     */
+    constructor(
+        AttestationStation _attestationStation,
+        address _allowlistAttestor,
+        address _coinbaseQuestAttestor,
+        address _optimistInviter
+    ) Semver(1, 0, 0) {
+        ATTESTATION_STATION = _attestationStation;
+        ALLOWLIST_ATTESTOR = _allowlistAttestor;
+        COINBASE_QUEST_ATTESTOR = _coinbaseQuestAttestor;
+        OPTIMIST_INVITER = _optimistInviter;
+    }
+
+    /**
+     * @notice Checks whether an address has a valid 'optimist.can-mint' attestation from the
+     *         allowlist attestor.
+     *
+     * @param _claimer Address to check.
+     *
+     * @return Whether or not the address has a valid attestation.
+     */
+    function _hasAttestationFromAllowlistAttestor(address _claimer) internal view returns (bool) {
+        // Expected attestation value is bytes32("true"), but we consider any non-zero value
+        // to be truthy.
+        return
+            ATTESTATION_STATION
+                .attestations(ALLOWLIST_ATTESTOR, _claimer, OPTIMIST_CAN_MINT_ATTESTATION_KEY)
+                .length > 0;
+    }
+
+    /**
+     * @notice Checks whether an address has a valid attestation from the Coinbase attestor.
+     *
+     * @param _claimer Address to check.
+     *
+     * @return Whether or not the address has a valid attestation.
+     */
+    function _hasAttestationFromCoinbaseQuestAttestor(address _claimer)
+        internal
+        view
+        returns (bool)
+    {
+        // Expected attestation value is bytes32("true"), but we consider any non-zero value
+        // to be truthy.
+        return
+            ATTESTATION_STATION
+                .attestations(
+                    COINBASE_QUEST_ATTESTOR,
+                    _claimer,
+                    COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY
+                )
+                .length > 0;
+    }
+
+    /**
+     * @notice Checks whether an address has a valid attestation from the OptimistInviter contract.
+     *
+     * @param _claimer Address to check.
+     *
+     * @return Whether or not the address has a valid attestation.
+     */
+    function _hasAttestationFromOptimistInviter(address _claimer) internal view returns (bool) {
+        // Expected attestation value is the inviter's address, but we just check that it's set.
+        return
+            ATTESTATION_STATION
+                .attestations(
+                    OPTIMIST_INVITER,
+                    _claimer,
+                    OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY
+                )
+                .length > 0;
+    }
+
+    /**
+     * @notice Checks whether a given address is allowed to mint the Optimist NFT yet. Since the
+     *         Optimist NFT will also be used as part of the Citizens House, mints are currently
+     *         restricted. Eventually anyone will be able to mint.
+     *
+     *         Currently, address is allowed to mint if it satisfies any of the following:
+     *         1) Has a valid 'optimist.can-mint' attestation from the allowlist attestor.
+     *         2) Has a valid 'coinbase.quest-eligible' attestation from Coinbase Quest attestor
+     *         3) Has a valid 'optimist.can-mint-from-invite' attestation from the OptimistInviter
+     *            contract.
+     *
+     * @return Whether or not the address is allowed to mint yet.
+     */
+    function isAllowedToMint(address _claimer) public view returns (bool) {
+        return
+            _hasAttestationFromAllowlistAttestor(_claimer) ||
+            _hasAttestationFromCoinbaseQuestAttestor(_claimer) ||
+            _hasAttestationFromOptimistInviter(_claimer);
+    }
+}

--- a/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
 import { AttestationStation } from "./AttestationStation.sol";
+import { OptimistConstants } from "./libraries/OptimistConstants.sol";
 
 /**
  * @title  OptimistAllowlist
@@ -22,12 +23,6 @@ contract OptimistAllowlist is Semver {
      */
     bytes32 public constant COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY =
         bytes32("coinbase.quest-eligible");
-
-    /**
-     * @notice Attestation key the OptimistInviter needs to issue to allow an address to mint.
-     */
-    bytes32 public constant OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY =
-        bytes32("optimist.can-mint-from-invite");
 
     /**
      * @notice Address of the AttestationStation contract.
@@ -125,7 +120,7 @@ contract OptimistAllowlist is Semver {
                 .attestations(
                     OPTIMIST_INVITER,
                     _claimer,
-                    OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY
+                    OptimistConstants.OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY
                 )
                 .length > 0;
     }

--- a/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
@@ -66,66 +66,6 @@ contract OptimistAllowlist is Semver {
     }
 
     /**
-     * @notice Checks whether an address has a valid 'optimist.can-mint' attestation from the
-     *         allowlist attestor.
-     *
-     * @param _claimer Address to check.
-     *
-     * @return Whether or not the address has a valid attestation.
-     */
-    function _hasAttestationFromAllowlistAttestor(address _claimer) internal view returns (bool) {
-        // Expected attestation value is bytes32("true"), but we consider any non-zero value
-        // to be truthy.
-        return
-            ATTESTATION_STATION
-                .attestations(ALLOWLIST_ATTESTOR, _claimer, OPTIMIST_CAN_MINT_ATTESTATION_KEY)
-                .length > 0;
-    }
-
-    /**
-     * @notice Checks whether an address has a valid attestation from the Coinbase attestor.
-     *
-     * @param _claimer Address to check.
-     *
-     * @return Whether or not the address has a valid attestation.
-     */
-    function _hasAttestationFromCoinbaseQuestAttestor(address _claimer)
-        internal
-        view
-        returns (bool)
-    {
-        // Expected attestation value is bytes32("true"), but we consider any non-zero value
-        // to be truthy.
-        return
-            ATTESTATION_STATION
-                .attestations(
-                    COINBASE_QUEST_ATTESTOR,
-                    _claimer,
-                    COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY
-                )
-                .length > 0;
-    }
-
-    /**
-     * @notice Checks whether an address has a valid attestation from the OptimistInviter contract.
-     *
-     * @param _claimer Address to check.
-     *
-     * @return Whether or not the address has a valid attestation.
-     */
-    function _hasAttestationFromOptimistInviter(address _claimer) internal view returns (bool) {
-        // Expected attestation value is the inviter's address, but we just check that it's set.
-        return
-            ATTESTATION_STATION
-                .attestations(
-                    OPTIMIST_INVITER,
-                    _claimer,
-                    OptimistConstants.OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY
-                )
-                .length > 0;
-    }
-
-    /**
      * @notice Checks whether a given address is allowed to mint the Optimist NFT yet. Since the
      *         Optimist NFT will also be used as part of the Citizens House, mints are currently
      *         restricted. Eventually anyone will be able to mint.
@@ -143,5 +83,75 @@ contract OptimistAllowlist is Semver {
             _hasAttestationFromAllowlistAttestor(_claimer) ||
             _hasAttestationFromCoinbaseQuestAttestor(_claimer) ||
             _hasAttestationFromOptimistInviter(_claimer);
+    }
+
+    /**
+     * @notice Checks whether an address has a valid 'optimist.can-mint' attestation from the
+     *         allowlist attestor.
+     *
+     * @param _claimer Address to check.
+     *
+     * @return Whether or not the address has a valid attestation.
+     */
+    function _hasAttestationFromAllowlistAttestor(address _claimer) internal view returns (bool) {
+        // Expected attestation value is bytes32("true")
+        return
+            _hasValidAttestation(ALLOWLIST_ATTESTOR, _claimer, OPTIMIST_CAN_MINT_ATTESTATION_KEY);
+    }
+
+    /**
+     * @notice Checks whether an address has a valid attestation from the Coinbase attestor.
+     *
+     * @param _claimer Address to check.
+     *
+     * @return Whether or not the address has a valid attestation.
+     */
+    function _hasAttestationFromCoinbaseQuestAttestor(address _claimer)
+        internal
+        view
+        returns (bool)
+    {
+        // Expected attestation value is bytes32("true")
+        return
+            _hasValidAttestation(
+                COINBASE_QUEST_ATTESTOR,
+                _claimer,
+                COINBASE_QUEST_ELIGIBLE_ATTESTATION_KEY
+            );
+    }
+
+    /**
+     * @notice Checks whether an address has a valid attestation from the OptimistInviter contract.
+     *
+     * @param _claimer Address to check.
+     *
+     * @return Whether or not the address has a valid attestation.
+     */
+    function _hasAttestationFromOptimistInviter(address _claimer) internal view returns (bool) {
+        // Expected attestation value is the inviter's address
+        return
+            _hasValidAttestation(
+                OPTIMIST_INVITER,
+                _claimer,
+                OptimistConstants.OPTIMIST_CAN_MINT_FROM_INVITE_ATTESTATION_KEY
+            );
+    }
+
+    /**
+     * @notice Checks whether an address has a valid truthy attestation.
+     *         Any attestation val other than bytes32("") is considered truthy.
+     *
+     * @param _creator Address that made the attestation.
+     * @param _about   Address attestation is about.
+     * @param _key     Key of the attestation.
+     *
+     * @return Whether or not the address has a valid truthy attestation.
+     */
+    function _hasValidAttestation(
+        address _creator,
+        address _about,
+        bytes32 _key
+    ) internal view returns (bool) {
+        return ATTESTATION_STATION.attestations(_creator, _about, _key).length > 0;
     }
 }

--- a/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
+++ b/packages/contracts-periphery/contracts/universal/op-nft/OptimistAllowlist.sol
@@ -76,6 +76,8 @@ contract OptimistAllowlist is Semver {
      *         3) Has a valid 'optimist.can-mint-from-invite' attestation from the OptimistInviter
      *            contract.
      *
+     * @param _claimer Address to check.
+     *
      * @return Whether or not the address is allowed to mint yet.
      */
     function isAllowedToMint(address _claimer) public view returns (bool) {


### PR DESCRIPTION
This contract will serve as the source of truth for whether someone can mint an Optimist NFT. In the next PR, will update Optimist.sol to use OptimistAllowlist to check mint eligibility.

Right now, it checks 3 signals
- attestations from our multisig (ALLOWLIST_ATTESTOR) - we've already issued ~70 of these
- attestations from the Coinbase Wallet Quest 
- attestations from the OptimistInviter contract (for people who claimed invites)
