### PR TITLE
semgrep: ignore op-bindings/bindings

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -18,5 +18,7 @@ tests/
 # Semgrep-action log folder
 .semgrep_logs/
 
+op-bindings/bindings
+
 packages/*/node_modules
 packages/*/test


### PR DESCRIPTION
**Description**

The code generated by abigen triggers a lot of
semgrep scan issues so ignore that directory

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
