### PR TITLE
fix(op-node): Correctly pop unsafe payload queue when payload is too …

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -420,6 +420,11 @@ func (eq *EngineQueue) tryNextUnsafePayload(ctx context.Context) error {
 		eq.unsafePayloads.Pop()
 		return nil
 	}
+	if uint64(first.BlockNumber) <= eq.unsafeHead.Number {
+		eq.log.Info("skipping unsafe payload, since it is older than unsafe head", "unsafe", eq.unsafeHead.ID(), "unsafe_payload", first.ID())
+		eq.unsafePayloads.Pop()
+		return nil
+	}
 
 	// Ensure that the unsafe payload builds upon the current unsafe head
 	// TODO: once we support snap-sync we can remove this condition, and handle the "SYNCING" status of the execution engine.


### PR DESCRIPTION
…older

Fixes #6092

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

See #6092

**Tests**

The test is minimalist. It only ensures that the unsafe payload queue is pop'd 

**Additional context**

**Metadata**

- Fixes #6092
