### PR TITLE
fix(ctb): Remove Semver Check L1StandardBridge.t.sol

### DIFF
--- a/packages/contracts-bedrock/.gas-snapshot
+++ b/packages/contracts-bedrock/.gas-snapshot
@@ -142,7 +142,7 @@ L1StandardBridge_FinalizeERC20Withdrawal_Test:test_finalizeERC20Withdrawal_succe
 L1StandardBridge_FinalizeERC20Withdrawal_TestFail:test_finalizeERC20Withdrawal_notMessenger_reverts() (gas: 31206)
 L1StandardBridge_FinalizeERC20Withdrawal_TestFail:test_finalizeERC20Withdrawal_notOtherBridge_reverts() (gas: 31562)
 L1StandardBridge_FinalizeETHWithdrawal_Test:test_finalizeETHWithdrawal_succeeds() (gas: 61722)
-L1StandardBridge_Getter_Test:test_getters_succeeds() (gas: 32875)
+L1StandardBridge_Getter_Test:test_getters_succeeds() (gas: 26157)
 L1StandardBridge_Initialize_Test:test_initialize_succeeds() (gas: 22050)
 L1StandardBridge_Receive_Test:test_receive_succeeds() (gas: 610719)
 L2CrossDomainMessenger_Test:test_messageVersion_succeeds() (gas: 8477)

--- a/packages/contracts-bedrock/contracts/test/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1StandardBridge.t.sol
@@ -25,7 +25,6 @@ contract L1StandardBridge_Getter_Test is Bridge_Initializer {
         assert(L1Bridge.OTHER_BRIDGE() == L2Bridge);
         assert(L1Bridge.messenger() == L1Messenger);
         assert(L1Bridge.MESSENGER() == L1Messenger);
-        assertEq(L1Bridge.version(), "1.1.1");
     }
 }
 


### PR DESCRIPTION
**Description**

Following @tynes [comment](https://github.com/ethereum-optimism/optimism/pull/6099#discussion_r1239095697), this pr splits out the change to remove the semver check on the `L1StandardBridge`.