### PR TITLE
feat(proxyd): moar consensus metrics

### DIFF
--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -239,8 +239,8 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 			log.Warn("error updating backend", "name", be.Name, "err", err)
 			return
 		}
+		RecordConsensusBackendPeerCount(be, peerCount)
 	}
-	RecordConsensusBackendPeerCount(be, peerCount)
 
 	latestBlockNumber, latestBlockHash, err := cp.fetchBlock(ctx, be, "latest")
 	if err != nil {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -369,6 +369,8 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 
 	RecordGroupConsensusLatestBlock(cp.backendGroup, proposedBlock)
 	RecordGroupConsensusCount(cp.backendGroup, len(consensusBackends))
+	RecordGroupConsensusFilteredCount(cp.backendGroup, len(filteredBackendsNames))
+	RecordGroupTotalCount(cp.backendGroup, len(cp.backendGroup.Backends))
 
 	log.Debug("group state", "proposedBlock", proposedBlock, "consensusBackends", strings.Join(consensusBackendsNames, ", "), "filteredBackends", strings.Join(filteredBackendsNames, ", "))
 }

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -481,7 +481,7 @@ func (cp *ConsensusPoller) setBackendState(be *Backend, peerCount uint64, blockN
 	bs.peerCount = peerCount
 	bs.latestBlockNumber = blockNumber
 	bs.latestBlockHash = blockHash
-	updateDelay = time.Now().Sub(bs.lastUpdate)
+	updateDelay = time.Since(bs.lastUpdate)
 	bs.lastUpdate = time.Now()
 	bs.backendStateMux.Unlock()
 	return

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -265,7 +265,23 @@ var (
 	consensusGroupCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "group_consensus_count",
-		Help:      "Consensus group count",
+		Help:      "Consensus group serving traffic count",
+	}, []string{
+		"backend_group_name",
+	})
+
+	consensusGroupFilteredCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "group_consensus_filtered_count",
+		Help:      "Consensus group filtered out from serving traffic count",
+	}, []string{
+		"backend_group_name",
+	})
+
+	consensusGroupTotalCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "group_consensus_total_count",
+		Help:      "Total count of candidates to be part of consensus group",
 	}, []string{
 		"backend_group_name",
 	})
@@ -368,6 +384,14 @@ func RecordGroupConsensusLatestBlock(group *BackendGroup, blockNumber hexutil.Ui
 
 func RecordGroupConsensusCount(group *BackendGroup, count int) {
 	consensusGroupCount.WithLabelValues(group.Name).Set(float64(count))
+}
+
+func RecordGroupConsensusFilteredCount(group *BackendGroup, count int) {
+	consensusGroupFilteredCount.WithLabelValues(group.Name).Set(float64(count))
+}
+
+func RecordGroupTotalCount(group *BackendGroup, count int) {
+	consensusGroupTotalCount.WithLabelValues(group.Name).Set(float64(count))
 }
 
 func RecordBackendLatestBlock(be *Backend, blockNumber hexutil.Uint64) {

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -395,5 +395,5 @@ func RecordConsensusBackendInSync(be *Backend, inSync bool) {
 }
 
 func RecordConsensusBackendUpdateDelay(be *Backend, delay time.Duration) {
-	consensusUpdateDelayBackend.WithLabelValues(be.Name).Set(float64(delay.Round(time.Millisecond)))
+	consensusUpdateDelayBackend.WithLabelValues(be.Name).Set(float64(delay.Milliseconds()))
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change adds the following consensus metrics:
* Consensus group count
* Ability to see which backends are currently banned (0/1 gauge per backend)
* Peer count per backend
* Sync status per backend
* Update delay (ms) per backend

**Tests**

Deployed to dev and checked in Grafana dashboard

**Invariants**

n/a

**Additional context**

This is part of the project Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes INF-204

**TODOs**
- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
