### PR TITLE
monorepo: delete dead top level dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.26.0",
-    "@codechecks/client": "^0.1.11",
-    "@ethersproject/abstract-provider": "^5.7.0"
+    "@codechecks/client": "^0.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@codechecks/client':
         specifier: ^0.1.11
         version: 0.1.11(typescript@4.9.3)
-      '@ethersproject/abstract-provider':
-        specifier: ^5.7.0
-        version: 5.7.0
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.18.2


### PR DESCRIPTION
**Description**

For some reason, abstract-provider was a top level dependency even tho it didn't need to be. This commit simply removes that dep.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
