### PR TITLE
op-node: Remove RPC flags from the required flag list

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -44,18 +44,19 @@ var (
 		Usage:   fmt.Sprintf("Predefined network selection. Available networks: %s", strings.Join(chaincfg.AvailableNetworks(), ", ")),
 		EnvVars: prefixEnvVars("NETWORK"),
 	}
+	/* Optional Flags */
 	RPCListenAddr = &cli.StringFlag{
 		Name:    "rpc.addr",
 		Usage:   "RPC listening address",
 		EnvVars: prefixEnvVars("RPC_ADDR"),
+		Value:   "127.0.0.1",
 	}
 	RPCListenPort = &cli.IntFlag{
 		Name:    "rpc.port",
 		Usage:   "RPC listening port",
 		EnvVars: prefixEnvVars("RPC_PORT"),
+		Value:   9545, // Note: op-service/rpc/cli.go uses 8545 as the default.
 	}
-
-	/* Optional Flags */
 	RPCEnableAdmin = &cli.BoolFlag{
 		Name:    "rpc.enable-admin",
 		Usage:   "Enable the admin API (experimental)",
@@ -153,7 +154,7 @@ var (
 	MetricsAddrFlag = &cli.StringFlag{
 		Name:    "metrics.addr",
 		Usage:   "Metrics listening address",
-		Value:   "0.0.0.0",
+		Value:   "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
 		EnvVars: prefixEnvVars("METRICS_ADDR"),
 	}
 	MetricsPortFlag = &cli.IntFlag{
@@ -170,7 +171,7 @@ var (
 	PprofAddrFlag = &cli.StringFlag{
 		Name:    "pprof.addr",
 		Usage:   "pprof listening address",
-		Value:   "0.0.0.0",
+		Value:   "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
 		EnvVars: prefixEnvVars("PPROF_ADDR"),
 	}
 	PprofPortFlag = &cli.IntFlag{
@@ -218,11 +219,11 @@ var (
 var requiredFlags = []cli.Flag{
 	L1NodeAddr,
 	L2EngineAddr,
-	RPCListenAddr,
-	RPCListenPort,
 }
 
 var optionalFlags = []cli.Flag{
+	RPCListenAddr,
+	RPCListenPort,
 	RollupConfig,
 	Network,
 	L1TrustRPC,

--- a/op-service/metrics/cli.go
+++ b/op-service/metrics/cli.go
@@ -25,7 +25,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    ListenAddrFlagName,
 			Usage:   "Metrics listening address",
-			Value:   "0.0.0.0",
+			Value:   "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "METRICS_ADDR"),
 		},
 		&cli.IntFlag{

--- a/op-service/pprof/cli.go
+++ b/op-service/pprof/cli.go
@@ -24,7 +24,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    ListenAddrFlagName,
 			Usage:   "pprof listening address",
-			Value:   "0.0.0.0",
+			Value:   "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "PPROF_ADDR"),
 		},
 		&cli.IntFlag{

--- a/op-service/rpc/cli.go
+++ b/op-service/rpc/cli.go
@@ -18,7 +18,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    ListenAddrFlagName,
 			Usage:   "rpc listening address",
-			Value:   "0.0.0.0",
+			Value:   "0.0.0.0", // TODO(CLI-4159): Switch to 127.0.0.1
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "RPC_ADDR"),
 		},
 		&cli.IntFlag{


### PR DESCRIPTION
**Description**

These flags are	not actually required to run the op-node. They now default to 0.0.0.0 for the address & 8545 for the port.

