### PR TITLE
fix(release): eth-optimism -> ethereum/optimism

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "eth-optimism/optimism" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "ethereum-optimism/optimism" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   snapshot-snapshot:
     name: Publish snapshot release to npm
-    if: github.repository == 'eth-optimism/optimism'
+    if: github.repository == 'ethereum-optimism/optimism'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.repository == 'eth-optimism/optimism'
+    if: github.repository == 'ethereum-optimism/optimism'
     # map the step outputs to job outputs
     outputs:
       fault-detector: ${{ steps.packages.outputs.fault-detector }}


### PR DESCRIPTION
- fix typo with eth-optimism/optimism supposed to be ethereum-optimism/optimism from https://github.com/ethereum-optimism/optimism/pull/6260
