### PR TITLE
[op-node] Add support for non-batched RPC calls when batchSize == 1

### DIFF
--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -24,6 +24,7 @@ type IterativeBatchCall[K any, V any] struct {
 
 	makeRequest func(K) (V, rpc.BatchElem)
 	getBatch    BatchCallContextFn
+	getSingle   CallContextFn
 
 	requestsValues []V
 	scheduled      chan rpc.BatchElem
@@ -35,6 +36,7 @@ func NewIterativeBatchCall[K any, V any](
 	requestsKeys []K,
 	makeRequest func(K) (V, rpc.BatchElem),
 	getBatch BatchCallContextFn,
+	getSingle CallContextFn,
 	batchSize int) *IterativeBatchCall[K, V] {
 
 	if len(requestsKeys) < batchSize {
@@ -47,6 +49,7 @@ func NewIterativeBatchCall[K any, V any](
 	out := &IterativeBatchCall[K, V]{
 		completed:    0,
 		getBatch:     getBatch,
+		getSingle:    getSingle,
 		requestsKeys: requestsKeys,
 		batchSize:    batchSize,
 		makeRequest:  makeRequest,
@@ -119,11 +122,23 @@ func (ibc *IterativeBatchCall[K, V]) Fetch(ctx context.Context) error {
 		break
 	}
 
-	if err := ibc.getBatch(ctx, batch); err != nil {
-		for _, r := range batch {
-			ibc.scheduled <- r
+	if len(batch) == 0 {
+		return nil
+	}
+
+	if ibc.batchSize == 1 {
+		first := batch[0]
+		if err := ibc.getSingle(ctx, &first.Result, first.Method, first.Args...); err != nil {
+			ibc.scheduled <- first
+			return err
 		}
-		return fmt.Errorf("failed batch-retrieval: %w", err)
+	} else {
+		if err := ibc.getBatch(ctx, batch); err != nil {
+			for _, r := range batch {
+				ibc.scheduled <- r
+			}
+			return fmt.Errorf("failed batch-retrieval: %w", err)
+		}
 	}
 	var result error
 	for _, elem := range batch {

--- a/op-node/sources/batching_test.go
+++ b/op-node/sources/batching_test.go
@@ -34,7 +34,8 @@ type batchTestCase struct {
 
 	batchSize int
 
-	batchCalls []batchCall
+	batchCalls  []batchCall
+	singleCalls []elemCall
 
 	mock.Mock
 }
@@ -53,7 +54,14 @@ func (tc *batchTestCase) GetBatch(ctx context.Context, b []rpc.BatchElem) error 
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	return tc.Mock.MethodCalled("get", b).Get(0).([]error)[0]
+	return tc.Mock.MethodCalled("getBatch", b).Get(0).([]error)[0]
+}
+
+func (tc *batchTestCase) GetSingle(ctx context.Context, result any, method string, args ...any) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return tc.Mock.MethodCalled("getSingle", (*(result.(*interface{}))).(*string), method, args[0]).Get(0).([]error)[0]
 }
 
 var mockErr = errors.New("mockErr")
@@ -64,7 +72,7 @@ func (tc *batchTestCase) Run(t *testing.T) {
 		keys[i] = i
 	}
 
-	makeMock := func(bci int, bc batchCall) func(args mock.Arguments) {
+	makeBatchMock := func(bci int, bc batchCall) func(args mock.Arguments) {
 		return func(args mock.Arguments) {
 			batch := args[0].([]rpc.BatchElem)
 			for i, elem := range batch {
@@ -94,10 +102,30 @@ func (tc *batchTestCase) Run(t *testing.T) {
 			})
 		}
 		if len(bc.elems) > 0 {
-			tc.On("get", batch).Once().Run(makeMock(bci, bc)).Return([]error{bc.rpcErr}) // wrap to preserve nil as type of error
+			tc.On("getBatch", batch).Once().Run(makeBatchMock(bci, bc)).Return([]error{bc.rpcErr}) // wrap to preserve nil as type of error
 		}
 	}
-	iter := NewIterativeBatchCall[int, *string](keys, makeTestRequest, tc.GetBatch, tc.batchSize)
+	makeSingleMock := func(eci int, ec elemCall) func(args mock.Arguments) {
+		return func(args mock.Arguments) {
+			result := args[0].(*string)
+			id := args[2].(int)
+			require.Equal(t, ec.id, id, "element should match expected element")
+			if ec.err {
+				*result = ""
+			} else {
+				*result = fmt.Sprintf("mock result id %d", id)
+			}
+		}
+	}
+	// mock the results of unbatched calls
+	for eci, ec := range tc.singleCalls {
+		var ret error
+		if ec.err {
+			ret = mockErr
+		}
+		tc.On("getSingle", new(string), "testing_foobar", ec.id).Once().Run(makeSingleMock(eci, ec)).Return([]error{ret})
+	}
+	iter := NewIterativeBatchCall[int, *string](keys, makeTestRequest, tc.GetBatch, tc.GetSingle, tc.batchSize)
 	for i, bc := range tc.batchCalls {
 		ctx := context.Background()
 		if bc.makeCtx != nil {
@@ -113,6 +141,20 @@ func (tc *batchTestCase) Run(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.ErrorContains(t, err, bc.err)
+			}
+		}
+	}
+	for i, ec := range tc.singleCalls {
+		ctx := context.Background()
+		err := iter.Fetch(ctx)
+		if err == io.EOF {
+			require.Equal(t, i, len(tc.singleCalls)-1, "EOF only on last call")
+		} else {
+			require.False(t, iter.Complete())
+			if ec.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		}
 	}
@@ -152,6 +194,37 @@ func TestFetchBatched(t *testing.T) {
 					},
 					err: "",
 				},
+			},
+		},
+		{
+			name:      "single element",
+			items:     1,
+			batchSize: 4,
+			singleCalls: []elemCall{
+				{id: 0, err: false},
+			},
+		},
+		{
+			name:      "unbatched",
+			items:     4,
+			batchSize: 1,
+			singleCalls: []elemCall{
+				{id: 0, err: false},
+				{id: 1, err: false},
+				{id: 2, err: false},
+				{id: 3, err: false},
+			},
+		},
+		{
+			name:      "unbatched with retry",
+			items:     4,
+			batchSize: 1,
+			singleCalls: []elemCall{
+				{id: 0, err: false},
+				{id: 1, err: true},
+				{id: 2, err: false},
+				{id: 3, err: false},
+				{id: 1, err: false},
 			},
 		},
 		{
@@ -240,7 +313,7 @@ func TestFetchBatched(t *testing.T) {
 		},
 		{
 			name:      "context timeout",
-			items:     1,
+			items:     2,
 			batchSize: 3,
 			batchCalls: []batchCall{
 				{
@@ -255,6 +328,7 @@ func TestFetchBatched(t *testing.T) {
 				{
 					elems: []elemCall{
 						{id: 0, err: false},
+						{id: 1, err: false},
 					},
 					err: "",
 				},

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -373,6 +373,7 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 			job.txHashes,
 			makeReceiptRequest,
 			job.client.BatchCallContext,
+			job.client.CallContext,
 			job.maxBatchSize,
 		)
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds support to op-node's batching implementation that uses unbatched calls when batchSize == 1, to support nodes that don't support JSON-RPC batching.

An alternative implementation would be to add a new node-provider-specific receipt fetcher that avoids RPC batching. This current PR seems more compatible with other future uses of the batching implementation.

**Tests**

Added new tests.

**Additional context**

Some node providers don't support batched JSON-RPC calls, for example AWS's [managed node offering](https://docs.aws.amazon.com/managed-blockchain/latest/ethereum-dev/ethereum-nodes.html). This PR allows running op-stack nodes using AWS as the L1 node.

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
