### PR TITLE
feat(op-challenger): Responder CallResolve

### DIFF
--- a/op-challenger/fault/responder.go
+++ b/op-challenger/fault/responder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -75,6 +76,20 @@ func (r *faultResponder) BuildTx(ctx context.Context, response Claim) ([]byte, e
 		}
 		return txData, nil
 	}
+}
+
+// CanResolve determines if the resolve function on the fault dispute game contract
+// would succeed. Returns true if the game can be resolved, otherwise false.
+func (r *faultResponder) CanResolve(ctx context.Context) bool {
+	txData, err := r.buildResolveData()
+	if err != nil {
+		return false
+	}
+	_, err = r.txMgr.Call(ctx, ethereum.CallMsg{
+		To:   &r.fdgAddr,
+		Data: txData,
+	}, nil)
+	return err == nil
 }
 
 // Resolve executes a resolve transaction to resolve a fault dispute game.

--- a/op-challenger/fault/responder_test.go
+++ b/op-challenger/fault/responder_test.go
@@ -26,6 +26,7 @@ var (
 type mockTxManager struct {
 	from      common.Address
 	sends     int
+	calls     int
 	sendFails bool
 }
 
@@ -42,7 +43,11 @@ func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (
 }
 
 func (m *mockTxManager) Call(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
-	panic("unimplemented")
+	if m.sendFails {
+		return nil, mockSendError
+	}
+	m.calls++
+	return []byte{}, nil
 }
 
 func (m *mockTxManager) BlockNumber(ctx context.Context) (uint64, error) {
@@ -60,6 +65,24 @@ func newTestFaultResponder(t *testing.T, sendFails bool) (*faultResponder, *mock
 	responder, err := NewFaultResponder(log, mockTxMgr, mockFdgAddress)
 	require.NoError(t, err)
 	return responder, mockTxMgr
+}
+
+// TestResponder_CanResolve_CallFails tests the [Responder.CanResolve] method
+// bubbles up the error returned by the [txmgr.Call] method.
+func TestResponder_CanResolve_CallFails(t *testing.T) {
+	responder, mockTxMgr := newTestFaultResponder(t, true)
+	resolved := responder.CanResolve(context.Background())
+	require.False(t, resolved)
+	require.Equal(t, 0, mockTxMgr.sends)
+}
+
+// TestResponder_CanResolve_Success tests the [Responder.CanResolve] method
+// succeeds when the call message is successfully sent through the txmgr.
+func TestResponder_CanResolve_Success(t *testing.T) {
+	responder, mockTxMgr := newTestFaultResponder(t, false)
+	resolved := responder.CanResolve(context.Background())
+	require.True(t, resolved)
+	require.Equal(t, 1, mockTxMgr.calls)
 }
 
 // TestResponder_Resolve_SendFails tests the [Responder.Resolve] method


### PR DESCRIPTION
**Description**

This PR replaces #6349 by using the `TxManager`'s `Call` method exposed by
the base pr of this stack.

A `CallResolve` function is added to the `Responder` fault subcomponent of
the op-challenger in this pr which `eth_call`'s the `resolve()` function
of the fault dispute game to check if the `Resolve` tx will succeed or not.

This is the alternative method to checking if the challenger can resolve a
dispute game instead of tracking the leftmost, uncontested dispute game node
and its clock.

**Tests**

Unit tests are performed using the minimal `mockTxManager` interface that
mocks `Call`.

**Metadata**

Fixes CLI-4232
