### PR TITLE
op-node: Add scoring for p2p sync request response

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -73,6 +73,15 @@ var (
 		Value:    "none",
 		EnvVar:   p2pEnv("TOPIC_SCORING"),
 	}
+
+	ApplicationScoring = cli.StringFlag{
+		Name: "p2p.scoring.application",
+		Usage: "Sets the application scoring strategy. " +
+			"Can be one of: none or light.",
+		Required: false,
+		Value:    "none",
+		EnvVar:   p2pEnv("APPLICATION_SCORING"),
+	}
 	P2PPrivPath = cli.StringFlag{
 		Name: "p2p.priv.path",
 		Usage: "Read the hex-encoded 32-byte private key for the peer ID from this txt file. Created if not already exists." +
@@ -309,6 +318,7 @@ var p2pFlags = []cli.Flag{
 	BanningThreshold,
 	BanningDuration,
 	TopicScoring,
+	ApplicationScoring,
 	ListenIP,
 	ListenTCPPort,
 	ListenUDPPort,

--- a/op-node/p2p/app_scores.go
+++ b/op-node/p2p/app_scores.go
@@ -1,0 +1,142 @@
+package p2p
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type ApplicationScoreParams struct {
+	ValidResponseCap    float64
+	ValidResponseWeight float64
+	ValidResponseDecay  float64
+
+	ErrorResponseCap    float64
+	ErrorResponseWeight float64
+	ErrorResponseDecay  float64
+
+	RejectedPayloadCap    float64
+	RejectedPayloadWeight float64
+	RejectedPayloadDecay  float64
+
+	DecayToZero float64
+	DecayPeriod time.Duration
+}
+
+// TODO: Validation of params
+// decay must be between 0 and 1
+// rewards must be weighted positive, penalties weighted negative
+
+type scoreBook interface {
+	GetPeerScores(id peer.ID) (store.PeerScores, error)
+	SetScore(id peer.ID, diff store.ScoreDiff) (store.PeerScores, error)
+}
+
+type peerApplicationScorer struct {
+	log            log.Logger
+	clock          clock.Clock
+	params         *ApplicationScoreParams
+	scorebook      scoreBook
+	connectedPeers func() []peer.ID
+
+	done sync.WaitGroup
+}
+
+func newPeerApplicationScorer(logger log.Logger, clock clock.Clock, params *ApplicationScoreParams, scorebook scoreBook, connectedPeers func() []peer.ID) *peerApplicationScorer {
+	return &peerApplicationScorer{
+		log:            logger,
+		clock:          clock,
+		params:         params,
+		scorebook:      scorebook,
+		connectedPeers: connectedPeers,
+	}
+}
+
+func (s *peerApplicationScorer) ApplicationScore(id peer.ID) float64 {
+	scores, err := s.scorebook.GetPeerScores(id)
+	if err != nil {
+		s.log.Error("Failed to load peer scores", "peer", id, "err", err)
+		return 0
+	}
+	score := scores.ReqResp.ValidResponses * s.params.ValidResponseWeight
+	score += scores.ReqResp.ErrorResponses * s.params.ErrorResponseWeight
+	score += scores.ReqResp.RejectedPayloads * s.params.RejectedPayloadWeight
+	return score
+}
+
+func (s *peerApplicationScorer) onValidResponse(id peer.ID) {
+	_, err := s.scorebook.SetScore(id, store.NewReqRespScoresDiff(func(target *store.ReqRespScores) {
+		target.ValidResponses = math.Min(target.ValidResponses+1, s.params.ValidResponseCap)
+	}))
+	if err != nil {
+		s.log.Error("Unable to update peer score", "peer", id, "err", err)
+		return
+	}
+}
+
+func (s *peerApplicationScorer) onResponseError(id peer.ID) {
+	_, err := s.scorebook.SetScore(id, store.NewReqRespScoresDiff(func(target *store.ReqRespScores) {
+		target.ErrorResponses = math.Min(target.ErrorResponses+1, s.params.ErrorResponseCap)
+	}))
+	if err != nil {
+		s.log.Error("Unable to update peer score", "peer", id, "err", err)
+		return
+	}
+}
+
+func (s *peerApplicationScorer) onRejectedPayload(id peer.ID) {
+	_, err := s.scorebook.SetScore(id, store.NewReqRespScoresDiff(func(target *store.ReqRespScores) {
+		target.RejectedPayloads = math.Min(target.RejectedPayloads+1, s.params.RejectedPayloadCap)
+	}))
+	if err != nil {
+		s.log.Error("Unable to update peer score", "peer", id, "err", err)
+		return
+	}
+}
+
+func (s *peerApplicationScorer) decayScores(id peer.ID) {
+	decay := func(value float64, decay float64) float64 {
+		value *= decay
+		if value < s.params.DecayToZero {
+			return 0
+		}
+		return value
+	}
+	_, err := s.scorebook.SetScore(id, store.NewReqRespScoresDiff(func(target *store.ReqRespScores) {
+		target.ValidResponses = decay(target.ValidResponses, s.params.ValidResponseDecay)
+		target.ErrorResponses = decay(target.ErrorResponses, s.params.ErrorResponseDecay)
+		target.RejectedPayloads = decay(target.RejectedPayloads, s.params.RejectedPayloadDecay)
+	}))
+	if err != nil {
+		s.log.Error("Unable to decay peer score", "peer", id, "err", err)
+		return
+	}
+}
+
+func (s *peerApplicationScorer) decayConnectedPeerScores() {
+	for _, id := range s.connectedPeers() {
+		s.decayScores(id)
+	}
+}
+
+func (s *peerApplicationScorer) start(ctx context.Context) {
+	s.done.Add(1)
+	go func() {
+		defer s.done.Done()
+		ticker := s.clock.NewTicker(s.params.DecayPeriod)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.Ch():
+				s.decayConnectedPeerScores()
+			}
+		}
+	}()
+}

--- a/op-node/p2p/application_params.go
+++ b/op-node/p2p/application_params.go
@@ -1,0 +1,73 @@
+package p2p
+
+import (
+	"fmt"
+	"time"
+)
+
+var LightApplicationScoreParams = func(blockTime uint64) ApplicationScoreParams {
+	slot := time.Duration(blockTime) * time.Second
+	if slot == 0 {
+		slot = 2 * time.Second
+	}
+	// We initialize an "epoch" as 6 blocks suggesting 6 blocks,
+	// each taking ~ 2 seconds, is 12 seconds
+	epoch := 6 * slot
+	tenEpochs := 10 * epoch
+	return ApplicationScoreParams{
+		ValidResponseCap:      10,
+		ValidResponseWeight:   1,
+		ValidResponseDecay:    ScoreDecay(tenEpochs, slot),
+		ErrorResponseCap:      10,
+		ErrorResponseWeight:   -16,
+		ErrorResponseDecay:    ScoreDecay(tenEpochs, slot),
+		RejectedPayloadCap:    10,
+		RejectedPayloadWeight: -50,
+		RejectedPayloadDecay:  ScoreDecay(tenEpochs, slot),
+		DecayToZero:           DecayToZero,
+		DecayPeriod:           slot,
+	}
+}
+
+var DisabledApplicationScoreParams = func(blockTime uint64) ApplicationScoreParams {
+	slot := time.Duration(blockTime) * time.Second
+	return ApplicationScoreParams{
+		ValidResponseCap:      0,
+		ValidResponseWeight:   0,
+		ValidResponseDecay:    0,
+		ErrorResponseCap:      0,
+		ErrorResponseWeight:   0,
+		ErrorResponseDecay:    0,
+		RejectedPayloadCap:    0,
+		RejectedPayloadWeight: 0,
+		RejectedPayloadDecay:  0,
+		DecayToZero:           DecayToZero,
+		DecayPeriod:           slot,
+	}
+}
+
+// ApplicationScoreParamsByName is a map of name to function that returns a [ApplicationScoringParams] based on the provided [rollup.Config].
+var ApplicationScoreParamsByName = map[string]func(blockTime uint64) ApplicationScoreParams{
+	"light": LightApplicationScoreParams,
+	"none":  DisabledApplicationScoreParams,
+}
+
+// AvailableApplicationScoreParams returns a list of available application score params.
+// These can be used as an input to [GetApplicationScoreParams] which returns the
+// corresponding [pubsub.PeerScoreParams].
+func AvailableApplicationScoreParams() []string {
+	var params []string
+	for name := range ApplicationScoreParamsByName {
+		params = append(params, name)
+	}
+	return params
+}
+
+func GetApplicationScoreParams(name string, blockTime uint64) (ApplicationScoreParams, error) {
+	params, ok := ApplicationScoreParamsByName[name]
+	if !ok {
+		return ApplicationScoreParams{}, fmt.Errorf("invalid params %s", name)
+	}
+
+	return params(blockTime), nil
+}

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -101,7 +101,7 @@ func loadTopicScoringParams(conf *p2p.Config, ctx *cli.Context, blockTime uint64
 		if err != nil {
 			return err
 		}
-		conf.TopicScoring = topicScoreParams
+		conf.TopicScoring = &topicScoreParams
 	}
 
 	return nil
@@ -117,7 +117,7 @@ func loadPeerScoringParams(conf *p2p.Config, ctx *cli.Context, blockTime uint64)
 		if err != nil {
 			return err
 		}
-		conf.PeerScoring = peerScoreParams
+		conf.PeerScoring = &peerScoreParams
 	}
 
 	return nil
@@ -133,7 +133,7 @@ func loadApplicationScoringParams(conf *p2p.Config, ctx *cli.Context, blockTime 
 		if err != nil {
 			return err
 		}
-		conf.ApplicationScoring = params
+		conf.ApplicationScoring = &params
 	}
 	return nil
 }

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -57,6 +57,9 @@ func NewConfig(ctx *cli.Context, blockTime uint64) (*p2p.Config, error) {
 	if err := loadPeerScoringParams(conf, ctx, blockTime); err != nil {
 		return nil, fmt.Errorf("failed to load p2p peer scoring options: %w", err)
 	}
+	if err := loadApplicationScoringParams(conf, ctx, blockTime); err != nil {
+		return nil, fmt.Errorf("failed to load p2p application scoring options: %w", err)
+	}
 
 	if err := loadBanningOptions(conf, ctx); err != nil {
 		return nil, fmt.Errorf("failed to load banning option: %w", err)
@@ -117,6 +120,21 @@ func loadPeerScoringParams(conf *p2p.Config, ctx *cli.Context, blockTime uint64)
 		conf.PeerScoring = peerScoreParams
 	}
 
+	return nil
+}
+
+// loadApplicationScoringParams loads the scoring options from the CLI context.
+//
+// If the scoring level is not set, no scoring is enabled.
+func loadApplicationScoringParams(conf *p2p.Config, ctx *cli.Context, blockTime uint64) error {
+	scoringLevel := ctx.GlobalString(flags.ApplicationScoring.Name)
+	if scoringLevel != "" {
+		params, err := p2p.GetApplicationScoreParams(scoringLevel, blockTime)
+		if err != nil {
+			return err
+		}
+		conf.ApplicationScoring = params
+	}
 	return nil
 }
 

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -63,8 +63,9 @@ type Config struct {
 	AltSync bool
 
 	// Pubsub Scoring Parameters
-	PeerScoring  pubsub.PeerScoreParams
-	TopicScoring pubsub.TopicScoreParams
+	PeerScoring        pubsub.PeerScoreParams
+	TopicScoring       pubsub.TopicScoreParams
+	ApplicationScoring ApplicationScoreParams
 
 	// Whether to ban peers based on their [PeerScoring] score. Should be negative.
 	BanningEnabled bool
@@ -152,6 +153,10 @@ func (conf *Config) BanDuration() time.Duration {
 
 func (conf *Config) TopicScoringParams() *pubsub.TopicScoreParams {
 	return &conf.TopicScoring
+}
+
+func (conf *Config) ApplicationScoringParams() *ApplicationScoreParams {
+	return &conf.ApplicationScoring
 }
 
 func (conf *Config) ReqRespSyncEnabled() bool {

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -63,9 +63,9 @@ type Config struct {
 	AltSync bool
 
 	// Pubsub Scoring Parameters
-	PeerScoring        pubsub.PeerScoreParams
-	TopicScoring       pubsub.TopicScoreParams
-	ApplicationScoring ApplicationScoreParams
+	PeerScoring        *pubsub.PeerScoreParams
+	TopicScoring       *pubsub.TopicScoreParams
+	ApplicationScoring *ApplicationScoreParams
 
 	// Whether to ban peers based on their [PeerScoring] score. Should be negative.
 	BanningEnabled bool
@@ -136,7 +136,7 @@ func (conf *Config) Disabled() bool {
 }
 
 func (conf *Config) PeerScoringParams() *pubsub.PeerScoreParams {
-	return &conf.PeerScoring
+	return conf.PeerScoring
 }
 
 func (conf *Config) BanPeers() bool {
@@ -152,11 +152,11 @@ func (conf *Config) BanDuration() time.Duration {
 }
 
 func (conf *Config) TopicScoringParams() *pubsub.TopicScoreParams {
-	return &conf.TopicScoring
+	return conf.TopicScoring
 }
 
 func (conf *Config) ApplicationScoringParams() *ApplicationScoreParams {
-	return &conf.ApplicationScoring
+	return conf.ApplicationScoring
 }
 
 func (conf *Config) ReqRespSyncEnabled() bool {

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -53,6 +53,7 @@ var MessageDomainValidSnappy = [4]byte{1, 0, 0, 0}
 type GossipSetupConfigurables interface {
 	PeerScoringParams() *pubsub.PeerScoreParams
 	TopicScoringParams() *pubsub.TopicScoreParams
+	ApplicationScoringParams() *ApplicationScoreParams
 	// ConfigureGossip creates configuration options to apply to the GossipSub setup
 	ConfigureGossip(rollupCfg *rollup.Config) []pubsub.Option
 }

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -447,7 +447,7 @@ func JoinGossip(p2pCtx context.Context, self peer.ID, topicScoreParams *pubsub.T
 	// A [TimeInMeshQuantum] value of 0 means the topic score is disabled.
 	// If we passed a topicScoreParams with [TimeInMeshQuantum] set to 0,
 	// libp2p errors since the params will be rejected.
-	if topicScoreParams != nil && topicScoreParams.TimeInMeshQuantum != 0 {
+	if topicScoreParams != nil {
 		if err = blocksTopic.SetScoreParams(topicScoreParams); err != nil {
 			return nil, fmt.Errorf("failed to set topic score params: %w", err)
 		}

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -146,7 +146,15 @@ func (conf *Config) Host(log log.Logger, reporter metrics.Reporter, metrics Host
 	}
 
 	peerScoreParams := conf.PeerScoringParams()
-	ps, err := store.NewExtendedPeerstore(context.Background(), log, clock.SystemClock, basePs, conf.Store, peerScoreParams.RetainScore)
+	var scoreRetention time.Duration
+	if peerScoreParams != nil {
+		// Use the same retention period as gossip will if available
+		scoreRetention = peerScoreParams.RetainScore
+	} else {
+		// Otherwsie default to a long but not infinite retention period.
+		scoreRetention = 24 * time.Hour
+	}
+	ps, err := store.NewExtendedPeerstore(context.Background(), log, clock.SystemClock, basePs, conf.Store, scoreRetention)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open extended peerstore: %w", err)
 	}

--- a/op-node/p2p/peer_scorer_test.go
+++ b/op-node/p2p/peer_scorer_test.go
@@ -38,26 +38,10 @@ func TestPeerScorer(t *testing.T) {
 	suite.Run(t, new(PeerScorerTestSuite))
 }
 
-// TestScorer_OnConnect ensures we can call the OnConnect method on the peer scorer.
-func (testSuite *PeerScorerTestSuite) TestScorer_OnConnect() {
-	scorer := p2p.NewScorer(
-		&rollup.Config{L2ChainID: big.NewInt(123)},
-		testSuite.mockStore,
-		testSuite.mockMetricer,
-		testSuite.logger,
-	)
-	scorer.OnConnect(peer.ID("alice"))
-}
+type customAppScorer struct{}
 
-// TestScorer_OnDisconnect ensures we can call the OnDisconnect method on the peer scorer.
-func (testSuite *PeerScorerTestSuite) TestScorer_OnDisconnect() {
-	scorer := p2p.NewScorer(
-		&rollup.Config{L2ChainID: big.NewInt(123)},
-		testSuite.mockStore,
-		testSuite.mockMetricer,
-		testSuite.logger,
-	)
-	scorer.OnDisconnect(peer.ID("alice"))
+func (c *customAppScorer) ApplicationScore(id peer.ID) float64 {
+	return 0
 }
 
 // TestScorer_SnapshotHook tests running the snapshot hook on the peer scorer.
@@ -67,6 +51,7 @@ func (testSuite *PeerScorerTestSuite) TestScorer_SnapshotHook() {
 		testSuite.mockStore,
 		testSuite.mockMetricer,
 		testSuite.logger,
+		&customAppScorer{},
 	)
 	inspectFn := scorer.SnapshotHook()
 

--- a/op-node/p2p/peer_scores.go
+++ b/op-node/p2p/peer_scores.go
@@ -13,7 +13,7 @@ func ConfigurePeerScoring(gossipConf GossipSetupConfigurables, scorer Scorer, lo
 	peerScoreThresholds := NewPeerScoreThresholds()
 	opts := []pubsub.Option{}
 	// Check the app specific score since libp2p doesn't export it's [validate] function :/
-	if peerScoreParams != nil && peerScoreParams.AppSpecificScore != nil {
+	if peerScoreParams != nil {
 		params := *peerScoreParams
 		params.AppSpecificScore = scorer.ApplicationScore
 		opts = []pubsub.Option{

--- a/op-node/p2p/peer_scores.go
+++ b/op-node/p2p/peer_scores.go
@@ -13,9 +13,11 @@ func ConfigurePeerScoring(gossipConf GossipSetupConfigurables, scorer Scorer, lo
 	peerScoreThresholds := NewPeerScoreThresholds()
 	opts := []pubsub.Option{}
 	// Check the app specific score since libp2p doesn't export it's [validate] function :/
-	if peerScoreParams != nil && peerScoreParams.AppSpecificScore != nil {
+	if peerScoreParams != nil {
+		params := *peerScoreParams
+		params.AppSpecificScore = scorer.ApplicationScore
 		opts = []pubsub.Option{
-			pubsub.WithPeerScore(peerScoreParams, &peerScoreThresholds),
+			pubsub.WithPeerScore(&params, &peerScoreThresholds),
 			pubsub.WithPeerScoreInspect(scorer.SnapshotHook(), peerScoreInspectFrequency),
 		}
 	} else {

--- a/op-node/p2p/peer_scores.go
+++ b/op-node/p2p/peer_scores.go
@@ -13,7 +13,7 @@ func ConfigurePeerScoring(gossipConf GossipSetupConfigurables, scorer Scorer, lo
 	peerScoreThresholds := NewPeerScoreThresholds()
 	opts := []pubsub.Option{}
 	// Check the app specific score since libp2p doesn't export it's [validate] function :/
-	if peerScoreParams != nil {
+	if peerScoreParams != nil && peerScoreParams.AppSpecificScore != nil {
 		params := *peerScoreParams
 		params.AppSpecificScore = scorer.ApplicationScore
 		opts = []pubsub.Option{

--- a/op-node/p2p/peer_scores_test.go
+++ b/op-node/p2p/peer_scores_test.go
@@ -114,8 +114,7 @@ func newGossipSubs(testSuite *PeerScoresTestSuite, ctx context.Context, hosts []
 				}
 			}))
 		opts = append(opts, ConfigurePeerScoring(&Config{
-			PeerScoring: pubsub.PeerScoreParams{
-				AppSpecificScore:  func(p peer.ID) float64 { return 0 },
+			PeerScoring: &pubsub.PeerScoreParams{
 				AppSpecificWeight: 1,
 				DecayInterval:     time.Second,
 				DecayToZero:       0.01,

--- a/op-node/p2p/prepared.go
+++ b/op-node/p2p/prepared.go
@@ -73,6 +73,10 @@ func (p *Prepared) PeerScoringParams() *pubsub.PeerScoreParams {
 	return nil
 }
 
+func (p *Prepared) ApplicationScoringParams() *ApplicationScoreParams {
+	return nil
+}
+
 func (p *Prepared) BanPeers() bool {
 	return false
 }

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -27,9 +27,31 @@ func (g GossipScores) Apply(rec *scoreRecord) {
 	rec.PeerScores.Gossip = g
 }
 
+type ReqRespScores struct {
+	ValidResponses   float64 `json:"validResponses"`
+	ErrorResponses   float64 `json:"errorResponses"`
+	RejectedPayloads float64 `json:"rejectedPayloads"`
+}
+
+type ReqRespScoreAdjuster func(target *ReqRespScores)
+
+type ReqRespScoresDiff struct {
+	adjuster ReqRespScoreAdjuster
+}
+
+func NewReqRespScoresDiff(adjuster ReqRespScoreAdjuster) ReqRespScoresDiff {
+	return ReqRespScoresDiff{
+		adjuster: adjuster,
+	}
+}
+
+func (r ReqRespScoresDiff) Apply(rec *scoreRecord) {
+	r.adjuster(&rec.PeerScores.ReqResp)
+}
+
 type PeerScores struct {
-	Gossip      GossipScores `json:"gossip"`
-	ReqRespSync float64      `json:"reqRespSync"`
+	Gossip  GossipScores  `json:"gossip"`
+	ReqResp ReqRespScores `json:"reqResp"`
 }
 
 // ScoreDatastore defines a type-safe API for getting and setting libp2p peer score information

--- a/op-node/p2p/store/serialize_test.go
+++ b/op-node/p2p/store/serialize_test.go
@@ -45,7 +45,31 @@ func TestParseHistoricSerializationsV0(t *testing.T) {
 						IPColocationFactor: 12.34,
 						BehavioralPenalty:  56.78,
 					},
-					ReqRespSync: 123456,
+					ReqResp: ReqRespScores{},
+				},
+				LastUpdate: 1923841,
+			},
+		},
+		{
+			data: `{"peerScores":{"gossip":{"total":1234.52382,"blocks":{"timeInMesh":1234,"firstMessageDeliveries":12,"meshMessageDeliveries":34,"invalidMessageDeliveries":56},"IPColocationFactor":12.34,"behavioralPenalty":56.78},"reqResp":{"validResponses":99,"errorResponses":88,"rejectedPayloads":77}},"lastUpdate":1923841}`,
+			expected: scoreRecord{
+				PeerScores: PeerScores{
+					Gossip: GossipScores{
+						Total: 1234.52382,
+						Blocks: TopicScores{
+							TimeInMesh:               1234,
+							FirstMessageDeliveries:   12,
+							MeshMessageDeliveries:    34,
+							InvalidMessageDeliveries: 56,
+						},
+						IPColocationFactor: 12.34,
+						BehavioralPenalty:  56.78,
+					},
+					ReqResp: ReqRespScores{
+						ValidResponses:   99,
+						ErrorResponses:   88,
+						RejectedPayloads: 77,
+					},
 				},
 				LastUpdate: 1923841,
 			},

--- a/op-node/p2p/sync_test.go
+++ b/op-node/p2p/sync_test.go
@@ -97,6 +97,12 @@ func setupSyncTestData(length uint64) (*rollup.Config, *syncTestData) {
 	return cfg, &syncTestData{payloads: payloads}
 }
 
+type noopSyncPeerScorer struct{}
+
+func (n noopSyncPeerScorer) onValidResponse(id peer.ID)   {}
+func (n noopSyncPeerScorer) onResponseError(id peer.ID)   {}
+func (n noopSyncPeerScorer) onRejectedPayload(id peer.ID) {}
+
 func TestSinglePeerSync(t *testing.T) {
 	t.Parallel() // Takes a while, but can run in parallel
 
@@ -137,7 +143,7 @@ func TestSinglePeerSync(t *testing.T) {
 	hostA.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
 
 	// Setup host B as the client
-	cl := NewSyncClient(log.New("role", "client"), cfg, hostB.NewStream, receivePayload, metrics.NoopMetrics)
+	cl := NewSyncClient(log.New("role", "client"), cfg, hostB.NewStream, receivePayload, metrics.NoopMetrics, noopSyncPeerScorer{})
 
 	// Setup host B (client) to sync from its peer Host A (server)
 	cl.AddPeer(hostA.ID())
@@ -186,7 +192,7 @@ func TestMultiPeerSync(t *testing.T) {
 		payloadByNumber := MakeStreamHandler(ctx, log.New("serve", "payloads_by_number"), srv.HandleSyncRequest)
 		h.SetStreamHandler(PayloadByNumberProtocolID(cfg.L2ChainID), payloadByNumber)
 
-		cl := NewSyncClient(log.New("role", "client"), cfg, h.NewStream, receivePayload, metrics.NoopMetrics)
+		cl := NewSyncClient(log.New("role", "client"), cfg, h.NewStream, receivePayload, metrics.NoopMetrics, noopSyncPeerScorer{})
 		return cl, received
 	}
 


### PR DESCRIPTION
**Description**

Introduce peer scoring for p2p sync req/resp handling.

Currently this is just a spike to see how things can be fit together and demonstrate the overall design.

Key parts:
 * Introduce `peerApplicationScorer` which is responsible for all the details of adjusting and combining non-gossip peer score components
 * The single `ReqRespSync` score component is replaced by a `ReqRespScores` object so we can track individual components. Test confirm this is backwards compatible.
 * Broke the peer store interface a bit by introducing `ReqRespScoresDiff` as an implementation of `ScoreDiff` that takes a function to update the scores. This means the specific changes made now leak outside of the module where previously they were private. It makes application scores much simpler though because the `SetScores` method already loads the previous value, applies the diff then saves it in a thread safe way. This lets us hook into that process to increment the scores as needed without having to add additional thread safety logic.
   *  Currently this passes through the full `PeerScores` struct, but it could be modified to have a separate object for application scores so the gossip scores controlled by libp2p aren't editable. Not sure its worth it though.

Also need to hook this into the request handling side to penalise peers when they hit rate limits and hook up banning for garbage responses (possibly should replace the `ErrorMessage` scores here but need to dig more into the details of what causes errors).

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Invariants**

For changes to critical code paths, please list and describe the invariants or key security properties of your new or changed code.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
