### PR TITLE
fix(pnpm): Don't build node-hid

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "node": ">=16",
     "pnpm": ">=8"
   },
+  "pnpm": {
+    "neverBuiltDependencies": [
+      "node-hid"
+    ]
+  },
   "scripts": {
     "clean": "npx nx run-many --target=clean",
     "build": "npx nx run-many --target=build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+neverBuiltDependencies:
+  - node-hid
+
 importers:
 
   .:
@@ -13406,7 +13409,6 @@ packages:
     resolution: {integrity: sha512-BA6G4V84kiNd1uAChub/Z/5s/xS3EHBCxotQ0nyYrUG65mXewUDHE1tWOSqA2dp3N+mV0Ffq9wo2AW9t4p/G7g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    requiresBuild: true
     dependencies:
       bindings: 1.5.0
       nan: 2.17.0
@@ -13419,7 +13421,6 @@ packages:
     resolution: {integrity: sha512-Skzhqow7hyLZU93eIPthM9yjot9lszg9xrKxESleEs05V2NcbUptZc5HFqzjOkSmL0sFlZFr3kmvaYebx06wrw==}
     engines: {node: '>=10'}
     hasBin: true
-    requiresBuild: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 3.2.1


### PR DESCRIPTION
- Skip building node-hid on pnpm install
- Fails for various reasons all the time in Op repo gateway repo and other repos
- Many versions of node-hid exist via recursive ethers related deps. The older ones are problematic
- Also problematic on macos
- Node-hid is not necessary to be built and is only a dev dependency for the libraries. Not necessary for our purposes just using it as an npm package we only need the production deps

