### PR TITLE
nit: correcting error msg in docs

### DIFF
--- a/docs/op-stack/src/docs/build/tutorials/add-attr.md
+++ b/docs/op-stack/src/docs/build/tutorials/add-attr.md
@@ -218,7 +218,7 @@ Finally, we’ll need to update `~/optimism/op-node/rollup/derive/attributes.go`
     ```go
     l1BurnTx, err := L1BurnDepositBytes(seqNumber, l1Info, sysConfig)
     if err != nil {
-            return nil, NewCriticalError(fmt.Errorf("failed to create l1InfoTx: %w", err))
+            return nil, NewCriticalError(fmt.Errorf("failed to create l1BurnTx: %w", err))
     }
     ```
     


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Correcting error msg in docs to say `l1BurnTx` instead of `l1InfoTx`

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
n/a

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
