### PR TITLE
feat(proxyd): add metric for degraded backend

### DIFF
--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -640,13 +640,13 @@ func TestConsensus(t *testing.T) {
 		defer func() { nodes["node1"].mockBackend.handler = oldHandler }()
 
 		nodes["node1"].mockBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			oldHandler.ServeHTTP(w, r)
 		}))
 
 		update()
 
-		// send 10 requests - so the latency window should be at ~100ms
+		// send 10 requests to make node1 degraded
 		numberReqs := 10
 		for numberReqs > 0 {
 			_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"0x101", false})
@@ -676,8 +676,8 @@ func TestConsensus(t *testing.T) {
 
 		msg := fmt.Sprintf("n1 %d, n2 %d",
 			len(nodes["node1"].mockBackend.Requests()), len(nodes["node2"].mockBackend.Requests()))
-		require.Equal(t, len(nodes["node1"].mockBackend.Requests()), 0, msg)
-		require.Equal(t, len(nodes["node2"].mockBackend.Requests()), 10, msg)
+		require.Equal(t, 0, len(nodes["node1"].mockBackend.Requests()), msg)
+		require.Equal(t, 10, len(nodes["node2"].mockBackend.Requests()), msg)
 	})
 
 	t.Run("rewrite response of eth_blockNumber", func(t *testing.T) {

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -628,6 +629,55 @@ func TestConsensus(t *testing.T) {
 			len(nodes["node1"].mockBackend.Requests()), len(nodes["node2"].mockBackend.Requests()))
 		require.Equal(t, len(nodes["node1"].mockBackend.Requests()), 10, msg)
 		require.Equal(t, len(nodes["node2"].mockBackend.Requests()), 0, msg)
+	})
+
+	t.Run("load balancing should not hit if node is degraded", func(t *testing.T) {
+		reset()
+		useOnlyNode1()
+
+		// replace node1 handler with one that adds a 100ms delay
+		oldHandler := nodes["node1"].mockBackend.handler
+		defer func() { nodes["node1"].mockBackend.handler = oldHandler }()
+
+		nodes["node1"].mockBackend.SetHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			oldHandler.ServeHTTP(w, r)
+		}))
+
+		update()
+
+		// send 10 requests - so the latency window should be at ~100ms
+		numberReqs := 10
+		for numberReqs > 0 {
+			_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"0x101", false})
+			require.NoError(t, err)
+			require.Equal(t, 200, statusCode)
+			numberReqs--
+		}
+
+		// bring back node2
+		nodes["node2"].handler.ResetOverrides()
+		update()
+
+		// reset request counts
+		nodes["node1"].mockBackend.Reset()
+		nodes["node2"].mockBackend.Reset()
+
+		require.Equal(t, 0, len(nodes["node1"].mockBackend.Requests()))
+		require.Equal(t, 0, len(nodes["node2"].mockBackend.Requests()))
+
+		numberReqs = 10
+		for numberReqs > 0 {
+			_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"0x101", false})
+			require.NoError(t, err)
+			require.Equal(t, 200, statusCode)
+			numberReqs--
+		}
+
+		msg := fmt.Sprintf("n1 %d, n2 %d",
+			len(nodes["node1"].mockBackend.Requests()), len(nodes["node2"].mockBackend.Requests()))
+		require.Equal(t, len(nodes["node1"].mockBackend.Requests()), 0, msg)
+		require.Equal(t, len(nodes["node2"].mockBackend.Requests()), 10, msg)
 	})
 
 	t.Run("rewrite response of eth_blockNumber", func(t *testing.T) {

--- a/proxyd/integration_tests/consensus_test.go
+++ b/proxyd/integration_tests/consensus_test.go
@@ -635,7 +635,7 @@ func TestConsensus(t *testing.T) {
 		reset()
 		useOnlyNode1()
 
-		// replace node1 handler with one that adds a 100ms delay
+		// replace node1 handler with one that adds a 500ms delay
 		oldHandler := nodes["node1"].mockBackend.handler
 		defer func() { nodes["node1"].mockBackend.handler = oldHandler }()
 

--- a/proxyd/integration_tests/testdata/consensus.toml
+++ b/proxyd/integration_tests/testdata/consensus.toml
@@ -3,6 +3,7 @@ rpc_port = 8545
 
 [backend]
 response_timeout_seconds = 1
+max_degraded_latency_threshold = "30ms"
 
 [backends]
 [backends.node1]

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -358,6 +358,14 @@ var (
 		"backend_name",
 	})
 
+	degradedBackends = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Name:      "backend_degraded",
+		Help:      "Bool gauge for degraded backends",
+	}, []string{
+		"backend_name",
+	})
+
 	networkErrorRateBackend = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "backend_error_rate",
@@ -493,6 +501,7 @@ func RecordConsensusBackendUpdateDelay(b *Backend, lastUpdate time.Time) {
 
 func RecordBackendNetworkLatencyAverageSlidingWindow(b *Backend, avgLatency time.Duration) {
 	avgLatencyBackend.WithLabelValues(b.Name).Set(float64(avgLatency.Milliseconds()))
+	degradedBackends.WithLabelValues(b.Name).Set(boolToFloat64(b.IsDegraded()))
 }
 
 func RecordBackendNetworkErrorRateSlidingWindow(b *Backend, rate float64) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change adds a new metric to track degraded backends.

**Additional context**

https://www.notion.so/oplabs/Consensus-Aware-RPC-Proxy-0138e029af814e4cbca2740c7888e02d

**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate. -- not applicable

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
