### PR TITLE
fix(ctb): Update hardhat.json to fix hh deploy

### DIFF
--- a/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
+++ b/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol
@@ -215,7 +215,7 @@ contract SystemDictator is OwnableUpgradeable {
     /**
      * @notice Configures the ProxyAdmin contract.
      */
-    function step1() external onlyOwner step(1) {
+    function step1() public onlyOwner step(1) {
         // Set the AddressManager in the ProxyAdmin.
         config.globalConfig.proxyAdmin.setAddressManager(config.globalConfig.addressManager);
 
@@ -260,7 +260,7 @@ contract SystemDictator is OwnableUpgradeable {
      * @notice Pauses the system by shutting down the L1CrossDomainMessenger and setting the
      *         deposit halt flag to tell the Sequencer's DTL to stop accepting deposits.
      */
-    function step2() external onlyOwner step(2) {
+    function step2() public onlyOwner step(2) {
         // Store the address of the old L1CrossDomainMessenger implementation. We will need this
         // address in the case that we have to exit early.
         oldL1CrossDomainMessenger = config.globalConfig.addressManager.getAddress(
@@ -408,6 +408,14 @@ contract SystemDictator is OwnableUpgradeable {
             payable(config.proxyAddressConfig.l1ERC721BridgeProxy),
             address(config.implementationAddressConfig.l1ERC721BridgeImpl)
         );
+    }
+
+    /**
+     * @notice Calls the first 2 steps of the migration process.
+     */
+    function phase1() external onlyOwner {
+        step1();
+        step2();
     }
 
     /**

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -2,6 +2,7 @@
   "finalSystemOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "portalGuardian": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "controller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+  "proxyAdminOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
 
   "l1StartingBlockTag": "earliest",
   "l1ChainID": 900,
@@ -16,12 +17,22 @@
   "batchSenderAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
 
   "l2OutputOracleSubmissionInterval": 6,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 0,
+  "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleProposer": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
   "l2OutputOracleChallenger": "0x6925B8704Ff96DEe942623d6FB5e946EF5884b63",
 
   "l2GenesisBlockBaseFeePerGas": "0x3B9ACA00",
-  "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
+  "l2GenesisBlockGasLimit": "0x17D7840",
+
+  "baseFeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+  "l1FeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+  "sequencerFeeVaultRecipient": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+
+  "governanceTokenName": "Optimism",
+  "governanceTokenSymbol": "OP",
+  "governanceTokenOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
   "sequencerFeeVaultRecipient": "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",
 

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -334,6 +334,25 @@ export const isStep = async (
 }
 
 /**
+ * Mini helper for checking if the current step is the first step in target phase.
+ *
+ * @param dictator SystemDictator contract.
+ * @param phase Target phase.
+ * @returns True if the current step is the first step in target phase.
+ */
+export const isStartOfPhase = async (
+  dictator: ethers.Contract,
+  phase: number
+): Promise<boolean> => {
+  const phaseToStep = {
+    1: 1,
+    2: 3,
+    3: 6,
+  }
+  return (await dictator.currentStep()) === phaseToStep[phase]
+}
+
+/**
  * Mini helper for executing a given step.
  *
  * @param opts Options for executing the step.
@@ -350,7 +369,8 @@ export const doStep = async (opts: {
   message: string
   checks: () => Promise<void>
 }): Promise<void> => {
-  if (!(await isStep(opts.SystemDictator, opts.step))) {
+  const isStepVal = await isStep(opts.SystemDictator, opts.step)
+  if (!isStepVal) {
     console.log(`Step already completed: ${opts.step}`)
     return
   }
@@ -379,6 +399,62 @@ export const doStep = async (opts: {
   await awaitCondition(
     async () => {
       return isStep(opts.SystemDictator, opts.step + 1)
+    },
+    30000,
+    1000
+  )
+
+  // Perform post-step checks.
+  await opts.checks()
+}
+
+/**
+ * Mini helper for executing a given phase.
+ *
+ * @param opts Options for executing the step.
+ * @param opts.isLiveDeployer True if the deployer is live.
+ * @param opts.SystemDictator SystemDictator contract.
+ * @param opts.step Step to execute.
+ * @param opts.message Message to print before executing the step.
+ * @param opts.checks Checks to perform after executing the step.
+ */
+export const doPhase = async (opts: {
+  isLiveDeployer?: boolean
+  SystemDictator: ethers.Contract
+  phase: number
+  message: string
+  checks: () => Promise<void>
+}): Promise<void> => {
+  const isStart = await isStartOfPhase(opts.SystemDictator, opts.phase)
+  if (!isStart) {
+    console.log(`Start of phase ${opts.phase} already completed`)
+    return
+  }
+
+  // Extra message to help the user understand what's going on.
+  console.log(opts.message)
+
+  // Either automatically or manually execute the step.
+  if (opts.isLiveDeployer) {
+    console.log(`Executing phase ${opts.phase}...`)
+    await opts.SystemDictator[`phase${opts.phase}`]()
+  } else {
+    const tx = await opts.SystemDictator.populateTransaction[
+      `phase${opts.phase}`
+    ]()
+    console.log(`Please execute phase ${opts.phase}...`)
+    console.log(`MSD address: ${opts.SystemDictator.address}`)
+    console.log(`JSON:`)
+    console.log(jsonifyTransaction(tx))
+    console.log(
+      await getTenderlySimulationLink(opts.SystemDictator.provider, tx)
+    )
+  }
+
+  // Wait for the step to complete.
+  await awaitCondition(
+    async () => {
+      return isStartOfPhase(opts.SystemDictator, opts.phase + 1)
     },
     30000,
     1000


### PR DESCRIPTION
Adds a `phase1()` methods to the MSD which consolidates the various stepN() methods into two groups.

This is the first PR in a series that will significantly reduce the number of multisig transactions which need to be executed.

I tested this primarily by running the deploy scripts locally.

```
npx hardhat deploy --tags setup,phase1,phase2
```
