### PR TITLE
fix(proxyd): clean up cache initialization

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -26,9 +26,7 @@ type ServerConfig struct {
 }
 
 type CacheConfig struct {
-	Enabled               bool   `toml:"enabled"`
-	BlockSyncRPCURL       string `toml:"block_sync_rpc_url"`
-	NumBlockConfirmations int    `toml:"num_block_confirmations"`
+	Enabled bool `toml:"enabled"`
 }
 
 type RedisConfig struct {

--- a/proxyd/integration_tests/testdata/caching.toml
+++ b/proxyd/integration_tests/testdata/caching.toml
@@ -10,8 +10,6 @@ namespace = "proxyd"
 
 [cache]
 enabled = true
-block_sync_rpc_url = "$GOOD_BACKEND_RPC_URL"
-
 
 [backends]
 [backends.good]


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change removed the left over configs from the cache refactoring. They were preventing proxyd to start with cache enabled.

**Tests**

Tested manually. Deployed to dev. Can see service starting correctly and cache metrics showing in grafana: https://optimistic.grafana.net/d/TRHRXiBVk/proxyd-k8s?orgId=1&refresh=10s&var-instance=dev-client-internal-devnet-proxyd-l1-consensus&var-backend_name=All&var-method=All&from=now-2d&to=now

**Invariants**

n/a

**Additional context**

This change is part of the Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes https://linear.app/optimism/issue/INF-227/fixproxyd-clean-up-cache-initialization

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
