### PR TITLE
specs: span-batch spec fixes

### DIFF
--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -150,11 +150,12 @@ Span-batch rules, in validation order:
   - Rules:
     - `start_epoch_num + sequence_window_size < inclusion_block_number` -> `drop`:
       i.e. the batch must be included timely.
-    - `start_epoch_num > epoch.number` -> `future`: i.e. all referenced L1 epochs must be there.
+    - `start_epoch_num > epoch.number + 1` -> `future`: i.e. the L1 origin may jump to the next L1 block, but not further.
     - `end_epoch_num == epoch.number`:
       - If `batch.l1_origin_check != epoch.hash[:20]` -> `drop`: verify the batch is intended for this L1 chain.
-    - `end_epoch_num < epoch.number` -> `drop`: must have been duplicate batch,
-      we may be past this L1 block in the safe L2 chain.
+    - `start_epoch_num < epoch.number` -> `drop`: must have been duplicate batch,
+      we may be past this L1 block in the safe L2 chain. If a span-batch overlaps with older information,
+      it is dropped, since partially valid span-batches are not accepted.
 - Max Sequencer time-drift checks:
   - Note: The max time-drift is enforced for the *batch as a whole*, to keep the possible output variants small.
   - Variables:

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -150,9 +150,13 @@ Span-batch rules, in validation order:
   - Rules:
     - `start_epoch_num + sequence_window_size < inclusion_block_number` -> `drop`:
       i.e. the batch must be included timely.
-    - `start_epoch_num > epoch.number + 1` -> `future`: i.e. the L1 origin may jump to the next L1 block, but not further.
-    - `end_epoch_num == epoch.number`:
-      - If `batch.l1_origin_check != epoch.hash[:20]` -> `drop`: verify the batch is intended for this L1 chain.
+    - `start_epoch_num > epoch.number + 1` -> `future`:
+      i.e. the L1 origin may jump to the next L1 block, but not further.
+    - If `end_epoch_num >= inclusion_block_number` -> `drop`:
+      if the end of the span is past the L1 block it was included in,
+      it cannot possibly reference the chain it was included in, and is thus non-canonical.
+    - If `batch.l1_origin_check` does not match the canonical L1 chain at `end_epoch_num` -> `drop`:
+      verify the batch is intended for this L1 chain.
     - `start_epoch_num < epoch.number` -> `drop`: must have been duplicate batch,
       we may be past this L1 block in the safe L2 chain. If a span-batch overlaps with older information,
       it is dropped, since partially valid span-batches are not accepted.

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -9,6 +9,16 @@
 
 - [Introduction](#introduction)
 - [Span batch format](#span-batch-format)
+- [Optimization Strategies](#optimization-strategies)
+  - [Truncating information and storing only necessary data](#truncating-information-and-storing-only-necessary-data)
+  - [`tx_data_headers` removal from initial specs](#tx_data_headers-removal-from-initial-specs)
+  - [`Chain ID` removal from initial specs](#chain-id-removal-from-initial-specs)
+  - [Reorganization of constant length transaction fields](#reorganization-of-constant-length-transaction-fields)
+  - [RLP encoding for only variable length fields](#rlp-encoding-for-only-variable-length-fields)
+  - [Store `y_parity` instead of `v`](#store-y_parity-instead-of-v)
+  - [Adjust `txs` Data Layout for Better Compression](#adjust-txs-data-layout-for-better-compression)
+  - [`fee_recipients` Encoding Scheme](#fee_recipients-encoding-scheme)
+- [How derivation works with Span Batch?](#how-derivation-works-with-span-batch)
 - [Integration](#integration)
   - [Channel Reader (Batch Decoding)](#channel-reader-batch-decoding)
   - [Batch Queue](#batch-queue)
@@ -53,7 +63,7 @@ Span-batches address these inefficiencies, with a new batch format version.
 
 ## Span batch format
 
-Note that span-batches, unlike previous V0 batches,
+Note that span-batches, unlike previous singular batches,
 encode *a range of consecutive* L2 blocks at the same time.
 
 Introduce version `1` to the [batch-format](./derivation.md#batch-format) table:
@@ -63,37 +73,69 @@ Introduce version `1` to the [batch-format](./derivation.md#batch-format) table:
 | 1               | `prefix ++ payload` |
 
 Notation:
-`++`: concatenation of byte-strings.
-`span_start`: first L2 block in the span
-`span_end`: last L2 block in the span
-`uvarint`: unsigned Base128 varint, as defined in [protobuf spec]
+
+- `++`: concatenation of byte-strings
+- `span_start`: first L2 block in the span
+- `span_end`: last L2 block in the span
+- `uvarint`: unsigned Base128 varint, as defined in [protobuf spec]
+- `rlp_encode`: a function that encodes a batch according to the [RLP format],
+  and `[x, y, z]` denotes a list containing items `x`, `y` and `z`
 
 [protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
 
 Where:
 
-- `prefix = rel_timestamp ++ parent_check ++ l1_origin_check`
-  - `rel_timestamp`: relative time since genesis, i.e. `span_start.timestamp - config.genesis.timestamp`.
-  - `parent_check`: first 20 bytes of parent hash, i.e. `span_start.parent_hash[:20]`.
-  - `l1_origin_check`: to ensure the intended L1 origins of this span of
-        L2 blocks are consistent with the L1 chain, the blockhash of the last L1 origin is referenced.
-        The hash is truncated to 20 bytes for efficiency, i.e. `span_end.l1_origin.hash[:20]`.
-- `payload = block_count ++ block_tx_counts ++ tx_data_headers ++ tx_data ++ tx_sigs`:
+- `prefix = rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check`
+  - `rel_timestamp`: `uvarint` relative timestamp since L2 genesis,
+    i.e. `span_start.timestamp - config.genesis.timestamp`.
+  - `l1_origin_num`: `uvarint` number of last l1 origin number. i.e. `span_end.l1_origin.number`
+  - `parent_check`: first 20 bytes of parent hash, the hash is truncated to 20 bytes for efficiency,
+    i.e. `span_start.parent_hash[:20]`.
+  - `l1_origin_check`: the block hash of the last L1 origin is referenced.
+    The hash is truncated to 20 bytes for efficiency, i.e. `span_end.l1_origin.hash[:20]`.
+- `payload = block_count ++ origin_bits ++ block_tx_counts ++ txs`:
   - `block_count`: `uvarint` number of L2 blocks.
   - `origin_bits`: bitlist of `block_count` bits, right-padded to a multiple of 8 bits:
     1 bit per L2 block, indicating if the L1 origin changed this L2 block.
   - `block_tx_counts`: for each block, a `uvarint` of `len(block.transactions)`.
-  - `tx_data_headers`: lengths of each `tx_data` entry, encodes as concatenated `uvarint` entries, (empty if there are
-    no entries).
-  - `tx_data`: [EIP-2718] encoded transactions.
-    - The `tx_signature` is truncated from each [EIP-2718] encoded tx. To be reconstructed from `tx_sigs`.
-      - `legacy`: starting at `v` RLP field
-      - `1` ([EIP-2930]): starting at `signatureYParity` RLP field
-      - `2` ([EIP-1559]): starting at `signature_y_parity` RLP field
-  - `tx_sigs`: concatenated list of transaction signatures:
-    - `v`, or `y_parity`, is encoded as `uvarint` (some legacy transactions combine the chain ID)
+  - `txs`: L2 transactions which is reorganized and encoded as below.
+- `txs = contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases`
+  - `contract_creation_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
+    1 bit per L2 transactions, indicating if transaction is a contract creation transaction.
+  - `y_parity_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
+    1 bit per L2 transactions, indicating the y parity value when recovering transaction sender address.
+  - `tx_sigs`: concatenated list of transaction signatures
     - `r` is encoded as big-endian `uint256`
     - `s` is encoded as big-endian `uint256`
+  - `tx_tos`: concatenated list of `to` field. `to` field in contract creation transaction will be `nil` and ignored.
+  - `tx_datas`: concatenated list of variable length rlp encoded data,
+    matching the encoding of the fields as in the [EIP-2718] format of the `TransactionType`.
+    - `legacy`: `rlp_encode(value, gasPrice, data)`
+    - `1`: ([EIP-2930]): `0x01 ++ rlp_encode(value, gasPrice, data, accessList)`
+    - `2`: ([EIP-1559]): `0x02 ++ rlp_encode(value, max_priority_fee_per_gas, max_fee_per_gas, data, access_list)`
+  - `tx_nonces`: concatenated list of `uvarint` of `nonce` field.
+  - `tx_gases`:  concatenated list of `uvarint` of gas limits.
+    - `legacy`: `gasLimit`
+    - `1`: ([EIP-2930]): `gasLimit`
+    - `2`: ([EIP-1559]): `gas_limit`
+
+Introduce version `2` to the [batch-format](./derivation.md#batch-format) table:
+
+| `batch_version` | `content`           |
+|-----------------|---------------------|
+| 2               | `prefix ++ payload` |
+
+Where:
+
+- `prefix = rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check`:
+  - Identical to `batch_version` 1
+- `payload = block_count ++ origin_bits ++ block_tx_counts ++ txs ++ fee_recipients`:
+  - Every field definition identical to `batch_version` 1 except that `fee_recipients` is
+    added to support more decentralized sequencing.
+  - `fee_recipients = fee_recipients_idxs + fee_recipients_set`
+    - `fee_recipients_set`: concatenated list of unique L2 fee recipient address.
+    - `fee_recipients_idxs`: for each block,
+      `uvarint` number of index to decode fee recipients from `fee_recipients_set`.
 
 [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
@@ -101,13 +143,91 @@ Where:
 
 [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
 
-> **TODO research/experimentation questions:**
->
-> - `tx_data` entries may be split up completely and tx attributes could be grouped into individual arrays, similar to
-    signatures.
-    > This may add more complexity, but organize data for improved compression.
-> - Backtesting: using this format, how are different types of chain history affected? Improved or not? And by what
-    margin?
+## Optimization Strategies
+
+### Truncating information and storing only necessary data
+
+The following fields stores truncated data:
+
+- `rel_timestamp`: We can save two bytes by storing `rel_timestamp` instead of the full `span_start.timestamp`.
+- `parent_check` and `l1_origin_check`: We can save twelve bytes by truncating twelve bytes from the full hash,
+  while having enough safety.
+
+### `tx_data_headers` removal from initial specs
+
+We do not need to store length per each `tx_datas` elements even if those are variable length,
+because the elements itself is RLP encoded, containing their length in RLP prefix.
+
+### `Chain ID` removal from initial specs
+
+Every transaction has chain id. We do not need to include chain id in span batch because L2 already knows its chain id,
+and use its own value for processing span batches while derivation.
+
+### Reorganization of constant length transaction fields
+
+`signature`, `nonce`, `gaslimit`, `to` field are constant size, so these were split up completely and
+are grouped into individual arrays.
+This adds more complexity, but organizes data for improved compression by grouping data with similar data pattern.
+
+### RLP encoding for only variable length fields
+
+Further size optimization can be done by packing variable length fields, such as `access_list`.
+However, doing this will introduce much more code complexity, comparing to benefiting by size reduction.
+
+Our goal is to find the sweet spot on code complexity - span batch size tradeoff.
+I decided that using RLP for all variable length fields will be the best option,
+not risking codebase with gnarly custom encoding/decoding implementations.
+
+### Store `y_parity` instead of `v`
+
+For legacy type transactions, `v = 2 * ChainID + y_parity`. For other types of transactions, `v = y_parity`.
+We may only store `y_parity`, which is single bit per L2 transaction.
+
+This optimization will benefit more when ratio between number of legacy type transactions over number of transactions
+excluding deposit tx is higher.
+Deposit transactions are excluded in batches and are never written at L1 so excluded while analyzing.
+
+### Adjust `txs` Data Layout for Better Compression
+
+There are (7 choose 2) * 5! = 2520 permutations of ordering fields of `txs`.
+It is not 7! because `contract_creation_bits` must be first decoded in order to decode `tx_tos`.
+We experimented to find out the best layout for compression.
+It turned out placing random data together(`TxSigs`, `TxTos`, `TxDatas`),
+then placing leftovers helped gzip to gain more size reduction.
+
+### `fee_recipients` Encoding Scheme
+
+Let `K` := number of unique fee recipients(cardinality) per span batch. Let `N` := number of L2 blocks.
+If we naively encode each fee recipients by concatenating every fee recipients, it will need `20 * N` bytes.
+If we manage `fee_recipients_idxs` and `fee_recipients_set`, It will need at most `max uvarint size * N = 8 * N`,
+`20 * K` bytes each. If `20 * N > 8 * N + 20 * K` then maintaining an index of fee recipients is reduces the size.
+
+we thought sequencer rotation happens not much often, so assumed that `K` will be much lesser than `N`.
+The assumption makes upper inequality to hold. Therefore, we decided to manage `fee_recipients_idxs` and
+`fee_recipients_set` separately. This adds complexity but reduces data.
+
+## How derivation works with Span Batch?
+
+- Block Timestamp
+  - The first L2 block's block timestamp is `rel_timestamp + L2Genesis.Timestamp`.
+  - Then we can derive other blocks timestamp by adding L2 block time for each.
+- L1 Origin Number
+  - The parent of the first L2 block's L1 origin number is `l1_origin_num - sum(origin_bits)`
+  - Then we can derive other blocks' L1 origin number with `origin_bits`
+  - `ith block's L1 origin number = (i-1)th block's L1 origin number + (origin_bits[i] ? 1 : 0)`
+- L1 Origin Hash
+  - We only need the `l1_origin_check`, the truncated L1 origin hash of the last L2 block of Span Batch.
+  - If the last block references canonical L1 chain as its origin,
+    we can ensure the all other blocks' origins are consistent with the canonical L1 chain.
+- Parent hash
+  - In V0 Batch spec, we need batch's parent hash to validate if batch's parent is consistent with current L2 safe head.
+  - But in the case of Span Batch, because it contains consecutive L2 blocks in the span,
+    we do not need to validate all blocks' parent hash except the first block.
+- Transactions
+  - Deposit transactions can be derived from its L1 origin, identical with V0 batch.
+  - User transactions can be derived by following way:
+    - Recover `V` value of TX signature from `y_parity_bits` and L2 chainId, as described in optimization strategies.
+    - When parsing `tx_tos`, `contract_creation_bits` is used to determine if the TX has `to` value or not.
 
 ## Integration
 
@@ -115,11 +235,7 @@ Where:
 
 The Channel Reader decodes the span-batch, as described in the [span-batch format](#span-batch-format).
 
-A set of derived attributes is computed, cached with the decoded result:
-
-- `l2_blocks_count`: number of L2 blocks in the span-batch
-- `start_timestamp`: `config.genesis.timestamp + batch.rel_timestamp`
-- `epoch_end`:
+A set of derived attributes is computed as described above. Then cached with the decoded result:
 
 ### Batch Queue
 
@@ -145,18 +261,19 @@ Span-batch rules, in validation order:
     which makes the later L2 blocks invalid.
   - Variables:
     - `origin_changed_bit = origin_bits[0]`: `true` if the first L2 block changed its L1 origin, `false` otherwise.
-    - `start_epoch_num = safe_l2_head.origin.block_number + (origin_changed_bit ? 1 : 0)`
-    - `end_epoch_num = safe_l2_head.origin.block_number + sum(origin_bits)`: block number of last referenced L1 origin
+    - `start_epoch_num = batch.l1_origin_num - sum(origin_bits) + (origin_changed_bit ? 1 : 0)`
+    - `end_epoch_num = batch.l1_origin_num`
   - Rules:
     - `start_epoch_num + sequence_window_size < inclusion_block_number` -> `drop`:
       i.e. the batch must be included timely.
-    - `start_epoch_num > epoch.number + 1` -> `future`:
-      i.e. the L1 origin may jump to the next L1 block, but not further.
-    - If `end_epoch_num >= inclusion_block_number` -> `drop`:
-      if the end of the span is past the L1 block it was included in,
-      it cannot possibly reference the chain it was included in, and is thus non-canonical.
+    - `start_epoch_num > epoch.number + 1` -> `drop`:
+      i.e. the L1 origin cannot change by more than one L1 block per L2 block.
     - If `batch.l1_origin_check` does not match the canonical L1 chain at `end_epoch_num` -> `drop`:
       verify the batch is intended for this L1 chain.
+      - After upper `l1_origin_check` check is passed, we don't need to check if the origin
+        is past `inclusion_block_number` because of the following invariant.
+      - Invariant: the epoch-num in the batch is always less than the inclusion block number,
+        if and only if the L1 epoch hash is correct.
     - `start_epoch_num < epoch.number` -> `drop`: must have been duplicate batch,
       we may be past this L1 block in the safe L2 chain. If a span-batch overlaps with older information,
       it is dropped, since partially valid span-batches are not accepted.
@@ -165,25 +282,25 @@ Span-batch rules, in validation order:
   - Variables:
     - `block_input`: an L2 block from the span-batch,
       with L1 origin as derived from the `origin_bits` and now established canonical L1 chain.
-    - `next_epoch` is relative to the `block_input`,
-      and may reach to the next origin outside of the L1 origins of the span.
+    - `next_epoch`: `block_input.origin`'s next L1 block.
+      It may reach to the next origin outside the L1 origins of the span.
   - Rules:
     - For each `block_input` that can be read from the span-batch:
       - `block_input.timestamp < block_input.origin.time` -> `drop`: enforce the min L2 timestamp rule.
       - `block_input.timestamp > block_input.origin.time + max_sequencer_drift`: enforce the L2 timestamp drift rule,
         but with exceptions to preserve above min L2 timestamp invariant:
         - `len(block_input.transactions) == 0`:
-          - `epoch.number == batch.epoch_num`:
-            this implies the batch does not already advance the L1 origin,
+          - `origin_bits[i] == 0`: `i` is the index of `block_input` in the span batch.
+            So this implies the block_input did not advance the L1 origin,
             and must thus be checked against `next_epoch`.
             - If `next_epoch` is not known -> `undecided`:
               without the next L1 origin we cannot yet determine if time invariant could have been kept.
-            - If `batch.timestamp >= next_epoch.time` -> `drop`:
+            - If `block_input.timestamp >= next_epoch.time` -> `drop`:
               the batch could have adopted the next L1 origin without breaking the `L2 time >= L1 time` invariant.
-        - `len(batch.transactions) > 0`: -> `drop`:
+        - `len(block_input.transactions) > 0`: -> `drop`:
           when exceeding the sequencer time drift, never allow the sequencer to include transactions.
 - And for all transactions:
-  - `drop` if the `batch.transactions` list contains a transaction
+  - `drop` if the `batch.tx_datas` list contains a transaction
     that is invalid or derived by other means exclusively:
     - any transaction that is empty (zero length `tx_data`)
     - any [deposited transactions][g-deposit-tx-type] (identified by the transaction type prefix byte in `tx_data`)


### PR DESCRIPTION
**Description**

Fixes issues in the span-batches spec, found by @testinprod-io @ImTei

Fixes:
- Correct `l1_origin` reference of span-batch to point to the end of the span, not the start.
- Check the span `future` case by comparing the start, not the end. And Flip the `>` to verify it's past the L1 origin of the L2 safe head (the `epoch`).
  - Based on further review: add `+1` to the L2 safe-head L1 origin, to handle the case where the start of the span continues with the L1 block after the L1 origin of the L2 safe head.
- Check the span past/duplicate case by checking if the span is older than the L1 origin of the L2 safe head (the `epoch`)
  - Based on further review: use the start of the span, and not the end, to detect when a span partially overlaps older already processed block data. The span is not guaranteed to reference the same chain, and consistency-checks of the resulting partially valid span would require access to more of the L2 chain history, so we drop the span instead. This matches the behavior of ignoring partially invalid spans that's already in the spec.
- Based on further review: make sure the L1 origin check of the span-batch is explicitly checked in the span-batch validation rules. And use the relationship to the inclusion in the L1 chain to drop span-batches that reference impossible L1 blocks.

Changes:
- change `anchor` to `span_start` for consistency with `span_end` name.

Update: continued spec improvements by @ImTei 
- Updated span-batch encoding
- Fixed derivation rules,  also updated to match new encoding
- Added section about optimization strategy

