### PR TITLE
op-e2e: bump a couple timeouts slightly

### DIFF
--- a/op-e2e/bridge_test.go
+++ b/op-e2e/bridge_test.go
@@ -76,7 +76,7 @@ func TestERC20BridgeDeposits(t *testing.T) {
 	// Approve WETH9 with the bridge
 	tx, err = WETH9.Approve(opts, predeploys.DevL1StandardBridgeAddr, new(big.Int).SetUint64(math.MaxUint64))
 	require.NoError(t, err)
-	_, err = waitForTransaction(tx.Hash(), l1Client, 3*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
+	_, err = waitForTransaction(tx.Hash(), l1Client, 6*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.NoError(t, err)
 
 	// Bridge the WETH9

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1279,7 +1279,7 @@ func TestStopStartBatcher(t *testing.T) {
 	receipt := sendTx()
 
 	// wait until the block the tx was first included in shows up in the safe chain on the verifier
-	safeBlockInclusionDuration := time.Duration(3*cfg.DeployConfig.L1BlockTime) * time.Second
+	safeBlockInclusionDuration := time.Duration(6*cfg.DeployConfig.L1BlockTime) * time.Second
 	_, err = waitForBlock(receipt.BlockNumber, l2Verif, safeBlockInclusionDuration)
 	require.Nil(t, err, "Waiting for block on verifier")
 


### PR DESCRIPTION
This increases two timeouts which have proved problematic locally and have caused flakes.  Because these are timeouts, and not sleeps, this should have no impact for successful test execution on other systems.

cc @ajsutton 