### PR TITLE
op-batcher: Add metrics for pending L2 transaction data size

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -228,6 +228,7 @@ func (s *channelManager) processBlocks() error {
 		}
 		blocksAdded += 1
 		latestL2ref = l2BlockRefFromBlockAndL1Info(block, l1info)
+		s.metr.RecordL2BlockInChannel(block)
 		// current block got added but channel is now full
 		if s.currentChannel.IsFull() {
 			break
@@ -298,6 +299,8 @@ func (s *channelManager) AddL2Block(block *types.Block) error {
 	if s.tip != (common.Hash{}) && s.tip != block.ParentHash() {
 		return ErrReorg
 	}
+
+	s.metr.RecordL2BlockInPendingQueue(block)
 	s.blocks = append(s.blocks, block)
 	s.tip = block.Hash()
 

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type noopMetrics struct {
@@ -23,6 +24,8 @@ func (*noopMetrics) RecordLatestL1Block(l1ref eth.L1BlockRef)               {}
 func (*noopMetrics) RecordL2BlocksLoaded(eth.L2BlockRef)                    {}
 func (*noopMetrics) RecordChannelOpened(derive.ChannelID, int)              {}
 func (*noopMetrics) RecordL2BlocksAdded(eth.L2BlockRef, int, int, int, int) {}
+func (*noopMetrics) RecordL2BlockInPendingQueue(*types.Block)               {}
+func (*noopMetrics) RecordL2BlockInChannel(*types.Block)                    {}
 
 func (*noopMetrics) RecordChannelClosed(derive.ChannelID, int, int, int, int, error) {}
 


### PR DESCRIPTION
**Description**

Same as the previous version. Has been tested on the internal devnet.
