### PR TITLE
fix: Fix bedrock markdown links checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,6 +690,10 @@ jobs:
           command: |
             npm i pnpm --global
       - run:
+          name: Install node_modules
+          command: |
+            pnpm install
+      - run:
           name: Lint check
           command: |
             pnpm lint:specs:check


### PR DESCRIPTION
- Fix link checker that was failing from no node_modules existing
