### PR TITLE
op-chain-ops: sanity check gas limit

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -208,6 +208,11 @@ func (d *DeployConfig) Check() error {
 	if d.L2GenesisBlockGasLimit == 0 {
 		return fmt.Errorf("%w: L2 genesis block gas limit cannot be 0", ErrInvalidDeployConfig)
 	}
+	// When the initial resource config is made to be configurable by the DeployConfig, ensure
+	// that this check is updated to use the values from the DeployConfig instead of the defaults.
+	if uint64(d.L2GenesisBlockGasLimit) < uint64(defaultResourceConfig.MaxResourceLimit+defaultResourceConfig.SystemTxMaxGas) {
+		return fmt.Errorf("%w: L2 genesis block gas limit is too small", ErrInvalidDeployConfig)
+	}
 	if d.L2GenesisBlockBaseFeePerGas == nil {
 		return fmt.Errorf("%w: L2 genesis block base fee per gas cannot be nil", ErrInvalidDeployConfig)
 	}

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -15,7 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-const defaultL2GasLimit = 15_000_000
+// defaultL2GasLimit represents the default gas limit for an L2 block.
+const defaultL2GasLimit = 30_000_000
 
 // NewL2Genesis will create a new L2 genesis
 func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, error) {

--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -25,7 +25,7 @@
   "governanceTokenName": "Optimism",
   "governanceTokenSymbol": "OP",
   "governanceTokenOwner": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
-  "l2GenesisBlockGasLimit": "0x17D7840",
+  "l2GenesisBlockGasLimit": "0x1c9c380",
   "l2GenesisBlockCoinbase": "0x4200000000000000000000000000000000000011",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
   "gasPriceOracleOverhead": 2100,

--- a/packages/contracts-bedrock/deploy-config/mainnet.ts
+++ b/packages/contracts-bedrock/deploy-config/mainnet.ts
@@ -37,7 +37,7 @@ const config: DeployConfig = {
   governanceTokenSymbol: 'OP',
   governanceTokenOwner: '0x90F79bf6EB2c4f870365E785982E1f101E93b906',
 
-  l2GenesisBlockGasLimit: '0x17D7840',
+  l2GenesisBlockGasLimit: '0x1c9c380',
   l2GenesisBlockCoinbase: '0x4200000000000000000000000000000000000011',
   l2GenesisBlockBaseFeePerGas: '0x3b9aca00',
 


### PR DESCRIPTION
**Description**

Prevent the `SystemConfig` to revert during deploy time by making the default L2 gas limit be 30 million. When the L2 gas limit is too small, it can cause issues with deposits because the deposits consume L2 gas.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
