### PR TITLE
op-batcher: Fix num_frames metrics

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -115,7 +115,7 @@ func (s *channel) isTimedOut() bool {
 
 // pendingChannelIsFullySubmitted returns true if the channel has been fully submitted.
 func (s *channel) isFullySubmitted() bool {
-	return s.IsFull() && len(s.pendingTransactions)+s.NumFrames() == 0
+	return s.IsFull() && len(s.pendingTransactions)+s.PendingFrames() == 0
 }
 
 func (s *channel) NoneSubmitted() bool {
@@ -170,8 +170,12 @@ func (s *channel) OutputBytes() int {
 	return s.channelBuilder.OutputBytes()
 }
 
-func (s *channel) NumFrames() int {
-	return s.channelBuilder.NumFrames()
+func (s *channel) TotalFrames() int {
+	return s.channelBuilder.TotalFrames()
+}
+
+func (s *channel) PendingFrames() int {
+	return s.channelBuilder.PendingFrames()
 }
 
 func (s *channel) OutputFrames() error {

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -119,6 +119,8 @@ type channelBuilder struct {
 	blocks []*types.Block
 	// frames data queue, to be send as txs
 	frames []frameData
+	// total frames counter
+	numFrames int
 	// total amount of output data of all frames created yet
 	outputBytes int
 }
@@ -382,6 +384,7 @@ func (c *channelBuilder) outputFrame() error {
 		data: buf.Bytes(),
 	}
 	c.frames = append(c.frames, frame)
+	c.numFrames++
 	c.outputBytes += len(frame.data)
 	return err // possibly io.EOF (last frame)
 }
@@ -394,6 +397,12 @@ func (c *channelBuilder) Close() {
 	}
 }
 
+// TotalFrames returns the total number of frames that were created in this channel so far.
+// It does not decrease when the frames queue is being emptied.
+func (c *channelBuilder) TotalFrames() int {
+	return c.numFrames
+}
+
 // HasFrame returns whether there's any available frame. If true, it can be
 // popped using NextFrame().
 //
@@ -403,7 +412,9 @@ func (c *channelBuilder) HasFrame() bool {
 	return len(c.frames) > 0
 }
 
-func (c *channelBuilder) NumFrames() int {
+// PendingFrames returns the number of pending frames in the frames queue.
+// It is larger zero iff HasFrames() returns true.
+func (c *channelBuilder) PendingFrames() int {
 	return len(c.frames)
 }
 

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -269,7 +269,7 @@ func (s *channelManager) outputFrames() error {
 	s.metr.RecordChannelClosed(
 		s.currentChannel.ID(),
 		len(s.blocks),
-		s.currentChannel.NumFrames(),
+		s.currentChannel.TotalFrames(),
 		inBytes,
 		outBytes,
 		s.currentChannel.FullErr(),
@@ -282,7 +282,7 @@ func (s *channelManager) outputFrames() error {
 	s.log.Info("Channel closed",
 		"id", s.currentChannel.ID(),
 		"blocks_pending", len(s.blocks),
-		"num_frames", s.currentChannel.NumFrames(),
+		"num_frames", s.currentChannel.TotalFrames(),
 		"input_bytes", inBytes,
 		"output_bytes", outBytes,
 		"full_reason", s.currentChannel.FullErr(),

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -88,7 +88,7 @@ func TestChannelNextTxData(t *testing.T) {
 		},
 	}
 	channel.channelBuilder.PushFrame(frame)
-	require.Equal(t, 1, channel.NumFrames())
+	require.Equal(t, 1, channel.PendingFrames())
 
 	// Now the nextTxData function should return the frame
 	returnedTxData, err = m.nextTxData(channel)
@@ -96,7 +96,7 @@ func TestChannelNextTxData(t *testing.T) {
 	expectedChannelID := expectedTxData.ID()
 	require.NoError(t, err)
 	require.Equal(t, expectedTxData, returnedTxData)
-	require.Equal(t, 0, channel.NumFrames())
+	require.Equal(t, 0, channel.PendingFrames())
 	require.Equal(t, expectedTxData, channel.pendingTransactions[expectedChannelID])
 }
 
@@ -123,13 +123,13 @@ func TestChannelTxConfirmed(t *testing.T) {
 		},
 	}
 	m.currentChannel.channelBuilder.PushFrame(frame)
-	require.Equal(t, 1, m.currentChannel.NumFrames())
+	require.Equal(t, 1, m.currentChannel.PendingFrames())
 	returnedTxData, err := m.nextTxData(m.currentChannel)
 	expectedTxData := txData{frame}
 	expectedChannelID := expectedTxData.ID()
 	require.NoError(t, err)
 	require.Equal(t, expectedTxData, returnedTxData)
-	require.Equal(t, 0, m.currentChannel.NumFrames())
+	require.Equal(t, 0, m.currentChannel.PendingFrames())
 	require.Equal(t, expectedTxData, m.currentChannel.pendingTransactions[expectedChannelID])
 	require.Len(t, m.currentChannel.pendingTransactions, 1)
 
@@ -171,20 +171,20 @@ func TestChannelTxFailed(t *testing.T) {
 		},
 	}
 	m.currentChannel.channelBuilder.PushFrame(frame)
-	require.Equal(t, 1, m.currentChannel.NumFrames())
+	require.Equal(t, 1, m.currentChannel.PendingFrames())
 	returnedTxData, err := m.nextTxData(m.currentChannel)
 	expectedTxData := txData{frame}
 	expectedChannelID := expectedTxData.ID()
 	require.NoError(t, err)
 	require.Equal(t, expectedTxData, returnedTxData)
-	require.Equal(t, 0, m.currentChannel.NumFrames())
+	require.Equal(t, 0, m.currentChannel.PendingFrames())
 	require.Equal(t, expectedTxData, m.currentChannel.pendingTransactions[expectedChannelID])
 	require.Len(t, m.currentChannel.pendingTransactions, 1)
 
 	// Trying to mark an unknown pending transaction as failed
 	// shouldn't modify state
 	m.TxFailed(frameID{})
-	require.Equal(t, 0, m.currentChannel.NumFrames())
+	require.Equal(t, 0, m.currentChannel.PendingFrames())
 	require.Equal(t, expectedTxData, m.currentChannel.pendingTransactions[expectedChannelID])
 
 	// Now we still have a pending transaction
@@ -192,5 +192,5 @@ func TestChannelTxFailed(t *testing.T) {
 	m.TxFailed(expectedChannelID)
 	require.Empty(t, m.currentChannel.pendingTransactions)
 	// There should be a frame in the pending channel now
-	require.Equal(t, 1, m.currentChannel.NumFrames())
+	require.Equal(t, 1, m.currentChannel.PendingFrames())
 }


### PR DESCRIPTION
**Description**

The metrics recorded the value of channelBuilder.NumFrames(). But this was only the number of pending frames in the frames queue.

This PR adds a new method TotalFrames() and separate numFrames tracking to distinguish between the number of pending frames and total frames of a channel.

**Tests**

Added test for `PendingFrames` and `TotalFrames`

**Additional context**

Fixes `num_frames` metrics of the batcher, which was mostly recording `1`s instead of the real total number of frames.

**Metadata**

- Fixes CLI-4073

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
