### PR TITLE
feat(op-challenger): Initial JsonProvider

### DIFF
--- a/op-challenger/fault/json_provider.go
+++ b/op-challenger/fault/json_provider.go
@@ -1,0 +1,70 @@
+package fault
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// JsonProvider is a [TraceProvider] that provides claims for specific
+// indices in the given trace.
+type JsonProvider struct {
+	files   []uint64
+	maxSize uint64
+}
+
+// NewJsonProvider returns a new [JsonProvider].
+// It accepts a `traceDir` which is the directory containing json failes whose names
+// are the trace indicies. It also accepts the `depth` of the trace.
+func NewJsonProvider(traceDir string, depth uint64) (*JsonProvider, error) {
+	// Read the files in the trace directory.
+	files, err := ioutil.ReadDir(traceDir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]uint64, len(files))
+	for i, file := range files {
+		u, err := strconv.ParseUint(file.Name()[:strings.IndexByte(file.Name(), '.')], 0, 64)
+		if err != nil {
+			return nil, err
+		}
+		names[i] = u
+	}
+	return &JsonProvider{
+		files:   names,
+		maxSize: uint64(1 << depth),
+	}, nil
+}
+
+// GetPreimage returns the preimage for the given hash.
+func (j *JsonProvider) GetPreimage(i uint64) ([]byte, error) {
+	// The index cannot be larger than the maximum index as computed by the depth.
+	if i >= j.maxSize {
+		return []byte{}, ErrIndexTooLarge
+	}
+	// We extend the deepest hash to the maximum depth if the trace is not expansive.
+	if i >= uint64(len(j.files)) {
+		return j.GetPreimage(uint64(len(j.files)) - 1)
+	}
+	return IndexToBytes(j.files[i]), nil
+}
+
+// Get returns the claim value at the given index in the trace.
+func (j *JsonProvider) Get(i uint64) (common.Hash, error) {
+	claimBytes, err := j.GetPreimage(i)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return crypto.Keccak256Hash(claimBytes), nil
+}
+
+// AbsolutePreState returns the preimage of the entire dispute game.
+// This is the undisputed starting state of the game.
+func (j *JsonProvider) AbsolutePreState() []byte {
+	out := make([]byte, 32)
+	out[31] = 140
+	return out
+}

--- a/op-challenger/fault/json_provider_test.go
+++ b/op-challenger/fault/json_provider_test.go
@@ -1,0 +1,126 @@
+package fault
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	traceLen      = 32
+	testDirectory = "__test_dir"
+)
+
+// beforeTestHook is meant to be called before each [JsonProvider] test.
+// It creates a directory with [traceLen] number of files.
+func beforeTestHook(t *testing.T) {
+	err := os.MkdirAll(testDirectory, 0755)
+	require.NoError(t, err)
+
+	for i := 0; i < traceLen; i++ {
+		content, err := json.Marshal("{}")
+		require.NoError(t, err)
+		require.NoError(t, ioutil.WriteFile(testDirectory+"/"+fmt.Sprint(i)+".json", content, 0644))
+	}
+
+}
+
+// postTestHook is meant to be called after each [JsonProvider] test.
+// It removes the test directory and all files in it.
+func postTestHook(t *testing.T) {
+	err := os.RemoveAll("__test_dir")
+	require.NoError(t, err)
+}
+
+// wrapTest is a helper function that wraps a test function with the
+// before and after hooks.
+func wrapTest(t *testing.T, test func(t *testing.T)) {
+	beforeTestHook(t)
+	// TODO: verify that the before test hook created the test directory
+	test(t)
+	postTestHook(t)
+	// TODO: verify that the post test hook removed the test directory
+}
+
+// TestJsonProvider_WithHooks tests the [JsonProvider] with the before and after hooks.
+func TestJsonProvider_WithHooks(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{"TestJsonProvider_GetPreimage", JsonProvider_GetPreimage_Test},
+		{"TestJsonProvider_Get", JsonProvider_Get_Test},
+		{"TestJsonProvider_AbsolutePreState", JsonProvider_AbsolutePreState_Test},
+	}
+	for _, test := range tests {
+		wrapTest(t, test.test)
+	}
+}
+
+// JsonProvider_GetPreimage_Test tests the [JsonProvider.GetPreimage] function.
+func JsonProvider_GetPreimage_Test(t *testing.T) {
+	provider, err := NewJsonProvider(testDirectory, 5)
+	require.NoError(t, err)
+
+	// Test that the preimage for the first index is the first file.
+	preimage, err := provider.GetPreimage(0)
+	require.NoError(t, err)
+	require.Equal(t, IndexToBytes(0), preimage)
+
+	// Test that the preimage for the last index is the last file.
+	preimage, err = provider.GetPreimage(traceLen - 1)
+	require.NoError(t, err)
+	require.Equal(t, IndexToBytes(traceLen-1), preimage)
+
+	// Test that the preimage for an index larger than the trace length is the last file.
+	preimage, err = provider.GetPreimage(traceLen)
+	require.NoError(t, err)
+	require.Equal(t, IndexToBytes(traceLen-1), preimage)
+
+	// Test that the preimage for an index larger than the maximum index is an error.
+	preimage, err = provider.GetPreimage(traceLen + 1)
+	require.Error(t, err)
+	require.Equal(t, []byte{}, preimage)
+	require.Equal(t, ErrIndexTooLarge, err)
+}
+
+// JsonProvider_Get_Test tests the [JsonProvider.Get] function.
+func JsonProvider_Get_Test(t *testing.T) {
+	provider, err := NewJsonProvider(testDirectory, 5)
+	require.NoError(t, err)
+
+	// Test that the first index is the first file.
+	content, err := provider.Get(0)
+	require.NoError(t, err)
+	require.Equal(t, "{}", content.String())
+
+	// Test that the last index is the last file.
+	content, err = provider.Get(traceLen - 1)
+	require.NoError(t, err)
+	require.Equal(t, "{}", content.String())
+
+	// Test that an index larger than the trace length is the last file.
+	content, err = provider.Get(traceLen)
+	require.NoError(t, err)
+	require.Equal(t, "{}", content.String())
+
+	// Test that an index larger than the maximum index is an error.
+	content, err = provider.Get(traceLen + 1)
+	require.Error(t, err)
+	require.Equal(t, []byte{}, content)
+	require.Equal(t, ErrIndexTooLarge, err)
+}
+
+// JsonProvider_AbsolutePreState_Test tests the [JsonProvider.AbsolutePreState] function.
+func JsonProvider_AbsolutePreState_Test(t *testing.T) {
+	provider, err := NewJsonProvider(testDirectory, 5)
+	require.NoError(t, err)
+
+	// Test that the first index is the first file.
+	content := provider.AbsolutePreState()
+	require.Equal(t, "{}", string(content))
+}


### PR DESCRIPTION
**Description**

Introduces the initial `JsonProvider` that reads JSON files from a directory
where filenames represent the trace indicies. The provider then implements
all required functions to satisfy the `TraceProvider` interface.

**Tests**

Unit tests are performed with pre and post test hooks to set up the json files in a test directory that is subsequently teared down post-test.

**Metadata**

Fixes CLI-4246
