### PR TITLE
op-challenger: Counter the root claim

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -42,13 +42,13 @@ func (a *Agent) AddClaim(claim Claim) error {
 func (a *Agent) PerformActions() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	for _, pair := range a.game.ClaimPairs() {
-		_ = a.move(pair.claim, pair.parent)
+	for _, claim := range a.game.Claims() {
+		_ = a.move(claim)
 	}
 }
 
 // move determines & executes the next move given a claim pair
-func (a *Agent) move(claim, parent Claim) error {
+func (a *Agent) move(claim Claim) error {
 	nextMove, err := a.solver.NextMove(claim)
 	if err != nil {
 		a.log.Warn("Failed to execute the next move", "err", err)

--- a/op-challenger/fault/cmd/examples/full.go
+++ b/op-challenger/fault/cmd/examples/full.go
@@ -25,14 +25,7 @@ func FullGame() {
 			Position: fault.NewPosition(0, 0),
 		},
 	}
-	counter := fault.Claim{
-		ClaimData: fault.ClaimData{
-			Value:    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000364"),
-			Position: fault.NewPosition(1, 0),
-		},
-		Parent: root.ClaimData,
-	}
 
-	o := fault.NewOrchestrator(maxDepth, []fault.TraceProvider{canonicalProvider, disputedProvider}, []string{"charlie", "mallory"}, root, counter)
+	o := fault.NewOrchestrator(maxDepth, []fault.TraceProvider{canonicalProvider, disputedProvider}, []string{"charlie", "mallory"}, root)
 	o.Start()
 }

--- a/op-challenger/fault/cmd/examples/solver.go
+++ b/op-challenger/fault/cmd/examples/solver.go
@@ -37,17 +37,6 @@ func SolverExampleOne() {
 		},
 	}
 
-	// Note: We have to create the first counter claim seperately because next move does not know how to counter
-	// the root claim at this time.
-	// Counter claim is d at trace index 3 from the canonical provider
-	counter := fault.Claim{
-		ClaimData: fault.ClaimData{
-			Value:    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000364"),
-			Position: fault.NewPosition(1, 0),
-		},
-		Parent: root.ClaimData,
-	}
-
 	canonicalProvider := fault.NewAlphabetProvider(canonical, uint64(maxDepth))
 	disputedProvider := fault.NewAlphabetProvider(disputed, uint64(maxDepth))
 
@@ -63,17 +52,22 @@ func SolverExampleOne() {
 	fmt.Println("go left to d, then right to x (cannonical is f), then left to e")
 	fmt.Println()
 	PrettyPrintAlphabetClaim("Root claim", root)
-	PrettyPrintAlphabetClaim("Counter claim", counter)
 
-	claim1, err := disputedSolver.NextMove(counter)
+	claim1, err := cannonicalSolver.NextMove(root)
 	if err != nil {
-		fmt.Printf("error getting claim from disputed provider: %v", err)
+		fmt.Printf("error getting claim from provider: %v", err)
 	}
-	PrettyPrintAlphabetClaim("Disputed moved", *claim1)
+	PrettyPrintAlphabetClaim("Cannonical move", *claim1)
 
-	claim2, err := cannonicalSolver.NextMove(*claim1)
+	claim2, err := disputedSolver.NextMove(*claim1)
 	if err != nil {
-		fmt.Printf("error getting claim from disputed provider: %v", err)
+		fmt.Printf("error getting claim from provider: %v", err)
 	}
-	PrettyPrintAlphabetClaim("Cannonical move", *claim2)
+	PrettyPrintAlphabetClaim("Disputed moved", *claim2)
+
+	claim3, err := cannonicalSolver.NextMove(*claim2)
+	if err != nil {
+		fmt.Printf("error getting claim from provider: %v", err)
+	}
+	PrettyPrintAlphabetClaim("Cannonical move", *claim3)
 }

--- a/op-challenger/fault/game_test.go
+++ b/op-challenger/fault/game_test.go
@@ -121,10 +121,7 @@ func TestGame_ClaimPairs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Validate claim pairs.
-	expected := []struct{ claim, parent Claim }{
-		{middle, top},
-		{bottom, middle},
-	}
-	pairs := g.ClaimPairs()
-	require.ElementsMatch(t, expected, pairs)
+	expected := []Claim{top, middle, bottom}
+	claims := g.Claims()
+	require.ElementsMatch(t, expected, claims)
 }

--- a/op-challenger/fault/solver.go
+++ b/op-challenger/fault/solver.go
@@ -23,6 +23,21 @@ func NewSolver(gameDepth int, traceProvider TraceProvider) *Solver {
 
 // NextMove returns the next move to make given the current state of the game.
 func (s *Solver) NextMove(claim Claim) (*Claim, error) {
+	// Special case of the root claim
+	if claim.IsRoot() {
+		agree, err := s.agreeWithClaim(claim.ClaimData)
+		if err != nil {
+			return nil, err
+		}
+		// Attack the root claim if we do not agree with it
+		if !agree {
+			return s.attack(claim)
+		} else {
+			return nil, nil
+		}
+
+	}
+
 	parentCorrect, err := s.agreeWithClaim(claim.Parent)
 	if err != nil {
 		return nil, err

--- a/op-challenger/fault/solver_test.go
+++ b/op-challenger/fault/solver_test.go
@@ -23,6 +23,20 @@ func TestSolver_NextMove_Opponent(t *testing.T) {
 		response   ClaimData
 	}{
 		{
+			7,
+			Claim{
+				ClaimData: ClaimData{
+					Value:    common.HexToHash("0x000000000000000000000000000000000000000000000000000000000000077a"),
+					Position: NewPosition(0, 0),
+				},
+				// Root claim has no parent
+			},
+			ClaimData{
+				Value:    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000364"),
+				Position: NewPosition(1, 0),
+			},
+		},
+		{
 			3,
 			Claim{
 				ClaimData: ClaimData{


### PR DESCRIPTION
**Description**

This adds the ability for the `Move` function to counter the root claim. Because the root claim does not have a parent & we no longer looked at the parent pair, we now iterate claims, not pairs of claims.

This also touches a lot of the example code to remove setting it up with the initial counter claim.

**Tests**

Unit tests to be able to counter the root claim.


