### PR TITLE
fix(ctb): Update Solidity Scripts to Triple Slash Natspec

### DIFF
--- a/packages/contracts-bedrock/scripts/FeeVaultWithdrawal.s.sol
+++ b/packages/contracts-bedrock/scripts/FeeVaultWithdrawal.s.sol
@@ -7,22 +7,18 @@ import { Predeploys } from "../contracts/libraries/Predeploys.sol";
 import { FeeVault } from "../contracts/universal/FeeVault.sol";
 import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
 
-/**
- * @title FeeVaultWithdrawal
- * @notice A script to make it very simple to withdraw from the fee vaults.
- *         The usage is as follows:
- *         $ forge script scripts/FeeVaultWithdrawal.s.sol \
- *             --rpc-url $ETH_RPC_URL --broadcast \
- *             --private-key $PRIVATE_KEY
- */
+/// @title FeeVaultWithdrawal
+/// @notice A script to make it very simple to withdraw from the fee vaults.
+///         The usage is as follows:
+///         $ forge script scripts/FeeVaultWithdrawal.s.sol \
+///             --rpc-url $ETH_RPC_URL --broadcast \
+///             --private-key $PRIVATE_KEY
 contract FeeVaultWithdrawal is Script {
     IMulticall3 private constant multicall = IMulticall3(MULTICALL3_ADDRESS);
     IMulticall3.Call3[] internal calls;
 
-    /**
-     * @notice The entrypoint function. Determines which FeeVaults can be withdrawn from and then
-     *         will send the transaction via Multicall3 to withdraw all FeeVaults.
-     */
+    /// @notice The entrypoint function. Determines which FeeVaults can be withdrawn from and then
+    ///        will send the transaction via Multicall3 to withdraw all FeeVaults.
     function run() external {
         require(address(multicall).code.length > 0);
 
@@ -60,19 +56,15 @@ contract FeeVaultWithdrawal is Script {
         }
     }
 
-    /**
-     * @notice Checks whether or not a FeeVault can be withdrawn. The balance of the account must
-     *         be larger than the `MIN_WITHDRAWAL_AMOUNT`.
-     */
+    /// @notice Checks whether or not a FeeVault can be withdrawn. The balance of the account must
+    ///         be larger than the `MIN_WITHDRAWAL_AMOUNT`.
     function canWithdrawal(address _vault) internal view returns (bool) {
         uint256 minWithdrawalAmount = FeeVault(payable(_vault)).MIN_WITHDRAWAL_AMOUNT();
         uint256 balance = _vault.balance;
         return balance >= minWithdrawalAmount;
     }
 
-    /**
-     * @notice Logs the information relevant to the user.
-     */
+    /// @notice Logs the information relevant to the user.
     function log(uint256 _balance, address _recipient, address _vault) internal view {
         string memory logline = string.concat(
             "Withdrawing ",

--- a/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
+++ b/packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.10;
 
-/**
- * @title Enum - Collection of enums used in Safe contracts.
- * @author Richard Meissner - @rmeissner
- */
+/// @title Enum - Collection of enums used in Safe contracts.
+/// @author Richard Meissner - @rmeissner
 abstract contract Enum {
     enum Operation {
         Call,
@@ -12,9 +10,7 @@ abstract contract Enum {
     }
 }
 
-/**
- * @title IGnosisSafe - Gnosis Safe Interface
- */
+/// @title IGnosisSafe - Gnosis Safe Interface
 interface IGnosisSafe {
     event AddedOwner(address owner);
     event ApproveHash(bytes32 indexed approvedHash, address indexed owner);

--- a/packages/contracts-bedrock/scripts/outputs/DeleteOutput.s.sol
+++ b/packages/contracts-bedrock/scripts/outputs/DeleteOutput.s.sol
@@ -13,39 +13,27 @@ import { FeeVault } from "../../contracts/universal/FeeVault.sol";
 import { L2OutputOracle } from "../../contracts/L1/L2OutputOracle.sol";
 import { Predeploys } from "../../contracts/libraries/Predeploys.sol";
 
-/**
- * @title DeleteOutput
- * @notice Deletes an output root from the L2OutputOracle.
- * @notice Example usage is provided in the README documentation.
- */
+/// @title DeleteOutput
+/// @notice Deletes an output root from the L2OutputOracle.
+/// @notice Example usage is provided in the README documentation.
 contract DeleteOutput is SafeBuilder {
-    /**
-     * @notice A set of contract addresses for the script.
-     */
+    /// @notice A set of contract addresses for the script.
     struct ContractSet {
         address Safe;
         address ProxyAdmin;
         address L2OutputOracleProxy;
     }
 
-    /**
-     * @notice A mapping of chainid to a ContractSet.
-     */
+    /// @notice A mapping of chainid to a ContractSet.
     mapping(uint256 => ContractSet) internal _contracts;
 
-    /**
-     * @notice The l2 output index we will delete.
-     */
+    /// @notice The l2 output index we will delete.
     uint256 internal index;
 
-    /**
-     * @notice The address of the L2OutputOracle to target.
-     */
+    /// @notice The address of the L2OutputOracle to target.
     address internal oracle;
 
-    /**
-     * @notice Place the contract addresses in storage for ux.
-     */
+    /// @notice Place the contract addresses in storage for ux.
     function setUp() external {
         _contracts[GOERLI] = ContractSet({
             Safe: 0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f,
@@ -54,11 +42,8 @@ contract DeleteOutput is SafeBuilder {
         });
     }
 
-    /**
-     * @notice Returns the ContractSet for the defined block chainid.
-     *
-     * @dev Reverts if no ContractSet is defined.
-     */
+    /// @notice Returns the ContractSet for the defined block chainid.
+    /// @dev Reverts if no ContractSet is defined.
     function contracts() public view returns (ContractSet memory) {
         ContractSet memory cs = _contracts[block.chainid];
         if (cs.Safe == address(0) || cs.ProxyAdmin == address(0) || cs.L2OutputOracleProxy == address(0)) {
@@ -67,9 +52,7 @@ contract DeleteOutput is SafeBuilder {
         return cs;
     }
 
-    /**
-     * @notice Executes the gnosis safe transaction to delete an L2 Output Root.
-     */
+    /// @notice Executes the gnosis safe transaction to delete an L2 Output Root.
     function run(uint256 _index) external returns (bool) {
         address _safe = contracts().Safe;
         address _proxyAdmin = contracts().ProxyAdmin;
@@ -77,18 +60,14 @@ contract DeleteOutput is SafeBuilder {
         return run(_safe, _proxyAdmin);
     }
 
-    /**
-     * @notice Follow up assertions to ensure that the script ran to completion.
-     */
+    /// @notice Follow up assertions to ensure that the script ran to completion.
     function _postCheck() internal view override {
         L2OutputOracle l2oo = L2OutputOracle(contracts().L2OutputOracleProxy);
         Types.OutputProposal memory proposal = l2oo.getL2Output(index);
         require(proposal.l2BlockNumber == 0, "DeleteOutput: Output deletion failed.");
     }
 
-    /**
-     * @notice Test coverage of the script.
-     */
+    /// @notice Test coverage of the script.
     function test_script_succeeds() skipWhenNotForking external {
         uint256 _index = getLatestIndex();
         require(_index != 0, "DeleteOutput: No outputs to delete.");
@@ -133,9 +112,7 @@ contract DeleteOutput is SafeBuilder {
         return abi.encodeCall(IMulticall3.aggregate3, (calls));
     }
 
-    /**
-     * @notice Computes the safe transaction hash.
-     */
+    /// @notice Computes the safe transaction hash.
     function computeSafeTransactionHash(uint256 _index) public returns (bytes32) {
         ContractSet memory cs = contracts();
         address _safe = cs.Safe;
@@ -146,41 +123,31 @@ contract DeleteOutput is SafeBuilder {
         return _getTransactionHash(_safe, _proxyAdmin);
     }
 
-    /**
-     * @notice Returns the challenger for the L2OutputOracle.
-     */
+    /// @notice Returns the challenger for the L2OutputOracle.
     function getChallenger() public view returns (address) {
         L2OutputOracle l2oo = L2OutputOracle(contracts().L2OutputOracleProxy);
         return l2oo.CHALLENGER();
     }
 
-    /**
-     * @notice Returns the L2 Block Number for the given index.
-     */
+    /// @notice Returns the L2 Block Number for the given index.
     function getL2BlockNumber(uint256 _index) public view returns (uint256) {
         L2OutputOracle l2oo = L2OutputOracle(contracts().L2OutputOracleProxy);
         return l2oo.getL2Output(_index).l2BlockNumber;
     }
 
-    /**
-     * @notice Returns the output root for the given index.
-     */
+    /// @notice Returns the output root for the given index.
     function getOutputFromIndex(uint256 _index) public view returns (bytes32) {
         L2OutputOracle l2oo = L2OutputOracle(contracts().L2OutputOracleProxy);
         return l2oo.getL2Output(_index).outputRoot;
     }
 
-    /**
-     * @notice Returns the output root with the corresponding to the L2 Block Number.
-     */
+    /// @notice Returns the output root with the corresponding to the L2 Block Number.
     function getOutputFromL2BlockNumber(uint256 l2BlockNumber) public view returns (bytes32) {
         L2OutputOracle l2oo = L2OutputOracle(contracts().L2OutputOracleProxy);
         return l2oo.getL2OutputAfter(l2BlockNumber).outputRoot;
     }
 
-    /**
-     * @notice Returns the latest l2 output index.
-     */
+    /// @notice Returns the latest l2 output index.
     function getLatestIndex() public view returns (uint256) {
         L2OutputOracle l2oo = L2OutputOracle(contracts().L2OutputOracleProxy);
         return l2oo.latestOutputIndex();

--- a/packages/contracts-bedrock/scripts/universal/EnhancedScript.sol
+++ b/packages/contracts-bedrock/scripts/universal/EnhancedScript.sol
@@ -5,25 +5,19 @@ import { console } from "forge-std/console.sol";
 import { Script } from "forge-std/Script.sol";
 import { Semver } from "../../contracts/universal/Semver.sol";
 
-/**
- * @title EnhancedScript
- * @notice Enhances forge-std' Script.sol with some additional application-specific functionality.
- *         Logs simulation links using Tenderly.
- */
+/// @title EnhancedScript
+/// @notice Enhances forge-std' Script.sol with some additional application-specific functionality.
+///         Logs simulation links using Tenderly.
 abstract contract EnhancedScript is Script {
-    /**
-     * @notice Helper function used to compute the hash of Semver's version string to be used in a
-     *         comparison.
-     */
+    /// @notice Helper function used to compute the hash of Semver's version string to be used in a
+    ///         comparison.
     function _versionHash(address _addr) internal view returns (bytes32) {
         return keccak256(bytes(Semver(_addr).version()));
     }
 
-    /**
-     * @notice Log a tenderly simulation link. The TENDERLY_USERNAME and TENDERLY_PROJECT
-     *         environment variables will be used if they are present. The vm is staticcall'ed
-     *         because of a compiler issue with the higher level ABI.
-     */
+    /// @notice Log a tenderly simulation link. The TENDERLY_USERNAME and TENDERLY_PROJECT
+    ///         environment variables will be used if they are present. The vm is staticcall'ed
+    ///         because of a compiler issue with the higher level ABI.
     function logSimulationLink(address _to, bytes memory _data, address _from) public view {
         (, bytes memory projData) = VM_ADDRESS.staticcall(
             abi.encodeWithSignature("envOr(string,string)", "TENDERLY_PROJECT", "TENDERLY_PROJECT")

--- a/packages/contracts-bedrock/scripts/universal/GlobalConstants.sol
+++ b/packages/contracts-bedrock/scripts/universal/GlobalConstants.sol
@@ -1,23 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-/**
- * @title GlobalConstants
- * @notice A set of constants.
- */
+/// @title GlobalConstants
+/// @notice A set of constants.
 contract GlobalConstants {
-    /**
-     * @notice Mainnet chain id.
-     */
+    /// @notice Mainnet chain id.
     uint256 constant MAINNET = 1;
 
-    /**
-     * @notice Goerli chain id.
-     */
+    /// @notice Goerli chain id.
     uint256 constant GOERLI = 5;
 
-    /**
-     * @notice Optimism Goerli chain id.
-     */
+    /// @notice Optimism Goerli chain id.
     uint256 constant OP_GOERLI = 420;
 }

--- a/packages/contracts-bedrock/scripts/upgrades/PostSherlock.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/PostSherlock.s.sol
@@ -12,20 +12,15 @@ import { SystemConfig } from "../../contracts/L1/SystemConfig.sol";
 import { ResourceMetering } from "../../contracts/L1/ResourceMetering.sol";
 import { Semver } from "../../contracts/universal/Semver.sol";
 
-/**
- * @title PostSherlockL1
- * @notice Upgrade script for upgrading the L1 contracts after the sherlock audit.
- */
+/// @title PostSherlockL1
+/// @notice Upgrade script for upgrading the L1 contracts after the sherlock audit.
 contract PostSherlockL1 is SafeBuilder {
-    /**
-     * @notice Address of the ProxyAdmin, passed in via constructor of `run`.
-     */
+
+    /// @notice Address of the ProxyAdmin, passed in via constructor of `run`.
     ProxyAdmin internal PROXY_ADMIN;
 
-    /**
-     * @notice Represents a set of L1 contracts. Used to represent a set of
-     *         implementations and also a set of proxies.
-     */
+    /// @notice Represents a set of L1 contracts. Used to represent a set of
+    ///         implementations and also a set of proxies.
     struct ContractSet {
         address L1CrossDomainMessenger;
         address L1StandardBridge;
@@ -36,19 +31,13 @@ contract PostSherlockL1 is SafeBuilder {
         address L1ERC721Bridge;
     }
 
-    /**
-     * @notice A mapping of chainid to a ContractSet of implementations.
-     */
+    /// @notice A mapping of chainid to a ContractSet of implementations.
     mapping(uint256 => ContractSet) internal implementations;
 
-    /**
-     * @notice A mapping of chainid to ContractSet of proxy addresses.
-     */
+    /// @notice A mapping of chainid to ContractSet of proxy addresses.
     mapping(uint256 => ContractSet) internal proxies;
 
-    /**
-     * @notice The expected versions for the contracts to be upgraded to.
-     */
+    /// @notice The expected versions for the contracts to be upgraded to.
     string constant internal L1CrossDomainMessenger_Version = "1.4.0";
     string constant internal L1StandardBridge_Version = "1.1.0";
     string constant internal L2OutputOracle_Version = "1.3.0";
@@ -57,9 +46,7 @@ contract PostSherlockL1 is SafeBuilder {
     string constant internal SystemConfig_Version = "1.3.0";
     string constant internal L1ERC721Bridge_Version = "1.1.1";
 
-    /**
-     * @notice Place the contract addresses in storage so they can be used when building calldata.
-     */
+    /// @notice Place the contract addresses in storage so they can be used when building calldata.
     function setUp() external {
         implementations[GOERLI] = ContractSet({
             L1CrossDomainMessenger: 0x9D1dACf9d9299D17EFFE1aAd559c06bb3Fbf9BC4,
@@ -82,9 +69,7 @@ contract PostSherlockL1 is SafeBuilder {
         });
     }
 
-    /**
-     * @notice Follow up assertions to ensure that the script ran to completion.
-     */
+    /// @notice Follow up assertions to ensure that the script ran to completion.
     function _postCheck() internal override view {
         ContractSet memory prox = getProxies();
         require(_versionHash(prox.L1CrossDomainMessenger) == keccak256(bytes(L1CrossDomainMessenger_Version)), "L1CrossDomainMessenger");
@@ -110,10 +95,8 @@ contract PostSherlockL1 is SafeBuilder {
         require(PROXY_ADMIN.getProxyImplementation(prox.L1ERC721Bridge).codehash == impl.L1ERC721Bridge.codehash, "L1ERC721Bridge codehash");
     }
 
-    /**
-     * @notice Test coverage of the logic. Should only run on goerli but other chains
-     *         could be added.
-     */
+    /// @notice Test coverage of the logic. Should only run on goerli but other chains
+    ///         could be added.
     function test_script_succeeds() skipWhenNotForking external {
         address _safe;
         address _proxyAdmin;
@@ -144,11 +127,9 @@ contract PostSherlockL1 is SafeBuilder {
         _postCheck();
     }
 
-    /**
-     * @notice Builds the calldata that the multisig needs to make for the upgrade to happen.
-     *         A total of 8 calls are made, 7 upgrade implementations and 1 sets the resource
-     *         config to the default value in the SystemConfig contract.
-     */
+    /// @notice Builds the calldata that the multisig needs to make for the upgrade to happen.
+    ///         A total of 8 calls are made, 7 upgrade implementations and 1 sets the resource
+    ///         config to the default value in the SystemConfig contract.
     function buildCalldata(address _proxyAdmin) internal override view returns (bytes memory) {
         IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](8);
 
@@ -236,18 +217,14 @@ contract PostSherlockL1 is SafeBuilder {
         return abi.encodeCall(IMulticall3.aggregate3, (calls));
     }
 
-    /**
-     * @notice Returns the ContractSet that represents the implementations for a given network.
-     */
+    /// @notice Returns the ContractSet that represents the implementations for a given network.
     function getImplementations() internal view returns (ContractSet memory) {
         ContractSet memory set = implementations[block.chainid];
         require(set.L1CrossDomainMessenger != address(0), "no implementations for this network");
         return set;
     }
 
-    /**
-     * @notice Returns the ContractSet that represents the proxies for a given network.
-     */
+    /// @notice Returns the ContractSet that represents the proxies for a given network.
     function getProxies() internal view returns (ContractSet memory) {
         ContractSet memory set = proxies[block.chainid];
         require(set.L1CrossDomainMessenger != address(0), "no proxies for this network");

--- a/packages/contracts-bedrock/scripts/upgrades/PostSherlockL2.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrades/PostSherlockL2.s.sol
@@ -8,20 +8,14 @@ import { IMulticall3 } from "forge-std/interfaces/IMulticall3.sol";
 import { Predeploys } from "../../contracts/libraries/Predeploys.sol";
 import { ProxyAdmin } from "../../contracts/universal/ProxyAdmin.sol";
 
-/**
- * @title PostSherlockL2
- * @notice Upgrades the L2 contracts.
- */
+/// @title PostSherlockL2
+/// @notice Upgrades the L2 contracts.
 contract PostSherlockL2 is SafeBuilder {
-    /**
-     * @notice The proxy admin predeploy on L2.
-     */
+    /// @notice The proxy admin predeploy on L2.
     ProxyAdmin constant PROXY_ADMIN = ProxyAdmin(0x4200000000000000000000000000000000000018);
 
-    /**
-     * @notice Represents a set of L2 predepploy contracts. Used to represent a set of
-     *         implementations and also a set of proxies.
-     */
+    /// @notice Represents a set of L2 predepploy contracts. Used to represent a set of
+    ///         implementations and also a set of proxies.
     struct ContractSet {
         address BaseFeeVault;
         address GasPriceOracle;
@@ -36,19 +30,13 @@ contract PostSherlockL2 is SafeBuilder {
         address OptimismMintableERC721Factory;
     }
 
-    /**
-     * @notice A mapping of chainid to a ContractSet of implementations.
-     */
+    /// @notice A mapping of chainid to a ContractSet of implementations.
     mapping(uint256 => ContractSet) internal implementations;
 
-    /**
-     * @notice A mapping of chainid to ContractSet of proxy addresses.
-     */
+    /// @notice A mapping of chainid to ContractSet of proxy addresses.
     mapping(uint256 => ContractSet) internal proxies;
 
-    /**
-     * @notice The expected versions for the contracts to be upgraded to.
-     */
+    /// @notice The expected versions for the contracts to be upgraded to.
     string constant internal BaseFeeVault_Version = "1.1.0";
     string constant internal GasPriceOracle_Version = "1.0.0";
     string constant internal L1Block_Version = "1.0.0";
@@ -61,9 +49,7 @@ contract PostSherlockL2 is SafeBuilder {
     string constant internal OptimismMintableERC20Factory_Version = "1.1.0";
     string constant internal OptimismMintableERC721Factory_Version = "1.2.0";
 
-    /**
-     * @notice Place the contract addresses in storage so they can be used when building calldata.
-     */
+    /// @notice Place the contract addresses in storage so they can be used when building calldata.
     function setUp() external {
         implementations[OP_GOERLI] = ContractSet({
             BaseFeeVault: 0x984eBeFb32A5c2862e92ce90EA0C81Ab69F026B5,
@@ -94,9 +80,7 @@ contract PostSherlockL2 is SafeBuilder {
         });
     }
 
-    /**
-     * @notice Follow up assertions to ensure that the script ran to completion.
-     */
+    /// @notice Follow up assertions to ensure that the script ran to completion.
     function _postCheck() internal override view {
         ContractSet memory prox = getProxies();
         require(_versionHash(prox.BaseFeeVault) == keccak256(bytes(BaseFeeVault_Version)), "BaseFeeVault");
@@ -126,10 +110,8 @@ contract PostSherlockL2 is SafeBuilder {
         require(PROXY_ADMIN.getProxyImplementation(prox.OptimismMintableERC721Factory).codehash == impl.OptimismMintableERC721Factory.codehash);
     }
 
-    /**
-     * @notice Test coverage of the logic. Should only run on goerli but other chains
-     *         could be added.
-     */
+    /// @notice Test coverage of the logic. Should only run on goerli but other chains
+    ///         could be added.
     function test_script_succeeds() skipWhenNotForking external {
         address _safe;
         address _proxyAdmin;
@@ -158,11 +140,9 @@ contract PostSherlockL2 is SafeBuilder {
         _postCheck();
     }
 
-    /**
-     * @notice Builds the calldata that the multisig needs to make for the upgrade to happen.
-     *         A total of 9 calls are made to the proxy admin to upgrade the implementations
-     *         of the predeploys.
-     */
+    /// @notice Builds the calldata that the multisig needs to make for the upgrade to happen.
+    ///         A total of 9 calls are made to the proxy admin to upgrade the implementations
+    ///         of the predeploys.
     function buildCalldata(address  _proxyAdmin) internal override view returns (bytes memory) {
         IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](11);
 
@@ -282,18 +262,14 @@ contract PostSherlockL2 is SafeBuilder {
         return abi.encodeCall(IMulticall3.aggregate3, (calls));
     }
 
-    /**
-     * @notice Returns the ContractSet that represents the implementations for a given network.
-     */
+    /// @notice Returns the ContractSet that represents the implementations for a given network.
     function getImplementations() internal view returns (ContractSet memory) {
         ContractSet memory set = implementations[block.chainid];
         require(set.BaseFeeVault != address(0), "no implementations for this network");
         return set;
     }
 
-    /**
-     * @notice Returns the ContractSet that represents the proxies for a given network.
-     */
+    /// @notice Returns the ContractSet that represents the proxies for a given network.
     function getProxies() internal view returns (ContractSet memory) {
         ContractSet memory set = proxies[block.chainid];
         require(set.BaseFeeVault != address(0), "no proxies for this network");


### PR DESCRIPTION
**Description**

Updates all Solidity files in `packages/contracts-bedrock/scripts/**` from seaport comment
styling to triple slash natspec.
