### PR TITLE
op-e2e: faster failures on bad genesis

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 )
@@ -215,6 +216,9 @@ func (s *L2Verifier) ActL2PipelineStep(t Testing) {
 		return
 	} else if err != nil && errors.Is(err, derive.ErrTemporary) {
 		s.log.Warn("Derivation process temporary error", "err", err)
+		if errors.Is(err, sync.WrongChainErr) { // action-tests don't back off on temporary errors. Avoid a bad genesis setup from looping.
+			t.Fatalf("genesis setup issue: %v", err)
+		}
 		return
 	} else if err != nil && errors.Is(err, derive.ErrCritical) {
 		t.Fatalf("derivation failed critically: %v", err)


### PR DESCRIPTION
**Description**

Ensures that a bad genesis generation is caught quickly. Prevents an infinite loops that bricks a computer. This is a small part of https://github.com/ethereum-optimism/optimism/pull/6123

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

