### PR TITLE
chore(ops): Fix ci-builder release action

### DIFF
--- a/ops/scripts/ci-docker-tag-op-stack-release.sh
+++ b/ops/scripts/ci-docker-tag-op-stack-release.sh
@@ -6,7 +6,7 @@ DOCKER_REPO=$1
 GIT_TAG=$2
 GIT_SHA=$3
 
-IMAGE_NAME=$(echo "$GIT_TAG" | grep -Eow '^(fault-detector|proxyd|indexer|op-[a-z0-9\-]*)' || true)
+IMAGE_NAME=$(echo "$GIT_TAG" | grep -Eow '^(ci-builder|fault-detector|proxyd|indexer|op-[a-z0-9\-]*)' || true)
 if [ -z "$IMAGE_NAME" ]; then
   echo "image name could not be parsed from git tag '$GIT_TAG'"
   exit 1

--- a/ops/tag-service/tag-service.py
+++ b/ops/tag-service/tag-service.py
@@ -16,6 +16,7 @@ MIN_VERSIONS = {
     'proxyd': '3.16.0',
     'indexer': '0.5.0',
     'fault-detector': '0.6.3'
+    'ci-builder': '0.6.0'
 }
 
 VALID_BUMPS = ('major', 'minor', 'patch', 'prerelease', 'finalize-prerelease')


### PR DESCRIPTION
## Overview

Fixes the tag-service action for ci-builder introduced in #6043 