### PR TITLE
ci: Change bedrock link checker to run nightly instead of on every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,10 +612,20 @@ jobs:
       - run:
           name: markdown lint
           command: yarn lint:specs:check
+
+  bedrock-markdown-links:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    steps:
+      - checkout
       - run:
           name: link lint
           command: |
-            docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback --exclude twitter.com --exclude-mail /input/README.md "/input/specs/**/*.md"
+            make bedrock-markdown-links
+      - slack/notify:
+          channel: C055R639XT9 #notify-link-check
+          event: fail
+          template: basic_fail_1
 
   fuzz-op-node:
     docker:
@@ -1619,3 +1629,15 @@ workflows:
           context:
             - slack
             - oplabs-fpp-nodes
+
+  scheduled-link-check:
+    triggers:
+      - schedule:
+          # Run once a day, only on the develop branch
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: [ "develop" ]
+    jobs:
+      - bedrock-markdown-links:
+          context: slack

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,6 @@ tag-bedrock-go-modules:
 update-op-geth:
 	./ops/scripts/update-op-geth.py
 .PHONY: update-op-geth
+
+bedrock-markdown-links:
+	docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback --exclude twitter.com --exclude-mail /input/README.md "/input/specs/**/*.md"


### PR DESCRIPTION
**Description**

Moves the bedrock markdown link check to a daily scheduled job rather than being run on every PR. This should make it less likely that we'll get blocked for spamming sites with suspicious looking requests and will at least reduce the noise on PRs if we do.

**Additional context**

Slack notification of failures is going to the new `notify-link-check` channel.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-3912/move-link-checking-to-a-scheduled-job