### PR TITLE
op-chain-ops: sanity check not empty bytecode

### DIFF
--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -1,6 +1,7 @@
 package genesis
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -108,6 +109,9 @@ func setProxies(db vm.StateDB, proxyAdminAddr common.Address, namespace *big.Int
 	depBytecode, err := bindings.GetDeployedBytecode("Proxy")
 	if err != nil {
 		return err
+	}
+	if len(depBytecode) == 0 {
+		return errors.New("Proxy has empty bytecode")
 	}
 
 	for i := uint64(0); i <= count; i++ {


### PR DESCRIPTION
**Description**

Sanity check that empty bytecode is not set in the state for the `Proxy`. There are other checks for this after the migration happens and this never should happen so this is just a sanity check to catch a problem earlier in the process.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

