### PR TITLE
fix: deposited tx type RLP encoding specs

### DIFF
--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -66,10 +66,10 @@ A deposit has the following fields
   deposited transaction is a contract creation.
 - `uint256 mint`: The ETH value to mint on L2.
 - `uint256 value`: The ETH value to send to the recipient account.
-- `bytes data`: The input data.
+- `uint64 gas`: The gas limit for the L2 transaction.
 - `bool isSystemTx`: If true, the transaction does not interact with the L2 block gas pool.
   - Note: boolean is disabled (enforced to be `false`) starting from the Regolith upgrade.
-- `uint64 gasLimit`: The gasLimit for the L2 transaction.
+- `bytes data`: The normal transaction data.
 
 In contrast to [EIP-155] transactions, this transaction type:
 

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -69,7 +69,7 @@ A deposit has the following fields
 - `uint64 gas`: The gas limit for the L2 transaction.
 - `bool isSystemTx`: If true, the transaction does not interact with the L2 block gas pool.
   - Note: boolean is disabled (enforced to be `false`) starting from the Regolith upgrade.
-- `bytes data`: The normal transaction data.
+- `bytes data`: The calldata.
 
 In contrast to [EIP-155] transactions, this transaction type:
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The RLP order in the specs was not consistent with the code.

**Metadata**

- Fixes #5558

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
