### PR TITLE
fix(op-challenger): Agent Stepping

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -94,6 +94,17 @@ func (a *Agent) step(claim Claim, game Game) error {
 	if claim.Depth() != a.maxDepth {
 		return nil
 	}
+
+	if game.AgreeWithClaimLevel(claim) {
+		a.log.Warn("Agree with leaf claim, skipping step", "claim_depth", claim.Depth(), "maxDepth", a.maxDepth)
+		return nil
+	}
+
+	if claim.Countered {
+		a.log.Info("Claim already stepped on", "claim_depth", claim.Depth(), "maxDepth", a.maxDepth)
+		return nil
+	}
+
 	a.log.Info("Attempting step", "claim_depth", claim.Depth(), "maxDepth", a.maxDepth)
 	step, err := a.solver.AttemptStep(claim)
 	if err != nil {

--- a/op-challenger/fault/loader.go
+++ b/op-challenger/fault/loader.go
@@ -56,6 +56,8 @@ func (l *loader) fetchClaim(ctx context.Context, arrIndex uint64) (Claim, error)
 			Value:    fetchedClaim.Claim,
 			Position: NewPositionFromGIndex(fetchedClaim.Position.Uint64()),
 		},
+		Countered:           fetchedClaim.Countered,
+		Clock:               fetchedClaim.Clock.Uint64(),
 		ContractIndex:       int(arrIndex),
 		ParentContractIndex: int(fetchedClaim.ParentIndex),
 	}

--- a/op-challenger/fault/loader_test.go
+++ b/op-challenger/fault/loader_test.go
@@ -40,16 +40,22 @@ func newMockClaimFetcher() *mockClaimFetcher {
 			Clock       *big.Int
 		}{
 			{
-				Claim:    [32]byte{0x00},
-				Position: big.NewInt(0),
+				Claim:     [32]byte{0x00},
+				Position:  big.NewInt(0),
+				Countered: false,
+				Clock:     big.NewInt(0),
 			},
 			{
-				Claim:    [32]byte{0x01},
-				Position: big.NewInt(0),
+				Claim:     [32]byte{0x01},
+				Position:  big.NewInt(0),
+				Countered: false,
+				Clock:     big.NewInt(0),
 			},
 			{
-				Claim:    [32]byte{0x02},
-				Position: big.NewInt(0),
+				Claim:     [32]byte{0x02},
+				Position:  big.NewInt(0),
+				Countered: false,
+				Clock:     big.NewInt(0),
 			},
 		},
 	}
@@ -101,6 +107,8 @@ func TestLoader_FetchClaims_Succeeds(t *testing.T) {
 				Value:    expectedClaims[0].Claim,
 				Position: NewPositionFromGIndex(expectedClaims[0].Position.Uint64()),
 			},
+			Countered:     false,
+			Clock:         uint64(0),
 			ContractIndex: 0,
 		},
 		{
@@ -112,6 +120,8 @@ func TestLoader_FetchClaims_Succeeds(t *testing.T) {
 				Value:    expectedClaims[0].Claim,
 				Position: NewPositionFromGIndex(expectedClaims[1].Position.Uint64()),
 			},
+			Countered:     false,
+			Clock:         uint64(0),
 			ContractIndex: 1,
 		},
 		{
@@ -123,6 +133,8 @@ func TestLoader_FetchClaims_Succeeds(t *testing.T) {
 				Value:    expectedClaims[0].Claim,
 				Position: NewPositionFromGIndex(expectedClaims[2].Position.Uint64()),
 			},
+			Countered:     false,
+			Clock:         uint64(0),
 			ContractIndex: 2,
 		},
 	}, claims)

--- a/op-challenger/fault/types.go
+++ b/op-challenger/fault/types.go
@@ -49,7 +49,13 @@ func (c *ClaimData) ValueBytes() [32]byte {
 // and the Parent field is empty & meaningless.
 type Claim struct {
 	ClaimData
-	Parent ClaimData
+	// WARN: Countered is a mutable field in the FaultDisputeGame contract
+	//       and rely on it for determining whether to step on leaf claims.
+	//       When caching is implemented for the Challenger, this will need
+	//       to be changed/removed to avoid invalid/stale contract state.
+	Countered bool
+	Clock     uint64
+	Parent    ClaimData
 	// Location of the claim & it's parent inside the contract. Does not exist
 	// for claims that have not made it to the contract.
 	ContractIndex       int


### PR DESCRIPTION
**Description**

Fixes the op-challenger Agent step logic to only step on claims for which we don't agree with their level.

To prevent continuously submitting duplicate step transactions, the Agent now checks the newly added `Countered` field on the `Claim` which is set to true on the leaf node iff it has been stepped on through the FaultDisputeGame contract.

Additionally, this PR "loads" the `Clock` field into the `Claim` struct so a follow on PR can build off the `Clock` to perform Alphabet Fault Dispute Game resolution.

A demonstration running `charlie.sh` and `mallory.sh` scripts with a populated alphabet fault dispute game on devnet is depicted below.

<img width="1728" alt="Screenshot 2023-07-18 at 3 48 05 PM" src="https://github.com/ethereum-optimism/optimism/assets/21288394/28c4be50-921e-4905-9ea3-c9b91dbd3858">


**Tests**

The Loader unit tests required alteration to accomodate the affixed `Clock` and `Countered` `Claim` fields.
