### PR TITLE
op-e2e: sanity checks for config

### DIFF
--- a/op-e2e/actions/l1_miner.go
+++ b/op-e2e/actions/l1_miner.go
@@ -109,7 +109,7 @@ func (s *L1Miner) ActL1IncludeTx(from common.Address) Action {
 func (s *L1Miner) IncludeTx(t Testing, tx *types.Transaction) {
 	from, err := s.l1Signer.Sender(tx)
 	require.NoError(t, err)
-	s.log.Info("including tx", "nonce", tx.Nonce(), "from", from)
+	s.log.Info("including tx", "nonce", tx.Nonce(), "from", from, "to", tx.To())
 	if tx.Gas() > s.l1BuildingHeader.GasLimit {
 		t.Fatalf("tx consumes %d gas, more than available in L1 block %d", tx.Gas(), s.l1BuildingHeader.GasLimit)
 	}

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -15,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer"
@@ -31,6 +33,7 @@ type L2Proposer struct {
 	log          log.Logger
 	l1           *ethclient.Client
 	driver       *proposer.L2OutputSubmitter
+	contract     *bindings.L2OutputOracleCaller
 	address      common.Address
 	privKey      *ecdsa.PrivateKey
 	contractAddr common.Address
@@ -55,7 +58,6 @@ func (f fakeTxMgr) Send(_ context.Context, _ txmgr.TxCandidate) (*types.Receipt,
 }
 
 func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {
-
 	proposerCfg := proposer.Config{
 		L2OutputOracleAddr: cfg.OutputOracleAddr,
 		PollInterval:       time.Second,
@@ -69,12 +71,20 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 
 	dr, err := proposer.NewL2OutputSubmitter(proposerCfg, log, metrics.NoopMetrics)
 	require.NoError(t, err)
+	contract, err := bindings.NewL2OutputOracleCaller(cfg.OutputOracleAddr, l1)
+	require.NoError(t, err)
+
+	address := crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey)
+	proposer, err := contract.PROPOSER(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Equal(t, proposer, address, "PROPOSER must be the proposer's address")
 
 	return &L2Proposer{
 		log:          log,
 		l1:           l1,
 		driver:       dr,
-		address:      crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey),
+		contract:     contract,
+		address:      address,
 		privKey:      cfg.ProposerKey,
 		contractAddr: cfg.OutputOracleAddr,
 	}

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -231,6 +231,11 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		SystemConfigProxy:           predeploys.DevSystemConfigAddr,
 	}
 
+	// Sanity check that the config is correct
+	require.Equal(t, deployParams.Secrets.Addresses().Batcher, deployParams.DeployConfig.BatchSenderAddress)
+	require.Equal(t, deployParams.Secrets.Addresses().SequencerP2P, deployParams.DeployConfig.P2PSequencerAddress)
+	require.Equal(t, deployParams.Secrets.Addresses().Proposer, deployParams.DeployConfig.L2OutputOracleProposer)
+
 	return &SetupData{
 		L1Cfg:         l1Genesis,
 		L2Cfg:         l2Genesis,


### PR DESCRIPTION
**Description**

Adds some additional sanity checks to `op-e2e` that makes later modifications easier. Assertions that the config values are correct are added.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
