### PR TITLE
feat(op-service): TxManager Call Method

### DIFF
--- a/op-challenger/fault/responder_test.go
+++ b/op-challenger/fault/responder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -38,6 +39,10 @@ func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (
 		false,
 		0,
 	), nil
+}
+
+func (m *mockTxManager) Call(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	panic("unimplemented")
 }
 
 func (m *mockTxManager) BlockNumber(ctx context.Context) (uint64, error) {

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -44,6 +44,9 @@ type fakeTxMgr struct {
 func (f fakeTxMgr) From() common.Address {
 	return f.from
 }
+func (f fakeTxMgr) Call(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	panic("unimplemented")
+}
 func (f fakeTxMgr) BlockNumber(_ context.Context) (uint64, error) {
 	panic("unimplemented")
 }

--- a/op-service/txmgr/mocks/TxManager.go
+++ b/op-service/txmgr/mocks/TxManager.go
@@ -4,8 +4,11 @@ package mocks
 
 import (
 	context "context"
+	big "math/big"
 
 	common "github.com/ethereum/go-ethereum/common"
+
+	ethereum "github.com/ethereum/go-ethereum"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -36,6 +39,32 @@ func (_m *TxManager) BlockNumber(ctx context.Context) (uint64, error) {
 
 	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
 		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Call provides a mock function with given fields: ctx, msg, blockNumber
+func (_m *TxManager) Call(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	ret := _m.Called(ctx, msg, blockNumber)
+
+	var r0 []byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, ethereum.CallMsg, *big.Int) ([]byte, error)); ok {
+		return rf(ctx, msg, blockNumber)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ethereum.CallMsg, *big.Int) []byte); ok {
+		r0 = rf(ctx, msg, blockNumber)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, ethereum.CallMsg, *big.Int) error); ok {
+		r1 = rf(ctx, msg, blockNumber)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -45,6 +45,10 @@ type TxManager interface {
 	// NOTE: Send can be called concurrently, the nonce will be managed internally.
 	Send(ctx context.Context, candidate TxCandidate) (*types.Receipt, error)
 
+	// Call is used to call a contract.
+	// Internally, it uses the [ethclient.Client.CallContract] method.
+	Call(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+
 	// From returns the sending address associated with the instance of the transaction manager.
 	// It is static for a single instance of a TxManager.
 	From() common.Address
@@ -58,6 +62,9 @@ type TxManager interface {
 type ETHBackend interface {
 	// BlockNumber returns the most recent block number.
 	BlockNumber(ctx context.Context) (uint64, error)
+
+	// CallContract executes an eth_call against the provided contract.
+	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 
 	// TransactionReceipt queries the backend for a receipt associated with
 	// txHash. If lookup does not fail, but the transaction is not found,
@@ -153,6 +160,12 @@ func (m *SimpleTxManager) Send(ctx context.Context, candidate TxCandidate) (*typ
 		m.resetNonce()
 	}
 	return receipt, err
+}
+
+// Call is used to call a contract.
+// Internally, it uses the [ethclient.Client.CallContract] method.
+func (m *SimpleTxManager) Call(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return m.backend.CallContract(ctx, msg, blockNumber)
 }
 
 // send performs the actual transaction creation and sending.

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -194,6 +194,11 @@ func (b *mockBackend) BlockNumber(ctx context.Context) (uint64, error) {
 	return b.blockHeight, nil
 }
 
+// Call mocks a call to the EVM.
+func (b *mockBackend) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}
+
 func (b *mockBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	return &types.Header{
 		BaseFee: b.g.basefee(),
@@ -647,6 +652,10 @@ func (b *failingBackend) HeaderByNumber(_ context.Context, _ *big.Int) (*types.H
 	return &types.Header{
 		BaseFee: b.baseFee,
 	}, nil
+}
+
+func (b *failingBackend) CallContract(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	return nil, errors.New("unimplemented")
 }
 
 func (b *failingBackend) SendTransaction(_ context.Context, _ *types.Transaction) error {


### PR DESCRIPTION
**Description**

This is the base PR in a stack to replace PR #6349.
It is rebuilt following comments on that pr.

It introduces a `Call` method on the `TxManager` interface in order to pass through
a `CallContract` onto the `TxManager`'s internal backend. This is done so that the
op-challenger can check if a tx resolving a dispute game will succeed or not.

**Tests**

TODO
