### PR TITLE
op-e2e: Add tests with two op-challenger instances completing the entire dispute game.

### DIFF
--- a/op-challenger/fault/alphabet_provider.go
+++ b/op-challenger/fault/alphabet_provider.go
@@ -48,9 +48,7 @@ func (ap *AlphabetProvider) Get(i uint64) (common.Hash, error) {
 }
 
 func (ap *AlphabetProvider) AbsolutePreState() []byte {
-	out := make([]byte, 32)
-	out[31] = 96 // ascii character 96 is "`"
-	return out
+	return common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
 }
 
 // BuildAlphabetPreimage constructs the claim bytes for the index and state item.

--- a/op-e2e/e2eutils/disputegame/deploy.go
+++ b/op-e2e/e2eutils/disputegame/deploy.go
@@ -43,13 +43,13 @@ func deployDisputeGameContracts(require *require.Assertions, ctx context.Context
 
 	// Now setup the fault dispute game type
 	// Start by deploying the AlphabetVM
-	_, tx, _, err = bindings.DeployAlphabetVM(opts, client, alphabetVMAbsolutePrestate)
+	_, tx, _, err = bindings.DeployAlphabetVM(opts, client, alphabetVMAbsolutePrestateClaim)
 	require.NoError(err)
 	alphaVMAddr, err := bind.WaitDeployed(ctx, client, tx)
 	require.NoError(err)
 
 	// Deploy the fault dispute game implementation
-	_, tx, _, err = bindings.DeployFaultDisputeGame(opts, client, alphabetVMAbsolutePrestate, big.NewInt(alphabetGameDepth), gameDuration, alphaVMAddr)
+	_, tx, _, err = bindings.DeployFaultDisputeGame(opts, client, alphabetVMAbsolutePrestateClaim, big.NewInt(alphabetGameDepth), gameDuration, alphaVMAddr)
 	require.NoError(err)
 	faultDisputeGameAddr, err := bind.WaitDeployed(ctx, client, tx)
 	require.NoError(err)

--- a/op-e2e/e2eutils/secrets.go
+++ b/op-e2e/e2eutils/secrets.go
@@ -137,6 +137,10 @@ func EncodePrivKey(priv *ecdsa.PrivateKey) hexutil.Bytes {
 	return privkey
 }
 
+func EncodePrivKeyToString(priv *ecdsa.PrivateKey) string {
+	return hexutil.Encode(EncodePrivKey(priv))
+}
+
 // Addresses computes the ethereum address of each account,
 // which can then be kept around for fast precomputed address access.
 func (s *Secrets) Addresses() *Addresses {

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
 	"github.com/ethereum-optimism/optimism/op-service/client/utils"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,16 +17,9 @@ func TestResolveDisputeGame(t *testing.T) {
 	InitParallel(t)
 
 	ctx := context.Background()
-	cfg := DefaultSystemConfig(t)
-	cfg.DeployConfig.L1BlockTime = 1
-	delete(cfg.Nodes, "verifier")
-	delete(cfg.Nodes, "sequencer")
-	cfg.SupportL1TimeTravel = true
-	sys, err := cfg.Start()
-	require.Nil(t, err, "Error starting up system")
-	defer sys.Close()
+	sys, l1Client := startL1OnlySystem(t)
+	t.Cleanup(sys.Close)
 
-	l1Client := sys.Clients["l1"]
 	gameDuration := 24 * time.Hour
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, l1Client, uint64(gameDuration.Seconds()))
 	game := disputeGameFactory.StartAlphabetGame(ctx, "zyxwvut")
@@ -34,12 +27,11 @@ func TestResolveDisputeGame(t *testing.T) {
 
 	game.WaitForGameStatus(ctx, disputegame.StatusInProgress)
 
-	honest := game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "honestAlice", func(c *config.Config) {
+	game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "HonestAlice", func(c *config.Config) {
 		c.AgreeWithProposedOutput = true // Agree with the proposed output, so disagree with the root claim
 		c.AlphabetTrace = "abcdefg"
-		c.TxMgrConfig.PrivateKey = hexutil.Encode(e2eutils.EncodePrivKey(cfg.Secrets.Alice))
+		c.TxMgrConfig.PrivateKey = e2eutils.EncodePrivKeyToString(sys.cfg.Secrets.Alice)
 	})
-	defer honest.Close()
 
 	game.WaitForClaimCount(ctx, 2)
 
@@ -48,5 +40,117 @@ func TestResolveDisputeGame(t *testing.T) {
 
 	// Challenger should resolve the game now that the clocks have expired.
 	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
-	require.NoError(t, honest.Close())
+}
+
+func TestChallengerCompleteDisputeGame(t *testing.T) {
+	InitParallel(t)
+
+	tests := []struct {
+		name              string
+		rootClaimAlphabet string
+		otherAlphabet     string
+		expectedResult    disputegame.Status
+		expectStep        bool
+	}{
+		{
+			name:              "ChallengerWins_DefenseStep",
+			rootClaimAlphabet: "abcdexyz",
+			otherAlphabet:     disputegame.CorrectAlphabet,
+			expectedResult:    disputegame.StatusChallengerWins,
+			expectStep:        true,
+		},
+		{
+			name:              "DefenderWins_DefenseStep",
+			rootClaimAlphabet: disputegame.CorrectAlphabet,
+			otherAlphabet:     "abcdexyz",
+			expectedResult:    disputegame.StatusDefenderWins,
+			expectStep:        false,
+		},
+		{
+			name:              "ChallengerWins_AttackStep",
+			rootClaimAlphabet: "abcdefghzyx",
+			otherAlphabet:     disputegame.CorrectAlphabet,
+			expectedResult:    disputegame.StatusChallengerWins,
+			expectStep:        true,
+		},
+		{
+			name:              "DefenderWins_AttackStep",
+			rootClaimAlphabet: disputegame.CorrectAlphabet,
+			otherAlphabet:     "abcdexyz",
+			expectedResult:    disputegame.StatusDefenderWins,
+			expectStep:        false,
+		},
+		{
+			name:              "DefenderIncorrectAtTraceZero",
+			rootClaimAlphabet: "zyxwvut",
+			otherAlphabet:     disputegame.CorrectAlphabet,
+			expectedResult:    disputegame.StatusChallengerWins,
+			expectStep:        true,
+		},
+		{
+			name:              "ChallengerIncorrectAtTraceZero",
+			rootClaimAlphabet: disputegame.CorrectAlphabet,
+			otherAlphabet:     "zyxwvut",
+			expectedResult:    disputegame.StatusDefenderWins,
+			expectStep:        false,
+		},
+		{
+			name:              "DefenderIncorrectAtLastTraceIndex",
+			rootClaimAlphabet: "abcdefghijklmnoz",
+			otherAlphabet:     disputegame.CorrectAlphabet,
+			expectedResult:    disputegame.StatusChallengerWins,
+			expectStep:        true,
+		},
+		{
+			name:              "ChallengerIncorrectAtLastTraceIndex",
+			rootClaimAlphabet: disputegame.CorrectAlphabet,
+			otherAlphabet:     "abcdefghijklmnoz",
+			expectedResult:    disputegame.StatusDefenderWins,
+			expectStep:        false,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			InitParallel(t)
+
+			ctx := context.Background()
+			sys, l1Client := startL1OnlySystem(t)
+			t.Cleanup(sys.Close)
+
+			gameDuration := 24 * time.Hour
+			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, l1Client, uint64(gameDuration.Seconds()))
+			game := disputeGameFactory.StartAlphabetGame(ctx, test.rootClaimAlphabet)
+			require.NotNil(t, game)
+
+			game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "Defender", func(c *config.Config) {
+				c.TxMgrConfig.PrivateKey = e2eutils.EncodePrivKeyToString(sys.cfg.Secrets.Mallory)
+			})
+
+			game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "Challenger", func(c *config.Config) {
+				c.AgreeWithProposedOutput = true // Agree with the proposed output, so disagree with the root claim
+				c.AlphabetTrace = test.otherAlphabet
+				c.TxMgrConfig.PrivateKey = e2eutils.EncodePrivKeyToString(sys.cfg.Secrets.Alice)
+			})
+
+			// Wait for a claim at the maximum depth that has been countered to indicate we're ready to resolve the game
+			game.WaitForClaimAtMaxDepth(ctx, test.expectStep)
+
+			sys.TimeTravelClock.AdvanceTime(gameDuration)
+			require.NoError(t, utils.WaitNextBlock(ctx, l1Client))
+
+			game.WaitForGameStatus(ctx, test.expectedResult)
+		})
+	}
+}
+
+func startL1OnlySystem(t *testing.T) (*System, *ethclient.Client) {
+	cfg := DefaultSystemConfig(t)
+	cfg.DeployConfig.L1BlockTime = 1
+	delete(cfg.Nodes, "verifier")
+	delete(cfg.Nodes, "sequencer")
+	cfg.SupportL1TimeTravel = true
+	sys, err := cfg.Start()
+	require.Nil(t, err, "Error starting up system")
+	return sys, sys.Clients["l1"]
 }


### PR DESCRIPTION
**Description**

Adds e2e tests to confirm an alphabet dispute game with two op-challengers will always resolve in favour of the correct alphabet.

Fixes some confusion around what the absolute pre-state is for the alphabet VM and when the pre-image should be used vs the hashed claim. As part of this switched to always using a hard coded hex value for the absolute pre-state so it's easy to see what the value should be and compare to what's actually included in the transaction.

The alphabet is defended.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4133/e2e-tests
