### PR TITLE
fix: Fix changeset versioning and release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
         id: changesets
         with:
           createGithubReleases: false
-          publish: pnpm release
+          publish: pnpm release:publish
+          version: pnpm release:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky install",
     "release": "npx nx run-many --target=build --skip-nx-cache && pnpm changeset publish",
     "release:check": "changeset status --verbose --since=origin/main",
-    "release:publish": "npx nx run-many --target=build && pnpm install && pnpm build && changeset publish",
+    "release:publish": "pnpm install --frozen-lockfile && npx nx run-many --target=build && pnpm build && changeset publish",
     "release:version": "changeset version && pnpm install --lockfile-only",
     "install:foundry": "curl -L https://foundry.paradigm.xyz | bash && pnpm update:foundry",
     "update:foundry": "foundryup -C $(cat .foundryrc)"


### PR DESCRIPTION
Fix issues with changeset publish flow
- Failed to update the changeset github action to use the new release:version and release:publish scripts in package.json
- noticed that we are pnpm installing after building which is backwards

This fixes a bug in the release pr where the lockfile isn't updated from pnpm installing the new package.json versions in the first pr. I went ahead and ran pnpm install on that pr myself which is stacked on top of this pr

