### PR TITLE
feat(op-challenger): L2OutputOracle Filter Query.

### DIFF
--- a/op-challenger/challenger/oracle.go
+++ b/op-challenger/challenger/oracle.go
@@ -1,0 +1,36 @@
+package challenger
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var ErrMissingEvent = errors.New("missing event")
+
+// BuildOutputLogFilter creates a filter query for the L2OutputOracle contract.
+//
+// The `OutputProposed` event is encoded as:
+// 0: bytes32 indexed outputRoot,
+// 1: uint256 indexed l2OutputIndex,
+// 2: uint256 indexed l2BlockNumber,
+// 3: uint256 l1Timestamp
+func BuildOutputLogFilter(l2ooABI *abi.ABI) (ethereum.FilterQuery, error) {
+	// Get the L2OutputOracle contract `OutputProposed` event
+	event := l2ooABI.Events["OutputProposed"]
+
+	// Sanity check that the `OutputProposed` event is defined
+	if event.ID == (common.Hash{}) {
+		return ethereum.FilterQuery{}, ErrMissingEvent
+	}
+
+	query := ethereum.FilterQuery{
+		Topics: [][]common.Hash{
+			{event.ID},
+		},
+	}
+
+	return query, nil
+}

--- a/op-challenger/challenger/oracle_test.go
+++ b/op-challenger/challenger/oracle_test.go
@@ -1,0 +1,52 @@
+package challenger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	eth "github.com/ethereum/go-ethereum"
+	abi "github.com/ethereum/go-ethereum/accounts/abi"
+	common "github.com/ethereum/go-ethereum/common"
+)
+
+// TestBuildOutputLogFilter_Succeeds tests that the Output
+// Log Filter is built correctly.
+func TestBuildOutputLogFilter_Succeeds(t *testing.T) {
+	// Create a mock event id
+	event := abi.Event{
+		ID: [32]byte{0x01},
+	}
+
+	filterQuery := eth.FilterQuery{
+		Topics: [][]common.Hash{
+			{event.ID},
+		},
+	}
+
+	// Mock the ABI
+	l2ooABI := abi.ABI{
+		Events: map[string]abi.Event{
+			"OutputProposed": event,
+		},
+	}
+
+	// Build the filter
+	query, err := BuildOutputLogFilter(&l2ooABI)
+	require.Equal(t, filterQuery, query)
+	require.NoError(t, err)
+}
+
+// TestBuildOutputLogFilter_Fails tests that the Output
+// Log Filter fails when the event definition is missing.
+func TestBuildOutputLogFilter_Fails(t *testing.T) {
+	// Mock the ABI
+	l2ooABI := abi.ABI{
+		Events: map[string]abi.Event{},
+	}
+
+	// Build the filter
+	_, err := BuildOutputLogFilter(&l2ooABI)
+	require.Error(t, err)
+	require.Equal(t, ErrMissingEvent, err)
+}


### PR DESCRIPTION
**Description**

Split out of #5636, this adds a simple tested function for building a filter query for the `L2OutputOracle` `OutputProposed` event.