### PR TITLE
op-e2e: only add a signer key to l1

### DIFF
--- a/op-e2e/geth.go
+++ b/op-e2e/geth.go
@@ -300,23 +300,25 @@ func createGethNode(l2 bool, nodeCfg *node.Config, ethCfg *ethconfig.Config, pri
 		return nil, nil, err
 	}
 
-	keydir := n.KeyStoreDir()
-	scryptN := 2
-	scryptP := 1
-	n.AccountManager().AddBackend(keystore.NewKeyStore(keydir, scryptN, scryptP))
-	ks := n.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+	if !l2 {
+		keydir := n.KeyStoreDir()
+		scryptN := 2
+		scryptP := 1
+		n.AccountManager().AddBackend(keystore.NewKeyStore(keydir, scryptN, scryptP))
+		ks := n.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 
-	password := "foobar"
-	for _, pk := range privateKeys {
-		act, err := ks.ImportECDSA(pk, password)
-		if err != nil {
-			n.Close()
-			return nil, nil, err
-		}
-		err = ks.Unlock(act, password)
-		if err != nil {
-			n.Close()
-			return nil, nil, err
+		password := "foobar"
+		for _, pk := range privateKeys {
+			act, err := ks.ImportECDSA(pk, password)
+			if err != nil {
+				n.Close()
+				return nil, nil, err
+			}
+			err = ks.Unlock(act, password)
+			if err != nil {
+				n.Close()
+				return nil, nil, err
+			}
 		}
 	}
 
@@ -341,5 +343,4 @@ func createGethNode(l2 bool, nodeCfg *node.Config, ethCfg *ethconfig.Config, pri
 		}
 	}
 	return n, backend, nil
-
 }


### PR DESCRIPTION
The current code adds the same signing key to all Ethereum clients (including the L2 nodes).  I found this to be quite confusing when parsing the code, and, it's unnecessary for the L2s to have signing keys.

cc @ajsutton 