### PR TITLE
fix: Fix npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "patch-package": "^6.4.7",
     "prettier": "^2.8.0",
     "prettier-plugin-solidity": "^1.0.0-beta.13",
+    "rimraf": "^5.0.1",
     "ts-mocha": "^10.0.0",
     "typescript": "^4.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       prettier-plugin-solidity:
         specifier: ^1.0.0-beta.13
         version: 1.0.0-beta.18(prettier@2.8.1)
+      rimraf:
+        specifier: ^5.0.1
+        version: 5.0.1
       ts-mocha:
         specifier: ^10.0.0
         version: 10.0.0(mocha@8.4.0)
@@ -9833,7 +9836,7 @@ packages:
       fs.realpath: 1.0.0
       minimatch: 8.0.4
       minipass: 4.2.8
-      path-scurry: 1.9.2
+      path-scurry: 1.10.0
     dev: true
 
   /global-modules@2.0.0:
@@ -12147,11 +12150,6 @@ packages:
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
-    dev: true
-
-  /lru-cache@9.1.2:
-    resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
-    engines: {node: 14 || >=16.14}
     dev: true
 
   /lru_map@0.3.3:
@@ -14531,14 +14529,6 @@ packages:
       minipass: 6.0.2
     dev: true
 
-  /path-scurry@1.9.2:
-    resolution: {integrity: sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      lru-cache: 9.1.2
-      minipass: 6.0.2
-    dev: true
-
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
@@ -15805,6 +15795,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 9.3.5
+    dev: true
+
+  /rimraf@5.0.1:
+    resolution: {integrity: sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      glob: 10.3.1
     dev: true
 
   /ripemd160@2.0.2:


### PR DESCRIPTION
- npm publish is broke because postpublish uses rimraff.  Rimraff is not installed by contracts-periphery

