### PR TITLE
proxyd/fix: error rate tolerance

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -557,7 +557,11 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 
 // IsHealthy checks if the backend is able to serve traffic, based on dynamic parameters
 func (b *Backend) IsHealthy() bool {
-	errorRate := b.networkErrorsSlidingWindow.Sum() / b.networkRequestsSlidingWindow.Sum()
+	errorRate := float64(0)
+	// avoid division-by-zero when the window is empty
+	if b.networkRequestsSlidingWindow.Sum() >= 10 {
+		errorRate = b.networkErrorsSlidingWindow.Sum() / b.networkRequestsSlidingWindow.Sum()
+	}
 	avgLatency := time.Duration(b.latencySlidingWindow.Avg())
 	if errorRate >= b.maxErrorRateThreshold {
 		return false


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This code fixes how we calculate the error rate.
tl;dr it adds a tolerance in which the error rate will be set to 0 until we have at least 10 data points.

When the sliding window has few data points, the error rate can be skewed quickly, causing the node to the banned. I.e. for an max error rate of 50%, it takes 1 error out of 2 requests to ban the node.

Also when the window is empty, it was previously causing an division by zero.

**Tests**

Manual

**Invariants**

n/a

**Additional context**

Original PR: https://github.com/ethereum-optimism/optimism/pull/5542
This change is part of the Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes https://linear.app/optimism/issue/INF-195/fix-error-rate

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
