### PR TITLE
op-chain-ops: migrate error handling

### DIFF
--- a/op-chain-ops/cmd/op-migrate/main.go
+++ b/op-chain-ops/cmd/op-migrate/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -168,10 +169,14 @@ func main() {
 
 			var block *types.Block
 			tag := config.L1StartingBlockTag
-			if tag.BlockNumber != nil {
-				block, err = l1Client.BlockByNumber(context.Background(), big.NewInt(tag.BlockNumber.Int64()))
-			} else if tag.BlockHash != nil {
-				block, err = l1Client.BlockByHash(context.Background(), *tag.BlockHash)
+			if tag == nil {
+				return errors.New("l1StartingBlockTag cannot be nil")
+			}
+			log.Info("Using L1 Starting Block Tag", "tag", tag.String())
+			if number, isNumber := tag.Number(); isNumber {
+				block, err = l1Client.BlockByNumber(context.Background(), big.NewInt(number.Int64()))
+			} else if hash, isHash := tag.Hash(); isHash {
+				block, err = l1Client.BlockByHash(context.Background(), hash)
 			} else {
 				return fmt.Errorf("invalid l1StartingBlockTag in deploy config: %v", tag)
 			}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -493,3 +493,18 @@ func (m *MarshalableRPCBlockNumberOrHash) UnmarshalJSON(b []byte) error {
 	*m = asMarshalable
 	return nil
 }
+
+// Number wraps the rpc.BlockNumberOrHash Number method.
+func (m *MarshalableRPCBlockNumberOrHash) Number() (rpc.BlockNumber, bool) {
+	return (*rpc.BlockNumberOrHash)(m).Number()
+}
+
+// Hash wraps the rpc.BlockNumberOrHash Hash method.
+func (m *MarshalableRPCBlockNumberOrHash) Hash() (common.Hash, bool) {
+	return (*rpc.BlockNumberOrHash)(m).Hash()
+}
+
+// String wraps the rpc.BlockNumberOrHash String method.
+func (m *MarshalableRPCBlockNumberOrHash) String() string {
+	return (*rpc.BlockNumberOrHash)(m).String()
+}


### PR DESCRIPTION
**Description**

The migration script entrypoint failed due to the
L1StartingBlockTag in the `DeployConfig` being set to `nil`. This adds a `nil` check as well as some better logging. The lower level methods for the usage of block tags are also used instead of manually accessing the values internal to the struct, this is what geth does internally.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

