### PR TITLE
feat(proxyd): track consensus for {safe,finalized} blocks and rewrite tags

### DIFF
--- a/proxyd/Dockerfile
+++ b/proxyd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.0-alpine3.15 as builder
+FROM golang:1.20.4-alpine3.18 as builder
 
 ARG GITCOMMIT=docker
 ARG GITDATE=docker
@@ -12,7 +12,7 @@ WORKDIR /app
 
 RUN make proxyd
 
-FROM alpine:3.15
+FROM alpine:3.18
 
 COPY ./proxyd/entrypoint.sh /bin/entrypoint.sh
 

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -556,7 +556,11 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		backends = bg.loadBalancedConsensusGroup()
 
 		// We also rewrite block tags to enforce compliance with consensus
-		rctx := RewriteContext{latest: bg.Consensus.GetConsensusBlockNumber()}
+		rctx := RewriteContext{
+			latest:    bg.Consensus.GetLatestBlockNumber(),
+			finalized: bg.Consensus.GetFinalizedBlockNumber(),
+			safe:      bg.Consensus.GetSafeBlockNumber(),
+		}
 
 		for i, req := range rpcReqs {
 			res := RPCRes{JSONRPC: JSONRPCVersion, ID: req.ID}

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -326,7 +326,7 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 // checkExpectedBlockTags for unexpected conditions on block tags
 // - finalized block number should never decrease
 // - safe block number should never decrease
-// - finalized block should be < safe block < latest block
+// - finalized block should be <= safe block <= latest block
 func (cp *ConsensusPoller) checkExpectedBlockTags(currentFinalized hexutil.Uint64, oldFinalized hexutil.Uint64,
 	currentSafe hexutil.Uint64, oldSafe hexutil.Uint64,
 	currentLatest hexutil.Uint64) bool {

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -220,7 +220,7 @@ func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller
 
 		banPeriod:          5 * time.Minute,
 		maxUpdateThreshold: 30 * time.Second,
-		maxBlockLag:        50,
+		maxBlockLag:        8, // quarter of an epoch, 8*12 seconds = 96 seconds ~ 1.6 minutes
 		minPeerCount:       3,
 	}
 

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -57,7 +57,7 @@ type backendState struct {
 	bannedUntil time.Time
 }
 
-func (bs backendState) IsBanned() bool {
+func (bs *backendState) IsBanned() bool {
 	return time.Now().Before(bs.bannedUntil)
 }
 
@@ -394,7 +394,7 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	if proposedBlock > 0 {
 		for !hasConsensus {
 			allAgreed := true
-			for be, _ := range candidates {
+			for be := range candidates {
 				actualBlockNumber, actualBlockHash, err := cp.fetchBlock(ctx, be, proposedBlock.String())
 				if err != nil {
 					log.Warn("error updating backend", "name", be.Name, "err", err)

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -177,6 +177,10 @@ func (cp *ConsensusPoller) AddListener(listener OnConsensusBroken) {
 	cp.listeners = append(cp.listeners, listener)
 }
 
+func (cp *ConsensusPoller) ClearListeners() {
+	cp.listeners = []OnConsensusBroken{}
+}
+
 func WithBanPeriod(banPeriod time.Duration) ConsensusOpt {
 	return func(cp *ConsensusPoller) {
 		cp.banPeriod = banPeriod
@@ -524,7 +528,7 @@ func (cp *ConsensusPoller) Ban(be *Backend) {
 	bs.finalizedBlockNumber = 0
 }
 
-// Unban remove any bans from the backends
+// Unban removes any bans from the backends
 func (cp *ConsensusPoller) Unban(be *Backend) {
 	bs := cp.backendState[be]
 	defer bs.backendStateMux.Unlock()
@@ -532,14 +536,14 @@ func (cp *ConsensusPoller) Unban(be *Backend) {
 	bs.bannedUntil = time.Now().Add(-10 * time.Hour)
 }
 
-// Reset remove any bans from the backends and reset their states
+// Reset reset all backend states
 func (cp *ConsensusPoller) Reset() {
 	for _, be := range cp.backendGroup.Backends {
 		cp.backendState[be] = &backendState{}
 	}
 }
 
-// fetchBlock Convenient wrapper to make a request to get a block directly from the backend
+// fetchBlock is a convenient wrapper to make a request to get a block directly from the backend
 func (cp *ConsensusPoller) fetchBlock(ctx context.Context, be *Backend, block string) (blockNumber hexutil.Uint64, blockHash string, err error) {
 	var rpcRes RPCRes
 	err = be.ForwardRPC(ctx, &rpcRes, "67", "eth_getBlockByNumber", block, false)
@@ -557,7 +561,7 @@ func (cp *ConsensusPoller) fetchBlock(ctx context.Context, be *Backend, block st
 	return
 }
 
-// getPeerCount Convenient wrapper to retrieve the current peer count from the backend
+// getPeerCount is a convenient wrapper to retrieve the current peer count from the backend
 func (cp *ConsensusPoller) getPeerCount(ctx context.Context, be *Backend) (count uint64, err error) {
 	var rpcRes RPCRes
 	err = be.ForwardRPC(ctx, &rpcRes, "67", "net_peerCount")

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -13,35 +13,68 @@ import (
 // ConsensusTracker abstracts how we store and retrieve the current consensus
 // allowing it to be stored locally in-memory or in a shared Redis cluster
 type ConsensusTracker interface {
-	GetConsensusBlockNumber() hexutil.Uint64
-	SetConsensusBlockNumber(blockNumber hexutil.Uint64)
+	GetLatestBlockNumber() hexutil.Uint64
+	SetLatestBlockNumber(blockNumber hexutil.Uint64)
+	GetFinalizedBlockNumber() hexutil.Uint64
+	SetFinalizedBlockNumber(blockNumber hexutil.Uint64)
+	GetSafeBlockNumber() hexutil.Uint64
+	SetSafeBlockNumber(blockNumber hexutil.Uint64)
 }
 
 // InMemoryConsensusTracker store and retrieve in memory, async-safe
 type InMemoryConsensusTracker struct {
-	consensusBlockNumber hexutil.Uint64
+	latestBlockNumber    hexutil.Uint64
+	finalizedBlockNumber hexutil.Uint64
+	safeBlockNumber      hexutil.Uint64
 	mutex                sync.Mutex
 }
 
 func NewInMemoryConsensusTracker() ConsensusTracker {
 	return &InMemoryConsensusTracker{
-		consensusBlockNumber: 0,
-		mutex:                sync.Mutex{},
+		mutex: sync.Mutex{},
 	}
 }
 
-func (ct *InMemoryConsensusTracker) GetConsensusBlockNumber() hexutil.Uint64 {
+func (ct *InMemoryConsensusTracker) GetLatestBlockNumber() hexutil.Uint64 {
 	defer ct.mutex.Unlock()
 	ct.mutex.Lock()
 
-	return ct.consensusBlockNumber
+	return ct.latestBlockNumber
 }
 
-func (ct *InMemoryConsensusTracker) SetConsensusBlockNumber(blockNumber hexutil.Uint64) {
+func (ct *InMemoryConsensusTracker) SetLatestBlockNumber(blockNumber hexutil.Uint64) {
 	defer ct.mutex.Unlock()
 	ct.mutex.Lock()
 
-	ct.consensusBlockNumber = blockNumber
+	ct.latestBlockNumber = blockNumber
+}
+
+func (ct *InMemoryConsensusTracker) GetFinalizedBlockNumber() hexutil.Uint64 {
+	defer ct.mutex.Unlock()
+	ct.mutex.Lock()
+
+	return ct.finalizedBlockNumber
+}
+
+func (ct *InMemoryConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.Uint64) {
+	defer ct.mutex.Unlock()
+	ct.mutex.Lock()
+
+	ct.finalizedBlockNumber = blockNumber
+}
+
+func (ct *InMemoryConsensusTracker) GetSafeBlockNumber() hexutil.Uint64 {
+	defer ct.mutex.Unlock()
+	ct.mutex.Lock()
+
+	return ct.safeBlockNumber
+}
+
+func (ct *InMemoryConsensusTracker) SetSafeBlockNumber(blockNumber hexutil.Uint64) {
+	defer ct.mutex.Unlock()
+	ct.mutex.Lock()
+
+	ct.safeBlockNumber = blockNumber
 }
 
 // RedisConsensusTracker uses a Redis `client` to store and retrieve consensus, async-safe
@@ -59,14 +92,29 @@ func NewRedisConsensusTracker(ctx context.Context, r *redis.Client, namespace st
 	}
 }
 
-func (ct *RedisConsensusTracker) key() string {
-	return fmt.Sprintf("consensus_latest_block:%s", ct.backendGroup)
+func (ct *RedisConsensusTracker) key(tag string) string {
+	return fmt.Sprintf("consensus:%s:%s", ct.backendGroup, tag)
 }
 
-func (ct *RedisConsensusTracker) GetConsensusBlockNumber() hexutil.Uint64 {
-	return hexutil.Uint64(hexutil.MustDecodeUint64(ct.client.Get(ct.ctx, ct.key()).Val()))
+func (ct *RedisConsensusTracker) GetLatestBlockNumber() hexutil.Uint64 {
+	return hexutil.Uint64(hexutil.MustDecodeUint64(ct.client.Get(ct.ctx, ct.key("latest")).Val()))
 }
 
-func (ct *RedisConsensusTracker) SetConsensusBlockNumber(blockNumber hexutil.Uint64) {
-	ct.client.Set(ct.ctx, ct.key(), blockNumber, 0)
+func (ct *RedisConsensusTracker) SetLatestBlockNumber(blockNumber hexutil.Uint64) {
+	ct.client.Set(ct.ctx, ct.key("latest"), blockNumber, 0)
+}
+
+func (ct *RedisConsensusTracker) GetFinalizedBlockNumber() hexutil.Uint64 {
+	return hexutil.Uint64(hexutil.MustDecodeUint64(ct.client.Get(ct.ctx, ct.key("finalized")).Val()))
+}
+
+func (ct *RedisConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.Uint64) {
+	ct.client.Set(ct.ctx, ct.key("finalized"), blockNumber, 0)
+}
+func (ct *RedisConsensusTracker) GetSafeBlockNumber() hexutil.Uint64 {
+	return hexutil.Uint64(hexutil.MustDecodeUint64(ct.client.Get(ct.ctx, ct.key("safe")).Val()))
+}
+
+func (ct *RedisConsensusTracker) SetSafeBlockNumber(blockNumber hexutil.Uint64) {
+	ct.client.Set(ct.ctx, ct.key("safe"), blockNumber, 0)
 }

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -93,8 +93,8 @@ backends = ["infura"]
 # consensus_ban_period = "1m"
 # Maximum delay for update the backend, default 30s
 # consensus_max_update_threshold = "20s"
-# Maximum block lag, default 50
-# consensus_max_block_lag = 10
+# Maximum block lag, default 8
+# consensus_max_block_lag = 16
 # Minimum peer count, default 3
 # consensus_min_peer_count = 4
 

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -80,6 +80,7 @@ func TestConsensus(t *testing.T) {
 			node.handler.ResetOverrides()
 			node.mockBackend.Reset()
 		}
+		bg.Consensus.ClearListeners()
 		bg.Consensus.Reset()
 	}
 

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -428,7 +428,7 @@ func TestConsensus(t *testing.T) {
 		require.Equal(t, "0xb1", bg.Consensus.GetSafeBlockNumber().String())
 	})
 
-	t.Run("latest dropped below safe, and stayed inconsistent after ban", func(t *testing.T) {
+	t.Run("latest dropped below safe, and stayed inconsistent", func(t *testing.T) {
 		reset()
 		useOnlyNode1()
 		overrideBlock("node1", "latest", "0xd1")

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -175,12 +175,12 @@ func TestConsensus(t *testing.T) {
 
 	t.Run("prevent using a backend lagging behind", func(t *testing.T) {
 		reset()
-		// node2 is 51 blocks ahead of node1 (0x101 + 51 = 0x134)
-		overrideBlock("node2", "latest", "0x134")
+		// node2 is 8+1 blocks ahead of node1 (0x101 + 8+1 = 0x10a)
+		overrideBlock("node2", "latest", "0x10a")
 		update()
 
-		// since we ignored node1, the consensus should be at 0x133
-		require.Equal(t, "0x134", bg.Consensus.GetLatestBlockNumber().String())
+		// since we ignored node1, the consensus should be at 0x10a
+		require.Equal(t, "0x10a", bg.Consensus.GetLatestBlockNumber().String())
 		require.Equal(t, "0xe1", bg.Consensus.GetSafeBlockNumber().String())
 		require.Equal(t, "0xc1", bg.Consensus.GetFinalizedBlockNumber().String())
 
@@ -192,8 +192,8 @@ func TestConsensus(t *testing.T) {
 
 	t.Run("prevent using a backend lagging behind - one before limit", func(t *testing.T) {
 		reset()
-		// node2 is 50 blocks ahead of node1 (0x101 + 50 = 0x133)
-		overrideBlock("node2", "latest", "0x133")
+		// node2 is 8 blocks ahead of node1 (0x101 + 8 = 0x109)
+		overrideBlock("node2", "latest", "0x109")
 		update()
 
 		// both nodes are in consensus with the lowest block

--- a/proxyd/integration_tests/testdata/consensus.toml
+++ b/proxyd/integration_tests/testdata/consensus.toml
@@ -18,7 +18,7 @@ consensus_aware = true
 consensus_handler = "noop" # allow more control over the consensus poller for tests
 consensus_ban_period = "1m"
 consensus_max_update_threshold = "2m"
-consensus_max_block_lag = 50
+consensus_max_block_lag = 8
 consensus_min_peer_count = 4
 
 [rpc_method_mappings]

--- a/proxyd/integration_tests/testdata/consensus_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_responses.yml
@@ -64,6 +64,17 @@
       }
     }
 - method: eth_getBlockByNumber
+  block: 0x10a
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0x10a",
+        "number": "0x10a"
+      }
+    }
+- method: eth_getBlockByNumber
   block: 0x132
   response: >
     {

--- a/proxyd/integration_tests/testdata/consensus_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_responses.yml
@@ -26,63 +26,85 @@
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash1",
-        "number": "0x1"
+        "hash": "hash_0x101",
+        "number": "0x101"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x1
+  block: 0x101
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash1",
-        "number": "0x1"
+        "hash": "hash_0x101",
+        "number": "0x101"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x2
+  block: 0x102
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash2",
-        "number": "0x2"
+        "hash": "hash_0x102",
+        "number": "0x102"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x3
+  block: 0x103
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash3",
-        "number": "0x3"
+        "hash": "hash_0x103",
+        "number": "0x103"
       }
     }
 - method: eth_getBlockByNumber
-  block: finalized
+  block: 0x132
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash_finalized",
-        "number": "0x555"
+        "hash": "hash_0x132",
+        "number": "0x132"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x555
+  block: 0x133
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash_finalized",
-        "number": "0x555"
+        "hash": "hash_0x133",
+        "number": "0x133"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x134
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0x134",
+        "number": "0x134"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x200
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0x200",
+        "number": "0x200"
       }
     }
 - method: eth_getBlockByNumber
@@ -92,40 +114,40 @@
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash_safe",
-        "number": "0x551"
+        "hash": "hash_0xe1",
+        "number": "0xe1"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x555
+  block: 0xe1
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash_safe",
-        "number": "0x551"
+        "hash": "hash_0xe1",
+        "number": "0xe1"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x5
+  block: finalized
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash5",
-        "number": "0x5"
+        "hash": "hash_0xc1",
+        "number": "0xc1"
       }
     }
 - method: eth_getBlockByNumber
-  block: 0x20
+  block: 0xc1
   response: >
     {
       "jsonrpc": "2.0",
       "id": 67,
       "result": {
-        "hash": "hash20",
-        "number": "0x20"
+        "hash": "hash_0xc1",
+        "number": "0xc1"
       }
     }

--- a/proxyd/integration_tests/testdata/consensus_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_responses.yml
@@ -63,3 +63,69 @@
         "number": "0x3"
       }
     }
+- method: eth_getBlockByNumber
+  block: finalized
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_finalized",
+        "number": "0x555"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x555
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_finalized",
+        "number": "0x555"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: safe
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_safe",
+        "number": "0x551"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x555
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_safe",
+        "number": "0x551"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x5
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash5",
+        "number": "0x5"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x20
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash20",
+        "number": "0x20"
+      }
+    }

--- a/proxyd/integration_tests/testdata/consensus_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_responses.yml
@@ -108,6 +108,17 @@
       }
     }
 - method: eth_getBlockByNumber
+  block: 0x91
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0x91",
+        "number": "0x91"
+      }
+    }
+- method: eth_getBlockByNumber
   block: safe
   response: >
     {
@@ -149,5 +160,16 @@
       "result": {
         "hash": "hash_0xc1",
         "number": "0xc1"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0xd1
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xd1",
+        "number": "0xd1"
       }
     }

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -467,7 +467,7 @@ func RecordBackendFinalizedBlock(b *Backend, blockNumber hexutil.Uint64) {
 }
 
 func RecordBackendUnexpectedBlockTags(b *Backend, unexpected bool) {
-	backendFinalizedBlockBackend.WithLabelValues(b.Name).Set(boolToFloat64(unexpected))
+	backendUnexpectedBlockTagsBackend.WithLabelValues(b.Name).Set(boolToFloat64(unexpected))
 }
 
 func RecordConsensusBackendBanned(b *Backend, banned bool) {

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -9,7 +9,9 @@ import (
 )
 
 type RewriteContext struct {
-	latest hexutil.Uint64
+	latest    hexutil.Uint64
+	finalized hexutil.Uint64
+	safe      hexutil.Uint64
 }
 
 type RewriteResult uint8
@@ -180,11 +182,13 @@ func rewriteTag(rctx RewriteContext, current string) (string, bool, error) {
 	}
 
 	switch *bnh.BlockNumber {
-	case rpc.SafeBlockNumber,
-		rpc.FinalizedBlockNumber,
-		rpc.PendingBlockNumber,
+	case rpc.PendingBlockNumber,
 		rpc.EarliestBlockNumber:
 		return current, false, nil
+	case rpc.FinalizedBlockNumber:
+		return rctx.finalized.String(), true, nil
+	case rpc.SafeBlockNumber:
+		return rctx.safe.String(), true, nil
 	case rpc.LatestBlockNumber:
 		return rctx.latest.String(), true, nil
 	default:

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -10,8 +10,8 @@ import (
 
 type RewriteContext struct {
 	latest    hexutil.Uint64
-	finalized hexutil.Uint64
 	safe      hexutil.Uint64
+	finalized hexutil.Uint64
 }
 
 type RewriteResult uint8

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -326,33 +326,33 @@ func TestRewriteRequest(t *testing.T) {
 		{
 			name: "eth_getBlockByNumber finalized",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), finalized: hexutil.Uint64(55)},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{"finalized"})},
 				res:  nil,
 			},
-			expected: RewriteNone,
+			expected: RewriteOverrideRequest,
 			check: func(t *testing.T, args args) {
 				var p []string
 				err := json.Unmarshal(args.req.Params, &p)
 				require.Nil(t, err)
 				require.Equal(t, 1, len(p))
-				require.Equal(t, "finalized", p[0])
+				require.Equal(t, hexutil.Uint64(55).String(), p[0])
 			},
 		},
 		{
 			name: "eth_getBlockByNumber safe",
 			args: args{
-				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				rctx: RewriteContext{latest: hexutil.Uint64(100), safe: hexutil.Uint64(50)},
 				req:  &RPCReq{Method: "eth_getBlockByNumber", Params: mustMarshalJSON([]string{"safe"})},
 				res:  nil,
 			},
-			expected: RewriteNone,
+			expected: RewriteOverrideRequest,
 			check: func(t *testing.T, args args) {
 				var p []string
 				err := json.Unmarshal(args.req.Params, &p)
 				require.Nil(t, err)
 				require.Equal(t, 1, len(p))
-				require.Equal(t, "safe", p[0])
+				require.Equal(t, hexutil.Uint64(50).String(), p[0])
 			},
 		},
 		{

--- a/proxyd/tools/mockserver/handler/handler.go
+++ b/proxyd/tools/mockserver/handler/handler.go
@@ -95,7 +95,7 @@ func (mh *MockedHandler) Handler(w http.ResponseWriter, req *http.Request) {
 	resBody := ""
 	if batched {
 		resBody = "[" + strings.Join(responses, ",") + "]"
-	} else {
+	} else if len(responses) > 0 {
 		resBody = responses[0]
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change adds the ability to track `finalized` and `safe` block tags within a backend group. It uses the same consensus poller mechanism, and converge to the lowest block.

Those tags are not used to form a consensus, only to maintain a consistent view from client perspective.

It shallowly check the values for sanity, i.e. tag values should never decrease, and `finalized` <= `safe` <= `latest`. In case of an unexpected scenario, we ban the backend and try to re-establish the consensus. If all backends are observing the same reorg, all of them will be banned and we'll stop serving traffic temporarily. 

Note this is a very rare event and we are trying to prevent overreacting to a bad node.

Re-establishing the consensus may result in `safe` or `finalized` to drop in the same way a backend would do if such reorg would be observed.

**Tests**

Added tests to cover new cases

**Invariants**

- bumped go to 1.20
- refactored tests
- refactored poller
- adjusted the max block lag to saner default of 8

**Additional context**

This is part of the project Consensus Aware RPC Proxy: https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d


**Metadata**

https://linear.app/optimism/issue/INF-246/add-safe-and-finalized-blocks-to-consensus-proxyd

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
