### PR TITLE
op-e2e: Start support for testing peer scoring

### DIFF
--- a/op-e2e/p2pstub/node.go
+++ b/op-e2e/p2pstub/node.go
@@ -1,0 +1,117 @@
+package p2pstub
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum/log"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type GossipTopic string
+
+const (
+	BlockTopic = GossipTopic("blocks")
+)
+
+type Config struct {
+	P2P    p2p.SetupP2P
+	Rollup rollup.Config
+}
+
+type P2PNode struct {
+	log    log.Logger
+	config *Config
+	gs     *pubsub.PubSub
+	host   host.Host
+	topics map[GossipTopic]*pubsub.Topic
+}
+
+func NewP2pNode(logger log.Logger, config Config) (*P2PNode, error) {
+	return &P2PNode{
+		log:    logger,
+		config: &config,
+		topics: make(map[GossipTopic]*pubsub.Topic),
+	}, nil
+}
+
+func (n *P2PNode) Start(ctx context.Context) error {
+	if err := n.config.P2P.Check(); err != nil {
+		return fmt.Errorf("invalid p2p config: %w", err)
+	}
+	h, err := n.config.P2P.Host(n.log, nil)
+	if err != nil {
+		return fmt.Errorf("create host: %w", err)
+	}
+	n.gs, err = p2p.NewGossipSub(ctx, h, nil, &n.config.Rollup, n.config.P2P, metrics.NoopMetrics, n.log)
+	n.host = h
+	return nil
+}
+
+func (n *P2PNode) Close() error {
+	return n.host.Close()
+}
+
+func (n *P2PNode) WaitForPeerCount(expected int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return e2eutils.WaitFor(ctx, 1*time.Second, func() (bool, error) {
+		return expected == len(n.host.Network().Peers()), nil
+	})
+}
+
+func (n *P2PNode) JoinTopic(topic GossipTopic) error {
+	if _, ok := n.topics[topic]; ok {
+		return fmt.Errorf("already joined topic: %v", topic)
+	}
+	var topicName string
+	switch topic {
+	case BlockTopic:
+		topicName = fmt.Sprintf("/optimism/%s/0/blocks", n.config.Rollup.L2ChainID.String())
+	default:
+		return fmt.Errorf("unknown topic: %v", topic)
+	}
+	t, err := n.gs.Join(topicName)
+	if err != nil {
+		return err
+	}
+	n.topics[topic] = t
+	return nil
+}
+
+func (n *P2PNode) WaitForPeerCountOnTopic(topic GossipTopic, expected int) error {
+	t, ok := n.topics[topic]
+	if !ok {
+		return fmt.Errorf("not joined to topic %v", topic)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return e2eutils.WaitFor(ctx, 1*time.Second, func() (bool, error) {
+		return expected == len(t.ListPeers()), nil
+	})
+}
+
+func (n *P2PNode) PublishGossip(ctx context.Context, topic GossipTopic, msg []byte) error {
+	t, ok := n.topics[topic]
+	if !ok {
+		return fmt.Errorf("not joined to topic %v", topic)
+	}
+	return t.Publish(ctx, msg)
+}
+
+func (n *P2PNode) DisconnectPeer(peerId peer.ID) error {
+	return n.host.Network().ClosePeer(peerId)
+}
+
+func (n *P2PNode) ConnectPeer(ctx context.Context, peerId peer.ID) error {
+	_, err := n.host.Network().DialPeer(ctx, peerId)
+	return err
+}

--- a/op-e2e/system_scoring_test.go
+++ b/op-e2e/system_scoring_test.go
@@ -1,0 +1,48 @@
+package op_e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/p2pstub"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBanPeerSendingInvalidGossip(t *testing.T) {
+	InitParallel(t)
+	ctx := context.Background()
+	cfg := DefaultSystemConfig(t)
+	delete(cfg.Nodes, "verifier") // Not needed in this test
+	cfg.P2PPeerScoring = true
+	// TODO: e2e setup needs to create the connction gater and connection manager
+	// prepared will need to implement p2p.ExtraHostFeatures
+	cfg.P2pNodes["nastyDude"] = &p2pstub.Config{}
+	cfg.P2PTopology = map[string][]string{
+		"nastyDude": {"sequencer"},
+	}
+	cfg.Loggers["nastyDude"] = testlog.Logger(t, log.LvlInfo).New("role", "nastyDude")
+
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	nastyDude := sys.P2PNodes["nastyDude"]
+	require.NoError(t, nastyDude.WaitForPeerCount(1), "should have connected to sequencer")
+
+	require.NoError(t, nastyDude.JoinTopic(p2pstub.BlockTopic))
+	require.NoError(t, nastyDude.WaitForPeerCountOnTopic(p2pstub.BlockTopic, 1))
+
+	require.NoError(t, nastyDude.PublishGossip(ctx, p2pstub.BlockTopic, []byte{1}))
+	require.NoError(t, nastyDude.PublishGossip(ctx, p2pstub.BlockTopic, []byte{2}))
+	require.NoError(t, nastyDude.PublishGossip(ctx, p2pstub.BlockTopic, []byte{3}))
+
+	// TODO: Make this work
+	// require.NoError(t, nastyDude.WaitForPeerCount(0), "should be disconnected for bad behaviour")
+
+	sequencerId := sys.RollupNodes["sequencer"].P2P().Host().ID()
+	require.NoError(t, nastyDude.DisconnectPeer(sequencerId))
+	require.NoError(t, nastyDude.WaitForPeerCount(0), "should be disconnected for bad behaviour")
+	require.Error(t, nastyDude.ConnectPeer(ctx, sequencerId), "should not be able to reconnect")
+}


### PR DESCRIPTION
**Description**

* Add a stub `P2PNode` to e2e tests that is just the p2p layer and allows low level access to call into libp2p.
* Add support for enabling peer scoring in e2e tests
* New system test to start exercising 

The big challenge here is that e2e tests use a `Mocknet` which replaces all the libp2p `Host` setup that would normally occur in op-node. There's a bunch of setup that then has to be shoehorned in which is a bit messy, but the major issue is that `Mocknet` doesn't seem to have any support for using a connection gater, so banned peers aren't blocked from connecting and we aren't able to properly test the peer scoring functionality.

The new stub `P2PNode` type was added because using just the P2P layer from op-node sets up validators on gossip topics which blocks sending invalid messages.

**Metadata**

- https://linear.app/optimism/issue/CLI-3603/op-e2e-peer-score-testing
