### PR TITLE
op-challenger API Cleanups

### DIFF
--- a/op-challenger/fault/cmd/main.go
+++ b/op-challenger/fault/cmd/main.go
@@ -11,17 +11,12 @@ func main() {
 	// go left to d, then right to f, then left to e
 	p := fault.Position{}
 	p.Print(3)
-	p.Attack()
+	p = p.Attack()
 	p.Print(3)
-	p.Defend()
+	p = p.Defend()
 	p.Print(3)
-	p.Attack()
+	p = p.Attack()
 	p.Print(3)
-
-	// GIN:    1	Trace Position is    0	Trace Depth is: 0	Trace Index is: 8
-	// GIN:   10	Trace Position is    0	Trace Depth is: 1	Trace Index is: 4
-	// GIN:  110	Trace Position is   10	Trace Depth is: 2	Trace Index is: 6
-	// GIN: 1100	Trace Position is  100	Trace Depth is: 3	Trace Index is: 5
 
 	// Example 2
 	// abcdefgh
@@ -29,15 +24,10 @@ func main() {
 	// go left r, then left to b, then right to q
 	p = fault.Position{}
 	p.Print(3)
-	p.Attack()
+	p = p.Attack()
 	p.Print(3)
-	p.Attack()
+	p = p.Attack()
 	p.Print(3)
-	p.Defend()
+	p = p.Defend()
 	p.Print(3)
-
-	// Trace Position is 0000	Trace Depth is: 0	Trace Index is: 8
-	// Trace Position is 0000	Trace Depth is: 1	Trace Index is: 4
-	// Trace Position is 0000	Trace Depth is: 2	Trace Index is: 2
-	// Trace Position is 0010	Trace Depth is: 3	Trace Index is: 3
 }

--- a/op-challenger/fault/position.go
+++ b/op-challenger/fault/position.go
@@ -55,16 +55,20 @@ func (p *Position) parent() {
 	p.indexAtDepth = p.indexAtDepth >> 1
 }
 
-// Attack moves this position to a position to the left which disagrees with this position.
-func (p *Position) Attack() {
-	p.move(false)
+// Attack creates a new position which is the attack position of this one.
+func (p *Position) Attack() Position {
+	p2 := NewPosition(p.depth, p.indexAtDepth)
+	p2.move(false)
+	return p2
 }
 
-// Defend moves this position to the right which agrees with this position. Note:
-func (p *Position) Defend() {
-	p.parent()
-	p.move(true)
-	p.move(false)
+// Defend creates a new position which is the defend position of this one.
+func (p *Position) Defend() Position {
+	p2 := NewPosition(p.depth, p.indexAtDepth)
+	p2.parent()
+	p2.move(true)
+	p2.move(false)
+	return p2
 }
 
 func (p *Position) Print(maxDepth int) {

--- a/op-challenger/fault/position.go
+++ b/op-challenger/fault/position.go
@@ -28,11 +28,11 @@ func (p *Position) IndexAtDepth() int {
 
 // TraceIndex calculates the what the index of the claim value would be inside the trace.
 // It is equivalent to going right until the final depth has been reached.
-func (p *Position) TraceIndex(maxDepth int) int {
+func (p *Position) TraceIndex(maxDepth int) uint64 {
 	// When we go right, we do a shift left and set the bottom bit to be 1.
 	// To do this in a single step, do all the shifts at once & or in all 1s for the bottom bits.
 	rd := maxDepth - p.depth
-	return p.indexAtDepth<<rd | ((1 << rd) - 1)
+	return uint64(p.indexAtDepth<<rd | ((1 << rd) - 1))
 }
 
 // move goes to the left or right child.

--- a/op-challenger/fault/position_test.go
+++ b/op-challenger/fault/position_test.go
@@ -35,7 +35,7 @@ type testNodeInfo struct {
 	GIndex       uint64
 	Depth        int
 	IndexAtDepth int
-	TraceIndex   int
+	TraceIndex   uint64
 }
 
 var treeNodesMaxDepth4 = []testNodeInfo{

--- a/op-challenger/fault/solver.go
+++ b/op-challenger/fault/solver.go
@@ -58,8 +58,7 @@ func (s *Solver) doNothing() (*Response, error) {
 
 // attack returns a response that attacks the claim.
 func (s *Solver) attack(claim Claim) (*Response, error) {
-	claim.Position.Attack()
-	value, err := s.traceAtPosition(&claim.Position)
+	value, err := s.traceAtPosition(claim.Position.Attack())
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +67,7 @@ func (s *Solver) attack(claim Claim) (*Response, error) {
 
 // defend returns a response that defends the claim.
 func (s *Solver) defend(claim Claim) (*Response, error) {
-	claim.Position.Defend()
-	value, err := s.traceAtPosition(&claim.Position)
+	value, err := s.traceAtPosition(claim.Position.Defend())
 	if err != nil {
 		return nil, err
 	}
@@ -78,14 +76,13 @@ func (s *Solver) defend(claim Claim) (*Response, error) {
 
 // agreeWithClaim returns true if the [Claim] is correct according to the internal [TraceProvider].
 func (s *Solver) agreeWithClaim(claim Claim) (bool, error) {
-	ourValue, err := s.traceAtPosition(&claim.Position)
+	ourValue, err := s.traceAtPosition(claim.Position)
 	return ourValue == claim.Value, err
 }
 
 // traceAtPosition returns the [common.Hash] from internal [TraceProvider] at the given [Position].
-func (s *Solver) traceAtPosition(p *Position) (common.Hash, error) {
-	// todo: update TraceIndex to return a uint64 to keep types consistent
+func (s *Solver) traceAtPosition(p Position) (common.Hash, error) {
 	index := p.TraceIndex(s.gameDepth)
-	hash, err := s.Get(uint64(index))
+	hash, err := s.Get(index)
 	return hash, err
 }


### PR DESCRIPTION
**Description**

Simplify the API by using uint64 as the trace index everywhere & return a new position object instead of mutating it when attacking or defending.
