### PR TITLE
op-wheel: add cheat code command

### DIFF
--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
@@ -379,9 +380,9 @@ func SetBalance(addr common.Address, amount *big.Int) HeadFn {
 	}
 }
 
-func SetCode(addr common.Address, code string) HeadFn {
+func SetCode(addr common.Address, code hexutil.Bytes) HeadFn {
 	return func(headState *state.StateDB) error {
-		headState.SetCode(addr, common.FromHex(code))
+		headState.SetCode(addr, code)
 		return nil
 	}
 }

--- a/op-wheel/cheat/cheat.go
+++ b/op-wheel/cheat/cheat.go
@@ -379,6 +379,13 @@ func SetBalance(addr common.Address, amount *big.Int) HeadFn {
 	}
 }
 
+func SetCode(addr common.Address, code string) HeadFn {
+	return func(headState *state.StateDB) error {
+		headState.SetCode(addr, common.FromHex(code))
+		return nil
+	}
+}
+
 func SetNonce(addr common.Address, nonce uint64) HeadFn {
 	return func(headState *state.StateDB) error {
 		headState.SetNonce(addr, nonce)

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -179,6 +180,10 @@ func addrFlag(name string, usage string) cli.GenericFlag {
 	return textFlag[*common.Address](name, usage, new(common.Address))
 }
 
+func bytesFlag(name string, usage string) cli.GenericFlag {
+	return textFlag[*hexutil.Bytes](name, usage, new(hexutil.Bytes))
+}
+
 func hashFlag(name string, usage string) cli.GenericFlag {
 	return textFlag[*common.Hash](name, usage, new(common.Hash))
 }
@@ -189,6 +194,10 @@ func bigFlag(name string, usage string) cli.GenericFlag {
 
 func addrFlagValue(name string, ctx *cli.Context) common.Address {
 	return *ctx.Generic(name).(*TextFlag[*common.Address]).Value
+}
+
+func bytesFlagValue(name string, ctx *cli.Context) hexutil.Bytes {
+	return *ctx.Generic(name).(*TextFlag[*hexutil.Bytes]).Value
 }
 
 func hashFlagValue(name string, ctx *cli.Context) common.Hash {
@@ -276,10 +285,10 @@ var (
 		Flags: []cli.Flag{
 			DataDirFlag,
 			addrFlag("address", "Address to change code of"),
-			cli.StringFlag{Name: "code", Usage: "New code of the account"},
+			bytesFlag("code", "New code of the account"),
 		},
 		Action: CheatAction(false, func(ctx *cli.Context, ch *cheat.Cheater) error {
-			return ch.RunAndClose(cheat.SetCode(addrFlagValue("address", ctx), ctx.String("code")))
+			return ch.RunAndClose(cheat.SetCode(addrFlagValue("address", ctx), bytesFlagValue("code", ctx)))
 		}),
 	}
 	CheatSetNonceCmd = cli.Command{

--- a/op-wheel/commands.go
+++ b/op-wheel/commands.go
@@ -271,6 +271,17 @@ var (
 			return ch.RunAndClose(cheat.SetBalance(addrFlagValue("address", ctx), bigFlagValue("balance", ctx)))
 		}),
 	}
+	CheatSetCodeCmd = cli.Command{
+		Name: "code",
+		Flags: []cli.Flag{
+			DataDirFlag,
+			addrFlag("address", "Address to change code of"),
+			cli.StringFlag{Name: "code", Usage: "New code of the account"},
+		},
+		Action: CheatAction(false, func(ctx *cli.Context, ch *cheat.Cheater) error {
+			return ch.RunAndClose(cheat.SetCode(addrFlagValue("address", ctx), ctx.String("code")))
+		}),
+	}
 	CheatSetNonceCmd = cli.Command{
 		Name: "nonce",
 		Flags: []cli.Flag{
@@ -440,6 +451,7 @@ var CheatCmd = cli.Command{
 	Subcommands: []cli.Command{
 		CheatStorageCmd,
 		CheatSetBalanceCmd,
+		CheatSetCodeCmd,
 		CheatSetNonceCmd,
 		CheatOvmOwnersCmd,
 		CheatPrintHeadBlock,


### PR DESCRIPTION
**Description**

Allows it to set into the state arbitrary code at an arbitrary account. This will make it very easy to patch contracts that contain immutables. Then we can patch the contracts to have different immutables without needing to update the proxies and worry about that.

We can also cheat the impl of the multisig to be a call forwarder so that we do not need to cheat so many storage slots and forget about particular slots.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

