### PR TITLE
op-program: Remove println

### DIFF
--- a/op-program/client/l2/db_test.go
+++ b/op-program/client/l2/db_test.go
@@ -1,6 +1,7 @@
 package l2
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestGet(t *testing.T) {
 		db := NewOracleBackedDB(oracle)
 		key := make([]byte, common.HashLength)
 		copy(rawdb.CodePrefix, key)
-		println(key[0])
+		fmt.Println(key[0])
 		expected := []byte{1, 2, 3}
 		oracle.Data[common.BytesToHash(key)] = expected
 		val, err := db.Get(key)

--- a/op-program/verify/cmd/goerli.go
+++ b/op-program/verify/cmd/goerli.go
@@ -98,7 +98,7 @@ func Run(l1RpcUrl string, l2RpcUrl string, l2OracleAddr common.Address) error {
 	defer func() {
 		err := os.RemoveAll(temp)
 		if err != nil {
-			println("Failed to remove temp dir:" + err.Error())
+			fmt.Println("Failed to remove temp dir:" + err.Error())
 		}
 	}()
 	fmt.Printf("Using temp dir: %s\n", temp)


### PR DESCRIPTION
**Description**

`println` is a golang builtin that shouldn't be used. Switch to using `fmt.Println` instead.
