### PR TITLE
op-bootnode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1304,6 +1304,9 @@ workflows:
           name: op-batcher-lint
           module: op-batcher
       - go-lint:
+          name: op-bootnode-lint
+          module: op-bootnode
+      - go-lint:
           name: op-bindings-lint
           module: op-bindings
       - go-lint:
@@ -1366,6 +1369,7 @@ workflows:
       - bedrock-go-tests:
           requires:
             - op-batcher-lint
+            - op-bootnode-lint
             - op-bindings-lint
             - op-chain-ops-lint
             - op-e2e-lint

--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 
 	opnode "github.com/ethereum-optimism/optimism/op-node"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -15,6 +12,7 @@ import (
 	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -69,14 +67,7 @@ func Main(cliCtx *cli.Context) error {
 
 	go p2pNode.DiscoveryProcess(ctx, logger, config, p2pConfig.TargetPeers())
 
-	interruptChannel := make(chan os.Signal, 1)
-	signal.Notify(interruptChannel, []os.Signal{
-		os.Interrupt,
-		os.Kill,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	}...)
-	<-interruptChannel
+	opio.BlockOnInterrupts()
 
 	return nil
 }

--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	opnode "github.com/ethereum-optimism/optimism/op-node"
 	"github.com/ethereum-optimism/optimism/op-node/eth"
@@ -64,7 +67,17 @@ func Main(cliCtx *cli.Context) error {
 		return fmt.Errorf("uninitialized discovery service")
 	}
 
-	p2pNode.DiscoveryProcess(ctx, logger, config, p2pConfig.TargetPeers())
+	go p2pNode.DiscoveryProcess(ctx, logger, config, p2pConfig.TargetPeers())
+
+	interruptChannel := make(chan os.Signal, 1)
+	signal.Notify(interruptChannel, []os.Signal{
+		os.Interrupt,
+		os.Kill,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	}...)
+	<-interruptChannel
+
 	return nil
 }
 

--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -1,0 +1,83 @@
+package bootnode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	opnode "github.com/ethereum-optimism/optimism/op-node"
+	"github.com/ethereum-optimism/optimism/op-node/eth"
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	p2pcli "github.com/ethereum-optimism/optimism/op-node/p2p/cli"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/urfave/cli"
+)
+
+type gossipNoop struct{}
+
+func (g *gossipNoop) OnUnsafeL2Payload(_ context.Context, _ peer.ID, _ *eth.ExecutionPayload) error {
+	return nil
+}
+
+type gossipConfig struct{}
+
+func (g *gossipConfig) P2PSequencerAddress() common.Address {
+	return common.Address{}
+}
+
+type l2Chain struct{}
+
+func (l *l2Chain) PayloadByNumber(_ context.Context, _ uint64) (*eth.ExecutionPayload, error) {
+	return nil, nil
+}
+
+func Main(cliCtx *cli.Context) error {
+	log.Info("Initializing bootnode")
+	logCfg := oplog.ReadCLIConfig(cliCtx)
+	logger := oplog.NewLogger(logCfg)
+	m := metrics.NewMetrics("default")
+	ctx := context.Background()
+
+	config, err := opnode.NewRollupConfig(cliCtx)
+	if err != nil {
+		return err
+	}
+	if err = validateConfig(config); err != nil {
+		return err
+	}
+
+	p2pConfig, err := p2pcli.NewConfig(cliCtx, config.BlockTime)
+	if err != nil {
+		return fmt.Errorf("failed to load p2p config: %w", err)
+	}
+
+	p2pNode, err := p2p.NewNodeP2P(ctx, config, logger, p2pConfig, &gossipNoop{}, &l2Chain{}, &gossipConfig{}, m)
+	if err != nil || p2pNode == nil {
+		return err
+	}
+	if p2pNode.Dv5Udp() == nil {
+		return fmt.Errorf("uninitialized discovery service")
+	}
+
+	p2pNode.DiscoveryProcess(ctx, logger, config, p2pConfig.TargetPeers())
+	return nil
+}
+
+// validateConfig ensures the minimal config required to run a bootnode
+func validateConfig(config *rollup.Config) error {
+	if config.L2ChainID == nil || config.L2ChainID.Uint64() == 0 {
+		return errors.New("chain ID is not set")
+	}
+	if config.Genesis.L2Time <= 0 {
+		return errors.New("genesis timestamp is not set")
+	}
+	if config.BlockTime <= 0 {
+		return errors.New("block time is not set")
+	}
+	return nil
+}

--- a/op-bootnode/cmd/main.go
+++ b/op-bootnode/cmd/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+
+	"github.com/ethereum-optimism/optimism/op-bootnode/bootnode"
+	"github.com/ethereum-optimism/optimism/op-bootnode/flags"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	// Set up logger with a default INFO level in case we fail to parse flags,
+	// otherwise the final critical log won't show what the parsing error was.
+	log.Root().SetHandler(
+		log.LvlFilterHandler(
+			log.LvlInfo,
+			log.StreamHandler(os.Stdout, log.TerminalFormat(true)),
+		),
+	)
+
+	app := cli.NewApp()
+	app.Flags = flags.Flags
+	app.Name = "bootnode"
+	app.Usage = "Rollup Bootnode"
+	app.Description = "Broadcasts incoming P2P peers to each other, enabling peer bootstrapping."
+	app.Action = bootnode.Main
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Crit("Application failed", "message", err)
+	}
+}

--- a/op-bootnode/flags/flags.go
+++ b/op-bootnode/flags/flags.go
@@ -1,0 +1,36 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
+	"github.com/ethereum-optimism/optimism/op-node/flags"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/urfave/cli"
+)
+
+const envVarPrefix = "OP_BOOTNODE"
+
+var (
+	RollupConfig = cli.StringFlag{
+		Name:   flags.RollupConfig.Name,
+		Usage:  "Rollup chain parameters",
+		EnvVar: opservice.PrefixEnvVar(envVarPrefix, "ROLLUP_CONFIG"),
+	}
+	Network = cli.StringFlag{
+		Name:   flags.Network.Name,
+		Usage:  fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
+		EnvVar: opservice.PrefixEnvVar(envVarPrefix, "NETWORK"),
+	}
+)
+
+var Flags = []cli.Flag{
+	RollupConfig,
+	Network,
+}
+
+func init() {
+	Flags = append(Flags, oplog.CLIFlags(envVarPrefix)...)
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added an implementation of a standalone bootnode that simply runs op-node's discovery process.

**Tests**

Test coverage is mostly provided by op-node's existing P2P package. We may want to add some E2E tests for this wrapper.

**Additional context**

This is the bootnode implementation that Base runs in production. It also supports bootstrapping networks before genesis, as only a small amount of genesis information is required to run a bootnode:
 - L2 chain ID
 - L2 genesis timestamp
 - L2 block time
 - L2 genesis block number (defaults to 0)
