### PR TITLE
feat(contracts-bedrock): Add ERC1155 bridge

### DIFF
--- a/packages/contracts-bedrock/contracts/L1/L1ERC1155Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1ERC1155Bridge.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import { ERC1155Holder } from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import { L2ERC1155Bridge } from "../L2/L2ERC1155Bridge.sol";
+import { ERC1155Bridge } from "../universal/ERC1155Bridge.sol";
+import { Semver } from "../universal/Semver.sol";
+
+/// @title L1ERC1155Bridge
+/// @notice The L1 ERC1155 bridge is a contract which works together with the L2 ERC1155 bridge to
+///         make it possible to transfer ERC1155 tokens from Ethereum to Optimism. This contract
+///         acts as an escrow for ERC1155 tokens deposited into L2.
+contract L1ERC1155Bridge is ERC1155Bridge, ERC1155Holder, Semver {
+    /// @notice Mapping of L1 token to L2 token to type ID to deposits, indicating the amount of L1 tokens
+    ///         by type ID deposited for L2 tokens.
+    mapping(address => mapping(address => mapping(uint256 => uint256))) public deposits;
+
+    /// @custom:semver 1.0.0
+    /// @notice Constructs the L1ERC1155Bridge contract.
+    /// @param _messenger   Address of the CrossDomainMessenger on this network.
+    /// @param _otherBridge Address of the ERC1155 bridge on the other network.
+    constructor(
+        address _messenger,
+        address _otherBridge
+    ) Semver(1, 0, 0) ERC1155Bridge(_messenger, _otherBridge) {}
+
+    /// @notice Completes an ERC1155 bridge from the other domain and sends the ERC1155 tokens to the
+    ///         recipient on this domain.
+    /// @param _localToken  Address of the ERC1155 token on this domain.
+    /// @param _remoteToken Address of the ERC1155 token on the other domain.
+    /// @param _from        Address that triggered the bridge on the other domain.
+    /// @param _to          Address to receive the token on this domain.
+    /// @param _id          Type ID of the token being deposited.
+    /// @param _amount      Amount of tokens to bridge.
+    /// @param _extraData   Optional data to forward to L2.
+    ///                     Data supplied here will not be used to execute any code on L2 and is
+    ///                     only emitted as extra data for the convenience of off-chain tooling.
+    function finalizeBridgeERC1155(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        bytes calldata _extraData
+    ) external onlyOtherBridge {
+        require(_localToken != address(this), "L1ERC1155Bridge: local token cannot be self");
+
+        // Reduce amount locked for token type ID for this L1/L2 token pair
+        deposits[_localToken][_remoteToken][_id] -= _amount;
+
+        // When a withdrawal is finalized on L1, the L1 Bridge transfers the NFT to the
+        // withdrawer.
+        IERC1155(_localToken).safeTransferFrom(address(this), _to, _id, _amount, "");
+
+        emit ERC1155BridgeFinalized(
+            _localToken,
+            _remoteToken,
+            _from,
+            _to,
+            _id,
+            _amount,
+            _extraData
+        );
+    }
+
+    /// @inheritdoc ERC1155Bridge
+    function _initiateBridgeERC1155(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) internal override {
+        require(_remoteToken != address(0), "L1ERC1155Bridge: remote token cannot be address(0)");
+
+        // Construct calldata for _l2Bridge.finalizeBridgeERC1155(_to, _id, _amount)
+        bytes memory message = abi.encodeWithSelector(
+            L2ERC1155Bridge.finalizeBridgeERC1155.selector,
+            _remoteToken,
+            _localToken,
+            _from,
+            _to,
+            _id,
+            _amount,
+            _extraData
+        );
+
+        // Lock tokens into bridge
+        deposits[_localToken][_remoteToken][_id] += _amount;
+        IERC1155(_localToken).safeTransferFrom(_from, address(this), _id, _amount, "");
+
+        // Send calldata into L2
+        MESSENGER.sendMessage(OTHER_BRIDGE, message, _minGasLimit);
+        emit ERC1155BridgeInitiated(
+            _localToken,
+            _remoteToken,
+            _from,
+            _to,
+            _id,
+            _amount,
+            _extraData
+        );
+    }
+}

--- a/packages/contracts-bedrock/contracts/L1/L1ERC1155Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L1/L1ERC1155Bridge.sol
@@ -12,21 +12,21 @@ import { Semver } from "../universal/Semver.sol";
 ///         make it possible to transfer ERC1155 tokens from Ethereum to Optimism. This contract
 ///         acts as an escrow for ERC1155 tokens deposited into L2.
 contract L1ERC1155Bridge is ERC1155Bridge, ERC1155Holder, Semver {
-    /// @notice Mapping of L1 token to L2 token to type ID to deposits, indicating the amount of L1 tokens
-    ///         by type ID deposited for L2 tokens.
+    /// @notice Mapping of L1 token to L2 token to type ID to deposits, indicating the amount of
+    ///         L1 tokens by type ID deposited for L2 tokens.
     mapping(address => mapping(address => mapping(uint256 => uint256))) public deposits;
 
     /// @custom:semver 1.0.0
     /// @notice Constructs the L1ERC1155Bridge contract.
     /// @param _messenger   Address of the CrossDomainMessenger on this network.
     /// @param _otherBridge Address of the ERC1155 bridge on the other network.
-    constructor(
-        address _messenger,
-        address _otherBridge
-    ) Semver(1, 0, 0) ERC1155Bridge(_messenger, _otherBridge) {}
+    constructor(address _messenger, address _otherBridge)
+        Semver(1, 0, 0)
+        ERC1155Bridge(_messenger, _otherBridge)
+    {}
 
-    /// @notice Completes an ERC1155 bridge from the other domain and sends the ERC1155 tokens to the
-    ///         recipient on this domain.
+    /// @notice Completes an ERC1155 bridge from the other domain and sends the ERC1155 tokens to
+    ///         the recipient on this domain.
     /// @param _localToken  Address of the ERC1155 token on this domain.
     /// @param _remoteToken Address of the ERC1155 token on the other domain.
     /// @param _from        Address that triggered the bridge on the other domain.

--- a/packages/contracts-bedrock/contracts/L2/L2ERC1155Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2ERC1155Bridge.sol
@@ -21,10 +21,10 @@ contract L2ERC1155Bridge is ERC1155Bridge, Semver {
     /// @notice Constructs the L2ERC1155Bridge contract.
     /// @param _messenger   Address of the CrossDomainMessenger on this network.
     /// @param _otherBridge Address of the ERC1155 bridge on the other network.
-    constructor(
-        address _messenger,
-        address _otherBridge
-    ) Semver(1, 0, 0) ERC1155Bridge(_messenger, _otherBridge) {}
+    constructor(address _messenger, address _otherBridge)
+        Semver(1, 0, 0)
+        ERC1155Bridge(_messenger, _otherBridge)
+    {}
 
     /// @notice Completes an ERC1155 bridge from the other domain and sends the ERC1155 token to the
     ///         recipient on this domain.
@@ -99,7 +99,8 @@ contract L2ERC1155Bridge is ERC1155Bridge, Semver {
             "L2ERC1155Bridge: remote token does not match given value"
         );
 
-        // When a withdrawal is initiated, we burn the amount of the type ID to prevent subsequent L2 usage
+        // When a withdrawal is initiated, we burn the amount of the type ID to prevent subsequent
+        // L2 usage
         // slither-disable-next-line reentrancy-events
         IOptimismMintableERC1155(_localToken).burn(_from, _id, _amount);
 

--- a/packages/contracts-bedrock/contracts/L2/L2ERC1155Bridge.sol
+++ b/packages/contracts-bedrock/contracts/L2/L2ERC1155Bridge.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { ERC1155Bridge } from "../universal/ERC1155Bridge.sol";
+import { L1ERC1155Bridge } from "../L1/L1ERC1155Bridge.sol";
+import { IOptimismMintableERC1155 } from "../universal/IOptimismMintableERC1155.sol";
+import { Semver } from "../universal/Semver.sol";
+
+/// @title L2ERC1155Bridge
+/// @notice The L2 ERC1155 bridge is a contract which works together with the L1 ERC1155 bridge to
+///         make it possible to transfer ERC1155 tokens from Ethereum to Optimism. This contract
+///         acts as a minter for new tokens when it hears about deposits into the L1 ERC1155 bridge.
+///         This contract also acts as a burner for tokens being withdrawn.
+///         **WARNING**: Do not bridge an ERC1155 that was originally deployed on Optimism. This
+///         bridge ONLY supports ERC1155s originally deployed on Ethereum. Users will need to
+///         wait for the one-week challenge period to elapse before their Optimism-native NFT
+///         can be refunded on L2.
+contract L2ERC1155Bridge is ERC1155Bridge, Semver {
+    /// @custom:semver 1.0.0
+    /// @notice Constructs the L2ERC1155Bridge contract.
+    /// @param _messenger   Address of the CrossDomainMessenger on this network.
+    /// @param _otherBridge Address of the ERC1155 bridge on the other network.
+    constructor(
+        address _messenger,
+        address _otherBridge
+    ) Semver(1, 0, 0) ERC1155Bridge(_messenger, _otherBridge) {}
+
+    /// @notice Completes an ERC1155 bridge from the other domain and sends the ERC1155 token to the
+    ///         recipient on this domain.
+    /// @param _localToken  Address of the ERC1155 token on this domain.
+    /// @param _remoteToken Address of the ERC1155 token on the other domain.
+    /// @param _from        Address that triggered the bridge on the other domain.
+    /// @param _to          Address to receive the token on this domain.
+    /// @param _id          Type ID of the token being deposited.
+    /// @param _amount      Amount of tokens to bridge.
+    /// @param _extraData   Optional data to forward to L1.
+    ///                     Data supplied here will not be used to execute any code on L1 and is
+    ///                     only emitted as extra data for the convenience of off-chain tooling.
+    function finalizeBridgeERC1155(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        bytes calldata _extraData
+    ) external onlyOtherBridge {
+        require(_localToken != address(this), "L2ERC1155Bridge: local token cannot be self");
+
+        // Note that supportsInterface makes a callback to the _localToken address which is user
+        // provided.
+        require(
+            ERC165Checker.supportsInterface(
+                _localToken,
+                type(IOptimismMintableERC1155).interfaceId
+            ),
+            "L2ERC1155Bridge: local token interface is not compliant"
+        );
+
+        require(
+            _remoteToken == IOptimismMintableERC1155(_localToken).remoteToken(),
+            "L2ERC1155Bridge: wrong remote token for Optimism Mintable ERC1155 local token"
+        );
+
+        // When a deposit is finalized, we give the amount of the same type ID to the account
+        // on L2. Note that mint makes a callback to the _to address which is user provided.
+        IOptimismMintableERC1155(_localToken).mint(_to, _id, _amount);
+
+        emit ERC1155BridgeFinalized(
+            _localToken,
+            _remoteToken,
+            _from,
+            _to,
+            _id,
+            _amount,
+            _extraData
+        );
+    }
+
+    /// @inheritdoc ERC1155Bridge
+    function _initiateBridgeERC1155(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) internal override {
+        require(_remoteToken != address(0), "L2ERC1155Bridge: remote token cannot be address(0)");
+
+        // Construct calldata for l1ERC1155Bridge.finalizeBridgeERC1155(_to, _id, _amount)
+        // slither-disable-next-line reentrancy-events
+        address remoteToken = IOptimismMintableERC1155(_localToken).remoteToken();
+        require(
+            remoteToken == _remoteToken,
+            "L2ERC1155Bridge: remote token does not match given value"
+        );
+
+        // When a withdrawal is initiated, we burn the amount of the type ID to prevent subsequent L2 usage
+        // slither-disable-next-line reentrancy-events
+        IOptimismMintableERC1155(_localToken).burn(_from, _id, _amount);
+
+        bytes memory message = abi.encodeWithSelector(
+            L1ERC1155Bridge.finalizeBridgeERC1155.selector,
+            remoteToken,
+            _localToken,
+            _from,
+            _to,
+            _id,
+            _amount,
+            _extraData
+        );
+
+        // Send message to L1 bridge
+        // slither-disable-next-line reentrancy-events
+        MESSENGER.sendMessage(OTHER_BRIDGE, message, _minGasLimit);
+
+        // slither-disable-next-line reentrancy-events
+        emit ERC1155BridgeInitiated(_localToken, remoteToken, _from, _to, _id, _amount, _extraData);
+    }
+}

--- a/packages/contracts-bedrock/contracts/universal/ERC1155Bridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/ERC1155Bridge.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { CrossDomainMessenger } from "./CrossDomainMessenger.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+/// @title ERC1155Bridge
+/// @notice ERC1155Bridge is a base contract for the L1 and L2 ERC1155 bridges.
+abstract contract ERC1155Bridge {
+    /// @notice Messenger contract on this domain.
+    CrossDomainMessenger public immutable MESSENGER;
+
+    /// @notice Address of the bridge on the other network.
+    address public immutable OTHER_BRIDGE;
+
+    /// @notice Reserve extra slots (to a total of 50) in the storage layout for future upgrades.
+    uint256[50] private __gap;
+
+    /// @notice Emitted when an ERC1155 bridge to the other network is initiated.
+    /// @param localToken  Address of the token on this domain.
+    /// @param remoteToken Address of the token on the remote domain.
+    /// @param from        Address that initiated bridging action.
+    /// @param to          Address to receive the token.
+    /// @param id          Type ID of the token deposited.
+    /// @param value       Amount of tokens deposited.
+    /// @param extraData   Extra data for use on the client-side.
+    event ERC1155BridgeInitiated(
+        address indexed localToken,
+        address indexed remoteToken,
+        address indexed from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes extraData
+    );
+
+    /// @notice Emitted when an ERC1155 bridge from the other network is finalized.
+    /// @param localToken  Address of the token on this domain.
+    /// @param remoteToken Address of the token on the remote domain.
+    /// @param from        Address that initiated bridging action.
+    /// @param to          Address to receive the token.
+    /// @param id          Type ID of the token deposited.
+    /// @param value       Amount of tokens deposited.
+    /// @param extraData   Extra data for use on the client-side.
+    event ERC1155BridgeFinalized(
+        address indexed localToken,
+        address indexed remoteToken,
+        address indexed from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes extraData
+    );
+
+    /// @notice Ensures that the caller is a cross-chain message from the other bridge.
+    modifier onlyOtherBridge() {
+        require(
+            msg.sender == address(MESSENGER) && MESSENGER.xDomainMessageSender() == OTHER_BRIDGE,
+            "ERC1155Bridge: function can only be called from the other bridge"
+        );
+        _;
+    }
+
+    /// @param _messenger   Address of the CrossDomainMessenger on this network.
+    /// @param _otherBridge Address of the ERC1155 bridge on the other network.
+    constructor(address _messenger, address _otherBridge) {
+        require(_messenger != address(0), "ERC1155Bridge: messenger cannot be address(0)");
+        require(_otherBridge != address(0), "ERC1155Bridge: other bridge cannot be address(0)");
+
+        MESSENGER = CrossDomainMessenger(_messenger);
+        OTHER_BRIDGE = _otherBridge;
+    }
+
+    /// @custom:legacy
+    /// @notice Legacy getter for messenger contract.
+    /// @return Messenger contract on this domain.
+    function messenger() external view returns (CrossDomainMessenger) {
+        return MESSENGER;
+    }
+
+    /// @custom:legacy
+    /// @notice Legacy getter for other bridge address.
+    /// @return Address of the bridge on the other network.
+    function otherBridge() external view returns (address) {
+        return OTHER_BRIDGE;
+    }
+
+    /// @notice Initiates a bridge of an ERC1155 to the caller's account on the other chain. Note that
+    ///         this function can only be called by EOAs. Smart contract wallets should use the
+    ///         `bridgeERC1155To` function after ensuring that the recipient address on the remote
+    ///         chain exists. Also note that the current owner of the tokens on this chain must
+    ///         approve this contract to operate the tokens before it can be bridged.
+    ///         **WARNING**: Do not bridge an ERC1155 that was originally deployed on Optimism. This
+    ///         bridge only supports ERC1155s originally deployed on Ethereum. Users will need to
+    ///         wait for the one-week challenge period to elapse before their Optimism-native ERC1155
+    ///         can be refunded on L2.
+    /// @param _localToken  Address of the ERC1155 on this domain.
+    /// @param _remoteToken Address of the ERC1155 on the remote domain.
+    /// @param _id          Type ID of the token to bridge.
+    /// @param _amount      Amount of tokens to bridge.
+    /// @param _minGasLimit Minimum gas limit for the bridge message on the other domain.
+    /// @param _extraData   Optional data to forward to the other chain. Data supplied here will not
+    ///                     be used to execute any code on the other chain and is only emitted as
+    ///                     extra data for the convenience of off-chain tooling.
+    function bridgeERC1155(
+        address _localToken,
+        address _remoteToken,
+        uint256 _id,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) external {
+        // Modifier requiring sender to be EOA. This prevents against a user error that would occur
+        // if the sender is a smart contract wallet that has a different address on the remote chain
+        // (or doesn't have an address on the remote chain at all). The user would fail to receive
+        // the tokens if they use this function because it sends the tokens to the same address as the
+        // caller. This check could be bypassed by a malicious contract via initcode, but it takes
+        // care of the user error we want to avoid.
+        require(!Address.isContract(msg.sender), "ERC1155Bridge: account is not externally owned");
+
+        _initiateBridgeERC1155(
+            _localToken,
+            _remoteToken,
+            msg.sender,
+            msg.sender,
+            _id,
+            _amount,
+            _minGasLimit,
+            _extraData
+        );
+    }
+
+    /// @notice Initiates a bridge of an ERC1155 to some recipient's account on the other chain. Note
+    ///         that the current owner of the tokens on this chain must approve this contract to
+    ///         operate the tokens before it can be bridged.
+    ///         **WARNING**: Do not bridge an ERC1155 that was originally deployed on Optimism. This
+    ///         bridge only supports ERC1155s originally deployed on Ethereum. Users will need to
+    ///         wait for the one-week challenge period to elapse before their Optimism-native tokens
+    ///         can be refunded on L2.
+    /// @param _localToken  Address of the ERC1155 on this domain.
+    /// @param _remoteToken Address of the ERC1155 on the remote domain.
+    /// @param _to          Address to receive the token on the other domain.
+    /// @param _id          Type ID of the token to bridge.
+    /// @param _amount      Amount of tokens to bridge.
+    /// @param _minGasLimit Minimum gas limit for the bridge message on the other domain.
+    /// @param _extraData   Optional data to forward to the other chain. Data supplied here will not
+    ///                     be used to execute any code on the other chain and is only emitted as
+    ///                     extra data for the convenience of off-chain tooling.
+    function bridgeERC1155To(
+        address _localToken,
+        address _remoteToken,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) external {
+        require(_to != address(0), "ERC1155Bridge: nft recipient cannot be address(0)");
+
+        _initiateBridgeERC1155(
+            _localToken,
+            _remoteToken,
+            msg.sender,
+            _to,
+            _id,
+            _amount,
+            _minGasLimit,
+            _extraData
+        );
+    }
+
+    /// @notice Internal function for initiating a token bridge to the other domain.
+    /// @param _localToken  Address of the ERC1155 on this domain.
+    /// @param _remoteToken Address of the ERC1155 on the remote domain.
+    /// @param _from        Address of the sender on this domain.
+    /// @param _to          Address to receive the token on the other domain.
+    /// @param _id          Type ID of the token to bridge.
+    /// @param _amount      Amount of tokens to bridge.
+    /// @param _minGasLimit Minimum gas limit for the bridge message on the other domain.
+    /// @param _extraData   Optional data to forward to the other domain. Data supplied here will
+    ///                     not be used to execute any code on the other domain and is only emitted
+    ///                     as extra data for the convenience of off-chain tooling.
+    function _initiateBridgeERC1155(
+        address _localToken,
+        address _remoteToken,
+        address _from,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) internal virtual;
+}

--- a/packages/contracts-bedrock/contracts/universal/ERC1155Bridge.sol
+++ b/packages/contracts-bedrock/contracts/universal/ERC1155Bridge.sol
@@ -85,15 +85,15 @@ abstract contract ERC1155Bridge {
         return OTHER_BRIDGE;
     }
 
-    /// @notice Initiates a bridge of an ERC1155 to the caller's account on the other chain. Note that
-    ///         this function can only be called by EOAs. Smart contract wallets should use the
+    /// @notice Initiates a bridge of an ERC1155 to the caller's account on the other chain. Note
+    ///         that this function can only be called by EOAs. Smart contract wallets should use the
     ///         `bridgeERC1155To` function after ensuring that the recipient address on the remote
     ///         chain exists. Also note that the current owner of the tokens on this chain must
     ///         approve this contract to operate the tokens before it can be bridged.
     ///         **WARNING**: Do not bridge an ERC1155 that was originally deployed on Optimism. This
     ///         bridge only supports ERC1155s originally deployed on Ethereum. Users will need to
-    ///         wait for the one-week challenge period to elapse before their Optimism-native ERC1155
-    ///         can be refunded on L2.
+    ///         wait for the one-week challenge period to elapse before their Optimism-native
+    ///         ERC1155 can be refunded on L2.
     /// @param _localToken  Address of the ERC1155 on this domain.
     /// @param _remoteToken Address of the ERC1155 on the remote domain.
     /// @param _id          Type ID of the token to bridge.
@@ -113,9 +113,9 @@ abstract contract ERC1155Bridge {
         // Modifier requiring sender to be EOA. This prevents against a user error that would occur
         // if the sender is a smart contract wallet that has a different address on the remote chain
         // (or doesn't have an address on the remote chain at all). The user would fail to receive
-        // the tokens if they use this function because it sends the tokens to the same address as the
-        // caller. This check could be bypassed by a malicious contract via initcode, but it takes
-        // care of the user error we want to avoid.
+        // the tokens if they use this function because it sends the tokens to the same address as
+        // the caller. This check could be bypassed by a malicious contract via initcode, but it
+        // takes care of the user error we want to avoid.
         require(!Address.isContract(msg.sender), "ERC1155Bridge: account is not externally owned");
 
         _initiateBridgeERC1155(
@@ -130,9 +130,9 @@ abstract contract ERC1155Bridge {
         );
     }
 
-    /// @notice Initiates a bridge of an ERC1155 to some recipient's account on the other chain. Note
-    ///         that the current owner of the tokens on this chain must approve this contract to
-    ///         operate the tokens before it can be bridged.
+    /// @notice Initiates a bridge of an ERC1155 to some recipient's account on the other chain.
+    ///         Note that the current owner of the tokens on this chain must approve this contract
+    ///         to operate the tokens before it can be bridged.
     ///         **WARNING**: Do not bridge an ERC1155 that was originally deployed on Optimism. This
     ///         bridge only supports ERC1155s originally deployed on Ethereum. Users will need to
     ///         wait for the one-week challenge period to elapse before their Optimism-native tokens

--- a/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC1155.sol
+++ b/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC1155.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+/// @title IOptimismMintableERC1155
+/// @notice Interface for contracts that are compatible with the OptimismMintableERC1155 standard.
+///         Tokens that follow this standard can be easily transferred across the ERC1155 bridge.
+interface IOptimismMintableERC1155 is IERC1155 {
+    /// @notice Emitted when tokens are minted.
+    /// @param account Address of the account the token were minted to.
+    /// @param id      Type ID of the minted tokens.
+    /// @param value   Amount of tokens minted.
+    event Mint(address indexed account, uint256 id, uint256 value);
+
+    /// @notice Equivalent to multiple Mint events for the same account.
+    /// @param account Address of the account the tokens were minted to.
+    /// @param ids     Type IDs of the minted tokens.
+    /// @param values  Amounts of tokens minted.
+    event MintBatch(address indexed account, uint256[] ids, uint256[] values);
+
+    /// @notice Emitted when tokens are burned.
+    /// @param account Address of the account the tokens were burned from.
+    /// @param id      Type ID of the burned tokens.
+    /// @param value   Amount of tokens burned.
+    event Burn(address indexed account, uint256 id, uint256 value);
+
+    /// @notice Equivalent to multiple Burn events for the same account.
+    /// @param account Address of the account the tokens were burned from.
+    /// @param ids     Type IDs of the burned tokens.
+    /// @param values  Amounts of tokens burned.
+    event BurnBatch(address indexed account, uint256[] ids, uint256[] values);
+
+    /// @notice Mints an amount of a token type to a user
+    /// @param _to     Address of the user to mint the token to.
+    /// @param _id     Type ID of the tokens to mint.
+    /// @param _amount Amount of tokens to mint.
+    function mint(address _to, uint256 _id, uint256 _amount) external;
+
+    /// @notice Batch version of mint. Mints multiple amounts of multiple token types to a user
+    /// @param _to      Address of the user to mint the token to.
+    /// @param _ids     Type IDs of the tokens to mint.
+    /// @param _amounts Amounts of tokens to mint.
+    function mintBatch(address _to, uint256[] memory _ids, uint256[] memory _amounts) external;
+
+    /// @notice Burns an amount of a token type from a user
+    /// @param _from  Address of the user to burn the token from.
+    /// @param _id    Type ID of the tokens to burn.
+    /// @param _amount Amount of tokens to burn.
+    function burn(address _from, uint256 _id, uint256 _amount) external;
+
+    /// @notice Batch version of Burn. Burns multiple amounts of multiple token types from a user
+    /// @param _from  Address of the user to burn the token from.
+    /// @param _ids    Type IDs of the tokens to burn.
+    /// @param _amounts Amounts of tokens to burn.
+    function burnBatch(address _from, uint256[] memory _ids, uint256[] memory _amounts) external;
+
+    /// @notice Chain ID of the chain where the remote token is deployed.
+    function REMOTE_CHAIN_ID() external view returns (uint256);
+
+    /// @notice Address of the token on the remote domain.
+    function REMOTE_TOKEN() external view returns (address);
+
+    /// @notice Address of the ERC1155 bridge on this network.
+    function BRIDGE() external view returns (address);
+
+    /// @notice Chain ID of the chain where the remote token is deployed.
+    function remoteChainId() external view returns (uint256);
+
+    /// @notice Address of the token on the remote domain.
+    function remoteToken() external view returns (address);
+
+    /// @notice Address of the ERC1155 bridge on this network.
+    function bridge() external view returns (address);
+}

--- a/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC1155.sol
+++ b/packages/contracts-bedrock/contracts/universal/IOptimismMintableERC1155.sol
@@ -35,25 +35,41 @@ interface IOptimismMintableERC1155 is IERC1155 {
     /// @param _to     Address of the user to mint the token to.
     /// @param _id     Type ID of the tokens to mint.
     /// @param _amount Amount of tokens to mint.
-    function mint(address _to, uint256 _id, uint256 _amount) external;
+    function mint(
+        address _to,
+        uint256 _id,
+        uint256 _amount
+    ) external;
 
     /// @notice Batch version of mint. Mints multiple amounts of multiple token types to a user
     /// @param _to      Address of the user to mint the token to.
     /// @param _ids     Type IDs of the tokens to mint.
     /// @param _amounts Amounts of tokens to mint.
-    function mintBatch(address _to, uint256[] memory _ids, uint256[] memory _amounts) external;
+    function mintBatch(
+        address _to,
+        uint256[] memory _ids,
+        uint256[] memory _amounts
+    ) external;
 
     /// @notice Burns an amount of a token type from a user
     /// @param _from  Address of the user to burn the token from.
     /// @param _id    Type ID of the tokens to burn.
     /// @param _amount Amount of tokens to burn.
-    function burn(address _from, uint256 _id, uint256 _amount) external;
+    function burn(
+        address _from,
+        uint256 _id,
+        uint256 _amount
+    ) external;
 
     /// @notice Batch version of Burn. Burns multiple amounts of multiple token types from a user
     /// @param _from  Address of the user to burn the token from.
     /// @param _ids    Type IDs of the tokens to burn.
     /// @param _amounts Amounts of tokens to burn.
-    function burnBatch(address _from, uint256[] memory _ids, uint256[] memory _amounts) external;
+    function burnBatch(
+        address _from,
+        uint256[] memory _ids,
+        uint256[] memory _amounts
+    ) external;
 
     /// @notice Chain ID of the chain where the remote token is deployed.
     function REMOTE_CHAIN_ID() external view returns (uint256);

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC1155.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC1155.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { ERC1155 } from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IOptimismMintableERC1155 } from "./IOptimismMintableERC1155.sol";
+import { Semver } from "../universal/Semver.sol";
+
+/// @title OptimismMintableERC1155
+/// @notice This contract is the remote representation for some token that lives on another network,
+///         typically an Optimism representation of an Ethereum-based token. Standard reference
+///         implementation that can be extended or modified according to your needs.
+contract OptimismMintableERC1155 is ERC1155, IOptimismMintableERC1155, Semver {
+    /// @inheritdoc IOptimismMintableERC1155
+    uint256 public immutable REMOTE_CHAIN_ID;
+
+    /// @inheritdoc IOptimismMintableERC1155
+    address public immutable REMOTE_TOKEN;
+
+    /// @inheritdoc IOptimismMintableERC1155
+    address public immutable BRIDGE;
+
+    /// @notice Modifier that prevents callers other than the bridge from calling the function.
+    modifier onlyBridge() {
+        require(
+            msg.sender == BRIDGE,
+            "OptimismMintableERC1155: only bridge can call this function"
+        );
+        _;
+    }
+
+    /// @custom:semver 1.0.0
+    /// @param _bridge        Address of the bridge on this network.
+    /// @param _remoteChainId Chain ID where the remote token is deployed.
+    /// @param _remoteToken   Address of the corresponding token on the other network.
+    /// @param _uri           ERC1155 uri.
+    constructor(
+        address _bridge,
+        uint256 _remoteChainId,
+        address _remoteToken,
+        string memory _uri
+    ) ERC1155(_uri) Semver(1, 0, 0) {
+        require(_bridge != address(0), "OptimismMintableERC1155: bridge cannot be address(0)");
+        require(_remoteChainId != 0, "OptimismMintableERC1155: remote chain id cannot be zero");
+        require(
+            _remoteToken != address(0),
+            "OptimismMintableERC1155: remote token cannot be address(0)"
+        );
+
+        REMOTE_CHAIN_ID = _remoteChainId;
+        REMOTE_TOKEN = _remoteToken;
+        BRIDGE = _bridge;
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function remoteChainId() external view returns (uint256) {
+        return REMOTE_CHAIN_ID;
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function remoteToken() external view returns (address) {
+        return REMOTE_TOKEN;
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function bridge() external view returns (address) {
+        return BRIDGE;
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function mint(address _to, uint256 _id, uint256 _amount) external virtual onlyBridge {
+        _mint(_to, _id, _amount, "");
+
+        emit Mint(_to, _id, _amount);
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function mintBatch(
+        address _to,
+        uint256[] memory _ids,
+        uint256[] memory _amounts
+    ) external virtual onlyBridge {
+        _mintBatch(_to, _ids, _amounts, "");
+
+        emit MintBatch(_to, _ids, _amounts);
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function burn(address _from, uint256 _id, uint256 _amount) external virtual onlyBridge {
+        _burn(_from, _id, _amount);
+
+        emit Burn(_from, _id, _amount);
+    }
+
+    /// @inheritdoc IOptimismMintableERC1155
+    function burnBatch(
+        address _from,
+        uint256[] memory _ids,
+        uint256[] memory _amounts
+    ) external virtual onlyBridge {
+        _burnBatch(_from, _ids, _amounts);
+
+        emit BurnBatch(_from, _ids, _amounts);
+    }
+
+    /// @notice Checks if a given interface ID is supported by this contract.
+    /// @param _interfaceId The interface ID to check.
+    /// @return True if the interface ID is supported, false otherwise.
+    function supportsInterface(
+        bytes4 _interfaceId
+    ) public view override(ERC1155, IERC165) returns (bool) {
+        bytes4 iface = type(IOptimismMintableERC1155).interfaceId;
+        return _interfaceId == iface || super.supportsInterface(_interfaceId);
+    }
+}

--- a/packages/contracts-bedrock/contracts/universal/OptimismMintableERC1155.sol
+++ b/packages/contracts-bedrock/contracts/universal/OptimismMintableERC1155.sol
@@ -68,7 +68,11 @@ contract OptimismMintableERC1155 is ERC1155, IOptimismMintableERC1155, Semver {
     }
 
     /// @inheritdoc IOptimismMintableERC1155
-    function mint(address _to, uint256 _id, uint256 _amount) external virtual onlyBridge {
+    function mint(
+        address _to,
+        uint256 _id,
+        uint256 _amount
+    ) external virtual onlyBridge {
         _mint(_to, _id, _amount, "");
 
         emit Mint(_to, _id, _amount);
@@ -86,7 +90,11 @@ contract OptimismMintableERC1155 is ERC1155, IOptimismMintableERC1155, Semver {
     }
 
     /// @inheritdoc IOptimismMintableERC1155
-    function burn(address _from, uint256 _id, uint256 _amount) external virtual onlyBridge {
+    function burn(
+        address _from,
+        uint256 _id,
+        uint256 _amount
+    ) external virtual onlyBridge {
         _burn(_from, _id, _amount);
 
         emit Burn(_from, _id, _amount);
@@ -106,9 +114,12 @@ contract OptimismMintableERC1155 is ERC1155, IOptimismMintableERC1155, Semver {
     /// @notice Checks if a given interface ID is supported by this contract.
     /// @param _interfaceId The interface ID to check.
     /// @return True if the interface ID is supported, false otherwise.
-    function supportsInterface(
-        bytes4 _interfaceId
-    ) public view override(ERC1155, IERC165) returns (bool) {
+    function supportsInterface(bytes4 _interfaceId)
+        public
+        view
+        override(ERC1155, IERC165)
+        returns (bool)
+    {
         bytes4 iface = type(IOptimismMintableERC1155).interfaceId;
         return _interfaceId == iface || super.supportsInterface(_interfaceId);
     }


### PR DESCRIPTION
From [BootNode](https://www.bootnode.dev/) we are opening this PR to start the conversation on whether having an ERC1155 bridge as part of the official stack, to complement the existing ETH, ERC20, and ERC721 bridge, makes sense to the Optimism community.

### Motivation

There are several reasons why it is a good idea to have an ERC1155 bridge on Optimism:

- 🧐**Missing piece of the stack**: Currently, there is no way to bridge ERC1155 tokens to Optimism.
- 👀**Other L2s have it**: Other L2 and sidechains already offer an ERC1155 bridge as part of their smart contract infrastructure. This puts Optimism at a competitive disadvantage, as developers may build their applications on other L2s with this functionality.
- ✊**Popular protocols are embracing it**: Popular protocols, such as Uniswap v4, are starting to embrace ERC1155 beyond current adoption. This means that there is a growing demand for ERC1155 tokens, and having an ERC1155 bridge on Optimism will make it easier for users to access these tokens.
- 🧩**Better than having individual teams create it**: If each team creates its own ERC1155 bridge, this will lead to fragmentation and a lack of standardization. Having a single, well-maintained ERC1155 bridge on Optimism will be better for the community as a whole.

### Solution
This pull request adds a new set of smart contracts for an ERC1155 bridge. We followed the structure of the ERC721 and Standard bridges for this first draft implementation.

- **OptimismMintableERC1155**:  Remote representation for some ERC1155 that lives on another network. Gives minting and burning capabilities to a bridge contract.
- **IOptimismMintableERC1155**: Interface for contracts that are compatible with the OptimismMintableERC1155 standard.
- **ERC1155Bridge**: Base abstract contract for the L1 and L2 ERC1155 bridges that includes the shared logic to pass messages to the other network using the messenger contract.
- **L1ERC1155Bridge**: Escrow for ERC1155 tokens deposited into L2. Works together with the L2 ERC1155 bridge to make it possible to transfer ERC1155 tokens from Ethereum to Optimism.
- **L2ERC1155Bridge**: Minter for new OptimismMintableERC1155 tokens when it hears about deposits into the L1ERC1155bridge. Also, acts as a burner for tokens being withdrawn. 

In case the solution is accepted, we can continue iterating on top of this: first obtaining some feedback, comments, and recommendations and then completing the pending tasks such as:
- Add support for ERC1155 batch functionality into the bridge contracts
- Perform internal review for improvements/fixes
- Add required tests
- Add/update docs
- Add deploy scripts
- Any other required tasks
