### PR TITLE
op-chain-ops: tighten definition of valid withdrawal

### DIFF
--- a/op-chain-ops/crossdomain/legacy_withdrawal.go
+++ b/op-chain-ops/crossdomain/legacy_withdrawal.go
@@ -68,7 +68,11 @@ func (w *LegacyWithdrawal) Decode(data []byte) error {
 		return fmt.Errorf("invalid selector: 0x%x", data[0:4])
 	}
 
-	msgSender := data[len(data)-len(predeploys.L2CrossDomainMessengerAddr):]
+	senderData := data[len(data)-len(predeploys.L2CrossDomainMessengerAddr):]
+	messageSender := common.BytesToAddress(senderData)
+	if messageSender != predeploys.L2CrossDomainMessengerAddr {
+		return fmt.Errorf("invalid message sender: %s", messageSender.Hex())
+	}
 
 	raw := data[4 : len(data)-len(predeploys.L2CrossDomainMessengerAddr)]
 
@@ -101,7 +105,7 @@ func (w *LegacyWithdrawal) Decode(data []byte) error {
 		return errors.New("cannot abi decode nonce")
 	}
 
-	w.MessageSender = common.BytesToAddress(msgSender)
+	w.MessageSender = messageSender
 	w.XDomainTarget = target
 	w.XDomainSender = sender
 	w.XDomainData = msgData


### PR DESCRIPTION
**Description**

Previously the definition of a valid withdrawal did not require that the `msg.sender` in the context of the `L2ToL1MessagePasser` to be the `L2CrossDomainMessenger.`

- https://github.com/ethereum-optimism/optimism/blob/25b5f1ccf97b00cbfb7e214c12e79f5b50c677d7/op-chain-ops/crossdomain/legacy_withdrawal.go#L61

From the POV of the Optimism bridge, a withdrawal is only valid if the caller of `passMessageToL1` on the `L2ToL1MessagePasser` is the `L2CrossDomainMessenger`. This is because the address of the `L2ToL1MessagePasser` is hardcoded in the `L1CrossDomainMessenger` for the proof validation.

- https://github.com/ethereum-optimism/optimism/blob/25b5f1ccf97b00cbfb7e214c12e79f5b50c677d7/packages/contracts/contracts/L1/messaging/L1CrossDomainMessenger.sol#L328

The `L2ToL1MessagePasser` is permissionless to call, so any account can call it. We must hold the invariant that random callers are not migrated as part of the bedrock upgrade such that they can now withdrawal.

- https://github.com/ethereum-optimism/optimism/blob/25b5f1ccf97b00cbfb7e214c12e79f5b50c677d7/packages/contracts/contracts/L2/predeploys/OVM_L2ToL1MessagePasser.sol#L29

Only the calls through the `L2CrossDomainMessenger` should be migrated.

- https://github.com/ethereum-optimism/optimism/blob/25b5f1ccf97b00cbfb7e214c12e79f5b50c677d7/packages/contracts/contracts/L2/messaging/L2CrossDomainMessenger.sol#LL79C82-L79C97

The migration process does check for the caller of the `L2ToL1MessagePasser` but not in all cases. This makes the process bug prone in the future if there are refactors or misconfiguration. It is unlikely that this code will ever be refactored and we can double check there is no misconfiguration, but this change will generally help me sleep better at night.

The migration witness data generated by `l2geth` will pull in "invalid withdrawals". We need to ensure that they are filtered out so that they are not migrated. Parsing the file into Go structs will result in a list of valid withdrawals and invalid withdrawals. Calls to the `L2ToL1MessagePasser` where the `msg.sender` is not the `L2CrossDomainMessenger` are allowed to be considered valid withdrawals in this context, which is not correct and means that any filtering logic MUST happen elsewhere. The caller of this function may or may not be aware that invalid withdrawals can be in the valid withdrawals slice.

- https://github.com/ethereum-optimism/optimism/blob/develop/op-chain-ops/crossdomain/witness.go#L212

If `!preCheck`, then the `msg.sender` check will filter the "valid" withdrawals slice. This means that if `preCheck == true` then invalid withdrawals will be migrated.

- https://github.com/ethereum-optimism/optimism/blob/25b5f1ccf97b00cbfb7e214c12e79f5b50c677d7/op-chain-ops/genesis/db_migration.go#L137
- https://github.com/ethereum-optimism/optimism/blob/25b5f1ccf97b00cbfb7e214c12e79f5b50c677d7/op-chain-ops/crossdomain/precheck.go#L101

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


