### PR TITLE
op-node: Log when reading channels

### DIFF
--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -124,6 +124,7 @@ func (cb *ChannelBank) Read() (data []byte, err error) {
 	if !ch.IsReady() {
 		return nil, io.EOF
 	}
+	cb.log.Info("Reading channel", "channel", first, "frames", len(ch.inputs))
 
 	delete(cb.channels, first)
 	cb.channelQueue = cb.channelQueue[1:]


### PR DESCRIPTION
**Description**

Logs when reading from a channel to match the log when it creates the channel.