### PR TITLE
contracts-bedrock: Convert Echidna tests to Forge invariants for OptimismPortal

### DIFF
--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -50,8 +50,7 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
         bool _isCreation,
         bytes memory _data
     ) public payable {
-        vm.assume(_isCreation == false || _to == address(0));
-        require(!_isCreation || _to == address(0), "OptimismPortal_Depositor: invalid test case.");
+        vm.assume((!_isCreation || _to == address(0)) && _data.length <= 120_000);
 
         uint256 preDepositvalue = bound(_value, 0, type(uint128).max);
         // Give the depositor some ether
@@ -70,8 +69,6 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
                 maxResourceLimit - cachedPrevBoughtGas
             )
         );
-
-        vm.assume(_data.length <= 120_000);
 
         try portal.depositTransaction{ value: value }(_to, value, gasLimit, _isCreation, _data) {
             // Do nothing; Call succeeded

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -27,10 +27,12 @@ contract OptimismPortal_Depositor {
         bool _isCreation,
         bytes memory _data
     ) public payable {
-        failedToComplete = true;
         require(!_isCreation || _to == address(0), "OptimismPortal_Depositor: invalid test case.");
-        portal.depositTransaction{ value: _mint }(_to, _value, _gasLimit, _isCreation, _data);
-        failedToComplete = false;
+        try portal.depositTransaction{ value: _mint }(_to, _value, _gasLimit, _isCreation, _data) {
+            // Do nothing; Call succeeded
+        } catch {
+            failedToComplete = true;
+        }
     }
 }
 

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -75,7 +75,6 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
 
         try portal.depositTransaction{ value: value }(_to, value, gasLimit, _isCreation, _data) {
             // Do nothing; Call succeeded
-            // failedToComplete = false;
         } catch {
             failedToComplete = true;
         }

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -32,9 +32,7 @@ contract OptimismPortal_Depositor {
         portal.depositTransaction{ value: _mint }(_to, _value, _gasLimit, _isCreation, _data);
         failedToComplete = false;
     }
-
 }
-
 
 contract OptimismPortal_Invariant_Harness is Portal_Initializer {
     // Reusable default values for a test withdrawal

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -1,5 +1,8 @@
 pragma solidity 0.8.15;
 
+import { StdUtils } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Vm.sol";
+
 import { OptimismPortal } from "../../L1/OptimismPortal.sol";
 import { L2OutputOracle } from "../../L1/L2OutputOracle.sol";
 import { AddressAliasHelper } from "../../vendor/AddressAliasHelper.sol";
@@ -10,26 +13,58 @@ import { Constants } from "../../libraries/Constants.sol";
 import { Portal_Initializer } from "../CommonTest.t.sol";
 import { Types } from "../../libraries/Types.sol";
 
-contract OptimismPortal_Depositor {
+contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
+    Vm internal vm;
     OptimismPortal internal portal;
     bool public failedToComplete;
 
-    constructor(OptimismPortal _portal) {
+    constructor(Vm _vm, OptimismPortal _portal) {
+        vm = _vm;
         portal = _portal;
+        initialize();
+    }
+
+    function initialize() internal initializer {
+        __ResourceMetering_init();
+    }
+
+    function resourceConfig() public pure returns (ResourceMetering.ResourceConfig memory) {
+        return _resourceConfig();
+    }
+
+    function _resourceConfig() internal pure override returns (ResourceMetering.ResourceConfig memory) {
+        ResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
+        return rcfg;
     }
 
     // A test intended to identify any unexpected halting conditions
     function depositTransactionCompletes(
         address _to,
-        uint256 _mint,
         uint256 _value,
         uint64 _gasLimit,
         bool _isCreation,
         bytes memory _data
     ) public payable {
+        vm.assume(_isCreation == false || _to == address(0));
         require(!_isCreation || _to == address(0), "OptimismPortal_Depositor: invalid test case.");
-        try portal.depositTransaction{ value: _mint }(_to, _value, _gasLimit, _isCreation, _data) {
+
+        uint256 preDepositvalue = bound(_value, 0, type(uint128).max);
+        // Give the depositor some ether
+        vm.deal(address(this), preDepositvalue);
+        // cache the contract's eth balance
+        uint256 preDepositBalance = address(this).balance;
+        uint256 value = bound(preDepositvalue, 0, preDepositBalance);
+
+       (,uint64 cachedPrevBoughtGas,) =  ResourceMetering(address(portal)).params();
+        ResourceMetering.ResourceConfig memory rcfg = resourceConfig();
+        uint256 maxResourceLimit = uint64(rcfg.maxResourceLimit);
+        uint64 gasLimit = uint64(bound(_gasLimit, portal.minimumGasLimit(uint64(_data.length)), maxResourceLimit - cachedPrevBoughtGas));
+
+        vm.assume(_data.length <= 120_000);
+
+        try portal.depositTransaction{ value: value }(_to, value, gasLimit, _isCreation, _data) {
             // Do nothing; Call succeeded
+            // failedToComplete = false;
         } catch {
             failedToComplete = true;
         }
@@ -96,7 +131,7 @@ contract OptimismPortal_Deposit_Invariant is Portal_Initializer {
     function setUp() public override {
         super.setUp();
         // Create a deposit actor.
-        actor = new OptimismPortal_Depositor(op);
+        actor = new OptimismPortal_Depositor(vm,op);
 
         targetContract(address(actor));
 

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -1,7 +1,40 @@
 pragma solidity 0.8.15;
 
+import { OptimismPortal } from "../../L1/OptimismPortal.sol";
+import { L2OutputOracle } from "../../L1/L2OutputOracle.sol";
+import { AddressAliasHelper } from "../../vendor/AddressAliasHelper.sol";
+import { SystemConfig } from "../../L1/SystemConfig.sol";
+import { ResourceMetering } from "../../L1/ResourceMetering.sol";
+import { Constants } from "../../libraries/Constants.sol";
+
 import { Portal_Initializer } from "../CommonTest.t.sol";
 import { Types } from "../../libraries/Types.sol";
+
+contract OptimismPortal_Depositor {
+    OptimismPortal internal portal;
+    bool public failedToComplete;
+
+    constructor(OptimismPortal _portal) {
+        portal = _portal;
+    }
+
+    // A test intended to identify any unexpected halting conditions
+    function depositTransactionCompletes(
+        address _to,
+        uint256 _mint,
+        uint256 _value,
+        uint64 _gasLimit,
+        bool _isCreation,
+        bytes memory _data
+    ) public payable {
+        failedToComplete = true;
+        require(!_isCreation || _to == address(0), "OptimismPortal_Depositor: invalid test case.");
+        portal.depositTransaction{ value: _mint }(_to, _value, _gasLimit, _isCreation, _data);
+        failedToComplete = false;
+    }
+
+}
+
 
 contract OptimismPortal_Invariant_Harness is Portal_Initializer {
     // Reusable default values for a test withdrawal
@@ -54,6 +87,34 @@ contract OptimismPortal_Invariant_Harness is Portal_Initializer {
         );
         // Fund the portal so that we can withdraw ETH.
         vm.deal(address(op), 0xFFFFFFFF);
+    }
+}
+
+contract OptimismPortal_Deposit_Invariant is Portal_Initializer {
+    OptimismPortal_Depositor internal actor;
+
+    function setUp() public override {
+        super.setUp();
+        // Create a deposit actor.
+        actor = new OptimismPortal_Depositor(op);
+
+        targetContract(address(actor));
+
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = actor.depositTransactionCompletes.selector;
+        FuzzSelector memory selector = FuzzSelector({ addr: address(actor), selectors: selectors });
+        targetSelector(selector);
+    }
+
+    /**
+     * @custom:invariant Deposits of any value should always succeed unless
+     * `_to` = `address(0)` or `_isCreation` = `true`.
+     *
+     * All deposits, barring creation transactions and transactions sent to `address(0)`,
+     * should always succeed.
+     */
+    function invariant_deposit_completes() external {
+        assertEq(actor.failedToComplete(), false);
     }
 }
 

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -32,7 +32,12 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
         return _resourceConfig();
     }
 
-    function _resourceConfig() internal pure override returns (ResourceMetering.ResourceConfig memory) {
+    function _resourceConfig()
+        internal
+        pure
+        override
+        returns (ResourceMetering.ResourceConfig memory)
+    {
         ResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
         return rcfg;
     }
@@ -55,10 +60,16 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
         uint256 preDepositBalance = address(this).balance;
         uint256 value = bound(preDepositvalue, 0, preDepositBalance);
 
-       (,uint64 cachedPrevBoughtGas,) =  ResourceMetering(address(portal)).params();
+        (, uint64 cachedPrevBoughtGas, ) = ResourceMetering(address(portal)).params();
         ResourceMetering.ResourceConfig memory rcfg = resourceConfig();
         uint256 maxResourceLimit = uint64(rcfg.maxResourceLimit);
-        uint64 gasLimit = uint64(bound(_gasLimit, portal.minimumGasLimit(uint64(_data.length)), maxResourceLimit - cachedPrevBoughtGas));
+        uint64 gasLimit = uint64(
+            bound(
+                _gasLimit,
+                portal.minimumGasLimit(uint64(_data.length)),
+                maxResourceLimit - cachedPrevBoughtGas
+            )
+        );
 
         vm.assume(_data.length <= 120_000);
 
@@ -131,7 +142,7 @@ contract OptimismPortal_Deposit_Invariant is Portal_Initializer {
     function setUp() public override {
         super.setUp();
         // Create a deposit actor.
-        actor = new OptimismPortal_Depositor(vm,op);
+        actor = new OptimismPortal_Depositor(vm, op);
 
         targetContract(address(actor));
 

--- a/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
+++ b/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
@@ -1,25 +1,25 @@
 # `OptimismPortal` Invariants
 
 ## Deposits of any value should always succeed unless `_to` = `address(0)` or `_isCreation` = `true`.
-**Test:** [`OptimismPortal.t.sol#L162`](../contracts/test/invariants/OptimismPortal.t.sol#L162)
+**Test:** [`OptimismPortal.t.sol#L158`](../contracts/test/invariants/OptimismPortal.t.sol#L158)
 
 All deposits, barring creation transactions and transactions sent to `address(0)`, should always succeed. 
 
 
 ## `finalizeWithdrawalTransaction` should revert if the finalization period has not elapsed.
-**Test:** [`OptimismPortal.t.sol#L192`](../contracts/test/invariants/OptimismPortal.t.sol#L192)
+**Test:** [`OptimismPortal.t.sol#L188`](../contracts/test/invariants/OptimismPortal.t.sol#L188)
 
 A withdrawal that has been proven should not be able to be finalized until after the finalization period has elapsed. 
 
 
 ## `finalizeWithdrawalTransaction` should revert if the withdrawal has already been finalized.
-**Test:** [`OptimismPortal.t.sol#L229`](../contracts/test/invariants/OptimismPortal.t.sol#L229)
+**Test:** [`OptimismPortal.t.sol#L225`](../contracts/test/invariants/OptimismPortal.t.sol#L225)
 
 Ensures that there is no chain of calls that can be made that allows a withdrawal to be finalized twice. 
 
 
 ## A withdrawal should **always** be able to be finalized `FINALIZATION_PERIOD_SECONDS` after it was successfully proven.
-**Test:** [`OptimismPortal.t.sol#L264`](../contracts/test/invariants/OptimismPortal.t.sol#L264)
+**Test:** [`OptimismPortal.t.sol#L260`](../contracts/test/invariants/OptimismPortal.t.sol#L260)
 
 This invariant asserts that there is no chain of calls that can be made that will prevent a withdrawal from being finalized exactly `FINALIZATION_PERIOD_SECONDS` after it was successfully proven. 
 

--- a/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
+++ b/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
@@ -1,25 +1,25 @@
 # `OptimismPortal` Invariants
 
 ## Deposits of any value should always succeed unless `_to` = `address(0)` or `_isCreation` = `true`.
-**Test:** [`OptimismPortal.t.sol#L114`](../contracts/test/invariants/OptimismPortal.t.sol#L114)
+**Test:** [`OptimismPortal.t.sol#L162`](../contracts/test/invariants/OptimismPortal.t.sol#L162)
 
 All deposits, barring creation transactions and transactions sent to `address(0)`, should always succeed. 
 
 
 ## `finalizeWithdrawalTransaction` should revert if the finalization period has not elapsed.
-**Test:** [`OptimismPortal.t.sol#L144`](../contracts/test/invariants/OptimismPortal.t.sol#L144)
+**Test:** [`OptimismPortal.t.sol#L192`](../contracts/test/invariants/OptimismPortal.t.sol#L192)
 
 A withdrawal that has been proven should not be able to be finalized until after the finalization period has elapsed. 
 
 
 ## `finalizeWithdrawalTransaction` should revert if the withdrawal has already been finalized.
-**Test:** [`OptimismPortal.t.sol#L181`](../contracts/test/invariants/OptimismPortal.t.sol#L181)
+**Test:** [`OptimismPortal.t.sol#L229`](../contracts/test/invariants/OptimismPortal.t.sol#L229)
 
 Ensures that there is no chain of calls that can be made that allows a withdrawal to be finalized twice. 
 
 
 ## A withdrawal should **always** be able to be finalized `FINALIZATION_PERIOD_SECONDS` after it was successfully proven.
-**Test:** [`OptimismPortal.t.sol#L216`](../contracts/test/invariants/OptimismPortal.t.sol#L216)
+**Test:** [`OptimismPortal.t.sol#L264`](../contracts/test/invariants/OptimismPortal.t.sol#L264)
 
 This invariant asserts that there is no chain of calls that can be made that will prevent a withdrawal from being finalized exactly `FINALIZATION_PERIOD_SECONDS` after it was successfully proven. 
 

--- a/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
+++ b/packages/contracts-bedrock/invariant-docs/OptimismPortal.md
@@ -1,19 +1,25 @@
 # `OptimismPortal` Invariants
 
+## Deposits of any value should always succeed unless `_to` = `address(0)` or `_isCreation` = `true`.
+**Test:** [`OptimismPortal.t.sol#L114`](../contracts/test/invariants/OptimismPortal.t.sol#L114)
+
+All deposits, barring creation transactions and transactions sent to `address(0)`, should always succeed. 
+
+
 ## `finalizeWithdrawalTransaction` should revert if the finalization period has not elapsed.
-**Test:** [`OptimismPortal.t.sol#L85`](../contracts/test/invariants/OptimismPortal.t.sol#L85)
+**Test:** [`OptimismPortal.t.sol#L144`](../contracts/test/invariants/OptimismPortal.t.sol#L144)
 
 A withdrawal that has been proven should not be able to be finalized until after the finalization period has elapsed. 
 
 
 ## `finalizeWithdrawalTransaction` should revert if the withdrawal has already been finalized.
-**Test:** [`OptimismPortal.t.sol#L122`](../contracts/test/invariants/OptimismPortal.t.sol#L122)
+**Test:** [`OptimismPortal.t.sol#L181`](../contracts/test/invariants/OptimismPortal.t.sol#L181)
 
 Ensures that there is no chain of calls that can be made that allows a withdrawal to be finalized twice. 
 
 
 ## A withdrawal should **always** be able to be finalized `FINALIZATION_PERIOD_SECONDS` after it was successfully proven.
-**Test:** [`OptimismPortal.t.sol#L157`](../contracts/test/invariants/OptimismPortal.t.sol#L157)
+**Test:** [`OptimismPortal.t.sol#L216`](../contracts/test/invariants/OptimismPortal.t.sol#L216)
 
 This invariant asserts that there is no chain of calls that can be made that will prevent a withdrawal from being finalized exactly `FINALIZATION_PERIOD_SECONDS` after it was successfully proven. 
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I have converted deposit logics in  `EchidnaFuzzOptimismPortal.sol` and added those ported ones into `OptimismPortal.t.sol` invariant  file.


**Additional context**

- https://github.com/ethereum-optimism/ecosystem-contributions/issues/49

**Metadata**

- Fixes #[Convert Echidna tests to Forge invariantes #4980] 

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
