### PR TITLE
feat(op-challenger): Tree-like Game State

### DIFF
--- a/op-challenger/fault/game.go
+++ b/op-challenger/fault/game.go
@@ -1,13 +1,151 @@
 package fault
 
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	// ErrClaimExists is returned when a claim already exists in the game state.
+	ErrClaimExists = errors.New("claim exists in game state")
+
+	// ErrClaimNotFound is returned when a claim does not exist in the game state.
+	ErrClaimNotFound = errors.New("claim not found in game state")
+)
+
 // Game is an interface that represents the state of a dispute game.
 type Game interface {
-	// Put adds a claim into the game state and returns its parent claim.
-	Put(claim Claim) (Claim, error)
+	// Put adds a claim into the game state.
+	Put(claim Claim) error
 
 	// ClaimPairs returns a list of claim pairs.
 	ClaimPairs() []struct {
 		claim  Claim
 		parent Claim
 	}
+}
+
+// Node is a node in the game state tree.
+type Node struct {
+	self     Claim
+	children []Node
+}
+
+// NodeKey is the key for a given list of [Claim] children.
+type NodeKey struct {
+	// Position is embedded to pass through its methods.
+	Position
+	// Value is the claim hash.
+	Value common.Hash
+}
+
+// FromClaim creates a [NodeKey] from a given [Claim].
+func FromClaim(claim *Claim) NodeKey {
+	return NodeKey{
+		Position: claim.Position,
+		Value:    claim.Value,
+	}
+}
+
+// gameState is a struct that represents the state of a dispute game.
+// The game state implements the [Game] interface.
+type gameState struct {
+	nodes map[NodeKey]Node
+}
+
+// NewGameState returns a new game state.
+func NewGameState() *gameState {
+	return &gameState{
+		nodes: make(map[NodeKey]Node),
+	}
+}
+
+// getParent returns the parent of a given [Claim].
+func (g *gameState) getParent(claim Claim) (Claim, error) {
+	// Create a new NodeKey from the claim.
+	key := FromClaim(&claim)
+
+	// Get the node from the game state.
+	node, ok := g.nodes[key]
+	if !ok {
+		return Claim{}, ErrClaimNotFound
+	}
+
+	// Return the parent.
+	if node.self.Parent == nil {
+		return Claim{}, ErrClaimNotFound
+	}
+	return *node.self.Parent, nil
+}
+
+// Put adds a claim into the game state.
+func (g *gameState) Put(claim Claim) error {
+	// Create a new NodeKey from the claim.
+	key := FromClaim(&claim)
+
+	// Check if the claim already exists.
+	if _, ok := g.nodes[key]; ok {
+		return ErrClaimExists
+	}
+
+	// Create a new node.
+	node := Node{
+		self:     claim,
+		children: make([]Node, 0),
+	}
+
+	// Add the node to the game state.
+	g.nodes[key] = node
+
+	// Update any parent nodes.
+	if claim.Parent != nil {
+		g.addChild(*claim.Parent, node)
+	}
+
+	return nil
+}
+
+// addChild adds a node to parent [Claim].
+func (g *gameState) addChild(parent Claim, child Node) {
+	// Create a new NodeKey from the child's parent.
+	parentKey := FromClaim(&parent)
+
+	// Get the parent node.
+	parentNode, ok := g.nodes[parentKey]
+	if !ok {
+		return
+	}
+
+	// Add the child to the parent node.
+	parentNode.children = append(parentNode.children, child)
+}
+
+// ClaimPairs returns a list of claim pairs.
+func (g *gameState) ClaimPairs() []struct {
+	claim  Claim
+	parent Claim
+} {
+	// Create a list of claim pairs.
+	pairs := make([]struct {
+		claim  Claim
+		parent Claim
+	}, 0)
+
+	// Iterate over the game state.
+	for _, node := range g.nodes {
+		// Iterate over the node's children.
+		for _, child := range node.children {
+			// Append the claim pair.
+			pairs = append(pairs, struct {
+				claim  Claim
+				parent Claim
+			}{
+				claim:  child.self,
+				parent: node.self,
+			})
+		}
+	}
+
+	return pairs
 }

--- a/op-challenger/fault/game_test.go
+++ b/op-challenger/fault/game_test.go
@@ -1,0 +1,121 @@
+package fault
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestClaims() []Claim {
+	top := Claim{
+		Value:         common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000768"),
+		Position:      NewPosition(0, 0),
+		Parent:        nil,
+		DefendsParent: false,
+	}
+
+	middle := Claim{
+		Value:         common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000768"),
+		Position:      NewPosition(1, 1),
+		Parent:        &top,
+		DefendsParent: true,
+	}
+
+	bottom := Claim{
+		Value:         common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000465"),
+		Position:      NewPosition(2, 2),
+		Parent:        &middle,
+		DefendsParent: false,
+	}
+
+	return []Claim{top, middle, bottom}
+}
+
+// TestGame_Put_AlreadyExists tests the [Game.Put] method using a [gameState] instance
+// errors when a claim already exists.
+func TestGame_Put_AlreadyExists(t *testing.T) {
+	// Create a new game state.
+	g := NewGameState()
+
+	// Create a new claim.
+	claim := Claim{
+		Value:    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000768"),
+		Position: NewPosition(1, 1),
+	}
+
+	// Put the claim into the game state.
+	err := g.Put(claim)
+	require.NoError(t, err)
+
+	// Put the claim into the game state again.
+	err = g.Put(claim)
+	require.ErrorIs(t, err, ErrClaimExists)
+}
+
+// TestGame_Put_ParentsAndChildren tests the [Game.Put] method using a [gameState] instance.
+func TestGame_Put_ParentsAndChildren(t *testing.T) {
+	// Create a new game state.
+	g := NewGameState()
+
+	// Create test claims
+	claims := createTestClaims()
+	top := claims[0]
+	middle := claims[1]
+	bottom := claims[2]
+
+	// Put the middle claim into the game state.
+	// We should expect no parent to exist, yet.
+	err := g.Put(middle)
+	require.NoError(t, err)
+	parent, err := g.getParent(middle)
+	require.NoError(t, err)
+	require.Equal(t, parent, top)
+
+	// Put the bottom claim into the game state.
+	// We should expect the parent to be the claim we just added.
+	err = g.Put(bottom)
+	require.NoError(t, err)
+	parent, err = g.getParent(bottom)
+	require.NoError(t, err)
+	require.Equal(t, parent, middle)
+
+	// Put the top claim into the game state.
+	// We should expect the highest parent to not have a parent.
+	// And the first claim to now have the highest parent as its parent.
+	err = g.Put(top)
+	require.NoError(t, err)
+	parent, err = g.getParent(top)
+	require.ErrorIs(t, err, ErrClaimNotFound)
+	require.Equal(t, parent, Claim{})
+}
+
+// TestGame_ClaimPairs tests the [Game.ClaimPairs] method using a [gameState] instance.
+func TestGame_ClaimPairs(t *testing.T) {
+	// Create a new game state.
+	g := NewGameState()
+
+	// Create test claims
+	claims := createTestClaims()
+
+	// Create a map of claim gindex to their parent.
+	parents := map[uint64]Claim{
+		0: {},
+		3: claims[0],
+		6: claims[1],
+	}
+
+	// Add the claims to the game state.
+	for _, claim := range claims {
+		err := g.Put(claim)
+		require.NoError(t, err)
+	}
+
+	// Get the list of claim pairs.
+	pairs := g.ClaimPairs()
+
+	// Validate the pairs parents are correct.
+	for _, pair := range pairs {
+		require.Equal(t, parents[pair.claim.ToGIndex()], pair.parent)
+	}
+}

--- a/op-challenger/fault/types.go
+++ b/op-challenger/fault/types.go
@@ -22,6 +22,8 @@ type TraceProvider interface {
 type Claim struct {
 	Value common.Hash
 	Position
+	Parent        *Claim
+	DefendsParent bool
 }
 
 type Response struct {


### PR DESCRIPTION
**Description**

Implements the `Game` state which an `Agent` will use to store `Claim`s and track their parents. The `gameState` struct adheres to the `Game` interface.

As opposed to #6113, this PR uses a "tree-like" structure whereby nodes directly contains a list to their children.

This PR also slightly modifies the `Claim` struct as discussed offline to contain a `Parent` reference and a `DefendParent` boolean.

**Metadata**

Fixes CLI-4116