### PR TITLE
Revert "semgrep: ignore op-bindings/bindings"

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -18,7 +18,5 @@ tests/
 # Semgrep-action log folder
 .semgrep_logs/
 
-op-bindings/bindings
-
 packages/*/node_modules
 packages/*/test


### PR DESCRIPTION
**Description**

The PR that I am reverting did not fix semgrep but did break the op-bidnings-build step on develop.
