### PR TITLE
updated WETH9 contract to 0.8.15 so it matches with other contracts

### DIFF
--- a/packages/contracts-bedrock/contracts/vendor/WETH9.sol
+++ b/packages/contracts-bedrock/contracts/vendor/WETH9.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.4.22 <0.6;
+pragma solidity ^0.8.15;
 
 contract WETH9 {
     string public name     = "Wrapped Ether";
@@ -28,7 +28,7 @@ contract WETH9 {
     mapping (address => uint)                       public  balanceOf;
     mapping (address => mapping (address => uint))  public  allowance;
 
-    function() external payable {
+    fallback() external payable {
         deposit();
     }
     function deposit() public payable {
@@ -38,7 +38,8 @@ contract WETH9 {
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
-        msg.sender.transfer(wad);
+        address payable senderAddr = payable(msg.sender);
+        senderAddr.transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
@@ -62,7 +63,7 @@ contract WETH9 {
     {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != type(uint128).max) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
I have updated the solidity version from ` >=0.4.22 <0.6 ` to `0.8.15` for WETH9.sol since all the other contracts in the directory have the `0.8.15` version. It was updated because to compile all the contract more than one version of solc was required. Some toolkits dont allow multiple versions of solc to be used while compiling and hence this update was neccessary.

When i updated the solidity version in WETH9.sol, there were some things which broke. Below are the list of changes and the reference for it.

**List of Changes**

1. `Compiler solc expected a state variable declaration` caused by the unamed function below
```
function() external payable {
        deposit();
    }
```
So i had to use `fallback` instead according to this: https://ethereum.stackexchange.com/a/89834

2. `"send" and "transfer" are only available for objects of type "address payable", not "address"` caused by code below.
```
msg.sender.transfer(wad);
```
So a `msg.sender` had to be converted to a payable address according to this: https://ethereum.stackexchange.com/a/113730

3. `Explicit type conversion not allowed from "int_const -1" to "uint128"` caused by usage on `uint(-1)` below.
```
if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
            require(allowance[src][msg.sender] >= wad);
            allowance[src][msg.sender] -= wad;
        }
```
So i used `type(uint128).max` instead according to: https://ethereum.stackexchange.com/a/94524

**Tests**

I was able to successfully compile the contract.

**Additional context**

This would ultimately help us have a single solc version which would enable us to compile all the contracts at once. Hardhat supports multiple solc versions but some do not.

