### PR TITLE
feat(indexer): index all L1 & L2 contract events

### DIFF
--- a/indexer/database/bridge.go
+++ b/indexer/database/bridge.go
@@ -3,9 +3,12 @@ package database
 import (
 	"errors"
 
+	"gorm.io/gorm"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"gorm.io/gorm"
+
+	"github.com/google/uuid"
 )
 
 /**
@@ -26,7 +29,7 @@ type TokenPair struct {
 }
 
 type Deposit struct {
-	GUID                 string `gorm:"primaryKey"`
+	GUID                 uuid.UUID `gorm:"primaryKey"`
 	InitiatedL1EventGUID string
 
 	Tx        Transaction `gorm:"embedded"`
@@ -39,7 +42,7 @@ type DepositWithTransactionHash struct {
 }
 
 type Withdrawal struct {
-	GUID                 string `gorm:"primaryKey"`
+	GUID                 uuid.UUID `gorm:"primaryKey"`
 	InitiatedL2EventGUID string
 
 	WithdrawalHash       common.Hash `gorm:"serializer:json"`

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -1,9 +1,11 @@
 package database
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"gorm.io/gorm"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/google/uuid"
 )
 
 /**
@@ -11,11 +13,11 @@ import (
  */
 
 type ContractEvent struct {
-	GUID            string      `gorm:"primaryKey"`
+	GUID            uuid.UUID   `gorm:"primaryKey"`
 	BlockHash       common.Hash `gorm:"serializer:json"`
 	TransactionHash common.Hash `gorm:"serializer:json"`
 
-	EventSignature hexutil.Bytes `gorm:"serializer:json"`
+	EventSignature common.Hash `gorm:"serializer:json"`
 	LogIndex       uint64
 	Timestamp      uint64
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/indexer/node"
 	"github.com/ethereum-optimism/optimism/indexer/processor"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/urfave/cli"
@@ -72,22 +73,30 @@ func NewIndexer(ctx *cli.Context) (*Indexer, error) {
 		return nil, err
 	}
 
-	// L1 Processor
+	// L1 Processor (hardhat devnet contracts). Make this configurable
+	l1Contracts := processor.L1Contracts{
+		OptimismPortal:         common.HexToAddress("0x6900000000000000000000000000000000000000"),
+		L2OutputOracle:         common.HexToAddress("0x6900000000000000000000000000000000000001"),
+		L1CrossDomainMessenger: common.HexToAddress("0x6900000000000000000000000000000000000002"),
+		L1StandardBridge:       common.HexToAddress("0x6900000000000000000000000000000000000003"),
+		L1ERC721Bridge:         common.HexToAddress("0x6900000000000000000000000000000000000004"),
+	}
 	l1EthClient, err := node.NewEthClient(ctx.GlobalString(flags.L1EthRPCFlag.Name))
 	if err != nil {
 		return nil, err
 	}
-	l1Processor, err := processor.NewL1Processor(l1EthClient, db)
+	l1Processor, err := processor.NewL1Processor(l1EthClient, db, l1Contracts)
 	if err != nil {
 		return nil, err
 	}
 
 	// L2Processor
+	l2Contracts := processor.L2ContractPredeploys() // Make this configurable
 	l2EthClient, err := node.NewEthClient(ctx.GlobalString(flags.L2EthRPCFlag.Name))
 	if err != nil {
 		return nil, err
 	}
-	l2Processor, err := processor.NewL2Processor(l2EthClient, db)
+	l2Processor, err := processor.NewL2Processor(l2EthClient, db, l2Contracts)
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -24,7 +24,7 @@ type L1Contracts struct {
 	L1ERC721Bridge         common.Address
 
 	// Some more contracts -- ProxyAdmin, SystemConfig, etcc
-	// Ignore the auxilliary contracts?
+	// Ignore the auxiliary contracts?
 
 	// Legacy contracts? We'll add this in to index the legacy chain.
 	// Remove afterwards?

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -30,7 +30,7 @@ type L1Contracts struct {
 	// Remove afterwards?
 }
 
-func (c L1Contracts) toArray() []common.Address {
+func (c L1Contracts) toSlice() []common.Address {
 	fields := reflect.VisibleFields(reflect.TypeOf(c))
 	v := reflect.ValueOf(c)
 
@@ -86,14 +86,11 @@ func NewL1Processor(ethClient node.EthClient, db *database.DB, l1Contracts L1Con
 func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1Contracts) func(db *database.DB, headers []*types.Header) error {
 	rawEthClient := ethclient.NewClient(ethClient.RawRpcClient())
 
-	contractAddrs := l1Contracts.toArray()
+	contractAddrs := l1Contracts.toSlice()
 	processLog.Info("processor configured with contracts", "contracts", l1Contracts)
 
 	return func(db *database.DB, headers []*types.Header) error {
 		numHeaders := len(headers)
-
-		/** Index Blocks **/
-
 		l1HeaderMap := make(map[common.Hash]*types.Header)
 		for _, header := range headers {
 			l1HeaderMap[header.Hash()] = header

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -38,7 +38,7 @@ func L2ContractPredeploys() L2Contracts {
 	}
 }
 
-func (c L2Contracts) toArray() []common.Address {
+func (c L2Contracts) toSlice() []common.Address {
 	fields := reflect.VisibleFields(reflect.TypeOf(c))
 	v := reflect.ValueOf(c)
 
@@ -93,7 +93,7 @@ func NewL2Processor(ethClient node.EthClient, db *database.DB, l2Contracts L2Con
 func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2Contracts) func(db *database.DB, headers []*types.Header) error {
 	rawEthClient := ethclient.NewClient(ethClient.RawRpcClient())
 
-	contractAddrs := l2Contracts.toArray()
+	contractAddrs := l2Contracts.toSlice()
 	processLog.Info("processor configured with contracts", "contracts", l2Contracts)
 	return func(db *database.DB, headers []*types.Header) error {
 		numHeaders := len(headers)

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -1,18 +1,60 @@
 package processor
 
 import (
+	"context"
+	"errors"
+	"reflect"
+
 	"github.com/ethereum-optimism/optimism/indexer/database"
 	"github.com/ethereum-optimism/optimism/indexer/node"
+	"github.com/google/uuid"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+type L2Contracts struct {
+	L2CrossDomainMessenger common.Address
+	L2StandardBridge       common.Address
+	L2ERC721Bridge         common.Address
+	L2ToL1MessagePasser    common.Address
+
+	// Some more contracts -- ProxyAdmin, SystemConfig, etcc
+	// Ignore the auxilliary contracts?
+
+	// Legacy Contracts? We'll add this in to index the legacy chain.
+	// Remove afterwards?
+}
+
+func L2ContractPredeploys() L2Contracts {
+	return L2Contracts{
+		L2CrossDomainMessenger: common.HexToAddress("0x4200000000000000000000000000000000000007"),
+		L2StandardBridge:       common.HexToAddress("0x4200000000000000000000000000000000000010"),
+		L2ERC721Bridge:         common.HexToAddress("0x4200000000000000000000000000000000000014"),
+		L2ToL1MessagePasser:    common.HexToAddress("0x4200000000000000000000000000000000000016"),
+	}
+}
+
+func (c L2Contracts) toArray() []common.Address {
+	fields := reflect.VisibleFields(reflect.TypeOf(c))
+	v := reflect.ValueOf(c)
+
+	contracts := make([]common.Address, len(fields))
+	for i, field := range fields {
+		contracts[i] = (v.FieldByName(field.Name).Interface()).(common.Address)
+	}
+
+	return contracts
+}
 
 type L2Processor struct {
 	processor
 }
 
-func NewL2Processor(ethClient node.EthClient, db *database.DB) (*L2Processor, error) {
+func NewL2Processor(ethClient node.EthClient, db *database.DB, l2Contracts L2Contracts) (*L2Processor, error) {
 	l2ProcessLog := log.New("processor", "l2")
 	l2ProcessLog.Info("initializing processor")
 
@@ -40,7 +82,7 @@ func NewL2Processor(ethClient node.EthClient, db *database.DB) (*L2Processor, er
 		processor: processor{
 			fetcher:    node.NewFetcher(ethClient, fromL2Header),
 			db:         db,
-			processFn:  l2ProcessFn(ethClient),
+			processFn:  l2ProcessFn(l2ProcessLog, ethClient, l2Contracts),
 			processLog: l2ProcessLog,
 		},
 	}
@@ -48,22 +90,78 @@ func NewL2Processor(ethClient node.EthClient, db *database.DB) (*L2Processor, er
 	return l2Processor, nil
 }
 
-func l2ProcessFn(ethClient node.EthClient) func(db *database.DB, headers []*types.Header) error {
-	return func(db *database.DB, headers []*types.Header) error {
+func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2Contracts) func(db *database.DB, headers []*types.Header) error {
+	rawEthClient := ethclient.NewClient(ethClient.RawRpcClient())
 
-		// index all l2 blocks for now
+	contractAddrs := l2Contracts.toArray()
+	processLog.Info("processor configured with contracts", "contracts", l2Contracts)
+	return func(db *database.DB, headers []*types.Header) error {
+		numHeaders := len(headers)
+
+		/** Index Blocks **/
+
 		l2Headers := make([]*database.L2BlockHeader, len(headers))
+		l2HeaderMap := make(map[common.Hash]*types.Header)
 		for i, header := range headers {
+			blockHash := header.Hash()
 			l2Headers[i] = &database.L2BlockHeader{
 				BlockHeader: database.BlockHeader{
-					Hash:       header.Hash(),
+					Hash:       blockHash,
 					ParentHash: header.ParentHash,
 					Number:     database.U256{Int: header.Number},
 					Timestamp:  header.Time,
 				},
 			}
+
+			l2HeaderMap[blockHash] = header
 		}
 
-		return db.Blocks.StoreL2BlockHeaders(l2Headers)
+		/** Index Contract Events **/
+
+		logFilter := ethereum.FilterQuery{FromBlock: headers[0].Number, ToBlock: headers[numHeaders-1].Number, Addresses: contractAddrs}
+		logs, err := rawEthClient.FilterLogs(context.Background(), logFilter)
+		if err != nil {
+			return err
+		}
+
+		numLogs := len(logs)
+		l2ContractEvents := make([]*database.L2ContractEvent, numLogs)
+		for i, log := range logs {
+			header, ok := l2HeaderMap[log.BlockHash]
+			if !ok {
+				// Log the individual headers in the batch?
+				processLog.Crit("contract event found with associated header not in the batch", "header", header, "log_index", log.Index)
+				return errors.New("parsed log with a block hash not in this batch")
+			}
+
+			l2ContractEvents[i] = &database.L2ContractEvent{
+				ContractEvent: database.ContractEvent{
+					GUID:            uuid.New(),
+					BlockHash:       log.BlockHash,
+					TransactionHash: log.TxHash,
+					EventSignature:  log.Topics[0],
+					LogIndex:        uint64(log.Index),
+					Timestamp:       header.Time,
+				},
+			}
+		}
+
+		/** Update Database **/
+
+		err = db.Blocks.StoreL2BlockHeaders(l2Headers)
+		if err != nil {
+			return err
+		}
+
+		if numLogs > 0 {
+			processLog.Info("detected new contract logs", "size", numLogs)
+			err = db.ContractEvents.StoreL2ContractEvents(l2ContractEvents)
+			if err != nil {
+				return err
+			}
+		}
+
+		// a-ok!
+		return nil
 	}
 }

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -98,7 +98,7 @@ func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2
 	return func(db *database.DB, headers []*types.Header) error {
 		numHeaders := len(headers)
 
-		/** Index Blocks **/
+		/** Index All L2 Blocks **/
 
 		l2Headers := make([]*database.L2BlockHeader, len(headers))
 		l2HeaderMap := make(map[common.Hash]*types.Header)
@@ -116,7 +116,7 @@ func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2
 			l2HeaderMap[blockHash] = header
 		}
 
-		/** Index Contract Events **/
+		/** Watch for Contract Events **/
 
 		logFilter := ethereum.FilterQuery{FromBlock: headers[0].Number, ToBlock: headers[numHeaders-1].Number, Addresses: contractAddrs}
 		logs, err := rawEthClient.FilterLogs(context.Background(), logFilter)

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -23,7 +23,7 @@ type L2Contracts struct {
 	L2ToL1MessagePasser    common.Address
 
 	// Some more contracts -- ProxyAdmin, SystemConfig, etcc
-	// Ignore the auxilliary contracts?
+	// Ignore the auxiliary contracts?
 
 	// Legacy Contracts? We'll add this in to index the legacy chain.
 	// Remove afterwards?


### PR DESCRIPTION
When starting the processor, the optimism contracts should be supplied. We watch these contracts and index as batches are processed.

## Aside
- Skip L1 blocks that do not have optimism activity.

## Followup
- Contract configuration. Right now the L1/L2 contracts are the hardcoded local devnet addresses