### PR TITLE
contracts-bedrock: deploy time checks

### DIFF
--- a/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
+++ b/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import '@eth-optimism/hardhat-deploy-config'
-import { ethers } from 'ethers'
+import { ethers, BigNumber } from 'ethers'
 
 import { assertContractVariable, deploy } from '../src/deploy-utils'
 
@@ -23,9 +23,14 @@ const deployFn: DeployFunction = async (hre) => {
     .toLowerCase()
 
   const l2GenesisBlockGasLimit = hre.deployConfig.l2GenesisBlockGasLimit
-  const l2GasLimitLowerBound = defaultResourceConfig.systemTxMaxGas + defaultResourceConfig.maxResourceLimit
+  const l2GasLimitLowerBound = BigNumber.from(
+    defaultResourceConfig.systemTxMaxGas +
+      defaultResourceConfig.maxResourceLimit
+  )
   if (l2GenesisBlockGasLimit.lt(l2GasLimitLowerBound)) {
-    throw new Error(`L2 genesis block gas limit must be at least ${l2GasLimitLowerBound}`)
+    throw new Error(
+      `L2 genesis block gas limit must be at least ${l2GasLimitLowerBound}`
+    )
   }
 
   await deploy({
@@ -38,7 +43,7 @@ const deployFn: DeployFunction = async (hre) => {
       batcherHash,
       l2GenesisBlockGasLimit,
       hre.deployConfig.p2pSequencerAddress,
-      defaultResourceConfig
+      defaultResourceConfig,
     ],
     postDeployAction: async (contract) => {
       await assertContractVariable(
@@ -65,8 +70,14 @@ const deployFn: DeployFunction = async (hre) => {
 
       const config = await contract.resourceConfig()
       assert(config.maxResourceLimit === defaultResourceConfig.maxResourceLimit)
-      assert(config.elasticityMultiplier === defaultResourceConfig.elasticityMultiplier)
-      assert(config.baseFeeMaxChangeDenominator === defaultResourceConfig.baseFeeMaxChangeDenominator)
+      assert(
+        config.elasticityMultiplier ===
+          defaultResourceConfig.elasticityMultiplier
+      )
+      assert(
+        config.baseFeeMaxChangeDenominator ===
+          defaultResourceConfig.baseFeeMaxChangeDenominator
+      )
       assert(config.systemTxMaxGas === defaultResourceConfig.systemTxMaxGas)
       assert(config.minimumBaseFee.eq(defaultResourceConfig.minimumBaseFee))
       assert(config.maximumBaseFee.eq(defaultResourceConfig.maximumBaseFee))

--- a/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
+++ b/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
@@ -70,9 +70,21 @@ const deployFn: DeployFunction = async (hre) => {
         config.baseFeeMaxChangeDenominator ===
           defaultResourceConfig.baseFeeMaxChangeDenominator
       )
-      assert(config.systemTxMaxGas === defaultResourceConfig.systemTxMaxGas)
-      assert(config.minimumBaseFee.eq(defaultResourceConfig.minimumBaseFee))
-      assert(config.maximumBaseFee.eq(defaultResourceConfig.maximumBaseFee))
+      assert(
+        BigNumber.from(config.systemTxMaxGas).eq(
+          defaultResourceConfig.systemTxMaxGas
+        )
+      )
+      assert(
+        BigNumber.from(config.minimumBaseFee).eq(
+          defaultResourceConfig.minimumBaseFee
+        )
+      )
+      assert(
+        BigNumber.from(config.maximumBaseFee).eq(
+          defaultResourceConfig.maximumBaseFee
+        )
+      )
     },
   })
 }

--- a/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
+++ b/packages/contracts-bedrock/deploy/017-SystemConfigImpl.ts
@@ -2,27 +2,19 @@ import assert from 'assert'
 
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import '@eth-optimism/hardhat-deploy-config'
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber } from 'ethers'
 
+import { defaultResourceConfig } from '../src/constants'
 import { assertContractVariable, deploy } from '../src/deploy-utils'
-
-const uint128Max = ethers.BigNumber.from('0xffffffffffffffffffffffffffffffff')
-
-const defaultResourceConfig = {
-  maxResourceLimit: 20_000_000,
-  elasticityMultiplier: 10,
-  baseFeeMaxChangeDenominator: 8,
-  minimumBaseFee: ethers.utils.parseUnits('1', 'gwei'),
-  systemTxMaxGas: 1_000_000,
-  maximumBaseFee: uint128Max,
-}
 
 const deployFn: DeployFunction = async (hre) => {
   const batcherHash = hre.ethers.utils
     .hexZeroPad(hre.deployConfig.batchSenderAddress, 32)
     .toLowerCase()
 
-  const l2GenesisBlockGasLimit = hre.deployConfig.l2GenesisBlockGasLimit
+  const l2GenesisBlockGasLimit = BigNumber.from(
+    hre.deployConfig.l2GenesisBlockGasLimit
+  )
   const l2GasLimitLowerBound = BigNumber.from(
     defaultResourceConfig.systemTxMaxGas +
       defaultResourceConfig.maxResourceLimit

--- a/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
+++ b/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-import { ethers, BigNumber } from 'ethers'
+import { ethers } from 'ethers'
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 import { awaitCondition } from '@eth-optimism/core-utils'
 import '@eth-optimism/hardhat-deploy-config'
@@ -10,6 +10,7 @@ import {
   getContractsFromArtifacts,
   getDeploymentAddress,
 } from '../src/deploy-utils'
+import { defaultResourceConfig } from '../src/constants'
 
 const deployFn: DeployFunction = async (hre) => {
   const { deployer } = await hre.getNamedAccounts()
@@ -102,16 +103,7 @@ const deployFn: DeployFunction = async (hre) => {
       unsafeBlockSigner: hre.deployConfig.p2pSequencerAddress,
       // The resource config is not exposed to the end user
       // to simplify deploy config. It may be introduced in the future.
-      resourceConfig: {
-        maxResourceLimit: 20_000_000,
-        elasticityMultiplier: 10,
-        baseFeeMaxChangeDenominator: 8,
-        minimumBaseFee: ethers.utils.parseUnits('1', 'gwei'),
-        systemTxMaxGas: 1_000_000,
-        maximumBaseFee: BigNumber.from(
-          '0xffffffffffffffffffffffffffffffff'
-        ).toString(),
-      },
+      resourceConfig: defaultResourceConfig,
     },
   }
 

--- a/packages/contracts-bedrock/src/constants.ts
+++ b/packages/contracts-bedrock/src/constants.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers'
+
 /**
  * Predeploys are Solidity contracts that are injected into the initial L2 state and provide
  * various useful functions.
@@ -25,4 +27,15 @@ export const predeploys = {
   ProxyAdmin: '0x4200000000000000000000000000000000000018',
   BaseFeeVault: '0x4200000000000000000000000000000000000019',
   L1FeeVault: '0x420000000000000000000000000000000000001a',
+}
+
+const uint128Max = ethers.BigNumber.from('0xffffffffffffffffffffffffffffffff')
+
+export const defaultResourceConfig = {
+  maxResourceLimit: 20_000_000,
+  elasticityMultiplier: 10,
+  baseFeeMaxChangeDenominator: 8,
+  minimumBaseFee: ethers.utils.parseUnits('1', 'gwei'),
+  systemTxMaxGas: 1_000_000,
+  maximumBaseFee: uint128Max,
 }


### PR DESCRIPTION
**Description**

Add deploy time checks to ensure that the config invariants are sane. There is an invariant such that the L2 gas limit must be larger than the amount of gas used by the system transaction plus the amount of gas that deposits can purchase on L1. This invariant is held checked in the migration code but not the typescript deployment code.

Closes CLI-3774

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

