### PR TITLE
sdk: fixup deposit eth task + hh config

### DIFF
--- a/packages/sdk/hardhat.config.ts
+++ b/packages/sdk/hardhat.config.ts
@@ -15,6 +15,12 @@ const config: HardhatUserConfig = {
     sources: './test/contracts',
   },
   networks: {
+    mainnet: {
+      url: process.env.L1_RPC || 'https://mainnet-l1-rehearsal.optimism.io',
+      accounts: [
+        'ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+      ],
+    },
     devnetL1: {
       url: 'http://localhost:8545',
       accounts: [
@@ -43,6 +49,10 @@ const config: HardhatUserConfig = {
       },
     ],
     deployments: {
+      mainnet: [
+        '../contracts/deployments/mainnet',
+        '../contracts-bedrock/deployments/mainnet'
+      ],
       hivenet: ['../contracts-bedrock/deployments/hivenet'],
       devnetL1: ['../contracts-bedrock/deployments/devnetL1'],
       goerli: [

--- a/packages/sdk/tasks/deposit-eth.ts
+++ b/packages/sdk/tasks/deposit-eth.ts
@@ -136,8 +136,8 @@ task('deposit-eth', 'Deposits ether to L2.')
       contractAddrs = {
         l1: {
           AddressManager: Deployment__AddressManager.address,
-          L1CrossDomainMessenger: Deployment__L1CrossDomainMessenger,
-          L1StandardBridge: Deployment__L1StandardBridge,
+          L1CrossDomainMessenger: Deployment__L1CrossDomainMessenger.address,
+          L1StandardBridge: Deployment__L1StandardBridge.address,
           StateCommitmentChain: ethers.constants.AddressZero,
           CanonicalTransactionChain: ethers.constants.AddressZero,
           BondManager: ethers.constants.AddressZero,


### PR DESCRIPTION
**Description**

Fixes hardhat config by adding mainnet network
and uses correct addresses in building the contracts object.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

