### PR TITLE
op-node: add support for a dynamic sequencer

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -61,7 +61,7 @@ def main():
         addresses = read_json(addresses_json_path)
     else:
         log.info('Deploying contracts.')
-        run_command(['yarn', 'hardhat', '--network', 'devnetL1', 'deploy', '--tags', 'l1'], env={
+        run_command(['yarn', 'hardhat', '--network', 'devnetL1', 'deploy', '--tags', 'l1', '--reset'], env={
             'CHAIN_ID': '900',
             'L1_RPC': 'http://localhost:8545',
             'PRIVATE_KEY_DEPLOYER': 'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'

--- a/op-e2e/migration_test.go
+++ b/op-e2e/migration_test.go
@@ -269,6 +269,8 @@ func TestMigration(t *testing.T) {
 	// Don't log state snapshots in test output
 	snapLog := log.New()
 	snapLog.SetHandler(log.DiscardHandler())
+	signer, err := p2p.NewLocalSigner(secrets.SequencerP2P)
+	require.NoError(t, err)
 	rollupNodeConfig := &node.Config{
 		L1: &node.L1EndpointConfig{
 			L1NodeAddr:       forkedL1URL,
@@ -311,7 +313,7 @@ func TestMigration(t *testing.T) {
 			DepositContractAddress: portal.Address,
 			L1SystemConfigAddress:  sysConfig.Address,
 		},
-		P2PSigner: &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(secrets.SequencerP2P)},
+		P2PSigner: &p2p.PreparedSigner{Signer: signer},
 		RPC: node.RPCConfig{
 			ListenAddr:  "127.0.0.1",
 			ListenPort:  0,

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -543,6 +543,7 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 			return nil, err
 		}
 		sys.RollupNodes[name] = node
+		cfg.Nodes[name] = &c
 
 		if action, ok := opts.Get("afterRollupNodeStart", name); ok {
 			action(&cfg, sys)

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -522,7 +522,11 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 			c.P2P = p
 
 			if c.Driver.SequencerEnabled && c.P2PSigner == nil {
-				c.P2PSigner = &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(cfg.Secrets.SequencerP2P)}
+				signer, err := p2p.NewLocalSigner(cfg.Secrets.SequencerP2P)
+				if err != nil {
+					return nil, fmt.Errorf("failed to prepare new local signer: %w", err)
+				}
+				c.P2PSigner = &p2p.PreparedSigner{Signer: signer}
 			}
 		}
 

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1647,9 +1647,9 @@ func TestStopStartBatcher(t *testing.T) {
 	require.Greater(t, newSeqStatus.SafeL2.Number, seqStatus.SafeL2.Number, "Safe chain did not advance after batcher was restarted")
 }
 
-// TestChangeSequencer tests that nodes react properly to a change of the system's sequencer. The initial sequecer stops when it becomes
+// TestDynamicSequencing tests that nodes react properly to a change of the system's sequencer. The initial sequecer stops when it becomes
 // aware that the system's sequencer has changed, and the new sequencer starts sequencing as soon as it becomes aware it is selected.
-func TestChangeSequencer(t *testing.T) {
+func TestDynamicSequencing(t *testing.T) {
 	parallel(t)
 
 	if !verboseGethNodes {
@@ -1661,6 +1661,10 @@ func TestChangeSequencer(t *testing.T) {
 	// Create signer for verifier using Mallory's private key
 	signerVerifier, err := p2p.NewLocalSigner(cfg.Secrets.Mallory)
 	require.Nil(t, err, "Error creating a signer for verifier")
+
+	// Enable dynamic sequencing on the sequencer and verifier
+	cfg.Nodes["sequencer"].Driver.SequencerDynamic = true
+	cfg.Nodes["verifier"].Driver.SequencerDynamic = true
 
 	// Enable sequencing on the verifier
 	cfg.Nodes["verifier"] = &rollupNode.Config{

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1687,7 +1687,7 @@ func TestChangeSequencer(t *testing.T) {
 
 	l1Client := sys.Clients["l1"]
 
-	// We give time for the node's driver to receive and process the L1 head to update the nodes' sequencing state appropiately
+	// We give time for the nodes' drivers to receive and process the L1 head and update their respective sequencing states
 	time.Sleep(time.Duration(cfg.DeployConfig.L1BlockTime+1) * time.Second)
 
 	// Check if Sequencer's sequencer is running
@@ -1718,6 +1718,9 @@ func TestChangeSequencer(t *testing.T) {
 	receipt, err := waitForTransaction(tx.Hash(), l1Client, txTimeoutDuration)
 	require.Nil(t, err, "waiting for sysconfig set unsafe block signer tx")
 	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful, "transaction failed")
+
+	// We give time for the nodes' drivers to receive and process the L1 head and update their respective sequencing states
+	time.Sleep(time.Duration(cfg.DeployConfig.L1BlockTime+1) * time.Second)
 
 	// Check if Sequencer's sequencer has stopped
 	require.True(t, sys.cfg.Nodes["sequencer"].Driver.SequencerStopped, "Sequencer's sequencer shouldn't be running")

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -132,6 +132,11 @@ var (
 		Required: false,
 		Value:    4,
 	}
+	SequencerDynamicFlag = cli.BoolFlag{
+		Name:   "sequencer.dynamic",
+		Usage:  "Automatically start/stop sequencing based on changes to the system sequencer",
+		EnvVar: prefixEnvVar("SEQUENCER_DYNAMIC"),
+	}
 	L1EpochPollIntervalFlag = cli.DurationFlag{
 		Name:     "l1.epoch-poll-interval",
 		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
@@ -230,6 +235,7 @@ var optionalFlags = []cli.Flag{
 	SequencerStoppedFlag,
 	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
+	SequencerDynamicFlag,
 	L1EpochPollIntervalFlag,
 	RPCEnableAdmin,
 	MetricsEnabledFlag,

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -384,6 +384,13 @@ func (n *OpNode) RequestL2Range(ctx context.Context, start, end eth.L2BlockRef) 
 	return nil
 }
 
+func (n *OpNode) P2PSignerAddress() (string, error) {
+	if n.p2pSigner == nil {
+		return "", errors.New("missing p2p signer, cannot get address")
+	}
+	return n.p2pSigner.Address(), nil
+}
+
 func (n *OpNode) P2P() p2p.Node {
 	return n.p2pNode
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -199,7 +199,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics)
+	n.l2Driver = driver.NewDriver(&cfg.Driver, n.runCfg, &cfg.Rollup, n.l2Source, n.l1Source, n, n, n.log, snapshotLog, n.metrics)
 
 	return nil
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -384,9 +385,9 @@ func (n *OpNode) RequestL2Range(ctx context.Context, start, end eth.L2BlockRef) 
 	return nil
 }
 
-func (n *OpNode) P2PSignerAddress() (string, error) {
+func (n *OpNode) P2PSignerAddress() (*common.Address, error) {
 	if n.p2pSigner == nil {
-		return "", errors.New("missing p2p signer, cannot get address")
+		return nil, errors.New("missing p2p signer, cannot get address")
 	}
 	return n.p2pSigner.Address(), nil
 }

--- a/op-node/node/runtime_config.go
+++ b/op-node/node/runtime_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 )
 
 var (
@@ -48,6 +49,7 @@ type runtimeConfigData struct {
 }
 
 var _ p2p.GossipRuntimeConfig = (*RuntimeConfig)(nil)
+var _ driver.DriverRuntimeConfig = (*RuntimeConfig)(nil)
 
 func NewRuntimeConfig(log log.Logger, l1Client RuntimeCfgL1Source, rollupCfg *rollup.Config) *RuntimeConfig {
 	return &RuntimeConfig{

--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -24,7 +24,12 @@ func LoadSignerSetup(ctx *cli.Context) (p2p.SignerSetup, error) {
 			return nil, fmt.Errorf("failed to read batch submitter key: %w", err)
 		}
 
-		return &p2p.PreparedSigner{Signer: p2p.NewLocalSigner(priv)}, nil
+		localSigner, err := p2p.NewLocalSigner(priv)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare new local signer: %w", err)
+		}
+
+		return &p2p.PreparedSigner{Signer: localSigner}, nil
 	}
 
 	// TODO: create remote signer

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -52,7 +52,9 @@ func TestVerifyBlockSignature(t *testing.T) {
 
 	t.Run("Valid", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: crypto.PubkeyToAddress(secrets.SequencerP2P.PublicKey)}
-		signer := &PreparedSigner{Signer: NewLocalSigner(secrets.SequencerP2P)}
+		localSigner, err := NewLocalSigner(secrets.SequencerP2P)
+		require.NoError(t, err)
+		signer := &PreparedSigner{Signer: localSigner}
 		sig, err := signer.Sign(context.Background(), SigningDomainBlocksV1, cfg.L2ChainID, msg)
 		require.NoError(t, err)
 		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig[:65], msg)
@@ -61,7 +63,9 @@ func TestVerifyBlockSignature(t *testing.T) {
 
 	t.Run("WrongSigner", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{P2PSeqAddress: common.HexToAddress("0x1234")}
-		signer := &PreparedSigner{Signer: NewLocalSigner(secrets.SequencerP2P)}
+		localSigner, err := NewLocalSigner(secrets.SequencerP2P)
+		require.NoError(t, err)
+		signer := &PreparedSigner{Signer: localSigner}
 		sig, err := signer.Sign(context.Background(), SigningDomainBlocksV1, cfg.L2ChainID, msg)
 		require.NoError(t, err)
 		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig[:65], msg)
@@ -77,7 +81,9 @@ func TestVerifyBlockSignature(t *testing.T) {
 
 	t.Run("NoSequencer", func(t *testing.T) {
 		runCfg := &testutils.MockRuntimeConfig{}
-		signer := &PreparedSigner{Signer: NewLocalSigner(secrets.SequencerP2P)}
+		localSigner, err := NewLocalSigner(secrets.SequencerP2P)
+		require.NoError(t, err)
+		signer := &PreparedSigner{Signer: localSigner}
 		sig, err := signer.Sign(context.Background(), SigningDomainBlocksV1, cfg.L2ChainID, msg)
 		require.NoError(t, err)
 		result := verifyBlockSignature(logger, cfg, runCfg, peerId, sig[:65], msg)

--- a/op-node/p2p/signer.go
+++ b/op-node/p2p/signer.go
@@ -18,7 +18,7 @@ var SigningDomainBlocksV1 = [32]byte{}
 type Signer interface {
 	Sign(ctx context.Context, domain [32]byte, chainID *big.Int, encodedMsg []byte) (sig *[65]byte, err error)
 	io.Closer
-	Address() string
+	Address() *common.Address
 }
 
 func SigningHash(domain [32]byte, chainID *big.Int, payloadBytes []byte) (common.Hash, error) {
@@ -42,12 +42,12 @@ func BlockSigningHash(cfg *rollup.Config, payloadBytes []byte) (common.Hash, err
 
 // LocalSigner is suitable for testing
 type LocalSigner struct {
-	address string
+	address *common.Address
 	priv    *ecdsa.PrivateKey
 	hasher  func(domain [32]byte, chainID *big.Int, payloadBytes []byte) (common.Hash, error)
 }
 
-func (s *LocalSigner) Address() string {
+func (s *LocalSigner) Address() *common.Address {
 	return s.address
 }
 
@@ -58,9 +58,9 @@ func NewLocalSigner(priv *ecdsa.PrivateKey) (*LocalSigner, error) {
 	if !ok {
 		return nil, errors.New("can't get local signer's address")
 	}
-	address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
+	address := crypto.PubkeyToAddress(*publicKeyECDSA)
 
-	return &LocalSigner{address: address, priv: priv, hasher: SigningHash}, nil
+	return &LocalSigner{address: &address, priv: priv, hasher: SigningHash}, nil
 }
 
 func (s *LocalSigner) Sign(ctx context.Context, domain [32]byte, chainID *big.Int, encodedMsg []byte) (sig *[65]byte, err error) {
@@ -79,7 +79,7 @@ func (s *LocalSigner) Sign(ctx context.Context, domain [32]byte, chainID *big.In
 }
 
 func (s *LocalSigner) Close() error {
-	s.address = ""
+	s.address = nil
 	s.priv = nil
 	return nil
 }

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,7 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// SequencerDynamic is true when the driver should automatically start/stop sequencing based on changes to the system sequencer.
+	SequencerDynamic bool `json:"sequencer_dynamic"`
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -102,7 +102,7 @@ type AltSync interface {
 }
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
-func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
+func NewDriver(driverCfg *Config, runCfg DriverRuntimeConfig, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics) *Driver {
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
 	findL1Origin := NewL1OriginSelector(log, cfg, sequencerConfDepth)
@@ -122,6 +122,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 		stopSequencer:    make(chan chan hashAndError, 10),
 		config:           cfg,
 		driverConfig:     driverCfg,
+		driverRunConfig:  runCfg,
 		done:             make(chan struct{}),
 		log:              log,
 		snapshotLog:      snapshotLog,

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -81,7 +81,7 @@ type Network interface {
 	// PublishL2Payload is called by the driver whenever there is a new payload to publish, synchronously with the driver main loop.
 	PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayload) error
 	// P2PSignerAddress returns the address of the P2P signer, if any. This is used to determine if the node is a sequencer.
-	P2PSignerAddress() (string, error)
+	P2PSignerAddress() (*common.Address, error)
 }
 
 type AltSync interface {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -80,6 +80,8 @@ type SequencerIface interface {
 type Network interface {
 	// PublishL2Payload is called by the driver whenever there is a new payload to publish, synchronously with the driver main loop.
 	PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayload) error
+	// P2PSignerAddress returns the address of the P2P signer, if any. This is used to determine if the node is a sequencer.
+	P2PSignerAddress() (string, error)
 }
 
 type AltSync interface {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -285,22 +285,22 @@ func (s *Driver) eventLoop() {
 			// We update the runtime config following the new L1 head
 			err := s.driverRunConfig.Load(ctx, newL1Head)
 			if err != nil {
-				s.log.Error("Critical error loading the runtime config", "err", err)
+				s.log.Error("Critical error while loading the runtime config", "err", err)
 				return
 			}
 			// Now we check if the sequencer has to be started or stopped. This is determined
 			// by comparing the network's p2p signer to the system's sequencer.
 			if !s.driverConfig.SequencerEnabled {
-				s.log.Info("Skipping sequencer update", "reason", "sequencing is disabled")
+				s.log.Info("Skipping sequencer check", "reason", "sequencing is disabled")
 			} else {
 				// We get the network's p2p signer address
 				signerAddress, err := s.network.P2PSignerAddress()
 				if err != nil {
-					s.log.Warn("Skipping sequencer update", "reason", err)
+					s.log.Warn("Skipping sequencer check", "reason", err)
 				} else {
 					// The sequencer is started if the network's p2p signer address is the same as the system's sequencer
 					// address. The sequencer is stopped if the signer's address isn't the system's sequencer's.
-					s.log.Debug("Checking if we need to update the sequencer state...")
+					s.log.Debug("Checking if we need to start/stop sequencer...")
 					l2_unsafe := s.derivation.UnsafeL2Head().Hash
 					// We get the system sequencer address from the updated runtime config
 					sequencerAddress := s.driverRunConfig.P2PSequencerAddress()
@@ -314,7 +314,7 @@ func (s *Driver) eventLoop() {
 						s.log.Info("Sequencer has been stopped", "l2_unsafe", l2_unsafe.Hex(), "reason", "not recognized as sequencer by the system")
 						s.driverConfig.SequencerStopped = true
 					} else {
-						s.log.Debug("No changes made. Sequencer state is up to date")
+						s.log.Debug("No changes made to sequencer mode", "reason", "sequencer is already in the correct state")
 					}
 				}
 			}

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -26,6 +26,7 @@ type SyncStatus = eth.SyncStatus
 const sealingDuration = time.Millisecond * 50
 
 type DriverRuntimeConfig interface {
+	Load(ctx context.Context, l1Ref eth.L1BlockRef) error
 }
 
 type Driver struct {
@@ -280,6 +281,7 @@ func (s *Driver) eventLoop() {
 
 		case newL1Head := <-s.l1HeadSig:
 			s.l1State.HandleNewL1HeadBlock(newL1Head)
+			s.driverRunConfig.Load(ctx, newL1Head)
 			reqStep() // a new L1 head may mean we have the data to not get an EOF again.
 		case newL1Safe := <-s.l1SafeSig:
 			s.l1State.HandleNewL1SafeBlock(newL1Safe)

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -283,7 +283,11 @@ func (s *Driver) eventLoop() {
 		case newL1Head := <-s.l1HeadSig:
 			s.l1State.HandleNewL1HeadBlock(newL1Head)
 			// We update the runtime config following the new L1 head
-			s.driverRunConfig.Load(ctx, newL1Head)
+			err := s.driverRunConfig.Load(ctx, newL1Head)
+			if err != nil {
+				s.log.Error("Critical error loading the runtime config", "err", err)
+				return
+			}
 			// Now we check if the sequencer has to be started or stopped. This is determined
 			// by comparing the network's p2p signer to the system's sequencer.
 			if !s.driverConfig.SequencerEnabled {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -298,8 +298,8 @@ func (s *Driver) eventLoop() {
 					return
 				}
 				// We get the p2p sequencer address from the driver run config, which was updated with Load(...) above with the new L1 data
-				sequencerAddress := s.driverRunConfig.P2PSequencerAddress().String()
-				if signerAddress == sequencerAddress && s.driverConfig.SequencerStopped {
+				sequencerAddress := s.driverRunConfig.P2PSequencerAddress()
+				if *signerAddress == sequencerAddress && s.driverConfig.SequencerStopped {
 					// If the network's p2p signer address matches that of the sequencer, we ensure that the the sequencer is not currently stopped
 					s.log.Warn("Recognized as sequencer by the system.")
 					h := hashAndErrorChannel{
@@ -307,7 +307,7 @@ func (s *Driver) eventLoop() {
 						err:  make(chan error, 1),
 					}
 					s.startSequencer <- h
-				} else if signerAddress != sequencerAddress && !s.driverConfig.SequencerStopped {
+				} else if *signerAddress != sequencerAddress && !s.driverConfig.SequencerStopped {
 					// If the p2p signer address doesn't match that of the sequencer, we ensure that the the sequencer is currently stopped
 					s.log.Warn("Not recognized as sequencer by the system.")
 					respCh := make(chan hashAndError, 1)

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -25,6 +25,9 @@ type SyncStatus = eth.SyncStatus
 // sealingDuration defines the expected time it takes to seal the block
 const sealingDuration = time.Millisecond * 50
 
+type DriverRuntimeConfig interface {
+}
+
 type Driver struct {
 	l1State L1StateIface
 
@@ -52,6 +55,9 @@ type Driver struct {
 
 	// Driver config: verifier and sequencer settings
 	driverConfig *Config
+
+	// Driver runtime config: runtime configuration
+	driverRunConfig DriverRuntimeConfig
 
 	// L1 Signals:
 	//

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -418,6 +418,10 @@ func (s *Driver) StopSequencer(ctx context.Context) (common.Hash, error) {
 	}
 }
 
+func (s *Driver) SequencerStopped() bool {
+	return s.driverConfig.SequencerStopped
+}
+
 // syncStatus returns the current sync status, and should only be called synchronously with
 // the driver event loop to avoid retrieval of an inconsistent status.
 func (s *Driver) syncStatus() *eth.SyncStatus {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -150,6 +150,7 @@ func NewDriverConfig(ctx *cli.Context) *driver.Config {
 		SequencerEnabled:    ctx.GlobalBool(flags.SequencerEnabledFlag.Name),
 		SequencerStopped:    ctx.GlobalBool(flags.SequencerStoppedFlag.Name),
 		SequencerMaxSafeLag: ctx.GlobalUint64(flags.SequencerMaxSafeLagFlag.Name),
+		SequencerDynamic:    ctx.GlobalBool(flags.SequencerDynamicFlag.Name),
 	}
 }
 


### PR DESCRIPTION
### Description

This pull request introduces changes enabling the op-node to work with a dynamic system sequencer, improving network fault tolerance and flexibility. This ensures continuous transaction processing during sequencer changes. The update also enables a rotating sequencer system to be implemented by merely changing the block signer's address in the SystemConfig smart contract, facilitating a straightforward sequencer decentralization mechanism. 

Note that a node dynamically reacting to changes of the system's sequencer is optional and enabled or disabled using a new flag of op-node, `sequencer.dynamic.` Currently this behavior is disabled by default.

### Key changes

1. **Update runtime configuration at new L1 heads** 
> The driver now updates the node's runtime configuration at every new L1 head processed, allowing to node to have access to the latest sequencer address of the system. This information is then used to determine which gossip to ignore and, if the node has dynamic sequencing enabled, whether sequencing should be stopped if the node is no longer the system sequencer (and vice-versa). Note that updating the runtime config after the initial loading (specifically at updates for every subsequent L1 block) was mentioned in comments in the code but was missing implementation.
2. **Expose P2P signer address** 
> The node can now access its P2P signer's address during runtime, allowing it to determine if it is the system's sequencer.
3. **Introduce dynamic sequencing** 
> If it has dynamic sequencing enabled, a node can automatically start sequencing if it is the system sequencer and stop if it isn't. This new mechanism ensures that sequencing is stopped if the system's sequencer does not match the node's p2p signer and ensures that sequencing is started if they match (in other words, if the node is the sequencer)
4. **Minor bug fixes:** 
> Devnet contracts deployment command includes a reset flag to avoid a potential error in deploy step 19, and op-e2e's system config was amended to include missing pointers to rollupNodes configs. Line breaks were also introduced in specs/deposits.md to fix lint errors.

### Tests

A new test evaluating how nodes react to changes of the system sequencer was introduced. This test verifies that a node selected as the sequencer gracefully stops when the system sequencer changes and that the node picked by the system automatically starts sequencing.

No further tests are needed since the existing tests of the op-node API cover the start/stop sequencer logic.

Enjoy

![maxresdefault](https://user-images.githubusercontent.com/105765223/231307897-ff0977ab-b2bc-4b37-b0be-c6e0237c2f31.jpg)
