### PR TITLE
cannon: Update pre-image input for local data

### DIFF
--- a/cannon/mipsevm/evm.go
+++ b/cannon/mipsevm/evm.go
@@ -27,6 +27,7 @@ var (
 	StepBytes4                      = crypto.Keccak256([]byte("step(bytes,bytes)"))[:4]
 	CheatBytes4                     = crypto.Keccak256([]byte("cheat(uint256,bytes32,bytes32,uint256)"))[:4]
 	LoadKeccak256PreimagePartBytes4 = crypto.Keccak256([]byte("loadKeccak256PreimagePart(uint256,bytes)"))[:4]
+	LoadLocalDataBytes4             = crypto.Keccak256([]byte("loadLocalData(uint256,bytes32,uint8)"))[:4]
 )
 
 // LoadContracts loads the Cannon contracts, from op-bindings package

--- a/cannon/mipsevm/evm.go
+++ b/cannon/mipsevm/evm.go
@@ -27,7 +27,7 @@ var (
 	StepBytes4                      = crypto.Keccak256([]byte("step(bytes,bytes)"))[:4]
 	CheatBytes4                     = crypto.Keccak256([]byte("cheat(uint256,bytes32,bytes32,uint256)"))[:4]
 	LoadKeccak256PreimagePartBytes4 = crypto.Keccak256([]byte("loadKeccak256PreimagePart(uint256,bytes)"))[:4]
-	LoadLocalDataBytes4             = crypto.Keccak256([]byte("loadLocalData(uint256,bytes32,uint8)"))[:4]
+	LoadLocalDataBytes4             = crypto.Keccak256([]byte("loadLocalData(uint256,bytes32,uint256,uint256)"))[:4]
 )
 
 // LoadContracts loads the Cannon contracts, from op-bindings package

--- a/cannon/mipsevm/witness.go
+++ b/cannon/mipsevm/witness.go
@@ -55,10 +55,13 @@ func (wit *StepWitness) EncodePreimageOracleInput() ([]byte, error) {
 		var input []byte
 		input = append(input, LoadLocalDataBytes4...)
 		input = append(input, wit.PreimageKey[:]...)
+
+		preimagePart := wit.PreimageValue[wit.PreimageOffset:]
 		var tmp [32]byte
-		copy(tmp[:], wit.PreimageValue[8:])
+		copy(tmp[:], preimagePart)
 		input = append(input, tmp[:]...)
-		input = append(input, uint32ToBytes32(uint32(len(wit.PreimageValue))-8)...)
+		input = append(input, uint32ToBytes32(32)...)
+		input = append(input, uint32ToBytes32(wit.PreimageOffset)...)
 		// Note: we can pad calldata to 32 byte multiple, but don't strictly have to
 		return input, nil
 	case preimage.Keccak256KeyType:

--- a/cannon/mipsevm/witness.go
+++ b/cannon/mipsevm/witness.go
@@ -49,16 +49,14 @@ func (wit *StepWitness) EncodePreimageOracleInput() ([]byte, error) {
 
 	switch preimage.KeyType(wit.PreimageKey[0]) {
 	case preimage.LocalKeyType:
-		// We have no on-chain form of preparing the bootstrap pre-images onchain yet.
-		// So instead we cheat them in.
-		// In production usage there should be an on-chain contract that exposes this,
-		// rather than going through the global keccak256 oracle.
+		if len(wit.PreimageValue) > 32+8 {
+			return nil, fmt.Errorf("local pre-image exceeds maximum size of 32 bytes with key 0x%x", wit.PreimageKey)
+		}
 		var input []byte
-		input = append(input, CheatBytes4...)
-		input = append(input, uint32ToBytes32(wit.PreimageOffset)...)
+		input = append(input, LoadLocalDataBytes4...)
 		input = append(input, wit.PreimageKey[:]...)
 		var tmp [32]byte
-		copy(tmp[:], wit.PreimageValue[wit.PreimageOffset:])
+		copy(tmp[:], wit.PreimageValue[8:])
 		input = append(input, tmp[:]...)
 		input = append(input, uint32ToBytes32(uint32(len(wit.PreimageValue))-8)...)
 		// Note: we can pad calldata to 32 byte multiple, but don't strictly have to


### PR DESCRIPTION
Use the new PreimageOracle interface to load local pre-image data.