### PR TITLE
dockerfile: ci-builder update

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -30,7 +30,7 @@ FROM ethereum/client-go:alltools-v1.10.25 as geth
 
 FROM ghcr.io/crytic/echidna/echidna:v2.0.4 as echidna-test
 
-FROM python:3.8.13-slim-bullseye
+FROM python:3.11.4-slim-bullseye
 
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
**Description**

Updates the version of python in the `ci-builder` package to a newer version of python 3. Without this change, the `bedrock-devnet` package will not run in `ci-builder`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
