### PR TITLE
feat: One branch changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "develop",
+  "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+# Always wait for previous release to finish before releasing again
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release:
     name: Release
@@ -62,6 +65,9 @@ jobs:
         with:
           version: nightly
 
+      # Makes a pr to publish the changesets that when
+      # merged will publish to npm
+      # see https://github.com/changesets/action
       - name: Publish To NPM or Create Release Pull Request
         uses: changesets/action@v1
         id: changesets


### PR DESCRIPTION
- Add concurrency to prevent corner case of a race condition with releases where the second one happens first
- Change base branch to master
- add a comment

The github changeset action was already configured to work correctly outside of the base branch
