### PR TITLE
feat(pops): Clobbered pops/dispute-game-contracts, seaport-style

### DIFF
--- a/packages/contracts-bedrock/contracts/dispute/IBondManager.sol
+++ b/packages/contracts-bedrock/contracts/dispute/IBondManager.sol
@@ -1,0 +1,44 @@
+/// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/**
+ * @title IBondManager
+ * @notice The Bond Manager holds ether posted as a bond for a bond id.
+ */
+interface IBondManager {
+    /**
+     * @notice Post a bond with a given id and owner.
+     * @dev This function will revert if the provided bondId is already in use.
+     * @param bondId is the id of the bond.
+     * @param owner is the address that owns the bond.
+     * @param minClaimHold is the minimum amount of time the owner
+     *        must wait before reclaiming their bond.
+     */
+    function post(
+        bytes32 bondId,
+        address owner,
+        uint256 minClaimHold
+    ) external payable;
+
+    /**
+     * @notice Seizes the bond with the given id.
+     * @dev This function will revert if there is no bond at the given id.
+     * @param bondId is the id of the bond.
+     */
+    function seize(bytes32 bondId) external;
+
+    /**
+     * @notice Seizes the bond with the given id and distributes it to recipients.
+     * @dev This function will revert if there is no bond at the given id.
+     * @param bondId is the id of the bond.
+     * @param recipients is a set of addresses to split the bond amongst.
+     */
+    function seizeAndSplit(bytes32 bondId, address[] calldata recipients) external;
+
+    /**
+     * @notice Reclaims the bond of the bond owner.
+     * @dev This function will revert if there is no bond at the given id.
+     * @param bondId is the id of the bond.
+     */
+    function reclaim(bytes32 bondId) external;
+}

--- a/packages/contracts-bedrock/contracts/dispute/IDisputeGame.sol
+++ b/packages/contracts-bedrock/contracts/dispute/IDisputeGame.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import { Claim, GameType, GameStatus, Timestamp } from "../libraries/DisputeTypes.sol";
+
+import { IVersioned } from "./IVersioned.sol";
+import { IBondManager } from "./IBondManager.sol";
+import { IInitializable } from "./IInitializable.sol";
+
+/**
+ * @title IDisputeGame
+ * @notice The generic interface for a DisputeGame contract.
+ */
+interface IDisputeGame is IInitializable, IVersioned {
+    /**
+     * @notice Emitted when the game is resolved.
+     * @param status The status of the game after resolution.
+     */
+    event Resolved(GameStatus indexed status);
+
+    /// @notice Returns the timestamp that the DisputeGame contract was created at.
+
+    /**
+     * @notice Returns the timestamp that the DisputeGame contract was created at.
+     * @return _createdAt The timestamp that the DisputeGame contract was created at.
+     */
+    function createdAt() external view returns (Timestamp _createdAt);
+
+    /**
+     * @notice Returns the current status of the game.
+     * @return _status The current status of the game.
+     */
+    function status() external view returns (GameStatus _status);
+
+    /**
+     * @notice Getter for the game type.
+     * @dev `clones-with-immutable-args` argument #1
+     * @dev The reference impl should be entirely different depending on the type (fault, validity)
+     *      i.e. The game type should indicate the security model.
+     * @return _gameType The type of proof system being used.
+     */
+    function gameType() external view returns (GameType _gameType);
+
+    /**
+     * @notice Getter for the root claim.
+     * @dev `clones-with-immutable-args` argument #2
+     * @return _rootClaim The root claim of the DisputeGame.
+     */
+    function rootClaim() external view returns (Claim _rootClaim);
+
+    /**
+     * @notice Getter for the extra data.
+     * @dev `clones-with-immutable-args` argument #3
+     * @return _extraData Any extra data supplied to the dispute game contract by the creator.
+     */
+    function extraData() external view returns (bytes memory _extraData);
+
+    /**
+     * @notice Returns the address of the `BondManager` used.
+     * @return _bondManager The address of the `BondManager` used.
+     */
+    function bondManager() external view returns (IBondManager _bondManager);
+
+    /**
+     * @notice If all necessary information has been gathered, this function should mark the game
+     *         status as either `CHALLENGER_WINS` or `DEFENDER_WINS` and return the status of
+     *         the resolved game. It is at this stage that the bonds should be awarded to the
+     *         necessary parties.
+     * @dev May only be called if the `status` is `IN_PROGRESS`.
+     * @return _status The status of the game after resolution.
+     */
+    function resolve() external returns (GameStatus _status);
+}

--- a/packages/contracts-bedrock/contracts/dispute/IInitializable.sol
+++ b/packages/contracts-bedrock/contracts/dispute/IInitializable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/**
+ * @title IInitializable
+ * @notice An interface for initializable contracts.
+ */
+interface IInitializable {
+    /**
+     * @notice Initializes the contract.
+     * @dev This function may only be called once.
+     */
+    function initialize() external;
+}

--- a/packages/contracts-bedrock/contracts/dispute/IVersioned.sol
+++ b/packages/contracts-bedrock/contracts/dispute/IVersioned.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/**
+ * @title IVersioned
+ * @notice An interface for semantically versioned contracts.
+ */
+interface IVersioned {
+    /**
+     * @notice Returns the semantic version of the contract
+     * @return _version The semantic version of the contract
+     */
+    function version() external pure returns (string memory _version);
+}

--- a/packages/contracts-bedrock/contracts/libraries/DisputeTypes.sol
+++ b/packages/contracts-bedrock/contracts/libraries/DisputeTypes.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+/**
+ * @notice A custom type for a generic hash.
+ */
+type Hash is bytes32;
+
+/**
+ * @notice A claim represents an MPT root representing the state of the fault proof program.
+ */
+type Claim is bytes32;
+
+/**
+ * @notice A claim hash represents a hash of a claim and a position within the game tree.
+ * @dev Keccak hash of abi.encodePacked(Claim, Position);
+ */
+type ClaimHash is bytes32;
+
+/**
+ * @notice A bond represents the amount of collateral that a user has locked up in a claim.
+ */
+type Bond is uint256;
+
+/**
+ * @notice A dedicated timestamp type.
+ */
+type Timestamp is uint64;
+
+/**
+ * @notice A dedicated duration type.
+ * @dev Unit: seconds
+ */
+type Duration is uint64;
+
+/**
+ * @notice A `Clock` represents a packed `Duration` and `Timestamp`
+ * @dev The packed layout of this type is as follows:
+ * ┌────────────┬────────────────┐
+ * │    Bits    │     Value      │
+ * ├────────────┼────────────────┤
+ * │ [0, 128)   │ Duration       │
+ * │ [128, 256) │ Timestamp      │
+ * └────────────┴────────────────┘
+ */
+type Clock is uint256;
+
+/**
+ * @notice A `Position` represents a position of a claim within the game tree.
+ * @dev The packed layout of this type is as follows:
+ * ┌────────────┬────────────────┐
+ * │    Bits    │     Value      │
+ * ├────────────┼────────────────┤
+ * │ [0, 128)   │ Depth          │
+ * │ [128, 256) │ Index at depth │
+ * └────────────┴────────────────┘
+ */
+type Position is uint256;
+
+/**
+ * @notice The current status of the dispute game.
+ */
+enum GameStatus {
+    // The game is currently in progress, and has not been resolved.
+    IN_PROGRESS,
+    // The game has concluded, and the `rootClaim` was challenged successfully.
+    CHALLENGER_WINS,
+    // The game has concluded, and the `rootClaim` could not be contested.
+    DEFENDER_WINS
+}
+
+/**
+ * @notice The type of proof system being used.
+ */
+enum GameType {
+    // The game will use a `IDisputeGame` implementation that utilizes fault proofs.
+    FAULT,
+    // The game will use a `IDisputeGame` implementation that utilizes validity proofs.
+    VALIDITY,
+    // The game will use a `IDisputeGame` implementation that utilizes attestation proofs.
+    ATTESTATION
+}


### PR DESCRIPTION
**Description**

Following the iterative introduction of the `op-challenger`, we introduce dispute game contracts iteratively in a `contracts-bedrock/contracts/dispute` directory. This PR adds a few initial interfaces and types.