### PR TITLE
fix comment of `ChainStorageContainer`

### DIFF
--- a/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
+++ b/packages/contracts/contracts/L1/rollup/ChainStorageContainer.sol
@@ -14,10 +14,9 @@ import { IChainStorageContainer } from "./IChainStorageContainer.sol";
  * functionality. This provides gas efficiency gains by enabling it to overwrite storage slots which
  * can no longer be used in a fraud proof due to the fraud window having passed, and the associated
  * chain state or transactions being finalized.
- * Three distinct Chain Storage Containers will be deployed on Layer 1:
+ * Two distinct Chain Storage Containers will be deployed on Layer 1:
  * 1. Stores transaction batches for the Canonical Transaction Chain
- * 2. Stores queued transactions for the Canonical Transaction Chain
- * 3. Stores chain state batches for the State Commitment Chain
+ * 2. Stores chain state batches for the State Commitment Chain
  *
  */
 contract ChainStorageContainer is IChainStorageContainer, Lib_AddressResolver {


### PR DESCRIPTION
There're in fact only two instances of `ChainStorageContainer` deployed on `Layer 1` .

Queued transactions for the Canonical Transaction Chain are stored in `CanonicalTransactionChain.queueElements` instead.