### PR TITLE
op-program: pre-image oracle (work in progress)

### DIFF
--- a/op-program/client/l1/hints.go
+++ b/op-program/client/l1/hints.go
@@ -1,0 +1,15 @@
+package l1
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
+)
+
+type L1BlockHint common.Hash
+
+var _ preimage.Hint = L1BlockHint{}
+
+func (l L1BlockHint) Hint() string {
+	return "l1-block " + (common.Hash)(l).String()
+}

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -1,9 +1,13 @@
 package l1
 
 import (
+	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type Oracle interface {
@@ -15,4 +19,40 @@ type Oracle interface {
 
 	// ReceiptsByBlockHash retrieves the receipts from the block with the given hash.
 	ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts)
+}
+
+// PreimageOracle implements Oracle using by interfacing with the pure preimage.Oracle
+// to fetch pre-images to decode into the requested data.
+type PreimageOracle struct {
+	oracle preimage.Oracle
+	hint   preimage.Hinter
+}
+
+var _ Oracle = (*PreimageOracle)(nil)
+
+func NewPreimageOracle(raw preimage.Oracle, hint preimage.Hinter) *PreimageOracle {
+	return &PreimageOracle{
+		oracle: raw,
+		hint:   hint,
+	}
+}
+
+func (p *PreimageOracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
+	p.hint.Hint(L1BlockHint(blockHash))
+	headerRlp := p.oracle.Get(preimage.Keccak256Key(blockHash))
+	var header types.Header
+	if err := rlp.DecodeBytes(headerRlp, &header); err != nil {
+		panic(fmt.Errorf("invalid header %s: %w", blockHash, err))
+	}
+	return eth.HeaderBlockInfo(&header)
+}
+
+func (p *PreimageOracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (p *PreimageOracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+	//TODO implement me
+	panic("implement me")
 }

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -1,0 +1,31 @@
+package l2
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
+)
+
+type L2BlockHint common.Hash
+
+var _ preimage.Hint = L2BlockHint{}
+
+func (l L2BlockHint) Hint() string {
+	return "l2-block " + (common.Hash)(l).String()
+}
+
+type L2StateNodeHint common.Hash
+
+var _ preimage.Hint = L2StateNodeHint{}
+
+func (l L2StateNodeHint) Hint() string {
+	return "l2-state-node " + (common.Hash)(l).String()
+}
+
+type L2CodeHint common.Hash
+
+var _ preimage.Hint = L2CodeHint{}
+
+func (l L2CodeHint) Hint() string {
+	return "l2-code " + (common.Hash)(l).String()
+}

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -1,8 +1,13 @@
 package l2
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
 )
 
 // StateOracle defines the high-level API used to retrieve L2 state data pre-images
@@ -25,4 +30,42 @@ type Oracle interface {
 
 	// BlockByHash retrieves the block with the given hash.
 	BlockByHash(blockHash common.Hash) *types.Block
+}
+
+// PreimageOracle implements Oracle using by interfacing with the pure preimage.Oracle
+// to fetch pre-images to decode into the requested data.
+type PreimageOracle struct {
+	oracle preimage.Oracle
+	hint   preimage.Hinter
+}
+
+var _ Oracle = (*PreimageOracle)(nil)
+
+func NewPreimageOracle(raw preimage.Oracle, hint preimage.Hinter) *PreimageOracle {
+	return &PreimageOracle{
+		oracle: raw,
+		hint:   hint,
+	}
+}
+
+func (p *PreimageOracle) BlockByHash(blockHash common.Hash) *types.Block {
+	p.hint.Hint(L2BlockHint(blockHash))
+	blockRlp := p.oracle.Get(preimage.Keccak256Key(blockHash))
+	var block types.Block
+	if err := rlp.DecodeBytes(blockRlp, &block); err != nil {
+		panic(fmt.Errorf("invalid block %s: %w", blockHash, err))
+	}
+	return &block
+}
+
+func (p *PreimageOracle) NodeByHash(nodeHash common.Hash) []byte {
+	p.hint.Hint(L2StateNodeHint(nodeHash))
+	node := p.oracle.Get(preimage.Keccak256Key(nodeHash))
+	return node
+}
+
+func (p *PreimageOracle) CodeByHash(codeHash common.Hash) []byte {
+	p.hint.Hint(L2CodeHint(codeHash))
+	code := p.oracle.Get(preimage.Keccak256Key(codeHash))
+	return code
 }

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -1,0 +1,1 @@
+package host

--- a/op-program/preimage/hints.go
+++ b/op-program/preimage/hints.go
@@ -1,0 +1,74 @@
+package preimage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type Hint interface {
+	Hint() string
+}
+
+type Hinter interface {
+	Hint(v Hint)
+}
+
+// HintWriter writes hints to an io.Writer (e.g. a special file descriptor, or a debug log),
+// for a pre-image oracle service to prepare specific pre-images.
+type HintWriter struct {
+	w io.Writer
+}
+
+var _ Hinter = (*HintWriter)(nil)
+
+func NewHintWriter(w io.Writer) *HintWriter {
+	return &HintWriter{w: w}
+}
+
+func (hw *HintWriter) Hint(v Hint) {
+	hint := v.Hint()
+	hintBytes := make([]byte, 8, 8+len(hint)+1)
+	binary.LittleEndian.PutUint64(hintBytes[:8], uint64(len(hint)))
+	hintBytes = append(hintBytes, []byte(hint)...)
+	hintBytes = append(hintBytes, 0) // to block writing on
+	_, err := hw.w.Write(hintBytes)
+	if err != nil {
+		panic(fmt.Errorf("failed to write pre-image hint: %w", err))
+	}
+}
+
+// HintReader reads the hints of HintWriter and passes them to a router for preparation of the requested pre-images.
+// Onchain the written hints are no-op.
+type HintReader struct {
+	r io.Reader
+}
+
+func NewHintReader(r io.Reader) *HintReader {
+	return &HintReader{r: r}
+}
+
+func (hr *HintReader) NextHint(router func(hint string) error) error {
+	var lengthPrefix [8]byte
+	if _, err := io.ReadFull(hr.r, lengthPrefix[:]); err != nil {
+		if err == io.EOF {
+			return io.EOF
+		}
+		return fmt.Errorf("failed to read hint length prefix: %w", err)
+	}
+	length := binary.LittleEndian.Uint64(lengthPrefix[:])
+	if length == 0 { // skip empty hints
+		return nil
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(hr.r, lengthPrefix[:]); err != nil {
+		return fmt.Errorf("failed to read hint payload (length %d): %w", length, err)
+	}
+	if err := router(string(payload)); err != nil {
+		return fmt.Errorf("failed to handle hint: %w", err)
+	}
+	if _, err := hr.r.Read([]byte{0}); err != nil {
+		return fmt.Errorf("failed to read trailing no-op byte to unblock hint writer: %w", err)
+	}
+	return nil
+}

--- a/op-program/preimage/oracle.go
+++ b/op-program/preimage/oracle.go
@@ -1,0 +1,105 @@
+package preimage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type Key interface {
+	PreimageKey() common.Hash
+}
+
+type Oracle interface {
+	Get(key Key) []byte
+}
+
+type Type byte
+
+const (
+	Keccak256Type Type = iota
+)
+
+func makeKey(typ Type, keyData []byte) common.Hash {
+	return crypto.Keccak256Hash([]byte{byte(typ)}, keyData)
+}
+
+type Keccak256Key common.Hash
+
+func (k Keccak256Key) PreimageKey() common.Hash {
+	return makeKey(Keccak256Type, k[:])
+}
+
+// OracleClient implements the Oracle by writing the pre-image key to the given stream,
+// and reading back a length-prefixed value.
+type OracleClient struct {
+	rw io.ReadWriter
+}
+
+func NewOracleClient(rw io.ReadWriter) *OracleClient {
+	return &OracleClient{rw: rw}
+}
+
+var _ Oracle = (*OracleClient)(nil)
+
+func (o *OracleClient) Get(key Key) []byte {
+	h := key.PreimageKey()
+	if _, err := o.rw.Write(h[:]); err != nil {
+		panic(fmt.Errorf("failed to write key %s (%T) to pre-image oracle: %w", key, key, err))
+	}
+
+	var lengthPrefix [8]byte
+	if _, err := io.ReadFull(o.rw, lengthPrefix[:]); err != nil {
+		panic(fmt.Errorf("failed to read pre-image length of key %s (%T) from pre-image oracle: %w", key, key, err))
+	}
+
+	length := binary.LittleEndian.Uint64(lengthPrefix[:])
+	if length == 0 { // don't read empty payloads
+		return nil
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(o.rw, payload); err != nil {
+		panic(fmt.Errorf("failed to read pre-image payload (length %d) of key %s (%T) from pre-image oracle: %w", length, key, key, err))
+	}
+
+	return payload
+}
+
+// OracleServer serves the pre-image requests of the OracleClient, implementing the same protocol as the onchain VM.
+type OracleServer struct {
+	rw io.ReadWriter
+}
+
+func NewOracleServer(rw io.ReadWriter) *OracleServer {
+	return &OracleServer{rw: rw}
+}
+
+func (o *OracleServer) NextPreimageRequest(getPreimage func(key common.Hash) ([]byte, error)) error {
+	var key common.Hash
+	if _, err := io.ReadFull(o.rw, key[:]); err != nil {
+		if err == io.EOF {
+			return io.EOF
+		}
+		return fmt.Errorf("failed to read requested pre-image key: %w", err)
+	}
+	value, err := getPreimage(key)
+	if err != nil {
+		return fmt.Errorf("failed to serve pre-image %s request: %w", key, err)
+	}
+
+	var lengthPrefix [8]byte
+	binary.LittleEndian.PutUint64(lengthPrefix[:], uint64(len(value)))
+	if _, err := o.rw.Write(lengthPrefix[:]); err != nil {
+		return fmt.Errorf("failed to write length-prefix %x: %w", lengthPrefix, err)
+	}
+	if len(value) == 0 {
+		return nil
+	}
+	if _, err := o.rw.Write(value); err != nil {
+		return fmt.Errorf("failed to write pre-image value (%d long): %w", len(value), err)
+	}
+	return nil
+}


### PR DESCRIPTION
**Description**

Based on top of #5392 

This implements a pre-image oracle interface, and implements the `Oracle` interfaces in l1 and l2 client packages as `PreimageOracle` that interacts with the preimage oracle to get the data.

This also includes "hinting": to indicate to the host what data is of interest for the next pre-image fetching. This can be a no-op by the host in the onchain environment, or when running in a read-only mode from a KV store of known preimages.

**Tests**

Work in progress.
