### PR TITLE
op-program: Fix op-program Makefile

### DIFF
--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -9,7 +9,7 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 op-program:
-	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-program ./cmd/main.go
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-program ./host/cmd/main.go
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
**Description**

Update the build command for `op-program` to adapt to the host/client split.

Currently this isn't built in CI (only the tests) as we aren't building docker images for op-program yet. https://linear.app/optimism/issue/CLI-3838/op-program-docker-build will add that and actually use this make target.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3851/fix-op-program-make-target
