### PR TITLE
op-e2e: Add helper to run op-challenger in e2e tests

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -1,6 +1,7 @@
 package op_challenger
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 // Main is the programmatic entry-point for running op-challenger
-func Main(logger log.Logger, cfg *config.Config) error {
+func Main(ctx context.Context, logger log.Logger, cfg *config.Config) error {
 	client, err := ethclient.Dial(cfg.L1EthRpc)
 	if err != nil {
 		return fmt.Errorf("failed to dial L1: %w", err)
@@ -50,6 +51,12 @@ func Main(logger log.Logger, cfg *config.Config) error {
 		logger.Info("Performing action")
 		_ = agent.Act()
 		caller.LogGameInfo()
-		time.Sleep(300 * time.Millisecond)
+		select {
+		// nosemgrep: dgryski.semgrep-go.timeafter.leaky-time-after
+		case <-time.After(300 * time.Millisecond):
+		// Continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }

--- a/op-challenger/cmd/main.go
+++ b/op-challenger/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -41,7 +42,7 @@ func main() {
 	}
 }
 
-type ConfigAction func(log log.Logger, config *config.Config) error
+type ConfigAction func(ctx context.Context, log log.Logger, config *config.Config) error
 
 func run(args []string, action ConfigAction) error {
 	oplog.SetupDefaults()
@@ -63,7 +64,7 @@ func run(args []string, action ConfigAction) error {
 		if err != nil {
 			return err
 		}
-		return action(logger, cfg)
+		return action(ctx.Context, logger, cfg)
 	}
 	return app.Run(args)
 }

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -137,7 +138,7 @@ func runWithArgs(cliArgs []string) (log.Logger, config.Config, error) {
 	cfg := new(config.Config)
 	var logger log.Logger
 	fullArgs := append([]string{"op-challenger"}, cliArgs...)
-	err := run(fullArgs, func(log log.Logger, config *config.Config) error {
+	err := run(fullArgs, func(ctx context.Context, log log.Logger, config *config.Config) error {
 		logger = log
 		cfg = config
 		return nil

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -1,0 +1,66 @@
+package challenger
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	op_challenger "github.com/ethereum-optimism/optimism/op-challenger"
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type Helper struct {
+	log    log.Logger
+	cancel func()
+	errors chan error
+}
+
+type Option func(config2 *config.Config)
+
+func NewChallenger(t *testing.T, ctx context.Context, l1Endpoint string, name string, options ...Option) *Helper {
+	log := testlog.Logger(t, log.LvlInfo).New("role", name)
+	log.Info("Creating challenger", "l1", l1Endpoint)
+	txmgrCfg := txmgr.NewCLIConfig(l1Endpoint)
+	txmgrCfg.NumConfirmations = 1
+	txmgrCfg.ReceiptQueryInterval = 1 * time.Second
+	cfg := &config.Config{
+		L1EthRpc:                l1Endpoint,
+		AlphabetTrace:           "",
+		AgreeWithProposedOutput: true,
+		TxMgrConfig:             txmgrCfg,
+	}
+	for _, option := range options {
+		option(cfg)
+	}
+	require.NotEmpty(t, cfg.TxMgrConfig.PrivateKey, "Missing private key for TxMgrConfig")
+
+	errCh := make(chan error, 1)
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer close(errCh)
+		errCh <- op_challenger.Main(ctx, log, cfg)
+	}()
+	return &Helper{
+		log:    log,
+		cancel: cancel,
+		errors: errCh,
+	}
+}
+
+func (h *Helper) Close() error {
+	h.cancel()
+	select {
+	case <-time.After(1 * time.Minute):
+		return errors.New("timed out while stopping challenger")
+	case err := <-h.errors:
+		if !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
**Description**

Enhance test by running a challenger that defends the output and confirm it wins. Still only has the root claim and a single counter-claim before resolving the game.

Modifies op-challenger `Main` to take a `Context` so that it can be stopped instead of running forever.

**Metadata**

- https://linear.app/optimism/issue/CLI-4133/e2e-tests
