### PR TITLE
chore: Update contract addresses

### DIFF
--- a/.changeset/eleven-wolves-hammer.md
+++ b/.changeset/eleven-wolves-hammer.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/contracts-bedrock': minor
+'@eth-optimism/sdk': minor
+---
+
+New contract addresses for rehersal. This is needed so canary releases publish correctly

--- a/packages/sdk/src/utils/chain-constants.ts
+++ b/packages/sdk/src/utils/chain-constants.ts
@@ -77,8 +77,8 @@ const getL1ContractsByNetworkName = (network: string): OEL1ContractsLike => {
     StateCommitmentChain: getDeployedAddress('StateCommitmentChain'),
     CanonicalTransactionChain: getDeployedAddress('CanonicalTransactionChain'),
     BondManager: getDeployedAddress('BondManager'),
-    OptimismPortal: '0x5b47E1A08Ea6d985D6649300584e6722Ec4B1383' as const,
-    L2OutputOracle: '0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0' as const,
+    OptimismPortal: getDeployedAddress('OptimismPortal'),
+    L2OutputOracle: getDeployedAddress('L2OutputOracle'),
   }
 }
 

--- a/packages/sdk/src/utils/chain-constants.ts
+++ b/packages/sdk/src/utils/chain-constants.ts
@@ -2,7 +2,10 @@ import {
   predeploys,
   getDeployedContractDefinition,
 } from '@eth-optimism/contracts'
-import { predeploys as bedrockPredeploys } from '@eth-optimism/contracts-bedrock'
+import {
+  predeploys as bedrockPredeploys,
+  getContractDefinition,
+} from '@eth-optimism/contracts-bedrock'
 
 import {
   L1ChainID,
@@ -77,8 +80,8 @@ const getL1ContractsByNetworkName = (network: string): OEL1ContractsLike => {
     StateCommitmentChain: getDeployedAddress('StateCommitmentChain'),
     CanonicalTransactionChain: getDeployedAddress('CanonicalTransactionChain'),
     BondManager: getDeployedAddress('BondManager'),
-    OptimismPortal: getDeployedAddress('OptimismPortal'),
-    L2OutputOracle: getDeployedAddress('L2OutputOracle'),
+    OptimismPortal: getContractDefinition('OptimismPortal').address,
+    L2OutputOracle: getContractDefinition('L2OutputOracle').address,
   }
 }
 


### PR DESCRIPTION
Changesets are needed on this branch so sdk publishes correctly in canary releases.  This allows the gateway to update too

We will also need a changeset on the actual upgrade