### PR TITLE
op-chain-ops: fund L1 devnet accounts

### DIFF
--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -244,6 +244,11 @@ func BuildL1DeveloperGenesis(config *DeployConfig) (*core.Genesis, error) {
 		return nil, err
 	}
 
+	if config.FundDevAccounts {
+		FundDevAccounts(stateDB)
+		SetPrecompileBalances(stateDB)
+	}
+
 	for _, dep := range deployments {
 		st, err := stateDB.StorageTrie(dep.Address)
 		if err != nil {


### PR DESCRIPTION
**Description**

This commit uses the deploy config value `fundDevAccounts` to determine if the standard `test test ...` accounts used by hardhat/foundry should be prefunded with ether. This makes testing using the devnet a bit easier.

Note that this code will be removed in the future because it is part of the devnet where the genesis is prepopulated with the contracts. It is not tenable to maintain 2 devnets, one with prepopulated genesis and one with a deployed genesis.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

