### PR TITLE
op-e2e: Support L1 time travel

### DIFF
--- a/op-e2e/fakepos.go
+++ b/op-e2e/fakepos.go
@@ -1,0 +1,124 @@
+package op_e2e
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/catalyst"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// fakePoS is a testing-only utility to attach to Geth,
+// to build a fake proof-of-stake L1 chain with fixed block time and basic lagging safe/finalized blocks.
+type fakePoS struct {
+	clock     clock.Clock
+	eth       *eth.Ethereum
+	log       log.Logger
+	blockTime uint64
+
+	finalizedDistance uint64
+	safeDistance      uint64
+
+	engineAPI *catalyst.ConsensusAPI
+	sub       ethereum.Subscription
+}
+
+func (f *fakePoS) Start() error {
+	if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
+		advancing.Start()
+	}
+	f.sub = event.NewSubscription(func(quit <-chan struct{}) error {
+		// poll every half a second: enough to catch up with any block time when ticks are missed
+		t := f.clock.NewTicker(time.Second / 2)
+		for {
+			select {
+			case now := <-t.Ch():
+				chain := f.eth.BlockChain()
+				head := chain.CurrentBlock()
+				finalized := chain.CurrentFinalBlock()
+				if finalized == nil { // fallback to genesis if nothing is finalized
+					finalized = chain.Genesis().Header()
+				}
+				safe := chain.CurrentSafeBlock()
+				if safe == nil { // fallback to finalized if nothing is safe
+					safe = finalized
+				}
+				if head.Number.Uint64() > f.finalizedDistance { // progress finalized block, if we can
+					finalized = f.eth.BlockChain().GetHeaderByNumber(head.Number.Uint64() - f.finalizedDistance)
+				}
+				if head.Number.Uint64() > f.safeDistance { // progress safe block, if we can
+					safe = f.eth.BlockChain().GetHeaderByNumber(head.Number.Uint64() - f.safeDistance)
+				}
+				// start building the block as soon as we are past the current head time
+				if head.Time >= uint64(now.Unix()) {
+					continue
+				}
+				newBlockTime := head.Time + f.blockTime
+				if time.Unix(int64(newBlockTime), 0).Add(5 * time.Minute).Before(f.clock.Now()) {
+					// We're a long way behind, let's skip some blocks...
+					newBlockTime = uint64(f.clock.Now().Unix())
+				}
+				res, err := f.engineAPI.ForkchoiceUpdatedV1(engine.ForkchoiceStateV1{
+					HeadBlockHash:      head.Hash(),
+					SafeBlockHash:      safe.Hash(),
+					FinalizedBlockHash: finalized.Hash(),
+				}, &engine.PayloadAttributes{
+					Timestamp:             newBlockTime,
+					Random:                common.Hash{},
+					SuggestedFeeRecipient: head.Coinbase,
+				})
+				if err != nil {
+					f.log.Error("failed to start building L1 block", "err", err)
+					continue
+				}
+				if res.PayloadID == nil {
+					f.log.Error("failed to start block building", "res", res)
+					continue
+				}
+				// wait with sealing, if we are not behind already
+				delay := time.Unix(int64(newBlockTime), 0).Sub(f.clock.Now())
+				tim := f.clock.NewTimer(delay)
+				select {
+				case <-tim.Ch():
+					// no-op
+				case <-quit:
+					tim.Stop()
+					return nil
+				}
+				payload, err := f.engineAPI.GetPayloadV1(*res.PayloadID)
+				if err != nil {
+					f.log.Error("failed to finish building L1 block", "err", err)
+					continue
+				}
+				if _, err := f.engineAPI.NewPayloadV1(*payload); err != nil {
+					f.log.Error("failed to insert built L1 block", "err", err)
+					continue
+				}
+				if _, err := f.engineAPI.ForkchoiceUpdatedV1(engine.ForkchoiceStateV1{
+					HeadBlockHash:      payload.BlockHash,
+					SafeBlockHash:      safe.Hash(),
+					FinalizedBlockHash: finalized.Hash(),
+				}, nil); err != nil {
+					f.log.Error("failed to make built L1 block canonical", "err", err)
+					continue
+				}
+			case <-quit:
+				return nil
+			}
+		}
+	})
+	return nil
+}
+
+func (f *fakePoS) Stop() error {
+	f.sub.Unsubscribe()
+	if advancing, ok := f.clock.(*clock.AdvancingClock); ok {
+		advancing.Stop()
+	}
+	return nil
+}

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -1,0 +1,41 @@
+package op_e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeTravel(t *testing.T) {
+	InitParallel(t)
+
+	cfg := DefaultSystemConfig(t)
+	delete(cfg.Nodes, "verifier")
+	cfg.SupportL1TimeTravel = true
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	defer sys.Close()
+
+	l1Client := sys.Clients["l1"]
+	preTravel, err := l1Client.BlockByNumber(context.Background(), nil)
+	require.NoError(t, err)
+
+	sys.TimeTravelClock.AdvanceTime(24 * time.Hour)
+
+	// Check that the L1 chain reaches the new time reasonably quickly (ie without taking a week)
+	// It should be able to jump straight to the new time with just a single block
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	err = e2eutils.WaitFor(ctx, time.Second, func() (bool, error) {
+		postTravel, err := l1Client.BlockByNumber(context.Background(), nil)
+		if err != nil {
+			return false, err
+		}
+		diff := time.Duration(postTravel.Time()-preTravel.Time()) * time.Second
+		return diff.Hours() > 23, nil
+	})
+	require.NoError(t, err)
+}

--- a/op-service/clock/advancing.go
+++ b/op-service/clock/advancing.go
@@ -1,0 +1,71 @@
+package clock
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type AdvancingClock struct {
+	*DeterministicClock
+	systemTime   Clock
+	ticker       Ticker
+	advanceEvery time.Duration
+	quit         chan interface{}
+	running      atomic.Bool
+
+	lastTick time.Time
+}
+
+// NewAdvancingClock creates a clock that, when started, advances at the same rate as the system clock but
+// can also be advanced arbitrary amounts using the AdvanceTime method.
+// Unlike the system clock, time does not progress smoothly but only increments when AdvancedTime is called or
+// approximately after advanceEvery duration has elapsed. When advancing based on the system clock, the total time
+// the system clock has advanced is added to the current time, preventing time differences from building up over time.
+func NewAdvancingClock(advanceEvery time.Duration) *AdvancingClock {
+	now := SystemClock.Now()
+	return &AdvancingClock{
+		DeterministicClock: NewDeterministicClock(now),
+		systemTime:         SystemClock,
+		advanceEvery:       advanceEvery,
+		quit:               make(chan interface{}),
+		lastTick:           now,
+	}
+}
+
+func (c *AdvancingClock) Start() {
+	if !c.running.CompareAndSwap(false, true) {
+		// Already running
+		return
+	}
+	c.ticker = c.systemTime.NewTicker(c.advanceEvery)
+	go func() {
+		for {
+			select {
+			case now := <-c.ticker.Ch():
+				c.onTick(now)
+			case <-c.quit:
+				return
+			}
+		}
+	}()
+}
+
+func (c *AdvancingClock) Stop() {
+	if !c.running.CompareAndSwap(true, false) {
+		// Already stopped
+		return
+	}
+	c.quit <- nil
+}
+
+func (c *AdvancingClock) onTick(now time.Time) {
+	if !now.After(c.lastTick) {
+		// Time hasn't progressed for some reason, so do nothing
+		return
+	}
+	// Advance time by however long it has been since the last update.
+	// Ensures we don't drift from system time by more and more over time
+	advanceBy := now.Sub(c.lastTick)
+	c.AdvanceTime(advanceBy)
+	c.lastTick = now
+}

--- a/op-service/clock/advancing_test.go
+++ b/op-service/clock/advancing_test.go
@@ -1,0 +1,58 @@
+package clock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdvancingClock_AdvancesByTimeBetweenTicks(t *testing.T) {
+	clock, realTime := newTestAdvancingClock(1 * time.Second)
+	clock.Start()
+	defer clock.Stop()
+	eventTicker := clock.NewTicker(1 * time.Second)
+
+	start := clock.Now()
+	realTime.AdvanceTime(1 * time.Second)
+	require.Equal(t, start.Add(1*time.Second), <-eventTicker.Ch(), "should trigger events when advancing")
+	require.Equal(t, start.Add(1*time.Second), clock.Now(), "Should advance on single tick")
+
+	start = clock.Now()
+	realTime.AdvanceTime(15 * time.Second)
+	require.Equal(t, start.Add(15*time.Second), <-eventTicker.Ch(), "should trigger events when advancing")
+	require.Equal(t, start.Add(15*time.Second), clock.Now(), "Should advance by time between ticks")
+}
+
+func TestAdvancingClock_Stop(t *testing.T) {
+	clock, realTime := newTestAdvancingClock(1 * time.Second)
+	clock.Start()
+	defer clock.Stop()
+	eventTicker := clock.NewTicker(1 * time.Second)
+
+	// Stop the clock again
+	clock.Stop()
+
+	start := clock.Now()
+	realTime.AdvanceTime(15 * time.Second)
+
+	clock.Start()
+	// Trigger the next tick
+	realTime.AdvanceTime(1 * time.Second)
+	// Time advances by the whole time the clock was stopped
+	// Note: if events were triggered while the clock was stopped, this event would be for the wrong time
+	require.Equal(t, start.Add(16*time.Second), <-eventTicker.Ch(), "should trigger events again after restarting")
+	require.Equal(t, start.Add(16*time.Second), clock.Now(), "Should advance by time between ticks after restarting")
+}
+
+func newTestAdvancingClock(advanceEvery time.Duration) (*AdvancingClock, *DeterministicClock) {
+	systemTime := NewDeterministicClock(time.UnixMilli(1000))
+	clock := &AdvancingClock{
+		DeterministicClock: NewDeterministicClock(time.UnixMilli(5000)),
+		systemTime:         systemTime,
+		advanceEvery:       advanceEvery,
+		quit:               make(chan interface{}),
+		lastTick:           systemTime.Now(),
+	}
+	return clock, systemTime
+}

--- a/op-service/clock/deterministic.go
+++ b/op-service/clock/deterministic.go
@@ -107,8 +107,12 @@ func (t *ticker) fire(now time.Time) bool {
 	if t.stopped {
 		return false
 	}
-	t.ch <- now
-	t.nextDue = now.Add(t.period)
+	// Publish without blocking and only update due time if we publish successfully
+	select {
+	case t.ch <- now:
+		t.nextDue = now.Add(t.period)
+	default:
+	}
 	return true
 }
 


### PR DESCRIPTION
**Description**

Introduces `AdvancingClock` which is a clock that keeps moving forward at the same rate as real time (but in more discrete steps) but also supports time travelling arbitrary distances into the future.

That clock is then used in the `fakePoS` we already used to drive L1 geth so that we can cause it to time travel. Combined with an upper limit on how many blocks it tries to catch up with consistent times, we can now time travel an arbitrary distance into the future with L1 keeping up practically instantly.

Time travel is only enabled for tests that opt in to it in the system config, avoiding any potential slow downs or effects on non-time travel tests.

L2 doesn't time travel as nicely, but it was able to catch back up to a 24 hour jump in L1 time in under 3 minutes. For the dispute game we only need to time travel L1, but there's potential for this to be able to accelerate withdrawal tests given it would only need to jump forward by a few minutes to an hour.
