### PR TITLE
op-program: Specify client program to run as an executable

### DIFF
--- a/op-e2e/build_helper.go
+++ b/op-e2e/build_helper.go
@@ -1,0 +1,25 @@
+package op_e2e
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BuildOpProgramClient builds the `op-program` client executable and returns the path to the resulting executable
+func BuildOpProgramClient(t *testing.T) string {
+	t.Log("Building op-program-client")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "make", "op-program-client")
+	cmd.Dir = "../op-program"
+	cmd.Stdout = os.Stdout // for debugging
+	cmd.Stderr = os.Stderr // for debugging
+	require.NoError(t, cmd.Run(), "Failed to build op-program-client")
+	t.Log("Built op-program-client successfully")
+	return "../op-program/bin/op-program-client"
+}

--- a/op-program/host/cmd/main.go
+++ b/op-program/host/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	cl "github.com/ethereum-optimism/optimism/op-program/client"
 	"github.com/ethereum-optimism/optimism/op-program/client/driver"
 	"github.com/ethereum-optimism/optimism/op-program/host"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
@@ -37,11 +36,6 @@ var VersionWithMeta = func() string {
 }()
 
 func main() {
-	if host.RunningProgramInClient() {
-		logger := oplog.NewLogger(oplog.DefaultCLIConfig())
-		cl.Main(logger)
-		panic("Client main should have exited process")
-	}
 	args := os.Args
 	if err := run(args, host.FaultProofProgram); errors.Is(err, driver.ErrClaimNotValid) {
 		log.Crit("Claim is invalid", "err", err)

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -220,22 +220,15 @@ func TestL2BlockNumber(t *testing.T) {
 	})
 }
 
-func TestDetached(t *testing.T) {
-	t.Run("DefaultFalse", func(t *testing.T) {
+func TestExec(t *testing.T) {
+	t.Run("DefaultEmpty", func(t *testing.T) {
 		cfg := configForArgs(t, addRequiredArgs())
-		require.False(t, cfg.Detached)
+		require.Equal(t, "", cfg.ExecCmd)
 	})
-	t.Run("Enabled", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs("--detached"))
-		require.True(t, cfg.Detached)
-	})
-	t.Run("EnabledWithArg", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs("--detached=true"))
-		require.True(t, cfg.Detached)
-	})
-	t.Run("Disabled", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs("--detached=false"))
-		require.False(t, cfg.Detached)
+	t.Run("Set", func(t *testing.T) {
+		cmd := "/bin/echo"
+		cfg := configForArgs(t, addRequiredArgs("--exec", cmd))
+		require.Equal(t, cmd, cfg.ExecCmd)
 	})
 }
 

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -49,8 +49,9 @@ type Config struct {
 	L2ClaimBlockNumber uint64
 	// L2ChainConfig is the op-geth chain config for the L2 execution engine
 	L2ChainConfig *params.ChainConfig
-	// Detached indicates that the program runs as a separate process
-	Detached bool
+	// ExecCmd specifies the client program to execute in a separate process.
+	// If unset, the fault proof client is run in the same process.
+	ExecCmd string
 }
 
 func (c *Config) Check() error {
@@ -148,7 +149,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*Config, error) {
 		L1URL:              ctx.GlobalString(flags.L1NodeAddr.Name),
 		L1TrustRPC:         ctx.GlobalBool(flags.L1TrustRPC.Name),
 		L1RPCKind:          sources.RPCProviderKind(ctx.GlobalString(flags.L1RPCProviderKind.Name)),
-		Detached:           ctx.GlobalBool(flags.Detached.Name),
+		ExecCmd:            ctx.String(flags.Exec.Name),
 	}, nil
 }
 

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -81,10 +81,10 @@ var (
 			return &out
 		}(),
 	}
-	Detached = cli.BoolFlag{
-		Name:   "detached",
-		Usage:  "Run the program as a separate process detached from the host",
-		EnvVar: service.PrefixEnvVar(envVarPrefix, "DETACHED"),
+	Exec = cli.StringFlag{
+		Name:   "exec",
+		Usage:  "Run the specified client program as a separate process detached from the host. Default is to run the client program in the host process.",
+		EnvVar: service.PrefixEnvVar(envVarPrefix, "EXEC"),
 	}
 )
 
@@ -106,7 +106,7 @@ var programFlags = []cli.Flag{
 	L1NodeAddr,
 	L1TrustRPC,
 	L1RPCProviderKind,
-	Detached,
+	Exec,
 }
 
 func init() {


### PR DESCRIPTION
**Description**

Require the user to specify the client program to run as an executable when using detached mode. Removes the env var approach to toggling between the host and client executables.

This makes the host program much more similar to the actual VM which executes an arbitrary program and means that it is executing the actual client executable rather than calling it programatically.

Downside is that the e2e test now needs to build the client program executable so it can execute it. This is done by executing `make` from the e2e test which isn't particularly pleasant. It does mean the test remains completely standalone without relying on the user compiling the executable before running it though.

**Tests**

Updated existing tests.

**Additional context**

Builds on #5546 

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3878/fpp-create-client-executable
