### PR TITLE
op-challenger: Properly implement stepping against trace index 0

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -102,19 +102,13 @@ func (a *Agent) step(claim Claim, game Game) error {
 		a.log.Warn("Failed to get a step", "err", err)
 		return err
 	}
-	stateData, err := a.trace.GetPreimage(step.PreStateTraceIndex)
-	if err != nil {
-		a.log.Warn("Failed to get a state data", "err", err)
-		return err
-	}
 
-	a.log.Info("Performing step",
-		"depth", step.LeafClaim.Depth(), "index_at_depth", step.LeafClaim.IndexAtDepth(), "value", step.LeafClaim.Value,
-		"is_attack", step.IsAttack, "prestate_trace_index", step.PreStateTraceIndex)
+	a.log.Info("Performing step", "is_attack", step.IsAttack,
+		"depth", step.LeafClaim.Depth(), "index_at_depth", step.LeafClaim.IndexAtDepth(), "value", step.LeafClaim.Value)
 	callData := StepCallData{
 		ClaimIndex: uint64(step.LeafClaim.ContractIndex),
 		IsAttack:   step.IsAttack,
-		StateData:  stateData,
+		StateData:  step.PreState,
 	}
 	return a.responder.Step(context.TODO(), callData)
 }

--- a/op-challenger/fault/alphabet_provider.go
+++ b/op-challenger/fault/alphabet_provider.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+var _ TraceProvider = (*AlphabetProvider)(nil)
+
 // AlphabetProvider is a [TraceProvider] that provides claims for specific
 // indices in the given trace.
 type AlphabetProvider struct {
@@ -43,6 +45,12 @@ func (ap *AlphabetProvider) Get(i uint64) (common.Hash, error) {
 		return common.Hash{}, err
 	}
 	return crypto.Keccak256Hash(claimBytes), nil
+}
+
+func (ap *AlphabetProvider) AbsolutePreState() []byte {
+	out := make([]byte, 32)
+	out[31] = 140 // ascii character 140 is "`"
+	return out
 }
 
 // BuildAlphabetPreimage constructs the claim bytes for the index and state item.

--- a/op-challenger/fault/solver_test.go
+++ b/op-challenger/fault/solver_test.go
@@ -102,17 +102,27 @@ func TestAttemptStep(t *testing.T) {
 	maxDepth := 3
 	canonicalProvider := NewAlphabetProvider("abcdefgh", uint64(maxDepth))
 	solver := NewSolver(maxDepth, canonicalProvider)
-	root, top, middle, bottom := createTestClaims()
-	g := NewGameState(false, root, testMaxDepth)
-	require.NoError(t, g.Put(top))
-	require.NoError(t, g.Put(middle))
-	require.NoError(t, g.Put(bottom))
+	_, _, middle, bottom := createTestClaims()
+
+	zero := Claim{
+		ClaimData: ClaimData{
+			// Zero value is a purposely disagree with claim value "a"
+			Position: NewPosition(3, 0),
+		},
+	}
 
 	step, err := solver.AttemptStep(bottom)
 	require.NoError(t, err)
 	require.Equal(t, bottom, step.LeafClaim)
 	require.True(t, step.IsAttack)
+	require.Equal(t, step.PreState, BuildAlphabetPreimage(3, "d"))
 
 	_, err = solver.AttemptStep(middle)
 	require.Error(t, err)
+
+	step, err = solver.AttemptStep(zero)
+	require.NoError(t, err)
+	require.Equal(t, zero, step.LeafClaim)
+	require.True(t, step.IsAttack)
+	require.Equal(t, canonicalProvider.AbsolutePreState(), step.PreState)
 }

--- a/op-challenger/fault/types.go
+++ b/op-challenger/fault/types.go
@@ -22,10 +22,12 @@ type StepCallData struct {
 
 // TraceProvider is a generic way to get a claim value at a specific
 // step in the trace.
-// The [AlphabetProvider] is a minimal implementation of this interface.
+// Get(i) = Keccak256(GetPreimage(i))
+// AbsolutePreState is the value of the trace that transitions to the trace value at index 0
 type TraceProvider interface {
 	Get(i uint64) (common.Hash, error)
 	GetPreimage(i uint64) ([]byte, error)
+	AbsolutePreState() []byte
 }
 
 // ClaimData is the core of a claim. It must be unique inside a specific game.

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -44,6 +44,6 @@
   "l1GenesisBlockTimestamp": "0x64935846",
   "l1StartingBlockTag": "earliest",
   "l2GenesisRegolithTimeOffset": "0x0",
-  "faultGameAbsolutePrestate": 15,
+  "faultGameAbsolutePrestate": 140,
   "faultGameMaxDepth": 4
 }


### PR DESCRIPTION
**Description**

When performing an attack step against trace index 0 we need to provide the absolute pre-state rather than pulling the value from the middle of the trace.

This PR also modifies the absolute pre-state that is stored in the devnet to match what the op-challenger is playing.

**Tests**

Unit tests for the op-challenger.

**Metadata**

- Fixes CLI-4198
