### PR TITLE
Fix Alphabet game pre-state

### DIFF
--- a/op-challenger/fault/alphabet_provider.go
+++ b/op-challenger/fault/alphabet_provider.go
@@ -49,7 +49,7 @@ func (ap *AlphabetProvider) Get(i uint64) (common.Hash, error) {
 
 func (ap *AlphabetProvider) AbsolutePreState() []byte {
 	out := make([]byte, 32)
-	out[31] = 140 // ascii character 140 is "`"
+	out[31] = 96 // ascii character 96 is "`"
 	return out
 }
 

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -44,7 +44,7 @@
   "l1GenesisBlockTimestamp": "0x64935846",
   "l1StartingBlockTag": "earliest",
   "l2GenesisRegolithTimeOffset": "0x0",
-  "faultGameAbsolutePrestate": 140,
+  "faultGameAbsolutePrestate": 96,
   "faultGameMaxDepth": 4,
   "faultGameMaxDuration": 604800
 }


### PR DESCRIPTION
**Description**

I accidentally used the number "140" to the character "`". 140 is in octal & it should be 96 in decimal.

