### PR TITLE
fix(op-node): save remaining batches when BatchUndecided occurs

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -194,7 +194,9 @@ batchLoop:
 			remaining = append(remaining, candidates[i+1:]...)
 			break batchLoop
 		case BatchUndecided:
-			remaining = append(remaining, batch)
+			// L1 information is insufficient to decide whether these batches are valid, retain the remaining batches
+			// and wait for more L1 information.
+			remaining = append(remaining, candidates[i:]...)
 			bq.batches[nextTimestamp] = remaining
 			return nil, io.EOF
 		default:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When L1 information is insufficient to decide whether these batches are valid, we save them and wait for more information.