### PR TITLE
fix(contracts-bedrock): SafeCall FFI Interface Fuzzing

### DIFF
--- a/packages/contracts-bedrock/contracts/test/SafeCall.t.sol
+++ b/packages/contracts-bedrock/contracts/test/SafeCall.t.sol
@@ -23,6 +23,8 @@ contract SafeCall_call_Test is CommonTest {
         vm.assume(to != address(0x000000000000000000636F6e736F6c652e6c6f67));
         // don't call the create2 deployer
         vm.assume(to != address(0x4e59b44847b379578588920cA78FbF26c0B4956C));
+        // don't call the ffi interface
+        vm.assume(to != address(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f));
 
         assertEq(from.balance, 0, "from balance is 0");
         vm.deal(from, value);


### PR DESCRIPTION
**Description**

Currently ci fails since the `to` address passed into `SafeCall` is fuzzed with the ffi interface address, resulting in the test failing. This simply adds an assumption that the `to` address is not the ffi interface contract address.