### PR TITLE
Update docker files to use golang:1.19.9 and alpine3.16

### DIFF
--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.0-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
 
 ARG VERSION=v0.0.0
 
@@ -23,7 +23,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-batcher VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin
 

--- a/op-chain-ops/Dockerfile
+++ b/op-chain-ops/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.15 as builder
+FROM golang:1.19.9-alpine3.15 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 

--- a/op-exporter/Dockerfile
+++ b/op-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.15 as builder
+FROM golang:1.19.9-alpine3.16 as builder
 
 # build from root of repo
 COPY ./op-exporter /app
@@ -7,7 +7,7 @@ WORKDIR /app/
 RUN apk --no-cache add make bash jq git
 RUN make build
 
-FROM alpine:3.15
+FROM alpine:3.16
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /app/op-exporter /usr/local/bin/

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.0-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
 
 ARG VERSION=v0.0.0
 
@@ -21,7 +21,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-node VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=builder /app/op-node/bin/op-node /usr/local/bin
 

--- a/op-program/Dockerfile
+++ b/op-program/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.0-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
 
 ARG VERSION=v0.0.0
 
@@ -22,7 +22,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-program VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=builder /app/op-program/bin/op-program /usr/local/bin
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.0-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
 
 ARG VERSION=v0.0.0
 
@@ -22,7 +22,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-proposer VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin
 

--- a/op-wheel/Dockerfile
+++ b/op-wheel/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.15 as builder
+FROM golang:1.19.9-alpine3.16 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
@@ -14,7 +14,7 @@ WORKDIR /app/op-wheel
 
 RUN go build -o op-wheel ./cmd/main.go
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=builder /app/op-wheel/op-wheel /usr/local/bin
 

--- a/ops-bedrock/Dockerfile.stateviz
+++ b/ops-bedrock/Dockerfile.stateviz
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-alpine3.15 as builder
+FROM golang:1.19.9-alpine3.16 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
@@ -14,7 +14,7 @@ COPY ./op-node /app/op-node
 
 RUN go build -o ./bin/stateviz ./cmd/stateviz
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=builder /app/op-node/bin/stateviz /usr/local/bin
 


### PR DESCRIPTION
**Description**

Update docker files to use `golang:1.19.9-alpine3.16` instead of `golang:1.19.0-alpine3.15` as there's a bug in the MIPS compiler in 1.19.0 (https://github.com/golang/go/issues/54991) which causes it to fail with the latest op-geth changes.  There isn't an `alpine3.15` version with the updated golang compiler so updating from `alpine:3.15` to alpine:3.16` for the images as well to be consistent with what we compile on.

**Metadata**

- Required for https://linear.app/optimism/issue/CLI-3867/update-op-geth-to-upstream-1116-release and https://github.com/ethereum-optimism/optimism/pull/5514

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
