### PR TITLE
feat(op-challenger): Game State ClaimPairs -> Claims [SPIKE]

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -38,8 +38,12 @@ func (a *Agent) AddClaim(claim Claim) error {
 func (a *Agent) PerformActions() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	for _, pair := range a.game.ClaimPairs() {
-		_ = a.move(pair.claim, pair.parent)
+	for _, claim := range a.game.Claims() {
+		parent := Claim{
+			Parent:    ClaimData{},
+			ClaimData: claim.Parent,
+		}
+		_ = a.move(claim, parent)
 	}
 }
 

--- a/op-challenger/fault/game_test.go
+++ b/op-challenger/fault/game_test.go
@@ -121,10 +121,11 @@ func TestGame_ClaimPairs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Validate claim pairs.
-	expected := []struct{ claim, parent Claim }{
-		{middle, top},
-		{bottom, middle},
+	expected := []Claim{
+		top,
+		middle,
+		bottom,
 	}
-	pairs := g.ClaimPairs()
-	require.ElementsMatch(t, expected, pairs)
+	claims := g.Claims()
+	require.ElementsMatch(t, expected, claims)
 }


### PR DESCRIPTION
**Description**

Spikes the switch from returning a list of `[Claim, Parent Claim]` pairs to returning all Claims in the game state.

The game state interface changes as a result from `ClaimPairs() []struct{claim Claim, parent Claim}` to `Claims() []Claim`.

Since each `Claim` object already contains its associated parent in the `Parent` field, we don't need to duplicate this data.

The downside to this approach is that the `Claim` object currently looks like this:
```golang
type Claim struct {
    ClaimData
    Parent ClaimData
}
```

So, when we return a list of `Claim` objects from the new `Claims() []Claim` method on the game state, we don't have the "Parent" populated as a `Claim`, but rather just `ClaimData`. This likely won't be a hindrance, but is something to consider if we make this change - particularly when it comes to the `Agent`'s `move(claim, parent Claim) error` function that requires the parent be a `Claim` as opposed to the game state's returned `ClaimData`.