### PR TITLE
cannon: Add Makefile to simplify common operations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Cannon Go lint
           command: |
-            golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+            make lint
           working_directory: cannon
       - run:
           name: Cannon Go tests

--- a/cannon/.gitignore
+++ b/cannon/.gitignore
@@ -11,3 +11,4 @@ state.json
 *.json
 *.pprof
 *.out
+bin

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -1,0 +1,30 @@
+GITCOMMIT := $(shell git rev-parse HEAD)
+GITDATE := $(shell git show -s --format='%ct')
+VERSION := v0.0.0
+
+LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
+LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)
+LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Version=$(VERSION)
+LDFLAGSSTRING +=-X github.com/ethereum-optimism/optimism/op-program/version.Meta=$(VERSION_META)
+LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
+
+cannon:
+	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/cannon .
+
+clean:
+	rm -rf bin
+
+elf:
+	make -C ./example elf
+
+test: elf
+	go test -v ./...
+
+lint:
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is"
+
+.PHONY: \
+	cannon \
+	clean \
+	test \
+	lint

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -26,11 +26,11 @@ make op-program # build
 
 # Switch back to cannon, and build the CLI
 cd ../cannon
-go build -o cannon .
+make cannon
 
 # Transform MIPS op-program client binary into first VM state.
 # This outputs state.json (VM state) and meta.json (for debug symbols).
-./cannon load-elf --path=../op-program/bin/op-program-client.elf
+./bin/cannon load-elf --path=../op-program/bin/op-program-client.elf
 
 # Run cannon emulator (with example inputs)
 # Note that the server-mode op-program command is passed into cannon (after the --),
@@ -39,7 +39,7 @@ go build -o cannon .
 # Note:
 #  - The L2 RPC is an archive L2 node on OP goerli.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
-./cannon run
+./bin/cannon run
 --pprof.cpu
 --info-at '%10000000'
 --proof-at never
@@ -62,7 +62,7 @@ go build -o cannon .
 # Add --proof-at '=12345' (or pick other pattern, see --help)
 # to pick a step to build a proof for (e.g. exact step, every N steps, etc.)
 
-# Also see `./cannon run --help` for more options
+# Also see `./bin/cannon run --help` for more options
 ```
 
 ## Contracts


### PR DESCRIPTION
**Description**
Add a `Makefile` to cannon.

Build executable into bin dir and add it to gitignore like other components.