### PR TITLE
fix(op-challenger): Small changes following #6413

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -29,6 +29,7 @@ func (t TraceType) String() string {
 	return string(t)
 }
 
+// Set implements the Set method required by the [cli.Generic] interface.
 func (t *TraceType) Set(value string) error {
 	if !ValidTraceType(TraceType(value)) {
 		return fmt.Errorf("unknown trace type: %q", value)

--- a/op-challenger/fault/responder.go
+++ b/op-challenger/fault/responder.go
@@ -5,13 +5,13 @@ import (
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	types2 "github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -63,7 +63,7 @@ func (r *faultResponder) buildResolveData() ([]byte, error) {
 }
 
 // BuildTx builds the transaction for the [faultResponder].
-func (r *faultResponder) BuildTx(ctx context.Context, response types2.Claim) ([]byte, error) {
+func (r *faultResponder) BuildTx(ctx context.Context, response types.Claim) ([]byte, error) {
 	if response.DefendsParent() {
 		txData, err := r.buildFaultDefendData(response.ParentContractIndex, response.ValueBytes())
 		if err != nil {
@@ -104,7 +104,7 @@ func (r *faultResponder) Resolve(ctx context.Context) error {
 }
 
 // Respond takes a [Claim] and executes the response action.
-func (r *faultResponder) Respond(ctx context.Context, response types2.Claim) error {
+func (r *faultResponder) Respond(ctx context.Context, response types.Claim) error {
 	txData, err := r.BuildTx(ctx, response)
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func (r *faultResponder) sendTxAndWait(ctx context.Context, txData []byte) error
 	if err != nil {
 		return err
 	}
-	if receipt.Status == types.ReceiptStatusFailed {
+	if receipt.Status == ethtypes.ReceiptStatusFailed {
 		r.log.Error("Responder tx successfully published but reverted", "tx_hash", receipt.TxHash)
 	} else {
 		r.log.Debug("Responder tx successfully published", "tx_hash", receipt.TxHash)
@@ -132,7 +132,7 @@ func (r *faultResponder) sendTxAndWait(ctx context.Context, txData []byte) error
 }
 
 // buildStepTxData creates the transaction data for the step function.
-func (r *faultResponder) buildStepTxData(stepData types2.StepCallData) ([]byte, error) {
+func (r *faultResponder) buildStepTxData(stepData types.StepCallData) ([]byte, error) {
 	return r.fdgAbi.Pack(
 		"step",
 		big.NewInt(int64(stepData.ClaimIndex)),
@@ -143,7 +143,7 @@ func (r *faultResponder) buildStepTxData(stepData types2.StepCallData) ([]byte, 
 }
 
 // Step accepts step data and executes the step on the fault dispute game contract.
-func (r *faultResponder) Step(ctx context.Context, stepData types2.StepCallData) error {
+func (r *faultResponder) Step(ctx context.Context, stepData types.StepCallData) error {
 	txData, err := r.buildStepTxData(stepData)
 	if err != nil {
 		return err

--- a/op-challenger/fault/responder_test.go
+++ b/op-challenger/fault/responder_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	types2 "github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/stretchr/testify/require"
@@ -31,12 +31,12 @@ type mockTxManager struct {
 	sendFails bool
 }
 
-func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*types.Receipt, error) {
+func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*ethtypes.Receipt, error) {
 	if m.sendFails {
 		return nil, mockSendError
 	}
 	m.sends++
-	return types.NewReceipt(
+	return ethtypes.NewReceipt(
 		[]byte{},
 		false,
 		0,
@@ -108,14 +108,14 @@ func TestResponder_Resolve_Success(t *testing.T) {
 // bubbles up the error returned by the [txmgr.Send] method.
 func TestResponder_Respond_SendFails(t *testing.T) {
 	responder, mockTxMgr := newTestFaultResponder(t, true)
-	err := responder.Respond(context.Background(), types2.Claim{
-		ClaimData: types2.ClaimData{
+	err := responder.Respond(context.Background(), types.Claim{
+		ClaimData: types.ClaimData{
 			Value:    common.Hash{0x01},
-			Position: types2.NewPositionFromGIndex(2),
+			Position: types.NewPositionFromGIndex(2),
 		},
-		Parent: types2.ClaimData{
+		Parent: types.ClaimData{
 			Value:    common.Hash{0x02},
-			Position: types2.NewPositionFromGIndex(1),
+			Position: types.NewPositionFromGIndex(1),
 		},
 		ContractIndex:       0,
 		ParentContractIndex: 0,
@@ -128,14 +128,14 @@ func TestResponder_Respond_SendFails(t *testing.T) {
 // succeeds when the tx candidate is successfully sent through the txmgr.
 func TestResponder_Respond_Success(t *testing.T) {
 	responder, mockTxMgr := newTestFaultResponder(t, false)
-	err := responder.Respond(context.Background(), types2.Claim{
-		ClaimData: types2.ClaimData{
+	err := responder.Respond(context.Background(), types.Claim{
+		ClaimData: types.ClaimData{
 			Value:    common.Hash{0x01},
-			Position: types2.NewPositionFromGIndex(2),
+			Position: types.NewPositionFromGIndex(2),
 		},
-		Parent: types2.ClaimData{
+		Parent: types.ClaimData{
 			Value:    common.Hash{0x02},
-			Position: types2.NewPositionFromGIndex(1),
+			Position: types.NewPositionFromGIndex(1),
 		},
 		ContractIndex:       0,
 		ParentContractIndex: 0,
@@ -148,14 +148,14 @@ func TestResponder_Respond_Success(t *testing.T) {
 // returns a tx candidate with the correct data for an attack tx.
 func TestResponder_BuildTx_Attack(t *testing.T) {
 	responder, _ := newTestFaultResponder(t, false)
-	responseClaim := types2.Claim{
-		ClaimData: types2.ClaimData{
+	responseClaim := types.Claim{
+		ClaimData: types.ClaimData{
 			Value:    common.Hash{0x01},
-			Position: types2.NewPositionFromGIndex(2),
+			Position: types.NewPositionFromGIndex(2),
 		},
-		Parent: types2.ClaimData{
+		Parent: types.ClaimData{
 			Value:    common.Hash{0x02},
-			Position: types2.NewPositionFromGIndex(1),
+			Position: types.NewPositionFromGIndex(1),
 		},
 		ContractIndex:       0,
 		ParentContractIndex: 7,
@@ -179,14 +179,14 @@ func TestResponder_BuildTx_Attack(t *testing.T) {
 // returns a tx candidate with the correct data for a defend tx.
 func TestResponder_BuildTx_Defend(t *testing.T) {
 	responder, _ := newTestFaultResponder(t, false)
-	responseClaim := types2.Claim{
-		ClaimData: types2.ClaimData{
+	responseClaim := types.Claim{
+		ClaimData: types.ClaimData{
 			Value:    common.Hash{0x01},
-			Position: types2.NewPositionFromGIndex(3),
+			Position: types.NewPositionFromGIndex(3),
 		},
-		Parent: types2.ClaimData{
+		Parent: types.ClaimData{
 			Value:    common.Hash{0x02},
-			Position: types2.NewPositionFromGIndex(6),
+			Position: types.NewPositionFromGIndex(6),
 		},
 		ContractIndex:       0,
 		ParentContractIndex: 7,


### PR DESCRIPTION
**Description**

This PR rips out non-critical suggestions from a review of #6413 in order to prevent blocking workflows.

Notice, unfortunately the `Set` method on `TraceType` is necessary in order to fully implement the `cli.Generic` interface.
