### PR TITLE
fix: Skip nx cache on releases

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -51,7 +51,7 @@ jobs:
           version: nightly
 
       - name: Build
-        run: pnpm build
+        run: npx nx run-many --target=build --skip-nx-cache
 
       - name: Setup Canary Snapshot
         run: pnpm changeset version --snapshot

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postinstall": "patch-package && (test -d docs/op-stack && cd docs/op-stack && npx yarn@1 install && cd ../.. || exit 0)",
     "ready": "pnpm lint && pnpm test",
     "prepare": "husky install",
-    "release": "pnpm build && pnpm changeset publish",
+    "release": "npx nx run-many --target=build --skip-nx-cache && pnpm changeset publish",
     "install:foundry": "curl -L https://foundry.paradigm.xyz | bash && pnpm update:foundry",
     "update:foundry": "foundryup -C $(cat .foundryrc)"
   },


### PR DESCRIPTION
- To be 100% safe don't use nx cache on releases
- We currently don't use remote cache but if we do it's always best to build clean
- This action as a bot does not have access to the git shas something we will need to add to our workflows manually

