### PR TITLE
fix(ci): resurrect ci-builder

### DIFF
--- a/ops/docker/ci-builder/CHANGELOG.md
+++ b/ops/docker/ci-builder/CHANGELOG.md
@@ -1,0 +1,133 @@
+# @eth-optimism/ci-builder
+
+## 0.5.0
+
+### Minor Changes
+
+- 80f2271f5: Update foundry
+
+### Patch Changes
+
+- 035391a1f: Bump foundry to edf15abd648bb96e2bcee342c1d72ec7d1066cd1
+
+## 0.4.0
+
+### Minor Changes
+
+- 05cc935b2: Bump foundry to 2ff99025abade470a795724c10648c800a41025e
+
+## 0.3.8
+
+### Patch Changes
+
+- 85dfa9fe2: Add echidna tests for encoding
+- ea0540e51: Update the slither version to fix echidna tests
+- 0f8fc58ad: Add echidna tests for Burn
+
+## 0.3.7
+
+### Patch Changes
+
+- 18d1ce3f4: Require rebuild on null ref
+- 1594678e0: Add echidna test for AliasHelper
+- 74fd040ce: Pin echidna version
+
+## 0.3.6
+
+### Patch Changes
+
+- 011acf411: Add echidna to ci-builder
+
+## 0.3.5
+
+### Patch Changes
+
+- c44ff357f: Update foundry in ci-builder
+
+## 0.3.4
+
+### Patch Changes
+
+- 8e22c28f: Update geth to 1.10.25
+
+## 0.3.3
+
+### Patch Changes
+
+- 3f485627: Pin slither version to 0.9.0
+
+## 0.3.2
+
+### Patch Changes
+
+- fcfcf6e7: Remove ugly shell hack
+- 009939e0: Fix codecov download step
+
+## 0.3.1
+
+### Patch Changes
+
+- 7375a949: Download and verify codecov uploader binary in the ci-builder image
+
+## 0.3.0
+
+### Minor Changes
+
+- 25c564bc: Automate foundry build
+
+## 0.2.4
+
+### Patch Changes
+
+- c6fab69f: Update foundry to fix a bug in coverage generation
+- f7323e0b: Upgrade foundry to support consistent storage layouts
+
+## 0.2.3
+
+### Patch Changes
+
+- 9ac88806: Update golang, geth and golangci-lint
+
+## 0.2.2
+
+### Patch Changes
+
+- c666fedc: Upgrade to Debian 11
+
+## 0.2.1
+
+### Patch Changes
+
+- 9bb6a152: Trigger release to update foundry version
+
+## 0.2.0
+
+### Minor Changes
+
+- e8909be0: Fix unbound variable in check_changed script
+
+  This now uses -z to check if a variable is unbound instead of -n.
+  This should fix the error when the script is being ran on develop.
+
+## 0.1.2
+
+### Patch Changes
+
+- 184f13b6: Retrigger release of ci-builder
+
+## 0.1.1
+
+### Patch Changes
+
+- 7bf30513: Fix publishing
+- a60502f9: Install new version of bash
+
+## 0.1.0
+
+### Minor Changes
+
+- 8c121ece: Update foundry in ci builder
+
+### Patch Changes
+
+- 445efe9d: Use ethereumoptimism/foundry:latest

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -1,0 +1,107 @@
+FROM debian:bullseye-20220822-slim as foundry-build
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /opt
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y curl build-essential git && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh && \
+    chmod +x ./rustup.sh && \
+    ./rustup.sh -y
+
+WORKDIR /opt/foundry
+
+# Only diff from upstream docker image is this clone instead
+# of COPY. We select a specific commit to use.
+RUN git clone https://github.com/foundry-rs/foundry.git . \
+    && git checkout da2392e58bb8a7fefeba46b40c4df1afad8ccd22
+
+RUN source $HOME/.profile && \
+    cargo build --release && \
+    strip /opt/foundry/target/release/forge && \
+    strip /opt/foundry/target/release/cast && \
+    strip /opt/foundry/target/release/anvil
+
+FROM ethereum/client-go:alltools-v1.10.25 as geth
+
+FROM ghcr.io/crytic/echidna/echidna:v2.0.4 as echidna-test
+
+FROM python:3.8.13-slim-bullseye
+
+ENV GOPATH=/go
+ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=foundry-build /opt/foundry/target/release/forge /usr/local/bin/forge
+COPY --from=foundry-build /opt/foundry/target/release/cast /usr/local/bin/cast
+COPY --from=foundry-build /opt/foundry/target/release/anvil /usr/local/bin/anvil
+COPY --from=geth /usr/local/bin/abigen /usr/local/bin/abigen
+COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
+COPY check-changed.sh /usr/local/bin/check-changed
+
+RUN apt-get update && \
+  apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl gnupg coreutils && \
+  curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
+  curl -sL https://go.dev/dl/go1.19.linux-amd64.tar.gz -o go1.19.linux-amd64.tar.gz && \
+  tar -C /usr/local/ -xzvf go1.19.linux-amd64.tar.gz && \
+  ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt && \
+  bash nodesource_setup.sh && \
+  apt-get install -y nodejs && \
+  npm i -g npm@8.11.0 \
+  npm i -g yarn && \
+  npm i -g depcheck && \
+  pip install slither-analyzer==0.9.1 && \
+  go install gotest.tools/gotestsum@latest && \
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0 && \
+  curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash && \
+  chmod +x /usr/local/bin/check-changed
+
+RUN echo "downloading solidity compilers" && \
+  curl -o solc-linux-amd64-v0.5.17+commit.d19bba13 -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.5.17+commit.d19bba13 && \
+  curl -o solc-linux-amd64-v0.8.9+commit.e5eed63a -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a  && \
+  curl -o solc-linux-amd64-v0.8.10+commit.fc410830 -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.10+commit.fc410830 && \
+  curl -o solc-linux-amd64-v0.8.12+commit.f00d7308 -sL https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.12+commit.f00d7308 && \
+  echo "verifying checksums" && \
+  (echo "c35ce7a4d3ffa5747c178b1e24c8541b2e5d8a82c1db3719eb4433a1f19e16f3 solc-linux-amd64-v0.5.17+commit.d19bba13" | sha256sum --check --status - || exit 1) && \
+  (echo "f851f11fad37496baabaf8d6cb5c057ca0d9754fddb7a351ab580d7fd728cb94 solc-linux-amd64-v0.8.9+commit.e5eed63a"  | sha256sum --check --status - || exit 1) && \
+  (echo "c7effacf28b9d64495f81b75228fbf4266ac0ec87e8f1adc489ddd8a4dd06d89 solc-linux-amd64-v0.8.10+commit.fc410830" | sha256sum --check --status - || exit 1) && \
+  (echo "556c3ec44faf8ff6b67933fa8a8a403abe82c978d6e581dbfec4bd07360bfbf3 solc-linux-amd64-v0.8.12+commit.f00d7308" | sha256sum --check --status - || exit 1) && \
+  echo "caching compilers" && \
+  mkdir -p ~/.cache/hardhat-nodejs/compilers/linux-amd64 && \
+  cp solc-linux-amd64-v0.5.17+commit.d19bba13 ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  cp solc-linux-amd64-v0.8.9+commit.e5eed63a  ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  cp solc-linux-amd64-v0.8.10+commit.fc410830 ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  cp solc-linux-amd64-v0.8.12+commit.f00d7308 ~/.cache/hardhat-nodejs/compilers/linux-amd64/ && \
+  mkdir -p ~/.svm/0.5.17 && \
+  cp solc-linux-amd64-v0.5.17+commit.d19bba13 ~/.svm/0.5.17/solc-0.5.17 && \
+  mkdir -p ~/.svm/0.8.9  && \
+  cp solc-linux-amd64-v0.8.9+commit.e5eed63a  ~/.svm/0.8.9/solc-0.8.9   && \
+  mkdir -p ~/.svm/0.8.10 && \
+  cp solc-linux-amd64-v0.8.10+commit.fc410830 ~/.svm/0.8.10/solc-0.8.10 && \
+  mkdir -p ~/.svm/0.8.12 && \
+  cp solc-linux-amd64-v0.8.12+commit.f00d7308 ~/.svm/0.8.12/solc-0.8.12 && \
+  rm solc-linux-amd64-v0.5.17+commit.d19bba13 && \
+  rm solc-linux-amd64-v0.8.9+commit.e5eed63a && \
+  rm solc-linux-amd64-v0.8.10+commit.fc410830 && \
+  rm solc-linux-amd64-v0.8.12+commit.f00d7308
+
+RUN echo "downloading and verifying Codecov uploader" && \
+  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import && \
+  curl -Os "https://uploader.codecov.io/latest/linux/codecov" && \
+  curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM" && \
+  curl -Os "https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig" && \
+  gpgv codecov.SHA256SUM.sig codecov.SHA256SUM && \
+  shasum -a 256 -c codecov.SHA256SUM || sha256sum -c codecov.SHA256SUM && \
+  cp codecov /usr/local/bin/codecov && \
+  chmod +x /usr/local/bin/codecov  && \
+  rm codecov
+
+RUN echo "downloading mockery tool" && \
+  mkdir -p mockery-tmp-dir && \
+  curl -o mockery-tmp-dir/mockery.tar.gz -sL https://github.com/vektra/mockery/releases/download/v2.28.1/mockery_2.28.1_Linux_x86_64.tar.gz && \
+  tar -xzvf mockery-tmp-dir/mockery.tar.gz -C mockery-tmp-dir && \
+  cp mockery-tmp-dir/mockery /usr/local/bin/mockery && \
+  chmod +x /usr/local/bin/mockery && \
+  rm -rf mockery-tmp-dir

--- a/ops/docker/ci-builder/check-changed.sh
+++ b/ops/docker/ci-builder/check-changed.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+
+# Usage: check-changed.sh <diff-pattern>.
+#
+# This script compares the files changed in the <diff-pattern> to the git diff,
+# and writes TRUE or FALSE to stdout if the diff matches/does not match. It is
+# used by CircleCI jobs to determine if they need to run.
+
+echoerr() { echo "$@" 1>&2; }
+
+# Check if this is a CircleCI PR.
+if [[ -z ${CIRCLE_PULL_REQUEST+x} ]]; then
+	# CIRCLE_PULL_REQUEST is unbound here
+	# Non-PR builds always require a rebuild.
+	echoerr "Not a PR build, requiring a total rebuild."
+	echo "TRUE"
+else
+	# CIRCLE_PULL_REQUEST is bound here
+	PACKAGE=$1
+	# Craft the URL to the GitHub API. The access token is optional for the monorepo since it's an open-source repo.
+	GITHUB_API_URL="https://api.github.com/repos/ethereum-optimism/optimism/pulls/${CIRCLE_PULL_REQUEST/https:\/\/github.com\/ethereum-optimism\/optimism\/pull\//}"
+	echoerr "GitHub URL:"
+	echoerr "$GITHUB_API_URL"
+	# Grab the PR's base ref using the GitHub API.
+	PR=$(curl -H "Authorization: token $GITHUB_ACCESS_TOKEN" -H "Accept: application/vnd.github.v3+json" --retry 3 --retry-delay 1 -s "$GITHUB_API_URL")
+	echoerr "PR data:"
+	echoerr "$PR"
+	REF=$(echo "$PR" | jq -r ".base.ref")
+
+	if [ "$REF" = "master" ]; then
+		echoerr "Base ref is master, requiring a total rebuild."
+		echo "TRUE"
+		exit 0
+	fi
+
+	if [ "$REF" = "null" ]; then
+		echoerr "Bad ref, requiring a total rebuild."
+		echo "TRUE"
+		exit 1
+	fi
+
+
+	echoerr "Base Ref:     $REF"
+	echoerr "Base Ref SHA: $(git show-branch --sha1-name "$REF")"
+ 	echoerr "Curr Ref:     $(git rev-parse --short HEAD)"
+
+ 	DIFF=$(git diff --dirstat=files,0 "$REF...HEAD")
+
+ 	# Compare HEAD to the PR's base ref, stripping out the change percentages that come with git diff --dirstat.
+ 	# Pass in the diff pattern to grep, and echo TRUE if there's a match. False otherwise.
+ 	(echo "$DIFF" | sed 's/^[ 0-9.]\+% //g' | grep -q -E "$PACKAGE" && echo "TRUE") || echo "FALSE"
+fi


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
ci-builder was accidentally deleted while removing legacy ops. Shouldn't impact anything but need to bring it back so we can continue to make changes to it in the future.