### PR TITLE
feat(proxyd): add limit to consensus block lag

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -105,6 +105,7 @@ type BackendGroupConfig struct {
 
 	ConsensusBanPeriod          TOMLDuration `toml:"consensus_ban_period"`
 	ConsensusMaxUpdateThreshold TOMLDuration `toml:"consensus_max_update_threshold"`
+	ConsensusMaxBlockLag        uint64       `toml:"consensus_max_block_lag"`
 	ConsensusMinPeerCount       int          `toml:"consensus_min_peer_count"`
 }
 

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -271,7 +271,7 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 
 	// find the highest block, in order to use it defining the highest non-lagging ancestor block
 	for _, be := range cp.backendGroup.Backends {
-		peerCount, backendLatestBlockNumber, _, lastUpdate := cp.getBackendState(be)
+		peerCount, backendLatestBlockNumber, _, lastUpdate, _ := cp.getBackendState(be)
 
 		if !be.skipPeerCountCheck && peerCount < cp.minPeerCount {
 			continue

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -93,6 +93,8 @@ backends = ["infura"]
 # consensus_ban_period = "1m"
 # Maximum delay for update the backend, default 30s
 # consensus_max_update_threshold = "20s"
+# Maximum block lag, default 50
+# consensus_max_block_lag = 10
 # Minimum peer count, default 3
 # consensus_min_peer_count = 4
 

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -135,7 +135,7 @@ func TestConsensus(t *testing.T) {
 		require.Equal(t, 1, len(consensusGroup))
 	})
 
-	t.Run("prevent using a backend lagging behind 2", func(t *testing.T) {
+	t.Run("prevent using a backend lagging behind - at limit", func(t *testing.T) {
 		h1.ResetOverrides()
 		h2.ResetOverrides()
 		bg.Consensus.Unban()
@@ -146,6 +146,7 @@ func TestConsensus(t *testing.T) {
 			Response: buildGetBlockResponse("0x1", "hash1"),
 		})
 
+		// 0x1 + 50 = 0x33
 		h2.AddOverride(&ms.MethodTemplate{
 			Method:   "eth_getBlockByNumber",
 			Block:    "latest",
@@ -163,6 +164,41 @@ func TestConsensus(t *testing.T) {
 		bg.Consensus.UpdateBackendGroupConsensus(ctx)
 
 		// since we ignored node1, the consensus should be at 0x100
+		require.Equal(t, "0x1", bg.Consensus.GetConsensusBlockNumber().String())
+
+		consensusGroup := bg.Consensus.GetConsensusGroup()
+
+		require.Equal(t, 2, len(consensusGroup))
+	})
+
+	t.Run("prevent using a backend lagging behind - one before limit", func(t *testing.T) {
+		h1.ResetOverrides()
+		h2.ResetOverrides()
+		bg.Consensus.Unban()
+
+		h1.AddOverride(&ms.MethodTemplate{
+			Method:   "eth_getBlockByNumber",
+			Block:    "latest",
+			Response: buildGetBlockResponse("0x1", "hash1"),
+		})
+
+		// 0x1 + 49 = 0x32
+		h2.AddOverride(&ms.MethodTemplate{
+			Method:   "eth_getBlockByNumber",
+			Block:    "latest",
+			Response: buildGetBlockResponse("0x32", "hash0x100"),
+		})
+		h2.AddOverride(&ms.MethodTemplate{
+			Method:   "eth_getBlockByNumber",
+			Block:    "0x100",
+			Response: buildGetBlockResponse("0x32", "hash0x100"),
+		})
+
+		for _, be := range bg.Backends {
+			bg.Consensus.UpdateBackend(ctx, be)
+		}
+		bg.Consensus.UpdateBackendGroupConsensus(ctx)
+
 		require.Equal(t, "0x1", bg.Consensus.GetConsensusBlockNumber().String())
 
 		consensusGroup := bg.Consensus.GetConsensusGroup()

--- a/proxyd/integration_tests/testdata/consensus.toml
+++ b/proxyd/integration_tests/testdata/consensus.toml
@@ -18,6 +18,7 @@ consensus_aware = true
 consensus_handler = "noop" # allow more control over the consensus poller for tests
 consensus_ban_period = "1m"
 consensus_max_update_threshold = "2m"
+consensus_max_block_lag = 50
 consensus_min_peer_count = 4
 
 [rpc_method_mappings]

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -328,6 +328,9 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusMaxUpdateThreshold > 0 {
 				copts = append(copts, WithMaxUpdateThreshold(time.Duration(bgcfg.ConsensusMaxUpdateThreshold)))
 			}
+			if bgcfg.ConsensusMaxBlockLag > 0 {
+				copts = append(copts, WithMaxBlockLag(bgcfg.ConsensusMaxBlockLag))
+			}
 			if bgcfg.ConsensusMinPeerCount > 0 {
 				copts = append(copts, WithMinPeerCount(uint64(bgcfg.ConsensusMinPeerCount)))
 			}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add a configurable limit to the maximum number of blocks a backend is allowed to lag behind.
When a backend is lagging too far, it is ignored from the consensus.

**Tests**

Integration tests + manual

**Invariants**

n/a

**Additional context**

This is part of the project Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes INF-201

**TODOs**
- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
