### PR TITLE
op-batcher: Add metrics for pending L2 transaction data size

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -271,6 +271,7 @@ func (s *channelManager) processBlocks() error {
 		}
 		blocksAdded += 1
 		latestL2ref = l2BlockRefFromBlockAndL1Info(block, l1info)
+		s.metr.RecordL2BlockInChannel(block)
 		// current block got added but channel is now full
 		if s.pendingChannel.IsFull() {
 			break
@@ -341,6 +342,8 @@ func (s *channelManager) AddL2Block(block *types.Block) error {
 	if s.tip != (common.Hash{}) && s.tip != block.ParentHash() {
 		return ErrReorg
 	}
+
+	s.metr.RecordL2BlockInPendingQueue(block)
 	s.blocks = append(s.blocks, block)
 	s.tip = block.Hash()
 

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type noopMetrics struct {
@@ -23,6 +24,8 @@ func (*noopMetrics) RecordLatestL1Block(l1ref eth.L1BlockRef)               {}
 func (*noopMetrics) RecordL2BlocksLoaded(eth.L2BlockRef)                    {}
 func (*noopMetrics) RecordChannelOpened(derive.ChannelID, int)              {}
 func (*noopMetrics) RecordL2BlocksAdded(eth.L2BlockRef, int, int, int, int) {}
+func (*noopMetrics) RecordL2BlockInPendingQueue(*types.Block)               {}
+func (*noopMetrics) RecordL2BlockInChannel(*types.Block)                    {}
 
 func (*noopMetrics) RecordChannelClosed(derive.ChannelID, int, int, int, int, error) {}
 


### PR DESCRIPTION
**Description**

This adds metrics to track the size of pending blocks (rather than just the number).
It is expressed in a counter & a gauge. There is no new counter for the pending size
in channels because that counter already exists as the `input_bytes` metrics.

Note: This is based off of the `op-batcher/v1.0.9-rc.1` tag.
