### PR TITLE
op-program: Build op-program client binary

### DIFF
--- a/op-node/eth/ssz.go
+++ b/op-node/eth/ssz.go
@@ -62,7 +62,9 @@ func unmarshalBytes32LE(in []byte, z *Uint256Quantity) {
 
 // MarshalSSZ encodes the ExecutionPayload as SSZ type
 func (payload *ExecutionPayload) MarshalSSZ(w io.Writer) (n int, err error) {
-	if len(payload.ExtraData) > math.MaxUint32-executionPayloadFixedPart {
+	// Cast to uint32 to enable 32-bit MIPS support where math.MaxUint32-executionPayloadFixedPart is too big for int
+	// In that case, len(payload.ExtraData) can't be longer than an int so this is always false anyway.
+	if uint32(len(payload.ExtraData)) > math.MaxUint32-uint32(executionPayloadFixedPart) {
 		return 0, ErrExtraDataTooLarge
 	}
 

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -8,8 +8,21 @@ LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Vers
 LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta=$(VERSION_META)
 LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
-op-program:
+op-program: \
+	op-program-host \
+	op-program-client \
+	op-program-client-mips
+
+op-program-host:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-program ./host/cmd/main.go
+
+op-program-client:
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-program-client ./client/cmd/main.go
+
+op-program-client-mips:
+	env GO111MODULE=on GOOS=linux GOARCH=mips GOMIPS=softfloat go build -v $(LDFLAGS) -o ./bin/op-program-client.elf ./client/cmd/main.go
+	# verify output with: readelf -h bin/op-program-client.elf
+	# result is mips32, big endian, R3000
 
 clean:
 	rm -rf bin

--- a/op-program/client/cmd/main.go
+++ b/op-program/client/cmd/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/ethereum-optimism/optimism/op-program/client"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+func main() {
+	// Default to a machine parsable but relatively human friendly log format.
+	// Don't do anything fancy to detect if color output is supported.
+	logger := oplog.NewLogger(oplog.CLIConfig{
+		Level:  "info",
+		Format: "logfmt",
+		Color:  false,
+	})
+	client.Main(logger)
+}


### PR DESCRIPTION
**Description**

Adds an entry point specifically for the fault proof program and updates the makefile to build the host and client. Also always builds a MIPs version of the client binary suitable for execution inside cannon.

Note the change in `ssz.go` to "fix" 32bit compatibility.  It may be better to just error when `ExtraData` is longer than 32 bytes given it's defined as a List with max length 32 bytes but there's a test specifically checking we can marshal a value longer than that.

**Metadata**

- https://linear.app/optimism/issue/CLI-3878/fpp-create-client-executable
