### PR TITLE
feat(ctb): Generate deployment README files

### DIFF
--- a/packages/contracts-bedrock/deployments/README.md
+++ b/packages/contracts-bedrock/deployments/README.md
@@ -1,0 +1,3 @@
+# Optimism Deployments
+- [Optimism (mainnet)](./mainnet#readme)
+- [Optimism Goerli (public testnet)](./goerli#readme)

--- a/packages/contracts-bedrock/deployments/goerli/README.md
+++ b/packages/contracts-bedrock/deployments/goerli/README.md
@@ -1,0 +1,293 @@
+# Optimism Goerli (public testnet)
+## Network Info
+- **Chain ID**: 420
+- **Public RPC**: https://goerli.optimism.io
+- **Block Explorer**: https://goerli-optimism.etherscan.io/
+## Layer 1 Contracts
+<table>
+<tr>
+<th>
+<img width="506px" height="0px" />
+<p><small>Contract</small></p>
+</th>
+<th>
+<img width="506px" height="0px" />
+<p><small>Address</small></p>
+</th>
+</tr>
+<tr>
+<td>
+AddressManager
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0xa6f73589243a6A7a9023b1Fa0651b1d89c177111">
+<code>0xa6f73589243a6A7a9023b1Fa0651b1d89c177111</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1CrossDomainMessengerProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0x5086d1eEF304eb5284A0f6720f79403b4e9bE294">
+<code>0x5086d1eEF304eb5284A0f6720f79403b4e9bE294</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1ERC721BridgeProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0x8DD330DdE8D9898d43b4dc840Da27A07dF91b3c9">
+<code>0x8DD330DdE8D9898d43b4dc840Da27A07dF91b3c9</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1StandardBridgeProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0x636Af16bf2f682dD3109e60102b8E1A089FedAa8">
+<code>0x636Af16bf2f682dD3109e60102b8E1A089FedAa8</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2OutputOracleProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0">
+<code>0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+OptimismMintableERC20FactoryProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0x883dcF8B05364083D849D8bD226bC8Cb4c42F9C5">
+<code>0x883dcF8B05364083D849D8bD226bC8Cb4c42F9C5</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+OptimismPortalProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0x5b47E1A08Ea6d985D6649300584e6722Ec4B1383">
+<code>0x5b47E1A08Ea6d985D6649300584e6722Ec4B1383</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+ProxyAdmin
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0x01d3670863c3F4b24D7b107900f0b75d4BbC6e0d">
+<code>0x01d3670863c3F4b24D7b107900f0b75d4BbC6e0d</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+SystemConfigProxy
+</td>
+<td align="center">
+<a href="https://goerli.etherscan.io/address/0xAe851f927Ee40dE99aaBb7461C00f9622ab91d60">
+<code>0xAe851f927Ee40dE99aaBb7461C00f9622ab91d60</code>
+</a>
+</td>
+</tr>
+</table>
+
+## Layer 2 Contracts
+<table>
+<tr>
+<th>
+<img width="506px" height="0px" />
+<p><small>Contract</small></p>
+</th>
+<th>
+<img width="506px" height="0px" />
+<p><small>Address</small></p>
+</th>
+</tr>
+<tr>
+<td>
+L2ToL1MessagePasser
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000016">
+<code>0x4200000000000000000000000000000000000016</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+DeployerWhitelist
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000002">
+<code>0x4200000000000000000000000000000000000002</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2CrossDomainMessenger
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000007">
+<code>0x4200000000000000000000000000000000000007</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+GasPriceOracle
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x420000000000000000000000000000000000000F">
+<code>0x420000000000000000000000000000000000000F</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2StandardBridge
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000010">
+<code>0x4200000000000000000000000000000000000010</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+SequencerFeeVault
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000011">
+<code>0x4200000000000000000000000000000000000011</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1BlockNumber
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000013">
+<code>0x4200000000000000000000000000000000000013</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1Block
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000015">
+<code>0x4200000000000000000000000000000000000015</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+LegacyERC20ETH
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000">
+<code>0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+WETH9
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000006">
+<code>0x4200000000000000000000000000000000000006</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+GovernanceToken
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000042">
+<code>0x4200000000000000000000000000000000000042</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+LegacyMessagePasser
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000000">
+<code>0x4200000000000000000000000000000000000000</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2ERC721Bridge
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000014">
+<code>0x4200000000000000000000000000000000000014</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+OptimismMintableERC721Factory
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000017">
+<code>0x4200000000000000000000000000000000000017</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+ProxyAdmin
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000018">
+<code>0x4200000000000000000000000000000000000018</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+BaseFeeVault
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x4200000000000000000000000000000000000019">
+<code>0x4200000000000000000000000000000000000019</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1FeeVault
+</td>
+<td align="center">
+<a href="https://goerli-optimism.etherscan.io//address/0x420000000000000000000000000000000000001a">
+<code>0x420000000000000000000000000000000000001a</code>
+</a>
+</td>
+</tr>
+</table>
+

--- a/packages/contracts-bedrock/deployments/mainnet/README.md
+++ b/packages/contracts-bedrock/deployments/mainnet/README.md
@@ -1,0 +1,293 @@
+# Optimism (mainnet)
+## Network Info
+- **Chain ID**: 10
+- **Public RPC**: https://mainnet.optimism.io
+- **Block Explorer**: https://optimistic.etherscan.io
+## Layer 1 Contracts
+<table>
+<tr>
+<th>
+<img width="506px" height="0px" />
+<p><small>Contract</small></p>
+</th>
+<th>
+<img width="506px" height="0px" />
+<p><small>Address</small></p>
+</th>
+</tr>
+<tr>
+<td>
+AddressManager
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0xdE1FCfB0851916CA5101820A69b13a4E276bd81F">
+<code>0xdE1FCfB0851916CA5101820A69b13a4E276bd81F</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1CrossDomainMessengerProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1">
+<code>0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1ERC721BridgeProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0x5a7749f83b81B301cAb5f48EB8516B986DAef23D">
+<code>0x5a7749f83b81B301cAb5f48EB8516B986DAef23D</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1StandardBridgeProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1">
+<code>0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2OutputOracleProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0xdfe97868233d1aa22e815a266982f2cf17685a27">
+<code>0xdfe97868233d1aa22e815a266982f2cf17685a27</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+OptimismMintableERC20FactoryProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0x75505a97BD334E7BD3C476893285569C4136Fa0F">
+<code>0x75505a97BD334E7BD3C476893285569C4136Fa0F</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+OptimismPortalProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0xbEb5Fc579115071764c7423A4f12eDde41f106Ed">
+<code>0xbEb5Fc579115071764c7423A4f12eDde41f106Ed</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+ProxyAdmin
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0x543bA4AADBAb8f9025686Bd03993043599c6fB04">
+<code>0x543bA4AADBAb8f9025686Bd03993043599c6fB04</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+SystemConfigProxy
+</td>
+<td align="center">
+<a href="https://etherscan.io/address/0x229047fed2591dbec1eF1118d64F7aF3dB9EB290">
+<code>0x229047fed2591dbec1eF1118d64F7aF3dB9EB290</code>
+</a>
+</td>
+</tr>
+</table>
+
+## Layer 2 Contracts
+<table>
+<tr>
+<th>
+<img width="506px" height="0px" />
+<p><small>Contract</small></p>
+</th>
+<th>
+<img width="506px" height="0px" />
+<p><small>Address</small></p>
+</th>
+</tr>
+<tr>
+<td>
+L2ToL1MessagePasser
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000016">
+<code>0x4200000000000000000000000000000000000016</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+DeployerWhitelist
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000002">
+<code>0x4200000000000000000000000000000000000002</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2CrossDomainMessenger
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000007">
+<code>0x4200000000000000000000000000000000000007</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+GasPriceOracle
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x420000000000000000000000000000000000000F">
+<code>0x420000000000000000000000000000000000000F</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2StandardBridge
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000010">
+<code>0x4200000000000000000000000000000000000010</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+SequencerFeeVault
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000011">
+<code>0x4200000000000000000000000000000000000011</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1BlockNumber
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000013">
+<code>0x4200000000000000000000000000000000000013</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1Block
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000015">
+<code>0x4200000000000000000000000000000000000015</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+LegacyERC20ETH
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000">
+<code>0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+WETH9
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006">
+<code>0x4200000000000000000000000000000000000006</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+GovernanceToken
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000042">
+<code>0x4200000000000000000000000000000000000042</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+LegacyMessagePasser
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000000">
+<code>0x4200000000000000000000000000000000000000</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L2ERC721Bridge
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000014">
+<code>0x4200000000000000000000000000000000000014</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+OptimismMintableERC721Factory
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000017">
+<code>0x4200000000000000000000000000000000000017</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+ProxyAdmin
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000018">
+<code>0x4200000000000000000000000000000000000018</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+BaseFeeVault
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000019">
+<code>0x4200000000000000000000000000000000000019</code>
+</a>
+</td>
+</tr>
+<tr>
+<td>
+L1FeeVault
+</td>
+<td align="center">
+<a href="https://optimistic.etherscan.io/address/0x420000000000000000000000000000000000001a">
+<code>0x420000000000000000000000000000000000001a</code>
+</a>
+</td>
+</tr>
+</table>
+

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -22,6 +22,7 @@
     "prebuild": "yarn ts-node scripts/verify-foundry-install.ts",
     "build": "hardhat compile && yarn autogen:artifacts && yarn build:ts && yarn typechain",
     "build:ts": "tsc -p tsconfig.build.json",
+    "autogen:markdown": "ts-node scripts/generate-markdown.ts",
     "autogen:artifacts": "ts-node scripts/generate-artifacts.ts",
     "autogen:invariant-docs": "ts-node scripts/invariant-doc-gen.ts",
     "deploy": "hardhat deploy",

--- a/packages/contracts-bedrock/scripts/generate-markdown.ts
+++ b/packages/contracts-bedrock/scripts/generate-markdown.ts
@@ -1,0 +1,235 @@
+import fs from 'fs'
+import path from 'path'
+
+import dirtree from 'directory-tree'
+
+import { predeploys } from '../src'
+
+interface DeploymentInfo {
+  folder: string
+  name: string
+  chainid: number
+  rpc?: string
+  l1Explorer?: string
+  l2Explorer?: string
+  notice?: string
+}
+
+const PUBLIC_DEPLOYMENTS: DeploymentInfo[] = [
+  {
+    folder: 'mainnet',
+    name: 'Optimism (mainnet)',
+    chainid: 10,
+    rpc: 'https://mainnet.optimism.io',
+    l1Explorer: 'https://etherscan.io',
+    l2Explorer: 'https://optimistic.etherscan.io',
+  },
+  {
+    folder: 'goerli',
+    name: 'Optimism Goerli (public testnet)',
+    chainid: 420,
+    rpc: 'https://goerli.optimism.io',
+    l1Explorer: 'https://goerli.etherscan.io',
+    l2Explorer: 'https://goerli-optimism.etherscan.io/',
+  },
+]
+
+// List of contracts that are part of a deployment but aren't meant to be used by the general
+// public. E.g., implementation addresses for proxy contracts or helpers used during the
+// deployment process. Although these addresses are public and users can technically try to use
+// them, there's no point in doing so. As a result, we hide these addresses to avoid confusion.
+const HIDDEN_CONTRACTS = [
+  // Implementation addresses:
+  'L1CrossDomainMessenger',
+  'L1ERC721Bridge',
+  'L1StandardBridge',
+  'L2OutputOracle',
+  'OptimismPortal',
+  'OptimismMintableERC20Factory',
+  'SystemConfig',
+  // Only used during the bedrock upgrade
+  'PortalSender',
+  'SystemDictator',
+  'SystemDictatorProxy',
+]
+
+interface ContractInfo {
+  name: string
+  address: string
+}
+
+/**
+ * Gets the full deployment folder path for a given deployment.
+ *
+ * @param name Deployment folder name.
+ * @returns Full path to the deployment folder.
+ */
+const getDeploymentFolderPath = (name: string): string => {
+  return path.resolve(__dirname, `../deployments/${name}`)
+}
+
+/**
+ * Helper function for adding a line to a string. Avoids having to add the ugly \n to each new line
+ * that you want to add a string.
+ *
+ * @param str String to add a line to.
+ * @param line Line to add to the string.
+ * @returns String with the added line and a newline at the end.
+ */
+const addline = (str: string, line: string): string => {
+  return str + line + '\n'
+}
+
+/**
+ * Generates a nicely formatted table presenting a list of contracts.
+ *
+ * @param contracts List of contracts to display.
+ * @param explorer URL for etherscan for the network that the contracts are deployed to.
+ * @returns Nicely formatted markdown-compatible table as a string.
+ */
+const buildContractsTable = (
+  contracts: ContractInfo[],
+  explorer?: string
+): string => {
+  // Being very verbose within this function to make it clear what's going on.
+  // We use HTML instead of markdown so we can get a table that displays well on GitHub.
+  // GitHub READMEs are 1012px wide. Adding a 506px image to each table header is a hack that
+  // allows us to create a table where each column is 1/2 the full README width.
+  let table = ``
+  table = addline(table, '<table>')
+  table = addline(table, '<tr>')
+  table = addline(table, '<th>')
+  table = addline(table, '<img width="506px" height="0px" />')
+  table = addline(table, '<p><small>Contract</small></p>')
+  table = addline(table, '</th>')
+  table = addline(table, '<th>')
+  table = addline(table, '<img width="506px" height="0px" />')
+  table = addline(table, '<p><small>Address</small></p>')
+  table = addline(table, '</th>')
+  table = addline(table, '</tr>')
+
+  for (const contract of contracts) {
+    // Don't add records for contract addresses that aren't meant to be public-facing.
+    if (HIDDEN_CONTRACTS.includes(contract.name)) {
+      continue
+    }
+
+    table = addline(table, '<tr>')
+    table = addline(table, '<td>')
+    table = addline(table, contract.name)
+    table = addline(table, '</td>')
+    table = addline(table, '<td align="center">')
+    if (explorer) {
+      table = addline(
+        table,
+        `<a href="${explorer}/address/${contract.address}">`
+      )
+      table = addline(table, `<code>${contract.address}</code>`)
+      table = addline(table, '</a>')
+    } else {
+      table = addline(table, `<code>${contract.address}</code>`)
+    }
+    table = addline(table, '</td>')
+    table = addline(table, '</tr>')
+  }
+
+  table = addline(table, '</table>')
+  return table
+}
+
+/**
+ * Gets the list of L1 contracts for a given deployment.
+ *
+ * @param deployment Folder where the deployment is located.
+ * @returns List of L1 contracts for thegiven deployment.
+ */
+const getL1Contracts = (deployment: string): ContractInfo[] => {
+  const l1ContractsFolder = getDeploymentFolderPath(deployment)
+  return dirtree(l1ContractsFolder)
+    .children.filter((child) => {
+      return child.extension === '.json'
+    })
+    .map((child) => {
+      return {
+        name: child.name.replace('.json', ''),
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        address: require(path.join(l1ContractsFolder, child.name)).address,
+      }
+    })
+}
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Gets the list of L2 contracts for a given deployment.
+ *
+ * @param deployment Folder where the deployment is located.
+ * @returns List of L2 system contracts for the given deployment.
+ */
+const getL2Contracts = (deployment: string): ContractInfo[] => {
+  // Deployment parameter is currently unused because all networks have the same predeploy
+  // addresses. However, we've had situations in the past where we've had to deploy one-off
+  // system contracts to a network. If we want to do that again in the future then we'll want some
+  // kind of custom logic based on the network in question. Hence, the deployment parameter.
+  return Object.entries(predeploys).map(([name, address]) => {
+    return {
+      name,
+      address,
+    }
+  })
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+const main = async () => {
+  for (const deployment of PUBLIC_DEPLOYMENTS) {
+    let md = ``
+    md = addline(md, `# ${deployment.name}`)
+    if (deployment.notice) {
+      md = addline(md, `## Notice`)
+      md = addline(md, deployment.notice)
+    }
+    md = addline(md, `## Network Info`)
+    md = addline(md, `- **Chain ID**: ${deployment.chainid}`)
+    if (deployment.rpc) {
+      md = addline(md, `- **Public RPC**: ${deployment.rpc}`)
+    }
+    if (deployment.l2Explorer) {
+      md = addline(md, `- **Block Explorer**: ${deployment.l2Explorer}`)
+    }
+    md = addline(md, `## Layer 1 Contracts`)
+    md = addline(
+      md,
+      buildContractsTable(
+        getL1Contracts(deployment.folder),
+        deployment.l1Explorer
+      )
+    )
+    md = addline(md, `## Layer 2 Contracts`)
+    md = addline(
+      md,
+      buildContractsTable(
+        getL2Contracts(deployment.folder),
+        deployment.l2Explorer
+      )
+    )
+
+    // Write the README file for the deployment
+    fs.writeFileSync(
+      path.join(getDeploymentFolderPath(deployment.folder), 'README.md'),
+      md
+    )
+  }
+
+  let primary = ``
+  primary = addline(primary, `# Optimism Deployments`)
+  for (const deployment of PUBLIC_DEPLOYMENTS) {
+    primary = addline(
+      primary,
+      `- [${deployment.name}](./${deployment.folder}#readme)`
+    )
+  }
+
+  // Write the primary README file
+  fs.writeFileSync(path.resolve(__dirname, '../deployments/README.md'), primary)
+}
+
+main()


### PR DESCRIPTION
**Description**

Ports the `autogen:markdown` script from the `contracts` package to `contracts-bedrock` and generates the files.

Draft until the artifacts are renamed to remove the OVM prefix.