### PR TITLE
feat(op-challenger): GameDepth CLI Flag

### DIFF
--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -20,35 +20,3 @@ to see a list of available options.
 
 `op-challenger` is configurable via command line flags and environment variables. The help menu
 shows the available config options and can be accessed by running `./op-challenger --help`.
-
-Note that there are many global options, but the most important ones are:
-
-- `OP_CHALLENGER_L1_ETH_RPC`: An L1 Ethereum RPC URL
-- `OP_CHALLENGER_ROLLUP_RPC`: A Rollup Node RPC URL
-- `OP_CHALLENGER_L2OO_ADDRESS`: The L2OutputOracle Contract Address
-- `OP_CHALLENGER_DGF_ADDRESS`: Dispute Game Factory Contract Address
-
-Here is a reduced output from running `./op-challenger --help`:
-
-```bash
-NAME:
-   op-challenger - Modular Challenger Agent
-USAGE:
-   main [global options] command [command options] [arguments...]
-VERSION:
-   1.0.0
-DESCRIPTION:
-   A modular op-stack challenge agent for output dispute games written in golang.
-COMMANDS:
-   help, h  Shows a list of commands or help for one command
-GLOBAL OPTIONS:
-   --l1-eth-rpc value                      HTTP provider URL for L1. [$OP_CHALLENGER_L1_ETH_RPC]
-   --rollup-rpc value                      HTTP provider URL for the rollup node. [$OP_CHALLENGER_ROLLUP_RPC]
-   --l2oo-address value                    Address of the L2OutputOracle contract. [$OP_CHALLENGER_L2OO_ADDRESS]
-   --dgf-address value                     Address of the DisputeGameFactory contract. [$OP_CHALLENGER_DGF_ADDRESS]
-   ...
-   --help, -h                              show help
-   --version, -v                           print the version
-```
-
-

--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -35,10 +35,9 @@ func Main(logger log.Logger, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create the responder: %w", err)
 	}
-	gameDepth := 4
-	trace := fault.NewAlphabetProvider(cfg.AlphabetTrace, uint64(gameDepth))
+	trace := fault.NewAlphabetProvider(cfg.AlphabetTrace, uint64(cfg.GameDepth))
 
-	agent := fault.NewAgent(loader, gameDepth, trace, responder, cfg.AgreeWithProposedOutput, logger)
+	agent := fault.NewAgent(loader, cfg.GameDepth, trace, responder, cfg.AgreeWithProposedOutput, logger)
 
 	caller, err := fault.NewFaultCallerFromBindings(cfg.GameAddress, client, logger)
 	if err != nil {

--- a/op-challenger/charlie.sh
+++ b/op-challenger/charlie.sh
@@ -14,4 +14,11 @@ MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
 FAULT_GAME_ADDRESS="0x8daf17a20c9dba35f005b6324f493785d239719d"
 
-./bin/op-challenger --l1-eth-rpc http://localhost:8545 --alphabet "abcdefgh" --game-address $FAULT_GAME_ADDRESS --private-key $CHARLIE_KEY --num-confirmations 1 --agree-with-proposed-output=true
+./bin/op-challenger \
+  --l1-eth-rpc http://localhost:8545 \
+  --alphabet "abcdefgh" \
+  --game-address $FAULT_GAME_ADDRESS \
+  --private-key $CHARLIE_KEY \
+  --num-confirmations 1 \
+  --game-depth 4 \
+  --agree-with-proposed-output=true

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -16,6 +16,7 @@ var (
 	gameAddressValue        = "0xaa00000000000000000000000000000000000000"
 	alphabetTrace           = "abcdefghijz"
 	agreeWithProposedOutput = "true"
+	gameDepth               = "4"
 )
 
 func TestLogLevel(t *testing.T) {
@@ -35,12 +36,12 @@ func TestLogLevel(t *testing.T) {
 
 func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs(t, addRequiredArgs())
-	defaultCfg := config.NewConfig(l1EthRpc, common.HexToAddress(gameAddressValue), alphabetTrace, true)
+	defaultCfg := config.NewConfig(l1EthRpc, common.HexToAddress(gameAddressValue), alphabetTrace, true, 4)
 	require.Equal(t, defaultCfg, cfg)
 }
 
 func TestDefaultConfigIsValid(t *testing.T) {
-	cfg := config.NewConfig(l1EthRpc, common.HexToAddress(gameAddressValue), alphabetTrace, true)
+	cfg := config.NewConfig(l1EthRpc, common.HexToAddress(gameAddressValue), alphabetTrace, true, 4)
 	require.NoError(t, cfg.Check())
 }
 
@@ -109,6 +110,18 @@ func TestAgreeWithProposedOutput(t *testing.T) {
 	})
 }
 
+func TestGameDepth(t *testing.T) {
+	t.Run("Required", func(t *testing.T) {
+		verifyArgsInvalid(t, "flag game-depth is required", addRequiredArgsExcept("--game-depth"))
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		value := "4"
+		cfg := configForArgs(t, addRequiredArgsExcept("--game-depth", "--game-depth="+value))
+		require.Equal(t, value, fmt.Sprint(cfg.GameDepth))
+	})
+}
+
 func verifyArgsInvalid(t *testing.T, messageContains string, cliArgs []string) {
 	_, _, err := runWithArgs(cliArgs)
 	require.ErrorContains(t, err, messageContains)
@@ -146,6 +159,7 @@ func addRequiredArgsExcept(name string, optionalArgs ...string) []string {
 
 func requiredArgs() map[string]string {
 	return map[string]string{
+		"--game-depth":                 gameDepth,
 		"--agree-with-proposed-output": agreeWithProposedOutput,
 		"--l1-eth-rpc":                 l1EthRpc,
 		"--game-address":               gameAddressValue,

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	GameAddress             common.Address // Address of the fault game
 	AlphabetTrace           string         // String for the AlphabetTraceProvider
 	AgreeWithProposedOutput bool           // Temporary config if we agree or disagree with the posted output
+	GameDepth               int            // Depth of the game tree
 
 	TxMgrConfig txmgr.CLIConfig
 }
@@ -34,6 +35,7 @@ func NewConfig(
 	GameAddress common.Address,
 	AlphabetTrace string,
 	AgreeWithProposedOutput bool,
+	GameDepth int,
 ) Config {
 	return Config{
 		L1EthRpc:                l1EthRpc,
@@ -41,6 +43,7 @@ func NewConfig(
 		AlphabetTrace:           AlphabetTrace,
 		TxMgrConfig:             txmgr.NewCLIConfig(l1EthRpc),
 		AgreeWithProposedOutput: AgreeWithProposedOutput,
+		GameDepth:               GameDepth,
 	}
 }
 
@@ -78,6 +81,7 @@ func NewConfigFromCLI(ctx *cli.Context) (*Config, error) {
 		GameAddress:             dgfAddress,
 		AlphabetTrace:           ctx.String(flags.AlphabetFlag.Name),
 		AgreeWithProposedOutput: ctx.Bool(flags.AgreeWithProposedOutputFlag.Name),
+		GameDepth:               ctx.Int(flags.GameDepthFlag.Name),
 		TxMgrConfig:             txMgrConfig,
 	}, nil
 }

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -13,10 +13,11 @@ var (
 	validGameAddress        = common.HexToAddress("0x7bdd3b028C4796eF0EAf07d11394d0d9d8c24139")
 	validAlphabetTrace      = "abcdefgh"
 	agreeWithProposedOutput = true
+	gameDepth               = 4
 )
 
 func validConfig() Config {
-	cfg := NewConfig(validL1EthRpc, validGameAddress, validAlphabetTrace, agreeWithProposedOutput)
+	cfg := NewConfig(validL1EthRpc, validGameAddress, validAlphabetTrace, agreeWithProposedOutput, gameDepth)
 	return cfg
 }
 

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -38,6 +38,11 @@ var (
 		Usage:   "Temporary hardcoded flag if we agree or disagree with the proposed output.",
 		EnvVars: prefixEnvVars("AGREE_WITH_PROPOSED_OUTPUT"),
 	}
+	GameDepthFlag = &cli.IntFlag{
+		Name:    "game-depth",
+		Usage:   "Depth of the game tree.",
+		EnvVars: prefixEnvVars("GAME_DEPTH"),
+	}
 	// Optional Flags
 )
 
@@ -47,6 +52,7 @@ var requiredFlags = []cli.Flag{
 	DGFAddressFlag,
 	AlphabetFlag,
 	AgreeWithProposedOutputFlag,
+	GameDepthFlag,
 }
 
 // optionalFlags is a list of unchecked cli flags

--- a/op-challenger/init_game.sh
+++ b/op-challenger/init_game.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 cd "$DIR"
 
-# build the challenger to keep it up to date
 make
 
 cd ..
@@ -21,20 +20,16 @@ CHARLIE_KEY="74feb147d72bfae943e6b4e483410933d9e447d5dc47d52432dcc2c1454dabb7"
 MALLORY_ADDRESS="0x4641c704a6c743f73ee1f36C7568Fbf4b80681e4"
 MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
-
-
 echo "----------------------------------------------------------------"
 echo " - Fetching balance of the sponsor"
 echo " - Balance: $(cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)"
 echo "----------------------------------------------------------------"
-
 
 echo "Funding Charlie"
 cast send $CHARLIE_ADDRESS --value 5ether --private-key $DEVNET_SPONSOR
 
 echo "Funding Mallory"
 cast send $MALLORY_ADDRESS --value 5ether --private-key $DEVNET_SPONSOR
-
 
 # Fault game type = 0
 GAME_TYPE=0
@@ -44,8 +39,6 @@ ROOT_CLAIM=$(cast keccak $(cast abi-encode "f(uint256,uint256)" 15 122))
 # Extra data is a dynamic `bytes` type that contains the L2 Block Number of the output proposal that the root claim disagrees with
 # Doesn't matter right now since we're not deleting outputs, so just set it to 1
 EXTRA_DATA=$(cast to-bytes32 1)
-
-
 
 echo "Initializing the game"
 cast call --private-key $MALLORY_KEY $DISPUTE_GAME_PROXY "create(uint8,bytes32,bytes)" $GAME_TYPE $ROOT_CLAIM $EXTRA_DATA

--- a/op-challenger/mallory.sh
+++ b/op-challenger/mallory.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-
 DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 cd "$DIR"
 
@@ -15,4 +14,11 @@ MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
 FAULT_GAME_ADDRESS="0x8daf17a20c9dba35f005b6324f493785d239719d"
 
-./bin/op-challenger --l1-eth-rpc http://localhost:8545 --alphabet "abcdexyz" --game-address $FAULT_GAME_ADDRESS --private-key $MALLORY_KEY --num-confirmations 1 --agree-with-proposed-output=false
+./bin/op-challenger \
+  --l1-eth-rpc http://localhost:8545 \
+  --alphabet "abcdexyz" \
+  --game-address $FAULT_GAME_ADDRESS \
+  --private-key $MALLORY_KEY \
+  --num-confirmations 1 \
+  --game-depth 4 \
+  --agree-with-proposed-output=false


### PR DESCRIPTION
**Description**

As discussed in the FPA sync, we'd like to make the game depth configurable in the challenger
via a CLI Flag. This PR introduces the `--game-depth` integer flag and sets this to the previously
hardcoded value of 4 in each of the challenger invocations, `charlie.sh` and `mallory.sh`.

Additionally, this PR cleans up the challenger scripts and improves legibility.

**Tests**

Adds config unit tests around the `GameDepth` following the established convention.

**Metadata**

Fixes CLI-4231
