### PR TITLE
feat(pops): Challenger Metrics

### DIFF
--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -1,0 +1,124 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/prometheus/client_golang/prometheus"
+
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+)
+
+const Namespace = "op_challenger"
+
+type Metricer interface {
+	RecordInfo(version string)
+	RecordUp()
+
+	// Records all L1 and L2 block events
+	opmetrics.RefMetricer
+
+	// Record Tx metrics
+	txmetrics.TxMetricer
+
+	RecordValidOutput(l2ref eth.L2BlockRef)
+	RecordInvalidOutput(l2ref eth.L2BlockRef)
+	RecordOutputChallenged(l2ref eth.L2BlockRef)
+}
+
+type Metrics struct {
+	ns       string
+	registry *prometheus.Registry
+	factory  opmetrics.Factory
+
+	opmetrics.RefMetrics
+	txmetrics.TxMetrics
+
+	info prometheus.GaugeVec
+	up   prometheus.Gauge
+}
+
+var _ Metricer = (*Metrics)(nil)
+
+func NewMetrics(procName string) *Metrics {
+	if procName == "" {
+		procName = "default"
+	}
+	ns := Namespace + "_" + procName
+
+	registry := opmetrics.NewRegistry()
+	factory := opmetrics.With(registry)
+
+	return &Metrics{
+		ns:       ns,
+		registry: registry,
+		factory:  factory,
+
+		RefMetrics: opmetrics.MakeRefMetrics(ns, factory),
+		TxMetrics:  txmetrics.MakeTxMetrics(ns, factory),
+
+		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "info",
+			Help:      "Pseudo-metric tracking version and config info",
+		}, []string{
+			"version",
+		}),
+		up: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "up",
+			Help:      "1 if the op-proposer has finished starting up",
+		}),
+	}
+}
+
+func (m *Metrics) Serve(ctx context.Context, host string, port int) error {
+	return opmetrics.ListenAndServe(ctx, m.registry, host, port)
+}
+
+func (m *Metrics) StartBalanceMetrics(ctx context.Context,
+	l log.Logger, client *ethclient.Client, account common.Address) {
+	opmetrics.LaunchBalanceMetrics(ctx, l, m.registry, m.ns, client, account)
+}
+
+// RecordInfo sets a pseudo-metric that contains versioning and
+// config info for the op-proposer.
+func (m *Metrics) RecordInfo(version string) {
+	m.info.WithLabelValues(version).Set(1)
+}
+
+// RecordUp sets the up metric to 1.
+func (m *Metrics) RecordUp() {
+	prometheus.MustRegister()
+	m.up.Set(1)
+}
+
+const (
+	ValidOutput      = "valid_output"
+	InvalidOutput    = "invalid_output"
+	OutputChallenged = "output_challenged"
+)
+
+// RecordValidOutput should be called when a valid output is found
+func (m *Metrics) RecordValidOutput(l2ref eth.L2BlockRef) {
+	m.RecordL2Ref(ValidOutput, l2ref)
+}
+
+// RecordInvalidOutput should be called when an invalid output is found
+func (m *Metrics) RecordInvalidOutput(l2ref eth.L2BlockRef) {
+	m.RecordL2Ref(InvalidOutput, l2ref)
+}
+
+// RecordOutputChallenged should be called when an output is challenged
+func (m *Metrics) RecordOutputChallenged(l2ref eth.L2BlockRef) {
+	m.RecordL2Ref(OutputChallenged, l2ref)
+}
+
+func (m *Metrics) Document() []opmetrics.DocumentedMetric {
+	return m.factory.Document()
+}

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -1,0 +1,21 @@
+package metrics
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+)
+
+type noopMetrics struct {
+	opmetrics.NoopRefMetrics
+	txmetrics.NoopTxMetrics
+}
+
+var NoopMetrics Metricer = new(noopMetrics)
+
+func (*noopMetrics) RecordInfo(version string) {}
+func (*noopMetrics) RecordUp()                 {}
+
+func (*noopMetrics) RecordValidOutput(l2ref eth.L2BlockRef)      {}
+func (*noopMetrics) RecordInvalidOutput(l2ref eth.L2BlockRef)    {}
+func (*noopMetrics) RecordOutputChallenged(l2ref eth.L2BlockRef) {}


### PR DESCRIPTION
### Description

This PR adds metrics to the challenger service.

Challenger metrics is nearly identical to the proposer service, with the following additional endpoints. (More can be added in future prs, but these are the core data series we should collect to track the challenger service).

```go
RecordValidOutput(l2ref eth.L2BlockRef)
RecordInvalidOutput(l2ref eth.L2BlockRef)
RecordOutputChallenged(l2ref eth.L2BlockRef)
```

### Background

Building off #5568, this PR introduces new changes to the `op-challenger` service.

The `op-challenger` is a naive, honest challenge agent that can be run as a standalone service for permissionless output proposal validation.

In the initial iteration of PoPs, only a permissioned set of challenge agents can dispute outputs as part of the **Attestation Dispute Game**. But once Fault Dispute Games are implemented, disputing outputs will be permissionless.

### Metadata

Fixes CLI-3943