### PR TITLE
op-challenger: Cleanup initialization & add Act command

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -13,38 +13,75 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// Main is the programmatic entry-point for running op-challenger
-func Main(logger log.Logger, cfg *config.Config) error {
+type Challenger struct {
+	agent  fault.Agent
+	logger log.Logger
+}
+
+// NewChallenger creates a new challenger agent.
+func NewChallenger(logger log.Logger, cfg *config.Config) (*Challenger, error) {
 	client, err := ethclient.Dial(cfg.L1EthRpc)
 	if err != nil {
-		return fmt.Errorf("failed to dial L1: %w", err)
+		return nil, fmt.Errorf("failed to dial L1: %w", err)
 	}
 
 	txMgr, err := txmgr.NewSimpleTxManager("challenger", logger, &metrics.NoopTxMetrics{}, cfg.TxMgrConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create the transaction manager: %w", err)
+		return nil, fmt.Errorf("failed to create the transaction manager: %w", err)
 	}
 
 	contract, err := bindings.NewFaultDisputeGameCaller(cfg.GameAddress, client)
 	if err != nil {
-		return fmt.Errorf("failed to bind the fault dispute game contract: %w", err)
+		return nil, fmt.Errorf("failed to bind the fault dispute game contract: %w", err)
 	}
 
 	loader := fault.NewLoader(logger, contract)
 	responder, err := fault.NewFaultResponder(logger, txMgr, cfg.GameAddress)
 	if err != nil {
-		return fmt.Errorf("failed to create the responder: %w", err)
+		return nil, fmt.Errorf("failed to create the responder: %w", err)
 	}
 	gameDepth := 4
 	trace := fault.NewAlphabetProvider(cfg.AlphabetTrace, uint64(gameDepth))
 
 	agent := fault.NewAgent(loader, gameDepth, trace, responder, cfg.AgreeWithProposedOutput, logger)
 
-	logger.Info("Fault game started")
+	return &Challenger{agent, logger}, nil
+}
 
+// Loop polls the specific fault dispute game contract & attempts to perform actions on a regular interval.
+func (c *Challenger) Loop() {
 	for {
-		logger.Info("Performing action")
-		_ = agent.Act()
+		c.Act()
 		time.Sleep(300 * time.Millisecond)
 	}
+}
+
+// Act runs all currently possible actions on a dispute game contract & then exits.
+func (c *Challenger) Act() {
+	c.logger.Info("Performing action")
+	_ = c.agent.Act()
+}
+
+// MainLoop is the programmatic entry-point for running op-challenger
+func MainLoop(logger log.Logger, cfg *config.Config) error {
+	c, err := NewChallenger(logger, cfg)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Fault game started")
+	c.Loop()
+	return nil
+}
+
+// MainAct is the programmatic entry-point for running op-challenger
+func MainAct(logger log.Logger, cfg *config.Config) error {
+	c, err := NewChallenger(logger, cfg)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Fault game started in single action mode")
+	c.Act()
+	return nil
 }

--- a/op-challenger/cmd/main.go
+++ b/op-challenger/cmd/main.go
@@ -36,7 +36,7 @@ var VersionWithMeta = func() string {
 
 func main() {
 	args := os.Args
-	if err := run(args, op_challenger.Main); err != nil {
+	if err := run(args, op_challenger.MainLoop); err != nil {
 		log.Crit("Application failed", "err", err)
 	}
 }
@@ -64,6 +64,24 @@ func run(args []string, action ConfigAction) error {
 			return err
 		}
 		return action(logger, cfg)
+	}
+	app.Commands = []*cli.Command{
+		{
+			Name: "act",
+			Action: func(ctx *cli.Context) error {
+				logger, err := setupLogging(ctx)
+				if err != nil {
+					return err
+				}
+				logger.Info("Starting op-challenger", "version", VersionWithMeta)
+
+				cfg, err := config.NewConfigFromCLI(ctx)
+				if err != nil {
+					return err
+				}
+				return op_challenger.MainAct(logger, cfg)
+			},
+		},
 	}
 	return app.Run(args)
 }


### PR DESCRIPTION
**Description**

This factors our some of the challenger setup code & adds an `Act` command which performs all actions against the current view of the contract & then exits. This is contrast to the primary loop mode which does this on a loop.