### PR TITLE
proxyd: skip peer count config per backend

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -132,6 +132,8 @@ type Backend struct {
 	stripTrailingXFF     bool
 	proxydIP             string
 
+	skipPeerCountCheck bool
+
 	maxDegradedLatencyThreshold time.Duration
 	maxLatencyThreshold         time.Duration
 	maxErrorRateThreshold       float64
@@ -204,6 +206,12 @@ func WithStrippedTrailingXFF() BackendOpt {
 func WithProxydIP(ip string) BackendOpt {
 	return func(b *Backend) {
 		b.proxydIP = ip
+	}
+}
+
+func WithSkipPeerCountCheck(skipPeerCountCheck bool) BackendOpt {
+	return func(b *Backend) {
+		b.skipPeerCountCheck = skipPeerCountCheck
 	}
 }
 

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -81,17 +81,18 @@ type BackendOptions struct {
 }
 
 type BackendConfig struct {
-	Username         string `toml:"username"`
-	Password         string `toml:"password"`
-	RPCURL           string `toml:"rpc_url"`
-	WSURL            string `toml:"ws_url"`
-	WSPort           int    `toml:"ws_port"`
-	MaxRPS           int    `toml:"max_rps"`
-	MaxWSConns       int    `toml:"max_ws_conns"`
-	CAFile           string `toml:"ca_file"`
-	ClientCertFile   string `toml:"client_cert_file"`
-	ClientKeyFile    string `toml:"client_key_file"`
-	StripTrailingXFF bool   `toml:"strip_trailing_xff"`
+	Username           string `toml:"username"`
+	Password           string `toml:"password"`
+	RPCURL             string `toml:"rpc_url"`
+	WSURL              string `toml:"ws_url"`
+	WSPort             int    `toml:"ws_port"`
+	MaxRPS             int    `toml:"max_rps"`
+	MaxWSConns         int    `toml:"max_ws_conns"`
+	CAFile             string `toml:"ca_file"`
+	ClientCertFile     string `toml:"client_cert_file"`
+	ClientKeyFile      string `toml:"client_key_file"`
+	StripTrailingXFF   bool   `toml:"strip_trailing_xff"`
+	SkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 }
 
 type BackendsConfig map[string]*BackendConfig

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -72,6 +72,9 @@ ca_file = ""
 client_cert_file = ""
 # Path to a custom client key file.
 client_key_file = ""
+# Allows backends to skip peer count checking, default false
+# consensus_skip_peer_count = true
+
 
 [backends.alchemy]
 rpc_url = ""

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -157,6 +157,7 @@ func Start(config *Config) (*Server, func(), error) {
 			opts = append(opts, WithStrippedTrailingXFF())
 		}
 		opts = append(opts, WithProxydIP(os.Getenv("PROXYD_IP")))
+		opts = append(opts, WithSkipPeerCountCheck(cfg.SkipPeerCountCheck))
 
 		back := NewBackend(name, rpcURL, wsURL, lim, rpcRequestSemaphore, opts...)
 		backendNames = append(backendNames, name)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Alchemy does not support `net_peerCount`, so we should skip this particular check.  This change adds the ability to skip peer count check per backend.

**Tests**

Manual

**Invariants**

n/a

**Additional context**

This is part of the project Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d


**Fixes**

- INF-197


**TODOs**
- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
