### PR TITLE
ci: Increase timeout for op-program verifying goerli.

### DIFF
--- a/op-program/verify/cmd/goerli.go
+++ b/op-program/verify/cmd/goerli.go
@@ -127,7 +127,7 @@ func Run(l1RpcUrl string, l2RpcUrl string, l2OracleAddr common.Address) error {
 }
 
 func runFaultProofProgram(ctx context.Context, args []string) error {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "./bin/op-program", args...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
**Description**

Increase timeout for op-program runs verifying goerli. Needs extra time when the batcher is delayed getting data on-chain.