### PR TITLE
op-e2e: fix import

### DIFF
--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/client/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +29,7 @@ func TestTimeTravel(t *testing.T) {
 	// It should be able to jump straight to the new time with just a single block
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
-	err = e2eutils.WaitFor(ctx, time.Second, func() (bool, error) {
+	err = utils.WaitFor(ctx, time.Second, func() (bool, error) {
 		postTravel, err := l1Client.BlockByNumber(context.Background(), nil)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
**Description**

Looks like a rebase/merge issue happened when migrating code to a different package, the diff in this commit references the old location of the code after the code was moved, resulting in this not building correctly. CI should have caught this but it did not for some reason.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

