### PR TITLE
feat(proxyd): normalize latency metrics in ms

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -482,7 +482,7 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 	}
 	duration := time.Since(start)
 	b.latencySlidingWindow.Add(float64(duration))
-	RecordBackendNetworkLatencyAverageSlidingWindow(b, b.latencySlidingWindow.Avg())
+	RecordBackendNetworkLatencyAverageSlidingWindow(b, time.Duration(b.latencySlidingWindow.Avg()))
 
 	sortBatchRPCResponse(rpcReqs, res)
 	return res, nil

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -442,8 +442,8 @@ func RecordConsensusBackendUpdateDelay(b *Backend, delay time.Duration) {
 	consensusUpdateDelayBackend.WithLabelValues(b.Name).Set(float64(delay.Milliseconds()))
 }
 
-func RecordBackendNetworkLatencyAverageSlidingWindow(b *Backend, avgLatency float64) {
-	avgLatencyBackend.WithLabelValues(b.Name).Set(avgLatency)
+func RecordBackendNetworkLatencyAverageSlidingWindow(b *Backend, avgLatency time.Duration) {
+	avgLatencyBackend.WithLabelValues(b.Name).Set(float64(avgLatency.Milliseconds()))
 }
 
 func RecordBackendNetworkRequestCountSlidingWindow(b *Backend, count uint) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change ensure latency is reported in millisenconds.

**Tests**

Manual tests.

**Invariants**

n/a

**Additional context**

This change is part of the Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

- Fixes https://linear.app/optimism/issue/INF-245/normalize-latency-in-ms

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
