### PR TITLE
ci: Exclude explorer.optimism.io from link checker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,4 +122,4 @@ update-op-geth:
 .PHONY: update-op-geth
 
 bedrock-markdown-links:
-	docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback --exclude twitter.com --exclude-mail /input/README.md "/input/specs/**/*.md"
+	docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback --exclude twitter.com --exclude explorer.optimism.io --exclude-mail /input/README.md "/input/specs/**/*.md"


### PR DESCRIPTION
**Description**

It regularly rejects requests from CI due to DoS prevention even though the link is valid.