### PR TITLE
Set go-reviewers as code owners for op-challenger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /cannon         @ethereum-optimism/go-reviewers
 /op-batcher     @ethereum-optimism/go-reviewers
 /op-chain-ops   @ethereum-optimism/go-reviewers
+/op-challenger  @ethereum-optimism/go-reviewers
 /op-e2e         @ethereum-optimism/go-reviewers
 /op-node        @ethereum-optimism/go-reviewers
 /op-node/rollup @protolambda @trianglesphere
@@ -37,8 +38,8 @@
 /endpoint-monitor @ethereum-optimism/infra-reviewers
 
 # Don't add owners if only package.json is updated
-/packages/*/package.json 
-/*/package.json 
+/packages/*/package.json
+/*/package.json
 
 # JavaScript Releases
 /packages/*/CHANGELOG.md @ethereum-optimism/release-managers


### PR DESCRIPTION
**Description**

For consistency with other `op-*` dirs, set `@ethereum-optimism/go-reviewers` as the code owner for `/op-challenger`