### PR TITLE
fix(op-proposer): Make Info and Up Fields Unexported

### DIFF
--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -37,8 +37,8 @@ type Metrics struct {
 	opmetrics.RefMetrics
 	txmetrics.TxMetrics
 
-	Info prometheus.GaugeVec
-	Up   prometheus.Gauge
+	info prometheus.GaugeVec
+	up   prometheus.Gauge
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -60,14 +60,14 @@ func NewMetrics(procName string) *Metrics {
 		RefMetrics: opmetrics.MakeRefMetrics(ns, factory),
 		TxMetrics:  txmetrics.MakeTxMetrics(ns, factory),
 
-		Info: *factory.NewGaugeVec(prometheus.GaugeOpts{
+		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "info",
 			Help:      "Pseudo-metric tracking version and config info",
 		}, []string{
 			"version",
 		}),
-		Up: factory.NewGauge(prometheus.GaugeOpts{
+		up: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "up",
 			Help:      "1 if the op-proposer has finished starting up",
@@ -87,13 +87,13 @@ func (m *Metrics) StartBalanceMetrics(ctx context.Context,
 // RecordInfo sets a pseudo-metric that contains versioning and
 // config info for the op-proposer.
 func (m *Metrics) RecordInfo(version string) {
-	m.Info.WithLabelValues(version).Set(1)
+	m.info.WithLabelValues(version).Set(1)
 }
 
 // RecordUp sets the up metric to 1.
 func (m *Metrics) RecordUp() {
 	prometheus.MustRegister()
-	m.Up.Set(1)
+	m.up.Set(1)
 }
 
 const (


### PR DESCRIPTION
**Description**

Quick fix for the `op-proposer` `metrics.go` to change the `Info` and `Up` fields to be unexported following @trianglesphere's comment on the `op-challenger` metrics here: https://github.com/ethereum-optimism/optimism/pull/5604#discussion_r1185337831.