### PR TITLE
op-node: Enable scoring connection gaters

### DIFF
--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -163,9 +163,8 @@ func (conf *Config) Host(log log.Logger, reporter metrics.Reporter, metrics Host
 	if err != nil {
 		return nil, fmt.Errorf("failed to open connection gater: %w", err)
 	}
-	// TODO(CLI-4015): apply connGtr enhancements
-	// connGtr = gating.AddBanExpiry(connGtr, ps, log, cl, reporter)
-	//connGtr = gating.AddScoring(connGtr, ps, 0)
+	connGtr = gating.AddBanExpiry(connGtr, ps, log, clock.SystemClock, metrics)
+	connGtr = gating.AddScoring(connGtr, ps, minAcceptedPeerScore)
 	connGtr = gating.AddMetering(connGtr, metrics)
 
 	connMngr, err := DefaultConnManager(conf)

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -204,11 +204,7 @@ func (n *NodeP2P) Peers() []peer.ID {
 }
 
 func (n *NodeP2P) GetPeerScore(id peer.ID) (float64, error) {
-	scores, err := n.store.GetPeerScores(id)
-	if err != nil {
-		return 0, err
-	}
-	return scores.Gossip.Total, nil
+	return n.store.GetPeerScore(id)
 }
 
 func (n *NodeP2P) IsStatic(id peer.ID) bool {

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -37,6 +37,9 @@ type ScoreDatastore interface {
 	// GetPeerScores returns the current scores for the specified peer
 	GetPeerScores(id peer.ID) (PeerScores, error)
 
+	// GetPeerScore returns the current combined score for the specified peer
+	GetPeerScore(id peer.ID) (float64, error)
+
 	// SetScore applies the given store diff to the specified peer
 	SetScore(id peer.ID, diff ScoreDiff) error
 }

--- a/op-node/p2p/store/scorebook.go
+++ b/op-node/p2p/store/scorebook.go
@@ -79,6 +79,14 @@ func (d *scoreBook) GetPeerScores(id peer.ID) (PeerScores, error) {
 	return record.PeerScores, nil
 }
 
+func (d *scoreBook) GetPeerScore(id peer.ID) (float64, error) {
+	scores, err := d.GetPeerScores(id)
+	if err != nil {
+		return 0, err
+	}
+	return scores.Gossip.Total, nil
+}
+
 func (d *scoreBook) SetScore(id peer.ID, diff ScoreDiff) error {
 	return d.book.SetRecord(id, diff)
 }

--- a/op-node/p2p/store/scorebook_test.go
+++ b/op-node/p2p/store/scorebook_test.go
@@ -163,6 +163,10 @@ func assertPeerScores(t *testing.T, store ExtendedPeerstore, id peer.ID, expecte
 	result, err := store.GetPeerScores(id)
 	require.NoError(t, err)
 	require.Equal(t, result, expected)
+
+	score, err := store.GetPeerScore(id)
+	require.NoError(t, err)
+	require.Equal(t, expected.Gossip.Total, score)
 }
 
 func createMemoryStore(t *testing.T) ExtendedPeerstore {


### PR DESCRIPTION
**Description**

Adds the ban expiry and scoring connection gaters into the p2p stack so that peer bans expiry correctly and peers with low scores are unable to connect (even if they disconnected before actually being banned).

**Tests**

Really need e2e tests to cover how this all hangs together (https://linear.app/optimism/issue/CLI-3603/op-e2e-peer-score-testing).

**Additional context**

Builds on #5779

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4015/op-node-utilize-the-ban-expiry-and-scoring-peer-gaters
