### PR TITLE
Add hook for executing cannon into trace provider.

### DIFF
--- a/op-challenger/fault/cannon/cannon_provider_test.go
+++ b/op-challenger/fault/cannon/cannon_provider_test.go
@@ -15,63 +15,79 @@ import (
 var testData embed.FS
 
 func TestGet(t *testing.T) {
-	provider := setupWithTestData(t)
+	dataDir := setupTestData(t)
 	t.Run("ExistingProof", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		value, err := provider.Get(0)
 		require.NoError(t, err)
 		require.Equal(t, common.HexToHash("0x45fd9aa59768331c726e719e76aa343e73123af888804604785ae19506e65e87"), value)
+		require.Empty(t, executor.generated)
 	})
 
 	t.Run("ProofUnavailable", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		_, err := provider.Get(7)
 		require.ErrorIs(t, err, os.ErrNotExist)
+		require.Contains(t, executor.generated, 7, "should have tried to generate the proof")
 	})
 
 	t.Run("MissingPostHash", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		_, err := provider.Get(1)
 		require.ErrorContains(t, err, "missing post hash")
+		require.Empty(t, executor.generated)
 	})
 
 	t.Run("IgnoreUnknownFields", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		value, err := provider.Get(2)
 		require.NoError(t, err)
 		expected := common.HexToHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 		require.Equal(t, expected, value)
+		require.Empty(t, executor.generated)
 	})
 }
 
 func TestGetPreimage(t *testing.T) {
-	provider := setupWithTestData(t)
+	dataDir := setupTestData(t)
 	t.Run("ExistingProof", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		value, proof, err := provider.GetPreimage(0)
 		require.NoError(t, err)
 		expected := common.Hex2Bytes("b8f068de604c85ea0e2acd437cdb47add074a2d70b81d018390c504b71fe26f400000000000000000000000000000000000000000000000000000000000000000000000000")
 		require.Equal(t, expected, value)
 		expectedProof := common.Hex2Bytes("08028e3c0000000000000000000000003c01000a24210b7c00200008000000008fa40004")
 		require.Equal(t, expectedProof, proof)
+		require.Empty(t, executor.generated)
 	})
 
 	t.Run("ProofUnavailable", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		_, _, err := provider.GetPreimage(7)
 		require.ErrorIs(t, err, os.ErrNotExist)
+		require.Contains(t, executor.generated, 7, "should have tried to generate the proof")
 	})
 
 	t.Run("MissingStateData", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		_, _, err := provider.GetPreimage(1)
 		require.ErrorContains(t, err, "missing state data")
+		require.Empty(t, executor.generated)
 	})
 
 	t.Run("IgnoreUnknownFields", func(t *testing.T) {
+		provider, executor := setupWithTestData(dataDir)
 		value, proof, err := provider.GetPreimage(2)
 		require.NoError(t, err)
 		expected := common.Hex2Bytes("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
 		require.Equal(t, expected, value)
 		expectedProof := common.Hex2Bytes("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 		require.Equal(t, expectedProof, proof)
+		require.Empty(t, executor.generated)
 	})
 }
 
-func setupWithTestData(t *testing.T) *CannonTraceProvider {
+func setupTestData(t *testing.T) string {
 	srcDir := filepath.Join("test_data", "proofs")
 	entries, err := testData.ReadDir(srcDir)
 	require.NoError(t, err)
@@ -84,5 +100,22 @@ func setupWithTestData(t *testing.T) *CannonTraceProvider {
 		err = os.WriteFile(filepath.Join(dataDir, "proofs", entry.Name()), file, 0o644)
 		require.NoErrorf(t, err, "writing %v", path)
 	}
-	return NewCannonTraceProvider(dataDir)
+	return dataDir
+}
+
+func setupWithTestData(dataDir string) (*CannonTraceProvider, *stubExecutor) {
+	executor := &stubExecutor{}
+	return &CannonTraceProvider{
+		dir:      dataDir,
+		executor: executor,
+	}, executor
+}
+
+type stubExecutor struct {
+	generated []int // Using int makes assertions easier
+}
+
+func (e *stubExecutor) GenerateProof(dir string, i uint64) error {
+	e.generated = append(e.generated, int(i))
+	return nil
 }

--- a/op-challenger/fault/cannon/executor.go
+++ b/op-challenger/fault/cannon/executor.go
@@ -1,0 +1,21 @@
+package cannon
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type executor struct {
+	logger log.Logger
+}
+
+func newExecutor(logger log.Logger) Executor {
+	return &executor{
+		logger: logger,
+	}
+}
+
+func (e *executor) GenerateProof(dir string, i uint64) error {
+	return fmt.Errorf("please execute cannon with --proof-at %v --proof-fmt %v/%v/%%d.json", i, dir, proofsDir)
+}

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -55,7 +55,7 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*se
 	var trace TraceProvider
 	switch cfg.TraceType {
 	case flags.TraceTypeCannon:
-		trace = cannon.NewCannonTraceProvider(cfg.CannonDatadir)
+		trace = cannon.NewCannonTraceProvider(logger, cfg.CannonDatadir)
 	case flags.TraceTypeAlphabet:
 		trace = NewAlphabetProvider(cfg.AlphabetTrace, uint64(cfg.GameDepth))
 	default:


### PR DESCRIPTION
**Description**

Currently just errors with information on what to manually generate.

**Tests**

Updated unit tests.

**Metadata**

- https://linear.app/optimism/issue/CLI-4242/execute-cannon
