### PR TITLE
fix: Add missing global deps as cache busters

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,9 @@
     "nx.json": "*",
     "tsconfig.json": "*",
     ".foundryrc": "*",
-    ".nvmrc": "*"
+    "pnpm.lock.yaml": "*",
+    ".npmrc": "*",
+    ".nvmrc":  "*"
   },
   "tasksRunnerOptions": {
     "default": {

--- a/ops/check-changed/main.py
+++ b/ops/check-changed/main.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+import json
 
 from github import Github
 
@@ -13,9 +14,11 @@ REBUILD_ALL_PATTERNS = [
     r'ops/check-changed/.*',
     r'^go\.mod',
     r'^go\.sum',
-    r'^pnpm-lock\.yaml',
     r'ops/check-changed/.*'
 ]
+with open("../../nx.json") as file:
+    nx_json_data = json.load(file)
+REBUILD_ALL_PATTERNS += nx_json_data["implicitDependencies"].keys()
 
 WHITELISTED_BRANCHES = {
     'master',


### PR DESCRIPTION
- Add missing deps
- Audited all check-changed via running `nx graph`

#### Minor issues with check-changed
- hardhat-deploy listed as dep for many packages falsely
- contracts listed as dep for many packages even though they don't exist

#### Major issues with check-changed
- All global deps are missing this includes pnpm.lock, .npmrc, .foundryrc .nvmrc nx.json and root package.json.

![image](https://github.com/ethereum-optimism/optimism/assets/35039927/e371667b-e7f6-4edf-8127-8a4e64a73026)

Later we should remove check-changed and let nx figure out what needs to run based on it's more robust dependency graph

