### PR TITLE
feat(ctb): Add doOwnershipTransfer to deploy utils

### DIFF
--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -323,6 +323,38 @@ export const printJsonTransaction = (tx: ethers.PopulatedTransaction): void => {
 }
 
 /**
+ * Mini helper for transferring a Proxy to the MSD
+ *
+ * @param opts Options for executing the step.
+ * @param opts.isLiveDeployer True if the deployer is live.
+ * @param opts.proxy proxy contract.
+ * @param opts.dictator dictator contract.
+ */
+export const doOwnershipTransfer = async (opts: {
+  isLiveDeployer?: boolean
+  proxy: ethers.Contract
+  name: string
+  transferFunc: string
+  dictator: ethers.Contract
+}): Promise<void> => {
+  if (opts.isLiveDeployer) {
+    await opts.proxy[opts.transferFunc](opts.dictator.address)
+  } else {
+    const tx = await opts.proxy.populateTransaction[opts.transferFunc](
+      opts.dictator.address
+    )
+    console.log(`
+    Please transfer ${opts.name} (proxy) owner to MSD
+      - ${opts.name} address: ${opts.proxy.address}
+      - MSD address: ${opts.dictator.address}
+    `)
+    printJsonTransaction(tx)
+    printCastCommand(tx)
+    await printTenderlySimulationLink(opts.dictator.provider, tx)
+  }
+}
+
+/**
  * Mini helper for checking if the current step is a target step.
  *
  * @param dictator SystemDictator contract.

--- a/packages/contracts-bedrock/src/deploy-utils.ts
+++ b/packages/contracts-bedrock/src/deploy-utils.ts
@@ -338,6 +338,7 @@ export const doOwnershipTransfer = async (opts: {
   dictator: ethers.Contract
 }): Promise<void> => {
   if (opts.isLiveDeployer) {
+    console.log(`Setting ${opts.name} owner to MSD`)
     await opts.proxy[opts.transferFunc](opts.dictator.address)
   } else {
     const tx = await opts.proxy.populateTransaction[opts.transferFunc](


### PR DESCRIPTION
1. Creates a reusable function `doOwnershipTransfer` which deduplicates the logic for transferring ownership of the 4 system contracts to the MSD.
2. Combines the `awaitCondition` call for each of those transfers into a single call at the end. This provides better support for a `multicall` based transfer, by printing out all the info required to create a batch of transactions at once. It also still supports a 'one at a time' transfer approach, as it will check all contracts before progressing.