### PR TITLE
contracts-bedrock: fix mainnet deploy-config export

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet.ts
+++ b/packages/contracts-bedrock/deploy-config/mainnet.ts
@@ -22,6 +22,5 @@ import mainnetJson from './mainnet.json'
 //
 // The following role is assigned to the Mint Manager contract:
 // - governanceTokenOwner
-const config: DeployConfig = mainnetJson
 
-export default config
+export default mainnetJson satisfies DeployConfig


### PR DESCRIPTION
**Description**

Fixes the export so it works as expected with hardhat deploy config.
Ported from `feat/mainnet`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

