### PR TITLE
Revert "fix(op-node): Remove Deprecated Public rpc.Api Field"

### DIFF
--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -37,6 +37,7 @@ func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Conf
 		apis: []rpc.API{{
 			Namespace:     "optimism",
 			Service:       api,
+			Public:        true,
 			Authenticated: false,
 		}},
 		appVersion: appVersion,
@@ -50,6 +51,7 @@ func (s *rpcServer) EnableAdminAPI(api *adminAPI) {
 		Namespace:     "admin",
 		Version:       "",
 		Service:       api,
+		Public:        true, // TODO: this field is deprecated. Do we even need this anymore?
 		Authenticated: false,
 	})
 }
@@ -59,6 +61,7 @@ func (s *rpcServer) EnableP2P(backend *p2p.APIBackend) {
 		Namespace:     p2p.NamespaceRPC,
 		Version:       "",
 		Service:       backend,
+		Public:        true,
 		Authenticated: false,
 	})
 }


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#5712

I believe that this breaking hive. Need to test to be sure.