### PR TITLE
proxyd/fix: rewrite should support BlockNumberOrHash

### DIFF
--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"encoding/json"
 	"errors"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 )

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -334,6 +334,18 @@ func TestRewriteRequest(t *testing.T) {
 			expected:    RewriteOverrideError,
 			expectedErr: ErrRewriteBlockOutOfRange,
 		},
+		{
+			name: "eth_getStorageAt using rpc.BlockNumberOrHash",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]string{
+					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
+					"0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08",
+					"0x1c4840bcb3de3ac403c0075b46c2c47d4396c5b624b6e1b2874ec04e8879b483"})},
+				res: nil,
+			},
+			expected: RewriteNone,
+		},
 	}
 
 	// generalize tests for other methods with same interface and behavior


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Block numbers are sometimes hashes, and the marshalling decides based on the contents.  We need to support accepting `BlockNumberOrHash` in tag rewrites.

Example request:

```
{"auth":"none","body":"{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"eth_getStorageAt\",\"params\":[\"0xae851f927ee40de99aabb7461c00f9622ab91d60\",\"0x65a7ed542fb37fe237fdfbdd70b31598523fe5b32879e307bae27a0bd9581c08\",\"0x1c4840bcb3de3ac403c0075b46c2c47d4396c5b624b6e1b2874ec04e8879b483\"]}","lvl":"info","msg":"Raw RPC request","req_id":"06d2e2e291ce6528958c","t":"2023-05-04T21:45:24.548498655Z"}
```

**Tests**

Add new test to cover this code path

**Invariants**

n/a

**Additional context**

This is part of the project Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

Tag rewrite PR: https://github.com/ethereum-optimism/optimism/pull/5586

**Fixes**

- INF-196


**TODOs**
- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
