### PR TITLE
fix(fault-detector): Change expected error to a warning

### DIFF
--- a/.changeset/few-shoes-deny.md
+++ b/.changeset/few-shoes-deny.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/fault-detector': patch
+---
+
+Fix false error to warning

--- a/packages/fault-detector/src/helpers.ts
+++ b/packages/fault-detector/src/helpers.ts
@@ -66,7 +66,7 @@ export const updateOracleCache = async <TSubmissionEventArgs>(
     latestBlock: endBlock,
   })
 
-  let failures = 0
+  let failures = []
   let currentBlock = cache.highestBlock + 1
   let step = endBlock - currentBlock
   while (currentBlock < endBlock) {
@@ -98,7 +98,7 @@ export const updateOracleCache = async <TSubmissionEventArgs>(
       currentBlock += step
       step = Math.ceil(step * 2)
     } catch (err) {
-      logger?.error('error fetching events', {
+      logger?.warn('error fetching events', {
         err,
         node: 'l1',
         section: 'getLogs',
@@ -110,14 +110,14 @@ export const updateOracleCache = async <TSubmissionEventArgs>(
       // When the step gets down to zero, we're pretty much guaranteed that range size isn't the
       // problem. If we get three failures like this in a row then we should just give up.
       if (step === 0) {
-        failures++
+        failures.push(err)
       } else {
-        failures = 0
+        failures = []
       }
 
-      // We've failed 3 times in a row, we're probably stuck.
-      if (failures >= 3) {
-        logger?.fatal('unable to fetch oracle events', { err })
+      // We've failed 5 times in a row, we're probably stuck.
+      if (failures.length >= 5) {
+        logger?.fatal('unable to fetch oracle events', { errors: failures })
         throw new Error('failed to update event cache')
       }
     }


### PR DESCRIPTION
- expected failure was logged as an error and not a warning
- log as warning instead so it doesn't ping alerts

