### PR TITLE
op-node: log shutdown before releasing client waitgroup

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -268,11 +268,11 @@ func (s *SyncClient) Start() {
 func (s *SyncClient) AddPeer(id peer.ID) {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
-	if _, ok := s.peers[id]; ok {
-		s.log.Warn("cannot register peer for sync duties, peer was already registered", "peer", id)
+	if s.closingPeers {
 		return
 	}
-	if s.closingPeers {
+	if _, ok := s.peers[id]; ok {
+		s.log.Warn("cannot register peer for sync duties, peer was already registered", "peer", id)
 		return
 	}
 	s.wg.Add(1)
@@ -492,9 +492,9 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	defer func() {
 		s.peersLock.Lock()
 		delete(s.peers, id) // clean up
+		s.log.Debug("stopped syncing loop of peer", "id", id)
 		s.wg.Done()
 		s.peersLock.Unlock()
-		s.log.Debug("stopped syncing loop of peer", "id", id)
 	}()
 
 	log := s.log.New("peer", id)


### PR DESCRIPTION
**Description**

Fix test issues where the test-logger was being used after the test shut down.

The `TestMultiPeerSync` defers the `.Close()` calls on the sync clients, but those then completed the wait-group in the sync client, before logging about the shutdown. This caused a race where the logger would panic because of the unexpected log.

The fix is to move the log before the `wg.Done()`.

Reviewing the code further there also seems to be a case where we could have a warn-log while the client was already shutting down. We now return early in `AddPeer` if we're closing already, to ensure post-shutdown AddPeer calls cannot accidentally create logs that make the test flake.
