### PR TITLE
proxyd: use health metrics slide window

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -88,7 +88,7 @@ var (
 	ErrNotHealthy = &RPCErr{
 		Code:          JSONRPCErrorInternal - 18,
 		Message:       "backend is currently not healthy to serve traffic",
-		HTTPErrorCode: 429,
+		HTTPErrorCode: 503,
 	}
 
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")

--- a/proxyd/integration_tests/testdata/consensus_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_responses.yml
@@ -1,3 +1,17 @@
+- method: net_peerCount
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": "0x10"
+    }
+- method: eth_syncing
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": false
+    }
 - method: eth_getBlockByNumber
   block: latest
   response: >

--- a/proxyd/pkg/avg-sliding-window/sliding.go
+++ b/proxyd/pkg/avg-sliding-window/sliding.go
@@ -97,10 +97,15 @@ func (sw *AvgSlidingWindow) inWindow(t time.Time) bool {
 	return windowStart.Before(t) && !t.After(now)
 }
 
-// Add inserts a new data point into the window, with value `val` with the current time
+// Add inserts a new data point into the window, with value `val` and the current time
 func (sw *AvgSlidingWindow) Add(val float64) {
 	t := sw.clock.Now()
 	sw.AddWithTime(t, val)
+}
+
+// Incr is an alias to insert a data point with value float64(1) and the current time
+func (sw *AvgSlidingWindow) Incr() {
+	sw.Add(1)
 }
 
 // AddWithTime inserts a new data point into the window, with value `val` and time `t`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change
* integrates the sliding window into the proxyd healthchecks
* add two more checks for backend consensus state: minimum peer count and node syncing

**Tests**

Modified current tests to comply with new checks.

**Invariants**

n/a

**Additional context**

* Sliding window: https://github.com/ethereum-optimism/optimism/pull/5531
* This change is part of the Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes https://linear.app/optimism/issue/INF-147/health-checks

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
