### PR TITLE
Allow validating RPC calls with an external service

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -124,22 +124,30 @@ type SenderRateLimitConfig struct {
 	Limit    int
 }
 
+type ExternalRPCValidatorConfig struct {
+	Enabled   bool   `toml:"enabled"`
+	URL       string `toml:"url"`
+	TimeoutMs int    `toml:"timeout_ms"`
+	FailOpen  bool   `toml:"fail_open"`
+}
+
 type Config struct {
-	WSBackendGroup        string                `toml:"ws_backend_group"`
-	Server                ServerConfig          `toml:"server"`
-	Cache                 CacheConfig           `toml:"cache"`
-	Redis                 RedisConfig           `toml:"redis"`
-	Metrics               MetricsConfig         `toml:"metrics"`
-	RateLimit             RateLimitConfig       `toml:"rate_limit"`
-	BackendOptions        BackendOptions        `toml:"backend"`
-	Backends              BackendsConfig        `toml:"backends"`
-	BatchConfig           BatchConfig           `toml:"batch"`
-	Authentication        map[string]string     `toml:"authentication"`
-	BackendGroups         BackendGroupsConfig   `toml:"backend_groups"`
-	RPCMethodMappings     map[string]string     `toml:"rpc_method_mappings"`
-	WSMethodWhitelist     []string              `toml:"ws_method_whitelist"`
-	WhitelistErrorMessage string                `toml:"whitelist_error_message"`
-	SenderRateLimit       SenderRateLimitConfig `toml:"sender_rate_limit"`
+	WSBackendGroup        string                     `toml:"ws_backend_group"`
+	Server                ServerConfig               `toml:"server"`
+	Cache                 CacheConfig                `toml:"cache"`
+	Redis                 RedisConfig                `toml:"redis"`
+	Metrics               MetricsConfig              `toml:"metrics"`
+	RateLimit             RateLimitConfig            `toml:"rate_limit"`
+	BackendOptions        BackendOptions             `toml:"backend"`
+	Backends              BackendsConfig             `toml:"backends"`
+	BatchConfig           BatchConfig                `toml:"batch"`
+	Authentication        map[string]string          `toml:"authentication"`
+	BackendGroups         BackendGroupsConfig        `toml:"backend_groups"`
+	RPCMethodMappings     map[string]string          `toml:"rpc_method_mappings"`
+	WSMethodWhitelist     []string                   `toml:"ws_method_whitelist"`
+	WhitelistErrorMessage string                     `toml:"whitelist_error_message"`
+	SenderRateLimit       SenderRateLimitConfig      `toml:"sender_rate_limit"`
+	ExternalRPCValidator  ExternalRPCValidatorConfig `toml:"external_rpc_validator"`
 }
 
 func ReadFromEnvOrConfig(value string) (string, error) {

--- a/proxyd/integration_tests/testdata/external_validator.toml
+++ b/proxyd/integration_tests/testdata/external_validator.toml
@@ -1,0 +1,23 @@
+[server]
+rpc_port = 8545
+
+[external_rpc_validator]
+enabled = true
+url = "localhost:5000"
+timeout_ms = 20
+fail_open = true
+
+[backend]
+response_timeout_seconds = 1
+
+[backends]
+[backends.good]
+rpc_url = "$GOOD_BACKEND_RPC_URL"
+ws_url = "$GOOD_BACKEND_RPC_URL"
+
+[backend_groups]
+[backend_groups.main]
+backends = ["good"]
+
+[rpc_method_mappings]
+eth_chainId = "main"

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -214,6 +214,17 @@ func Start(config *Config) (*Server, func(), error) {
 		rpcCache = newRPCCache(newCacheWithCompression(cache))
 	}
 
+	validators := []RPCValidator{
+		basicRPCValidator{},
+	}
+	if config.ExternalRPCValidator.Enabled {
+		validators = append(validators, newExternalRPCValidator(
+			config.ExternalRPCValidator.URL,
+			config.ExternalRPCValidator.FailOpen,
+			time.Duration(config.ExternalRPCValidator.TimeoutMs),
+		))
+	}
+
 	srv, err := NewServer(
 		backendGroups,
 		wsBackendGroup,
@@ -230,6 +241,7 @@ func Start(config *Config) (*Server, func(), error) {
 		config.Server.MaxRequestBodyLogLen,
 		config.BatchConfig.MaxSize,
 		redisClient,
+		validators,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -116,22 +116,6 @@ func ParseRPCRes(r io.Reader) (*RPCRes, error) {
 	return res, nil
 }
 
-func ValidateRPCReq(req *RPCReq) error {
-	if req.JSONRPC != JSONRPCVersion {
-		return ErrInvalidRequest("invalid JSON-RPC version")
-	}
-
-	if req.Method == "" {
-		return ErrInvalidRequest("no method specified")
-	}
-
-	if !IsValidID(req.ID) {
-		return ErrInvalidRequest("invalid ID")
-	}
-
-	return nil
-}
-
 func NewRPCErrorRes(id json.RawMessage, err error) *RPCRes {
 	var rpcErr *RPCErr
 	if rr, ok := err.(*RPCErr); ok {

--- a/proxyd/validation.go
+++ b/proxyd/validation.go
@@ -1,0 +1,119 @@
+package proxyd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	validationMethod = "validator_isAllowed"
+)
+
+type RPCValidator interface {
+	IsAllowed(ctx context.Context, req *RPCReq) (bool, string)
+}
+
+type externalRPCValidator struct {
+	client *http.Client
+	rpcURL string
+
+	failOpen bool
+}
+
+func newExternalRPCValidator(rpcURL string, failOpen bool, timeout time.Duration) externalRPCValidator {
+	return externalRPCValidator{
+		client:   &http.Client{Timeout: timeout},
+		rpcURL:   rpcURL,
+		failOpen: failOpen,
+	}
+}
+
+func (v externalRPCValidator) IsAllowed(ctx context.Context, req *RPCReq) (bool, string) {
+	rpcRes, err := v.doRequest(ctx, req)
+	if err != nil {
+		log.Warn(
+			"error validating request via external validator",
+			"validation_url", v.rpcURL,
+			"req_id", GetReqID(ctx),
+			"auth", GetAuthCtx(ctx),
+			"err", err,
+		)
+		return v.failOpen, "unable to validate RPC request"
+	}
+
+	jsonRes, ok := rpcRes.Result.(bool)
+	if !ok {
+		log.Warn(
+			"invalid response from external validator",
+			"validation_url", v.rpcURL,
+			"req_id", GetReqID(ctx),
+			"auth", GetAuthCtx(ctx),
+			"err", err,
+		)
+		return v.failOpen, "unable to validate RPC request"
+	}
+	return jsonRes, ""
+}
+
+func (v externalRPCValidator) doRequest(ctx context.Context, req *RPCReq) (*RPCRes, error) {
+	validationReq := RPCReq{
+		JSONRPC: JSONRPCVersion,
+		Method:  validationMethod,
+		ID:      []byte("1"),
+		Params:  mustMarshalJSON(req),
+	}
+
+	body := mustMarshalJSON(validationReq)
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", v.rpcURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("content-type", "application/json")
+	httpRes, err := v.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	if httpRes.StatusCode != 200 {
+		return nil, fmt.Errorf("validation response code %d", httpRes.StatusCode)
+	}
+
+	defer httpRes.Body.Close()
+	resB, err := io.ReadAll(httpRes.Body)
+	if err != nil {
+		return nil, wrapErr(err, "error reading validation response body")
+	}
+
+	var rpcRes *RPCRes
+	if err := json.Unmarshal(resB, &rpcRes); err != nil {
+		return nil, wrapErr(err, "invalid backend response")
+	}
+
+	return rpcRes, nil
+}
+
+type basicRPCValidator struct{}
+
+func (b basicRPCValidator) IsAllowed(ctx context.Context, req *RPCReq) (bool, string) {
+	if req.JSONRPC != JSONRPCVersion {
+		return false, "invalid JSON-RPC version"
+	}
+
+	if req.Method == "" {
+		return false, "no method specified"
+	}
+
+	if !IsValidID(req.ID) {
+		return false, "invalid ID"
+	}
+
+	return true, ""
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
1. Creates interface for RPC validators, that each get called before and RPC is allowed. 
2. Gives proxyd ability to call external validation service. This is a service providing jsonrpc method called `validator_isAllowed`, and returns a boolean on whether or not the rpc is allowed. 

**Tests**
1. Added test for timeout of external validation timeout. Will add more if design is agreed uppon

**Invariants**
none

**Additional context**
Rather than having a second proxy to further validate RPC's, this PR gives proxyd the ability to make a validation rpc call. The method `valiadator_isAllowed` would need to be standardized.

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
