### PR TITLE
feat(indexer) processor module with basic l1Processor & l2Processor

### DIFF
--- a/indexer/cmd/indexer-refresh/main.go
+++ b/indexer/cmd/indexer-refresh/main.go
@@ -29,7 +29,7 @@ func main() {
 	)
 
 	app := cli.NewApp()
-	app.Flags = flags.Flags
+	app.Flags = []cli.Flag{flags.LogLevelFlag, flags.L1EthRPCFlag, flags.L2EthRPCFlag, flags.DBNameFlag}
 	app.Version = fmt.Sprintf("%s-%s", GitVersion, params.VersionWithCommit(GitCommit, GitDate))
 	app.Name = "indexer"
 	app.Usage = "Indexer Service"

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -29,8 +29,6 @@ type L2ContractEvent struct {
 }
 
 type ContractEventsView interface {
-	L1ContractEventByGUID(string) (*L1ContractEvent, error)
-	L2ContractEventByGUID(string) (*L2ContractEvent, error)
 }
 
 type ContractEventsDB interface {
@@ -59,29 +57,9 @@ func (db *contractEventsDB) StoreL1ContractEvents(events []*L1ContractEvent) err
 	return result.Error
 }
 
-func (db *contractEventsDB) L1ContractEventByGUID(guid string) (*L1ContractEvent, error) {
-	var event L1ContractEvent
-	result := db.gorm.First(&event, "guid = ?", guid)
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return &event, nil
-}
-
 // L2
 
 func (db *contractEventsDB) StoreL2ContractEvents(events []*L2ContractEvent) error {
 	result := db.gorm.Create(&events)
 	return result.Error
-}
-
-func (db *contractEventsDB) L2ContractEventByGUID(guid string) (*L2ContractEvent, error) {
-	var event L2ContractEvent
-	result := db.gorm.First(&event, "guid = ?", guid)
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return &event, nil
 }

--- a/indexer/database/db.go
+++ b/indexer/database/db.go
@@ -34,3 +34,20 @@ func NewDB(dsn string) (*DB, error) {
 
 	return db, nil
 }
+
+// Transaction executes all operations conducted with the supplied database in a single
+// transaction. If the supplied function errors, the transaction is rolled back.
+func (db *DB) Transaction(fn func(db *DB) error) error {
+	return db.gorm.Transaction(func(tx *gorm.DB) error {
+		return fn(dbFromGormTx(tx))
+	})
+}
+
+func dbFromGormTx(tx *gorm.DB) *DB {
+	return &DB{
+		gorm:           tx,
+		Blocks:         newBlocksDB(tx),
+		ContractEvents: newContractEventsDB(tx),
+		Bridge:         newBridgeDB(tx),
+	}
+}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -3,7 +3,6 @@ package indexer
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/ethereum-optimism/optimism/indexer/database"
 	"github.com/ethereum-optimism/optimism/indexer/flags"
@@ -13,12 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/urfave/cli"
-)
-
-const (
-	// defaultDialTimeout is default duration the service will wait on
-	// startup to make a connection to either the L1 or L2 backends.
-	defaultDialTimeout = 5 * time.Second
 )
 
 // Main is the entrypoint into the indexer service. This method returns

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1,13 +1,17 @@
 package indexer
 
 import (
-	"context"
+	"fmt"
 	"os"
 	"time"
 
-	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/indexer/flags"
+	"github.com/ethereum-optimism/optimism/indexer/node"
+	"github.com/ethereum-optimism/optimism/indexer/processor"
+
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/urfave/cli"
 )
 
@@ -23,7 +27,23 @@ const (
 // e.g. GitVersion, to be captured and used once the function is executed.
 func Main(gitVersion string) func(ctx *cli.Context) error {
 	return func(ctx *cli.Context) error {
-		log.Info("Initializing indexer")
+		log.Info("initializing indexer")
+		indexer, err := NewIndexer(ctx)
+		if err != nil {
+			log.Error("unable to initialize indexer", "err", err)
+			return err
+		}
+
+		log.Info("starting indexer")
+		if err := indexer.Start(); err != nil {
+			log.Error("unable to start indexer", "err", err)
+		}
+
+		defer indexer.Stop()
+		log.Info("indexer started")
+
+		// Never terminate
+		<-(chan struct{})(nil)
 		return nil
 	}
 }
@@ -31,53 +51,56 @@ func Main(gitVersion string) func(ctx *cli.Context) error {
 // Indexer is a service that configures the necessary resources for
 // running the Sync and BlockHandler sub-services.
 type Indexer struct {
-	l1Client *ethclient.Client
-	l2Client *ethclient.Client
+	db *database.DB
+
+	l1Processor *processor.L1Processor
+	l2Processor *processor.L2Processor
 }
 
 // NewIndexer initializes the Indexer, gathering any resources
 // that will be needed by the TxIndexer and StateIndexer
 // sub-services.
-func NewIndexer() (*Indexer, error) {
-	ctx := context.Background()
-
-	var logHandler log.Handler = log.StreamHandler(os.Stdout, log.TerminalFormat(true))
+func NewIndexer(ctx *cli.Context) (*Indexer, error) {
 	// TODO https://linear.app/optimism/issue/DX-55/api-implement-rest-api-with-mocked-data
 	// do json format too
 	// TODO https://linear.app/optimism/issue/DX-55/api-implement-rest-api-with-mocked-data
-	// pass in loglevel from config
-	// logHandler = log.StreamHandler(os.Stdout, log.JSONFormat())
-	logLevel, err := log.LvlFromString("info")
+
+	// defaults to debug unless explicitly set
+	logLevel, err := log.LvlFromString(ctx.GlobalString(flags.LogLevelFlag.Name))
 	if err != nil {
 		return nil, err
 	}
 
+	logHandler := log.StreamHandler(os.Stdout, log.TerminalFormat(true))
 	log.Root().SetHandler(log.LvlFilterHandler(logLevel, logHandler))
 
-	// Connect to L1 and L2 providers. Perform these last since they are the
-	// most expensive.
-	// TODO https://linear.app/optimism/issue/DX-55/api-implement-rest-api-with-mocked-data
-	// pass in rpc url from config
-	l1Client, _, err := dialEthClientWithTimeout(ctx, "http://localhost:8545")
+	dsn := fmt.Sprintf("database=%s", ctx.GlobalString(flags.DBNameFlag.Name))
+	db, err := database.NewDB(dsn)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO https://linear.app/optimism/issue/DX-55/api-implement-rest-api-with-mocked-data
-	// pass in rpc url from config
-	l2Client, _, err := dialEthClientWithTimeout(ctx, "http://localhost:9545")
+	// L1 Processor
+	l1EthClient, err := node.NewEthClient(ctx.GlobalString(flags.L1EthRPCFlag.Name))
+	if err != nil {
+		return nil, err
+	}
+	l1Processor, err := processor.NewL1Processor(l1EthClient, db)
 	if err != nil {
 		return nil, err
 	}
 
+	// L2Processor
+	l2EthClient, err := node.NewEthClient(ctx.GlobalString(flags.L2EthRPCFlag.Name))
+	if err != nil {
+		return nil, err
+	}
+	l2Processor, err := processor.NewL2Processor(l2EthClient, db)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Indexer{
-		l1Client: l1Client,
-		l2Client: l2Client,
-	}, nil
+	return &Indexer{db, l1Processor, l2Processor}, nil
 }
 
 // Serve spins up a REST API server at the given hostname and port.
@@ -88,25 +111,11 @@ func (b *Indexer) Serve() error {
 // Start starts the starts the indexing service on L1 and L2 chains and also
 // starts the REST server.
 func (b *Indexer) Start() error {
+	go b.l1Processor.Start()
+	go b.l2Processor.Start()
 	return nil
 }
 
 // Stop stops the indexing service on L1 and L2 chains.
 func (b *Indexer) Stop() {
-}
-
-// dialL1EthClientWithTimeout attempts to dial the L1 provider using the
-// provided URL. If the dial doesn't complete within defaultDialTimeout seconds,
-// this method will return an error.
-func dialEthClientWithTimeout(ctx context.Context, url string) (
-	*ethclient.Client, *rpc.Client, error) {
-
-	ctxt, cancel := context.WithTimeout(ctx, defaultDialTimeout)
-	defer cancel()
-
-	c, err := rpc.DialContext(ctxt, url)
-	if err != nil {
-		return nil, nil, err
-	}
-	return ethclient.NewClient(c), c, nil
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -65,7 +65,6 @@ func NewIndexer(ctx *cli.Context) (*Indexer, error) {
 	// do json format too
 	// TODO https://linear.app/optimism/issue/DX-55/api-implement-rest-api-with-mocked-data
 
-	// defaults to debug unless explicitly set
 	logLevel, err := log.LvlFromString(ctx.GlobalString(flags.LogLevelFlag.Name))
 	if err != nil {
 		return nil, err
@@ -100,7 +99,13 @@ func NewIndexer(ctx *cli.Context) (*Indexer, error) {
 		return nil, err
 	}
 
-	return &Indexer{db, l1Processor, l2Processor}, nil
+	indexer := &Indexer{
+		db:          db,
+		l1Processor: l1Processor,
+		l2Processor: l2Processor,
+	}
+
+	return indexer, nil
 }
 
 // Serve spins up a REST API server at the given hostname and port.
@@ -113,6 +118,7 @@ func (b *Indexer) Serve() error {
 func (b *Indexer) Start() error {
 	go b.l1Processor.Start()
 	go b.l2Processor.Start()
+
 	return nil
 }
 

--- a/indexer/node/bigint.go
+++ b/indexer/node/bigint.go
@@ -15,7 +15,7 @@ func clampBigInt(start, end *big.Int, size uint64) *big.Int {
 		return end
 	}
 
-	// we result the allocated temp as the new end
+	// we re-use the allocated temp as the new end
 	temp.Add(start, big.NewInt(int64(size-1)))
 	return temp
 }

--- a/indexer/node/client_test.go
+++ b/indexer/node/client_test.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
+
+var _ EthClient = &MockEthClient{}
 
 type MockEthClient struct {
 	mock.Mock
@@ -21,6 +24,11 @@ func (m *MockEthClient) FinalizedBlockHeight() (*big.Int, error) {
 func (m *MockEthClient) BlockHeadersByRange(from, to *big.Int) ([]*types.Header, error) {
 	args := m.Called(from, to)
 	return args.Get(0).([]*types.Header), args.Error(1)
+}
+
+func (m *MockEthClient) BlockHeaderByHash(hash common.Hash) (*types.Header, error) {
+	args := m.Called(hash)
+	return args.Get(0).(*types.Header), args.Error(1)
 }
 
 func (m *MockEthClient) RawRpcClient() *rpc.Client {

--- a/indexer/node/fetcher.go
+++ b/indexer/node/fetcher.go
@@ -20,9 +20,8 @@ type Fetcher struct {
 // NewFetcher instantiates a new instance of Fetcher against the supplied rpc client.
 // The Fetcher will start fetching blocks starting from the supplied header unless
 // nil, indicating genesis.
-func NewFetcher(ethClient EthClient, fromHeader *types.Header) (*Fetcher, error) {
-	fetcher := &Fetcher{ethClient: ethClient, lastHeader: fromHeader}
-	return fetcher, nil
+func NewFetcher(ethClient EthClient, fromHeader *types.Header) *Fetcher {
+	return &Fetcher{ethClient: ethClient, lastHeader: fromHeader}
 }
 
 // NextConfirmedHeaders retrives the next set of headers that have been
@@ -50,7 +49,7 @@ func (f *Fetcher) NextFinalizedHeaders() ([]*types.Header, error) {
 		return nil, err
 	}
 
-	numHeaders := int64(len(headers))
+	numHeaders := len(headers)
 	if numHeaders == 0 {
 		return nil, nil
 	} else if f.lastHeader != nil && headers[0].ParentHash != f.lastHeader.Hash() {

--- a/indexer/node/fetcher_test.go
+++ b/indexer/node/fetcher_test.go
@@ -38,8 +38,7 @@ func TestFetcherNextFinalizedHeadersNoOp(t *testing.T) {
 
 	// start from block 0 as the latest fetched block
 	lastHeader := &types.Header{Number: bigZero}
-	fetcher, err := NewFetcher(client, lastHeader)
-	assert.NoError(t, err)
+	fetcher := NewFetcher(client, lastHeader)
 
 	// no new headers when matched with head
 	client.On("FinalizedBlockHeight").Return(big.NewInt(0), nil)
@@ -52,14 +51,13 @@ func TestFetcherNextFinalizedHeadersCursored(t *testing.T) {
 	client := new(MockEthClient)
 
 	// start from genesis
-	fetcher, err := NewFetcher(client, nil)
-	assert.NoError(t, err)
+	fetcher := NewFetcher(client, nil)
 
 	// blocks [0..4]
 	headers := makeHeaders(5, nil)
 	client.On("FinalizedBlockHeight").Return(big.NewInt(4), nil).Times(1) // Times so that we can override next
 	client.On("BlockHeadersByRange", mock.MatchedBy(bigIntMatcher(0)), mock.MatchedBy(bigIntMatcher(4))).Return(headers, nil)
-	headers, err = fetcher.NextFinalizedHeaders()
+	headers, err := fetcher.NextFinalizedHeaders()
 	assert.NoError(t, err)
 	assert.Len(t, headers, 5)
 
@@ -76,8 +74,7 @@ func TestFetcherNextFinalizedHeadersMaxHeaderBatch(t *testing.T) {
 	client := new(MockEthClient)
 
 	// start from genesis
-	fetcher, err := NewFetcher(client, nil)
-	assert.NoError(t, err)
+	fetcher := NewFetcher(client, nil)
 
 	// blocks [0..maxBatchSize] size == maxBatchSize = 1
 	headers := makeHeaders(maxHeaderBatchSize, nil)
@@ -85,7 +82,7 @@ func TestFetcherNextFinalizedHeadersMaxHeaderBatch(t *testing.T) {
 
 	// clamped by the max batch size
 	client.On("BlockHeadersByRange", mock.MatchedBy(bigIntMatcher(0)), mock.MatchedBy(bigIntMatcher(maxHeaderBatchSize-1))).Return(headers, nil)
-	headers, err = fetcher.NextFinalizedHeaders()
+	headers, err := fetcher.NextFinalizedHeaders()
 	assert.NoError(t, err)
 	assert.Len(t, headers, maxHeaderBatchSize)
 
@@ -101,14 +98,13 @@ func TestFetcherMismatchedProviderStateError(t *testing.T) {
 	client := new(MockEthClient)
 
 	// start from genesis
-	fetcher, err := NewFetcher(client, nil)
-	assert.NoError(t, err)
+	fetcher := NewFetcher(client, nil)
 
 	// blocks [0..4]
 	headers := makeHeaders(5, nil)
 	client.On("FinalizedBlockHeight").Return(big.NewInt(4), nil).Times(1) // Times so that we can override next
 	client.On("BlockHeadersByRange", mock.MatchedBy(bigIntMatcher(0)), mock.MatchedBy(bigIntMatcher(4))).Return(headers, nil)
-	headers, err = fetcher.NextFinalizedHeaders()
+	headers, err := fetcher.NextFinalizedHeaders()
 	assert.NoError(t, err)
 	assert.Len(t, headers, 5)
 

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -1,0 +1,69 @@
+package processor
+
+import (
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/indexer/node"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type L1Processor struct {
+	processor
+}
+
+func NewL1Processor(ethClient node.EthClient, db *database.DB) (*L1Processor, error) {
+	l1ProcessLog := log.New("processor", "l1")
+	l1ProcessLog.Info("creating processor")
+
+	latestHeader, err := db.Blocks.FinalizedL1BlockHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	var fromL1Header *types.Header
+	if latestHeader != nil {
+		l1ProcessLog.Info("detected last indexed state", "height", latestHeader.Number.Int, "hash", latestHeader.Hash)
+		l1Header, err := ethClient.BlockHeaderByHash(latestHeader.Hash)
+		if err != nil {
+			return nil, err
+		}
+
+		fromL1Header = l1Header
+	} else {
+		// we shouldn't start from genesis with l1. Need a "genesis" height to be defined here
+		l1ProcessLog.Info("no indexed state, starting from genesis")
+		fromL1Header = nil
+	}
+
+	l1Processor := &L1Processor{
+		processor: processor{
+			fetcher:    node.NewFetcher(ethClient, fromL1Header),
+			db:         db,
+			processFn:  l1ProcessFn(ethClient),
+			processLog: l1ProcessLog,
+		},
+	}
+
+	return l1Processor, nil
+}
+
+func l1ProcessFn(ethClient node.EthClient) func(db *database.DB, headers []*types.Header) error {
+	return func(db *database.DB, headers []*types.Header) error {
+
+		// index all l2 blocks for now
+		l1Headers := make([]*database.L1BlockHeader, len(headers))
+		for i, header := range headers {
+			l1Headers[i] = &database.L1BlockHeader{
+				BlockHeader: database.BlockHeader{
+					Hash:       header.Hash(),
+					ParentHash: header.ParentHash,
+					Number:     database.U256{Int: header.Number},
+					Timestamp:  header.Time,
+				},
+			}
+		}
+
+		return db.Blocks.StoreL1BlockHeaders(l1Headers)
+	}
+}

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -14,7 +14,7 @@ type L1Processor struct {
 
 func NewL1Processor(ethClient node.EthClient, db *database.DB) (*L1Processor, error) {
 	l1ProcessLog := log.New("processor", "l1")
-	l1ProcessLog.Info("creating processor")
+	l1ProcessLog.Info("initializing processor")
 
 	latestHeader, err := db.Blocks.FinalizedL1BlockHeader()
 	if err != nil {
@@ -23,9 +23,10 @@ func NewL1Processor(ethClient node.EthClient, db *database.DB) (*L1Processor, er
 
 	var fromL1Header *types.Header
 	if latestHeader != nil {
-		l1ProcessLog.Info("detected last indexed state", "height", latestHeader.Number.Int, "hash", latestHeader.Hash)
+		l1ProcessLog.Info("detected last indexed block", "height", latestHeader.Number.Int, "hash", latestHeader.Hash)
 		l1Header, err := ethClient.BlockHeaderByHash(latestHeader.Hash)
 		if err != nil {
+			l1ProcessLog.Error("unable to fetch header for last indexed block", "hash", latestHeader.Hash, "err", err)
 			return nil, err
 		}
 

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -14,7 +14,7 @@ type L2Processor struct {
 
 func NewL2Processor(ethClient node.EthClient, db *database.DB) (*L2Processor, error) {
 	l2ProcessLog := log.New("processor", "l2")
-	l2ProcessLog.Info("creating processor")
+	l2ProcessLog.Info("initializing processor")
 
 	latestHeader, err := db.Blocks.FinalizedL2BlockHeader()
 	if err != nil {
@@ -23,9 +23,10 @@ func NewL2Processor(ethClient node.EthClient, db *database.DB) (*L2Processor, er
 
 	var fromL2Header *types.Header
 	if latestHeader != nil {
-		l2ProcessLog.Info("detected last indexed state", "height", latestHeader.Number.Int, "hash", latestHeader.Hash)
+		l2ProcessLog.Info("detected last indexed block", "height", latestHeader.Number.Int, "hash", latestHeader.Hash)
 		l2Header, err := ethClient.BlockHeaderByHash(latestHeader.Hash)
 		if err != nil {
+			l2ProcessLog.Error("unable to fetch header for last indexed block", "hash", latestHeader.Hash, "err", err)
 			return nil, err
 		}
 

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -1,0 +1,68 @@
+package processor
+
+import (
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/indexer/node"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type L2Processor struct {
+	processor
+}
+
+func NewL2Processor(ethClient node.EthClient, db *database.DB) (*L2Processor, error) {
+	l2ProcessLog := log.New("processor", "l2")
+	l2ProcessLog.Info("creating processor")
+
+	latestHeader, err := db.Blocks.FinalizedL2BlockHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	var fromL2Header *types.Header
+	if latestHeader != nil {
+		l2ProcessLog.Info("detected last indexed state", "height", latestHeader.Number.Int, "hash", latestHeader.Hash)
+		l2Header, err := ethClient.BlockHeaderByHash(latestHeader.Hash)
+		if err != nil {
+			return nil, err
+		}
+
+		fromL2Header = l2Header
+	} else {
+		l2ProcessLog.Info("no indexed state, starting from genesis")
+		fromL2Header = nil
+	}
+
+	l2Processor := &L2Processor{
+		processor: processor{
+			fetcher:    node.NewFetcher(ethClient, fromL2Header),
+			db:         db,
+			processFn:  l2ProcessFn(ethClient),
+			processLog: l2ProcessLog,
+		},
+	}
+
+	return l2Processor, nil
+}
+
+func l2ProcessFn(ethClient node.EthClient) func(db *database.DB, headers []*types.Header) error {
+	return func(db *database.DB, headers []*types.Header) error {
+
+		// index all l2 blocks for now
+		l2Headers := make([]*database.L2BlockHeader, len(headers))
+		for i, header := range headers {
+			l2Headers[i] = &database.L2BlockHeader{
+				BlockHeader: database.BlockHeader{
+					Hash:       header.Hash(),
+					ParentHash: header.ParentHash,
+					Number:     database.U256{Int: header.Number},
+					Timestamp:  header.Time,
+				},
+			}
+		}
+
+		return db.Blocks.StoreL2BlockHeaders(l2Headers)
+	}
+}

--- a/indexer/processor/processor.go
+++ b/indexer/processor/processor.go
@@ -1,0 +1,68 @@
+package processor
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/indexer/node"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const defaultLoopInterval = 5 * time.Second
+
+// processFn is the the function used to process unindexed headers. In
+// the event of a failure, all database operations are not committed
+type processFn func(*database.DB, []*types.Header) error
+
+type processor struct {
+	fetcher *node.Fetcher
+
+	db         *database.DB
+	processFn  processFn
+	processLog log.Logger
+}
+
+// Start kicks off the processing loop. This is a blocking operation and should be run within its own goroutine
+func (p processor) Start() {
+	pollTicker := time.NewTicker(defaultLoopInterval)
+	p.processLog.Info("starting processor...")
+
+	for {
+		select {
+		case <-pollTicker.C:
+			p.processLog.Info("checking for new headers...")
+
+			headers, err := p.fetcher.NextFinalizedHeaders()
+			if err != nil {
+				p.processLog.Error("unable to query for headers", "err", err)
+				continue
+			}
+
+			if len(headers) == 0 {
+				p.processLog.Info("no new headers. indexer must be at head...")
+				continue
+			}
+
+			batchLog := p.processLog.New("startHeight", headers[0].Number, "endHeight", headers[len(headers)-1].Number)
+			batchLog.Info("indexing batch of headers")
+
+			// process the headers within a databse transaction
+			err = p.db.Transaction(func(db *database.DB) error {
+				return p.processFn(db, headers)
+			})
+
+			if err != nil {
+				// TODO: next poll should retry starting from this same batch of headers
+				batchLog.Info("error while indexing batch", "err", err)
+				panic(err)
+			} else {
+				batchLog.Info("done indexing batch")
+			}
+		}
+	}
+}
+
+// Stop kills the goroutine running the processing loop
+func (p processor) Stop() {}

--- a/indexer/processor/processor.go
+++ b/indexer/processor/processor.go
@@ -52,8 +52,9 @@ func (p processor) Start() {
 			return p.processFn(db, headers)
 		})
 
+		// TODO(DX-79) if processFn failed, the next poll should retry starting from this same batch of headers
+
 		if err != nil {
-			// TODO(DX-79) next poll should retry starting from this same batch of headers
 			batchLog.Info("unable to index batch", "err", err)
 			panic(err)
 		} else {


### PR DESCRIPTION
Introduce a `processor` modules that exposes `L1Processor` and `L2Processors`. These structs define the core logic that indexes new batches retrieved from the fetcher. All database operations for a given batch are wrapped in a database transaction.

The L1 & L2 processors simply index block headers right now.

## Aside
- `indexer-refresh` command was updated such that the new indexer can now be run e2e.
- `EthClient#FinalizedBlockHeight` switched to "latest" blocktag instead of "finalized" blocktag to avoid dealing with issues with the local devnet. We'll address this
- L1Processor needs some additional config such that it doesn't start from genesis. It should start from the L1 block corresponding to L2 genesis