### PR TITLE
Set up pnpm in release workflows

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -31,6 +31,11 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.5
+
       - name: Setup Node.js 16.x
         uses: actions/setup-node@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.5
+
       - name: Setup Node.js 16.x
         uses: actions/setup-node@master
         with:


### PR DESCRIPTION
Without this the `Publish Packages (canary)` action fails with:

```
[Publish Packages (canary)](https://github.com/ethereum-optimism/optimism/actions/runs/5414704935/jobs/9842137115#step:3:15)
Unable to locate executable file: pnpm. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```
