### PR TITLE
fix: bedrock-markdown-links pnpm not found error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install pnpm package manager
+          command: |
+            npm i pnpm --global
+      - run:
           name: Lint check
           command: |
             pnpm lint:specs:check


### PR DESCRIPTION
- missed installing pnpm in a bedrock-markdown-links job
