### PR TITLE
op-node: Add persistence of peer scores in peer store

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -465,6 +465,8 @@ func (cfg SystemConfig) Start(_opts ...SystemConfigOption) (*System, error) {
 			if p, ok := p2pNodes[name]; ok {
 				return p, nil
 			}
+			// TODO: This will need to be modified to use sys.Mocknet.AddPeerWithPeerstore so we can make the peerstore
+			// an extended peerstore.
 			h, err := sys.Mocknet.GenPeer()
 			if err != nil {
 				return nil, fmt.Errorf("failed to init p2p host for node %s", name)

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -132,8 +133,8 @@ type ConnectionGater interface {
 	ListBlockedSubnets() []*net.IPNet
 }
 
-func DefaultConnGater(conf *Config) (connmgr.ConnectionGater, error) {
-	return conngater.NewBasicConnectionGater(conf.Store)
+func DefaultConnGater(store ds.Datastore, ps store.ScoreDatastore) (connmgr.ConnectionGater, error) {
+	return conngater.NewBasicConnectionGater(store)
 }
 
 func DefaultConnManager(conf *Config) (connmgr.ConnManager, error) {

--- a/op-node/p2p/peer_scores.go
+++ b/op-node/p2p/peer_scores.go
@@ -1,20 +1,20 @@
 package p2p
 
 import (
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	log "github.com/ethereum/go-ethereum/log"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	host "github.com/libp2p/go-libp2p/core/host"
 )
 
 // ConfigurePeerScoring configures the peer scoring parameters for the pubsub
-func ConfigurePeerScoring(h host.Host, g ConnectionGater, gossipConf GossipSetupConfigurables, m GossipMetricer, log log.Logger) []pubsub.Option {
+func ConfigurePeerScoring(g ConnectionGater, ps store.ExtendedPeerstore, gossipConf GossipSetupConfigurables, m GossipMetricer, log log.Logger) []pubsub.Option {
 	// If we want to completely disable scoring config here, we can use the [peerScoringParams]
 	// to return early without returning any [pubsub.Option].
 	peerScoreParams := gossipConf.PeerScoringParams()
 	peerScoreThresholds := NewPeerScoreThresholds()
 	banEnabled := gossipConf.BanPeers()
 	peerGater := NewPeerGater(g, log, banEnabled)
-	scorer := NewScorer(peerGater, h.Peerstore(), m, gossipConf.PeerBandScorer(), log)
+	scorer := NewScorer(peerGater, ps, m, gossipConf.PeerBandScorer(), log)
 	opts := []pubsub.Option{}
 	// Check the app specific score since libp2p doesn't export it's [validate] function :/
 	if peerScoreParams != nil && peerScoreParams.AppSpecificScore != nil {

--- a/op-node/p2p/store/datastore.go
+++ b/op-node/p2p/store/datastore.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	ds "github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+)
+
+type datastore struct {
+	peerstore.Peerstore
+	peerstore.CertifiedAddrBook
+}
+
+type ScoreType string
+
+const (
+	gossipType ScoreType = "gossip"
+)
+
+func NewExtendedPeerstore(ps peerstore.Peerstore, store ds.Batching) (ExtendedPeerstore, error) {
+	cab, ok := peerstore.GetCertifiedAddrBook(ps)
+	if !ok {
+		return nil, errors.New("peerstore should also be a certified address book")
+	}
+	return &datastore{
+		Peerstore:         ps,
+		CertifiedAddrBook: cab,
+	}, nil
+}
+
+func (d *datastore) GetPeerScores(id peer.ID) (PeerScores, error) {
+	scores := PeerScores{}
+	if score, err := d.loadScoreComponent(id, gossipType); err != nil {
+		return PeerScores{}, fmt.Errorf("load gossip score: %w", err)
+	} else {
+		scores.gossip = score
+	}
+	return scores, nil
+}
+
+func (d *datastore) loadScoreComponent(id peer.ID, scoreType ScoreType) (float64, error) {
+	if val, err := d.Get(id, scoreKey(scoreType)); errors.Is(err, peerstore.ErrNotFound) {
+		return 0, nil
+	} else if err != nil {
+		return 0, err
+	} else {
+		score, ok := val.(float64)
+		if !ok {
+			return 0, fmt.Errorf("stored score of type %v was not a float64", scoreType)
+		}
+		return score, nil
+	}
+}
+
+func (d *datastore) SetGossipScore(id peer.ID, score float64) error {
+	return d.Put(id, scoreKey(gossipType), score)
+}
+
+func scoreKey(scoreType ScoreType) string {
+	return fmt.Sprintf("score-%v", scoreType)
+}
+
+var _ ExtendedPeerstore = (*datastore)(nil)

--- a/op-node/p2p/store/datastore_test.go
+++ b/op-node/p2p/store/datastore_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEmptyScoreComponents(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	result, err := store.GetPeerScores(id)
+	require.NoError(t, err)
+	require.Equal(t, result, PeerScores{})
+}
+
+func TestRoundTripGossipScore(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	score := 123.45
+	err := store.SetGossipScore(id, score)
+	require.NoError(t, err)
+
+	elements, err := store.GetPeerScores(id)
+	require.NoError(t, err)
+	require.Equal(t, elements, PeerScores{gossip: score})
+}
+
+func TestUpdateGossipScore(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	score := 123.45
+	require.NoError(t, store.SetGossipScore(id, 444.223))
+	require.NoError(t, store.SetGossipScore(id, score))
+
+	result, err := store.GetPeerScores(id)
+	require.NoError(t, err)
+	require.Equal(t, result, PeerScores{gossip: score})
+}
+
+func createMemoryStore(t *testing.T) ExtendedPeerstore {
+	store := sync.MutexWrap(ds.NewMapDatastore())
+	ps, err := pstoreds.NewPeerstore(context.Background(), store, pstoreds.DefaultOpts())
+	require.NoError(t, err, "Failed to create peerstore")
+	eps, err := NewExtendedPeerstore(ps, store)
+	require.NoError(t, err)
+	return eps
+}

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+)
+
+type PeerScores struct {
+	gossip float64
+}
+
+// ScoreDatastore defines a type-safe API for getting and setting libp2p peer score information
+type ScoreDatastore interface {
+	// GetPeerScores returns the current scores for the specified peer
+	GetPeerScores(id peer.ID) (PeerScores, error)
+
+	// SetGossipScore stores the latest gossip score for a peer
+	SetGossipScore(id peer.ID, score float64) error
+}
+
+// ExtendedPeerstore defines a type-safe API to work with additional peer metadata based on a libp2p peerstore.Peerstore
+type ExtendedPeerstore interface {
+	peerstore.Peerstore
+	ScoreDatastore
+	peerstore.CertifiedAddrBook
+}


### PR DESCRIPTION
**Description**

Introduces the concept of `ExtendedPeerstore` which provides a type-safe API for storing additional peer data - initially peer scores from various scoring sources.

Currently it doesn't actually use the information in the store but does update the store periodically with the latest gossip score for each peer. The extended peer store is also passed into the method that creates the connection gater to prove the plumbing all fits together but the gater hasn't been updated to actually use it.

Also simplifies the setup initialisation of the p2p layer by removing the connection gater and manager constructors from the config. These are both created as part of the `config.Host` call anyway so the config has control over them.

Currently scores are stored as meta entries for peers. This is simple but overly naive.  The underlying `datastore.Batching` has been passed into the constructor to ensure that it is available when being wired up as an optimised implementation will likely use that directly. We will have to implement some form of GC if we move out of using meta (but that will give us flexibility on how long to retain scoring information which is likely to be required anyway).

Also pretty sure the API to get scores isn't the most useful thing. For disconnection we'll want to be able to get a total score value out rather than individual components, but not sure the peer store should be involved in applying weightings to calculate that score.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- https://linear.app/optimism/issue/CLI-3246/persist-peer-scores
