### PR TITLE
feat(ctb): SafeCall send function to call with zero calldata bytes

### DIFF
--- a/packages/contracts-bedrock/contracts/libraries/SafeCall.sol
+++ b/packages/contracts-bedrock/contracts/libraries/SafeCall.sol
@@ -7,6 +7,34 @@ pragma solidity 0.8.15;
  */
 library SafeCall {
     /**
+     * @notice Performs a low level call without copying any returndata.
+     * @dev Passes no calldata to the call context.
+     *
+     * @param _target   Address to call
+     * @param _gas      Amount of gas to pass to the call
+     * @param _value    Amount of value to pass to the call
+     */
+    function send(
+        address _target,
+        uint256 _gas,
+        uint256 _value
+    ) internal returns (bool) {
+        bool _success;
+        assembly {
+            _success := call(
+                _gas, // gas
+                _target, // recipient
+                _value, // ether value
+                0, // inloc
+                0, // inlen
+                0, // outloc
+                0 // outlen
+            )
+        }
+        return _success;
+    }
+
+    /**
      * @notice Perform a low level call without copying any returndata
      *
      * @param _target   Address to call


### PR DESCRIPTION
**Description**

Splits the `SafeCall` `send` function into a separate PR which calls the `target` with zero calldata bytes and the specified `value`. Follows the pr in #5649 