### PR TITLE
op-program: Fix l2 engine API to avoid fetching L2 blocks after the agreed head

### DIFF
--- a/op-e2e/actions/l2_engine_test.go
+++ b/op-e2e/actions/l2_engine_test.go
@@ -191,7 +191,7 @@ func TestL2EngineAPIFail(gt *testing.T) {
 }
 
 func TestEngineAPITests(t *testing.T) {
-	test.RunEngineAPITests(t, func() engineapi.EngineBackend {
+	test.RunEngineAPITests(t, func(t *testing.T) engineapi.EngineBackend {
 		jwtPath := e2eutils.WriteDefaultJWT(t)
 		dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 		sd := e2eutils.Setup(t, dp, defaultAlloc)

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -301,7 +301,7 @@ func (ea *L2EngineAPI) NewPayloadV1(ctx context.Context, payload *eth.ExecutionP
 	}
 	// If we already have the block locally, ignore the entire execution and just
 	// return a fake success.
-	if block := ea.backend.GetBlockByHash(payload.BlockHash); block != nil {
+	if block := ea.backend.GetBlock(payload.BlockHash, uint64(payload.BlockNumber)); block != nil {
 		ea.log.Warn("Ignoring already known beacon payload", "number", payload.BlockNumber, "hash", payload.BlockHash, "age", common.PrettyAge(time.Unix(int64(block.Time()), 0)))
 		hash := block.Hash()
 		return &eth.PayloadStatusV1{Status: eth.ExecutionValid, LatestValidHash: &hash}, nil

--- a/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
+++ b/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
@@ -18,7 +18,7 @@ import (
 var gasLimit = eth.Uint64Quantity(30_000_000)
 var feeRecipient = common.Address{}
 
-func RunEngineAPITests(t *testing.T, createBackend func() engineapi.EngineBackend) {
+func RunEngineAPITests(t *testing.T, createBackend func(t *testing.T) engineapi.EngineBackend) {
 	t.Run("CreateBlock", func(t *testing.T) {
 		api := newTestHelper(t, createBackend)
 
@@ -292,10 +292,10 @@ type testHelper struct {
 	assert  *require.Assertions
 }
 
-func newTestHelper(t *testing.T, createBackend func() engineapi.EngineBackend) *testHelper {
+func newTestHelper(t *testing.T, createBackend func(t *testing.T) engineapi.EngineBackend) *testHelper {
 	logger := testlog.Logger(t, log.LvlDebug)
 	ctx := context.Background()
-	backend := createBackend()
+	backend := createBackend(t)
 	api := engineapi.NewL2EngineAPI(logger, backend)
 	test := &testHelper{
 		t:       t,

--- a/op-program/host/l2/l2.go
+++ b/op-program/host/l2/l2.go
@@ -19,7 +19,7 @@ func NewFetchingEngine(ctx context.Context, logger log.Logger, cfg *config.Confi
 	if err != nil {
 		return nil, err
 	}
-	oracle, err := NewFetchingL2Oracle(ctx, logger, cfg.L2URL)
+	oracle, err := NewFetchingL2Oracle(ctx, logger, cfg.L2URL, cfg.L2Head)
 	if err != nil {
 		return nil, fmt.Errorf("connect l2 oracle: %w", err)
 	}


### PR DESCRIPTION
**Description**

As part of importing new blocks, the engine-api checks to see if the block has already been imported. The FPP L2 code needs to ensure this doesn't trigger a request to the oracle for that block. In fetching mode that will cause it to fetch a block beyond the agreed chain head and skip execution of the block and in replay mode it will result in a panic because the block data isn't (or shouldn't be) available.

Updated the engine API to request the existing block by hash and number and the oracle backend then avoids requesting the block from the oracle if it is above the agreed l2 head starting point.

Since unknown blocks can't be requested (the oracle would panic), removed that test and a few nil checks that are no longer relevant.

Finally, updated the l2 fetcher so that it checks each block it requests and panics if it is above the agreed L2 head. This provides additional safety to avoid unexpectedly populating the oracle with data beyond the agreed point.  It's still possible that state or code could be populated from beyond the l2 head, but would be much harder to know as you'd normally get the hash to retrieve from the block (eg starting from the state root in the block).

**Tests**

Updated the stub oracle to fail the test if a request is made for an unknown block.


**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3816/limit-l2-fetching-to-historic-blocks
