### PR TITLE
op-node: Add extended peer store to store scores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.14.0
 	github.com/schollz/progressbar/v3 v3.13.0
-	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.9
 	github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa
@@ -163,6 +162,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
-	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-libp2p v0.25.1
 	github.com/libp2p/go-libp2p-pubsub v0.9.0
 	github.com/libp2p/go-libp2p-testing v0.12.0
@@ -106,6 +105,7 @@ require (
 	github.com/koron/go-ssdp v0.0.3 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,15 +20,18 @@ require (
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
+	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/libp2p/go-libp2p v0.25.1
 	github.com/libp2p/go-libp2p-pubsub v0.9.0
 	github.com/libp2p/go-libp2p-testing v0.12.0
 	github.com/mattn/go-isatty v0.0.17
+	github.com/multiformats/go-base32 v0.1.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.14.0
 	github.com/schollz/progressbar/v3 v3.13.0
+	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.9
 	github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa
@@ -104,7 +107,6 @@ require (
 	github.com/koron/go-ssdp v0.0.3 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
@@ -128,7 +130,6 @@ require (
 	github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
@@ -162,7 +163,6 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect

--- a/op-node/p2p/store/extended.go
+++ b/op-node/p2p/store/extended.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	ds "github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+)
+
+type extendedStore struct {
+	peerstore.Peerstore
+	peerstore.CertifiedAddrBook
+	*scoreBook
+}
+
+func NewExtendedPeerstore(ctx context.Context, ps peerstore.Peerstore, store ds.Batching) (ExtendedPeerstore, error) {
+	cab, ok := peerstore.GetCertifiedAddrBook(ps)
+	if !ok {
+		return nil, errors.New("peerstore should also be a certified address book")
+	}
+	sb, err := newScoreBook(ctx, store)
+	if err != nil {
+		return nil, fmt.Errorf("create scorebook: %w", err)
+	}
+	return &extendedStore{
+		Peerstore:         ps,
+		CertifiedAddrBook: cab,
+		scoreBook:         sb,
+	}, nil
+}
+
+var _ ExtendedPeerstore = (*extendedStore)(nil)

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+)
+
+type PeerScores struct {
+	Gossip float64
+}
+
+// ScoreDatastore defines a type-safe API for getting and setting libp2p peer score information
+type ScoreDatastore interface {
+	// GetPeerScores returns the current scores for the specified peer
+	GetPeerScores(id peer.ID) (PeerScores, error)
+
+	// SetGossipScore stores the latest gossip score for a peer
+	SetGossipScore(id peer.ID, score float64) error
+}
+
+// ExtendedPeerstore defines a type-safe API to work with additional peer metadata based on a libp2p peerstore.Peerstore
+type ExtendedPeerstore interface {
+	peerstore.Peerstore
+	ScoreDatastore
+	peerstore.CertifiedAddrBook
+}

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -9,13 +9,19 @@ type PeerScores struct {
 	Gossip float64
 }
 
+type ScoreType int
+
+const (
+	TypeGossip ScoreType = iota
+)
+
 // ScoreDatastore defines a type-safe API for getting and setting libp2p peer score information
 type ScoreDatastore interface {
 	// GetPeerScores returns the current scores for the specified peer
 	GetPeerScores(id peer.ID) (PeerScores, error)
 
-	// SetGossipScore stores the latest gossip score for a peer
-	SetGossipScore(id peer.ID, score float64) error
+	// SetScore stores the latest score for the specified peer and score type
+	SetScore(id peer.ID, scoreType ScoreType, score float64) error
 }
 
 // ExtendedPeerstore defines a type-safe API to work with additional peer metadata based on a libp2p peerstore.Peerstore

--- a/op-node/p2p/store/scorebook.go
+++ b/op-node/p2p/store/scorebook.go
@@ -21,8 +21,6 @@ type scoreBook struct {
 
 var scoresBase = ds.NewKey("/peers/scores")
 
-type ScoreType string
-
 const (
 	scoreDataV0    = "0"
 	scoreCacheSize = 100
@@ -65,14 +63,19 @@ func (d *scoreBook) getPeerScoresNoLock(id peer.ID) (PeerScores, error) {
 	return scores, nil
 }
 
-func (d *scoreBook) SetGossipScore(id peer.ID, score float64) error {
+func (d *scoreBook) SetScore(id peer.ID, scoreType ScoreType, score float64) error {
 	d.Lock()
 	defer d.Unlock()
 	scores, err := d.getPeerScoresNoLock(id)
 	if err != nil {
 		return err
 	}
-	scores.Gossip = score
+	switch scoreType {
+	case TypeGossip:
+		scores.Gossip = score
+	default:
+		return fmt.Errorf("unknown score type: %v", scoreType)
+	}
 	data, err := serializeScoresV0(scores)
 	if err != nil {
 		return fmt.Errorf("encode scores for peer %v: %w", id, err)

--- a/op-node/p2p/store/scorebook.go
+++ b/op-node/p2p/store/scorebook.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	ds "github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-base32"
+)
+
+type scoreBook struct {
+	ctx   context.Context
+	store ds.Batching
+	cache *lru.Cache[peer.ID, PeerScores]
+	sync.RWMutex
+}
+
+var scoresBase = ds.NewKey("/peers/scores")
+
+type ScoreType string
+
+const (
+	scoreDataV0    = "0"
+	scoreCacheSize = 100
+)
+
+func newScoreBook(ctx context.Context, store ds.Batching) (*scoreBook, error) {
+	cache, err := lru.New[peer.ID, PeerScores](scoreCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("creating cache: %w", err)
+	}
+	return &scoreBook{
+		ctx:   ctx,
+		store: store,
+		cache: cache,
+	}, nil
+}
+
+func (d *scoreBook) GetPeerScores(id peer.ID) (PeerScores, error) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.getPeerScoresNoLock(id)
+}
+
+func (d *scoreBook) getPeerScoresNoLock(id peer.ID) (PeerScores, error) {
+	scores, ok := d.cache.Get(id)
+	if ok {
+		return scores, nil
+	}
+	data, err := d.store.Get(d.ctx, scoreKey(id))
+	if errors.Is(err, ds.ErrNotFound) {
+		return PeerScores{}, nil
+	} else if err != nil {
+		return PeerScores{}, fmt.Errorf("load scores for peer %v: %w", id, err)
+	}
+	scores, err = deserializeScoresV0(data)
+	if err != nil {
+		return PeerScores{}, fmt.Errorf("invalid score data for peer %v: %w", id, err)
+	}
+	d.cache.Add(id, scores)
+	return scores, nil
+}
+
+func (d *scoreBook) SetGossipScore(id peer.ID, score float64) error {
+	d.Lock()
+	defer d.Unlock()
+	scores, err := d.getPeerScoresNoLock(id)
+	if err != nil {
+		return err
+	}
+	scores.Gossip = score
+	data, err := serializeScoresV0(scores)
+	if err != nil {
+		return fmt.Errorf("encode scores for peer %v: %w", id, err)
+	}
+	err = d.store.Put(d.ctx, scoreKey(id), data)
+	if err != nil {
+		return fmt.Errorf("storing updated scores for peer %v: %w", id, err)
+	}
+	d.cache.Add(id, scores)
+	return nil
+}
+
+func scoreKey(id peer.ID) ds.Key {
+	return scoresBase.ChildString(base32.RawStdEncoding.EncodeToString([]byte(id))).ChildString(scoreDataV0)
+}

--- a/op-node/p2p/store/scorebook_test.go
+++ b/op-node/p2p/store/scorebook_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEmptyScoreComponents(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	assertPeerScores(t, store, id, PeerScores{})
+}
+
+func TestRoundTripGossipScore(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	score := 123.45
+	err := store.SetGossipScore(id, score)
+	require.NoError(t, err)
+
+	assertPeerScores(t, store, id, PeerScores{Gossip: score})
+}
+
+func TestUpdateGossipScore(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	score := 123.45
+	require.NoError(t, store.SetGossipScore(id, 444.223))
+	require.NoError(t, store.SetGossipScore(id, score))
+
+	assertPeerScores(t, store, id, PeerScores{Gossip: score})
+}
+
+func TestStoreScoresForMultiplePeers(t *testing.T) {
+	id1 := peer.ID("aaaa")
+	id2 := peer.ID("bbbb")
+	store := createMemoryStore(t)
+	score1 := 123.45
+	score2 := 453.22
+	require.NoError(t, store.SetGossipScore(id1, score1))
+	require.NoError(t, store.SetGossipScore(id2, score2))
+
+	assertPeerScores(t, store, id1, PeerScores{Gossip: score1})
+	assertPeerScores(t, store, id2, PeerScores{Gossip: score2})
+}
+
+func TestPersistData(t *testing.T) {
+	id := peer.ID("aaaa")
+	score := 123.45
+	backingStore := sync.MutexWrap(ds.NewMapDatastore())
+	store := createPeerstoreWithBacking(t, backingStore)
+
+	require.NoError(t, store.SetGossipScore(id, score))
+
+	// Close and recreate a new store from the same backing
+	require.NoError(t, store.Close())
+	store = createPeerstoreWithBacking(t, backingStore)
+
+	assertPeerScores(t, store, id, PeerScores{Gossip: score})
+}
+
+func assertPeerScores(t *testing.T, store ExtendedPeerstore, id peer.ID, expected PeerScores) {
+	result, err := store.GetPeerScores(id)
+	require.NoError(t, err)
+	require.Equal(t, result, expected)
+}
+
+func createMemoryStore(t *testing.T) ExtendedPeerstore {
+	store := sync.MutexWrap(ds.NewMapDatastore())
+	return createPeerstoreWithBacking(t, store)
+}
+
+func createPeerstoreWithBacking(t *testing.T, store *sync.MutexDatastore) ExtendedPeerstore {
+	ps, err := pstoreds.NewPeerstore(context.Background(), store, pstoreds.DefaultOpts())
+	require.NoError(t, err, "Failed to create peerstore")
+	eps, err := NewExtendedPeerstore(context.Background(), ps, store)
+	require.NoError(t, err)
+	return eps
+}

--- a/op-node/p2p/store/serialize.go
+++ b/op-node/p2p/store/serialize.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	pool "github.com/libp2p/go-buffer-pool"
+)
+
+func serializeScoresV0(scores PeerScores) ([]byte, error) {
+	var b pool.Buffer
+	err := binary.Write(&b, binary.BigEndian, scores.Gossip)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func deserializeScoresV0(data []byte) (PeerScores, error) {
+	var scores PeerScores
+	r := bytes.NewReader(data)
+	err := binary.Read(r, binary.BigEndian, &scores.Gossip)
+	if err != nil {
+		return PeerScores{}, err
+	}
+	return scores, nil
+}

--- a/op-node/p2p/store/serialize.go
+++ b/op-node/p2p/store/serialize.go
@@ -3,12 +3,10 @@ package store
 import (
 	"bytes"
 	"encoding/binary"
-
-	pool "github.com/libp2p/go-buffer-pool"
 )
 
 func serializeScoresV0(scores PeerScores) ([]byte, error) {
-	var b pool.Buffer
+	var b bytes.Buffer
 	err := binary.Write(&b, binary.BigEndian, scores.Gossip)
 	if err != nil {
 		return nil, err

--- a/op-node/p2p/store/serialize_test.go
+++ b/op-node/p2p/store/serialize_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/status-im/keycard-go/hexutils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +30,7 @@ func TestParseHistoricSerializationsV0(t *testing.T) {
 	}{
 		{
 			name:     "GossipOnly",
-			data:     hexutils.HexToBytes("40934A18644523F6"),
+			data:     common.Hex2Bytes("40934A18644523F6"),
 			expected: PeerScores{Gossip: 1234.52382},
 		},
 	}

--- a/op-node/p2p/store/serialize_test.go
+++ b/op-node/p2p/store/serialize_test.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/status-im/keycard-go/hexutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundtripScoresV0(t *testing.T) {
+	scores := PeerScores{
+		Gossip: 1234.52382,
+	}
+	data, err := serializeScoresV0(scores)
+	require.NoError(t, err)
+
+	result, err := deserializeScoresV0(data)
+	require.NoError(t, err)
+	require.Equal(t, scores, result)
+}
+
+// TestParseHistoricSerializations checks that existing data can still be deserialized
+// Adding new fields should not require bumping the version, only removing fields
+// A new entry should be added to this test each time any fields are changed to ensure it can always be deserialized
+func TestParseHistoricSerializationsV0(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected PeerScores
+	}{
+		{
+			name:     "GossipOnly",
+			data:     hexutils.HexToBytes("40934A18644523F6"),
+			expected: PeerScores{Gossip: 1234.52382},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			result, err := deserializeScoresV0(test.data)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Starts building an extended peer store that supports persisting peer scores. Not currently hooked up and lacking pruning of old entries, but defines the interface and has a sensible implementation for persisting scores.

**Tests**

Unit tests for persistence functions.

**Invariants**

**Metadata**

- https://linear.app/optimism/issue/CLI-3246/persist-peer-scores
