### PR TITLE
fix(docs): remove breadcrumbs

### DIFF
--- a/docs/op-stack/src/.vuepress/styles/index.styl
+++ b/docs/op-stack/src/.vuepress/styles/index.styl
@@ -315,3 +315,7 @@ div.theme-container:not(.has-sidebar) {
 .color-ecosystem {
   color: #ea94db;
 }
+
+.page .page-title h1 {
+  margin-top: -1.9rem !important;
+}

--- a/docs/op-stack/src/.vuepress/theme/components/Page.vue
+++ b/docs/op-stack/src/.vuepress/theme/components/Page.vue
@@ -1,7 +1,5 @@
 <template>
   <main class="page">
-    <BreadCrumb :key="$route.path" />
-
     <slot name="top" />
 
     <PageInfo :key="$route.path" />


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Removes breadcrumbs from the docs for now. Was causing a loading issue that would crash the sidebar.