### PR TITLE
feat(op-challenger): DisputeGameFactory Watcher

### DIFF
--- a/op-challenger/challenger/challenger.go
+++ b/op-challenger/challenger/challenger.go
@@ -74,7 +74,7 @@ func (c *Challenger) NewOracleSubscription() (*Subscription, error) {
 
 // NewFactorySubscription creates a new [Subscription] listening to the DisputeGameFactory contract.
 func (c *Challenger) NewFactorySubscription() (*Subscription, error) {
-	query, err := c.BuildDisputeGameLogFilter()
+	query, err := BuildDisputeGameLogFilter(c.dgfABI)
 	if err != nil {
 		return nil, err
 	}

--- a/op-challenger/challenger/challenger.go
+++ b/op-challenger/challenger/challenger.go
@@ -72,6 +72,15 @@ func (c *Challenger) NewOracleSubscription() (*Subscription, error) {
 	return NewSubscription(query, c.Client(), c.log), nil
 }
 
+// NewFactorySubscription creates a new [Subscription] listening to the DisputeGameFactory contract.
+func (c *Challenger) NewFactorySubscription() (*Subscription, error) {
+	query, err := c.BuildDisputeGameLogFilter()
+	if err != nil {
+		return nil, err
+	}
+	return NewSubscription(query, c.Client(), c.log), nil
+}
+
 // NewChallenger creates a new Challenger
 func NewChallenger(cfg config.Config, l log.Logger, m metrics.Metricer) (*Challenger, error) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/op-challenger/challenger/factory.go
+++ b/op-challenger/challenger/factory.go
@@ -31,8 +31,3 @@ func BuildDisputeGameLogFilter(contract *abi.ABI) (ethereum.FilterQuery, error) 
 
 	return query, nil
 }
-
-// BuildDisputeGameLogFilter creates a filter query for the DisputeGameFactory contract.
-func (c *Challenger) BuildDisputeGameLogFilter() (ethereum.FilterQuery, error) {
-	return BuildDisputeGameLogFilter(c.dgfABI)
-}

--- a/op-challenger/challenger/factory.go
+++ b/op-challenger/challenger/factory.go
@@ -1,0 +1,38 @@
+package challenger
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var ErrMissingFactoryEvent = errors.New("missing factory event")
+
+// BuildDisputeGameLogFilter creates a filter query for the DisputeGameFactory contract.
+//
+// The `DisputeGameCreated` event is encoded as:
+// 0: address indexed disputeProxy,
+// 1: GameType indexed gameType,
+// 2: Claim indexed rootClaim,
+func BuildDisputeGameLogFilter(contract *abi.ABI) (ethereum.FilterQuery, error) {
+	event := contract.Events["DisputeGameCreated"]
+
+	if event.ID == (common.Hash{}) {
+		return ethereum.FilterQuery{}, ErrMissingFactoryEvent
+	}
+
+	query := ethereum.FilterQuery{
+		Topics: [][]common.Hash{
+			{event.ID},
+		},
+	}
+
+	return query, nil
+}
+
+// BuildDisputeGameLogFilter creates a filter query for the DisputeGameFactory contract.
+func (c *Challenger) BuildDisputeGameLogFilter() (ethereum.FilterQuery, error) {
+	return BuildDisputeGameLogFilter(c.dgfABI)
+}

--- a/op-challenger/challenger/factory_test.go
+++ b/op-challenger/challenger/factory_test.go
@@ -1,0 +1,46 @@
+package challenger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	eth "github.com/ethereum/go-ethereum"
+	abi "github.com/ethereum/go-ethereum/accounts/abi"
+	common "github.com/ethereum/go-ethereum/common"
+)
+
+// TestBuildDisputeGameLogFilter_Succeeds tests that the DisputeGame
+// Log Filter is built correctly.
+func TestBuildDisputeGameLogFilter_Succeeds(t *testing.T) {
+	event := abi.Event{
+		ID: [32]byte{0x01},
+	}
+
+	filterQuery := eth.FilterQuery{
+		Topics: [][]common.Hash{
+			{event.ID},
+		},
+	}
+
+	dgfABI := abi.ABI{
+		Events: map[string]abi.Event{
+			"DisputeGameCreated": event,
+		},
+	}
+
+	query, err := BuildDisputeGameLogFilter(&dgfABI)
+	require.Equal(t, filterQuery, query)
+	require.NoError(t, err)
+}
+
+// TestBuildDisputeGameLogFilter_Fails tests that the DisputeGame
+// Log Filter fails when the event definition is missing.
+func TestBuildDisputeGameLogFilter_Fails(t *testing.T) {
+	dgfABI := abi.ABI{
+		Events: map[string]abi.Event{},
+	}
+
+	_, err := BuildDisputeGameLogFilter(&dgfABI)
+	require.ErrorIs(t, ErrMissingFactoryEvent, err)
+}

--- a/op-challenger/cmd/watch/cmd.go
+++ b/op-challenger/cmd/watch/cmd.go
@@ -25,4 +25,25 @@ var Subcommands = cli.Commands{
 			return Oracle(logger, cfg)
 		},
 	},
+<<<<<<< HEAD
+=======
+	{
+		Name:  "factory",
+		Usage: "Watches the DisputeGameFactory for new dispute games",
+		Action: func(ctx *cli.Context) error {
+			logger, err := config.LoggerFromCLI(ctx)
+			if err != nil {
+				return err
+			}
+			logger.Info("Listening for new dispute games")
+
+			cfg, err := config.NewConfigFromCLI(ctx)
+			if err != nil {
+				return err
+			}
+
+			return Factory(logger, cfg)
+		},
+	},
+>>>>>>> 3d199507d (Add DisputeGameFactory dispute game creation listening logic.)
 }

--- a/op-challenger/cmd/watch/cmd.go
+++ b/op-challenger/cmd/watch/cmd.go
@@ -25,8 +25,6 @@ var Subcommands = cli.Commands{
 			return Oracle(logger, cfg)
 		},
 	},
-<<<<<<< HEAD
-=======
 	{
 		Name:  "factory",
 		Usage: "Watches the DisputeGameFactory for new dispute games",
@@ -45,5 +43,4 @@ var Subcommands = cli.Commands{
 			return Factory(logger, cfg)
 		},
 	},
->>>>>>> 3d199507d (Add DisputeGameFactory dispute game creation listening logic.)
 }

--- a/op-challenger/cmd/watch/factory.go
+++ b/op-challenger/cmd/watch/factory.go
@@ -41,6 +41,8 @@ func Factory(logger log.Logger, cfg *config.Config) error {
 		return err
 	}
 
+	defer subscription.Quit()
+
 	interruptChannel := make(chan os.Signal, 1)
 	signal.Notify(interruptChannel, []os.Signal{
 		os.Interrupt,

--- a/op-challenger/cmd/watch/factory.go
+++ b/op-challenger/cmd/watch/factory.go
@@ -1,0 +1,76 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/challenger"
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+)
+
+// Factory listens to the DisputeGameFactory for newly created dispute games.
+func Factory(logger log.Logger, cfg *config.Config) error {
+	if err := cfg.Check(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	m := metrics.NewMetrics("default")
+
+	service, err := challenger.NewChallenger(*cfg, logger, m)
+	if err != nil {
+		logger.Error("Unable to create the Challenger", "error", err)
+		return err
+	}
+
+	logger.Info("Listening for DisputeGameCreated events from the DisputeGameFactory contract", "dgf", cfg.DGFAddress.String())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subscription, err := service.NewFactorySubscription()
+	if err != nil {
+		logger.Error("Unable to create the subscription", "error", err)
+		return err
+	}
+
+	err = subscription.Subscribe()
+	if err != nil {
+		logger.Error("Unable to subscribe to the DisputeGameFactory contract", "error", err)
+		return err
+	}
+
+	metricsCfg := cfg.MetricsConfig
+	if metricsCfg.Enabled {
+		log.Info("starting metrics server", "addr", metricsCfg.ListenAddr, "port", metricsCfg.ListenPort)
+		go func() {
+			if err := m.Serve(ctx, metricsCfg.ListenAddr, metricsCfg.ListenPort); err != nil {
+				logger.Error("error starting metrics server", err)
+			}
+		}()
+		m.StartBalanceMetrics(ctx, logger, service.Client(), service.From())
+	}
+
+	m.RecordUp()
+
+	interruptChannel := make(chan os.Signal, 1)
+	signal.Notify(interruptChannel, []os.Signal{
+		os.Interrupt,
+		os.Kill,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	}...)
+
+	for {
+		select {
+		case log := <-subscription.Logs():
+			logger.Info("Received log", "log", log)
+		case <-interruptChannel:
+			logger.Info("Received interrupt signal, exiting...")
+		}
+	}
+}


### PR DESCRIPTION
**Description**

Stacked ontop of #5831, this pr contains the logic for the `watch factory`
subcommand to listen for newly created dispute games from the dispute
game factory.

**Metadata**

Fixes CLI-4063
