### PR TITLE
feat(ctp): add deploy script for OptimistAllowlist & Optimist

### DIFF
--- a/packages/contracts-periphery/config/deploy/ethereum.ts
+++ b/packages/contracts-periphery/config/deploy/ethereum.ts
@@ -5,9 +5,11 @@ const config: DeployConfig = {
   l2ProxyOwnerAddress: '',
   optimistName: '',
   optimistSymbol: '',
-  attestorAddress: '',
-  optimistInviterName: '',
+  optimistBaseUriAttestorAddress: '',
   optimistInviterInviteGranter: '',
+  optimistInviterName: '',
+  optimistAllowlistAllowlistAttestor: '',
+  optimistAllowlistCoinbaseQuestAttestor: '',
 }
 
 export default config

--- a/packages/contracts-periphery/config/deploy/goerli.ts
+++ b/packages/contracts-periphery/config/deploy/goerli.ts
@@ -5,9 +5,13 @@ const config: DeployConfig = {
   l2ProxyOwnerAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistName: 'Optimist',
   optimistSymbol: 'OPTIMIST',
-  attestorAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
+  optimistBaseUriAttestorAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistInviterInviteGranter: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistInviterName: 'OptimistInviter',
+  optimistAllowlistAllowlistAttestor:
+    '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
+  optimistAllowlistCoinbaseQuestAttestor:
+    '0x661B7Acca8ebd93AFd349a088e9a9A00053DB1BF',
 }
 
 export default config

--- a/packages/contracts-periphery/config/deploy/hardhat.ts
+++ b/packages/contracts-periphery/config/deploy/hardhat.ts
@@ -5,9 +5,13 @@ const config: DeployConfig = {
   l2ProxyOwnerAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   optimistName: 'OP Citizenship',
   optimistSymbol: 'OPNFT',
-  attestorAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  optimistBaseUriAttestorAddress: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   optimistInviterInviteGranter: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   optimistInviterName: 'OptimistInviter',
+  optimistAllowlistAllowlistAttestor:
+    '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  optimistAllowlistCoinbaseQuestAttestor:
+    '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
 }
 
 export default config

--- a/packages/contracts-periphery/config/deploy/localhost.ts
+++ b/packages/contracts-periphery/config/deploy/localhost.ts
@@ -1,0 +1,5 @@
+import config from './hardhat'
+
+// uses the same config as hardhat.ts
+
+export default config

--- a/packages/contracts-periphery/config/deploy/mainnet.ts
+++ b/packages/contracts-periphery/config/deploy/mainnet.ts
@@ -5,9 +5,13 @@ const config: DeployConfig = {
   l2ProxyOwnerAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistName: 'Optimist',
   optimistSymbol: 'OPTIMIST',
-  attestorAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
+  optimistBaseUriAttestorAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistInviterInviteGranter: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistInviterName: 'OptimistInviter',
+  optimistAllowlistAllowlistAttestor:
+    '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
+  optimistAllowlistCoinbaseQuestAttestor:
+    '0x661B7Acca8ebd93AFd349a088e9a9A00053DB1BF',
 }
 
 export default config

--- a/packages/contracts-periphery/config/deploy/optimism-goerli.ts
+++ b/packages/contracts-periphery/config/deploy/optimism-goerli.ts
@@ -2,12 +2,17 @@ import { DeployConfig } from '../../src'
 
 const config: DeployConfig = {
   ddd: '0x9C6373dE60c2D3297b18A8f964618ac46E011B58',
+  // EcoPod test account
   l2ProxyOwnerAddress: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
   optimistName: 'Optimist',
   optimistSymbol: 'OPTIMIST',
-  attestorAddress: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
+  optimistBaseUriAttestorAddress: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
   optimistInviterInviteGranter: '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
   optimistInviterName: 'OptimistInviter',
+  optimistAllowlistAllowlistAttestor:
+    '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
+  optimistAllowlistCoinbaseQuestAttestor:
+    '0x8F0EBDaA1cF7106bE861753B0f9F5c0250fE0819',
 }
 
 export default config

--- a/packages/contracts-periphery/config/deploy/optimism.ts
+++ b/packages/contracts-periphery/config/deploy/optimism.ts
@@ -5,9 +5,13 @@ const config: DeployConfig = {
   l2ProxyOwnerAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistName: 'Optimist',
   optimistSymbol: 'OPTIMIST',
-  attestorAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
+  optimistBaseUriAttestorAddress: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistInviterInviteGranter: '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
   optimistInviterName: 'OptimistInviter',
+  optimistAllowlistAllowlistAttestor:
+    '0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3',
+  optimistAllowlistCoinbaseQuestAttestor:
+    '0x661B7Acca8ebd93AFd349a088e9a9A00053DB1BF',
 }
 
 export default config

--- a/packages/contracts-periphery/deploy/op-nft/OptimistAllowlistImpl.ts
+++ b/packages/contracts-periphery/deploy/op-nft/OptimistAllowlistImpl.ts
@@ -1,0 +1,55 @@
+/* Imports: External */
+import { DeployFunction } from 'hardhat-deploy/dist/types'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import '@nomiclabs/hardhat-ethers'
+import '@eth-optimism/hardhat-deploy-config'
+import 'hardhat-deploy'
+import type { DeployConfig } from '../../src'
+
+const deployFn: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const deployConfig = hre.deployConfig as DeployConfig
+
+  const { deployer } = await hre.getNamedAccounts()
+
+  console.log(`Deploying OptimistAllowlist implementation with ${deployer}`)
+
+  const Deployment__AttestationStation = await hre.deployments.get(
+    'AttestationStationProxy'
+  )
+
+  const Deployment__OptimistInviter = await hre.deployments.get(
+    'OptimistInviterProxy'
+  )
+
+  const attestationStationAddress = Deployment__AttestationStation.address
+  const optimistInviterAddress = Deployment__OptimistInviter.address
+
+  console.log(`Using ${attestationStationAddress} as the ATTESTATION_STATION`)
+  console.log(
+    `Using ${deployConfig.optimistAllowlistAllowlistAttestor} as ALLOWLIST_ATTESTOR`
+  )
+  console.log(
+    `Using ${deployConfig.optimistAllowlistCoinbaseQuestAttestor} as COINBASE_QUEST_ATTESTOR`
+  )
+  console.log(`Using ${optimistInviterAddress} as OPTIMIST_INVITER`)
+
+  const { deploy } = await hre.deployments.deterministic('OptimistAllowlist', {
+    salt: hre.ethers.utils.solidityKeccak256(['string'], ['OptimistAllowlist']),
+    from: deployer,
+    args: [
+      attestationStationAddress,
+      deployConfig.optimistAllowlistAllowlistAttestor,
+      deployConfig.optimistAllowlistCoinbaseQuestAttestor,
+      optimistInviterAddress,
+    ],
+    log: true,
+  })
+
+  await deploy()
+}
+
+deployFn.tags = ['OptimistAllowlistImpl', 'OptimistEnvironment']
+deployFn.dependencies = ['AttestationStationProxy', 'OptimistInviterProxy']
+
+export default deployFn

--- a/packages/contracts-periphery/deploy/op-nft/OptimistImpl.ts
+++ b/packages/contracts-periphery/deploy/op-nft/OptimistImpl.ts
@@ -14,13 +14,19 @@ const deployFn: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   console.log(`Deploying Optimist implementation with ${deployer}`)
 
-  const Deployment__AttestationStation = await hre.deployments.get(
+  const Deployment__AttestationStationProxy = await hre.deployments.get(
     'AttestationStationProxy'
   )
-  const attestationStationAddress = Deployment__AttestationStation.address
+  const attestationStationAddress = Deployment__AttestationStationProxy.address
+  console.log(`Using ${attestationStationAddress} as the ATTESTATION_STATION`)
+  console.log(
+    `Using ${deployConfig.optimistBaseUriAttestorAddress} as BASE_URI_ATTESTOR`
+  )
 
-  console.log(`Using ${attestationStationAddress} as the AttestationStation`)
-  console.log(`Using ${deployConfig.attestorAddress} as ATTESTOR`)
+  const Deployment__OptimistAllowlistProxy = await hre.deployments.get(
+    'OptimistAllowlistProxy'
+  )
+  const optimistAllowlistAddress = Deployment__OptimistAllowlistProxy.address
 
   const { deploy } = await hre.deployments.deterministic('Optimist', {
     salt: hre.ethers.utils.solidityKeccak256(['string'], ['Optimist']),
@@ -28,8 +34,9 @@ const deployFn: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     args: [
       deployConfig.optimistName,
       deployConfig.optimistSymbol,
-      deployConfig.attestorAddress,
+      deployConfig.optimistBaseUriAttestorAddress,
       attestationStationAddress,
+      optimistAllowlistAddress,
     ],
     log: true,
   })
@@ -37,6 +44,7 @@ const deployFn: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   await deploy()
 }
 
-deployFn.tags = ['Optimist', 'OptimistEnvironment']
+deployFn.tags = ['OptimistImpl', 'OptimistEnvironment']
+deployFn.dependencies = ['AttestationStationProxy', 'OptimistAllowlistProxy']
 
 export default deployFn

--- a/packages/contracts-periphery/deploy/op-nft/OptimistInviterImpl.ts
+++ b/packages/contracts-periphery/deploy/op-nft/OptimistInviterImpl.ts
@@ -37,7 +37,7 @@ const deployFn: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   await deploy()
 }
 
-deployFn.tags = ['OptimistInviter', 'OptimistEnvironment']
+deployFn.tags = ['OptimistInviterImpl', 'OptimistEnvironment']
 deployFn.dependencies = ['AttestationStationProxy']
 
 export default deployFn

--- a/packages/contracts-periphery/src/config/deploy.ts
+++ b/packages/contracts-periphery/src/config/deploy.ts
@@ -31,7 +31,7 @@ export interface DeployConfig {
   /**
    * Address of the privileged attestor for the Optimist contract.
    */
-  attestorAddress: string
+  optimistBaseUriAttestorAddress: string
 
   /**
    * Address of the privileged account for the OptimistInviter contract that can grant invites.
@@ -42,6 +42,17 @@ export interface DeployConfig {
    * Name of OptimistInviter contract, used for the EIP712 domain separator.
    */
   optimistInviterName: string
+
+  /**
+   * Address of previleged account for the OptimistAllowlist contract that can add/remove people
+   * from allowlist.
+   */
+  optimistAllowlistAllowlistAttestor: string
+
+  /**
+   * Address of Coinbase attestor that attests to whether someone has completed Quest.
+   */
+  optimistAllowlistCoinbaseQuestAttestor: string
 
   /**
    * Address of the owner of the proxies on L2. There will be a ProxyAdmin deployed as a predeploy
@@ -70,7 +81,7 @@ export const configSpec: DeployConfigSpec<DeployConfig> = {
     type: 'string',
     default: 'OPTIMIST',
   },
-  attestorAddress: {
+  optimistBaseUriAttestorAddress: {
     type: 'address',
   },
   optimistInviterInviteGranter: {
@@ -79,6 +90,15 @@ export const configSpec: DeployConfigSpec<DeployConfig> = {
   optimistInviterName: {
     type: 'string',
   },
+
+  optimistAllowlistAllowlistAttestor: {
+    type: 'address',
+  },
+
+  optimistAllowlistCoinbaseQuestAttestor: {
+    type: 'address',
+  },
+
   l2ProxyOwnerAddress: {
     type: 'address',
   },

--- a/packages/contracts-periphery/src/helpers/setupProxyContract.ts
+++ b/packages/contracts-periphery/src/helpers/setupProxyContract.ts
@@ -1,0 +1,126 @@
+import assert from 'assert'
+
+import { ethers, utils } from 'ethers'
+
+const { getAddress } = utils
+
+type ProxyConfig = {
+  targetImplAddress: string
+  targetProxyOwnerAddress: string
+  postUpgradeCallCalldata?: string
+}
+
+// Sets up the newly deployed proxy contract such that:
+// 1. The proxy's implementation is set to the target implementation
+// 2. The proxy's admin is set to the target proxy owner
+//
+// If the values are set correctly already, it makes no transactions.
+
+const setupProxyContract = async (
+  proxyContract: ethers.Contract,
+  proxyOwnerSigner: ethers.Signer,
+  {
+    targetImplAddress,
+    targetProxyOwnerAddress,
+    postUpgradeCallCalldata,
+  }: ProxyConfig
+) => {
+  const currentAdmin = await proxyContract
+    .connect(ethers.constants.AddressZero)
+    .callStatic.admin()
+
+  // The proxy owner signer needs to be the current admin, otherwise we don't have permission
+  // to update the implmentation or admin
+  const proxyOwnerSignerAddress = await proxyOwnerSigner.getAddress()
+  assert(
+    proxyOwnerSignerAddress === currentAdmin,
+    'proxyOwnerSigner is not the admin'
+  )
+
+  // Gets the current implementation address the proxy is pointing to.
+  // callStatic is used since the `Proxy.implementation()` is not a view function and ethers will
+  // try to make a transaction if we don't use callStatic. Using the zero address as `from` lets us
+  // call functions on the proxy and not trigger the delegatecall. See Proxy.sol proxyCallIfNotAdmin
+  // modifier for more details.
+  const currentImplementation = await proxyContract
+    .connect(ethers.constants.AddressZero)
+    .callStatic.implementation()
+  console.log(`implementation currently set to ${currentImplementation}`)
+
+  if (getAddress(currentImplementation) !== getAddress(targetImplAddress)) {
+    // If the proxy isn't pointing to the correct implementation, we need to set it to the correct
+    // one, then call initialize() in the proxy's context.
+
+    console.log('implementation not set to correct contract')
+    console.log(`Setting implementation to ${targetImplAddress}`)
+
+    let tx: ethers.providers.TransactionResponse
+    if (!postUpgradeCallCalldata) {
+      console.log(
+        'postUpgradeCallCalldata is not provided. Using Proxy.upgrade()'
+      )
+      // Point the proxy to the target implementation
+      tx = await proxyContract
+        .connect(proxyOwnerSigner)
+        .upgradeTo(targetImplAddress)
+    } else {
+      console.log(
+        'postUpgradeCallCalldata is provided. Using Proxy.upgradeAndCall()'
+      )
+      // Point the proxy to the target implementation,
+      // and call function in the proxy's context
+      tx = await proxyContract
+        .connect(proxyOwnerSigner)
+        .upgradeToAndCall(targetImplAddress, postUpgradeCallCalldata)
+    }
+
+    const receipt = await tx.wait()
+
+    console.log(`implementation set in ${receipt.transactionHash}`)
+  } else {
+    console.log(`implementation already set correctly to ${targetImplAddress}`)
+  }
+
+  console.log(`admin set to ${currentAdmin}`)
+  if (getAddress(currentAdmin) !== getAddress(targetProxyOwnerAddress)) {
+    // If the proxy admin isn't the l2ProxyOwnerAddress, we need to update it
+    // We're assuming that the proxy admin is the ddd right now.
+
+    console.log('detected admin is not set correctly')
+    console.log(`Setting admin to ${targetProxyOwnerAddress}`)
+
+    // change admin to the l2ProxyOwnerAddress
+    const tx = await proxyContract
+      .connect(proxyOwnerSigner)
+      .changeAdmin(targetProxyOwnerAddress)
+
+    const receipt = await tx.wait()
+
+    console.log(`admin set in ${receipt.transactionHash}`)
+  } else {
+    console.log(`admin already set correctly to ${targetProxyOwnerAddress}`)
+  }
+
+  const updatedImplementation = await proxyContract
+    .connect(ethers.constants.AddressZero)
+    .callStatic.implementation()
+
+  const updatedAdmin = await proxyContract
+    .connect(ethers.constants.AddressZero)
+    .callStatic.admin()
+
+  assert(
+    getAddress(updatedAdmin) === getAddress(targetProxyOwnerAddress),
+    'Something went wrong - admin not set correctly after transaction'
+  )
+  assert(
+    getAddress(updatedImplementation) === getAddress(targetImplAddress),
+    'Something went wrong - implementation not set correctly after transaction'
+  )
+
+  console.log(
+    `Proxy at ${proxyContract.address} is set up with implementation: ${updatedImplementation} and admin: ${updatedAdmin}`
+  )
+}
+
+export { setupProxyContract }


### PR DESCRIPTION
**Description**
- Adds deploy script for OptimistAllowlistImpl
- Adds deploy script for OptimistAllowlistProxy
- Updates deploy scripts for Optimist
- Refactors some common logic into setupProxyContract (checking implementation & admin for proxy is set correctly then updating them if necessary)

Tested locally against hardhat to check.

**Overall deploy flow**

- Deploy OptimistInviterImpl
- Deploy OptimistInviterProxy
- Deploy OptimistAllowlistImpl
- Deploy OptimistAllowlistProxy
- Deploy OptimistImpl
==========> Up to this point we can just run `hardhat deploy --tags OptimistImpl`

- Manually submit transaction to OptimistProxy admin multisig to upgrade (but not initialize) implementation to the new OptimistImpl