### PR TITLE
ci: add mockery tool to ci-builder docker container

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -97,3 +97,11 @@ RUN echo "downloading and verifying Codecov uploader" && \
   cp codecov /usr/local/bin/codecov && \
   chmod +x /usr/local/bin/codecov  && \
   rm codecov
+
+RUN echo "downloading mockery tool" && \
+  mkdir -p mockery-tmp-dir && \
+  curl -o mockery-tmp-dir/mockery.tar.gz -sL https://github.com/vektra/mockery/releases/download/v2.28.1/mockery_2.28.1_Linux_x86_64.tar.gz && \
+  tar -xzvf mockery-tmp-dir/mockery.tar.gz && \
+  cp mockery-tmp-dir/mockery /usr/local/bin/mockery && \
+  chmod +x /usr/local/bin/mockery && \
+  rm -rf mockery-tmp-dir

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -101,7 +101,7 @@ RUN echo "downloading and verifying Codecov uploader" && \
 RUN echo "downloading mockery tool" && \
   mkdir -p mockery-tmp-dir && \
   curl -o mockery-tmp-dir/mockery.tar.gz -sL https://github.com/vektra/mockery/releases/download/v2.28.1/mockery_2.28.1_Linux_x86_64.tar.gz && \
-  tar -xzvf mockery-tmp-dir/mockery.tar.gz && \
+  tar -xzvf mockery-tmp-dir/mockery.tar.gz -C mockery-tmp-dir && \
   cp mockery-tmp-dir/mockery /usr/local/bin/mockery && \
   chmod +x /usr/local/bin/mockery && \
   rm -rf mockery-tmp-dir


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds the `mockery` tool to the `ci-builder` docker container. See https://github.com/ethereum-optimism/optimism/pull/5839 for PR that introduces usage of `mockery` in CI.

**Tests**

N/A

**Invariants**

N/A

**Additional context**

❓How do I go about adding this to the [CHANGELOG.md](https://github.com/ethereum-optimism/optimism/blob/develop/ops/docker/ci-builder/CHANGELOG.md) file? Seems like it was autogenerated in the previous change but it wasn't clear to me where/how to update that.

**Metadata**

- Unblocks #5839 

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
