### PR TITLE
ci: Update op-e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -620,7 +620,7 @@ jobs:
           name: run tests
           command: |
             gotestsum --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>.xml \
-            -- -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out ./...
+            -- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out ./...
           working_directory: <<parameters.module>>
       - run:
           name: upload coverage
@@ -651,9 +651,10 @@ jobs:
           command: |
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
-            OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=true OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
+            # Note: -parallel must be set to match the number of cores in the resource class
+            OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false OP_E2E_USE_HTTP=<<parameters.use_http>>  gotestsum \
             --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>_http_<<parameters.use_http>>.xml \
-            -- -timeout=20m ./...
+            -- -timeout=20m -parallel=8 ./...
           working_directory: <<parameters.module>>
       - store_test_results:
           path: /tmp/test-results

--- a/op-e2e/actions/l2_batcher_test.go
+++ b/op-e2e/actions/l2_batcher_test.go
@@ -384,7 +384,7 @@ func TestExtendedTimeWithoutL1Batches(gt *testing.T) {
 }
 
 // TestBigL2Txs tests a high-throughput case with constrained batcher:
-//   - Fill 100 L2 blocks to near max-capacity, with txs of 120 KB each
+//   - Fill 40 L2 blocks to near max-capacity, with txs of 120 KB each
 //   - Buffer the L2 blocks into channels together as much as possible, submit data-txs only when necessary
 //     (just before crossing the max RLP channel size)
 //   - Limit the data-tx size to 40 KB, to force data to be split across multiple datat-txs
@@ -428,7 +428,7 @@ func TestBigL2Txs(gt *testing.T) {
 	}
 
 	// build many L2 blocks filled to the brim with large txs of random data
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 40; i++ {
 		aliceNonce, err := cl.PendingNonceAt(t.Ctx(), dp.Addresses.Alice)
 		status := sequencer.SyncStatus()
 		// build empty L1 blocks as necessary, so the L2 sequencer can continue to include txs while not drifting too far out

--- a/op-e2e/migration_test.go
+++ b/op-e2e/migration_test.go
@@ -121,6 +121,7 @@ var hardcodedSlots = []storageSlot{
 }
 
 func TestMigration(t *testing.T) {
+	parallel(t)
 	if !config.enabled {
 		t.Skipf("skipping migration tests")
 		return

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -20,6 +20,7 @@ import (
 
 // TestMissingGasLimit tests that op-geth cannot build a block without gas limit while optimism is active in the chain config.
 func TestMissingGasLimit(t *testing.T) {
+	parallel(t)
 	cfg := DefaultSystemConfig(t)
 	cfg.DeployConfig.FundDevAccounts = false
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -42,6 +43,7 @@ func TestMissingGasLimit(t *testing.T) {
 // TestInvalidDepositInFCU runs an invalid deposit through a FCU/GetPayload/NewPayload/FCU set of calls.
 // This tests that deposits must always allow the block to be built even if they are invalid.
 func TestInvalidDepositInFCU(t *testing.T) {
+	parallel(t)
 	cfg := DefaultSystemConfig(t)
 	cfg.DeployConfig.FundDevAccounts = false
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -76,6 +78,7 @@ func TestInvalidDepositInFCU(t *testing.T) {
 }
 
 func TestPreregolith(t *testing.T) {
+	parallel(t)
 	futureTimestamp := hexutil.Uint64(4)
 	tests := []struct {
 		name         string
@@ -255,6 +258,7 @@ func TestPreregolith(t *testing.T) {
 }
 
 func TestRegolith(t *testing.T) {
+	parallel(t)
 	tests := []struct {
 		name             string
 		regolithTime     hexutil.Uint64

--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -425,6 +425,8 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 	for i := 0; i <= 8; i++ {
 		i := i // avoid loop var capture
 		t.Run(fmt.Sprintf("withdrawal test#%d", i+1), func(t *testing.T) {
+			parallel(t)
+
 			// Create our system configuration, funding all accounts we created for L1/L2, and start it
 			cfg := DefaultSystemConfig(t)
 			cfg.DeployConfig.FinalizationPeriodSeconds = 6


### PR DESCRIPTION
**Description**

This fixes go based CI in several ways
1. Set test.parallel flag so it matches the actual amount of CPUs request
2. Add more calls to t.Parallel in op-e2e
3. Reduce the amount of blocks in TestBigL2Txs to reduce the test time.

CI Time for op-e2e goes from 16 min -> 4:30 min.

**Metadata**

- Fixes CLI-3762
