### PR TITLE
op-program: Do not pass args to detached client program

### DIFF
--- a/op-program/client/program.go
+++ b/op-program/client/program.go
@@ -26,11 +26,14 @@ func Main(logger log.Logger) {
 	log.Info("Starting fault proof program client")
 	preimageOracle := CreatePreimageChannel()
 	preimageHinter := CreateHinterChannel()
-	err := RunProgram(logger, preimageOracle, preimageHinter)
-	if err != nil {
-		log.Error("Program failed", "err", err)
+	if err := RunProgram(logger, preimageOracle, preimageHinter); errors.Is(err, cldr.ErrClaimNotValid) {
+		log.Error("Claim is invalid", "err", err)
 		os.Exit(1)
+	} else if err != nil {
+		log.Error("Program failed", "err", err)
+		os.Exit(2)
 	} else {
+		log.Info("Claim successfully verified")
 		os.Exit(0)
 	}
 }

--- a/op-program/host/cmd/main.go
+++ b/op-program/host/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	cl "github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum-optimism/optimism/op-program/client/driver"
 	"github.com/ethereum-optimism/optimism/op-program/host"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -36,6 +37,11 @@ var VersionWithMeta = func() string {
 }()
 
 func main() {
+	if host.RunningProgramInClient() {
+		logger := oplog.NewLogger(oplog.DefaultCLIConfig())
+		cl.Main(logger)
+		panic("Client main should have exited process")
+	}
 	args := os.Args
 	if err := run(args, host.FaultProofProgram); errors.Is(err, driver.ErrClaimNotValid) {
 		log.Crit("Claim is invalid", "err", err)

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -36,11 +36,6 @@ func RunningProgramInClient() bool {
 
 // FaultProofProgram is the programmatic entry-point for the fault proof program
 func FaultProofProgram(logger log.Logger, cfg *config.Config) error {
-	if RunningProgramInClient() {
-		cl.Main(logger)
-		panic("Client main should have exited process")
-	}
-
 	if err := cfg.Check(); err != nil {
 		return fmt.Errorf("invalid config: %w", err)
 	}
@@ -102,7 +97,7 @@ func FaultProofProgram(logger log.Logger, cfg *config.Config) error {
 
 	var cmd *exec.Cmd
 	if cfg.Detached {
-		cmd = exec.CommandContext(ctx, os.Args[0], os.Args[1:]...)
+		cmd = exec.CommandContext(ctx, os.Args[0])
 		cmd.ExtraFiles = make([]*os.File, cl.MaxFd-3) // not including stdin, stdout and stderr
 		cmd.ExtraFiles[cl.HClientRFd-3] = hClientRW.Reader()
 		cmd.ExtraFiles[cl.HClientWFd-3] = hClientRW.Writer()


### PR DESCRIPTION
**Description**

Now that the op client bootstraps via the oracle we don't need to pass any command line args to it.

**Metadata**

- Part of https://linear.app/optimism/issue/CLI-3890/fpp-dangerous-exec-command-warning
