### PR TITLE
op-node: Add peer score diffs to increment and decay application scores

### DIFF
--- a/op-node/p2p/store/scorebook_test.go
+++ b/op-node/p2p/store/scorebook_test.go
@@ -45,6 +45,88 @@ func TestUpdateGossipScore(t *testing.T) {
 	assertPeerScores(t, store, id, PeerScores{Gossip: GossipScores{Total: score}})
 }
 
+func TestIncrementValidResponses(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	inc := IncrementValidResponses{Cap: 2.1}
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{ValidResponses: 1}})
+
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{ValidResponses: 2}})
+
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{ValidResponses: 2.1}})
+}
+
+func TestIncrementErrorResponses(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	inc := IncrementErrorResponses{Cap: 2.1}
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{ErrorResponses: 1}})
+
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{ErrorResponses: 2}})
+
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{ErrorResponses: 2.1}})
+}
+
+func TestIncrementRejectedPayloads(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	inc := IncrementRejectedPayloads{Cap: 2.1}
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{RejectedPayloads: 1}})
+
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{RejectedPayloads: 2}})
+
+	setScoreRequired(t, store, id, inc)
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{RejectedPayloads: 2.1}})
+}
+
+func TestDecayApplicationScores(t *testing.T) {
+	id := peer.ID("aaaa")
+	store := createMemoryStore(t)
+	for i := 0; i < 10; i++ {
+		setScoreRequired(t, store, id, IncrementValidResponses{Cap: 100})
+		setScoreRequired(t, store, id, IncrementErrorResponses{Cap: 100})
+		setScoreRequired(t, store, id, IncrementRejectedPayloads{Cap: 100})
+	}
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{
+		ValidResponses:   10,
+		ErrorResponses:   10,
+		RejectedPayloads: 10,
+	}})
+
+	setScoreRequired(t, store, id, &DecayApplicationScores{
+		ValidResponseDecay:   0.8,
+		ErrorResponseDecay:   0.4,
+		RejectedPayloadDecay: 0.5,
+		DecayToZero:          0.1,
+	})
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{
+		ValidResponses:   10 * 0.8,
+		ErrorResponses:   10 * 0.4,
+		RejectedPayloads: 10 * 0.5,
+	}})
+
+	// Should be set to exactly zero when below DecayToZero
+	setScoreRequired(t, store, id, &DecayApplicationScores{
+		ValidResponseDecay:   0.8,
+		ErrorResponseDecay:   0.4,
+		RejectedPayloadDecay: 0.5,
+		DecayToZero:          5,
+	})
+	assertPeerScores(t, store, id, PeerScores{ReqResp: ReqRespScores{
+		ValidResponses:   10 * 0.8 * 0.8, // Not yet below 5 so preserved
+		ErrorResponses:   0,
+		RejectedPayloads: 0,
+	}})
+}
+
 func TestStoreScoresForMultiplePeers(t *testing.T) {
 	id1 := peer.ID("aaaa")
 	id2 := peer.ID("bbbb")
@@ -215,7 +297,7 @@ func createPeerstoreWithBacking(t *testing.T, store *sync.MutexDatastore) Extend
 	return eps
 }
 
-func setScoreRequired(t *testing.T, store ScoreDatastore, id peer.ID, diff *GossipScores) {
+func setScoreRequired(t *testing.T, store ScoreDatastore, id peer.ID, diff ScoreDiff) {
 	_, err := store.SetScore(id, diff)
 	require.NoError(t, err)
 }

--- a/op-node/p2p/store/serialize_test.go
+++ b/op-node/p2p/store/serialize_test.go
@@ -45,7 +45,31 @@ func TestParseHistoricSerializationsV0(t *testing.T) {
 						IPColocationFactor: 12.34,
 						BehavioralPenalty:  56.78,
 					},
-					ReqRespSync: 123456,
+					ReqResp: ReqRespScores{},
+				},
+				LastUpdate: 1923841,
+			},
+		},
+		{
+			data: `{"peerScores":{"gossip":{"total":1234.52382,"blocks":{"timeInMesh":1234,"firstMessageDeliveries":12,"meshMessageDeliveries":34,"invalidMessageDeliveries":56},"IPColocationFactor":12.34,"behavioralPenalty":56.78},"reqResp":{"validResponses":99,"errorResponses":88,"rejectedPayloads":77}},"lastUpdate":1923841}`,
+			expected: scoreRecord{
+				PeerScores: PeerScores{
+					Gossip: GossipScores{
+						Total: 1234.52382,
+						Blocks: TopicScores{
+							TimeInMesh:               1234,
+							FirstMessageDeliveries:   12,
+							MeshMessageDeliveries:    34,
+							InvalidMessageDeliveries: 56,
+						},
+						IPColocationFactor: 12.34,
+						BehavioralPenalty:  56.78,
+					},
+					ReqResp: ReqRespScores{
+						ValidResponses:   99,
+						ErrorResponses:   88,
+						RejectedPayloads: 77,
+					},
 				},
 				LastUpdate: 1923841,
 			},


### PR DESCRIPTION
**Description**

Adds `scoreDiff` implementations to support incrementing and decaying application score elements.

**Tests**

Added unit tests.

**Metadata**

- https://linear.app/optimism/issue/CLI-3732/implement-p2p-req-resp-peer-scoring
