### PR TITLE
feat(proxyd): add support to rewrite debug_getRawReceipts

### DIFF
--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -87,7 +87,7 @@ Cache use Redis and can be enabled for the following immutable methods:
 * `eth_getBlockByHash`
 * `eth_getTransactionByBlockHashAndIndex`
 * `eth_getUncleByBlockHashAndIndex`
-
+* `debug_getRawReceipts` (block hash only)
 
 ## Metrics
 

--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -71,6 +71,7 @@ The following request methods are rewritten:
 * `eth_getBlockByNumber`
 * `eth_getTransactionByBlockNumberAndIndex`
 * `eth_getUncleByBlockNumberAndIndex`
+* `debug_getRawReceipts`
 
 And `eth_blockNumber` response is overridden with current block consensus.
 

--- a/proxyd/cache.go
+++ b/proxyd/cache.go
@@ -3,9 +3,10 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
-	"github.com/ethereum/go-ethereum/rpc"
 	"strings"
 	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/golang/snappy"

--- a/proxyd/cache_test.go
+++ b/proxyd/cache_test.go
@@ -101,6 +101,20 @@ func TestRPCCacheImmutableRPCs(t *testing.T) {
 			},
 			name: "eth_getUncleByBlockHashAndIndex",
 		},
+		{
+			req: &RPCReq{
+				JSONRPC: "2.0",
+				Method:  "debug_getRawReceipts",
+				Params:  mustMarshalJSON([]string{"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b"}),
+				ID:      ID,
+			},
+			res: &RPCRes{
+				JSONRPC: "2.0",
+				Result:  `{"debug_getRawReceipts":"!"}`,
+				ID:      ID,
+			},
+			name: "debug_getRawReceipts",
+		},
 	}
 
 	for _, rpc := range rpcs {
@@ -172,6 +186,15 @@ func TestRPCCacheUnsupportedMethod(t *testing.T) {
 				Method:  "eth_gasPrice",
 				ID:      ID,
 			},
+		},
+		{
+			req: &RPCReq{
+				JSONRPC: "2.0",
+				Method:  "debug_getRawReceipts",
+				Params:  mustMarshalJSON([]string{"0x100"}),
+				ID:      ID,
+			},
+			name: "debug_getRawReceipts",
 		},
 	}
 

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -63,24 +63,26 @@ func RewriteRequest(rctx RewriteContext, req *RPCReq, res *RPCRes) (RewriteResul
 	case "eth_getLogs",
 		"eth_newFilter":
 		return rewriteRange(rctx, req, res, 0)
+	case "debug_getRawReceipts":
+		return rewriteParam(rctx, req, res, 0, true)
 	case "eth_getBalance",
 		"eth_getCode",
 		"eth_getTransactionCount",
 		"eth_call":
-		return rewriteParam(rctx, req, res, 1)
+		return rewriteParam(rctx, req, res, 1, false)
 	case "eth_getStorageAt":
-		return rewriteParam(rctx, req, res, 2)
+		return rewriteParam(rctx, req, res, 2, false)
 	case "eth_getBlockTransactionCountByNumber",
 		"eth_getUncleCountByBlockNumber",
 		"eth_getBlockByNumber",
 		"eth_getTransactionByBlockNumberAndIndex",
 		"eth_getUncleByBlockNumberAndIndex":
-		return rewriteParam(rctx, req, res, 0)
+		return rewriteParam(rctx, req, res, 0, false)
 	}
 	return RewriteNone, nil
 }
 
-func rewriteParam(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int) (RewriteResult, error) {
+func rewriteParam(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int, required bool) (RewriteResult, error) {
 	var p []interface{}
 	err := json.Unmarshal(req.Params, &p)
 	if err != nil {
@@ -89,9 +91,9 @@ func rewriteParam(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int) (Rewri
 
 	// we assume latest if the param is missing,
 	// and we don't rewrite if there is not enough params
-	if len(p) == pos {
+	if len(p) == pos && !required {
 		p = append(p, "latest")
-	} else if len(p) < pos {
+	} else if len(p) <= pos {
 		return RewriteNone, nil
 	}
 

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -148,6 +148,58 @@ func TestRewriteRequest(t *testing.T) {
 			expected:    RewriteOverrideError,
 			expectedErr: ErrRewriteBlockOutOfRange,
 		},
+		/* required parameter at pos 0 */
+		{
+			name: "debug_getRawReceipts latest",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{"latest"})},
+				res:  nil,
+			},
+			expected: RewriteOverrideRequest,
+			check: func(t *testing.T, args args) {
+				var p []string
+				err := json.Unmarshal(args.req.Params, &p)
+				require.Nil(t, err)
+				require.Equal(t, 1, len(p))
+				require.Equal(t, hexutil.Uint64(100).String(), p[0])
+			},
+		},
+		{
+			name: "debug_getRawReceipts within range",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{hexutil.Uint64(55).String()})},
+				res:  nil,
+			},
+			expected: RewriteNone,
+			check: func(t *testing.T, args args) {
+				var p []string
+				err := json.Unmarshal(args.req.Params, &p)
+				require.Nil(t, err)
+				require.Equal(t, 1, len(p))
+				require.Equal(t, hexutil.Uint64(55).String(), p[0])
+			},
+		},
+		{
+			name: "debug_getRawReceipts out of range",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{hexutil.Uint64(111).String()})},
+				res:  nil,
+			},
+			expected:    RewriteOverrideError,
+			expectedErr: ErrRewriteBlockOutOfRange,
+		},
+		{
+			name: "debug_getRawReceipts missing parameter",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{})},
+				res:  nil,
+			},
+			expected: RewriteNone,
+		},
 		/* default block parameter */
 		{
 			name: "eth_getCode omit block, should add",

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -200,6 +200,22 @@ func TestRewriteRequest(t *testing.T) {
 			},
 			expected: RewriteNone,
 		},
+		{
+			name: "debug_getRawReceipts with block hash",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100)},
+				req:  &RPCReq{Method: "debug_getRawReceipts", Params: mustMarshalJSON([]string{"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b"})},
+				res:  nil,
+			},
+			expected: RewriteNone,
+			check: func(t *testing.T, args args) {
+				var p []string
+				err := json.Unmarshal(args.req.Params, &p)
+				require.Nil(t, err)
+				require.Equal(t, 1, len(p))
+				require.Equal(t, "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", p[0])
+			},
+		},
 		/* default block parameter */
 		{
 			name: "eth_getCode omit block, should add",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change adds support for `debug_getRawReceipts` method.

**Tests**

Added new tests.

**Invariants**

We cache only requests that are block hash, block numbers should never be cached.

**Additional context**

https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**Metadata**

https://linear.app/optimism/issue/INF-257/add-debug-getrawreceipts-to-rewrite-methods

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
