### PR TITLE
feat(op-challenger): Oracle Watcher

### DIFF
--- a/op-challenger/challenger/challenger.go
+++ b/op-challenger/challenger/challenger.go
@@ -54,6 +54,24 @@ type Challenger struct {
 	networkTimeout time.Duration
 }
 
+// From returns the address of the account used to send transactions.
+func (c *Challenger) From() common.Address {
+	return c.txMgr.From()
+}
+
+// Client returns the client for the settlement layer.
+func (c *Challenger) Client() *ethclient.Client {
+	return c.l1Client
+}
+
+func (c *Challenger) NewOracleSubscription() (*Subscription, error) {
+	query, err := c.BuildOutputLogFilter()
+	if err != nil {
+		return nil, err
+	}
+	return NewSubscription(query, c.Client(), c.log), nil
+}
+
 // NewChallenger creates a new Challenger
 func NewChallenger(cfg config.Config, l log.Logger, m metrics.Metricer) (*Challenger, error) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/op-challenger/challenger/challenger.go
+++ b/op-challenger/challenger/challenger.go
@@ -65,7 +65,7 @@ func (c *Challenger) Client() *ethclient.Client {
 }
 
 func (c *Challenger) NewOracleSubscription() (*Subscription, error) {
-	query, err := c.BuildOutputLogFilter()
+	query, err := BuildOutputLogFilter(c.l2ooABI)
 	if err != nil {
 		return nil, err
 	}

--- a/op-challenger/challenger/oracle.go
+++ b/op-challenger/challenger/oracle.go
@@ -34,3 +34,8 @@ func BuildOutputLogFilter(l2ooABI *abi.ABI) (ethereum.FilterQuery, error) {
 
 	return query, nil
 }
+
+// BuildOutputLogFilter creates a filter query for the L2OutputOracle contract.
+func (c *Challenger) BuildOutputLogFilter() (ethereum.FilterQuery, error) {
+	return BuildOutputLogFilter(c.l2ooABI)
+}

--- a/op-challenger/challenger/oracle.go
+++ b/op-challenger/challenger/oracle.go
@@ -34,8 +34,3 @@ func BuildOutputLogFilter(l2ooABI *abi.ABI) (ethereum.FilterQuery, error) {
 
 	return query, nil
 }
-
-// BuildOutputLogFilter creates a filter query for the L2OutputOracle contract.
-func (c *Challenger) BuildOutputLogFilter() (ethereum.FilterQuery, error) {
-	return BuildOutputLogFilter(c.l2ooABI)
-}

--- a/op-challenger/challenger/subscription.go
+++ b/op-challenger/challenger/subscription.go
@@ -61,6 +61,11 @@ func (s *Subscription) Started() bool {
 	return s.started
 }
 
+// Logs returns the log channel.
+func (s *Subscription) Logs() <-chan types.Log {
+	return s.logs
+}
+
 // Subscribe constructs the subscription.
 func (s *Subscription) Subscribe() error {
 	s.log.Info("Subscribing to", "query", s.query.Topics, "id", s.id)

--- a/op-challenger/cmd/watch/cmd.go
+++ b/op-challenger/cmd/watch/cmd.go
@@ -25,11 +25,4 @@ var Subcommands = cli.Commands{
 			return Oracle(logger, cfg)
 		},
 	},
-	{
-		Name:  "factory",
-		Usage: "Watches the DisputeGameFactory for new dispute games",
-		Action: func(ctx *cli.Context) error {
-			panic("factory not implemented")
-		},
-	},
 }

--- a/op-challenger/cmd/watch/cmd.go
+++ b/op-challenger/cmd/watch/cmd.go
@@ -1,0 +1,35 @@
+package watch
+
+import (
+	"github.com/urfave/cli"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+)
+
+var Subcommands = cli.Commands{
+	{
+		Name:  "oracle",
+		Usage: "Watches the L2OutputOracle for new output proposals",
+		Action: func(ctx *cli.Context) error {
+			logger, err := config.LoggerFromCLI(ctx)
+			if err != nil {
+				return err
+			}
+			logger.Info("Listening for new output proposals")
+
+			cfg, err := config.NewConfigFromCLI(ctx)
+			if err != nil {
+				return err
+			}
+
+			return Oracle(logger, cfg)
+		},
+	},
+	{
+		Name:  "factory",
+		Usage: "Watches the DisputeGameFactory for new dispute games",
+		Action: func(ctx *cli.Context) error {
+			panic("factory not implemented")
+		},
+	},
+}

--- a/op-challenger/cmd/watch/oracle.go
+++ b/op-challenger/cmd/watch/oracle.go
@@ -1,0 +1,76 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	log "github.com/ethereum/go-ethereum/log"
+
+	challenger "github.com/ethereum-optimism/optimism/op-challenger/challenger"
+	config "github.com/ethereum-optimism/optimism/op-challenger/config"
+	metrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
+)
+
+// Oracle listens to the L2OutputOracle for newly proposed outputs.
+func Oracle(logger log.Logger, cfg *config.Config) error {
+	if err := cfg.Check(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	m := metrics.NewMetrics("default")
+
+	service, err := challenger.NewChallenger(*cfg, logger, m)
+	if err != nil {
+		logger.Error("Unable to create the Challenger", "error", err)
+		return err
+	}
+
+	logger.Info("Listening for OutputProposed events from the L2OutputOracle contract", "l2oo", cfg.L2OOAddress.String())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subscription, err := service.NewOracleSubscription()
+	if err != nil {
+		logger.Error("Unable to create the subscription", "error", err)
+		return err
+	}
+
+	err = subscription.Subscribe()
+	if err != nil {
+		logger.Error("Unable to subscribe to the L2OutputOracle contract", "error", err)
+		return err
+	}
+
+	metricsCfg := cfg.MetricsConfig
+	if metricsCfg.Enabled {
+		log.Info("starting metrics server", "addr", metricsCfg.ListenAddr, "port", metricsCfg.ListenPort)
+		go func() {
+			if err := m.Serve(ctx, metricsCfg.ListenAddr, metricsCfg.ListenPort); err != nil {
+				logger.Error("error starting metrics server", err)
+			}
+		}()
+		m.StartBalanceMetrics(ctx, logger, service.Client(), service.From())
+	}
+
+	m.RecordUp()
+
+	interruptChannel := make(chan os.Signal, 1)
+	signal.Notify(interruptChannel, []os.Signal{
+		os.Interrupt,
+		os.Kill,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	}...)
+
+	for {
+		select {
+		case log := <-subscription.Logs():
+			logger.Info("Received log", "log", log)
+		case <-interruptChannel:
+			logger.Info("Received interrupt signal, exiting...")
+		}
+	}
+}

--- a/op-challenger/cmd/watch/oracle.go
+++ b/op-challenger/cmd/watch/oracle.go
@@ -7,11 +7,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	log "github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/log"
 
-	challenger "github.com/ethereum-optimism/optimism/op-challenger/challenger"
-	config "github.com/ethereum-optimism/optimism/op-challenger/config"
-	metrics "github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-challenger/challenger"
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 )
 
 // Oracle listens to the L2OutputOracle for newly proposed outputs.

--- a/op-challenger/cmd/watch/oracle.go
+++ b/op-challenger/cmd/watch/oracle.go
@@ -1,7 +1,6 @@
 package watch
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -29,8 +28,6 @@ func Oracle(logger log.Logger, cfg *config.Config) error {
 	}
 
 	logger.Info("Listening for OutputProposed events from the L2OutputOracle contract", "l2oo", cfg.L2OOAddress.String())
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	subscription, err := service.NewOracleSubscription()
 	if err != nil {
@@ -43,19 +40,6 @@ func Oracle(logger log.Logger, cfg *config.Config) error {
 		logger.Error("Unable to subscribe to the L2OutputOracle contract", "error", err)
 		return err
 	}
-
-	metricsCfg := cfg.MetricsConfig
-	if metricsCfg.Enabled {
-		log.Info("starting metrics server", "addr", metricsCfg.ListenAddr, "port", metricsCfg.ListenPort)
-		go func() {
-			if err := m.Serve(ctx, metricsCfg.ListenAddr, metricsCfg.ListenPort); err != nil {
-				logger.Error("error starting metrics server", err)
-			}
-		}()
-		m.StartBalanceMetrics(ctx, logger, service.Client(), service.From())
-	}
-
-	m.RecordUp()
 
 	interruptChannel := make(chan os.Signal, 1)
 	signal.Notify(interruptChannel, []os.Signal{

--- a/op-challenger/cmd/watch/oracle.go
+++ b/op-challenger/cmd/watch/oracle.go
@@ -41,6 +41,8 @@ func Oracle(logger log.Logger, cfg *config.Config) error {
 		return err
 	}
 
+	defer subscription.Quit()
+
 	interruptChannel := make(chan os.Signal, 1)
 	signal.Notify(interruptChannel, []os.Signal{
 		os.Interrupt,

--- a/op-challenger/config/logging.go
+++ b/op-challenger/config/logging.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"fmt"
+
+	log "github.com/ethereum/go-ethereum/log"
+	cli "github.com/urfave/cli"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+// LoggerFromCLI creates a [log.Logger] from the
+// supplied [cli.Context].
+func LoggerFromCLI(ctx *cli.Context) (log.Logger, error) {
+	logCfg := oplog.ReadCLIConfig(ctx)
+	if err := logCfg.Check(); err != nil {
+		return nil, fmt.Errorf("log config error: %w", err)
+	}
+	logger := oplog.NewLogger(logCfg)
+	return logger, nil
+}


### PR DESCRIPTION
**Description**

- Sets up the `op-challenger` subcommand dispatch.
- Adds an L2OutputOracle `OutputProposed` event watcher as part of the `watch` subcommand.

**Metadata**

Fixes CLI-4062