### PR TITLE
Revert "[op-node] Add support for non-batched RPC calls when batchSize == 1"

### DIFF
--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -24,7 +24,6 @@ type IterativeBatchCall[K any, V any] struct {
 
 	makeRequest func(K) (V, rpc.BatchElem)
 	getBatch    BatchCallContextFn
-	getSingle   CallContextFn
 
 	requestsValues []V
 	scheduled      chan rpc.BatchElem
@@ -36,7 +35,6 @@ func NewIterativeBatchCall[K any, V any](
 	requestsKeys []K,
 	makeRequest func(K) (V, rpc.BatchElem),
 	getBatch BatchCallContextFn,
-	getSingle CallContextFn,
 	batchSize int) *IterativeBatchCall[K, V] {
 
 	if len(requestsKeys) < batchSize {
@@ -49,7 +47,6 @@ func NewIterativeBatchCall[K any, V any](
 	out := &IterativeBatchCall[K, V]{
 		completed:    0,
 		getBatch:     getBatch,
-		getSingle:    getSingle,
 		requestsKeys: requestsKeys,
 		batchSize:    batchSize,
 		makeRequest:  makeRequest,
@@ -122,23 +119,11 @@ func (ibc *IterativeBatchCall[K, V]) Fetch(ctx context.Context) error {
 		break
 	}
 
-	if len(batch) == 0 {
-		return nil
-	}
-
-	if ibc.batchSize == 1 {
-		first := batch[0]
-		if err := ibc.getSingle(ctx, &first.Result, first.Method, first.Args...); err != nil {
-			ibc.scheduled <- first
-			return err
+	if err := ibc.getBatch(ctx, batch); err != nil {
+		for _, r := range batch {
+			ibc.scheduled <- r
 		}
-	} else {
-		if err := ibc.getBatch(ctx, batch); err != nil {
-			for _, r := range batch {
-				ibc.scheduled <- r
-			}
-			return fmt.Errorf("failed batch-retrieval: %w", err)
-		}
+		return fmt.Errorf("failed batch-retrieval: %w", err)
 	}
 	var result error
 	for _, elem := range batch {

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -373,7 +373,6 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 			job.txHashes,
 			makeReceiptRequest,
 			job.client.BatchCallContext,
-			job.client.CallContext,
 			job.maxBatchSize,
 		)
 	}


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#5426

The change caused CI to fail here: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/16566/workflows/c3c21446-c755-45e1-9ce9-f2914e3bcc7d/jobs/612077/steps

cc @mdehoog 

We'll look into the CI failure, but reverting for now.