### PR TITLE
chore: More robust caching strategy for pnpm installs in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,20 +115,23 @@ jobs:
           name: Restore PNPM Package Cache
           keys:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
+      # Fetch node_modules into the pnpm store
+      # This will cache node_modules based on pnpm-lock so other steps can instantly install them with `pnpm install --prefer-offline`
+      # --prefer-offline installs node_modules instantly by just reading from cache if it exists rather than fetching from network
+      # when installing node_modules pnpm simply adds symlinks instead of copying the files which is why it is pretty much instant to run --prefer-offline
+      # this allows a caching strategy of only checking pnpm-lockfile so we don't have to keep it in sync with our packages
+      # For more information see https://pnpm.io/cli/fetch
       - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile
+          name: Fetch dependencies
+          command: pnpm fetch --frozen-lockfile --prefer-offline
       - save_cache:
           name: Save PNPM Package Cache
           key: pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - "node_modules"
-            - "packages/chain-mon/node_modules"
-            - "packages/common-ts/node_modules"
-            - "packages/contracts-bedrock/node_modules"
-            - "packages/core-utils/node_modules"
-            - "packages/sdk/node_modules"
-            - "packages/contracts-ts/node_modules"
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --offline
       - run:
           name: print forge version
           command: forge --version
@@ -327,6 +330,10 @@ jobs:
           name: print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: test and generate coverage
           command: pnpm coverage:lcov
@@ -348,6 +355,10 @@ jobs:
       - checkout
       - check-changed:
           patterns: contracts-bedrock,op-node
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: print forge version
           command: forge --version
@@ -372,6 +383,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: contracts-bedrock,op-node
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: build contracts
           command: pnpm build
@@ -454,6 +469,10 @@ jobs:
       - checkout
       - check-changed:
           patterns: contracts-bedrock
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: slither
           command: |
@@ -469,6 +488,10 @@ jobs:
           name: Restore PNPM Package Cache
           keys:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - check-changed:
           patterns: contracts-bedrock
       - run:
@@ -484,6 +507,10 @@ jobs:
       - attach_workspace: { at: "." }
       - check-changed:
           patterns: contracts-bedrock
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Compile with metadata hash
           command: pnpm clean && pnpm build:with-metadata
@@ -515,6 +542,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: contracts-bedrock
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Echidna Fuzz <<parameters.echidna_target>>
           command: pnpm echidna:<<parameters.echidna_target>>
@@ -527,6 +558,10 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: check go bindings
           command: make && git diff --exit-code
@@ -556,6 +591,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: <<parameters.package_name>>,<<parameters.dependencies>>
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Lint
           command: pnpm lint && git diff --exit-code
@@ -581,6 +620,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm.lock.yaml" }}
       - check-changed:
           patterns: sdk,contracts-bedrock,contracts
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Check generated and build
           command: pnpm generate:check
@@ -599,6 +642,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm.lock.yaml" }}
       - check-changed:
           patterns: sdk,contracts-bedrock,contracts
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: anvil-l1
           background: true
@@ -653,7 +700,7 @@ jobs:
             npm i yarn@1 --global
       - run:
           name: pnpm dev deps
-          command: pnpm install
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: specs toc
           command: pnpm lint:specs:toc && git diff --exit-code ./specs
@@ -673,7 +720,7 @@ jobs:
       - run:
           name: Install node_modules
           command: |
-            pnpm install
+            pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Lint check
           command: |
@@ -747,6 +794,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: packages
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Check common-ts
           command: npx depcheck
@@ -866,6 +917,10 @@ jobs:
       - checkout
       - check-changed:
           patterns: <<parameters.working_directory>>,<<parameters.dependencies>>
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Lint
           command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...
@@ -975,7 +1030,7 @@ jobs:
       - run:
           name: Install and build
           command: |
-            pnpm install && pnpm build
+            pnpm install --frozen-lockfile --prefer-offline && pnpm build
       - run:
           name: generate cannon prestate
           command: make cannon-prestate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,10 +330,6 @@ jobs:
           name: print forge version
           command: forge --version
           working_directory: packages/contracts-bedrock
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: test and generate coverage
           command: pnpm coverage:lcov
@@ -355,10 +351,6 @@ jobs:
       - checkout
       - check-changed:
           patterns: contracts-bedrock,op-node
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: print forge version
           command: forge --version
@@ -383,10 +375,6 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: contracts-bedrock,op-node
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: build contracts
           command: pnpm build
@@ -469,10 +457,6 @@ jobs:
       - checkout
       - check-changed:
           patterns: contracts-bedrock
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: slither
           command: |
@@ -499,69 +483,12 @@ jobs:
           command: pnpm validate-spacers
           working_directory: packages/contracts-bedrock
 
-  bedrock-echidna-build:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    steps:
-      - checkout
-      - attach_workspace: { at: "." }
-      - check-changed:
-          patterns: contracts-bedrock
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
-      - run:
-          name: Compile with metadata hash
-          command: pnpm clean && pnpm build:with-metadata
-          working_directory: packages/contracts-bedrock
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "node_modules"
-            - packages/contracts-bedrock
-
-  bedrock-echidna-run:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    parameters:
-      echidna_target:
-        description: Which echidna fuzz contract to run
-        type: string
-      size:
-        description: Custom resource class size for the run
-        type: string
-        default: large
-    resource_class: <<parameters.size>>
-    steps:
-      - checkout
-      - attach_workspace: { at: "." }
-      - restore_cache:
-          name: Restore PNPM Package Cache
-          keys:
-            - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
-      - check-changed:
-          patterns: contracts-bedrock
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
-      - run:
-          name: Echidna Fuzz <<parameters.echidna_target>>
-          command: pnpm echidna:<<parameters.echidna_target>>
-          working_directory: packages/contracts-bedrock
-          no_output_timeout: 15m
-
   op-bindings-build:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: check go bindings
           command: make && git diff --exit-code
@@ -695,10 +622,6 @@ jobs:
           command: |
             npm i pnpm --global
       - run:
-          name: Install yarn package manager
-          command: |
-            npm i yarn@1 --global
-      - run:
           name: pnpm dev deps
           command: pnpm install --frozen-lockfile --prefer-offline
       - run:
@@ -794,10 +717,6 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: packages
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Check common-ts
           command: npx depcheck
@@ -917,10 +836,6 @@ jobs:
       - checkout
       - check-changed:
           patterns: <<parameters.working_directory>>,<<parameters.dependencies>>
-      # populate node modules from the cache
-      - run:
-          name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: Lint
           command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,15 +643,10 @@ jobs:
       - checkout
       - check-changed:
           patterns: specs/(.*)\.md$
-      # TODO remove me after ci builder updated
       - run:
           name: Install pnpm package manager
           command: |
             npm i pnpm --global
-      # TODO remove me after ci builder updated
-      # A github dep clones-with-immutable-args is installed via github
-      # packages installed via npm via github automatically run postpack scripts
-      # their postpack script happens to use yarn so we need it here
       - run:
           name: Install yarn package manager
           command: |
@@ -671,7 +666,6 @@ jobs:
       image: ubuntu-2204:2022.07.1
     steps:
       - checkout
-      # TODO remove me after ci builder updated
       - run:
           name: Install pnpm package manager
           command: |


### PR DESCRIPTION
Changes our caching strategy to only cache based on pnpm-lockfile.yaml instead of packages/*/package.json. This has 2 advantages:
- Removes false cache misses when the package.json changes but the deps didn't
- Makes the circle config more robust to breakage. We don't have to manually keep it in sync everytime we add and remove a package
  - This protects us since the first time we add a new package it will work and pass checks and possibly merge if we forget and then fail on second run when cache is badly populated