### PR TITLE
op-chain-ops: cleanup default gas limit

### DIFF
--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -15,8 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// defaultL2GasLimit represents the default gas limit for an L2 block.
-const defaultL2GasLimit = 30_000_000
+// defaultGasLimit represents the default gas limit for a genesis block.
+const defaultGasLimit = 30_000_000
 
 // BedrockTransitionBlockExtraData represents the default extra data for the bedrock transition block.
 var BedrockTransitionBlockExtraData = []byte("BEDROCK")
@@ -66,7 +66,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 
 	gasLimit := config.L2GenesisBlockGasLimit
 	if gasLimit == 0 {
-		gasLimit = defaultL2GasLimit
+		gasLimit = defaultGasLimit
 	}
 	baseFee := config.L2GenesisBlockBaseFeePerGas
 	if baseFee == nil {
@@ -144,7 +144,7 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 
 	gasLimit := config.L1GenesisBlockGasLimit
 	if gasLimit == 0 {
-		gasLimit = 15_000_000
+		gasLimit = defaultGasLimit
 	}
 	baseFee := config.L1GenesisBlockBaseFeePerGas
 	if baseFee == nil {

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -120,7 +120,7 @@ func BuildL1DeveloperGenesis(config *DeployConfig) (*core.Genesis, error) {
 	}
 	gasLimit := uint64(config.L2GenesisBlockGasLimit)
 	if gasLimit == 0 {
-		gasLimit = defaultL2GasLimit
+		gasLimit = defaultGasLimit
 	}
 
 	data, err = sysCfgABI.Pack(
@@ -298,7 +298,7 @@ func deployL1Contracts(config *DeployConfig, backend *backends.SimulatedBackend)
 	}
 	gasLimit := uint64(config.L2GenesisBlockGasLimit)
 	if gasLimit == 0 {
-		gasLimit = defaultL2GasLimit
+		gasLimit = defaultGasLimit
 	}
 
 	constructors = append(constructors, []deployer.Constructor{


### PR DESCRIPTION
**Description**

Use a single default value for when configuring the genesis value of the block gas limit for both L1 and L2 when it is not set in the deploy config. The value defaults to 30 million when it is not explicitly set.

This PR is slowly moving changes out of https://github.com/ethereum-optimism/optimism/pull/6123 into their own smaller PRs so that they can be merged in independently of the final functionality.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

