### PR TITLE
Fix incomplete `supportsInterface` function

### DIFF
--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
@@ -107,12 +107,14 @@ contract OptimismMintableERC20 is IOptimismMintableERC20, ILegacyMintableERC20, 
      * @return Whether or not the interface is supported by this contract.
      */
     function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
-        bytes4 iface1 = type(IERC165).interfaceId;
         // Interface corresponding to the legacy L2StandardERC20.
-        bytes4 iface2 = type(ILegacyMintableERC20).interfaceId;
+        bytes4 iface1 = type(ILegacyMintableERC20).interfaceId;
         // Interface corresponding to the updated OptimismMintableERC20 (this contract).
-        bytes4 iface3 = type(IOptimismMintableERC20).interfaceId;
-        return _interfaceId == iface1 || _interfaceId == iface2 || _interfaceId == iface3;
+        bytes4 iface2 = type(IOptimismMintableERC20).interfaceId;
+        return
+            _interfaceId == iface1 ||
+            _interfaceId == iface2 ||
+            ERC20.supportsInterface(_interfaceId);
     }
 
     /**


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR fixes the incomplete `supportsInterface` function in `OptimismMintableERC20` contract by using
`ERC20.supportsInterface(_interfaceId);` 

The `supportsInterface` function in the `OptimismMintableERC20` contract is incomplete. It's because it does not call `ERC20.supportsInterface` to ensure that any interfaces defined by its parent contracts are correctly reported. This could result in unexpected behavior if other contracts or systems rely on the correct implementation of the `supportsInterface` function.

[OptimismMintableERC20.sol#L109-L116](https://github.com/ethereum-optimism/optimism/blob/1afd173e324fd55442f15075a30314e2497176ee/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol#L109-L116)
```solidity
    function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
        bytes4 iface1 = type(IERC165).interfaceId;
        // Interface corresponding to the legacy L2StandardERC20.
        bytes4 iface2 = type(ILegacyMintableERC20).interfaceId;
        // Interface corresponding to the updated OptimismMintableERC20 (this contract).
        bytes4 iface3 = type(IOptimismMintableERC20).interfaceId;
        return _interfaceId == iface1 || _interfaceId == iface2 || _interfaceId == iface3;
    }
```

The line `bytes4 iface1 = type(IERC165).interfaceId;` has been removed since `ERC20.supportsInterface(_interfaceId);` is being used. `OptimismMintableERC20` inherits `ERC165`.


[OpenZeppelin ERC165.sol#L26-L28](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/6bd6b76d1156e20e45d1016f355d154141c7e5b9/contracts/utils/introspection/ERC165.sol#L26-L28)
```solidity
    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
        return interfaceId == type(IERC165).interfaceId;
    }
```



**Tests**

It seems there is no existing test for `supportsInterface` behavior.

**Invariants**

**Additional context**

**Metadata**

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
