### PR TITLE
require fee increase & gas re-estimation for retried transactions

### DIFF
--- a/op-service/txmgr/price_bump_test.go
+++ b/op-service/txmgr/price_bump_test.go
@@ -30,51 +30,52 @@ func (tc *priceBumpTest) run(t *testing.T) {
 }
 
 func TestUpdateFees(t *testing.T) {
+	require.Equal(t, int64(10), priceBump, "test must be updated if priceBump is adjusted")
 	tests := []priceBumpTest{
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 90, newBasefee: 900,
-			expectedTip: 115, expectedFC: 2415,
+			expectedTip: 110, expectedFC: 2310,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 101, newBasefee: 1000,
-			expectedTip: 115, expectedFC: 2415,
+			expectedTip: 110, expectedFC: 2310,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 100, newBasefee: 1001,
-			expectedTip: 115, expectedFC: 2415,
+			expectedTip: 110, expectedFC: 2310,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 101, newBasefee: 900,
-			expectedTip: 115, expectedFC: 2415,
+			expectedTip: 110, expectedFC: 2310,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 90, newBasefee: 1010,
-			expectedTip: 115, expectedFC: 2415,
+			expectedTip: 110, expectedFC: 2310,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 101, newBasefee: 2000,
-			expectedTip: 115, expectedFC: 4115,
+			expectedTip: 110, expectedFC: 4110,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 120, newBasefee: 900,
-			expectedTip: 120, expectedFC: 2415,
+			expectedTip: 120, expectedFC: 2310,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 120, newBasefee: 1100,
-			expectedTip: 120, expectedFC: 2415,
+			expectedTip: 120, expectedFC: 2320,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 120, newBasefee: 1140,
-			expectedTip: 120, expectedFC: 2415,
+			expectedTip: 120, expectedFC: 2400,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,

--- a/op-service/txmgr/price_bump_test.go
+++ b/op-service/txmgr/price_bump_test.go
@@ -34,7 +34,7 @@ func TestUpdateFees(t *testing.T) {
 		{
 			prevGasTip: 100, prevBasefee: 1000,
 			newGasTip: 90, newBasefee: 900,
-			expectedTip: 100, expectedFC: 2100,
+			expectedTip: 115, expectedFC: 2415,
 		},
 		{
 			prevGasTip: 100, prevBasefee: 1000,

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -734,12 +734,14 @@ func doGasPriceIncrease(t *testing.T, txTipCap, txFeeCap, newTip, newBaseFee int
 		GasTipCap: big.NewInt(txTipCap),
 		GasFeeCap: big.NewInt(txFeeCap),
 	})
-	newTx := mgr.increaseGasPrice(context.Background(), tx)
+	newTx, err := mgr.increaseGasPrice(context.Background(), tx)
+	require.NoError(t, err)
 	return tx, newTx
 }
 
 func TestIncreaseGasPrice(t *testing.T) {
 	// t.Parallel()
+	require.Equal(t, int64(10), priceBump, "test must be updated if priceBump is adjusted")
 	tests := []struct {
 		name string
 		run  func(t *testing.T)
@@ -781,15 +783,16 @@ func TestIncreaseGasPrice(t *testing.T) {
 			run: func(t *testing.T) {
 				_, newTx := doGasPriceIncrease(t, 100, 2200, 120, 1050)
 				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(120)) == 0, "new tx tip must be equal L1")
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(2530)) == 0, "new tx fee cap must be equal to the threshold value")
+				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(2420)) == 0, "new tx fee cap must be equal to the threshold value")
 			},
 		},
 		{
 			name: "uses L1 FC when larger and threshold tip",
 			run: func(t *testing.T) {
 				_, newTx := doGasPriceIncrease(t, 100, 2200, 100, 2000)
-				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(115)) == 0, "new tx tip must be equal the threshold value")
-				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(4115)) == 0, "new tx fee cap must be equal L1")
+				require.True(t, newTx.GasTipCap().Cmp(big.NewInt(110)) == 0, "new tx tip must be equal the threshold value")
+				t.Log("Vals:", newTx.GasFeeCap())
+				require.True(t, newTx.GasFeeCap().Cmp(big.NewInt(4110)) == 0, "new tx fee cap must be equal L1")
 			},
 		},
 	}
@@ -804,9 +807,11 @@ func TestIncreaseGasPrice(t *testing.T) {
 func TestIncreaseGasPriceNotExponential(t *testing.T) {
 	t.Parallel()
 
+	borkedTip := int64(10)
+	borkedFee := int64(45)
 	borkedBackend := failingBackend{
-		gasTip:  big.NewInt(10),
-		baseFee: big.NewInt(45),
+		gasTip:  big.NewInt(borkedTip),
+		baseFee: big.NewInt(borkedFee),
 	}
 
 	mgr := &SimpleTxManager{
@@ -831,17 +836,20 @@ func TestIncreaseGasPriceNotExponential(t *testing.T) {
 	})
 
 	// Run IncreaseGasPrice a bunch of times in a row to simulate a very fast resubmit loop.
-	for i := 0; i < 20; i++ {
+	var err error
+	for i := 0; i < 30; i++ {
 		ctx := context.Background()
-		tx = mgr.increaseGasPrice(ctx, tx)
+		tx, err = mgr.increaseGasPrice(ctx, tx)
+		require.NoError(t, err)
 	}
 	lastTip, lastFee := tx.GasTipCap(), tx.GasFeeCap()
-	require.Equal(t, lastTip.Int64(), int64(50))  // 5x borked tip
-	require.Equal(t, lastFee.Int64(), int64(500)) // 5x borked tip + 2*(5x borked base fee)
+	require.Equal(t, lastTip.Int64(), feeLimitMultiplier*borkedTip)
+	require.Equal(t, lastFee.Int64(), feeLimitMultiplier*(borkedTip+2*borkedFee))
 	// Confirm that fees stop rising
 	for i := 0; i < 5; i++ {
 		ctx := context.Background()
-		tx = mgr.increaseGasPrice(ctx, tx)
+		tx, err := mgr.increaseGasPrice(ctx, tx)
+		require.NoError(t, err)
 		require.True(t, tx.GasTipCap().Cmp(lastTip) == 0, "suggested tx tip must stop increasing")
 		require.True(t, tx.GasFeeCap().Cmp(lastFee) == 0, "suggested tx fee must stop increasing")
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Currently the txmgr retry logic will not bump a transaction's tip and max-fee in the case the latest suggested values are lower than the original values.  When a transaction is stuck in the mempool (e.g. due to too low fees or bad gaslimit estimate) this regularly results in retry failures with error message "resubmitted already known transaction" or "replacement transaction underpriced".

This PR imposes a mandatory fee increase with each retry (up to a point) to ensure a retried tx isn't immediately rejected in this manner.

We also see txs get stuck in the mempool because of extremely high gaslimit estimation (e.g. gaslimit nearly equals block gas limit).  In these cases, increasing fees alone does not solve the problem. To fix this scenario, this change makes the txmgr re-estimate gas with each retry.  We have also created a [geth PR](https://github.com/ethereum/go-ethereum/pull/27502) to fix what we suspect is causing the high gaslimit estimates.  (Fee re-estimation also seems to be helpful in detecting if resubmitting the tx would just fail anyway due to a state change.)

**Tests**

Updated unit tests to capture the new behavior.

**Additional context**

The issues addressed here have caused the Base goerli proposer to get stuck multiple times. Historically we have resorted to unjamming the proposer by manually submitting a transaction with a higher fee and lower gaslimit to replace the stuck transaction.

This issue does not happen with the batcher because batcher txs are simple sends, and we believe the underlying cause of the bad gas usage estimation only arises for reverting contract txs. Proposer txs revert quite frequently with the error message "block hash does not match the hash at the expected height".
