### PR TITLE
feat(sdk): Add a bedrock warning

### DIFF
--- a/.changeset/tough-flies-fetch.md
+++ b/.changeset/tough-flies-fetch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Add warning if bedrock is not turned on

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -144,6 +144,12 @@ export class CrossChainMessenger {
     bedrock?: boolean
   }) {
     this.bedrock = opts.bedrock ?? false
+
+    if (!this.bedrock) {
+      console.warn(
+        'Bedrock compatibility is disabled in CrossChainMessenger.  Please enable it if you are using Bedrock.'
+      )
+    }
     this.l1SignerOrProvider = toSignerOrProvider(opts.l1SignerOrProvider)
     this.l2SignerOrProvider = toSignerOrProvider(opts.l2SignerOrProvider)
 


### PR DESCRIPTION
- We saw 2 users of the sdk run into issues where they failed to set bedrock true and the error message wasn't very helpful
- add a console.warn if bedrock is false
- in future version of sdk we can make bedrock the default