### PR TITLE
op-program: Support running in offline mode.

### DIFF
--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -79,6 +79,12 @@ func TestNetwork(t *testing.T) {
 	}
 }
 
+func TestDataDir(t *testing.T) {
+	expected := "/tmp/mainTestDataDir"
+	cfg := configForArgs(t, addRequiredArgs("--datadir", expected))
+	require.Equal(t, expected, cfg.DataDir)
+}
+
 func TestL2(t *testing.T) {
 	expected := "https://example.com:8545"
 	cfg := configForArgs(t, addRequiredArgs("--l2", expected))
@@ -168,14 +174,6 @@ func TestL1RPCKind(t *testing.T) {
 	t.Run("UnknownKind", func(t *testing.T) {
 		verifyArgsInvalid(t, "\"foo\"", addRequiredArgs("--l1.rpckind", "foo"))
 	})
-}
-
-// Offline support will be added later, but for now it just bails out with an error
-func TestOfflineModeNotSupported(t *testing.T) {
-	logger := log.New()
-	cfg := config.NewConfig(&chaincfg.Goerli, "genesis.json", common.HexToHash(l1HeadValue), common.HexToHash(l2HeadValue), common.HexToHash(l2ClaimValue))
-	err := FaultProofProgram(logger, cfg)
-	require.ErrorContains(t, err, "offline mode not supported")
 }
 
 func TestL2Claim(t *testing.T) {

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -18,10 +18,12 @@ var (
 	ErrInvalidL2Head       = errors.New("invalid l2 head")
 	ErrL1AndL2Inconsistent = errors.New("l1 and l2 options must be specified together or both omitted")
 	ErrInvalidL2Claim      = errors.New("invalid l2 claim")
+	ErrDataDirRequired     = errors.New("datadir must be specified when in non-fetching mode")
 )
 
 type Config struct {
 	Rollup        *rollup.Config
+	DataDir       string
 	L2URL         string
 	L2GenesisPath string
 	L1Head        common.Hash
@@ -53,6 +55,9 @@ func (c *Config) Check() error {
 	}
 	if (c.L1URL != "") != (c.L2URL != "") {
 		return ErrL1AndL2Inconsistent
+	}
+	if !c.FetchingEnabled() && c.DataDir == "" {
+		return ErrDataDirRequired
 	}
 	return nil
 }
@@ -95,6 +100,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*Config, error) {
 	}
 	return &Config{
 		Rollup:        rollupCfg,
+		DataDir:       ctx.GlobalString(flags.DataDir.Name),
 		L2URL:         ctx.GlobalString(flags.L2NodeAddr.Name),
 		L2GenesisPath: ctx.GlobalString(flags.L2GenesisPath.Name),
 		L2Head:        l2Head,

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -15,7 +15,8 @@ var validL1Head = common.Hash{0xaa}
 var validL2Head = common.Hash{0xbb}
 var validL2Claim = common.Hash{0xcc}
 
-func TestDefaultConfigIsValid(t *testing.T) {
+// TestValidConfigIsValid checks that the config provided by validConfig is actually valid
+func TestValidConfigIsValid(t *testing.T) {
 	err := validConfig().Check()
 	require.NoError(t, err)
 }
@@ -121,6 +122,17 @@ func TestFetchingEnabled(t *testing.T) {
 	})
 }
 
+func TestRequireDataDirInNonFetchingMode(t *testing.T) {
+	cfg := validConfig()
+	cfg.DataDir = ""
+	cfg.L1URL = ""
+	cfg.L2URL = ""
+	err := cfg.Check()
+	require.ErrorIs(t, err, ErrDataDirRequired)
+}
+
 func validConfig() *Config {
-	return NewConfig(validRollupConfig, validL2GenesisPath, validL1Head, validL2Head, validL2Claim)
+	cfg := NewConfig(validRollupConfig, validL2GenesisPath, validL1Head, validL2Head, validL2Claim)
+	cfg.DataDir = "/tmp/configTest"
+	return cfg
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -26,6 +26,11 @@ var (
 		Usage:  fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
 		EnvVar: service.PrefixEnvVar(envVarPrefix, "NETWORK"),
 	}
+	DataDir = cli.StringFlag{
+		Name:   "datadir",
+		Usage:  "Directory to use for preimage data storage. Default uses in-memory storage",
+		EnvVar: service.PrefixEnvVar(envVarPrefix, "DATADIR"),
+	}
 	L2NodeAddr = cli.StringFlag{
 		Name:   "l2",
 		Usage:  "Address of L2 JSON-RPC endpoint to use (eth and debug namespace required)",
@@ -85,6 +90,7 @@ var requiredFlags = []cli.Flag{
 var programFlags = []cli.Flag{
 	RollupConfig,
 	Network,
+	DataDir,
 	L2NodeAddr,
 	L1NodeAddr,
 	L1TrustRPC,


### PR DESCRIPTION
**Description**

Update the setup code for op-program to support running in offline mode.  A `--datadir` CLI arg is added to specify the directory to use to store preimage data. If the `--l1` and `--l2` options are specified the preimages are fetched, otherwise only the pre-populated preimages are used to replay the derivation.

In-memory kv store is still supported in fetching mode if no `--datadir` is supplied because it makes testing easier (and the host part of op-program is essentially just a test harness).

**Tests**

Tests for the new CLI arg and config option. Will need to add e2e tests to cover the setup changes.

**Additional context**

Builds on #5463, #5465 and #5452

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3748/read-only-execution-mode
