### PR TITLE
feat(sdk): Update `message-utils` to mimic `MigrateWithdrawalGasLimit`

### DIFF
--- a/packages/sdk/src/utils/message-utils.ts
+++ b/packages/sdk/src/utils/message-utils.ts
@@ -55,15 +55,19 @@ export const migratedWithdrawalGasLimit = (
   chainID: number
 ): BigNumber => {
   // Compute the gas limit and cap at 25 million
-  const dataCost = BigNumber.from(hexDataLength(data)).mul(RELAY_PER_BYTE_DATA_COST)
+  const dataCost = BigNumber.from(hexDataLength(data)).mul(
+    RELAY_PER_BYTE_DATA_COST
+  )
   let overhead: number
   if (chainID === 420) {
     overhead = 200_000
   } else {
     // Constant overhead
-    overhead = RELAY_CONSTANT_OVERHEAD +
+    overhead =
+      RELAY_CONSTANT_OVERHEAD +
       // Dynamic overhead (EIP-150)
-      (MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR * 1_000_000) / MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR +
+      (MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR * 1_000_000) /
+        MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR +
       // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
       // factors. (Conservative)
       RELAY_CALL_OVERHEAD +

--- a/packages/sdk/src/utils/message-utils.ts
+++ b/packages/sdk/src/utils/message-utils.ts
@@ -5,6 +5,15 @@ import { LowLevelMessage } from '../interfaces'
 
 const { hexDataLength } = utils
 
+// Constants used by `CrossDomainMessenger.baseGas`
+const RELAY_CONSTANT_OVERHEAD = 200_000
+const RELAY_PER_BYTE_DATA_COST = 16
+const MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR = 64
+const MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR = 63
+const RELAY_CALL_OVERHEAD = 40_000
+const RELAY_RESERVED_GAS = 40_000
+const RELAY_GAS_CHECK_BUFFER = 5_000
+
 /**
  * Utility for hashing a LowLevelMessage object.
  *
@@ -46,11 +55,26 @@ export const migratedWithdrawalGasLimit = (
   chainID: number
 ): BigNumber => {
   // Compute the gas limit and cap at 25 million
-  const dataCost = BigNumber.from(hexDataLength(data)).mul(16)
-  let overhead = 200_000
-  if (chainID !== 420) {
-    overhead = 1_000_000
+  const dataCost = BigNumber.from(hexDataLength(data)).mul(RELAY_PER_BYTE_DATA_COST)
+  let overhead: number
+  if (chainID === 420) {
+    overhead = 200_000
+  } else {
+    // Constant overhead
+    overhead = RELAY_CONSTANT_OVERHEAD +
+      // Dynamic overhead (EIP-150)
+      (MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR * 1_000_000) / MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR +
+      // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
+      // factors. (Conservative)
+      RELAY_CALL_OVERHEAD +
+      // Relay reserved gas (to ensure execution of `relayMessage` completes after the
+      // subcontext finishes executing) (Conservative)
+      RELAY_RESERVED_GAS +
+      // Gas reserved for the execution between the `hasMinGas` check and the `CALL`
+      // opcode. (Conservative)
+      RELAY_GAS_CHECK_BUFFER
   }
+
   let minGasLimit = dataCost.add(overhead)
   if (minGasLimit.gt(25_000_000)) {
     minGasLimit = BigNumber.from(25_000_000)

--- a/packages/sdk/src/utils/message-utils.ts
+++ b/packages/sdk/src/utils/message-utils.ts
@@ -58,25 +58,26 @@ export const migratedWithdrawalGasLimit = (
   const dataCost = BigNumber.from(hexDataLength(data)).mul(
     RELAY_PER_BYTE_DATA_COST
   )
-  let overhead: number
+  let overhead: BigNumber
   if (chainID === 420) {
-    overhead = 200_000
+    overhead = BigNumber.from(200_000)
   } else {
     // Constant overhead
-    overhead =
+    overhead = BigNumber.from(
       RELAY_CONSTANT_OVERHEAD +
-      // Dynamic overhead (EIP-150)
-      (MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR * 1_000_000) /
-        MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR +
-      // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
-      // factors. (Conservative)
-      RELAY_CALL_OVERHEAD +
-      // Relay reserved gas (to ensure execution of `relayMessage` completes after the
-      // subcontext finishes executing) (Conservative)
-      RELAY_RESERVED_GAS +
-      // Gas reserved for the execution between the `hasMinGas` check and the `CALL`
-      // opcode. (Conservative)
-      RELAY_GAS_CHECK_BUFFER
+        // Dynamic overhead (EIP-150)
+        (MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR * 1_000_000) /
+          MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR +
+        // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
+        // factors. (Conservative)
+        RELAY_CALL_OVERHEAD +
+        // Relay reserved gas (to ensure execution of `relayMessage` completes after the
+        // subcontext finishes executing) (Conservative)
+        RELAY_RESERVED_GAS +
+        // Gas reserved for the execution between the `hasMinGas` check and the `CALL`
+        // opcode. (Conservative)
+        RELAY_GAS_CHECK_BUFFER
+    )
   }
 
   let minGasLimit = dataCost.add(overhead)


### PR DESCRIPTION
## Overview

Updates the `migratedWithdrawalGasLimit` function in the SDK's `message-utils.ts` to mimic the new behavior of `MigrateWithdrawalGasLimit` in #5648.

**Metadata**

Closes CLI-3970