### PR TITLE
proxyd: round-robin load balancing for consensus group

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -596,36 +596,7 @@ func (b *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch b
 	// When `consensus_aware` is set to `true`, the backend group acts as a load balancer
 	// serving traffic from any backend that agrees in the consensus group
 	if b.Consensus != nil {
-		cg := b.Consensus.GetConsensusGroup()
-		backendsHealthy := make([]*Backend, 0, len(cg))
-		backendsDegraded := make([]*Backend, 0, len(cg))
-		// separate into unhealthy, degraded and healthy backends
-		for _, be := range cg {
-			// unhealthy are filtered out and not attempted
-			if !be.IsHealthy() {
-				continue
-			}
-			if be.IsDegraded() {
-				backendsDegraded = append(backendsDegraded, be)
-				continue
-			}
-			backendsHealthy = append(backendsHealthy, be)
-		}
-
-		// shuffle both slices
-		r := rand.New(rand.NewSource(time.Now().UnixNano()))
-		r.Shuffle(len(backendsHealthy), func(i, j int) {
-			backendsHealthy[i], backendsHealthy[j] = backendsHealthy[j], backendsHealthy[i]
-		})
-		r = rand.New(rand.NewSource(time.Now().UnixNano()))
-		r.Shuffle(len(backendsDegraded), func(i, j int) {
-			backendsDegraded[i], backendsDegraded[j] = backendsDegraded[j], backendsDegraded[i]
-		})
-
-		// healthy are put into a priority position
-		// degraded backends are used as fallback
-		backends = backendsHealthy
-		backends = append(backends, backendsDegraded...)
+		backends = b.loadBalancedConsensusGroup()
 	}
 
 	rpcRequestsTotal.Inc()
@@ -705,6 +676,40 @@ func (b *BackendGroup) ProxyWS(ctx context.Context, clientConn *websocket.Conn, 
 	}
 
 	return nil, ErrNoBackends
+}
+
+func (b *BackendGroup) loadBalancedConsensusGroup() []*Backend {
+	cg := b.Consensus.GetConsensusGroup()
+
+	backendsHealthy := make([]*Backend, 0, len(cg))
+	backendsDegraded := make([]*Backend, 0, len(cg))
+	// separate into healthy, degraded and unhealthy backends
+	for _, be := range cg {
+		// unhealthy are filtered out and not attempted
+		if !be.IsHealthy() {
+			continue
+		}
+		if be.IsDegraded() {
+			backendsDegraded = append(backendsDegraded, be)
+			continue
+		}
+		backendsHealthy = append(backendsHealthy, be)
+	}
+
+	// shuffle both slices
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Shuffle(len(backendsHealthy), func(i, j int) {
+		backendsHealthy[i], backendsHealthy[j] = backendsHealthy[j], backendsHealthy[i]
+	})
+	r.Shuffle(len(backendsDegraded), func(i, j int) {
+		backendsDegraded[i], backendsDegraded[j] = backendsDegraded[j], backendsDegraded[i]
+	})
+
+	// healthy are put into a priority position
+	// degraded backends are used as fallback
+	backendsHealthy = append(backendsHealthy, backendsDegraded...)
+
+	return backendsHealthy
 }
 
 func calcBackoff(i int) time.Duration {

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -3,6 +3,7 @@ package integration_tests
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -47,6 +48,7 @@ func TestConsensus(t *testing.T) {
 	ctx := context.Background()
 	svr, shutdown, err := proxyd.Start(config)
 	require.NoError(t, err)
+	client := NewProxydClient("http://127.0.0.1:8545")
 	defer shutdown()
 
 	bg := svr.BackendGroups["node"]
@@ -354,6 +356,45 @@ func TestConsensus(t *testing.T) {
 
 		// should resolve to 0x1, the highest common ancestor
 		require.Equal(t, "0x1", bg.Consensus.GetConsensusBlockNumber().String())
+	})
+
+	t.Run("load balancing should hit both backends", func(t *testing.T) {
+		h1.ResetOverrides()
+		h2.ResetOverrides()
+		bg.Consensus.Unban()
+
+		for _, be := range bg.Backends {
+			bg.Consensus.UpdateBackend(ctx, be)
+		}
+		bg.Consensus.UpdateBackendGroupConsensus(ctx)
+
+		require.Equal(t, 2, len(bg.Consensus.GetConsensusGroup()))
+
+		node1.Reset()
+		node2.Reset()
+
+		require.Equal(t, 0, len(node1.Requests()))
+		require.Equal(t, 0, len(node2.Requests()))
+
+		// there is a random component to this test,
+		// since our round-robin implementation shuffles the ordering
+		// to achieve uniform distribution
+
+		// so we just make 100 requests per backend and expect the number of requests to be somewhat balanced
+		// i.e. each backend should be hit minimally by at least 50% of the requests
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+
+		numberReqs := len(consensusGroup) * 100
+		for numberReqs > 0 {
+			_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"0x1", false})
+			require.NoError(t, err)
+			require.Equal(t, 200, statusCode)
+			numberReqs--
+		}
+
+		msg := fmt.Sprintf("n1 %d, n2 %d", len(node1.Requests()), len(node2.Requests()))
+		require.GreaterOrEqual(t, len(node1.Requests()), 50, msg)
+		require.GreaterOrEqual(t, len(node2.Requests()), 50, msg)
 	})
 }
 

--- a/proxyd/integration_tests/testdata/consensus.toml
+++ b/proxyd/integration_tests/testdata/consensus.toml
@@ -1,5 +1,5 @@
 [server]
-rpc_port = 8080
+rpc_port = 8545
 
 [backend]
 response_timeout_seconds = 1

--- a/proxyd/integration_tests/testdata/consensus_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_responses.yml
@@ -1,3 +1,10 @@
+- method: eth_chainId
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": "hello",
+    }
 - method: net_peerCount
   response: >
     {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change makes the background act as a load balancing using the consensus group as targets.

We aim to get a uniform random distribution between healthy nodes, and use degraded nodes as a fallback.
The same retry mechanism applies - meaning if a supposed host can't serve the request, the backend group still will try the next candidate.

**Tests**

Modified current tests to comply with new behavior.

**Invariants**

n/a

**Additional context**

* This change is part of the Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes https://linear.app/optimism/issue/INF-131/round-robin-load-balancing

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
