### PR TITLE
op-program: Switch L1 Oracle to retrieve *types.Header

### DIFF
--- a/op-program/client/l1/cache_test.go
+++ b/op-program/client/l1/cache_test.go
@@ -15,17 +15,17 @@ func TestCachingOracle_HeaderByBlockHash(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	stub := newStubOracle(t)
 	oracle := NewCachingOracle(stub)
-	block := testutils.RandomBlockInfo(rng)
+	header := testutils.RandomHeader(rng)
 
 	// Initial call retrieves from the stub
-	stub.blocks[block.Hash()] = block
-	result := oracle.HeaderByBlockHash(block.Hash())
-	require.Equal(t, block, result)
+	stub.blocks[header.Hash()] = header
+	result := oracle.HeaderByBlockHash(header.Hash())
+	require.Equal(t, header, result)
 
 	// Later calls should retrieve from cache
-	delete(stub.blocks, block.Hash())
-	result = oracle.HeaderByBlockHash(block.Hash())
-	require.Equal(t, block, result)
+	delete(stub.blocks, header.Hash())
+	result = oracle.HeaderByBlockHash(header.Hash())
+	require.Equal(t, header, result)
 }
 
 func TestCachingOracle_TransactionsByBlockHash(t *testing.T) {
@@ -35,17 +35,17 @@ func TestCachingOracle_TransactionsByBlockHash(t *testing.T) {
 	block, _ := testutils.RandomBlock(rng, 3)
 
 	// Initial call retrieves from the stub
-	stub.blocks[block.Hash()] = block
+	stub.blocks[block.Hash()] = block.Header()
 	stub.txs[block.Hash()] = block.Transactions()
-	actualBlock, actualTxs := oracle.TransactionsByBlockHash(block.Hash())
-	require.Equal(t, block, actualBlock)
+	actualHeader, actualTxs := oracle.TransactionsByBlockHash(block.Hash())
+	require.Equal(t, block.Header(), actualHeader)
 	require.Equal(t, block.Transactions(), actualTxs)
 
 	// Later calls should retrieve from cache
 	delete(stub.blocks, block.Hash())
 	delete(stub.txs, block.Hash())
-	actualBlock, actualTxs = oracle.TransactionsByBlockHash(block.Hash())
-	require.Equal(t, block, actualBlock)
+	actualHeader, actualTxs = oracle.TransactionsByBlockHash(block.Hash())
+	require.Equal(t, block.Header(), actualHeader)
 	require.Equal(t, block.Transactions(), actualTxs)
 }
 
@@ -56,16 +56,16 @@ func TestCachingOracle_ReceiptsByBlockHash(t *testing.T) {
 	block, rcpts := testutils.RandomBlock(rng, 3)
 
 	// Initial call retrieves from the stub
-	stub.blocks[block.Hash()] = block
+	stub.blocks[block.Hash()] = block.Header()
 	stub.rcpts[block.Hash()] = rcpts
-	actualBlock, actualRcpts := oracle.ReceiptsByBlockHash(block.Hash())
-	require.Equal(t, block, actualBlock)
+	actualHeader, actualRcpts := oracle.ReceiptsByBlockHash(block.Hash())
+	require.Equal(t, block.Header(), actualHeader)
 	require.EqualValues(t, rcpts, actualRcpts)
 
 	// Later calls should retrieve from cache
 	delete(stub.blocks, block.Hash())
 	delete(stub.rcpts, block.Hash())
-	actualBlock, actualRcpts = oracle.ReceiptsByBlockHash(block.Hash())
-	require.Equal(t, block, actualBlock)
+	actualHeader, actualRcpts = oracle.ReceiptsByBlockHash(block.Hash())
+	require.Equal(t, block.Header(), actualHeader)
 	require.EqualValues(t, rcpts, actualRcpts)
 }

--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -1,18 +1,17 @@
 package l1
 
 import (
-	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type Oracle interface {
 	// HeaderByBlockHash retrieves the block header with the given hash.
-	HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo
+	HeaderByBlockHash(blockHash common.Hash) *types.Header
 
 	// TransactionsByBlockHash retrieves the transactions from the block with the given hash.
-	TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions)
+	TransactionsByBlockHash(blockHash common.Hash) (*types.Header, types.Transactions)
 
 	// ReceiptsByBlockHash retrieves the receipts from the block with the given hash.
-	ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts)
+	ReceiptsByBlockHash(blockHash common.Hash) (*types.Header, types.Receipts)
 }

--- a/op-program/client/l1/stub_oracle_test.go
+++ b/op-program/client/l1/stub_oracle_test.go
@@ -3,7 +3,6 @@ package l1
 import (
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -12,7 +11,7 @@ type stubOracle struct {
 	t *testing.T
 
 	// blocks maps block hash to eth.BlockInfo
-	blocks map[common.Hash]eth.BlockInfo
+	blocks map[common.Hash]*types.Header
 
 	// txs maps block hash to transactions
 	txs map[common.Hash]types.Transactions
@@ -24,12 +23,12 @@ type stubOracle struct {
 func newStubOracle(t *testing.T) *stubOracle {
 	return &stubOracle{
 		t:      t,
-		blocks: make(map[common.Hash]eth.BlockInfo),
+		blocks: make(map[common.Hash]*types.Header),
 		txs:    make(map[common.Hash]types.Transactions),
 		rcpts:  make(map[common.Hash]types.Receipts),
 	}
 }
-func (o stubOracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
+func (o stubOracle) HeaderByBlockHash(blockHash common.Hash) *types.Header {
 	info, ok := o.blocks[blockHash]
 	if !ok {
 		o.t.Fatalf("unknown block %s", blockHash)
@@ -37,7 +36,7 @@ func (o stubOracle) HeaderByBlockHash(blockHash common.Hash) eth.BlockInfo {
 	return info
 }
 
-func (o stubOracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Transactions) {
+func (o stubOracle) TransactionsByBlockHash(blockHash common.Hash) (*types.Header, types.Transactions) {
 	txs, ok := o.txs[blockHash]
 	if !ok {
 		o.t.Fatalf("unknown txs %s", blockHash)
@@ -45,7 +44,7 @@ func (o stubOracle) TransactionsByBlockHash(blockHash common.Hash) (eth.BlockInf
 	return o.HeaderByBlockHash(blockHash), txs
 }
 
-func (o stubOracle) ReceiptsByBlockHash(blockHash common.Hash) (eth.BlockInfo, types.Receipts) {
+func (o stubOracle) ReceiptsByBlockHash(blockHash common.Hash) (*types.Header, types.Receipts) {
 	rcpts, ok := o.rcpts[blockHash]
 	if !ok {
 		o.t.Fatalf("unknown rcpts %s", blockHash)

--- a/op-program/host/l1/l1.go
+++ b/op-program/host/l1/l1.go
@@ -3,24 +3,21 @@ package l1
 import (
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-node/sources"
 	cll1 "github.com/ethereum-optimism/optimism/op-program/client/l1"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 func NewFetchingL1(ctx context.Context, logger log.Logger, cfg *config.Config) (derive.L1Fetcher, error) {
-	rpc, err := client.NewRPC(ctx, logger, cfg.L1URL)
+	rpcClient, err := rpc.DialContext(ctx, cfg.L1URL)
 	if err != nil {
 		return nil, err
 	}
 
-	source, err := sources.NewL1Client(rpc, logger, nil, sources.L1ClientDefaultConfig(cfg.Rollup, cfg.L1TrustRPC, cfg.L1RPCKind))
-	if err != nil {
-		return nil, err
-	}
-	oracle := cll1.NewCachingOracle(NewFetchingL1Oracle(ctx, logger, source))
+	client := ethclient.NewClient(rpcClient)
+	oracle := cll1.NewCachingOracle(NewFetchingL1Oracle(ctx, logger, client))
 	return cll1.NewOracleL1Client(logger, oracle, cfg.L1Head), err
 }


### PR DESCRIPTION
**Description**

Change L1 Oracle to return `*types.Header` instead of `eth.BlockInfo` so that the header RLP can be generated and stored in the key value store.

**Additional context**

Requires changing from using `sources.L1Client` to a plain `ethclient.Client` which has fewer features.  We'll either need to reimplement things like advanced receipt checking and the `trustRPC` setting or remove those options from the CLI.