### PR TITLE
ops: update L1 geth for devnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1008,7 +1008,7 @@ jobs:
     steps:
       - checkout
       - check-changed:
-          patterns: op-(.+),packages
+          patterns: op-(.+),packages,ops-bedrock
       - run:
           name: Install latest golang
           command: |

--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.11.2
+FROM ethereum/client-go:v1.12.0
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
**Description**

Updates to the latest geth for the devnet to ensure that our system works against the latest changes
to L1

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

