### PR TITLE
op-chain-ops: enable fuzzing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,6 +639,18 @@ jobs:
           command: make fuzz
           working_directory: op-node
 
+  fuzz-op-chain-ops:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    steps:
+      - checkout
+      - check-changed:
+          patterns: op-chain-ops,op-bindings
+      - run:
+          name: Fuzz
+          command: make fuzz
+          working_directory: op-chain-ops
+
   depcheck:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
@@ -1282,6 +1294,7 @@ workflows:
       - semgrep-scan
       - go-mod-tidy
       - fuzz-op-node
+      - fuzz-op-chain-ops
       - bedrock-markdown
       - go-lint:
           name: op-batcher-lint

--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -4,4 +4,10 @@ op-migrate:
 test:
 	go test ./...
 
+fuzz:
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzEncodeDecodeWithdrawal ./crossdomain
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzEncodeDecodeLegacyWithdrawal ./crossdomain
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzAliasing ./crossdomain
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzVersionedNonce ./crossdomain
+
 .PHONY: op-migrate test


### PR DESCRIPTION
**Description**

There have been fuzz tests in `op-chain-ops` for awhile but they have not been being ran in CI. This enables the fuzzing in CI following the same pattern as fuzzing for `op-node`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

