### PR TITLE
fix(op-challenger): Refactor Solver Component into its own Module

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/solver"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -19,7 +20,7 @@ type Responder interface {
 }
 
 type Agent struct {
-	solver                  *Solver
+	solver                  *solver.Solver
 	loader                  Loader
 	responder               Responder
 	maxDepth                int
@@ -29,7 +30,7 @@ type Agent struct {
 
 func NewAgent(loader Loader, maxDepth int, trace types.TraceProvider, responder Responder, agreeWithProposedOutput bool, log log.Logger) *Agent {
 	return &Agent{
-		solver:                  NewSolver(maxDepth, trace),
+		solver:                  solver.NewSolver(maxDepth, trace),
 		loader:                  loader,
 		responder:               responder,
 		maxDepth:                maxDepth,
@@ -49,7 +50,7 @@ func (a *Agent) Act(ctx context.Context) error {
 	}
 	// Create counter claims
 	for _, claim := range game.Claims() {
-		if err := a.move(ctx, claim, game); err != nil && !errors.Is(err, ErrGameDepthReached) {
+		if err := a.move(ctx, claim, game); err != nil && !errors.Is(err, types.ErrGameDepthReached) {
 			log.Error("Failed to move", "err", err)
 		}
 	}

--- a/op-challenger/fault/solver/solver.go
+++ b/op-challenger/fault/solver/solver.go
@@ -1,4 +1,4 @@
-package fault
+package solver
 
 import (
 	"errors"
@@ -9,9 +9,8 @@ import (
 )
 
 var (
-	ErrGameDepthReached = errors.New("game depth reached")
-	ErrStepNonLeafNode  = errors.New("cannot step on non-leaf claims")
-	ErrStepAgreedClaim  = errors.New("cannot step on claims we agree with")
+	ErrStepNonLeafNode = errors.New("cannot step on non-leaf claims")
+	ErrStepAgreedClaim = errors.New("cannot step on claims we agree with")
 )
 
 // Solver uses a [TraceProvider] to determine the moves to make in a dispute game.
@@ -62,7 +61,7 @@ func (s *Solver) handleMiddle(claim types.Claim) (*types.Claim, error) {
 		return nil, err
 	}
 	if claim.Depth() == s.gameDepth {
-		return nil, ErrGameDepthReached
+		return nil, types.ErrGameDepthReached
 	}
 	if claimCorrect {
 		return s.defend(claim)

--- a/op-challenger/fault/test/alphabet.go
+++ b/op-challenger/fault/test/alphabet.go
@@ -3,16 +3,16 @@ package test
 import (
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/fault"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/alphabet"
 )
 
 func NewAlphabetClaimBuilder(t *testing.T, maxDepth int) *ClaimBuilder {
-	alphabetProvider := &alphabetWithProofProvider{fault.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))}
+	alphabetProvider := &alphabetWithProofProvider{alphabet.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))}
 	return NewClaimBuilder(t, maxDepth, alphabetProvider)
 }
 
 type alphabetWithProofProvider struct {
-	*fault.AlphabetProvider
+	*alphabet.AlphabetProvider
 }
 
 func (a *alphabetWithProofProvider) GetPreimage(i uint64) ([]byte, []byte, error) {

--- a/op-challenger/fault/test/alphabet.go
+++ b/op-challenger/fault/test/alphabet.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/fault"
+)
+
+func NewAlphabetClaimBuilder(t *testing.T, maxDepth int) *ClaimBuilder {
+	alphabetProvider := &alphabetWithProofProvider{fault.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))}
+	return NewClaimBuilder(t, maxDepth, alphabetProvider)
+}
+
+type alphabetWithProofProvider struct {
+	*fault.AlphabetProvider
+}
+
+func (a *alphabetWithProofProvider) GetPreimage(i uint64) ([]byte, []byte, error) {
+	preimage, _, err := a.AlphabetProvider.GetPreimage(i)
+	if err != nil {
+		return nil, nil, err
+	}
+	return preimage, []byte{byte(i)}, nil
+}

--- a/op-challenger/fault/test/claim_builder.go
+++ b/op-challenger/fault/test/claim_builder.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/fault/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -22,11 +21,7 @@ func NewClaimBuilder(t *testing.T, maxDepth int, provider types.TraceProvider) *
 	return &ClaimBuilder{
 		require:  require.New(t),
 		maxDepth: maxDepth,
-<<<<<<< HEAD:op-challenger/fault/claimbuilder_test.go
-		correct:  &alphabetWithProofProvider{alphabet.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))},
-=======
 		correct:  provider,
->>>>>>> 99df402dd (Solver module):op-challenger/fault/test/claim_builder.go
 	}
 }
 
@@ -114,54 +109,3 @@ func (c *ClaimBuilder) DefendClaim(claim types.Claim, correct bool) types.Claim 
 		Parent: claim.ClaimData,
 	}
 }
-<<<<<<< HEAD:op-challenger/fault/claimbuilder_test.go
-
-type SequenceBuilder struct {
-	builder   *ClaimBuilder
-	lastClaim types.Claim
-}
-
-// Seq starts building a claim by following a sequence of attack and defend moves from the root
-// The returned SequenceBuilder can be used to add additional moves. e.g:
-// claim := Seq(true).Attack(false).Attack(true).Defend(true).Get()
-func (c *ClaimBuilder) Seq(rootCorrect bool) *SequenceBuilder {
-	claim := c.CreateRootClaim(rootCorrect)
-	return &SequenceBuilder{
-		builder:   c,
-		lastClaim: claim,
-	}
-}
-
-func (s *SequenceBuilder) Attack(correct bool) *SequenceBuilder {
-	claim := s.builder.AttackClaim(s.lastClaim, correct)
-	return &SequenceBuilder{
-		builder:   s.builder,
-		lastClaim: claim,
-	}
-}
-
-func (s *SequenceBuilder) Defend(correct bool) *SequenceBuilder {
-	claim := s.builder.DefendClaim(s.lastClaim, correct)
-	return &SequenceBuilder{
-		builder:   s.builder,
-		lastClaim: claim,
-	}
-}
-
-func (s *SequenceBuilder) Get() types.Claim {
-	return s.lastClaim
-}
-
-type alphabetWithProofProvider struct {
-	*alphabet.AlphabetProvider
-}
-
-func (a *alphabetWithProofProvider) GetPreimage(i uint64) ([]byte, []byte, error) {
-	preimage, _, err := a.AlphabetProvider.GetPreimage(i)
-	if err != nil {
-		return nil, nil, err
-	}
-	return preimage, []byte{byte(i)}, nil
-}
-=======
->>>>>>> 99df402dd (Solver module):op-challenger/fault/test/claim_builder.go

--- a/op-challenger/fault/test/claim_builder.go
+++ b/op-challenger/fault/test/claim_builder.go
@@ -1,4 +1,4 @@
-package fault
+package test
 
 import (
 	"math/big"
@@ -17,11 +17,16 @@ type ClaimBuilder struct {
 	correct  types.TraceProvider
 }
 
-func NewClaimBuilder(t *testing.T, maxDepth int) *ClaimBuilder {
+// NewClaimBuilder creates a new [ClaimBuilder].
+func NewClaimBuilder(t *testing.T, maxDepth int, provider types.TraceProvider) *ClaimBuilder {
 	return &ClaimBuilder{
 		require:  require.New(t),
 		maxDepth: maxDepth,
+<<<<<<< HEAD:op-challenger/fault/claimbuilder_test.go
 		correct:  &alphabetWithProofProvider{alphabet.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth))},
+=======
+		correct:  provider,
+>>>>>>> 99df402dd (Solver module):op-challenger/fault/test/claim_builder.go
 	}
 }
 
@@ -109,6 +114,7 @@ func (c *ClaimBuilder) DefendClaim(claim types.Claim, correct bool) types.Claim 
 		Parent: claim.ClaimData,
 	}
 }
+<<<<<<< HEAD:op-challenger/fault/claimbuilder_test.go
 
 type SequenceBuilder struct {
 	builder   *ClaimBuilder
@@ -157,3 +163,5 @@ func (a *alphabetWithProofProvider) GetPreimage(i uint64) ([]byte, []byte, error
 	}
 	return preimage, []byte{byte(i)}, nil
 }
+=======
+>>>>>>> 99df402dd (Solver module):op-challenger/fault/test/claim_builder.go

--- a/op-challenger/fault/test/seq_builder.go
+++ b/op-challenger/fault/test/seq_builder.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+)
+
+type SequenceBuilder struct {
+	builder   *ClaimBuilder
+	lastClaim types.Claim
+}
+
+// Seq starts building a claim by following a sequence of attack and defend moves from the root
+// The returned SequenceBuilder can be used to add additional moves. e.g:
+// claim := Seq(true).Attack(false).Attack(true).Defend(true).Get()
+func (c *ClaimBuilder) Seq(rootCorrect bool) *SequenceBuilder {
+	claim := c.CreateRootClaim(rootCorrect)
+	return &SequenceBuilder{
+		builder:   c,
+		lastClaim: claim,
+	}
+}
+
+func (s *SequenceBuilder) Attack(correct bool) *SequenceBuilder {
+	claim := s.builder.AttackClaim(s.lastClaim, correct)
+	return &SequenceBuilder{
+		builder:   s.builder,
+		lastClaim: claim,
+	}
+}
+
+func (s *SequenceBuilder) Defend(correct bool) *SequenceBuilder {
+	claim := s.builder.DefendClaim(s.lastClaim, correct)
+	return &SequenceBuilder{
+		builder:   s.builder,
+		lastClaim: claim,
+	}
+}
+
+func (s *SequenceBuilder) Get() types.Claim {
+	return s.lastClaim
+}

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -4,6 +4,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+<<<<<<< HEAD
+=======
+var (
+	ErrIndexTooLarge    = errors.New("index is larger than the maximum index")
+	ErrGameDepthReached = errors.New("game depth reached")
+)
+
+>>>>>>> 99df402dd (Solver module)
 type GameStatus uint8
 
 const (

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -1,17 +1,15 @@
 package types
 
 import (
+	"errors"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
-<<<<<<< HEAD
-=======
 var (
-	ErrIndexTooLarge    = errors.New("index is larger than the maximum index")
 	ErrGameDepthReached = errors.New("game depth reached")
 )
 
->>>>>>> 99df402dd (Solver module)
 type GameStatus uint8
 
 const (


### PR DESCRIPTION
**Description**

Following #6413, this PR implements the suggested change to refactor
the `Solver` component into its own "submodule" within the `fault` module
of the `op-challenger`.

The core `Solver` logic is placed inside `fault/solver/solver.go`, with
alphabet tests inside `solver_test.go`.

In a pr stacked ontop of this, and still as part of CLI-4275, the solver
will be further refactored to separate out tightly coupled internal logic.

Once this logic is decoupled, the solver tests can be focussed onto unit
functions and a generic solver testing utility can be built that can be
typed with various `TraceProvider` instances (eg `AlphabetTraceProvider`
and `CannonTraceProvider`) and run in those fault module testbeds.

**Metadata**

Fixes CLI-4275.

