### PR TITLE
op-service/metrics: Add subsystem to event metrics

### DIFF
--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -100,7 +100,7 @@ func NewMetrics(procName string) *Metrics {
 			Help:      "1 if the op-batcher has finished starting up",
 		}),
 
-		ChannelEvs: opmetrics.NewEventVec(factory, ns, "channel", "Channel", []string{"stage"}),
+		ChannelEvs: opmetrics.NewEventVec(factory, ns, "", "channel", "Channel", []string{"stage"}),
 
 		PendingBlocksCount: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
@@ -145,7 +145,7 @@ func NewMetrics(procName string) *Metrics {
 			Buckets:   append([]float64{0.1, 0.2}, prometheus.LinearBuckets(0.3, 0.05, 14)...),
 		}),
 
-		BatcherTxEvs: opmetrics.NewEventVec(factory, ns, "batcher_tx", "BatcherTx", []string{"stage"}),
+		BatcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),
 	}
 }
 

--- a/op-service/metrics/event.go
+++ b/op-service/metrics/event.go
@@ -16,17 +16,19 @@ func (e *Event) Record() {
 	e.LastTime.SetToCurrentTime()
 }
 
-func NewEvent(factory Factory, ns string, name string, displayName string) Event {
+func NewEvent(factory Factory, ns string, subsystem string, name string, displayName string) Event {
 	return Event{
 		Total: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      fmt.Sprintf("%s_total", name),
 			Help:      fmt.Sprintf("Count of %s events", displayName),
+			Subsystem: subsystem,
 		}),
 		LastTime: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      fmt.Sprintf("last_%s_unix", name),
 			Help:      fmt.Sprintf("Timestamp of last %s event", displayName),
+			Subsystem: subsystem,
 		}),
 	}
 }
@@ -41,17 +43,19 @@ func (e *EventVec) Record(lvs ...string) {
 	e.LastTime.WithLabelValues(lvs...).SetToCurrentTime()
 }
 
-func NewEventVec(factory Factory, ns string, name string, displayName string, labelNames []string) EventVec {
+func NewEventVec(factory Factory, ns string, subsystem string, name string, displayName string, labelNames []string) EventVec {
 	return EventVec{
 		Total: *factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      fmt.Sprintf("%s_total", name),
 			Help:      fmt.Sprintf("Count of %s events", displayName),
+			Subsystem: subsystem,
 		}, labelNames),
 		LastTime: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      fmt.Sprintf("last_%s_unix", name),
 			Help:      fmt.Sprintf("Timestamp of last %s event", displayName),
+			Subsystem: subsystem,
 		}, labelNames),
 	}
 }

--- a/op-service/txmgr/metrics/tx_metrics.go
+++ b/op-service/txmgr/metrics/tx_metrics.go
@@ -73,8 +73,8 @@ func MakeTxMetrics(ns string, factory metrics.Factory) TxMetrics {
 			Help:      "Count of publish errors. Labells are sanitized error strings",
 			Subsystem: "txmgr",
 		}, []string{"error"}),
-		confirmEvent: metrics.NewEventVec(factory, ns, "confirm", "tx confirm", []string{"status"}),
-		publishEvent: metrics.NewEvent(factory, ns, "publish", "tx publish"),
+		confirmEvent: metrics.NewEventVec(factory, ns, "txmgr", "confirm", "tx confirm", []string{"status"}),
+		publishEvent: metrics.NewEvent(factory, ns, "txmgr", "publish", "tx publish"),
 		rpcError: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Name:      "rpc_error_count",


### PR DESCRIPTION
**Description**

Adds the subsystem back to event metrics.

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
