### PR TITLE
feat(chain-mon): Set SDK to bedrock true

### DIFF
--- a/packages/chain-mon/src/wd-mon/service.ts
+++ b/packages/chain-mon/src/wd-mon/service.ts
@@ -103,6 +103,7 @@ export class WithdrawalMonitor extends BaseServiceV2<Options, Metrics, State> {
       l2SignerOrProvider: this.options.l2RpcProvider,
       l1ChainId: await getChainId(this.options.l1RpcProvider),
       l2ChainId: await getChainId(this.options.l2RpcProvider),
+      bedrock: true,
     })
 
     // Not detected by default.


### PR DESCRIPTION
Not having this value set is causing an unhandled error on startup.