### PR TITLE
contracts-bedrock: mainnet proxy admin owner config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -18,7 +18,7 @@
   "l2OutputOracleProposer": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
   "l2OutputOracleChallenger": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
   "finalizationPeriodSeconds": 2,
-  "proxyAdminOwner": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+  "proxyAdminOwner": "0x7871d1187A97cbbE40710aC119AA3d412944e4Fe",
   "baseFeeVaultRecipient": "0xa3d596EAfaB6B13Ab18D40FaE1A962700C84ADEa",
   "l1FeeVaultRecipient": "0xa3d596EAfaB6B13Ab18D40FaE1A962700C84ADEa",
   "sequencerFeeVaultRecipient": "0xa3d596EAfaB6B13Ab18D40FaE1A962700C84ADEa",


### PR DESCRIPTION
**Description**

Sets the proxy admin owner to the gnosis safe on L2. I double checked that `proxyAdminOwner` is the appropriate config value, as you can see [here](https://github.com/ethereum-optimism/optimism/blob/06245265f0c741c2f316d40052115ebcefeeb6e3/op-chain-ops/genesis/config.go#L471). There is a different config value for the L1 that is the `finalSystemOwner` as seen [here](https://github.com/ethereum-optimism/optimism/blob/06245265f0c741c2f316d40052115ebcefeeb6e3/packages/contracts-bedrock/deploy/021-SystemDictatorSteps-2.ts#L311) and
[here](https://github.com/ethereum-optimism/optimism/blob/06245265f0c741c2f316d40052115ebcefeeb6e3/packages/contracts-bedrock/contracts/deployment/SystemDictator.sol#L436) as well as [here](https://github.com/ethereum-optimism/optimism/blob/06245265f0c741c2f316d40052115ebcefeeb6e3/packages/contracts-bedrock/deploy/019-SystemDictatorInit.ts#L47).

External links:
- https://app.safe.global/home?safe=oeth:0x7871d1187A97cbbE40710aC119AA3d412944e4Fe
- https://optimistic.etherscan.io/address/0x7871d1187A97cbbE40710aC119AA3d412944e4Fe

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

