### PR TITLE
feat: `forge fmt`

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   $schema: 'http://json.schemastore.org/prettierrc',
+  plugins: ['prettier-plugin-solidity'],
   trailingComma: 'es5',
   tabWidth: 2,
   semi: false,

--- a/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1CrossDomainMessenger.sol
@@ -18,10 +18,7 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, Semver {
     /// @custom:semver 1.4.1
     /// @notice Constructs the L1CrossDomainMessenger contract.
     /// @param _portal Address of the OptimismPortal contract on this network.
-    constructor(OptimismPortal _portal)
-        Semver(1, 4, 1)
-        CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER)
-    {
+    constructor(OptimismPortal _portal) Semver(1, 4, 1) CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER) {
         PORTAL = _portal;
         initialize();
     }
@@ -32,12 +29,7 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, Semver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessage(
-        address _to,
-        uint64 _gasLimit,
-        uint256 _value,
-        bytes memory _data
-    ) internal override {
+    function _sendMessage(address _to, uint64 _gasLimit, uint256 _value, bytes memory _data) internal override {
         PORTAL.depositTransaction{ value: _value }(_to, _value, _gasLimit, false, _data);
     }
 

--- a/packages/contracts-bedrock/contracts/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1ERC721Bridge.sol
@@ -19,10 +19,7 @@ contract L1ERC721Bridge is ERC721Bridge, Semver {
     /// @notice Constructs the L1ERC721Bridge contract.
     /// @param _messenger   Address of the CrossDomainMessenger on this network.
     /// @param _otherBridge Address of the ERC721 bridge on the other network.
-    constructor(address _messenger, address _otherBridge)
-        Semver(1, 1, 2)
-        ERC721Bridge(_messenger, _otherBridge)
-    {}
+    constructor(address _messenger, address _otherBridge) Semver(1, 1, 2) ERC721Bridge(_messenger, _otherBridge) { }
 
     /// @notice Completes an ERC721 bridge from the other domain and sends the ERC721 token to the
     ///         recipient on this domain.
@@ -76,13 +73,7 @@ contract L1ERC721Bridge is ERC721Bridge, Semver {
 
         // Construct calldata for _l2Token.finalizeBridgeERC721(_to, _tokenId)
         bytes memory message = abi.encodeWithSelector(
-            L2ERC721Bridge.finalizeBridgeERC721.selector,
-            _remoteToken,
-            _localToken,
-            _from,
-            _to,
-            _tokenId,
-            _extraData
+            L2ERC721Bridge.finalizeBridgeERC721.selector, _remoteToken, _localToken, _from, _to, _tokenId, _extraData
         );
 
         // Lock token into bridge

--- a/packages/contracts-bedrock/contracts/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1StandardBridge.sol
@@ -22,12 +22,7 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @param to        Address of the recipient on L2.
     /// @param amount    Amount of ETH deposited.
     /// @param extraData Extra data attached to the deposit.
-    event ETHDepositInitiated(
-        address indexed from,
-        address indexed to,
-        uint256 amount,
-        bytes extraData
-    );
+    event ETHDepositInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData);
 
     /// @custom:legacy
     /// @notice Emitted whenever a withdrawal of ETH from L2 to L1 is finalized.
@@ -35,12 +30,7 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @param to        Address of the recipient on L1.
     /// @param amount    Amount of ETH withdrawn.
     /// @param extraData Extra data attached to the withdrawal.
-    event ETHWithdrawalFinalized(
-        address indexed from,
-        address indexed to,
-        uint256 amount,
-        bytes extraData
-    );
+    event ETHWithdrawalFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData);
 
     /// @custom:legacy
     /// @notice Emitted whenever an ERC20 deposit is initiated.
@@ -82,7 +72,7 @@ contract L1StandardBridge is StandardBridge, Semver {
     constructor(address payable _messenger)
         Semver(1, 1, 1)
         StandardBridge(_messenger, payable(Predeploys.L2_STANDARD_BRIDGE))
-    {}
+    { }
 
     /// @notice Allows EOAs to bridge ETH by sending directly to the bridge.
     receive() external payable override onlyEOA {
@@ -110,11 +100,7 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @param _extraData   Optional data to forward to L2.
     ///                     Data supplied here will not be used to execute any code on L2 and is
     ///                     only emitted as extra data for the convenience of off-chain tooling.
-    function depositETHTo(
-        address _to,
-        uint32 _minGasLimit,
-        bytes calldata _extraData
-    ) external payable {
+    function depositETHTo(address _to, uint32 _minGasLimit, bytes calldata _extraData) external payable {
         _initiateETHDeposit(msg.sender, _to, _minGasLimit, _extraData);
     }
 
@@ -134,15 +120,7 @@ contract L1StandardBridge is StandardBridge, Semver {
         uint32 _minGasLimit,
         bytes calldata _extraData
     ) external virtual onlyEOA {
-        _initiateERC20Deposit(
-            _l1Token,
-            _l2Token,
-            msg.sender,
-            msg.sender,
-            _amount,
-            _minGasLimit,
-            _extraData
-        );
+        _initiateERC20Deposit(_l1Token, _l2Token, msg.sender, msg.sender, _amount, _minGasLimit, _extraData);
     }
 
     /// @custom:legacy
@@ -163,15 +141,7 @@ contract L1StandardBridge is StandardBridge, Semver {
         uint32 _minGasLimit,
         bytes calldata _extraData
     ) external virtual {
-        _initiateERC20Deposit(
-            _l1Token,
-            _l2Token,
-            msg.sender,
-            _to,
-            _amount,
-            _minGasLimit,
-            _extraData
-        );
+        _initiateERC20Deposit(_l1Token, _l2Token, msg.sender, _to, _amount, _minGasLimit, _extraData);
     }
 
     /// @custom:legacy
@@ -180,12 +150,10 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @param _to        Address of the recipient on L1.
     /// @param _amount    Amount of ETH to withdraw.
     /// @param _extraData Optional data forwarded from L2.
-    function finalizeETHWithdrawal(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes calldata _extraData
-    ) external payable {
+    function finalizeETHWithdrawal(address _from, address _to, uint256 _amount, bytes calldata _extraData)
+        external
+        payable
+    {
         finalizeBridgeETH(_from, _to, _amount, _extraData);
     }
 
@@ -220,12 +188,7 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @param _to          Address of the recipient on L2.
     /// @param _minGasLimit Minimum gas limit for the deposit message on L2.
     /// @param _extraData   Optional data to forward to L2.
-    function _initiateETHDeposit(
-        address _from,
-        address _to,
-        uint32 _minGasLimit,
-        bytes memory _extraData
-    ) internal {
+    function _initiateETHDeposit(address _from, address _to, uint32 _minGasLimit, bytes memory _extraData) internal {
         _initiateBridgeETH(_from, _to, msg.value, _minGasLimit, _extraData);
     }
 
@@ -252,12 +215,10 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @inheritdoc StandardBridge
     /// @notice Emits the legacy ETHDepositInitiated event followed by the ETHBridgeInitiated event.
     ///         This is necessary for backwards compatibility with the legacy bridge.
-    function _emitETHBridgeInitiated(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes memory _extraData
-    ) internal override {
+    function _emitETHBridgeInitiated(address _from, address _to, uint256 _amount, bytes memory _extraData)
+        internal
+        override
+    {
         emit ETHDepositInitiated(_from, _to, _amount, _extraData);
         super._emitETHBridgeInitiated(_from, _to, _amount, _extraData);
     }
@@ -265,12 +226,10 @@ contract L1StandardBridge is StandardBridge, Semver {
     /// @inheritdoc StandardBridge
     /// @notice Emits the legacy ERC20DepositInitiated event followed by the ERC20BridgeInitiated
     ///         event. This is necessary for backwards compatibility with the legacy bridge.
-    function _emitETHBridgeFinalized(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes memory _extraData
-    ) internal override {
+    function _emitETHBridgeFinalized(address _from, address _to, uint256 _amount, bytes memory _extraData)
+        internal
+        override
+    {
         emit ETHWithdrawalFinalized(_from, _to, _amount, _extraData);
         super._emitETHBridgeFinalized(_from, _to, _amount, _extraData);
     }

--- a/packages/contracts-bedrock/contracts/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/contracts/L1/L2OutputOracle.sol
@@ -43,10 +43,7 @@ contract L2OutputOracle is Initializable, Semver {
     /// @param l2BlockNumber The L2 block number of the output root.
     /// @param l1Timestamp   The L1 timestamp when proposed.
     event OutputProposed(
-        bytes32 indexed outputRoot,
-        uint256 indexed l2OutputIndex,
-        uint256 indexed l2BlockNumber,
-        uint256 l1Timestamp
+        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
     );
 
     /// @notice Emitted when outputs are deleted.
@@ -72,10 +69,7 @@ contract L2OutputOracle is Initializable, Semver {
         uint256 _finalizationPeriodSeconds
     ) Semver(1, 3, 1) {
         require(_l2BlockTime > 0, "L2OutputOracle: L2 block time must be greater than 0");
-        require(
-            _submissionInterval > 0,
-            "L2OutputOracle: submission interval must be greater than 0"
-        );
+        require(_submissionInterval > 0, "L2OutputOracle: submission interval must be greater than 0");
 
         SUBMISSION_INTERVAL = _submissionInterval;
         L2_BLOCK_TIME = _l2BlockTime;
@@ -89,10 +83,7 @@ contract L2OutputOracle is Initializable, Semver {
     /// @notice Initializer.
     /// @param _startingBlockNumber Block number for the first recoded L2 block.
     /// @param _startingTimestamp   Timestamp for the first recoded L2 block.
-    function initialize(uint256 _startingBlockNumber, uint256 _startingTimestamp)
-        public
-        initializer
-    {
+    function initialize(uint256 _startingBlockNumber, uint256 _startingTimestamp) public initializer {
         require(
             _startingTimestamp <= block.timestamp,
             "L2OutputOracle: starting L2 timestamp must be less than current time"
@@ -108,15 +99,11 @@ contract L2OutputOracle is Initializable, Semver {
     ///                       All outputs after this output will also be deleted.
     // solhint-disable-next-line ordering
     function deleteL2Outputs(uint256 _l2OutputIndex) external {
-        require(
-            msg.sender == CHALLENGER,
-            "L2OutputOracle: only the challenger address can delete outputs"
-        );
+        require(msg.sender == CHALLENGER, "L2OutputOracle: only the challenger address can delete outputs");
 
         // Make sure we're not *increasing* the length of the array.
         require(
-            _l2OutputIndex < l2Outputs.length,
-            "L2OutputOracle: cannot delete outputs after the latest output index"
+            _l2OutputIndex < l2Outputs.length, "L2OutputOracle: cannot delete outputs after the latest output index"
         );
 
         // Do not allow deleting any outputs that have already been finalized.
@@ -142,16 +129,11 @@ contract L2OutputOracle is Initializable, Semver {
     /// @param _l2BlockNumber The L2 block number that resulted in _outputRoot.
     /// @param _l1BlockHash   A block hash which must be included in the current chain.
     /// @param _l1BlockNumber The block number with the specified block hash.
-    function proposeL2Output(
-        bytes32 _outputRoot,
-        uint256 _l2BlockNumber,
-        bytes32 _l1BlockHash,
-        uint256 _l1BlockNumber
-    ) external payable {
-        require(
-            msg.sender == PROPOSER,
-            "L2OutputOracle: only the proposer address can propose new outputs"
-        );
+    function proposeL2Output(bytes32 _outputRoot, uint256 _l2BlockNumber, bytes32 _l1BlockHash, uint256 _l1BlockNumber)
+        external
+        payable
+    {
+        require(msg.sender == PROPOSER, "L2OutputOracle: only the proposer address can propose new outputs");
 
         require(
             _l2BlockNumber == nextBlockNumber(),
@@ -163,10 +145,7 @@ contract L2OutputOracle is Initializable, Semver {
             "L2OutputOracle: cannot propose L2 output in the future"
         );
 
-        require(
-            _outputRoot != bytes32(0),
-            "L2OutputOracle: L2 output proposal cannot be the zero hash"
-        );
+        require(_outputRoot != bytes32(0), "L2OutputOracle: L2 output proposal cannot be the zero hash");
 
         if (_l1BlockHash != bytes32(0)) {
             // This check allows the proposer to propose an output based on a given L1 block,
@@ -197,11 +176,7 @@ contract L2OutputOracle is Initializable, Semver {
     /// @notice Returns an output by index. Needed to return a struct instead of a tuple.
     /// @param _l2OutputIndex Index of the output to return.
     /// @return The output at the given index.
-    function getL2Output(uint256 _l2OutputIndex)
-        external
-        view
-        returns (Types.OutputProposal memory)
-    {
+    function getL2Output(uint256 _l2OutputIndex) external view returns (Types.OutputProposal memory) {
         return l2Outputs[_l2OutputIndex];
     }
 
@@ -218,10 +193,7 @@ contract L2OutputOracle is Initializable, Semver {
         );
 
         // Make sure there's at least one output proposed.
-        require(
-            l2Outputs.length > 0,
-            "L2OutputOracle: cannot get output as no outputs have been proposed yet"
-        );
+        require(l2Outputs.length > 0, "L2OutputOracle: cannot get output as no outputs have been proposed yet");
 
         // Find the output via binary search, guaranteed to exist.
         uint256 lo = 0;
@@ -243,11 +215,7 @@ contract L2OutputOracle is Initializable, Semver {
     ///         block.
     /// @param _l2BlockNumber L2 block number to find a checkpoint for.
     /// @return First checkpoint that commits to the given L2 block number.
-    function getL2OutputAfter(uint256 _l2BlockNumber)
-        external
-        view
-        returns (Types.OutputProposal memory)
-    {
+    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (Types.OutputProposal memory) {
         return l2Outputs[getL2OutputIndexAfter(_l2BlockNumber)];
     }
 
@@ -269,10 +237,7 @@ contract L2OutputOracle is Initializable, Semver {
     ///         block number.
     /// @return Latest submitted L2 block number.
     function latestBlockNumber() public view returns (uint256) {
-        return
-            l2Outputs.length == 0
-                ? startingBlockNumber
-                : l2Outputs[l2Outputs.length - 1].l2BlockNumber;
+        return l2Outputs.length == 0 ? startingBlockNumber : l2Outputs[l2Outputs.length - 1].l2BlockNumber;
     }
 
     /// @notice Computes the block number of the next L2 block that needs to be checkpointed.

--- a/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
+++ b/packages/contracts-bedrock/contracts/L1/OptimismPortal.sol
@@ -67,22 +67,13 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     /// @param to         Address that the deposit transaction is directed to.
     /// @param version    Version of this deposit transaction event.
     /// @param opaqueData ABI encoded deposit data to be parsed off-chain.
-    event TransactionDeposited(
-        address indexed from,
-        address indexed to,
-        uint256 indexed version,
-        bytes opaqueData
-    );
+    event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData);
 
     /// @notice Emitted when a withdrawal transaction is proven.
     /// @param withdrawalHash Hash of the withdrawal transaction.
     /// @param from           Address that triggered the withdrawal transaction.
     /// @param to             Address that the withdrawal transaction is directed to.
-    event WithdrawalProven(
-        bytes32 indexed withdrawalHash,
-        address indexed from,
-        address indexed to
-    );
+    event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
 
     /// @notice Emitted when a withdrawal transaction is finalized.
     /// @param withdrawalHash Hash of the withdrawal transaction.
@@ -109,12 +100,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     /// @param _guardian Address that can pause withdrawals.
     /// @param _paused Sets the contract's pausability state.
     /// @param _config Address of the SystemConfig contract.
-    constructor(
-        L2OutputOracle _l2Oracle,
-        address _guardian,
-        bool _paused,
-        SystemConfig _config
-    ) Semver(1, 7, 2) {
+    constructor(L2OutputOracle _l2Oracle, address _guardian, bool _paused, SystemConfig _config) Semver(1, 7, 2) {
         L2_ORACLE = _l2Oracle;
         GUARDIAN = _guardian;
         SYSTEM_CONFIG = _config;
@@ -173,12 +159,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     ///         Used internally by the ResourceMetering contract.
     ///         The SystemConfig is the source of truth for the resource config.
     /// @return ResourceMetering ResourceConfig
-    function _resourceConfig()
-        internal
-        view
-        override
-        returns (ResourceMetering.ResourceConfig memory)
-    {
+    function _resourceConfig() internal view override returns (ResourceMetering.ResourceConfig memory) {
         return SYSTEM_CONFIG.resourceConfig();
     }
 
@@ -196,10 +177,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         // Prevent users from creating a deposit transaction where this address is the message
         // sender on L2. Because this is checked here, we do not need to check again in
         // `finalizeWithdrawalTransaction`.
-        require(
-            _tx.target != address(this),
-            "OptimismPortal: you cannot send messages to the portal contract"
-        );
+        require(_tx.target != address(this), "OptimismPortal: you cannot send messages to the portal contract");
 
         // Get the output root and load onto the stack to prevent multiple mloads. This will
         // revert if there is no output root for the given block number.
@@ -207,8 +185,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
 
         // Verify that the output root can be generated with the elements in the proof.
         require(
-            outputRoot == Hashing.hashOutputRootProof(_outputRootProof),
-            "OptimismPortal: invalid output root proof"
+            outputRoot == Hashing.hashOutputRootProof(_outputRootProof), "OptimismPortal: invalid output root proof"
         );
 
         // Load the ProvenWithdrawal into memory, using the withdrawal hash as a unique identifier.
@@ -222,9 +199,8 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         // to re-prove their withdrawal only in the case that the output root for their specified
         // output index has been updated.
         require(
-            provenWithdrawal.timestamp == 0 ||
-                L2_ORACLE.getL2Output(provenWithdrawal.l2OutputIndex).outputRoot !=
-                provenWithdrawal.outputRoot,
+            provenWithdrawal.timestamp == 0
+                || L2_ORACLE.getL2Output(provenWithdrawal.l2OutputIndex).outputRoot != provenWithdrawal.outputRoot,
             "OptimismPortal: withdrawal hash has already been proven"
         );
 
@@ -244,10 +220,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         // be relayed on L1.
         require(
             SecureMerkleTrie.verifyInclusionProof(
-                abi.encode(storageKey),
-                hex"01",
-                _withdrawalProof,
-                _outputRootProof.messagePasserStorageRoot
+                abi.encode(storageKey), hex"01", _withdrawalProof, _outputRootProof.messagePasserStorageRoot
             ),
             "OptimismPortal: invalid withdrawal inclusion proof"
         );
@@ -267,16 +240,12 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
 
     /// @notice Finalizes a withdrawal transaction.
     /// @param _tx Withdrawal transaction to finalize.
-    function finalizeWithdrawalTransaction(Types.WithdrawalTransaction memory _tx)
-        external
-        whenNotPaused
-    {
+    function finalizeWithdrawalTransaction(Types.WithdrawalTransaction memory _tx) external whenNotPaused {
         // Make sure that the l2Sender has not yet been set. The l2Sender is set to a value other
         // than the default value when a withdrawal transaction is being finalized. This check is
         // a defacto reentrancy guard.
         require(
-            l2Sender == Constants.DEFAULT_L2_SENDER,
-            "OptimismPortal: can only trigger one withdrawal per transaction"
+            l2Sender == Constants.DEFAULT_L2_SENDER, "OptimismPortal: can only trigger one withdrawal per transaction"
         );
 
         // Grab the proven withdrawal from the `provenWithdrawals` map.
@@ -286,10 +255,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         // A withdrawal can only be finalized if it has been proven. We know that a withdrawal has
         // been proven at least once when its timestamp is non-zero. Unproven withdrawals will have
         // a timestamp of zero.
-        require(
-            provenWithdrawal.timestamp != 0,
-            "OptimismPortal: withdrawal has not been proven yet"
-        );
+        require(provenWithdrawal.timestamp != 0, "OptimismPortal: withdrawal has not been proven yet");
 
         // As a sanity check, we make sure that the proven withdrawal's timestamp is greater than
         // starting timestamp inside the L2OutputOracle. Not strictly necessary but extra layer of
@@ -310,9 +276,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
 
         // Grab the OutputProposal from the L2OutputOracle, will revert if the output that
         // corresponds to the given index has not been proposed yet.
-        Types.OutputProposal memory proposal = L2_ORACLE.getL2Output(
-            provenWithdrawal.l2OutputIndex
-        );
+        Types.OutputProposal memory proposal = L2_ORACLE.getL2Output(provenWithdrawal.l2OutputIndex);
 
         // Check that the output root that was used to prove the withdrawal is the same as the
         // current output root for the given output index. An output root may change if it is
@@ -329,10 +293,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         );
 
         // Check that this withdrawal has not already been finalized, this is replay protection.
-        require(
-            finalizedWithdrawals[withdrawalHash] == false,
-            "OptimismPortal: withdrawal has already been finalized"
-        );
+        require(finalizedWithdrawals[withdrawalHash] == false, "OptimismPortal: withdrawal has already been finalized");
 
         // Mark the withdrawal as finalized so it can't be replayed.
         finalizedWithdrawals[withdrawalHash] = true;
@@ -373,28 +334,20 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
     /// @param _gasLimit   Amount of L2 gas to purchase by burning gas on L1.
     /// @param _isCreation Whether or not the transaction is a contract creation.
     /// @param _data       Data to trigger the recipient with.
-    function depositTransaction(
-        address _to,
-        uint256 _value,
-        uint64 _gasLimit,
-        bool _isCreation,
-        bytes memory _data
-    ) public payable metered(_gasLimit) {
+    function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)
+        public
+        payable
+        metered(_gasLimit)
+    {
         // Just to be safe, make sure that people specify address(0) as the target when doing
         // contract creations.
         if (_isCreation) {
-            require(
-                _to == address(0),
-                "OptimismPortal: must send to address(0) when creating a contract"
-            );
+            require(_to == address(0), "OptimismPortal: must send to address(0) when creating a contract");
         }
 
         // Prevent depositing transactions that have too small of a gas limit. Users should pay
         // more for more resource usage.
-        require(
-            _gasLimit >= minimumGasLimit(uint64(_data.length)),
-            "OptimismPortal: gas limit too small"
-        );
+        require(_gasLimit >= minimumGasLimit(uint64(_data.length)), "OptimismPortal: gas limit too small");
 
         // Prevent the creation of deposit transactions that have too much calldata. This gives an
         // upper limit on the size of unsafe blocks over the p2p network. 120kb is chosen to ensure
@@ -411,13 +364,7 @@ contract OptimismPortal is Initializable, ResourceMetering, Semver {
         // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
         // We use opaque data so that we can update the TransactionDeposited event in the future
         // without breaking the current interface.
-        bytes memory opaqueData = abi.encodePacked(
-            msg.value,
-            _value,
-            _gasLimit,
-            _isCreation,
-            _data
-        );
+        bytes memory opaqueData = abi.encodePacked(msg.value, _value, _gasLimit, _isCreation, _data);
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.

--- a/packages/contracts-bedrock/contracts/L1/ResourceMetering.sol
+++ b/packages/contracts-bedrock/contracts/L1/ResourceMetering.sol
@@ -76,16 +76,16 @@ abstract contract ResourceMetering is Initializable {
         uint256 blockDiff = block.number - params.prevBlockNum;
 
         ResourceConfig memory config = _resourceConfig();
-        int256 targetResourceLimit = int256(uint256(config.maxResourceLimit)) /
-            int256(uint256(config.elasticityMultiplier));
+        int256 targetResourceLimit =
+            int256(uint256(config.maxResourceLimit)) / int256(uint256(config.elasticityMultiplier));
 
         if (blockDiff > 0) {
             // Handle updating EIP-1559 style gas parameters. We use EIP-1559 to restrict the rate
             // at which deposits can be created and therefore limit the potential for deposits to
             // spam the L2 system. Fee scheme is very similar to EIP-1559 with minor changes.
             int256 gasUsedDelta = int256(uint256(params.prevBoughtGas)) - targetResourceLimit;
-            int256 baseFeeDelta = (int256(uint256(params.prevBaseFee)) * gasUsedDelta) /
-                (targetResourceLimit * int256(uint256(config.baseFeeMaxChangeDenominator)));
+            int256 baseFeeDelta = (int256(uint256(params.prevBaseFee)) * gasUsedDelta)
+                / (targetResourceLimit * int256(uint256(config.baseFeeMaxChangeDenominator)));
 
             // Update base fee by adding the base fee delta and clamp the resulting value between
             // min and max.
@@ -155,10 +155,6 @@ abstract contract ResourceMetering is Initializable {
     ///         child contract.
     // solhint-disable-next-line func-name-mixedcase
     function __ResourceMetering_init() internal onlyInitializing {
-        params = ResourceParams({
-            prevBaseFee: 1 gwei,
-            prevBoughtGas: 0,
-            prevBlockNum: uint64(block.number)
-        });
+        params = ResourceParams({ prevBaseFee: 1 gwei, prevBoughtGas: 0, prevBlockNum: uint64(block.number) });
     }
 }

--- a/packages/contracts-bedrock/contracts/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/contracts/L1/SystemConfig.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Semver } from "../universal/Semver.sol";
 import { ResourceMetering } from "./ResourceMetering.sol";
 
@@ -212,29 +210,19 @@ contract SystemConfig is OwnableUpgradeable, Semver {
     function _setResourceConfig(ResourceMetering.ResourceConfig memory _config) internal {
         // Min base fee must be less than or equal to max base fee.
         require(
-            _config.minimumBaseFee <= _config.maximumBaseFee,
-            "SystemConfig: min base fee must be less than max base"
+            _config.minimumBaseFee <= _config.maximumBaseFee, "SystemConfig: min base fee must be less than max base"
         );
         // Base fee change denominator must be greater than 1.
-        require(
-            _config.baseFeeMaxChangeDenominator > 1,
-            "SystemConfig: denominator must be larger than 1"
-        );
+        require(_config.baseFeeMaxChangeDenominator > 1, "SystemConfig: denominator must be larger than 1");
         // Max resource limit plus system tx gas must be less than or equal to the L2 gas limit.
         // The gas limit must be increased before these values can be increased.
-        require(
-            _config.maxResourceLimit + _config.systemTxMaxGas <= gasLimit,
-            "SystemConfig: gas limit too low"
-        );
+        require(_config.maxResourceLimit + _config.systemTxMaxGas <= gasLimit, "SystemConfig: gas limit too low");
         // Elasticity multiplier must be greater than 0.
-        require(
-            _config.elasticityMultiplier > 0,
-            "SystemConfig: elasticity multiplier cannot be 0"
-        );
+        require(_config.elasticityMultiplier > 0, "SystemConfig: elasticity multiplier cannot be 0");
         // No precision loss when computing target resource limit.
         require(
-            ((_config.maxResourceLimit / _config.elasticityMultiplier) *
-                _config.elasticityMultiplier) == _config.maxResourceLimit,
+            ((_config.maxResourceLimit / _config.elasticityMultiplier) * _config.elasticityMultiplier)
+                == _config.maxResourceLimit,
             "SystemConfig: precision loss with target resource limit"
         );
 

--- a/packages/contracts-bedrock/contracts/L2/BaseFeeVault.sol
+++ b/packages/contracts-bedrock/contracts/L2/BaseFeeVault.sol
@@ -14,9 +14,8 @@ contract BaseFeeVault is FeeVault, Semver {
     /// @param _recipient           Wallet that will receive the fees.
     /// @param _minWithdrawalAmount Minimum balance for withdrawals.
     /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        WithdrawalNetwork _withdrawalNetwork
-    ) FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork) Semver(1, 2, 1) {}
+    constructor(address _recipient, uint256 _minWithdrawalAmount, WithdrawalNetwork _withdrawalNetwork)
+        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
+        Semver(1, 2, 1)
+    { }
 }

--- a/packages/contracts-bedrock/contracts/L2/CrossDomainOwnable.sol
+++ b/packages/contracts-bedrock/contracts/L2/CrossDomainOwnable.sol
@@ -14,8 +14,7 @@ abstract contract CrossDomainOwnable is Ownable {
     ///         `msg.sender` is the owner of the contract.
     function _checkOwner() internal view override {
         require(
-            owner() == AddressAliasHelper.undoL1ToL2Alias(msg.sender),
-            "CrossDomainOwnable: caller is not the owner"
+            owner() == AddressAliasHelper.undoL1ToL2Alias(msg.sender), "CrossDomainOwnable: caller is not the owner"
         );
     }
 }

--- a/packages/contracts-bedrock/contracts/L2/CrossDomainOwnable2.sol
+++ b/packages/contracts-bedrock/contracts/L2/CrossDomainOwnable2.sol
@@ -15,18 +15,10 @@ abstract contract CrossDomainOwnable2 is Ownable {
     ///         `xDomainMessageSender` is the owner of the contract. This value is set to the caller
     ///         of the L1CrossDomainMessenger.
     function _checkOwner() internal view override {
-        L2CrossDomainMessenger messenger = L2CrossDomainMessenger(
-            Predeploys.L2_CROSS_DOMAIN_MESSENGER
-        );
+        L2CrossDomainMessenger messenger = L2CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
 
-        require(
-            msg.sender == address(messenger),
-            "CrossDomainOwnable2: caller is not the messenger"
-        );
+        require(msg.sender == address(messenger), "CrossDomainOwnable2: caller is not the messenger");
 
-        require(
-            owner() == messenger.xDomainMessageSender(),
-            "CrossDomainOwnable2: caller is not the owner"
-        );
+        require(owner() == messenger.xDomainMessageSender(), "CrossDomainOwnable2: caller is not the owner");
     }
 }

--- a/packages/contracts-bedrock/contracts/L2/CrossDomainOwnable3.sol
+++ b/packages/contracts-bedrock/contracts/L2/CrossDomainOwnable3.sol
@@ -20,11 +20,7 @@ abstract contract CrossDomainOwnable3 is Ownable {
     /// @param previousOwner The previous owner of the contract.
     /// @param newOwner      The new owner of the contract.
     /// @param isLocal       Configures the `isLocal` contract variable.
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner,
-        bool isLocal
-    );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner, bool isLocal);
 
     /// @notice Allows for ownership to be transferred with specifying the locality.
     /// @param _owner   The new owner of the contract.
@@ -46,19 +42,11 @@ abstract contract CrossDomainOwnable3 is Ownable {
         if (isLocal) {
             require(owner() == msg.sender, "CrossDomainOwnable3: caller is not the owner");
         } else {
-            L2CrossDomainMessenger messenger = L2CrossDomainMessenger(
-                Predeploys.L2_CROSS_DOMAIN_MESSENGER
-            );
+            L2CrossDomainMessenger messenger = L2CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
 
-            require(
-                msg.sender == address(messenger),
-                "CrossDomainOwnable3: caller is not the messenger"
-            );
+            require(msg.sender == address(messenger), "CrossDomainOwnable3: caller is not the messenger");
 
-            require(
-                owner() == messenger.xDomainMessageSender(),
-                "CrossDomainOwnable3: caller is not the owner"
-            );
+            require(owner() == messenger.xDomainMessageSender(), "CrossDomainOwnable3: caller is not the owner");
         }
     }
 }

--- a/packages/contracts-bedrock/contracts/L2/GasPriceOracle.sol
+++ b/packages/contracts-bedrock/contracts/L2/GasPriceOracle.sol
@@ -25,7 +25,7 @@ contract GasPriceOracle is Semver {
 
     /// @custom:semver 1.0.1
     /// @notice Constructs the GasPriceOracle contract.
-    constructor() Semver(1, 0, 1) {}
+    constructor() Semver(1, 0, 1) { }
 
     /// @notice Computes the L1 portion of the fee based on the size of the rlp encoded input
     ///         transaction, the current L1 base fee, and the various dynamic parameters.
@@ -34,7 +34,7 @@ contract GasPriceOracle is Semver {
     function getL1Fee(bytes memory _data) external view returns (uint256) {
         uint256 l1GasUsed = getL1GasUsed(_data);
         uint256 l1Fee = l1GasUsed * l1BaseFee();
-        uint256 divisor = 10**DECIMALS;
+        uint256 divisor = 10 ** DECIMALS;
         uint256 unscaled = l1Fee * scalar();
         uint256 scaled = unscaled / divisor;
         return scaled;

--- a/packages/contracts-bedrock/contracts/L2/L1Block.sol
+++ b/packages/contracts-bedrock/contracts/L2/L1Block.sol
@@ -40,7 +40,7 @@ contract L1Block is Semver {
 
     /// @custom:semver 1.0.1
     /// @notice Constructs the L1Block contract.
-    constructor() Semver(1, 0, 1) {}
+    constructor() Semver(1, 0, 1) { }
 
     /// @notice Updates the L1 block values.
     /// @param _number         L1 blocknumber.
@@ -61,10 +61,7 @@ contract L1Block is Semver {
         uint256 _l1FeeOverhead,
         uint256 _l1FeeScalar
     ) external {
-        require(
-            msg.sender == DEPOSITOR_ACCOUNT,
-            "L1Block: only the depositor account can set L1 block values"
-        );
+        require(msg.sender == DEPOSITOR_ACCOUNT, "L1Block: only the depositor account can set L1 block values");
 
         number = _number;
         timestamp = _timestamp;

--- a/packages/contracts-bedrock/contracts/L2/L1FeeVault.sol
+++ b/packages/contracts-bedrock/contracts/L2/L1FeeVault.sol
@@ -14,9 +14,8 @@ contract L1FeeVault is FeeVault, Semver {
     /// @param _recipient           Wallet that will receive the fees.
     /// @param _minWithdrawalAmount Minimum balance for withdrawals.
     /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        WithdrawalNetwork _withdrawalNetwork
-    ) FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork) Semver(1, 2, 1) {}
+    constructor(address _recipient, uint256 _minWithdrawalAmount, WithdrawalNetwork _withdrawalNetwork)
+        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
+        Semver(1, 2, 1)
+    { }
 }

--- a/packages/contracts-bedrock/contracts/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2CrossDomainMessenger.sol
@@ -17,10 +17,7 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, Semver {
     /// @custom:semver 1.4.1
     /// @notice Constructs the L2CrossDomainMessenger contract.
     /// @param _l1CrossDomainMessenger Address of the L1CrossDomainMessenger contract.
-    constructor(address _l1CrossDomainMessenger)
-        Semver(1, 4, 1)
-        CrossDomainMessenger(_l1CrossDomainMessenger)
-    {
+    constructor(address _l1CrossDomainMessenger) Semver(1, 4, 1) CrossDomainMessenger(_l1CrossDomainMessenger) {
         initialize();
     }
 
@@ -38,15 +35,10 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, Semver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessage(
-        address _to,
-        uint64 _gasLimit,
-        uint256 _value,
-        bytes memory _data
-    ) internal override {
-        L2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal{
-            value: _value
-        }(_to, _gasLimit, _data);
+    function _sendMessage(address _to, uint64 _gasLimit, uint256 _value, bytes memory _data) internal override {
+        L2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal{ value: _value }(
+            _to, _gasLimit, _data
+        );
     }
 
     /// @inheritdoc CrossDomainMessenger

--- a/packages/contracts-bedrock/contracts/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2ERC721Bridge.sol
@@ -21,10 +21,7 @@ contract L2ERC721Bridge is ERC721Bridge, Semver {
     /// @notice Constructs the L2ERC721Bridge contract.
     /// @param _messenger   Address of the CrossDomainMessenger on this network.
     /// @param _otherBridge Address of the ERC721 bridge on the other network.
-    constructor(address _messenger, address _otherBridge)
-        Semver(1, 1, 1)
-        ERC721Bridge(_messenger, _otherBridge)
-    {}
+    constructor(address _messenger, address _otherBridge) Semver(1, 1, 1) ERC721Bridge(_messenger, _otherBridge) { }
 
     /// @notice Completes an ERC721 bridge from the other domain and sends the ERC721 token to the
     ///         recipient on this domain.
@@ -87,10 +84,7 @@ contract L2ERC721Bridge is ERC721Bridge, Semver {
         // Construct calldata for l1ERC721Bridge.finalizeBridgeERC721(_to, _tokenId)
         // slither-disable-next-line reentrancy-events
         address remoteToken = IOptimismMintableERC721(_localToken).remoteToken();
-        require(
-            remoteToken == _remoteToken,
-            "L2ERC721Bridge: remote token does not match given value"
-        );
+        require(remoteToken == _remoteToken, "L2ERC721Bridge: remote token does not match given value");
 
         // When a withdrawal is initiated, we burn the withdrawer's NFT to prevent subsequent L2
         // usage
@@ -98,13 +92,7 @@ contract L2ERC721Bridge is ERC721Bridge, Semver {
         IOptimismMintableERC721(_localToken).burn(_from, _tokenId);
 
         bytes memory message = abi.encodeWithSelector(
-            L1ERC721Bridge.finalizeBridgeERC721.selector,
-            remoteToken,
-            _localToken,
-            _from,
-            _to,
-            _tokenId,
-            _extraData
+            L1ERC721Bridge.finalizeBridgeERC721.selector, remoteToken, _localToken, _from, _to, _tokenId, _extraData
         );
 
         // Send message to L1 bridge

--- a/packages/contracts-bedrock/contracts/L2/L2StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2StandardBridge.sol
@@ -56,17 +56,12 @@ contract L2StandardBridge is StandardBridge, Semver {
     constructor(address payable _otherBridge)
         Semver(1, 1, 1)
         StandardBridge(payable(Predeploys.L2_CROSS_DOMAIN_MESSENGER), _otherBridge)
-    {}
+    { }
 
     /// @notice Allows EOAs to bridge ETH by sending directly to the bridge.
     receive() external payable override onlyEOA {
         _initiateWithdrawal(
-            Predeploys.LEGACY_ERC20_ETH,
-            msg.sender,
-            msg.sender,
-            msg.value,
-            RECEIVE_DEFAULT_GAS_LIMIT,
-            bytes("")
+            Predeploys.LEGACY_ERC20_ETH, msg.sender, msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, bytes("")
         );
     }
 
@@ -78,12 +73,12 @@ contract L2StandardBridge is StandardBridge, Semver {
     /// @param _amount      Amount of the L2 token to withdraw.
     /// @param _minGasLimit Minimum gas limit to use for the transaction.
     /// @param _extraData   Extra data attached to the withdrawal.
-    function withdraw(
-        address _l2Token,
-        uint256 _amount,
-        uint32 _minGasLimit,
-        bytes calldata _extraData
-    ) external payable virtual onlyEOA {
+    function withdraw(address _l2Token, uint256 _amount, uint32 _minGasLimit, bytes calldata _extraData)
+        external
+        payable
+        virtual
+        onlyEOA
+    {
         _initiateWithdrawal(_l2Token, msg.sender, msg.sender, _amount, _minGasLimit, _extraData);
     }
 
@@ -100,13 +95,11 @@ contract L2StandardBridge is StandardBridge, Semver {
     /// @param _amount      Amount of the L2 token to withdraw.
     /// @param _minGasLimit Minimum gas limit to use for the transaction.
     /// @param _extraData   Extra data attached to the withdrawal.
-    function withdrawTo(
-        address _l2Token,
-        address _to,
-        uint256 _amount,
-        uint32 _minGasLimit,
-        bytes calldata _extraData
-    ) external payable virtual {
+    function withdrawTo(address _l2Token, address _to, uint256 _amount, uint32 _minGasLimit, bytes calldata _extraData)
+        external
+        payable
+        virtual
+    {
         _initiateWithdrawal(_l2Token, msg.sender, _to, _amount, _minGasLimit, _extraData);
     }
 
@@ -168,40 +161,22 @@ contract L2StandardBridge is StandardBridge, Semver {
     /// @notice Emits the legacy WithdrawalInitiated event followed by the ETHBridgeInitiated event.
     ///         This is necessary for backwards compatibility with the legacy bridge.
     /// @inheritdoc StandardBridge
-    function _emitETHBridgeInitiated(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes memory _extraData
-    ) internal override {
-        emit WithdrawalInitiated(
-            address(0),
-            Predeploys.LEGACY_ERC20_ETH,
-            _from,
-            _to,
-            _amount,
-            _extraData
-        );
+    function _emitETHBridgeInitiated(address _from, address _to, uint256 _amount, bytes memory _extraData)
+        internal
+        override
+    {
+        emit WithdrawalInitiated(address(0), Predeploys.LEGACY_ERC20_ETH, _from, _to, _amount, _extraData);
         super._emitETHBridgeInitiated(_from, _to, _amount, _extraData);
     }
 
     /// @notice Emits the legacy DepositFinalized event followed by the ETHBridgeFinalized event.
     ///         This is necessary for backwards compatibility with the legacy bridge.
     /// @inheritdoc StandardBridge
-    function _emitETHBridgeFinalized(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes memory _extraData
-    ) internal override {
-        emit DepositFinalized(
-            address(0),
-            Predeploys.LEGACY_ERC20_ETH,
-            _from,
-            _to,
-            _amount,
-            _extraData
-        );
+    function _emitETHBridgeFinalized(address _from, address _to, uint256 _amount, bytes memory _extraData)
+        internal
+        override
+    {
+        emit DepositFinalized(address(0), Predeploys.LEGACY_ERC20_ETH, _from, _to, _amount, _extraData);
         super._emitETHBridgeFinalized(_from, _to, _amount, _extraData);
     }
 

--- a/packages/contracts-bedrock/contracts/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2ToL1MessagePasser.sol
@@ -50,7 +50,7 @@ contract L2ToL1MessagePasser is Semver {
 
     /// @custom:semver 1.0.1
     /// @notice Constructs the L2ToL1MessagePasser contract.
-    constructor() Semver(1, 0, 1) {}
+    constructor() Semver(1, 0, 1) { }
 
     /// @notice Allows users to withdraw ETH by sending directly to this contract.
     receive() external payable {
@@ -71,11 +71,7 @@ contract L2ToL1MessagePasser is Semver {
     /// @param _target   Address to call on L1 execution.
     /// @param _gasLimit Minimum gas limit for executing the message on L1.
     /// @param _data     Data to forward to L1 target.
-    function initiateWithdrawal(
-        address _target,
-        uint256 _gasLimit,
-        bytes memory _data
-    ) public payable {
+    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) public payable {
         bytes32 withdrawalHash = Hashing.hashWithdrawal(
             Types.WithdrawalTransaction({
                 nonce: messageNonce(),
@@ -89,15 +85,7 @@ contract L2ToL1MessagePasser is Semver {
 
         sentMessages[withdrawalHash] = true;
 
-        emit MessagePassed(
-            messageNonce(),
-            msg.sender,
-            _target,
-            msg.value,
-            _gasLimit,
-            _data,
-            withdrawalHash
-        );
+        emit MessagePassed(messageNonce(), msg.sender, _target, msg.value, _gasLimit, _data, withdrawalHash);
 
         unchecked {
             ++msgNonce;

--- a/packages/contracts-bedrock/contracts/L2/SequencerFeeVault.sol
+++ b/packages/contracts-bedrock/contracts/L2/SequencerFeeVault.sol
@@ -15,11 +15,10 @@ contract SequencerFeeVault is FeeVault, Semver {
     /// @param _recipient           Wallet that will receive the fees.
     /// @param _minWithdrawalAmount Minimum balance for withdrawals.
     /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        WithdrawalNetwork _withdrawalNetwork
-    ) FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork) Semver(1, 2, 1) {}
+    constructor(address _recipient, uint256 _minWithdrawalAmount, WithdrawalNetwork _withdrawalNetwork)
+        FeeVault(_recipient, _minWithdrawalAmount, _withdrawalNetwork)
+        Semver(1, 2, 1)
+    { }
 
     /// @custom:legacy
     /// @notice Legacy getter for the recipient address.

--- a/packages/contracts-bedrock/contracts/cannon/MIPS.sol
+++ b/packages/contracts-bedrock/contracts/cannon/MIPS.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.7.6;
 
 interface IPreimageOracle {
-  function readPreimage(bytes32 key, uint256 offset) external view returns (bytes32 dat, uint256 datLen);
+    function readPreimage(bytes32 key, uint256 offset) external view returns (bytes32 dat, uint256 datLen);
 }
 
 // https://inst.eecs.berkeley.edu/~cs61c/resources/MIPS_Green_Sheet.pdf
@@ -23,607 +23,686 @@ interface IPreimageOracle {
 // The Step input is a packed VM state, with binary-merkle-tree witness data for memory reads/writes.
 // The Step outputs a keccak256 hash of the packed VM State, and logs the resulting state for offchain usage.
 contract MIPS {
-
-  struct State {
-    bytes32 memRoot;
-    bytes32 preimageKey;
-    uint32 preimageOffset;
-    uint32 pc;
-    uint32 nextPC;  // State is executing a branch/jump delay slot if nextPC != pc+4
-    uint32 lo;
-    uint32 hi;
-    uint32 heap;
-    uint8 exitCode;
-    bool exited;
-    uint64 step;
-    uint32[32] registers;
-  }
-
-  // total State size: 32+32+6*4+1+1+8+32*4 = 226 bytes
-
-  uint32 constant public BRK_START = 0x40000000;
-
-  uint32 constant FD_STDIN = 0;
-  uint32 constant FD_STDOUT = 1;
-  uint32 constant FD_STDERR = 2;
-  uint32 constant FD_HINT_READ = 3;
-  uint32 constant FD_HINT_WRITE = 4;
-  uint32 constant FD_PREIMAGE_READ = 5;
-  uint32 constant FD_PREIMAGE_WRITE = 6;
-
-  uint32 constant EBADF = 0x9;
-  uint32 constant EINVAL = 0x16;
-
-  IPreimageOracle public oracle;
-
-  function SE(uint32 dat, uint32 idx) internal pure returns (uint32) {
-    bool isSigned = (dat >> (idx-1)) != 0;
-    uint256 signed = ((1 << (32-idx)) - 1) << idx;
-    uint256 mask = (1 << idx) - 1;
-    return uint32(dat&mask | (isSigned ? signed : 0));
-  }
-
-  function outputState() internal returns (bytes32 out) {
-    assembly {
-      // copies 'size' bytes, right-aligned in word at 'from', to 'to', incl. trailing data
-      function copyMem(from, to, size) -> fromOut, toOut {
-        mstore(to, mload(add(from, sub(32, size))))
-        fromOut := add(from, 32)
-        toOut := add(to, size)
-      }
-      let from := 0x80 // state
-      let start := mload(0x40) // free mem ptr
-      let to := start
-      from, to := copyMem(from, to, 32) // memRoot
-      from, to := copyMem(from, to, 32) // preimageKey
-      from, to := copyMem(from, to, 4) // preimageOffset
-      from, to := copyMem(from, to, 4) // pc
-      from, to := copyMem(from, to, 4) // nextPC
-      from, to := copyMem(from, to, 4) // lo
-      from, to := copyMem(from, to, 4) // hi
-      from, to := copyMem(from, to, 4) // heap
-      from, to := copyMem(from, to, 1) // exitCode
-      from, to := copyMem(from, to, 1) // exited
-      from, to := copyMem(from, to, 8) // step
-      from := add(from, 32) // offset to registers
-      for { let i := 0 } lt(i, 32) { i := add(i, 1) } { from, to := copyMem(from, to, 4) } // registers
-      mstore(to, 0) // clean up end
-      log0(start, sub(to, start)) // log the resulting MIPS state, for debugging
-      out := keccak256(start, sub(to, start))
+    struct State {
+        bytes32 memRoot;
+        bytes32 preimageKey;
+        uint32 preimageOffset;
+        uint32 pc;
+        uint32 nextPC; // State is executing a branch/jump delay slot if nextPC != pc+4
+        uint32 lo;
+        uint32 hi;
+        uint32 heap;
+        uint8 exitCode;
+        bool exited;
+        uint64 step;
+        uint32[32] registers;
     }
-    return out;
-  }
 
-  function handleSyscall() internal returns (bytes32) {
-    State memory state;
-    assembly {
-      state := 0x80
+    // total State size: 32+32+6*4+1+1+8+32*4 = 226 bytes
+
+    uint32 public constant BRK_START = 0x40000000;
+
+    uint32 constant FD_STDIN = 0;
+    uint32 constant FD_STDOUT = 1;
+    uint32 constant FD_STDERR = 2;
+    uint32 constant FD_HINT_READ = 3;
+    uint32 constant FD_HINT_WRITE = 4;
+    uint32 constant FD_PREIMAGE_READ = 5;
+    uint32 constant FD_PREIMAGE_WRITE = 6;
+
+    uint32 constant EBADF = 0x9;
+    uint32 constant EINVAL = 0x16;
+
+    IPreimageOracle public oracle;
+
+    function SE(uint32 dat, uint32 idx) internal pure returns (uint32) {
+        bool isSigned = (dat >> (idx - 1)) != 0;
+        uint256 signed = ((1 << (32 - idx)) - 1) << idx;
+        uint256 mask = (1 << idx) - 1;
+        return uint32(dat & mask | (isSigned ? signed : 0));
     }
-    uint32 syscall_no = state.registers[2];
-    uint32 v0 = 0;
-    uint32 v1 = 0;
 
-    uint32 a0 = state.registers[4];
-    uint32 a1 = state.registers[5];
-    uint32 a2 = state.registers[6];
+    function outputState() internal returns (bytes32 out) {
+        assembly {
+            // copies 'size' bytes, right-aligned in word at 'from', to 'to', incl. trailing data
+            function copyMem(from, to, size) -> fromOut, toOut {
+                mstore(to, mload(add(from, sub(32, size))))
+                fromOut := add(from, 32)
+                toOut := add(to, size)
+            }
+            let from := 0x80 // state
+            let start := mload(0x40) // free mem ptr
+            let to := start
+            from, to := copyMem(from, to, 32) // memRoot
+            from, to := copyMem(from, to, 32) // preimageKey
+            from, to := copyMem(from, to, 4) // preimageOffset
+            from, to := copyMem(from, to, 4) // pc
+            from, to := copyMem(from, to, 4) // nextPC
+            from, to := copyMem(from, to, 4) // lo
+            from, to := copyMem(from, to, 4) // hi
+            from, to := copyMem(from, to, 4) // heap
+            from, to := copyMem(from, to, 1) // exitCode
+            from, to := copyMem(from, to, 1) // exited
+            from, to := copyMem(from, to, 8) // step
+            from := add(from, 32) // offset to registers
+            for { let i := 0 } lt(i, 32) { i := add(i, 1) } { from, to := copyMem(from, to, 4) } // registers
+            mstore(to, 0) // clean up end
+            log0(start, sub(to, start)) // log the resulting MIPS state, for debugging
+            out := keccak256(start, sub(to, start))
+        }
+        return out;
+    }
 
-    if (syscall_no == 4090) {
-      // mmap
-      uint32 sz = a1;
-      if (sz&4095 != 0) { // adjust size to align with page size
-        sz += 4096 - (sz&4095);
-      }
-      if (a0 == 0) {
-        v0 = state.heap;
-        state.heap += sz;
-      } else {
-        v0 = a0;
-      }
-    } else if (syscall_no == 4045) {
-      // brk
-      v0 = BRK_START;
-    } else if (syscall_no == 4120) {
-      // clone (not supported)
-      v0 = 1;
-    } else if (syscall_no == 4246) {
-      // exit group
-      state.exited = true;
-      state.exitCode = uint8(a0);
-      return outputState();
-    } else if (syscall_no == 4003) { // read
-      // args: a0 = fd, a1 = addr, a2 = count
-      // returns: v0 = read, v1 = err code
-      if (a0 == FD_STDIN) {
-        // leave v0 and v1 zero: read nothing, no error
-      } else if (a0 == FD_PREIMAGE_READ) { // pre-image oracle
-        // verify proof 1 is correct, and get the existing memory.
-        uint32 mem = readMem(a1 & 0xFFffFFfc, 1); // mask the addr to align it to 4 bytes
-        (bytes32 dat, uint256 datLen) = oracle.readPreimage(state.preimageKey, state.preimageOffset);
-        assembly { // assembly for more precise ops, and no var count limit
-          let alignment := and(a1, 3) // the read might not start at an aligned address
-          let space := sub(4, alignment) // remaining space in memory word
-          if lt(space, datLen) { datLen := space } // if less space than data, shorten data
-          if lt(a2, datLen) { datLen := a2 } // if requested to read less, read less
-          dat := shr(sub(256, mul(datLen, 8)), dat) // right-align data
-          dat := shl(mul(alignment, 8), dat) // position data to insert into memory word
-          let mask := sub(shl(mul(sub(4, alignment), 8), 1), 1) // mask all bytes after start
-          let suffixMask := sub(shl(mul(add(sub(4, alignment), datLen), 8), 1), 1) // mask of all bytes starting from end, maybe none
-          mask := and(mask, not(suffixMask)) // reduce mask to just cover the data we insert
-          mem := or(and(mem, not(mask)), dat) // clear masked part of original memory, and insert data
+    function handleSyscall() internal returns (bytes32) {
+        State memory state;
+        assembly {
+            state := 0x80
         }
-        writeMem(a1 & 0xFFffFFfc, 1, mem);
-        state.preimageOffset += uint32(datLen);
-        v0 = uint32(datLen);
-      } else if (a0 == FD_HINT_READ) { // hint response
-        // don't actually read into memory, just say we read it all, we ignore the result anyway
-        v0 = a2;
-      } else {
-        v0 = 0xFFffFFff;
-        v1 = EBADF;
-      }
-    } else if (syscall_no == 4004) { // write
-      // args: a0 = fd, a1 = addr, a2 = count
-      // returns: v0 = written, v1 = err code
-      if (a0 == FD_STDOUT || a0 == FD_STDERR || a0 == FD_HINT_WRITE) {
-        v0 = a2; // tell program we have written everything
-      } else if (a0 == FD_PREIMAGE_WRITE) { // pre-image oracle
-        uint32 mem = readMem(a1 & 0xFFffFFfc, 1); // mask the addr to align it to 4 bytes
-        bytes32 key = state.preimageKey;
-        assembly { // assembly for more precise ops, and no var count limit
-          let alignment := and(a1, 3) // the read might not start at an aligned address
-          let space := sub(4, alignment) // remaining space in memory word
-          if lt(space, a2) { a2 := space } // if less space than data, shorten data
-          key := shl(mul(a2, 8), key) // shift key, make space for new info
-          let mask := sub(shl(mul(a2, 8), 1), 1) // mask for extracting value from memory
-          mem := and(shr(mul(sub(space, a2), 8), mem), mask) // align value to right, mask it
-          key := or(key, mem) // insert into key
+        uint32 syscall_no = state.registers[2];
+        uint32 v0 = 0;
+        uint32 v1 = 0;
+
+        uint32 a0 = state.registers[4];
+        uint32 a1 = state.registers[5];
+        uint32 a2 = state.registers[6];
+
+        if (syscall_no == 4090) {
+            // mmap
+            uint32 sz = a1;
+            if (sz & 4095 != 0) {
+                // adjust size to align with page size
+                sz += 4096 - (sz & 4095);
+            }
+            if (a0 == 0) {
+                v0 = state.heap;
+                state.heap += sz;
+            } else {
+                v0 = a0;
+            }
+        } else if (syscall_no == 4045) {
+            // brk
+            v0 = BRK_START;
+        } else if (syscall_no == 4120) {
+            // clone (not supported)
+            v0 = 1;
+        } else if (syscall_no == 4246) {
+            // exit group
+            state.exited = true;
+            state.exitCode = uint8(a0);
+            return outputState();
+        } else if (syscall_no == 4003) {
+            // read
+            // args: a0 = fd, a1 = addr, a2 = count
+            // returns: v0 = read, v1 = err code
+            if (a0 == FD_STDIN) {
+                // leave v0 and v1 zero: read nothing, no error
+            } else if (a0 == FD_PREIMAGE_READ) {
+                // pre-image oracle
+                // verify proof 1 is correct, and get the existing memory.
+                uint32 mem = readMem(a1 & 0xFFffFFfc, 1); // mask the addr to align it to 4 bytes
+                (bytes32 dat, uint256 datLen) = oracle.readPreimage(state.preimageKey, state.preimageOffset);
+                assembly {
+                    // assembly for more precise ops, and no var count limit
+                    let alignment := and(a1, 3) // the read might not start at an aligned address
+                    let space := sub(4, alignment) // remaining space in memory word
+                    if lt(space, datLen) { datLen := space } // if less space than data, shorten data
+                    if lt(a2, datLen) { datLen := a2 } // if requested to read less, read less
+                    dat := shr(sub(256, mul(datLen, 8)), dat) // right-align data
+                    dat := shl(mul(alignment, 8), dat) // position data to insert into memory word
+                    let mask := sub(shl(mul(sub(4, alignment), 8), 1), 1) // mask all bytes after start
+                    let suffixMask := sub(shl(mul(add(sub(4, alignment), datLen), 8), 1), 1) // mask of all bytes
+                        // starting from end, maybe none
+                    mask := and(mask, not(suffixMask)) // reduce mask to just cover the data we insert
+                    mem := or(and(mem, not(mask)), dat) // clear masked part of original memory, and insert data
+                }
+                writeMem(a1 & 0xFFffFFfc, 1, mem);
+                state.preimageOffset += uint32(datLen);
+                v0 = uint32(datLen);
+            } else if (a0 == FD_HINT_READ) {
+                // hint response
+                // don't actually read into memory, just say we read it all, we ignore the result anyway
+                v0 = a2;
+            } else {
+                v0 = 0xFFffFFff;
+                v1 = EBADF;
+            }
+        } else if (syscall_no == 4004) {
+            // write
+            // args: a0 = fd, a1 = addr, a2 = count
+            // returns: v0 = written, v1 = err code
+            if (a0 == FD_STDOUT || a0 == FD_STDERR || a0 == FD_HINT_WRITE) {
+                v0 = a2; // tell program we have written everything
+            } else if (a0 == FD_PREIMAGE_WRITE) {
+                // pre-image oracle
+                uint32 mem = readMem(a1 & 0xFFffFFfc, 1); // mask the addr to align it to 4 bytes
+                bytes32 key = state.preimageKey;
+                assembly {
+                    // assembly for more precise ops, and no var count limit
+                    let alignment := and(a1, 3) // the read might not start at an aligned address
+                    let space := sub(4, alignment) // remaining space in memory word
+                    if lt(space, a2) { a2 := space } // if less space than data, shorten data
+                    key := shl(mul(a2, 8), key) // shift key, make space for new info
+                    let mask := sub(shl(mul(a2, 8), 1), 1) // mask for extracting value from memory
+                    mem := and(shr(mul(sub(space, a2), 8), mem), mask) // align value to right, mask it
+                    key := or(key, mem) // insert into key
+                }
+                state.preimageKey = key;
+                state.preimageOffset = 0; // reset offset, to read new pre-image data from the start
+                v0 = a2;
+            } else {
+                v0 = 0xFFffFFff;
+                v1 = EBADF;
+            }
+        } else if (syscall_no == 4055) {
+            // fcntl
+            // args: a0 = fd, a1 = cmd
+            if (a1 == 3) {
+                // F_GETFL: get file descriptor flags
+                if (a0 == FD_STDIN || a0 == FD_PREIMAGE_READ || a0 == FD_HINT_READ) {
+                    v0 = 0; // O_RDONLY
+                } else if (a0 == FD_STDOUT || a0 == FD_STDERR || a0 == FD_PREIMAGE_WRITE || a0 == FD_HINT_WRITE) {
+                    v0 = 1; // O_WRONLY
+                } else {
+                    v0 = 0xFFffFFff;
+                    v1 = EBADF;
+                }
+            } else {
+                v0 = 0xFFffFFff;
+                v1 = EINVAL; // cmd not recognized by this kernel
+            }
         }
-        state.preimageKey = key;
-        state.preimageOffset = 0; // reset offset, to read new pre-image data from the start
-        v0 = a2;
-      } else {
-        v0 = 0xFFffFFff;
-        v1 = EBADF;
-      }
-    } else if (syscall_no == 4055) { // fcntl
-      // args: a0 = fd, a1 = cmd
-      if (a1 == 3) { // F_GETFL: get file descriptor flags
-        if (a0 == FD_STDIN || a0 == FD_PREIMAGE_READ || a0 == FD_HINT_READ) {
-          v0 = 0; // O_RDONLY
-        } else if (a0 == FD_STDOUT || a0 == FD_STDERR || a0 == FD_PREIMAGE_WRITE || a0 == FD_HINT_WRITE) {
-          v0 = 1; // O_WRONLY
+
+        state.registers[2] = v0;
+        state.registers[7] = v1;
+
+        state.pc = state.nextPC;
+        state.nextPC = state.nextPC + 4;
+
+        return outputState();
+    }
+
+    function handleBranch(uint32 opcode, uint32 insn, uint32 rtReg, uint32 rs) internal returns (bytes32) {
+        State memory state;
+        assembly {
+            state := 0x80
+        }
+        bool shouldBranch = false;
+
+        if (opcode == 4 || opcode == 5) {
+            // beq/bne
+            uint32 rt = state.registers[rtReg];
+            shouldBranch = (rs == rt && opcode == 4) || (rs != rt && opcode == 5);
+        } else if (opcode == 6) {
+            shouldBranch = int32(rs) <= 0; // blez
+        } else if (opcode == 7) {
+            shouldBranch = int32(rs) > 0; // bgtz
+        } else if (opcode == 1) {
+            // regimm
+            uint32 rtv = ((insn >> 16) & 0x1F);
+            if (rtv == 0) shouldBranch = int32(rs) < 0; // bltz
+            if (rtv == 1) shouldBranch = int32(rs) >= 0; // bgez
+        }
+
+        uint32 prevPC = state.pc;
+        state.pc = state.nextPC; // execute the delay slot first
+        if (shouldBranch) {
+            state.nextPC = prevPC + 4 + (SE(insn & 0xFFFF, 16) << 2); // then continue with the instruction the branch
+                // jumps to.
         } else {
-          v0 = 0xFFffFFff;
-          v1 = EBADF;
+            state.nextPC = state.nextPC + 4; // branch not taken
         }
-      } else {
-        v0 = 0xFFffFFff;
-        v1 = EINVAL; // cmd not recognized by this kernel
-      }
+
+        return outputState();
     }
 
-    state.registers[2] = v0;
-    state.registers[7] = v1;
-
-    state.pc = state.nextPC;
-    state.nextPC = state.nextPC + 4;
-
-    return outputState();
-  }
-
-  function handleBranch(uint32 opcode, uint32 insn, uint32 rtReg, uint32 rs) internal returns (bytes32) {
-    State memory state;
-    assembly {
-      state := 0x80
-    }
-    bool shouldBranch = false;
-
-    if (opcode == 4 || opcode == 5) {   // beq/bne
-      uint32 rt = state.registers[rtReg];
-      shouldBranch = (rs == rt && opcode == 4) || (rs != rt && opcode == 5);
-    } else if (opcode == 6) { shouldBranch = int32(rs) <= 0; // blez
-    } else if (opcode == 7) { shouldBranch = int32(rs) > 0; // bgtz
-    } else if (opcode == 1) {
-      // regimm
-      uint32 rtv = ((insn >> 16) & 0x1F);
-      if (rtv == 0) shouldBranch = int32(rs) < 0;  // bltz
-      if (rtv == 1) shouldBranch = int32(rs) >= 0; // bgez
-    }
-
-    uint32 prevPC = state.pc;
-    state.pc = state.nextPC; // execute the delay slot first
-    if (shouldBranch) {
-      state.nextPC = prevPC + 4 + (SE(insn&0xFFFF, 16)<<2); // then continue with the instruction the branch jumps to.
-    } else {
-      state.nextPC = state.nextPC + 4; // branch not taken
-    }
-
-    return outputState();
-  }
-
-  function handleHiLo(uint32 func, uint32 rs, uint32 rt, uint32 storeReg) internal returns (bytes32) {
-    State memory state;
-    assembly {
-      state := 0x80
-    }
-    uint32 val;
-    if (func == 0x10) val = state.hi; // mfhi
-    else if (func == 0x11) state.hi = rs; // mthi
-    else if (func == 0x12) val = state.lo; // mflo
-    else if (func == 0x13) state.lo = rs; // mtlo
-    else if (func == 0x18) { // mult
-      uint64 acc = uint64(int64(int32(rs))*int64(int32(rt)));
-      state.hi = uint32(acc>>32);
-      state.lo = uint32(acc);
-    } else if (func == 0x19) { // multu
-      uint64 acc = uint64(uint64(rs)*uint64(rt));
-      state.hi = uint32(acc>>32);
-      state.lo = uint32(acc);
-    } else if (func == 0x1a) { // div
-      state.hi = uint32(int32(rs)%int32(rt));
-      state.lo = uint32(int32(rs)/int32(rt));
-    } else if (func == 0x1b) { // divu
-      state.hi = rs%rt;
-      state.lo = rs/rt;
-    }
-
-    if (storeReg != 0) {
-      state.registers[storeReg] = val;
-    }
-
-    state.pc = state.nextPC;
-    state.nextPC = state.nextPC + 4;
-
-    return outputState();
-  }
-
-  function handleJump(uint32 linkReg, uint32 dest) internal returns (bytes32) {
-    State memory state;
-    assembly {
-      state := 0x80
-    }
-    uint32 prevPC = state.pc;
-    state.pc = state.nextPC;
-    state.nextPC = dest;
-    if (linkReg != 0) {
-      state.registers[linkReg] = prevPC+8; // set the link-register to the instr after the delay slot instruction.
-    }
-    return outputState();
-  }
-
-  function handleRd(uint32 storeReg, uint32 val, bool conditional) internal returns (bytes32) {
-    State memory state;
-    assembly {
-      state := 0x80
-    }
-    require(storeReg < 32, "valid register");
-    // never write to reg 0, and it can be conditional (movz, movn)
-    if (storeReg != 0 && conditional) {
-      state.registers[storeReg] = val;
-    }
-
-    state.pc = state.nextPC;
-    state.nextPC = state.nextPC + 4;
-
-    return outputState();
-  }
-
-  function proofOffset(uint8 proofIndex) internal pure returns (uint256 offset) {
-    // A proof of 32 bit memory, with 32-byte leaf values, is (32-5)=27 bytes32 entries.
-    // And the leaf value itself needs to be encoded as well. And proof.offset == 358
-    offset = 358 + (uint256(proofIndex) * (28*32));
-    uint256 s = 0;
-    assembly { s := calldatasize() }
-    require(s >= (offset + 28*32), "check that there is enough calldata");
-    return offset;
-  }
-
-  function readMem(uint32 addr, uint8 proofIndex) internal pure returns (uint32 out) {
-    uint256 offset = proofOffset(proofIndex);
-    assembly {
-      if and(addr, 3) { revert(0, 0) } // quick addr alignment check
-      let leaf := calldataload(offset)
-      offset := add(offset, 32)
-      function hashPair(a, b) -> h {
-        mstore(0, a) // use scratch space slots to hash the two nodes together
-        mstore(32, b)
-        h := keccak256(0, 64)
-      }
-      let path := shr(5, addr)
-      let node := leaf // starting from the leaf node, work back up by combining with siblings, to reconstruct the root
-      for { let i := 0 } lt(i, 27) { i := add(i, 1) } {
-        let sibling := calldataload(offset)
-        offset := add(offset, 32)
-        switch and(shr(i, path), 1)
-        case 0 { node := hashPair(node, sibling) }
-        case 1 { node := hashPair(sibling, node) }
-      }
-      let memRoot := mload(0x80) // load memRoot, first field of state
-      if iszero(eq(node, memRoot)) { // verify the root matches
-        mstore(0, 0x0badf00d)
-        revert(0, 32)
-      }
-      // bits to shift = (32 - 4 - (addr % 32)) * 8
-      let shamt := shl(3, sub(sub(32, 4), and(addr, 31)))
-      out := and(shr(shamt, leaf), 0xFFffFFff)
-    }
-    return out;
-  }
-
-  // writeMem writes the value by first overwriting the part of the leaf, and then recomputing the memory merkle root.
-  function writeMem(uint32 addr, uint8 proofIndex, uint32 value) internal pure {
-    uint256 offset = proofOffset(proofIndex);
-    assembly {
-      if and(addr, 3) { revert(0, 0) } // quick addr alignment check
-      let leaf := calldataload(offset)
-      let shamt := shl(3, sub(sub(32, 4), and(addr, 31)))
-      // mask out 4 bytes, and OR in the value
-      leaf := or(and(leaf, not(shl(shamt, 0xFFffFFff))), shl(shamt, value))
-      offset := add(offset, 32)
-      function hashPair(a, b) -> h {
-        mstore(0, a) // use scratch space slots to hash the two nodes together
-        mstore(32, b)
-        h := keccak256(0, 64)
-      }
-      let path := shr(5, addr)
-      let node := leaf // starting from the leaf node, work back up by combining with siblings, to reconstruct the root
-      for { let i := 0 } lt(i, 27) { i := add(i, 1) } {
-        let sibling := calldataload(offset)
-        offset := add(offset, 32)
-        switch and(shr(i, path), 1)
-        case 0 { node := hashPair(node, sibling) }
-        case 1 { node := hashPair(sibling, node) }
-      }
-      mstore(0x80, node) // store new memRoot, first field of state
-    }
-  }
-
-  // will revert if any required input state is missing
-  function Step(bytes calldata stateData, bytes calldata proof) public returns (bytes32) {
-    State memory state;
-    // packed data is ~6 times smaller
-    assembly {
-      if iszero(eq(state, 0x80)) { // expected state mem offset check
-        revert(0,0)
-      }
-      if iszero(eq(mload(0x40), mul(32, 48))) { // expected memory check
-        revert(0,0)
-      }
-      if iszero(eq(stateData.offset, 100)) { // 32*3+4=100 expected state data offset
-        revert(0,0)
-      }
-      if iszero(eq(proof.offset, 358)) { // 100+32+226=358 expected proof offset
-        revert(0,0)
-      }
-      function putField(callOffset, memOffset, size) -> callOffsetOut, memOffsetOut {
-        // calldata is packed, thus starting left-aligned, shift-right to pad and right-align
-        let w := shr(shl(3, sub(32, size)), calldataload(callOffset))
-        mstore(memOffset, w)
-        callOffsetOut := add(callOffset, size)
-        memOffsetOut := add(memOffset, 32)
-      }
-      let c := stateData.offset // calldata offset
-      let m := 0x80 // mem offset
-      c, m := putField(c, m, 32) // memRoot
-      c, m := putField(c, m, 32) // preimageKey
-      c, m := putField(c, m, 4) // preimageOffset
-      c, m := putField(c, m, 4) // pc
-      c, m := putField(c, m, 4) // nextPC
-      c, m := putField(c, m, 4) // lo
-      c, m := putField(c, m, 4) // hi
-      c, m := putField(c, m, 4) // heap
-      c, m := putField(c, m, 1) // exitCode
-      c, m := putField(c, m, 1) // exited
-      c, m := putField(c, m, 8) // step
-      mstore(m, add(m, 32)) // offset to registers
-      m := add(m, 32)
-      for { let i := 0 } lt(i, 32) { i := add(i, 1) } { c, m := putField(c, m, 4) } // registers
-    }
-    if(state.exited) { // don't change state once exited
-      return outputState();
-    }
-    state.step += 1;
-
-    // instruction fetch
-    uint32 insn = readMem(state.pc, 0);
-
-    uint32 opcode = insn >> 26; // 6-bits
-
-    // j-type j/jal
-    if (opcode == 2 || opcode == 3) {
-      // TODO(CLI-4136): likely bug in original code: MIPS spec says this should be in the "current" region;
-      // a 256 MB aligned region (i.e. use top 4 bits of branch delay slot (pc+4))
-      return handleJump(opcode == 2 ? 0 : 31, SE(insn&0x03FFFFFF, 26) << 2);
-    }
-
-    // register fetch
-    uint32 rs; // source register 1 value
-    uint32 rt; // source register 2 / temp value
-    uint32 rtReg = (insn >> 16) & 0x1F;
-
-    // R-type or I-type (stores rt)
-    rs = state.registers[(insn >> 21) & 0x1F];
-    uint32 rdReg = rtReg;
-    if (opcode == 0 || opcode == 0x1c) {
-      // R-type (stores rd)
-      rt = state.registers[rtReg];
-      rdReg = (insn >> 11) & 0x1F;
-    } else if (opcode < 0x20) {
-      // rt is SignExtImm
-      // don't sign extend for andi, ori, xori
-      if (opcode == 0xC || opcode == 0xD || opcode == 0xe) {
-        // ZeroExtImm
-        rt = insn&0xFFFF;
-      } else {
-        // SignExtImm
-        rt = SE(insn&0xFFFF, 16);
-      }
-    } else if (opcode >= 0x28 || opcode == 0x22 || opcode == 0x26) {
-      // store rt value with store
-      rt = state.registers[rtReg];
-
-      // store actual rt with lwl and lwr
-      rdReg = rtReg;
-    }
-
-    if ((opcode >= 4 && opcode < 8) || opcode == 1) {
-      return handleBranch(opcode, insn, rtReg, rs);
-    }
-
-    uint32 storeAddr = 0xFF_FF_FF_FF;
-    // memory fetch (all I-type)
-    // we do the load for stores also
-    uint32 mem;
-    if (opcode >= 0x20) {
-      // M[R[rs]+SignExtImm]
-      rs += SE(insn&0xFFFF, 16);
-      uint32 addr = rs & 0xFFFFFFFC;
-      mem = readMem(addr, 1);
-      if (opcode >= 0x28 && opcode != 0x30) {
-        // store
-        storeAddr = addr;
-        // store opcodes don't write back to a register
-        rdReg = 0;
-      }
-    }
-
-    // ALU
-    uint32 val = execute(insn, rs, rt, mem) & 0xffFFffFF; // swr outputs more than 4 bytes without the mask
-
-    uint32 func = insn & 0x3f; // 6-bits
-    if (opcode == 0 && func >= 8 && func < 0x1c) {
-      if (func == 8 || func == 9) { // jr/jalr
-        return handleJump(func == 8 ? 0 : rdReg, rs);
-      }
-
-      if (func == 0xa) { // movz
-        return handleRd(rdReg, rs, rt == 0);
-      }
-      if (func == 0xb) { // movn
-        return handleRd(rdReg, rs, rt != 0);
-      }
-
-      // syscall (can read and write)
-      if (func == 0xC) {
-        return handleSyscall();
-      }
-
-      // lo and hi registers
-      // can write back
-      if (func >= 0x10 && func < 0x1c) {
-        return handleHiLo(func, rs, rt, rdReg);
-      }
-    }
-
-    // stupid sc, write a 1 to rt
-    if (opcode == 0x38 && rtReg != 0) {
-      state.registers[rtReg] = 1;
-    }
-
-    // write memory
-    if (storeAddr != 0xFF_FF_FF_FF) {
-      writeMem(storeAddr, 1, val);
-    }
-
-    // write back the value to destination register
-    return handleRd(rdReg, val, true);
-  }
-
-  function execute(uint32 insn, uint32 rs, uint32 rt, uint32 mem) internal pure returns (uint32) {
-    uint32 opcode = insn >> 26;    // 6-bits
-    uint32 func = insn & 0x3f; // 6-bits
-    // TODO(CLI-4136): deref the immed into a register
-
-    if (opcode < 0x20) {
-      // transform ArithLogI
-      // TODO(CLI-4136): replace with table
-      if (opcode >= 8 && opcode < 0xF) {
-        if (opcode == 8) { func = 0x20; }        // addi
-        else if (opcode == 9) { func = 0x21; }   // addiu
-        else if (opcode == 0xa) { func = 0x2a; } // slti
-        else if (opcode == 0xb) { func = 0x2B; } // sltiu
-        else if (opcode == 0xc) { func = 0x24; } // andi
-        else if (opcode == 0xd) { func = 0x25; } // ori
-        else if (opcode == 0xe) { func = 0x26; } // xori
-        opcode = 0;
-      }
-
-      // 0 is opcode SPECIAL
-      if (opcode == 0) {
-        uint32 shamt = (insn >> 6) & 0x1f;
-        if (func < 0x20) {
-          if (func >= 0x08) { return rs;  // jr/jalr/div + others
-          // Shift and ShiftV
-          } else if (func == 0x00) { return rt << shamt;      // sll
-          } else if (func == 0x02) { return rt >> shamt;      // srl
-          } else if (func == 0x03) { return SE(rt >> shamt, 32-shamt);      // sra
-          } else if (func == 0x04) { return rt << (rs&0x1F);         // sllv
-          } else if (func == 0x06) { return rt >> (rs&0x1F);         // srlv
-          } else if (func == 0x07) { return SE(rt >> rs, 32-rs);     // srav
-          }
+    function handleHiLo(uint32 func, uint32 rs, uint32 rt, uint32 storeReg) internal returns (bytes32) {
+        State memory state;
+        assembly {
+            state := 0x80
         }
-        // 0x10-0x13 = mfhi, mthi, mflo, mtlo
-        // R-type (ArithLog)
-        if (func == 0x20 || func == 0x21) { return rs+rt;   // add or addu
-        } else if (func == 0x22 || func == 0x23) { return rs-rt;   // sub or subu
-        } else if (func == 0x24) { return rs&rt;            // and
-        } else if (func == 0x25) { return (rs|rt);          // or
-        } else if (func == 0x26) { return (rs^rt);          // xor
-        } else if (func == 0x27) { return ~(rs|rt);         // nor
-        } else if (func == 0x2a) {
-          return int32(rs)<int32(rt) ? 1 : 0; // slt
-        } else if (func == 0x2B) {
-          return rs<rt ? 1 : 0;               // sltu
+        uint32 val;
+        if (func == 0x10) {
+            val = state.hi;
+        } // mfhi
+        else if (func == 0x11) {
+            state.hi = rs;
+        } // mthi
+        else if (func == 0x12) {
+            val = state.lo;
+        } // mflo
+        else if (func == 0x13) {
+            state.lo = rs;
+        } // mtlo
+        else if (func == 0x18) {
+            // mult
+            uint64 acc = uint64(int64(int32(rs)) * int64(int32(rt)));
+            state.hi = uint32(acc >> 32);
+            state.lo = uint32(acc);
+        } else if (func == 0x19) {
+            // multu
+            uint64 acc = uint64(uint64(rs) * uint64(rt));
+            state.hi = uint32(acc >> 32);
+            state.lo = uint32(acc);
+        } else if (func == 0x1a) {
+            // div
+            state.hi = uint32(int32(rs) % int32(rt));
+            state.lo = uint32(int32(rs) / int32(rt));
+        } else if (func == 0x1b) {
+            // divu
+            state.hi = rs % rt;
+            state.lo = rs / rt;
         }
-      } else if (opcode == 0xf) { return rt<<16; // lui
-      } else if (opcode == 0x1c) {  // SPECIAL2
-        if (func == 2) return uint32(int32(rs)*int32(rt)); // mul
-        if (func == 0x20 || func == 0x21) { // clo
-          if (func == 0x20) rs = ~rs;
-          uint32 i = 0; while (rs&0x80000000 != 0) { i++; rs <<= 1; } return i;
+
+        if (storeReg != 0) {
+            state.registers[storeReg] = val;
         }
-      }
-    } else if (opcode < 0x28) {
-      if (opcode == 0x20) {  // lb
-        return SE((mem >> (24-(rs&3)*8)) & 0xFF, 8);
-      } else if (opcode == 0x21) {  // lh
-        return SE((mem >> (16-(rs&2)*8)) & 0xFFFF, 16);
-      } else if (opcode == 0x22) {  // lwl
-        uint32 val = mem << ((rs&3)*8);
-        uint32 mask = uint32(0xFFFFFFFF) << ((rs&3)*8);
-        return (rt & ~mask) | val;
-      } else if (opcode == 0x23) { return mem;   // lw
-      } else if (opcode == 0x24) {  // lbu
-        return (mem >> (24-(rs&3)*8)) & 0xFF;
-      } else if (opcode == 0x25) {  // lhu
-        return (mem >> (16-(rs&2)*8)) & 0xFFFF;
-      } else if (opcode == 0x26) {  // lwr
-        uint32 val = mem >> (24-(rs&3)*8);
-        uint32 mask = uint32(0xFFFFFFFF) >> (24-(rs&3)*8);
-        return (rt & ~mask) | val;
-      }
-    } else if (opcode == 0x28) { // sb
-      uint32 val = (rt&0xFF) << (24-(rs&3)*8);
-      uint32 mask = 0xFFFFFFFF ^ uint32(0xFF << (24-(rs&3)*8));
-      return (mem & mask) | val;
-    } else if (opcode == 0x29) { // sh
-      uint32 val = (rt&0xFFFF) << (16-(rs&2)*8);
-      uint32 mask = 0xFFFFFFFF ^ uint32(0xFFFF << (16-(rs&2)*8));
-      return (mem & mask) | val;
-    } else if (opcode == 0x2a) {  // swl
-      uint32 val = rt >> ((rs&3)*8);
-      uint32 mask = uint32(0xFFFFFFFF) >> ((rs&3)*8);
-      return (mem & ~mask) | val;
-    } else if (opcode == 0x2b) { // sw
-      return rt;
-    } else if (opcode == 0x2e) {  // swr
-      uint32 val = rt << (24-(rs&3)*8);
-      uint32 mask = uint32(0xFFFFFFFF) << (24-(rs&3)*8);
-      return (mem & ~mask) | val;
-    } else if (opcode == 0x30) { return mem; // ll
-    } else if (opcode == 0x38) { return rt; // sc
+
+        state.pc = state.nextPC;
+        state.nextPC = state.nextPC + 4;
+
+        return outputState();
     }
 
-    revert("invalid instruction");
-  }
+    function handleJump(uint32 linkReg, uint32 dest) internal returns (bytes32) {
+        State memory state;
+        assembly {
+            state := 0x80
+        }
+        uint32 prevPC = state.pc;
+        state.pc = state.nextPC;
+        state.nextPC = dest;
+        if (linkReg != 0) {
+            state.registers[linkReg] = prevPC + 8; // set the link-register to the instr after the delay slot
+                // instruction.
+        }
+        return outputState();
+    }
+
+    function handleRd(uint32 storeReg, uint32 val, bool conditional) internal returns (bytes32) {
+        State memory state;
+        assembly {
+            state := 0x80
+        }
+        require(storeReg < 32, "valid register");
+        // never write to reg 0, and it can be conditional (movz, movn)
+        if (storeReg != 0 && conditional) {
+            state.registers[storeReg] = val;
+        }
+
+        state.pc = state.nextPC;
+        state.nextPC = state.nextPC + 4;
+
+        return outputState();
+    }
+
+    function proofOffset(uint8 proofIndex) internal pure returns (uint256 offset) {
+        // A proof of 32 bit memory, with 32-byte leaf values, is (32-5)=27 bytes32 entries.
+        // And the leaf value itself needs to be encoded as well. And proof.offset == 358
+        offset = 358 + (uint256(proofIndex) * (28 * 32));
+        uint256 s = 0;
+        assembly {
+            s := calldatasize()
+        }
+        require(s >= (offset + 28 * 32), "check that there is enough calldata");
+        return offset;
+    }
+
+    function readMem(uint32 addr, uint8 proofIndex) internal pure returns (uint32 out) {
+        uint256 offset = proofOffset(proofIndex);
+        assembly {
+            if and(addr, 3) { revert(0, 0) } // quick addr alignment check
+            let leaf := calldataload(offset)
+            offset := add(offset, 32)
+            function hashPair(a, b) -> h {
+                mstore(0, a) // use scratch space slots to hash the two nodes together
+                mstore(32, b)
+                h := keccak256(0, 64)
+            }
+            let path := shr(5, addr)
+            let node := leaf // starting from the leaf node, work back up by combining with siblings, to reconstruct the
+                // root
+            for { let i := 0 } lt(i, 27) { i := add(i, 1) } {
+                let sibling := calldataload(offset)
+                offset := add(offset, 32)
+                switch and(shr(i, path), 1)
+                case 0 { node := hashPair(node, sibling) }
+                case 1 { node := hashPair(sibling, node) }
+            }
+            let memRoot := mload(0x80) // load memRoot, first field of state
+            if iszero(eq(node, memRoot)) {
+                // verify the root matches
+                mstore(0, 0x0badf00d)
+                revert(0, 32)
+            }
+            // bits to shift = (32 - 4 - (addr % 32)) * 8
+            let shamt := shl(3, sub(sub(32, 4), and(addr, 31)))
+            out := and(shr(shamt, leaf), 0xFFffFFff)
+        }
+        return out;
+    }
+
+    // writeMem writes the value by first overwriting the part of the leaf, and then recomputing the memory merkle root.
+    function writeMem(uint32 addr, uint8 proofIndex, uint32 value) internal pure {
+        uint256 offset = proofOffset(proofIndex);
+        assembly {
+            if and(addr, 3) { revert(0, 0) } // quick addr alignment check
+            let leaf := calldataload(offset)
+            let shamt := shl(3, sub(sub(32, 4), and(addr, 31)))
+            // mask out 4 bytes, and OR in the value
+            leaf := or(and(leaf, not(shl(shamt, 0xFFffFFff))), shl(shamt, value))
+            offset := add(offset, 32)
+            function hashPair(a, b) -> h {
+                mstore(0, a) // use scratch space slots to hash the two nodes together
+                mstore(32, b)
+                h := keccak256(0, 64)
+            }
+            let path := shr(5, addr)
+            let node := leaf // starting from the leaf node, work back up by combining with siblings, to reconstruct the
+                // root
+            for { let i := 0 } lt(i, 27) { i := add(i, 1) } {
+                let sibling := calldataload(offset)
+                offset := add(offset, 32)
+                switch and(shr(i, path), 1)
+                case 0 { node := hashPair(node, sibling) }
+                case 1 { node := hashPair(sibling, node) }
+            }
+            mstore(0x80, node) // store new memRoot, first field of state
+        }
+    }
+
+    // will revert if any required input state is missing
+    function Step(bytes calldata stateData, bytes calldata proof) public returns (bytes32) {
+        State memory state;
+        // packed data is ~6 times smaller
+        assembly {
+            if iszero(eq(state, 0x80)) {
+                // expected state mem offset check
+                revert(0, 0)
+            }
+            if iszero(eq(mload(0x40), mul(32, 48))) {
+                // expected memory check
+                revert(0, 0)
+            }
+            if iszero(eq(stateData.offset, 100)) {
+                // 32*3+4=100 expected state data offset
+                revert(0, 0)
+            }
+            if iszero(eq(proof.offset, 358)) {
+                // 100+32+226=358 expected proof offset
+                revert(0, 0)
+            }
+            function putField(callOffset, memOffset, size) -> callOffsetOut, memOffsetOut {
+                // calldata is packed, thus starting left-aligned, shift-right to pad and right-align
+                let w := shr(shl(3, sub(32, size)), calldataload(callOffset))
+                mstore(memOffset, w)
+                callOffsetOut := add(callOffset, size)
+                memOffsetOut := add(memOffset, 32)
+            }
+            let c := stateData.offset // calldata offset
+            let m := 0x80 // mem offset
+            c, m := putField(c, m, 32) // memRoot
+            c, m := putField(c, m, 32) // preimageKey
+            c, m := putField(c, m, 4) // preimageOffset
+            c, m := putField(c, m, 4) // pc
+            c, m := putField(c, m, 4) // nextPC
+            c, m := putField(c, m, 4) // lo
+            c, m := putField(c, m, 4) // hi
+            c, m := putField(c, m, 4) // heap
+            c, m := putField(c, m, 1) // exitCode
+            c, m := putField(c, m, 1) // exited
+            c, m := putField(c, m, 8) // step
+            mstore(m, add(m, 32)) // offset to registers
+            m := add(m, 32)
+            for { let i := 0 } lt(i, 32) { i := add(i, 1) } { c, m := putField(c, m, 4) } // registers
+        }
+        if (state.exited) {
+            // don't change state once exited
+            return outputState();
+        }
+        state.step += 1;
+
+        // instruction fetch
+        uint32 insn = readMem(state.pc, 0);
+
+        uint32 opcode = insn >> 26; // 6-bits
+
+        // j-type j/jal
+        if (opcode == 2 || opcode == 3) {
+            // TODO(CLI-4136): likely bug in original code: MIPS spec says this should be in the "current" region;
+            // a 256 MB aligned region (i.e. use top 4 bits of branch delay slot (pc+4))
+            return handleJump(opcode == 2 ? 0 : 31, SE(insn & 0x03FFFFFF, 26) << 2);
+        }
+
+        // register fetch
+        uint32 rs; // source register 1 value
+        uint32 rt; // source register 2 / temp value
+        uint32 rtReg = (insn >> 16) & 0x1F;
+
+        // R-type or I-type (stores rt)
+        rs = state.registers[(insn >> 21) & 0x1F];
+        uint32 rdReg = rtReg;
+        if (opcode == 0 || opcode == 0x1c) {
+            // R-type (stores rd)
+            rt = state.registers[rtReg];
+            rdReg = (insn >> 11) & 0x1F;
+        } else if (opcode < 0x20) {
+            // rt is SignExtImm
+            // don't sign extend for andi, ori, xori
+            if (opcode == 0xC || opcode == 0xD || opcode == 0xe) {
+                // ZeroExtImm
+                rt = insn & 0xFFFF;
+            } else {
+                // SignExtImm
+                rt = SE(insn & 0xFFFF, 16);
+            }
+        } else if (opcode >= 0x28 || opcode == 0x22 || opcode == 0x26) {
+            // store rt value with store
+            rt = state.registers[rtReg];
+
+            // store actual rt with lwl and lwr
+            rdReg = rtReg;
+        }
+
+        if ((opcode >= 4 && opcode < 8) || opcode == 1) {
+            return handleBranch(opcode, insn, rtReg, rs);
+        }
+
+        uint32 storeAddr = 0xFF_FF_FF_FF;
+        // memory fetch (all I-type)
+        // we do the load for stores also
+        uint32 mem;
+        if (opcode >= 0x20) {
+            // M[R[rs]+SignExtImm]
+            rs += SE(insn & 0xFFFF, 16);
+            uint32 addr = rs & 0xFFFFFFFC;
+            mem = readMem(addr, 1);
+            if (opcode >= 0x28 && opcode != 0x30) {
+                // store
+                storeAddr = addr;
+                // store opcodes don't write back to a register
+                rdReg = 0;
+            }
+        }
+
+        // ALU
+        uint32 val = execute(insn, rs, rt, mem) & 0xffFFffFF; // swr outputs more than 4 bytes without the mask
+
+        uint32 func = insn & 0x3f; // 6-bits
+        if (opcode == 0 && func >= 8 && func < 0x1c) {
+            if (func == 8 || func == 9) {
+                // jr/jalr
+                return handleJump(func == 8 ? 0 : rdReg, rs);
+            }
+
+            if (func == 0xa) {
+                // movz
+                return handleRd(rdReg, rs, rt == 0);
+            }
+            if (func == 0xb) {
+                // movn
+                return handleRd(rdReg, rs, rt != 0);
+            }
+
+            // syscall (can read and write)
+            if (func == 0xC) {
+                return handleSyscall();
+            }
+
+            // lo and hi registers
+            // can write back
+            if (func >= 0x10 && func < 0x1c) {
+                return handleHiLo(func, rs, rt, rdReg);
+            }
+        }
+
+        // stupid sc, write a 1 to rt
+        if (opcode == 0x38 && rtReg != 0) {
+            state.registers[rtReg] = 1;
+        }
+
+        // write memory
+        if (storeAddr != 0xFF_FF_FF_FF) {
+            writeMem(storeAddr, 1, val);
+        }
+
+        // write back the value to destination register
+        return handleRd(rdReg, val, true);
+    }
+
+    function execute(uint32 insn, uint32 rs, uint32 rt, uint32 mem) internal pure returns (uint32) {
+        uint32 opcode = insn >> 26; // 6-bits
+        uint32 func = insn & 0x3f; // 6-bits
+        // TODO(CLI-4136): deref the immed into a register
+
+        if (opcode < 0x20) {
+            // transform ArithLogI
+            // TODO(CLI-4136): replace with table
+            if (opcode >= 8 && opcode < 0xF) {
+                if (opcode == 8) func = 0x20; // addi
+
+                else if (opcode == 9) func = 0x21; // addiu
+
+                else if (opcode == 0xa) func = 0x2a; // slti
+
+                else if (opcode == 0xb) func = 0x2B; // sltiu
+
+                else if (opcode == 0xc) func = 0x24; // andi
+
+                else if (opcode == 0xd) func = 0x25; // ori
+
+                else if (opcode == 0xe) func = 0x26; // xori
+                opcode = 0;
+            }
+
+            // 0 is opcode SPECIAL
+            if (opcode == 0) {
+                uint32 shamt = (insn >> 6) & 0x1f;
+                if (func < 0x20) {
+                    if (func >= 0x08) return rs; // jr/jalr/div + others
+
+                    // Shift and ShiftV
+                    else if (func == 0x00) return rt << shamt; // sll
+
+                    else if (func == 0x02) return rt >> shamt; // srl
+
+                    else if (func == 0x03) return SE(rt >> shamt, 32 - shamt); // sra
+
+                    else if (func == 0x04) return rt << (rs & 0x1F); // sllv
+
+                    else if (func == 0x06) return rt >> (rs & 0x1F); // srlv
+
+                    else if (func == 0x07) return SE(rt >> rs, 32 - rs); // srav
+                }
+                // 0x10-0x13 = mfhi, mthi, mflo, mtlo
+                // R-type (ArithLog)
+                if (func == 0x20 || func == 0x21) {
+                    return rs + rt; // add or addu
+                } else if (func == 0x22 || func == 0x23) {
+                    return rs - rt; // sub or subu
+                } else if (func == 0x24) {
+                    return rs & rt; // and
+                } else if (func == 0x25) {
+                    return (rs | rt); // or
+                } else if (func == 0x26) {
+                    return (rs ^ rt); // xor
+                } else if (func == 0x27) {
+                    return ~(rs | rt); // nor
+                } else if (func == 0x2a) {
+                    return int32(rs) < int32(rt) ? 1 : 0; // slt
+                } else if (func == 0x2B) {
+                    return rs < rt ? 1 : 0; // sltu
+                }
+            } else if (opcode == 0xf) {
+                return rt << 16; // lui
+            } else if (opcode == 0x1c) {
+                // SPECIAL2
+                if (func == 2) return uint32(int32(rs) * int32(rt)); // mul
+                if (func == 0x20 || func == 0x21) {
+                    // clo
+                    if (func == 0x20) rs = ~rs;
+                    uint32 i = 0;
+                    while (rs & 0x80000000 != 0) {
+                        i++;
+                        rs <<= 1;
+                    }
+                    return i;
+                }
+            }
+        } else if (opcode < 0x28) {
+            if (opcode == 0x20) {
+                // lb
+                return SE((mem >> (24 - (rs & 3) * 8)) & 0xFF, 8);
+            } else if (opcode == 0x21) {
+                // lh
+                return SE((mem >> (16 - (rs & 2) * 8)) & 0xFFFF, 16);
+            } else if (opcode == 0x22) {
+                // lwl
+                uint32 val = mem << ((rs & 3) * 8);
+                uint32 mask = uint32(0xFFFFFFFF) << ((rs & 3) * 8);
+                return (rt & ~mask) | val;
+            } else if (opcode == 0x23) {
+                return mem; // lw
+            } else if (opcode == 0x24) {
+                // lbu
+                return (mem >> (24 - (rs & 3) * 8)) & 0xFF;
+            } else if (opcode == 0x25) {
+                // lhu
+                return (mem >> (16 - (rs & 2) * 8)) & 0xFFFF;
+            } else if (opcode == 0x26) {
+                // lwr
+                uint32 val = mem >> (24 - (rs & 3) * 8);
+                uint32 mask = uint32(0xFFFFFFFF) >> (24 - (rs & 3) * 8);
+                return (rt & ~mask) | val;
+            }
+        } else if (opcode == 0x28) {
+            // sb
+            uint32 val = (rt & 0xFF) << (24 - (rs & 3) * 8);
+            uint32 mask = 0xFFFFFFFF ^ uint32(0xFF << (24 - (rs & 3) * 8));
+            return (mem & mask) | val;
+        } else if (opcode == 0x29) {
+            // sh
+            uint32 val = (rt & 0xFFFF) << (16 - (rs & 2) * 8);
+            uint32 mask = 0xFFFFFFFF ^ uint32(0xFFFF << (16 - (rs & 2) * 8));
+            return (mem & mask) | val;
+        } else if (opcode == 0x2a) {
+            // swl
+            uint32 val = rt >> ((rs & 3) * 8);
+            uint32 mask = uint32(0xFFFFFFFF) >> ((rs & 3) * 8);
+            return (mem & ~mask) | val;
+        } else if (opcode == 0x2b) {
+            // sw
+            return rt;
+        } else if (opcode == 0x2e) {
+            // swr
+            uint32 val = rt << (24 - (rs & 3) * 8);
+            uint32 mask = uint32(0xFFFFFFFF) << (24 - (rs & 3) * 8);
+            return (mem & ~mask) | val;
+        } else if (opcode == 0x30) {
+            return mem; // ll
+        } else if (opcode == 0x38) {
+            return rt; // sc
+        }
+
+        revert("invalid instruction");
+    }
 }

--- a/packages/contracts-bedrock/contracts/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/contracts/cannon/PreimageOracle.sol
@@ -6,11 +6,7 @@ contract PreimageOracle {
     mapping(bytes32 => mapping(uint256 => bytes32)) public preimageParts;
     mapping(bytes32 => mapping(uint256 => bool)) public preimagePartOk;
 
-    function readPreimage(bytes32 key, uint256 offset)
-        external
-        view
-        returns (bytes32 dat, uint256 datLen)
-    {
+    function readPreimage(bytes32 key, uint256 offset) external view returns (bytes32 dat, uint256 datLen) {
         require(preimagePartOk[key][offset], "preimage must exist");
         datLen = 32;
         uint256 length = preimageLengths[key];
@@ -26,12 +22,7 @@ contract PreimageOracle {
     // and restrict local pre-image insertion to the dispute-managing contract.
     // For now we permit anyone to write any pre-image unchecked, to make testing easy.
     // This method is DANGEROUS. And NOT FOR PRODUCTION.
-    function cheat(
-        uint256 partOffset,
-        bytes32 key,
-        bytes32 part,
-        uint256 size
-    ) external {
+    function cheat(uint256 partOffset, bytes32 key, bytes32 part, uint256 size) external {
         preimagePartOk[key][partOffset] = true;
         preimageParts[key][partOffset] = part;
         preimageLengths[key] = size;
@@ -47,9 +38,7 @@ contract PreimageOracle {
             // len(sig) + len(partOffset) + len(preimage offset) = 4 + 32 + 32 = 0x44
             size := calldataload(0x44)
             // revert if part offset >= size+8 (i.e. parts must be within bounds)
-            if iszero(lt(partOffset, add(size, 8))) {
-                revert(0, 0)
-            }
+            if iszero(lt(partOffset, add(size, 8))) { revert(0, 0) }
             // we leave solidity slots 0x40 and 0x60 untouched,
             // and everything after as scratch-memory.
             let ptr := 0x80

--- a/packages/contracts-bedrock/contracts/dispute/DisputeGameFactory.sol
+++ b/packages/contracts-bedrock/contracts/dispute/DisputeGameFactory.sol
@@ -5,9 +5,7 @@ import "../libraries/DisputeTypes.sol";
 import "../libraries/DisputeErrors.sol";
 
 import { ClonesWithImmutableArgs } from "@cwia/ClonesWithImmutableArgs.sol";
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Semver } from "../universal/Semver.sol";
 
 import { IDisputeGame } from "./interfaces/IDisputeGame.sol";
@@ -54,11 +52,11 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, Semver {
     }
 
     /// @inheritdoc IDisputeGameFactory
-    function games(
-        GameType _gameType,
-        Claim _rootClaim,
-        bytes calldata _extraData
-    ) external view returns (IDisputeGame proxy_, uint256 timestamp_) {
+    function games(GameType _gameType, Claim _rootClaim, bytes calldata _extraData)
+        external
+        view
+        returns (IDisputeGame proxy_, uint256 timestamp_)
+    {
         Hash uuid = getGameUUID(_gameType, _rootClaim, _extraData);
         GameId slot = _disputeGames[uuid];
         (address addr, uint256 timestamp) = _unpackSlot(slot);
@@ -67,11 +65,7 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, Semver {
     }
 
     /// @inheritdoc IDisputeGameFactory
-    function gameAtIndex(uint256 _index)
-        external
-        view
-        returns (IDisputeGame proxy_, uint256 timestamp_)
-    {
+    function gameAtIndex(uint256 _index) external view returns (IDisputeGame proxy_, uint256 timestamp_) {
         GameId slot = _disputeGameList[_index];
         (address addr, uint256 timestamp) = _unpackSlot(slot);
         proxy_ = IDisputeGame(addr);
@@ -79,11 +73,10 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, Semver {
     }
 
     /// @inheritdoc IDisputeGameFactory
-    function create(
-        GameType gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) external returns (IDisputeGame proxy) {
+    function create(GameType gameType, Claim rootClaim, bytes calldata extraData)
+        external
+        returns (IDisputeGame proxy)
+    {
         // Grab the implementation contract for the given `GameType`.
         IDisputeGame impl = gameImpls[gameType];
 
@@ -113,11 +106,7 @@ contract DisputeGameFactory is OwnableUpgradeable, IDisputeGameFactory, Semver {
     }
 
     /// @inheritdoc IDisputeGameFactory
-    function getGameUUID(
-        GameType gameType,
-        Claim rootClaim,
-        bytes memory extraData
-    ) public pure returns (Hash _uuid) {
+    function getGameUUID(GameType gameType, Claim rootClaim, bytes memory extraData) public pure returns (Hash _uuid) {
         assembly {
             // Grab the offsets of the other memory locations we will need to temporarily overwrite.
             let gameTypeOffset := sub(extraData, 0x60)

--- a/packages/contracts-bedrock/contracts/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/contracts/dispute/FaultDisputeGame.sol
@@ -56,11 +56,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
     mapping(ClaimHash => bool) internal claims;
 
     /// @param _absolutePrestate The absolute prestate of the instruction trace.
-    constructor(
-        Claim _absolutePrestate,
-        uint256 _maxGameDepth,
-        IBigStepper _vm
-    ) Semver(0, 0, 2) {
+    constructor(Claim _absolutePrestate, uint256 _maxGameDepth, IBigStepper _vm) Semver(0, 0, 2) {
         ABSOLUTE_PRESTATE = _absolutePrestate;
         MAX_GAME_DEPTH = _maxGameDepth;
         VM = _vm;
@@ -136,9 +132,9 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
             // Assert that the given prestate commits to the instruction at `gindex - 1` and
             // that the `_stateData` is the preimage for the prestate claim digest.
             if (
-                Position.unwrap(preStatePos.rightIndex(MAX_GAME_DEPTH)) !=
-                Position.unwrap(postStatePos.rightIndex(MAX_GAME_DEPTH)) - 1 ||
-                keccak256(_stateData) != Claim.unwrap(preStateClaim)
+                Position.unwrap(preStatePos.rightIndex(MAX_GAME_DEPTH))
+                    != Position.unwrap(postStatePos.rightIndex(MAX_GAME_DEPTH)) - 1
+                    || keccak256(_stateData) != Claim.unwrap(preStateClaim)
             ) {
                 revert InvalidPrestate();
             }
@@ -162,11 +158,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
     /// @param _challengeIndex The index of the claim being moved against.
     /// @param _pivot The claim at the next logical position in the game.
     /// @param _isAttack Whether or not the move is an attack or defense.
-    function move(
-        uint256 _challengeIndex,
-        Claim _pivot,
-        bool _isAttack
-    ) public payable {
+    function move(uint256 _challengeIndex, Claim _pivot, bool _isAttack) public payable {
         // Moves cannot be made unless the game is currently in progress.
         if (status != GameStatus.IN_PROGRESS) {
             revert GameNotInProgress();
@@ -210,11 +202,10 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
         Duration nextDuration = Duration.wrap(
             uint64(
                 // First, fetch the duration of the grandparent claim.
-                Duration.unwrap(grandparentClock.duration()) +
-                    // Second, add the difference between the current block timestamp and the
-                    // parent's clock timestamp.
-                    block.timestamp -
-                    Timestamp.unwrap(parent.clock.timestamp())
+                Duration.unwrap(grandparentClock.duration())
+                // Second, add the difference between the current block timestamp and the
+                // parent's clock timestamp.
+                + block.timestamp - Timestamp.unwrap(parent.clock.timestamp())
             )
         );
 
@@ -286,7 +277,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
         // The most recent claim is always a dangling, non-bottom node so we start with that
         uint256 leftMostIndex = claimData.length - 1;
         uint256 leftMostTraceIndex = type(uint128).max;
-        for (uint256 i = leftMostIndex; i < type(uint64).max; ) {
+        for (uint256 i = leftMostIndex; i < type(uint64).max;) {
             // Fetch the claim at the current index.
             ClaimData storage claim = claimData[i];
 
@@ -318,9 +309,10 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
         // If the left-most dangling node is at an even depth, the defender wins.
         // Otherwise, the challenger wins and the root claim is deemed invalid.
         if (
-            // slither-disable-next-line weak-prng
-            claimData[leftMostIndex].position.depth() % 2 == 0 &&
-            leftMostTraceIndex != type(uint128).max
+            claimData[leftMostIndex]
+                .position
+                // slither-disable-next-line weak-prng
+                .depth() % 2 == 0 && leftMostTraceIndex != type(uint128).max
         ) {
             status_ = GameStatus.DEFENDER_WINS;
         } else {
@@ -346,15 +338,7 @@ contract FaultDisputeGame is IFaultDisputeGame, Clone, Semver {
     }
 
     /// @inheritdoc IDisputeGame
-    function gameData()
-        external
-        pure
-        returns (
-            GameType gameType_,
-            Claim rootClaim_,
-            bytes memory extraData_
-        )
-    {
+    function gameData() external pure returns (GameType gameType_, Claim rootClaim_, bytes memory extraData_) {
         gameType_ = gameType();
         rootClaim_ = rootClaim();
         extraData_ = extraData();

--- a/packages/contracts-bedrock/contracts/dispute/interfaces/IBigStepper.sol
+++ b/packages/contracts-bedrock/contracts/dispute/interfaces/IBigStepper.sol
@@ -28,7 +28,5 @@ interface IBigStepper {
     /// @param _stateData The preimage of the prestate hash.
     /// @param _proof A proof for the inclusion of the prestate's memory in the merkle tree.
     /// @return postState_ The poststate hash after the instruction step.
-    function step(bytes calldata _stateData, bytes calldata _proof)
-        external
-        returns (bytes32 postState_);
+    function step(bytes calldata _stateData, bytes calldata _proof) external returns (bytes32 postState_);
 }

--- a/packages/contracts-bedrock/contracts/dispute/interfaces/IBondManager.sol
+++ b/packages/contracts-bedrock/contracts/dispute/interfaces/IBondManager.sol
@@ -30,11 +30,7 @@ interface IBondManager {
     /// @param _bondOwner is the address that owns the bond.
     /// @param _minClaimHold is the minimum amount of time the owner
     ///        must wait before reclaiming their bond.
-    function post(
-        bytes32 _bondId,
-        address _bondOwner,
-        uint128 _minClaimHold
-    ) external payable;
+    function post(bytes32 _bondId, address _bondOwner, uint128 _minClaimHold) external payable;
 
     /// @notice Seizes the bond with the given id.
     /// @dev This function will revert if there is no bond at the given id.

--- a/packages/contracts-bedrock/contracts/dispute/interfaces/IDisputeGame.sol
+++ b/packages/contracts-bedrock/contracts/dispute/interfaces/IDisputeGame.sol
@@ -57,12 +57,5 @@ interface IDisputeGame is IInitializable {
     /// @return gameType_ The type of proof system being used.
     /// @return rootClaim_ The root claim of the DisputeGame.
     /// @return extraData_ Any extra data supplied to the dispute game contract by the creator.
-    function gameData()
-        external
-        pure
-        returns (
-            GameType gameType_,
-            Claim rootClaim_,
-            bytes memory extraData_
-        );
+    function gameData() external pure returns (GameType gameType_, Claim rootClaim_, bytes memory extraData_);
 }

--- a/packages/contracts-bedrock/contracts/dispute/interfaces/IDisputeGameFactory.sol
+++ b/packages/contracts-bedrock/contracts/dispute/interfaces/IDisputeGameFactory.sol
@@ -12,11 +12,7 @@ interface IDisputeGameFactory {
     /// @param disputeProxy The address of the dispute game proxy
     /// @param gameType The type of the dispute game proxy's implementation
     /// @param rootClaim The root claim of the dispute game
-    event DisputeGameCreated(
-        address indexed disputeProxy,
-        GameType indexed gameType,
-        Claim indexed rootClaim
-    );
+    event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
 
     /// @notice Emitted when a new game implementation added to the factory
     /// @param impl The implementation contract for the given `GameType`.
@@ -36,11 +32,10 @@ interface IDisputeGameFactory {
     /// @return _proxy The clone of the `DisputeGame` created with the given parameters.
     ///         Returns `address(0)` if nonexistent.
     /// @return _timestamp The timestamp of the creation of the dispute game.
-    function games(
-        GameType gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) external view returns (IDisputeGame _proxy, uint256 _timestamp);
+    function games(GameType gameType, Claim rootClaim, bytes calldata extraData)
+        external
+        view
+        returns (IDisputeGame _proxy, uint256 _timestamp);
 
     /// @notice `gameAtIndex` returns the dispute game contract address and its creation timestamp
     ///          at the given index. Each created dispute game increments the underlying index.
@@ -48,10 +43,7 @@ interface IDisputeGameFactory {
     /// @return _proxy The clone of the `DisputeGame` created with the given parameters.
     ///         Returns `address(0)` if nonexistent.
     /// @return _timestamp The timestamp of the creation of the dispute game.
-    function gameAtIndex(uint256 _index)
-        external
-        view
-        returns (IDisputeGame _proxy, uint256 _timestamp);
+    function gameAtIndex(uint256 _index) external view returns (IDisputeGame _proxy, uint256 _timestamp);
 
     /// @notice `gameImpls` is a mapping that maps `GameType`s to their respective
     ///         `IDisputeGame` implementations.
@@ -65,11 +57,9 @@ interface IDisputeGameFactory {
     /// @param rootClaim The root claim of the DisputeGame.
     /// @param extraData Any extra data that should be provided to the created dispute game.
     /// @return proxy The address of the created DisputeGame proxy.
-    function create(
-        GameType gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) external returns (IDisputeGame proxy);
+    function create(GameType gameType, Claim rootClaim, bytes calldata extraData)
+        external
+        returns (IDisputeGame proxy);
 
     /// @notice Sets the implementation contract for a specific `GameType`.
     /// @dev May only be called by the `owner`.
@@ -84,9 +74,8 @@ interface IDisputeGameFactory {
     /// @param rootClaim The root claim of the DisputeGame.
     /// @param extraData Any extra data that should be provided to the created dispute game.
     /// @return _uuid The unique identifier for the given dispute game parameters.
-    function getGameUUID(
-        GameType gameType,
-        Claim rootClaim,
-        bytes memory extraData
-    ) external pure returns (Hash _uuid);
+    function getGameUUID(GameType gameType, Claim rootClaim, bytes memory extraData)
+        external
+        pure
+        returns (Hash _uuid);
 }

--- a/packages/contracts-bedrock/contracts/dispute/lib/LibHashing.sol
+++ b/packages/contracts-bedrock/contracts/dispute/lib/LibHashing.sol
@@ -6,7 +6,6 @@ import "../../libraries/DisputeTypes.sol";
 /// @title Hashing
 /// @notice This library contains all of the hashing utilities used in the Cannon contracts.
 library LibHashing {
-
     /// @notice Hashes a claim and a position together.
     /// @param _claim A Claim type.
     /// @param _position The position of `claim`.

--- a/packages/contracts-bedrock/contracts/dispute/lib/LibPosition.sol
+++ b/packages/contracts-bedrock/contracts/dispute/lib/LibPosition.sol
@@ -6,7 +6,6 @@ import "../../libraries/DisputeTypes.sol";
 /// @title LibPosition
 /// @notice This library contains helper functions for working with the `Position` type.
 library LibPosition {
-
     /// @notice Computes a generalized index (2^{depth} + indexAtDepth).
     /// @param _depth The depth of the position.
     /// @param _indexAtDepth The index at the depth of the position.
@@ -36,13 +35,14 @@ library LibPosition {
             _position := or(_position, shr(8, _position))
             _position := or(_position, shr(16, _position))
 
-            depth_ := or(
-                depth_,
-                byte(
-                    shr(251, mul(_position, shl(224, 0x07c4acdd))),
-                    0x0009010a0d15021d0b0e10121619031e080c141c0f111807131b17061a05041f
+            depth_ :=
+                or(
+                    depth_,
+                    byte(
+                        shr(251, mul(_position, shl(224, 0x07c4acdd))),
+                        0x0009010a0d15021d0b0e10121619031e080c141c0f111807131b17061a05041f
+                    )
                 )
-            )
         }
     }
 
@@ -93,10 +93,7 @@ library LibPosition {
     /// @param _position The position to get the relative deepest, right most gindex of.
     /// @param _maxDepth The maximum depth of the game.
     /// @return rightIndex_ The deepest, right most gindex relative to the `position`.
-    function rightIndex(
-        Position _position,
-        uint256 _maxDepth
-    ) internal pure returns (Position rightIndex_) {
+    function rightIndex(Position _position, uint256 _maxDepth) internal pure returns (Position rightIndex_) {
         uint256 msb = depth(_position);
         assembly {
             let remaining := sub(_maxDepth, msb)
@@ -110,17 +107,11 @@ library LibPosition {
     /// @param _position The position to get the relative trace index of.
     /// @param _maxDepth The maximum depth of the game.
     /// @return traceIndex_ The trace index relative to the `position`.
-    function traceIndex(
-        Position _position,
-        uint256 _maxDepth
-    ) internal pure returns (uint256 traceIndex_) {
+    function traceIndex(Position _position, uint256 _maxDepth) internal pure returns (uint256 traceIndex_) {
         uint256 msb = depth(_position);
         assembly {
             let remaining := sub(_maxDepth, msb)
-            traceIndex_ := sub(
-                or(shl(remaining, _position), sub(shl(remaining, 1), 1)),
-                shl(_maxDepth, 1)
-            )
+            traceIndex_ := sub(or(shl(remaining, _position), sub(shl(remaining, 1), 1)), shl(_maxDepth, 1))
         }
     }
 

--- a/packages/contracts-bedrock/contracts/echidna/FuzzHashing.sol
+++ b/packages/contracts-bedrock/contracts/echidna/FuzzHashing.sol
@@ -51,20 +51,8 @@ contract EchidnaFuzzHashing {
 
         // hash the cross domain message using the unversioned and versioned functions for
         // comparison
-        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(
-            encodedNonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
-        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV0(
-            _target,
-            _sender,
-            _data,
-            encodedNonce
-        );
+        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(encodedNonce, _sender, _target, _value, _gasLimit, _data);
+        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV0(_target, _sender, _data, encodedNonce);
 
         // check that the output of both functions matches
         if (sampleHash1 != sampleHash2) {
@@ -89,22 +77,8 @@ contract EchidnaFuzzHashing {
 
         // hash the cross domain message using the unversioned and versioned functions for
         // comparison
-        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(
-            encodedNonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
-        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV1(
-            encodedNonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
+        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(encodedNonce, _sender, _target, _value, _gasLimit, _data);
+        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV1(encodedNonce, _sender, _target, _value, _gasLimit, _data);
 
         // check that the output of both functions matches
         if (sampleHash1 != sampleHash2) {

--- a/packages/contracts-bedrock/contracts/governance/GovernanceToken.sol
+++ b/packages/contracts-bedrock/contracts/governance/GovernanceToken.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 ///         inflation schedule.
 contract GovernanceToken is ERC20Burnable, ERC20Votes, Ownable {
     /// @notice Constructs the GovernanceToken contract.
-    constructor() ERC20("Optimism", "OP") ERC20Permit("Optimism") {}
+    constructor() ERC20("Optimism", "OP") ERC20Permit("Optimism") { }
 
     /// @notice Allows the owner to mint tokens.
     /// @param _account The account receiving minted tokens.
@@ -27,11 +27,7 @@ contract GovernanceToken is ERC20Burnable, ERC20Votes, Ownable {
     /// @param from   The account sending tokens.
     /// @param to     The account receiving tokens.
     /// @param amount The amount of tokens being transfered.
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override(ERC20, ERC20Votes) {
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
         super._afterTokenTransfer(from, to, amount);
     }
 

--- a/packages/contracts-bedrock/contracts/governance/MintManager.sol
+++ b/packages/contracts-bedrock/contracts/governance/MintManager.sol
@@ -41,10 +41,7 @@ contract MintManager is Ownable {
     /// @param _amount  The amount of tokens to mint.
     function mint(address _account, uint256 _amount) public onlyOwner {
         if (mintPermittedAfter > 0) {
-            require(
-                mintPermittedAfter <= block.timestamp,
-                "MintManager: minting not permitted yet"
-            );
+            require(mintPermittedAfter <= block.timestamp, "MintManager: minting not permitted yet");
 
             require(
                 _amount <= (governanceToken.totalSupply() * MINT_CAP) / DENOMINATOR,
@@ -59,10 +56,7 @@ contract MintManager is Ownable {
     /// @notice Upgrade the owner of the governance token to a new MintManager.
     /// @param _newMintManager The MintManager to upgrade to.
     function upgrade(address _newMintManager) public onlyOwner {
-        require(
-            _newMintManager != address(0),
-            "MintManager: mint manager cannot be the zero address"
-        );
+        require(_newMintManager != address(0), "MintManager: mint manager cannot be the zero address");
 
         governanceToken.transferOwnership(_newMintManager);
     }

--- a/packages/contracts-bedrock/contracts/legacy/DeployerWhitelist.sol
+++ b/packages/contracts-bedrock/contracts/legacy/DeployerWhitelist.sol
@@ -36,15 +36,12 @@ contract DeployerWhitelist is Semver {
 
     /// @notice Blocks functions to anyone except the contract owner.
     modifier onlyOwner() {
-        require(
-            msg.sender == owner,
-            "DeployerWhitelist: function can only be called by the owner of this contract"
-        );
+        require(msg.sender == owner, "DeployerWhitelist: function can only be called by the owner of this contract");
         _;
     }
 
     /// @custom:semver 1.0.1
-    constructor() Semver(1, 0, 1) {}
+    constructor() Semver(1, 0, 1) { }
 
     /// @notice Adds or removes an address from the deployment whitelist.
     /// @param _deployer      Address to update permissions for.
@@ -60,10 +57,7 @@ contract DeployerWhitelist is Semver {
         // Prevent users from setting the whitelist owner to address(0) except via
         // enableArbitraryContractDeployment. If you want to burn the whitelist owner, send it to
         // any other address that doesn't have a corresponding knowable private key.
-        require(
-            _owner != address(0),
-            "DeployerWhitelist: can only be disabled via enableArbitraryContractDeployment"
-        );
+        require(_owner != address(0), "DeployerWhitelist: can only be disabled via enableArbitraryContractDeployment");
 
         emit OwnerChanged(owner, _owner);
         owner = _owner;

--- a/packages/contracts-bedrock/contracts/legacy/L1BlockNumber.sol
+++ b/packages/contracts-bedrock/contracts/legacy/L1BlockNumber.sol
@@ -15,7 +15,7 @@ import { Semver } from "../universal/Semver.sol";
 ///        contract instead.
 contract L1BlockNumber is Semver {
     /// @custom:semver 1.0.1
-    constructor() Semver(1, 0, 1) {}
+    constructor() Semver(1, 0, 1) { }
 
     /// @notice Returns the L1 block number.
     receive() external payable {

--- a/packages/contracts-bedrock/contracts/legacy/L1ChugSplashProxy.sol
+++ b/packages/contracts-bedrock/contracts/legacy/L1ChugSplashProxy.sol
@@ -22,12 +22,10 @@ contract L1ChugSplashProxy {
     bytes13 internal constant DEPLOY_CODE_PREFIX = 0x600D380380600D6000396000f3;
 
     /// @notice bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
-    bytes32 internal constant IMPLEMENTATION_KEY =
-        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    bytes32 internal constant IMPLEMENTATION_KEY = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
     /// @notice bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1)
-    bytes32 internal constant OWNER_KEY =
-        0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+    bytes32 internal constant OWNER_KEY = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
     /// @notice Blocks a function from being called when the parent signals that the system should
     ///         be paused via an isUpgrading function.
@@ -37,9 +35,8 @@ contract L1ChugSplashProxy {
         // We do a low-level call because there's no guarantee that the owner actually *is* an
         // L1ChugSplashDeployer contract and Solidity will throw errors if we do a normal call and
         // it turns out that it isn't the right type of contract.
-        (bool success, bytes memory returndata) = owner.staticcall(
-            abi.encodeWithSelector(IL1ChugSplashDeployer.isUpgrading.selector)
-        );
+        (bool success, bytes memory returndata) =
+            owner.staticcall(abi.encodeWithSelector(IL1ChugSplashDeployer.isUpgrading.selector));
 
         // If the call was unsuccessful then we assume that there's no "isUpgrading" method and we
         // can just continue as normal. We also expect that the return value is exactly 32 bytes
@@ -195,9 +192,7 @@ contract L1ChugSplashProxy {
             returndatacopy(0x0, 0x0, returndatasize())
 
             // Success == 0 means a revert. We'll revert too and pass the data up.
-            if iszero(success) {
-                revert(0x0, returndatasize())
-            }
+            if iszero(success) { revert(0x0, returndatasize()) }
 
             // Otherwise we'll just return and pass the data up.
             return(0x0, returndatasize())

--- a/packages/contracts-bedrock/contracts/legacy/LegacyERC20ETH.sol
+++ b/packages/contracts-bedrock/contracts/legacy/LegacyERC20ETH.sol
@@ -14,9 +14,7 @@ import { OptimismMintableERC20 } from "../universal/OptimismMintableERC20.sol";
 ///         disabled as part of the EVM equivalence upgrade.
 contract LegacyERC20ETH is OptimismMintableERC20 {
     /// @notice Initializes the contract as an Optimism Mintable ERC20.
-    constructor()
-        OptimismMintableERC20(Predeploys.L2_STANDARD_BRIDGE, address(0), "Ether", "ETH")
-    {}
+    constructor() OptimismMintableERC20(Predeploys.L2_STANDARD_BRIDGE, address(0), "Ether", "ETH") { }
 
     /// @notice Returns the ETH balance of the target account. Overrides the base behavior of the
     ///         contract to preserve the invariant that the balance within this contract always
@@ -53,11 +51,7 @@ contract LegacyERC20ETH is OptimismMintableERC20 {
 
     /// @custom:blocked
     /// @notice Transfers funds from some sender account.
-    function transferFrom(
-        address,
-        address,
-        uint256
-    ) public virtual override returns (bool) {
+    function transferFrom(address, address, uint256) public virtual override returns (bool) {
         revert("LegacyERC20ETH: transferFrom is disabled");
     }
 

--- a/packages/contracts-bedrock/contracts/legacy/LegacyMessagePasser.sol
+++ b/packages/contracts-bedrock/contracts/legacy/LegacyMessagePasser.sol
@@ -14,7 +14,7 @@ contract LegacyMessagePasser is Semver {
     mapping(bytes32 => bool) public sentMessages;
 
     /// @custom:semver 1.0.1
-    constructor() Semver(1, 0, 1) {}
+    constructor() Semver(1, 0, 1) { }
 
     /// @notice Passes a message to L1.
     /// @param _message Message to pass to L1.

--- a/packages/contracts-bedrock/contracts/legacy/LegacyMintableERC20.sol
+++ b/packages/contracts-bedrock/contracts/legacy/LegacyMintableERC20.sol
@@ -24,12 +24,9 @@ contract LegacyMintableERC20 is ILegacyMintableERC20, ERC20 {
     /// @param _l1Token Address of the corresponding L1 token.
     /// @param _name ERC20 name.
     /// @param _symbol ERC20 symbol.
-    constructor(
-        address _l2Bridge,
-        address _l1Token,
-        string memory _name,
-        string memory _symbol
-    ) ERC20(_name, _symbol) {
+    constructor(address _l2Bridge, address _l1Token, string memory _name, string memory _symbol)
+        ERC20(_name, _symbol)
+    {
         l1Token = _l1Token;
         l2Bridge = _l2Bridge;
     }
@@ -43,9 +40,8 @@ contract LegacyMintableERC20 is ILegacyMintableERC20, ERC20 {
     /// @notice EIP165 implementation.
     function supportsInterface(bytes4 _interfaceId) public pure returns (bool) {
         bytes4 firstSupportedInterface = bytes4(keccak256("supportsInterface(bytes4)")); // ERC165
-        bytes4 secondSupportedInterface = ILegacyMintableERC20.l1Token.selector ^
-            ILegacyMintableERC20.mint.selector ^
-            ILegacyMintableERC20.burn.selector;
+        bytes4 secondSupportedInterface = ILegacyMintableERC20.l1Token.selector ^ ILegacyMintableERC20.mint.selector
+            ^ ILegacyMintableERC20.burn.selector;
         return _interfaceId == firstSupportedInterface || _interfaceId == secondSupportedInterface;
     }
 

--- a/packages/contracts-bedrock/contracts/legacy/ResolvedDelegateProxy.sol
+++ b/packages/contracts-bedrock/contracts/legacy/ResolvedDelegateProxy.sol
@@ -32,9 +32,7 @@ contract ResolvedDelegateProxy {
     /// @notice Fallback, performs a delegatecall to the resolved implementation address.
     // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
-        address target = addressManager[address(this)].getAddress(
-            (implementationName[address(this)])
-        );
+        address target = addressManager[address(this)].getAddress((implementationName[address(this)]));
 
         require(target != address(0), "ResolvedDelegateProxy: target address must be initialized");
 

--- a/packages/contracts-bedrock/contracts/libraries/Arithmetic.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Arithmetic.sol
@@ -12,11 +12,7 @@ library Arithmetic {
     /// @param _min   The minimum value.
     /// @param _max   The maximum value.
     /// @return The clamped value.
-    function clamp(
-        int256 _value,
-        int256 _min,
-        int256 _max
-    ) internal pure returns (int256) {
+    function clamp(int256 _value, int256 _min, int256 _max) internal pure returns (int256) {
         return SignedMath.min(SignedMath.max(_value, _min), _max);
     }
 
@@ -26,13 +22,7 @@ library Arithmetic {
     /// @param _denominator Fractional denominator.
     /// @param _exponent    Power function exponent.
     /// @return Result of c * (1 - 1/d)^exp.
-    function cdexp(
-        int256 _coefficient,
-        int256 _denominator,
-        int256 _exponent
-    ) internal pure returns (int256) {
-        return
-            (_coefficient *
-                (FixedPointMathLib.powWad(1e18 - (1e18 / _denominator), _exponent * 1e18))) / 1e18;
+    function cdexp(int256 _coefficient, int256 _denominator, int256 _exponent) internal pure returns (int256) {
+        return (_coefficient * (FixedPointMathLib.powWad(1e18 - (1e18 / _denominator), _exponent * 1e18))) / 1e18;
     }
 }

--- a/packages/contracts-bedrock/contracts/libraries/Bytes.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Bytes.sol
@@ -12,11 +12,7 @@ library Bytes {
     /// @param _start Starting index of the slice.
     /// @param _length Length of the slice.
     /// @return Slice of the input byte array.
-    function slice(
-        bytes memory _bytes,
-        uint256 _start,
-        uint256 _length
-    ) internal pure returns (bytes memory) {
+    function slice(bytes memory _bytes, uint256 _start, uint256 _length) internal pure returns (bytes memory) {
         unchecked {
             require(_length + 31 >= _length, "slice_overflow");
             require(_start + _length >= _start, "slice_overflow");
@@ -56,9 +52,7 @@ library Bytes {
                 } lt(mc, end) {
                     mc := add(mc, 0x20)
                     cc := add(cc, 0x20)
-                } {
-                    mstore(mc, mload(cc))
-                }
+                } { mstore(mc, mload(cc)) }
 
                 mstore(tempBytes, _length)
 
@@ -125,11 +119,7 @@ library Bytes {
             let nibblesStart := add(_nibbles, 0x20)
 
             // Loop through each byte in the input array
-            for {
-                let i := 0x00
-            } lt(i, bytesLength) {
-                i := add(i, 0x01)
-            } {
+            for { let i := 0x00 } lt(i, bytesLength) { i := add(i, 0x01) } {
                 // Get the starting offset of the next 2 bytes in the nibbles array
                 let offset := add(nibblesStart, shl(0x01, i))
                 // Load the byte at the current index within the `_bytes` array

--- a/packages/contracts-bedrock/contracts/libraries/Clone.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Clone.sol
@@ -46,11 +46,7 @@ contract Clone {
     /// @param argOffset The offset of the arg in the packed data
     /// @param arrLen Number of elements in the array
     /// @return arr The array
-    function _getArgUint256Array(uint256 argOffset, uint64 arrLen)
-        internal
-        pure
-        returns (uint256[] memory arr)
-    {
+    function _getArgUint256Array(uint256 argOffset, uint64 arrLen) internal pure returns (uint256[] memory arr) {
         uint256 offset = _getImmutableArgsOffset() + argOffset;
         arr = new uint256[](arrLen);
 
@@ -63,11 +59,7 @@ contract Clone {
     /// @param argOffset The offset of the arg in the packed data
     /// @param arrLen Number of elements in the array
     /// @return arr The array
-    function _getArgDynBytes(uint256 argOffset, uint64 arrLen)
-        internal
-        pure
-        returns (bytes memory arr)
-    {
+    function _getArgDynBytes(uint256 argOffset, uint64 arrLen) internal pure returns (bytes memory arr) {
         uint256 offset = _getImmutableArgsOffset() + argOffset;
         arr = new bytes(arrLen);
 

--- a/packages/contracts-bedrock/contracts/libraries/Constants.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Constants.sol
@@ -23,11 +23,7 @@ library Constants {
 
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.
-    function DEFAULT_RESOURCE_CONFIG()
-        internal
-        pure
-        returns (ResourceMetering.ResourceConfig memory)
-    {
+    function DEFAULT_RESOURCE_CONFIG() internal pure returns (ResourceMetering.ResourceConfig memory) {
         ResourceMetering.ResourceConfig memory config = ResourceMetering.ResourceConfig({
             maxResourceLimit: 20_000_000,
             elasticityMultiplier: 10,

--- a/packages/contracts-bedrock/contracts/libraries/DisputeTypes.sol
+++ b/packages/contracts-bedrock/contracts/libraries/DisputeTypes.sol
@@ -60,8 +60,9 @@ type Position is uint128;
 type GameType is uint8;
 
 /// @notice The current status of the dispute game.
-enum GameStatus {
-    // The game is currently in progress, and has not been resolved.
+enum GameStatus
+// The game is currently in progress, and has not been resolved.
+{
     IN_PROGRESS,
     // The game has concluded, and the `rootClaim` was challenged successfully.
     CHALLENGER_WINS,

--- a/packages/contracts-bedrock/contracts/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Encoding.sol
@@ -13,11 +13,7 @@ library Encoding {
     ///         transaction is prefixed with 0x7e to identify its EIP-2718 type.
     /// @param _tx User deposit transaction to encode.
     /// @return RLP encoded L2 deposit transaction.
-    function encodeDepositTransaction(Types.UserDepositTransaction memory _tx)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function encodeDepositTransaction(Types.UserDepositTransaction memory _tx) internal pure returns (bytes memory) {
         bytes32 source = Hashing.hashDepositSource(_tx.l1BlockHash, _tx.logIndex);
         bytes[] memory raw = new bytes[](8);
         raw[0] = RLPWriter.writeBytes(abi.encodePacked(source));
@@ -64,20 +60,12 @@ library Encoding {
     /// @param _data   Data to send with the message.
     /// @param _nonce  Message nonce.
     /// @return Encoded cross domain message.
-    function encodeCrossDomainMessageV0(
-        address _target,
-        address _sender,
-        bytes memory _data,
-        uint256 _nonce
-    ) internal pure returns (bytes memory) {
-        return
-            abi.encodeWithSignature(
-                "relayMessage(address,address,bytes,uint256)",
-                _target,
-                _sender,
-                _data,
-                _nonce
-            );
+    function encodeCrossDomainMessageV0(address _target, address _sender, bytes memory _data, uint256 _nonce)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSignature("relayMessage(address,address,bytes,uint256)", _target, _sender, _data, _nonce);
     }
 
     /// @notice Encodes a cross domain message based on the V1 (current) encoding.
@@ -96,16 +84,15 @@ library Encoding {
         uint256 _gasLimit,
         bytes memory _data
     ) internal pure returns (bytes memory) {
-        return
-            abi.encodeWithSignature(
-                "relayMessage(uint256,address,address,uint256,uint256,bytes)",
-                _nonce,
-                _sender,
-                _target,
-                _value,
-                _gasLimit,
-                _data
-            );
+        return abi.encodeWithSignature(
+            "relayMessage(uint256,address,address,uint256,uint256,bytes)",
+            _nonce,
+            _sender,
+            _target,
+            _value,
+            _gasLimit,
+            _data
+        );
     }
 
     /// @notice Adds a version number into the first two bytes of a message nonce.

--- a/packages/contracts-bedrock/contracts/libraries/Hashing.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Hashing.sol
@@ -12,11 +12,7 @@ library Hashing {
     ///         system.
     /// @param _tx User deposit transaction to hash.
     /// @return Hash of the RLP encoded L2 deposit transaction.
-    function hashDepositTransaction(Types.UserDepositTransaction memory _tx)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function hashDepositTransaction(Types.UserDepositTransaction memory _tx) internal pure returns (bytes32) {
         return keccak256(Encoding.encodeDepositTransaction(_tx));
     }
 
@@ -26,11 +22,7 @@ library Hashing {
     /// @param _l1BlockHash Hash of the L1 block where the deposit was included.
     /// @param _logIndex    The index of the log that created the deposit transaction.
     /// @return Hash of the deposit transaction's "source hash".
-    function hashDepositSource(bytes32 _l1BlockHash, uint256 _logIndex)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function hashDepositSource(bytes32 _l1BlockHash, uint256 _logIndex) internal pure returns (bytes32) {
         bytes32 depositId = keccak256(abi.encode(_l1BlockHash, _logIndex));
         return keccak256(abi.encode(bytes32(0), depositId));
     }
@@ -68,12 +60,11 @@ library Hashing {
     /// @param _data   Data to send with the message.
     /// @param _nonce  Message nonce.
     /// @return Hashed cross domain message.
-    function hashCrossDomainMessageV0(
-        address _target,
-        address _sender,
-        bytes memory _data,
-        uint256 _nonce
-    ) internal pure returns (bytes32) {
+    function hashCrossDomainMessageV0(address _target, address _sender, bytes memory _data, uint256 _nonce)
+        internal
+        pure
+        returns (bytes32)
+    {
         return keccak256(Encoding.encodeCrossDomainMessageV0(_target, _sender, _data, _nonce));
     }
 
@@ -93,50 +84,28 @@ library Hashing {
         uint256 _gasLimit,
         bytes memory _data
     ) internal pure returns (bytes32) {
-        return
-            keccak256(
-                Encoding.encodeCrossDomainMessageV1(
-                    _nonce,
-                    _sender,
-                    _target,
-                    _value,
-                    _gasLimit,
-                    _data
-                )
-            );
+        return keccak256(Encoding.encodeCrossDomainMessageV1(_nonce, _sender, _target, _value, _gasLimit, _data));
     }
 
     /// @notice Derives the withdrawal hash according to the encoding in the L2 Withdrawer contract
     /// @param _tx Withdrawal transaction to hash.
     /// @return Hashed withdrawal transaction.
-    function hashWithdrawal(Types.WithdrawalTransaction memory _tx)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                abi.encode(_tx.nonce, _tx.sender, _tx.target, _tx.value, _tx.gasLimit, _tx.data)
-            );
+    function hashWithdrawal(Types.WithdrawalTransaction memory _tx) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_tx.nonce, _tx.sender, _tx.target, _tx.value, _tx.gasLimit, _tx.data));
     }
 
     /// @notice Hashes the various elements of an output root proof into an output root hash which
     ///         can be used to check if the proof is valid.
     /// @param _outputRootProof Output root proof which should hash to an output root.
     /// @return Hashed output root proof.
-    function hashOutputRootProof(Types.OutputRootProof memory _outputRootProof)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                abi.encode(
-                    _outputRootProof.version,
-                    _outputRootProof.stateRoot,
-                    _outputRootProof.messagePasserStorageRoot,
-                    _outputRootProof.latestBlockhash
-                )
-            );
+    function hashOutputRootProof(Types.OutputRootProof memory _outputRootProof) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _outputRootProof.version,
+                _outputRootProof.stateRoot,
+                _outputRootProof.messagePasserStorageRoot,
+                _outputRootProof.latestBlockhash
+            )
+        );
     }
 }

--- a/packages/contracts-bedrock/contracts/libraries/LegacyCrossDomainUtils.sol
+++ b/packages/contracts-bedrock/contracts/libraries/LegacyCrossDomainUtils.sol
@@ -14,19 +14,13 @@ library LegacyCrossDomainUtils {
     /// @param _message Message to send to the target.
     /// @param _messageNonce Nonce for the provided message.
     /// @return ABI encoded cross domain calldata.
-    function encodeXDomainCalldata(
-        address _target,
-        address _sender,
-        bytes memory _message,
-        uint256 _messageNonce
-    ) internal pure returns (bytes memory) {
-        return
-            abi.encodeWithSignature(
-                "relayMessage(address,address,bytes,uint256)",
-                _target,
-                _sender,
-                _message,
-                _messageNonce
-            );
+    function encodeXDomainCalldata(address _target, address _sender, bytes memory _message, uint256 _messageNonce)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSignature(
+            "relayMessage(address,address,bytes,uint256)", _target, _sender, _message, _messageNonce
+        );
     }
 }

--- a/packages/contracts-bedrock/contracts/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/contracts/libraries/Predeploys.sol
@@ -8,8 +8,7 @@ library Predeploys {
     address internal constant L2_TO_L1_MESSAGE_PASSER = 0x4200000000000000000000000000000000000016;
 
     /// @notice Address of the L2CrossDomainMessenger predeploy.
-    address internal constant L2_CROSS_DOMAIN_MESSENGER =
-        0x4200000000000000000000000000000000000007;
+    address internal constant L2_CROSS_DOMAIN_MESSENGER = 0x4200000000000000000000000000000000000007;
 
     /// @notice Address of the L2StandardBridge predeploy.
     address internal constant L2_STANDARD_BRIDGE = 0x4200000000000000000000000000000000000010;
@@ -21,12 +20,10 @@ library Predeploys {
     address internal constant SEQUENCER_FEE_WALLET = 0x4200000000000000000000000000000000000011;
 
     /// @notice Address of the OptimismMintableERC20Factory predeploy.
-    address internal constant OPTIMISM_MINTABLE_ERC20_FACTORY =
-        0x4200000000000000000000000000000000000012;
+    address internal constant OPTIMISM_MINTABLE_ERC20_FACTORY = 0x4200000000000000000000000000000000000012;
 
     /// @notice Address of the OptimismMintableERC721Factory predeploy.
-    address internal constant OPTIMISM_MINTABLE_ERC721_FACTORY =
-        0x4200000000000000000000000000000000000017;
+    address internal constant OPTIMISM_MINTABLE_ERC721_FACTORY = 0x4200000000000000000000000000000000000017;
 
     /// @notice Address of the L1Block predeploy.
     address internal constant L1_BLOCK_ATTRIBUTES = 0x4200000000000000000000000000000000000015;

--- a/packages/contracts-bedrock/contracts/libraries/SafeCall.sol
+++ b/packages/contracts-bedrock/contracts/libraries/SafeCall.sol
@@ -9,22 +9,19 @@ library SafeCall {
     /// @param _target   Address to call
     /// @param _gas      Amount of gas to pass to the call
     /// @param _value    Amount of value to pass to the call
-    function send(
-        address _target,
-        uint256 _gas,
-        uint256 _value
-    ) internal returns (bool) {
+    function send(address _target, uint256 _gas, uint256 _value) internal returns (bool) {
         bool _success;
         assembly {
-            _success := call(
-                _gas, // gas
-                _target, // recipient
-                _value, // ether value
-                0, // inloc
-                0, // inlen
-                0, // outloc
-                0 // outlen
-            )
+            _success :=
+                call(
+                    _gas, // gas
+                    _target, // recipient
+                    _value, // ether value
+                    0, // inloc
+                    0, // inlen
+                    0, // outloc
+                    0 // outlen
+                )
         }
         return _success;
     }
@@ -34,23 +31,19 @@ library SafeCall {
     /// @param _gas      Amount of gas to pass to the call
     /// @param _value    Amount of value to pass to the call
     /// @param _calldata Calldata to pass to the call
-    function call(
-        address _target,
-        uint256 _gas,
-        uint256 _value,
-        bytes memory _calldata
-    ) internal returns (bool) {
+    function call(address _target, uint256 _gas, uint256 _value, bytes memory _calldata) internal returns (bool) {
         bool _success;
         assembly {
-            _success := call(
-                _gas, // gas
-                _target, // recipient
-                _value, // ether value
-                add(_calldata, 32), // inloc
-                mload(_calldata), // inlen
-                0, // outloc
-                0 // outlen
-            )
+            _success :=
+                call(
+                    _gas, // gas
+                    _target, // recipient
+                    _value, // ether value
+                    add(_calldata, 32), // inloc
+                    mload(_calldata), // inlen
+                    0, // outloc
+                    0 // outlen
+                )
         }
         return _success;
     }
@@ -82,9 +75,7 @@ library SafeCall {
         bool _hasMinGas;
         assembly {
             // Equation: gas × 63 ≥ minGas × 64 + 63(40_000 + reservedGas)
-            _hasMinGas := iszero(
-                lt(mul(gas(), 63), add(mul(_minGas, 64), mul(add(40000, _reservedGas), 63)))
-            )
+            _hasMinGas := iszero(lt(mul(gas(), 63), add(mul(_minGas, 64), mul(add(40000, _reservedGas), 63))))
         }
         return _hasMinGas;
     }
@@ -96,12 +87,10 @@ library SafeCall {
     /// @param _minGas   The minimum amount of gas that may be passed to the call
     /// @param _value    Amount of value to pass to the call
     /// @param _calldata Calldata to pass to the call
-    function callWithMinGas(
-        address _target,
-        uint256 _minGas,
-        uint256 _value,
-        bytes memory _calldata
-    ) internal returns (bool) {
+    function callWithMinGas(address _target, uint256 _minGas, uint256 _value, bytes memory _calldata)
+        internal
+        returns (bool)
+    {
         bool _success;
         bool _hasMinGas = hasMinGas(_minGas, 0);
         assembly {
@@ -132,15 +121,16 @@ library SafeCall {
             // `_minGas` does not account for the `memory_expansion_cost` and `code_execution_cost`
             // factors of the dynamic cost of the `CALL` opcode), the call will receive at least
             // the minimum amount of gas specified.
-            _success := call(
-                gas(), // gas
-                _target, // recipient
-                _value, // ether value
-                add(_calldata, 32), // inloc
-                mload(_calldata), // inlen
-                0x00, // outloc
-                0x00 // outlen
-            )
+            _success :=
+                call(
+                    gas(), // gas
+                    _target, // recipient
+                    _value, // ether value
+                    add(_calldata, 32), // inloc
+                    mload(_calldata), // inlen
+                    0x00, // outloc
+                    0x00 // outlen
+                )
         }
         return _success;
     }

--- a/packages/contracts-bedrock/contracts/libraries/rlp/RLPReader.sol
+++ b/packages/contracts-bedrock/contracts/libraries/rlp/RLPReader.sol
@@ -50,10 +50,7 @@ library RLPReader {
      */
     function toRLPItem(bytes memory _in) internal pure returns (RLPItem memory) {
         // Empty arrays are not RLP items.
-        require(
-            _in.length > 0,
-            "RLPReader: length of an RLP item must be greater than zero to be decodable"
-        );
+        require(_in.length > 0, "RLPReader: length of an RLP item must be greater than zero to be decodable");
 
         MemoryPointer ptr;
         assembly {
@@ -73,15 +70,9 @@ library RLPReader {
     function readList(RLPItem memory _in) internal pure returns (RLPItem[] memory) {
         (uint256 listOffset, uint256 listLength, RLPItemType itemType) = _decodeLength(_in);
 
-        require(
-            itemType == RLPItemType.LIST_ITEM,
-            "RLPReader: decoded item type for list is not a list item"
-        );
+        require(itemType == RLPItemType.LIST_ITEM, "RLPReader: decoded item type for list is not a list item");
 
-        require(
-            listOffset + listLength == _in.length,
-            "RLPReader: list item has an invalid data remainder"
-        );
+        require(listOffset + listLength == _in.length, "RLPReader: list item has an invalid data remainder");
 
         // Solidity in-memory arrays can't be increased in size, but *can* be decreased in size by
         // writing to the length. Since we can't know the number of RLP items without looping over
@@ -92,11 +83,8 @@ library RLPReader {
         uint256 itemCount = 0;
         uint256 offset = listOffset;
         while (offset < _in.length) {
-            (uint256 itemOffset, uint256 itemLength, ) = _decodeLength(
-                RLPItem({
-                    length: _in.length - offset,
-                    ptr: MemoryPointer.wrap(MemoryPointer.unwrap(_in.ptr) + offset)
-                })
+            (uint256 itemOffset, uint256 itemLength,) = _decodeLength(
+                RLPItem({ length: _in.length - offset, ptr: MemoryPointer.wrap(MemoryPointer.unwrap(_in.ptr) + offset) })
             );
 
             // We don't need to check itemCount < out.length explicitly because Solidity already
@@ -139,15 +127,9 @@ library RLPReader {
     function readBytes(RLPItem memory _in) internal pure returns (bytes memory) {
         (uint256 itemOffset, uint256 itemLength, RLPItemType itemType) = _decodeLength(_in);
 
-        require(
-            itemType == RLPItemType.DATA_ITEM,
-            "RLPReader: decoded item type for bytes is not a data item"
-        );
+        require(itemType == RLPItemType.DATA_ITEM, "RLPReader: decoded item type for bytes is not a data item");
 
-        require(
-            _in.length == itemOffset + itemLength,
-            "RLPReader: bytes value contains an invalid remainder"
-        );
+        require(_in.length == itemOffset + itemLength, "RLPReader: bytes value contains an invalid remainder");
 
         return _copy(_in.ptr, itemOffset, itemLength);
     }
@@ -183,22 +165,11 @@ library RLPReader {
      * @return Length of the encoded data.
      * @return RLP item type (LIST_ITEM or DATA_ITEM).
      */
-    function _decodeLength(RLPItem memory _in)
-        private
-        pure
-        returns (
-            uint256,
-            uint256,
-            RLPItemType
-        )
-    {
+    function _decodeLength(RLPItem memory _in) private pure returns (uint256, uint256, RLPItemType) {
         // Short-circuit if there's nothing to decode, note that we perform this check when
         // the user creates an RLP item via toRLPItem, but it's always possible for them to bypass
         // that function and create an RLP item directly. So we need to check this anyway.
-        require(
-            _in.length > 0,
-            "RLPReader: length of an RLP item must be greater than zero to be decodable"
-        );
+        require(_in.length > 0, "RLPReader: length of an RLP item must be greater than zero to be decodable");
 
         MemoryPointer ptr = _in.ptr;
         uint256 prefix;
@@ -216,8 +187,7 @@ library RLPReader {
             uint256 strLen = prefix - 0x80;
 
             require(
-                _in.length > strLen,
-                "RLPReader: length of content must be greater than string length (short string)"
+                _in.length > strLen, "RLPReader: length of content must be greater than string length (short string)"
             );
 
             bytes1 firstByteOfContent;
@@ -246,8 +216,7 @@ library RLPReader {
             }
 
             require(
-                firstByteOfContent != 0x00,
-                "RLPReader: length of content must not have any leading zeros (long string)"
+                firstByteOfContent != 0x00, "RLPReader: length of content must not have any leading zeros (long string)"
             );
 
             uint256 strLen;
@@ -255,10 +224,7 @@ library RLPReader {
                 strLen := shr(sub(256, mul(8, lenOfStrLen)), mload(add(ptr, 1)))
             }
 
-            require(
-                strLen > 55,
-                "RLPReader: length of content must be greater than 55 bytes (long string)"
-            );
+            require(strLen > 55, "RLPReader: length of content must be greater than 55 bytes (long string)");
 
             require(
                 _in.length > lenOfStrLen + strLen,
@@ -271,10 +237,7 @@ library RLPReader {
             // slither-disable-next-line variable-scope
             uint256 listLen = prefix - 0xc0;
 
-            require(
-                _in.length > listLen,
-                "RLPReader: length of content must be greater than list length (short list)"
-            );
+            require(_in.length > listLen, "RLPReader: length of content must be greater than list length (short list)");
 
             return (1, listLen, RLPItemType.LIST_ITEM);
         } else {
@@ -292,8 +255,7 @@ library RLPReader {
             }
 
             require(
-                firstByteOfContent != 0x00,
-                "RLPReader: length of content must not have any leading zeros (long list)"
+                firstByteOfContent != 0x00, "RLPReader: length of content must not have any leading zeros (long list)"
             );
 
             uint256 listLen;
@@ -301,10 +263,7 @@ library RLPReader {
                 listLen := shr(sub(256, mul(8, lenOfListLen)), mload(add(ptr, 1)))
             }
 
-            require(
-                listLen > 55,
-                "RLPReader: length of content must be greater than 55 bytes (long list)"
-            );
+            require(listLen > 55, "RLPReader: length of content must be greater than 55 bytes (long list)");
 
             require(
                 _in.length > lenOfListLen + listLen,
@@ -324,11 +283,7 @@ library RLPReader {
      *
      * @return Copied bytes.
      */
-    function _copy(
-        MemoryPointer _src,
-        uint256 _offset,
-        uint256 _length
-    ) private pure returns (bytes memory) {
+    function _copy(MemoryPointer _src, uint256 _offset, uint256 _length) private pure returns (bytes memory) {
         bytes memory out = new bytes(_length);
         if (_length == 0) {
             return out;
@@ -341,17 +296,9 @@ library RLPReader {
         assembly {
             let dest := add(out, 32)
             let i := 0
-            for {
+            for { } lt(i, _length) { i := add(i, 32) } { mstore(add(dest, i), mload(add(src, i))) }
 
-            } lt(i, _length) {
-                i := add(i, 32)
-            } {
-                mstore(add(dest, i), mload(add(src, i)))
-            }
-
-            if gt(i, _length) {
-                mstore(add(dest, _length), 0)
-            }
+            if gt(i, _length) { mstore(add(dest, _length), 0) }
         }
 
         return out;

--- a/packages/contracts-bedrock/contracts/libraries/rlp/RLPWriter.sol
+++ b/packages/contracts-bedrock/contracts/libraries/rlp/RLPWriter.sol
@@ -111,7 +111,7 @@ library RLPWriter {
             encoded = new bytes(lenLen + 1);
             encoded[0] = bytes1(uint8(lenLen) + uint8(_offset) + 55);
             for (i = 1; i <= lenLen; i++) {
-                encoded[i] = bytes1(uint8((_len / (256**(lenLen - i))) % 256));
+                encoded[i] = bytes1(uint8((_len / (256 ** (lenLen - i))) % 256));
             }
         }
 
@@ -151,11 +151,7 @@ library RLPWriter {
      * @param _src  Source location.
      * @param _len  Length of memory to copy.
      */
-    function _memcpy(
-        uint256 _dest,
-        uint256 _src,
-        uint256 _len
-    ) private pure {
+    function _memcpy(uint256 _dest, uint256 _src, uint256 _len) private pure {
         uint256 dest = _dest;
         uint256 src = _src;
         uint256 len = _len;
@@ -170,7 +166,7 @@ library RLPWriter {
 
         uint256 mask;
         unchecked {
-            mask = 256**(32 - len) - 1;
+            mask = 256 ** (32 - len) - 1;
         }
         assembly {
             let srcpart := and(mload(src), not(mask))

--- a/packages/contracts-bedrock/contracts/libraries/trie/MerkleTrie.sol
+++ b/packages/contracts-bedrock/contracts/libraries/trie/MerkleTrie.sol
@@ -70,12 +70,11 @@ library MerkleTrie {
      *
      * @return Whether or not the proof is valid.
      */
-    function verifyInclusionProof(
-        bytes memory _key,
-        bytes memory _value,
-        bytes[] memory _proof,
-        bytes32 _root
-    ) internal pure returns (bool) {
+    function verifyInclusionProof(bytes memory _key, bytes memory _value, bytes[] memory _proof, bytes32 _root)
+        internal
+        pure
+        returns (bool)
+    {
         return Bytes.equal(_value, get(_key, _proof, _root));
     }
 
@@ -88,11 +87,7 @@ library MerkleTrie {
      *
      * @return Value of the key if it exists.
      */
-    function get(
-        bytes memory _key,
-        bytes[] memory _proof,
-        bytes32 _root
-    ) internal pure returns (bytes memory) {
+    function get(bytes memory _key, bytes[] memory _proof, bytes32 _root) internal pure returns (bytes memory) {
         require(_key.length > 0, "MerkleTrie: empty key");
 
         TrieNode[] memory proof = _parseProof(_proof);
@@ -105,10 +100,7 @@ library MerkleTrie {
             TrieNode memory currentNode = proof[i];
 
             // Key index should never exceed total key length or we'll be out of bounds.
-            require(
-                currentKeyIndex <= key.length,
-                "MerkleTrie: key index exceeds total key length"
-            );
+            require(currentKeyIndex <= key.length, "MerkleTrie: key index exceeds total key length");
 
             if (currentKeyIndex == 0) {
                 // First proof element is always the root node.
@@ -124,10 +116,7 @@ library MerkleTrie {
                 );
             } else {
                 // Nodes smaller than 32 bytes aren't hashed.
-                require(
-                    Bytes.equal(currentNode.encoded, currentNodeID),
-                    "MerkleTrie: invalid internal node hash"
-                );
+                require(Bytes.equal(currentNode.encoded, currentNodeID), "MerkleTrie: invalid internal node hash");
             }
 
             if (currentNode.decoded.length == BRANCH_NODE_LENGTH) {
@@ -138,16 +127,10 @@ library MerkleTrie {
                     // even when the value wasn't explicitly placed there. Geth treats a value of
                     // bytes(0) as "key does not exist" and so we do the same.
                     bytes memory value = RLPReader.readBytes(currentNode.decoded[TREE_RADIX]);
-                    require(
-                        value.length > 0,
-                        "MerkleTrie: value length must be greater than zero (branch)"
-                    );
+                    require(value.length > 0, "MerkleTrie: value length must be greater than zero (branch)");
 
                     // Extra proof elements are not allowed.
-                    require(
-                        i == proof.length - 1,
-                        "MerkleTrie: value node must be last node in proof (branch)"
-                    );
+                    require(i == proof.length - 1, "MerkleTrie: value node must be last node in proof (branch)");
 
                     return value;
                 } else {
@@ -191,16 +174,10 @@ library MerkleTrie {
                     // say that if the value is empty, the key should not exist and the proof is
                     // invalid.
                     bytes memory value = RLPReader.readBytes(currentNode.decoded[1]);
-                    require(
-                        value.length > 0,
-                        "MerkleTrie: value length must be greater than zero (leaf)"
-                    );
+                    require(value.length > 0, "MerkleTrie: value length must be greater than zero (leaf)");
 
                     // Extra proof elements are not allowed.
-                    require(
-                        i == proof.length - 1,
-                        "MerkleTrie: value node must be last node in proof (leaf)"
-                    );
+                    require(i == proof.length - 1, "MerkleTrie: value node must be last node in proof (leaf)");
 
                     return value;
                 } else if (prefix == PREFIX_EXTENSION_EVEN || prefix == PREFIX_EXTENSION_ODD) {
@@ -231,7 +208,7 @@ library MerkleTrie {
     function _parseProof(bytes[] memory _proof) private pure returns (TrieNode[] memory) {
         uint256 length = _proof.length;
         TrieNode[] memory proof = new TrieNode[](length);
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             proof[i] = TrieNode({ encoded: _proof[i], decoded: RLPReader.readList(_proof[i]) });
             unchecked {
                 ++i;
@@ -271,14 +248,10 @@ library MerkleTrie {
      *
      * @return Number of shared nibbles.
      */
-    function _getSharedNibbleLength(bytes memory _a, bytes memory _b)
-        private
-        pure
-        returns (uint256)
-    {
+    function _getSharedNibbleLength(bytes memory _a, bytes memory _b) private pure returns (uint256) {
         uint256 shared;
         uint256 max = (_a.length < _b.length) ? _a.length : _b.length;
-        for (; shared < max && _a[shared] == _b[shared]; ) {
+        for (; shared < max && _a[shared] == _b[shared];) {
             unchecked {
                 ++shared;
             }

--- a/packages/contracts-bedrock/contracts/libraries/trie/SecureMerkleTrie.sol
+++ b/packages/contracts-bedrock/contracts/libraries/trie/SecureMerkleTrie.sol
@@ -23,12 +23,11 @@ library SecureMerkleTrie {
      *
      * @return Whether or not the proof is valid.
      */
-    function verifyInclusionProof(
-        bytes memory _key,
-        bytes memory _value,
-        bytes[] memory _proof,
-        bytes32 _root
-    ) internal pure returns (bool) {
+    function verifyInclusionProof(bytes memory _key, bytes memory _value, bytes[] memory _proof, bytes32 _root)
+        internal
+        pure
+        returns (bool)
+    {
         bytes memory key = _getSecureKey(_key);
         return MerkleTrie.verifyInclusionProof(key, _value, _proof, _root);
     }
@@ -42,11 +41,7 @@ library SecureMerkleTrie {
      *
      * @return Value of the key if it exists.
      */
-    function get(
-        bytes memory _key,
-        bytes[] memory _proof,
-        bytes32 _root
-    ) internal pure returns (bytes memory) {
+    function get(bytes memory _key, bytes[] memory _proof, bytes32 _root) internal pure returns (bytes memory) {
         bytes memory key = _getSecureKey(_key);
         return MerkleTrie.get(key, _proof, _root);
     }

--- a/packages/contracts-bedrock/contracts/periphery/TransferOnion.sol
+++ b/packages/contracts-bedrock/contracts/periphery/TransferOnion.sol
@@ -33,11 +33,7 @@ contract TransferOnion is ReentrancyGuard {
     /// @param _token  Address of the token to distribute.
     /// @param _sender Address of the sender to distribute from.
     /// @param _shell  Initial shell of the onion.
-    constructor(
-        ERC20 _token,
-        address _sender,
-        bytes32 _shell
-    ) {
+    constructor(ERC20 _token, address _sender, bytes32 _shell) {
         TOKEN = _token;
         SENDER = _sender;
         shell = _shell;
@@ -48,7 +44,7 @@ contract TransferOnion is ReentrancyGuard {
     function peel(Layer[] memory _layers) public nonReentrant {
         bytes32 tempShell = shell;
         uint256 length = _layers.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             Layer memory layer = _layers[i];
 
             // Confirm that the onion layer is correct.

--- a/packages/contracts-bedrock/contracts/test/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/contracts/test/BenchmarkTest.t.sol
@@ -9,18 +9,14 @@ import { CrossDomainMessenger } from "../universal/CrossDomainMessenger.sol";
 import { ResourceMetering } from "../L1/ResourceMetering.sol";
 
 // Free function for setting the prevBaseFee param in the OptimismPortal.
-function setPrevBaseFee(
-    Vm _vm,
-    address _op,
-    uint128 _prevBaseFee
-) {
+function setPrevBaseFee(Vm _vm, address _op, uint128 _prevBaseFee) {
     _vm.store(address(_op), bytes32(uint256(1)), bytes32((block.number << 192) | _prevBaseFee));
 }
 
 contract SetPrevBaseFee_Test is Portal_Initializer {
     function test_setPrevBaseFee_succeeds() external {
         setPrevBaseFee(vm, address(op), 100 gwei);
-        (uint128 prevBaseFee, , uint64 prevBlockNum) = op.params();
+        (uint128 prevBaseFee,, uint64 prevBlockNum) = op.params();
         assertEq(uint256(prevBaseFee), 100 gwei);
         assertEq(uint256(prevBlockNum), block.number);
     }
@@ -56,8 +52,7 @@ contract GasBenchMark_OptimismPortal is Portal_Initializer {
         // Get withdrawal proof data we can use for testing.
         bytes32 _storageRoot;
         bytes32 _stateRoot;
-        (_stateRoot, _storageRoot, _outputRoot, , _withdrawalProof) = ffi
-            .getProveWithdrawalTransactionInputs(_defaultTx);
+        (_stateRoot, _storageRoot, _outputRoot,, _withdrawalProof) = ffi.getProveWithdrawalTransactionInputs(_defaultTx);
 
         // Setup a dummy output root proof for reuse.
         _outputRootProof = Types.OutputRootProof({
@@ -78,11 +73,7 @@ contract GasBenchMark_OptimismPortal is Portal_Initializer {
         oracle.proposeL2Output(_outputRoot, _proposedBlockNumber, 0, 0);
 
         // Warp beyond the finalization period for the block we've proposed.
-        vm.warp(
-            oracle.getL2Output(_proposedOutputIndex).timestamp +
-                oracle.FINALIZATION_PERIOD_SECONDS() +
-                1
-        );
+        vm.warp(oracle.getL2Output(_proposedOutputIndex).timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
 
         // Fund the portal so that we can withdraw ETH.
         vm.deal(address(op), 0xFFFFFFFF);
@@ -90,32 +81,19 @@ contract GasBenchMark_OptimismPortal is Portal_Initializer {
 
     function test_depositTransaction_benchmark() external {
         op.depositTransaction{ value: NON_ZERO_VALUE }(
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
+            NON_ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA
         );
     }
 
     function test_depositTransaction_benchmark_1() external {
         setPrevBaseFee(vm, address(op), 1 gwei);
         op.depositTransaction{ value: NON_ZERO_VALUE }(
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
+            NON_ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA
         );
     }
 
     function test_proveWithdrawalTransaction_benchmark() external {
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
     }
 }
 
@@ -124,8 +102,8 @@ contract GasBenchMark_L1CrossDomainMessenger is Messenger_Initializer {
         vm.pauseGasMetering();
         setPrevBaseFee(vm, address(op), 1 gwei);
         // The amount of data typically sent during a bridge deposit.
-        bytes
-            memory data = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        bytes memory data =
+            hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         vm.resumeGasMetering();
         L1Messenger.sendMessage(bob, data, uint32(100));
     }
@@ -134,8 +112,8 @@ contract GasBenchMark_L1CrossDomainMessenger is Messenger_Initializer {
         vm.pauseGasMetering();
         setPrevBaseFee(vm, address(op), 10 gwei);
         // The amount of data typically sent during a bridge deposit.
-        bytes
-            memory data = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        bytes memory data =
+            hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         vm.resumeGasMetering();
         L1Messenger.sendMessage(bob, data, uint32(100));
     }

--- a/packages/contracts-bedrock/contracts/test/Bytes.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Bytes.t.sol
@@ -47,8 +47,8 @@ contract Bytes_slice_Test is Test {
     ///         in memory. In this case, we test that a 2 byte slice between the 32nd byte of the
     ///         first word and the 1st byte of the second word is correct.
     function test_slice_acrossWords_works() public {
-        bytes
-            memory input = hex"00000000000000000000000000000000000000000000000000000000000000112200000000000000000000000000000000000000000000000000000000000000";
+        bytes memory input =
+            hex"00000000000000000000000000000000000000000000000000000000000000112200000000000000000000000000000000000000000000000000000000000000";
 
         assertEq(Bytes.slice(input, 31, 2), hex"1122");
     }
@@ -57,21 +57,16 @@ contract Bytes_slice_Test is Test {
     ///         words in memory. In this case, we test that a 34 byte slice between 3 separate words
     ///        returns the correct result.
     function test_slice_acrossMultipleWords_works() public {
-        bytes
-            memory input = hex"000000000000000000000000000000000000000000000000000000000000001122FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1100000000000000000000000000000000000000000000000000000000000000";
-        bytes
-            memory expected = hex"1122FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF11";
+        bytes memory input =
+            hex"000000000000000000000000000000000000000000000000000000000000001122FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1100000000000000000000000000000000000000000000000000000000000000";
+        bytes memory expected = hex"1122FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF11";
 
         assertEq(Bytes.slice(input, 31, 34), expected);
     }
 
     /// @notice Tests that the `slice` function correctly updates the free memory pointer depending
     ///         on the length of the slice.
-    function testFuzz_slice_memorySafety_succeeds(
-        bytes memory _input,
-        uint256 _start,
-        uint256 _length
-    ) public {
+    function testFuzz_slice_memorySafety_succeeds(bytes memory _input, uint256 _start, uint256 _length) public {
         // The start should never be more than the length of the input bytes array - 1
         vm.assume(_start < _input.length);
         // The length should never be more than the length of the input bytes array - the starting
@@ -124,11 +119,7 @@ contract Bytes_slice_Test is Test {
 contract Bytes_slice_TestFail is Test {
     /// @notice Tests that, when given an input bytes array of length `n`, the `slice` function will
     ///         always revert if `_start + _length > n`.
-    function testFuzz_slice_outOfBounds_reverts(
-        bytes memory _input,
-        uint256 _start,
-        uint256 _length
-    ) public {
+    function testFuzz_slice_outOfBounds_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
         // We want a valid start index and a length that will not overflow.
         vm.assume(_start < _input.length && _length < type(uint256).max - 31);
         // But, we want an invalid slice length.
@@ -140,11 +131,7 @@ contract Bytes_slice_TestFail is Test {
 
     /// @notice Tests that, when given a length `n` that is greater than `type(uint256).max - 31`,
     ///         the `slice` function reverts.
-    function testFuzz_slice_lengthOverflows_reverts(
-        bytes memory _input,
-        uint256 _start,
-        uint256 _length
-    ) public {
+    function testFuzz_slice_lengthOverflows_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
         // Ensure that the `_length` will overflow if a number >= 31 is added to it.
         vm.assume(_length > type(uint256).max - 31);
 
@@ -154,11 +141,7 @@ contract Bytes_slice_TestFail is Test {
 
     /// @notice Tests that, when given a start index `n` that is greater than
     ///         `type(uint256).max - n`, the `slice` function reverts.
-    function testFuzz_slice_rangeOverflows_reverts(
-        bytes memory _input,
-        uint256 _start,
-        uint256 _length
-    ) public {
+    function testFuzz_slice_rangeOverflows_reverts(bytes memory _input, uint256 _start, uint256 _length) public {
         // Ensure that `_length` is a realistic length of a slice. This is to make sure
         // we revert on the correct require statement.
         vm.assume(_length < _input.length);
@@ -187,10 +170,10 @@ contract Bytes_toNibbles_Test is Test {
     ///         of 256 nibbles corresponding to the input data. This test exists to ensure that,
     ///         given a large input, the `toNibbles` function works as expected.
     function test_toNibbles_expectedResult128Bytes_works() public {
-        bytes
-            memory input = hex"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f";
-        bytes
-            memory expected = hex"0000000100020003000400050006000700080009000a000b000c000d000e000f0100010101020103010401050106010701080109010a010b010c010d010e010f0200020102020203020402050206020702080209020a020b020c020d020e020f0300030103020303030403050306030703080309030a030b030c030d030e030f0400040104020403040404050406040704080409040a040b040c040d040e040f0500050105020503050405050506050705080509050a050b050c050d050e050f0600060106020603060406050606060706080609060a060b060c060d060e060f0700070107020703070407050706070707080709070a070b070c070d070e070f";
+        bytes memory input =
+            hex"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f";
+        bytes memory expected =
+            hex"0000000100020003000400050006000700080009000a000b000c000d000e000f0100010101020103010401050106010701080109010a010b010c010d010e010f0200020102020203020402050206020702080209020a020b020c020d020e020f0300030103020303030403050306030703080309030a030b030c030d030e030f0400040104020403040404050406040704080409040a040b040c040d040e040f0500050105020503050405050506050705080509050a050b050c050d050e050f0600060106020603060406050606060706080609060a060b060c060d060e060f0700070107020703070407050706070707080709070a070b070c070d070e070f";
         bytes memory actual = Bytes.toNibbles(input);
 
         assertEq(input.length * 2, actual.length);
@@ -264,13 +247,14 @@ contract Bytes_equal_Test is Test {
     function manualEq(bytes memory _a, bytes memory _b) internal pure returns (bool) {
         bool _eq;
         assembly {
-            _eq := and(
-                // Check if the contents of the two bytes arrays are equal in memory.
-                eq(keccak256(add(0x20, _a), mload(_a)), keccak256(add(0x20, _b), mload(_b))),
-                // Check if the length of the two bytes arrays are equal in memory.
-                // This is redundant given the above check, but included for completeness.
-                eq(mload(_a), mload(_b))
-            )
+            _eq :=
+                and(
+                    // Check if the contents of the two bytes arrays are equal in memory.
+                    eq(keccak256(add(0x20, _a), mload(_a)), keccak256(add(0x20, _b), mload(_b))),
+                    // Check if the length of the two bytes arrays are equal in memory.
+                    // This is redundant given the above check, but included for completeness.
+                    eq(mload(_a), mload(_b))
+                )
         }
         return _eq;
     }

--- a/packages/contracts-bedrock/contracts/test/Clones.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Clones.t.sol
@@ -117,9 +117,7 @@ contract Clones_Test is Test {
         assertEq(fetched, param);
     }
 
-    function testFuzz_clone_uintArrayArg_succeeds(uint256 argOffset, uint256[] memory param)
-        public
-    {
+    function testFuzz_clone_uintArrayArg_succeeds(uint256 argOffset, uint256[] memory param) public {
         ExampleClone implementation = new ExampleClone(argOffset);
         ExampleCloneFactory factory = new ExampleCloneFactory(implementation);
         ExampleClone clone = factory.createUintArrayClone(param);

--- a/packages/contracts-bedrock/contracts/test/CommonTest.t.sol
+++ b/packages/contracts-bedrock/contracts/test/CommonTest.t.sol
@@ -47,12 +47,7 @@ contract CommonTest is Test {
     bytes32 nonZeroHash = keccak256(abi.encode("NON_ZERO"));
     bytes NON_ZERO_DATA = hex"0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff0000";
 
-    event TransactionDeposited(
-        address indexed from,
-        address indexed to,
-        uint256 indexed version,
-        bytes opaqueData
-    );
+    event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData);
 
     FFIInterface ffi;
 
@@ -81,12 +76,7 @@ contract CommonTest is Test {
         bool _isCreation,
         bytes memory _data
     ) internal {
-        emit TransactionDeposited(
-            _from,
-            _to,
-            0,
-            abi.encodePacked(_mint, _value, _gasLimit, _isCreation, _data)
-        );
+        emit TransactionDeposited(_from, _to, 0, abi.encodePacked(_mint, _value, _gasLimit, _isCreation, _data));
     }
 }
 
@@ -95,8 +85,7 @@ contract L2OutputOracle_Initializer is CommonTest {
     L2OutputOracle oracle;
     L2OutputOracle oracleImpl;
 
-    L2ToL1MessagePasser messagePasser =
-        L2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER));
+    L2ToL1MessagePasser messagePasser = L2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER));
 
     // Constructor arguments
     address internal proposer = 0x000000000000000000000000000000000000AbBa;
@@ -111,10 +100,7 @@ contract L2OutputOracle_Initializer is CommonTest {
     uint256 initL1Time;
 
     event OutputProposed(
-        bytes32 indexed outputRoot,
-        uint256 indexed l2OutputIndex,
-        uint256 indexed l2BlockNumber,
-        uint256 l1Timestamp
+        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
     );
 
     event OutputsDeleted(uint256 indexed prevNextOutputIndex, uint256 indexed newNextOutputIndex);
@@ -166,8 +152,7 @@ contract L2OutputOracle_Initializer is CommonTest {
         Proxy proxy = new Proxy(multisig);
         vm.prank(multisig);
         proxy.upgradeToAndCall(
-            address(oracleImpl),
-            abi.encodeCall(L2OutputOracle.initialize, (startingBlockNumber, startingTimestamp))
+            address(oracleImpl), abi.encodeCall(L2OutputOracle.initialize, (startingBlockNumber, startingTimestamp))
         );
         oracle = L2OutputOracle(address(proxy));
         vm.label(address(oracle), "L2OutputOracle");
@@ -186,11 +171,7 @@ contract Portal_Initializer is L2OutputOracle_Initializer {
     SystemConfig systemConfig;
 
     event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
-    event WithdrawalProven(
-        bytes32 indexed withdrawalHash,
-        address indexed from,
-        address indexed to
-    );
+    event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
 
     function setUp() public virtual override {
         super.setUp();
@@ -216,10 +197,7 @@ contract Portal_Initializer is L2OutputOracle_Initializer {
 
         Proxy proxy = new Proxy(multisig);
         vm.prank(multisig);
-        proxy.upgradeToAndCall(
-            address(opImpl),
-            abi.encodeWithSelector(OptimismPortal.initialize.selector, false)
-        );
+        proxy.upgradeToAndCall(address(opImpl), abi.encodeWithSelector(OptimismPortal.initialize.selector, false));
         op = OptimismPortal(payable(address(proxy)));
         vm.label(address(op), "OptimismPortal");
     }
@@ -228,16 +206,9 @@ contract Portal_Initializer is L2OutputOracle_Initializer {
 contract Messenger_Initializer is Portal_Initializer {
     AddressManager internal addressManager;
     L1CrossDomainMessenger internal L1Messenger;
-    L2CrossDomainMessenger internal L2Messenger =
-        L2CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
+    L2CrossDomainMessenger internal L2Messenger = L2CrossDomainMessenger(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
 
-    event SentMessage(
-        address indexed target,
-        address sender,
-        bytes message,
-        uint256 messageNonce,
-        uint256 gasLimit
-    );
+    event SentMessage(address indexed target, address sender, bytes message, uint256 messageNonce, uint256 gasLimit);
 
     event SentMessageExtension1(address indexed sender, uint256 value);
 
@@ -286,10 +257,7 @@ contract Messenger_Initializer is Portal_Initializer {
         L1Messenger = L1CrossDomainMessenger(address(proxy));
         L1Messenger.initialize();
 
-        vm.etch(
-            Predeploys.L2_CROSS_DOMAIN_MESSENGER,
-            address(new L2CrossDomainMessenger(address(L1Messenger))).code
-        );
+        vm.etch(Predeploys.L2_CROSS_DOMAIN_MESSENGER, address(new L2CrossDomainMessenger(address(L1Messenger))).code);
 
         L2Messenger.initialize();
 
@@ -300,10 +268,7 @@ contract Messenger_Initializer is Portal_Initializer {
         vm.label(Predeploys.LEGACY_ERC20_ETH, "LegacyERC20ETH");
         vm.label(Predeploys.L2_CROSS_DOMAIN_MESSENGER, "L2CrossDomainMessenger");
 
-        vm.label(
-            AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger)),
-            "L1CrossDomainMessenger_aliased"
-        );
+        vm.label(AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger)), "L1CrossDomainMessenger_aliased");
     }
 }
 
@@ -322,56 +287,26 @@ contract Bridge_Initializer is Messenger_Initializer {
 
     event ETHDepositInitiated(address indexed from, address indexed to, uint256 amount, bytes data);
 
-    event ETHWithdrawalFinalized(
-        address indexed from,
-        address indexed to,
-        uint256 amount,
-        bytes data
-    );
+    event ETHWithdrawalFinalized(address indexed from, address indexed to, uint256 amount, bytes data);
 
     event ERC20DepositInitiated(
-        address indexed l1Token,
-        address indexed l2Token,
-        address indexed from,
-        address to,
-        uint256 amount,
-        bytes data
+        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 
     event ERC20WithdrawalFinalized(
-        address indexed l1Token,
-        address indexed l2Token,
-        address indexed from,
-        address to,
-        uint256 amount,
-        bytes data
+        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 
     event WithdrawalInitiated(
-        address indexed l1Token,
-        address indexed l2Token,
-        address indexed from,
-        address to,
-        uint256 amount,
-        bytes data
+        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 
     event DepositFinalized(
-        address indexed l1Token,
-        address indexed l2Token,
-        address indexed from,
-        address to,
-        uint256 amount,
-        bytes data
+        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 
     event DepositFailed(
-        address indexed l1Token,
-        address indexed l2Token,
-        address indexed from,
-        address to,
-        uint256 amount,
-        bytes data
+        address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes data
     );
 
     event ETHBridgeInitiated(address indexed from, address indexed to, uint256 amount, bytes data);
@@ -405,11 +340,7 @@ contract Bridge_Initializer is Messenger_Initializer {
         // Deploy the L1 bridge and initialize it with the address of the
         // L1CrossDomainMessenger
         L1ChugSplashProxy proxy = new L1ChugSplashProxy(multisig);
-        vm.mockCall(
-            multisig,
-            abi.encodeWithSelector(IL1ChugSplashDeployer.isUpgrading.selector),
-            abi.encode(true)
-        );
+        vm.mockCall(multisig, abi.encodeWithSelector(IL1ChugSplashDeployer.isUpgrading.selector), abi.encode(true));
         vm.startPrank(multisig);
         proxy.setCode(address(new L1StandardBridge(payable(address(L1Messenger)))).code);
         vm.clearMockedCalls();
@@ -497,8 +428,7 @@ contract ERC721Bridge_Initializer is Messenger_Initializer {
         // Deploy the implementation for the L2ERC721Bridge and etch it into the predeploy address.
         vm.etch(
             Predeploys.L2_ERC721_BRIDGE,
-            address(new L2ERC721Bridge(Predeploys.L2_CROSS_DOMAIN_MESSENGER, address(L1Bridge)))
-                .code
+            address(new L2ERC721Bridge(Predeploys.L2_CROSS_DOMAIN_MESSENGER, address(L1Bridge))).code
         );
 
         // Set up a reference to the L2ERC721Bridge.
@@ -516,24 +446,13 @@ contract FeeVault_Initializer is Bridge_Initializer {
 
     event Withdrawal(uint256 value, address to, address from);
 
-    event Withdrawal(
-        uint256 value,
-        address to,
-        address from,
-        FeeVault.WithdrawalNetwork withdrawalNetwork
-    );
+    event Withdrawal(uint256 value, address to, address from, FeeVault.WithdrawalNetwork withdrawalNetwork);
 }
 
 contract FFIInterface is Test {
     function getProveWithdrawalTransactionInputs(Types.WithdrawalTransaction memory _tx)
         external
-        returns (
-            bytes32,
-            bytes32,
-            bytes32,
-            bytes32,
-            bytes[] memory
-        )
+        returns (bytes32, bytes32, bytes32, bytes32, bytes[] memory)
     {
         string[] memory cmds = new string[](8);
         cmds[0] = "scripts/differential-testing/differential-testing";
@@ -644,10 +563,7 @@ contract FFIInterface is Test {
         return abi.decode(result, (bytes32));
     }
 
-    function encodeDepositTransaction(Types.UserDepositTransaction calldata txn)
-        external
-        returns (bytes memory)
-    {
+    function encodeDepositTransaction(Types.UserDepositTransaction calldata txn) external returns (bytes memory) {
         string[] memory cmds = new string[](11);
         cmds[0] = "scripts/differential-testing/differential-testing";
         cmds[1] = "encodeDepositTransaction";
@@ -699,12 +615,7 @@ contract FFIInterface is Test {
 
     function getMerkleTrieFuzzCase(string memory variant)
         external
-        returns (
-            bytes32,
-            bytes memory,
-            bytes memory,
-            bytes[] memory
-        )
+        returns (bytes32, bytes memory, bytes memory, bytes[] memory)
     {
         string[] memory cmds = new string[](5);
         cmds[0] = "./test-case-generator/fuzz";
@@ -748,12 +659,8 @@ contract CallerCaller {
         emit WhatHappened(success, returndata);
         assembly {
             switch success
-            case 0 {
-                revert(add(returndata, 0x20), mload(returndata))
-            }
-            default {
-                return(add(returndata, 0x20), mload(returndata))
-            }
+            case 0 { revert(add(returndata, 0x20), mload(returndata)) }
+            default { return(add(returndata, 0x20), mload(returndata)) }
         }
     }
 }
@@ -777,12 +684,8 @@ contract ConfigurableCaller {
             emit WhatHappened(success, returndata);
             assembly {
                 switch success
-                case 0 {
-                    revert(add(returndata, 0x20), mload(returndata))
-                }
-                default {
-                    return(add(returndata, 0x20), mload(returndata))
-                }
+                case 0 { revert(add(returndata, 0x20), mload(returndata)) }
+                default { return(add(returndata, 0x20), mload(returndata)) }
             }
         }
     }

--- a/packages/contracts-bedrock/contracts/test/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/CrossDomainMessenger.t.sol
@@ -28,9 +28,7 @@ contract CrossDomainMessenger_BaseGas_Test is Messenger_Initializer {
     ///         or equal to the minimum gas limit value on the OptimismPortal.
     ///         This guarantees that the messengers will always pass sufficient
     ///         gas to the OptimismPortal.
-    function testFuzz_baseGas_portalMinGasLimit_succeeds(bytes memory _data, uint32 _minGasLimit)
-        external
-    {
+    function testFuzz_baseGas_portalMinGasLimit_succeeds(bytes memory _data, uint32 _minGasLimit) external {
         vm.assume(_data.length <= type(uint64).max);
         uint64 baseGas = L1Messenger.baseGas(_data, _minGasLimit);
         uint64 minGasLimit = op.minimumGasLimit(uint64(_data.length));

--- a/packages/contracts-bedrock/contracts/test/CrossDomainOwnable2.t.sol
+++ b/packages/contracts-bedrock/contracts/test/CrossDomainOwnable2.t.sol
@@ -61,12 +61,7 @@ contract CrossDomainOwnable2_Test is Messenger_Initializer {
         bytes memory message = abi.encodeWithSelector(XDomainSetter2.set.selector, 1);
 
         bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce(nonce, 1),
-            sender,
-            target,
-            value,
-            minGasLimit,
-            message
+            Encoding.encodeVersionedNonce(nonce, 1), sender, target, value, minGasLimit, message
         );
 
         // It should be a failed message. The revert is caught,
@@ -75,14 +70,7 @@ contract CrossDomainOwnable2_Test is Messenger_Initializer {
         emit FailedRelayedMessage(hash);
 
         vm.prank(AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger)));
-        L2Messenger.relayMessage(
-            Encoding.encodeVersionedNonce(nonce, 1),
-            sender,
-            target,
-            value,
-            minGasLimit,
-            message
-        );
+        L2Messenger.relayMessage(Encoding.encodeVersionedNonce(nonce, 1), sender, target, value, minGasLimit, message);
 
         assertEq(setter.value(), 0);
     }

--- a/packages/contracts-bedrock/contracts/test/CrossDomainOwnable3.t.sol
+++ b/packages/contracts-bedrock/contracts/test/CrossDomainOwnable3.t.sol
@@ -30,11 +30,7 @@ contract CrossDomainOwnable3_Test is Messenger_Initializer {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     /// @dev CrossDomainOwnable3.sol transferOwnership event
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner,
-        bool isLocal
-    );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner, bool isLocal);
 
     /// @dev Sets up the test suite.
     function setUp() public override {
@@ -111,12 +107,7 @@ contract CrossDomainOwnable3_Test is Messenger_Initializer {
         bytes memory message = abi.encodeWithSelector(XDomainSetter3.set.selector, 1);
 
         bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce(nonce, 1),
-            sender,
-            target,
-            value,
-            minGasLimit,
-            message
+            Encoding.encodeVersionedNonce(nonce, 1), sender, target, value, minGasLimit, message
         );
 
         // It should be a failed message. The revert is caught,
@@ -125,14 +116,7 @@ contract CrossDomainOwnable3_Test is Messenger_Initializer {
         emit FailedRelayedMessage(hash);
 
         vm.prank(AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger)));
-        L2Messenger.relayMessage(
-            Encoding.encodeVersionedNonce(nonce, 1),
-            sender,
-            target,
-            value,
-            minGasLimit,
-            message
-        );
+        L2Messenger.relayMessage(Encoding.encodeVersionedNonce(nonce, 1), sender, target, value, minGasLimit, message);
 
         assertEq(setter.value(), 0);
     }

--- a/packages/contracts-bedrock/contracts/test/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/contracts/test/DisputeGameFactory.t.sol
@@ -13,11 +13,7 @@ contract DisputeGameFactory_Init is Test {
     DisputeGameFactory factory;
     FakeClone fakeClone;
 
-    event DisputeGameCreated(
-        address indexed disputeProxy,
-        GameType indexed gameType,
-        Claim indexed rootClaim
-    );
+    event DisputeGameCreated(address indexed disputeProxy, GameType indexed gameType, Claim indexed rootClaim);
 
     event ImplementationSet(address indexed impl, GameType indexed gameType);
 
@@ -39,11 +35,7 @@ contract DisputeGameFactory_Init is Test {
 contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
     /// @dev Tests that the `create` function succeeds when creating a new dispute game
     ///      with a `GameType` that has an implementation set.
-    function testFuzz_create_succeeds(
-        uint8 gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) public {
+    function testFuzz_create_succeeds(uint8 gameType, Claim rootClaim, bytes calldata extraData) public {
         // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible values.
         GameType gt = GameType.wrap(uint8(bound(gameType, 0, 2)));
 
@@ -70,11 +62,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
 
     /// @dev Tests that the `create` function reverts when there is no implementation
     ///      set for the given `GameType`.
-    function testFuzz_create_noImpl_reverts(
-        uint8 gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) public {
+    function testFuzz_create_noImpl_reverts(uint8 gameType, Claim rootClaim, bytes calldata extraData) public {
         // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible values.
         GameType gt = GameType.wrap(uint8(bound(gameType, 0, 2)));
 
@@ -83,11 +71,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
     }
 
     /// @dev Tests that the `create` function reverts when there exists a dispute game with the same UUID.
-    function testFuzz_create_sameUUID_reverts(
-        uint8 gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) public {
+    function testFuzz_create_sameUUID_reverts(uint8 gameType, Claim rootClaim, bytes calldata extraData) public {
         // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible values.
         GameType gt = GameType.wrap(uint8(bound(gameType, 0, 2)));
 
@@ -108,10 +92,7 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
 
         // Ensure that the `create` function reverts when called with parameters that would result in the same UUID.
         vm.expectRevert(
-            abi.encodeWithSelector(
-                GameAlreadyExists.selector,
-                factory.getGameUUID(gt, rootClaim, extraData)
-            )
+            abi.encodeWithSelector(GameAlreadyExists.selector, factory.getGameUUID(gt, rootClaim, extraData))
         );
         factory.create(gt, rootClaim, extraData);
     }
@@ -145,17 +126,12 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_Init {
 contract DisputeGameFactory_GetGameUUID_Test is DisputeGameFactory_Init {
     /// @dev Tests that the `getGameUUID` function returns the correct hash when comparing
     ///      against the keccak256 hash of the abi-encoded parameters.
-    function testDiff_getGameUUID_succeeds(
-        uint8 gameType,
-        Claim rootClaim,
-        bytes calldata extraData
-    ) public {
+    function testDiff_getGameUUID_succeeds(uint8 gameType, Claim rootClaim, bytes calldata extraData) public {
         // Ensure that the `gameType` is within the bounds of the `GameType` enum's possible values.
         GameType gt = GameType.wrap(uint8(bound(gameType, 0, 2)));
 
         assertEq(
-            Hash.unwrap(factory.getGameUUID(gt, rootClaim, extraData)),
-            keccak256(abi.encode(gt, rootClaim, extraData))
+            Hash.unwrap(factory.getGameUUID(gt, rootClaim, extraData)), keccak256(abi.encode(gt, rootClaim, extraData))
         );
     }
 }

--- a/packages/contracts-bedrock/contracts/test/Encoding.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Encoding.t.sol
@@ -14,9 +14,7 @@ import { Encoding } from "../libraries/Encoding.sol";
 contract Encoding_Test is CommonTest {
     /// @dev Tests encoding and decoding a nonce and version.
     function testFuzz_nonceVersioning_succeeds(uint240 _nonce, uint16 _version) external {
-        (uint240 nonce, uint16 version) = Encoding.decodeVersionedNonce(
-            Encoding.encodeVersionedNonce(_nonce, _version)
-        );
+        (uint240 nonce, uint16 version) = Encoding.decodeVersionedNonce(Encoding.encodeVersionedNonce(_nonce, _version));
         assertEq(version, _version);
         assertEq(nonce, _nonce);
     }
@@ -44,23 +42,9 @@ contract Encoding_Test is CommonTest {
         uint8 version = _version % 2;
         uint256 nonce = Encoding.encodeVersionedNonce(_nonce, version);
 
-        bytes memory encoding = Encoding.encodeCrossDomainMessage(
-            nonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
+        bytes memory encoding = Encoding.encodeCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
 
-        bytes memory _encoding = ffi.encodeCrossDomainMessage(
-            nonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
+        bytes memory _encoding = ffi.encodeCrossDomainMessage(nonce, _sender, _target, _value, _gasLimit, _data);
 
         assertEq(encoding, _encoding);
     }
@@ -75,19 +59,9 @@ contract Encoding_Test is CommonTest {
         uint8 version = 0;
         uint256 nonce = Encoding.encodeVersionedNonce(_nonce, version);
 
-        bytes memory legacyEncoding = LegacyCrossDomainUtils.encodeXDomainCalldata(
-            _target,
-            _sender,
-            _data,
-            nonce
-        );
+        bytes memory legacyEncoding = LegacyCrossDomainUtils.encodeXDomainCalldata(_target, _sender, _data, nonce);
 
-        bytes memory bedrockEncoding = Encoding.encodeCrossDomainMessageV0(
-            _target,
-            _sender,
-            _data,
-            nonce
-        );
+        bytes memory bedrockEncoding = Encoding.encodeCrossDomainMessageV0(_target, _sender, _data, nonce);
 
         assertEq(legacyEncoding, bedrockEncoding);
     }
@@ -104,15 +78,7 @@ contract Encoding_Test is CommonTest {
         uint64 _logIndex
     ) external {
         Types.UserDepositTransaction memory t = Types.UserDepositTransaction(
-            _from,
-            _to,
-            isCreate,
-            _value,
-            _mint,
-            _gas,
-            _data,
-            bytes32(uint256(0)),
-            _logIndex
+            _from, _to, isCreate, _value, _mint, _gas, _data, bytes32(uint256(0)), _logIndex
         );
 
         bytes memory txn = Encoding.encodeDepositTransaction(t);

--- a/packages/contracts-bedrock/contracts/test/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/contracts/test/FaultDisputeGame.t.sol
@@ -89,21 +89,14 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
 
     /// @dev Tests that the root claim's data is set correctly when the game is initialized.
     function test_initialRootClaimData_succeeds() public {
-        (
-            uint32 parentIndex,
-            bool countered,
-            Claim claim,
-            Position position,
-            Clock clock
-        ) = gameProxy.claimData(0);
+        (uint32 parentIndex, bool countered, Claim claim, Position position, Clock clock) = gameProxy.claimData(0);
 
         assertEq(parentIndex, type(uint32).max);
         assertEq(countered, false);
         assertEq(Claim.unwrap(claim), Claim.unwrap(ROOT_CLAIM));
         assertEq(Position.unwrap(position), 1);
         assertEq(
-            Clock.unwrap(clock),
-            Clock.unwrap(LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))))
+            Clock.unwrap(clock), Clock.unwrap(LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp))))
         );
     }
 
@@ -201,13 +194,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         gameProxy.attack(0, counter);
 
         // Grab the claim data of the attack.
-        (
-            uint32 parentIndex,
-            bool countered,
-            Claim claim,
-            Position position,
-            Clock clock
-        ) = gameProxy.claimData(1);
+        (uint32 parentIndex, bool countered, Claim claim, Position position, Clock clock) = gameProxy.claimData(1);
 
         // Assert correctness of the attack claim's data.
         assertEq(parentIndex, 0);
@@ -215,8 +202,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(Claim.unwrap(claim), Claim.unwrap(counter));
         assertEq(Position.unwrap(position), Position.unwrap(Position.wrap(1).move(true)));
         assertEq(
-            Clock.unwrap(clock),
-            Clock.unwrap(LibClock.wrap(Duration.wrap(5), Timestamp.wrap(uint64(block.timestamp))))
+            Clock.unwrap(clock), Clock.unwrap(LibClock.wrap(Duration.wrap(5), Timestamp.wrap(uint64(block.timestamp))))
         );
 
         // Grab the claim data of the parent.
@@ -229,9 +215,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         assertEq(Position.unwrap(position), 1);
         assertEq(
             Clock.unwrap(clock),
-            Clock.unwrap(
-                LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp - 5)))
-            )
+            Clock.unwrap(LibClock.wrap(Duration.wrap(0), Timestamp.wrap(uint64(block.timestamp - 5))))
         );
     }
 
@@ -304,11 +288,7 @@ contract GamePlayer {
     uint256 internal maxDepth;
 
     /// @notice Initializes the player
-    function init(
-        FaultDisputeGame _gameProxy,
-        GamePlayer _counterParty,
-        Vm _vm
-    ) public {
+    function init(FaultDisputeGame _gameProxy, GamePlayer _counterParty, Vm _vm) public {
         gameProxy = _gameProxy;
         counterParty = _counterParty;
         vm = _vm;
@@ -318,9 +298,7 @@ contract GamePlayer {
     /// @notice Perform the next move in the game.
     function play(uint256 _parentIndex) public virtual {
         // Grab the claim data at the parent index.
-        (uint32 grandparentIndex, , Claim parentClaim, Position parentPos, ) = gameProxy.claimData(
-            _parentIndex
-        );
+        (uint32 grandparentIndex,, Claim parentClaim, Position parentPos,) = gameProxy.claimData(_parentIndex);
 
         // The position to move to.
         Position movePos;
@@ -342,9 +320,7 @@ contract GamePlayer {
             Claim ourParentClaim = claimAt(parentPos);
 
             // Fetch our claim at the grandparent's position.
-            (, , Claim grandparentClaim, Position grandparentPos, ) = gameProxy.claimData(
-                grandparentIndex
-            );
+            (,, Claim grandparentClaim, Position grandparentPos,) = gameProxy.claimData(grandparentIndex);
             Claim ourGrandparentClaim = claimAt(grandparentPos);
 
             if (Claim.unwrap(ourParentClaim) != Claim.unwrap(parentClaim)) {
@@ -358,8 +334,8 @@ contract GamePlayer {
                 // Flag the move as an attack.
                 isAttack = true;
             } else if (
-                Claim.unwrap(ourParentClaim) == Claim.unwrap(parentClaim) &&
-                Claim.unwrap(ourGrandparentClaim) == Claim.unwrap(grandparentClaim)
+                Claim.unwrap(ourParentClaim) == Claim.unwrap(parentClaim)
+                    && Claim.unwrap(ourGrandparentClaim) == Claim.unwrap(grandparentClaim)
             ) {
                 movePos = parentPos.move(false);
             }
@@ -382,10 +358,7 @@ contract GamePlayer {
 
                 // Walk up until the valid position that commits to the prestate's
                 // trace index is found.
-                while (
-                    Position.unwrap(statePos.parent().rightIndex(maxDepth)) ==
-                    Position.unwrap(leafPos)
-                ) {
+                while (Position.unwrap(statePos.parent().rightIndex(maxDepth)) == Position.unwrap(leafPos)) {
                     statePos = statePos.parent();
                 }
 
@@ -393,7 +366,7 @@ contract GamePlayer {
                 // index.
                 uint256 len = gameProxy.claimDataLen();
                 for (uint256 i = 0; i < len; i++) {
-                    (, , , Position pos, ) = gameProxy.claimData(i);
+                    (,,, Position pos,) = gameProxy.claimData(i);
                     if (Position.unwrap(pos) == Position.unwrap(statePos)) {
                         stateIndex = i;
                         break;
@@ -428,7 +401,7 @@ contract GamePlayer {
 
                 // If we have a second move position, attack the grandparent.
                 if (Position.unwrap(movePos2) != 0) {
-                    (, , , Position grandparentPos, ) = gameProxy.claimData(grandparentIndex);
+                    (,,, Position grandparentPos,) = gameProxy.claimData(grandparentIndex);
                     Claim ourGrandparentClaim = claimAt(grandparentPos.move(true));
 
                     gameProxy.attack(grandparentIndex, ourGrandparentClaim);
@@ -659,11 +632,7 @@ contract AlphabetVM is IBigStepper {
     }
 
     /// @inheritdoc IBigStepper
-    function step(bytes calldata _stateData, bytes calldata)
-        external
-        view
-        returns (bytes32 postState_)
-    {
+    function step(bytes calldata _stateData, bytes calldata) external view returns (bytes32 postState_) {
         uint256 traceIndex;
         uint256 claim;
         if (_stateData.length == 0) {

--- a/packages/contracts-bedrock/contracts/test/FeeVault.t.sol
+++ b/packages/contracts-bedrock/contracts/test/FeeVault.t.sol
@@ -31,9 +31,7 @@ contract FeeVault_Test is Bridge_Initializer {
         );
         vm.etch(
             Predeploys.L1_FEE_VAULT,
-            address(
-                new L1FeeVault(bob, otherMinimumWithdrawalAmount, FeeVault.WithdrawalNetwork.L2)
-            ).code
+            address(new L1FeeVault(bob, otherMinimumWithdrawalAmount, FeeVault.WithdrawalNetwork.L2)).code
         );
 
         vm.label(Predeploys.BASE_FEE_VAULT, "BaseFeeVault");

--- a/packages/contracts-bedrock/contracts/test/GasPriceOracle.t.sol
+++ b/packages/contracts-bedrock/contracts/test/GasPriceOracle.t.sol
@@ -94,9 +94,8 @@ contract GasPriceOracle_Test is CommonTest {
 
     /// @dev Tests that `setGasPrice` reverts since it was removed in bedrock.
     function test_setGasPrice_doesNotExist_reverts() external {
-        (bool success, bytes memory returndata) = address(gasOracle).call(
-            abi.encodeWithSignature("setGasPrice(uint256)", 1)
-        );
+        (bool success, bytes memory returndata) =
+            address(gasOracle).call(abi.encodeWithSignature("setGasPrice(uint256)", 1));
 
         assertEq(success, false);
         assertEq(returndata, hex"");
@@ -104,9 +103,8 @@ contract GasPriceOracle_Test is CommonTest {
 
     /// @dev Tests that `setL1BaseFee` reverts since it was removed in bedrock.
     function test_setL1BaseFee_doesNotExist_reverts() external {
-        (bool success, bytes memory returndata) = address(gasOracle).call(
-            abi.encodeWithSignature("setL1BaseFee(uint256)", 1)
-        );
+        (bool success, bytes memory returndata) =
+            address(gasOracle).call(abi.encodeWithSignature("setL1BaseFee(uint256)", 1));
 
         assertEq(success, false);
         assertEq(returndata, hex"");

--- a/packages/contracts-bedrock/contracts/test/Hashing.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Hashing.t.sol
@@ -16,10 +16,7 @@ contract Hashing_hashDepositSource_Test is CommonTest {
     /// @notice Tests that hashDepositSource returns the correct hash in a simple case.
     function test_hashDepositSource_succeeds() external {
         assertEq(
-            Hashing.hashDepositSource(
-                0xd25df7858efc1778118fb133ac561b138845361626dfb976699c5287ed0f4959,
-                0x1
-            ),
+            Hashing.hashDepositSource(0xd25df7858efc1778118fb133ac561b138845361626dfb976699c5287ed0f4959, 0x1),
             0xf923fb07134d7d287cb52c770cc619e17e82606c21a875c92f4c63b65280a5cc
         );
     }
@@ -54,14 +51,7 @@ contract Hashing_hashCrossDomainMessage_Test is CommonTest {
         uint256 _messageNonce
     ) external {
         assertEq(
-            keccak256(
-                LegacyCrossDomainUtils.encodeXDomainCalldata(
-                    _target,
-                    _sender,
-                    _message,
-                    _messageNonce
-                )
-            ),
+            keccak256(LegacyCrossDomainUtils.encodeXDomainCalldata(_target, _sender, _message, _messageNonce)),
             Hashing.hashCrossDomainMessageV0(_target, _sender, _message, _messageNonce)
         );
     }
@@ -78,9 +68,7 @@ contract Hashing_hashWithdrawal_Test is CommonTest {
         bytes memory _data
     ) external {
         assertEq(
-            Hashing.hashWithdrawal(
-                Types.WithdrawalTransaction(_nonce, _sender, _target, _value, _gasLimit, _data)
-            ),
+            Hashing.hashWithdrawal(Types.WithdrawalTransaction(_nonce, _sender, _target, _value, _gasLimit, _data)),
             ffi.hashWithdrawal(_nonce, _sender, _target, _value, _gasLimit, _data)
         );
     }
@@ -103,12 +91,7 @@ contract Hashing_hashOutputRootProof_Test is CommonTest {
                     latestBlockhash: _latestBlockhash
                 })
             ),
-            ffi.hashOutputRootProof(
-                _version,
-                _stateRoot,
-                _messagePasserStorageRoot,
-                _latestBlockhash
-            )
+            ffi.hashOutputRootProof(_version, _stateRoot, _messagePasserStorageRoot, _latestBlockhash)
         );
     }
 }

--- a/packages/contracts-bedrock/contracts/test/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1CrossDomainMessenger.t.sol
@@ -44,14 +44,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
                 0,
                 L1Messenger.baseGas(hex"ff", 100),
                 false,
-                Encoding.encodeCrossDomainMessage(
-                    L1Messenger.messageNonce(),
-                    alice,
-                    recipient,
-                    0,
-                    100,
-                    hex"ff"
-                )
+                Encoding.encodeCrossDomainMessage(L1Messenger.messageNonce(), alice, recipient, 0, 100, hex"ff")
             )
         );
 
@@ -64,14 +57,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
             0,
             L1Messenger.baseGas(hex"ff", 100),
             false,
-            Encoding.encodeCrossDomainMessage(
-                L1Messenger.messageNonce(),
-                alice,
-                recipient,
-                0,
-                100,
-                hex"ff"
-            )
+            Encoding.encodeCrossDomainMessage(L1Messenger.messageNonce(), alice, recipient, 0, 100, hex"ff")
         );
 
         // SentMessage event
@@ -112,9 +98,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
         vm.store(address(op), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
 
         // Expect a revert.
-        vm.expectRevert(
-            "CrossDomainMessenger: only version 0 or 1 messages are supported at this time"
-        );
+        vm.expectRevert("CrossDomainMessenger: only version 0 or 1 messages are supported at this time");
 
         // Try to relay a v2 message.
         vm.prank(address(op));
@@ -143,12 +127,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
         vm.expectEmit(true, true, true, true);
 
         bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            target,
-            0,
-            0,
-            hex"1111"
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, hex"1111"
         );
 
         emit RelayedMessage(hash);
@@ -179,23 +158,13 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
         vm.prank(address(op));
         vm.expectRevert("CrossDomainMessenger: message cannot be replayed");
         L1Messenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            target,
-            0,
-            0,
-            message
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, message
         );
 
         vm.store(address(op), 0, bytes32(abi.encode(sender)));
         vm.expectRevert("CrossDomainMessenger: message cannot be replayed");
         L1Messenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            target,
-            0,
-            0,
-            message
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, message
         );
     }
 
@@ -206,16 +175,9 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
         bytes memory message = hex"1111";
 
-        vm.expectRevert(
-            "CrossDomainMessenger: value must be zero unless message is from a system address"
-        );
+        vm.expectRevert("CrossDomainMessenger: value must be zero unless message is from a system address");
         L1Messenger.relayMessage{ value: 100 }(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            target,
-            0,
-            0,
-            message
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, 0, 0, message
         );
     }
 
@@ -230,12 +192,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
         vm.store(address(op), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));
         vm.prank(address(op));
         L1Messenger.relayMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            address(0),
-            address(0),
-            0,
-            0,
-            hex""
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), address(0), address(0), 0, 0, hex""
         );
 
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
@@ -253,12 +210,7 @@ contract L1CrossDomainMessenger_Test is Messenger_Initializer {
         vm.expectCall(target, hex"1111");
 
         bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }),
-            sender,
-            target,
-            value,
-            0,
-            hex"1111"
+            Encoding.encodeVersionedNonce({ _nonce: 0, _version: 1 }), sender, target, value, 0, hex"1111"
         );
 
         vm.store(address(op), bytes32(senderSlotIndex), bytes32(abi.encode(sender)));

--- a/packages/contracts-bedrock/contracts/test/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1ERC721Bridge.t.sol
@@ -13,7 +13,7 @@ import { L1ERC721Bridge } from "../L1/L1ERC721Bridge.sol";
 
 /// @dev Test ERC721 contract.
 contract TestERC721 is ERC721 {
-    constructor() ERC721("Test", "TST") {}
+    constructor() ERC721("Test", "TST") { }
 
     function mint(address to, uint256 tokenId) public {
         _mint(to, tokenId);
@@ -84,15 +84,8 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
                     address(otherBridge),
                     abi.encodeCall(
                         L2ERC721Bridge.finalizeBridgeERC721,
-                        (
-                            address(remoteToken),
-                            address(localToken),
-                            alice,
-                            alice,
-                            tokenId,
-                            hex"5678"
-                        )
-                    ),
+                        (address(remoteToken), address(localToken), alice, alice, tokenId, hex"5678")
+                        ),
                     1234
                 )
             )
@@ -100,14 +93,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
 
         // Expect an event to be emitted.
         vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
         // Bridge the token.
         vm.prank(alice);
@@ -180,7 +166,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
                     abi.encodeCall(
                         L2ERC721Bridge.finalizeBridgeERC721,
                         (address(remoteToken), address(localToken), alice, bob, tokenId, hex"5678")
-                    ),
+                        ),
                     1234
                 )
             )
@@ -188,25 +174,11 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
 
         // Expect an event to be emitted.
         vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            bob,
-            tokenId,
-            hex"5678"
-        );
+        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, bob, tokenId, hex"5678");
 
         // Bridge the token.
         vm.prank(alice);
-        bridge.bridgeERC721To(
-            address(localToken),
-            address(remoteToken),
-            bob,
-            tokenId,
-            1234,
-            hex"5678"
-        );
+        bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
 
         // Token is locked in the bridge.
         assertEq(bridge.deposits(address(localToken), address(remoteToken), tokenId), true);
@@ -245,14 +217,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
         // Bridge the token.
         vm.prank(bob);
         vm.expectRevert("ERC721: transfer from incorrect owner");
-        bridge.bridgeERC721To(
-            address(localToken),
-            address(remoteToken),
-            bob,
-            tokenId,
-            1234,
-            hex"5678"
-        );
+        bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
 
         // Token is not locked in the bridge.
         assertEq(bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
@@ -267,14 +232,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
 
         // Expect an event to be emitted.
         vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeFinalized(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        emit ERC721BridgeFinalized(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
         // Finalize a withdrawal.
         vm.mockCall(
@@ -283,14 +241,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
             abi.encode(otherBridge)
         );
         vm.prank(address(L1Messenger));
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
         // Token is not locked in the bridge.
         assertEq(bridge.deposits(address(localToken), address(remoteToken), tokenId), false);
@@ -303,14 +254,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
         // Finalize a withdrawal.
         vm.prank(alice);
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
     /// @dev Tests that the ERC721 bridge finalize reverts when not called
@@ -318,20 +262,11 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
     function test_finalizeBridgeERC721_notFromRemoteMessenger_reverts() external {
         // Finalize a withdrawal.
         vm.mockCall(
-            address(L1Messenger),
-            abi.encodeWithSelector(L1Messenger.xDomainMessageSender.selector),
-            abi.encode(alice)
+            address(L1Messenger), abi.encodeWithSelector(L1Messenger.xDomainMessageSender.selector), abi.encode(alice)
         );
         vm.prank(address(L1Messenger));
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
     /// @dev Tests that the ERC721 bridge finalize reverts when the local token
@@ -345,14 +280,7 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
         );
         vm.prank(address(L1Messenger));
         vm.expectRevert("L1ERC721Bridge: local token cannot be self");
-        bridge.finalizeBridgeERC721(
-            address(bridge),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(bridge), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
     /// @dev Tests that the ERC721 bridge finalize reverts when the remote token
@@ -366,13 +294,6 @@ contract L1ERC721Bridge_Test is Messenger_Initializer {
         );
         vm.prank(address(L1Messenger));
         vm.expectRevert("L1ERC721Bridge: Token ID is not escrowed in the L1 Bridge");
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 }

--- a/packages/contracts-bedrock/contracts/test/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L1StandardBridge.t.sol
@@ -37,7 +37,7 @@ contract L1StandardBridge_Initialize_Test is Bridge_Initializer {
     }
 }
 
-contract L1StandardBridge_Initialize_TestFail is Bridge_Initializer {}
+contract L1StandardBridge_Initialize_TestFail is Bridge_Initializer { }
 
 contract L1StandardBridge_Receive_Test is Bridge_Initializer {
     /// @dev Tests receive bridges ETH successfully.
@@ -56,25 +56,19 @@ contract L1StandardBridge_Receive_Test is Bridge_Initializer {
             abi.encodeWithSelector(
                 CrossDomainMessenger.sendMessage.selector,
                 address(L2Bridge),
-                abi.encodeWithSelector(
-                    StandardBridge.finalizeBridgeETH.selector,
-                    alice,
-                    alice,
-                    100,
-                    hex""
-                ),
+                abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 100, hex""),
                 200_000
             )
         );
 
         vm.prank(alice, alice);
-        (bool success, ) = address(L1Bridge).call{ value: 100 }(hex"");
+        (bool success,) = address(L1Bridge).call{ value: 100 }(hex"");
         assertEq(success, true);
         assertEq(address(op).balance, 100);
     }
 }
 
-contract L1StandardBridge_Receive_TestFail {}
+contract L1StandardBridge_Receive_TestFail { }
 
 contract PreBridgeETH is Bridge_Initializer {
     /// @dev Asserts the expected calls and events for bridging ETH depending
@@ -85,46 +79,24 @@ contract PreBridgeETH is Bridge_Initializer {
         uint256 version = 0; // Internal constant in the OptimismPortal: DEPOSIT_VERSION
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
 
-        bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeETH.selector,
-            alice,
-            alice,
-            500,
-            hex"dead"
-        );
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 500, hex"dead");
 
         if (isLegacy) {
             vm.expectCall(
-                address(L1Bridge),
-                500,
-                abi.encodeWithSelector(L1Bridge.depositETH.selector, 50000, hex"dead")
+                address(L1Bridge), 500, abi.encodeWithSelector(L1Bridge.depositETH.selector, 50000, hex"dead")
             );
         } else {
-            vm.expectCall(
-                address(L1Bridge),
-                500,
-                abi.encodeWithSelector(L1Bridge.bridgeETH.selector, 50000, hex"dead")
-            );
+            vm.expectCall(address(L1Bridge), 500, abi.encodeWithSelector(L1Bridge.bridgeETH.selector, 50000, hex"dead"));
         }
         vm.expectCall(
             address(L1Messenger),
             500,
-            abi.encodeWithSelector(
-                CrossDomainMessenger.sendMessage.selector,
-                address(L2Bridge),
-                message,
-                50000
-            )
+            abi.encodeWithSelector(CrossDomainMessenger.sendMessage.selector, address(L2Bridge), message, 50000)
         );
 
         bytes memory innerMessage = abi.encodeWithSelector(
-            CrossDomainMessenger.relayMessage.selector,
-            nonce,
-            address(L1Bridge),
-            address(L2Bridge),
-            500,
-            50000,
-            message
+            CrossDomainMessenger.relayMessage.selector, nonce, address(L1Bridge), address(L2Bridge), 500, 50000, message
         );
 
         uint64 baseGas = L1Messenger.baseGas(message, 50000);
@@ -132,22 +104,11 @@ contract PreBridgeETH is Bridge_Initializer {
             address(op),
             500,
             abi.encodeWithSelector(
-                OptimismPortal.depositTransaction.selector,
-                address(L2Messenger),
-                500,
-                baseGas,
-                false,
-                innerMessage
+                OptimismPortal.depositTransaction.selector, address(L2Messenger), 500, baseGas, false, innerMessage
             )
         );
 
-        bytes memory opaqueData = abi.encodePacked(
-            uint256(500),
-            uint256(500),
-            baseGas,
-            false,
-            innerMessage
-        );
+        bytes memory opaqueData = abi.encodePacked(uint256(500), uint256(500), baseGas, false, innerMessage);
 
         vm.expectEmit(true, true, true, true, address(L1Bridge));
         emit ETHDepositInitiated(alice, alice, 500, hex"dead");
@@ -218,68 +179,37 @@ contract PreBridgeETHTo is Bridge_Initializer {
 
         if (isLegacy) {
             vm.expectCall(
-                address(L1Bridge),
-                600,
-                abi.encodeWithSelector(L1Bridge.depositETHTo.selector, bob, 60000, hex"dead")
+                address(L1Bridge), 600, abi.encodeWithSelector(L1Bridge.depositETHTo.selector, bob, 60000, hex"dead")
             );
         } else {
             vm.expectCall(
-                address(L1Bridge),
-                600,
-                abi.encodeWithSelector(L1Bridge.bridgeETHTo.selector, bob, 60000, hex"dead")
+                address(L1Bridge), 600, abi.encodeWithSelector(L1Bridge.bridgeETHTo.selector, bob, 60000, hex"dead")
             );
         }
 
-        bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeETH.selector,
-            alice,
-            bob,
-            600,
-            hex"dead"
-        );
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, bob, 600, hex"dead");
 
         // the L1 bridge should call
         // L1CrossDomainMessenger.sendMessage
         vm.expectCall(
             address(L1Messenger),
-            abi.encodeWithSelector(
-                CrossDomainMessenger.sendMessage.selector,
-                address(L2Bridge),
-                message,
-                60000
-            )
+            abi.encodeWithSelector(CrossDomainMessenger.sendMessage.selector, address(L2Bridge), message, 60000)
         );
 
         bytes memory innerMessage = abi.encodeWithSelector(
-            CrossDomainMessenger.relayMessage.selector,
-            nonce,
-            address(L1Bridge),
-            address(L2Bridge),
-            600,
-            60000,
-            message
+            CrossDomainMessenger.relayMessage.selector, nonce, address(L1Bridge), address(L2Bridge), 600, 60000, message
         );
 
         uint64 baseGas = L1Messenger.baseGas(message, 60000);
         vm.expectCall(
             address(op),
             abi.encodeWithSelector(
-                OptimismPortal.depositTransaction.selector,
-                address(L2Messenger),
-                600,
-                baseGas,
-                false,
-                innerMessage
+                OptimismPortal.depositTransaction.selector, address(L2Messenger), 600, baseGas, false, innerMessage
             )
         );
 
-        bytes memory opaqueData = abi.encodePacked(
-            uint256(600),
-            uint256(600),
-            baseGas,
-            false,
-            innerMessage
-        );
+        bytes memory opaqueData = abi.encodePacked(uint256(600), uint256(600), baseGas, false, innerMessage);
 
         vm.expectEmit(true, true, true, true, address(L1Bridge));
         emit ETHDepositInitiated(alice, bob, 600, hex"dead");
@@ -330,7 +260,7 @@ contract L1StandardBridge_BridgeETHTo_Test is PreBridgeETHTo {
     }
 }
 
-contract L1StandardBridge_DepositETHTo_TestFail is Bridge_Initializer {}
+contract L1StandardBridge_DepositETHTo_TestFail is Bridge_Initializer { }
 
 contract L1StandardBridge_DepositERC20_Test is Bridge_Initializer {
     using stdStorage for StdStorage;
@@ -358,61 +288,32 @@ contract L1StandardBridge_DepositERC20_Test is Bridge_Initializer {
 
         // The L1Bridge should transfer alice's tokens to itself
         vm.expectCall(
-            address(L1Token),
-            abi.encodeWithSelector(ERC20.transferFrom.selector, alice, address(L1Bridge), 100)
+            address(L1Token), abi.encodeWithSelector(ERC20.transferFrom.selector, alice, address(L1Bridge), 100)
         );
 
         bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeERC20.selector,
-            address(L2Token),
-            address(L1Token),
-            alice,
-            alice,
-            100,
-            hex""
+            StandardBridge.finalizeBridgeERC20.selector, address(L2Token), address(L1Token), alice, alice, 100, hex""
         );
 
         // the L1 bridge should call L1CrossDomainMessenger.sendMessage
         vm.expectCall(
             address(L1Messenger),
-            abi.encodeWithSelector(
-                CrossDomainMessenger.sendMessage.selector,
-                address(L2Bridge),
-                message,
-                10000
-            )
+            abi.encodeWithSelector(CrossDomainMessenger.sendMessage.selector, address(L2Bridge), message, 10000)
         );
 
         bytes memory innerMessage = abi.encodeWithSelector(
-            CrossDomainMessenger.relayMessage.selector,
-            nonce,
-            address(L1Bridge),
-            address(L2Bridge),
-            0,
-            10000,
-            message
+            CrossDomainMessenger.relayMessage.selector, nonce, address(L1Bridge), address(L2Bridge), 0, 10000, message
         );
 
         uint64 baseGas = L1Messenger.baseGas(message, 10000);
         vm.expectCall(
             address(op),
             abi.encodeWithSelector(
-                OptimismPortal.depositTransaction.selector,
-                address(L2Messenger),
-                0,
-                baseGas,
-                false,
-                innerMessage
+                OptimismPortal.depositTransaction.selector, address(L2Messenger), 0, baseGas, false, innerMessage
             )
         );
 
-        bytes memory opaqueData = abi.encodePacked(
-            uint256(0),
-            uint256(0),
-            baseGas,
-            false,
-            innerMessage
-        );
+        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
 
         // Should emit both the bedrock and legacy events
         vm.expectEmit(true, true, true, true, address(L1Bridge));
@@ -465,33 +366,15 @@ contract L1StandardBridge_DepositERC20To_Test is Bridge_Initializer {
         address l1MessengerAliased = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
 
         bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeERC20.selector,
-            address(L2Token),
-            address(L1Token),
-            alice,
-            bob,
-            1000,
-            hex""
+            StandardBridge.finalizeBridgeERC20.selector, address(L2Token), address(L1Token), alice, bob, 1000, hex""
         );
 
         bytes memory innerMessage = abi.encodeWithSelector(
-            CrossDomainMessenger.relayMessage.selector,
-            nonce,
-            address(L1Bridge),
-            address(L2Bridge),
-            0,
-            10000,
-            message
+            CrossDomainMessenger.relayMessage.selector, nonce, address(L1Bridge), address(L2Bridge), 0, 10000, message
         );
 
         uint64 baseGas = L1Messenger.baseGas(message, 10000);
-        bytes memory opaqueData = abi.encodePacked(
-            uint256(0),
-            uint256(0),
-            baseGas,
-            false,
-            innerMessage
-        );
+        bytes memory opaqueData = abi.encodePacked(uint256(0), uint256(0), baseGas, false, innerMessage);
 
         deal(address(L1Token), alice, 100000, true);
 
@@ -520,28 +403,17 @@ contract L1StandardBridge_DepositERC20To_Test is Bridge_Initializer {
         // the L1 bridge should call L1CrossDomainMessenger.sendMessage
         vm.expectCall(
             address(L1Messenger),
-            abi.encodeWithSelector(
-                CrossDomainMessenger.sendMessage.selector,
-                address(L2Bridge),
-                message,
-                10000
-            )
+            abi.encodeWithSelector(CrossDomainMessenger.sendMessage.selector, address(L2Bridge), message, 10000)
         );
         // The L1 XDM should call OptimismPortal.depositTransaction
         vm.expectCall(
             address(op),
             abi.encodeWithSelector(
-                OptimismPortal.depositTransaction.selector,
-                address(L2Messenger),
-                0,
-                baseGas,
-                false,
-                innerMessage
+                OptimismPortal.depositTransaction.selector, address(L2Messenger), 0, baseGas, false, innerMessage
             )
         );
         vm.expectCall(
-            address(L1Token),
-            abi.encodeWithSelector(ERC20.transferFrom.selector, alice, address(L1Bridge), 1000)
+            address(L1Token), abi.encodeWithSelector(ERC20.transferFrom.selector, alice, address(L1Bridge), 1000)
         );
 
         vm.prank(alice);
@@ -583,7 +455,7 @@ contract L1StandardBridge_FinalizeETHWithdrawal_Test is Bridge_Initializer {
     }
 }
 
-contract L1StandardBridge_FinalizeETHWithdrawal_TestFail is Bridge_Initializer {}
+contract L1StandardBridge_FinalizeETHWithdrawal_TestFail is Bridge_Initializer { }
 
 contract L1StandardBridge_FinalizeERC20Withdrawal_Test is Bridge_Initializer {
     using stdStorage for StdStorage;
@@ -595,12 +467,8 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is Bridge_Initializer {
     function test_finalizeERC20Withdrawal_succeeds() external {
         deal(address(L1Token), address(L1Bridge), 100, true);
 
-        uint256 slot = stdstore
-            .target(address(L1Bridge))
-            .sig("deposits(address,address)")
-            .with_key(address(L1Token))
-            .with_key(address(L2Token))
-            .find();
+        uint256 slot = stdstore.target(address(L1Bridge)).sig("deposits(address,address)").with_key(address(L1Token))
+            .with_key(address(L2Token)).find();
 
         // Give the L1 bridge some ERC20 tokens
         vm.store(address(L1Bridge), bytes32(slot), bytes32(uint256(100)));
@@ -612,10 +480,7 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is Bridge_Initializer {
         vm.expectEmit(true, true, true, true, address(L1Bridge));
         emit ERC20BridgeFinalized(address(L1Token), address(L2Token), alice, alice, 100, hex"");
 
-        vm.expectCall(
-            address(L1Token),
-            abi.encodeWithSelector(ERC20.transfer.selector, alice, 100)
-        );
+        vm.expectCall(address(L1Token), abi.encodeWithSelector(ERC20.transfer.selector, alice, 100));
 
         vm.mockCall(
             address(L1Bridge.messenger()),
@@ -623,14 +488,7 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_Test is Bridge_Initializer {
             abi.encode(address(L1Bridge.OTHER_BRIDGE()))
         );
         vm.prank(address(L1Bridge.messenger()));
-        L1Bridge.finalizeERC20Withdrawal(
-            address(L1Token),
-            address(L2Token),
-            alice,
-            alice,
-            100,
-            hex""
-        );
+        L1Bridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
 
         assertEq(L1Token.balanceOf(address(L1Bridge)), 0);
         assertEq(L1Token.balanceOf(address(alice)), 100);
@@ -647,14 +505,7 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_TestFail is Bridge_Initializer
         );
         vm.prank(address(28));
         vm.expectRevert("StandardBridge: function can only be called from the other bridge");
-        L1Bridge.finalizeERC20Withdrawal(
-            address(L1Token),
-            address(L2Token),
-            alice,
-            alice,
-            100,
-            hex""
-        );
+        L1Bridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
     }
 
     /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
@@ -666,14 +517,7 @@ contract L1StandardBridge_FinalizeERC20Withdrawal_TestFail is Bridge_Initializer
         );
         vm.prank(address(L1Bridge.messenger()));
         vm.expectRevert("StandardBridge: function can only be called from the other bridge");
-        L1Bridge.finalizeERC20Withdrawal(
-            address(L1Token),
-            address(L2Token),
-            alice,
-            alice,
-            100,
-            hex""
-        );
+        L1Bridge.finalizeERC20Withdrawal(address(L1Token), address(L2Token), alice, alice, 100, hex"");
     }
 }
 

--- a/packages/contracts-bedrock/contracts/test/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2CrossDomainMessenger.t.sol
@@ -29,14 +29,8 @@ contract L2CrossDomainMessenger_Test is Messenger_Initializer {
 
     /// @dev Tests that `sendMessage` executes successfully.
     function test_sendMessage_succeeds() external {
-        bytes memory xDomainCallData = Encoding.encodeCrossDomainMessage(
-            L2Messenger.messageNonce(),
-            alice,
-            recipient,
-            0,
-            100,
-            hex"ff"
-        );
+        bytes memory xDomainCallData =
+            Encoding.encodeCrossDomainMessage(L2Messenger.messageNonce(), alice, recipient, 0, 100, hex"ff");
         vm.expectCall(
             address(messagePasser),
             abi.encodeWithSelector(
@@ -95,9 +89,7 @@ contract L2CrossDomainMessenger_Test is Messenger_Initializer {
         address caller = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
 
         // Expect a revert.
-        vm.expectRevert(
-            "CrossDomainMessenger: only version 0 or 1 messages are supported at this time"
-        );
+        vm.expectRevert("CrossDomainMessenger: only version 0 or 1 messages are supported at this time");
 
         // Try to relay a v2 message.
         vm.prank(caller);
@@ -123,14 +115,8 @@ contract L2CrossDomainMessenger_Test is Messenger_Initializer {
 
         vm.expectEmit(true, true, true, true);
 
-        bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce(0, 1),
-            sender,
-            target,
-            0,
-            0,
-            hex"1111"
-        );
+        bytes32 hash =
+            Hashing.hashCrossDomainMessage(Encoding.encodeVersionedNonce(0, 1), sender, target, 0, 0, hex"1111");
 
         emit RelayedMessage(hash);
 
@@ -159,14 +145,7 @@ contract L2CrossDomainMessenger_Test is Messenger_Initializer {
 
         vm.prank(caller);
         vm.expectRevert("CrossDomainMessenger: message cannot be replayed");
-        L1Messenger.relayMessage(
-            Encoding.encodeVersionedNonce(0, 1),
-            sender,
-            target,
-            0,
-            0,
-            message
-        );
+        L1Messenger.relayMessage(Encoding.encodeVersionedNonce(0, 1), sender, target, 0, 0, message);
     }
 
     /// @dev Tests that `relayMessage` correctly resets the `xDomainMessageSender`
@@ -177,14 +156,7 @@ contract L2CrossDomainMessenger_Test is Messenger_Initializer {
 
         address caller = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
         vm.prank(caller);
-        L2Messenger.relayMessage(
-            Encoding.encodeVersionedNonce(0, 1),
-            address(0),
-            address(0),
-            0,
-            0,
-            hex""
-        );
+        L2Messenger.relayMessage(Encoding.encodeVersionedNonce(0, 1), address(0), address(0), 0, 0, hex"");
 
         vm.expectRevert("CrossDomainMessenger: xDomainMessageSender is not set");
         L2Messenger.xDomainMessageSender();
@@ -199,14 +171,8 @@ contract L2CrossDomainMessenger_Test is Messenger_Initializer {
         address caller = AddressAliasHelper.applyL1ToL2Alias(address(L1Messenger));
         uint256 value = 100;
 
-        bytes32 hash = Hashing.hashCrossDomainMessage(
-            Encoding.encodeVersionedNonce(0, 1),
-            sender,
-            target,
-            value,
-            0,
-            hex"1111"
-        );
+        bytes32 hash =
+            Hashing.hashCrossDomainMessage(Encoding.encodeVersionedNonce(0, 1), sender, target, value, 0, hex"1111");
 
         vm.etch(target, address(new Reverter()).code);
         vm.deal(address(caller), value);

--- a/packages/contracts-bedrock/contracts/test/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2ERC721Bridge.t.sol
@@ -13,7 +13,7 @@ import { OptimismMintableERC721 } from "../universal/OptimismMintableERC721.sol"
 import { L2ERC721Bridge } from "../L2/L2ERC721Bridge.sol";
 
 contract TestERC721 is ERC721 {
-    constructor() ERC721("Test", "TST") {}
+    constructor() ERC721("Test", "TST") { }
 
     function mint(address to, uint256 tokenId) public {
         _mint(to, tokenId);
@@ -23,7 +23,7 @@ contract TestERC721 is ERC721 {
 contract TestMintableERC721 is OptimismMintableERC721 {
     constructor(address _bridge, address _remoteToken)
         OptimismMintableERC721(_bridge, 1, _remoteToken, "Test", "TST")
-    {}
+    { }
 
     function mint(address to, uint256 tokenId) public {
         _mint(to, tokenId);
@@ -95,15 +95,8 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
                     address(otherBridge),
                     abi.encodeCall(
                         L2ERC721Bridge.finalizeBridgeERC721,
-                        (
-                            address(remoteToken),
-                            address(localToken),
-                            alice,
-                            alice,
-                            tokenId,
-                            hex"5678"
-                        )
-                    ),
+                        (address(remoteToken), address(localToken), alice, alice, tokenId, hex"5678")
+                        ),
                     1234
                 )
             )
@@ -111,14 +104,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
 
         // Expect an event to be emitted.
         vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
         // Bridge the token.
         vm.prank(alice);
@@ -187,7 +173,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
                     abi.encodeCall(
                         L1ERC721Bridge.finalizeBridgeERC721,
                         (address(remoteToken), address(localToken), alice, bob, tokenId, hex"5678")
-                    ),
+                        ),
                     1234
                 )
             )
@@ -195,25 +181,11 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
 
         // Expect an event to be emitted.
         vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeInitiated(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            bob,
-            tokenId,
-            hex"5678"
-        );
+        emit ERC721BridgeInitiated(address(localToken), address(remoteToken), alice, bob, tokenId, hex"5678");
 
         // Bridge the token.
         vm.prank(alice);
-        bridge.bridgeERC721To(
-            address(localToken),
-            address(remoteToken),
-            bob,
-            tokenId,
-            1234,
-            hex"5678"
-        );
+        bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
 
         // Token is burned.
         vm.expectRevert("ERC721: invalid token ID");
@@ -247,14 +219,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         // Bridge the token.
         vm.prank(bob);
         vm.expectRevert("L2ERC721Bridge: Withdrawal is not being initiated by NFT owner");
-        bridge.bridgeERC721To(
-            address(localToken),
-            address(remoteToken),
-            bob,
-            tokenId,
-            1234,
-            hex"5678"
-        );
+        bridge.bridgeERC721To(address(localToken), address(remoteToken), bob, tokenId, 1234, hex"5678");
 
         // Token is not locked in the bridge.
         assertEq(localToken.ownerOf(tokenId), alice);
@@ -268,14 +233,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
 
         // Expect an event to be emitted.
         vm.expectEmit(true, true, true, true);
-        emit ERC721BridgeFinalized(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        emit ERC721BridgeFinalized(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
         // Finalize a withdrawal.
         vm.mockCall(
@@ -284,14 +242,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
             abi.encode(otherBridge)
         );
         vm.prank(address(L2Messenger));
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
 
         // Token is not locked in the bridge.
         assertEq(localToken.ownerOf(tokenId), alice);
@@ -317,12 +268,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         vm.prank(address(L2Messenger));
         vm.expectRevert("L2ERC721Bridge: local token interface is not compliant");
         bridge.finalizeBridgeERC721(
-            address(address(nonCompliantToken)),
-            address(address(0x01)),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
+            address(address(nonCompliantToken)), address(address(0x01)), alice, alice, tokenId, hex"5678"
         );
     }
 
@@ -331,34 +277,18 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         // Finalize a withdrawal.
         vm.prank(alice);
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
     /// @dev Tests that `finalizeBridgeERC721` reverts when not called by the remote bridge.
     function test_finalizeBridgeERC721_notFromRemoteMessenger_reverts() external {
         // Finalize a withdrawal.
         vm.mockCall(
-            address(L2Messenger),
-            abi.encodeWithSelector(L2Messenger.xDomainMessageSender.selector),
-            abi.encode(alice)
+            address(L2Messenger), abi.encodeWithSelector(L2Messenger.xDomainMessageSender.selector), abi.encode(alice)
         );
         vm.prank(address(L2Messenger));
         vm.expectRevert("ERC721Bridge: function can only be called from the other bridge");
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
     /// @dev Tests that `finalizeBridgeERC721` reverts when the local token is the
@@ -372,14 +302,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         );
         vm.prank(address(L2Messenger));
         vm.expectRevert("L2ERC721Bridge: local token cannot be self");
-        bridge.finalizeBridgeERC721(
-            address(bridge),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(bridge), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 
     /// @dev Tests that `finalizeBridgeERC721` reverts when already finalized.
@@ -392,14 +315,7 @@ contract L2ERC721Bridge_Test is Messenger_Initializer {
         );
         vm.prank(address(L2Messenger));
         vm.expectRevert("ERC721: token already minted");
-        bridge.finalizeBridgeERC721(
-            address(localToken),
-            address(remoteToken),
-            alice,
-            alice,
-            tokenId,
-            hex"5678"
-        );
+        bridge.finalizeBridgeERC721(address(localToken), address(remoteToken), alice, alice, tokenId, hex"5678");
     }
 }
 

--- a/packages/contracts-bedrock/contracts/test/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2OutputOracle.t.sol
@@ -193,16 +193,10 @@ contract L2OutputOracle_getter_Test is L2OutputOracle_Initializer {
         assertEq(oracle.computeL2Timestamp(startingBlockNumber), startingTimestamp);
 
         // check timestamp for the first block after the starting block
-        assertEq(
-            oracle.computeL2Timestamp(startingBlockNumber + 1),
-            startingTimestamp + l2BlockTime
-        );
+        assertEq(oracle.computeL2Timestamp(startingBlockNumber + 1), startingTimestamp + l2BlockTime);
 
         // check timestamp for some other block number
-        assertEq(
-            oracle.computeL2Timestamp(startingBlockNumber + 96024),
-            startingTimestamp + l2BlockTime * 96024
-        );
+        assertEq(oracle.computeL2Timestamp(startingBlockNumber + 96024), startingTimestamp + l2BlockTime * 96024);
     }
 }
 
@@ -274,15 +268,8 @@ contract L2OutputOracle_proposeL2Output_Test is L2OutputOracle_Initializer {
         uint256 nextBlockNumber = oracle.nextBlockNumber();
         warpToProposeTime(nextBlockNumber);
         vm.prank(proposer);
-        vm.expectRevert(
-            "L2OutputOracle: block hash does not match the hash at the expected height"
-        );
-        oracle.proposeL2Output(
-            nonZeroHash,
-            nextBlockNumber,
-            bytes32(uint256(0x01)),
-            block.number - 1
-        );
+        vm.expectRevert("L2OutputOracle: block hash does not match the hash at the expected height");
+        oracle.proposeL2Output(nonZeroHash, nextBlockNumber, bytes32(uint256(0x01)), block.number - 1);
     }
 
     /// @dev Tests that `proposeL2Output` reverts when given a block number
@@ -300,9 +287,7 @@ contract L2OutputOracle_proposeL2Output_Test is L2OutputOracle_Initializer {
         vm.prank(proposer);
 
         // This will fail when foundry no longer returns zerod block hashes
-        vm.expectRevert(
-            "L2OutputOracle: block hash does not match the hash at the expected height"
-        );
+        vm.expectRevert("L2OutputOracle: block hash does not match the hash at the expected height");
         oracle.proposeL2Output(nonZeroHash, nextBlockNumber, l1BlockHash, l1BlockNumber - 1);
     }
 }
@@ -452,10 +437,7 @@ contract L2OutputOracleUpgradeable_Test is L2OutputOracle_Initializer {
 
         NextImpl nextImpl = new NextImpl();
         vm.startPrank(multisig);
-        proxy.upgradeToAndCall(
-            address(nextImpl),
-            abi.encodeWithSelector(NextImpl.initialize.selector)
-        );
+        proxy.upgradeToAndCall(address(nextImpl), abi.encodeWithSelector(NextImpl.initialize.selector));
         assertEq(proxy.implementation(), address(nextImpl));
 
         // Verify that the NextImpl contract initialized its values according as expected

--- a/packages/contracts-bedrock/contracts/test/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2StandardBridge.t.sol
@@ -33,13 +33,8 @@ contract L2StandardBridge_Test is Bridge_Initializer {
         assertEq(address(messagePasser).balance, 0);
         uint256 nonce = L2Messenger.messageNonce();
 
-        bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeETH.selector,
-            alice,
-            alice,
-            100,
-            hex""
-        );
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 100, hex"");
         uint64 baseGas = L2Messenger.baseGas(message, 200_000);
         bytes memory withdrawalData = abi.encodeWithSelector(
             CrossDomainMessenger.relayMessage.selector,
@@ -70,13 +65,7 @@ contract L2StandardBridge_Test is Bridge_Initializer {
         // L2ToL1MessagePasser will emit a MessagePassed event
         vm.expectEmit(true, true, true, true, address(messagePasser));
         emit MessagePassed(
-            nonce,
-            address(L2Messenger),
-            address(L1Messenger),
-            100,
-            baseGas,
-            withdrawalData,
-            withdrawalHash
+            nonce, address(L2Messenger), address(L1Messenger), 100, baseGas, withdrawalData, withdrawalHash
         );
 
         // SentMessage event emitted by the CrossDomainMessenger
@@ -100,15 +89,12 @@ contract L2StandardBridge_Test is Bridge_Initializer {
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
             abi.encodeWithSelector(
-                L2ToL1MessagePasser.initiateWithdrawal.selector,
-                address(L1Messenger),
-                baseGas,
-                withdrawalData
+                L2ToL1MessagePasser.initiateWithdrawal.selector, address(L1Messenger), baseGas, withdrawalData
             )
         );
 
         vm.prank(alice, alice);
-        (bool success, ) = address(L2Bridge).call{ value: 100 }(hex"");
+        (bool success,) = address(L2Bridge).call{ value: 100 }(hex"");
         assertEq(success, true);
         assertEq(address(messagePasser).balance, 100);
     }
@@ -161,23 +147,11 @@ contract PreBridgeERC20 is Bridge_Initializer {
         assertEq(ERC20(_l2Token).balanceOf(alice), 100);
         uint256 nonce = L2Messenger.messageNonce();
         bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeERC20.selector,
-            address(L1Token),
-            _l2Token,
-            alice,
-            alice,
-            100,
-            hex""
+            StandardBridge.finalizeBridgeERC20.selector, address(L1Token), _l2Token, alice, alice, 100, hex""
         );
         uint64 baseGas = L2Messenger.baseGas(message, 1000);
         bytes memory withdrawalData = abi.encodeWithSelector(
-            CrossDomainMessenger.relayMessage.selector,
-            nonce,
-            address(L2Bridge),
-            address(L1Bridge),
-            0,
-            1000,
-            message
+            CrossDomainMessenger.relayMessage.selector, nonce, address(L2Bridge), address(L1Bridge), 0, 1000, message
         );
         bytes32 withdrawalHash = Hashing.hashWithdrawal(
             Types.WithdrawalTransaction({
@@ -192,48 +166,29 @@ contract PreBridgeERC20 is Bridge_Initializer {
 
         if (_isLegacy) {
             vm.expectCall(
-                address(L2Bridge),
-                abi.encodeWithSelector(L2Bridge.withdraw.selector, _l2Token, 100, 1000, hex"")
+                address(L2Bridge), abi.encodeWithSelector(L2Bridge.withdraw.selector, _l2Token, 100, 1000, hex"")
             );
         } else {
             vm.expectCall(
                 address(L2Bridge),
-                abi.encodeWithSelector(
-                    L2Bridge.bridgeERC20.selector,
-                    _l2Token,
-                    address(L1Token),
-                    100,
-                    1000,
-                    hex""
-                )
+                abi.encodeWithSelector(L2Bridge.bridgeERC20.selector, _l2Token, address(L1Token), 100, 1000, hex"")
             );
         }
 
         vm.expectCall(
             address(L2Messenger),
-            abi.encodeWithSelector(
-                CrossDomainMessenger.sendMessage.selector,
-                address(L1Bridge),
-                message,
-                1000
-            )
+            abi.encodeWithSelector(CrossDomainMessenger.sendMessage.selector, address(L1Bridge), message, 1000)
         );
 
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
             abi.encodeWithSelector(
-                L2ToL1MessagePasser.initiateWithdrawal.selector,
-                address(L1Messenger),
-                baseGas,
-                withdrawalData
+                L2ToL1MessagePasser.initiateWithdrawal.selector, address(L1Messenger), baseGas, withdrawalData
             )
         );
 
         // The L2Bridge should burn the tokens
-        vm.expectCall(
-            _l2Token,
-            abi.encodeWithSelector(OptimismMintableERC20.burn.selector, alice, 100)
-        );
+        vm.expectCall(_l2Token, abi.encodeWithSelector(OptimismMintableERC20.burn.selector, alice, 100));
 
         vm.expectEmit(true, true, true, true);
         emit WithdrawalInitiated(address(L1Token), _l2Token, alice, alice, 100, hex"");
@@ -243,13 +198,7 @@ contract PreBridgeERC20 is Bridge_Initializer {
 
         vm.expectEmit(true, true, true, true);
         emit MessagePassed(
-            nonce,
-            address(L2Messenger),
-            address(L1Messenger),
-            0,
-            baseGas,
-            withdrawalData,
-            withdrawalHash
+            nonce, address(L2Messenger), address(L1Messenger), 0, baseGas, withdrawalData, withdrawalHash
         );
 
         // SentMessage event emitted by the CrossDomainMessenger
@@ -318,23 +267,11 @@ contract PreBridgeERC20To is Bridge_Initializer {
         assertEq(ERC20(L2Token).balanceOf(alice), 100);
         uint256 nonce = L2Messenger.messageNonce();
         bytes memory message = abi.encodeWithSelector(
-            StandardBridge.finalizeBridgeERC20.selector,
-            address(L1Token),
-            _l2Token,
-            alice,
-            bob,
-            100,
-            hex""
+            StandardBridge.finalizeBridgeERC20.selector, address(L1Token), _l2Token, alice, bob, 100, hex""
         );
         uint64 baseGas = L2Messenger.baseGas(message, 1000);
         bytes memory withdrawalData = abi.encodeWithSelector(
-            CrossDomainMessenger.relayMessage.selector,
-            nonce,
-            address(L2Bridge),
-            address(L1Bridge),
-            0,
-            1000,
-            message
+            CrossDomainMessenger.relayMessage.selector, nonce, address(L2Bridge), address(L1Bridge), 0, 1000, message
         );
         bytes32 withdrawalHash = Hashing.hashWithdrawal(
             Types.WithdrawalTransaction({
@@ -355,13 +292,7 @@ contract PreBridgeERC20To is Bridge_Initializer {
 
         vm.expectEmit(true, true, true, true, address(messagePasser));
         emit MessagePassed(
-            nonce,
-            address(L2Messenger),
-            address(L1Messenger),
-            0,
-            baseGas,
-            withdrawalData,
-            withdrawalHash
+            nonce, address(L2Messenger), address(L1Messenger), 0, baseGas, withdrawalData, withdrawalHash
         );
 
         // SentMessage event emitted by the CrossDomainMessenger
@@ -374,56 +305,31 @@ contract PreBridgeERC20To is Bridge_Initializer {
 
         if (_isLegacy) {
             vm.expectCall(
-                address(L2Bridge),
-                abi.encodeWithSelector(
-                    L2Bridge.withdrawTo.selector,
-                    _l2Token,
-                    bob,
-                    100,
-                    1000,
-                    hex""
-                )
+                address(L2Bridge), abi.encodeWithSelector(L2Bridge.withdrawTo.selector, _l2Token, bob, 100, 1000, hex"")
             );
         } else {
             vm.expectCall(
                 address(L2Bridge),
                 abi.encodeWithSelector(
-                    L2Bridge.bridgeERC20To.selector,
-                    _l2Token,
-                    address(L1Token),
-                    bob,
-                    100,
-                    1000,
-                    hex""
+                    L2Bridge.bridgeERC20To.selector, _l2Token, address(L1Token), bob, 100, 1000, hex""
                 )
             );
         }
 
         vm.expectCall(
             address(L2Messenger),
-            abi.encodeWithSelector(
-                CrossDomainMessenger.sendMessage.selector,
-                address(L1Bridge),
-                message,
-                1000
-            )
+            abi.encodeWithSelector(CrossDomainMessenger.sendMessage.selector, address(L1Bridge), message, 1000)
         );
 
         vm.expectCall(
             Predeploys.L2_TO_L1_MESSAGE_PASSER,
             abi.encodeWithSelector(
-                L2ToL1MessagePasser.initiateWithdrawal.selector,
-                address(L1Messenger),
-                baseGas,
-                withdrawalData
+                L2ToL1MessagePasser.initiateWithdrawal.selector, address(L1Messenger), baseGas, withdrawalData
             )
         );
 
         // The L2Bridge should burn the tokens
-        vm.expectCall(
-            address(L2Token),
-            abi.encodeWithSelector(OptimismMintableERC20.burn.selector, alice, 100)
-        );
+        vm.expectCall(address(L2Token), abi.encodeWithSelector(OptimismMintableERC20.burn.selector, alice, 100));
 
         vm.prank(alice, alice);
     }
@@ -460,10 +366,7 @@ contract L2StandardBridge_Bridge_Test is Bridge_Initializer {
             abi.encode(address(L2Bridge.OTHER_BRIDGE()))
         );
 
-        vm.expectCall(
-            address(L2Token),
-            abi.encodeWithSelector(OptimismMintableERC20.mint.selector, alice, 100)
-        );
+        vm.expectCall(address(L2Token), abi.encodeWithSelector(OptimismMintableERC20.mint.selector, alice, 100));
 
         // Should emit both the bedrock and legacy events
         vm.expectEmit(true, true, true, true, address(L2Bridge));

--- a/packages/contracts-bedrock/contracts/test/L2ToL1MessagePasser.t.sol
+++ b/packages/contracts-bedrock/contracts/test/L2ToL1MessagePasser.t.sol
@@ -72,28 +72,13 @@ contract L2ToL1MessagePasserTest is CommonTest {
     ///      log when called by a contract.
     function test_initiateWithdrawal_fromContract_succeeds() external {
         bytes32 withdrawalHash = Hashing.hashWithdrawal(
-            Types.WithdrawalTransaction(
-                messagePasser.messageNonce(),
-                address(this),
-                address(4),
-                100,
-                64000,
-                hex""
-            )
+            Types.WithdrawalTransaction(messagePasser.messageNonce(), address(this), address(4), 100, 64000, hex"")
         );
 
         vm.expectEmit(true, true, true, true);
-        emit MessagePassed(
-            messagePasser.messageNonce(),
-            address(this),
-            address(4),
-            100,
-            64000,
-            hex"",
-            withdrawalHash
-        );
+        emit MessagePassed(messagePasser.messageNonce(), address(this), address(4), 100, 64000, hex"", withdrawalHash);
 
-        vm.deal(address(this), 2**64);
+        vm.deal(address(this), 2 ** 64);
         messagePasser.initiateWithdrawal{ value: 100 }(address(4), 64000, hex"");
     }
 
@@ -108,10 +93,9 @@ contract L2ToL1MessagePasserTest is CommonTest {
 
         // EOA emulation
         vm.prank(alice, alice);
-        vm.deal(alice, 2**64);
-        bytes32 withdrawalHash = Hashing.hashWithdrawal(
-            Types.WithdrawalTransaction(nonce, alice, target, value, gasLimit, data)
-        );
+        vm.deal(alice, 2 ** 64);
+        bytes32 withdrawalHash =
+            Hashing.hashWithdrawal(Types.WithdrawalTransaction(nonce, alice, target, value, gasLimit, data));
 
         vm.expectEmit(true, true, true, true);
         emit MessagePassed(nonce, alice, target, value, gasLimit, data, withdrawalHash);
@@ -126,11 +110,7 @@ contract L2ToL1MessagePasserTest is CommonTest {
 
     /// @dev Tests that `burn` succeeds and destroys the ETH held in the contract.
     function test_burn_succeeds() external {
-        messagePasser.initiateWithdrawal{ value: NON_ZERO_VALUE }(
-            NON_ZERO_ADDRESS,
-            NON_ZERO_GASLIMIT,
-            NON_ZERO_DATA
-        );
+        messagePasser.initiateWithdrawal{ value: NON_ZERO_VALUE }(NON_ZERO_ADDRESS, NON_ZERO_GASLIMIT, NON_ZERO_DATA);
 
         assertEq(address(messagePasser).balance, NON_ZERO_VALUE);
         vm.expectEmit(true, false, false, false);

--- a/packages/contracts-bedrock/contracts/test/LibPosition.t.sol
+++ b/packages/contracts-bedrock/contracts/test/LibPosition.t.sol
@@ -15,7 +15,7 @@ contract LibPosition_Test is Test {
     function boundIndexAtDepth(uint8 _depth, uint64 _indexAtDepth) internal view returns (uint64) {
         // Index at depth bound: [0, 2 ** _depth-1]
         if (_depth > 0) {
-            return uint64(bound(_indexAtDepth, 0, 2**(_depth - 1)));
+            return uint64(bound(_indexAtDepth, 0, 2 ** (_depth - 1)));
         } else {
             return 0;
         }
@@ -29,7 +29,8 @@ contract LibPosition_Test is Test {
         assertEq(position.depth(), _depth);
     }
 
-    /// @notice Tests that the `indexAtDepth` function correctly shifts out the `indexAtDepth` from a packed `Position` type.
+    /// @notice Tests that the `indexAtDepth` function correctly shifts out the `indexAtDepth` from a packed `Position`
+    /// type.
     function testFuzz_indexAtDepth_correctness_succeeds(uint8 _depth, uint64 _indexAtDepth) public {
         _depth = uint8(bound(_depth, 0, MAX_DEPTH));
         _indexAtDepth = boundIndexAtDepth(_depth, _indexAtDepth);
@@ -76,11 +77,7 @@ contract LibPosition_Test is Test {
 
     /// @notice Tests that the `rightIndex` function correctly computes the deepest, right most index relative
     ///         to a given position.
-    function testFuzz_rightIndex_correctness_succeeds(
-        uint64 _maxDepth,
-        uint8 _depth,
-        uint64 _indexAtDepth
-    ) public {
+    function testFuzz_rightIndex_correctness_succeeds(uint64 _maxDepth, uint8 _depth, uint64 _indexAtDepth) public {
         // Max depth bound: [1, 63]
         // The max game depth MUST be at least 1.
         _maxDepth = uint8(bound(_maxDepth, 1, MAX_DEPTH));

--- a/packages/contracts-bedrock/contracts/test/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/contracts/test/MerkleTrie.t.sol
@@ -10,12 +10,9 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"6b6579326262";
         bytes memory val = hex"6176616c32";
         bytes[] memory proof = new bytes[](3);
-        proof[
-            0
-        ] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
-        proof[
-            1
-        ] = hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
+        proof[0] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
+        proof[1] =
+            hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
         proof[2] = hex"ca83206262856176616c32";
 
         assertEq(val, MerkleTrie.get(key, proof, root));
@@ -24,18 +21,12 @@ contract MerkleTrie_get_Test is CommonTest {
     function test_get_validProof2_succeeds() external {
         bytes32 root = 0xd582f99275e227a1cf4284899e5ff06ee56da8859be71b553397c69151bc942f;
         bytes memory key = hex"6b6579316161";
-        bytes
-            memory val = hex"303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
+        bytes memory val = hex"303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
         bytes[] memory proof = new bytes[](3);
-        proof[
-            0
-        ] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
-        proof[
-            1
-        ] = hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
-        proof[
-            2
-        ] = hex"ef83206161aa303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
+        proof[0] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
+        proof[1] =
+            hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
+        proof[2] = hex"ef83206161aa303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
 
         assertEq(val, MerkleTrie.get(key, proof, root));
     }
@@ -43,12 +34,10 @@ contract MerkleTrie_get_Test is CommonTest {
     function test_get_validProof3_succeeds() external {
         bytes32 root = 0xf838216fa749aefa91e0b672a9c06d3e6e983f913d7107b5dab4af60b5f5abed;
         bytes memory key = hex"6b6579316161";
-        bytes
-            memory val = hex"303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
+        bytes memory val = hex"303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
         bytes[] memory proof = new bytes[](1);
-        proof[
-            0
-        ] = hex"f387206b6579316161aa303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
+        proof[0] =
+            hex"f387206b6579316161aa303132333435363738393031323334353637383930313233343536373839303132333435363738397878";
 
         assertEq(val, MerkleTrie.get(key, proof, root));
     }
@@ -66,18 +55,14 @@ contract MerkleTrie_get_Test is CommonTest {
     function test_get_validProof5_succeeds() external {
         bytes32 root = 0xcb65032e2f76c48b82b5c24b3db8f670ce73982869d38cd39a624f23d62a9e89;
         bytes memory key = hex"6b657931";
-        bytes
-            memory val = hex"30313233343536373839303132333435363738393031323334353637383930313233343536373839566572795f4c6f6e67";
+        bytes memory val =
+            hex"30313233343536373839303132333435363738393031323334353637383930313233343536373839566572795f4c6f6e67";
         bytes[] memory proof = new bytes[](3);
-        proof[
-            0
-        ] = hex"e68416b65793a0f3f387240403976788281c0a6ee5b3fc08360d276039d635bb824ea7e6fed779";
-        proof[
-            1
-        ] = hex"f87180a034d14ccc7685aa2beb64f78b11ee2a335eae82047ef97c79b7dda7f0732b9f4ca05fb052b64e23d177131d9f32e9c5b942209eb7229e9a07c99a5d93245f53af18a09a137197a43a880648d5887cce656a5e6bbbe5e44ecb4f264395ccaddbe1acca80808080808080808080808080";
-        proof[
-            2
-        ] = hex"f862808080808080a057895fdbd71e2c67c2f9274a56811ff5cf458720a7fa713a135e3890f8cafcf8808080808080808080b130313233343536373839303132333435363738393031323334353637383930313233343536373839566572795f4c6f6e67";
+        proof[0] = hex"e68416b65793a0f3f387240403976788281c0a6ee5b3fc08360d276039d635bb824ea7e6fed779";
+        proof[1] =
+            hex"f87180a034d14ccc7685aa2beb64f78b11ee2a335eae82047ef97c79b7dda7f0732b9f4ca05fb052b64e23d177131d9f32e9c5b942209eb7229e9a07c99a5d93245f53af18a09a137197a43a880648d5887cce656a5e6bbbe5e44ecb4f264395ccaddbe1acca80808080808080808080808080";
+        proof[2] =
+            hex"f862808080808080a057895fdbd71e2c67c2f9274a56811ff5cf458720a7fa713a135e3890f8cafcf8808080808080808080b130313233343536373839303132333435363738393031323334353637383930313233343536373839566572795f4c6f6e67";
 
         assertEq(val, MerkleTrie.get(key, proof, root));
     }
@@ -87,12 +72,9 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"6b657932";
         bytes memory val = hex"73686f7274";
         bytes[] memory proof = new bytes[](3);
-        proof[
-            0
-        ] = hex"e68416b65793a0f3f387240403976788281c0a6ee5b3fc08360d276039d635bb824ea7e6fed779";
-        proof[
-            1
-        ] = hex"f87180a034d14ccc7685aa2beb64f78b11ee2a335eae82047ef97c79b7dda7f0732b9f4ca05fb052b64e23d177131d9f32e9c5b942209eb7229e9a07c99a5d93245f53af18a09a137197a43a880648d5887cce656a5e6bbbe5e44ecb4f264395ccaddbe1acca80808080808080808080808080";
+        proof[0] = hex"e68416b65793a0f3f387240403976788281c0a6ee5b3fc08360d276039d635bb824ea7e6fed779";
+        proof[1] =
+            hex"f87180a034d14ccc7685aa2beb64f78b11ee2a335eae82047ef97c79b7dda7f0732b9f4ca05fb052b64e23d177131d9f32e9c5b942209eb7229e9a07c99a5d93245f53af18a09a137197a43a880648d5887cce656a5e6bbbe5e44ecb4f264395ccaddbe1acca80808080808080808080808080";
         proof[2] = hex"df808080808080c9823262856176616c338080808080808080808573686f7274";
 
         assertEq(val, MerkleTrie.get(key, proof, root));
@@ -103,15 +85,11 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"6b657933";
         bytes memory val = hex"31323334353637383930313233343536373839303132333435363738393031";
         bytes[] memory proof = new bytes[](3);
-        proof[
-            0
-        ] = hex"e68416b65793a0f3f387240403976788281c0a6ee5b3fc08360d276039d635bb824ea7e6fed779";
-        proof[
-            1
-        ] = hex"f87180a034d14ccc7685aa2beb64f78b11ee2a335eae82047ef97c79b7dda7f0732b9f4ca05fb052b64e23d177131d9f32e9c5b942209eb7229e9a07c99a5d93245f53af18a09a137197a43a880648d5887cce656a5e6bbbe5e44ecb4f264395ccaddbe1acca80808080808080808080808080";
-        proof[
-            2
-        ] = hex"f839808080808080c9823363856176616c338080808080808080809f31323334353637383930313233343536373839303132333435363738393031";
+        proof[0] = hex"e68416b65793a0f3f387240403976788281c0a6ee5b3fc08360d276039d635bb824ea7e6fed779";
+        proof[1] =
+            hex"f87180a034d14ccc7685aa2beb64f78b11ee2a335eae82047ef97c79b7dda7f0732b9f4ca05fb052b64e23d177131d9f32e9c5b942209eb7229e9a07c99a5d93245f53af18a09a137197a43a880648d5887cce656a5e6bbbe5e44ecb4f264395ccaddbe1acca80808080808080808080808080";
+        proof[2] =
+            hex"f839808080808080c9823363856176616c338080808080808080809f31323334353637383930313233343536373839303132333435363738393031";
 
         assertEq(val, MerkleTrie.get(key, proof, root));
     }
@@ -156,12 +134,9 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes32 root = 0xd582f99275e227a1cf4284899e5ff06ee56da8859be71b553397c69151bc942f;
         bytes memory key = hex"6b657932";
         bytes[] memory proof = new bytes[](3);
-        proof[
-            0
-        ] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
-        proof[
-            1
-        ] = hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
+        proof[0] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
+        proof[1] =
+            hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
         proof[2] = hex"ca83206262856176616c32";
 
         vm.expectRevert("MerkleTrie: path remainder must share all nibbles with key");
@@ -172,9 +147,7 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes32 root = 0xd582f99275e227a1cf4284899e5ff06ee56da8859be71b553397c69151bc942f;
         bytes memory key = hex"616e7972616e646f6d6b6579";
         bytes[] memory proof = new bytes[](1);
-        proof[
-            0
-        ] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
+        proof[0] = hex"e68416b65793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
 
         vm.expectRevert("MerkleTrie: path remainder must share all nibbles with key");
         MerkleTrie.get(key, proof, root);
@@ -185,9 +158,8 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"6b6579316161";
         bytes[] memory proof = new bytes[](3);
         proof[0] = hex"e216a04892c039d654f1be9af20e88ae53e9ab5fa5520190e0fb2f805823e45ebad22f";
-        proof[
-            1
-        ] = hex"f84780d687206e6f746865728d33343938683472697568677765808080808080808080a0854405b57aa6dc458bc41899a761cbbb1f66a4998af6dd0e8601c1b845395ae38080808080";
+        proof[1] =
+            hex"f84780d687206e6f746865728d33343938683472697568677765808080808080808080a0854405b57aa6dc458bc41899a761cbbb1f66a4998af6dd0e8601c1b845395ae38080808080";
         proof[2] = hex"d687206e6f746865728d33343938683472697568677765";
 
         vm.expectRevert("MerkleTrie: invalid internal node hash");
@@ -199,15 +171,11 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"6b6579326262";
         bytes[] memory proof = new bytes[](5);
         proof[0] = hex"2fd2ba5ee42358802ffbe0900152a55fabe953ae880ef29abef154d639c09248a016e2";
-        proof[
-            1
-        ] = hex"f84780d687206e6f746865728d33343938683472697568677765808080808080808080a0854405b57aa6dc458bc41899a761cbbb1f66a4998af6dd0e8601c1b845395ae38080808080";
-        proof[
-            2
-        ] = hex"e583165793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
-        proof[
-            3
-        ] = hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
+        proof[1] =
+            hex"f84780d687206e6f746865728d33343938683472697568677765808080808080808080a0854405b57aa6dc458bc41899a761cbbb1f66a4998af6dd0e8601c1b845395ae38080808080";
+        proof[2] = hex"e583165793a03101b4447781f1e6c51ce76c709274fc80bd064f3a58ff981b6015348a826386";
+        proof[3] =
+            hex"f84580a0582eed8dd051b823d13f8648cdcd08aa2d8dac239f458863c4620e8c4d605debca83206262856176616c32ca83206363856176616c3380808080808080808080808080";
         proof[4] = hex"ca83206262856176616c32";
 
         vm.expectRevert("RLPReader: decoded item type for list is not a list item");
@@ -231,9 +199,8 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"aa";
         bytes[] memory proof = new bytes[](3);
         proof[0] = hex"e21aa09862c6b113008c4204c13755693cbb868acc25ebaa98db11df8c89a0c0dd3157";
-        proof[
-            1
-        ] = hex"f380808080808080808080a0de2a9c6a46b6ea71ab9e881c8420570cf19e833c85df6026b04f085016e78f00c220118080808080";
+        proof[1] =
+            hex"f380808080808080808080a0de2a9c6a46b6ea71ab9e881c8420570cf19e833c85df6026b04f085016e78f00c220118080808080";
         proof[2] = hex"de2a9c6a46b6ea71ab9e881c8420570cf19e833c85df6026b04f085016e78f";
 
         vm.expectRevert("MerkleTrie: invalid internal node hash");
@@ -278,9 +245,8 @@ contract MerkleTrie_get_Test is CommonTest {
         bytes memory key = hex"aa";
         bytes[] memory proof = new bytes[](3);
         proof[0] = hex"e21aa07ea462226a3dc0a46afb4ded39306d7a84d311ada3557dfc75a909fd25530905";
-        proof[
-            1
-        ] = hex"f380808080808080808080a027f11bd3af96d137b9287632f44dd00fea1ca1bd70386c30985ede8cc287476e808080c220338080";
+        proof[1] =
+            hex"f380808080808080808080a027f11bd3af96d137b9287632f44dd00fea1ca1bd70386c30985ede8cc287476e808080c220338080";
         proof[2] = hex"e48200bba0a6911545ed01c2d3f4e15b8b27c7bfba97738bd5e6dd674dd07033428a4c53af";
 
         vm.expectRevert("MerkleTrie: path remainder must share all nibbles with key");
@@ -303,8 +269,7 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_validProofs_succeeds(bytes4) external {
         // Generate a test case with a valid proof of inclusion for the k/v pair in the trie.
-        (bytes32 root, bytes memory key, bytes memory val, bytes[] memory proof) = ffi
-            .getMerkleTrieFuzzCase("valid");
+        (bytes32 root, bytes memory key, bytes memory val, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("valid");
 
         // Assert that our expected value is equal to our actual value.
         assertEq(val, MerkleTrie.get(key, proof, root));
@@ -313,9 +278,7 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_invalidRoot_reverts(bytes4) external {
         // Get a random test case with a valid trie / proof
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "valid"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("valid");
 
         bytes32 rootHash = keccak256(abi.encodePacked(root));
         vm.expectRevert("MerkleTrie: invalid root hash");
@@ -326,9 +289,7 @@ contract MerkleTrie_get_Test is CommonTest {
     function testFuzz_get_extraProofElements_reverts(bytes4) external {
         // Generate an invalid test case with an extra proof element attached to an otherwise
         // valid proof of inclusion for the passed k/v.
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "extra_proof_elems"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("extra_proof_elems");
 
         vm.expectRevert("MerkleTrie: value node must be last node in proof (leaf)");
         MerkleTrie.get(key, proof, root);
@@ -337,9 +298,8 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_invalidLargeInternalHash_reverts(bytes4) external {
         // Generate an invalid test case where a long proof element is incorrect for the root.
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "invalid_large_internal_hash"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) =
+            ffi.getMerkleTrieFuzzCase("invalid_large_internal_hash");
 
         vm.expectRevert("MerkleTrie: invalid large internal hash");
         MerkleTrie.get(key, proof, root);
@@ -348,9 +308,8 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_invalidInternalNodeHash_reverts(bytes4) external {
         // Generate an invalid test case where a small proof element is incorrect for the root.
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "invalid_internal_node_hash"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) =
+            ffi.getMerkleTrieFuzzCase("invalid_internal_node_hash");
 
         vm.expectRevert("MerkleTrie: invalid internal node hash");
         MerkleTrie.get(key, proof, root);
@@ -359,9 +318,7 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_corruptedProof_reverts(bytes4) external {
         // Generate an invalid test case where the proof is malformed.
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "corrupted_proof"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("corrupted_proof");
 
         vm.expectRevert("RLPReader: decoded item type for list is not a list item");
         MerkleTrie.get(key, proof, root);
@@ -371,9 +328,7 @@ contract MerkleTrie_get_Test is CommonTest {
     function testFuzz_get_invalidDataRemainder_reverts(bytes4) external {
         // Generate an invalid test case where a random element of the proof has more bytes than the
         // length designates within the RLP list encoding.
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "invalid_data_remainder"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("invalid_data_remainder");
 
         vm.expectRevert("RLPReader: list item has an invalid data remainder");
         MerkleTrie.get(key, proof, root);
@@ -383,9 +338,7 @@ contract MerkleTrie_get_Test is CommonTest {
     function testFuzz_get_prefixedValidKey_reverts(bytes4) external {
         // Get a random test case with a valid trie / proof and a valid key that is prefixed
         // with random bytes
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "prefixed_valid_key"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("prefixed_valid_key");
 
         // Ambiguous revert check- all that we care is that it *does* fail. This case may
         // fail within different branches.
@@ -396,9 +349,7 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_emptyKey_reverts(bytes4) external {
         // Get a random test case with a valid trie / proof and an empty key
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "empty_key"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("empty_key");
 
         vm.expectRevert("MerkleTrie: empty key");
         MerkleTrie.get(key, proof, root);
@@ -407,9 +358,7 @@ contract MerkleTrie_get_Test is CommonTest {
     /// @notice The `bytes4` parameter is to enable parallel fuzz runs; it is ignored.
     function testFuzz_get_partialProof_reverts(bytes4) external {
         // Get a random test case with a valid trie / partially correct proof
-        (bytes32 root, bytes memory key, , bytes[] memory proof) = ffi.getMerkleTrieFuzzCase(
-            "partial_proof"
-        );
+        (bytes32 root, bytes memory key,, bytes[] memory proof) = ffi.getMerkleTrieFuzzCase("partial_proof");
 
         vm.expectRevert("MerkleTrie: ran out of proof elements");
         MerkleTrie.get(key, proof, root);

--- a/packages/contracts-bedrock/contracts/test/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismMintableERC20.t.sol
@@ -2,10 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Bridge_Initializer } from "./CommonTest.t.sol";
-import {
-    ILegacyMintableERC20,
-    IOptimismMintableERC20
-} from "../universal/IOptimismMintableERC20.sol";
+import { ILegacyMintableERC20, IOptimismMintableERC20 } from "../universal/IOptimismMintableERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract OptimismMintableERC20_Test is Bridge_Initializer {
@@ -87,10 +84,8 @@ contract OptimismMintableERC20_Test is Bridge_Initializer {
         assertEq(iface2, type(ILegacyMintableERC20).interfaceId);
         assert(L2Token.supportsInterface(iface2));
 
-        bytes4 iface3 = L2Token.remoteToken.selector ^
-            L2Token.bridge.selector ^
-            L2Token.mint.selector ^
-            L2Token.burn.selector;
+        bytes4 iface3 =
+            L2Token.remoteToken.selector ^ L2Token.bridge.selector ^ L2Token.mint.selector ^ L2Token.burn.selector;
         assertEq(iface3, type(IOptimismMintableERC20).interfaceId);
         assert(L2Token.supportsInterface(iface3));
     }

--- a/packages/contracts-bedrock/contracts/test/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismMintableERC20Factory.t.sol
@@ -6,11 +6,7 @@ import { LibRLP } from "./RLP.t.sol";
 
 contract OptimismMintableTokenFactory_Test is Bridge_Initializer {
     event StandardL2TokenCreated(address indexed remoteToken, address indexed localToken);
-    event OptimismMintableERC20Created(
-        address indexed localToken,
-        address indexed remoteToken,
-        address deployer
-    );
+    event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     function setUp() public override {
         super.setUp();

--- a/packages/contracts-bedrock/contracts/test/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismMintableERC721.t.sol
@@ -2,16 +2,11 @@
 pragma solidity 0.8.15;
 
 import { ERC721, IERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import {
-    IERC721Enumerable
-} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ERC721Bridge_Initializer } from "./CommonTest.t.sol";
-import {
-    OptimismMintableERC721,
-    IOptimismMintableERC721
-} from "../universal/OptimismMintableERC721.sol";
+import { OptimismMintableERC721, IOptimismMintableERC721 } from "../universal/OptimismMintableERC721.sol";
 
 contract OptimismMintableERC721_Test is ERC721Bridge_Initializer {
     ERC721 internal L1Token;

--- a/packages/contracts-bedrock/contracts/test/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismMintableERC721Factory.t.sol
@@ -10,11 +10,7 @@ import { OptimismMintableERC721Factory } from "../universal/OptimismMintableERC7
 contract OptimismMintableERC721Factory_Test is ERC721Bridge_Initializer {
     OptimismMintableERC721Factory internal factory;
 
-    event OptimismMintableERC721Created(
-        address indexed localToken,
-        address indexed remoteToken,
-        address deployer
-    );
+    event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     function setUp() public override {
         super.setUp();
@@ -41,9 +37,8 @@ contract OptimismMintableERC721Factory_Test is ERC721Bridge_Initializer {
 
         // Create the token.
         vm.prank(alice);
-        OptimismMintableERC721 created = OptimismMintableERC721(
-            factory.createOptimismMintableERC721(address(1234), "L2Token", "L2T")
-        );
+        OptimismMintableERC721 created =
+            OptimismMintableERC721(factory.createOptimismMintableERC721(address(1234), "L2Token", "L2T"));
 
         // Token address should be correct.
         assertEq(address(created), predicted);

--- a/packages/contracts-bedrock/contracts/test/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/OptimismPortal.t.sol
@@ -96,9 +96,9 @@ contract OptimismPortal_Test is Portal_Initializer {
         emitTransactionDeposited(alice, alice, 100, 100, 100_000, false, hex"");
 
         // give alice money and send as an eoa
-        vm.deal(alice, 2**64);
+        vm.deal(alice, 2 ** 64);
         vm.prank(alice, alice);
-        (bool s, ) = address(op).call{ value: 100 }(hex"");
+        (bool s,) = address(op).call{ value: 100 }(hex"");
 
         assert(s);
         assertEq(address(op).balance, 100);
@@ -130,21 +130,12 @@ contract OptimismPortal_Test is Portal_Initializer {
     /// @dev Tests that `depositTransaction` reverts when the gas limit is too small.
     function test_depositTransaction_smallGasLimit_reverts() external {
         vm.expectRevert("OptimismPortal: gas limit too small");
-        op.depositTransaction({
-            _to: address(1),
-            _value: 0,
-            _gasLimit: 0,
-            _isCreation: false,
-            _data: hex""
-        });
+        op.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
     }
 
     /// @dev Tests that `depositTransaction` succeeds for small,
     ///      but sufficient, gas limits.
-    function testFuzz_depositTransaction_smallGasLimit_succeeds(
-        bytes memory _data,
-        bool _shouldFail
-    ) external {
+    function testFuzz_depositTransaction_smallGasLimit_succeeds(bytes memory _data, bool _shouldFail) external {
         vm.assume(_data.length <= type(uint64).max);
 
         uint64 gasLimit = op.minimumGasLimit(uint64(_data.length));
@@ -153,13 +144,7 @@ contract OptimismPortal_Test is Portal_Initializer {
             vm.expectRevert("OptimismPortal: gas limit too small");
         }
 
-        op.depositTransaction({
-            _to: address(0x40),
-            _value: 0,
-            _gasLimit: gasLimit,
-            _isCreation: false,
-            _data: _data
-        });
+        op.depositTransaction({ _to: address(0x40), _value: 0, _gasLimit: gasLimit, _isCreation: false, _data: _data });
     }
 
     /// @dev Tests that `minimumGasLimit` succeeds for small calldata sizes.
@@ -177,22 +162,10 @@ contract OptimismPortal_Test is Portal_Initializer {
         vm.prank(address(this), address(this));
         vm.expectEmit(true, true, false, true);
         emitTransactionDeposited(
-            address(this),
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
+            address(this), NON_ZERO_ADDRESS, ZERO_VALUE, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA
         );
 
-        op.depositTransaction(
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
-        );
+        op.depositTransaction(NON_ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA);
     }
 
     /// @dev Tests that `depositTransaction` succeeds for a contract depositing a tx with 0 value.
@@ -208,13 +181,7 @@ contract OptimismPortal_Test is Portal_Initializer {
             NON_ZERO_DATA
         );
 
-        op.depositTransaction(
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
-        );
+        op.depositTransaction(NON_ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA);
     }
 
     /// @dev Tests that `depositTransaction` succeeds for an EOA
@@ -225,13 +192,7 @@ contract OptimismPortal_Test is Portal_Initializer {
 
         vm.expectEmit(true, true, false, true);
         emitTransactionDeposited(
-            address(this),
-            ZERO_ADDRESS,
-            ZERO_VALUE,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            true,
-            NON_ZERO_DATA
+            address(this), ZERO_ADDRESS, ZERO_VALUE, ZERO_VALUE, NON_ZERO_GASLIMIT, true, NON_ZERO_DATA
         );
 
         op.depositTransaction(ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, true, NON_ZERO_DATA);
@@ -261,21 +222,11 @@ contract OptimismPortal_Test is Portal_Initializer {
 
         vm.expectEmit(true, true, false, true);
         emitTransactionDeposited(
-            address(this),
-            NON_ZERO_ADDRESS,
-            NON_ZERO_VALUE,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
+            address(this), NON_ZERO_ADDRESS, NON_ZERO_VALUE, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA
         );
 
         op.depositTransaction{ value: NON_ZERO_VALUE }(
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
+            NON_ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA
         );
         assertEq(address(op).balance, NON_ZERO_VALUE);
     }
@@ -294,11 +245,7 @@ contract OptimismPortal_Test is Portal_Initializer {
         );
 
         op.depositTransaction{ value: NON_ZERO_VALUE }(
-            NON_ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            false,
-            NON_ZERO_DATA
+            NON_ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, false, NON_ZERO_DATA
         );
     }
 
@@ -309,22 +256,10 @@ contract OptimismPortal_Test is Portal_Initializer {
 
         vm.expectEmit(true, true, false, true);
         emitTransactionDeposited(
-            address(this),
-            ZERO_ADDRESS,
-            NON_ZERO_VALUE,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            true,
-            hex""
+            address(this), ZERO_ADDRESS, NON_ZERO_VALUE, ZERO_VALUE, NON_ZERO_GASLIMIT, true, hex""
         );
 
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
-            ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            true,
-            hex""
-        );
+        op.depositTransaction{ value: NON_ZERO_VALUE }(ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, true, hex"");
         assertEq(address(op).balance, NON_ZERO_VALUE);
     }
 
@@ -341,13 +276,7 @@ contract OptimismPortal_Test is Portal_Initializer {
             NON_ZERO_DATA
         );
 
-        op.depositTransaction{ value: NON_ZERO_VALUE }(
-            ZERO_ADDRESS,
-            ZERO_VALUE,
-            NON_ZERO_GASLIMIT,
-            true,
-            NON_ZERO_DATA
-        );
+        op.depositTransaction{ value: NON_ZERO_VALUE }(ZERO_ADDRESS, ZERO_VALUE, NON_ZERO_GASLIMIT, true, NON_ZERO_DATA);
         assertEq(address(op).balance, NON_ZERO_VALUE);
     }
 
@@ -357,9 +286,7 @@ contract OptimismPortal_Test is Portal_Initializer {
         vm.mockCall(
             address(op.L2_ORACLE()),
             abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
-            abi.encode(
-                Types.OutputProposal(bytes32(uint256(1)), uint128(ts), uint128(startingBlockNumber))
-            )
+            abi.encode(Types.OutputProposal(bytes32(uint256(1)), uint128(ts), uint128(startingBlockNumber)))
         );
 
         // warp to the finalization period
@@ -424,8 +351,8 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
             data: hex""
         });
         // Get withdrawal proof data we can use for testing.
-        (_stateRoot, _storageRoot, _outputRoot, _withdrawalHash, _withdrawalProof) = ffi
-            .getProveWithdrawalTransactionInputs(_defaultTx);
+        (_stateRoot, _storageRoot, _outputRoot, _withdrawalHash, _withdrawalProof) =
+            ffi.getProveWithdrawalTransactionInputs(_defaultTx);
 
         // Setup a dummy output root proof for reuse.
         _outputRootProof = Types.OutputRootProof({
@@ -446,11 +373,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         oracle.proposeL2Output(_outputRoot, _proposedBlockNumber, 0, 0);
 
         // Warp beyond the finalization period for the block we've proposed.
-        vm.warp(
-            oracle.getL2Output(_proposedOutputIndex).timestamp +
-                oracle.FINALIZATION_PERIOD_SECONDS() +
-                1
-        );
+        vm.warp(oracle.getL2Output(_proposedOutputIndex).timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         // Fund the portal so that we can withdraw ETH.
         vm.deal(address(op), 0xFFFFFFFF);
     }
@@ -483,12 +406,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
     function test_proveWithdrawalTransaction_onSelfCall_reverts() external {
         _defaultTx.target = address(op);
         vm.expectRevert("OptimismPortal: you cannot send messages to the portal contract");
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
     }
 
     /// @dev Tests that `proveWithdrawalTransaction` reverts when
@@ -497,12 +415,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // Modify the version to invalidate the withdrawal proof.
         _outputRootProof.version = bytes32(uint256(1));
         vm.expectRevert("OptimismPortal: invalid output root proof");
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
     }
 
     /// @dev Tests that `proveWithdrawalTransaction` reverts when the withdrawal is missing.
@@ -510,12 +423,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // modify the default test values to invalidate the proof.
         _defaultTx.data = hex"abcd";
         vm.expectRevert("MerkleTrie: path remainder must share all nibbles with key");
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
     }
 
     /// @dev Tests that `proveWithdrawalTransaction` reverts when the withdrawal has already
@@ -523,20 +431,10 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
     function test_proveWithdrawalTransaction_replayProve_reverts() external {
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         vm.expectRevert("OptimismPortal: withdrawal hash has already been proven");
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
     }
 
     /// @dev Tests that `proveWithdrawalTransaction` succeeds when the withdrawal has already
@@ -544,12 +442,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
     function test_proveWithdrawalTransaction_replayProveChangedOutputRoot_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Compute the storage slot of the outputRoot corresponding to the `withdrawalHash`
         // inside of the `provenWithdrawal`s mapping.
@@ -571,31 +464,19 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // our proof with a changed outputRoot
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Ensure that the withdrawal was updated within the mapping
-        (, uint128 timestamp, ) = op.provenWithdrawals(_withdrawalHash);
+        (, uint128 timestamp,) = op.provenWithdrawals(_withdrawalHash);
         assertEq(timestamp, block.timestamp);
     }
 
     /// @dev Tests that `proveWithdrawalTransaction` succeeds when the withdrawal has already
     ///      been proven and the output root, output index, and l2BlockNumber have changed.
-    function test_proveWithdrawalTransaction_replayProveChangedOutputRootAndOutputIndex_succeeds()
-        external
-    {
+    function test_proveWithdrawalTransaction_replayProveChangedOutputRootAndOutputIndex_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Compute the storage slot of the outputRoot corresponding to the `withdrawalHash`
         // inside of the `provenWithdrawal`s mapping.
@@ -616,10 +497,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // Propose the same output root again, creating the same output at a different index + l2BlockNumber.
         vm.startPrank(op.L2_ORACLE().PROPOSER());
         op.L2_ORACLE().proposeL2Output(
-            proposal.outputRoot,
-            op.L2_ORACLE().nextBlockNumber(),
-            blockhash(block.number),
-            block.number
+            proposal.outputRoot, op.L2_ORACLE().nextBlockNumber(), blockhash(block.number), block.number
         );
         vm.stopPrank();
 
@@ -630,15 +508,10 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // our proof with a changed outputRoot + a different output index
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex + 1,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex + 1, _outputRootProof, _withdrawalProof);
 
         // Ensure that the withdrawal was updated within the mapping
-        (, uint128 timestamp, ) = op.provenWithdrawals(_withdrawalHash);
+        (, uint128 timestamp,) = op.provenWithdrawals(_withdrawalHash);
         assertEq(timestamp, block.timestamp);
     }
 
@@ -646,12 +519,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
     function test_proveWithdrawalTransaction_validWithdrawalProof_succeeds() external {
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
     }
 
     /// @dev Tests that `finalizeWithdrawalTransaction` succeeds.
@@ -660,12 +528,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
 
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         vm.expectEmit(true, true, false, true);
@@ -701,12 +564,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
 
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Mock a call where the resulting output root is anything but the original output root. In
         // this case we just use bytes32(uint256(1)).
@@ -730,27 +588,18 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // Prove our withdrawal
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Warp to after the finalization period
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
 
         // Mock a startingTimestamp change on the L2 Oracle
         vm.mockCall(
-            address(op.L2_ORACLE()),
-            abi.encodeWithSignature("startingTimestamp()"),
-            abi.encode(block.timestamp + 1)
+            address(op.L2_ORACLE()), abi.encodeWithSignature("startingTimestamp()"), abi.encode(block.timestamp + 1)
         );
 
         // Attempt to finalize the withdrawal
-        vm.expectRevert(
-            "OptimismPortal: withdrawal timestamp less than L2 Oracle starting timestamp"
-        );
+        vm.expectRevert("OptimismPortal: withdrawal timestamp less than L2 Oracle starting timestamp");
         op.finalizeWithdrawalTransaction(_defaultTx);
 
         // Ensure that bob's balance has remained the same
@@ -765,12 +614,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // Prove our withdrawal
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Warp to after the finalization period
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
@@ -781,18 +625,12 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
             address(op.L2_ORACLE()),
             abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
             abi.encode(
-                Types.OutputProposal(
-                    bytes32(uint256(0)),
-                    uint128(block.timestamp),
-                    uint128(_proposedBlockNumber)
-                )
+                Types.OutputProposal(bytes32(uint256(0)), uint128(block.timestamp), uint128(_proposedBlockNumber))
             )
         );
 
         // Attempt to finalize the withdrawal
-        vm.expectRevert(
-            "OptimismPortal: output root proven is not the same as current output root"
-        );
+        vm.expectRevert("OptimismPortal: output root proven is not the same as current output root");
         op.finalizeWithdrawalTransaction(_defaultTx);
 
         // Ensure that bob's balance has remained the same
@@ -807,12 +645,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         // Prove our withdrawal
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Warp to after the finalization period
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
@@ -822,13 +655,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         vm.mockCall(
             address(op.L2_ORACLE()),
             abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
-            abi.encode(
-                Types.OutputProposal(
-                    _outputRoot,
-                    uint128(block.timestamp + 1),
-                    uint128(_proposedBlockNumber)
-                )
-            )
+            abi.encode(Types.OutputProposal(_outputRoot, uint128(block.timestamp + 1), uint128(_proposedBlockNumber)))
         );
 
         // Attempt to finalize the withdrawal
@@ -846,12 +673,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
 
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         vm.expectEmit(true, true, true, true);
@@ -869,21 +691,10 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         vm.mockCall(
             address(op.L2_ORACLE()),
             abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
-            abi.encode(
-                Types.OutputProposal(
-                    _outputRoot,
-                    uint128(recentTimestamp),
-                    uint128(_proposedBlockNumber)
-                )
-            )
+            abi.encode(Types.OutputProposal(_outputRoot, uint128(recentTimestamp), uint128(_proposedBlockNumber)))
         );
 
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         vm.expectRevert("OptimismPortal: proven withdrawal finalization period has not elapsed");
         op.finalizeWithdrawalTransaction(_defaultTx);
@@ -894,12 +705,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
     function test_finalizeWithdrawalTransaction_onReplay_reverts() external {
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(_withdrawalHash, alice, bob);
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         vm.expectEmit(true, true, true, true);
@@ -925,8 +731,8 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         });
 
         // Get updated proof inputs.
-        (bytes32 stateRoot, bytes32 storageRoot, , , bytes[] memory withdrawalProof) = ffi
-            .getProveWithdrawalTransactionInputs(insufficientGasTx);
+        (bytes32 stateRoot, bytes32 storageRoot,,, bytes[] memory withdrawalProof) =
+            ffi.getProveWithdrawalTransactionInputs(insufficientGasTx);
         Types.OutputRootProof memory outputRootProof = Types.OutputRootProof({
             version: bytes32(0),
             stateRoot: stateRoot,
@@ -946,12 +752,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
             )
         );
 
-        op.proveWithdrawalTransaction(
-            insufficientGasTx,
-            _proposedOutputIndex,
-            outputRootProof,
-            withdrawalProof
-        );
+        op.proveWithdrawalTransaction(insufficientGasTx, _proposedOutputIndex, outputRootProof, withdrawalProof);
 
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         vm.expectRevert("SafeCall: Not enough gas");
@@ -989,23 +790,12 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         vm.mockCall(
             address(op.L2_ORACLE()),
             abi.encodeWithSelector(L2OutputOracle.getL2Output.selector),
-            abi.encode(
-                Types.OutputProposal(
-                    outputRoot,
-                    uint128(finalizedTimestamp),
-                    uint128(_proposedBlockNumber)
-                )
-            )
+            abi.encode(Types.OutputProposal(outputRoot, uint128(finalizedTimestamp), uint128(_proposedBlockNumber)))
         );
 
         vm.expectEmit(true, true, true, true);
         emit WithdrawalProven(withdrawalHash, alice, address(this));
-        op.proveWithdrawalTransaction(
-            _testTx,
-            _proposedBlockNumber,
-            outputRootProof,
-            withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_testTx, _proposedBlockNumber, outputRootProof, withdrawalProof);
 
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         vm.expectCall(address(this), _testTx.data);
@@ -1026,10 +816,10 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
         bytes memory _data
     ) external {
         vm.assume(
-            _target != address(op) && // Cannot call the optimism portal or a contract
-                _target.code.length == 0 && // No accounts with code
-                _target != CONSOLE && // The console has no code but behaves like a contract
-                uint160(_target) > 9 // No precompiles (or zero address)
+            _target != address(op) // Cannot call the optimism portal or a contract
+                && _target.code.length == 0 // No accounts with code
+                && _target != CONSOLE // The console has no code but behaves like a contract
+                && uint160(_target) > 9 // No precompiles (or zero address)
         );
 
         // Total ETH supply is currently about 120M ETH.
@@ -1082,7 +872,7 @@ contract OptimismPortal_FinalizeWithdrawal_Test is Portal_Initializer {
             proof,
             withdrawalProof
         );
-        (bytes32 _root, , ) = op.provenWithdrawals(withdrawalHash);
+        (bytes32 _root,,) = op.provenWithdrawals(withdrawalHash);
         assertTrue(_root != bytes32(0));
 
         // Warp past the finalization period
@@ -1138,10 +928,7 @@ contract OptimismPortalUpgradeable_Test is Portal_Initializer {
 
         NextImpl nextImpl = new NextImpl();
         vm.startPrank(multisig);
-        proxy.upgradeToAndCall(
-            address(nextImpl),
-            abi.encodeWithSelector(NextImpl.initialize.selector)
-        );
+        proxy.upgradeToAndCall(address(nextImpl), abi.encodeWithSelector(NextImpl.initialize.selector));
         assertEq(proxy.implementation(), address(nextImpl));
 
         // Verify that the NextImpl contract initialized its values according as expected
@@ -1184,10 +971,7 @@ contract OptimismPortalResourceFuzz_Test is Portal_Initializer {
         vm.assume(_baseFeeMaxChangeDenominator > 1);
         vm.assume(uint256(_maxResourceLimit) + uint256(_systemTxMaxGas) <= gasLimit);
         vm.assume(_elasticityMultiplier > 0);
-        vm.assume(
-            ((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier) ==
-                _maxResourceLimit
-        );
+        vm.assume(((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier) == _maxResourceLimit);
         _prevBoughtGas = uint64(bound(_prevBoughtGas, 0, _maxResourceLimit - _gasLimit));
         _blockDiff = uint8(bound(_blockDiff, 0, 3));
 
@@ -1201,9 +985,7 @@ contract OptimismPortalResourceFuzz_Test is Portal_Initializer {
             maximumBaseFee: _maximumBaseFee
         });
         vm.mockCall(
-            address(systemConfig),
-            abi.encodeWithSelector(systemConfig.resourceConfig.selector),
-            abi.encode(rcfg)
+            address(systemConfig), abi.encodeWithSelector(systemConfig.resourceConfig.selector), abi.encode(rcfg)
         );
 
         // Set the resource params

--- a/packages/contracts-bedrock/contracts/test/Proxy.t.sol
+++ b/packages/contracts-bedrock/contracts/test/Proxy.t.sol
@@ -29,8 +29,7 @@ contract Proxy_Test is Test {
 
     address alice = address(64);
 
-    bytes32 internal constant IMPLEMENTATION_KEY =
-        bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1);
+    bytes32 internal constant IMPLEMENTATION_KEY = bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1);
 
     bytes32 internal constant OWNER_KEY = bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1);
 
@@ -155,10 +154,7 @@ contract Proxy_Test is Test {
         vm.expectEmit(true, true, true, true);
         emit Upgraded(address(simpleStorage));
         vm.prank(alice);
-        proxy.upgradeToAndCall(
-            address(simpleStorage),
-            abi.encodeWithSelector(simpleStorage.set.selector, 1, 1)
-        );
+        proxy.upgradeToAndCall(address(simpleStorage), abi.encodeWithSelector(simpleStorage.set.selector, 1, 1));
 
         // The call should have impacted the state
         uint256 result = SimpleStorage(address(proxy)).get(1);
@@ -191,10 +187,7 @@ contract Proxy_Test is Test {
         // The attempt to `upgradeToAndCall`
         // should revert when it is not called by the owner.
         vm.expectRevert();
-        proxy.upgradeToAndCall(
-            address(simpleStorage),
-            abi.encodeWithSelector(simpleStorage.set.selector, 1, 1)
-        );
+        proxy.upgradeToAndCall(address(simpleStorage), abi.encodeWithSelector(simpleStorage.set.selector, 1, 1));
     }
 
     function test_upgradeToAndCall_isPayable_succeeds() external {
@@ -204,8 +197,7 @@ contract Proxy_Test is Test {
         // value.
         vm.prank(alice);
         proxy.upgradeToAndCall{ value: 1 ether }(
-            address(simpleStorage),
-            abi.encodeWithSelector(simpleStorage.set.selector, 1, 1)
+            address(simpleStorage), abi.encodeWithSelector(simpleStorage.set.selector, 1, 1)
         );
 
         // The implementation address should be correct
@@ -267,10 +259,7 @@ contract Proxy_Test is Test {
         (bool success, bytes memory returndata) = address(proxy).call(hex"");
         assertEq(success, false);
 
-        bytes memory err = abi.encodeWithSignature(
-            "Error(string)",
-            "Proxy: implementation not initialized"
-        );
+        bytes memory err = abi.encodeWithSignature("Error(string)", "Proxy: implementation not initialized");
 
         assertEq(returndata, err);
     }

--- a/packages/contracts-bedrock/contracts/test/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/contracts/test/ProxyAdmin.t.sol
@@ -86,14 +86,8 @@ contract ProxyAdmin_Test is Test {
 
     function test_proxyType_succeeds() external {
         assertEq(uint256(admin.proxyType(address(proxy))), uint256(ProxyAdmin.ProxyType.ERC1967));
-        assertEq(
-            uint256(admin.proxyType(address(chugsplash))),
-            uint256(ProxyAdmin.ProxyType.CHUGSPLASH)
-        );
-        assertEq(
-            uint256(admin.proxyType(address(resolved))),
-            uint256(ProxyAdmin.ProxyType.RESOLVED)
-        );
+        assertEq(uint256(admin.proxyType(address(chugsplash))), uint256(ProxyAdmin.ProxyType.CHUGSPLASH));
+        assertEq(uint256(admin.proxyType(address(resolved))), uint256(ProxyAdmin.ProxyType.RESOLVED));
     }
 
     function test_erc1967GetProxyImplementation_succeeds() external {
@@ -222,11 +216,7 @@ contract ProxyAdmin_Test is Test {
 
     function upgradeAndCall(address payable _proxy) internal {
         vm.prank(alice);
-        admin.upgradeAndCall(
-            _proxy,
-            address(implementation),
-            abi.encodeWithSelector(SimpleStorage.set.selector, 1, 1)
-        );
+        admin.upgradeAndCall(_proxy, address(implementation), abi.encodeWithSelector(SimpleStorage.set.selector, 1, 1));
 
         address impl = admin.getProxyImplementation(_proxy);
         assertEq(impl, address(implementation));

--- a/packages/contracts-bedrock/contracts/test/RLP.t.sol
+++ b/packages/contracts-bedrock/contracts/test/RLP.t.sol
@@ -11,60 +11,38 @@ library LibRLP {
     using Bytes32AddressLib for bytes32;
 
     function computeAddress(address deployer, uint256 nonce) internal pure returns (address) {
-        // The integer zero is treated as an empty byte string, and as a result it only has a length prefix, 0x80, computed via 0x80 + 0.
-        // A one byte integer uses its own value as its length prefix, there is no additional "0x80 + length" prefix that comes before it.
-        if (nonce == 0x00)
-            return
-                keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, bytes1(0x80)))
-                    .fromLast20Bytes();
-        if (nonce <= 0x7f)
-            return
-                keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, uint8(nonce)))
-                    .fromLast20Bytes();
+        // The integer zero is treated as an empty byte string, and as a result it only has a length prefix, 0x80,
+        // computed via 0x80 + 0.
+        // A one byte integer uses its own value as its length prefix, there is no additional "0x80 + length" prefix
+        // that comes before it.
+        if (nonce == 0x00) {
+            return keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, bytes1(0x80))).fromLast20Bytes();
+        }
+        if (nonce <= 0x7f) {
+            return keccak256(abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, uint8(nonce))).fromLast20Bytes();
+        }
 
-        // Nonces greater than 1 byte all follow a consistent encoding scheme, where each value is preceded by a prefix of 0x80 + length.
-        if (nonce <= type(uint8).max)
-            return
-                keccak256(
-                    abi.encodePacked(
-                        bytes1(0xd7),
-                        bytes1(0x94),
-                        deployer,
-                        bytes1(0x81),
-                        uint8(nonce)
-                    )
-                ).fromLast20Bytes();
-        if (nonce <= type(uint16).max)
-            return
-                keccak256(
-                    abi.encodePacked(
-                        bytes1(0xd8),
-                        bytes1(0x94),
-                        deployer,
-                        bytes1(0x82),
-                        uint16(nonce)
-                    )
-                ).fromLast20Bytes();
-        if (nonce <= type(uint24).max)
-            return
-                keccak256(
-                    abi.encodePacked(
-                        bytes1(0xd9),
-                        bytes1(0x94),
-                        deployer,
-                        bytes1(0x83),
-                        uint24(nonce)
-                    )
-                ).fromLast20Bytes();
+        // Nonces greater than 1 byte all follow a consistent encoding scheme, where each value is preceded by a prefix
+        // of 0x80 + length.
+        if (nonce <= type(uint8).max) {
+            return keccak256(abi.encodePacked(bytes1(0xd7), bytes1(0x94), deployer, bytes1(0x81), uint8(nonce)))
+                .fromLast20Bytes();
+        }
+        if (nonce <= type(uint16).max) {
+            return keccak256(abi.encodePacked(bytes1(0xd8), bytes1(0x94), deployer, bytes1(0x82), uint16(nonce)))
+                .fromLast20Bytes();
+        }
+        if (nonce <= type(uint24).max) {
+            return keccak256(abi.encodePacked(bytes1(0xd9), bytes1(0x94), deployer, bytes1(0x83), uint24(nonce)))
+                .fromLast20Bytes();
+        }
 
         // More details about RLP encoding can be found here: https://eth.wiki/fundamentals/rlp
         // 0xda = 0xc0 (short RLP prefix) + 0x16 (length of: 0x94 ++ proxy ++ 0x84 ++ nonce)
         // 0x94 = 0x80 + 0x14 (0x14 = the length of an address, 20 bytes, in hex)
         // 0x84 = 0x80 + 0x04 (0x04 = the bytes length of the nonce, 4 bytes, in hex)
         // We assume nobody can have a nonce large enough to require more than 32 bytes.
-        return
-            keccak256(
-                abi.encodePacked(bytes1(0xda), bytes1(0x94), deployer, bytes1(0x84), uint32(nonce))
-            ).fromLast20Bytes();
+        return keccak256(abi.encodePacked(bytes1(0xda), bytes1(0x94), deployer, bytes1(0x84), uint32(nonce)))
+            .fromLast20Bytes();
     }
 }

--- a/packages/contracts-bedrock/contracts/test/RLPReader.t.sol
+++ b/packages/contracts-bedrock/contracts/test/RLPReader.t.sol
@@ -24,16 +24,12 @@ contract RLPReader_readBytes_Test is CommonTest {
     }
 
     function test_readBytes_invalidStringLength_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be > than length of string length (long string)"
-        );
+        vm.expectRevert("RLPReader: length of content must be > than length of string length (long string)");
         RLPReader.readBytes(hex"b9");
     }
 
     function test_readBytes_invalidListLength_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be > than length of list length (long list)"
-        );
+        vm.expectRevert("RLPReader: length of content must be > than length of list length (long list)");
         RLPReader.readBytes(hex"ff");
     }
 
@@ -43,9 +39,7 @@ contract RLPReader_readBytes_Test is CommonTest {
     }
 
     function test_readBytes_invalidPrefix_reverts() external {
-        vm.expectRevert(
-            "RLPReader: invalid prefix, single byte < 0x80 are not prefixed (short string)"
-        );
+        vm.expectRevert("RLPReader: invalid prefix, single byte < 0x80 are not prefixed (short string)");
         RLPReader.readBytes(hex"810a");
     }
 }
@@ -109,9 +103,7 @@ contract RLPReader_readList_Test is CommonTest {
 
     function test_readList_listLongerThan32Elements_reverts() external {
         vm.expectRevert(stdError.indexOOBError);
-        RLPReader.readList(
-            hex"e1454545454545454545454545454545454545454545454545454545454545454545"
-        );
+        RLPReader.readList(hex"e1454545454545454545454545454545454545454545454545454545454545454545");
     }
 
     function test_readList_listOfLists_succeeds() external {
@@ -143,64 +135,44 @@ contract RLPReader_readList_Test is CommonTest {
     }
 
     function test_readList_invalidShortList_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than list length (short list)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than list length (short list)");
         RLPReader.readList(hex"efdebd");
     }
 
     function test_readList_longStringLength_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than list length (short list)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than list length (short list)");
         RLPReader.readList(hex"efb83600");
     }
 
     function test_readList_notLongEnough_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than list length (short list)"
-        );
-        RLPReader.readList(
-            hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than list length (short list)");
+        RLPReader.readList(hex"efdebdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
     function test_readList_int32Overflow_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than total length (long string)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than total length (long string)");
         RLPReader.readList(hex"bf0f000000000000021111");
     }
 
     function test_readList_int32Overflow2_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than total length (long list)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than total length (long list)");
         RLPReader.readList(hex"ff0f000000000000021111");
     }
 
     function test_readList_incorrectLengthInArray_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must not have any leading zeros (long string)"
-        );
-        RLPReader.readList(
-            hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0"
-        );
+        vm.expectRevert("RLPReader: length of content must not have any leading zeros (long string)");
+        RLPReader.readList(hex"b9002100dc2b275d0f74e8a53e6f4ec61b27f24278820be3f82ea2110e582081b0565df0");
     }
 
     function test_readList_leadingZerosInLongLengthArray1_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must not have any leading zeros (long string)"
-        );
+        vm.expectRevert("RLPReader: length of content must not have any leading zeros (long string)");
         RLPReader.readList(
             hex"b90040000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
         );
     }
 
     function test_readList_leadingZerosInLongLengthArray2_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must not have any leading zeros (long string)"
-        );
+        vm.expectRevert("RLPReader: length of content must not have any leading zeros (long string)");
         RLPReader.readList(hex"b800");
     }
 
@@ -222,9 +194,7 @@ contract RLPReader_readList_Test is CommonTest {
     }
 
     function test_readList_invalidValue_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than string length (short string)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than string length (short string)");
         RLPReader.readList(hex"91");
     }
 
@@ -234,30 +204,22 @@ contract RLPReader_readList_Test is CommonTest {
     }
 
     function test_readList_notEnoughContentForString1_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than total length (long string)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than total length (long string)");
         RLPReader.readList(hex"ba010000aabbccddeeff");
     }
 
     function test_readList_notEnoughContentForString2_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than total length (long string)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than total length (long string)");
         RLPReader.readList(hex"b840ffeeddccbbaa99887766554433221100");
     }
 
     function test_readList_notEnoughContentForList1_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than total length (long list)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than total length (long list)");
         RLPReader.readList(hex"f90180");
     }
 
     function test_readList_notEnoughContentForList2_reverts() external {
-        vm.expectRevert(
-            "RLPReader: length of content must be greater than total length (long list)"
-        );
+        vm.expectRevert("RLPReader: length of content must be greater than total length (long list)");
         RLPReader.readList(hex"ffffffffffffffffff0001020304050607");
     }
 

--- a/packages/contracts-bedrock/contracts/test/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/contracts/test/ResolvedDelegateProxy.t.sol
@@ -23,9 +23,7 @@ contract ResolvedDelegateProxy_Test is Test {
         addressManager.setAddress("SimpleImplementation", address(impl));
 
         // Set up the proxy.
-        proxy = SimpleImplementation(
-            address(new ResolvedDelegateProxy(addressManager, "SimpleImplementation"))
-        );
+        proxy = SimpleImplementation(address(new ResolvedDelegateProxy(addressManager, "SimpleImplementation")));
     }
 
     /// @dev Tests that the proxy properly bubbles up returndata when the delegatecall succeeds.
@@ -45,9 +43,7 @@ contract ResolvedDelegateProxy_Test is Test {
     ///      address manager is not set.
     function test_fallback_addressManagerNotSet_reverts() public {
         AddressManager am = new AddressManager();
-        SimpleImplementation p = SimpleImplementation(
-            address(new ResolvedDelegateProxy(am, "SimpleImplementation"))
-        );
+        SimpleImplementation p = SimpleImplementation(address(new ResolvedDelegateProxy(am, "SimpleImplementation")));
 
         vm.expectRevert("ResolvedDelegateProxy: target address must be initialized");
         p.foo(0);

--- a/packages/contracts-bedrock/contracts/test/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/contracts/test/ResourceMetering.t.sol
@@ -29,22 +29,13 @@ contract MeterUser is ResourceMetering {
         return _resourceConfig();
     }
 
-    function _resourceConfig()
-        internal
-        view
-        override
-        returns (ResourceMetering.ResourceConfig memory)
-    {
+    function _resourceConfig() internal view override returns (ResourceMetering.ResourceConfig memory) {
         return innerConfig;
     }
 
-    function use(uint64 _amount) public metered(_amount) {}
+    function use(uint64 _amount) public metered(_amount) { }
 
-    function set(
-        uint128 _prevBaseFee,
-        uint64 _prevBoughtGas,
-        uint64 _prevBlockNum
-    ) public {
+    function set(uint128 _prevBaseFee, uint64 _prevBoughtGas, uint64 _prevBlockNum) public {
         params = ResourceMetering.ResourceParams({
             prevBaseFee: _prevBaseFee,
             prevBoughtGas: _prevBoughtGas,
@@ -145,12 +136,12 @@ contract ResourceMetering_Test is Test {
 
         meter.use(target * elasticityMultiplier);
 
-        (, uint64 prevBoughtGas, ) = meter.params();
+        (, uint64 prevBoughtGas,) = meter.params();
         assertEq(prevBoughtGas, target * elasticityMultiplier);
 
         vm.roll(initialBlockNum + 1);
         meter.use(0);
-        (uint128 postBaseFee, , ) = meter.params();
+        (uint128 postBaseFee,,) = meter.params();
         assertEq(postBaseFee, 2125000000);
     }
 
@@ -165,7 +156,7 @@ contract ResourceMetering_Test is Test {
         meter.setParams(rcfg);
         meter.use(target * elasticityMultiplier);
 
-        (, uint64 prevBoughtGas, ) = meter.params();
+        (, uint64 prevBoughtGas,) = meter.params();
         assertEq(prevBoughtGas, target * elasticityMultiplier);
 
         vm.roll(initialBlockNum + 2);
@@ -207,11 +198,7 @@ contract CustomMeterUser is ResourceMetering {
     uint256 public startGas;
     uint256 public endGas;
 
-    constructor(
-        uint128 _prevBaseFee,
-        uint64 _prevBoughtGas,
-        uint64 _prevBlockNum
-    ) {
+    constructor(uint128 _prevBaseFee, uint64 _prevBoughtGas, uint64 _prevBlockNum) {
         params = ResourceMetering.ResourceParams({
             prevBaseFee: _prevBaseFee,
             prevBoughtGas: _prevBoughtGas,
@@ -219,12 +206,7 @@ contract CustomMeterUser is ResourceMetering {
         });
     }
 
-    function _resourceConfig()
-        internal
-        pure
-        override
-        returns (ResourceMetering.ResourceConfig memory)
-    {
+    function _resourceConfig() internal pure override returns (ResourceMetering.ResourceConfig memory) {
         return Constants.DEFAULT_RESOURCE_CONFIG();
     }
 
@@ -250,15 +232,13 @@ contract ArtifactResourceMetering_Test is Test {
 
     string internal outfile;
 
-    // keccak256(abi.encodeWithSignature("Error(string)", "ResourceMetering: cannot buy more gas than available gas limit"))
-    bytes32 internal cannotBuyMoreGas =
-        0x84edc668cfd5e050b8999f43ff87a1faaa93e5f935b20bc1dd4d3ff157ccf429;
+    // keccak256(abi.encodeWithSignature("Error(string)", "ResourceMetering: cannot buy more gas than available gas
+    // limit"))
+    bytes32 internal cannotBuyMoreGas = 0x84edc668cfd5e050b8999f43ff87a1faaa93e5f935b20bc1dd4d3ff157ccf429;
     // keccak256(abi.encodeWithSignature("Panic(uint256)", 0x11))
-    bytes32 internal overflowErr =
-        0x1ca389f2c8264faa4377de9ce8e14d6263ef29c68044a9272d405761bab2db27;
+    bytes32 internal overflowErr = 0x1ca389f2c8264faa4377de9ce8e14d6263ef29c68044a9272d405761bab2db27;
     // keccak256(hex"")
-    bytes32 internal emptyReturnData =
-        0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+    bytes32 internal emptyReturnData = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
 
     /// @dev Sets up the tests with constants from the ResourceMetering contract.
     function setUp() public {
@@ -272,7 +252,7 @@ contract ArtifactResourceMetering_Test is Test {
         targetResourceLimit = uint64(rcfg.maxResourceLimit) / uint64(rcfg.elasticityMultiplier);
 
         outfile = string.concat(vm.projectRoot(), "/.resource-metering.csv");
-        try vm.removeFile(outfile) {} catch {}
+        try vm.removeFile(outfile) { } catch { }
     }
 
     /// @dev Generates a CSV file. No more than the L1 block gas limit should
@@ -348,9 +328,7 @@ contract ArtifactResourceMetering_Test is Test {
                                 // Call the metering code and catch the various
                                 // types of errors.
                                 uint256 gasConsumed = 0;
-                                try meter.use{ gas: 30_000_000 }(requestedGas) returns (
-                                    uint256 _gasConsumed
-                                ) {
+                                try meter.use{ gas: 30_000_000 }(requestedGas) returns (uint256 _gasConsumed) {
                                     gasConsumed = _gasConsumed;
                                 } catch (bytes memory err) {
                                     bytes32 hash = keccak256(err);

--- a/packages/contracts-bedrock/contracts/test/SafeCall.t.sol
+++ b/packages/contracts-bedrock/contracts/test/SafeCall.t.sol
@@ -9,12 +9,7 @@ import { SafeCall } from "../libraries/SafeCall.sol";
 
 contract SafeCall_Test is CommonTest {
     /// @dev Tests that the `send` function succeeds.
-    function testFuzz_send_succeeds(
-        address from,
-        address to,
-        uint256 gas,
-        uint64 value
-    ) external {
+    function testFuzz_send_succeeds(address from, address to, uint256 gas, uint64 value) external {
         vm.assume(from.balance == 0);
         vm.assume(to.balance == 0);
         // no precompiles (mainnet)
@@ -49,13 +44,7 @@ contract SafeCall_Test is CommonTest {
     }
 
     /// @dev Tests that `call` succeeds.
-    function testFuzz_call_succeeds(
-        address from,
-        address to,
-        uint256 gas,
-        uint64 value,
-        bytes memory data
-    ) external {
+    function testFuzz_call_succeeds(address from, address to, uint256 gas, uint64 value, bytes memory data) external {
         vm.assume(from.balance == 0);
         vm.assume(to.balance == 0);
         // no precompiles (mainnet)
@@ -145,12 +134,7 @@ contract SafeCall_Test is CommonTest {
             if (i < 65_907) {
                 assertFalse(caller.makeSafeCall(i, 25_000));
             } else {
-                vm.expectCallMinGas(
-                    address(caller),
-                    0,
-                    25_000,
-                    abi.encodeWithSelector(caller.setA.selector, 1)
-                );
+                vm.expectCallMinGas(address(caller), 0, 25_000, abi.encodeWithSelector(caller.setA.selector, 1));
                 assertTrue(caller.makeSafeCall(i, 25_000));
             }
 
@@ -170,12 +154,7 @@ contract SafeCall_Test is CommonTest {
             if (i < 15_278_606) {
                 assertFalse(caller.makeSafeCall(i, 15_000_000));
             } else {
-                vm.expectCallMinGas(
-                    address(caller),
-                    0,
-                    15_000_000,
-                    abi.encodeWithSelector(caller.setA.selector, 1)
-                );
+                vm.expectCallMinGas(address(caller), 0, 15_000_000, abi.encodeWithSelector(caller.setA.selector, 1));
                 assertTrue(caller.makeSafeCall(i, 15_000_000));
             }
 
@@ -188,23 +167,11 @@ contract SimpleSafeCaller {
     uint256 public a;
 
     function makeSafeCall(uint64 gas, uint64 minGas) external returns (bool) {
-        return
-            SafeCall.call(
-                address(this),
-                gas,
-                0,
-                abi.encodeWithSelector(this.makeSafeCallMinGas.selector, minGas)
-            );
+        return SafeCall.call(address(this), gas, 0, abi.encodeWithSelector(this.makeSafeCallMinGas.selector, minGas));
     }
 
     function makeSafeCallMinGas(uint64 minGas) external returns (bool) {
-        return
-            SafeCall.callWithMinGas(
-                address(this),
-                minGas,
-                0,
-                abi.encodeWithSelector(this.setA.selector, 1)
-            );
+        return SafeCall.callWithMinGas(address(this), minGas, 0, abi.encodeWithSelector(this.setA.selector, 1));
     }
 
     function setA(uint256 _a) external {

--- a/packages/contracts-bedrock/contracts/test/SequencerFeeVault.t.sol
+++ b/packages/contracts-bedrock/contracts/test/SequencerFeeVault.t.sol
@@ -20,8 +20,7 @@ contract SequencerFeeVault_Test is FeeVault_Initializer {
         super.setUp();
         vm.etch(
             Predeploys.SEQUENCER_FEE_WALLET,
-            address(new SequencerFeeVault(recipient, NON_ZERO_VALUE, FeeVault.WithdrawalNetwork.L1))
-                .code
+            address(new SequencerFeeVault(recipient, NON_ZERO_VALUE, FeeVault.WithdrawalNetwork.L1)).code
         );
         vm.label(Predeploys.SEQUENCER_FEE_WALLET, "SequencerFeeVault");
     }
@@ -41,7 +40,7 @@ contract SequencerFeeVault_Test is FeeVault_Initializer {
         uint256 balance = address(vault).balance;
 
         vm.prank(alice);
-        (bool success, ) = address(vault).call{ value: 100 }(hex"");
+        (bool success,) = address(vault).call{ value: 100 }(hex"");
 
         assertEq(success, true);
         assertEq(address(vault).balance, balance + 100);
@@ -52,9 +51,7 @@ contract SequencerFeeVault_Test is FeeVault_Initializer {
     function test_withdraw_notEnough_reverts() external {
         assert(address(vault).balance < vault.MIN_WITHDRAWAL_AMOUNT());
 
-        vm.expectRevert(
-            "FeeVault: withdrawal amount must be greater than minimum withdrawal amount"
-        );
+        vm.expectRevert("FeeVault: withdrawal amount must be greater than minimum withdrawal amount");
         vault.withdraw();
     }
 
@@ -69,23 +66,13 @@ contract SequencerFeeVault_Test is FeeVault_Initializer {
         vm.expectEmit(true, true, true, true, address(Predeploys.SEQUENCER_FEE_WALLET));
         emit Withdrawal(address(vault).balance, vault.RECIPIENT(), address(this));
         vm.expectEmit(true, true, true, true, address(Predeploys.SEQUENCER_FEE_WALLET));
-        emit Withdrawal(
-            address(vault).balance,
-            vault.RECIPIENT(),
-            address(this),
-            FeeVault.WithdrawalNetwork.L1
-        );
+        emit Withdrawal(address(vault).balance, vault.RECIPIENT(), address(this), FeeVault.WithdrawalNetwork.L1);
 
         // The entire vault's balance is withdrawn
         vm.expectCall(
             Predeploys.L2_STANDARD_BRIDGE,
             address(vault).balance,
-            abi.encodeWithSelector(
-                StandardBridge.bridgeETHTo.selector,
-                vault.l1FeeWallet(),
-                35_000,
-                bytes("")
-            )
+            abi.encodeWithSelector(StandardBridge.bridgeETHTo.selector, vault.l1FeeWallet(), 35_000, bytes(""))
         );
 
         vault.withdraw();
@@ -103,8 +90,7 @@ contract SequencerFeeVault_L2Withdrawal_Test is FeeVault_Initializer {
         super.setUp();
         vm.etch(
             Predeploys.SEQUENCER_FEE_WALLET,
-            address(new SequencerFeeVault(recipient, NON_ZERO_VALUE, FeeVault.WithdrawalNetwork.L2))
-                .code
+            address(new SequencerFeeVault(recipient, NON_ZERO_VALUE, FeeVault.WithdrawalNetwork.L2)).code
         );
         vm.label(Predeploys.SEQUENCER_FEE_WALLET, "SequencerFeeVault");
     }
@@ -120,12 +106,7 @@ contract SequencerFeeVault_L2Withdrawal_Test is FeeVault_Initializer {
         vm.expectEmit(true, true, true, true, address(Predeploys.SEQUENCER_FEE_WALLET));
         emit Withdrawal(address(vault).balance, vault.RECIPIENT(), address(this));
         vm.expectEmit(true, true, true, true, address(Predeploys.SEQUENCER_FEE_WALLET));
-        emit Withdrawal(
-            address(vault).balance,
-            vault.RECIPIENT(),
-            address(this),
-            FeeVault.WithdrawalNetwork.L2
-        );
+        emit Withdrawal(address(vault).balance, vault.RECIPIENT(), address(this), FeeVault.WithdrawalNetwork.L2);
 
         // The entire vault's balance is withdrawn
         vm.expectCall(recipient, address(vault).balance, bytes(""));

--- a/packages/contracts-bedrock/contracts/test/StandardBridge.t.sol
+++ b/packages/contracts-bedrock/contracts/test/StandardBridge.t.sol
@@ -3,47 +3,38 @@ pragma solidity 0.8.15;
 
 import { StandardBridge } from "../universal/StandardBridge.sol";
 import { CommonTest } from "./CommonTest.t.sol";
-import {
-    OptimismMintableERC20,
-    ILegacyMintableERC20
-} from "../universal/OptimismMintableERC20.sol";
+import { OptimismMintableERC20, ILegacyMintableERC20 } from "../universal/OptimismMintableERC20.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @title StandardBridgeTester
 /// @notice Simple wrapper around the StandardBridge contract that exposes
 ///         internal functions so they can be more easily tested directly.
 contract StandardBridgeTester is StandardBridge {
-    constructor(address payable _messenger, address payable _otherBridge)
-        StandardBridge(_messenger, _otherBridge)
-    {}
+    constructor(address payable _messenger, address payable _otherBridge) StandardBridge(_messenger, _otherBridge) { }
 
     function isOptimismMintableERC20(address _token) external view returns (bool) {
         return _isOptimismMintableERC20(_token);
     }
 
-    function isCorrectTokenPair(address _mintableToken, address _otherToken)
-        external
-        view
-        returns (bool)
-    {
+    function isCorrectTokenPair(address _mintableToken, address _otherToken) external view returns (bool) {
         return _isCorrectTokenPair(_mintableToken, _otherToken);
     }
 
-    receive() external payable override {}
+    receive() external payable override { }
 }
 
 /// @title LegacyMintable
 /// @notice Simple implementation of the legacy OptimismMintableERC20.
 contract LegacyMintable is ERC20, ILegacyMintableERC20 {
-    constructor(string memory _name, string memory _ticker) ERC20(_name, _ticker) {}
+    constructor(string memory _name, string memory _ticker) ERC20(_name, _ticker) { }
 
     function l1Token() external pure returns (address) {
         return address(0);
     }
 
-    function mint(address _to, uint256 _amount) external pure {}
+    function mint(address _to, uint256 _amount) external pure { }
 
-    function burn(address _from, uint256 _amount) external pure {}
+    function burn(address _from, uint256 _amount) external pure { }
 
     /// @notice Implements ERC165. This implementation should not be changed as
     ///         it is how the actual legacy optimism mintable token does the
@@ -51,9 +42,8 @@ contract LegacyMintable is ERC20, ILegacyMintableERC20 {
     ///         assuming different compiler version is no problem.
     function supportsInterface(bytes4 _interfaceId) external pure returns (bool) {
         bytes4 firstSupportedInterface = bytes4(keccak256("supportsInterface(bytes4)")); // ERC165
-        bytes4 secondSupportedInterface = ILegacyMintableERC20.l1Token.selector ^
-            ILegacyMintableERC20.mint.selector ^
-            ILegacyMintableERC20.burn.selector;
+        bytes4 secondSupportedInterface = ILegacyMintableERC20.l1Token.selector ^ ILegacyMintableERC20.mint.selector
+            ^ ILegacyMintableERC20.burn.selector;
         return _interfaceId == firstSupportedInterface || _interfaceId == secondSupportedInterface;
     }
 }

--- a/packages/contracts-bedrock/contracts/test/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/contracts/test/SystemConfig.t.sol
@@ -166,11 +166,7 @@ contract SystemConfig_Setters_TestFail is SystemConfig_Init {
 }
 
 contract SystemConfig_Setters_Test is SystemConfig_Init {
-    event ConfigUpdate(
-        uint256 indexed version,
-        SystemConfig.UpdateType indexed updateType,
-        bytes data
-    );
+    event ConfigUpdate(uint256 indexed version, SystemConfig.UpdateType indexed updateType, bytes data);
 
     /// @dev Tests that `setBatcherHash` updates the batcher hash successfully.
     function testFuzz_setBatcherHash_succeeds(bytes32 newBatcherHash) external {
@@ -185,11 +181,7 @@ contract SystemConfig_Setters_Test is SystemConfig_Init {
     /// @dev Tests that `setGasConfig` updates the overhead and scalar successfully.
     function testFuzz_setGasConfig_succeeds(uint256 newOverhead, uint256 newScalar) external {
         vm.expectEmit(true, true, true, true);
-        emit ConfigUpdate(
-            0,
-            SystemConfig.UpdateType.GAS_CONFIG,
-            abi.encode(newOverhead, newScalar)
-        );
+        emit ConfigUpdate(0, SystemConfig.UpdateType.GAS_CONFIG, abi.encode(newOverhead, newScalar));
 
         vm.prank(sysConf.owner());
         sysConf.setGasConfig(newOverhead, newScalar);
@@ -200,9 +192,7 @@ contract SystemConfig_Setters_Test is SystemConfig_Init {
     /// @dev Tests that `setGasLimit` updates the gas limit successfully.
     function testFuzz_setGasLimit_succeeds(uint64 newGasLimit) external {
         uint64 minimumGasLimit = sysConf.minimumGasLimit();
-        newGasLimit = uint64(
-            bound(uint256(newGasLimit), uint256(minimumGasLimit), uint256(type(uint64).max))
-        );
+        newGasLimit = uint64(bound(uint256(newGasLimit), uint256(minimumGasLimit), uint256(type(uint64).max)));
 
         vm.expectEmit(true, true, true, true);
         emit ConfigUpdate(0, SystemConfig.UpdateType.GAS_LIMIT, abi.encode(newGasLimit));
@@ -215,11 +205,7 @@ contract SystemConfig_Setters_Test is SystemConfig_Init {
     /// @dev Tests that `setUnsafeBlockSigner` updates the block signer successfully.
     function testFuzz_setUnsafeBlockSigner_succeeds(address newUnsafeSigner) external {
         vm.expectEmit(true, true, true, true);
-        emit ConfigUpdate(
-            0,
-            SystemConfig.UpdateType.UNSAFE_BLOCK_SIGNER,
-            abi.encode(newUnsafeSigner)
-        );
+        emit ConfigUpdate(0, SystemConfig.UpdateType.UNSAFE_BLOCK_SIGNER, abi.encode(newUnsafeSigner));
 
         vm.prank(sysConf.owner());
         sysConf.setUnsafeBlockSigner(newUnsafeSigner);

--- a/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/CrossDomainMessenger.t.sol
@@ -24,12 +24,7 @@ contract RelayActor is StdUtils {
     Vm vm;
     bool doFail;
 
-    constructor(
-        OptimismPortal _op,
-        L1CrossDomainMessenger _xdm,
-        Vm _vm,
-        bool _doFail
-    ) {
+    constructor(OptimismPortal _op, L1CrossDomainMessenger _xdm, Vm _vm, bool _doFail) {
         op = _op;
         xdm = _xdm;
         vm = _vm;
@@ -39,11 +34,7 @@ contract RelayActor is StdUtils {
     /**
      * Relays a message to the `L1CrossDomainMessenger` with a random `version`, and `_message`.
      */
-    function relay(
-        uint8 _version,
-        uint8 _value,
-        bytes memory _message
-    ) external {
+    function relay(uint8 _version, uint8 _value, bytes memory _message) external {
         address target = address(0x04); // ID precompile
         address sender = Predeploys.L2_CROSS_DOMAIN_MESSENGER;
 
@@ -65,20 +56,13 @@ contract RelayActor is StdUtils {
 
         // If the message should succeed, supply it `baseGas`. If not, supply it an amount of
         // gas that is too low to complete the call.
-        uint256 gas = doFail
-            ? bound(minGasLimit, 60_000, 80_000)
-            : xdm.baseGas(_message, minGasLimit);
+        uint256 gas = doFail ? bound(minGasLimit, 60_000, 80_000) : xdm.baseGas(_message, minGasLimit);
 
         // Compute the cross domain message hash and store it in `hashes`.
         // The `relayMessage` function will always encode the message as a version 1
         // message after checking that the V0 hash has not already been relayed.
         bytes32 _hash = Hashing.hashCrossDomainMessageV1(
-            Encoding.encodeVersionedNonce(0, _version),
-            sender,
-            target,
-            _value,
-            minGasLimit,
-            _message
+            Encoding.encodeVersionedNonce(0, _version), sender, target, _value, minGasLimit, _message
         );
         hashes.push(_hash);
         numHashes += 1;
@@ -92,16 +76,9 @@ contract RelayActor is StdUtils {
         if (!doFail) {
             vm.expectCallMinGas(address(0x04), _value, minGasLimit, _message);
         }
-        try
-            xdm.relayMessage{ gas: gas, value: _value }(
-                Encoding.encodeVersionedNonce(0, _version),
-                sender,
-                target,
-                _value,
-                minGasLimit,
-                _message
-            )
-        {} catch {
+        try xdm.relayMessage{ gas: gas, value: _value }(
+            Encoding.encodeVersionedNonce(0, _version), sender, target, _value, minGasLimit, _message
+        ) { } catch {
             // If any of these calls revert, set `reverted` to true to fail the invariant test.
             // NOTE: This is to get around forge's invariant fuzzer ignoring reverted calls
             // to this function.

--- a/packages/contracts-bedrock/contracts/test/invariants/Hashing.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/Hashing.t.sol
@@ -54,20 +54,8 @@ contract Hash_CrossDomainHasher {
 
         // hash the cross domain message using the unversioned and versioned functions for
         // comparison
-        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(
-            encodedNonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
-        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV0(
-            _target,
-            _sender,
-            _data,
-            encodedNonce
-        );
+        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(encodedNonce, _sender, _target, _value, _gasLimit, _data);
+        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV0(_target, _sender, _data, encodedNonce);
 
         // check that the output of both functions matches
         if (sampleHash1 != sampleHash2) {
@@ -92,22 +80,8 @@ contract Hash_CrossDomainHasher {
 
         // hash the cross domain message using the unversioned and versioned functions for
         // comparison
-        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(
-            encodedNonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
-        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV1(
-            encodedNonce,
-            _sender,
-            _target,
-            _value,
-            _gasLimit,
-            _data
-        );
+        bytes32 sampleHash1 = Hashing.hashCrossDomainMessage(encodedNonce, _sender, _target, _value, _gasLimit, _data);
+        bytes32 sampleHash2 = Hashing.hashCrossDomainMessageV1(encodedNonce, _sender, _target, _value, _gasLimit, _data);
 
         // check that the output of both functions matches
         if (sampleHash1 != sampleHash2) {

--- a/packages/contracts-bedrock/contracts/test/invariants/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/L2OutputOracle.t.sol
@@ -16,12 +16,9 @@ contract L2OutputOracle_Proposer {
     /**
      * @dev Allows the actor to propose an L2 output to the `L2OutputOracle`
      */
-    function proposeL2Output(
-        bytes32 _outputRoot,
-        uint256 _l2BlockNumber,
-        bytes32 _l1BlockHash,
-        uint256 _l1BlockNumber
-    ) external {
+    function proposeL2Output(bytes32 _outputRoot, uint256 _l2BlockNumber, bytes32 _l1BlockHash, uint256 _l1BlockNumber)
+        external
+    {
         // Act as the proposer and propose a new output.
         vm.prank(oracle.PROPOSER());
         oracle.proposeL2Output(_outputRoot, _l2BlockNumber, _l1BlockHash, _l1BlockNumber);

--- a/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/OptimismPortal.t.sol
@@ -32,12 +32,7 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
         return _resourceConfig();
     }
 
-    function _resourceConfig()
-        internal
-        pure
-        override
-        returns (ResourceMetering.ResourceConfig memory)
-    {
+    function _resourceConfig() internal pure override returns (ResourceMetering.ResourceConfig memory) {
         ResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
         return rcfg;
     }
@@ -59,15 +54,11 @@ contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
         uint256 preDepositBalance = address(this).balance;
         uint256 value = bound(preDepositvalue, 0, preDepositBalance);
 
-        (, uint64 cachedPrevBoughtGas, ) = ResourceMetering(address(portal)).params();
+        (, uint64 cachedPrevBoughtGas,) = ResourceMetering(address(portal)).params();
         ResourceMetering.ResourceConfig memory rcfg = resourceConfig();
         uint256 maxResourceLimit = uint64(rcfg.maxResourceLimit);
         uint64 gasLimit = uint64(
-            bound(
-                _gasLimit,
-                portal.minimumGasLimit(uint64(_data.length)),
-                maxResourceLimit - cachedPrevBoughtGas
-            )
+            bound(_gasLimit, portal.minimumGasLimit(uint64(_data.length)), maxResourceLimit - cachedPrevBoughtGas)
         );
 
         try portal.depositTransaction{ value: value }(_to, value, gasLimit, _isCreation, _data) {
@@ -103,8 +94,8 @@ contract OptimismPortal_Invariant_Harness is Portal_Initializer {
             data: hex""
         });
         // Get withdrawal proof data we can use for testing.
-        (_stateRoot, _storageRoot, _outputRoot, _withdrawalHash, _withdrawalProof) = ffi
-            .getProveWithdrawalTransactionInputs(_defaultTx);
+        (_stateRoot, _storageRoot, _outputRoot, _withdrawalHash, _withdrawalProof) =
+            ffi.getProveWithdrawalTransactionInputs(_defaultTx);
 
         // Setup a dummy output root proof for reuse.
         _outputRootProof = Types.OutputRootProof({
@@ -122,11 +113,7 @@ contract OptimismPortal_Invariant_Harness is Portal_Initializer {
         oracle.proposeL2Output(_outputRoot, _proposedBlockNumber, 0, 0);
 
         // Warp beyond the finalization period for the block we've proposed.
-        vm.warp(
-            oracle.getL2Output(_proposedOutputIndex).timestamp +
-                oracle.FINALIZATION_PERIOD_SECONDS() +
-                1
-        );
+        vm.warp(oracle.getL2Output(_proposedOutputIndex).timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
         // Fund the portal so that we can withdraw ETH.
         vm.deal(address(op), 0xFFFFFFFF);
     }
@@ -165,12 +152,7 @@ contract OptimismPortal_CannotTimeTravel is OptimismPortal_Invariant_Harness {
         super.setUp();
 
         // Prove the withdrawal transaction
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Set the target contract to the portal proxy
         targetContract(address(op));
@@ -196,12 +178,7 @@ contract OptimismPortal_CannotFinalizeTwice is OptimismPortal_Invariant_Harness 
         super.setUp();
 
         // Prove the withdrawal transaction
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);
@@ -233,12 +210,7 @@ contract OptimismPortal_CanAlwaysFinalizeAfterWindow is OptimismPortal_Invariant
         super.setUp();
 
         // Prove the withdrawal transaction
-        op.proveWithdrawalTransaction(
-            _defaultTx,
-            _proposedOutputIndex,
-            _outputRootProof,
-            _withdrawalProof
-        );
+        op.proveWithdrawalTransaction(_defaultTx, _proposedOutputIndex, _outputRootProof, _withdrawalProof);
 
         // Warp past the finalization period.
         vm.warp(block.timestamp + oracle.FINALIZATION_PERIOD_SECONDS() + 1);

--- a/packages/contracts-bedrock/contracts/test/invariants/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/ResourceMetering.t.sol
@@ -35,12 +35,7 @@ contract ResourceMetering_User is StdUtils, ResourceMetering {
         return _resourceConfig();
     }
 
-    function _resourceConfig()
-        internal
-        pure
-        override
-        returns (ResourceMetering.ResourceConfig memory)
-    {
+    function _resourceConfig() internal pure override returns (ResourceMetering.ResourceConfig memory) {
         ResourceMetering.ResourceConfig memory rcfg = Constants.DEFAULT_RESOURCE_CONFIG();
         return rcfg;
     }
@@ -56,8 +51,7 @@ contract ResourceMetering_User is StdUtils, ResourceMetering {
         uint256 cachedPrevBlockNum = uint256(params.prevBlockNum);
 
         ResourceMetering.ResourceConfig memory rcfg = resourceConfig();
-        uint256 targetResourceLimit = uint256(rcfg.maxResourceLimit) /
-            uint256(rcfg.elasticityMultiplier);
+        uint256 targetResourceLimit = uint256(rcfg.maxResourceLimit) / uint256(rcfg.elasticityMultiplier);
 
         // check that the last block's base fee hasn't dropped below the minimum
         if (cachedPrevBaseFee < uint256(rcfg.minimumBaseFee)) {
@@ -74,11 +68,7 @@ contract ResourceMetering_User is StdUtils, ResourceMetering {
         // raise or lower the baseFee after this block, respectively
         uint256 gasToBurn;
         if (_raiseBaseFee) {
-            gasToBurn = bound(
-                _gasToBurn,
-                uint256(targetResourceLimit),
-                uint256(rcfg.maxResourceLimit)
-            );
+            gasToBurn = bound(_gasToBurn, uint256(targetResourceLimit), uint256(rcfg.maxResourceLimit));
         } else {
             gasToBurn = bound(_gasToBurn, 0, targetResourceLimit);
         }
@@ -94,39 +84,35 @@ contract ResourceMetering_User is StdUtils, ResourceMetering {
         // empty blocks in between), ensure this block's baseFee increased, but not by
         // more than the max amount per block
         if (
-            (cachedPrevBoughtGas > uint256(targetResourceLimit)) &&
-            (uint256(params.prevBlockNum) - cachedPrevBlockNum == 1)
+            (cachedPrevBoughtGas > uint256(targetResourceLimit))
+                && (uint256(params.prevBlockNum) - cachedPrevBlockNum == 1)
         ) {
             failedRaiseBaseFee = failedRaiseBaseFee || (params.prevBaseFee <= cachedPrevBaseFee);
             failedMaxRaiseBaseFeePerBlock =
-                failedMaxRaiseBaseFeePerBlock ||
-                ((uint256(params.prevBaseFee) - cachedPrevBaseFee) < maxBaseFeeChange);
+                failedMaxRaiseBaseFeePerBlock || ((uint256(params.prevBaseFee) - cachedPrevBaseFee) < maxBaseFeeChange);
         }
 
         // If the last block used less than the target amount of gas, (or was empty),
         // ensure that: this block's baseFee was decreased, but not by more than the max amount
         if (
-            (cachedPrevBoughtGas < uint256(targetResourceLimit)) ||
-            (uint256(params.prevBlockNum) - cachedPrevBlockNum > 1)
+            (cachedPrevBoughtGas < uint256(targetResourceLimit))
+                || (uint256(params.prevBlockNum) - cachedPrevBlockNum > 1)
         ) {
             // Invariant: baseFee should decrease
-            failedLowerBaseFee =
-                failedLowerBaseFee ||
-                (uint256(params.prevBaseFee) > cachedPrevBaseFee);
+            failedLowerBaseFee = failedLowerBaseFee || (uint256(params.prevBaseFee) > cachedPrevBaseFee);
 
             if (params.prevBlockNum - cachedPrevBlockNum == 1) {
                 // No empty blocks
                 // Invariant: baseFee should not have decreased by more than the maximum amount
-                failedMaxLowerBaseFeePerBlock =
-                    failedMaxLowerBaseFeePerBlock ||
-                    ((cachedPrevBaseFee - uint256(params.prevBaseFee)) <= maxBaseFeeChange);
+                failedMaxLowerBaseFeePerBlock = failedMaxLowerBaseFeePerBlock
+                    || ((cachedPrevBaseFee - uint256(params.prevBaseFee)) <= maxBaseFeeChange);
             } else if (params.prevBlockNum - cachedPrevBlockNum > 1) {
                 // We have at least one empty block
                 // Update the maxBaseFeeChange to account for multiple blocks having passed
                 unchecked {
                     maxBaseFeeChange = uint256(
-                        int256(cachedPrevBaseFee) -
-                            Arithmetic.clamp(
+                        int256(cachedPrevBaseFee)
+                            - Arithmetic.clamp(
                                 Arithmetic.cdexp(
                                     int256(cachedPrevBaseFee),
                                     int256(uint256(rcfg.baseFeeMaxChangeDenominator)),
@@ -144,14 +130,13 @@ contract ResourceMetering_User is StdUtils, ResourceMetering {
                 underflow = underflow || maxBaseFeeChange > cachedPrevBaseFee;
 
                 // Invariant: baseFee should not have decreased by more than the maximum amount
-                failedMaxLowerBaseFeePerBlock =
-                    failedMaxLowerBaseFeePerBlock ||
-                    ((cachedPrevBaseFee - uint256(params.prevBaseFee)) <= maxBaseFeeChange);
+                failedMaxLowerBaseFeePerBlock = failedMaxLowerBaseFeePerBlock
+                    || ((cachedPrevBaseFee - uint256(params.prevBaseFee)) <= maxBaseFeeChange);
             }
         }
     }
 
-    function _burnInternal(uint64 _gasToBurn) private metered(_gasToBurn) {}
+    function _burnInternal(uint64 _gasToBurn) private metered(_gasToBurn) { }
 }
 
 contract ResourceMetering_Invariant is StdInvariant, Test {
@@ -228,7 +213,7 @@ contract ResourceMetering_Invariant is StdInvariant, Test {
      *
      * After a block consumes less than the target gas, the base fee cannot be lowered more
      * than the maximum amount allowed. The max base fee change (per-block) is derived as
-     *follows: `prevBaseFee / BASE_FEE_MAX_CHANGE_DENOMINATOR`
+     * follows: `prevBaseFee / BASE_FEE_MAX_CHANGE_DENOMINATOR`
      */
     function invariant_never_exceed_max_decrease() external {
         assertFalse(actor.failedMaxLowerBaseFeePerBlock());

--- a/packages/contracts-bedrock/contracts/test/invariants/SafeCall.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/SafeCall.t.sol
@@ -84,12 +84,7 @@ contract SafeCaller_Actor is StdUtils {
         FAILS = _fails;
     }
 
-    function performSafeCallMinGas(
-        uint64 gas,
-        uint64 minGas,
-        address to,
-        uint8 value
-    ) external {
+    function performSafeCallMinGas(uint64 gas, uint64 minGas, address to, uint8 value) external {
         // Only send to EOAs - we exclude the console as it has no code but reverts when called
         // with a selector that doesn't exist due to the foundry hook.
         vm.assume(to.code.length == 0 && to != 0x000000000000000000636F6e736F6c652e6c6f67);
@@ -112,11 +107,7 @@ contract SafeCaller_Actor is StdUtils {
             msg.sender,
             gas,
             value,
-            abi.encodeWithSelector(
-                SafeCall_Succeeds_Invariants.performSafeCallMinGas.selector,
-                to,
-                minGas
-            )
+            abi.encodeWithSelector(SafeCall_Succeeds_Invariants.performSafeCallMinGas.selector, to, minGas)
         );
 
         if (success && FAILS) numCalls++;

--- a/packages/contracts-bedrock/contracts/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/contracts/test/invariants/SystemConfig.t.sol
@@ -30,10 +30,7 @@ contract SystemConfig_GasLimitLowerBound_Invariant is Test {
         // that can modify the gas limit within the SystemConfig.
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = config.setGasLimit.selector;
-        FuzzSelector memory selector = FuzzSelector({
-            addr: address(config),
-            selectors: selectors
-        });
+        FuzzSelector memory selector = FuzzSelector({ addr: address(config), selectors: selectors });
         targetSelector(selector);
     }
 

--- a/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/contracts/universal/CrossDomainMessenger.sol
@@ -149,13 +149,7 @@ abstract contract CrossDomainMessenger is
     /// @param message      Message to trigger the recipient address with.
     /// @param messageNonce Unique nonce attached to the message.
     /// @param gasLimit     Minimum gas limit that the message can be executed with.
-    event SentMessage(
-        address indexed target,
-        address sender,
-        bytes message,
-        uint256 messageNonce,
-        uint256 gasLimit
-    );
+    event SentMessage(address indexed target, address sender, bytes message, uint256 messageNonce, uint256 gasLimit);
 
     /// @notice Additional event data to emit, required as of Bedrock. Cannot be merged with the
     ///         SentMessage event without breaking the ABI of this contract, this is good enough.
@@ -183,11 +177,7 @@ abstract contract CrossDomainMessenger is
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message to trigger the target address with.
     /// @param _minGasLimit Minimum gas limit that the message can be executed with.
-    function sendMessage(
-        address _target,
-        bytes calldata _message,
-        uint32 _minGasLimit
-    ) external payable {
+    function sendMessage(address _target, bytes calldata _message, uint32 _minGasLimit) external payable {
         // Triggers a message to the other messenger. Note that the amount of gas provided to the
         // message is the amount of gas requested by the user PLUS the base gas value. We want to
         // guarantee the property that the call to the target contract will always have at least
@@ -197,13 +187,7 @@ abstract contract CrossDomainMessenger is
             baseGas(_message, _minGasLimit),
             msg.value,
             abi.encodeWithSelector(
-                this.relayMessage.selector,
-                messageNonce(),
-                msg.sender,
-                _target,
-                msg.value,
-                _minGasLimit,
-                _message
+                this.relayMessage.selector, messageNonce(), msg.sender, _target, msg.value, _minGasLimit, _message
             )
         );
 
@@ -233,31 +217,19 @@ abstract contract CrossDomainMessenger is
         bytes calldata _message
     ) external payable {
         (, uint16 version) = Encoding.decodeVersionedNonce(_nonce);
-        require(
-            version < 2,
-            "CrossDomainMessenger: only version 0 or 1 messages are supported at this time"
-        );
+        require(version < 2, "CrossDomainMessenger: only version 0 or 1 messages are supported at this time");
 
         // If the message is version 0, then it's a migrated legacy withdrawal. We therefore need
         // to check that the legacy version of the message has not already been relayed.
         if (version == 0) {
             bytes32 oldHash = Hashing.hashCrossDomainMessageV0(_target, _sender, _message, _nonce);
-            require(
-                successfulMessages[oldHash] == false,
-                "CrossDomainMessenger: legacy withdrawal already relayed"
-            );
+            require(successfulMessages[oldHash] == false, "CrossDomainMessenger: legacy withdrawal already relayed");
         }
 
         // We use the v1 message hash as the unique identifier for the message because it commits
         // to the value and minimum gas limit of the message.
-        bytes32 versionedHash = Hashing.hashCrossDomainMessageV1(
-            _nonce,
-            _sender,
-            _target,
-            _value,
-            _minGasLimit,
-            _message
-        );
+        bytes32 versionedHash =
+            Hashing.hashCrossDomainMessageV1(_nonce, _sender, _target, _value, _minGasLimit, _message);
 
         if (_isOtherMessenger()) {
             // These properties should always hold when the message is first submitted (as
@@ -265,26 +237,16 @@ abstract contract CrossDomainMessenger is
             assert(msg.value == _value);
             assert(!failedMessages[versionedHash]);
         } else {
-            require(
-                msg.value == 0,
-                "CrossDomainMessenger: value must be zero unless message is from a system address"
-            );
+            require(msg.value == 0, "CrossDomainMessenger: value must be zero unless message is from a system address");
 
-            require(
-                failedMessages[versionedHash],
-                "CrossDomainMessenger: message cannot be replayed"
-            );
+            require(failedMessages[versionedHash], "CrossDomainMessenger: message cannot be replayed");
         }
 
         require(
-            _isUnsafeTarget(_target) == false,
-            "CrossDomainMessenger: cannot send message to blocked system address"
+            _isUnsafeTarget(_target) == false, "CrossDomainMessenger: cannot send message to blocked system address"
         );
 
-        require(
-            successfulMessages[versionedHash] == false,
-            "CrossDomainMessenger: message has already been relayed"
-        );
+        require(successfulMessages[versionedHash] == false, "CrossDomainMessenger: message has already been relayed");
 
         // If there is not enough gas left to perform the external call and finish the execution,
         // return early and assign the message to the failedMessages mapping.
@@ -296,8 +258,8 @@ abstract contract CrossDomainMessenger is
         // If `xDomainMsgSender` is not the default L2 sender, this function
         // is being re-entered. This marks the message as failed to allow it to be replayed.
         if (
-            !SafeCall.hasMinGas(_minGasLimit, RELAY_RESERVED_GAS + RELAY_GAS_CHECK_BUFFER) ||
-            xDomainMsgSender != Constants.DEFAULT_L2_SENDER
+            !SafeCall.hasMinGas(_minGasLimit, RELAY_RESERVED_GAS + RELAY_GAS_CHECK_BUFFER)
+                || xDomainMsgSender != Constants.DEFAULT_L2_SENDER
         ) {
             failedMessages[versionedHash] = true;
             emit FailedRelayedMessage(versionedHash);
@@ -342,8 +304,7 @@ abstract contract CrossDomainMessenger is
     /// @return Address of the sender of the currently executing message on the other chain.
     function xDomainMessageSender() external view returns (address) {
         require(
-            xDomainMsgSender != Constants.DEFAULT_L2_SENDER,
-            "CrossDomainMessenger: xDomainMessageSender is not set"
+            xDomainMsgSender != Constants.DEFAULT_L2_SENDER, "CrossDomainMessenger: xDomainMessageSender is not set"
         );
 
         return xDomainMsgSender;
@@ -366,22 +327,21 @@ abstract contract CrossDomainMessenger is
     /// @return Amount of gas required to guarantee message receipt.
     function baseGas(bytes calldata _message, uint32 _minGasLimit) public pure returns (uint64) {
         return
-            // Constant overhead
-            RELAY_CONSTANT_OVERHEAD +
-            // Calldata overhead
-            (uint64(_message.length) * MIN_GAS_CALLDATA_OVERHEAD) +
-            // Dynamic overhead (EIP-150)
-            ((_minGasLimit * MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR) /
-                MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR) +
-            // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
-            // factors. (Conservative)
-            RELAY_CALL_OVERHEAD +
-            // Relay reserved gas (to ensure execution of `relayMessage` completes after the
-            // subcontext finishes executing) (Conservative)
-            RELAY_RESERVED_GAS +
-            // Gas reserved for the execution between the `hasMinGas` check and the `CALL`
-            // opcode. (Conservative)
-            RELAY_GAS_CHECK_BUFFER;
+        // Constant overhead
+        RELAY_CONSTANT_OVERHEAD
+        // Calldata overhead
+        + (uint64(_message.length) * MIN_GAS_CALLDATA_OVERHEAD)
+        // Dynamic overhead (EIP-150)
+        + ((_minGasLimit * MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR) / MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR)
+        // Gas reserved for the worst-case cost of 3/5 of the `CALL` opcode's dynamic gas
+        // factors. (Conservative)
+        + RELAY_CALL_OVERHEAD
+        // Relay reserved gas (to ensure execution of `relayMessage` completes after the
+        // subcontext finishes executing) (Conservative)
+        + RELAY_RESERVED_GAS
+        // Gas reserved for the execution between the `hasMinGas` check and the `CALL`
+        // opcode. (Conservative)
+        + RELAY_GAS_CHECK_BUFFER;
     }
 
     /// @notice Initializer.
@@ -397,12 +357,7 @@ abstract contract CrossDomainMessenger is
     /// @param _gasLimit Minimum gas limit the message can be executed with.
     /// @param _value    Amount of ETH to send with the message.
     /// @param _data     Message data.
-    function _sendMessage(
-        address _to,
-        uint64 _gasLimit,
-        uint256 _value,
-        bytes memory _data
-    ) internal virtual;
+    function _sendMessage(address _to, uint64 _gasLimit, uint256 _value, bytes memory _data) internal virtual;
 
     /// @notice Checks whether the message is coming from the other messenger. Implemented by child
     ///         contracts because the logic for this depends on the network where the messenger is

--- a/packages/contracts-bedrock/contracts/universal/ERC721Bridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/ERC721Bridge.sol
@@ -112,15 +112,7 @@ abstract contract ERC721Bridge {
         // care of the user error we want to avoid.
         require(!Address.isContract(msg.sender), "ERC721Bridge: account is not externally owned");
 
-        _initiateBridgeERC721(
-            _localToken,
-            _remoteToken,
-            msg.sender,
-            msg.sender,
-            _tokenId,
-            _minGasLimit,
-            _extraData
-        );
+        _initiateBridgeERC721(_localToken, _remoteToken, msg.sender, msg.sender, _tokenId, _minGasLimit, _extraData);
     }
 
     /// @notice Initiates a bridge of an NFT to some recipient's account on the other chain. Note
@@ -148,15 +140,7 @@ abstract contract ERC721Bridge {
     ) external {
         require(_to != address(0), "ERC721Bridge: nft recipient cannot be address(0)");
 
-        _initiateBridgeERC721(
-            _localToken,
-            _remoteToken,
-            msg.sender,
-            _to,
-            _tokenId,
-            _minGasLimit,
-            _extraData
-        );
+        _initiateBridgeERC721(_localToken, _remoteToken, msg.sender, _to, _tokenId, _minGasLimit, _extraData);
     }
 
     /// @notice Internal function for initiating a token bridge to the other domain.

--- a/packages/contracts-bedrock/contracts/universal/FeeVault.sol
+++ b/packages/contracts-bedrock/contracts/universal/FeeVault.sol
@@ -49,18 +49,14 @@ abstract contract FeeVault {
     /// @param _recipient           Wallet that will receive the fees.
     /// @param _minWithdrawalAmount Minimum balance for withdrawals.
     /// @param _withdrawalNetwork   Network which the recipient will receive fees on.
-    constructor(
-        address _recipient,
-        uint256 _minWithdrawalAmount,
-        WithdrawalNetwork _withdrawalNetwork
-    ) {
+    constructor(address _recipient, uint256 _minWithdrawalAmount, WithdrawalNetwork _withdrawalNetwork) {
         RECIPIENT = _recipient;
         MIN_WITHDRAWAL_AMOUNT = _minWithdrawalAmount;
         WITHDRAWAL_NETWORK = _withdrawalNetwork;
     }
 
     /// @notice Allow the contract to receive ETH.
-    receive() external payable {}
+    receive() external payable { }
 
     /// @notice Triggers a withdrawal of funds to the fee wallet on L1 or L2.
     function withdraw() external {
@@ -79,9 +75,7 @@ abstract contract FeeVault {
             SafeCall.send(RECIPIENT, gasleft(), value);
         } else {
             L2StandardBridge(payable(Predeploys.L2_STANDARD_BRIDGE)).bridgeETHTo{ value: value }(
-                RECIPIENT,
-                WITHDRAWAL_MIN_GAS,
-                bytes("")
+                RECIPIENT, WITHDRAWAL_MIN_GAS, bytes("")
             );
         }
     }

--- a/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC721.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {
-    IERC721Enumerable
-} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
 /// @title IOptimismMintableERC721
 /// @notice Interface for contracts that are compatible with the OptimismMintableERC721 standard.

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20.sol
@@ -40,12 +40,10 @@ contract OptimismMintableERC20 is IOptimismMintableERC20, ILegacyMintableERC20, 
     /// @param _remoteToken Address of the corresponding L1 token.
     /// @param _name        ERC20 name.
     /// @param _symbol      ERC20 symbol.
-    constructor(
-        address _bridge,
-        address _remoteToken,
-        string memory _name,
-        string memory _symbol
-    ) ERC20(_name, _symbol) Semver(1, 0, 1) {
+    constructor(address _bridge, address _remoteToken, string memory _name, string memory _symbol)
+        ERC20(_name, _symbol)
+        Semver(1, 0, 1)
+    {
         REMOTE_TOKEN = _remoteToken;
         BRIDGE = _bridge;
     }

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20Factory.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20Factory.sol
@@ -26,11 +26,7 @@ contract OptimismMintableERC20Factory is Semver {
     /// @param localToken  Address of the created token on the local chain.
     /// @param remoteToken Address of the corresponding token on the remote chain.
     /// @param deployer    Address of the account that deployed the token.
-    event OptimismMintableERC20Created(
-        address indexed localToken,
-        address indexed remoteToken,
-        address deployer
-    );
+    event OptimismMintableERC20Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     /// @custom:semver 1.1.1
     /// @notice The semver MUST be bumped any time that there is a change in
@@ -48,11 +44,10 @@ contract OptimismMintableERC20Factory is Semver {
     /// @param _name        ERC20 name.
     /// @param _symbol      ERC20 symbol.
     /// @return Address of the newly created token.
-    function createStandardL2Token(
-        address _remoteToken,
-        string memory _name,
-        string memory _symbol
-    ) external returns (address) {
+    function createStandardL2Token(address _remoteToken, string memory _name, string memory _symbol)
+        external
+        returns (address)
+    {
         return createOptimismMintableERC20(_remoteToken, _name, _symbol);
     }
 
@@ -61,19 +56,13 @@ contract OptimismMintableERC20Factory is Semver {
     /// @param _name        ERC20 name.
     /// @param _symbol      ERC20 symbol.
     /// @return Address of the newly created token.
-    function createOptimismMintableERC20(
-        address _remoteToken,
-        string memory _name,
-        string memory _symbol
-    ) public returns (address) {
-        require(
-            _remoteToken != address(0),
-            "OptimismMintableERC20Factory: must provide remote token address"
-        );
+    function createOptimismMintableERC20(address _remoteToken, string memory _name, string memory _symbol)
+        public
+        returns (address)
+    {
+        require(_remoteToken != address(0), "OptimismMintableERC20Factory: must provide remote token address");
 
-        address localToken = address(
-            new OptimismMintableERC20(BRIDGE, _remoteToken, _name, _symbol)
-        );
+        address localToken = address(new OptimismMintableERC20(BRIDGE, _remoteToken, _name, _symbol));
 
         // Emit the old event too for legacy support.
         emit StandardL2TokenCreated(_remoteToken, localToken);

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import {
-    ERC721Enumerable
-} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import { ERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
@@ -48,10 +46,7 @@ contract OptimismMintableERC721 is ERC721Enumerable, IOptimismMintableERC721, Se
     ) ERC721(_name, _symbol) Semver(1, 1, 1) {
         require(_bridge != address(0), "OptimismMintableERC721: bridge cannot be address(0)");
         require(_remoteChainId != 0, "OptimismMintableERC721: remote chain id cannot be zero");
-        require(
-            _remoteToken != address(0),
-            "OptimismMintableERC721: remote token cannot be address(0)"
-        );
+        require(_remoteToken != address(0), "OptimismMintableERC721: remote token cannot be address(0)");
 
         REMOTE_CHAIN_ID = _remoteChainId;
         REMOTE_TOKEN = _remoteToken;
@@ -102,12 +97,7 @@ contract OptimismMintableERC721 is ERC721Enumerable, IOptimismMintableERC721, Se
     /// @notice Checks if a given interface ID is supported by this contract.
     /// @param _interfaceId The interface ID to check.
     /// @return True if the interface ID is supported, false otherwise.
-    function supportsInterface(bytes4 _interfaceId)
-        public
-        view
-        override(ERC721Enumerable, IERC165)
-        returns (bool)
-    {
+    function supportsInterface(bytes4 _interfaceId) public view override(ERC721Enumerable, IERC165) returns (bool) {
         bytes4 iface = type(IOptimismMintableERC721).interfaceId;
         return _interfaceId == iface || super.supportsInterface(_interfaceId);
     }

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721Factory.sol
@@ -20,11 +20,7 @@ contract OptimismMintableERC721Factory is Semver {
     /// @param localToken  Address of the token on the this domain.
     /// @param remoteToken Address of the token on the remote domain.
     /// @param deployer    Address of the initiator of the deployment
-    event OptimismMintableERC721Created(
-        address indexed localToken,
-        address indexed remoteToken,
-        address deployer
-    );
+    event OptimismMintableERC721Created(address indexed localToken, address indexed remoteToken, address deployer);
 
     /// @custom:semver 1.2.1
     /// @notice The semver MUST be bumped any time that there is a change in
@@ -41,19 +37,13 @@ contract OptimismMintableERC721Factory is Semver {
     /// @param _remoteToken Address of the corresponding token on the other domain.
     /// @param _name        ERC721 name.
     /// @param _symbol      ERC721 symbol.
-    function createOptimismMintableERC721(
-        address _remoteToken,
-        string memory _name,
-        string memory _symbol
-    ) external returns (address) {
-        require(
-            _remoteToken != address(0),
-            "OptimismMintableERC721Factory: L1 token address cannot be address(0)"
-        );
+    function createOptimismMintableERC721(address _remoteToken, string memory _name, string memory _symbol)
+        external
+        returns (address)
+    {
+        require(_remoteToken != address(0), "OptimismMintableERC721Factory: L1 token address cannot be address(0)");
 
-        address localToken = address(
-            new OptimismMintableERC721(BRIDGE, REMOTE_CHAIN_ID, _remoteToken, _name, _symbol)
-        );
+        address localToken = address(new OptimismMintableERC721(BRIDGE, REMOTE_CHAIN_ID, _remoteToken, _name, _symbol));
 
         isOptimismMintableERC721[localToken] = true;
         emit OptimismMintableERC721Created(localToken, _remoteToken, msg.sender);

--- a/packages/contracts-bedrock/contracts/universal/Proxy.sol
+++ b/packages/contracts-bedrock/contracts/universal/Proxy.sol
@@ -8,13 +8,11 @@ pragma solidity 0.8.15;
 contract Proxy {
     /// @notice The storage slot that holds the address of the implementation.
     ///         bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
-    bytes32 internal constant IMPLEMENTATION_KEY =
-        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    bytes32 internal constant IMPLEMENTATION_KEY = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
     /// @notice The storage slot that holds the address of the owner.
     ///         bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1)
-    bytes32 internal constant OWNER_KEY =
-        0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+    bytes32 internal constant OWNER_KEY = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
     /// @notice An event that is emitted each time the implementation is changed. This event is part
     ///         of the EIP-1967 specification.
@@ -140,9 +138,7 @@ contract Proxy {
             returndatacopy(0x0, 0x0, returndatasize())
 
             // Success == 0 means a revert. We'll revert too and pass the data up.
-            if iszero(success) {
-                revert(0x0, returndatasize())
-            }
+            if iszero(success) { revert(0x0, returndatasize()) }
 
             // Otherwise we'll just return and pass the data up.
             return(0x0, returndatasize())

--- a/packages/contracts-bedrock/contracts/universal/ProxyAdmin.sol
+++ b/packages/contracts-bedrock/contracts/universal/ProxyAdmin.sol
@@ -182,18 +182,18 @@ contract ProxyAdmin is Ownable {
     /// @param _proxy          Address of the proxy to upgrade.
     /// @param _implementation Address of the new implementation address.
     /// @param _data           Data to trigger the new implementation with.
-    function upgradeAndCall(
-        address payable _proxy,
-        address _implementation,
-        bytes memory _data
-    ) external payable onlyOwner {
+    function upgradeAndCall(address payable _proxy, address _implementation, bytes memory _data)
+        external
+        payable
+        onlyOwner
+    {
         ProxyType ptype = proxyType[_proxy];
         if (ptype == ProxyType.ERC1967) {
             Proxy(_proxy).upgradeToAndCall{ value: msg.value }(_implementation, _data);
         } else {
             // reverts if proxy type is unknown
             upgrade(_proxy, _implementation);
-            (bool success, ) = _proxy.call{ value: msg.value }(_data);
+            (bool success,) = _proxy.call{ value: msg.value }(_data);
             require(success, "ProxyAdmin: call to proxy after upgrade failed");
         }
     }

--- a/packages/contracts-bedrock/contracts/universal/Semver.sol
+++ b/packages/contracts-bedrock/contracts/universal/Semver.sol
@@ -18,11 +18,7 @@ contract Semver {
     /// @param _major Version number (major).
     /// @param _minor Version number (minor).
     /// @param _patch Version number (patch).
-    constructor(
-        uint256 _major,
-        uint256 _minor,
-        uint256 _patch
-    ) {
+    constructor(uint256 _major, uint256 _minor, uint256 _patch) {
         MAJOR_VERSION = _major;
         MINOR_VERSION = _minor;
         PATCH_VERSION = _patch;
@@ -31,15 +27,14 @@ contract Semver {
     /// @notice Returns the full semver contract version.
     /// @return Semver contract version as a string.
     function version() public view returns (string memory) {
-        return
-            string(
-                abi.encodePacked(
-                    Strings.toString(MAJOR_VERSION),
-                    ".",
-                    Strings.toString(MINOR_VERSION),
-                    ".",
-                    Strings.toString(PATCH_VERSION)
-                )
-            );
+        return string(
+            abi.encodePacked(
+                Strings.toString(MAJOR_VERSION),
+                ".",
+                Strings.toString(MINOR_VERSION),
+                ".",
+                Strings.toString(PATCH_VERSION)
+            )
+        );
     }
 }

--- a/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/StandardBridge.sol
@@ -50,24 +50,14 @@ abstract contract StandardBridge {
     /// @param to        Address of the receiver.
     /// @param amount    Amount of ETH sent.
     /// @param extraData Extra data sent with the transaction.
-    event ETHBridgeInitiated(
-        address indexed from,
-        address indexed to,
-        uint256 amount,
-        bytes extraData
-    );
+    event ETHBridgeInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData);
 
     /// @notice Emitted when an ETH bridge is finalized on this chain.
     /// @param from      Address of the sender.
     /// @param to        Address of the receiver.
     /// @param amount    Amount of ETH sent.
     /// @param extraData Extra data sent with the transaction.
-    event ETHBridgeFinalized(
-        address indexed from,
-        address indexed to,
-        uint256 amount,
-        bytes extraData
-    );
+    event ETHBridgeFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData);
 
     /// @notice Emitted when an ERC20 bridge is initiated to the other chain.
     /// @param localToken  Address of the ERC20 on this chain.
@@ -105,18 +95,14 @@ abstract contract StandardBridge {
     ///         calling code within their constructors, but also doesn't really matter since we're
     ///         just trying to prevent users accidentally depositing with smart contract wallets.
     modifier onlyEOA() {
-        require(
-            !Address.isContract(msg.sender),
-            "StandardBridge: function can only be called from an EOA"
-        );
+        require(!Address.isContract(msg.sender), "StandardBridge: function can only be called from an EOA");
         _;
     }
 
     /// @notice Ensures that the caller is a cross-chain message from the other bridge.
     modifier onlyOtherBridge() {
         require(
-            msg.sender == address(MESSENGER) &&
-                MESSENGER.xDomainMessageSender() == address(OTHER_BRIDGE),
+            msg.sender == address(MESSENGER) && MESSENGER.xDomainMessageSender() == address(OTHER_BRIDGE),
             "StandardBridge: function can only be called from the other bridge"
         );
         _;
@@ -161,11 +147,7 @@ abstract contract StandardBridge {
     /// @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
     ///                     not be triggered with this data, but it will be emitted and can be used
     ///                     to identify the transaction.
-    function bridgeETHTo(
-        address _to,
-        uint32 _minGasLimit,
-        bytes calldata _extraData
-    ) public payable {
+    function bridgeETHTo(address _to, uint32 _minGasLimit, bytes calldata _extraData) public payable {
         _initiateBridgeETH(msg.sender, _to, msg.value, _minGasLimit, _extraData);
     }
 
@@ -187,15 +169,7 @@ abstract contract StandardBridge {
         uint32 _minGasLimit,
         bytes calldata _extraData
     ) public virtual onlyEOA {
-        _initiateBridgeERC20(
-            _localToken,
-            _remoteToken,
-            msg.sender,
-            msg.sender,
-            _amount,
-            _minGasLimit,
-            _extraData
-        );
+        _initiateBridgeERC20(_localToken, _remoteToken, msg.sender, msg.sender, _amount, _minGasLimit, _extraData);
     }
 
     /// @notice Sends ERC20 tokens to a receiver's address on the other chain. Note that if the
@@ -218,15 +192,7 @@ abstract contract StandardBridge {
         uint32 _minGasLimit,
         bytes calldata _extraData
     ) public virtual {
-        _initiateBridgeERC20(
-            _localToken,
-            _remoteToken,
-            msg.sender,
-            _to,
-            _amount,
-            _minGasLimit,
-            _extraData
-        );
+        _initiateBridgeERC20(_localToken, _remoteToken, msg.sender, _to, _amount, _minGasLimit, _extraData);
     }
 
     /// @notice Finalizes an ETH bridge on this chain. Can only be triggered by the other
@@ -237,12 +203,11 @@ abstract contract StandardBridge {
     /// @param _extraData Extra data to be sent with the transaction. Note that the recipient will
     ///                   not be triggered with this data, but it will be emitted and can be used
     ///                   to identify the transaction.
-    function finalizeBridgeETH(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes calldata _extraData
-    ) public payable onlyOtherBridge {
+    function finalizeBridgeETH(address _from, address _to, uint256 _amount, bytes calldata _extraData)
+        public
+        payable
+        onlyOtherBridge
+    {
         require(msg.value == _amount, "StandardBridge: amount sent does not match amount required");
         require(_to != address(this), "StandardBridge: cannot send to self");
         require(_to != address(MESSENGER), "StandardBridge: cannot send to messenger");
@@ -305,10 +270,7 @@ abstract contract StandardBridge {
         uint32 _minGasLimit,
         bytes memory _extraData
     ) internal {
-        require(
-            msg.value == _amount,
-            "StandardBridge: bridging ETH must include sufficient ETH value"
-        );
+        require(msg.value == _amount, "StandardBridge: bridging ETH must include sufficient ETH value");
 
         // Emit the correct events. By default this will be _amount, but child
         // contracts may override this function in order to emit legacy events as well.
@@ -316,13 +278,7 @@ abstract contract StandardBridge {
 
         MESSENGER.sendMessage{ value: _amount }(
             address(OTHER_BRIDGE),
-            abi.encodeWithSelector(
-                this.finalizeBridgeETH.selector,
-                _from,
-                _to,
-                _amount,
-                _extraData
-            ),
+            abi.encodeWithSelector(this.finalizeBridgeETH.selector, _from, _to, _amount, _extraData),
             _minGasLimit
         );
     }
@@ -384,9 +340,8 @@ abstract contract StandardBridge {
     /// @param _token Address of the token to check.
     /// @return True if the token is an OptimismMintableERC20.
     function _isOptimismMintableERC20(address _token) internal view returns (bool) {
-        return
-            ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId) ||
-            ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
+        return ERC165Checker.supportsInterface(_token, type(ILegacyMintableERC20).interfaceId)
+            || ERC165Checker.supportsInterface(_token, type(IOptimismMintableERC20).interfaceId);
     }
 
     /// @notice Checks if the "other token" is the correct pair token for the OptimismMintableERC20.
@@ -395,14 +350,8 @@ abstract contract StandardBridge {
     /// @param _mintableToken OptimismMintableERC20 to check against.
     /// @param _otherToken    Pair token to check.
     /// @return True if the other token is the correct pair token for the OptimismMintableERC20.
-    function _isCorrectTokenPair(address _mintableToken, address _otherToken)
-        internal
-        view
-        returns (bool)
-    {
-        if (
-            ERC165Checker.supportsInterface(_mintableToken, type(ILegacyMintableERC20).interfaceId)
-        ) {
+    function _isCorrectTokenPair(address _mintableToken, address _otherToken) internal view returns (bool) {
+        if (ERC165Checker.supportsInterface(_mintableToken, type(ILegacyMintableERC20).interfaceId)) {
             return _otherToken == ILegacyMintableERC20(_mintableToken).l1Token();
         } else {
             return _otherToken == IOptimismMintableERC20(_mintableToken).remoteToken();
@@ -415,12 +364,10 @@ abstract contract StandardBridge {
     /// @param _to        Address of the receiver.
     /// @param _amount    Amount of ETH sent.
     /// @param _extraData Extra data sent with the transaction.
-    function _emitETHBridgeInitiated(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes memory _extraData
-    ) internal virtual {
+    function _emitETHBridgeInitiated(address _from, address _to, uint256 _amount, bytes memory _extraData)
+        internal
+        virtual
+    {
         emit ETHBridgeInitiated(_from, _to, _amount, _extraData);
     }
 
@@ -430,12 +377,10 @@ abstract contract StandardBridge {
     /// @param _to        Address of the receiver.
     /// @param _amount    Amount of ETH sent.
     /// @param _extraData Extra data sent with the transaction.
-    function _emitETHBridgeFinalized(
-        address _from,
-        address _to,
-        uint256 _amount,
-        bytes memory _extraData
-    ) internal virtual {
+    function _emitETHBridgeFinalized(address _from, address _to, uint256 _amount, bytes memory _extraData)
+        internal
+        virtual
+    {
         emit ETHBridgeFinalized(_from, _to, _amount, _extraData);
     }
 

--- a/packages/contracts-bedrock/contracts/vendor/WETH9.sol
+++ b/packages/contracts-bedrock/contracts/vendor/WETH9.sol
@@ -16,53 +16,52 @@
 pragma solidity >=0.4.22 <0.6;
 
 contract WETH9 {
-    string public name     = "Wrapped Ether";
-    string public symbol   = "WETH";
-    uint8  public decimals = 18;
+    string public name = "Wrapped Ether";
+    string public symbol = "WETH";
+    uint8 public decimals = 18;
 
-    event  Approval(address indexed src, address indexed guy, uint wad);
-    event  Transfer(address indexed src, address indexed dst, uint wad);
-    event  Deposit(address indexed dst, uint wad);
-    event  Withdrawal(address indexed src, uint wad);
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    event Deposit(address indexed dst, uint256 wad);
+    event Withdrawal(address indexed src, uint256 wad);
 
-    mapping (address => uint)                       public  balanceOf;
-    mapping (address => mapping (address => uint))  public  allowance;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
 
     function() external payable {
         deposit();
     }
+
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
         emit Deposit(msg.sender, msg.value);
     }
-    function withdraw(uint wad) public {
+
+    function withdraw(uint256 wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
         msg.sender.transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
-    function totalSupply() public view returns (uint) {
+    function totalSupply() public view returns (uint256) {
         return address(this).balance;
     }
 
-    function approve(address guy, uint wad) public returns (bool) {
+    function approve(address guy, uint256 wad) public returns (bool) {
         allowance[msg.sender][guy] = wad;
         emit Approval(msg.sender, guy, wad);
         return true;
     }
 
-    function transfer(address dst, uint wad) public returns (bool) {
+    function transfer(address dst, uint256 wad) public returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(address src, address dst, uint wad)
-        public
-        returns (bool)
-    {
+    function transferFrom(address src, address dst, uint256 wad) public returns (bool) {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != uint256(-1)) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }
@@ -75,7 +74,6 @@ contract WETH9 {
         return true;
     }
 }
-
 
 /*
                     GNU GENERAL PUBLIC LICENSE

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -28,6 +28,11 @@ fs_permissions = [
   { access = 'read', path = './forge-artifacts/' },
 ]
 
+[fmt]
+max_line_length = 100
+wrap_comments = true
+bracket_spacing = true
+
 [profile.ci]
 fuzz_runs = 512
 

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -28,13 +28,8 @@
     "slither": "./scripts/slither.sh",
     "slither:triage": "TRIAGE_MODE=1 ./scripts/slither.sh",
     "clean": "rm -rf ./dist ./artifacts ./forge-artifacts ./cache ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo ./src/contract-artifacts.ts ./test-case-generator/fuzz",
-    "lint:ts:check": "eslint . --max-warnings=0",
-    "lint:forge-tests:check": "ts-node scripts/forge-test-names.ts",
-    "lint:contracts:check": "yarn solhint -f table 'contracts/**/!(DisputeTypes).sol' && yarn prettier --check 'contracts/**/!(DisputeTypes).sol' && yarn lint:forge-tests:check",
-    "lint:check": "yarn lint:contracts:check && yarn lint:ts:check",
-    "lint:ts:fix": "eslint --fix .",
-    "lint:contracts:fix": "yarn solhint --fix 'contracts/**/!(DisputeTypes).sol' && yarn prettier --write 'contracts/**/!(DisputeTypes).sol'",
-    "lint:fix": "yarn lint:contracts:fix && yarn lint:ts:fix",
+    "lint:check": "ts-node scripts/forge-test-names.ts",
+    "lint:fix": "forge fmt",
     "lint": "yarn lint:fix && yarn lint:check",
     "echidna:aliasing": "echidna-test --contract EchidnaFuzzAddressAliasing --config ./echidna.yaml .",
     "echidna:burn:gas": "echidna-test --contract EchidnaFuzzBurnGas --config ./echidna.yaml .",
@@ -53,13 +48,9 @@
     "ethers": "^5.7.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.45.1",
-    "@typescript-eslint/parser": "^5.45.1",
     "ds-test": "https://github.com/dapphub/ds-test.git#9310e879db8ba3ea6d5c6489a579118fd264a3f5",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#e8a047e3f40f13fa37af6fe14e6e06283d9a060e",
     "glob": "^7.1.6",
-    "solhint": "^3.3.7",
-    "solhint-plugin-prettier": "^0.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"
   }

--- a/packages/contracts-periphery/package.json
+++ b/packages/contracts-periphery/package.json
@@ -82,7 +82,7 @@
     "node-fetch": "^2.6.7",
     "prettier": "^2.8.0",
     "prettier-plugin-solidity": "^1.0.0-beta.18",
-    "solhint": "^3.3.6",
+    "solhint": "^3.4.1",
     "solhint-plugin-prettier": "^0.0.5",
     "solidity-coverage": "^0.7.17",
     "ts-node": "^10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,6 +2721,13 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
+"@solidity-parser/parser@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.16.0.tgz#1fb418c816ca1fc3a1e94b08bcfe623ec4e1add4"
+  integrity sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -3452,7 +3459,7 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
+acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -3466,11 +3473,6 @@ acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
-
-acorn@^6.0.7:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
-  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
 acorn@^8.4.1:
   version "8.4.1"
@@ -3522,7 +3524,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.6.1, ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3530,6 +3532,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.6.1, ajv@^6.9.1:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 amdefine@>=0.0.4:
@@ -3559,7 +3571,7 @@ ansi-colors@^4.1.3:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
-ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
+ansi-escapes@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
@@ -3635,10 +3647,10 @@ ansicolors@~0.3.2:
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
   integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
 
-antlr4@4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.1.tgz#69984014f096e9e775f53dd9744bf994d8959773"
-  integrity sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==
+antlr4@^4.11.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.13.0.tgz#25c0b17f0d9216de114303d38bafd6f181d5447f"
+  integrity sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew==
 
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"
@@ -3863,15 +3875,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-parents@0.0.1:
+ast-parents@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/ast-parents/-/ast-parents-0.0.1.tgz#508fd0f05d0c48775d9eccda2e174423261e8dd3"
-  integrity sha1-UI/Q8F0MSHddnszaLhdEIyYejdM=
-
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+  integrity sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==
 
 astral-regex@^2.0.0:
   version "2.0.0"
@@ -4969,25 +4976,6 @@ call-bind@^1.0.0, call-bind@^1.0.2, call-bind@~1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-caller-callsite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
-  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
-  dependencies:
-    callsites "^2.0.0"
-
-caller-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
-  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
-  dependencies:
-    caller-callsite "^2.0.0"
-
-callsites@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -5309,13 +5297,6 @@ cli-cursor@3.1.0, cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
-  dependencies:
-    restore-cursor "^2.0.0"
-
 cli-spinners@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
@@ -5353,11 +5334,6 @@ cli-truncate@^3.1.0:
   dependencies:
     slice-ansi "^5.0.0"
     string-width "^5.0.0"
-
-cli-width@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
-  integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -5518,15 +5494,15 @@ command-line-usage@^6.1.0:
     table-layout "^1.0.2"
     typical "^5.2.0"
 
-commander@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
-  integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
-
 commander@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
+
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -5667,16 +5643,6 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^5.0.7:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
-  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
-  dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.1"
-    parse-json "^4.0.0"
-
 cosmiconfig@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
@@ -5687,6 +5653,16 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+cosmiconfig@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.2.0.tgz#f7d17c56a590856cd1e7cee98734dca272b0d8fd"
+  integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
 
 crc-32@^1.2.0:
   version "1.2.0"
@@ -5860,7 +5836,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -6926,14 +6902,6 @@ eslint-plugin-unicorn@^42.0.0:
     semver "^7.3.5"
     strip-indent "^3.0.0"
 
-eslint-scope@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
-  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -6949,13 +6917,6 @@ eslint-scope@^7.1.1:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-utils@^1.3.1:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
-  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
 
 eslint-utils@^2.0.0:
   version "2.1.0"
@@ -6985,48 +6946,6 @@ eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
-
-eslint@^5.6.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
-    chalk "^2.1.0"
-    cross-spawn "^6.0.5"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    eslint-scope "^4.0.3"
-    eslint-utils "^1.3.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
-    esquery "^1.0.1"
-    esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
-    globals "^11.7.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    inquirer "^6.2.2"
-    js-yaml "^3.13.0"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.11"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    progress "^2.0.0"
-    regexpp "^2.0.1"
-    semver "^5.5.1"
-    strip-ansi "^4.0.0"
-    strip-json-comments "^2.0.1"
-    table "^5.2.3"
-    text-table "^0.2.0"
 
 eslint@^8.16.0:
   version "8.16.0"
@@ -7069,15 +6988,6 @@ eslint@^8.16.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
-  dependencies:
-    acorn "^6.0.7"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
-
 espree@^9.3.2:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
@@ -7097,14 +7007,14 @@ esprima@^4.0.0, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1, esquery@^1.4.0:
+esquery@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0, esrecurse@^4.3.0:
+esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
@@ -7864,7 +7774,7 @@ extendable-error@^0.1.5:
   resolved "https://registry.yarnpkg.com/extendable-error/-/extendable-error-0.1.7.tgz#60b9adf206264ac920058a7395685ae4670c2b96"
   integrity sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==
 
-external-editor@^3.0.3, external-editor@^3.1.0:
+external-editor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
   integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
@@ -7913,6 +7823,11 @@ fast-diff@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
+fast-diff@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@3.2.7, fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.7"
@@ -7988,20 +7903,6 @@ figures@3.2.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
-
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
-file-entry-cache@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
-  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
-  dependencies:
-    flat-cache "^2.0.1"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -8130,15 +8031,6 @@ find-yarn-workspace-root@^2.0.0:
   dependencies:
     micromatch "^4.0.2"
 
-flat-cache@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
-  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
-  dependencies:
-    flatted "^2.0.0"
-    rimraf "2.6.3"
-    write "1.0.3"
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -8163,11 +8055,6 @@ flatstr@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
   integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
-
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 flatted@^3.1.0:
   version "3.2.2"
@@ -8707,6 +8594,17 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 global-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
@@ -8731,7 +8629,7 @@ global@~4.4.0:
     min-document "^2.19.0"
     process "^0.11.10"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
@@ -9295,12 +9193,7 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
-ignore@^5.0.4:
+ignore@^5.0.4, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -9334,14 +9227,6 @@ immutable@^4.0.0-rc.12:
   version "4.0.0-rc.14"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.14.tgz#29ba96631ec10867d1348515ac4e6bdba462f071"
   integrity sha512-pfkvmRKJSoW7JFx0QeYlAmT+kNYvn5j0u7bnpNq4N2RCvHSTlLT208G8jgaquNe+Q8kCPHKOSpxJkyvLDpYq0w==
-
-import-fresh@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
-  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
-  dependencies:
-    caller-path "^2.0.0"
-    resolve-from "^3.0.0"
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -9388,25 +9273,6 @@ ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
-
-inquirer@^6.2.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
-  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
-  dependencies:
-    ansi-escapes "^3.2.0"
-    chalk "^2.4.2"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^2.0.0"
-    lodash "^4.17.12"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rxjs "^6.4.0"
-    string-width "^2.1.0"
-    strip-ansi "^5.1.0"
-    through "^2.3.6"
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -9636,11 +9502,6 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
-
-is-directory@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
-  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
@@ -10047,7 +9908,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@3.x, js-yaml@^3.10.0, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.6.1:
+js-yaml@3.x, js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.6.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -10104,11 +9965,6 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-parse-better-errors@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -10142,6 +9998,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -10533,14 +10394,6 @@ levelup@^4.3.2:
     level-supports "~1.0.0"
     xtend "~4.0.0"
 
-levn@^0.3.0, levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -10548,6 +10401,14 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -10691,12 +10552,17 @@ lodash.startcase@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
 lodash@4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11367,11 +11233,6 @@ mime@^2.4.6:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
-
 mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -11749,11 +11610,6 @@ murmur-128@^0.2.1:
     encode-utf8 "^1.0.2"
     fmix "^0.1.0"
     imul "^1.0.0"
-
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nan@^2.14.0:
   version "2.15.0"
@@ -12278,13 +12134,6 @@ once@1.x, once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
-  dependencies:
-    mimic-fn "^1.0.0"
-
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
@@ -12309,7 +12158,7 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -12545,14 +12394,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-json@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
-  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  dependencies:
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
-
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -12636,11 +12477,6 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
-
-path-is-inside@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
@@ -12932,11 +12768,6 @@ prettier-plugin-solidity@^1.0.0-beta.18:
     solidity-comments-extractor "^0.0.7"
     string-width "^4.2.2"
 
-prettier@^1.14.3:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^2.1.2, prettier@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
@@ -12951,6 +12782,11 @@ prettier@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
   integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+
+prettier@^2.8.3:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^27.5.1:
   version "27.5.1"
@@ -12987,11 +12823,6 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
-
-progress@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prom-client@^13.1.0:
   version "13.2.0"
@@ -13488,11 +13319,6 @@ regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
-regexpp@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
-  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
-
 regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -13655,7 +13481,7 @@ require-from-string@^1.1.0:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
   integrity sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=
 
-require-from-string@^2.0.0:
+require-from-string@^2.0.0, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -13748,14 +13574,6 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
-  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
-  dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
-
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -13780,13 +13598,6 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
 
 rimraf@^2.2.8, rimraf@^2.6.3:
   version "2.7.1"
@@ -13831,11 +13642,6 @@ rollup@^3.7.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-run-async@^2.2.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
-  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -13848,7 +13654,7 @@ rustbn.js@~0.2.0:
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
-rxjs@6, rxjs@^6.4.0, rxjs@^6.6.7:
+rxjs@6, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -13989,7 +13795,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -14239,15 +14045,6 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
-slice-ansi@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
-  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  dependencies:
-    ansi-styles "^3.2.0"
-    astral-regex "^1.0.0"
-    is-fullwidth-code-point "^2.0.0"
-
 slice-ansi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
@@ -14363,27 +14160,30 @@ solhint-plugin-prettier@^0.0.5:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-solhint@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.6.tgz#abe9af185a9a7defefba480047b3e42cbe9a1210"
-  integrity sha512-HWUxTAv2h7hx3s3hAab3ifnlwb02ZWhwFU/wSudUHqteMS3ll9c+m1FlGn9V8ztE2rf3Z82fQZA005Wv7KpcFA==
+solhint@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.4.1.tgz#8ea15b21c13d1be0b53fd46d605a24d0b36a0c46"
+  integrity sha512-pzZn2RlZhws1XwvLPVSsxfHrwsteFf5eySOhpAytzXwKQYbTCJV6z8EevYDiSVKMpWrvbKpEtJ055CuEmzp4Xg==
   dependencies:
-    "@solidity-parser/parser" "^0.13.2"
-    ajv "^6.6.1"
-    antlr4 "4.7.1"
-    ast-parents "0.0.1"
-    chalk "^2.4.2"
-    commander "2.18.0"
-    cosmiconfig "^5.0.7"
-    eslint "^5.6.0"
-    fast-diff "^1.1.2"
-    glob "^7.1.3"
-    ignore "^4.0.6"
-    js-yaml "^3.12.0"
-    lodash "^4.17.11"
+    "@solidity-parser/parser" "^0.16.0"
+    ajv "^6.12.6"
+    antlr4 "^4.11.0"
+    ast-parents "^0.0.1"
+    chalk "^4.1.2"
+    commander "^10.0.0"
+    cosmiconfig "^8.0.0"
+    fast-diff "^1.2.0"
+    glob "^8.0.3"
+    ignore "^5.2.4"
+    js-yaml "^4.1.0"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
     semver "^6.3.0"
+    strip-ansi "^6.0.1"
+    table "^6.8.1"
+    text-table "^0.2.0"
   optionalDependencies:
-    prettier "^1.14.3"
+    prettier "^2.8.3"
 
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"
@@ -14668,7 +14468,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -14898,7 +14698,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -15050,15 +14850,16 @@ table-layout@^1.0.2:
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
 
-table@^5.2.3:
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
-  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+table@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
   dependencies:
-    ajv "^6.10.2"
-    lodash "^4.17.14"
-    slice-ansi "^2.1.0"
-    string-width "^3.0.0"
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tape@^4.6.3:
   version "4.14.0"
@@ -15199,7 +15000,7 @@ through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.8:
+through@^2.3.4, through@^2.3.8, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -16845,13 +16646,6 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-write@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
-  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
-  dependencies:
-    mkdirp "^0.5.1"
 
 ws@7.4.6:
   version "7.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14385,28 +14385,6 @@ solhint@^3.3.6:
   optionalDependencies:
     prettier "^1.14.3"
 
-solhint@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.7.tgz#b5da4fedf7a0fee954cb613b6c55a5a2b0063aa7"
-  integrity sha512-NjjjVmXI3ehKkb3aNtRJWw55SUVJ8HMKKodwe0HnejA+k0d2kmhw7jvpa+MCTbcEgt8IWSwx0Hu6aCo/iYOZzQ==
-  dependencies:
-    "@solidity-parser/parser" "^0.14.1"
-    ajv "^6.6.1"
-    antlr4 "4.7.1"
-    ast-parents "0.0.1"
-    chalk "^2.4.2"
-    commander "2.18.0"
-    cosmiconfig "^5.0.7"
-    eslint "^5.6.0"
-    fast-diff "^1.1.2"
-    glob "^7.1.3"
-    ignore "^4.0.6"
-    js-yaml "^3.12.0"
-    lodash "^4.17.11"
-    semver "^6.3.0"
-  optionalDependencies:
-    prettier "^1.14.3"
-
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz#99d8f1361438f84019795d928b931f4e5c39ca19"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Migrates away from `prettier` to `forge fmt`. This is a big diff to mission critical code, so we want to see that the artifacts do not generate diffs in their bytecode. This change greatly reduces the amount of time it takes to lint as well as allows us to remove additional dependencies. Each dep adds the possibility of a backdoor

`solhint` was sparsely maintained and does not support the latest solidity features