### PR TITLE
op-node: Preserve topic scores as float64 instead of truncating to uint64

### DIFF
--- a/op-node/p2p/peer_scorer.go
+++ b/op-node/p2p/peer_scorer.go
@@ -143,9 +143,9 @@ func (s *scorer) SnapshotHook() pubsub.ExtendedPeerScoreInspectFn {
 			}
 			if topSnap, ok := snap.Topics[blocksTopicName]; ok {
 				diff.Blocks.TimeInMesh = float64(topSnap.TimeInMesh) / float64(time.Second)
-				diff.Blocks.MeshMessageDeliveries = uint64(topSnap.MeshMessageDeliveries)
-				diff.Blocks.FirstMessageDeliveries = uint64(topSnap.FirstMessageDeliveries)
-				diff.Blocks.InvalidMessageDeliveries = uint64(topSnap.InvalidMessageDeliveries)
+				diff.Blocks.MeshMessageDeliveries = topSnap.MeshMessageDeliveries
+				diff.Blocks.FirstMessageDeliveries = topSnap.FirstMessageDeliveries
+				diff.Blocks.InvalidMessageDeliveries = topSnap.InvalidMessageDeliveries
 			}
 			if err := s.peerStore.SetScore(id, &diff); err != nil {
 				s.log.Warn("Unable to update peer gossip score", "err", err)

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -11,9 +11,9 @@ import (
 
 type TopicScores struct {
 	TimeInMesh               float64 `json:"timeInMesh"` // in seconds
-	FirstMessageDeliveries   uint64  `json:"firstMessageDeliveries"`
-	MeshMessageDeliveries    uint64  `json:"meshMessageDeliveries"`
-	InvalidMessageDeliveries uint64  `json:"invalidMessageDeliveries"`
+	FirstMessageDeliveries   float64 `json:"firstMessageDeliveries"`
+	MeshMessageDeliveries    float64 `json:"meshMessageDeliveries"`
+	InvalidMessageDeliveries float64 `json:"invalidMessageDeliveries"`
 }
 
 type GossipScores struct {


### PR DESCRIPTION
**Description**

The block topic metrics have decay applied so are genuinely float64 values.  Preserve accuracy by recording them as float instead of truncating to uint64.

