### PR TITLE
chore(ci): Fix slither timeout

### DIFF
--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -4,8 +4,10 @@ rm -rf artifacts forge-artifacts
 
 # See slither.config.json for slither settings
 if [[ -z "$TRIAGE_MODE" ]]; then
+  echo "Building contracts"
+  forge build --build-info --force
   echo "Running slither"
-  slither .
+  slither --ignore-compile .
 else
   echo "Running slither in triage mode"
   # Slither's triage mode will run an 'interview' in the terminal, allowing you to review each of


### PR DESCRIPTION
## Overview

The `contracts-bedrock-slither` job has been timing out due to a lack of output from slither until compilation has completed. This PR adds the `--ignore-compile` flag to slither and builds the contracts prior to invoking it so that the build progress is emitted to stdout as it goes.