### PR TITLE
contracts-bedrock: fix semver tag

### DIFF
--- a/packages/contracts-bedrock/contracts/L2/L1FeeVault.sol
+++ b/packages/contracts-bedrock/contracts/L2/L1FeeVault.sol
@@ -12,7 +12,7 @@ import { FeeVault } from "../universal/FeeVault.sol";
  */
 contract L1FeeVault is FeeVault, Semver {
     /**
-     * @custom:semver 1.0.0
+     * @custom:semver 1.1.0
      *
      * @param _recipient Address that will receive the accumulated fees.
      */


### PR DESCRIPTION
**Description**

The docstring for `L1FeeVault` was not bumped
properly. This commit bumps the commit message.
We should have automation around this kind of thing to prevent it from happening in the future.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
