### PR TITLE
fix(sdk): Fix multicall3 support for sdk

### DIFF
--- a/.changeset/cuddly-panthers-trade.md
+++ b/.changeset/cuddly-panthers-trade.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': minor
+---
+
+Add support for claiming multicall3 withdrawals

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -455,6 +455,11 @@ export class CrossChainMessenger {
       }
 
       const withdrawal = withdrawals[multiWithdrawalIndex]
+      if (!withdrawal) {
+        throw new Error(
+          `withdrawal index ${multiWithdrawalIndex} out of bounds there are ${withdrawals.length} withdrawals`
+        )
+      }
       messageNonce = withdrawal.nonce
       gasLimit = withdrawal.gasLimit
     }
@@ -643,7 +648,13 @@ export class CrossChainMessenger {
         message as TransactionLike
       )
 
-      return messages[multiWithdrawalIndex]
+      const out = messages[multiWithdrawalIndex]
+      if (!out) {
+        throw new Error(
+          `withdrawal index ${multiWithdrawalIndex} out of bounds. There are ${messages.length} withdrawals`
+        )
+      }
+      return out
     }
   }
 

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -333,11 +333,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<CrossChainMessage> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
 
     // Bedrock messages are already in the correct format.
@@ -405,11 +405,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<LowLevelMessage> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       throw new Error(`can only convert L2 to L1 messages to low level`)
@@ -421,7 +421,7 @@ export class CrossChainMessenger {
     if (version.eq(0)) {
       updated = await this.toBedrockCrossChainMessage(
         resolved,
-        multiWithdrawalIndex
+        messageIndex
       )
     } else {
       updated = resolved
@@ -454,10 +454,10 @@ export class CrossChainMessenger {
         throw new Error(`no withdrawals found in receipt`)
       }
 
-      const withdrawal = withdrawals[multiWithdrawalIndex]
+      const withdrawal = withdrawals[messageIndex]
       if (!withdrawal) {
         throw new Error(
-          `withdrawal index ${multiWithdrawalIndex} out of bounds there are ${withdrawals.length} withdrawals`
+          `withdrawal index ${messageIndex} out of bounds there are ${withdrawals.length} withdrawals`
         )
       }
       messageNonce = withdrawal.nonce
@@ -604,7 +604,7 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<CrossChainMessage> {
     if (!message) {
       throw new Error('message is undefined')
@@ -648,10 +648,10 @@ export class CrossChainMessenger {
         message as TransactionLike
       )
 
-      const out = messages[multiWithdrawalIndex]
+      const out = messages[messageIndex]
       if (!out) {
         throw new Error(
-          `withdrawal index ${multiWithdrawalIndex} out of bounds. There are ${messages.length} withdrawals`
+          `withdrawal index ${messageIndex} out of bounds. There are ${messages.length} withdrawals`
         )
       }
       return out
@@ -670,13 +670,13 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<MessageStatus> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
-    const receipt = await this.getMessageReceipt(resolved, multiWithdrawalIndex)
+    const receipt = await this.getMessageReceipt(resolved, messageIndex)
 
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       if (receipt === null) {
@@ -694,7 +694,7 @@ export class CrossChainMessenger {
         if (this.bedrock) {
           const output = await this.getMessageBedrockOutput(
             resolved,
-            multiWithdrawalIndex
+            messageIndex
           )
           if (output === null) {
             return MessageStatus.STATE_ROOT_NOT_PUBLISHED
@@ -703,7 +703,7 @@ export class CrossChainMessenger {
           // Convert the message to the low level message that was proven.
           const withdrawal = await this.toLowLevelMessage(
             resolved,
-            multiWithdrawalIndex
+            messageIndex
           )
 
           // Attempt to fetch the proven withdrawal.
@@ -723,7 +723,7 @@ export class CrossChainMessenger {
         } else {
           const stateRoot = await this.getMessageStateRoot(
             resolved,
-            multiWithdrawalIndex
+            messageIndex
           )
           if (stateRoot === null) {
             return MessageStatus.STATE_ROOT_NOT_PUBLISHED
@@ -765,11 +765,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<MessageReceipt> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
     // legacy withdrawals relayed prebedrock are v1
     const messageHashV0 = hashCrossDomainMessagev0(
@@ -877,12 +877,12 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<MessageReceipt> {
     // Resolving once up-front is slightly more efficient.
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
 
     let totalTimeMs = 0
@@ -890,7 +890,7 @@ export class CrossChainMessenger {
       const tick = Date.now()
       const receipt = await this.getMessageReceipt(
         resolved,
-        multiWithdrawalIndex
+        messageIndex
       )
       if (receipt !== null) {
         return receipt
@@ -926,12 +926,12 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<void> {
     // Resolving once up-front is slightly more efficient.
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
 
     let totalTimeMs = 0
@@ -939,7 +939,7 @@ export class CrossChainMessenger {
       const tick = Date.now()
       const currentStatus = await this.getMessageStatus(
         resolved,
-        multiWithdrawalIndex
+        messageIndex
       )
 
       // Handle special cases for L1 to L2 messages.
@@ -1009,7 +1009,7 @@ export class CrossChainMessenger {
       bufferPercent?: number
       from?: string
     },
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<BigNumber> {
     let resolved: CrossChainMessage | CrossChainMessageRequest
     let from: string
@@ -1019,7 +1019,7 @@ export class CrossChainMessenger {
     } else {
       resolved = await this.toCrossChainMessage(
         message as MessageLike,
-        multiWithdrawalIndex
+        messageIndex
       )
       from = opts?.from || (resolved as CrossChainMessage).sender
     }
@@ -1055,13 +1055,13 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<number> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
-    const status = await this.getMessageStatus(resolved, multiWithdrawalIndex)
+    const status = await this.getMessageStatus(resolved, messageIndex)
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       if (
         status === MessageStatus.RELAYED ||
@@ -1101,7 +1101,7 @@ export class CrossChainMessenger {
         // when the state root is published.
         const stateRoot = await this.getMessageStateRoot(
           resolved,
-          multiWithdrawalIndex
+          messageIndex
         )
         const challengePeriod = await this.getChallengePeriodSeconds()
         const targetBlock = await this.l1Provider.getBlock(
@@ -1135,13 +1135,13 @@ export class CrossChainMessenger {
     const challengePeriod =
       oracleVersion === '1.0.0'
         ? // The ABI in the SDK does not contain FINALIZATION_PERIOD_SECONDS
-          // in OptimismPortal, so making an explicit call instead.
-          BigNumber.from(
-            await this.contracts.l1.OptimismPortal.provider.call({
-              to: this.contracts.l1.OptimismPortal.address,
-              data: '0xf4daa291', // FINALIZATION_PERIOD_SECONDS
-            })
-          )
+        // in OptimismPortal, so making an explicit call instead.
+        BigNumber.from(
+          await this.contracts.l1.OptimismPortal.provider.call({
+            to: this.contracts.l1.OptimismPortal.address,
+            data: '0xf4daa291', // FINALIZATION_PERIOD_SECONDS
+          })
+        )
         : await this.contracts.l1.L2OutputOracle.FINALIZATION_PERIOD_SECONDS()
     return challengePeriod.toNumber()
   }
@@ -1177,11 +1177,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<BedrockOutputData | null> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
 
     // Outputs are only a thing for L2 to L1 messages.
@@ -1236,11 +1236,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<StateRoot | null> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
 
     // State roots are only a thing for L2 to L1 messages.
@@ -1429,11 +1429,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<CrossChainMessageProof> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       throw new Error(`can only generate proofs for L2 to L1 messages`)
@@ -1441,7 +1441,7 @@ export class CrossChainMessenger {
 
     const stateRoot = await this.getMessageStateRoot(
       resolved,
-      multiWithdrawalIndex
+      messageIndex
     )
     if (stateRoot === null) {
       throw new Error(`state root for message not yet published`)
@@ -1498,11 +1498,11 @@ export class CrossChainMessenger {
     /**
      * The index of the withdrawal if multiple are made with multicall
      */
-    multiWithdrawalIndex = 0
+    messageIndex = 0
   ): Promise<BedrockCrossChainMessageProof> {
     const resolved = await this.toCrossChainMessage(
       message,
-      multiWithdrawalIndex
+      messageIndex
     )
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       throw new Error(`can only generate proofs for L2 to L1 messages`)
@@ -1510,7 +1510,7 @@ export class CrossChainMessenger {
 
     const output = await this.getMessageBedrockOutput(
       resolved,
-      multiWithdrawalIndex
+      messageIndex
     )
     if (output === null) {
       throw new Error(`state root for message not yet published`)
@@ -1518,7 +1518,7 @@ export class CrossChainMessenger {
 
     const withdrawal = await this.toLowLevelMessage(
       resolved,
-      multiWithdrawalIndex
+      messageIndex
     )
     const hash = hashLowLevelMessage(withdrawal)
     const messageSlot = hashMessageHash(hash)
@@ -1870,11 +1870,11 @@ export class CrossChainMessenger {
       /**
        * The index of the withdrawal if multiple are made with multicall
        */
-      multiWithdrawalIndex = 0
+      messageIndex = 0
     ): Promise<TransactionRequest> => {
       const resolved = await this.toCrossChainMessage(
         message,
-        multiWithdrawalIndex
+        messageIndex
       )
       if (resolved.direction === MessageDirection.L2_TO_L1) {
         throw new Error(`cannot resend L2 to L1 message`)
@@ -1924,11 +1924,11 @@ export class CrossChainMessenger {
       /**
        * The index of the withdrawal if multiple are made with multicall
        */
-      multiWithdrawalIndex = 0
+      messageIndex = 0
     ): Promise<TransactionRequest> => {
       const resolved = await this.toCrossChainMessage(
         message,
-        multiWithdrawalIndex
+        messageIndex
       )
       if (resolved.direction === MessageDirection.L1_TO_L2) {
         throw new Error('cannot finalize L1 to L2 message')
@@ -1942,11 +1942,11 @@ export class CrossChainMessenger {
 
       const withdrawal = await this.toLowLevelMessage(
         resolved,
-        multiWithdrawalIndex
+        messageIndex
       )
       const proof = await this.getBedrockMessageProof(
         resolved,
-        multiWithdrawalIndex
+        messageIndex
       )
 
       const args = [
@@ -1993,11 +1993,11 @@ export class CrossChainMessenger {
       /**
        * The index of the withdrawal if multiple are made with multicall
        */
-      multiWithdrawalIndex = 0
+      messageIndex = 0
     ): Promise<TransactionRequest> => {
       const resolved = await this.toCrossChainMessage(
         message,
-        multiWithdrawalIndex
+        messageIndex
       )
       if (resolved.direction === MessageDirection.L1_TO_L2) {
         throw new Error(`cannot finalize L1 to L2 message`)
@@ -2006,7 +2006,7 @@ export class CrossChainMessenger {
       if (this.bedrock) {
         const withdrawal = await this.toLowLevelMessage(
           resolved,
-          multiWithdrawalIndex
+          messageIndex
         )
         return this.contracts.l1.OptimismPortal.populateTransaction.finalizeWithdrawalTransaction(
           [
@@ -2023,7 +2023,7 @@ export class CrossChainMessenger {
         // L1CrossDomainMessenger relayMessage is the only method that isn't fully backwards
         // compatible, so we need to use the legacy interface. When we fully upgrade to Bedrock we
         // should be able to remove this code.
-        const proof = await this.getMessageProof(resolved, multiWithdrawalIndex)
+        const proof = await this.getMessageProof(resolved, messageIndex)
         const legacyL1XDM = new ethers.Contract(
           this.contracts.l1.L1CrossDomainMessenger.address,
           getContractInterface('L1CrossDomainMessenger'),
@@ -2284,13 +2284,13 @@ export class CrossChainMessenger {
       /**
        * The index of the withdrawal if multiple are made with multicall
        */
-      multiWithdrawalIndex = 0
+      messageIndex = 0
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
         await this.populateTransaction.proveMessage(
           message,
           opts,
-          multiWithdrawalIndex
+          messageIndex
         )
       )
     },

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -335,10 +335,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<CrossChainMessage> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
 
     // Bedrock messages are already in the correct format.
     const { version } = decodeVersionedNonce(resolved.messageNonce)
@@ -374,7 +371,9 @@ export class CrossChainMessenger {
     }
   }
 
-  private async getWithdrawalsFromMessage(message: MessageLike): Promise<ethers.utils.Result[]> {
+  private async getWithdrawalsFromMessage(
+    message: MessageLike
+  ): Promise<ethers.utils.Result[]> {
     const resolved = await this.toCrossChainMessage(message)
     const receipt = await this.l2Provider.getTransactionReceipt(
       resolved.transactionHash
@@ -407,10 +406,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<LowLevelMessage> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       throw new Error(`can only convert L2 to L1 messages to low level`)
     }
@@ -419,10 +415,7 @@ export class CrossChainMessenger {
     const { version } = decodeVersionedNonce(resolved.messageNonce)
     let updated: CrossChainMessage
     if (version.eq(0)) {
-      updated = await this.toBedrockCrossChainMessage(
-        resolved,
-        messageIndex
-      )
+      updated = await this.toBedrockCrossChainMessage(resolved, messageIndex)
     } else {
       updated = resolved
     }
@@ -672,10 +665,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<MessageStatus> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
     const receipt = await this.getMessageReceipt(resolved, messageIndex)
 
     if (resolved.direction === MessageDirection.L1_TO_L2) {
@@ -767,10 +757,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<MessageReceipt> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
     // legacy withdrawals relayed prebedrock are v1
     const messageHashV0 = hashCrossDomainMessagev0(
       resolved.target,
@@ -880,18 +867,12 @@ export class CrossChainMessenger {
     messageIndex = 0
   ): Promise<MessageReceipt> {
     // Resolving once up-front is slightly more efficient.
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
 
     let totalTimeMs = 0
     while (totalTimeMs < (opts.timeoutMs || Infinity)) {
       const tick = Date.now()
-      const receipt = await this.getMessageReceipt(
-        resolved,
-        messageIndex
-      )
+      const receipt = await this.getMessageReceipt(resolved, messageIndex)
       if (receipt !== null) {
         return receipt
       } else {
@@ -929,18 +910,12 @@ export class CrossChainMessenger {
     messageIndex = 0
   ): Promise<void> {
     // Resolving once up-front is slightly more efficient.
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
 
     let totalTimeMs = 0
     while (totalTimeMs < (opts.timeoutMs || Infinity)) {
       const tick = Date.now()
-      const currentStatus = await this.getMessageStatus(
-        resolved,
-        messageIndex
-      )
+      const currentStatus = await this.getMessageStatus(resolved, messageIndex)
 
       // Handle special cases for L1 to L2 messages.
       if (resolved.direction === MessageDirection.L1_TO_L2) {
@@ -1057,10 +1032,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<number> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
     const status = await this.getMessageStatus(resolved, messageIndex)
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       if (
@@ -1099,10 +1071,7 @@ export class CrossChainMessenger {
         // If the message is still within the challenge period, then we need to estimate exactly
         // the amount of time left until the challenge period expires. The challenge period starts
         // when the state root is published.
-        const stateRoot = await this.getMessageStateRoot(
-          resolved,
-          messageIndex
-        )
+        const stateRoot = await this.getMessageStateRoot(resolved, messageIndex)
         const challengePeriod = await this.getChallengePeriodSeconds()
         const targetBlock = await this.l1Provider.getBlock(
           stateRoot.batch.blockNumber
@@ -1135,13 +1104,13 @@ export class CrossChainMessenger {
     const challengePeriod =
       oracleVersion === '1.0.0'
         ? // The ABI in the SDK does not contain FINALIZATION_PERIOD_SECONDS
-        // in OptimismPortal, so making an explicit call instead.
-        BigNumber.from(
-          await this.contracts.l1.OptimismPortal.provider.call({
-            to: this.contracts.l1.OptimismPortal.address,
-            data: '0xf4daa291', // FINALIZATION_PERIOD_SECONDS
-          })
-        )
+          // in OptimismPortal, so making an explicit call instead.
+          BigNumber.from(
+            await this.contracts.l1.OptimismPortal.provider.call({
+              to: this.contracts.l1.OptimismPortal.address,
+              data: '0xf4daa291', // FINALIZATION_PERIOD_SECONDS
+            })
+          )
         : await this.contracts.l1.L2OutputOracle.FINALIZATION_PERIOD_SECONDS()
     return challengePeriod.toNumber()
   }
@@ -1179,10 +1148,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<BedrockOutputData | null> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
 
     // Outputs are only a thing for L2 to L1 messages.
     if (resolved.direction === MessageDirection.L1_TO_L2) {
@@ -1238,10 +1204,7 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<StateRoot | null> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
 
     // State roots are only a thing for L2 to L1 messages.
     if (resolved.direction === MessageDirection.L1_TO_L2) {
@@ -1431,18 +1394,12 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<CrossChainMessageProof> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       throw new Error(`can only generate proofs for L2 to L1 messages`)
     }
 
-    const stateRoot = await this.getMessageStateRoot(
-      resolved,
-      messageIndex
-    )
+    const stateRoot = await this.getMessageStateRoot(resolved, messageIndex)
     if (stateRoot === null) {
       throw new Error(`state root for message not yet published`)
     }
@@ -1500,26 +1457,17 @@ export class CrossChainMessenger {
      */
     messageIndex = 0
   ): Promise<BedrockCrossChainMessageProof> {
-    const resolved = await this.toCrossChainMessage(
-      message,
-      messageIndex
-    )
+    const resolved = await this.toCrossChainMessage(message, messageIndex)
     if (resolved.direction === MessageDirection.L1_TO_L2) {
       throw new Error(`can only generate proofs for L2 to L1 messages`)
     }
 
-    const output = await this.getMessageBedrockOutput(
-      resolved,
-      messageIndex
-    )
+    const output = await this.getMessageBedrockOutput(resolved, messageIndex)
     if (output === null) {
       throw new Error(`state root for message not yet published`)
     }
 
-    const withdrawal = await this.toLowLevelMessage(
-      resolved,
-      messageIndex
-    )
+    const withdrawal = await this.toLowLevelMessage(resolved, messageIndex)
     const hash = hashLowLevelMessage(withdrawal)
     const messageSlot = hashMessageHash(hash)
 
@@ -1872,10 +1820,7 @@ export class CrossChainMessenger {
        */
       messageIndex = 0
     ): Promise<TransactionRequest> => {
-      const resolved = await this.toCrossChainMessage(
-        message,
-        messageIndex
-      )
+      const resolved = await this.toCrossChainMessage(message, messageIndex)
       if (resolved.direction === MessageDirection.L2_TO_L1) {
         throw new Error(`cannot resend L2 to L1 message`)
       }
@@ -1926,10 +1871,7 @@ export class CrossChainMessenger {
        */
       messageIndex = 0
     ): Promise<TransactionRequest> => {
-      const resolved = await this.toCrossChainMessage(
-        message,
-        messageIndex
-      )
+      const resolved = await this.toCrossChainMessage(message, messageIndex)
       if (resolved.direction === MessageDirection.L1_TO_L2) {
         throw new Error('cannot finalize L1 to L2 message')
       }
@@ -1940,14 +1882,8 @@ export class CrossChainMessenger {
         )
       }
 
-      const withdrawal = await this.toLowLevelMessage(
-        resolved,
-        messageIndex
-      )
-      const proof = await this.getBedrockMessageProof(
-        resolved,
-        messageIndex
-      )
+      const withdrawal = await this.toLowLevelMessage(resolved, messageIndex)
+      const proof = await this.getBedrockMessageProof(resolved, messageIndex)
 
       const args = [
         [
@@ -1995,19 +1931,13 @@ export class CrossChainMessenger {
        */
       messageIndex = 0
     ): Promise<TransactionRequest> => {
-      const resolved = await this.toCrossChainMessage(
-        message,
-        messageIndex
-      )
+      const resolved = await this.toCrossChainMessage(message, messageIndex)
       if (resolved.direction === MessageDirection.L1_TO_L2) {
         throw new Error(`cannot finalize L1 to L2 message`)
       }
 
       if (this.bedrock) {
-        const withdrawal = await this.toLowLevelMessage(
-          resolved,
-          messageIndex
-        )
+        const withdrawal = await this.toLowLevelMessage(resolved, messageIndex)
         return this.contracts.l1.OptimismPortal.populateTransaction.finalizeWithdrawalTransaction(
           [
             withdrawal.messageNonce,
@@ -2287,11 +2217,7 @@ export class CrossChainMessenger {
       messageIndex = 0
     ): Promise<BigNumber> => {
       return this.l1Provider.estimateGas(
-        await this.populateTransaction.proveMessage(
-          message,
-          opts,
-          messageIndex
-        )
+        await this.populateTransaction.proveMessage(message, opts, messageIndex)
       )
     },
 

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -409,6 +409,8 @@ export class CrossChainMessenger {
       updated.message
     )
 
+    // EVERYTHING following here is basically repeating the logic from getMessagesByTransaction 
+    // consider cleaning this up
     // We need to figure out the final withdrawal data that was used to compute the withdrawal hash
     // inside the L2ToL1Message passer contract. Exact mechanism here depends on whether or not
     // this is a legacy message or a new Bedrock message.
@@ -1098,13 +1100,13 @@ export class CrossChainMessenger {
     const challengePeriod =
       oracleVersion === '1.0.0'
         ? // The ABI in the SDK does not contain FINALIZATION_PERIOD_SECONDS
-          // in OptimismPortal, so making an explicit call instead.
-          BigNumber.from(
-            await this.contracts.l1.OptimismPortal.provider.call({
-              to: this.contracts.l1.OptimismPortal.address,
-              data: '0xf4daa291', // FINALIZATION_PERIOD_SECONDS
-            })
-          )
+        // in OptimismPortal, so making an explicit call instead.
+        BigNumber.from(
+          await this.contracts.l1.OptimismPortal.provider.call({
+            to: this.contracts.l1.OptimismPortal.address,
+            data: '0xf4daa291', // FINALIZATION_PERIOD_SECONDS
+          })
+        )
         : await this.contracts.l1.L2OutputOracle.FINALIZATION_PERIOD_SECONDS()
     return challengePeriod.toNumber()
   }

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -374,13 +374,13 @@ export class CrossChainMessenger {
     }
   }
 
-  public async getWithdrawalsFromMessage(message: MessageLike) {
+  public async getWithdrawalsFromMessage(message: MessageLike): Promise<ethers.utils.Result[]> {
     const resolved = await this.toCrossChainMessage(message)
     const receipt = await this.l2Provider.getTransactionReceipt(
       resolved.transactionHash
     )
 
-    const withdrawals: any[] = []
+    const withdrawals: ethers.utils.Result[] = []
     for (const log of receipt.logs) {
       if (log.address === this.contracts.l2.BedrockMessagePasser.address) {
         const decoded =

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -374,7 +374,7 @@ export class CrossChainMessenger {
     }
   }
 
-  public async getWithdrawalsFromMessage(message: MessageLike): Promise<ethers.utils.Result[]> {
+  private async getWithdrawalsFromMessage(message: MessageLike): Promise<ethers.utils.Result[]> {
     const resolved = await this.toCrossChainMessage(message)
     const receipt = await this.l2Provider.getTransactionReceipt(
       resolved.transactionHash

--- a/packages/sdk/test/cross-chain-messenger.spec.ts
+++ b/packages/sdk/test/cross-chain-messenger.spec.ts
@@ -565,24 +565,26 @@ describe('CrossChainMessenger', () => {
       })
 
       describe('when the transaction sent more than one message', () => {
-        it('should not throw an error', async () => {
+        it('should be able to get second message by passing in an idex', async () => {
           const messages = [...Array(2)].map(() => {
             return DUMMY_MESSAGE
           })
 
           const tx = await l1Messenger.triggerSentMessageEvents(messages)
-          await expect(
-            messenger.toCrossChainMessage(tx)
-          ).not.to.be.rejectedWith('expected 1 message, got 2')
+          const foundCrossChainMessages =
+            await messenger.getMessagesByTransaction(tx)
+          expect(await messenger.toCrossChainMessage(tx, 1)).to.deep.eq(
+            foundCrossChainMessages[1]
+          )
         })
       })
 
       describe('when the transaction sent no messages', () => {
-        it('should not throw an error', async () => {
+        it('should throw an out of bounds error', async () => {
           const tx = await l1Messenger.triggerSentMessageEvents([])
-          await expect(
-            messenger.toCrossChainMessage(tx)
-          ).not.to.be.rejectedWith('expected 1 message, got 0')
+          await expect(messenger.toCrossChainMessage(tx)).to.be.rejectedWith(
+            `withdrawal index 0 out of bounds. There are 0 withdrawals`
+          )
         })
       })
     })

--- a/packages/sdk/test/cross-chain-messenger.spec.ts
+++ b/packages/sdk/test/cross-chain-messenger.spec.ts
@@ -565,24 +565,24 @@ describe('CrossChainMessenger', () => {
       })
 
       describe('when the transaction sent more than one message', () => {
-        it('should throw an error', async () => {
+        it('should not throw an error', async () => {
           const messages = [...Array(2)].map(() => {
             return DUMMY_MESSAGE
           })
 
           const tx = await l1Messenger.triggerSentMessageEvents(messages)
-          await expect(messenger.toCrossChainMessage(tx)).to.be.rejectedWith(
-            'expected 1 message, got 2'
-          )
+          await expect(
+            messenger.toCrossChainMessage(tx)
+          ).not.to.be.rejectedWith('expected 1 message, got 2')
         })
       })
 
       describe('when the transaction sent no messages', () => {
-        it('should throw an error', async () => {
+        it('should not throw an error', async () => {
           const tx = await l1Messenger.triggerSentMessageEvents([])
-          await expect(messenger.toCrossChainMessage(tx)).to.be.rejectedWith(
-            'expected 1 message, got 0'
-          )
+          await expect(
+            messenger.toCrossChainMessage(tx)
+          ).not.to.be.rejectedWith('expected 1 message, got 0')
         })
       })
     })


### PR DESCRIPTION
fixes https://github.com/ethereum-optimism/optimism/issues/5983

- fixes multicall3 withdrawals for sdk
- I have tests for this in https://github.com/ethereum-optimism/optimism/pull/6024 passing locally but they fail ci for unrelated reasons
  - they are failing because the packages I yarn installed broke other packages
  - I plan on fixing this in it's own seperate pr via upgrading some packages and implementing no-hoisting for affected packages to make them less fragile
