### PR TITLE
data-transport-layer: better logging around shutoff block

### DIFF
--- a/.changeset/good-clocks-relax.md
+++ b/.changeset/good-clocks-relax.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/data-transport-layer': patch
+---
+
+Add better logging to DTL about shutoff block

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -277,6 +277,12 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
             depositTargetL1Block,
             handleEventsTransactionEnqueued
           )
+        } else {
+          this.logger.info('Deposit shutoff reached', {
+            depositTargetL1Block,
+            highestSyncedL1Block,
+            depositShutoffBlock,
+          })
         }
 
         await this._syncEvents(


### PR DESCRIPTION
**Description**

Adds logging that will make it obvious that the shutoff block has been reached. Without this logging, it may be possible to mistake that the shutoff block has been reached because it has been set.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
