### PR TITLE
op-challenger: Pass context through correctly

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -52,10 +52,10 @@ func Main(ctx context.Context, logger log.Logger, cfg *config.Config) error {
 		_ = agent.Act(ctx)
 		status, _ := caller.GetGameStatus(ctx)
 		if status != 0 {
-			caller.LogGameStatus()
+			caller.LogGameStatus(ctx)
 			return nil
 		} else {
-			caller.LogGameInfo()
+			caller.LogGameInfo(ctx)
 		}
 		select {
 		case <-time.After(300 * time.Millisecond):

--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -40,13 +40,13 @@ func (a *Agent) Act(ctx context.Context) error {
 	}
 	// Create counter claims
 	for _, claim := range game.Claims() {
-		if err := a.move(claim, game); err != nil {
+		if err := a.move(ctx, claim, game); err != nil {
 			log.Error("Failed to move", "err", err)
 		}
 	}
 	// Step on all leaf claims
 	for _, claim := range game.Claims() {
-		if err := a.step(claim, game); err != nil {
+		if err := a.step(ctx, claim, game); err != nil {
 			log.Error("Failed to step", "err", err)
 		}
 	}
@@ -83,7 +83,7 @@ func (a *Agent) newGameFromContracts(ctx context.Context) (Game, error) {
 }
 
 // move determines & executes the next move given a claim
-func (a *Agent) move(claim Claim, game Game) error {
+func (a *Agent) move(ctx context.Context, claim Claim, game Game) error {
 	nextMove, err := a.solver.NextMove(claim, game.AgreeWithClaimLevel(claim))
 	if err != nil {
 		a.log.Warn("Failed to execute the next move", "err", err)
@@ -102,11 +102,11 @@ func (a *Agent) move(claim Claim, game Game) error {
 		return nil
 	}
 	log.Info("Performing move")
-	return a.responder.Respond(context.TODO(), move)
+	return a.responder.Respond(ctx, move)
 }
 
 // step determines & executes the next step against a leaf claim through the responder
-func (a *Agent) step(claim Claim, game Game) error {
+func (a *Agent) step(ctx context.Context, claim Claim, game Game) error {
 	if claim.Depth() != a.maxDepth {
 		return nil
 	}
@@ -136,5 +136,5 @@ func (a *Agent) step(claim Claim, game Game) error {
 		IsAttack:   step.IsAttack,
 		StateData:  step.PreState,
 	}
-	return a.responder.Step(context.TODO(), callData)
+	return a.responder.Step(ctx, callData)
 }

--- a/op-challenger/fault/caller.go
+++ b/op-challenger/fault/caller.go
@@ -44,13 +44,13 @@ func NewFaultCallerFromBindings(fdgAddr common.Address, client *ethclient.Client
 }
 
 // LogGameInfo logs the game info.
-func (fc *FaultCaller) LogGameInfo() {
-	status, err := fc.GetGameStatus(context.Background())
+func (fc *FaultCaller) LogGameInfo(ctx context.Context) {
+	status, err := fc.GetGameStatus(ctx)
 	if err != nil {
 		fc.log.Error("failed to get game status", "err", err)
 		return
 	}
-	claimLen, err := fc.GetClaimDataLength(context.Background())
+	claimLen, err := fc.GetClaimDataLength(ctx)
 	if err != nil {
 		fc.log.Error("failed to get claim count", "err", err)
 		return
@@ -66,8 +66,8 @@ func (fc *FaultCaller) GetGameStatus(ctx context.Context) (uint8, error) {
 	return fc.Status(&bind.CallOpts{Context: ctx})
 }
 
-func (fc *FaultCaller) LogGameStatus() {
-	status, err := fc.GetGameStatus(context.Background())
+func (fc *FaultCaller) LogGameStatus(ctx context.Context) {
+	status, err := fc.GetGameStatus(ctx)
 	if err != nil {
 		fc.log.Error("failed to get game status", "err", err)
 		return
@@ -80,8 +80,8 @@ func (fc *FaultCaller) GetClaimDataLength(ctx context.Context) (*big.Int, error)
 	return fc.ClaimDataLen(&bind.CallOpts{Context: ctx})
 }
 
-func (fc *FaultCaller) LogClaimDataLength() {
-	claimLen, err := fc.GetClaimDataLength(context.Background())
+func (fc *FaultCaller) LogClaimDataLength(ctx context.Context) {
+	claimLen, err := fc.GetClaimDataLength(ctx)
 	if err != nil {
 		fc.log.Error("failed to get claim count", "err", err)
 		return


### PR DESCRIPTION
**Description**

Fix op-challenger to pass through the context to where its needed instead of using `context.Background()` or `context.TODO()`.