### PR TITLE
feat(op-challenger): EthCall Alphabet FDG Resolve

### DIFF
--- a/op-challenger/fault/resolver.go
+++ b/op-challenger/fault/resolver.go
@@ -1,0 +1,57 @@
+package fault
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// ContractCaller is a minimal interface of [ethclient.Client] to allow for mocking.
+type ContractCaller interface {
+	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+}
+
+type Resolver struct {
+	ContractCaller
+	fdgAddr common.Address
+	fdgAbi  *abi.ABI
+}
+
+// NewResolver creates a new [Resolver] instance.
+func NewResolver(client ContractCaller, fdgAddr common.Address) (*Resolver, error) {
+	fdgAbi, err := bindings.FaultDisputeGameMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return &Resolver{
+		client,
+		fdgAddr,
+		fdgAbi,
+	}, nil
+}
+
+// buildResolveData creates the transaction data for the Resolve function.
+func (r *Resolver) buildResolveData() ([]byte, error) {
+	return r.fdgAbi.Pack("resolve")
+}
+
+// CallResolve executes an eth_call to the Resolve function.
+func (r *Resolver) CallResolve(ctx context.Context) (bool, error) {
+	resolveData, err := r.buildResolveData()
+	if err != nil {
+		return false, err
+	}
+	_, err = r.CallContract(ctx, ethereum.CallMsg{
+		To:   &r.fdgAddr,
+		Data: resolveData,
+	}, nil)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/op-challenger/fault/resolver_test.go
+++ b/op-challenger/fault/resolver_test.go
@@ -1,0 +1,50 @@
+package fault
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errMock = errors.New("mock error")
+)
+
+type mockContractCaller struct {
+	callResolveErrors bool
+}
+
+func (m *mockContractCaller) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	if m.callResolveErrors {
+		return nil, errMock
+	}
+	return nil, nil
+}
+
+func TestResolver_CallResolve(t *testing.T) {
+	t.Run("should call resolve", func(t *testing.T) {
+		m := &mockContractCaller{}
+		r, err := NewResolver(m, common.Address{})
+		require.NoError(t, err)
+
+		res, err := r.CallResolve(context.Background())
+		require.NoError(t, err)
+		require.True(t, res)
+	})
+
+	t.Run("should return error if eth_call fails", func(t *testing.T) {
+		m := &mockContractCaller{callResolveErrors: true}
+		r, err := NewResolver(m, common.Address{})
+		require.NoError(t, err)
+
+		res, err := r.CallResolve(context.Background())
+		require.Error(t, err)
+		require.False(t, res)
+	})
+}


### PR DESCRIPTION
**Description**

Introduces a `Resolver` fault subcomponent for the op-challenger agent to call the `resolve` method of the FaultDisputeGame.

This is the alternative method to checking if the challenger can resolve a dispute game instead of tracking the leftmost,
uncontested dispute game node and its clock.

**Tests**

Unit tests are performed using the minimal `ContractCaller` interface that implments `CallContext`.

**Metadata**

Fixes CLI-4232
