### PR TITLE
sdk: deposit eth task delete dead code

### DIFF
--- a/packages/sdk/tasks/deposit-eth.ts
+++ b/packages/sdk/tasks/deposit-eth.ts
@@ -27,12 +27,6 @@ task('deposit-eth', 'Deposits ether to L2.')
     'http://localhost:9545',
     types.string
   )
-  .addParam(
-    'opNodeProviderUrl',
-    'op-node provider URL',
-    'http://localhost:7545',
-    types.string
-  )
   .addOptionalParam('to', 'Recipient of the ether', '', types.string)
   .addOptionalParam(
     'amount',


### PR DESCRIPTION
**Description**

Removes a dead argumen from the deposit eth hh task in the sdk. This task is ran in CI and is useful for testing an end to end deposit withdrawal flow for ether.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


