### PR TITLE
message-utils: use BigNumber

### DIFF
--- a/packages/sdk/src/utils/message-utils.ts
+++ b/packages/sdk/src/utils/message-utils.ts
@@ -63,11 +63,12 @@ export const migratedWithdrawalGasLimit = (
     overhead = BigNumber.from(200_000)
   } else {
     // Dynamic overhead (EIP-150)
-    const dynamicOverhead = MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR.mul(1_000_000).div(MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR)
+    const dynamicOverhead = MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR.mul(
+      1_000_000
+    ).div(MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR)
 
     // Constant overhead
-    overhead = RELAY_CONSTANT_OVERHEAD
-      .add(dynamicOverhead)
+    overhead = RELAY_CONSTANT_OVERHEAD.add(dynamicOverhead)
       .add(RELAY_CALL_OVERHEAD)
       // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
       // factors. (Conservative)

--- a/packages/sdk/src/utils/message-utils.ts
+++ b/packages/sdk/src/utils/message-utils.ts
@@ -63,6 +63,10 @@ export const migratedWithdrawalGasLimit = (
     overhead = BigNumber.from(200_000)
   } else {
     // Dynamic overhead (EIP-150)
+    // We use a constant 1 million gas limit due to the overhead of simulating all migrated withdrawal
+    // transactions during the migration. This is a conservative estimate, and if a withdrawal
+    // uses more than the minimum gas limit, it will fail and need to be replayed with a higher
+    // gas limit.
     const dynamicOverhead = MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR.mul(
       1_000_000
     ).div(MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates the arithmetic to use bignumber to ensure there are no overflows or loss of precision