### PR TITLE
Performance + nonce management improvements to withdrawals script

### DIFF
--- a/op-chain-ops/cmd/withdrawals/main.go
+++ b/op-chain-ops/cmd/withdrawals/main.go
@@ -317,6 +317,9 @@ func main() {
 						"xNonce", wd.XDomainNonce,
 						"xSender", wd.XDomainSender,
 						"sender", wd.MessageSender,
+						"success", isSuccess,
+						"failed", isFailed,
+						"failed-new", isFailedNew,
 					)
 					return
 				}

--- a/op-chain-ops/cmd/withdrawals/main.go
+++ b/op-chain-ops/cmd/withdrawals/main.go
@@ -7,10 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"os"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/ethereum/go-ethereum/consensus/misc"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
@@ -39,7 +43,7 @@ import (
 var abiTrue = common.Hash{31: 0x01}
 
 // batchSize represents the number of withdrawals to prove/finalize at a time.
-var batchSize = 10
+var batchSize = 25
 
 // callFrame represents the response returned from geth's
 // `debug_traceTransaction` callTracer
@@ -75,7 +79,8 @@ type suspiciousWithdrawal struct {
 }
 
 func main() {
-	log.Root().SetHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(isatty.IsTerminal(os.Stderr.Fd()))))
+	lvlHdlr := log.StreamHandler(os.Stderr, log.TerminalFormat(isatty.IsTerminal(os.Stderr.Fd())))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, lvlHdlr))
 
 	app := &cli.App{
 		Name:  "withdrawals",
@@ -216,167 +221,440 @@ func main() {
 				}
 			}
 
-			// Create a wait group for the transaction goroutines
-			var wg sync.WaitGroup
+			nonce, err := clients.L1Client.NonceAt(context.Background(), opts.From, nil)
+			if err != nil {
+				return err
+			}
 
-			// Loop through withdrawals (`batchSize` wds at a time) and prove each batch in parallel.
-			for i := 0; i < len(wds); i += batchSize {
-				log.Info("Proving withdrawals", "start", i, "end", i+batchSize)
+			// The goroutines below use an atomic increment-and-get, so we need
+			// to subtract one here to make the initial value correct.
+			nonce--
 
-				// If we're on the last batch, it's likely that the number of withdrawals in the array is not
-				// divisible by `batchSize`. In this case, we need to adjust the size of the final batch.
-				var upperBound int
-				if i+batchSize > len(wds) {
-					upperBound = len(wds) % batchSize
-				} else {
-					upperBound = batchSize
-				}
+			log.Info("starting nonce", "nonce", nonce)
 
-				nonce, err := clients.L1Client.NonceAt(context.Background(), opts.From, nil)
+			proveWithdrawals := func(wd *crossdomain.LegacyWithdrawal, bf *big.Int, i int) {
+				// migrate the withdrawal
+				withdrawal, err := crossdomain.MigrateWithdrawal(wd, &l1xdmAddr, l2ChainID)
 				if err != nil {
-					return err
+					log.Error("error migrating withdrawal", "err", err)
+					return
 				}
 
-				// Iterate through the `batchSize` withdrawals in the current batch and submit them in parallel.
-				for j := 0; j < upperBound; j++ {
-					wd := wds[i+j]
-
-					// Add the goroutine to the waitgroup
-					wg.Add(1)
-
-					// Submit the proveWithdrawalTransaction in a goroutine
-					go func(wd *crossdomain.LegacyWithdrawal, nonce uint64) {
-						defer wg.Done()
-
-						// migrate the withdrawal
-						withdrawal, err := crossdomain.MigrateWithdrawal(wd, &l1xdmAddr, l2ChainID)
-						if err != nil {
-							log.Error("error migrating withdrawal", "err", err)
-							return
-						}
-
-						// Pass to Portal
-						hash, err := withdrawal.Hash()
-						if err != nil {
-							log.Error("error hashing withdrawal", "err", err)
-							return
-						}
-
-						lcdm := wd.CrossDomainMessage()
-						legacyXdmHash, err := lcdm.Hash()
-						if err != nil {
-							log.Error("error hashing legacy withdrawal", "err", err)
-							return
-						}
-
-						// check to see if the withdrawal has already been successfully
-						// relayed or received
-						isSuccess, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, legacyXdmHash)
-						if err != nil {
-							log.Error("error checking legacy withdrawal status", "err", err)
-							return
-						}
-						isFailed, err := contracts.L1CrossDomainMessenger.FailedMessages(&bind.CallOpts{}, legacyXdmHash)
-						if err != nil {
-							log.Error("error checking legacy withdrawal status", "err", err)
-							return
-						}
-
-						xdmHash := crypto.Keccak256Hash(withdrawal.Data)
-						if err != nil {
-							log.Error("error hashing crossdomain message", "err", err)
-							return
-						}
-
-						isSuccessNew, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, xdmHash)
-						if err != nil {
-							log.Error("error checking withdrawal status", "err", err)
-							return
-						}
-						isFailedNew, err := contracts.L1CrossDomainMessenger.FailedMessages(&bind.CallOpts{}, xdmHash)
-						if err != nil {
-							log.Error("error checking withdrawal status", "err", err)
-							return
-						}
-
-						log.Info("cross domain messenger status", "hash", legacyXdmHash.Hex(), "success", isSuccess, "failed", isFailed, "is-success-new", isSuccessNew, "is-failed-new", isFailedNew)
-
-						// compute the storage slot
-						slot, err := withdrawal.StorageSlot()
-						if err != nil {
-							log.Error("error computing storage slot", "err", err)
-							return
-						}
-						// successful messages can be skipped, received messages failed their execution and should be replayed
-						if isSuccessNew {
-							log.Info("Message already relayed", "index", i, "hash", hash.Hex(), "slot", slot.Hex())
-							return
-						}
-
-						// check the storage value of the slot to ensure that it is in
-						// the L2 storage. Without this check, the proof will fail
-						storageValue, err := clients.L2Client.StorageAt(context.Background(), predeploys.L2ToL1MessagePasserAddr, slot, nil)
-						if err != nil {
-							log.Error("error fetching storage slot value", "err", err)
-							return
-						}
-						log.Debug("L2ToL1MessagePasser status", "value", common.Bytes2Hex(storageValue))
-
-						// the value should be set to a boolean in storage
-						if !bytes.Equal(storageValue, abiTrue.Bytes()) {
-							log.Error("storage slot %x not found in state", "slot", slot.Hex())
-							return
-						}
-
-						legacySlot, err := wd.StorageSlot()
-						if err != nil {
-							log.Error("error computing legacy storage slot", "err", err)
-							return
-						}
-						legacyStorageValue, err := clients.L2Client.StorageAt(context.Background(), predeploys.LegacyMessagePasserAddr, legacySlot, nil)
-						if err != nil {
-							log.Error("error fetching legacy storage slot value", "err", err)
-							return
-						}
-						log.Debug("LegacyMessagePasser status", "value", common.Bytes2Hex(legacyStorageValue))
-
-						// check to see if its already been proven
-						proven, err := contracts.OptimismPortal.ProvenWithdrawals(&bind.CallOpts{}, hash)
-						if err != nil {
-							log.Error("error fetching proven withdrawal status", "err", err)
-							return
-						}
-
-						// if it has not been proven, then prove it
-						if proven.Timestamp.Cmp(common.Big0) == 0 {
-							log.Info("Proving withdrawal to OptimismPortal")
-
-							// make a copy of opts
-							optsCopy := *opts
-							optsCopy.Nonce = new(big.Int).SetUint64(nonce)
-
-							if err := proveWithdrawalTransaction(contracts, clients, &optsCopy, withdrawal, bedrockStartingBlockNumber); err != nil {
-								log.Error("error proving withdrawal", "err", err)
-								return
-							}
-
-							proven, err = contracts.OptimismPortal.ProvenWithdrawals(&bind.CallOpts{}, hash)
-							if err != nil {
-								log.Error("error fetching proven withdrawal status", "err", err)
-								return
-							}
-
-							if proven.Timestamp.Cmp(common.Big0) == 0 {
-								log.Error("error proving withdrawal", "wdHash", hash)
-							}
-						} else {
-							log.Info("Withdrawal already proven to OptimismPortal")
-						}
-					}(wd, nonce+uint64(j))
+				// Pass to Portal
+				hash, err := withdrawal.Hash()
+				if err != nil {
+					log.Error("error hashing withdrawal", "err", err)
+					return
 				}
 
-				// Wait for all of the goroutines to finish before moving on to the next batch.
-				wg.Wait()
+				lcdm := wd.CrossDomainMessage()
+				legacyXdmHash, err := lcdm.Hash()
+				if err != nil {
+					log.Error("error hashing legacy withdrawal", "err", err)
+					return
+				}
+
+				// check to see if the withdrawal has already been successfully
+				// relayed or received
+				isSuccess, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, legacyXdmHash)
+				if err != nil {
+					log.Error("error checking legacy withdrawal status", "err", err)
+					return
+				}
+				isFailed, err := contracts.L1CrossDomainMessenger.FailedMessages(&bind.CallOpts{}, legacyXdmHash)
+				if err != nil {
+					log.Error("error checking legacy withdrawal status", "err", err)
+					return
+				}
+
+				xdmHash := crypto.Keccak256Hash(withdrawal.Data)
+				if err != nil {
+					log.Error("error hashing crossdomain message", "err", err)
+					return
+				}
+
+				isSuccessNew, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, xdmHash)
+				if err != nil {
+					log.Error("error checking withdrawal status", "err", err)
+					return
+				}
+				isFailedNew, err := contracts.L1CrossDomainMessenger.FailedMessages(&bind.CallOpts{}, xdmHash)
+				if err != nil {
+					log.Error("error checking withdrawal status", "err", err)
+					return
+				}
+
+				log.Info("cross domain messenger status", "hash", legacyXdmHash.Hex(), "success", isSuccess, "failed", isFailed, "is-success-new", isSuccessNew, "is-failed-new", isFailedNew)
+
+				// compute the storage slot
+				slot, err := withdrawal.StorageSlot()
+				if err != nil {
+					log.Error("error computing storage slot", "err", err)
+					return
+				}
+				// successful messages can be skipped, received messages failed their execution and should be replayed
+				if isSuccessNew {
+					log.Info("Message already relayed", "index", i, "hash", hash.Hex(), "slot", slot.Hex())
+					return
+				}
+
+				// check the storage value of the slot to ensure that it is in
+				// the L2 storage. Without this check, the proof will fail
+				storageValue, err := clients.L2Client.StorageAt(context.Background(), predeploys.L2ToL1MessagePasserAddr, slot, nil)
+				if err != nil {
+					log.Error("error fetching storage slot value", "err", err)
+					return
+				}
+				log.Debug("L2ToL1MessagePasser status", "value", common.Bytes2Hex(storageValue))
+
+				// the value should be set to a boolean in storage
+				if !bytes.Equal(storageValue, abiTrue.Bytes()) {
+					log.Error("storage slot %x not found in state", "slot", slot.Hex())
+					return
+				}
+
+				legacySlot, err := wd.StorageSlot()
+				if err != nil {
+					log.Error("error computing legacy storage slot", "err", err)
+					return
+				}
+				legacyStorageValue, err := clients.L2Client.StorageAt(context.Background(), predeploys.LegacyMessagePasserAddr, legacySlot, nil)
+				if err != nil {
+					log.Error("error fetching legacy storage slot value", "err", err)
+					return
+				}
+				log.Debug("LegacyMessagePasser status", "value", common.Bytes2Hex(legacyStorageValue))
+
+				// check to see if its already been proven
+				proven, err := contracts.OptimismPortal.ProvenWithdrawals(&bind.CallOpts{}, hash)
+				if err != nil {
+					log.Error("error fetching proven withdrawal status", "err", err)
+					return
+				}
+
+				// if it has not been proven, then prove it
+				if proven.Timestamp.Cmp(common.Big0) == 0 {
+					log.Info("Proving withdrawal to OptimismPortal")
+
+					// create a transactor
+					optsCopy, err := newTransactor(ctx)
+					if err != nil {
+						log.Crit("error creating transactor", "err", err)
+						return
+					}
+
+					optsCopy.Nonce = new(big.Int).SetUint64(atomic.AddUint64(&nonce, 1))
+					optsCopy.GasTipCap = big.NewInt(2_500_000_000)
+					optsCopy.GasFeeCap = bf
+
+					if err := proveWithdrawalTransaction(contracts, clients, optsCopy, withdrawal, bedrockStartingBlockNumber); err != nil {
+						log.Error("error proving withdrawal", "err", err)
+						return
+					}
+
+					proven, err = contracts.OptimismPortal.ProvenWithdrawals(&bind.CallOpts{}, hash)
+					if err != nil {
+						log.Error("error fetching proven withdrawal status", "err", err)
+						return
+					}
+
+					if proven.Timestamp.Cmp(common.Big0) == 0 {
+						log.Error("error proving withdrawal", "wdHash", hash)
+					}
+				} else {
+					log.Info("Withdrawal already proven to OptimismPortal")
+				}
+			}
+
+			finalizeWithdrawals := func(wd *crossdomain.LegacyWithdrawal, bf *big.Int, i int) {
+				// migrate the withdrawal
+				withdrawal, err := crossdomain.MigrateWithdrawal(wd, &l1xdmAddr, l2ChainID)
+				if err != nil {
+					log.Error("error migrating withdrawal", "err", err)
+					return
+				}
+
+				// Pass to Portal
+				hash, err := withdrawal.Hash()
+				if err != nil {
+					log.Error("error hashing withdrawal", "err", err)
+					return
+				}
+
+				lcdm := wd.CrossDomainMessage()
+				legacyXdmHash, err := lcdm.Hash()
+				if err != nil {
+					log.Error("error hashing legacy withdrawal", "err", err)
+					return
+				}
+
+				// check to see if the withdrawal has already been successfully
+				// relayed or received
+				isSuccess, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, legacyXdmHash)
+				if err != nil {
+					log.Error("error checking legacy withdrawal status", "err", err)
+					return
+				}
+
+				xdmHash := crypto.Keccak256Hash(withdrawal.Data)
+				if err != nil {
+					log.Error("error hashing crossdomain message", "err", err)
+					return
+				}
+
+				// check to see if its already been proven
+				proven, err := contracts.OptimismPortal.ProvenWithdrawals(&bind.CallOpts{}, hash)
+				if err != nil {
+					log.Error("error fetching proven withdrawal status", "err", err)
+					return
+				}
+
+				// check to see if the withdrawal has been finalized already
+				isFinalized, err := contracts.OptimismPortal.FinalizedWithdrawals(&bind.CallOpts{}, hash)
+				if err != nil {
+					log.Error("error fetching finalized withdrawal status", "err", err)
+					return
+				}
+
+				// Log an error if the withdrawal has not been proven
+				// It should have been proven in the previous loop
+				if proven.Timestamp.Cmp(common.Big0) == 0 {
+					log.Error("withdrawal has not been proven", "wdHash", hash)
+					return
+				}
+
+				if !isFinalized {
+					initialTime := proven.Timestamp.Uint64()
+					var block *types.Block
+					for {
+						log.Info("Waiting for finalization")
+						block, err = clients.L1Client.BlockByNumber(context.Background(), nil)
+						if err != nil {
+							log.Error("error fetching block", "err", err)
+						}
+						if block.Time() >= initialTime+period.Uint64() {
+							log.Info("can be finalized")
+							break
+						}
+						time.Sleep(1 * time.Second)
+					}
+
+					// Get the ETH balance of the withdrawal target *before* the finalization
+					targetBalBefore, err := clients.L1Client.BalanceAt(context.Background(), wd.XDomainTarget, nil)
+					if err != nil {
+						log.Error("error fetching target balance before", "err", err)
+						return
+					}
+					log.Debug("Balance before finalization", "balance", targetBalBefore, "account", wd.XDomainTarget)
+
+					log.Info("Finalizing withdrawal")
+
+					// make a copy of opts
+					optsCopy, err := newTransactor(ctx)
+					if err != nil {
+						log.Crit("error creating transactor", "err", err)
+						return
+					}
+
+					optsCopy.Nonce = new(big.Int).SetUint64(atomic.AddUint64(&nonce, 1))
+					optsCopy.GasTipCap = big.NewInt(2_500_000_000)
+					optsCopy.GasFeeCap = bf
+
+					receipt, err := finalizeWithdrawalTransaction(contracts, clients, optsCopy, wd, withdrawal)
+					if err != nil {
+						log.Error("error finalizing withdrawal", "err", err)
+						return
+					}
+					log.Info("withdrawal finalized", "tx-hash", receipt.TxHash, "withdrawal-hash", hash)
+
+					finalizationTrace, err := callTrace(clients, receipt)
+					if err != nil {
+						log.Error("error fetching finalization trace", "err", err)
+						return
+					}
+
+					isSuccessNewPost, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, xdmHash)
+					if err != nil {
+						log.Error("error fetching new post success status", "err", err)
+						return
+					}
+
+					// This would indicate that there is a replayability problem
+					if isSuccess && isSuccessNewPost {
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "should revert"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+						panic("DOUBLE PLAYED DEPOSIT ALLOWED")
+					}
+
+					callFrame := findWithdrawalCall(&finalizationTrace, wd, l1xdmAddr)
+					if callFrame == nil {
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "cannot find callframe"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+						return
+					}
+
+					traceJson, err := json.MarshalIndent(callFrame, "", "    ")
+					if err != nil {
+						log.Error("error marshalling callframe", "err", err)
+						return
+					}
+					log.Debug(fmt.Sprintf("%v", string(traceJson)))
+
+					abi, err := bindings.L1StandardBridgeMetaData.GetAbi()
+					if err != nil {
+						log.Error("error getting abi of the L1StandardBridge", "err", err)
+						return
+					}
+
+					calldata := hexutil.MustDecode(callFrame.Input)
+
+					// this must be the L1 standard bridge
+					method, err := abi.MethodById(calldata)
+					// Handle L1StandardBridge specific logic
+					if err == nil {
+						args, err := method.Inputs.Unpack(calldata[4:])
+						if err != nil {
+							log.Error("error unpacking calldata", "err", err)
+							return
+						}
+
+						log.Info("decoded calldata", "name", method.Name)
+
+						switch method.Name {
+						case "finalizeERC20Withdrawal":
+							if err := handleFinalizeERC20Withdrawal(args, receipt, l1StandardBridgeAddress); err != nil {
+								log.Error("error handling finalizeERC20Withdrawal", "err", err)
+								return
+							}
+						case "finalizeETHWithdrawal":
+							if err := handleFinalizeETHWithdrawal(args); err != nil {
+								log.Error("error handling finalizeETHWithdrawal", "err", err)
+								return
+							}
+						default:
+							log.Info("Unhandled method", "name", method.Name)
+						}
+					}
+
+					// Ensure that the target's balance was increasedData correctly
+					wdValue, err := wd.Value()
+					if err != nil {
+						log.Error("error getting withdrawal value", "err", err)
+						return
+					}
+					if method != nil {
+						log.Info("withdrawal action", "function", method.Name, "value", wdValue)
+					} else {
+						log.Info("unknown method", "to", wd.XDomainTarget, "data", hexutil.Encode(wd.XDomainData))
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "unknown method"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+					}
+
+					// check that the user's intents are actually executed
+					if common.HexToAddress(callFrame.To) != wd.XDomainTarget {
+						log.Info("target mismatch", "index", i)
+
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "target mismatch"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+					}
+					if !bytes.Equal(hexutil.MustDecode(callFrame.Input), wd.XDomainData) {
+						log.Info("calldata mismatch", "index", i)
+
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "calldata mismatch"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+						return
+					}
+					if callFrame.BigValue().Cmp(wdValue) != 0 {
+						log.Info("value mismatch", "index", i)
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "value mismatch"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+						return
+					}
+
+					// Get the ETH balance of the withdrawal target *after* the finalization
+					targetBalAfter, err := clients.L1Client.BalanceAt(context.Background(), wd.XDomainTarget, nil)
+					if err != nil {
+						log.Error("error getting target balance after", "err", err)
+						return
+					}
+
+					diff := new(big.Int).Sub(targetBalAfter, targetBalBefore)
+					log.Debug("balances", "before", targetBalBefore, "after", targetBalAfter, "diff", diff)
+
+					isSuccessNewPost, err = contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, xdmHash)
+					if err != nil {
+						log.Error("error getting success", "err", err)
+						return
+					}
+
+					if diff.Cmp(wdValue) != 0 && isSuccessNewPost && isSuccess {
+						log.Info("native eth balance diff mismatch", "index", i, "diff", diff, "val", wdValue)
+						if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "balance mismatch"); err != nil {
+							log.Error("error writing suspicious withdrawal", "err", err)
+							return
+						}
+						return
+					}
+				} else {
+					log.Info("Already finalized")
+				}
+			}
+
+			getBaseFee := func() (*big.Int, error) {
+				block, err := clients.L1Client.BlockByNumber(context.Background(), nil)
+				if err != nil {
+					return nil, err
+				}
+
+				baseFee := misc.CalcBaseFee(params.MainnetChainConfig, block.Header())
+				baseFee = baseFee.Add(baseFee, big.NewInt(10_000_000_000))
+				return baseFee, nil
+			}
+
+			batchTxs := func(cb func(*crossdomain.LegacyWithdrawal, *big.Int, int)) error {
+				sem := make(chan struct{}, batchSize)
+
+				var bf *big.Int
+				var err error
+				for i, wd := range wds {
+					if i == 0 || i%batchSize == 0 {
+						bf, err = getBaseFee()
+						if err != nil {
+							return err
+						}
+					}
+
+					if i%5 == 0 {
+						log.Info("kicking off batch transaction", "i", i, "len", len(wds))
+					}
+
+					sem <- struct{}{}
+
+					go func(wd *crossdomain.LegacyWithdrawal, bf *big.Int, i int) {
+						defer func() { <-sem }()
+						cb(wd, bf, i)
+						// Avoid hammering Cloudflare/our infrastructure too much
+						time.Sleep(50*time.Millisecond + time.Duration(rand.Intn(100))*time.Millisecond)
+					}(wd, bf, i)
+				}
+
+				return nil
+			}
+
+			if err := batchTxs(proveWithdrawals); err != nil {
+				return err
 			}
 
 			// Now that all of the withdrawals have been proven, we can finalize them.
@@ -385,275 +663,11 @@ func main() {
 			log.Info("All withdrawals have been proven! Moving on to finalization.")
 
 			// Loop through withdrawals (`batchSize` wds at a time) and finalize each batch in parallel.
-			for i := 0; i < len(wds); i += batchSize {
-				log.Info("Finalizing withdrawals", "start", i, "end", i+batchSize)
 
-				// If we're on the last batch, it's likely that the number of withdrawals in the array is not
-				// divisible by `batchSize`. In this case, we need to adjust the size of the final batch.
-				var upperBound int
-				if i+batchSize > len(wds) {
-					upperBound = len(wds) % batchSize
-				} else {
-					upperBound = batchSize
-				}
-
-				nonce, err := clients.L1Client.NonceAt(context.Background(), opts.From, nil)
-				if err != nil {
-					return err
-				}
-
-				// Iterate through the `batchSize` withdrawals in the current batch and submit them in parallel.
-				for j := 0; j < upperBound; j++ {
-					wd := wds[i+j]
-
-					// Add the goroutine to the waitgroup
-					wg.Add(1)
-
-					// Submit the finalizeWithdrawalTransaction in a goroutine
-					go func(wd *crossdomain.LegacyWithdrawal, nonce uint64) {
-						defer wg.Done()
-
-						// migrate the withdrawal
-						withdrawal, err := crossdomain.MigrateWithdrawal(wd, &l1xdmAddr, l2ChainID)
-						if err != nil {
-							log.Error("error migrating withdrawal", "err", err)
-							return
-						}
-
-						// Pass to Portal
-						hash, err := withdrawal.Hash()
-						if err != nil {
-							log.Error("error hashing withdrawal", "err", err)
-							return
-						}
-
-						lcdm := wd.CrossDomainMessage()
-						legacyXdmHash, err := lcdm.Hash()
-						if err != nil {
-							log.Error("error hashing legacy withdrawal", "err", err)
-							return
-						}
-
-						// check to see if the withdrawal has already been successfully
-						// relayed or received
-						isSuccess, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, legacyXdmHash)
-						if err != nil {
-							log.Error("error checking legacy withdrawal status", "err", err)
-							return
-						}
-
-						xdmHash := crypto.Keccak256Hash(withdrawal.Data)
-						if err != nil {
-							log.Error("error hashing crossdomain message", "err", err)
-							return
-						}
-
-						// check to see if its already been proven
-						proven, err := contracts.OptimismPortal.ProvenWithdrawals(&bind.CallOpts{}, hash)
-						if err != nil {
-							log.Error("error fetching proven withdrawal status", "err", err)
-							return
-						}
-
-						// check to see if the withdrawal has been finalized already
-						isFinalized, err := contracts.OptimismPortal.FinalizedWithdrawals(&bind.CallOpts{}, hash)
-						if err != nil {
-							log.Error("error fetching finalized withdrawal status", "err", err)
-							return
-						}
-
-						// Log an error if the withdrawal has not been proven
-						// It should have been proven in the previous loop
-						if proven.Timestamp.Cmp(common.Big0) == 0 {
-							log.Error("withdrawal has not been proven", "wdHash", hash)
-							return
-						}
-
-						if !isFinalized {
-							initialTime := proven.Timestamp.Uint64()
-							var block *types.Block
-							for {
-								log.Info("Waiting for finalization")
-								block, err = clients.L1Client.BlockByNumber(context.Background(), nil)
-								if err != nil {
-									log.Error("error fetching block", "err", err)
-								}
-								if block.Time() >= initialTime+period.Uint64() {
-									log.Info("can be finalized")
-									break
-								}
-								time.Sleep(1 * time.Second)
-							}
-
-							// Get the ETH balance of the withdrawal target *before* the finalization
-							targetBalBefore, err := clients.L1Client.BalanceAt(context.Background(), wd.XDomainTarget, nil)
-							if err != nil {
-								log.Error("error fetching target balance before", "err", err)
-								return
-							}
-							log.Debug("Balance before finalization", "balance", targetBalBefore, "account", wd.XDomainTarget)
-
-							log.Info("Finalizing withdrawal")
-
-							// make a copy of opts
-							optsCopy := *opts
-							optsCopy.Nonce = new(big.Int).SetUint64(nonce)
-
-							receipt, err := finalizeWithdrawalTransaction(contracts, clients, &optsCopy, wd, withdrawal)
-							if err != nil {
-								log.Error("error finalizing withdrawal", "err", err)
-								return
-							}
-							log.Info("withdrawal finalized", "tx-hash", receipt.TxHash, "withdrawal-hash", hash)
-
-							finalizationTrace, err := callTrace(clients, receipt)
-							if err != nil {
-								log.Error("error fetching finalization trace", "err", err)
-								return
-							}
-
-							isSuccessNewPost, err := contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, xdmHash)
-							if err != nil {
-								log.Error("error fetching new post success status", "err", err)
-								return
-							}
-
-							// This would indicate that there is a replayability problem
-							if isSuccess && isSuccessNewPost {
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "should revert"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-								panic("DOUBLE PLAYED DEPOSIT ALLOWED")
-							}
-
-							callFrame := findWithdrawalCall(&finalizationTrace, wd, l1xdmAddr)
-							if callFrame == nil {
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "cannot find callframe"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-								return
-							}
-
-							traceJson, err := json.MarshalIndent(callFrame, "", "    ")
-							if err != nil {
-								log.Error("error marshalling callframe", "err", err)
-								return
-							}
-							log.Debug(fmt.Sprintf("%v", string(traceJson)))
-
-							abi, err := bindings.L1StandardBridgeMetaData.GetAbi()
-							if err != nil {
-								log.Error("error getting abi of the L1StandardBridge", "err", err)
-								return
-							}
-
-							calldata := hexutil.MustDecode(callFrame.Input)
-
-							// this must be the L1 standard bridge
-							method, err := abi.MethodById(calldata)
-							// Handle L1StandardBridge specific logic
-							if err == nil {
-								args, err := method.Inputs.Unpack(calldata[4:])
-								if err != nil {
-									log.Error("error unpacking calldata", "err", err)
-									return
-								}
-
-								log.Info("decoded calldata", "name", method.Name)
-
-								switch method.Name {
-								case "finalizeERC20Withdrawal":
-									if err := handleFinalizeERC20Withdrawal(args, receipt, l1StandardBridgeAddress); err != nil {
-										log.Error("error handling finalizeERC20Withdrawal", "err", err)
-										return
-									}
-								case "finalizeETHWithdrawal":
-									if err := handleFinalizeETHWithdrawal(args); err != nil {
-										log.Error("error handling finalizeETHWithdrawal", "err", err)
-										return
-									}
-								default:
-									log.Info("Unhandled method", "name", method.Name)
-								}
-							}
-
-							// Ensure that the target's balance was increasedData correctly
-							wdValue, err := wd.Value()
-							if err != nil {
-								log.Error("error getting withdrawal value", "err", err)
-								return
-							}
-							if method != nil {
-								log.Info("withdrawal action", "function", method.Name, "value", wdValue)
-							} else {
-								log.Info("unknown method", "to", wd.XDomainTarget, "data", hexutil.Encode(wd.XDomainData))
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "unknown method"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-							}
-
-							// check that the user's intents are actually executed
-							if common.HexToAddress(callFrame.To) != wd.XDomainTarget {
-								log.Info("target mismatch", "index", i)
-
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "target mismatch"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-							}
-							if !bytes.Equal(hexutil.MustDecode(callFrame.Input), wd.XDomainData) {
-								log.Info("calldata mismatch", "index", i)
-
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "calldata mismatch"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-								return
-							}
-							if callFrame.BigValue().Cmp(wdValue) != 0 {
-								log.Info("value mismatch", "index", i)
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "value mismatch"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-								return
-							}
-
-							// Get the ETH balance of the withdrawal target *after* the finalization
-							targetBalAfter, err := clients.L1Client.BalanceAt(context.Background(), wd.XDomainTarget, nil)
-							if err != nil {
-								log.Error("error getting target balance after", "err", err)
-								return
-							}
-
-							diff := new(big.Int).Sub(targetBalAfter, targetBalBefore)
-							log.Debug("balances", "before", targetBalBefore, "after", targetBalAfter, "diff", diff)
-
-							isSuccessNewPost, err = contracts.L1CrossDomainMessenger.SuccessfulMessages(&bind.CallOpts{}, xdmHash)
-							if err != nil {
-								log.Error("error getting success", "err", err)
-								return
-							}
-
-							if diff.Cmp(wdValue) != 0 && isSuccessNewPost && isSuccess {
-								log.Info("native eth balance diff mismatch", "index", i, "diff", diff, "val", wdValue)
-								if err := writeSuspicious(f, withdrawal, wd, finalizationTrace, i, "balance mismatch"); err != nil {
-									log.Error("error writing suspicious withdrawal", "err", err)
-									return
-								}
-								return
-							}
-						} else {
-							log.Info("Already finalized")
-						}
-					}(wd, nonce+uint64(j))
-				}
-
-				wg.Wait()
+			if err := batchTxs(finalizeWithdrawals); err != nil {
+				return err
 			}
+
 			return nil
 		},
 	}
@@ -849,6 +863,8 @@ func proveWithdrawalTransaction(c *contracts, cl *util.Clients, opts *bind.Trans
 	if err != nil {
 		return err
 	}
+
+	log.Info("proving withdrawal", "tx-hash", tx.Hash(), "nonce", tx.Nonce())
 
 	receipt, err := bind.WaitMined(context.Background(), cl.L1Client, tx)
 	if err != nil {

--- a/op-chain-ops/cmd/withdrawals/main.go
+++ b/op-chain-ops/cmd/withdrawals/main.go
@@ -309,7 +309,15 @@ func main() {
 
 				// the value should be set to a boolean in storage
 				if !bytes.Equal(storageValue, abiTrue.Bytes()) {
-					log.Error("storage slot %x not found in state", "slot", slot.Hex())
+					log.Error(
+						"storage slot not found in state",
+						"slot", slot.Hex(),
+						"xTarget", wd.XDomainTarget,
+						"xData", wd.XDomainData,
+						"xNonce", wd.XDomainNonce,
+						"xSender", wd.XDomainSender,
+						"sender", wd.MessageSender,
+					)
 					return
 				}
 
@@ -886,6 +894,14 @@ func finalizeWithdrawalTransaction(
 	withdrawal *crossdomain.Withdrawal,
 ) (*types.Receipt, error) {
 	if wd.XDomainTarget == (common.Address{}) {
+		log.Warn(
+			"nil withdrawal target",
+			"xTarget", wd.XDomainTarget,
+			"xData", wd.XDomainData,
+			"xNonce", wd.XDomainNonce,
+			"xSender", wd.XDomainSender,
+			"sender", wd.MessageSender,
+		)
 		return nil, errors.New("withdrawal target is nil, should never happen")
 	}
 


### PR DESCRIPTION
This PR improves performance of the withdrawals script by using a concurrency-limited set of goroutines rather than batches. This allows transactions to always fill the mempool. Additionally, fixes a bug with nonce management where failed transactions would bump the nonce and cause nonce gaps in the mempool, leading to stuck transactions.