### PR TITLE
feat: Add script to stop people from accidentally using yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint:specs:fix": "npx markdownlint-cli2-fix \"./specs/**/*.md\"",
     "lint:specs:check": "npx markdownlint-cli2  \"./specs/**/*.md\"",
     "lint:specs:toc": "npx doctoc '--title=**Table of Contents**' ./specs",
+    "preinstall": "npx only-allow pnpm",
     "postinstall": "patch-package && (test -d docs/op-stack && cd docs/op-stack && npx yarn@1 install && cd ../.. || exit 0)",
     "ready": "pnpm lint && pnpm test",
     "prepare": "husky install",


### PR DESCRIPTION
- Add extra protection so if folks accidentally use yarn from muscle memory they don't mess up their node modules and need to rm -rf node_modules to fix
<img width="985" alt="image" src="https://github.com/ethereum-optimism/optimism/assets/35039927/546f0cd7-df17-4fe6-8560-431336e40426">
