### PR TITLE
Current syntax throws inaccurate error in op-proposer start script

### DIFF
--- a/docs/op-stack/src/docs/build/getting-started.md
+++ b/docs/op-stack/src/docs/build/getting-started.md
@@ -522,12 +522,12 @@ Now start `op-proposer`, which proposes new state roots.
 cd ~/optimism/op-proposer
 
 ./bin/op-proposer \
-    --poll-interval 12s \
-    --rpc.port 8560 \
-    --rollup-rpc http://localhost:8547 \
-    --l2oo-address $L2OO_ADDR \
-    --private-key $PROPOSER_KEY \
-    --l1-eth-rpc $L1_RPC
+    --poll-interval=12s \
+    --rpc.port=8560 \
+    --rollup-rpc=http://localhost:8547 \
+    --l2oo-address=$L2OO_ADDR \
+    --private-key=$PROPOSER_KEY \
+    --l1-eth-rpc=$L1_RPC
 ```
 
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Absence of the '=' symbol in the script to start op-proposer throws a misleading error.

**Tests**
The existing script: 

```
./bin/op-proposer \
    --poll-interval 12s \
    --rpc.port 8560 \
    --rollup-rpc http://localhost:8547 \
    --l2oo-address $L2OO_ADDR \
    --private-key $PROPOSER_KEY \
    --l1-eth-rpc $L1_RPC
```
produces this error:
`t=2023-06-28T15:16:56+0000 lvl=crit msg="Application failed" message="flag l1-eth-rpc is required"`

Updating the script with `=`:
```
./bin/op-proposer \
    --poll-interval=12s \
    --rpc.port=8560 \
    --rollup-rpc=http://localhost:8547 \
    --l2oo-address=$L2OO_ADDR \
    --private-key=$PROPOSER_KEY \
    --l1-eth-rpc=$L1_RPC
```
produces what I assume to be an accurate error:
```
INFO [06-28|15:22:40.444] Initializing L2 Output Submitter 
ERROR[06-28|15:22:40.444] Unable to create the L2 Output Submitter error="invalid address: " 
CRIT [06-28|15:22:40.444] Application failed                       message="invalid address: " 
```

- Fixes #[Link to Issue]
https://github.com/ethereum-optimism/optimism/issues/6174