### PR TITLE
op-chain-ops: remove clique signer address from config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -77,7 +77,6 @@ type DeployConfig struct {
 	L1BlockTime                 uint64         `json:"l1BlockTime"`
 	L1GenesisBlockTimestamp     hexutil.Uint64 `json:"l1GenesisBlockTimestamp"`
 	L1GenesisBlockNonce         hexutil.Uint64 `json:"l1GenesisBlockNonce"`
-	CliqueSignerAddress         common.Address `json:"cliqueSignerAddress"` // proof of stake genesis if left zeroed.
 	L1GenesisBlockGasLimit      hexutil.Uint64 `json:"l1GenesisBlockGasLimit"`
 	L1GenesisBlockDifficulty    *hexutil.Big   `json:"l1GenesisBlockDifficulty"`
 	L1GenesisBlockMixHash       common.Hash    `json:"l1GenesisBlockMixHash"`

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
 

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -111,36 +111,26 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 	}
 
 	chainConfig := params.ChainConfig{
-		ChainID:             uint642Big(config.L1ChainID),
-		HomesteadBlock:      big.NewInt(0),
-		DAOForkBlock:        nil,
-		DAOForkSupport:      false,
-		EIP150Block:         big.NewInt(0),
-		EIP155Block:         big.NewInt(0),
-		EIP158Block:         big.NewInt(0),
-		ByzantiumBlock:      big.NewInt(0),
-		ConstantinopleBlock: big.NewInt(0),
-		PetersburgBlock:     big.NewInt(0),
-		IstanbulBlock:       big.NewInt(0),
-		MuirGlacierBlock:    big.NewInt(0),
-		BerlinBlock:         big.NewInt(0),
-		LondonBlock:         big.NewInt(0),
-		ArrowGlacierBlock:   big.NewInt(0),
-		GrayGlacierBlock:    big.NewInt(0),
-		ShanghaiTime:        u64ptr(0),
-	}
-
-	if config.CliqueSignerAddress != (common.Address{}) {
-		// warning: clique has an overly strict block header timestamp check against the system wallclock,
-		// causing blocks to get scheduled as "future block" and not get mined instantly when produced.
-		chainConfig.Clique = &params.CliqueConfig{
-			Period: config.L1BlockTime,
-			Epoch:  30000,
-		}
-	} else {
-		chainConfig.MergeNetsplitBlock = big.NewInt(0)
-		chainConfig.TerminalTotalDifficulty = big.NewInt(0)
-		chainConfig.TerminalTotalDifficultyPassed = true
+		ChainID:                       uint642Big(config.L1ChainID),
+		HomesteadBlock:                big.NewInt(0),
+		DAOForkBlock:                  nil,
+		DAOForkSupport:                false,
+		EIP150Block:                   big.NewInt(0),
+		EIP155Block:                   big.NewInt(0),
+		EIP158Block:                   big.NewInt(0),
+		ByzantiumBlock:                big.NewInt(0),
+		ConstantinopleBlock:           big.NewInt(0),
+		PetersburgBlock:               big.NewInt(0),
+		IstanbulBlock:                 big.NewInt(0),
+		MuirGlacierBlock:              big.NewInt(0),
+		BerlinBlock:                   big.NewInt(0),
+		LondonBlock:                   big.NewInt(0),
+		ArrowGlacierBlock:             big.NewInt(0),
+		GrayGlacierBlock:              big.NewInt(0),
+		ShanghaiTime:                  u64ptr(0),
+		MergeNetsplitBlock:            big.NewInt(0),
+		TerminalTotalDifficulty:       big.NewInt(0),
+		TerminalTotalDifficultyPassed: true,
 	}
 
 	gasLimit := config.L1GenesisBlockGasLimit
@@ -160,16 +150,11 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 		timestamp = hexutil.Uint64(time.Now().Unix())
 	}
 
-	extraData := make([]byte, 0)
-	if config.CliqueSignerAddress != (common.Address{}) {
-		extraData = append(append(make([]byte, 32), config.CliqueSignerAddress[:]...), make([]byte, crypto.SignatureLength)...)
-	}
-
 	return &core.Genesis{
 		Config:     &chainConfig,
 		Nonce:      uint64(config.L1GenesisBlockNonce),
 		Timestamp:  uint64(timestamp),
-		ExtraData:  extraData,
+		ExtraData:  make([]byte, 0),
 		GasLimit:   uint64(gasLimit),
 		Difficulty: difficulty.ToInt(),
 		Mixhash:    config.L1GenesisBlockMixHash,

--- a/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-devnet-l1.json
@@ -18,7 +18,6 @@
   "l2OutputOracleChallenger": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
 
   "l1BlockTime": 15,
-  "cliqueSignerAddress": "0xca062b0fd91172d89bcd4bb084ac4e21972cc467",
 
   "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",

--- a/op-chain-ops/genesis/testdata/test-deploy-config-full.json
+++ b/op-chain-ops/genesis/testdata/test-deploy-config-full.json
@@ -16,7 +16,6 @@
   "l2OutputOracleChallenger": "0x7770000000000000000000000000000000000002",
   "l1BlockTime": 15,
   "l1GenesisBlockNonce": "0x0",
-  "cliqueSignerAddress": "0x0000000000000000000000000000000000000000",
   "l1GenesisBlockGasLimit": "0x1c9c380",
   "l1GenesisBlockDifficulty": "0x1",
   "finalSystemOwner": "0x0000000000000000000000000000000000000111",

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -77,7 +77,6 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 
 		L1BlockTime:                 tp.L1BlockTime,
 		L1GenesisBlockNonce:         0,
-		CliqueSignerAddress:         common.Address{}, // proof of stake, no clique
 		L1GenesisBlockTimestamp:     hexutil.Uint64(time.Now().Unix()),
 		L1GenesisBlockGasLimit:      30_000_000,
 		L1GenesisBlockDifficulty:    uint64ToBig(1),
@@ -284,7 +283,6 @@ func ForkedDeployConfig(t require.TestingT, mnemonicCfg *MnemonicConfig, startBl
 		L2GenesisBlockBaseFeePerGas: uint64ToBig(0x3B9ACA00),
 		L2GenesisBlockDifficulty:    uint64ToBig(0),
 		L1BlockTime:                 12,
-		CliqueSignerAddress:         addrs.CliqueSigner,
 		FinalizationPeriodSeconds:   2,
 		DeploymentWaitConfirmations: 1,
 		EIP1559Elasticity:           10,

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -102,7 +102,6 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 
 		L1BlockTime:                 2,
 		L1GenesisBlockNonce:         4660,
-		CliqueSignerAddress:         common.Address{}, // op-e2e used to run Clique, but now uses fake Proof of Stake.
 		L1GenesisBlockTimestamp:     hexutil.Uint64(time.Now().Unix()),
 		L1GenesisBlockGasLimit:      30_000_000,
 		L1GenesisBlockDifficulty:    uint642big(1),

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -27,6 +27,10 @@ fi
 if [ ! -d "$GETH_CHAINDATA_DIR" ]; then
 	echo "$GETH_CHAINDATA_DIR missing, running init"
 	echo "Initializing genesis."
+	# Handle setting the clique config in the extra data
+	EXTRA_DATA="$BLOCK_SIGNER_ADDRESS""0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	jq -r --arg extraData "$EXTRA_DATA" '.extraData |= $extraData' | tee $GENESIS_FILE_PATH
+
 	geth --verbosity="$VERBOSITY" init \
 		--datadir="$GETH_DATA_DIR" \
 		"$GENESIS_FILE_PATH"

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -15,7 +15,6 @@
   "l2OutputOracleChallenger": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
   "l2GenesisBlockGasLimit": "0x1c9c380",
   "l1BlockTime": 3,
-  "cliqueSignerAddress": "0xca062b0fd91172d89bcd4bb084ac4e21972cc467",
   "baseFeeVaultRecipient": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "l1FeeVaultRecipient": "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
   "sequencerFeeVaultRecipient": "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",


### PR DESCRIPTION
**Description**

Having an alternate code path for using clique on L1 instead of fake pos only adds complexity. This commit removes the concept of the clique signer from the deploy config so that it cannot be misconfigured accidentally by setting the value.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
