### PR TITLE
op-node: Add channel_input_bytes metric

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -64,6 +64,7 @@ type Metricer interface {
 	RecordSequencerBuildingDiffTime(duration time.Duration)
 	RecordSequencerSealingTime(duration time.Duration)
 	Document() []metrics.DocumentedMetric
+	RecordChannelInputBytes(num int)
 	// P2P Metrics
 	SetPeerScores(scores map[string]float64)
 	ClientPayloadByNumberEvent(num uint64, resultCode byte, duration time.Duration)
@@ -130,6 +131,8 @@ type Metrics struct {
 	PeerScores        *prometheus.GaugeVec
 	GossipEventsTotal *prometheus.CounterVec
 	BandwidthTotal    *prometheus.GaugeVec
+
+	ChannelInputBytes prometheus.Gauge
 
 	registry *prometheus.Registry
 	factory  metrics.Factory
@@ -329,6 +332,12 @@ func NewMetrics(procName string) *Metrics {
 			Help:      "P2P bandwidth by direction",
 		}, []string{
 			"direction",
+		}),
+
+		ChannelInputBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "channel_input_bytes",
+			Help:      "Number of compressed bytes added to the channel",
 		}),
 
 		P2PReqDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
@@ -635,6 +644,10 @@ func (m *Metrics) PayloadsQuarantineSize(n int) {
 	m.PayloadsQuarantineTotal.Set(float64(n))
 }
 
+func (m *Metrics) RecordChannelInputBytes(inputCompressedBytes int) {
+	m.ChannelInputBytes.Set(float64(inputCompressedBytes))
+}
+
 type noopMetricer struct{}
 
 var NoopMetrics Metricer = new(noopMetricer)
@@ -736,4 +749,7 @@ func (n *noopMetricer) ServerPayloadByNumberEvent(num uint64, resultCode byte, d
 }
 
 func (n *noopMetricer) PayloadsQuarantineSize(int) {
+}
+
+func (n *noopMetricer) RecordChannelInputBytes(int) {
 }

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -15,6 +15,7 @@ type Metrics interface {
 	RecordL1Ref(name string, ref eth.L1BlockRef)
 	RecordL2Ref(name string, ref eth.L2BlockRef)
 	RecordUnsafePayloadsBuffer(length uint64, memSize uint64, next eth.BlockID)
+	RecordChannelInputBytes(inputCompresedBytes int)
 }
 
 type L1Fetcher interface {
@@ -82,7 +83,7 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher)
-	chInReader := NewChannelInReader(log, bank)
+	chInReader := NewChannelInReader(log, bank, metrics)
 	batchQueue := NewBatchQueue(log, cfg, chInReader)
 	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, engine)
 	attributesQueue := NewAttributesQueue(log, cfg, attrBuilder, batchQueue)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -21,6 +21,7 @@ type Metrics interface {
 
 	RecordL1Ref(name string, ref eth.L1BlockRef)
 	RecordL2Ref(name string, ref eth.L2BlockRef)
+	RecordChannelInputBytes(inputCompresedBytes int)
 
 	RecordUnsafePayloadsBuffer(length uint64, memSize uint64, next eth.BlockID)
 

--- a/op-node/testutils/metrics.go
+++ b/op-node/testutils/metrics.go
@@ -1,14 +1,17 @@
 package testutils
 
-import "github.com/ethereum-optimism/optimism/op-node/eth"
+import (
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+)
 
 // TestDerivationMetrics implements the metrics used in the derivation pipeline as no-op operations.
 // Optionally a test may hook into the metrics
 type TestDerivationMetrics struct {
-	FnRecordL1ReorgDepth   func(d uint64)
-	FnRecordL1Ref          func(name string, ref eth.L1BlockRef)
-	FnRecordL2Ref          func(name string, ref eth.L2BlockRef)
-	FnRecordUnsafePayloads func(length uint64, memSize uint64, next eth.BlockID)
+	FnRecordL1ReorgDepth      func(d uint64)
+	FnRecordL1Ref             func(name string, ref eth.L1BlockRef)
+	FnRecordL2Ref             func(name string, ref eth.L2BlockRef)
+	FnRecordUnsafePayloads    func(length uint64, memSize uint64, next eth.BlockID)
+	FnRecordChannelInputBytes func(inputCompresedBytes int)
 }
 
 func (t *TestDerivationMetrics) RecordL1ReorgDepth(d uint64) {
@@ -32,6 +35,12 @@ func (t *TestDerivationMetrics) RecordL2Ref(name string, ref eth.L2BlockRef) {
 func (t *TestDerivationMetrics) RecordUnsafePayloadsBuffer(length uint64, memSize uint64, next eth.BlockID) {
 	if t.FnRecordUnsafePayloads != nil {
 		t.FnRecordUnsafePayloads(length, memSize, next)
+	}
+}
+
+func (t *TestDerivationMetrics) RecordChannelInputBytes(inputCompresedBytes int) {
+	if t.FnRecordChannelInputBytes != nil {
+		t.FnRecordChannelInputBytes(inputCompresedBytes)
 	}
 }
 


### PR DESCRIPTION
Adds gauge metric for the amount of compressed bytes read from the channel just prior to batch decoding.

This is useful when paired with the batcher `output_bytes` to get a better sense on the data rates throughout the system.