### PR TITLE
feat(op-batcher): Dry Run

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -86,6 +86,7 @@ type CLIConfig struct {
 	MaxL1TxSize uint64
 
 	Stopped bool
+	DryRun  bool
 
 	TxMgrConfig      txmgr.CLIConfig
 	RPCConfig        rpc.CLIConfig
@@ -129,6 +130,7 @@ func NewConfig(ctx *cli.Context) CLIConfig {
 		MaxChannelDuration:     ctx.GlobalUint64(flags.MaxChannelDurationFlag.Name),
 		MaxL1TxSize:            ctx.GlobalUint64(flags.MaxL1TxSizeBytesFlag.Name),
 		Stopped:                ctx.GlobalBool(flags.StoppedFlag.Name),
+		DryRun:                 ctx.GlobalBool(flags.DryRunFlag.Name),
 		TxMgrConfig:            txmgr.ReadCLIConfig(ctx),
 		RPCConfig:              rpc.ReadCLIConfig(ctx),
 		LogConfig:              oplog.ReadCLIConfig(ctx),

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -70,9 +70,19 @@ func NewBatchSubmitterFromCLIConfig(cfg CLIConfig, l log.Logger, m metrics.Metri
 		return nil, fmt.Errorf("querying rollup config: %w", err)
 	}
 
-	txManager, err := txmgr.NewSimpleTxManager("batcher", l, m, cfg.TxMgrConfig)
-	if err != nil {
-		return nil, err
+	// Create a mock tx manager if we are in dry run mode
+	var txManager txmgr.TxManager
+	if cfg.DryRun {
+		l.Warn("Running in dry run mode. No transactions will be submitted to L1.")
+		txManager, err = txmgr.NewMockTxManager("batcher", l, m, cfg.TxMgrConfig)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		txManager, err = txmgr.NewSimpleTxManager("batcher", l, m, cfg.TxMgrConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	batcherCfg := Config{

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -73,6 +73,11 @@ var (
 		Usage:  "Initialize the batcher in a stopped state. The batcher can be started using the admin_startBatcher RPC",
 		EnvVar: opservice.PrefixEnvVar(EnvVarPrefix, "STOPPED"),
 	}
+	DryRunFlag = cli.BoolFlag{
+		Name:   "dry-run",
+		Usage:  "Run the batcher in dry-run mode. No transactions will be submitted to L1.",
+		EnvVar: opservice.PrefixEnvVar(EnvVarPrefix, "DRY_RUN"),
+	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )
@@ -91,6 +96,7 @@ var optionalFlags = []cli.Flag{
 	MaxL1TxSizeBytesFlag,
 	StoppedFlag,
 	SequencerHDPathFlag,
+	DryRunFlag,
 }
 
 func init() {


### PR DESCRIPTION
**Description**

Adds a `--dry-run` flag for the op-batcher using a mock tx manager backend.

**Metadata**

Fixes CLI-3243
