### PR TITLE
feat(op-challenger): AlphabetProvider Tracer

### DIFF
--- a/op-challenger/fault/alphabet_provider.go
+++ b/op-challenger/fault/alphabet_provider.go
@@ -1,0 +1,49 @@
+package fault
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// AlphabetProvider is a [TraceProvider] that provides claims for specific
+// indices in the given trace.
+type AlphabetProvider struct {
+	state  []string
+	maxLen uint64
+}
+
+// NewAlphabetProvider returns a new [AlphabetProvider].
+func NewAlphabetProvider(state string, depth uint64) *AlphabetProvider {
+	return &AlphabetProvider{
+		state:  strings.Split(state, ""),
+		maxLen: (1 << depth),
+	}
+}
+
+// Get returns the claim value at the given index in the trace.
+func (ap *AlphabetProvider) Get(i uint64) (common.Hash, error) {
+	// The index cannot be larger than the maximum index as computed by the depth.
+	if i >= ap.maxLen {
+		return common.Hash{}, ErrIndexTooLarge
+	}
+	// We extend the deepest hash to the maximum depth if the trace is not expansive.
+	if i >= uint64(len(ap.state)) {
+		return ap.Get(uint64(len(ap.state)) - 1)
+	}
+	return ap.ComputeAlphabetClaim(i), nil
+}
+
+// ComputeAlphabetClaim computes the claim for the given index in the trace.
+func (ap *AlphabetProvider) ComputeAlphabetClaim(i uint64) common.Hash {
+	concatenated := append(IndexToBytes(i), []byte(ap.state[i])...)
+	return common.BytesToHash(concatenated)
+}
+
+// IndexToBytes converts an index to a byte slice big endian
+func IndexToBytes(i uint64) []byte {
+	big := new(big.Int)
+	big.SetUint64(i)
+	return big.Bytes()
+}

--- a/op-challenger/fault/alphabet_provider_test.go
+++ b/op-challenger/fault/alphabet_provider_test.go
@@ -1,0 +1,57 @@
+package fault
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzIndexToBytes tests the IndexToBytes function.
+func FuzzIndexToBytes(f *testing.F) {
+	f.Fuzz(func(t *testing.T, index uint64) {
+		translated := IndexToBytes(index)
+		original := new(big.Int)
+		original.SetBytes(translated)
+		require.Equal(t, original.Uint64(), index)
+	})
+}
+
+// TestComputeAlphabetClaim tests the ComputeAlphabetClaim function.
+func TestComputeAlphabetClaim(t *testing.T) {
+	ap := NewAlphabetProvider("abc", 2)
+	claim := ap.ComputeAlphabetClaim(0)
+	concatenated := append(IndexToBytes(0), []byte("a")...)
+	expected := common.BytesToHash(concatenated)
+	require.Equal(t, expected, claim)
+}
+
+// TestGet tests the Get function.
+func TestGet(t *testing.T) {
+	ap := NewAlphabetProvider("abc", 2)
+	claim, err := ap.Get(0)
+	require.NoError(t, err)
+	concatenated := append(IndexToBytes(0), []byte("a")...)
+	expected := common.BytesToHash(concatenated)
+	require.Equal(t, expected, claim)
+}
+
+// TestGet_IndexTooLarge tests the Get function with an index
+// greater than the number of indices: 2^depth - 1.
+func TestGet_IndexTooLarge(t *testing.T) {
+	ap := NewAlphabetProvider("abc", 2)
+	_, err := ap.Get(4)
+	require.ErrorIs(t, err, ErrIndexTooLarge)
+}
+
+// TestGet_Extends tests the Get function with an index that is larger
+// than the trace, but smaller than the maximum depth.
+func TestGet_Extends(t *testing.T) {
+	ap := NewAlphabetProvider("abc", 2)
+	claim, err := ap.Get(3)
+	require.NoError(t, err)
+	concatenated := append(IndexToBytes(2), []byte("c")...)
+	expected := common.BytesToHash(concatenated)
+	require.Equal(t, expected, claim)
+}

--- a/op-challenger/fault/types.go
+++ b/op-challenger/fault/types.go
@@ -13,8 +13,9 @@ var (
 
 // TraceProvider is a generic way to get a claim value at a specific
 // step in the trace.
+// The [AlphabetProvider] is a minimal implementation of this interface.
 type TraceProvider interface {
-	Get(i int) (common.Hash, error)
+	Get(i uint64) (common.Hash, error)
 }
 
 type Claim struct {


### PR DESCRIPTION
**Description**

Introduces the simple `AlphabetProvider` tracing provider to the `op-challenger`.

**Metadata**

Fixes CLI-4115