### PR TITLE
ci: move devnet test to make target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -989,17 +989,8 @@ jobs:
           name: Bring up the stack
           command: make devnet-up
       - run:
-          name: Check L2 config
-          command: go run cmd/check-l2/main.go --l2-rpc-url http://localhost:9545 --l1-rpc-url http://localhost:8545
-          working_directory: op-chain-ops
-      - run:
-          name: Deposit ERC20 through the bridge
-          command: timeout 8m npx hardhat deposit-erc20 --network devnetL1 --l1-contracts-json-path ../../.devnet/addresses.json
-          working_directory: packages/sdk
-      - run:
-          name: Deposit ETH through the bridge
-          command: timeout 8m npx hardhat deposit-eth --network devnetL1 --l1-contracts-json-path ../../.devnet/addresses.json
-          working_directory: packages/sdk
+          name: Test the stack
+          command: make devnet-test
       - run:
           name: Dump op-node logs
           command: |

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ devnet-up:
 # alias for devnet-up
 devnet-up-deploy: devnet-up
 
+devnet-test:
+	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=. --test
+.PHONY: devnet-test
+
 devnet-down:
 	@(cd ./ops-bedrock && GENESIS_TIMESTAMP=$(shell date +%s) docker-compose stop)
 .PHONY: devnet-down

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -18,6 +18,7 @@ pjoin = os.path.join
 parser = argparse.ArgumentParser(description='Bedrock devnet launcher')
 parser.add_argument('--monorepo-dir', help='Directory of the monorepo', default=os.getcwd())
 parser.add_argument('--allocs', help='Only create the allocs and exit', type=bool, action=argparse.BooleanOptionalAction)
+parser.add_argument('--test', help='Tests the deployment, must already be deployed', type=bool, action=argparse.BooleanOptionalAction)
 
 log = logging.getLogger()
 
@@ -57,6 +58,8 @@ def main():
     ops_bedrock_dir = pjoin(monorepo_dir, 'ops-bedrock')
     deploy_config_dir = pjoin(contracts_bedrock_dir, 'deploy-config'),
     devnet_config_path = pjoin(contracts_bedrock_dir, 'deploy-config', 'devnetL1.json')
+    ops_chain_ops = pjoin(monorepo_dir, 'op-chain-ops')
+    sdk_dir = pjoin(monorepo_dir, 'packages', 'sdk')
 
     paths = Bunch(
       mono_repo_dir=monorepo_dir,
@@ -68,6 +71,8 @@ def main():
       devnet_config_path=devnet_config_path,
       op_node_dir=op_node_dir,
       ops_bedrock_dir=ops_bedrock_dir,
+      ops_chain_ops=ops_chain_ops,
+      sdk_dir=sdk_dir,
       genesis_l1_path=pjoin(devnet_dir, 'genesis-l1.json'),
       genesis_l2_path=pjoin(devnet_dir, 'genesis-l2.json'),
       allocs_path=pjoin(devnet_dir, 'allocs-l1.json'),
@@ -75,6 +80,11 @@ def main():
       sdk_addresses_json_path=pjoin(devnet_dir, 'sdk-addresses.json'),
       rollup_config_path=pjoin(devnet_dir, 'rollup.json')
     )
+
+    if args.test:
+      log.info('Testing deployed devnet')
+      devnet_test(paths)
+      return
 
     os.makedirs(devnet_dir, exist_ok=True)
 
@@ -250,8 +260,26 @@ def wait_for_rpc_server(url):
             log.info(f'Waiting for RPC server at {url}')
             time.sleep(1)
 
+def devnet_test(paths):
+    # Check the L2 config
+    run_command(
+        ['go', 'run', 'cmd/check-l2/main.go', '--l2-rpc-url', 'http://localhost:9545', '--l1-rpc-url', 'http://localhost:8545'],
+        cwd=paths.ops_chain_ops,
+    )
 
-def run_command(args, check=True, shell=False, cwd=None, env=None):
+    run_command(
+         ['npx', 'hardhat',  'deposit-erc20', '--network',  'devnetL1', '--l1-contracts-json-path', paths.addresses_json_path],
+         cwd=paths.sdk_dir,
+         timeout=8*60,
+    )
+
+    run_command(
+         ['npx', 'hardhat',  'deposit-eth', '--network',  'devnetL1', '--l1-contracts-json-path', paths.addresses_json_path],
+         cwd=paths.sdk_dir,
+         timeout=8*60,
+    )
+
+def run_command(args, check=True, shell=False, cwd=None, env=None, timeout=None):
     env = env if env else {}
     return subprocess.run(
         args,
@@ -261,7 +289,8 @@ def run_command(args, check=True, shell=False, cwd=None, env=None):
             **os.environ,
             **env
         },
-        cwd=cwd
+        cwd=cwd,
+        timeout=timeout
     )
 
 


### PR DESCRIPTION
When encountering devnet test failures in CI, they're challenging to resolve and reproduce locally because the commands are embedded into the CI configuration and not the Makefile.

This PR simply extracts the commands from the CI steps and embeds them into the devnet python module, allowing for the python script to be invoked with a new `--test` flag to execute those steps.  It also adds a `devnet-test` make target to allow simple invocation of the script in test mode.