### PR TITLE
op-node: Remove beta-1 config

### DIFF
--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -10,35 +10,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 )
 
-var Beta1 = rollup.Config{
-	Genesis: rollup.Genesis{
-		L1: eth.BlockID{
-			Hash:   common.HexToHash("0x59c72db5fec5bf231e61ba59854cff33945ff6652699c55f2431ac2c010610d5"),
-			Number: 8046397,
-		},
-		L2: eth.BlockID{
-			Hash:   common.HexToHash("0xa89b19033c8b43365e244f425a7e4acb5bae21d1893e1be0eb8cddeb29950d72"),
-			Number: 0,
-		},
-		L2Time: 1669088016,
-		SystemConfig: eth.SystemConfig{
-			BatcherAddr: common.HexToAddress("0x793b6822fd651af8c58039847be64cb9ee854bc9"),
-			Overhead:    eth.Bytes32(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000834")),
-			Scalar:      eth.Bytes32(common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000f4240")),
-			GasLimit:    30000000,
-		},
-	},
-	BlockTime:              2,
-	MaxSequencerDrift:      3600,
-	SeqWindowSize:          120,
-	ChannelTimeout:         30,
-	L1ChainID:              big.NewInt(5),
-	L2ChainID:              big.NewInt(902),
-	BatchInboxAddress:      common.HexToAddress("0xFb3aECf08940785D4fB3Ad87cDC6e1Ceb20e9aac"),
-	DepositContractAddress: common.HexToAddress("0xf91795564662DcC9a17de67463ec5BA9C6DC207b"),
-	L1SystemConfigAddress:  common.HexToAddress("0x686df068eaa71af78dadc1c427e35600e0fadac5"),
-}
-
 var Goerli = rollup.Config{
 	Genesis: rollup.Genesis{
 		L1: eth.BlockID{
@@ -70,7 +41,6 @@ var Goerli = rollup.Config{
 }
 
 var NetworksByName = map[string]rollup.Config{
-	"beta-1": Beta1,
 	"goerli": Goerli,
 }
 

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -79,12 +79,6 @@ func TestNetwork(t *testing.T) {
 		expected := cfg
 		t.Run("Network_"+name, func(t *testing.T) {
 			args := replaceRequiredArg("--network", name)
-			if name == "beta-1" {
-				// No built-in config for beta-1 which is fine as it's no longer in use.
-				// Newly added named networks should hook up the L2 chain config
-				genesisFile := writeValidGenesis(t)
-				args = append(args, "--l2.genesis", genesisFile)
-			}
 			cfg := configForArgs(t, args)
 			require.Equal(t, expected, *cfg.Rollup)
 		})
@@ -119,10 +113,6 @@ func TestL2Genesis(t *testing.T) {
 	t.Run("NotRequiredForGoerli", func(t *testing.T) {
 		cfg := configForArgs(t, replaceRequiredArg("--network", "goerli"))
 		require.Equal(t, config.OPGoerliChainConfig, cfg.L2ChainConfig)
-	})
-
-	t.Run("RequiredForNamedNetworkWithNoL2ChainConfig", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag l2.genesis is required", replaceRequiredArg("--network", "beta-1"))
 	})
 }
 


### PR DESCRIPTION
**Description**

Remove beta-1 config. `--network=beta-1` is no longer supported as the network has been shut down.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3887/remove-beta-1-network-definition

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
