### PR TITLE
Fixed op-stack docs `docsRepo` link

### DIFF
--- a/docs/op-stack/src/.vuepress/config.js
+++ b/docs/op-stack/src/.vuepress/config.js
@@ -23,7 +23,7 @@ module.exports = {
     hostname: 'https://stack.optimism.io',
     logo: '/assets/logos/logo.png',
     docsDir: 'src',
-    docsRepo: 'https://github.com/ethereum-optimism/optimism/blob/develop/docs/op-stack/src/.vuepress/config.js',
+    docsRepo: 'https://github.com/ethereum-optimism/optimism/blob/develop/docs/op-stack/src/docs/build/getting-started.md',
     docsBranch: 'main',
     lastUpdated: false,
     darkmode: 'disable',

--- a/docs/op-stack/src/.vuepress/config.js
+++ b/docs/op-stack/src/.vuepress/config.js
@@ -23,7 +23,7 @@ module.exports = {
     hostname: 'https://stack.optimism.io',
     logo: '/assets/logos/logo.png',
     docsDir: 'src',
-    docsRepo: 'https://github.com/ethereum-optimism/opstack-docs',
+    docsRepo: 'https://github.com/ethereum-optimism/optimism/blob/develop/docs/op-stack/src/.vuepress/config.js',
     docsBranch: 'main',
     lastUpdated: false,
     darkmode: 'disable',


### PR DESCRIPTION
Initially Editing the page link in [op-stack docs](https://stack.optimism.io/docs/build/getting-started/#) was redirecting to https://github.com/ethereum-optimism/opstack-docs/edit/main/src/docs/build/getting-started.md . 

Fix - changed the `docsRepo` to https://github.com/ethereum-optimism/optimism/blob/develop/docs/op-stack/src/docs/build/getting-started.md 


![image](https://github.com/ethereum-optimism/optimism/assets/96972634/1b5b9384-f074-4924-b5ec-8301c4e2aa11)
