### PR TITLE
op-program: Implement oracle based L1 fetcher

### DIFF
--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
-	ErrNotFound     = errors.New("not found")
+	ErrNotFound     = ethereum.NotFound
 	ErrUnknownLabel = errors.New("unknown label")
 )
 
@@ -20,8 +22,9 @@ type OracleL1Client struct {
 	head   eth.L1BlockRef
 }
 
-func NewOracleL1Client(oracle Oracle, l1Head common.Hash) *OracleL1Client {
+func NewOracleL1Client(logger log.Logger, oracle Oracle, l1Head common.Hash) *OracleL1Client {
 	head := eth.InfoToL1BlockRef(oracle.HeaderByHash(l1Head))
+	logger.Info("L1 head loaded", "hash", head.Hash, "number", head.Number)
 	return &OracleL1Client{
 		oracle: oracle,
 		head:   head,
@@ -29,26 +32,22 @@ func NewOracleL1Client(oracle Oracle, l1Head common.Hash) *OracleL1Client {
 }
 
 func (o OracleL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
-	switch label {
-	case eth.Unsafe:
-		return o.head, nil
-	case eth.Safe:
-		return o.head, nil
-	case eth.Finalized:
-		return o.head, nil
+	if label != eth.Unsafe && label != eth.Safe && label != eth.Finalized {
+		return eth.L1BlockRef{}, fmt.Errorf("%w: %s", ErrUnknownLabel, label)
 	}
-	return eth.L1BlockRef{}, fmt.Errorf("%w: %s", ErrUnknownLabel, label)
+	// The L1 head is pre-agreed and unchanging so it can be used for all of unsafe, safe and finalized
+	return o.head, nil
 }
 
 func (o OracleL1Client) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
 	if number > o.head.Number {
 		return eth.L1BlockRef{}, fmt.Errorf("%w: block number %d", ErrNotFound, number)
 	}
-	head := o.head
-	for head.Number > number {
-		head = eth.InfoToL1BlockRef(o.oracle.HeaderByHash(head.ParentHash))
+	block := o.head
+	for block.Number > number {
+		block = eth.InfoToL1BlockRef(o.oracle.HeaderByHash(block.ParentHash))
 	}
-	return head, nil
+	return block, nil
 }
 
 func (o OracleL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {

--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -1,0 +1,70 @@
+package l1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	ErrNotFound     = errors.New("not found")
+	ErrUnknownLabel = errors.New("unknown label")
+)
+
+type OracleL1Client struct {
+	oracle Oracle
+	head   eth.L1BlockRef
+}
+
+func NewOracleL1Client(oracle Oracle, l1Head common.Hash) *OracleL1Client {
+	head := eth.InfoToL1BlockRef(oracle.HeaderByHash(l1Head))
+	return &OracleL1Client{
+		oracle: oracle,
+		head:   head,
+	}
+}
+
+func (o OracleL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
+	switch label {
+	case eth.Unsafe:
+		return o.head, nil
+	case eth.Safe:
+		return o.head, nil
+	case eth.Finalized:
+		return o.head, nil
+	}
+	return eth.L1BlockRef{}, fmt.Errorf("%w: %s", ErrUnknownLabel, label)
+}
+
+func (o OracleL1Client) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+	if number > o.head.Number {
+		return eth.L1BlockRef{}, fmt.Errorf("%w: block number %d", ErrNotFound, number)
+	}
+	head := o.head
+	for head.Number > number {
+		head = eth.InfoToL1BlockRef(o.oracle.HeaderByHash(head.ParentHash))
+	}
+	return head, nil
+}
+
+func (o OracleL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
+	return eth.InfoToL1BlockRef(o.oracle.HeaderByHash(hash)), nil
+}
+
+func (o OracleL1Client) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	return o.oracle.HeaderByHash(hash), nil
+}
+
+func (o OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	info, rcpts := o.oracle.ReceiptsByHash(blockHash)
+	return info, rcpts, nil
+}
+
+func (o OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	info, txs := o.oracle.TransactionsByHash(hash)
+	return info, txs, nil
+}

--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -23,7 +23,7 @@ type OracleL1Client struct {
 }
 
 func NewOracleL1Client(logger log.Logger, oracle Oracle, l1Head common.Hash) *OracleL1Client {
-	head := eth.InfoToL1BlockRef(oracle.HeaderByHash(l1Head))
+	head := eth.InfoToL1BlockRef(oracle.HeaderByBlockHash(l1Head))
 	logger.Info("L1 head loaded", "hash", head.Hash, "number", head.Number)
 	return &OracleL1Client{
 		oracle: oracle,
@@ -45,25 +45,25 @@ func (o OracleL1Client) L1BlockRefByNumber(ctx context.Context, number uint64) (
 	}
 	block := o.head
 	for block.Number > number {
-		block = eth.InfoToL1BlockRef(o.oracle.HeaderByHash(block.ParentHash))
+		block = eth.InfoToL1BlockRef(o.oracle.HeaderByBlockHash(block.ParentHash))
 	}
 	return block, nil
 }
 
 func (o OracleL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
-	return eth.InfoToL1BlockRef(o.oracle.HeaderByHash(hash)), nil
+	return eth.InfoToL1BlockRef(o.oracle.HeaderByBlockHash(hash)), nil
 }
 
 func (o OracleL1Client) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
-	return o.oracle.HeaderByHash(hash), nil
+	return o.oracle.HeaderByBlockHash(hash), nil
 }
 
 func (o OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
-	info, rcpts := o.oracle.ReceiptsByHash(blockHash)
+	info, rcpts := o.oracle.ReceiptsByBlockHash(blockHash)
 	return info, rcpts, nil
 }
 
 func (o OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	info, txs := o.oracle.TransactionsByHash(hash)
+	info, txs := o.oracle.TransactionsByBlockHash(hash)
 	return info, txs, nil
 }

--- a/op-program/client/l1/client_test.go
+++ b/op-program/client/l1/client_test.go
@@ -1,0 +1,206 @@
+package l1
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+var _ derive.L1Fetcher = (*OracleL1Client)(nil)
+
+var head = blockNum(1000)
+
+func TestInfoByHash(t *testing.T) {
+	client, oracle := newClient(t)
+	hash := common.HexToHash("0xAABBCC")
+	expected := &sources.HeaderInfo{}
+	oracle.blocks[hash] = expected
+
+	info, err := client.InfoByHash(context.Background(), hash)
+	require.NoError(t, err)
+	require.Equal(t, expected, info)
+}
+
+func TestL1BlockRefByHash(t *testing.T) {
+	client, oracle := newClient(t)
+	hash := common.HexToHash("0xAABBCC")
+	header := &sources.HeaderInfo{}
+	oracle.blocks[hash] = header
+	expected := eth.InfoToL1BlockRef(header)
+
+	ref, err := client.L1BlockRefByHash(context.Background(), hash)
+	require.NoError(t, err)
+	require.Equal(t, expected, ref)
+}
+
+func TestFetchReceipts(t *testing.T) {
+	client, oracle := newClient(t)
+	hash := common.HexToHash("0xAABBCC")
+	expectedInfo := &sources.HeaderInfo{}
+	expectedReceipts := types.Receipts{
+		&types.Receipt{},
+	}
+	oracle.blocks[hash] = expectedInfo
+	oracle.rcpts[hash] = expectedReceipts
+
+	info, rcpts, err := client.FetchReceipts(context.Background(), hash)
+	require.NoError(t, err)
+	require.Equal(t, expectedInfo, info)
+	require.Equal(t, expectedReceipts, rcpts)
+}
+
+func TestInfoAndTxsByHash(t *testing.T) {
+	client, oracle := newClient(t)
+	hash := common.HexToHash("0xAABBCC")
+	expectedInfo := &sources.HeaderInfo{}
+	expectedTxs := types.Transactions{
+		&types.Transaction{},
+	}
+	oracle.blocks[hash] = expectedInfo
+	oracle.txs[hash] = expectedTxs
+
+	info, txs, err := client.InfoAndTxsByHash(context.Background(), hash)
+	require.NoError(t, err)
+	require.Equal(t, expectedInfo, info)
+	require.Equal(t, expectedTxs, txs)
+}
+
+func TestL1BlockRefByLabel(t *testing.T) {
+	t.Run("Unsafe", func(t *testing.T) {
+		client, _ := newClient(t)
+		ref, err := client.L1BlockRefByLabel(context.Background(), eth.Unsafe)
+		require.NoError(t, err)
+		require.Equal(t, eth.InfoToL1BlockRef(head), ref)
+	})
+	t.Run("Safe", func(t *testing.T) {
+		client, _ := newClient(t)
+		ref, err := client.L1BlockRefByLabel(context.Background(), eth.Safe)
+		require.NoError(t, err)
+		require.Equal(t, eth.InfoToL1BlockRef(head), ref)
+	})
+	t.Run("Finalized", func(t *testing.T) {
+		client, _ := newClient(t)
+		ref, err := client.L1BlockRefByLabel(context.Background(), eth.Finalized)
+		require.NoError(t, err)
+		require.Equal(t, eth.InfoToL1BlockRef(head), ref)
+	})
+	t.Run("UnknownLabel", func(t *testing.T) {
+		client, _ := newClient(t)
+		ref, err := client.L1BlockRefByLabel(context.Background(), eth.BlockLabel("unknown"))
+		require.ErrorIs(t, err, ErrUnknownLabel)
+		require.Equal(t, eth.L1BlockRef{}, ref)
+	})
+}
+
+func TestL1BlockRefByNumber(t *testing.T) {
+	t.Run("Head", func(t *testing.T) {
+		client, _ := newClient(t)
+		ref, err := client.L1BlockRefByNumber(context.Background(), head.NumberU64())
+		require.NoError(t, err)
+		require.Equal(t, eth.InfoToL1BlockRef(head), ref)
+	})
+	t.Run("AfterHead", func(t *testing.T) {
+		client, _ := newClient(t)
+		ref, err := client.L1BlockRefByNumber(context.Background(), head.NumberU64()+1)
+		require.ErrorIs(t, err, ErrNotFound)
+		require.Equal(t, eth.L1BlockRef{}, ref)
+	})
+	t.Run("ParentOfHead", func(t *testing.T) {
+		client, oracle := newClient(t)
+		parent := blockNum(head.NumberU64() - 1)
+		oracle.blocks[parent.Hash()] = parent
+
+		ref, err := client.L1BlockRefByNumber(context.Background(), parent.NumberU64())
+		require.NoError(t, err)
+		require.Equal(t, eth.InfoToL1BlockRef(parent), ref)
+	})
+	t.Run("AncestorOfHead", func(t *testing.T) {
+		client, oracle := newClient(t)
+		block := head
+		blocks := []eth.BlockInfo{block}
+		for i := 0; i < 10; i++ {
+			block = blockNum(block.NumberU64() - 1)
+			oracle.blocks[block.Hash()] = block
+			blocks = append(blocks, block)
+		}
+
+		for _, block := range blocks {
+			ref, err := client.L1BlockRefByNumber(context.Background(), block.NumberU64())
+			require.NoError(t, err)
+			require.Equal(t, eth.InfoToL1BlockRef(block), ref)
+		}
+	})
+}
+
+func newClient(t *testing.T) (*OracleL1Client, *stubOracle) {
+	stub := &stubOracle{
+		t:      t,
+		blocks: make(map[common.Hash]eth.BlockInfo),
+		txs:    make(map[common.Hash]types.Transactions),
+		rcpts:  make(map[common.Hash]types.Receipts),
+	}
+	stub.blocks[head.Hash()] = head
+	client := NewOracleL1Client(stub, head.Hash())
+	return client, stub
+}
+
+type stubOracle struct {
+	t *testing.T
+
+	// blocks maps block hash to eth.BlockInfo
+	blocks map[common.Hash]eth.BlockInfo
+
+	// txs maps block hash to transactions
+	txs map[common.Hash]types.Transactions
+
+	// rcpts maps Block hash to receipts
+	rcpts map[common.Hash]types.Receipts
+}
+
+func (o stubOracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
+	info, ok := o.blocks[blockHash]
+	if !ok {
+		o.t.Fatalf("unknown block %s", blockHash)
+	}
+	return info
+}
+
+func (o stubOracle) TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+	txs, ok := o.txs[blockHash]
+	if !ok {
+		o.t.Fatalf("unknown txs %s", blockHash)
+	}
+	return o.HeaderByHash(blockHash), txs
+}
+
+func (o stubOracle) ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+	rcpts, ok := o.rcpts[blockHash]
+	if !ok {
+		o.t.Fatalf("unknown rcpts %s", blockHash)
+	}
+	return o.HeaderByHash(blockHash), rcpts
+}
+
+func blockNum(num uint64) eth.BlockInfo {
+	parentNum := num - 1
+	return &testutils.MockBlockInfo{
+		InfoHash:        common.BytesToHash(big.NewInt(int64(num)).Bytes()),
+		InfoParentHash:  common.BytesToHash(big.NewInt(int64(parentNum)).Bytes()),
+		InfoCoinbase:    common.Address{},
+		InfoRoot:        common.Hash{},
+		InfoNum:         num,
+		InfoTime:        num * 2,
+		InfoMixDigest:   [32]byte{},
+		InfoBaseFee:     nil,
+		InfoReceiptRoot: common.Hash{},
+		InfoGasUsed:     0,
+	}
+}

--- a/op-program/client/l1/client_test.go
+++ b/op-program/client/l1/client_test.go
@@ -169,7 +169,7 @@ type stubOracle struct {
 	rcpts map[common.Hash]types.Receipts
 }
 
-func (o stubOracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
+func (o stubOracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
 	info, ok := o.blocks[blockHash]
 	if !ok {
 		o.t.Fatalf("unknown block %s", blockHash)
@@ -177,20 +177,20 @@ func (o stubOracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
 	return info
 }
 
-func (o stubOracle) TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+func (o stubOracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
 	txs, ok := o.txs[blockHash]
 	if !ok {
 		o.t.Fatalf("unknown txs %s", blockHash)
 	}
-	return o.HeaderByHash(blockHash), txs
+	return o.HeaderByBlockHash(blockHash), txs
 }
 
-func (o stubOracle) ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+func (o stubOracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
 	rcpts, ok := o.rcpts[blockHash]
 	if !ok {
 		o.t.Fatalf("unknown rcpts %s", blockHash)
 	}
-	return o.HeaderByHash(blockHash), rcpts
+	return o.HeaderByBlockHash(blockHash), rcpts
 }
 
 func blockNum(num uint64) eth.BlockInfo {

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -1,0 +1,18 @@
+package l1
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type Oracle interface {
+	// HeaderByHash retrieves the block header with the given hash.
+	HeaderByHash(blockHash common.Hash) eth.BlockInfo
+
+	// TransactionsByHash retrieves the transactions from the block with the given hash.
+	TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions)
+
+	// ReceiptsByHash retrieves the receipts from the block with the given hash.
+	ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts)
+}

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Oracle interface {
-	// HeaderByHash retrieves the block header with the given hash.
-	HeaderByHash(blockHash common.Hash) eth.BlockInfo
+	// HeaderByBlockHash retrieves the block header with the given hash.
+	HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo
 
-	// TransactionsByHash retrieves the transactions from the block with the given hash.
-	TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions)
+	// TransactionsByBlockHash retrieves the transactions from the block with the given hash.
+	TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions)
 
-	// ReceiptsByHash retrieves the receipts from the block with the given hash.
-	ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts)
+	// ReceiptsByBlockHash retrieves the receipts from the block with the given hash.
+	ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts)
 }

--- a/op-program/client/l2/engine_backend.go
+++ b/op-program/client/l2/engine_backend.go
@@ -39,6 +39,7 @@ func NewOracleBackedL2Chain(logger log.Logger, oracle Oracle, chainCfg *params.C
 	if err != nil {
 		return nil, fmt.Errorf("loading l2 head: %w", err)
 	}
+	logger.Info("Loaded L2 head", "hash", head.Hash(), "number", head.Number())
 	return &OracleBackedL2Chain{
 		log:      logger,
 		oracle:   oracle,

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -11,66 +11,58 @@ import (
 
 var validRollupConfig = &chaincfg.Goerli
 var validL2GenesisPath = "genesis.json"
+var validL1Head = common.HexToHash("0x112233889988FF")
 var validL2Head = common.HexToHash("0x6303578b1fa9480389c51bbcef6fe045bb877da39740819e9eb5f36f94949bd0")
 
 func TestDefaultConfigIsValid(t *testing.T) {
-	err := NewConfig(validRollupConfig, validL2GenesisPath, validL2Head).Check()
+	err := NewConfig(validRollupConfig, validL2GenesisPath, validL1Head, validL2Head).Check()
 	require.NoError(t, err)
 }
 
 func TestRollupConfig(t *testing.T) {
 	t.Run("Required", func(t *testing.T) {
-		err := NewConfig(nil, validL2GenesisPath, validL2Head).Check()
+		err := NewConfig(nil, validL2GenesisPath, validL1Head, validL2Head).Check()
 		require.ErrorIs(t, err, ErrMissingRollupConfig)
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
-		err := NewConfig(&rollup.Config{}, validL2GenesisPath, validL2Head).Check()
+		err := NewConfig(&rollup.Config{}, validL2GenesisPath, validL1Head, validL2Head).Check()
 		require.ErrorIs(t, err, rollup.ErrBlockTimeZero)
 	})
 }
 
-func TestL2Genesis(t *testing.T) {
-	t.Run("Required", func(t *testing.T) {
-		err := NewConfig(validRollupConfig, "", validL2Head).Check()
-		require.ErrorIs(t, err, ErrMissingL2Genesis)
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		err := NewConfig(validRollupConfig, validL2GenesisPath, validL2Head).Check()
-		require.NoError(t, err)
-	})
+func TestL1HeadRequired(t *testing.T) {
+	err := NewConfig(validRollupConfig, validL2GenesisPath, common.Hash{}, validL2Head).Check()
+	require.ErrorIs(t, err, ErrInvalidL1Head)
 }
 
-func TestL2Head(t *testing.T) {
-	t.Run("Required", func(t *testing.T) {
-		err := NewConfig(validRollupConfig, validL2GenesisPath, common.Hash{}).Check()
-		require.ErrorIs(t, err, ErrInvalidL2Head)
-	})
+func TestL2HeadRequired(t *testing.T) {
+	err := NewConfig(validRollupConfig, validL2GenesisPath, validL1Head, common.Hash{}).Check()
+	require.ErrorIs(t, err, ErrInvalidL2Head)
+}
 
-	t.Run("Valid", func(t *testing.T) {
-		err := NewConfig(validRollupConfig, validL2GenesisPath, validL2Head).Check()
-		require.NoError(t, err)
-	})
+func TestL2GenesisRequired(t *testing.T) {
+	err := NewConfig(validRollupConfig, "", validL1Head, validL2Head).Check()
+	require.ErrorIs(t, err, ErrMissingL2Genesis)
 }
 
 func TestFetchingArgConsistency(t *testing.T) {
 	t.Run("RequireL2WhenL1Set", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L1URL = "https://example.com:1234"
 		require.ErrorIs(t, cfg.Check(), ErrL1AndL2Inconsistent)
 	})
 	t.Run("RequireL1WhenL2Set", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L2URL = "https://example.com:1234"
 		require.ErrorIs(t, cfg.Check(), ErrL1AndL2Inconsistent)
 	})
 	t.Run("AllowNeitherSet", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		require.NoError(t, cfg.Check())
 	})
 	t.Run("AllowBothSet", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L1URL = "https://example.com:1234"
 		cfg.L2URL = "https://example.com:4678"
 		require.NoError(t, cfg.Check())
@@ -79,30 +71,30 @@ func TestFetchingArgConsistency(t *testing.T) {
 
 func TestFetchingEnabled(t *testing.T) {
 	t.Run("FetchingNotEnabledWhenNoFetcherUrlsSpecified", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		require.False(t, cfg.FetchingEnabled(), "Should not enable fetching when node URL not supplied")
 	})
 
 	t.Run("FetchingEnabledWhenFetcherUrlsSpecified", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L2URL = "https://example.com:1234"
 		require.False(t, cfg.FetchingEnabled(), "Should not enable fetching when node URL not supplied")
 	})
 
 	t.Run("FetchingNotEnabledWhenNoL1UrlSpecified", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L2URL = "https://example.com:1234"
 		require.False(t, cfg.FetchingEnabled(), "Should not enable L1 fetching when L1 node URL not supplied")
 	})
 
 	t.Run("FetchingNotEnabledWhenNoL2UrlSpecified", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L1URL = "https://example.com:1234"
 		require.False(t, cfg.FetchingEnabled(), "Should not enable L2 fetching when L2 node URL not supplied")
 	})
 
 	t.Run("FetchingEnabledWhenBothFetcherUrlsSpecified", func(t *testing.T) {
-		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL2Head)
+		cfg := NewConfig(&chaincfg.Beta1, validL2GenesisPath, validL1Head, validL2Head)
 		cfg.L1URL = "https://example.com:1234"
 		cfg.L2URL = "https://example.com:5678"
 		require.True(t, cfg.FetchingEnabled(), "Should enable fetching when node URL supplied")

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -31,15 +31,20 @@ var (
 		Usage:  "Address of L2 JSON-RPC endpoint to use (eth and debug namespace required)",
 		EnvVar: service.PrefixEnvVar(envVarPrefix, "L2_RPC"),
 	}
-	L2GenesisPath = cli.StringFlag{
-		Name:   "l2.genesis",
-		Usage:  "Path to the op-geth genesis file",
-		EnvVar: service.PrefixEnvVar(envVarPrefix, "L2_GENESIS"),
+	L1Head = cli.StringFlag{
+		Name:   "l1.head",
+		Usage:  "Hash of the L1 head block. Derivation stops after this block is processed.",
+		EnvVar: service.PrefixEnvVar(envVarPrefix, "L1_HEAD"),
 	}
 	L2Head = cli.StringFlag{
 		Name:   "l2.head",
 		Usage:  "Hash of the agreed L2 block to start derivation from",
 		EnvVar: service.PrefixEnvVar(envVarPrefix, "L2_HEAD"),
+	}
+	L2GenesisPath = cli.StringFlag{
+		Name:   "l2.genesis",
+		Usage:  "Path to the op-geth genesis file",
+		EnvVar: service.PrefixEnvVar(envVarPrefix, "L2_GENESIS"),
 	}
 	L1NodeAddr = cli.StringFlag{
 		Name:   "l1",
@@ -70,8 +75,9 @@ var programFlags = []cli.Flag{
 	RollupConfig,
 	Network,
 	L2NodeAddr,
-	L2GenesisPath,
+	L1Head,
 	L2Head,
+	L2GenesisPath,
 	L1NodeAddr,
 	L1TrustRPC,
 	L1RPCProviderKind,
@@ -96,6 +102,9 @@ func CheckRequired(ctx *cli.Context) error {
 	}
 	if ctx.GlobalString(L2Head.Name) == "" {
 		return fmt.Errorf("flag %s is required", L2Head.Name)
+	}
+	if ctx.GlobalString(L1Head.Name) == "" {
+		return fmt.Errorf("flag %s is required", L1Head.Name)
 	}
 	return nil
 }

--- a/op-program/host/l1/fetcher.go
+++ b/op-program/host/l1/fetcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type Source interface {
@@ -17,17 +18,20 @@ type Source interface {
 
 type FetchingL1Oracle struct {
 	ctx    context.Context
+	logger log.Logger
 	source Source
 }
 
-func NewFetchingL1Oracle(ctx context.Context, source Source) *FetchingL1Oracle {
+func NewFetchingL1Oracle(ctx context.Context, logger log.Logger, source Source) *FetchingL1Oracle {
 	return &FetchingL1Oracle{
 		ctx:    ctx,
+		logger: logger,
 		source: source,
 	}
 }
 
 func (o FetchingL1Oracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
+	o.logger.Trace("HeaderByHash", "hash", blockHash)
 	info, err := o.source.InfoByHash(o.ctx, blockHash)
 	if err != nil {
 		panic(fmt.Errorf("retrieve block %s: %w", blockHash, err))
@@ -39,6 +43,7 @@ func (o FetchingL1Oracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
 }
 
 func (o FetchingL1Oracle) TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+	o.logger.Trace("TransactionsByHash", "hash", blockHash)
 	info, txs, err := o.source.InfoAndTxsByHash(o.ctx, blockHash)
 	if err != nil {
 		panic(fmt.Errorf("retrieve transactions for block %s: %w", blockHash, err))
@@ -50,6 +55,7 @@ func (o FetchingL1Oracle) TransactionsByHash(blockHash common.Hash) (eth.BlockIn
 }
 
 func (o FetchingL1Oracle) ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+	o.logger.Trace("ReceiptsByHash", "hash", blockHash)
 	info, rcpts, err := o.source.FetchReceipts(o.ctx, blockHash)
 	if err != nil {
 		panic(fmt.Errorf("retrieve receipts for block %s: %w", blockHash, err))

--- a/op-program/host/l1/fetcher.go
+++ b/op-program/host/l1/fetcher.go
@@ -30,8 +30,8 @@ func NewFetchingL1Oracle(ctx context.Context, logger log.Logger, source Source) 
 	}
 }
 
-func (o FetchingL1Oracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
-	o.logger.Trace("HeaderByHash", "hash", blockHash)
+func (o FetchingL1Oracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
+	o.logger.Trace("HeaderByBlockHash", "hash", blockHash)
 	info, err := o.source.InfoByHash(o.ctx, blockHash)
 	if err != nil {
 		panic(fmt.Errorf("retrieve block %s: %w", blockHash, err))
@@ -42,8 +42,8 @@ func (o FetchingL1Oracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
 	return info
 }
 
-func (o FetchingL1Oracle) TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
-	o.logger.Trace("TransactionsByHash", "hash", blockHash)
+func (o FetchingL1Oracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+	o.logger.Trace("TransactionsByBlockHash", "hash", blockHash)
 	info, txs, err := o.source.InfoAndTxsByHash(o.ctx, blockHash)
 	if err != nil {
 		panic(fmt.Errorf("retrieve transactions for block %s: %w", blockHash, err))
@@ -54,8 +54,8 @@ func (o FetchingL1Oracle) TransactionsByHash(blockHash common.Hash) (eth.BlockIn
 	return info, txs
 }
 
-func (o FetchingL1Oracle) ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
-	o.logger.Trace("ReceiptsByHash", "hash", blockHash)
+func (o FetchingL1Oracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+	o.logger.Trace("ReceiptsByBlockHash", "hash", blockHash)
 	info, rcpts, err := o.source.FetchReceipts(o.ctx, blockHash)
 	if err != nil {
 		panic(fmt.Errorf("retrieve receipts for block %s: %w", blockHash, err))

--- a/op-program/host/l1/fetcher.go
+++ b/op-program/host/l1/fetcher.go
@@ -1,0 +1,54 @@
+package l1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type Source interface {
+	InfoByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, error)
+	InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error)
+	FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error)
+}
+
+type FetchingL1Oracle struct {
+	ctx    context.Context
+	source Source
+}
+
+func (o FetchingL1Oracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
+	info, err := o.source.InfoByHash(o.ctx, blockHash)
+	if err != nil {
+		panic(fmt.Errorf("retrieve block %s: %w", blockHash, err))
+	}
+	if info == nil {
+		panic(fmt.Errorf("unknown block: %s", blockHash))
+	}
+	return info
+}
+
+func (o FetchingL1Oracle) TransactionsByHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+	info, txs, err := o.source.InfoAndTxsByHash(o.ctx, blockHash)
+	if err != nil {
+		panic(fmt.Errorf("retrieve transactions for block %s: %w", blockHash, err))
+	}
+	if info == nil || txs == nil {
+		panic(fmt.Errorf("unknown block: %s", blockHash))
+	}
+	return info, txs
+}
+
+func (o FetchingL1Oracle) ReceiptsByHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+	info, rcpts, err := o.source.FetchReceipts(o.ctx, blockHash)
+	if err != nil {
+		panic(fmt.Errorf("retrieve receipts for block %s: %w", blockHash, err))
+	}
+	if info == nil || rcpts == nil {
+		panic(fmt.Errorf("unknown block: %s", blockHash))
+	}
+	return info, rcpts
+}

--- a/op-program/host/l1/fetcher.go
+++ b/op-program/host/l1/fetcher.go
@@ -20,6 +20,13 @@ type FetchingL1Oracle struct {
 	source Source
 }
 
+func NewFetchingL1Oracle(ctx context.Context, source Source) *FetchingL1Oracle {
+	return &FetchingL1Oracle{
+		ctx:    ctx,
+		source: source,
+	}
+}
+
 func (o FetchingL1Oracle) HeaderByHash(blockHash common.Hash) eth.BlockInfo {
 	info, err := o.source.InfoByHash(o.ctx, blockHash)
 	if err != nil {

--- a/op-program/host/l1/fetcher_test.go
+++ b/op-program/host/l1/fetcher_test.go
@@ -28,7 +28,7 @@ func TestHeaderByHash(t *testing.T) {
 		source := &stubSource{nextInfo: expected}
 		oracle := newFetchingOracle(t, source)
 
-		actual := oracle.HeaderByHash(expected.Hash())
+		actual := oracle.HeaderByBlockHash(expected.Hash())
 		require.Equal(t, expected, actual)
 	})
 
@@ -36,7 +36,7 @@ func TestHeaderByHash(t *testing.T) {
 		oracle := newFetchingOracle(t, &stubSource{})
 		hash := common.HexToHash("0x4455")
 		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
-			oracle.HeaderByHash(hash)
+			oracle.HeaderByBlockHash(hash)
 		})
 	})
 
@@ -47,7 +47,7 @@ func TestHeaderByHash(t *testing.T) {
 
 		hash := common.HexToHash("0x8888")
 		require.PanicsWithError(t, fmt.Errorf("retrieve block %s: %w", hash, err).Error(), func() {
-			oracle.HeaderByHash(hash)
+			oracle.HeaderByBlockHash(hash)
 		})
 	})
 }
@@ -61,7 +61,7 @@ func TestTransactionsByHash(t *testing.T) {
 		source := &stubSource{nextInfo: expectedInfo, nextTxs: expectedTxs}
 		oracle := newFetchingOracle(t, source)
 
-		info, txs := oracle.TransactionsByHash(expectedInfo.Hash())
+		info, txs := oracle.TransactionsByBlockHash(expectedInfo.Hash())
 		require.Equal(t, expectedInfo, info)
 		require.Equal(t, expectedTxs, txs)
 	})
@@ -70,7 +70,7 @@ func TestTransactionsByHash(t *testing.T) {
 		oracle := newFetchingOracle(t, &stubSource{})
 		hash := common.HexToHash("0x4455")
 		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
-			oracle.TransactionsByHash(hash)
+			oracle.TransactionsByBlockHash(hash)
 		})
 	})
 
@@ -78,7 +78,7 @@ func TestTransactionsByHash(t *testing.T) {
 		oracle := newFetchingOracle(t, &stubSource{nextInfo: &sources.HeaderInfo{}})
 		hash := common.HexToHash("0x4455")
 		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
-			oracle.TransactionsByHash(hash)
+			oracle.TransactionsByBlockHash(hash)
 		})
 	})
 
@@ -89,7 +89,7 @@ func TestTransactionsByHash(t *testing.T) {
 
 		hash := common.HexToHash("0x8888")
 		require.PanicsWithError(t, fmt.Errorf("retrieve transactions for block %s: %w", hash, err).Error(), func() {
-			oracle.TransactionsByHash(hash)
+			oracle.TransactionsByBlockHash(hash)
 		})
 	})
 }
@@ -103,7 +103,7 @@ func TestReceiptsByHash(t *testing.T) {
 		source := &stubSource{nextInfo: expectedInfo, nextRcpts: expectedRcpts}
 		oracle := newFetchingOracle(t, source)
 
-		info, rcpts := oracle.ReceiptsByHash(expectedInfo.Hash())
+		info, rcpts := oracle.ReceiptsByBlockHash(expectedInfo.Hash())
 		require.Equal(t, expectedInfo, info)
 		require.Equal(t, expectedRcpts, rcpts)
 	})
@@ -112,7 +112,7 @@ func TestReceiptsByHash(t *testing.T) {
 		oracle := newFetchingOracle(t, &stubSource{})
 		hash := common.HexToHash("0x4455")
 		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
-			oracle.ReceiptsByHash(hash)
+			oracle.ReceiptsByBlockHash(hash)
 		})
 	})
 
@@ -120,7 +120,7 @@ func TestReceiptsByHash(t *testing.T) {
 		oracle := newFetchingOracle(t, &stubSource{nextInfo: &sources.HeaderInfo{}})
 		hash := common.HexToHash("0x4455")
 		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
-			oracle.ReceiptsByHash(hash)
+			oracle.ReceiptsByBlockHash(hash)
 		})
 	})
 
@@ -131,7 +131,7 @@ func TestReceiptsByHash(t *testing.T) {
 
 		hash := common.HexToHash("0x8888")
 		require.PanicsWithError(t, fmt.Errorf("retrieve receipts for block %s: %w", hash, err).Error(), func() {
-			oracle.ReceiptsByHash(hash)
+			oracle.ReceiptsByBlockHash(hash)
 		})
 	})
 }

--- a/op-program/host/l1/fetcher_test.go
+++ b/op-program/host/l1/fetcher_test.go
@@ -1,0 +1,161 @@
+package l1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/sources"
+	cll1 "github.com/ethereum-optimism/optimism/op-program/client/l1"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Needs to implement the Oracle interface
+var _ cll1.Oracle = (*FetchingL1Oracle)(nil)
+
+// Want to be able to use an L1Client as the data source
+var _ Source = (*sources.L1Client)(nil)
+
+func TestHeaderByHash(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		expected := &sources.HeaderInfo{}
+		source := &stubSource{nextInfo: expected}
+		oracle := newFetchingOracle(source)
+
+		actual := oracle.HeaderByHash(expected.Hash())
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("UnknownBlock", func(t *testing.T) {
+		oracle := newFetchingOracle(&stubSource{})
+		hash := common.HexToHash("0x4455")
+		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
+			oracle.HeaderByHash(hash)
+		})
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		err := errors.New("kaboom")
+		source := &stubSource{nextErr: err}
+		oracle := newFetchingOracle(source)
+
+		hash := common.HexToHash("0x8888")
+		require.PanicsWithError(t, fmt.Errorf("retrieve block %s: %w", hash, err).Error(), func() {
+			oracle.HeaderByHash(hash)
+		})
+	})
+}
+
+func TestTransactionsByHash(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		expectedInfo := &sources.HeaderInfo{}
+		expectedTxs := types.Transactions{
+			&types.Transaction{},
+		}
+		source := &stubSource{nextInfo: expectedInfo, nextTxs: expectedTxs}
+		oracle := newFetchingOracle(source)
+
+		info, txs := oracle.TransactionsByHash(expectedInfo.Hash())
+		require.Equal(t, expectedInfo, info)
+		require.Equal(t, expectedTxs, txs)
+	})
+
+	t.Run("UnknownBlock_NoInfo", func(t *testing.T) {
+		oracle := newFetchingOracle(&stubSource{})
+		hash := common.HexToHash("0x4455")
+		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
+			oracle.TransactionsByHash(hash)
+		})
+	})
+
+	t.Run("UnknownBlock_NoTxs", func(t *testing.T) {
+		oracle := newFetchingOracle(&stubSource{nextInfo: &sources.HeaderInfo{}})
+		hash := common.HexToHash("0x4455")
+		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
+			oracle.TransactionsByHash(hash)
+		})
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		err := errors.New("kaboom")
+		source := &stubSource{nextErr: err}
+		oracle := newFetchingOracle(source)
+
+		hash := common.HexToHash("0x8888")
+		require.PanicsWithError(t, fmt.Errorf("retrieve transactions for block %s: %w", hash, err).Error(), func() {
+			oracle.TransactionsByHash(hash)
+		})
+	})
+}
+
+func TestReceiptsByHash(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		expectedInfo := &sources.HeaderInfo{}
+		expectedRcpts := types.Receipts{
+			&types.Receipt{},
+		}
+		source := &stubSource{nextInfo: expectedInfo, nextRcpts: expectedRcpts}
+		oracle := newFetchingOracle(source)
+
+		info, rcpts := oracle.ReceiptsByHash(expectedInfo.Hash())
+		require.Equal(t, expectedInfo, info)
+		require.Equal(t, expectedRcpts, rcpts)
+	})
+
+	t.Run("UnknownBlock_NoInfo", func(t *testing.T) {
+		oracle := newFetchingOracle(&stubSource{})
+		hash := common.HexToHash("0x4455")
+		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
+			oracle.ReceiptsByHash(hash)
+		})
+	})
+
+	t.Run("UnknownBlock_NoTxs", func(t *testing.T) {
+		oracle := newFetchingOracle(&stubSource{nextInfo: &sources.HeaderInfo{}})
+		hash := common.HexToHash("0x4455")
+		require.PanicsWithError(t, fmt.Errorf("unknown block: %s", hash).Error(), func() {
+			oracle.ReceiptsByHash(hash)
+		})
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		err := errors.New("kaboom")
+		source := &stubSource{nextErr: err}
+		oracle := newFetchingOracle(source)
+
+		hash := common.HexToHash("0x8888")
+		require.PanicsWithError(t, fmt.Errorf("retrieve receipts for block %s: %w", hash, err).Error(), func() {
+			oracle.ReceiptsByHash(hash)
+		})
+	})
+}
+
+func newFetchingOracle(source Source) *FetchingL1Oracle {
+	return &FetchingL1Oracle{
+		ctx:    context.Background(),
+		source: source,
+	}
+}
+
+type stubSource struct {
+	nextInfo  eth.BlockInfo
+	nextTxs   types.Transactions
+	nextRcpts types.Receipts
+	nextErr   error
+}
+
+func (s stubSource) InfoByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, error) {
+	return s.nextInfo, s.nextErr
+}
+
+func (s stubSource) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	return s.nextInfo, s.nextTxs, s.nextErr
+}
+
+func (s stubSource) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	return s.nextInfo, s.nextRcpts, s.nextErr
+}

--- a/op-program/host/l1/l1.go
+++ b/op-program/host/l1/l1.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
+	cll1 "github.com/ethereum-optimism/optimism/op-program/client/l1"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -16,5 +17,10 @@ func NewFetchingL1(ctx context.Context, logger log.Logger, cfg *config.Config) (
 		return nil, err
 	}
 
-	return sources.NewL1Client(rpc, logger, nil, sources.L1ClientDefaultConfig(cfg.Rollup, cfg.L1TrustRPC, cfg.L1RPCKind))
+	source, err := sources.NewL1Client(rpc, logger, nil, sources.L1ClientDefaultConfig(cfg.Rollup, cfg.L1TrustRPC, cfg.L1RPCKind))
+	if err != nil {
+		return nil, err
+	}
+	oracle := NewFetchingL1Oracle(ctx, logger, source)
+	return cll1.NewOracleL1Client(logger, oracle, cfg.L1Head), err
 }


### PR DESCRIPTION
**Description**

Provides an implementation of `derive.L1Fetcher` that uses data from the L1 oracle interface. Currently the only implementation of this fetches information from an L1 node but it's now done in a way that could be replaced with a pre-populated oracle for offline replay.

Adds the `--l1.head` CLI arg to the host program which sets the head block for L1 that the derivation pipeline stops processing at. This allows the fault proof program to process up to a specific "safe" L2 block rather than continuing processing until the latest L1 chain head.

**Tests**

Lots of unit tests.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3745/fetching-l1-oracle
- Fixes https://linear.app/optimism/issue/CLI-3746/oracle-backed-l1-fetcher