### PR TITLE
Add changeset for #6148

### DIFF
--- a/.changeset/cyan-games-change.md
+++ b/.changeset/cyan-games-change.md
@@ -1,7 +1,0 @@
----
-'@eth-optimism/contracts-bedrock': patch
-'@eth-optimism/core-utils': patch
-'@eth-optimism/sdk': patch
----
-
-delete dead typescript https://github.com/ethereum-optimism/optimism/pull/6148

--- a/.changeset/cyan-games-change.md
+++ b/.changeset/cyan-games-change.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+'@eth-optimism/core-utils': patch
+'@eth-optimism/sdk': patch
+---
+
+delete dead typescript https://github.com/ethereum-optimism/optimism/pull/6148

--- a/.changeset/shy-yaks-smell.md
+++ b/.changeset/shy-yaks-smell.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+'@eth-optimism/core-utils': patch
+'@eth-optimism/sdk': patch
+---
+
+Delete dead typescript https://github.com/ethereum-optimism/optimism/pull/6148

--- a/.changeset/shy-yaks-smell.md
+++ b/.changeset/shy-yaks-smell.md
@@ -4,4 +4,4 @@
 '@eth-optimism/sdk': patch
 ---
 
-Delete dead typescript https://github.com/ethereum-optimism/optimism/pull/6148
+Delete dead typescript https://github.com/ethereum-optimism/optimism/pull/6148.


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/pull/6148 changed the the build directory for the contracts-bedrock package. This is causing the most recent canary release of the sdk to not build properly: 
```
Error: Cannot find module '@eth-optimism/contracts-bedrock/forge-artifacts/L1StandardBridge.sol/L1StandardBridge.json'
Require stack:
- /__w/gateway/gateway/node_modules/.pnpm/@eth-optimism+sdk@0.0.0-20230629165646_ethers@5.7.2/node_modules/@eth-optimism/sdk/dist/utils/contracts.js
- /__w/gateway/gateway/node_modules/.pnpm/@eth-optimism+sdk@0.0.0-20230629165646_ethers@5.7.2/node_modules/@eth-optimism/sdk/dist/utils/index.js
- /__w/gateway/gateway/node_modules/.pnpm/@eth-optimism+sdk@0.0.0-20230629165646_ethers@5.7.2/node_modules/@eth-optimism/sdk/dist/index.js
- /__w/gateway/gateway/packages/common-ts/build/index.js
- /__w/gateway/gateway/packages/frontend/e2e/tests/bridge.spec.ts
- /__w/gateway/gateway/node_modules/.pnpm/@playwright+test@1.27.1/node_modules/@playwright/test/lib/loader.js
- /__w/gateway/gateway/node_modules/.pnpm/@playwright+test@1.27.1/node_modules/@playwright/test/lib/runner.js
- /__w/gateway/gateway/node_modules/.pnpm/@playwright+test@1.27.1/node_modules/@playwright/test/lib/cli.js
- /__w/gateway/gateway/node_modules/.pnpm/playwright-core@1.27.1/node_modules/playwright-core/lib/cli/cli.js
- /__w/gateway/gateway/node_modules/.pnpm/playwright-core@1.27.1/node_modules/playwright-core/cli.js
- /__w/gateway/gateway/node_modules/.pnpm/@playwright+test@1.27.1/node_modules/@playwright/test/cli.js

   at ../../../node_modules/.pnpm/@eth-optimism+sdk@0.0.0-20[230](https://github.com/ethereum-optimism/gateway/actions/runs/5415046723/jobs/9842944650?pr=2310#step:6:231)629165646_ethers@5.7.2/node_modules/@eth-optimism/sdk/src/utils/contracts.ts:3
```
