### PR TITLE
op-program: Continue derivation after temporary errors

### DIFF
--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -61,6 +61,11 @@ func (d *Driver) Step(ctx context.Context) error {
 		}
 		d.logger.Debug("Data is lacking")
 		return nil
+	} else if errors.Is(err, derive.ErrTemporary) {
+		// While most temporary errors are due to requests for external data failing which can't happen,
+		// they may also be returned due to other events like channels timing out so need to be handled
+		d.logger.Warn("Temporary error in derivation", "err", err)
+		return nil
 	} else if err != nil {
 		return fmt.Errorf("pipeline err: %w", err)
 	}

--- a/op-program/client/driver/driver_test.go
+++ b/op-program/client/driver/driver_test.go
@@ -23,7 +23,7 @@ func TestDerivationComplete(t *testing.T) {
 func TestTemporaryError(t *testing.T) {
 	driver := createDriver(t, fmt.Errorf("whoopsie: %w", derive.ErrTemporary))
 	err := driver.Step(context.Background())
-	require.ErrorIs(t, err, derive.ErrTemporary)
+	require.NoError(t, err, "should allow derivation to continue after temporary error")
 }
 
 func TestNotEnoughDataError(t *testing.T) {


### PR DESCRIPTION
**Description**

Log a warning and continue the derivation process when `op-program` receives a temporary error from the derivation pipeline. While the vast majority of temporary errors are because of calls to the L1 or L2 apis failing which can't happen in op-program, they can also happen when batches are invalid or timeout. eg:
```
t=2023-07-09T06:21:31+0000 lvl=info msg="Advancing bq origin"                    origin=0x791b0016ce33a5f2eae950070cbf70c8da0fde224b2f9b27aca55cbc24f5bd85:9315124 originBehind=false
t=2023-07-09T06:21:31+0000 lvl=info msg="channel timed out"                      channel=eb8bc381675d3486e24ea4ba14d4b0be frames=2
t=2023-07-09T06:21:31+0000 lvl=eror msg="Error creating batch reader from channel data" err="unexpected EOF"
t=2023-07-09T06:21:31+0000 lvl=eror msg="Program failed"                         err="pipeline err: engine stage failed: temp: unexpected EOF"
```

In op-program failing to retrieve data will panic rather than throw a temporary error so its safe to continue derivation when a temporary error is received as it is expected to recover.

**Tests**

Updated unit tests.
