### PR TITLE
op-service: App module

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -2,11 +2,12 @@ package op_challenger
 
 import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 // Main is the programmatic entry-point for running op-challenger
-func Main(logger log.Logger, cfg *config.Config) error {
+func Main(logger log.Logger, cfg *config.Config, metricsFactory opmetrics.Factory) error {
 	logger.Info("Fault game started")
 	return nil
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -6,7 +6,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	opservice "github.com/ethereum-optimism/optimism/op-service"
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	txmgr "github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
@@ -47,7 +46,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{}
 
 func init() {
-	optionalFlags = append(optionalFlags, oplog.CLIFlags(envVarPrefix)...)
+	// TODO: Introduce a txmgr app.Service to handle flag management and creating the txmgr.
 	optionalFlags = append(optionalFlags, txmgr.CLIFlags(envVarPrefix)...)
 
 	Flags = append(requiredFlags, optionalFlags...)

--- a/op-service/app/app.go
+++ b/op-service/app/app.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"fmt"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+)
+
+type Service interface {
+	Flags(envVarPrefix string) []cli.Flag
+	Subcommands() cli.Commands
+	Init(logger log.Logger, ctx *cli.Context) error
+}
+
+type PreConfigure func(app *cli.App)
+
+type Action func(l log.Logger, ctx *cli.Context) error
+
+func Run(args []string, envVarPrefix string, configure PreConfigure, action Action, services ...Service) error {
+	oplog.SetupDefaults()
+
+	app := cli.NewApp()
+	configure(app)
+
+	app.Flags = append(app.Flags, oplog.CLIFlags(envVarPrefix)...)
+	for _, service := range services {
+		app.Flags = append(app.Flags, service.Flags(envVarPrefix)...)
+		app.Commands = append(app.Commands, service.Subcommands()...)
+	}
+
+	app.Action = func(ctx *cli.Context) error {
+		logger, err := setupLogging(ctx)
+		if err != nil {
+			return err
+		}
+		for _, service := range services {
+			if err := service.Init(logger, ctx); err != nil {
+				return err
+			}
+		}
+		logger.Info("Starting", "app", app.Name, "version", app.Version)
+
+		// TODO: Add interrupt handling here
+		return action(logger, ctx)
+	}
+	return app.Run(args)
+}
+
+func setupLogging(ctx *cli.Context) (log.Logger, error) {
+	logCfg := oplog.ReadCLIConfig(ctx)
+	if err := logCfg.Check(); err != nil {
+		return nil, fmt.Errorf("log config error: %w", err)
+	}
+	logger := oplog.NewLogger(logCfg)
+	return logger, nil
+}

--- a/op-service/metrics/service.go
+++ b/op-service/metrics/service.go
@@ -1,0 +1,121 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/olekukonko/tablewriter"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/urfave/cli/v2"
+)
+
+// TODO: Provide info metric with version automatically
+
+type Service struct {
+	registerMetrics RegisterMetrics
+	config          CLIConfig
+	registry        *prometheus.Registry
+	factory         Factory
+}
+
+func (s *Service) Flags(envVarPrefix string) []cli.Flag {
+	return CLIFlags(envVarPrefix)
+}
+
+func (s *Service) Subcommands() cli.Commands {
+	return cli.Commands{
+		{
+			Name: "doc",
+			Subcommands: cli.Commands{
+				{
+					Name:  "metrics",
+					Usage: "Dumps a list of supported metrics to stdout",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "format",
+							Value: "markdown",
+							Usage: "Output format (json|markdown)",
+						},
+					},
+					Action: func(ctx *cli.Context) error {
+						s.registerMetrics(s)
+						supportedMetrics := s.Document()
+						format := ctx.String("format")
+
+						if format != "markdown" && format != "json" {
+							return fmt.Errorf("invalid format: %s", format)
+						}
+
+						if format == "json" {
+							enc := json.NewEncoder(os.Stdout)
+							return enc.Encode(supportedMetrics)
+						}
+
+						table := tablewriter.NewWriter(os.Stdout)
+						table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+						table.SetCenterSeparator("|")
+						table.SetAutoWrapText(false)
+						table.SetHeader([]string{"Metric", "Description", "Labels", "Type"})
+						var data [][]string
+						for _, metric := range supportedMetrics {
+							labels := strings.Join(metric.Labels, ",")
+							data = append(data, []string{metric.Name, metric.Help, labels, metric.Type})
+						}
+						table.AppendBulk(data)
+						table.Render()
+						return nil
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *Service) Init(logger log.Logger, ctx *cli.Context) error {
+	s.config = ReadCLIConfig(ctx)
+	if err := s.config.Check(); err != nil {
+		return fmt.Errorf("metrics config error: %w", err)
+	}
+	if s.config.Enabled {
+		logger.Info("starting metrics server", "addr", s.config.ListenAddr, "port", s.config.ListenPort)
+		go func() {
+			if err := ListenAndServe(ctx.Context, s.registry, s.config.ListenAddr, s.config.ListenPort); err != nil {
+				logger.Error("error starting metrics server", err)
+			}
+		}()
+		// TODO: Support starting balance metrics?
+	}
+	return nil
+}
+
+func (s *Service) StartBalanceMetrics(ctx context.Context, l log.Logger, ns string, client *ethclient.Client, account common.Address) {
+	if !s.config.Enabled {
+		return
+	}
+	LaunchBalanceMetrics(ctx, l, s.registry, ns, client, account)
+}
+
+func (s *Service) Factory() Factory {
+	return s.factory
+}
+
+func (s *Service) Document() []DocumentedMetric {
+	return s.factory.Document()
+}
+
+type RegisterMetrics func(service *Service)
+
+func NewService(registerMetrics RegisterMetrics) *Service {
+	registry := NewRegistry()
+	return &Service{
+		registerMetrics: registerMetrics,
+		registry:        registry,
+		factory:         With(registry),
+	}
+}


### PR DESCRIPTION
**Description**

Strawman for an `app` module in `op-service` to make it easy to create new services with optional components. Logging config is automatically added and other services like metrics can be added as additional options.

Plenty of rough edges here but putting up to enable some discussion.  Demoed as an integration for op-challenger since that is a new service we're currently building with logging and metrics.

I'm not particularly sure if this is the right way to expose components created by services (eg the metrics `Registry`) so that they can be accessed by the actual application code.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
