### PR TITLE
deploy-config: temp fix for new config

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -84,8 +84,11 @@ contract DeployConfig is Script {
         eip1559Denominator = stdJson.readUint(_json, "$.eip1559Denominator");
         eip1559Elasticity = stdJson.readUint(_json, "$.eip1559Elasticity");
         l2GenesisRegolithTimeOffset = stdJson.readUint(_json, "$.l2GenesisRegolithTimeOffset");
-        faultGameAbsolutePrestate = stdJson.readUint(_json, "$.faultGameAbsolutePrestate");
-        faultGameMaxDepth = stdJson.readUint(_json, "$.faultGameMaxDepth");
+
+        if (block.chainid == 900) {
+            faultGameAbsolutePrestate = stdJson.readUint(_json, "$.faultGameAbsolutePrestate");
+            faultGameMaxDepth = stdJson.readUint(_json, "$.faultGameMaxDepth");
+        }
     }
 
     function l1StartingBlockTag() public returns (bytes32) {


### PR DESCRIPTION
**Description**

Hides new config behind a particular chain id so that it doesn't try to be parsed in the getting started guide. We will implement a form of fallback config in the future.

Fixes https://github.com/ethereum-optimism/optimism/issues/6141
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

