### PR TITLE
fix(packages/atst): Typo in README.md

### DIFF
--- a/packages/atst/src/README.md
+++ b/packages/atst/src/README.md
@@ -18,7 +18,7 @@ Vitest snapshots for the vitest tests
 
 CLI implementations of atst read and write
 
-## contants
+## constants
 
 Internal and external constants
 


### PR DESCRIPTION
Changing contants to con**s**tants.