### PR TITLE
fix: hardhat dev dependency

### DIFF
--- a/.changeset/eleven-experts-crash.md
+++ b/.changeset/eleven-experts-crash.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+contracts-bedrock was exporting hardhat when it didn't need to be

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -56,8 +56,7 @@
     "@eth-optimism/core-utils": "^0.12.0",
     "@openzeppelin/contracts": "4.7.3",
     "@openzeppelin/contracts-upgradeable": "4.7.3",
-    "ethers": "^5.7.0",
-    "hardhat": "^2.9.6"
+    "ethers": "^5.7.0"
   },
   "devDependencies": {
     "@eth-optimism/hardhat-deploy-config": "^0.2.6",
@@ -82,6 +81,7 @@
     "ethereum-waffle": "^3.0.0",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#46264e9788017fc74f9f58b7efa0bc6e1df6d410",
     "glob": "^7.1.6",
+    "hardhat": "^2.9.6",
     "hardhat-deploy": "^0.11.4",
     "solhint": "^3.3.7",
     "solhint-plugin-prettier": "^0.0.5",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**


**Tests**

Hardhat was listed as a dependency when it should be a dev dependency. Was breaking some external monorepo stuff when adding a package that relied on contracts-bedrock because hardhat was being resolved from there and not from the top level.
