### PR TITLE
hardhat-deploy-config: add getter

### DIFF
--- a/.changeset/poor-carrots-walk.md
+++ b/.changeset/poor-carrots-walk.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/hardhat-deploy-config': patch
+---
+
+Add getter for other network's deploy config

--- a/packages/hardhat-deploy-config/src/type-extensions.ts
+++ b/packages/hardhat-deploy-config/src/type-extensions.ts
@@ -24,8 +24,8 @@ declare module 'hardhat/types/config' {
 declare module 'hardhat/types/runtime' {
   interface HardhatRuntimeEnvironment {
     deployConfig: {
-      // TODO: Is there any good way to type this?
       [key: string]: any
+      getDeployConfig(arg0: string): { [key: string]: any }
     }
   }
 }


### PR DESCRIPTION
**Description**

Add a getter to the `hre.deployConfig` object
that gives access to alternative network's deploy
configs. This is useful because multiple networks
can be linked and share config. In particular when L2 networks are used with L1 networks, the entire
deploy config has be be shared with both networks
so it results in a copy paste.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

