### PR TITLE
fix(ctb): Port EAS Contracts to Triple Slash Natspec Styling

### DIFF
--- a/packages/contracts-bedrock/contracts/EAS/Common.sol
+++ b/packages/contracts-bedrock/contracts/EAS/Common.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.0;
 
 // A representation of an empty/uninitialized UID.
@@ -14,18 +13,14 @@ error InvalidLength();
 error InvalidSignature();
 error NotFound();
 
-/**
- * @dev A struct representing EIP712 signature data.
- */
+/// @dev A struct representing EIP712 signature data.
 struct EIP712Signature {
     uint8 v; // The recovery ID.
     bytes32 r; // The x-coordinate of the nonce R.
     bytes32 s; // The signature data.
 }
 
-/**
- * @dev A struct representing a single attestation.
- */
+/// @dev A struct representing a single attestation.
 struct Attestation {
     bytes32 uid; // A unique identifier of the attestation.
     bytes32 schema; // The unique identifier of the schema.
@@ -42,26 +37,18 @@ struct Attestation {
 // Maximum upgrade forward-compatibility storage gap.
 uint32 constant MAX_GAP = 50;
 
-/**
- * @dev A helper function to work with unchecked iterators in loops.
- *
- * @param i The index to increment.
- *
- * @return j The incremented index.
- */
+/// @dev A helper function to work with unchecked iterators in loops.
+/// @param i The index to increment.
+/// @return j The incremented index.
 function uncheckedInc(uint256 i) pure returns (uint256 j) {
     unchecked {
         j = i + 1;
     }
 }
 
-/**
- * @dev A helper function that converts a string to a bytes32.
- *
- * @param str The string to convert.
- *
- * @return The converted bytes32.
- */
+/// @dev A helper function that converts a string to a bytes32.
+/// @param str The string to convert.
+/// @return The converted bytes32.
 function stringToBytes32(string memory str) pure returns (bytes32) {
     bytes32 result;
 
@@ -72,13 +59,9 @@ function stringToBytes32(string memory str) pure returns (bytes32) {
     return result;
 }
 
-/**
- * @dev A helper function that converts a bytes32 to a string.
- *
- * @param data The bytes32 data to convert.
- *
- * @return The converted string.
- */
+/// @dev A helper function that converts a bytes32 to a string.
+/// @param data The bytes32 data to convert.
+/// @return The converted string.
 function bytes32ToString(bytes32 data) pure returns (string memory) {
     bytes memory byteArray = new bytes(32);
 

--- a/packages/contracts-bedrock/contracts/EAS/EAS.sol
+++ b/packages/contracts-bedrock/contracts/EAS/EAS.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity 0.8.19;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
@@ -85,32 +84,23 @@ contract EAS is IEAS, Semver, EIP712Verifier {
     // Upgrade forward-compatibility storage gap
     uint256[MAX_GAP - 3] private __gap;
 
-    /**
-     * @dev Creates a new EAS instance.
-     */
+    /// @dev Creates a new EAS instance.
     constructor() Semver(1, 0, 0) EIP712Verifier("EAS", "1.0.0") {
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function getSchemaRegistry() external pure returns (ISchemaRegistry) {
         return _schemaRegistry;
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function attest(AttestationRequest calldata request) external payable returns (bytes32) {
         AttestationRequestData[] memory requests = new AttestationRequestData[](1);
         requests[0] = request.data;
-
         return _attest(request.schema, requests, msg.sender, msg.value, true).uids[0];
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function attestByDelegation(
         DelegatedAttestationRequest calldata delegatedRequest
     ) external payable returns (bytes32) {
@@ -118,13 +108,10 @@ contract EAS is IEAS, Semver, EIP712Verifier {
 
         AttestationRequestData[] memory data = new AttestationRequestData[](1);
         data[0] = delegatedRequest.data;
-
         return _attest(delegatedRequest.schema, data, delegatedRequest.attester, msg.value, true).uids[0];
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function multiAttest(MultiAttestationRequest[] calldata multiRequests) external payable returns (bytes32[] memory) {
         // Since a multi-attest call is going to make multiple attestations for multiple schemas, we'd need to collect
         // all the returned UIDs into a single list.
@@ -170,9 +157,7 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return _mergeUIDs(totalUids, totalUidsCount);
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function multiAttestByDelegation(
         MultiDelegatedAttestationRequest[] calldata multiDelegatedRequests
     ) external payable returns (bytes32[] memory) {
@@ -239,9 +224,7 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return _mergeUIDs(totalUids, totalUidsCount);
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function revoke(RevocationRequest calldata request) external payable {
         RevocationRequestData[] memory requests = new RevocationRequestData[](1);
         requests[0] = request.data;
@@ -249,9 +232,7 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         _revoke(request.schema, requests, msg.sender, msg.value, true);
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function revokeByDelegation(DelegatedRevocationRequest calldata delegatedRequest) external payable {
         _verifyRevoke(delegatedRequest);
 
@@ -261,9 +242,7 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         _revoke(delegatedRequest.schema, data, delegatedRequest.revoker, msg.value, true);
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function multiRevoke(MultiRevocationRequest[] calldata multiRequests) external payable {
         // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
         // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
@@ -287,9 +266,7 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         }
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function multiRevokeByDelegation(
         MultiDelegatedRevocationRequest[] calldata multiDelegatedRequests
     ) external payable {
@@ -339,31 +316,21 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         }
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function timestamp(bytes32 data) external returns (uint64) {
         uint64 time = _time();
-
         _timestamp(data, time);
-
         return time;
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function revokeOffchain(bytes32 data) external returns (uint64) {
         uint64 time = _time();
-
         _revokeOffchain(msg.sender, data, time);
-
         return time;
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function multiRevokeOffchain(bytes32[] calldata data) external returns (uint64) {
         uint64 time = _time();
 
@@ -375,9 +342,7 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return time;
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function multiTimestamp(bytes32[] calldata data) external returns (uint64) {
         uint64 time = _time();
 
@@ -389,45 +354,33 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return time;
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function getAttestation(bytes32 uid) external view returns (Attestation memory) {
         return _db[uid];
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function isAttestationValid(bytes32 uid) public view returns (bool) {
         return _db[uid].uid != 0;
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function getTimestamp(bytes32 data) external view returns (uint64) {
         return _timestamps[data];
     }
 
-    /**
-     * @inheritdoc IEAS
-     */
+    /// @inheritdoc IEAS
     function getRevokeOffchain(address revoker, bytes32 data) external view returns (uint64) {
         return _revocationsOffchain[revoker][data];
     }
 
-    /**
-     * @dev Attests to a specific schema.
-     *
-     * @param schema // the unique identifier of the schema to attest to.
-     * @param data The arguments of the attestation requests.
-     * @param attester The attesting account.
-     * @param availableValue The total available ETH amount that can be sent to the resolver.
-     * @param last Whether this is the last attestations/revocations set.
-     *
-     * @return The UID of the new attestations and the total sent ETH amount.
-     */
+    /// @dev Attests to a specific schema.
+    /// @param schema // the unique identifier of the schema to attest to.
+    /// @param data The arguments of the attestation requests.
+    /// @param attester The attesting account.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return The UID of the new attestations and the total sent ETH amount.
     function _attest(
         bytes32 schema,
         AttestationRequestData[] memory data,
@@ -512,17 +465,13 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return res;
     }
 
-    /**
-     * @dev Revokes an existing attestation to a specific schema.
-     *
-     * @param schema The unique identifier of the schema to attest to.
-     * @param data The arguments of the revocation requests.
-     * @param revoker The revoking account.
-     * @param availableValue The total available ETH amount that can be sent to the resolver.
-     * @param last Whether this is the last attestations/revocations set.
-     *
-     * @return Returns the total sent ETH amount.
-     */
+    /// @dev Revokes an existing attestation to a specific schema.
+    /// @param schema The unique identifier of the schema to attest to.
+    /// @param data The arguments of the revocation requests.
+    /// @param revoker The revoking account.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return Returns the total sent ETH amount.
     function _revoke(
         bytes32 schema,
         RevocationRequestData[] memory data,
@@ -581,18 +530,14 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return _resolveAttestations(schemaRecord, attestations, values, true, availableValue, last);
     }
 
-    /**
-     * @dev Resolves a new attestation or a revocation of an existing attestation.
-     *
-     * @param schemaRecord The schema of the attestation.
-     * @param attestation The data of the attestation to make/revoke.
-     * @param value An explicit ETH amount to send to the resolver.
-     * @param isRevocation Whether to resolve an attestation or its revocation.
-     * @param availableValue The total available ETH amount that can be sent to the resolver.
-     * @param last Whether this is the last attestations/revocations set.
-     *
-     * @return Returns the total sent ETH amount.
-     */
+    /// @dev Resolves a new attestation or a revocation of an existing attestation.
+    /// @param schemaRecord The schema of the attestation.
+    /// @param attestation The data of the attestation to make/revoke.
+    /// @param value An explicit ETH amount to send to the resolver.
+    /// @param isRevocation Whether to resolve an attestation or its revocation.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return Returns the total sent ETH amount.
     function _resolveAttestation(
         SchemaRecord memory schemaRecord,
         Attestation memory attestation,
@@ -641,18 +586,14 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return value;
     }
 
-    /**
-     * @dev Resolves multiple attestations or revocations of existing attestations.
-     *
-     * @param schemaRecord The schema of the attestation.
-     * @param attestations The data of the attestations to make/revoke.
-     * @param values Explicit ETH amounts to send to the resolver.
-     * @param isRevocation Whether to resolve an attestation or its revocation.
-     * @param availableValue The total available ETH amount that can be sent to the resolver.
-     * @param last Whether this is the last attestations/revocations set.
-     *
-     * @return Returns the total sent ETH amount.
-     */
+    /// @dev Resolves multiple attestations or revocations of existing attestations.
+    /// @param schemaRecord The schema of the attestation.
+    /// @param attestations The data of the attestations to make/revoke.
+    /// @param values Explicit ETH amounts to send to the resolver.
+    /// @param isRevocation Whether to resolve an attestation or its revocation.
+    /// @param availableValue The total available ETH amount that can be sent to the resolver.
+    /// @param last Whether this is the last attestations/revocations set.
+    /// @return Returns the total sent ETH amount.
     function _resolveAttestations(
         SchemaRecord memory schemaRecord,
         Attestation[] memory attestations,
@@ -715,14 +656,10 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         return totalUsedValue;
     }
 
-    /**
-     * @dev Calculates a UID for a given attestation.
-     *
-     * @param attestation The input attestation.
-     * @param bump A bump value to use in case of a UID conflict.
-     *
-     * @return Attestation UID.
-     */
+    /// @dev Calculates a UID for a given attestation.
+    /// @param attestation The input attestation.
+    /// @param bump A bump value to use in case of a UID conflict.
+    /// @return Attestation UID.
     function _getUID(Attestation memory attestation, uint32 bump) private pure returns (bytes32) {
         return
             keccak256(
@@ -740,11 +677,8 @@ contract EAS is IEAS, Semver, EIP712Verifier {
             );
     }
 
-    /**
-     * @dev Refunds remaining ETH amount to the attester.
-     *
-     * @param remainingValue The remaining ETH amount that was not sent to the resolver.
-     */
+    /// @dev Refunds remaining ETH amount to the attester.
+    /// @param remainingValue The remaining ETH amount that was not sent to the resolver.
     function _refund(uint256 remainingValue) private {
         if (remainingValue > 0) {
             // Using a regular transfer here might revert, for some non-EOA attesters, due to exceeding of the 2300
@@ -754,12 +688,9 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         }
     }
 
-    /**
-     * @dev Timestamps the specified bytes32 data.
-     *
-     * @param data The data to timestamp.
-     * @param time The timestamp.
-     */
+    /// @dev Timestamps the specified bytes32 data.
+    /// @param data The data to timestamp.
+    /// @param time The timestamp.
     function _timestamp(bytes32 data, uint64 time) private {
         if (_timestamps[data] != 0) {
             revert AlreadyTimestamped();
@@ -770,12 +701,9 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         emit Timestamped(data, time);
     }
 
-    /**
-     * @dev Timestamps the specified bytes32 data.
-     *
-     * @param data The data to timestamp.
-     * @param time The timestamp.
-     */
+    /// @dev Timestamps the specified bytes32 data.
+    /// @param data The data to timestamp.
+    /// @param time The timestamp.
     function _revokeOffchain(address revoker, bytes32 data, uint64 time) private {
         mapping(bytes32 => uint64) storage revocations = _revocationsOffchain[revoker];
 
@@ -788,22 +716,17 @@ contract EAS is IEAS, Semver, EIP712Verifier {
         emit RevokedOffchain(revoker, data, time);
     }
 
-    /**
-     * @dev Returns the current's block timestamp. This method is overridden during tests and used to simulate the
-     * current block time.
-     */
+    /// @dev Returns the current's block timestamp.
+    ///      This method is overridden during tests and
+    ///      used to simulate the current block time.
     function _time() internal view virtual returns (uint64) {
         return uint64(block.timestamp);
     }
 
-    /**
-     * @dev Merges lists of UIDs.
-     *
-     * @param uidLists The provided lists of UIDs.
-     * @param uidsCount Total UIDs count.
-     *
-     * @return A merged and flatten list of all the UIDs.
-     */
+    /// @dev Merges lists of UIDs.
+    /// @param uidLists The provided lists of UIDs.
+    /// @param uidsCount Total UIDs count.
+    /// @return A merged and flatten list of all the UIDs.
     function _mergeUIDs(bytes32[][] memory uidLists, uint256 uidsCount) private pure returns (bytes32[] memory) {
         bytes32[] memory uids = new bytes32[](uidsCount);
 

--- a/packages/contracts-bedrock/contracts/EAS/IEAS.sol
+++ b/packages/contracts-bedrock/contracts/EAS/IEAS.sol
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.0;
 
 import { ISchemaRegistry } from "./ISchemaRegistry.sol";
 import { Attestation, EIP712Signature } from "./Common.sol";
 
-/**
- * @dev A struct representing the arguments of the attestation request.
- */
+/// @dev A struct representing the arguments of the attestation request.
 struct AttestationRequestData {
     address recipient; // The recipient of the attestation.
     uint64 expirationTime; // The time when the attestation expires (Unix timestamp).
@@ -17,17 +14,13 @@ struct AttestationRequestData {
     uint256 value; // An explicit ETH amount to send to the resolver. This is important to prevent accidental user errors.
 }
 
-/**
- * @dev A struct representing the full arguments of the attestation request.
- */
+/// @dev A struct representing the full arguments of the attestation request.
 struct AttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData data; // The arguments of the attestation request.
 }
 
-/**
- * @dev A struct representing the full arguments of the full delegated attestation request.
- */
+/// @dev A struct representing the full arguments of the full delegated attestation request.
 struct DelegatedAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData data; // The arguments of the attestation request.
@@ -35,17 +28,13 @@ struct DelegatedAttestationRequest {
     address attester; // The attesting account.
 }
 
-/**
- * @dev A struct representing the full arguments of the multi attestation request.
- */
+/// @dev A struct representing the full arguments of the multi attestation request.
 struct MultiAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData[] data; // The arguments of the attestation request.
 }
 
-/**
- * @dev A struct representing the full arguments of the delegated multi attestation request.
- */
+/// @dev A struct representing the full arguments of the delegated multi attestation request.
 struct MultiDelegatedAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData[] data; // The arguments of the attestation requests.
@@ -53,25 +42,19 @@ struct MultiDelegatedAttestationRequest {
     address attester; // The attesting account.
 }
 
-/**
- * @dev A struct representing the arguments of the revocation request.
- */
+/// @dev A struct representing the arguments of the revocation request.
 struct RevocationRequestData {
     bytes32 uid; // The UID of the attestation to revoke.
     uint256 value; // An explicit ETH amount to send to the resolver. This is important to prevent accidental user errors.
 }
 
-/**
- * @dev A struct representing the full arguments of the revocation request.
- */
+/// @dev A struct representing the full arguments of the revocation request.
 struct RevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData data; // The arguments of the revocation request.
 }
 
-/**
- * @dev A struct representing the arguments of the full delegated revocation request.
- */
+/// @dev A struct representing the arguments of the full delegated revocation request.
 struct DelegatedRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData data; // The arguments of the revocation request.
@@ -79,17 +62,13 @@ struct DelegatedRevocationRequest {
     address revoker; // The revoking account.
 }
 
-/**
- * @dev A struct representing the full arguments of the multi revocation request.
- */
+/// @dev A struct representing the full arguments of the multi revocation request.
 struct MultiRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData[] data; // The arguments of the revocation request.
 }
 
-/**
- * @dev A struct representing the full arguments of the delegated multi revocation request.
- */
+/// @dev A struct representing the full arguments of the delegated multi revocation request.
 struct MultiDelegatedRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData[] data; // The arguments of the revocation requests.
@@ -100,366 +79,298 @@ struct MultiDelegatedRevocationRequest {
 /// @title IEAS
 /// @notice The Ethereum Attestation Service interface.
 interface IEAS {
-    /**
-     * @dev Emitted when an attestation has been made.
-     *
-     * @param recipient The recipient of the attestation.
-     * @param attester The attesting account.
-     * @param uid The UID the revoked attestation.
-     * @param schema The UID of the schema.
-     */
+    /// @dev Emitted when an attestation has been made.
+    /// @param recipient The recipient of the attestation.
+    /// @param attester The attesting account.
+    /// @param uid The UID the revoked attestation.
+    /// @param schema The UID of the schema.
     event Attested(address indexed recipient, address indexed attester, bytes32 uid, bytes32 indexed schema);
 
-    /**
-     * @dev Emitted when an attestation has been revoked.
-     *
-     * @param recipient The recipient of the attestation.
-     * @param attester The attesting account.
-     * @param schema The UID of the schema.
-     * @param uid The UID the revoked attestation.
-     */
+    /// @dev Emitted when an attestation has been revoked.
+    /// @param recipient The recipient of the attestation.
+    /// @param attester The attesting account.
+    /// @param schema The UID of the schema.
+    /// @param uid The UID the revoked attestation.
     event Revoked(address indexed recipient, address indexed attester, bytes32 uid, bytes32 indexed schema);
 
-    /**
-     * @dev Emitted when a data has been timestamped.
-     *
-     * @param data The data.
-     * @param timestamp The timestamp.
-     */
+    /// @dev Emitted when a data has been timestamped.
+    /// @param data The data.
+    /// @param timestamp The timestamp.
     event Timestamped(bytes32 indexed data, uint64 indexed timestamp);
 
-    /**
-     * @dev Emitted when a data has been revoked.
-     *
-     * @param revoker The address of the revoker.
-     * @param data The data.
-     * @param timestamp The timestamp.
-     */
+    /// @dev Emitted when a data has been revoked.
+    /// @param revoker The address of the revoker.
+    /// @param data The data.
+    /// @param timestamp The timestamp.
     event RevokedOffchain(address indexed revoker, bytes32 indexed data, uint64 indexed timestamp);
 
-    /**
-     * @dev Returns the address of the global schema registry.
-     *
-     * @return The address of the global schema registry.
-     */
+    /// @notice Returns the address of the global schema registry.
+    /// @return The address of the global schema registry.
     function getSchemaRegistry() external view returns (ISchemaRegistry);
 
-    /**
-     * @dev Attests to a specific schema.
-     *
-     * @param request The arguments of the attestation request.
-     *
-     * Example:
-     *
-     * attest({
-     *     schema: "0facc36681cbe2456019c1b0d1e7bedd6d1d40f6f324bf3dd3a4cef2999200a0",
-     *     data: {
-     *         recipient: "0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf",
-     *         expirationTime: 0,
-     *         revocable: true,
-     *         refUID: "0x0000000000000000000000000000000000000000000000000000000000000000",
-     *         data: "0xF00D",
-     *         value: 0
-     *     }
-     * })
-     *
-     * @return The UID of the new attestation.
-     */
+    /// @notice Attests to a specific schema.
+    ///
+    ///      Example:
+    ///
+    ///      attest({
+    ///         schema: "0facc36681cbe2456019c1b0d1e7bedd6d1d40f6f324bf3dd3a4cef2999200a0",
+    ///         data: {
+    ///             recipient: "0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf",
+    ///             expirationTime: 0,
+    ///             revocable: true,
+    ///             refUID: "0x0000000000000000000000000000000000000000000000000000000000000000",
+    ///             data: "0xF00D",
+    ///             value: 0
+    ///         }
+    ///      })
+    ///
+    /// @param request The arguments of the attestation request.
+    /// @return The UID of the new attestation.
     function attest(AttestationRequest calldata request) external payable returns (bytes32);
 
-    /**
-     * @dev Attests to a specific schema via the provided EIP712 signature.
-     *
-     * @param delegatedRequest The arguments of the delegated attestation request.
-     *
-     * Example:
-     *
-     * attestByDelegation({
-     *     schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
-     *     data: {
-     *         recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-     *         expirationTime: 1673891048,
-     *         revocable: true,
-     *         refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-     *         data: '0x1234',
-     *         value: 0
-     *     },
-     *     signature: {
-     *         v: 28,
-     *         r: '0x148c...b25b',
-     *         s: '0x5a72...be22'
-     *     },
-     *     attester: '0xc5E8740aD971409492b1A63Db8d83025e0Fc427e'
-     * })
-     *
-     * @return The UID of the new attestation.
-     */
+    /// @notice Attests to a specific schema via the provided EIP712 signature.
+    ///
+    ///         Example:
+    ///
+    ///         attestByDelegation({
+    ///             schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
+    ///             data: {
+    ///                 recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    ///                 expirationTime: 1673891048,
+    ///                 revocable: true,
+    ///                 refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    ///                 data: '0x1234',
+    ///                 value: 0
+    ///             },
+    ///             signature: {
+    ///                 v: 28,
+    ///                 r: '0x148c...b25b',
+    ///                 s: '0x5a72...be22'
+    ///             },
+    ///             attester: '0xc5E8740aD971409492b1A63Db8d83025e0Fc427e'
+    ///         })
+    ///
+    /// @param delegatedRequest The arguments of the delegated attestation request.
+    /// @return The UID of the new attestation.
     function attestByDelegation(
         DelegatedAttestationRequest calldata delegatedRequest
     ) external payable returns (bytes32);
 
-    /**
-     * @dev Attests to multiple schemas.
-     *
-     * @param multiRequests The arguments of the multi attestation requests. The requests should be grouped by distinct
-     * schema ids to benefit from the best batching optimization.
-     *
-     * Example:
-     *
-     * multiAttest([{
-     *     schema: '0x33e9094830a5cba5554d1954310e4fbed2ef5f859ec1404619adea4207f391fd',
-     *     data: [{
-     *         recipient: '0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf',
-     *         expirationTime: 1673891048,
-     *         revocable: true,
-     *         refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-     *         data: '0x1234',
-     *         value: 1000
-     *     },
-     *     {
-     *         recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-     *         expirationTime: 0,
-     *         revocable: false,
-     *         refUID: '0x480df4a039efc31b11bfdf491b383ca138b6bde160988222a2a3509c02cee174',
-     *         data: '0x00',
-     *         value: 0
-     *     }],
-     * },
-     * {
-     *     schema: '0x5ac273ce41e3c8bfa383efe7c03e54c5f0bff29c9f11ef6ffa930fc84ca32425',
-     *     data: [{
-     *         recipient: '0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf',
-     *         expirationTime: 0,
-     *         revocable: true,
-     *         refUID: '0x75bf2ed8dca25a8190c50c52db136664de25b2449535839008ccfdab469b214f',
-     *         data: '0x12345678',
-     *         value: 0
-     *     },
-     * }])
-     *
-     * @return The UIDs of the new attestations.
-     */
+    /// @notice Attests to multiple schemas.
+    ///
+    ///         Example:
+    ///
+    ///         multiAttest([{
+    ///             schema: '0x33e9094830a5cba5554d1954310e4fbed2ef5f859ec1404619adea4207f391fd',
+    ///             data: [{
+    ///                 recipient: '0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf',
+    ///                 expirationTime: 1673891048,
+    ///                 revocable: true,
+    ///                 refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    ///                 data: '0x1234',
+    ///                 value: 1000
+    ///             },
+    ///             {
+    ///                 recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    ///                 expirationTime: 0,
+    ///                 revocable: false,
+    ///                 refUID: '0x480df4a039efc31b11bfdf491b383ca138b6bde160988222a2a3509c02cee174',
+    ///                 data: '0x00',
+    ///                 value: 0
+    ///             }],
+    ///         },
+    ///         {
+    ///             schema: '0x5ac273ce41e3c8bfa383efe7c03e54c5f0bff29c9f11ef6ffa930fc84ca32425',
+    ///             data: [{
+    ///                 recipient: '0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf',
+    ///                 expirationTime: 0,
+    ///                 revocable: true,
+    ///                 refUID: '0x75bf2ed8dca25a8190c50c52db136664de25b2449535839008ccfdab469b214f',
+    ///                 data: '0x12345678',
+    ///                 value: 0
+    ///             },
+    ///         }])
+    ///
+    /// @param multiRequests The arguments of the multi attestation requests. The requests should be grouped by distinct
+    ///        schema ids to benefit from the best batching optimization.
+    /// @return The UIDs of the new attestations.
     function multiAttest(MultiAttestationRequest[] calldata multiRequests) external payable returns (bytes32[] memory);
 
-    /**
-     * @dev Attests to multiple schemas using via provided EIP712 signatures.
-     *
-     * @param multiDelegatedRequests The arguments of the delegated multi attestation requests. The requests should be
-     * grouped by distinct schema ids to benefit from the best batching optimization.
-     *
-     * Example:
-     *
-     * multiAttestByDelegation([{
-     *     schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
-     *     data: [{
-     *         recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-     *         expirationTime: 1673891048,
-     *         revocable: true,
-     *         refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-     *         data: '0x1234',
-     *         value: 0
-     *     },
-     *     {
-     *         recipient: '0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf',
-     *         expirationTime: 0,
-     *         revocable: false,
-     *         refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-     *         data: '0x00',
-     *         value: 0
-     *     }],
-     *     signatures: [{
-     *         v: 28,
-     *         r: '0x148c...b25b',
-     *         s: '0x5a72...be22'
-     *     },
-     *     {
-     *         v: 28,
-     *         r: '0x487s...67bb',
-     *         s: '0x12ad...2366'
-     *     }],
-     *     attester: '0x1D86495b2A7B524D747d2839b3C645Bed32e8CF4'
-     * }])
-     *
-     * @return The UIDs of the new attestations.
-     */
+    /// @notice Attests to multiple schemas using via provided EIP712 signatures.
+    ///
+    ///         Example:
+    ///
+    ///         multiAttestByDelegation([{
+    ///             schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
+    ///             data: [{
+    ///                 recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    ///                 expirationTime: 1673891048,
+    ///                 revocable: true,
+    ///                 refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    ///                 data: '0x1234',
+    ///                 value: 0
+    ///             },
+    ///             {
+    ///                 recipient: '0xdEADBeAFdeAdbEafdeadbeafDeAdbEAFdeadbeaf',
+    ///                 expirationTime: 0,
+    ///                 revocable: false,
+    ///                 refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    ///                 data: '0x00',
+    ///                 value: 0
+    ///             }],
+    ///             signatures: [{
+    ///                 v: 28,
+    ///                 r: '0x148c...b25b',
+    ///                 s: '0x5a72...be22'
+    ///             },
+    ///             {
+    ///                 v: 28,
+    ///                 r: '0x487s...67bb',
+    ///                 s: '0x12ad...2366'
+    ///             }],
+    ///             attester: '0x1D86495b2A7B524D747d2839b3C645Bed32e8CF4'
+    ///         }])
+    ///
+    /// @param multiDelegatedRequests The arguments of the delegated multi attestation requests. The requests should be
+    ///        grouped by distinct schema ids to benefit from the best batching optimization.
+    /// @return The UIDs of the new attestations.
     function multiAttestByDelegation(
         MultiDelegatedAttestationRequest[] calldata multiDelegatedRequests
     ) external payable returns (bytes32[] memory);
 
-    /**
-     * @dev Revokes an existing attestation to a specific schema.
-     *
-     * Example:
-     *
-     * revoke({
-     *     schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
-     *     data: {
-     *         uid: '0x101032e487642ee04ee17049f99a70590c735b8614079fc9275f9dd57c00966d',
-     *         value: 0
-     *     }
-     * })
-     *
-     * @param request The arguments of the revocation request.
-     */
+    /// @notice Revokes an existing attestation to a specific schema.
+    ///
+    ///         Example:
+    ///
+    ///         revoke({
+    ///             schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
+    ///             data: {
+    ///                 uid: '0x101032e487642ee04ee17049f99a70590c735b8614079fc9275f9dd57c00966d',
+    ///                 value: 0
+    ///             }
+    ///         })
+    ///
+    /// @param request The arguments of the revocation request.
     function revoke(RevocationRequest calldata request) external payable;
 
-    /**
-     * @dev Revokes an existing attestation to a specific schema via the provided EIP712 signature.
-     *
-     * Example:
-     *
-     * revokeByDelegation({
-     *     schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
-     *     data: {
-     *         uid: '0xcbbc12102578c642a0f7b34fe7111e41afa25683b6cd7b5a14caf90fa14d24ba',
-     *         value: 0
-     *     },
-     *     signature: {
-     *         v: 27,
-     *         r: '0xb593...7142',
-     *         s: '0x0f5b...2cce'
-     *     },
-     *     revoker: '0x244934dd3e31bE2c81f84ECf0b3E6329F5381992'
-     * })
-     *
-     * @param delegatedRequest The arguments of the delegated revocation request.
-     */
+    /// @notice Revokes an existing attestation to a specific schema via the provided EIP712 signature.
+    ///
+    ///         Example:
+    ///
+    ///         revokeByDelegation({
+    ///             schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
+    ///             data: {
+    ///                 uid: '0xcbbc12102578c642a0f7b34fe7111e41afa25683b6cd7b5a14caf90fa14d24ba',
+    ///                 value: 0
+    ///             },
+    ///             signature: {
+    ///                 v: 27,
+    ///                 r: '0xb593...7142',
+    ///                 s: '0x0f5b...2cce'
+    ///             },
+    ///             revoker: '0x244934dd3e31bE2c81f84ECf0b3E6329F5381992'
+    ///         })
+    ///
+    /// @param delegatedRequest The arguments of the delegated revocation request.
     function revokeByDelegation(DelegatedRevocationRequest calldata delegatedRequest) external payable;
 
-    /**
-     * @dev Revokes existing attestations to multiple schemas.
-     *
-     * @param multiRequests The arguments of the multi revocation requests. The requests should be grouped by distinct
-     * schema ids to benefit from the best batching optimization.
-     *
-     * Example:
-     *
-     * multiRevoke([{
-     *     schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
-     *     data: [{
-     *         uid: '0x211296a1ca0d7f9f2cfebf0daaa575bea9b20e968d81aef4e743d699c6ac4b25',
-     *         value: 1000
-     *     },
-     *     {
-     *         uid: '0xe160ac1bd3606a287b4d53d5d1d6da5895f65b4b4bab6d93aaf5046e48167ade',
-     *         value: 0
-     *     }],
-     * },
-     * {
-     *     schema: '0x5ac273ce41e3c8bfa383efe7c03e54c5f0bff29c9f11ef6ffa930fc84ca32425',
-     *     data: [{
-     *         uid: '0x053d42abce1fd7c8fcddfae21845ad34dae287b2c326220b03ba241bc5a8f019',
-     *         value: 0
-     *     },
-     * }])
-     */
+    /// @notice Revokes existing attestations to multiple schemas.
+    ///
+    ///         Example:
+    ///
+    ///         multiRevoke([{
+    ///             schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
+    ///             data: [{
+    ///                 uid: '0x211296a1ca0d7f9f2cfebf0daaa575bea9b20e968d81aef4e743d699c6ac4b25',
+    ///                 value: 1000
+    ///             },
+    ///             {
+    ///                 uid: '0xe160ac1bd3606a287b4d53d5d1d6da5895f65b4b4bab6d93aaf5046e48167ade',
+    ///                 value: 0
+    ///             }],
+    ///         },
+    ///         {
+    ///             schema: '0x5ac273ce41e3c8bfa383efe7c03e54c5f0bff29c9f11ef6ffa930fc84ca32425',
+    ///             data: [{
+    ///                 uid: '0x053d42abce1fd7c8fcddfae21845ad34dae287b2c326220b03ba241bc5a8f019',
+    ///                 value: 0
+    ///             },
+    ///         }])
+    ///
+    /// @param multiRequests The arguments of the multi revocation requests. The requests should be grouped by distinct
+    ///        schema ids to benefit from the best batching optimization.
     function multiRevoke(MultiRevocationRequest[] calldata multiRequests) external payable;
 
-    /**
-     * @dev Revokes existing attestations to multiple schemas via provided EIP712 signatures.
-     *
-     * @param multiDelegatedRequests The arguments of the delegated multi revocation attestation requests. The requests should be
-     * grouped by distinct schema ids to benefit from the best batching optimization.
-     *
-     * Example:
-     *
-     * multiRevokeByDelegation([{
-     *     schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
-     *     data: [{
-     *         uid: '0x211296a1ca0d7f9f2cfebf0daaa575bea9b20e968d81aef4e743d699c6ac4b25',
-     *         value: 1000
-     *     },
-     *     {
-     *         uid: '0xe160ac1bd3606a287b4d53d5d1d6da5895f65b4b4bab6d93aaf5046e48167ade',
-     *         value: 0
-     *     }],
-     *     signatures: [{
-     *         v: 28,
-     *         r: '0x148c...b25b',
-     *         s: '0x5a72...be22'
-     *     },
-     *     {
-     *         v: 28,
-     *         r: '0x487s...67bb',
-     *         s: '0x12ad...2366'
-     *     }],
-     *     revoker: '0x244934dd3e31bE2c81f84ECf0b3E6329F5381992'
-     * }])
-     *
-     */
+    /// @notice Revokes existing attestations to multiple schemas via provided EIP712 signatures.
+    ///
+    ///         Example:
+    ///
+    ///         multiRevokeByDelegation([{
+    ///             schema: '0x8e72f5bc0a8d4be6aa98360baa889040c50a0e51f32dbf0baa5199bd93472ebc',
+    ///             data: [{
+    ///                 uid: '0x211296a1ca0d7f9f2cfebf0daaa575bea9b20e968d81aef4e743d699c6ac4b25',
+    ///                 value: 1000
+    ///             },
+    ///             {
+    ///                 uid: '0xe160ac1bd3606a287b4d53d5d1d6da5895f65b4b4bab6d93aaf5046e48167ade',
+    ///                 value: 0
+    ///             }],
+    ///             signatures: [{
+    ///                 v: 28,
+    ///                 r: '0x148c...b25b',
+    ///                 s: '0x5a72...be22'
+    ///             },
+    ///             {
+    ///                 v: 28,
+    ///                 r: '0x487s...67bb',
+    ///                 s: '0x12ad...2366'
+    ///             }],
+    ///             revoker: '0x244934dd3e31bE2c81f84ECf0b3E6329F5381992'
+    ///         }])
+    ///
+    /// @param multiDelegatedRequests The arguments of the delegated multi revocation attestation requests. The requests should be
+    ///        grouped by distinct schema ids to benefit from the best batching optimization.
     function multiRevokeByDelegation(
         MultiDelegatedRevocationRequest[] calldata multiDelegatedRequests
     ) external payable;
 
-    /**
-     * @dev Timestamps the specified bytes32 data.
-     *
-     * @param data The data to timestamp.
-     *
-     * @return The timestamp the data was timestamped with.
-     */
+    /// @notice Timestamps the specified bytes32 data.
+    /// @param data The data to timestamp.
+    /// @return The timestamp the data was timestamped with.
     function timestamp(bytes32 data) external returns (uint64);
 
-    /**
-     * @dev Timestamps the specified multiple bytes32 data.
-     *
-     * @param data The data to timestamp.
-     *
-     * @return The timestamp the data was timestamped with.
-     */
+    /// @notice Timestamps the specified multiple bytes32 data.
+    /// @param data The data to timestamp.
+    /// @return The timestamp the data was timestamped with.
     function multiTimestamp(bytes32[] calldata data) external returns (uint64);
 
-    /**
-     * @dev Revokes the specified bytes32 data.
-     *
-     * @param data The data to timestamp.
-     *
-     * @return The timestamp the data was revoked with.
-     */
+    /// @notice Revokes the specified bytes32 data.
+    /// @param data The data to timestamp.
+    /// @return The timestamp the data was revoked with.
     function revokeOffchain(bytes32 data) external returns (uint64);
 
-    /**
-     * @dev Revokes the specified multiple bytes32 data.
-     *
-     * @param data The data to timestamp.
-     *
-     * @return The timestamp the data was revoked with.
-     */
+    /// @notice Revokes the specified multiple bytes32 data.
+    /// @param data The data to timestamp.
+    /// @return The timestamp the data was revoked with.
     function multiRevokeOffchain(bytes32[] calldata data) external returns (uint64);
 
-    /**
-     * @dev Returns an existing attestation by UID.
-     *
-     * @param uid The UID of the attestation to retrieve.
-     *
-     * @return The attestation data members.
-     */
+    /// @notice Returns an existing attestation by UID.
+    /// @param uid The UID of the attestation to retrieve.
+    /// @return The attestation data members.
     function getAttestation(bytes32 uid) external view returns (Attestation memory);
 
-    /**
-     * @dev Checks whether an attestation exists.
-     *
-     * @param uid The UID of the attestation to retrieve.
-     *
-     * @return Whether an attestation exists.
-     */
+    /// @notice Checks whether an attestation exists.
+    /// @param uid The UID of the attestation to retrieve.
+    /// @return Whether an attestation exists.
     function isAttestationValid(bytes32 uid) external view returns (bool);
 
-    /**
-     * @dev Returns the timestamp that the specified data was timestamped with.
-     *
-     * @param data The data to query.
-     *
-     * @return The timestamp the data was timestamped with.
-     */
+    /// @notice Returns the timestamp that the specified data was timestamped with.
+    /// @param data The data to query.
+    /// @return The timestamp the data was timestamped with.
     function getTimestamp(bytes32 data) external view returns (uint64);
 
-    /**
-     * @dev Returns the timestamp that the specified data was timestamped with.
-     *
-     * @param data The data to query.
-     *
-     * @return The timestamp the data was timestamped with.
-     */
+    /// @notice Returns the timestamp that the specified data was timestamped with.
+    /// @param data The data to query.
+    /// @return The timestamp the data was timestamped with.
     function getRevokeOffchain(address revoker, bytes32 data) external view returns (uint64);
 }

--- a/packages/contracts-bedrock/contracts/EAS/ISchemaRegistry.sol
+++ b/packages/contracts-bedrock/contracts/EAS/ISchemaRegistry.sol
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.0;
 
 import { ISchemaResolver } from "./resolver/ISchemaResolver.sol";
 
-/**
- * @title A struct representing a record for a submitted schema.
- */
+/// @title A struct representing a record for a submitted schema.
 struct SchemaRecord {
     bytes32 uid; // The unique identifier of the schema.
     ISchemaResolver resolver; // Optional schema resolver.
@@ -17,31 +14,20 @@ struct SchemaRecord {
 /// @title ISchemaRegistry
 /// @notice The interface of global attestation schemas for the Ethereum Attestation Service protocol.
 interface ISchemaRegistry {
-    /**
-     * @dev Emitted when a new schema has been registered
-     *
-     * @param uid The schema UID.
-     * @param registerer The address of the account used to register the schema.
-     */
+    /// @dev Emitted when a new schema has been registered
+    /// @param uid The schema UID.
+    /// @param registerer The address of the account used to register the schema.
     event Registered(bytes32 indexed uid, address registerer);
 
-    /**
-     * @dev Submits and reserves a new schema
-     *
-     * @param schema The schema data schema.
-     * @param resolver An optional schema resolver.
-     * @param revocable Whether the schema allows revocations explicitly.
-     *
-     * @return The UID of the new schema.
-     */
+    /// @dev Submits and reserves a new schema
+    /// @param schema The schema data schema.
+    /// @param resolver An optional schema resolver.
+    /// @param revocable Whether the schema allows revocations explicitly.
+    /// @return The UID of the new schema.
     function register(string calldata schema, ISchemaResolver resolver, bool revocable) external returns (bytes32);
 
-    /**
-     * @dev Returns an existing schema by UID
-     *
-     * @param uid The UID of the schema to retrieve.
-     *
-     * @return The schema data members.
-     */
+    /// @dev Returns an existing schema by UID
+    /// @param uid The UID of the schema to retrieve.
+    /// @return The schema data members.
     function getSchema(bytes32 uid) external view returns (SchemaRecord memory);
 }

--- a/packages/contracts-bedrock/contracts/EAS/SchemaRegistry.sol
+++ b/packages/contracts-bedrock/contracts/EAS/SchemaRegistry.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity 0.8.19;
 
 import { Semver } from "../universal/Semver.sol";
@@ -22,14 +21,10 @@ contract SchemaRegistry is ISchemaRegistry, Semver {
     // Upgrade forward-compatibility storage gap
     uint256[MAX_GAP - 1] private __gap;
 
-    /**
-     * @dev Creates a new SchemaRegistry instance.
-     */
+    /// @dev Creates a new SchemaRegistry instance.
     constructor() Semver(1, 0, 0) {}
 
-    /**
-     * @inheritdoc ISchemaRegistry
-     */
+    /// @inheritdoc ISchemaRegistry
     function register(string calldata schema, ISchemaResolver resolver, bool revocable) external returns (bytes32) {
         SchemaRecord memory schemaRecord = SchemaRecord({
             uid: EMPTY_UID,
@@ -51,20 +46,14 @@ contract SchemaRegistry is ISchemaRegistry, Semver {
         return uid;
     }
 
-    /**
-     * @inheritdoc ISchemaRegistry
-     */
+    /// @inheritdoc ISchemaRegistry
     function getSchema(bytes32 uid) external view returns (SchemaRecord memory) {
         return _registry[uid];
     }
 
-    /**
-     * @dev Calculates a UID for a given schema.
-     *
-     * @param schemaRecord The input schema.
-     *
-     * @return schema UID.
-     */
+    /// @dev Calculates a UID for a given schema.
+    /// @param schemaRecord The input schema.
+    /// @return schema UID.
     function _getUID(SchemaRecord memory schemaRecord) private pure returns (bytes32) {
         return keccak256(abi.encodePacked(schemaRecord.schema, schemaRecord.resolver, schemaRecord.revocable));
     }

--- a/packages/contracts-bedrock/contracts/EAS/eip712/EIP712Verifier.sol
+++ b/packages/contracts-bedrock/contracts/EAS/eip712/EIP712Verifier.sol
@@ -36,59 +36,44 @@ abstract contract EIP712Verifier is EIP712 {
     // Upgrade forward-compatibility storage gap
     uint256[MAX_GAP - 1] private __gap;
 
-    /**
-     * @dev Creates a new EIP712Verifier instance.
-     *
-     * @param version The current major version of the signing domain
-     */
+    /// @dev Creates a new EIP712Verifier instance.
+    /// @param version The current major version of the signing domain
     constructor(string memory name, string memory version) EIP712(name, version) {
         _name = stringToBytes32(name);
     }
 
-    /**
-     * @dev Returns the domain separator used in the encoding of the signatures for attest, and revoke.
-     */
+    /// @notice Returns the domain separator used in the encoding of the signatures for attest, and revoke.
     function getDomainSeparator() external view returns (bytes32) {
         return _domainSeparatorV4();
     }
 
-    /**
-     * @dev Returns the current nonce per-account.
-     *
-     * @param account The requested account.
-     *
-     * @return The current nonce.
-     */
+    /// @notice Returns the current nonce per-account.
+    /// @param account The requested account.
+    /// @return The current nonce.
     function getNonce(address account) external view returns (uint256) {
         return _nonces[account];
     }
 
-    /**
-     * Returns the EIP712 type hash for the attest function.
-     */
+    /// @notice Returns the EIP712 type hash for the attest function.
+    /// @return The EIP712 attest function type hash.
     function getAttestTypeHash() external pure returns (bytes32) {
         return ATTEST_TYPEHASH;
     }
 
-    /**
-     * Returns the EIP712 type hash for the revoke function.
-     */
+    /// @notice Returns the EIP712 type hash for the revoke function.
+    /// @return hash_ The EIP712 revoke function type hash.
     function getRevokeTypeHash() external pure returns (bytes32) {
         return REVOKE_TYPEHASH;
     }
 
-    /**
-     * Returns the EIP712 name.
-     */
+    /// @notice Returns the EIP712 name.
+    /// @return The EIP712 name.
     function getName() external view returns (string memory) {
         return bytes32ToString(_name);
     }
 
-    /**
-     * @dev Verifies delegated attestation request.
-     *
-     * @param request The arguments of the delegated attestation request.
-     */
+    /// @notice Verifies delegated attestation request.
+    /// @param request The arguments of the delegated attestation request.
     function _verifyAttest(DelegatedAttestationRequest memory request) internal {
         AttestationRequestData memory data = request.data;
         EIP712Signature memory signature = request.signature;
@@ -118,11 +103,8 @@ abstract contract EIP712Verifier is EIP712 {
         }
     }
 
-    /**
-     * @dev Verifies delegated revocation request.
-     *
-     * @param request The arguments of the delegated revocation request.
-     */
+    /// @notice Verifies delegated revocation request.
+    /// @param request The arguments of the delegated revocation request.
     function _verifyRevoke(DelegatedRevocationRequest memory request) internal {
         RevocationRequestData memory data = request.data;
         EIP712Signature memory signature = request.signature;

--- a/packages/contracts-bedrock/contracts/EAS/resolver/ISchemaResolver.sol
+++ b/packages/contracts-bedrock/contracts/EAS/resolver/ISchemaResolver.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.0;
 
 import { Attestation } from "../Common.sol";
@@ -7,50 +6,33 @@ import { Attestation } from "../Common.sol";
 /// @title ISchemaResolver
 /// @notice The interface of an optional schema resolver.
 interface ISchemaResolver {
-    /**
-     * @dev Returns whether the resolver supports ETH transfers.
-     */
+    /// @notice Checks if the resolve can be sent ETH.
+    /// @return Whether the resolver supports ETH transfers.
     function isPayable() external pure returns (bool);
 
-    /**
-     * @dev Processes an attestation and verifies whether it's valid.
-     *
-     * @param attestation The new attestation.
-     *
-     * @return Whether the attestation is valid.
-     */
+    /// @notice Processes an attestation and verifies whether it's valid.
+    /// @param attestation The new attestation.
+    /// @return Whether the attestation is valid.
     function attest(Attestation calldata attestation) external payable returns (bool);
 
-    /**
-     * @dev Processes multiple attestations and verifies whether they are valid.
-     *
-     * @param attestations The new attestations.
-     * @param values Explicit ETH amounts which were sent with each attestation.
-     *
-     * @return Whether all the attestations are valid.
-     */
+    /// @notice Processes multiple attestations and verifies whether they are valid.
+    /// @param attestations The new attestations.
+    /// @param values Explicit ETH amounts which were sent with each attestation.
+    /// @return Whether all the attestations are valid.
     function multiAttest(
         Attestation[] calldata attestations,
         uint256[] calldata values
     ) external payable returns (bool);
 
-    /**
-     * @dev Processes an attestation revocation and verifies if it can be revoked.
-     *
-     * @param attestation The existing attestation to be revoked.
-     *
-     * @return Whether the attestation can be revoked.
-     */
+    /// @notice Processes an attestation revocation and verifies if it can be revoked.
+    /// @param attestation The existing attestation to be revoked.
+    /// @return Whether the attestation can be revoked.
     function revoke(Attestation calldata attestation) external payable returns (bool);
 
-    /**
-     * @dev Processes revocation of multiple attestation and verifies they can be revoked.
-     *
-     * @param attestations The existing attestations to be revoked.
-     * @param values Explicit ETH amounts which were sent with each revocation.
-     *
-     * @return Whether the attestations can be revoked.
-     */
+    /// @notice Processes revocation of multiple attestation and verifies they can be revoked.
+    /// @param attestations The existing attestations to be revoked.
+    /// @param values Explicit ETH amounts which were sent with each revocation.
+    /// @return Whether the attestations can be revoked.
     function multiRevoke(
         Attestation[] calldata attestations,
         uint256[] calldata values

--- a/packages/contracts-bedrock/contracts/EAS/resolver/SchemaResolver.sol
+++ b/packages/contracts-bedrock/contracts/EAS/resolver/SchemaResolver.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity 0.8.19;
 
 import { Semver } from "../../universal/Semver.sol";
@@ -19,11 +18,8 @@ abstract contract SchemaResolver is ISchemaResolver, Semver {
     // The global EAS contract.
     IEAS internal immutable _eas;
 
-    /**
-     * @dev Creates a new resolver.
-     *
-     * @param eas The address of the global EAS contract.
-     */
+    /// @dev Creates a new resolver.
+    /// @param eas The address of the global EAS contract.
     constructor(IEAS eas) Semver(1, 0, 0) {
         if (address(eas) == address(0)) {
             revert InvalidEAS();
@@ -32,41 +28,31 @@ abstract contract SchemaResolver is ISchemaResolver, Semver {
         _eas = eas;
     }
 
-    /**
-     * @dev Ensures that only the EAS contract can make this call.
-     */
+    /// @dev Ensures that only the EAS contract can make this call.
     modifier onlyEAS() {
         _onlyEAS();
 
         _;
     }
 
-    /**
-     * @inheritdoc ISchemaResolver
-     */
+    /// @inheritdoc ISchemaResolver
     function isPayable() public pure virtual returns (bool) {
         return false;
     }
 
-    /**
-     * @dev ETH callback.
-     */
+    /// @dev ETH callback.
     receive() external payable virtual {
         if (!isPayable()) {
             revert NotPayable();
         }
     }
 
-    /**
-     * @inheritdoc ISchemaResolver
-     */
+    /// @inheritdoc ISchemaResolver
     function attest(Attestation calldata attestation) external payable onlyEAS returns (bool) {
         return onAttest(attestation, msg.value);
     }
 
-    /**
-     * @inheritdoc ISchemaResolver
-     */
+    /// @inheritdoc ISchemaResolver
     function multiAttest(
         Attestation[] calldata attestations,
         uint256[] calldata values
@@ -100,16 +86,12 @@ abstract contract SchemaResolver is ISchemaResolver, Semver {
         return true;
     }
 
-    /**
-     * @inheritdoc ISchemaResolver
-     */
+    /// @inheritdoc ISchemaResolver
     function revoke(Attestation calldata attestation) external payable onlyEAS returns (bool) {
         return onRevoke(attestation, msg.value);
     }
 
-    /**
-     * @inheritdoc ISchemaResolver
-     */
+    /// @inheritdoc ISchemaResolver
     function multiRevoke(
         Attestation[] calldata attestations,
         uint256[] calldata values
@@ -143,35 +125,25 @@ abstract contract SchemaResolver is ISchemaResolver, Semver {
         return true;
     }
 
-    /**
-     * @dev A resolver callback that should be implemented by child contracts.
-     *
-     * @param attestation The new attestation.
-     * @param value An explicit ETH amount that was sent to the resolver. Please note that this value is verified in
-     * both attest() and multiAttest() callbacks EAS-only callbacks and that in case of multi attestations, it'll
-     * usually hold that msg.value != value, since msg.value aggregated the sent ETH amounts for all the attestations
-     * in the batch.
-     *
-     * @return Whether the attestation is valid.
-     */
+    /// @notice A resolver callback that should be implemented by child contracts.
+    /// @param attestation The new attestation.
+    /// @param value An explicit ETH amount that was sent to the resolver. Please note that this value is verified in
+    ///        both attest() and multiAttest() callbacks EAS-only callbacks and that in case of multi attestations, it'll
+    ///        usually hold that msg.value != value, since msg.value aggregated the sent ETH amounts for all the attestations
+    ///        in the batch.
+    /// @return Whether the attestation is valid.
     function onAttest(Attestation calldata attestation, uint256 value) internal virtual returns (bool);
 
-    /**
-     * @dev Processes an attestation revocation and verifies if it can be revoked.
-     *
-     * @param attestation The existing attestation to be revoked.
-     * @param value An explicit ETH amount that was sent to the resolver. Please note that this value is verified in
-     * both revoke() and multiRevoke() callbacks EAS-only callbacks and that in case of multi attestations, it'll
-     * usually hold that msg.value != value, since msg.value aggregated the sent ETH amounts for all the attestations
-     * in the batch.
-     *
-     * @return Whether the attestation can be revoked.
-     */
+    /// @notice Processes an attestation revocation and verifies if it can be revoked.
+    /// @param attestation The existing attestation to be revoked.
+    /// @param value An explicit ETH amount that was sent to the resolver. Please note that this value is verified in
+    ///        both revoke() and multiRevoke() callbacks EAS-only callbacks and that in case of multi attestations, it'll
+    ///        usually hold that msg.value != value, since msg.value aggregated the sent ETH amounts for all the attestations
+    ///        in the batch.
+    /// @return Whether the attestation can be revoked.
     function onRevoke(Attestation calldata attestation, uint256 value) internal virtual returns (bool);
 
-    /**
-     * @dev Ensures that only the EAS contract can make this call.
-     */
+    /// @notice Ensures that only the EAS contract can make this call.
     function _onlyEAS() private view {
         if (msg.sender != address(_eas)) {
             revert AccessDenied();


### PR DESCRIPTION
**Description**

Following the port of EAS contracts to `contracts-bedrock` in #6328,
this PR ports the styling to triple slash natspec styling as well
as fix some other styling to be inline with ctb in preparation
for `forge fmt`.

**Metadata**

Fixes CLI-4249
