### PR TITLE
feat(op-challenger): L2OutputOracle Event Listeners

### DIFF
--- a/op-challenger/challenger/challenger.go
+++ b/op-challenger/challenger/challenger.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/ethereum/go-ethereum/log"
 
 	config "github.com/ethereum-optimism/optimism/op-challenger/config"
+	flags "github.com/ethereum-optimism/optimism/op-challenger/flags"
 	metrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
 
 	bindings "github.com/ethereum-optimism/optimism/op-bindings/bindings"
@@ -36,6 +37,8 @@ type Challenger struct {
 	l1Client *ethclient.Client
 
 	rollupClient *sources.RollupClient
+
+	gameType flags.GameType
 
 	// l2 Output Oracle contract
 	l2ooContract     *bindings.L2OutputOracleCaller
@@ -104,9 +107,11 @@ func NewChallenger(cfg config.Config, l log.Logger, m metrics.Metricer) (*Challe
 		ctx:    ctx,
 		cancel: cancel,
 
+		l1Client: l1Client,
+
 		rollupClient: rollupClient,
 
-		l1Client: l1Client,
+		gameType: cfg.GameType,
 
 		l2ooContract:     l2ooContract,
 		l2ooContractAddr: cfg.L2OOAddress,
@@ -120,7 +125,10 @@ func NewChallenger(cfg config.Config, l log.Logger, m metrics.Metricer) (*Challe
 
 // Start runs the challenger in a goroutine.
 func (c *Challenger) Start() error {
-	c.log.Error("challenger not implemented.")
+	c.wg.Add(1)
+	c.log.Info("challenger listening to the L2OutputOracle")
+	go c.oracle()
+	c.log.Info("dispute game factory listening not implemented")
 	return nil
 }
 

--- a/op-challenger/challenger/oracle.go
+++ b/op-challenger/challenger/oracle.go
@@ -1,0 +1,123 @@
+package challenger
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	_ "net/http/pprof"
+	"time"
+
+	goEth "github.com/ethereum/go-ethereum"
+	common "github.com/ethereum/go-ethereum/common"
+	goTypes "github.com/ethereum/go-ethereum/core/types"
+
+	flags "github.com/ethereum-optimism/optimism/op-challenger/flags"
+
+	eth "github.com/ethereum-optimism/optimism/op-node/eth"
+)
+
+var supportedL2OutputVersion = eth.Bytes32{}
+
+// oracle executes the Challenger's oracle hook.
+// This function is intended to be spawned in a goroutine.
+// It will run until the Challenger's context is cancelled.
+//
+// The oracle hook listen's for `OutputProposed` events from the L2 Output Oracle contract.
+// When it receives an event, it will validate the output against the trusted rollup node.
+// If an output is invalid, it will create a dispute game of the given configuration.
+func (c *Challenger) oracle() {
+	defer c.wg.Done()
+
+	// The `OutputProposed` event is encoded as:
+	// 0: bytes32 indexed outputRoot,
+	// 1: uint256 indexed l2OutputIndex,
+	// 2: uint256 indexed l2BlockNumber,
+	// 3: uint256 l1Timestamp
+
+	// Listen for `OutputProposed` events from the L2 Output Oracle contract
+	event := c.l2ooABI.Events["OutputProposed"]
+	query := goEth.FilterQuery{
+		Topics: [][]common.Hash{
+			{event.ID},
+		},
+	}
+
+	logs := make(chan goTypes.Log)
+	sub, err := c.l1Client.SubscribeFilterLogs(context.Background(), query, logs)
+	if err != nil {
+		c.log.Error("failed to subscribe to logs", "err", err)
+		return
+	}
+
+	for {
+		select {
+		case err := <-sub.Err():
+			c.log.Error("failed to subscribe to logs", "err", err)
+			return
+
+		case vLog := <-logs:
+			l2BlockNumber := new(big.Int).SetBytes(vLog.Topics[3][:])
+			expected := vLog.Topics[1]
+			c.log.Info("Validating output", "l2BlockNumber", l2BlockNumber, "outputRoot", expected.Hex())
+			isValid, rootClaim, err := c.ValidateOutput(c.ctx, l2BlockNumber, (eth.Bytes32)(expected))
+			if err != nil || isValid {
+				break
+			}
+
+			c.metr.RecordInvalidOutput(
+				eth.L2BlockRef{
+					Hash:   vLog.Topics[0],
+					Number: l2BlockNumber.Uint64(),
+				},
+			)
+			c.log.Debug("Creating dispute game for", "l2BlockNumber", l2BlockNumber, "rootClaim", rootClaim)
+			cCtx, cancel := context.WithTimeout(c.ctx, 10*time.Minute)
+			_, err = c.createDisputeGame(cCtx, c.gameType, rootClaim, l2BlockNumber)
+			if err != nil {
+				c.log.Error("Failed to challenge transaction", "err", err)
+				cancel()
+				break
+			}
+			c.metr.RecordDisputeGameCreated(eth.L2BlockRef{
+				Hash:   common.Hash(*rootClaim),
+				Number: l2BlockNumber.Uint64(),
+			})
+			cancel()
+		case <-c.done:
+			return
+		}
+	}
+}
+
+// createDisputeGame creates a dispute game.
+// It will create a dispute game of type `gameType` with the given output and l2BlockNumber.
+// The `gameType` must be a valid dispute game type as defined by the `GameType` enum in the DisputeGameFactory contract.
+func (c *Challenger) createDisputeGame(ctx context.Context, gameType flags.GameType, output *eth.Bytes32, l2BlockNumber *big.Int) (*common.Address, error) {
+	c.log.Info("dispute game creation not implemented", "gameType", gameType, "output", output, "l2BlockNumber", l2BlockNumber)
+	return nil, errors.New("dispute game creation not implemented")
+}
+
+// ValidateOutput checks that a given output is expected via a trusted rollup node rpc.
+// It returns: if the output is correct, error
+func (c *Challenger) ValidateOutput(ctx context.Context, l2BlockNumber *big.Int, expected eth.Bytes32) (bool, *eth.Bytes32, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.networkTimeout)
+	defer cancel()
+	output, err := c.rollupClient.OutputAtBlock(ctx, l2BlockNumber.Uint64())
+	if err != nil {
+		c.log.Error("failed to fetch output for l2BlockNumber %d: %w", l2BlockNumber, err)
+		return true, nil, err
+	}
+	if output.Version != supportedL2OutputVersion {
+		c.log.Error("unsupported l2 output version: %s", output.Version)
+		return true, nil, errors.New("unsupported l2 output version")
+	}
+	// If the block numbers don't match, we should try to fetch the output again
+	if output.BlockRef.Number != l2BlockNumber.Uint64() {
+		c.log.Error("invalid blockNumber: next blockNumber is %v, blockNumber of block is %v", l2BlockNumber, output.BlockRef.Number)
+		return true, nil, errors.New("invalid blockNumber")
+	}
+	if output.OutputRoot == expected {
+		c.metr.RecordValidOutput(output.BlockRef)
+	}
+	return output.OutputRoot != expected, &output.OutputRoot, nil
+}

--- a/op-challenger/challenger/oracle_test.go
+++ b/op-challenger/challenger/oracle_test.go
@@ -1,0 +1,29 @@
+package challenger
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/flags"
+
+	eth "github.com/ethereum-optimism/optimism/op-node/eth"
+)
+
+// TestCreateDisputeGame_Fails tests that the createDisputeGame function
+// is not implemented.
+func TestCreateDisputeGame_Fails(t *testing.T) {
+	challenger := &Challenger{}
+
+	// Create a valid dispute game
+	_, err := challenger.createDisputeGame(
+		context.Background(), // Context
+		flags.GameType(0),    // Attestation Dispute Game
+		&eth.Bytes32{},       // Output Root
+		big.NewInt(0),        // L2 Block Number
+	)
+
+	if err.Error() != "dispute game creation not implemented" {
+		t.Errorf("expected error: dispute game creation not implemented, got: %v", err)
+	}
+}

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -29,6 +29,7 @@ type Metricer interface {
 	RecordValidOutput(l2ref eth.L2BlockRef)
 	RecordInvalidOutput(l2ref eth.L2BlockRef)
 	RecordOutputChallenged(l2ref eth.L2BlockRef)
+	RecordDisputeGameCreated(l2ref eth.L2BlockRef)
 }
 
 type Metrics struct {
@@ -99,9 +100,10 @@ func (m *Metrics) RecordUp() {
 }
 
 const (
-	ValidOutput      = "valid_output"
-	InvalidOutput    = "invalid_output"
-	OutputChallenged = "output_challenged"
+	ValidOutput        = "valid_output"
+	InvalidOutput      = "invalid_output"
+	OutputChallenged   = "output_challenged"
+	DisputeGameCreated = "dispute_game_created"
 )
 
 // RecordValidOutput should be called when a valid output is found
@@ -117,6 +119,11 @@ func (m *Metrics) RecordInvalidOutput(l2ref eth.L2BlockRef) {
 // RecordOutputChallenged should be called when an output is challenged
 func (m *Metrics) RecordOutputChallenged(l2ref eth.L2BlockRef) {
 	m.RecordL2Ref(OutputChallenged, l2ref)
+}
+
+// RecordDisputeGameCreated should be called when a dispute game is created
+func (m *Metrics) RecordDisputeGameCreated(l2ref eth.L2BlockRef) {
+	m.RecordL2Ref(DisputeGameCreated, l2ref)
 }
 
 func (m *Metrics) Document() []opmetrics.DocumentedMetric {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -16,6 +16,7 @@ var NoopMetrics Metricer = new(noopMetrics)
 func (*noopMetrics) RecordInfo(version string) {}
 func (*noopMetrics) RecordUp()                 {}
 
-func (*noopMetrics) RecordValidOutput(l2ref eth.L2BlockRef)      {}
-func (*noopMetrics) RecordInvalidOutput(l2ref eth.L2BlockRef)    {}
-func (*noopMetrics) RecordOutputChallenged(l2ref eth.L2BlockRef) {}
+func (*noopMetrics) RecordValidOutput(l2ref eth.L2BlockRef)        {}
+func (*noopMetrics) RecordInvalidOutput(l2ref eth.L2BlockRef)      {}
+func (*noopMetrics) RecordOutputChallenged(l2ref eth.L2BlockRef)   {}
+func (*noopMetrics) RecordDisputeGameCreated(l2ref eth.L2BlockRef) {}


### PR DESCRIPTION
**Description**

Introduces an L2OutputOracle event listener for proposed outputs.

Wanted to keep this pr fairly minimal, but if it makes sense, can introduce subcommands here for the various functions to "verify" outputs, "attest" dgs, "create" dispute games, etc, etc.