### PR TITLE
ci-builder: bump slither to 0.9.3

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
   npm i -g npm@8.11.0 \
   npm i -g yarn && \
   npm i -g depcheck && \
-  pip install slither-analyzer==0.9.1 && \
+  pip install slither-analyzer==0.9.3 && \
   go install gotest.tools/gotestsum@latest && \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0 && \
   curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash && \


### PR DESCRIPTION
**Description**

This commit bumps slither to the latest release at 0.9.3

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
