### PR TITLE
feat: Better clean script and more robust only-allow pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pnpm": ">=8"
   },
   "scripts": {
-    "clean": "npx nx run-many --target=clean",
+    "clean": "pnpm recursive run clean; rm -rf node_modules packages/*/node_modules",
     "bindings": "nx bindings @eth-optimism/contracts-bedrock",
     "build": "npx nx run-many --target=build",
     "test": "npx nx run-many --target=test",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pnpm": ">=8"
   },
   "scripts": {
-    "clean": "pnpm recursive run clean; rm -rf node_modules packages/*/node_modules",
+    "clean": "pnpm recursive run clean; rm -rf node_modules packages/*/node_modules && echo 'Finished cleaning. Run `pnpm install && pnpm build` from root of repo to rebuild the repo.'",
     "bindings": "nx bindings @eth-optimism/contracts-bedrock",
     "build": "npx nx run-many --target=build",
     "test": "npx nx run-many --target=test",

--- a/packages/chain-mon/package.json
+++ b/packages/chain-mon/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "nyc hardhat test && nyc merge .nyc_output coverage.json",
     "build": "tsc -p ./tsconfig.json",
     "clean": "rimraf  dist/ ./tsconfig.tsbuildinfo",
+    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm lint:fix && pnpm lint:check",
     "pre-commit": "lint-staged",
     "lint:fix": "pnpm lint:check --fix",

--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -12,6 +12,7 @@
     "all": "pnpm clean && pnpm build && pnpm test && pnpm lint:fix && pnpm lint",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
+    "preinstall": "npx only-allow pnpm",
     "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "pnpm lint:check --fix",
     "lint": "pnpm lint:fix && pnpm lint:check",

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -29,6 +29,7 @@
     "slither": "./scripts/slither.sh",
     "slither:triage": "TRIAGE_MODE=1 ./scripts/slither.sh",
     "clean": "rm -rf ./dist ./artifacts ./forge-artifacts ./cache ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo ./src/contract-artifacts.ts ./test-case-generator/fuzz",
+    "preinstall": "npx only-allow pnpm",
     "lint:ts:check": "eslint . --max-warnings=0",
     "lint:forge-tests:check": "ts-node scripts/forge-test-names.ts",
     "lint:contracts:check": "pnpm solhint -f table 'contracts/**/!(DisputeTypes|RLPReader|EAS|SchemaRegistry|IEAS|ISchemaRegistry|SchemaResolver|EIP712Verifier|ISchemaResolver).sol' && pnpm prettier --check 'contracts/**/!(DisputeTypes|RLPReader|EAS|SchemaRegistry|IEAS|ISchemaRegistry|SchemaResolver|EIP712Verifier|ISchemaResolver).sol' && pnpm lint:forge-tests:check",

--- a/packages/contracts-ts/package.json
+++ b/packages/contracts-ts/package.json
@@ -36,6 +36,8 @@
   ],
   "scripts": {
     "build": "tsup",
+    "clean": "rm -rf ./dist",
+    "preinstall": "npx only-allow pnpm",
     "generate": "wagmi generate && pnpm build && pnpm lint:fix",
     "generate:check": "pnpm generate && git diff --exit-code ./addresses.json && git diff --exit-code ./abis.json",
     "lint": "prettier --check .",

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -11,6 +11,7 @@
     "all": "pnpm clean && pnpm build && pnpm test && pnpm lint:fix && pnpm lint",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
+    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm lint:fix && pnpm lint:check",
     "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "pnpm lint:check --fix",

--- a/packages/replica-healthcheck/package.json
+++ b/packages/replica-healthcheck/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "echo 'No tests defined.'",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf ./dist ./tsconfig.tsbuildinfo",
+    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm run lint:fix && pnpm run lint:check",
     "pre-commit": "lint-staged",
     "lint:fix": "pnpm lint:check --fix",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,6 +12,7 @@
     "all": "pnpm clean && pnpm build && pnpm test && pnpm lint:fix && pnpm lint",
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist/ ./tsconfig.tsbuildinfo",
+    "preinstall": "npx only-allow pnpm",
     "lint": "pnpm lint:fix && pnpm lint:check",
     "lint:check": "eslint . --max-warnings=0",
     "lint:fix": "pnpm lint:check --fix",


### PR DESCRIPTION
- remove dependency on nx to clean so it doesn't depend on node_modules being installed. Use pnpm recursive instead
- clean node_modules too

