### PR TITLE
op-program: key-value store for pre-images

### DIFF
--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -1,0 +1,51 @@
+package l1
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+)
+
+type OracleL1Client struct {
+	oracle Oracle
+}
+
+func NewOracleL1Client(oracle Oracle) *OracleL1Client {
+	return &OracleL1Client{oracle: oracle}
+}
+
+func (o OracleL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o OracleL1Client) L1BlockRefByNumber(ctx context.Context, u uint64) (eth.L1BlockRef, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o OracleL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o OracleL1Client) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (o OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+var _ derive.L1Fetcher = (*OracleL1Client)(nil)

--- a/op-program/client/l1/hints.go
+++ b/op-program/client/l1/hints.go
@@ -1,0 +1,15 @@
+package l1
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
+)
+
+type L1BlockHint common.Hash
+
+var _ preimage.Hint = L1BlockHint{}
+
+func (l L1BlockHint) Hint() string {
+	return "l1-block " + (common.Hash)(l).String()
+}

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -1,0 +1,45 @@
+package l1
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
+)
+
+// Oracle retrieves the requested data in any way.
+type Oracle interface {
+
+	// BlockByHash retrieves the block with the given hash.
+	// Returns an error if the block is not available.
+	BlockByHash(blockHash common.Hash) (*types.Block, error)
+}
+
+// PreimageOracle implements Oracle using by interfacing with the pure preimage.Oracle
+// to fetch pre-images to decode into the requested data.
+type PreimageOracle struct {
+	oracle preimage.Oracle
+	hint   preimage.Hinter
+}
+
+var _ Oracle = (*PreimageOracle)(nil)
+
+func NewPreimageOracle(raw preimage.Oracle, hint preimage.Hinter) *PreimageOracle {
+	return &PreimageOracle{
+		oracle: raw,
+		hint:   hint,
+	}
+}
+
+func (p *PreimageOracle) BlockByHash(blockHash common.Hash) (*types.Block, error) {
+	p.hint.Hint(L1BlockHint(blockHash))
+	blockRlp := p.oracle.Get(preimage.Keccak256Key(blockHash))
+	var block types.Block
+	if err := rlp.DecodeBytes(blockRlp, &block); err != nil {
+		panic(fmt.Errorf("invalid block %s: %w", blockHash, err))
+	}
+	return &block, nil
+}

--- a/op-program/client/l2/hints.go
+++ b/op-program/client/l2/hints.go
@@ -1,0 +1,31 @@
+package l2
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
+)
+
+type L2BlockHint common.Hash
+
+var _ preimage.Hint = L2BlockHint{}
+
+func (l L2BlockHint) Hint() string {
+	return "l2-block " + (common.Hash)(l).String()
+}
+
+type L2StateNodeHint common.Hash
+
+var _ preimage.Hint = L2StateNodeHint{}
+
+func (l L2StateNodeHint) Hint() string {
+	return "l2-state-node " + (common.Hash)(l).String()
+}
+
+type L2CodeHint common.Hash
+
+var _ preimage.Hint = L2CodeHint{}
+
+func (l L2CodeHint) Hint() string {
+	return "l2-code " + (common.Hash)(l).String()
+}

--- a/op-program/client/l2/oracle.go
+++ b/op-program/client/l2/oracle.go
@@ -1,8 +1,13 @@
 package l2
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
 )
 
 // StateOracle defines the high-level API used to retrieve L2 state data pre-images
@@ -28,4 +33,42 @@ type Oracle interface {
 	// BlockByHash retrieves the block with the given hash.
 	// Returns an error if the block is not available.
 	BlockByHash(blockHash common.Hash) (*types.Block, error)
+}
+
+// PreimageOracle implements Oracle using by interfacing with the pure preimage.Oracle
+// to fetch pre-images to decode into the requested data.
+type PreimageOracle struct {
+	oracle preimage.Oracle
+	hint   preimage.Hinter
+}
+
+var _ Oracle = (*PreimageOracle)(nil)
+
+func NewPreimageOracle(raw preimage.Oracle, hint preimage.Hinter) *PreimageOracle {
+	return &PreimageOracle{
+		oracle: raw,
+		hint:   hint,
+	}
+}
+
+func (p *PreimageOracle) BlockByHash(blockHash common.Hash) (*types.Block, error) {
+	p.hint.Hint(L2BlockHint(blockHash))
+	blockRlp := p.oracle.Get(preimage.Keccak256Key(blockHash))
+	var block types.Block
+	if err := rlp.DecodeBytes(blockRlp, &block); err != nil {
+		panic(fmt.Errorf("invalid block %s: %w", blockHash, err))
+	}
+	return &block, nil
+}
+
+func (p *PreimageOracle) NodeByHash(nodeHash common.Hash) ([]byte, error) {
+	p.hint.Hint(L2StateNodeHint(nodeHash))
+	node := p.oracle.Get(preimage.Keccak256Key(nodeHash))
+	return node, nil
+}
+
+func (p *PreimageOracle) CodeByHash(codeHash common.Hash) ([]byte, error) {
+	p.hint.Hint(L2CodeHint(codeHash))
+	code := p.oracle.Get(preimage.Keccak256Key(codeHash))
+	return code, nil
 }

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -1,0 +1,1 @@
+package host

--- a/op-program/host/kvstore/disk.go
+++ b/op-program/host/kvstore/disk.go
@@ -1,0 +1,64 @@
+package kvstore
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// read/write mode for user/group/other, not executable.
+const diskPermission = 0666
+
+// DiskKV is a disk-backed key-value store, every key-value pair is a hex-encoded .txt file, with the value as content.
+// DiskKV is safe for concurrent use; Puts may conflict, but write the exact same data anyway.
+type DiskKV struct {
+	path string
+}
+
+// NewDiskKV creates a DiskKV that puts/gets pre-images as files in the given directory path.
+// The path must exist, or subsequent Put/Get calls will error when it does not.
+func NewDiskKV(path string) *DiskKV {
+	return &DiskKV{path: path}
+}
+
+func (d *DiskKV) pathKey(k common.Hash) string {
+	return path.Join(d.path, k.String()+".txt")
+}
+
+func (d *DiskKV) Put(k common.Hash, v []byte) error {
+	// no O_EXCL, the pre-image may already exist. It's fine to overwrite it.
+	f, err := os.OpenFile(d.pathKey(k), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, diskPermission)
+	if err != nil {
+		return fmt.Errorf("failed to open new pre-image file %s: %w", k, err)
+	}
+	if _, err := f.Write([]byte(hex.EncodeToString(v))); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("failed to write pre-image %s to disk: %w", k, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close pre-image %s file: %w", k, err)
+	}
+	return nil
+}
+
+func (d *DiskKV) Get(k common.Hash) ([]byte, error) {
+	f, err := os.OpenFile(d.pathKey(k), os.O_RDONLY, diskPermission)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, NotFoundErr
+		}
+		return nil, fmt.Errorf("failed to open pre-image file %s: %w", k, err)
+	}
+	defer f.Close() // fine to ignore closing error here
+	dat, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read pre-image from file %s: %w", k, err)
+	}
+	return hex.DecodeString(string(dat))
+}
+
+var _ KV = (*DiskKV)(nil)

--- a/op-program/host/kvstore/disk_test.go
+++ b/op-program/host/kvstore/disk_test.go
@@ -1,0 +1,9 @@
+package kvstore
+
+import "testing"
+
+func TestDiskKV(t *testing.T) {
+	tmp := t.TempDir() // automatically removed by testing cleanup
+	kv := NewDiskKV(tmp)
+	kvTest(t, kv)
+}

--- a/op-program/host/kvstore/kv.go
+++ b/op-program/host/kvstore/kv.go
@@ -1,0 +1,16 @@
+package kvstore
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// NotFoundErr is returned when a pre-image cannot be found in the KV store.
+var NotFoundErr = errors.New("not found")
+
+// KV is a Key-Value store interface for pre-image data.
+type KV interface {
+	Put(k common.Hash, v []byte) error
+	Get(k common.Hash) ([]byte, error)
+}

--- a/op-program/host/kvstore/kv_test.go
+++ b/op-program/host/kvstore/kv_test.go
@@ -1,0 +1,47 @@
+package kvstore
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func kvTest(t *testing.T, kv KV) {
+	t.Run("roundtrip", func(t *testing.T) {
+		t.Parallel()
+		_, err := kv.Get(common.Hash{0xaa})
+		require.Equal(t, err, NotFoundErr, "file (in new tmp dir) does not exist yet")
+
+		require.NoError(t, kv.Put(common.Hash{0xaa}, []byte("hello world")))
+		dat, err := kv.Get(common.Hash{0xaa})
+		require.NoError(t, err, "pre-image must exist now")
+		require.Equal(t, "hello world", string(dat), "pre-image must match")
+	})
+
+	t.Run("empty pre-image", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, kv.Put(common.Hash{0xbb}, []byte{}))
+		dat, err := kv.Get(common.Hash{0xbb})
+		require.NoError(t, err, "pre-image must exist now")
+		require.Zero(t, len(dat), "pre-image must be empty")
+	})
+
+	t.Run("zero pre-image key", func(t *testing.T) {
+		t.Parallel()
+		// in case we give a pre-image a special empty key. If it was a hash then we wouldn't know the pre-image.
+		require.NoError(t, kv.Put(common.Hash{}, []byte("hello")))
+		dat, err := kv.Get(common.Hash{})
+		require.NoError(t, err, "pre-image must exist now")
+		require.Equal(t, "hello", string(dat), "pre-image must match")
+	})
+
+	t.Run("non-string value", func(t *testing.T) {
+		t.Parallel()
+		// in case we give a pre-image a special empty key. If it was a hash then we wouldn't know the pre-image.
+		require.NoError(t, kv.Put(common.Hash{0xcc}, []byte{4, 2}))
+		dat, err := kv.Get(common.Hash{0xcc})
+		require.NoError(t, err, "pre-image must exist now")
+		require.Equal(t, []byte{4, 2}, dat, "pre-image must match")
+	})
+}

--- a/op-program/host/kvstore/mem.go
+++ b/op-program/host/kvstore/mem.go
@@ -1,0 +1,38 @@
+package kvstore
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// MemKV implements the KV store interface in memory, backed by a regular Go map.
+// This should only be used in testing, as large programs may require more pre-image data than available memory.
+// MemKV is safe for concurrent use.
+type MemKV struct {
+	sync.RWMutex
+	m map[common.Hash][]byte
+}
+
+var _ KV = (*MemKV)(nil)
+
+func NewMemKV() *MemKV {
+	return &MemKV{m: make(map[common.Hash][]byte)}
+}
+
+func (m *MemKV) Put(k common.Hash, v []byte) error {
+	m.Lock()
+	defer m.Unlock()
+	m.m[k] = v
+	return nil
+}
+
+func (m *MemKV) Get(k common.Hash) ([]byte, error) {
+	m.RLock()
+	defer m.RUnlock()
+	v, ok := m.m[k]
+	if !ok {
+		return nil, NotFoundErr
+	}
+	return v, nil
+}

--- a/op-program/host/kvstore/mem_test.go
+++ b/op-program/host/kvstore/mem_test.go
@@ -1,0 +1,8 @@
+package kvstore
+
+import "testing"
+
+func TestMemKV(t *testing.T) {
+	kv := NewMemKV()
+	kvTest(t, kv)
+}

--- a/op-program/preimage/hints.go
+++ b/op-program/preimage/hints.go
@@ -1,0 +1,74 @@
+package preimage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type Hint interface {
+	Hint() string
+}
+
+type Hinter interface {
+	Hint(v Hint)
+}
+
+// HintWriter writes hints to an io.Writer (e.g. a special file descriptor, or a debug log),
+// for a pre-image oracle service to prepare specific pre-images.
+type HintWriter struct {
+	w io.Writer
+}
+
+var _ Hinter = (*HintWriter)(nil)
+
+func NewHintWriter(w io.Writer) *HintWriter {
+	return &HintWriter{w: w}
+}
+
+func (hw *HintWriter) Hint(v Hint) {
+	hint := v.Hint()
+	hintBytes := make([]byte, 8, 8+len(hint)+1)
+	binary.LittleEndian.PutUint64(hintBytes[:8], uint64(len(hint)))
+	hintBytes = append(hintBytes, []byte(hint)...)
+	hintBytes = append(hintBytes, 0) // to block writing on
+	_, err := hw.w.Write(hintBytes)
+	if err != nil {
+		panic(fmt.Errorf("failed to write pre-image hint: %w", err))
+	}
+}
+
+// HintReader reads the hints of HintWriter and passes them to a router for preparation of the requested pre-images.
+// Onchain the written hints are no-op.
+type HintReader struct {
+	r io.Reader
+}
+
+func NewHintReader(r io.Reader) *HintReader {
+	return &HintReader{r: r}
+}
+
+func (hr *HintReader) NextHint(router func(hint string) error) error {
+	var lengthPrefix [8]byte
+	if _, err := io.ReadFull(hr.r, lengthPrefix[:]); err != nil {
+		if err == io.EOF {
+			return io.EOF
+		}
+		return fmt.Errorf("failed to read hint length prefix: %w", err)
+	}
+	length := binary.LittleEndian.Uint64(lengthPrefix[:])
+	if length == 0 { // skip empty hints
+		return nil
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(hr.r, lengthPrefix[:]); err != nil {
+		return fmt.Errorf("failed to read hint payload (length %d): %w", length, err)
+	}
+	if err := router(string(payload)); err != nil {
+		return fmt.Errorf("failed to handle hint: %w", err)
+	}
+	if _, err := hr.r.Read([]byte{0}); err != nil {
+		return fmt.Errorf("failed to read trailing no-op byte to unblock hint writer: %w", err)
+	}
+	return nil
+}

--- a/op-program/preimage/oracle.go
+++ b/op-program/preimage/oracle.go
@@ -1,0 +1,105 @@
+package preimage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type Key interface {
+	PreimageKey() common.Hash
+}
+
+type Oracle interface {
+	Get(key Key) []byte
+}
+
+type Type byte
+
+const (
+	Keccak256Type Type = iota
+)
+
+func makeKey(typ Type, keyData []byte) common.Hash {
+	return crypto.Keccak256Hash([]byte{byte(typ)}, keyData)
+}
+
+type Keccak256Key common.Hash
+
+func (k Keccak256Key) PreimageKey() common.Hash {
+	return makeKey(Keccak256Type, k[:])
+}
+
+// OracleClient implements the Oracle by writing the pre-image key to the given stream,
+// and reading back a length-prefixed value.
+type OracleClient struct {
+	rw io.ReadWriter
+}
+
+func NewOracleClient(rw io.ReadWriter) *OracleClient {
+	return &OracleClient{rw: rw}
+}
+
+var _ Oracle = (*OracleClient)(nil)
+
+func (o *OracleClient) Get(key Key) []byte {
+	h := key.PreimageKey()
+	if _, err := o.rw.Write(h[:]); err != nil {
+		panic(fmt.Errorf("failed to write key %s (%T) to pre-image oracle: %w", key, key, err))
+	}
+
+	var lengthPrefix [8]byte
+	if _, err := io.ReadFull(o.rw, lengthPrefix[:]); err != nil {
+		panic(fmt.Errorf("failed to read pre-image length of key %s (%T) from pre-image oracle: %w", key, key, err))
+	}
+
+	length := binary.LittleEndian.Uint64(lengthPrefix[:])
+	if length == 0 { // don't read empty payloads
+		return nil
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(o.rw, payload); err != nil {
+		panic(fmt.Errorf("failed to read pre-image payload (length %d) of key %s (%T) from pre-image oracle: %w", length, key, key, err))
+	}
+
+	return payload
+}
+
+// OracleServer serves the pre-image requests of the OracleClient, implementing the same protocol as the onchain VM.
+type OracleServer struct {
+	rw io.ReadWriter
+}
+
+func NewOracleServer(rw io.ReadWriter) *OracleServer {
+	return &OracleServer{rw: rw}
+}
+
+func (o *OracleServer) NextPreimageRequest(getPreimage func(key common.Hash) ([]byte, error)) error {
+	var key common.Hash
+	if _, err := io.ReadFull(o.rw, key[:]); err != nil {
+		if err == io.EOF {
+			return io.EOF
+		}
+		return fmt.Errorf("failed to read requested pre-image key: %w", err)
+	}
+	value, err := getPreimage(key)
+	if err != nil {
+		return fmt.Errorf("failed to serve pre-image %s request: %w", key, err)
+	}
+
+	var lengthPrefix [8]byte
+	binary.LittleEndian.PutUint64(lengthPrefix[:], uint64(len(value)))
+	if _, err := o.rw.Write(lengthPrefix[:]); err != nil {
+		return fmt.Errorf("failed to write length-prefix %x: %w", lengthPrefix, err)
+	}
+	if len(value) == 0 {
+		return nil
+	}
+	if _, err := o.rw.Write(value); err != nil {
+		return fmt.Errorf("failed to write pre-image value (%d long): %w", len(value), err)
+	}
+	return nil
+}


### PR DESCRIPTION
**Description**

Based on #5393 (for stack consistency with later PRs)

Implements basic key-value stores for pre-image data. Integration follows in separate PR.

**Tests**

KV-stores are tested with basic put/get interactions, the KV interface is pretty simple.

**Metadata**

Fix CLI-3747

