### PR TITLE
op-proposer,txmgr: Cleanup flags

### DIFF
--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -110,6 +110,7 @@ var optionalFlags = []cli.Flag{
 	TargetNumFramesFlag,
 	ApproxComprRatioFlag,
 	StoppedFlag,
+	SequencerHDPathFlag,
 }
 
 func init() {

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -59,11 +59,11 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
+	L2OutputHDPathFlag,
 }
 
 func init() {
-	requiredFlags = append(requiredFlags, oprpc.CLIFlags(envVarPrefix)...)
-
+	optionalFlags = append(optionalFlags, oprpc.CLIFlags(envVarPrefix)...)
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(envVarPrefix)...)
 	optionalFlags = append(optionalFlags, opmetrics.CLIFlags(envVarPrefix)...)
 	optionalFlags = append(optionalFlags, oppprof.CLIFlags(envVarPrefix)...)

--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -60,10 +60,8 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Usage:  "The HD path used to derive the sequencer wallet from the mnemonic. The mnemonic flag must also be set.",
 			EnvVar: opservice.PrefixEnvVar(envPrefix, "HD_PATH"),
 		},
-		SequencerHDPathFlag,
-		L2OutputHDPathFlag,
 		cli.StringFlag{
-			Name:   "private-key",
+			Name:   PrivateKeyFlagName,
 			Usage:  "The private key to use with the service. Must not be used with mnemonic.",
 			EnvVar: opservice.PrefixEnvVar(envPrefix, "PRIVATE_KEY"),
 		},


### PR DESCRIPTION
**Description**

This makes `op-rpc` flags optional in the proposer.
This also removes legacy flags from the txmgr (they are still retained in the batcher/proposer).
