### PR TITLE
op-node: Set DialBackoff when dialing op-geth

### DIFF
--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -59,7 +59,11 @@ func (cfg *L2EndpointConfig) Setup(ctx context.Context, log log.Logger, rollupCf
 		return nil, nil, err
 	}
 	auth := rpc.WithHTTPAuth(gn.NewJWTAuth(cfg.L2EngineJWTSecret))
-	l2Node, err := client.NewRPC(ctx, log, cfg.L2EngineAddr, client.WithGethRPCOptions(auth))
+	opts := []client.RPCOption{
+		client.WithGethRPCOptions(auth),
+		client.WithDialBackoff(10),
+	}
+	l2Node, err := client.NewRPC(ctx, log, cfg.L2EngineAddr, opts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**Description**

This is important to help the op-node be more resilient to nodes starting in different orders.

**Tests**

No tests.


