### PR TITLE
Update derivation.md

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -107,7 +107,7 @@ To derive the L2 blocks in an epoch `E`, we need the following inputs:
   is the sequencing window size (note that this means that epochs are overlapping). In particular, we need:
   - The [batcher transactions][g-batcher-transaction] included in the sequencing window. These allow us to
       reconstruct [sequencer batches][g-sequencer-batch] containing the transactions to include in L2 blocks (each batch
-      maps to a single L2 block).
+      maps to multiple L2 blocks).
     - Note that it is impossible to have a batcher transaction containing a batch relative to epoch `E` on L1 block
         `E`, as the batch must contain the hash of L1 block `E`.
   - The [deposits][g-deposits] made in L1 block `E` (in the form of events emitted by the [deposit

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -107,7 +107,7 @@ To derive the L2 blocks in an epoch `E`, we need the following inputs:
   is the sequencing window size (note that this means that epochs are overlapping). In particular, we need:
   - The [batcher transactions][g-batcher-transaction] included in the sequencing window. These allow us to
       reconstruct [sequencer batches][g-sequencer-batch] containing the transactions to include in L2 blocks (each batch
-      maps to multiple L2 blocks).
+      contains a list of L2 blocks).
     - Note that it is impossible to have a batcher transaction containing a batch relative to epoch `E` on L1 block
         `E`, as the batch must contain the hash of L1 block `E`.
   - The [deposits][g-deposits] made in L1 block `E` (in the form of events emitted by the [deposit


### PR DESCRIPTION
In the existing implementation, it seems that a batch corresponds to multiple L2 blocks.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
I have reviewed the following two links. In the current implementation, there is only one transaction per block, and a batch contains multiple transactions. Therefore, a batch corresponds to multiple L2 blocks. The statement in the documentation, 'each batch maps to a single L2 block,' is incorrect.
https://optimistic.etherscan.io/blocks
https://optimistic.etherscan.io/batch/839397
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
