### PR TITLE
ops: Move ci-builder into GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1371,3 +1371,18 @@ workflows:
             - oplabs-gcr-release
           requires:
             - hold
+  release-ci-builder:
+    jobs:
+      - docker-publish:
+          name: ci-builder-docker-publish
+          filters:
+            tags:
+              only: /^ci-builder\/v.*/
+            branches:
+              ignore: /.*/
+          docker_file: ./ops/docker/ci-builder/Dockerfile
+          docker_name: ci-builder
+          docker_tags: <<pipeline.git.revision>>,latest
+          docker_context: ./ops/docker/ci-builder/Dockerfile
+          context:
+            - oplabs-gcr


### PR DESCRIPTION
Adds a CCI job to publish `ci-builder` into GCR rather than using changesets. Subsequent PRs will update the Dockerfiles across the monorepo to use the GCR-based `ci-builder` rather than the one on Docker hub.

To release a new version of the CI builder, push a tag that starts with `ci-builder/v`.
