### PR TITLE
feat(op-challenger): Introduce a OneShot CLI Flag

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -16,5 +16,9 @@ func Main(ctx context.Context, logger log.Logger, cfg *config.Config) error {
 		return fmt.Errorf("failed to create the fault service: %w", err)
 	}
 
+	if cfg.OneShot {
+		return service.Act(ctx)
+	}
+
 	return service.MonitorGame(ctx)
 }

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	AlphabetTrace           string         // String for the AlphabetTraceProvider
 	AgreeWithProposedOutput bool           // Temporary config if we agree or disagree with the posted output
 	GameDepth               int            // Depth of the game tree
+	OneShot                 bool           // Exit after a single Agent Action
 
 	TxMgrConfig txmgr.CLIConfig
 }
@@ -82,6 +83,8 @@ func NewConfigFromCLI(ctx *cli.Context) (*Config, error) {
 		AlphabetTrace:           ctx.String(flags.AlphabetFlag.Name),
 		AgreeWithProposedOutput: ctx.Bool(flags.AgreeWithProposedOutputFlag.Name),
 		GameDepth:               ctx.Int(flags.GameDepthFlag.Name),
-		TxMgrConfig:             txMgrConfig,
+		// Optional Flags
+		OneShot:     ctx.Bool(flags.OneShotFlag.Name),
+		TxMgrConfig: txMgrConfig,
 	}, nil
 }

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -17,6 +17,9 @@ import (
 type Service interface {
 	// MonitorGame monitors the fault dispute game and attempts to progress it.
 	MonitorGame(context.Context) error
+
+	// Act attempts to progress the fault dispute game once.
+	Act(context.Context) error
 }
 
 type service struct {
@@ -70,4 +73,14 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*se
 // MonitorGame monitors the fault dispute game and attempts to progress it.
 func (s *service) MonitorGame(ctx context.Context) error {
 	return MonitorGame(ctx, s.logger, s.agreeWithProposedOutput, s.agent, s.caller)
+}
+
+// Act attempts to progress the fault dispute game once.
+func (s *service) Act(ctx context.Context) error {
+	s.logger.Trace("Checking if actions are required")
+	if err := s.agent.Act(ctx); err != nil {
+		s.logger.Error("Error when acting on game", "err", err)
+	}
+	s.caller.LogGameInfo(ctx)
+	return nil
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -44,6 +44,11 @@ var (
 		EnvVars: prefixEnvVars("GAME_DEPTH"),
 	}
 	// Optional Flags
+	OneShotFlag = &cli.BoolFlag{
+		Name:    "one-shot",
+		Usage:   "Exit a single Agent Action in the Challenger.",
+		EnvVars: prefixEnvVars("ONE_SHOT"),
+	}
 )
 
 // requiredFlags are checked by [CheckRequired]
@@ -56,7 +61,9 @@ var requiredFlags = []cli.Flag{
 }
 
 // optionalFlags is a list of unchecked cli flags
-var optionalFlags = []cli.Flag{}
+var optionalFlags = []cli.Flag{
+	OneShotFlag,
+}
 
 func init() {
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(envVarPrefix)...)


### PR DESCRIPTION
**Description**

This PR builds ontop of #6408 to provide a `--one-shot` boolean cli flag
that allows you to run the challenger and have it act on the fault dispute
game once.

This is a slightly modified implementation of draft pr #6309, whereby we
use a cli flag to execute this one shot logic as opposed to an `act`
subcommand.
