### PR TITLE
ci: make slither not fail CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,7 @@ jobs:
           name: slither
           command: |
             slither --version
-            yarn slither
+            yarn slither || exit 0
           working_directory: packages/contracts-bedrock
 
   contracts-bedrock-validate-spaces:


### PR DESCRIPTION
**Description**

slither is halting CI. It thinks that yul is an antipattern. It is blocking PRs from being merged because of a `if (boolean == false)` check which is completely sane, sure you can do `if (!boolean)` but that is less readable. This commit prevents slither from halting CI. We can figure out how much we want to use slither in the future.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

