### PR TITLE
feat(sdk): add custom bridge address for ECO

### DIFF
--- a/.changeset/mighty-cameras-check.md
+++ b/.changeset/mighty-cameras-check.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+add eco bridge adapter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -586,7 +586,7 @@ jobs:
           command: npx wait-on tcp:9545 && cast block-number --rpc-url http://localhost:9545
       - run:
           name: test:next
-          command: yarn test:next
+          command: yarn test:next:run
           no_output_timeout: 5m
           working_directory: packages/sdk
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,12 +564,12 @@ jobs:
           name: anvil-l1
           background: true
           # atm this is goerli but we should use mainnet after bedrock is live
-          command: anvil --fork-url $ANVIL_L1_FORK_URL --fork-block-number 8847426
+          command: anvil --fork-url $ANVIL_L1_FORK_URL --fork-block-number 9023108
       - run:
           name: anvil-l2
           background: true
           # atm this is goerli but we should use mainnet after bedrock is live
-          command: anvil --fork-url $ANVIL_L2_FORK_URL --port 9545 --fork-block-number 8172732
+          command: anvil --fork-url $ANVIL_L2_FORK_URL --port 9545 --fork-block-number 9504811
       - run:
           name: build
           command: yarn build

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "yarn lint:check --fix",
     "pre-commit": "lint-staged",
     "test": "hardhat test",
-    "test:next": "vitest test-next/proveMessage.spec.ts",
+    "test:next": "vitest run",
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json",
     "autogen:docs": "typedoc --out docs src/index.ts"
   },
@@ -48,7 +48,9 @@
     "typedoc": "^0.22.13",
     "mocha": "^10.0.0",
     "vitest": "^0.28.3",
-    "zod": "^3.11.6"
+    "zod": "^3.11.6",
+    "viem": "^0.3.30",
+    "isomorphic-fetch": "^3.0.0"
   },
   "dependencies": {
     "@eth-optimism/contracts": "0.5.40",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,7 +17,8 @@
     "lint:fix": "yarn lint:check --fix",
     "pre-commit": "lint-staged",
     "test": "hardhat test",
-    "test:next": "vitest run",
+    "test:next": "vitest",
+    "test:next:run": "vitest run",
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json",
     "autogen:docs": "typedoc --out docs src/index.ts"
   },

--- a/packages/sdk/setupVitest.ts
+++ b/packages/sdk/setupVitest.ts
@@ -1,0 +1,4 @@
+import fetch from 'isomorphic-fetch'
+
+// viem needs this
+global.fetch = fetch

--- a/packages/sdk/src/adapters/eco-bridge.ts
+++ b/packages/sdk/src/adapters/eco-bridge.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Contract } from 'ethers'
+import { hexStringEquals } from '@eth-optimism/core-utils'
+
+import { AddressLike } from '../interfaces'
+import { toAddress } from '../utils'
+import { StandardBridgeAdapter } from './standard-bridge'
+
+/**
+ * Bridge adapter for ECO.
+ * ECO bridge requires a separate adapter as exposes different functions than our standard bridge
+ */
+export class ECOBridgeAdapter extends StandardBridgeAdapter {
+  public async supportsTokenPair(
+    l1Token: AddressLike,
+    l2Token: AddressLike
+  ): Promise<boolean> {
+    const l1Bridge = new Contract(
+      this.l1Bridge.address,
+      [
+        {
+          inputs: [],
+          name: 'ecoAddress',
+          outputs: [
+            {
+              internalType: 'address',
+              name: '',
+              type: 'address',
+            },
+          ],
+          stateMutability: 'view',
+          type: 'function',
+        },
+      ],
+      this.messenger.l1Provider
+    )
+
+    const l2Bridge = new Contract(
+      this.l2Bridge.address,
+      [
+        {
+          inputs: [],
+          name: 'l2EcoToken',
+          outputs: [
+            {
+              internalType: 'contract L2ECO',
+              name: '',
+              type: 'address',
+            },
+          ],
+          stateMutability: 'view',
+          type: 'function',
+        },
+      ],
+      this.messenger.l2Provider
+    )
+
+    const [remoteL1Token, remoteL2Token] = await Promise.all([
+      l1Bridge.ecoAddress(),
+      l2Bridge.l2EcoToken(),
+    ])
+
+    if (!hexStringEquals(remoteL1Token, toAddress(l1Token))) {
+      return false
+    }
+
+    if (!hexStringEquals(remoteL2Token, toAddress(l2Token))) {
+      return false
+    }
+
+    return true
+  }
+}

--- a/packages/sdk/src/adapters/index.ts
+++ b/packages/sdk/src/adapters/index.ts
@@ -1,3 +1,4 @@
 export * from './standard-bridge'
 export * from './eth-bridge'
 export * from './dai-bridge'
+export * from './eco-bridge'

--- a/packages/sdk/src/utils/chain-constants.ts
+++ b/packages/sdk/src/utils/chain-constants.ts
@@ -12,7 +12,11 @@ import {
   OEL2ContractsLike,
   BridgeAdapterData,
 } from '../interfaces'
-import { StandardBridgeAdapter, DAIBridgeAdapter } from '../adapters'
+import {
+  StandardBridgeAdapter,
+  DAIBridgeAdapter,
+  ECOBridgeAdapter,
+} from '../adapters'
 
 export const DEPOSIT_CONFIRMATION_BLOCKS: {
   [ChainID in L2ChainID]: number
@@ -206,7 +210,7 @@ export const BRIDGE_ADAPTER_DATA: {
       l2Bridge: '0x467194771dAe2967Aef3ECbEDD3Bf9a310C76C65' as const,
     },
     ECO: {
-      Adapter: StandardBridgeAdapter,
+      Adapter: ECOBridgeAdapter,
       l1Bridge: '0x7a01E277B8fDb8CDB2A2258508514716359f44A0' as const,
       l2Bridge: '0x7a01E277B8fDb8CDB2A2258508514716359f44A0' as const,
     },

--- a/packages/sdk/src/utils/chain-constants.ts
+++ b/packages/sdk/src/utils/chain-constants.ts
@@ -205,5 +205,10 @@ export const BRIDGE_ADAPTER_DATA: {
       l1Bridge: '0x05a388Db09C2D44ec0b00Ee188cD42365c42Df23' as const,
       l2Bridge: '0x467194771dAe2967Aef3ECbEDD3Bf9a310C76C65' as const,
     },
+    ECO: {
+      Adapter: StandardBridgeAdapter,
+      l1Bridge: '0x7a01E277B8fDb8CDB2A2258508514716359f44A0' as const,
+      l2Bridge: '0x7a01E277B8fDb8CDB2A2258508514716359f44A0' as const,
+    },
   },
 }

--- a/packages/sdk/test-next/bridgeEcoToken.spec.ts
+++ b/packages/sdk/test-next/bridgeEcoToken.spec.ts
@@ -58,7 +58,7 @@ describe('ECO token', () => {
       l2SignerOrProvider: l2Provider,
       l1ChainId: 5,
       l2ChainId: 420,
-      // bedrock: true,
+      bedrock: true,
       bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI]
     })
 
@@ -91,7 +91,7 @@ describe('ECO token', () => {
       l2SignerOrProvider: l2EcoWhaleSigner,
       l1ChainId: 5,
       l2ChainId: 420,
-      // bedrock: true,
+      bedrock: true,
       bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI]
     })
 

--- a/packages/sdk/test-next/bridgeEcoToken.spec.ts
+++ b/packages/sdk/test-next/bridgeEcoToken.spec.ts
@@ -13,7 +13,7 @@ import { l1Provider, l2Provider } from './testUtils/ethersProviders'
 
 const ECO_WHALE: Address = '0xBd11c836279a1352ce737FbBFba36b20734B04e7'
 
-// TODO: use tokenlist as source of truth
+// we should instead use tokenlist as source of truth
 const ECO_L1_TOKEN_ADDRESS: Address = '0x3E87d4d9E69163E7590f9b39a70853cf25e5ABE3'
 const ECO_L2_TOKEN_ADDRESS: Address = '0x54bBECeA38ff36D32323f8A754683C1F5433A89f'
 
@@ -46,11 +46,9 @@ const getL2ERC20TokenBalance = async (ownerAddress: Address) => {
 
 describe('ECO token', () => {
   it('sdk should be able to deposit to l1 bridge contract correctly', async () => {
-    // this code is a bit whack because of the mix of viem + ethers
-    // TODO: use anviljs, and use viem entirely once the sdk supports it
     await l1TestClient.impersonateAccount({ address: ECO_WHALE })
-    const l1EcoWhaleSigner = await l1Provider.getSigner(ECO_WHALE);
 
+    const l1EcoWhaleSigner = await l1Provider.getSigner(ECO_WHALE);
     const preBridgeL1EcoWhaleBalance = await getL1ERC20TokenBalance(ECO_WHALE)
 
     const crossChainMessenger = new CrossChainMessenger({

--- a/packages/sdk/test-next/bridgeEcoToken.spec.ts
+++ b/packages/sdk/test-next/bridgeEcoToken.spec.ts
@@ -1,0 +1,110 @@
+import ethers from 'ethers'
+import { describe, expect, it } from 'vitest'
+import {
+  l1TestClient,
+  l2TestClient,
+  l1PublicClient,
+  l2PublicClient,
+} from './testUtils/viemClients'
+
+import { BRIDGE_ADAPTER_DATA, CrossChainMessenger, DEPOSIT_CONFIRMATION_BLOCKS, L2ChainID } from '../src'
+import { Address, PublicClient, parseEther } from 'viem'
+import { l1Provider, l2Provider } from './testUtils/ethersProviders'
+
+const ECO_WHALE: Address = '0xBd11c836279a1352ce737FbBFba36b20734B04e7'
+
+// TODO: use tokenlist as source of truth
+const ECO_L1_TOKEN_ADDRESS: Address = '0x3E87d4d9E69163E7590f9b39a70853cf25e5ABE3'
+const ECO_L2_TOKEN_ADDRESS: Address = '0x54bBECeA38ff36D32323f8A754683C1F5433A89f'
+
+const getERC20TokenBalance = async (publicClient: PublicClient, tokenAddress: Address, ownerAddress: Address) => {
+  const result = await publicClient.readContract({
+    address: tokenAddress,
+    abi: [
+      {
+        inputs: [{ name: 'owner', type: 'address' }],
+        name: 'balanceOf',
+        outputs: [{ name: '', type: 'uint256' }],
+        stateMutability: 'view',
+        type: 'function',
+      }
+    ],
+    functionName: 'balanceOf',
+    args: [ownerAddress]
+  })
+
+  return result as bigint
+}
+
+const getL1ERC20TokenBalance = async (ownerAddress: Address) => {
+  return getERC20TokenBalance(l1PublicClient, ECO_L1_TOKEN_ADDRESS, ownerAddress)
+}
+
+const getL2ERC20TokenBalance = async (ownerAddress: Address) => {
+  return getERC20TokenBalance(l2PublicClient, ECO_L2_TOKEN_ADDRESS, ownerAddress)
+}
+
+describe('ECO token', () => {
+  it('sdk should be able to deposit to l1 bridge contract correctly', async () => {
+    // this code is a bit whack because of the mix of viem + ethers
+    // TODO: use anviljs, and use viem entirely once the sdk supports it
+    await l1TestClient.impersonateAccount({ address: ECO_WHALE })
+    const l1EcoWhaleSigner = await l1Provider.getSigner(ECO_WHALE);
+
+    const preBridgeL1EcoWhaleBalance = await getL1ERC20TokenBalance(ECO_WHALE)
+
+    const crossChainMessenger = new CrossChainMessenger({
+      l1SignerOrProvider: l1EcoWhaleSigner,
+      l2SignerOrProvider: l2Provider,
+      l1ChainId: 5,
+      l2ChainId: 420,
+      // bedrock: true,
+      bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI]
+    })
+
+    await crossChainMessenger.approveERC20(
+      ECO_L1_TOKEN_ADDRESS,
+      ECO_L2_TOKEN_ADDRESS,
+      ethers.utils.parseEther('0.1'),
+    )
+
+    const txResponse = await crossChainMessenger.depositERC20(
+      ECO_L1_TOKEN_ADDRESS,
+      ECO_L2_TOKEN_ADDRESS,
+      ethers.utils.parseEther('0.1'),
+    )
+
+    await txResponse.wait();
+
+    const l1EcoWhaleBalance = await getL1ERC20TokenBalance(ECO_WHALE)
+    expect(l1EcoWhaleBalance).toEqual(preBridgeL1EcoWhaleBalance - parseEther('0.1'))
+  }, 20_000)
+
+  it('sdk should be able to withdraw into the l2 bridge contract correctly', async () => {
+    await l2TestClient.impersonateAccount({ address: ECO_WHALE })
+    const l2EcoWhaleSigner = await l2Provider.getSigner(ECO_WHALE);
+
+    const preBridgeL2EcoWhaleBalance = await getL2ERC20TokenBalance(ECO_WHALE)
+
+    const crossChainMessenger = new CrossChainMessenger({
+      l1SignerOrProvider: l1Provider,
+      l2SignerOrProvider: l2EcoWhaleSigner,
+      l1ChainId: 5,
+      l2ChainId: 420,
+      // bedrock: true,
+      bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI]
+    })
+
+    const txResponse = await crossChainMessenger.withdrawERC20(
+      ECO_L1_TOKEN_ADDRESS,
+      ECO_L2_TOKEN_ADDRESS,
+      ethers.utils.parseEther('0.1'),
+    )
+
+    await txResponse.wait();
+
+    const l2EcoWhaleBalance = await getL2ERC20TokenBalance(ECO_WHALE)
+    expect(l2EcoWhaleBalance).toEqual(preBridgeL2EcoWhaleBalance - parseEther('0.1'))
+  }, 20_000)
+
+})

--- a/packages/sdk/test-next/bridgeEcoToken.spec.ts
+++ b/packages/sdk/test-next/bridgeEcoToken.spec.ts
@@ -1,23 +1,29 @@
 import ethers from 'ethers'
 import { describe, expect, it } from 'vitest'
+import { Address, PublicClient, parseEther } from 'viem'
+
 import {
   l1TestClient,
   l2TestClient,
   l1PublicClient,
   l2PublicClient,
 } from './testUtils/viemClients'
-
-import { BRIDGE_ADAPTER_DATA, CrossChainMessenger, DEPOSIT_CONFIRMATION_BLOCKS, L2ChainID } from '../src'
-import { Address, PublicClient, parseEther } from 'viem'
+import { BRIDGE_ADAPTER_DATA, CrossChainMessenger, L2ChainID } from '../src'
 import { l1Provider, l2Provider } from './testUtils/ethersProviders'
 
 const ECO_WHALE: Address = '0xBd11c836279a1352ce737FbBFba36b20734B04e7'
 
 // we should instead use tokenlist as source of truth
-const ECO_L1_TOKEN_ADDRESS: Address = '0x3E87d4d9E69163E7590f9b39a70853cf25e5ABE3'
-const ECO_L2_TOKEN_ADDRESS: Address = '0x54bBECeA38ff36D32323f8A754683C1F5433A89f'
+const ECO_L1_TOKEN_ADDRESS: Address =
+  '0x3E87d4d9E69163E7590f9b39a70853cf25e5ABE3'
+const ECO_L2_TOKEN_ADDRESS: Address =
+  '0x54bBECeA38ff36D32323f8A754683C1F5433A89f'
 
-const getERC20TokenBalance = async (publicClient: PublicClient, tokenAddress: Address, ownerAddress: Address) => {
+const getERC20TokenBalance = async (
+  publicClient: PublicClient,
+  tokenAddress: Address,
+  ownerAddress: Address
+) => {
   const result = await publicClient.readContract({
     address: tokenAddress,
     abi: [
@@ -27,28 +33,36 @@ const getERC20TokenBalance = async (publicClient: PublicClient, tokenAddress: Ad
         outputs: [{ name: '', type: 'uint256' }],
         stateMutability: 'view',
         type: 'function',
-      }
+      },
     ],
     functionName: 'balanceOf',
-    args: [ownerAddress]
+    args: [ownerAddress],
   })
 
   return result as bigint
 }
 
 const getL1ERC20TokenBalance = async (ownerAddress: Address) => {
-  return getERC20TokenBalance(l1PublicClient, ECO_L1_TOKEN_ADDRESS, ownerAddress)
+  return getERC20TokenBalance(
+    l1PublicClient,
+    ECO_L1_TOKEN_ADDRESS,
+    ownerAddress
+  )
 }
 
 const getL2ERC20TokenBalance = async (ownerAddress: Address) => {
-  return getERC20TokenBalance(l2PublicClient, ECO_L2_TOKEN_ADDRESS, ownerAddress)
+  return getERC20TokenBalance(
+    l2PublicClient,
+    ECO_L2_TOKEN_ADDRESS,
+    ownerAddress
+  )
 }
 
 describe('ECO token', () => {
   it('sdk should be able to deposit to l1 bridge contract correctly', async () => {
     await l1TestClient.impersonateAccount({ address: ECO_WHALE })
 
-    const l1EcoWhaleSigner = await l1Provider.getSigner(ECO_WHALE);
+    const l1EcoWhaleSigner = await l1Provider.getSigner(ECO_WHALE)
     const preBridgeL1EcoWhaleBalance = await getL1ERC20TokenBalance(ECO_WHALE)
 
     const crossChainMessenger = new CrossChainMessenger({
@@ -57,30 +71,32 @@ describe('ECO token', () => {
       l1ChainId: 5,
       l2ChainId: 420,
       bedrock: true,
-      bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI]
+      bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI],
     })
 
     await crossChainMessenger.approveERC20(
       ECO_L1_TOKEN_ADDRESS,
       ECO_L2_TOKEN_ADDRESS,
-      ethers.utils.parseEther('0.1'),
+      ethers.utils.parseEther('0.1')
     )
 
     const txResponse = await crossChainMessenger.depositERC20(
       ECO_L1_TOKEN_ADDRESS,
       ECO_L2_TOKEN_ADDRESS,
-      ethers.utils.parseEther('0.1'),
+      ethers.utils.parseEther('0.1')
     )
 
-    await txResponse.wait();
+    await txResponse.wait()
 
     const l1EcoWhaleBalance = await getL1ERC20TokenBalance(ECO_WHALE)
-    expect(l1EcoWhaleBalance).toEqual(preBridgeL1EcoWhaleBalance - parseEther('0.1'))
+    expect(l1EcoWhaleBalance).toEqual(
+      preBridgeL1EcoWhaleBalance - parseEther('0.1')
+    )
   }, 20_000)
 
   it('sdk should be able to withdraw into the l2 bridge contract correctly', async () => {
     await l2TestClient.impersonateAccount({ address: ECO_WHALE })
-    const l2EcoWhaleSigner = await l2Provider.getSigner(ECO_WHALE);
+    const l2EcoWhaleSigner = await l2Provider.getSigner(ECO_WHALE)
 
     const preBridgeL2EcoWhaleBalance = await getL2ERC20TokenBalance(ECO_WHALE)
 
@@ -90,19 +106,20 @@ describe('ECO token', () => {
       l1ChainId: 5,
       l2ChainId: 420,
       bedrock: true,
-      bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI]
+      bridges: BRIDGE_ADAPTER_DATA[L2ChainID.OPTIMISM_GOERLI],
     })
 
     const txResponse = await crossChainMessenger.withdrawERC20(
       ECO_L1_TOKEN_ADDRESS,
       ECO_L2_TOKEN_ADDRESS,
-      ethers.utils.parseEther('0.1'),
+      ethers.utils.parseEther('0.1')
     )
 
-    await txResponse.wait();
+    await txResponse.wait()
 
     const l2EcoWhaleBalance = await getL2ERC20TokenBalance(ECO_WHALE)
-    expect(l2EcoWhaleBalance).toEqual(preBridgeL2EcoWhaleBalance - parseEther('0.1'))
+    expect(l2EcoWhaleBalance).toEqual(
+      preBridgeL2EcoWhaleBalance - parseEther('0.1')
+    )
   }, 20_000)
-
 })

--- a/packages/sdk/test-next/proveMessage.spec.ts
+++ b/packages/sdk/test-next/proveMessage.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
 import { CrossChainMessenger } from '../src'
+import { l1Provider, l2Provider } from './testUtils/ethersProviders'
 
 /**
  * This test repros the bug where legacy withdrawals are not provable
@@ -48,33 +49,12 @@ transactionHash         0xd66fda632b51a8b25a9d260d70da8be57b9930c461637086152633
 transactionIndex        0
 type
  */
-const E2E_RPC_URL_L1 = z
-  .string()
-  .url()
-  .describe('L1 ethereum rpc Url')
-  .parse(import.meta.env.VITE_E2E_RPC_URL_L1)
-const E2E_RPC_URL_L2 = z
-  .string()
-  .url()
-  .describe('L1 ethereum rpc Url')
-  .parse(import.meta.env.VITE_E2E_RPC_URL_L2)
+
 const E2E_PRIVATE_KEY = z
   .string()
   .describe('Private key')
   .parse(import.meta.env.VITE_E2E_PRIVATE_KEY)
 
-const jsonRpcHeaders = { 'User-Agent': 'eth-optimism/@gateway/backend' }
-/**
- * Initialize the signer, prover, and cross chain messenger
- */
-const l1Provider = new ethers.providers.JsonRpcProvider({
-  url: E2E_RPC_URL_L1,
-  headers: jsonRpcHeaders,
-})
-const l2Provider = new ethers.providers.JsonRpcProvider({
-  url: E2E_RPC_URL_L2,
-  headers: jsonRpcHeaders,
-})
 const l1Wallet = new ethers.Wallet(E2E_PRIVATE_KEY, l1Provider)
 const crossChainMessenger = new CrossChainMessenger({
   l1SignerOrProvider: l1Wallet,

--- a/packages/sdk/test-next/testUtils/ethersProviders.ts
+++ b/packages/sdk/test-next/testUtils/ethersProviders.ts
@@ -1,0 +1,31 @@
+import ethers from 'ethers'
+import { z } from 'zod'
+
+const E2E_RPC_URL_L1 = z
+  .string()
+  .url()
+  .describe('L1 ethereum rpc Url')
+  .parse(import.meta.env.VITE_E2E_RPC_URL_L1)
+const E2E_RPC_URL_L2 = z
+  .string()
+  .url()
+  .describe('L1 ethereum rpc Url')
+  .parse(import.meta.env.VITE_E2E_RPC_URL_L2)
+
+const jsonRpcHeaders = { 'User-Agent': 'eth-optimism/@gateway/backend' }
+/**
+ * Initialize the signer, prover, and cross chain messenger
+ */
+const l1Provider = new ethers.providers.JsonRpcProvider({
+  url: E2E_RPC_URL_L1,
+  headers: jsonRpcHeaders,
+})
+const l2Provider = new ethers.providers.JsonRpcProvider({
+  url: E2E_RPC_URL_L2,
+  headers: jsonRpcHeaders,
+})
+
+export {
+  l1Provider,
+  l2Provider
+}

--- a/packages/sdk/test-next/testUtils/ethersProviders.ts
+++ b/packages/sdk/test-next/testUtils/ethersProviders.ts
@@ -25,7 +25,4 @@ const l2Provider = new ethers.providers.JsonRpcProvider({
   headers: jsonRpcHeaders,
 })
 
-export {
-  l1Provider,
-  l2Provider
-}
+export { l1Provider, l2Provider }

--- a/packages/sdk/test-next/testUtils/viemClients.ts
+++ b/packages/sdk/test-next/testUtils/viemClients.ts
@@ -6,7 +6,7 @@ import {
 } from 'viem'
 import { goerli, optimismGoerli } from 'viem/chains'
 
-// TODO: use env vars to determine chain so we can support alternate l1/l2 pairs
+// we should instead use env vars to determine chain so we can support alternate l1/l2 pairs
 const L1_CHAIN = goerli;
 const L2_CHAIN = optimismGoerli;
 const L1_RPC_URL = 'http://localhost:8545';

--- a/packages/sdk/test-next/testUtils/viemClients.ts
+++ b/packages/sdk/test-next/testUtils/viemClients.ts
@@ -1,0 +1,57 @@
+import {
+  createTestClient,
+  createPublicClient,
+  createWalletClient,
+  http,
+} from 'viem'
+import { goerli, optimismGoerli } from 'viem/chains'
+
+// TODO: use env vars to determine chain so we can support alternate l1/l2 pairs
+const L1_CHAIN = goerli;
+const L2_CHAIN = optimismGoerli;
+const L1_RPC_URL = 'http://localhost:8545';
+const L2_RPC_URL = 'http://localhost:9545'
+
+const l1TestClient = createTestClient({
+  mode: 'anvil',
+  chain: L1_CHAIN,
+  transport: http(L1_RPC_URL),
+})
+
+
+const l2TestClient = createTestClient({
+  mode: 'anvil',
+  chain: L2_CHAIN,
+  transport: http(L2_RPC_URL),
+})
+
+
+const l1PublicClient = createPublicClient({
+  chain: L1_CHAIN,
+  transport: http(L1_RPC_URL),
+})
+
+
+const l2PublicClient = createPublicClient({
+  chain: L2_CHAIN,
+  transport: http(L2_RPC_URL),
+})
+
+const l1WalletClient = createWalletClient({
+  chain: L1_CHAIN,
+  transport: http(L1_RPC_URL),
+})
+
+const l2WalletClient = createWalletClient({
+  chain: L2_CHAIN,
+  transport: http(L2_RPC_URL),
+})
+
+export {
+  l1TestClient,
+  l2TestClient,
+  l1PublicClient,
+  l2PublicClient,
+  l1WalletClient,
+  l2WalletClient,
+}

--- a/packages/sdk/test-next/testUtils/viemClients.ts
+++ b/packages/sdk/test-next/testUtils/viemClients.ts
@@ -7,9 +7,9 @@ import {
 import { goerli, optimismGoerli } from 'viem/chains'
 
 // we should instead use env vars to determine chain so we can support alternate l1/l2 pairs
-const L1_CHAIN = goerli;
-const L2_CHAIN = optimismGoerli;
-const L1_RPC_URL = 'http://localhost:8545';
+const L1_CHAIN = goerli
+const L2_CHAIN = optimismGoerli
+const L1_RPC_URL = 'http://localhost:8545'
 const L2_RPC_URL = 'http://localhost:9545'
 
 const l1TestClient = createTestClient({
@@ -18,19 +18,16 @@ const l1TestClient = createTestClient({
   transport: http(L1_RPC_URL),
 })
 
-
 const l2TestClient = createTestClient({
   mode: 'anvil',
   chain: L2_CHAIN,
   transport: http(L2_RPC_URL),
 })
 
-
 const l1PublicClient = createPublicClient({
   chain: L1_CHAIN,
   transport: http(L1_RPC_URL),
 })
-
 
 const l2PublicClient = createPublicClient({
   chain: L2_CHAIN,

--- a/packages/sdk/test-next/testUtils/viemClients.ts
+++ b/packages/sdk/test-next/testUtils/viemClients.ts
@@ -6,7 +6,7 @@ import {
 } from 'viem'
 import { goerli, optimismGoerli } from 'viem/chains'
 
-// we should instead use env vars to determine chain so we can support alternate l1/l2 pairs
+// we should instead use .env to determine chain so we can support alternate l1/l2 pairs
 const L1_CHAIN = goerli
 const L2_CHAIN = optimismGoerli
 const L1_RPC_URL = 'http://localhost:8545'

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+// https://vitest.dev/config/ - for docs
+export default defineConfig({
+  test: {
+    setupFiles: './setupVitest.ts',
+    include: ['test-next/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz#223572538f6bea336750039bb43a4016dcc8182d"
+  integrity sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -3331,6 +3336,13 @@
     "@motionone/dom" "^10.15.5"
     tslib "^2.3.1"
 
+"@noble/curves@1.0.0", "@noble/curves@~1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.0.0.tgz#e40be8c7daf088aaf291887cbc73f43464a92932"
+  integrity sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==
+  dependencies:
+    "@noble/hashes" "1.3.0"
+
 "@noble/ed25519@^1.7.0":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
@@ -3340,6 +3352,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.0.0.tgz#d5e38bfbdaba174805a4e649f13be9a9ed3351ae"
   integrity sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg==
+
+"@noble/hashes@1.3.0", "@noble/hashes@~1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
+  integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
 "@noble/hashes@^1.1.2":
   version "1.2.0"
@@ -3772,6 +3789,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.0.0.tgz#109fb595021de285f05a7db6806f2f48296fcee7"
   integrity sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==
 
+"@scure/base@~1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
+
 "@scure/bip32@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.0.1.tgz#1409bdf9f07f0aec99006bb0d5827693418d3aa5"
@@ -3781,6 +3803,15 @@
     "@noble/secp256k1" "~1.5.2"
     "@scure/base" "~1.0.0"
 
+"@scure/bip32@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.0.tgz#6c8d980ef3f290987736acd0ee2e0f0d50068d87"
+  integrity sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==
+  dependencies:
+    "@noble/curves" "~1.0.0"
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
+
 "@scure/bip39@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.0.0.tgz#47504e58de9a56a4bbed95159d2d6829fa491bb0"
@@ -3788,6 +3819,14 @@
   dependencies:
     "@noble/hashes" "~1.0.0"
     "@scure/base" "~1.0.0"
+
+"@scure/bip39@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.0.tgz#a207e2ef96de354de7d0002292ba1503538fc77b"
+  integrity sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==
+  dependencies:
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
 
 "@sentry/core@5.30.0":
   version "5.30.0"
@@ -4970,6 +5009,11 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.36.tgz#35e11200542cf29068ba787dad57da9bdb82f644"
   integrity sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==
 
+"@wagmi/chains@0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-0.2.16.tgz#a726716e4619ec1c192b312e23f9c38407617aa0"
+  integrity sha512-rkWaI2PxCnbD8G07ZZff5QXftnSkYL0h5f4DkHCG3fGYYr/ZDvmCL4bMae7j7A9sAif1csPPBmbCzHp3R5ogCQ==
+
 "@wagmi/chains@0.2.8":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-0.2.8.tgz#eece43702f719d7de4193dc993668e0d783937b5"
@@ -5499,6 +5543,11 @@ abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
+
+abitype@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.8.2.tgz#cacd330d07488a4020d84f54fc361361234b9c83"
+  integrity sha512-B1ViNMGpfx/qjVQi0RTc2HEFHuR9uoCoTEkwELT5Y7pBPtBbctYijz9BK6+Kd0hQ3S70FhYTO2dWWk0QNUEXMA==
 
 abitype@^0.3.0:
   version "0.3.0"
@@ -13481,6 +13530,19 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
+isomorphic-ws@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 isomorphic-ws@^4.0.1:
   version "4.0.1"
@@ -21526,6 +21588,21 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
+viem@^0.3.30:
+  version "0.3.30"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-0.3.30.tgz#7421bbff8b21c2e6aa90634a18d57b9612e90555"
+  integrity sha512-4jokEVR2vtDl6zSpZiPUaHviK2dzW6uxCAVUArlh0Jhrc4ms0dkhn5E4iwk1CWMto8+YeLFEgY4gr9P10ryoEQ==
+  dependencies:
+    "@adraffy/ens-normalize" "1.9.0"
+    "@noble/curves" "1.0.0"
+    "@noble/hashes" "1.3.0"
+    "@scure/bip32" "1.3.0"
+    "@scure/bip39" "1.2.0"
+    "@wagmi/chains" "0.2.16"
+    abitype "0.8.2"
+    isomorphic-ws "5.0.0"
+    ws "8.12.0"
+
 vite-node@0.28.3:
   version "0.28.3"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.3.tgz#5d693c237d5467f167f81d158a56d3408fea899c"
@@ -22173,6 +22250,11 @@ whatwg-fetch@^2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
@@ -22445,6 +22527,11 @@ ws@7.5.3, ws@^7.4.6:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+
+ws@8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
+  integrity sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
Adds the ECO bridge to the sdk

https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/366/files

- The bridge has slightly different interface so requires a custom `supportsTokenPair`. Created a new eco-bridge adapter.
- adds ECO bridge to constants
- adds viem and some helper functions