### PR TITLE
ci: Add go.mod and go.sum to rebuild all patterns

### DIFF
--- a/ops/check-changed/main.py
+++ b/ops/check-changed/main.py
@@ -11,7 +11,9 @@ REBUILD_ALL_PATTERNS = [
     r'^\.github/\.*',
     r'^package\.json',
     r'^yarn\.lock',
-    r'ops/check-changed/.*'
+    r'ops/check-changed/.*',
+    r'^go\.mod',
+    r'^go\.sum',
 ]
 
 WHITELISTED_BRANCHES = {


### PR DESCRIPTION
**Description**

Add go.mod and go.sum to rebuild all patterns.

Any new go code winds up using these dependency definitions by default and they don't change often so it's safer to rebuild everything when they change to avoid surprises. For example the last op-geth update let a compile error slip through in contract differential testing (https://github.com/ethereum-optimism/optimism/pull/5588).