### PR TITLE
op-service: Log a warning when an RPC request has to be retried

### DIFF
--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -224,7 +224,7 @@ func createRetryingRPC(ctx context.Context, logger log.Logger, url string) (clie
 	if err != nil {
 		return nil, err
 	}
-	return opclient.NewRetryingClient(rpc, maxRPCRetries), nil
+	return opclient.NewRetryingClient(logger, rpc, maxRPCRetries), nil
 }
 
 func routeHints(logger log.Logger, hHostRW io.ReadWriter, hinter preimage.HintHandler) chan error {

--- a/op-service/client/retry.go
+++ b/op-service/client/retry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hashicorp/go-multierror"
 
@@ -19,6 +20,7 @@ var (
 
 // retryingClient wraps a [client.RPC] with a backoff strategy.
 type retryingClient struct {
+	log           log.Logger
 	c             client.RPC
 	retryAttempts int
 	strategy      backoff.Strategy
@@ -26,11 +28,12 @@ type retryingClient struct {
 
 // NewRetryingClient creates a new retrying client.
 // The backoff strategy is optional, if not provided, the default exponential backoff strategy is used.
-func NewRetryingClient(c client.RPC, retries int, strategy ...backoff.Strategy) *retryingClient {
+func NewRetryingClient(logger log.Logger, c client.RPC, retries int, strategy ...backoff.Strategy) *retryingClient {
 	if len(strategy) == 0 {
 		strategy = []backoff.Strategy{ExponentialBackoff}
 	}
 	return &retryingClient{
+		log:           logger,
 		c:             c,
 		retryAttempts: retries,
 		strategy:      strategy[0],
@@ -50,7 +53,11 @@ func (b *retryingClient) CallContext(ctx context.Context, result any, method str
 	return backoff.DoCtx(ctx, b.retryAttempts, b.strategy, func() error {
 		cCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-		return b.c.CallContext(cCtx, result, method, args...)
+		err := b.c.CallContext(cCtx, result, method, args...)
+		if err != nil {
+			b.log.Warn("RPC request failed", "method", method, "err", err)
+		}
+		return err
 	})
 }
 
@@ -85,6 +92,7 @@ func (b *retryingClient) BatchCallContext(ctx context.Context, input []rpc.Batch
 		}
 		err := b.c.BatchCallContext(cCtx, batch)
 		if err != nil {
+			b.log.Warn("Batch request failed", "err", err)
 			// Whole call failed, retry all pending elems again
 			return err
 		}
@@ -107,6 +115,7 @@ func (b *retryingClient) BatchCallContext(ctx context.Context, input []rpc.Batch
 		}
 		if len(failed) > 0 {
 			pending = failed
+			b.log.Warn("Batch request returned errors", "err", combinedErr)
 			return combinedErr
 		}
 		return nil
@@ -118,6 +127,9 @@ func (b *retryingClient) EthSubscribe(ctx context.Context, channel any, args ...
 	err := backoff.DoCtx(ctx, b.retryAttempts, b.strategy, func() error {
 		var err error
 		sub, err = b.c.EthSubscribe(ctx, channel, args...)
+		if err != nil {
+			b.log.Warn("Subscription request failed", "err", err)
+		}
 		return err
 	})
 	return sub, err


### PR DESCRIPTION
**Description**

When the retrying RPC client has to retry a request, log a warning so the user knows that something didn't work. Will fix op-program goerli-verify job timing out because it went 10 minutes with no output and provide useful information to the user when things aren't working correctly.
