### PR TITLE
contracts-bedrock: add l1 deploy tag

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -61,7 +61,7 @@ def main():
         addresses = read_json(addresses_json_path)
     else:
         log.info('Deploying contracts.')
-        run_command(['yarn', 'hardhat', '--network', 'devnetL1', 'deploy'], env={
+        run_command(['yarn', 'hardhat', '--network', 'devnetL1', 'deploy', '--tags', 'l1'], env={
             'CHAIN_ID': '900',
             'L1_RPC': 'http://localhost:8545',
             'PRIVATE_KEY_DEPLOYER': 'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'

--- a/packages/contracts-bedrock/deploy/000-ProxyAdmin.ts
+++ b/packages/contracts-bedrock/deploy/000-ProxyAdmin.ts
@@ -17,6 +17,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['ProxyAdmin', 'setup']
+deployFn.tags = ['ProxyAdmin', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/001-AddressManager.ts
+++ b/packages/contracts-bedrock/deploy/001-AddressManager.ts
@@ -17,6 +17,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['AddressManager', 'setup']
+deployFn.tags = ['AddressManager', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/002-L1StandardBridgeProxy.ts
+++ b/packages/contracts-bedrock/deploy/002-L1StandardBridgeProxy.ts
@@ -16,6 +16,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1StandardBridgeProxy', 'setup']
+deployFn.tags = ['L1StandardBridgeProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/003-L2OutputOracleProxy.ts
+++ b/packages/contracts-bedrock/deploy/003-L2OutputOracleProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L2OutputOracleProxy', 'setup']
+deployFn.tags = ['L2OutputOracleProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/004-L1CrossDomainMessengerProxy.ts
+++ b/packages/contracts-bedrock/deploy/004-L1CrossDomainMessengerProxy.ts
@@ -13,6 +13,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1CrossDomainMessengerProxy', 'setup']
+deployFn.tags = ['L1CrossDomainMessengerProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/005-OptimismPortalProxy.ts
+++ b/packages/contracts-bedrock/deploy/005-OptimismPortalProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismPortalProxy', 'setup']
+deployFn.tags = ['OptimismPortalProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/006-OptimismMintableERC20FactoryProxy.ts
+++ b/packages/contracts-bedrock/deploy/006-OptimismMintableERC20FactoryProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismMintableERC20FactoryProxy', 'setup']
+deployFn.tags = ['OptimismMintableERC20FactoryProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/007-L1ERC721BridgeProxy.ts
+++ b/packages/contracts-bedrock/deploy/007-L1ERC721BridgeProxy.ts
@@ -16,6 +16,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1ERC721BridgeProxy', 'setup']
+deployFn.tags = ['L1ERC721BridgeProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/008-SystemConfigProxy.ts
+++ b/packages/contracts-bedrock/deploy/008-SystemConfigProxy.ts
@@ -20,6 +20,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemConfigProxy', 'setup']
+deployFn.tags = ['SystemConfigProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/009-SystemDictatorProxy.ts
+++ b/packages/contracts-bedrock/deploy/009-SystemDictatorProxy.ts
@@ -16,6 +16,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemDictatorProxy', 'setup']
+deployFn.tags = ['SystemDictatorProxy', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/010-L1CrossDomainMessengerImpl.ts
+++ b/packages/contracts-bedrock/deploy/010-L1CrossDomainMessengerImpl.ts
@@ -26,6 +26,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1CrossDomainMessengerImpl', 'setup']
+deployFn.tags = ['L1CrossDomainMessengerImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/011-L1StandardBridgeImpl.ts
+++ b/packages/contracts-bedrock/deploy/011-L1StandardBridgeImpl.ts
@@ -32,6 +32,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1StandardBridgeImpl', 'setup']
+deployFn.tags = ['L1StandardBridgeImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/012-L2OutputOracleImpl.ts
+++ b/packages/contracts-bedrock/deploy/012-L2OutputOracleImpl.ts
@@ -60,6 +60,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L2OutputOracleImpl', 'setup']
+deployFn.tags = ['L2OutputOracleImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/013-OptimismPortalImpl.ts
+++ b/packages/contracts-bedrock/deploy/013-OptimismPortalImpl.ts
@@ -67,6 +67,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismPortalImpl', 'setup']
+deployFn.tags = ['OptimismPortalImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/014-OptimismMintableERC20FactoryImpl.ts
+++ b/packages/contracts-bedrock/deploy/014-OptimismMintableERC20FactoryImpl.ts
@@ -26,6 +26,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['OptimismMintableERC20FactoryImpl', 'setup']
+deployFn.tags = ['OptimismMintableERC20FactoryImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/015-L1ERC721BridgeImpl.ts
+++ b/packages/contracts-bedrock/deploy/015-L1ERC721BridgeImpl.ts
@@ -27,6 +27,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['L1ERC721BridgeImpl', 'setup']
+deployFn.tags = ['L1ERC721BridgeImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/016-PortalSenderImpl.ts
+++ b/packages/contracts-bedrock/deploy/016-PortalSenderImpl.ts
@@ -26,6 +26,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['PortalSenderImpl', 'setup']
+deployFn.tags = ['PortalSenderImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
+++ b/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
@@ -66,6 +66,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemConfigImpl', 'setup']
+deployFn.tags = ['SystemConfigImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/018-SystemDictatorImpl.ts
+++ b/packages/contracts-bedrock/deploy/018-SystemDictatorImpl.ts
@@ -12,6 +12,6 @@ const deployFn: DeployFunction = async (hre) => {
   })
 }
 
-deployFn.tags = ['SystemDictatorImpl', 'setup']
+deployFn.tags = ['SystemDictatorImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -200,6 +200,6 @@ const deployFn: DeployFunction = async (hre) => {
   }
 }
 
-deployFn.tags = ['SystemDictatorImpl', 'setup']
+deployFn.tags = ['SystemDictatorImpl', 'setup', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
+++ b/packages/contracts-bedrock/deploy/020-SystemDictatorSteps-1.ts
@@ -279,14 +279,14 @@ const deployFn: DeployFunction = async (hre) => {
       need to restart the system, run exit1() followed by finalize().
     `,
     checks: async () => {
-      assert(
-        (await AddressManager.getAddress('OVM_L1CrossDomainMessenger')) ===
-          ethers.constants.AddressZero
+      const messenger = await AddressManager.getAddress(
+        'OVM_L1CrossDomainMessenger'
       )
+      assert(messenger === ethers.constants.AddressZero)
     },
   })
 }
 
-deployFn.tags = ['SystemDictatorSteps', 'phase1']
+deployFn.tags = ['SystemDictatorSteps', 'phase1', 'l1']
 
 export default deployFn

--- a/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
+++ b/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts
@@ -116,10 +116,8 @@ const deployFn: DeployFunction = async (hre) => {
         'BondManager',
       ]
       for (const dead of deads) {
-        assert(
-          (await AddressManager.getAddress(dead)) ===
-            ethers.constants.AddressZero
-        )
+        const addr = await AddressManager.getAddress(dead)
+        assert(addr === ethers.constants.AddressZero)
       }
     },
   })
@@ -372,6 +370,6 @@ const deployFn: DeployFunction = async (hre) => {
   }
 }
 
-deployFn.tags = ['SystemDictatorSteps', 'phase2']
+deployFn.tags = ['SystemDictatorSteps', 'phase2', 'l1']
 
 export default deployFn


### PR DESCRIPTION
**Description**

Prepares for adding in L2 deployment scripts by adding a `l1` tag to the deploy scripts that should run on L1. Also add the tag flag to the deployment that happens in CI. The L2 contract deployments will be added in another commit. It is not a problem if the L2 contracts are deployed to L1 in a testing environment but using tags to save time and gas should be done. Also lints a few lines of code where awaits are nested, nested awaits are difficult to read.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
