### PR TITLE
feat: bi-directionally index StandardBridge contract events

### DIFF
--- a/indexer/api/api_test.go
+++ b/indexer/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -25,7 +26,7 @@ func (mbv *MockBridgeView) DepositsByAddress(address common.Address) ([]*databas
 		{
 			Deposit: database.Deposit{
 				GUID:                 uuid.MustParse(guid1),
-				InitiatedL1EventGUID: guid2,
+				InitiatedL1EventGUID: uuid.MustParse(guid2),
 				Tx:                   database.Transaction{},
 				TokenPair:            database.TokenPair{},
 			},
@@ -34,13 +35,28 @@ func (mbv *MockBridgeView) DepositsByAddress(address common.Address) ([]*databas
 	}, nil
 }
 
+// DepositsByAddress mocks returning deposits by an address
+func (mbv *MockBridgeView) DepositByMessageNonce(nonce *big.Int) (*database.Deposit, error) {
+	return &database.Deposit{
+		GUID:                 uuid.MustParse(guid1),
+		InitiatedL1EventGUID: uuid.MustParse(guid2),
+		Tx:                   database.Transaction{},
+		TokenPair:            database.TokenPair{},
+	}, nil
+}
+
+// LatestDepositMessageNonce mocks returning the latest cross domain message nonce for a deposit
+func (mbv *MockBridgeView) LatestDepositMessageNonce() (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
 // WithdrawalsByAddress mocks returning withdrawals by an address
 func (mbv *MockBridgeView) WithdrawalsByAddress(address common.Address) ([]*database.WithdrawalWithTransactionHashes, error) {
 	return []*database.WithdrawalWithTransactionHashes{
 		{
 			Withdrawal: database.Withdrawal{
 				GUID:                 uuid.MustParse(guid2),
-				InitiatedL2EventGUID: guid1,
+				InitiatedL2EventGUID: uuid.MustParse(guid1),
 				WithdrawalHash:       common.HexToHash("0x456"),
 				Tx:                   database.Transaction{},
 				TokenPair:            database.TokenPair{},
@@ -48,6 +64,33 @@ func (mbv *MockBridgeView) WithdrawalsByAddress(address common.Address) ([]*data
 			L2TransactionHash: common.HexToHash("0x789"),
 		},
 	}, nil
+}
+
+// WithdrawalsByMessageNonce mocks returning withdrawals by a withdrawal hash
+func (mbv *MockBridgeView) WithdrawalByMessageNonce(nonce *big.Int) (*database.Withdrawal, error) {
+	return &database.Withdrawal{
+		GUID:                 uuid.MustParse(guid2),
+		InitiatedL2EventGUID: uuid.MustParse(guid1),
+		WithdrawalHash:       common.HexToHash("0x456"),
+		Tx:                   database.Transaction{},
+		TokenPair:            database.TokenPair{},
+	}, nil
+}
+
+// WithdrawalsByHash mocks returning withdrawals by a withdrawal hash
+func (mbv *MockBridgeView) WithdrawalByHash(address common.Hash) (*database.Withdrawal, error) {
+	return &database.Withdrawal{
+		GUID:                 uuid.MustParse(guid2),
+		InitiatedL2EventGUID: uuid.MustParse(guid1),
+		WithdrawalHash:       common.HexToHash("0x456"),
+		Tx:                   database.Transaction{},
+		TokenPair:            database.TokenPair{},
+	}, nil
+}
+
+// LatestWithdrawalMessageNonce mocks returning the latest cross domain message nonce for a withdrawal
+func (mbv *MockBridgeView) LatestWithdrawalMessageNonce() (*big.Int, error) {
+	return big.NewInt(0), nil
 }
 
 func TestHealthz(t *testing.T) {

--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/google/uuid"
 
 	"gorm.io/gorm"
@@ -19,6 +21,15 @@ type BlockHeader struct {
 	ParentHash common.Hash `gorm:"serializer:json"`
 	Number     U256
 	Timestamp  uint64
+}
+
+func BlockHeaderFromHeader(header *types.Header) BlockHeader {
+	return BlockHeader{
+		Hash:       header.Hash(),
+		ParentHash: header.ParentHash,
+		Number:     U256{Int: header.Number},
+		Timestamp:  header.Time,
+	}
 }
 
 type L1BlockHeader struct {

--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -23,7 +23,7 @@ type BlockHeader struct {
 	Timestamp  uint64
 }
 
-func BlockHeaderFromHeader(header *types.Header) BlockHeader {
+func BlockHeaderFromGethHeader(header *types.Header) BlockHeader {
 	return BlockHeader{
 		Hash:       header.Hash(),
 		ParentHash: header.ParentHash,

--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -52,8 +52,9 @@ type LegacyStateBatch struct {
 }
 
 type OutputProposal struct {
-	OutputRoot          common.Hash `gorm:"primaryKey;serializer:json"`
-	L2BlockNumber       U256
+	OutputRoot    common.Hash `gorm:"primaryKey;serializer:json"`
+	L2BlockNumber U256
+
 	L1ContractEventGUID uuid.UUID
 }
 

--- a/indexer/database/bridge.go
+++ b/indexer/database/bridge.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"errors"
+	"math/big"
 
 	"gorm.io/gorm"
 
@@ -30,7 +31,16 @@ type TokenPair struct {
 
 type Deposit struct {
 	GUID                 uuid.UUID `gorm:"primaryKey"`
-	InitiatedL1EventGUID string
+	InitiatedL1EventGUID uuid.UUID
+	FinalizedL2EventGUID uuid.UUID `gorm:"default:null"`
+
+	// Since we're only currently indexing a single StandardBridge,
+	// the message nonce serves as a unique identifier for this
+	// deposit. Once this generalizes to more than 1 deployed
+	// bridge, we need to include the `CrossDomainMessenger` address
+	// such that the (messenger_addr, nonce) is the unique identifer
+	// for a bridge msg
+	SentMessageNonce U256
 
 	Tx        Transaction `gorm:"embedded"`
 	TokenPair TokenPair   `gorm:"embedded"`
@@ -43,11 +53,19 @@ type DepositWithTransactionHash struct {
 
 type Withdrawal struct {
 	GUID                 uuid.UUID `gorm:"primaryKey"`
-	InitiatedL2EventGUID string
+	InitiatedL2EventGUID uuid.UUID
+
+	// Since we're only currently indexing a single StandardBridge,
+	// the message nonce serves as a unique identifier for this
+	// withdrawal. Once this generalizes to more than 1 deployed
+	// bridge, we need to include the `CrossDomainMessenger` address
+	// such that the (messenger_addr, nonce) is the unique identifer
+	// for a bridge msg
+	SentMessageNonce U256
 
 	WithdrawalHash       common.Hash `gorm:"serializer:json"`
-	ProvenL1EventGUID    *string
-	FinalizedL1EventGUID *string
+	ProvenL1EventGUID    uuid.UUID   `gorm:"default:null"`
+	FinalizedL1EventGUID uuid.UUID   `gorm:"default:null"`
 
 	Tx        Transaction `gorm:"embedded"`
 	TokenPair TokenPair   `gorm:"embedded"`
@@ -63,16 +81,23 @@ type WithdrawalWithTransactionHashes struct {
 
 type BridgeView interface {
 	DepositsByAddress(address common.Address) ([]*DepositWithTransactionHash, error)
+	DepositByMessageNonce(*big.Int) (*Deposit, error)
+	LatestDepositMessageNonce() (*big.Int, error)
+
 	WithdrawalsByAddress(address common.Address) ([]*WithdrawalWithTransactionHashes, error)
+	WithdrawalByMessageNonce(*big.Int) (*Withdrawal, error)
+	LatestWithdrawalMessageNonce() (*big.Int, error)
 }
 
 type BridgeDB interface {
 	BridgeView
 
 	StoreDeposits([]*Deposit) error
+	MarkFinalizedDepositEvent(uuid.UUID, uuid.UUID) error
+
 	StoreWithdrawals([]*Withdrawal) error
-	MarkProvenWithdrawalEvent(string, string) error
-	MarkFinalizedWithdrawalEvent(string, string) error
+	MarkProvenWithdrawalEvent(uuid.UUID, uuid.UUID) error
+	MarkFinalizedWithdrawalEvent(uuid.UUID, uuid.UUID) error
 }
 
 /**
@@ -114,6 +139,46 @@ func (db *bridgeDB) DepositsByAddress(address common.Address) ([]*DepositWithTra
 	return deposits, nil
 }
 
+func (db *bridgeDB) DepositByMessageNonce(nonce *big.Int) (*Deposit, error) {
+	var deposit Deposit
+	result := db.gorm.First(&deposit, "sent_message_nonce = ?", U256{Int: nonce})
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
+		return nil, result.Error
+	}
+
+	return &deposit, nil
+}
+
+func (db *bridgeDB) LatestDepositMessageNonce() (*big.Int, error) {
+	var deposit Deposit
+	result := db.gorm.Order("sent_message_nonce DESC").Take(&deposit)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
+		return nil, result.Error
+	}
+
+	return deposit.SentMessageNonce.Int, nil
+}
+
+func (db *bridgeDB) MarkFinalizedDepositEvent(guid, finalizationEventGUID uuid.UUID) error {
+	var deposit Deposit
+	result := db.gorm.First(&deposit, "guid = ?", guid)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	deposit.FinalizedL2EventGUID = finalizationEventGUID
+	result = db.gorm.Save(&deposit)
+	return result.Error
+}
+
 // Withdrawals
 
 func (db *bridgeDB) StoreWithdrawals(withdrawals []*Withdrawal) error {
@@ -121,26 +186,26 @@ func (db *bridgeDB) StoreWithdrawals(withdrawals []*Withdrawal) error {
 	return result.Error
 }
 
-func (db *bridgeDB) MarkProvenWithdrawalEvent(guid, provenL1EventGuid string) error {
+func (db *bridgeDB) MarkProvenWithdrawalEvent(guid, provenL1EventGuid uuid.UUID) error {
 	var withdrawal Withdrawal
 	result := db.gorm.First(&withdrawal, "guid = ?", guid)
 	if result.Error != nil {
 		return result.Error
 	}
 
-	withdrawal.ProvenL1EventGUID = &provenL1EventGuid
+	withdrawal.ProvenL1EventGUID = provenL1EventGuid
 	result = db.gorm.Save(&withdrawal)
 	return result.Error
 }
 
-func (db *bridgeDB) MarkFinalizedWithdrawalEvent(guid, finalizedL1EventGuid string) error {
+func (db *bridgeDB) MarkFinalizedWithdrawalEvent(guid, finalizedL1EventGuid uuid.UUID) error {
 	var withdrawal Withdrawal
 	result := db.gorm.First(&withdrawal, "guid = ?", guid)
 	if result.Error != nil {
 		return result.Error
 	}
 
-	withdrawal.FinalizedL1EventGUID = &finalizedL1EventGuid
+	withdrawal.FinalizedL1EventGUID = finalizedL1EventGuid
 	result = db.gorm.Save(&withdrawal)
 	return result.Error
 }
@@ -166,4 +231,32 @@ func (db *bridgeDB) WithdrawalsByAddress(address common.Address) ([]*WithdrawalW
 	}
 
 	return withdrawals, nil
+}
+
+func (db *bridgeDB) WithdrawalByMessageNonce(nonce *big.Int) (*Withdrawal, error) {
+	var withdrawal Withdrawal
+	result := db.gorm.First(&withdrawal, "sent_message_nonce = ?", U256{Int: nonce})
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
+		return nil, result.Error
+	}
+
+	return &withdrawal, nil
+}
+
+func (db *bridgeDB) LatestWithdrawalMessageNonce() (*big.Int, error) {
+	var withdrawal Withdrawal
+	result := db.gorm.Order("sent_message_nonce DESC").Take(&withdrawal)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+
+		return nil, result.Error
+	}
+
+	return withdrawal.SentMessageNonce.Int, nil
 }

--- a/indexer/database/bridge.go
+++ b/indexer/database/bridge.go
@@ -33,7 +33,6 @@ type TokenPair struct {
 type Deposit struct {
 	GUID                 uuid.UUID `gorm:"primaryKey"`
 	InitiatedL1EventGUID uuid.UUID
-	FinalizedL2EventGUID uuid.UUID `gorm:"default:null"`
 
 	// Since we're only currently indexing a single StandardBridge,
 	// the message nonce serves as a unique identifier for this
@@ -42,6 +41,8 @@ type Deposit struct {
 	// such that the (messenger_addr, nonce) is the unique identifer
 	// for a bridge msg
 	SentMessageNonce U256
+
+	FinalizedL2EventGUID *uuid.UUID
 
 	Tx        Transaction `gorm:"embedded"`
 	TokenPair TokenPair   `gorm:"embedded"`
@@ -176,7 +177,7 @@ func (db *bridgeDB) MarkFinalizedDepositEvent(guid, finalizationEventGUID uuid.U
 		return result.Error
 	}
 
-	deposit.FinalizedL2EventGUID = finalizationEventGUID
+	deposit.FinalizedL2EventGUID = &finalizationEventGUID
 	result = db.gorm.Save(&deposit)
 	return result.Error
 }

--- a/indexer/database/bridge.go
+++ b/indexer/database/bridge.go
@@ -38,7 +38,7 @@ type Deposit struct {
 	// the message nonce serves as a unique identifier for this
 	// deposit. Once this generalizes to more than 1 deployed
 	// bridge, we need to include the `CrossDomainMessenger` address
-	// such that the (messenger_addr, nonce) is the unique identifer
+	// such that the (messenger_addr, nonce) is the unique identifier
 	// for a bridge msg
 	SentMessageNonce U256
 
@@ -61,7 +61,7 @@ type Withdrawal struct {
 	// the message nonce serves as a unique identifier for this
 	// withdrawal. Once this generalizes to more than 1 deployed
 	// bridge, we need to include the `CrossDomainMessenger` address
-	// such that the (messenger_addr, nonce) is the unique identifer
+	// such that the (messenger_addr, nonce) is the unique identifier
 	// for a bridge msg
 	SentMessageNonce U256
 
@@ -209,7 +209,7 @@ func (db *bridgeDB) MarkFinalizedWithdrawalEvent(guid, finalizedL1EventGuid uuid
 	}
 
 	if withdrawal.ProvenL1EventGUID == nil {
-		return errors.New(fmt.Sprintf("withdrawal %s marked finalized prior to being proven", guid))
+		return fmt.Errorf("withdrawal %s marked finalized prior to being proven", guid)
 	}
 
 	withdrawal.FinalizedL1EventGUID = &finalizedL1EventGuid

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -23,7 +23,7 @@ type ContractEvent struct {
 	Timestamp      uint64
 }
 
-func ContractEventFromLog(log *types.Log, timestamp uint64) ContractEvent {
+func ContractEventFromGethLog(log *types.Log, timestamp uint64) ContractEvent {
 	return ContractEvent{
 		GUID: uuid.New(),
 

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/google/uuid"
 )
@@ -20,6 +21,20 @@ type ContractEvent struct {
 	EventSignature common.Hash `gorm:"serializer:json"`
 	LogIndex       uint64
 	Timestamp      uint64
+}
+
+func ContractEventFromLog(log *types.Log, timestamp uint64) ContractEvent {
+	return ContractEvent{
+		GUID: uuid.New(),
+
+		BlockHash:       log.BlockHash,
+		TransactionHash: log.TxHash,
+
+		EventSignature: log.Topics[0],
+		LogIndex:       uint64(log.Index),
+
+		Timestamp: timestamp,
+	}
 }
 
 type L1ContractEvent struct {

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS l2_block_headers (
 	hash                     VARCHAR NOT NULL PRIMARY KEY,
 	parent_hash              VARCHAR NOT NULL,
 	number                   UINT256,
-	timestamp                INTEGER NOT NULL CHECK (timestamp > 0),
+	timestamp                INTEGER NOT NULL CHECK (timestamp > 0)
 );
 
 /** 
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS deposits (
 
     -- Event causing the deposit
     initiated_l1_event_guid VARCHAR NOT NULL REFERENCES l1_contract_events(guid),
-    sent_message_nonce      UINT256 NOT NULL UNIQUE,
+    sent_message_nonce      UINT256 UNIQUE,
 
     -- Finalization marker for the deposit
     finalized_l2_event_guid VARCHAR REFERENCES l2_contract_events(guid),
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS withdrawals (
 
     -- Event causing this withdrawal
     initiated_l2_event_guid VARCHAR NOT NULL REFERENCES l2_contract_events(guid),
-    sent_message_nonce      UINT256 NOT NULL UNIQUE,
+    sent_message_nonce      UINT256 UNIQUE,
 
     -- Multistep (bedrock) process of a withdrawal
     withdrawal_hash      VARCHAR NOT NULL,

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -10,14 +10,15 @@ CREATE TABLE IF NOT EXISTS l1_block_headers (
 	hash        VARCHAR NOT NULL PRIMARY KEY,
 	parent_hash VARCHAR NOT NULL,
 	number      UINT256,
-	timestamp   INTEGER NOT NULL
+	timestamp   INTEGER NOT NULL CHECK (timestamp > 0)
 );
 
 CREATE TABLE IF NOT EXISTS l2_block_headers (
-	hash        VARCHAR NOT NULL PRIMARY KEY,
-	parent_hash VARCHAR NOT NULL,
-	number      UINT256,
-	timestamp   INTEGER NOT NULL
+    -- Block header
+	hash                     VARCHAR NOT NULL PRIMARY KEY,
+	parent_hash              VARCHAR NOT NULL,
+	number                   UINT256,
+	timestamp                INTEGER NOT NULL CHECK (timestamp > 0),
 );
 
 /** 
@@ -30,7 +31,7 @@ CREATE TABLE IF NOT EXISTS l1_contract_events (
     transaction_hash VARCHAR NOT NULL,
     event_signature  VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
-    timestamp        INTEGER NOT NULL
+    timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
 );
 
 CREATE TABLE IF NOT EXISTS l2_contract_events (
@@ -39,7 +40,7 @@ CREATE TABLE IF NOT EXISTS l2_contract_events (
     transaction_hash VARCHAR NOT NULL,
     event_signature  VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
-    timestamp        INTEGER NOT NULL
+    timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
 );
 
 -- Tables that index finalization markers for L2 blocks.
@@ -69,6 +70,10 @@ CREATE TABLE IF NOT EXISTS deposits (
 
     -- Event causing the deposit
     initiated_l1_event_guid VARCHAR NOT NULL REFERENCES l1_contract_events(guid),
+    sent_message_nonce      UINT256 NOT NULL UNIQUE,
+
+    -- Finalization marker for the deposit
+    finalized_l2_event_guid VARCHAR REFERENCES l2_contract_events(guid),
 
     -- Deposit information (do we need indexes on from/to?)
 	from_address     VARCHAR NOT NULL,
@@ -78,7 +83,7 @@ CREATE TABLE IF NOT EXISTS deposits (
 	l2_token_address VARCHAR NOT NULL,
 	amount           UINT256,
 	data             VARCHAR NOT NULL,
-    timestamp        INTEGER NOT NULL
+    timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
 );
 
 CREATE TABLE IF NOT EXISTS withdrawals (
@@ -86,6 +91,7 @@ CREATE TABLE IF NOT EXISTS withdrawals (
 
     -- Event causing this withdrawal
     initiated_l2_event_guid VARCHAR NOT NULL REFERENCES l2_contract_events(guid),
+    sent_message_nonce      UINT256 NOT NULL UNIQUE,
 
     -- Multistep (bedrock) process of a withdrawal
     withdrawal_hash      VARCHAR NOT NULL,
@@ -101,5 +107,5 @@ CREATE TABLE IF NOT EXISTS withdrawals (
 	l2_token_address VARCHAR NOT NULL,
 	amount           UINT256,
 	data             VARCHAR NOT NULL,
-    timestamp        INTEGER NOT NULL
+    timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
 );

--- a/indexer/processor/contract_events.go
+++ b/indexer/processor/contract_events.go
@@ -78,20 +78,19 @@ func DecodeFromProcessedEvents[ABI any](p *ProcessedContractEvents, name string,
 	return decodedEvents, nil
 }
 
-func UnpackLog[EventType any](log *types.Log, name string, contractAbi *abi.ABI) (*EventType, error) {
+func UnpackLog(out interface{}, log *types.Log, name string, contractAbi *abi.ABI) error {
 	eventAbi, ok := contractAbi.Events[name]
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("event %s not present in supplied ABI", name))
+		return errors.New(fmt.Sprintf("event %s not present in supplied ABI", name))
 	} else if len(log.Topics) == 0 {
-		return nil, errors.New("anonymous events are not supported")
+		return errors.New("anonymous events are not supported")
 	} else if log.Topics[0] != eventAbi.ID {
-		return nil, errors.New("event signature mismatch not present in supplied ABI")
+		return errors.New("event signature mismatch not present in supplied ABI")
 	}
 
-	var event EventType
-	err := contractAbi.UnpackIntoInterface(&event, name, log.Data)
+	err := contractAbi.UnpackIntoInterface(out, name, log.Data)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// handle topics if present
@@ -104,11 +103,11 @@ func UnpackLog[EventType any](log *types.Log, name string, contractAbi *abi.ABI)
 		}
 
 		// The first topic (event signature) is ommitted
-		err := abi.ParseTopics(&event, indexedArgs, log.Topics[1:])
+		err := abi.ParseTopics(out, indexedArgs, log.Topics[1:])
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return &event, nil
+	return nil
 }

--- a/indexer/processor/contract_events.go
+++ b/indexer/processor/contract_events.go
@@ -35,7 +35,7 @@ func NewProcessedContractEvents() *ProcessedContractEvents {
 }
 
 func (p *ProcessedContractEvents) AddLog(log *types.Log, time uint64) *database.ContractEvent {
-	contractEvent := database.ContractEventFromLog(log, time)
+	contractEvent := database.ContractEventFromGethLog(log, time)
 
 	p.events = append(p.events, &contractEvent)
 	p.eventsBySignature[contractEvent.EventSignature] = append(p.eventsBySignature[contractEvent.EventSignature], &contractEvent)

--- a/indexer/processor/contract_events.go
+++ b/indexer/processor/contract_events.go
@@ -1,0 +1,114 @@
+package processor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/indexer/database"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/google/uuid"
+)
+
+type ProcessedContractEvents struct {
+	events            []*database.ContractEvent
+	eventsBySignature map[common.Hash][]*database.ContractEvent
+	eventByLogIndex   map[uint]*database.ContractEvent
+	eventLog          map[uuid.UUID]*types.Log
+}
+
+func NewProcessedContractEvents() *ProcessedContractEvents {
+	return &ProcessedContractEvents{
+		events:            []*database.ContractEvent{},
+		eventsBySignature: make(map[common.Hash][]*database.ContractEvent),
+		eventByLogIndex:   make(map[uint]*database.ContractEvent),
+		eventLog:          make(map[uuid.UUID]*types.Log),
+	}
+}
+
+func (p *ProcessedContractEvents) AddLog(log *types.Log, time uint64) *database.ContractEvent {
+	contractEvent := database.ContractEventFromLog(log, time)
+
+	p.events = append(p.events, &contractEvent)
+	p.eventsBySignature[contractEvent.EventSignature] = append(p.eventsBySignature[contractEvent.EventSignature], &contractEvent)
+	p.eventByLogIndex[log.Index] = &contractEvent
+	p.eventLog[contractEvent.GUID] = log
+
+	return &contractEvent
+}
+
+func DecodeFromProcessedEvents[ABI any](p *ProcessedContractEvents, name string, contractAbi *abi.ABI) ([]*ABI, error) {
+	eventAbi, ok := contractAbi.Events[name]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("event %s not present in supplied ABI", name))
+	}
+
+	decodedEvents := []*ABI{}
+	for _, event := range p.eventsBySignature[eventAbi.ID] {
+		log := p.eventLog[event.GUID]
+
+		var decodedEvent ABI
+		err := contractAbi.UnpackIntoInterface(&decodedEvent, name, log.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		// handle topics if present
+		if len(log.Topics) > 1 {
+			var indexedArgs abi.Arguments
+			for _, arg := range eventAbi.Inputs {
+				if arg.Indexed {
+					indexedArgs = append(indexedArgs, arg)
+				}
+			}
+
+			// The first topic (event signature) is ommitted
+			err := abi.ParseTopics(&decodedEvent, indexedArgs, log.Topics[1:])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		decodedEvents = append(decodedEvents, &decodedEvent)
+	}
+
+	return decodedEvents, nil
+}
+
+func UnpackLog[EventType any](log *types.Log, name string, contractAbi *abi.ABI) (*EventType, error) {
+	eventAbi, ok := contractAbi.Events[name]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("event %s not present in supplied ABI", name))
+	} else if len(log.Topics) == 0 {
+		return nil, errors.New("anonymous events are not supported")
+	} else if log.Topics[0] != eventAbi.ID {
+		return nil, errors.New("event signature mismatch not present in supplied ABI")
+	}
+
+	var event EventType
+	err := contractAbi.UnpackIntoInterface(&event, name, log.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	// handle topics if present
+	if len(log.Topics) > 1 {
+		var indexedArgs abi.Arguments
+		for _, arg := range eventAbi.Inputs {
+			if arg.Indexed {
+				indexedArgs = append(indexedArgs, arg)
+			}
+		}
+
+		// The first topic (event signature) is ommitted
+		err := abi.ParseTopics(&event, indexedArgs, log.Topics[1:])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &event, nil
+}

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -192,7 +192,7 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 				continue
 			}
 
-			indexedL1Headers = append(indexedL1Headers, &database.L1BlockHeader{BlockHeader: database.BlockHeaderFromHeader(header)})
+			indexedL1Headers = append(indexedL1Headers, &database.L1BlockHeader{BlockHeader: database.BlockHeaderFromGethHeader(header)})
 		}
 
 		/** Update Database **/

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -231,7 +231,7 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 			}
 
 			// forward along contract events to the bridge processor
-			err = l1BridgeProcessContractEvents(processLog, db, ethClient, processedContractEvents)
+			err = l1BridgeProcessContractEvents(processLog, db, ethClient, processedContractEvents, l1Contracts)
 			if err != nil {
 				return err
 			}

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -244,7 +244,7 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 	}
 }
 
-func l1BridgeProcessContractEvents(processLog log.Logger, db *database.DB, ethClient node.EthClient, events *ProcessedContractEvents) error {
+func l1BridgeProcessContractEvents(processLog log.Logger, db *database.DB, ethClient node.EthClient, events *ProcessedContractEvents, l1Contracts L1Contracts) error {
 	rawEthClient := ethclient.NewClient(ethClient.RawRpcClient())
 
 	// Process New Deposits
@@ -296,8 +296,8 @@ func l1BridgeProcessContractEvents(processLog log.Logger, db *database.DB, ethCl
 		// Check if the L2Processor is behind or really has missed an event. We can compare against the
 		// OptimismPortal#ProvenWithdrawal on-chain mapping relative to the latest indexed L2 height
 		if withdrawal == nil {
-			var bridgeAddress common.Address
-			var portalAddress common.Address
+			bridgeAddress := l1Contracts.L1StandardBridge
+			portalAddress := l1Contracts.OptimismPortal
 			if provenWithdrawalEvent.From != bridgeAddress || provenWithdrawalEvent.To != bridgeAddress {
 				// non-bridge withdrawal
 				continue

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -20,6 +21,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	ethAddress = common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")
 )
 
 type L1Contracts struct {
@@ -122,10 +127,10 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 			headerMap[header.Hash()] = header
 		}
 
-		/** Watch for Contract Events **/
+		/** Watch for all Optimism Contract Events **/
 
 		logFilter := ethereum.FilterQuery{FromBlock: headers[0].Number, ToBlock: headers[numHeaders-1].Number, Addresses: contractAddrs}
-		logs, err := rawEthClient.FilterLogs(context.Background(), logFilter)
+		logs, err := rawEthClient.FilterLogs(context.Background(), logFilter) // []types.Log
 		if err != nil {
 			return err
 		}
@@ -135,7 +140,10 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 		legacyStateBatches := []*database.LegacyStateBatch{}
 
 		numLogs := len(logs)
+		logsByIndex := make(map[uint]*types.Log, numLogs)
+
 		l1ContractEvents := make([]*database.L1ContractEvent, numLogs)
+		l1ContractEventLogs := make(map[uuid.UUID]*types.Log)
 		l1HeadersOfInterest := make(map[common.Hash]bool)
 		for i, log := range logs {
 			header, ok := headerMap[log.BlockHash]
@@ -144,16 +152,8 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 				return errors.New("parsed log with a block hash not in this batch")
 			}
 
-			contractEvent := &database.L1ContractEvent{
-				ContractEvent: database.ContractEvent{
-					GUID:            uuid.New(),
-					BlockHash:       log.BlockHash,
-					TransactionHash: log.TxHash,
-					EventSignature:  log.Topics[0],
-					LogIndex:        uint64(log.Index),
-					Timestamp:       header.Time,
-				},
-			}
+			logsByIndex[log.Index] = &logs[i]
+			contractEvent := &database.L1ContractEvent{ContractEvent: database.ContractEventFromLog(&log, header.Time)}
 
 			l1ContractEvents[i] = contractEvent
 			l1HeadersOfInterest[log.BlockHash] = true
@@ -194,63 +194,164 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 
 		// we iterate on the original array to maintain ordering. probably can find a more efficient
 		// way to iterate over the `l1HeadersOfInterest` map while maintaining ordering
-		l1Headers := []*database.L1BlockHeader{}
+		indexedL1Headers := []*database.L1BlockHeader{}
 		for _, header := range headers {
-			blockHash := header.Hash()
-			if _, hasLogs := l1HeadersOfInterest[blockHash]; !hasLogs {
+			_, hasLogs := l1HeadersOfInterest[header.Hash()]
+			if !hasLogs {
 				continue
 			}
 
-			l1Headers = append(l1Headers, &database.L1BlockHeader{
-				BlockHeader: database.BlockHeader{
-					Hash:       blockHash,
-					ParentHash: header.ParentHash,
-					Number:     database.U256{Int: header.Number},
-					Timestamp:  header.Time,
-				},
-			})
+			indexedL1Headers = append(
+				indexedL1Headers,
+				&database.L1BlockHeader{BlockHeader: database.BlockHeaderFromHeader(header)},
+			)
 		}
 
 		/** Update Database **/
 
-		numL1Headers := len(l1Headers)
-		if numL1Headers == 0 {
-			processLog.Info("no l1 blocks of interest")
-			return nil
-		}
-
-		processLog.Info("saving l1 blocks of interest", "size", numL1Headers, "batch_size", numHeaders)
-		err = db.Blocks.StoreL1BlockHeaders(l1Headers)
-		if err != nil {
-			return err
-		}
-
-		// Since the headers to index are derived from the existence of logs, we know in this branch `numLogs > 0`
-		processLog.Info("saving contract logs", "size", numLogs)
-		err = db.ContractEvents.StoreL1ContractEvents(l1ContractEvents)
-		if err != nil {
-			return err
-		}
-
-		// Mark L2 checkpoints that have been recorded on L1 (L2OutputProposal & StateBatchAppended events)
-		numLegacyStateBatches := len(legacyStateBatches)
-		if numLegacyStateBatches > 0 {
-			latestBatch := legacyStateBatches[numLegacyStateBatches-1]
-			latestL2Height := latestBatch.PrevTotal + latestBatch.Size - 1
-			processLog.Info("detected legacy state batches", "size", numLegacyStateBatches, "latest_l2_block_number", latestL2Height)
-		}
-
-		numOutputProposals := len(outputProposals)
-		if numOutputProposals > 0 {
-			latestL2Height := outputProposals[numOutputProposals-1].L2BlockNumber.Int
-			processLog.Info("detected output proposals", "size", numOutputProposals, "latest_l2_block_number", latestL2Height)
-			err := db.Blocks.StoreOutputProposals(outputProposals)
+		numIndexedL1Headers := len(indexedL1Headers)
+		if numIndexedL1Headers > 0 {
+			processLog.Info("saved l1 blocks of interest within batch", "num", numIndexedL1Headers, "batchSize", numHeaders)
+			err = db.Blocks.StoreL1BlockHeaders(indexedL1Headers)
 			if err != nil {
 				return err
 			}
+
+			// Since the headers to index are derived from the existence of logs, we know in this branch `numLogs > 0`
+			processLog.Info("saving contract logs", "size", numLogs)
+			err = db.ContractEvents.StoreL1ContractEvents(l1ContractEvents)
+			if err != nil {
+				return err
+			}
+
+			// Mark L2 checkpoints that have been recorded on L1 (L2OutputProposal & StateBatchAppended events)
+			numLegacyStateBatches := len(legacyStateBatches)
+			if numLegacyStateBatches > 0 {
+				latestBatch := legacyStateBatches[numLegacyStateBatches-1]
+				latestL2Height := latestBatch.PrevTotal + latestBatch.Size - 1
+				processLog.Info("detected legacy state batches", "size", numLegacyStateBatches, "latest_l2_block_number", latestL2Height)
+			}
+
+			numOutputProposals := len(outputProposals)
+			if numOutputProposals > 0 {
+				latestL2Height := outputProposals[numOutputProposals-1].L2BlockNumber.Int
+				processLog.Info("detected output proposals", "size", numOutputProposals, "latest_l2_block_number", latestL2Height)
+				err := db.Blocks.StoreOutputProposals(outputProposals)
+				if err != nil {
+					return err
+				}
+			}
+
+			// forward along contract events to the bridge processor
+			err = l1BridgeProcessContractEvents(processLog, db, l1ContractEvents, l1ContractEventLogs, logsByIndex)
+			if err != nil {
+				return err
+			}
+		} else {
+			processLog.Info("no l1 blocks of interest within batch")
 		}
 
 		// a-ok!
 		return nil
 	}
+}
+
+func l1BridgeProcessContractEvents(
+	processLog log.Logger,
+	db *database.DB,
+	events []*database.L1ContractEvent,
+	eventLogs map[uuid.UUID]*types.Log,
+	logsByIndex map[uint]*types.Log,
+) error {
+	l1StandardBridgeABI, err := bindings.L1StandardBridgeMetaData.GetAbi()
+	if err != nil {
+		return err
+	}
+
+	l1CrossDomainMessengerABI, err := bindings.L1CrossDomainMessengerMetaData.GetAbi()
+	if err != nil {
+		return err
+	}
+
+	type MessageData struct {
+		Sender       common.Address
+		Message      []byte
+		MessageNonce *big.Int
+		GasLimit     *big.Int
+	}
+
+	type BridgeData struct {
+		From      common.Address
+		To        common.Address
+		Amount    *big.Int
+		ExtraData []byte
+	}
+
+	l1StandardBridgeDeposits := []*database.Deposit{}
+	ethBridgeInitiatedEventSig := l1StandardBridgeABI.Events["ETHBridgeInitiated"].ID
+	sentMessageEventSig := l1CrossDomainMessengerABI.Events["SentMessage"].ID
+	for _, contractEvent := range events {
+		eventSig := contractEvent.EventSignature
+		log := eventLogs[contractEvent.GUID]
+		if eventSig == ethBridgeInitiatedEventSig {
+			// (1) Deconstruct the bridge event
+			var bridgeData BridgeData
+			err = l1StandardBridgeABI.UnpackIntoInterface(&bridgeData, "ETHBridgeInitiated", log.Data)
+			if err != nil || len(log.Topics) != 3 {
+				processLog.Crit("unexpected ETHDepositInitiated log format", "tx", log.TxHash, "err", err)
+				return err
+			}
+
+			// from/to are indexed event fields (not present in the log data)
+			bridgeData.From = common.BytesToAddress(log.Topics[1].Bytes())
+			bridgeData.To = common.BytesToAddress(log.Topics[2].Bytes())
+
+			// (2) Look for the sent message event to extract the associated messager nonce
+			//       - The `SentMessage` event is the second after the bridge initiated event. BridgeInitiated -> Portal#DepositTransaction -> SentMesage ...
+			sentMsgLog := logsByIndex[log.Index+2]
+			if sentMsgLog.Topics[0] != sentMessageEventSig {
+				processLog.Crit("expected CrossDomainMessenger#SentMessage to follow StandardBridge#EthBridgeInitiated event", "event_sig", sentMsgLog.Topics[0], "sent_message_sig", sentMessageEventSig)
+				return errors.New("unexpected bridge event ordering")
+			}
+
+			expectedMsg, err := l1StandardBridgeABI.Pack("finalizeBridgeETH", bridgeData.From, bridgeData.To, bridgeData.Amount, bridgeData.ExtraData)
+			if err != nil {
+				processLog.Crit("unable to create bridge message")
+				return err
+			}
+
+			var sentMsgData MessageData
+			err = l1CrossDomainMessengerABI.UnpackIntoInterface(&sentMsgData, "SentMessage", sentMsgLog.Data)
+			if err != nil {
+				processLog.Crit("unexpected SentMessage log format", "tx", log.TxHash, "err", err)
+				return err
+			} else if !bytes.Equal(sentMsgData.Message, expectedMsg) {
+				processLog.Crit("SentMessage message mismatch", "expected_bridge_msg", hex.EncodeToString(expectedMsg), "event_msg", hex.EncodeToString(sentMsgData.Message))
+				return errors.New("bridge message mismatch")
+			}
+
+			// (3) Record the deposit
+			l1StandardBridgeDeposits = append(l1StandardBridgeDeposits, &database.Deposit{
+				GUID:                 uuid.New(),
+				InitiatedL1EventGUID: contractEvent.GUID,
+				SentMessageNonce:     database.U256{Int: sentMsgData.MessageNonce},
+				TokenPair:            database.TokenPair{L1TokenAddress: ethAddress, L2TokenAddress: ethAddress},
+				Tx: database.Transaction{
+					FromAddress: common.BytesToAddress(log.Topics[1].Bytes()),
+					ToAddress:   common.BytesToAddress(log.Topics[2].Bytes()),
+					Amount:      database.U256{Int: bridgeData.Amount},
+					Data:        bridgeData.ExtraData,
+					Timestamp:   contractEvent.Timestamp,
+				},
+			})
+		}
+	}
+
+	if len(l1StandardBridgeDeposits) > 0 {
+		processLog.Info("detected L1StandardBridge deposits", "num", len(l1StandardBridgeDeposits))
+		return db.Bridge.StoreDeposits(l1StandardBridgeDeposits)
+	}
+
+	// no-op
+	return nil
 }

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -207,7 +207,7 @@ func l2BridgeProcessContractEvents(processLog log.Logger, db *database.DB, ethCl
 
 	numFinalizedDeposits := len(finalizationBridgeEvents)
 	if numFinalizedDeposits > 0 {
-		processLog.Info("finalized deposits", "size", numFinalizedDeposits)
+		processLog.Info("finalized L1StandardBridge deposits", "size", numFinalizedDeposits)
 	}
 
 	// a-ok

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -1,12 +1,15 @@
 package processor
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"math/big"
 	"reflect"
 
 	"github.com/ethereum-optimism/optimism/indexer/database"
 	"github.com/ethereum-optimism/optimism/indexer/node"
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/google/uuid"
 
 	"github.com/ethereum/go-ethereum"
@@ -125,7 +128,10 @@ func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2
 		}
 
 		numLogs := len(logs)
+		logsByIndex := make(map[uint]*types.Log, numLogs)
+
 		l2ContractEvents := make([]*database.L2ContractEvent, numLogs)
+		l2ContractEventLogs := make(map[uuid.UUID]*types.Log)
 		for i, log := range logs {
 			header, ok := l2HeaderMap[log.BlockHash]
 			if !ok {
@@ -133,16 +139,11 @@ func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2
 				return errors.New("parsed log with a block hash not in this batch")
 			}
 
-			l2ContractEvents[i] = &database.L2ContractEvent{
-				ContractEvent: database.ContractEvent{
-					GUID:            uuid.New(),
-					BlockHash:       log.BlockHash,
-					TransactionHash: log.TxHash,
-					EventSignature:  log.Topics[0],
-					LogIndex:        uint64(log.Index),
-					Timestamp:       header.Time,
-				},
-			}
+			logsByIndex[log.Index] = &logs[i]
+			contractEvent := &database.L2ContractEvent{ContractEvent: database.ContractEventFromLog(&log, header.Time)}
+
+			l2ContractEvents[i] = contractEvent
+			l2ContractEventLogs[contractEvent.GUID] = &logs[i]
 		}
 
 		/** Update Database **/
@@ -159,9 +160,125 @@ func l2ProcessFn(processLog log.Logger, ethClient node.EthClient, l2Contracts L2
 			if err != nil {
 				return err
 			}
+
+			// forward along contract events to the bridge processor
+			err = l2BridgeProcessContractEvents(processLog, db, ethClient, l2ContractEvents, l2ContractEventLogs, logsByIndex)
+			if err != nil {
+				return err
+			}
 		}
 
 		// a-ok!
 		return nil
 	}
+}
+
+func l2BridgeProcessContractEvents(
+	processLog log.Logger,
+	db *database.DB,
+	ethClient node.EthClient,
+	events []*database.L2ContractEvent,
+	eventLogs map[uuid.UUID]*types.Log,
+	logsByIndex map[uint]*types.Log,
+) error {
+	rawEthClient := ethclient.NewClient(ethClient.RawRpcClient())
+
+	l2StandardBridgeABI, err := bindings.L2StandardBridgeMetaData.GetAbi()
+	if err != nil {
+		return err
+	}
+
+	l2CrossDomainMessengerABI, err := bindings.L2CrossDomainMessengerMetaData.GetAbi()
+	if err != nil {
+		return err
+	}
+
+	type BridgeData struct {
+		From      common.Address
+		To        common.Address
+		Amount    *big.Int
+		ExtraData []byte
+	}
+
+	numFinalizedDeposits := 0
+	ethBridgeFinalizedEventSig := l2StandardBridgeABI.Events["ETHBridgeFinalized"].ID
+	relayedMessageEventSig := l2CrossDomainMessengerABI.Events["RelayedMessage"].ID
+	relayMessageMethod := l2CrossDomainMessengerABI.Methods["relayMessage"]
+	for _, contractEvent := range events {
+		eventSig := contractEvent.EventSignature
+		log := eventLogs[contractEvent.GUID]
+		if eventSig == ethBridgeFinalizedEventSig {
+			// (1) Ensure the RelayedMessage follows the log right after the bridge event
+			relayedMsgLog := logsByIndex[log.Index+1]
+			if relayedMsgLog.Topics[0] != relayedMessageEventSig {
+				processLog.Crit("expected CrossDomainMessenger#RelayedMessage following StandardBridge#EthBridgeFinalized event", "event_sig", relayedMsgLog.Topics[0], "relayed_message_sig", relayedMessageEventSig)
+				return errors.New("unexpected bridge event ordering")
+			}
+
+			// unfortunately there's no way to extract the nonce on the relayed message event. we can
+			// extract the nonce by unpacking the transaction input for the `relayMessage` transaction
+			tx, isPending, err := rawEthClient.TransactionByHash(context.Background(), relayedMsgLog.TxHash)
+			if err != nil || isPending {
+				processLog.Crit("CrossDomainMessager#relayeMessage transaction query err or found pending", err, "err", "isPending", isPending)
+				return errors.New("unable to query relayMessage tx")
+			}
+
+			txData := tx.Data()
+			fnSelector := txData[:4]
+			if !bytes.Equal(fnSelector, relayMessageMethod.ID) {
+				processLog.Crit("expected relayMessage function selector")
+				return errors.New("RelayMessage log does not match relayMessage transaction")
+			}
+
+			fnData := txData[4:]
+			inputsMap := make(map[string]interface{})
+			err = relayMessageMethod.Inputs.UnpackIntoMap(inputsMap, fnData)
+			if err != nil {
+				processLog.Crit("unable to unpack CrossDomainMessenger#relayMessage function data", "err", err)
+				return err
+			}
+
+			nonce, ok := inputsMap["_nonce"].(*big.Int)
+			if !ok {
+				processLog.Crit("unable to extract _nonce from CrossDomainMessenger#relayMessage function call")
+				return errors.New("unable to extract relayMessage nonce")
+			}
+
+			// (2) Mark initiated L1 deposit as finalized
+			deposit, err := db.Bridge.DepositByMessageNonce(nonce)
+			if err != nil {
+				processLog.Error("error querying initiated deposit messsage using nonce", "nonce", nonce)
+				return err
+			} else if deposit == nil {
+				latestNonce, err := db.Bridge.LatestDepositMessageNonce()
+				if err != nil {
+					return err
+				}
+
+				// check if the the L1Processor is behind or really has missed an event
+				if latestNonce == nil || nonce.Cmp(latestNonce) > 0 {
+					processLog.Warn("behind on indexed L1 deposits", "deposit_message_nonce", nonce, "latest_deposit_message_nonce", latestNonce)
+					return errors.New("waiting for L1Processor to catch up")
+				} else {
+					processLog.Crit("missing indexed deposit for this finalization event", "deposit_message_nonce", nonce, "tx_hash", log.TxHash, "log_index", log.Index)
+					return errors.New("missing deposit message")
+				}
+			}
+
+			err = db.Bridge.MarkFinalizedDepositEvent(deposit.GUID, contractEvent.GUID)
+			if err != nil {
+				processLog.Error("error finalizing deposit", "err", err)
+				return err
+			}
+
+			numFinalizedDeposits++
+		}
+	}
+
+	// a-ok!
+	if numFinalizedDeposits > 0 {
+		processLog.Info("finalized deposits", "num", numFinalizedDeposits)
+	}
+
+	return nil
 }

--- a/indexer/processor/optimism_portal.go
+++ b/indexer/processor/optimism_portal.go
@@ -1,0 +1,69 @@
+package processor
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type OptimismPortalWithdrawalProvenEvent struct {
+	*bindings.OptimismPortalWithdrawalProven
+
+	RawEvent *database.ContractEvent
+}
+
+type OptimismPortalProvenWithdrawal struct {
+	OutputRoot    [32]byte
+	Timestamp     *big.Int
+	L2OutputIndex *big.Int
+}
+
+func OptimismPortalWithdrawalProvenEvents(events *ProcessedContractEvents) ([]OptimismPortalWithdrawalProvenEvent, error) {
+	optimismPortalAbi, err := bindings.OptimismPortalMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	processedWithdrawalProvenEvents := events.eventsBySignature[optimismPortalAbi.Events["WithdrawalProven"].ID]
+	provenEvents := make([]OptimismPortalWithdrawalProvenEvent, len(processedWithdrawalProvenEvents))
+	for i, provenEvent := range processedWithdrawalProvenEvents {
+
+		provenEvents[i] = OptimismPortalWithdrawalProvenEvent{nil, provenEvent}
+	}
+
+	return provenEvents, nil
+}
+
+func OptimismPortalQueryProvenWithdrawal(ethClient *ethclient.Client, portalAddress common.Address, withdrawalHash common.Hash) (OptimismPortalProvenWithdrawal, error) {
+	var provenWithdrawal OptimismPortalProvenWithdrawal
+
+	optimismPortalAbi, err := bindings.OptimismPortalMetaData.GetAbi()
+	if err != nil {
+		return provenWithdrawal, err
+	}
+
+	name := "provenWithdrawals"
+	txData, err := optimismPortalAbi.Pack(name, withdrawalHash)
+	if err != nil {
+		return provenWithdrawal, err
+	}
+
+	callMsg := ethereum.CallMsg{To: &portalAddress, Data: txData}
+	data, err := ethClient.CallContract(context.Background(), callMsg, nil)
+	if err != nil {
+		return provenWithdrawal, err
+	}
+
+	err = optimismPortalAbi.UnpackIntoInterface(&provenWithdrawal, name, data)
+	if err != nil {
+		return provenWithdrawal, err
+	}
+
+	return provenWithdrawal, nil
+}

--- a/indexer/processor/processor.go
+++ b/indexer/processor/processor.go
@@ -55,8 +55,8 @@ func (p processor) Start() {
 		firstHeader := unprocessedHeaders[0]
 		lastHeader := unprocessedHeaders[len(unprocessedHeaders)-1]
 		batchLog := p.processLog.New("batch_start_block_number", firstHeader.Number, "batch_end_block_number", lastHeader.Number)
-		batchLog.Info("processing batch")
 		err := p.db.Transaction(func(db *database.DB) error {
+			batchLog.Info("processing batch")
 			return p.processFn(db, unprocessedHeaders)
 		})
 

--- a/indexer/processor/standard_bridge.go
+++ b/indexer/processor/standard_bridge.go
@@ -1,0 +1,233 @@
+package processor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+var (
+	ethAddress = common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")
+)
+
+type StandardBridgeInitiatedEvent struct {
+	*bindings.L1StandardBridgeERC20BridgeInitiated
+
+	CrossDomainMessengerNonce *big.Int
+	RawEvent                  *database.ContractEvent
+}
+
+type StandardBridgeFinalizedEvent struct {
+	*bindings.L1StandardBridgeERC20BridgeFinalized
+
+	CrossDomainMessengerNonce *big.Int
+	RawEvent                  *database.ContractEvent
+}
+
+// StandardBridgeInitiatedEvents extracts all initiated bridge events from the contracts that follow the StandardBridge ABI. The
+// correlated CrossDomainMessenger nonce is also parsed from the associated messenger events.
+func StandardBridgeInitiatedEvents(events *ProcessedContractEvents) ([]*StandardBridgeInitiatedEvent, error) {
+	l1StandardBridgeABI, err := bindings.L1StandardBridgeMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	l1CrossDomainMessengerABI, err := bindings.L1CrossDomainMessengerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	ethBridgeInitiatedEventAbi := l1StandardBridgeABI.Events["ETHBridgeInitiated"]
+	erc20BridgeInitiatedEventAbi := l1StandardBridgeABI.Events["ERC20BridgeInitiated"]
+	sentMessageEventAbi := l1CrossDomainMessengerABI.Events["SentMessage"]
+
+	ethBridgeInitiatedEvents := events.eventsBySignature[ethBridgeInitiatedEventAbi.ID]
+	erc20BridgeInitiatedEvents := events.eventsBySignature[erc20BridgeInitiatedEventAbi.ID]
+	initiatedBridgeEvents := []*StandardBridgeInitiatedEvent{}
+
+	// Handle ETH Bridge
+	for _, bridgeInitiatedEvent := range ethBridgeInitiatedEvents {
+		log := events.eventLog[bridgeInitiatedEvent.GUID]
+		bridgeData, err := UnpackLog[bindings.L1StandardBridgeETHBridgeInitiated](log, ethBridgeInitiatedEventAbi.Name, l1StandardBridgeABI)
+		if err != nil {
+			return nil, err
+		}
+
+		// Look for the sent message event to extract the associated messager nonce
+		//       - The `SentMessage` event is the second after the bridge initiated event. BridgeInitiated -> Portal#DepositTransaction -> SentMesage ...
+		sentMsgLog := events.eventLog[events.eventByLogIndex[log.Index+2].GUID]
+		sentMsgData, err := UnpackLog[bindings.L1CrossDomainMessengerSentMessage](sentMsgLog, sentMessageEventAbi.Name, l1CrossDomainMessengerABI)
+		if err != nil {
+			return nil, err
+		}
+
+		expectedMsg, err := l1StandardBridgeABI.Pack("finalizeBridgeETH", bridgeData.From, bridgeData.To, bridgeData.Amount, bridgeData.ExtraData)
+		if err != nil {
+			return nil, err
+		} else if !bytes.Equal(sentMsgData.Message, expectedMsg) {
+			return nil, errors.New("bridge cross domain message mismatch")
+		}
+
+		initiatedBridgeEvents = append(initiatedBridgeEvents, &StandardBridgeInitiatedEvent{
+			&bindings.L1StandardBridgeERC20BridgeInitiated{
+				// Default ETH
+				LocalToken: ethAddress, RemoteToken: ethAddress,
+
+				// BridgeDAta
+				From: bridgeData.From, To: bridgeData.To, Amount: bridgeData.Amount, ExtraData: bridgeData.ExtraData,
+			},
+			sentMsgData.MessageNonce,
+			bridgeInitiatedEvent,
+		})
+	}
+
+	// Handle ERC20 Bridge
+	for _, bridgeInitiatedEvent := range erc20BridgeInitiatedEvents {
+		log := events.eventLog[bridgeInitiatedEvent.GUID]
+		bridgeData, err := UnpackLog[bindings.L1StandardBridgeERC20BridgeInitiated](log, erc20BridgeInitiatedEventAbi.Name, l1StandardBridgeABI)
+		if err != nil {
+			return nil, err
+		}
+
+		// Look for the sent message event to extract the associated messager nonce
+		//       - The `SentMessage` event is the second after the bridge initiated event. BridgeInitiated -> Portal#DepositTransaction -> SentMesage ...
+		sentMsgLog := events.eventLog[events.eventByLogIndex[log.Index+2].GUID]
+		sentMsgData, err := UnpackLog[bindings.L1CrossDomainMessengerSentMessage](sentMsgLog, sentMessageEventAbi.Name, l1CrossDomainMessengerABI)
+		if err != nil {
+			return nil, err
+		}
+
+		expectedMsg, err := l1StandardBridgeABI.Pack("finalizeBridgeERC20", bridgeData.RemoteToken, bridgeData.LocalToken, bridgeData.From, bridgeData.To, bridgeData.Amount, bridgeData.ExtraData)
+		if err != nil {
+			return nil, err
+		} else if !bytes.Equal(sentMsgData.Message, expectedMsg) {
+			return nil, errors.New("bridge cross domain message mismatch")
+		}
+
+		initiatedBridgeEvents = append(initiatedBridgeEvents, &StandardBridgeInitiatedEvent{bridgeData, sentMsgData.MessageNonce, bridgeInitiatedEvent})
+	}
+
+	return initiatedBridgeEvents, nil
+}
+
+// StandardBridgeFinalizedEvents extracts all finalization bridge events from the contracts that follow the StandardBridge ABI. The
+// correlated CrossDomainMessenger nonce is also parsed by looking at the parameters of the corresponding relayMessage transaction data.
+func StandardBridgeFinalizedEvents(rawEthClient *ethclient.Client, events *ProcessedContractEvents) ([]*StandardBridgeFinalizedEvent, error) {
+	l1StandardBridgeABI, err := bindings.L1StandardBridgeMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	l1CrossDomainMessengerABI, err := bindings.L1CrossDomainMessengerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	ethBridgeFinalizedEventAbi := l1StandardBridgeABI.Events["ETHBridgeFinalized"]
+	erc20BridgeFinalizedEventAbi := l1StandardBridgeABI.Events["ERC20BridgeFinalized"]
+	relayedMessageEventAbi := l1CrossDomainMessengerABI.Events["RelayedMessage"]
+	relayMessageMethodAbi := l1CrossDomainMessengerABI.Methods["relayMessage"]
+
+	ethBridgeFinalizedEvents := events.eventsBySignature[ethBridgeFinalizedEventAbi.ID]
+	erc20BridgeFinalizedEvents := events.eventsBySignature[erc20BridgeFinalizedEventAbi.ID]
+	finalizedBridgeEvents := []*StandardBridgeFinalizedEvent{}
+
+	// Handle ETH Bridge
+	for _, bridgeFinalizedEvent := range ethBridgeFinalizedEvents {
+		log := events.eventLog[bridgeFinalizedEvent.GUID]
+		bridgeData, err := UnpackLog[bindings.L1StandardBridgeETHBridgeFinalized](log, ethBridgeFinalizedEventAbi.Name, l1StandardBridgeABI)
+		if err != nil {
+			return nil, err
+		}
+
+		// Look for the RelayedMessage event that follows right after the BridgeFinalized Event
+		relayedMsgLog := events.eventLog[events.eventByLogIndex[log.Index+1].GUID]
+		if relayedMsgLog.Topics[0] != relayedMessageEventAbi.ID {
+			return nil, errors.New("unexpected bridge event ordering")
+		}
+
+		// There's no way to extract the nonce on the relayed message event. we can extract
+		// the nonce by unpacking the transaction input for the `relayMessage` transaction
+		tx, isPending, err := rawEthClient.TransactionByHash(context.Background(), relayedMsgLog.TxHash)
+		if err != nil || isPending {
+			return nil, errors.New("unable to query relayMessage tx for bridge finalization event")
+		}
+
+		txData := tx.Data()
+		if !bytes.Equal(txData[:4], relayMessageMethodAbi.ID) {
+			return nil, errors.New("bridge finalization event does not match relayMessage tx invocation")
+		}
+
+		inputsMap := make(map[string]interface{})
+		err = relayMessageMethodAbi.Inputs.UnpackIntoMap(inputsMap, txData[4:])
+		if err != nil {
+			return nil, err
+		}
+
+		nonce, ok := inputsMap["_nonce"].(*big.Int)
+		if !ok {
+			return nil, errors.New("unable to extract `_nonce` parameter from relayMessage transaction")
+		}
+
+		finalizedBridgeEvents = append(finalizedBridgeEvents, &StandardBridgeFinalizedEvent{
+			&bindings.L1StandardBridgeERC20BridgeFinalized{
+				// Default ETH
+				LocalToken: ethAddress, RemoteToken: ethAddress,
+
+				// BridgeDAta
+				From: bridgeData.From, To: bridgeData.To, Amount: bridgeData.Amount, ExtraData: bridgeData.ExtraData,
+			},
+			nonce,
+			bridgeFinalizedEvent,
+		})
+	}
+
+	// Handle ERC20 Bridge
+	for _, bridgeFinalizedEvent := range erc20BridgeFinalizedEvents {
+		log := events.eventLog[bridgeFinalizedEvent.GUID]
+		bridgeData, err := UnpackLog[bindings.L1StandardBridgeERC20BridgeFinalized](log, erc20BridgeFinalizedEventAbi.Name, l1StandardBridgeABI)
+		if err != nil {
+			return nil, err
+		}
+
+		// Look for the RelayedMessage event that follows right after the BridgeFinalized Event
+		relayedMsgLog := events.eventLog[events.eventByLogIndex[log.Index+1].GUID]
+		if relayedMsgLog.Topics[0] != relayedMessageEventAbi.ID {
+			return nil, errors.New("unexpected bridge event ordering")
+		}
+
+		// There's no way to extract the nonce on the relayed message event. we can extract
+		// the nonce by unpacking the transaction input for the `relayMessage` transaction
+		tx, isPending, err := rawEthClient.TransactionByHash(context.Background(), relayedMsgLog.TxHash)
+		if err != nil || isPending {
+			return nil, errors.New("unable to query relayMessage tx for bridge finalization event")
+		}
+
+		txData := tx.Data()
+		if !bytes.Equal(txData[:4], relayMessageMethodAbi.ID) {
+			return nil, errors.New("bridge finalization event does not match relayMessage tx invocation")
+		}
+
+		inputsMap := make(map[string]interface{})
+		err = relayMessageMethodAbi.Inputs.UnpackIntoMap(inputsMap, txData[4:])
+		if err != nil {
+			return nil, err
+		}
+
+		nonce, ok := inputsMap["_nonce"].(*big.Int)
+		if !ok {
+			return nil, errors.New("unable to extract `_nonce` parameter from relayMessage transaction")
+		}
+
+		finalizedBridgeEvents = append(finalizedBridgeEvents, &StandardBridgeFinalizedEvent{bridgeData, nonce, bridgeFinalizedEvent})
+	}
+
+	return finalizedBridgeEvents, nil
+}

--- a/indexer/processor/standard_bridge.go
+++ b/indexer/processor/standard_bridge.go
@@ -18,7 +18,7 @@ var (
 )
 
 type StandardBridgeInitiatedEvent struct {
-	// We hardcode to ERC20 since ETH can be psuedo-represented as an ERC20 utilizing
+	// We hardcode to ERC20 since ETH can be pseudo-represented as an ERC20 utilizing
 	// the hardcoded ETH address
 	*bindings.L1StandardBridgeERC20BridgeInitiated
 
@@ -27,7 +27,7 @@ type StandardBridgeInitiatedEvent struct {
 }
 
 type StandardBridgeFinalizedEvent struct {
-	// We hardcode to ERC20 since ETH can be psuedo-represented as an ERC20 utilizing
+	// We hardcode to ERC20 since ETH can be pseudo-represented as an ERC20 utilizing
 	// the hardcoded ETH address
 	*bindings.L1StandardBridgeERC20BridgeFinalized
 


### PR DESCRIPTION
closes ethereum-optimism/devx#24

Fully index deposits & withdrawals reading from the standardized bridge contract. This will enable us to also automatically index 3rdparty bridges that follow the same ABI with little extra work

_**Note:**_ For withdrawals, we have to handle the bedrock two-step withdrawal process. For any 3rdparty bridge, we'll solely rely on the finalization marker and will not support custom two-step withdrawal implementations. If a 3rdparty bridge wishes to have the same two-step withdrawal process, they should reuse the deployed`L2CrossDomainMessenger` in their standard bridge extension as the underlying message passer.


TODO:
- update `integration_tests` so that the bridge can be tested e2e without manual tests
- create a legacy adapter such we can index legacy deposit/withdrawals pre-bedrock
- If a deposit/withdrawal cant be indexed due to L1/L2 processor needing to catchup, we should instead pause the processor at that step and wait for the precondition rather than failing the entire batch and continually retrying which results in unnecessarily extra work
- Improve the abstraction for the processor. `processor/contract_events.go` is a step in this direction. The processor should be pipelined `ProcessHeaders -> ProcessContractEvents -> ... forward contract events to fill custom tables...`. Rather than figure out this abstraction upfront, lets unblock e2e functionality and let the right abstraction reveal itself
