### PR TITLE
FE-1002: supportsTokenPair should return false whenever the check catches an error

### DIFF
--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -186,14 +186,7 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       // If the L2 token is not an L2StandardERC20, it may throw an error. If there's a call
       // exception then we assume that the token is not supported. Other errors are thrown. Since
       // the JSON-RPC API is not well-specified, we need to handle multiple possible error codes.
-      if (
-        err.message.toString().includes('CALL_EXCEPTION') ||
-        err.stack.toString().includes('execution reverted')
-      ) {
-        return false
-      } else {
-        throw err
-      }
+      return false
     }
   }
 

--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -186,7 +186,10 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       // If the L2 token is not an L2StandardERC20, it may throw an error. If there's a call
       // exception then we assume that the token is not supported. Other errors are thrown. Since
       // the JSON-RPC API is not well-specified, we need to handle multiple possible error codes.
-      if (!err?.message?.toString().includes('CALL_EXCEPTION') && !err?.stack?.toString().includes('execution reverted') {
+      if (
+        !err?.message?.toString().includes('CALL_EXCEPTION') &&
+        !err?.stack?.toString().includes('execution reverted')
+      ) {
         console.error('Unexpected error when checking bridge', err)
       }
       return false

--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -186,6 +186,9 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       // If the L2 token is not an L2StandardERC20, it may throw an error. If there's a call
       // exception then we assume that the token is not supported. Other errors are thrown. Since
       // the JSON-RPC API is not well-specified, we need to handle multiple possible error codes.
+      if (!err?.message?.toString().includes('CALL_EXCEPTION') && !err?.stack?.toString().includes('execution reverted') {
+        console.error('Unexpected error when checking bridge', e)
+      }
       return false
     }
   }

--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -187,7 +187,7 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
       // exception then we assume that the token is not supported. Other errors are thrown. Since
       // the JSON-RPC API is not well-specified, we need to handle multiple possible error codes.
       if (!err?.message?.toString().includes('CALL_EXCEPTION') && !err?.stack?.toString().includes('execution reverted') {
-        console.error('Unexpected error when checking bridge', e)
+        console.error('Unexpected error when checking bridge', err)
       }
       return false
     }


### PR DESCRIPTION
This caused a firefox-specific error where, err.stack was not defined and therefore threw an uncaught exception. Since there is not a reliable way to determine the type of JSON RPC error and since we expect non standard tokens to hit this code path, we should just default to returning false whenever an error is caught in this function.