### PR TITLE
fix(op-bootnode): Add go-reviewers as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 /op-node        @ethereum-optimism/go-reviewers
 /op-node/rollup @protolambda @trianglesphere
 /op-proposer    @ethereum-optimism/go-reviewers
+/op-bootnode    @ethereum-optimism/go-reviewers
 /op-program     @ethereum-optimism/go-reviewers
 /op-service     @ethereum-optimism/go-reviewers
 /ops-bedrock    @ethereum-optimism/go-reviewers


### PR DESCRIPTION
**Description**

Adds the `go-reviewers` as the codeowner for the `op-bootnode` package