### PR TITLE
op-program: Add server mode

### DIFF
--- a/op-e2e/system_fpp_test.go
+++ b/op-e2e/system_fpp_test.go
@@ -108,7 +108,7 @@ func testVerifyL2OutputRoot(t *testing.T, detached bool) {
 
 	// Check the FPP confirms the expected output
 	t.Log("Running fault proof in fetching mode")
-	err = opp.FaultProofProgram(log, fppConfig)
+	err = opp.FaultProofProgram(ctx, log, fppConfig)
 	require.NoError(t, err)
 
 	t.Log("Shutting down network")
@@ -124,13 +124,13 @@ func testVerifyL2OutputRoot(t *testing.T, detached bool) {
 	// Should be able to rerun in offline mode using the pre-fetched images
 	fppConfig.L1URL = ""
 	fppConfig.L2URL = ""
-	err = opp.FaultProofProgram(log, fppConfig)
+	err = opp.FaultProofProgram(ctx, log, fppConfig)
 	require.NoError(t, err)
 
 	// Check that a fault is detected if we provide an incorrect claim
 	t.Log("Running fault proof with invalid claim")
 	fppConfig.L2Claim = common.Hash{0xaa}
-	err = opp.FaultProofProgram(log, fppConfig)
+	err = opp.FaultProofProgram(ctx, log, fppConfig)
 	if detached {
 		require.Error(t, err, "exit status 1")
 	} else {

--- a/op-program/host/cmd/main.go
+++ b/op-program/host/cmd/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
-	"github.com/ethereum-optimism/optimism/op-program/client/driver"
 	"github.com/ethereum-optimism/optimism/op-program/host"
 	"github.com/ethereum-optimism/optimism/op-program/host/config"
 	"github.com/ethereum-optimism/optimism/op-program/host/flags"
@@ -37,12 +35,8 @@ var VersionWithMeta = func() string {
 
 func main() {
 	args := os.Args
-	if err := run(args, host.FaultProofProgram); errors.Is(err, driver.ErrClaimNotValid) {
-		log.Crit("Claim is invalid", "err", err)
-	} else if err != nil {
+	if err := run(args, host.Main); err != nil {
 		log.Crit("Application failed", "err", err)
-	} else {
-		log.Info("Claim successfully verified")
 	}
 }
 

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -232,6 +232,28 @@ func TestExec(t *testing.T) {
 	})
 }
 
+func TestServerMode(t *testing.T) {
+	t.Run("DefaultFalse", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs())
+		require.False(t, cfg.ServerMode)
+	})
+	t.Run("Enabled", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs("--server"))
+		require.True(t, cfg.ServerMode)
+	})
+	t.Run("EnabledWithArg", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs("--server=true"))
+		require.True(t, cfg.ServerMode)
+	})
+	t.Run("DisabledWithArg", func(t *testing.T) {
+		cfg := configForArgs(t, addRequiredArgs("--server=false"))
+		require.False(t, cfg.ServerMode)
+	})
+	t.Run("InvalidArg", func(t *testing.T) {
+		verifyArgsInvalid(t, "invalid boolean value \"foo\" for -server", addRequiredArgs("--server=foo"))
+	})
+}
+
 func verifyArgsInvalid(t *testing.T, messageContains string, cliArgs []string) {
 	_, _, err := runWithArgs(cliArgs)
 	require.ErrorContains(t, err, messageContains)

--- a/op-program/host/config/config_test.go
+++ b/op-program/host/config/config_test.go
@@ -142,6 +142,14 @@ func TestRequireDataDirInNonFetchingMode(t *testing.T) {
 	require.ErrorIs(t, err, ErrDataDirRequired)
 }
 
+func TestRejectExecAndServerMode(t *testing.T) {
+	cfg := validConfig()
+	cfg.ServerMode = true
+	cfg.ExecCmd = "echo"
+	err := cfg.Check()
+	require.ErrorIs(t, err, ErrNoExecInServerMode)
+}
+
 func validConfig() *Config {
 	cfg := NewConfig(validRollupConfig, validL2Genesis, validL1Head, validL2Head, validL2Claim, validL2ClaimBlockNum)
 	cfg.DataDir = "/tmp/configTest"

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -86,6 +86,11 @@ var (
 		Usage:  "Run the specified client program as a separate process detached from the host. Default is to run the client program in the host process.",
 		EnvVar: service.PrefixEnvVar(envVarPrefix, "EXEC"),
 	}
+	Server = cli.BoolFlag{
+		Name:   "server",
+		Usage:  "Run in pre-image server mode without executing any client program.",
+		EnvVar: service.PrefixEnvVar(envVarPrefix, "SERVER"),
+	}
 )
 
 // Flags contains the list of configuration options available to the binary.
@@ -107,6 +112,7 @@ var programFlags = []cli.Flag{
 	L1TrustRPC,
 	L1RPCProviderKind,
 	Exec,
+	Server,
 }
 
 func init() {

--- a/op-program/host/host_test.go
+++ b/op-program/host/host_test.go
@@ -1,0 +1,63 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-program/client"
+	"github.com/ethereum-optimism/optimism/op-program/client/l1"
+	"github.com/ethereum-optimism/optimism/op-program/host/config"
+	"github.com/ethereum-optimism/optimism/op-program/host/kvstore"
+	"github.com/ethereum-optimism/optimism/op-program/io"
+	"github.com/ethereum-optimism/optimism/op-program/preimage"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerMode(t *testing.T) {
+	dir := t.TempDir()
+
+	l1Head := common.Hash{0x11}
+	cfg := config.NewConfig(&chaincfg.Goerli, config.OPGoerliChainConfig, l1Head, common.Hash{0x22}, common.Hash{0x33}, 1000)
+	cfg.DataDir = dir
+	cfg.ServerMode = true
+
+	preimageServer, preimageClient, err := io.CreateBidirectionalChannel()
+	require.NoError(t, err)
+	defer preimageClient.Close()
+	hintServer, hintClient, err := io.CreateBidirectionalChannel()
+	require.NoError(t, err)
+	defer hintClient.Close()
+	logger := testlog.Logger(t, log.LvlTrace)
+	result := make(chan error)
+	go func() {
+		result <- PreimageServer(context.Background(), logger, cfg, preimageServer, hintServer)
+	}()
+
+	pClient := preimage.NewOracleClient(preimageClient)
+	hClient := preimage.NewHintWriter(hintClient)
+	l1PreimageOracle := l1.NewPreimageOracle(pClient, hClient)
+
+	require.Equal(t, l1Head.Bytes(), pClient.Get(client.L1HeadLocalIndex), "Should get preimages")
+
+	// Should exit when a preimage is unavailable
+	require.Panics(t, func() {
+		l1PreimageOracle.HeaderByBlockHash(common.HexToHash("0x1234"))
+	}, "Preimage should not be available")
+	require.ErrorIs(t, waitFor(result), kvstore.ErrNotFound)
+}
+
+func waitFor(ch chan error) error {
+	timeout := time.After(30 * time.Second)
+	select {
+	case err := <-ch:
+		return err
+	case <-timeout:
+		return errors.New("timed out")
+	}
+}

--- a/op-program/preimage/hints.go
+++ b/op-program/preimage/hints.go
@@ -43,7 +43,9 @@ func NewHintReader(rw io.ReadWriter) *HintReader {
 	return &HintReader{rw: rw}
 }
 
-func (hr *HintReader) NextHint(router func(hint string) error) error {
+type HintHandler func(hint string) error
+
+func (hr *HintReader) NextHint(router HintHandler) error {
 	var length uint32
 	if err := binary.Read(hr.rw, binary.BigEndian, &length); err != nil {
 		if err == io.EOF {

--- a/op-program/preimage/oracle.go
+++ b/op-program/preimage/oracle.go
@@ -47,7 +47,9 @@ func NewOracleServer(rw io.ReadWriter) *OracleServer {
 	return &OracleServer{rw: rw}
 }
 
-func (o *OracleServer) NextPreimageRequest(getPreimage func(key common.Hash) ([]byte, error)) error {
+type PreimageGetter func(key common.Hash) ([]byte, error)
+
+func (o *OracleServer) NextPreimageRequest(getPreimage PreimageGetter) error {
 	var key common.Hash
 	if _, err := io.ReadFull(o.rw, key[:]); err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
**Description**

Adds a server mode to the op-program host so that it inits the prefetchers and key-value store but doesn't run the actual fault proof program. Instead it listens for preimage hints and requests via additional file handles using the same protocol as the fault proof client does.

This is designed so that the FPVM can remain completely agnostic to the program it runs, it simply forwards any preimage requests from the program to the FPP host in server mode.  In on-chain mode the FPVM would ignore all hints and retrieve pre-images from the oracle contracts - this just allows running the off-chain emulation in MIPS mode to create the full trace.

**Tests**

Added a test specifically for server mode and unit tests around the new config and CLI args.

**Additional context**

Builds on #5547 

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3877/fpp-add-server-mode-to-host
