### PR TITLE
hive: Update ubuntu image used for hive to meet minimum go requirement.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1063,7 +1063,7 @@ jobs:
       sim:
         type: string
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
       docker_layer_caching: true
       resource_class: large
     steps:


### PR DESCRIPTION
**Description**

Update the docker image used to run hive tests as it now requires go 1.19.