### PR TITLE
fix(op-challenger): Remove Agent TraceProvider

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -10,7 +10,6 @@ import (
 
 type Agent struct {
 	solver                  *Solver
-	trace                   TraceProvider
 	loader                  Loader
 	responder               Responder
 	maxDepth                int
@@ -21,7 +20,6 @@ type Agent struct {
 func NewAgent(loader Loader, maxDepth int, trace TraceProvider, responder Responder, agreeWithProposedOutput bool, log log.Logger) Agent {
 	return Agent{
 		solver:                  NewSolver(maxDepth, trace),
-		trace:                   trace,
 		loader:                  loader,
 		responder:               responder,
 		maxDepth:                maxDepth,


### PR DESCRIPTION
**Description**

Remove the `TraceProvider` from the Agent struct since it's unused and only passed into the construction of the `Solver`.
