### PR TITLE
op-node: finalize while syncing

### DIFF
--- a/op-e2e/actions/sync_test.go
+++ b/op-e2e/actions/sync_test.go
@@ -49,3 +49,46 @@ func TestDerivationWithFlakyL1RPC(gt *testing.T) {
 	// Verifier should be synced, even though it hit lots of temporary L1 RPC errors
 	require.Equal(t, sequencer.L2Unsafe(), verifier.L2Safe(), "verifier is synced")
 }
+
+func TestFinalizeWhileSyncing(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+	log := testlog.Logger(t, log.LvlError) // mute all the temporary derivation errors that we forcefully create
+	_, _, miner, sequencer, _, verifier, _, batcher := setupReorgTestActors(t, dp, sd, log)
+
+	sequencer.ActL2PipelineFull(t)
+	verifier.ActL2PipelineFull(t)
+
+	verifierStartStatus := verifier.SyncStatus()
+
+	// Build an L1 chain with 64 + 1 blocks, containing batches of L2 chain.
+	// Enough to go past the finalityDelay of the engine queue,
+	// to make the verifier finalize while it syncs.
+	miner.ActEmptyBlock(t)
+	for i := 0; i < 64+1; i++ {
+		sequencer.ActL1HeadSignal(t)
+		sequencer.ActL2PipelineFull(t)
+		sequencer.ActBuildToL1Head(t)
+		batcher.ActSubmitAll(t)
+		miner.ActL1StartBlock(12)(t)
+		miner.ActL1IncludeTx(batcher.batcherAddr)(t)
+		miner.ActL1EndBlock(t)
+	}
+	l1Head := miner.l1Chain.CurrentHeader()
+	// finalize all of L1
+	miner.ActL1Safe(t, l1Head.Number.Uint64())
+	miner.ActL1Finalize(t, l1Head.Number.Uint64())
+
+	// Now signal L1 finality to the verifier, while the verifier is not synced.
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL1SafeSignal(t)
+	verifier.ActL1FinalizedSignal(t)
+
+	// Now sync the verifier, without repeating the signal.
+	// While it's syncing, it should finalize on interval now, based on the future L1 finalized block it remembered.
+	verifier.ActL2PipelineFull(t)
+
+	// Verify the verifier finalized something new
+	require.Less(t, verifierStartStatus.FinalizedL2.Number, verifier.SyncStatus().FinalizedL2.Number, "verifier finalized L2 blocks during sync")
+}


### PR DESCRIPTION
**Description**

Finalize while syncing. The last finalized L1 signal is now always retained in the engine queue, even if it does not match recently processed L1 blocks (the `finalityData` buffer). When the finalized L1 block is past the current traversed L1 origin, the engine queue will now try to verify it's on the correct chain, and finalize it. It only does so every 64 L1 blocks, based on the last attempt, to avoid frequent repeats and duplicate work.

**Tests**

Added an action test to create a finalized L1 chain, and then make the verifier sync it, and verify it finalizes even after getting a signal for data it didn't traverse to yet at the time of the signal.

**Metadata**

Fix CLI-3794

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
