### PR TITLE
op-program: Specify l2 block number to stop derivation at

### DIFF
--- a/op-program/host/cmd/main.go
+++ b/op-program/host/cmd/main.go
@@ -173,7 +173,7 @@ func FaultProofProgram(logger log.Logger, cfg *config.Config) error {
 	}
 
 	logger.Info("Starting derivation")
-	d := cldr.NewDriver(logger, cfg.Rollup, l1Source, l2Source)
+	d := cldr.NewDriver(logger, cfg.Rollup, l1Source, l2Source, cfg.L2ClaimBlockNumber)
 	for {
 		if err = d.Step(ctx); errors.Is(err, io.EOF) {
 			break

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var validRollupConfig = &chaincfg.Goerli
-var validL2Genesis = params.GoerliChainConfig
-var validL1Head = common.Hash{0xaa}
-var validL2Head = common.Hash{0xbb}
-var validL2Claim = common.Hash{0xcc}
+var (
+	validRollupConfig    = &chaincfg.Goerli
+	validL2Genesis       = params.GoerliChainConfig
+	validL1Head          = common.Hash{0xaa}
+	validL2Head          = common.Hash{0xbb}
+	validL2Claim         = common.Hash{0xcc}
+	validL2ClaimBlockNum = uint64(15)
+)
 
 // TestValidConfigIsValid checks that the config provided by validConfig is actually valid
 func TestValidConfigIsValid(t *testing.T) {
@@ -57,6 +60,13 @@ func TestL2ClaimRequired(t *testing.T) {
 	config.L2Claim = common.Hash{}
 	err := config.Check()
 	require.ErrorIs(t, err, ErrInvalidL2Claim)
+}
+
+func TestL2ClaimBlockNumberRequired(t *testing.T) {
+	config := validConfig()
+	config.L2ClaimBlockNumber = 0
+	err := config.Check()
+	require.ErrorIs(t, err, ErrInvalidL2ClaimBlock)
 }
 
 func TestL2GenesisRequired(t *testing.T) {
@@ -133,7 +143,7 @@ func TestRequireDataDirInNonFetchingMode(t *testing.T) {
 }
 
 func validConfig() *Config {
-	cfg := NewConfig(validRollupConfig, validL2Genesis, validL1Head, validL2Head, validL2Claim)
+	cfg := NewConfig(validRollupConfig, validL2Genesis, validL1Head, validL2Head, validL2Claim, validL2ClaimBlockNum)
 	cfg.DataDir = "/tmp/configTest"
 	return cfg
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -51,6 +51,11 @@ var (
 		Usage:  "Claimed L2 output root to validate",
 		EnvVar: service.PrefixEnvVar(envVarPrefix, "L2_CLAIM"),
 	}
+	L2BlockNumber = cli.Uint64Flag{
+		Name:   "l2.blocknumber",
+		Usage:  "Number of the L2 block that the claim is from",
+		EnvVar: service.PrefixEnvVar(envVarPrefix, "L2_BLOCK_NUM"),
+	}
 	L2GenesisPath = cli.StringFlag{
 		Name:   "l2.genesis",
 		Usage:  "Path to the op-geth genesis file",
@@ -85,6 +90,7 @@ var requiredFlags = []cli.Flag{
 	L1Head,
 	L2Head,
 	L2Claim,
+	L2BlockNumber,
 	L2GenesisPath,
 }
 var programFlags = []cli.Flag{
@@ -113,7 +119,7 @@ func CheckRequired(ctx *cli.Context) error {
 		return fmt.Errorf("cannot specify both %s and %s", RollupConfig.Name, Network.Name)
 	}
 	for _, flag := range requiredFlags {
-		if ctx.GlobalString(flag.GetName()) == "" {
+		if !ctx.IsSet(flag.GetName()) {
 			return fmt.Errorf("flag %s is required", flag.GetName())
 		}
 	}


### PR DESCRIPTION
**Description**

Adds a `--l2.blocknumber` option that the derivation will stop at and check the claim. This avoids the need to find a L1 head that includes exactly the batches required to derive the L2 block the claim is from and none beyond that.

Also found that `main_test` was getting tests interfering with each other when run in parallel. That shouldn't be possible, but something in the cli lib seems to do it so unmarking them as parallel safe.

**Tests**

Added unit tests.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3818/fpp-halt-execution-when-target-l2-block-reached
