### PR TITLE
op-program: Ensure go routines all complete cleanly

### DIFF
--- a/op-program/io/safeclose.go
+++ b/op-program/io/safeclose.go
@@ -1,0 +1,25 @@
+package io
+
+import (
+	"io"
+	"sync"
+)
+
+type safeClose struct {
+	c    io.Closer
+	once sync.Once
+}
+
+func (s *safeClose) Close() error {
+	var err error
+	s.once.Do(func() {
+		err = s.c.Close()
+	})
+	return err
+}
+
+func NewSafeClose(c io.Closer) io.Closer {
+	return &safeClose{
+		c: c,
+	}
+}

--- a/op-program/io/safeclose_test.go
+++ b/op-program/io/safeclose_test.go
@@ -1,0 +1,51 @@
+package io
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnlyCallsCloseOnce(t *testing.T) {
+	delegate := new(mockCloser)
+	defer delegate.AssertExpectations(t)
+
+	safeClose := NewSafeClose(delegate)
+	// Only expects one close call
+	delegate.ExpectClose(nil)
+
+	require.NoError(t, safeClose.Close())
+	require.NoError(t, safeClose.Close())
+}
+
+func TestReturnsErrorFromFirstCall(t *testing.T) {
+	delegate := new(mockCloser)
+	defer delegate.AssertExpectations(t)
+
+	safeClose := NewSafeClose(delegate)
+	err := errors.New("expected")
+	// Only expects one close call
+	delegate.ExpectClose(err)
+
+	require.ErrorIs(t, safeClose.Close(), err)
+	// Later calls should not return an error as they didn't need to call Close
+	require.NoError(t, safeClose.Close())
+}
+
+type mockCloser struct {
+	mock.Mock
+}
+
+func (t *mockCloser) Close() error {
+	err := t.Mock.MethodCalled("Close").Get(0)
+	if err != nil {
+		return err.(error)
+	}
+	return nil
+}
+
+func (t *mockCloser) ExpectClose(err error) {
+	t.Mock.On("Close").Return(err)
+}


### PR DESCRIPTION
**Description**

Tidy up the handling of goroutines to ensure any created go routines are exited prior to the two main entry point functions (`FaultProofProgram` and `PreimageServer`) returning.

This avoids test failures caused by dangling go routines like:  https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/17480/workflows/9981daa8-1817-4189-8cdb-239bc65f86ab/jobs/670118

Winds up being more difficult than I'd really like because we need to close file channels to signal that the preimage server, hinter and client program should exit, but also ensure we only call `Close()` once because the behaviour is officially undefined when calling it multiple times (and we do use multiple implementations in different modes so can't rely on the fact that File will just return an error that we ignore).

Very open to any suggestions for simplifying.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3910/fix-dangling-go-routines
