### PR TITLE
op-chain-ops: check-migration-quick

### DIFF
--- a/op-chain-ops/cmd/check-migration-quick/main.go
+++ b/op-chain-ops/cmd/check-migration-quick/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/urfave/cli"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/db"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func main() {
+	log.Root().SetHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(isatty.IsTerminal(os.Stderr.Fd()))))
+
+	app := &cli.App{
+		Name:  "check-migration-quick",
+		Usage: "Quick check for a migrated database that only checks the header magic in the extradata",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "db-path",
+				Usage:    "Path to database",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:  "db-cache",
+				Usage: "LevelDB cache size in mb",
+				Value: 1024,
+			},
+			&cli.IntFlag{
+				Name:  "db-handles",
+				Usage: "LevelDB number of handles",
+				Value: 60,
+			},
+		},
+		Action: func(ctx *cli.Context) error {
+			dbCache := ctx.Int("db-cache")
+			dbHandles := ctx.Int("db-handles")
+
+			ldb, err := db.Open(ctx.String("db-path"), dbCache, dbHandles)
+			if err != nil {
+				return err
+			}
+
+			hash := rawdb.ReadHeadHeaderHash(ldb)
+			log.Info("Reading chain tip from database", "hash", hash)
+			num := rawdb.ReadHeaderNumber(ldb, hash)
+			if num == nil {
+				return fmt.Errorf("cannot find header number for %s", hash)
+			}
+
+			header := rawdb.ReadHeader(ldb, hash, *num)
+			log.Info("Read header from database", "number", *num)
+
+			log.Info(
+				"Header info",
+				"parentHash", header.ParentHash.Hex(),
+				"root", header.Root.Hex(),
+				"number", header.Number,
+				"gasLimit", header.GasLimit,
+				"time", header.Time,
+				"extra", hexutil.Encode(header.Extra),
+			)
+
+			if !bytes.Equal(header.Extra, genesis.BedrockTransitionBlockExtraData) {
+				return fmt.Errorf("expected extra data to be %x, but got %x", genesis.BedrockTransitionBlockExtraData, header.Extra)
+			}
+
+			if err := ldb.Close(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Crit("error in migration", "err", err)
+	}
+}


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a new tool that can be used as part of the migration that checks a minimal amount of information to ensure that the database migration was successful. It checks the extradata in the block header for the bedrock magic and errors if its not found. It will log information about the block header as well.

Closes CLI-3915

A clear and concise description of the features you're adding in this pull request.


