### PR TITLE
Avoid copying `.git/` to Docker images

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.18.0-alpine3.15 as builder
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 COPY ./indexer /go/indexer
-COPY ./.git /go/.git
 COPY ./indexer/go.mod /go/indexer/go.mod
 COPY ./indexer/go.sum /go/indexer/go.sum
 

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -13,8 +13,6 @@ COPY ./op-signer /app/op-signer
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 
-COPY ./.git /app/.git
-
 WORKDIR /app/op-batcher
 
 RUN go mod download

--- a/op-chain-ops/Dockerfile
+++ b/op-chain-ops/Dockerfile
@@ -7,7 +7,6 @@ COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
-COPY ./.git /app/.git
 
 WORKDIR /app/op-chain-ops
 

--- a/op-challenger/Dockerfile
+++ b/op-challenger/Dockerfile
@@ -12,7 +12,6 @@ COPY ./op-service /app/op-service
 COPY ./op-signer /app/op-signer
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
-COPY ./.git /app/.git
 
 WORKDIR /app/op-challenger
 

--- a/op-heartbeat/Dockerfile
+++ b/op-heartbeat/Dockerfile
@@ -4,7 +4,6 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # build op-heartbeat with local monorepo go modules
 COPY ./op-heartbeat /app/op-heartbeat
-COPY ./.git /app/.git
 COPY ./op-heartbeat/go.mod /app/go.mod
 COPY ./op-heartbeat/go.sum /app/go.sum
 

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -11,7 +11,6 @@ COPY ./op-service /app/op-service
 COPY ./op-bindings /app/op-bindings
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
-COPY ./.git /app/.git
 
 WORKDIR /app/op-node
 

--- a/op-program/Dockerfile
+++ b/op-program/Dockerfile
@@ -12,7 +12,6 @@ COPY ./op-service /app/op-service
 COPY ./op-bindings /app/op-bindings
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
-COPY ./.git /app/.git
 
 WORKDIR /app/op-program
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -12,7 +12,6 @@ COPY ./op-service /app/op-service
 COPY ./op-signer /app/op-signer
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
-COPY ./.git /app/.git
 
 WORKDIR /app/op-proposer
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The Dockerfiles were copying `optimism/.git/` to the images. This behavior was causing issues with a `docker-compose.yml` file that depended on the Dockerfiles in `optimism/op-*/`

The main concern with removing the `.git/` artifacts from the images is losing version control when accessing the containers in interactive mode

**Tests**

No tests added, the devnet seems to behave as expected. Tested sending ether on both local L1 and local L2. Can do more extensive testing if needed

**Additional context**

Workin' on a simple `docker-compose` which uses anvil as a drop-in replacement for the L1 (instead of geth). Will be useful for cross-chain-comm apps that depend on existing L1 apps 🤔 

**Metadata**

- N/A

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
