### PR TITLE
feat: send bedrock upgrade txs using foundry

### DIFF
--- a/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx1.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx1.s.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { SafeBuilder } from "./SafeBuilder.sol";
+import { AddressManager } from "../../contracts/legacy/AddressManager.sol";
+import { ProxyAdmin } from "../../contracts/universal/ProxyAdmin.sol";
+import { Proxy } from "../../contracts/universal/Proxy.sol";
+import { L1ChugSplashProxy } from "../../contracts/legacy/L1ChugSplashProxy.sol";
+import { Proxy } from "../../contracts/universal/Proxy.sol";
+import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract BedrockUpgrade is SafeBuilder {
+    /**
+     * @notice A set of contracts for this upgrade transaction.
+     */
+    struct ContractSet {
+        address proxyAdmin;
+        address addressManager;
+        address l1StandardBridgeProxy;
+        address l1ERC721BridgeProxy;
+        address systemDicator;
+    }
+
+    /**
+     * @notice A mapping of chainid to a ContractSet of implementations.
+     */
+    mapping(uint256 => ContractSet) internal _implementations;
+
+    /**
+     * @notice Sets up the ContractSets for the bedrock upgrade.
+     */
+    function setUp() external {
+        _implementations[MAINNET] = ContractSet({
+            proxyAdmin: address(0x6486ff256710d098a35f75b6fd0f4a5a1e045ec3),
+            addressManager: address(0x6486ff256710D098a35F75b6FD0F4A5a1e045Ec3),
+            l1StandardBridgeProxy: address(0x2907b87d7b7b27f60b37b57ff9156b752b419900),
+            l1ERC721BridgeProxy: address(0xeFDd8B586cB777134216D54a6f344AFA5871e0d7),
+            systemDicator: address(0xd6322f9d48439103d2e9c3bdA7A43F851FbB2423)
+        });
+    }
+
+    function buildCalldata(address) internal override view returns (bytes memory) {
+        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](3);
+
+        ContractSet memory contractSet = implementations();
+
+        // Transfer ownership of AddressManager to the systemDicator
+        calls[0] = IMulticall3.Call3({
+            target: contractSet.addressManager,
+            allowFailure: false,
+            callData: abi.encodeCall(
+                Ownable.transferOwnership,
+                (contractSet.systemDicator)
+            )
+        });
+
+        // Transfer ownership of l1StandardBridgeProxy to the systemDicator
+        calls[1] = IMulticall3.Call3({
+            target: contractSet.l1StandardBridgeProxy,
+            allowFailure: false,
+            callData: abi.encodeCall(
+                L1ChugSplashProxy.setOwner,
+                (contractSet.systemDicator)
+            )
+        });
+
+        // Transfer ownership of the l1ERC721BridgeProxy to the systemDicator
+        calls[2] = IMulticall3.Call3({
+            target: contractSet.l1ERC721BridgeProxy,
+            allowFailure: false,
+            callData: abi.encodeCall(
+                Proxy.changeAdmin,
+                (contractSet.systemDicator)
+            )
+        });
+
+        return abi.encodeCall(IMulticall3.aggregate3, (calls));
+    }
+
+    function implementations() public view returns (ContractSet memory) {
+        ContractSet memory cs = _implementations[block.chainid];
+        require(cs.proxyAdmin != address(0), "implementations not set");
+        return cs;
+    }
+
+    /**
+     * @notice Follow up assertions to ensure that the script ran to completion.
+     */
+    function _postCheck() internal override view {
+        ContractSet memory contractSet = implementations();
+        require(Ownable(contractSet.addressManager).owner() == contractSet.systemDictator, "AddressManager");
+        require(L1ChugSplashProxy(contractSet.l1StandardBridgeProxy).getOwner() == contractSet.systemDicator, "l1StandardBridgeProxy");
+        require(Proxy(contractSet.l1ERC721BridgeProxy).admin() == contractSet.systemDicator, "l1ERC721BridgeProxy");
+    }
+
+    function test_script_succeeds() skipWhenNotForking external {
+        address safe;
+        address proxyAdmin;
+
+        if (block.chainid == GOERLI) {
+            safe = 0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f;
+            proxyAdmin = 0x01d3670863c3F4b24D7b107900f0b75d4BbC6e0d;
+        }
+
+        require(safe != address(0) && proxyAdmin != address(0));
+
+        address[] memory owners = IGnosisSafe(payable(safe)).getOwners();
+
+        for (uint256 i; i < owners.length; i++) {
+            address owner = owners[i];
+            vm.startBroadcast(owner);
+            bool success = _run(safe, proxyAdmin);
+            vm.stopBroadcast();
+
+            if (success) {
+                console.log("tx success");
+                break;
+            }
+        }
+
+        _postCheck();
+    }
+}

--- a/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx2.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx2.s.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { SafeBuilder } from "./SafeBuilder.sol";
+import { AddressManager } from "../../contracts/legacy/AddressManager.sol";
+import { ProxyAdmin } from "../../contracts/universal/ProxyAdmin.sol";
+import { L1ChugSplashProxy } from "../../contracts/legacy/L1ChugSplashProxy.sol";
+import { Proxy } from "../../contracts/universal/Proxy.sol";
+import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
+import { SystemDictator } from "../../contracts/deployment/SystemDictator.sol";
+import { JSONConfig } from "./JSONConfig.sol";
+
+contract BedrockUpgrade is SafeBuilder {
+    /**
+     * @notice A set of contracts for this upgrade transaction.
+     */
+    struct ContractSet {
+        address systemDictator;
+    }
+
+    /**
+     * @notice A json config files.
+     */
+    JSONConfig internal config;
+
+    /**
+     * @notice A mapping of chainid to a ContractSet of implementations.
+     */
+    mapping(uint256 => ContractSet) internal _implementations;
+
+    /**
+     * @notice A mapping of chainid to ContractSet of proxy addresses.
+     */
+    mapping(uint256 => ContractSet) internal proxies;
+
+    function setUp() external {
+        _implementations[MAINNET] = ContractSet({
+            systemDictator: address(0xd6322f9d48439103d2e9c3bdA7A43F851FbB2423)
+        });
+    }
+
+    function run(string memory _config, address _safe, address _proxyAdmin) external {
+        config = new JSONConfig(_config);
+        _run(_safe, _proxyAdmin);
+    }
+
+    function buildCalldata(address) internal override view returns (bytes memory) {
+        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](2);
+
+        ContractSet memory contractSet = implementations();
+
+        // Call step1
+        calls[0] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(SystemDictator.step1, ())
+        });
+
+        // Call step2
+        calls[1] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(SystemDictator.step2, ())
+        });
+
+        return abi.encodeCall(IMulticall3.aggregate3, (calls));
+    }
+
+    function implementations() public view returns (ContractSet memory) {
+        ContractSet memory cs = _implementations[block.chainid];
+        require(cs.systemDictator != address(0), "implementations not set");
+        return cs;
+    }
+
+    /**
+     * @notice Follow up assertions to ensure that the script ran to completion.
+     */
+    function _postCheck() internal override view {
+        ContractSet memory contractSet = implementations();
+        require(SystemDictator(contractSet.systemDictator).currentStep() == uint8(3), "SystemDictator");
+    }
+
+    function test_script_succeeds() skipWhenNotForking external {
+        address safe;
+        address proxyAdmin;
+
+        if (block.chainid == GOERLI) {
+            safe = 0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f;
+            proxyAdmin = 0x01d3670863c3F4b24D7b107900f0b75d4BbC6e0d;
+        }
+
+        require(safe != address(0) && proxyAdmin != address(0));
+
+        address[] memory owners = IGnosisSafe(payable(safe)).getOwners();
+
+        for (uint256 i; i < owners.length; i++) {
+            address owner = owners[i];
+            vm.startBroadcast(owner);
+            bool success = _run(safe, proxyAdmin);
+            vm.stopBroadcast();
+
+            if (success) {
+                console.log("tx success");
+                break;
+            }
+        }
+
+        _postCheck();
+    }
+}

--- a/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx3.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx3.s.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { SafeBuilder } from "./SafeBuilder.sol";
+import { AddressManager } from "../../contracts/legacy/AddressManager.sol";
+import { ProxyAdmin } from "../../contracts/universal/ProxyAdmin.sol";
+import { L1ChugSplashProxy } from "../../contracts/legacy/L1ChugSplashProxy.sol";
+import { Proxy } from "../../contracts/universal/Proxy.sol";
+import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
+import { SystemDictator } from "../../contracts/deployment/SystemDictator.sol";
+
+contract BedrockUpgrade is SafeBuilder {
+    /**
+     * @notice A set of contracts for this bedrock upgrade tx.
+     */
+    struct ContractSet {
+        address systemDictator;
+    }
+
+    /**
+     * @notice The L2OO dynamic config to upgrade the SystemDictator to.
+     */
+    SystemDictator.L2OutputOracleDynamicConfig internal config;
+
+    /**
+     * @notice Dynamic config bool.
+     */
+    bool internal optimismPortalDynamicConfig;
+
+    /**
+     * @notice A mapping of chainid to a ContractSet of implementations.
+     */
+    mapping(uint256 => ContractSet) internal _implementations;
+
+    /**
+     * @notice A mapping of chainid to ContractSet of proxy addresses.
+     */
+    mapping(uint256 => ContractSet) internal proxies;
+
+    function setUp() external {
+        _implementations[MAINNET] = ContractSet({
+            systemDictator: address(0xd6322f9d48439103d2e9c3bdA7A43F851FbB2423)
+        });
+        config = SystemDictator.L2OutputOracleDynamicConfig({
+            l2OutputOracleStartingBlockNumber: 0,
+            l2OutputOracleStartingTimestamp: 0
+        });
+        optimismPortalDynamicConfig = false;
+    }
+
+    function buildCalldata(address) internal override view returns (bytes memory) {
+        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
+
+        ContractSet memory contractSet = implementations();
+
+        // Call updateDynamicConfig
+        calls[0] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(
+                SystemDictator.updateDynamicConfig,
+                (config, optimismPortalDynamicConfig)
+            )
+        });
+
+        return abi.encodeCall(IMulticall3.aggregate3, (calls));
+    }
+
+    function implementations() public view returns (ContractSet memory) {
+        ContractSet memory cs = _implementations[block.chainid];
+        require(cs.systemDictator != address(0), "implementations not set");
+        return cs;
+    }
+
+    /**
+     * @notice Follow up assertions to ensure that the script ran to completion.
+     */
+    function _postCheck() internal override view {
+        ContractSet memory contractSet = implementations();
+        require(SystemDictator(contractSet.systemDictator).dynamicConfigSet() == true, "SystemDictator");
+        require(
+            SystemDictator(contractSet.systemDictator).l2OutputOracleDynamicConfig() == config,
+            "SystemDictator"
+        );
+        require(
+            SystemDictator(contractSet.systemDictator).optimismPortalDynamicConfig() == optimismPortalDynamicConfig,
+            "SystemDictator"
+        );
+    }
+
+    function test_script_succeeds() skipWhenNotForking external {
+        address safe;
+        address proxyAdmin;
+
+        if (block.chainid == GOERLI) {
+            safe = 0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f;
+            proxyAdmin = 0x01d3670863c3F4b24D7b107900f0b75d4BbC6e0d;
+        }
+
+        require(safe != address(0) && proxyAdmin != address(0));
+
+        address[] memory owners = IGnosisSafe(payable(safe)).getOwners();
+
+        for (uint256 i; i < owners.length; i++) {
+            address owner = owners[i];
+            vm.startBroadcast(owner);
+            bool success = _run(safe, proxyAdmin);
+            vm.stopBroadcast();
+
+            if (success) {
+                console.log("tx success");
+                break;
+            }
+        }
+
+        _postCheck();
+    }
+}

--- a/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx4.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/BedrockUpgradeTx4.s.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { SafeBuilder } from "./SafeBuilder.sol";
+import { AddressManager } from "../../contracts/legacy/AddressManager.sol";
+import { ProxyAdmin } from "../../contracts/universal/ProxyAdmin.sol";
+import { L1ChugSplashProxy } from "../../contracts/legacy/L1ChugSplashProxy.sol";
+import { Proxy } from "../../contracts/universal/Proxy.sol";
+import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
+import { SystemDictator } from "../../contracts/deployment/SystemDictator.sol";
+
+contract BedrockUpgrade is SafeBuilder {
+    /**
+     * @notice A set of contracts for this bedrock upgrade tx.
+     */
+    struct ContractSet {
+        address systemDictator;
+    }
+
+    /**
+     * @notice A mapping of chainid to a ContractSet of implementations.
+     */
+    mapping(uint256 => ContractSet) internal _implementations;
+
+    /**
+     * @notice A mapping of chainid to ContractSet of proxy addresses.
+     */
+    mapping(uint256 => ContractSet) internal proxies;
+
+    function setUp() external {
+        _implementations[MAINNET] = ContractSet({
+            systemDictator: address(0xd6322f9d48439103d2e9c3bdA7A43F851FbB2423)
+        });
+    }
+
+    function buildCalldata(address) internal override view returns (bytes memory) {
+        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](4);
+
+        ContractSet memory contractSet = implementations();
+
+        calls[0] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(SystemDictator.step3, ())
+        });
+
+        calls[1] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(SystemDictator.step4, ())
+        });
+
+        calls[2] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(SystemDictator.step5, ())
+        });
+
+        calls[3] = IMulticall3.Call3({
+            target: contractSet.systemDictator,
+            allowFailure: false,
+            callData: abi.encodeCall(SystemDictator.finalize, ())
+        });
+
+        return abi.encodeCall(IMulticall3.aggregate3, (calls));
+    }
+
+    function implementations() public view returns (ContractSet memory) {
+        ContractSet memory cs = _implementations[block.chainid];
+        require(cs.systemDictator != address(0), "implementations not set");
+        return cs;
+    }
+
+    /**
+     * @notice Follow up assertions to ensure that the script ran to completion.
+     */
+    function _postCheck() internal override view {
+        ContractSet memory contractSet = implementations();
+        require(SystemDictator(contractSet.systemDictator).finalized() == true, "SystemDictator");
+    }
+
+    function test_script_succeeds() skipWhenNotForking external {
+        address safe;
+        address proxyAdmin;
+
+        if (block.chainid == GOERLI) {
+            safe = 0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f;
+            proxyAdmin = 0x01d3670863c3F4b24D7b107900f0b75d4BbC6e0d;
+        }
+
+        require(safe != address(0) && proxyAdmin != address(0));
+
+        address[] memory owners = IGnosisSafe(payable(safe)).getOwners();
+
+        for (uint256 i; i < owners.length; i++) {
+            address owner = owners[i];
+            vm.startBroadcast(owner);
+            bool success = _run(safe, proxyAdmin);
+            vm.stopBroadcast();
+
+            if (success) {
+                console.log("tx success");
+                break;
+            }
+        }
+
+        _postCheck();
+    }
+}

--- a/packages/contracts-bedrock/scripts/upgrades/JSONConfig.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/JSONConfig.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Test } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+
+contract JSONConfig {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    string private _json;
+
+    constructor(string memory _path) {
+        string[] memory cmds = new string[](3);
+        cmds[0] = "bash";
+        cmds[1] = "-c";
+        cmds[2] = string.concat("cat ", _path);
+        bytes memory json = vm.ffi(cmds);
+        _json = string(json);
+    }
+
+    function readUint(string memory _key) external returns (uint256) {
+        return stdJson.readUint(_json, _key);
+    }
+
+    function readAddress(string memory _key) external returns (address) {
+        return stdJson.readAddress(_json, _key);
+    }
+}


### PR DESCRIPTION
**Description**

Introduces 4 transaction batch scripts following the migration rehearsal json batches in [`feat/mainnettx`](https://github.com/ethereum-optimism/optimism/tree/feat/mainnetx/MULTISIG_REHEARSAL).

Each batch script uses `SafeBuilder` and can read from json using the `JSONConfig` contract deployed with the specified string json file path. 

The reason why `JSONConfig` exists is to break out of the sandbox for the fs access, it just uses `bash` and `cat` to read a file from disk. We could hardcode values into the contracts but that will add extra overhead in the process, which is why I wrote `JSONConfig.sol` originally.
