### PR TITLE
ops: Fix the CI builder docker context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1383,6 +1383,6 @@ workflows:
           docker_file: ./ops/docker/ci-builder/Dockerfile
           docker_name: ci-builder
           docker_tags: <<pipeline.git.revision>>,latest
-          docker_context: ./ops/docker/ci-builder/Dockerfile
+          docker_context: ./ops/docker/ci-builder
           context:
             - oplabs-gcr


### PR DESCRIPTION
Docker context was set to the `Dockerfile` rather than the containing directory.
