### PR TITLE
op-e2e: pending block test + op-geth update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,6 +190,6 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101105.2-0.20230502202351-9cc072e922f6
+replace github.com/ethereum/go-ethereum v1.11.6 => github.com/ethereum-optimism/op-geth v1.101105.2-0.20230526154603-bdab05ca786f
 
 //replace github.com/ethereum/go-ethereum v1.11.6 => ../go-ethereum

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101105.2-0.20230502202351-9cc072e922f6 h1:Fh9VBmDCwjVn8amx1Dfrx+hIh16C/FDkS17EN25MGO8=
-github.com/ethereum-optimism/op-geth v1.101105.2-0.20230502202351-9cc072e922f6/go.mod h1:X9t7oeerFMU9/zMIjZKT/jbIca+O05QqtBTLjL+XVeA=
+github.com/ethereum-optimism/op-geth v1.101105.2-0.20230526154603-bdab05ca786f h1:+yZN8K/4AIN5f+gazMwZAeqzDG2EL2GydMrccjnEK+A=
+github.com/ethereum-optimism/op-geth v1.101105.2-0.20230526154603-bdab05ca786f/go.mod h1:X9t7oeerFMU9/zMIjZKT/jbIca+O05QqtBTLjL+XVeA=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fjl/memsize v0.0.1 h1:+zhkb+dhUgx0/e+M8sF0QqiouvMQUiKR+QYvdxIOKcQ=

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1394,6 +1394,7 @@ func TestPendingBlockIsLatest(t *testing.T) {
 
 	t.Run("block", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
+			// TODO(CLI-4044): pending-block ID change
 			pending, err := l2Seq.BlockByNumber(context.Background(), big.NewInt(-1))
 			require.NoError(t, err)
 			latest, err := l2Seq.BlockByNumber(context.Background(), nil)
@@ -1408,6 +1409,7 @@ func TestPendingBlockIsLatest(t *testing.T) {
 	})
 	t.Run("header", func(t *testing.T) {
 		for i := 0; i < 10; i++ {
+			// TODO(CLI-4044): pending-block ID change
 			pending, err := l2Seq.HeaderByNumber(context.Background(), big.NewInt(-1))
 			require.NoError(t, err)
 			latest, err := l2Seq.HeaderByNumber(context.Background(), nil)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1232,6 +1232,14 @@ func TestFees(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, l1Fee, gpoL1Fee, "l1 fee mismatch")
 
+	require.Equal(t, receipt.L1Fee, l1Fee, "l1 fee in receipt is correct")
+	require.Equal(t,
+		new(big.Float).Mul(
+			new(big.Float).SetInt(l1Header.BaseFee),
+			new(big.Float).Mul(new(big.Float).SetInt(receipt.L1GasUsed), receipt.FeeScalar),
+		),
+		new(big.Float).SetInt(receipt.L1Fee), "fee field in receipt matches gas used times scalar times basefee")
+
 	// Calculate total fee
 	baseFeeRecipientDiff.Add(baseFeeRecipientDiff, coinbaseDiff)
 	totalFee := new(big.Int).Add(baseFeeRecipientDiff, l1FeeRecipientDiff)


### PR DESCRIPTION
**Description**

Tests that the pending block matches the latest block, a change introduced in https://github.com/ethereum-optimism/op-geth/pull/93

~~Added a temporary `go.mod` change so it runs CI with that op-geth PR. We should merge the geth PR first, and then update the go.mod to point at the main branch.~~ Matches latest `optimism` branch op-geth commit now (previous v1.11.6 changes were included before this PR already, and don't really affect the op-node other than e2e testing, this strictly introduces the receipt L1-fee overhead metadata fix and the pending-block change).