### PR TITLE
op-node: Add `admin_sequencerActive` RPC method

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -121,6 +121,10 @@ func (s *l2VerifierBackend) StopSequencer(ctx context.Context) (common.Hash, err
 	return common.Hash{}, errors.New("stopping the L2Verifier sequencer is not supported")
 }
 
+func (s *l2VerifierBackend) SequencerActive(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
 	return s.derivation.Finalized()
 }

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -28,6 +28,7 @@ type driverClient interface {
 	ResetDerivationPipeline(context.Context) error
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
+	SequencerActive(context.Context) (bool, error)
 }
 
 type rpcMetrics interface {
@@ -63,6 +64,12 @@ func (n *adminAPI) StopSequencer(ctx context.Context) (common.Hash, error) {
 	recordDur := n.m.RecordRPCServerRequest("admin_stopSequencer")
 	defer recordDur()
 	return n.dr.StopSequencer(ctx)
+}
+
+func (n *adminAPI) SequencerActive(ctx context.Context) (bool, error) {
+	recordDur := n.m.RecordRPCServerRequest("admin_sequencerActive")
+	defer recordDur()
+	return n.dr.SequencerActive(ctx)
 }
 
 type nodeAPI struct {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -227,3 +227,7 @@ func (c *mockDriverClient) StartSequencer(ctx context.Context, blockHash common.
 func (c *mockDriverClient) StopSequencer(ctx context.Context) (common.Hash, error) {
 	return c.Mock.MethodCalled("StopSequencer").Get(0).(common.Hash), nil
 }
+
+func (c *mockDriverClient) SequencerActive(ctx context.Context) (bool, error) {
+	return c.Mock.MethodCalled("SequencerActive").Get(0).(bool), nil
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -127,6 +127,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, al
 		forceReset:       make(chan chan struct{}, 10),
 		startSequencer:   make(chan hashAndErrorChannel, 10),
 		stopSequencer:    make(chan chan hashAndError, 10),
+		sequencerActive:  make(chan chan bool, 10),
 		sequencerNotifs:  sequencerStateListener,
 		config:           cfg,
 		driverConfig:     driverCfg,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -47,6 +47,11 @@ type Driver struct {
 	// It tells the caller that the sequencer stopped by returning the latest sequenced L2 block hash.
 	stopSequencer chan chan hashAndError
 
+	// Upon receiving a channel in this channel, the current sequencer status is queried.
+	// It tells the caller the status by outputting a boolean to the provided channel:
+	// true when the sequencer is active, false when it is not.
+	sequencerActive chan chan bool
+
 	// sequencerNotifs is notified when the sequencer is started or stopped
 	sequencerNotifs SequencerStateListener
 
@@ -373,6 +378,8 @@ func (s *Driver) eventLoop() {
 				s.driverConfig.SequencerStopped = true
 				respCh <- hashAndError{hash: s.derivation.UnsafeL2Head().Hash}
 			}
+		case respCh := <-s.sequencerActive:
+			respCh <- !s.driverConfig.SequencerStopped
 		case <-s.done:
 			return
 		}
@@ -432,6 +439,24 @@ func (s *Driver) StopSequencer(ctx context.Context) (common.Hash, error) {
 			return common.Hash{}, ctx.Err()
 		case he := <-respCh:
 			return he.hash, he.err
+		}
+	}
+}
+
+func (s *Driver) SequencerActive(ctx context.Context) (bool, error) {
+	if !s.driverConfig.SequencerEnabled {
+		return false, nil
+	}
+	respCh := make(chan bool, 1)
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case s.sequencerActive <- respCh:
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case active := <-respCh:
+			return active, nil
 		}
 	}
 }

--- a/op-node/sources/rollupclient.go
+++ b/op-node/sources/rollupclient.go
@@ -52,3 +52,9 @@ func (r *RollupClient) StopSequencer(ctx context.Context) (common.Hash, error) {
 	err := r.rpc.CallContext(ctx, &result, "admin_stopSequencer")
 	return result, err
 }
+
+func (r *RollupClient) SequencerActive(ctx context.Context) (bool, error) {
+	var result bool
+	err := r.rpc.CallContext(ctx, &result, "admin_sequencerActive")
+	return result, err
+}


### PR DESCRIPTION
**Description**

Add `admin_sequencerActive` RPC method.

Returns true if the node is actively sequencing, otherwise false. This is essentially a parallel with the `eth_mining` API from execution clients.

**Tests**

Updated e2e tests for admin API to cover the new endpoint.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4160/rpc-to-get-current-sequencer-state
