### PR TITLE
op-node: Precompute sync status per derivation loop

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -118,6 +118,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 	return &Driver{
 		l1State:          l1State,
 		derivation:       derivationPipeline,
+		stateReq:         make(chan chan struct{}),
 		forceReset:       make(chan chan struct{}, 10),
 		startSequencer:   make(chan hashAndErrorChannel, 10),
 		stopSequencer:    make(chan chan hashAndError, 10),

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -118,7 +118,6 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 	return &Driver{
 		l1State:          l1State,
 		derivation:       derivationPipeline,
-		stateReq:         make(chan chan struct{}),
 		forceReset:       make(chan chan struct{}, 10),
 		startSequencer:   make(chan hashAndErrorChannel, 10),
 		stopSequencer:    make(chan chan hashAndError, 10),

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -326,6 +326,8 @@ func (s *Driver) eventLoop() {
 				stepAttempts = 0
 				reqStep() // continue with the next step if we can
 			}
+		case respCh := <-s.stateReq:
+			respCh <- struct{}{}
 		case respCh := <-s.forceReset:
 			s.log.Warn("Derivation pipeline is manually reset")
 			s.derivation.Reset()

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	gosync "sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -31,9 +32,6 @@ type Driver struct {
 	// The derivation pipeline is reset whenever we reorg.
 	// The derivation pipeline determines the new l2Safe.
 	derivation DerivationPipeline
-
-	// Requests to block the event loop for synchronous execution to avoid reading an inconsistent state
-	stateReq chan chan struct{}
 
 	// Upon receiving a channel in this channel, the derivation pipeline is forced to be reset.
 	// It tells the caller that the reset occurred by closing the passed in channel.
@@ -81,6 +79,9 @@ type Driver struct {
 	done        chan struct{}
 
 	wg gosync.WaitGroup
+
+	// Stores a consistent view of the current sync status.
+	syncStatusCache atomic.Pointer[eth.SyncStatus]
 }
 
 // Start starts up the state loop.
@@ -207,6 +208,8 @@ func (s *Driver) eventLoop() {
 	lastUnsafeL2 := s.derivation.UnsafeL2Head()
 
 	for {
+		s.updateSyncStatusCache()
+
 		// If we are sequencing, and the L1 state is ready, update the trigger for the next sequencer action.
 		// This may adjust at any time based on fork-choice changes or previous errors.
 		// And avoid sequencing if the derivation pipeline indicates the engine is not ready.
@@ -320,8 +323,6 @@ func (s *Driver) eventLoop() {
 				stepAttempts = 0
 				reqStep() // continue with the next step if we can
 			}
-		case respCh := <-s.stateReq:
-			respCh <- struct{}{}
 		case respCh := <-s.forceReset:
 			s.log.Warn("Derivation pipeline is manually reset")
 			s.derivation.Reset()
@@ -426,34 +427,22 @@ func (s *Driver) syncStatus() *eth.SyncStatus {
 	}
 }
 
-// SyncStatus blocks the driver event loop and captures the syncing status.
-// If the event loop is too busy and the context expires, a context error is returned.
-func (s *Driver) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
-	wait := make(chan struct{})
-	select {
-	case s.stateReq <- wait:
-		resp := s.syncStatus()
-		<-wait
-		return resp, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
+// updateSyncStatusCache updates the cached sync status
+func (s *Driver) updateSyncStatusCache() {
+	ss := s.syncStatus()
+	s.syncStatusCache.Store(ss)
 }
 
-// BlockRefWithStatus blocks the driver event loop and captures the syncing status,
-// along with an L2 block reference by number consistent with that same status.
-// If the event loop is too busy and the context expires, a context error is returned.
+// SyncStatus returns the syncing status.
+func (s *Driver) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
+	return s.syncStatusCache.Load(), nil
+}
+
+// BlockRefWithStatus returns the syncing status along with an L2 block reference by number consistent with that same status.
 func (s *Driver) BlockRefWithStatus(ctx context.Context, num uint64) (eth.L2BlockRef, *eth.SyncStatus, error) {
-	wait := make(chan struct{})
-	select {
-	case s.stateReq <- wait:
-		resp := s.syncStatus()
-		ref, err := s.l2.L2BlockRefByNumber(ctx, num)
-		<-wait
-		return ref, resp, err
-	case <-ctx.Done():
-		return eth.L2BlockRef{}, nil, ctx.Err()
-	}
+	resp := s.syncStatusCache.Load()
+	ref, err := s.l2.L2BlockRefByNumber(ctx, num)
+	return ref, resp, err
 }
 
 // deferJSONString helps avoid a JSON-encoding performance hit if the snapshot logger does not run


### PR DESCRIPTION
**Description**

This allows the sync status to be retrieved quickly via RPC. Caching the sync status is cheap as it only involves simple state reads.

**Metadata**

- Fixes CLI-3815