### PR TITLE
op-program: Use pointers for receiver types

### DIFF
--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -31,7 +31,7 @@ func NewOracleL1Client(logger log.Logger, oracle Oracle, l1Head common.Hash) *Or
 	}
 }
 
-func (o OracleL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
+func (o *OracleL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
 	if label != eth.Unsafe && label != eth.Safe && label != eth.Finalized {
 		return eth.L1BlockRef{}, fmt.Errorf("%w: %s", ErrUnknownLabel, label)
 	}
@@ -39,7 +39,7 @@ func (o OracleL1Client) L1BlockRefByLabel(ctx context.Context, label eth.BlockLa
 	return o.head, nil
 }
 
-func (o OracleL1Client) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
+func (o *OracleL1Client) L1BlockRefByNumber(ctx context.Context, number uint64) (eth.L1BlockRef, error) {
 	if number > o.head.Number {
 		return eth.L1BlockRef{}, fmt.Errorf("%w: block number %d", ErrNotFound, number)
 	}
@@ -50,20 +50,20 @@ func (o OracleL1Client) L1BlockRefByNumber(ctx context.Context, number uint64) (
 	return block, nil
 }
 
-func (o OracleL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
+func (o *OracleL1Client) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
 	return eth.InfoToL1BlockRef(o.oracle.HeaderByBlockHash(hash)), nil
 }
 
-func (o OracleL1Client) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+func (o *OracleL1Client) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
 	return o.oracle.HeaderByBlockHash(hash), nil
 }
 
-func (o OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+func (o *OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	info, rcpts := o.oracle.ReceiptsByBlockHash(blockHash)
 	return info, rcpts, nil
 }
 
-func (o OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+func (o *OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	info, txs := o.oracle.TransactionsByBlockHash(hash)
 	return info, txs, nil
 }

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -33,19 +33,19 @@ func NewOracleEngine(rollupCfg *rollup.Config, logger log.Logger, backend engine
 	}
 }
 
-func (o OracleEngine) GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayload, error) {
+func (o *OracleEngine) GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayload, error) {
 	return o.api.GetPayloadV1(ctx, payloadId)
 }
 
-func (o OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
+func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	return o.api.ForkchoiceUpdatedV1(ctx, state, attr)
 }
 
-func (o OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
+func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
 	return o.api.NewPayloadV1(ctx, payload)
 }
 
-func (o OracleEngine) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayload, error) {
+func (o *OracleEngine) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayload, error) {
 	block := o.backend.GetBlockByHash(hash)
 	if block == nil {
 		return nil, ErrNotFound
@@ -53,7 +53,7 @@ func (o OracleEngine) PayloadByHash(ctx context.Context, hash common.Hash) (*eth
 	return eth.BlockAsPayload(block)
 }
 
-func (o OracleEngine) PayloadByNumber(ctx context.Context, n uint64) (*eth.ExecutionPayload, error) {
+func (o *OracleEngine) PayloadByNumber(ctx context.Context, n uint64) (*eth.ExecutionPayload, error) {
 	hash := o.backend.GetCanonicalHash(n)
 	if hash == (common.Hash{}) {
 		return nil, ErrNotFound
@@ -61,7 +61,7 @@ func (o OracleEngine) PayloadByNumber(ctx context.Context, n uint64) (*eth.Execu
 	return o.PayloadByHash(ctx, hash)
 }
 
-func (o OracleEngine) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
+func (o *OracleEngine) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
 	var header *types.Header
 	switch label {
 	case eth.Unsafe:
@@ -83,7 +83,7 @@ func (o OracleEngine) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabe
 	return derive.L2BlockToBlockRef(block, &o.rollupCfg.Genesis)
 }
 
-func (o OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
+func (o *OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error) {
 	block := o.backend.GetBlockByHash(l2Hash)
 	if block == nil {
 		return eth.L2BlockRef{}, ErrNotFound
@@ -91,7 +91,7 @@ func (o OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) 
 	return derive.L2BlockToBlockRef(block, &o.rollupCfg.Genesis)
 }
 
-func (o OracleEngine) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
+func (o *OracleEngine) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
 	payload, err := o.PayloadByHash(ctx, hash)
 	if err != nil {
 		return eth.SystemConfig{}, err

--- a/op-program/host/l1/fetcher.go
+++ b/op-program/host/l1/fetcher.go
@@ -30,7 +30,7 @@ func NewFetchingL1Oracle(ctx context.Context, logger log.Logger, source Source) 
 	}
 }
 
-func (o FetchingL1Oracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
+func (o *FetchingL1Oracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
 	o.logger.Trace("HeaderByBlockHash", "hash", blockHash)
 	info, err := o.source.InfoByHash(o.ctx, blockHash)
 	if err != nil {
@@ -42,7 +42,7 @@ func (o FetchingL1Oracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo
 	return info
 }
 
-func (o FetchingL1Oracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+func (o *FetchingL1Oracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
 	o.logger.Trace("TransactionsByBlockHash", "hash", blockHash)
 	info, txs, err := o.source.InfoAndTxsByHash(o.ctx, blockHash)
 	if err != nil {
@@ -54,7 +54,7 @@ func (o FetchingL1Oracle) TransactionsByBlockHash(blockHash common.Hash) (eth.Bl
 	return info, txs
 }
 
-func (o FetchingL1Oracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+func (o *FetchingL1Oracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
 	o.logger.Trace("ReceiptsByBlockHash", "hash", blockHash)
 	info, rcpts, err := o.source.FetchReceipts(o.ctx, blockHash)
 	if err != nil {


### PR DESCRIPTION
**Description**

Given the structs are always used via pointers and contain fields that use points (which are modified), should use pointers for receiver types.
