### PR TITLE
discord: update discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to build Optimism, check out the [Protocol Specs](./specs/).
 
 ## Community
 
-General discussion happens most frequently on the [Optimism discord](https://discord-gateway.optimism.io).
+General discussion happens most frequently on the [Optimism discord](https://discord.gg/optimism).
 Governance discussion can also be found on the [Optimism Governance Forum](https://gov.optimism.io/).
 
 ## Contributing

--- a/docs/op-stack/README.md
+++ b/docs/op-stack/README.md
@@ -1,6 +1,6 @@
 # The OP Stack Docs
 
-[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord-gateway.optimism.io)
+[![Discord](https://img.shields.io/discord/667044843901681675.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discord.gg/optimism)
 [![Twitter Follow](https://img.shields.io/twitter/follow/optimismPBC.svg?label=optimismPBC&style=social)](https://twitter.com/optimismPBC)
 
 The OP Stack is an open, collectively maintained development stack for blockchain ecosystems.

--- a/docs/op-stack/src/.vuepress/theme/components/Anchor.js
+++ b/docs/op-stack/src/.vuepress/theme/components/Anchor.js
@@ -57,7 +57,7 @@ export default Vue.extend({
                             "Support"
                         ]),
                         h("div", { class: "anchor-support-links" }, [
-                            h("a", { attrs: { href: "https://discord.optimism.io", target: "_blank" } }, [
+                            h("a", { attrs: { href: "https://discord.gg/optimism", target: "_blank" } }, [
                                 h("div", [
                                     h("i", { attrs: { class: "fab fa-discord" } }),
                                     " Discord community "

--- a/docs/op-stack/src/docs/contribute.md
+++ b/docs/op-stack/src/docs/contribute.md
@@ -30,4 +30,4 @@ If you’re looking for other ways to get involved, here are a few options:
 - Grab an idea from the [project ideas list](https://github.com/ethereum-optimism/optimism-project-ideas) to and building
 - Suggest a new idea for the [project ideas list](https://github.com/ethereum-optimism/optimism-project-ideas)
 - Improve the [Optimism Community Hub](https://community.optimism.io/) [documentation](https://github.com/ethereum-optimism/community-hub) or [tutorials](https://github.com/ethereum-optimism/optimism-tutorial)
-- Become an Optimism Ambassador, Support Nerd, and more in the [Optimism Discord](https://discord-gateway.optimism.io/)
+- Become an Optimism Ambassador, Support Nerd, and more in the [Optimism Discord](https://discord.gg/optimism)

--- a/packages/atst/README.md
+++ b/packages/atst/README.md
@@ -63,7 +63,7 @@ Also some more hooks exported by the cli but these are likely the only ones you 
 
 Please see our [contributing.md](https://github.com/ethereum-optimism/optimism/blob/develop/CONTRIBUTING.md). No contribution is too small.
 
-Having your contribution denied feels bad. 
+Having your contribution denied feels bad.
 Please consider [opening an issue](https://github.com/ethereum-optimism/optimism/issues) before adding any new features or apis.
 
 
@@ -73,5 +73,5 @@ If you have any problems, these resources could help you:
 
 - [sdk documentation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/atst/docs/sdk.md)
 - [cli documentation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/atst/docs/cli.md)
-- [Optimism Discord](https://discord-gateway.optimism.io/)
-- [Telegram group](https://t.me/+zwpJ8Ohqgl8yNjNh) 
+- [Optimism Discord](https://discord.gg/optimism)
+- [Telegram group](https://t.me/+zwpJ8Ohqgl8yNjNh)


### PR DESCRIPTION
Update discord invite links.

CI was breaking because some of the docs, like the readme, are being checked for uptime, to make sure it's not a dead link. The `discord-gateway.optimism.io` site is no longer used, so those links need to be updated. I also changed the `https://discord.optimism.io` in the op-stack docs, since that one still redirects to the now disabled `discord-gateway`.
