### PR TITLE
feat(fault-detector): Better package.json

### DIFF
--- a/.changeset/rotten-cheetahs-guess.md
+++ b/.changeset/rotten-cheetahs-guess.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': patch
+---
+
+Add better source maps and developer support

--- a/packages/fault-detector/package.json
+++ b/packages/fault-detector/package.json
@@ -9,10 +9,12 @@
     "dist/*"
   ],
   "scripts": {
-    "start": "ts-node ./src/service.ts",
+    "start": "node --enable-source-maps dist/src/service.js",
+    "dev": "tsx watch ./src/service.ts",
     "test": "hardhat test",
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json",
     "build": "tsc -p tsconfig.json",
+    "preview": "yarn build && yarn start",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
     "lint": "yarn lint:fix && yarn lint:check",
     "pre-commit": "lint-staged",
@@ -44,7 +46,7 @@
     "ethers": "^5.7.0",
     "hardhat": "^2.9.6",
     "lodash": "^4.17.21",
-    "ts-node": "^10.9.1"
+    "tsx": "^3.12.7"
   },
   "dependencies": {
     "@eth-optimism/common-ts": "^0.8.1",

--- a/packages/fault-detector/tsconfig.json
+++ b/packages/fault-detector/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "sourceMap": true
   },
   "include": [
     "package.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20912,6 +20912,17 @@ tsx@^3.12.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+tsx@^3.12.7:
+  version "3.12.7"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-3.12.7.tgz#b3b8b0fc79afc8260d1e14f9e995616c859a91e9"
+  integrity sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==
+  dependencies:
+    "@esbuild-kit/cjs-loader" "^2.4.2"
+    "@esbuild-kit/core-utils" "^3.0.0"
+    "@esbuild-kit/esm-loader" "^2.5.5"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 tty-table@^4.1.5:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/tty-table/-/tty-table-4.1.6.tgz#6bd58338f36c94cce478c3337934d8a65ab40a73"


### PR DESCRIPTION
Running the fault detector saw a bunch of stuff to fix to make debugging easier both in prod and locally

- replace ts-node with tsx.  Tsx is better faster and more likely to "just work" without headaches
- add a dev script that will reload the server when changes happen
- add a serve script to serve the production build
- add a preview script to preview the production build
- turn on source maps with --enable-source-maps

