### PR TITLE
fix(op-challenger): Refactor AlphabetTraceProvider into a Module

### DIFF
--- a/op-challenger/fault/alphabet/provider.go
+++ b/op-challenger/fault/alphabet/provider.go
@@ -1,15 +1,17 @@
-package fault
+package alphabet
 
 import (
+	"errors"
 	"math/big"
 	"strings"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-var _ types.TraceProvider = (*AlphabetProvider)(nil)
+var (
+	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
+)
 
 // AlphabetProvider is a [TraceProvider] that provides claims for specific
 // indices in the given trace.
@@ -30,7 +32,7 @@ func NewAlphabetProvider(state string, depth uint64) *AlphabetProvider {
 func (ap *AlphabetProvider) GetPreimage(i uint64) ([]byte, []byte, error) {
 	// The index cannot be larger than the maximum index as computed by the depth.
 	if i >= ap.maxLen {
-		return nil, nil, types.ErrIndexTooLarge
+		return nil, nil, ErrIndexTooLarge
 	}
 	// We extend the deepest hash to the maximum depth if the trace is not expansive.
 	if i >= uint64(len(ap.state)) {

--- a/op-challenger/fault/alphabet/provider_test.go
+++ b/op-challenger/fault/alphabet/provider_test.go
@@ -1,10 +1,9 @@
-package fault
+package alphabet
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -72,7 +71,7 @@ func TestGetPreimage_Succeeds(t *testing.T) {
 func TestGetPreimage_TooLargeIndex_Fails(t *testing.T) {
 	ap := NewAlphabetProvider("abc", 2)
 	_, _, err := ap.GetPreimage(4)
-	require.ErrorIs(t, err, types.ErrIndexTooLarge)
+	require.ErrorIs(t, err, ErrIndexTooLarge)
 }
 
 // TestGet_Succeeds tests the Get function.
@@ -89,7 +88,7 @@ func TestGet_Succeeds(t *testing.T) {
 func TestGet_IndexTooLarge(t *testing.T) {
 	ap := NewAlphabetProvider("abc", 2)
 	_, err := ap.Get(4)
-	require.ErrorIs(t, err, types.ErrIndexTooLarge)
+	require.ErrorIs(t, err, ErrIndexTooLarge)
 }
 
 // TestGet_Extends tests the Get function with an index that is larger

--- a/op-challenger/fault/claimbuilder_test.go
+++ b/op-challenger/fault/claimbuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func NewClaimBuilder(t *testing.T, maxDepth int) *ClaimBuilder {
 	return &ClaimBuilder{
 		require:  require.New(t),
 		maxDepth: maxDepth,
-		correct:  &alphabetWithProofProvider{NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))},
+		correct:  &alphabetWithProofProvider{alphabet.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))},
 	}
 }
 
@@ -146,7 +147,7 @@ func (s *SequenceBuilder) Get() types.Claim {
 }
 
 type alphabetWithProofProvider struct {
-	*AlphabetProvider
+	*alphabet.AlphabetProvider
 }
 
 func (a *alphabetWithProofProvider) GetPreimage(i uint64) ([]byte, []byte, error) {

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/cannon"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -57,7 +58,7 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*se
 	case config.TraceTypeCannon:
 		trace = cannon.NewCannonTraceProvider(logger, cfg.CannonDatadir)
 	case config.TraceTypeAlphabet:
-		trace = NewAlphabetProvider(cfg.AlphabetTrace, uint64(cfg.GameDepth))
+		trace = alphabet.NewAlphabetProvider(cfg.AlphabetTrace, uint64(cfg.GameDepth))
 	default:
 		return nil, fmt.Errorf("unsupported trace type: %v", cfg.TraceType)
 	}

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -1,13 +1,7 @@
 package types
 
 import (
-	"errors"
-
 	"github.com/ethereum/go-ethereum/common"
-)
-
-var (
-	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
 )
 
 type GameStatus uint8

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/deployer"
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
-	"github.com/ethereum-optimism/optimism/op-challenger/fault"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-service/client/utils"
@@ -67,7 +67,7 @@ func NewFactoryHelper(t *testing.T, ctx context.Context, client *ethclient.Clien
 func (h *FactoryHelper) StartAlphabetGame(ctx context.Context, claimedAlphabet string) *FaultGameHelper {
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
-	trace := fault.NewAlphabetProvider(claimedAlphabet, 4)
+	trace := alphabet.NewAlphabetProvider(claimedAlphabet, 4)
 	rootClaim, err := trace.Get(lastAlphabetTraceIndex)
 	h.require.NoError(err)
 	tx, err := h.factory.Create(h.opts, faultGameType, rootClaim, alphaExtraData)


### PR DESCRIPTION
**Description**

This PR follows #6413 in its suggestion to refactor the `AlphabetTraceProvider`
into its own submodule, `op-challenger/fault/alphabet/`, as done with the
`CannonTraceProvider` in `fault/cannon/`.

Notes
- `alphabet_provider.go` is renamed to `provider.go` since alphabet is path-specified.
- `alphabet_provider_test.go` is also renamed to `provider_test.go`.
- The index too large error is pulled into the `alphabet` module as opposed to
  the parent `types/` module since it's, thus far, alphabet-provider specific
  and removes cyclical dependencies between `alphabet` and `fault` modules.

**Metadata**

Fixes CLI-4273
