### PR TITLE
[op-node] Add support for non-batched RPC calls when batchSize == 1 (flaky test fixed)

### DIFF
--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -24,6 +24,7 @@ type IterativeBatchCall[K any, V any] struct {
 
 	makeRequest func(K) (V, rpc.BatchElem)
 	getBatch    BatchCallContextFn
+	getSingle   CallContextFn
 
 	requestsValues []V
 	scheduled      chan rpc.BatchElem
@@ -35,6 +36,7 @@ func NewIterativeBatchCall[K any, V any](
 	requestsKeys []K,
 	makeRequest func(K) (V, rpc.BatchElem),
 	getBatch BatchCallContextFn,
+	getSingle CallContextFn,
 	batchSize int) *IterativeBatchCall[K, V] {
 
 	if len(requestsKeys) < batchSize {
@@ -47,6 +49,7 @@ func NewIterativeBatchCall[K any, V any](
 	out := &IterativeBatchCall[K, V]{
 		completed:    0,
 		getBatch:     getBatch,
+		getSingle:    getSingle,
 		requestsKeys: requestsKeys,
 		batchSize:    batchSize,
 		makeRequest:  makeRequest,
@@ -119,11 +122,23 @@ func (ibc *IterativeBatchCall[K, V]) Fetch(ctx context.Context) error {
 		break
 	}
 
-	if err := ibc.getBatch(ctx, batch); err != nil {
-		for _, r := range batch {
-			ibc.scheduled <- r
+	if len(batch) == 0 {
+		return nil
+	}
+
+	if ibc.batchSize == 1 {
+		first := batch[0]
+		if err := ibc.getSingle(ctx, &first.Result, first.Method, first.Args...); err != nil {
+			ibc.scheduled <- first
+			return err
 		}
-		return fmt.Errorf("failed batch-retrieval: %w", err)
+	} else {
+		if err := ibc.getBatch(ctx, batch); err != nil {
+			for _, r := range batch {
+				ibc.scheduled <- r
+			}
+			return fmt.Errorf("failed batch-retrieval: %w", err)
+		}
 	}
 	var result error
 	for _, elem := range batch {

--- a/op-node/sources/batching.go
+++ b/op-node/sources/batching.go
@@ -87,6 +87,11 @@ func (ibc *IterativeBatchCall[K, V]) Fetch(ctx context.Context) error {
 	ibc.resetLock.RLock()
 	defer ibc.resetLock.RUnlock()
 
+	// return early if context is Done
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// collect a batch from the requests channel
 	batch := make([]rpc.BatchElem, 0, ibc.batchSize)
 	// wait for first element

--- a/op-node/sources/receipts.go
+++ b/op-node/sources/receipts.go
@@ -373,6 +373,7 @@ func (job *receiptsFetchingJob) runFetcher(ctx context.Context) error {
 			job.txHashes,
 			makeReceiptRequest,
 			job.client.BatchCallContext,
+			job.client.CallContext,
 			job.maxBatchSize,
 		)
 	}


### PR DESCRIPTION
Redo of #5426 (reverted in #5430), with a flaky test fix. The test was flaky because there was a chance that the mocked method could be called early if the `select` didn't return due to the context being closed. The fix is to introduce an early check of the `ctx.Err()` to the `Fetch` method: https://github.com/ethereum-optimism/optimism/blob/916513af6e4d708706bcaf0d2d1ba17b03fe9910/op-node/sources/batching.go#L90-L93

Copied previous description below:

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds support to op-node's batching implementation that uses unbatched calls when batchSize == 1, to support nodes that don't support JSON-RPC batching.

An alternative implementation would be to add a new node-provider-specific receipt fetcher that avoids RPC batching. This current PR seems more compatible with other future uses of the batching implementation.

**Tests**

Added new tests.

**Additional context**

Some node providers don't support batched JSON-RPC calls, for example AWS's [managed node offering](https://docs.aws.amazon.com/managed-blockchain/latest/ethereum-dev/ethereum-nodes.html). This PR allows running op-stack nodes using AWS as the L1 node.

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
