### PR TITLE
feat(op-service): DialEthClientWithRetry

### DIFF
--- a/indexer/services/l1/bridge/eth_bridge.go
+++ b/indexer/services/l1/bridge/eth_bridge.go
@@ -28,11 +28,8 @@ func (e *EthBridge) GetDepositsByBlockRange(ctx context.Context, start, end uint
 		End:     &end,
 	}
 
-	var iter *bindings.L1StandardBridgeETHDepositInitiatedIterator
-	err := backoff.Do(3, backoff.Exponential(), func() error {
-		var err error
-		iter, err = e.contract.FilterETHDepositInitiated(opts, nil, nil)
-		return err
+	iter, err := backoff.DoResult(3, backoff.Exponential(), func() (*bindings.L1StandardBridgeETHDepositInitiatedIterator, error) {
+		return e.contract.FilterETHDepositInitiated(opts, nil, nil)
 	})
 	if err != nil {
 		return nil, err

--- a/indexer/services/l1/bridge/portal.go
+++ b/indexer/services/l1/bridge/portal.go
@@ -37,11 +37,8 @@ func (p *Portal) GetProvenWithdrawalsByBlockRange(ctx context.Context, start, en
 		End:     &end,
 	}
 
-	var iter *bindings.OptimismPortalWithdrawalProvenIterator
-	err := backoff.Do(3, backoff.Exponential(), func() error {
-		var err error
-		iter, err = p.contract.FilterWithdrawalProven(opts, nil, nil, nil)
-		return err
+	iter, err := backoff.DoResult(3, backoff.Exponential(), func() (*bindings.OptimismPortalWithdrawalProvenIterator, error) {
+		return p.contract.FilterWithdrawalProven(opts, nil, nil, nil)
 	})
 	if err != nil {
 		return nil, err
@@ -71,11 +68,8 @@ func (p *Portal) GetFinalizedWithdrawalsByBlockRange(ctx context.Context, start,
 		End:     &end,
 	}
 
-	var iter *bindings.OptimismPortalWithdrawalFinalizedIterator
-	err := backoff.Do(3, backoff.Exponential(), func() error {
-		var err error
-		iter, err = p.contract.FilterWithdrawalFinalized(opts, nil)
-		return err
+	iter, err := backoff.DoResult(3, backoff.Exponential(), func() (*bindings.OptimismPortalWithdrawalFinalizedIterator, error) {
+		return p.contract.FilterWithdrawalFinalized(opts, nil)
 	})
 	if err != nil {
 		return nil, err

--- a/indexer/services/l1/bridge/standard_bridge.go
+++ b/indexer/services/l1/bridge/standard_bridge.go
@@ -28,11 +28,8 @@ func (s *StandardBridge) GetDepositsByBlockRange(ctx context.Context, start, end
 		End:     &end,
 	}
 
-	var iter *bindings.L1StandardBridgeERC20DepositInitiatedIterator
-	err := backoff.Do(3, backoff.Exponential(), func() error {
-		var err error
-		iter, err = s.contract.FilterERC20DepositInitiated(opts, nil, nil, nil)
-		return err
+	iter, err := backoff.DoResult(3, backoff.Exponential(), func() (*bindings.L1StandardBridgeERC20DepositInitiatedIterator, error) {
+		return s.contract.FilterERC20DepositInitiated(opts, nil, nil, nil)
 	})
 	if err != nil {
 		return nil, err

--- a/indexer/services/l2/bridge/standard_bridge.go
+++ b/indexer/services/l2/bridge/standard_bridge.go
@@ -35,11 +35,8 @@ func (s *StandardBridge) GetWithdrawalsByBlockRange(ctx context.Context, start, 
 		End:     &end,
 	}
 
-	var iter *bindings.L2StandardBridgeWithdrawalInitiatedIterator
-	err := backoff.Do(3, backoff.Exponential(), func() error {
-		var err error
-		iter, err = s.l2SB.FilterWithdrawalInitiated(opts, nil, nil, nil)
-		return err
+	iter, err := backoff.DoResult(3, backoff.Exponential(), func() (*bindings.L2StandardBridgeWithdrawalInitiatedIterator, error) {
+		return s.l2SB.FilterWithdrawalInitiated(opts, nil, nil, nil)
 	})
 	if err != nil {
 		return nil, err

--- a/indexer/services/query/headers.go
+++ b/indexer/services/query/headers.go
@@ -10,11 +10,7 @@ import (
 
 // HeaderByNumberWithRetry retries getting headers.
 func HeaderByNumberWithRetry(ctx context.Context, client *ethclient.Client) (*types.Header, error) {
-	var res *types.Header
-	err := backoff.DoCtx(ctx, 3, backoff.Exponential(), func() error {
-		var err error
-		res, err = client.HeaderByNumber(ctx, nil)
-		return err
+	return backoff.DoResultCtx(ctx, 3, backoff.Exponential(), func() (*types.Header, error) {
+		return client.HeaderByNumber(ctx, nil)
 	})
-	return res, err
 }

--- a/op-node/client/rpc.go
+++ b/op-node/client/rpc.go
@@ -102,17 +102,15 @@ func NewRPC(ctx context.Context, lgr log.Logger, addr string, opts ...RPCOption)
 // Dials a JSON-RPC endpoint repeatedly, with a backoff, until a client connection is established. Auth is optional.
 func dialRPCClientWithBackoff(ctx context.Context, log log.Logger, addr string, attempts int, opts ...rpc.ClientOption) (*rpc.Client, error) {
 	bOff := backoff.Exponential()
-	var ret *rpc.Client
-	err := backoff.DoCtx(ctx, attempts, bOff, func() error {
+	ret, err := backoff.DoResultCtx(ctx, attempts, bOff, func() (*rpc.Client, error) {
 		client, err := rpc.DialOptions(ctx, addr, opts...)
 		if err != nil {
 			if client == nil {
-				return fmt.Errorf("failed to dial address (%s): %w", addr, err)
+				return nil, fmt.Errorf("failed to dial address (%s): %w", addr, err)
 			}
 			log.Warn("failed to dial address, but may connect later", "addr", addr, "err", err)
 		}
-		ret = client
-		return nil
+		return client, nil
 	})
 	if err != nil {
 		return nil, err

--- a/op-node/sources/sync_client.go
+++ b/op-node/sources/sync_client.go
@@ -142,12 +142,12 @@ func (s *SyncClient) eventLoop() {
 			s.log.Debug("Shutting down RPC sync worker")
 			return
 		case reqNum := <-s.requests:
-			err := backoff.DoCtx(s.resCtx, 5, backoffStrategy, func() error {
+			err := backoff.DoCtx(s.resCtx, 5, backoffStrategy, func() (any, error) {
 				// Limit the maximum time for fetching payloads
 				ctx, cancel := context.WithTimeout(s.resCtx, time.Second*10)
 				defer cancel()
 				// We are only fetching one block at a time here.
-				return s.fetchUnsafeBlockFromRpc(ctx, reqNum)
+				return nil, s.fetchUnsafeBlockFromRpc(ctx, reqNum)
 			})
 			if err != nil {
 				if err == s.resCtx.Err() {

--- a/op-program/host/prefetcher/retry.go
+++ b/op-program/host/prefetcher/retry.go
@@ -29,14 +29,14 @@ func NewRetryingL1Source(logger log.Logger, source L1Source) *RetryingL1Source {
 
 func (s *RetryingL1Source) InfoByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, error) {
 	var info eth.BlockInfo
-	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() error {
+	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() (any, error) {
 		res, err := s.source.InfoByHash(ctx, blockHash)
 		if err != nil {
 			s.logger.Warn("Failed to retrieve info", "hash", blockHash, "err", err)
-			return err
+			return nil, err
 		}
 		info = res
-		return nil
+		return nil, nil
 	})
 	return info, err
 }
@@ -44,15 +44,15 @@ func (s *RetryingL1Source) InfoByHash(ctx context.Context, blockHash common.Hash
 func (s *RetryingL1Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	var info eth.BlockInfo
 	var txs types.Transactions
-	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() error {
+	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() (any, error) {
 		i, t, err := s.source.InfoAndTxsByHash(ctx, blockHash)
 		if err != nil {
 			s.logger.Warn("Failed to retrieve l1 info and txs", "hash", blockHash, "err", err)
-			return err
+			return nil, err
 		}
 		info = i
 		txs = t
-		return nil
+		return nil, nil
 	})
 	return info, txs, err
 }
@@ -60,15 +60,15 @@ func (s *RetryingL1Source) InfoAndTxsByHash(ctx context.Context, blockHash commo
 func (s *RetryingL1Source) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	var info eth.BlockInfo
 	var rcpts types.Receipts
-	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() error {
+	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() (any, error) {
 		i, r, err := s.source.FetchReceipts(ctx, blockHash)
 		if err != nil {
 			s.logger.Warn("Failed to fetch receipts", "hash", blockHash, "err", err)
-			return err
+			return nil, err
 		}
 		info = i
 		rcpts = r
-		return nil
+		return nil, nil
 	})
 	return info, rcpts, err
 }
@@ -84,43 +84,43 @@ type RetryingL2Source struct {
 func (s *RetryingL2Source) InfoAndTxsByHash(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	var info eth.BlockInfo
 	var txs types.Transactions
-	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() error {
+	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() (any, error) {
 		i, t, err := s.source.InfoAndTxsByHash(ctx, blockHash)
 		if err != nil {
 			s.logger.Warn("Failed to retrieve l2 info and txs", "hash", blockHash, "err", err)
-			return err
+			return nil, err
 		}
 		info = i
 		txs = t
-		return nil
+		return nil, nil
 	})
 	return info, txs, err
 }
 
 func (s *RetryingL2Source) NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	var node []byte
-	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() error {
+	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() (any, error) {
 		n, err := s.source.NodeByHash(ctx, hash)
 		if err != nil {
 			s.logger.Warn("Failed to retrieve node", "hash", hash, "err", err)
-			return err
+			return nil, err
 		}
 		node = n
-		return nil
+		return nil, nil
 	})
 	return node, err
 }
 
 func (s *RetryingL2Source) CodeByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
 	var code []byte
-	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() error {
+	err := backoff.DoCtx(ctx, maxAttempts, s.strategy, func() (any, error) {
 		c, err := s.source.CodeByHash(ctx, hash)
 		if err != nil {
 			s.logger.Warn("Failed to retrieve code", "hash", hash, "err", err)
-			return err
+			return nil, err
 		}
 		code = c
-		return nil
+		return nil, nil
 	})
 	return code, err
 }

--- a/op-service/backoff/operation_test.go
+++ b/op-service/backoff/operation_test.go
@@ -14,21 +14,49 @@ func TestDo(t *testing.T) {
 
 	start := time.Now()
 	var i int
-	require.NoError(t, Do(2, strategy, func() error {
+	require.NoError(t, Do(2, strategy, func() (any, error) {
 		if i == 1 {
-			return nil
+			return nil, nil
 		}
 
 		i++
-		return dummyErr
+		return nil, dummyErr
 	}))
 	require.True(t, time.Since(start) > 10*time.Millisecond)
 
 	start = time.Now()
 	// add one because the first attempt counts
-	err := Do(3, strategy, func() error {
-		return dummyErr
+	err := Do(3, strategy, func() (any, error) {
+		return nil, dummyErr
 	})
+	require.Equal(t, dummyErr, err.(*ErrFailedPermanently).LastErr)
+	require.True(t, time.Since(start) > 20*time.Millisecond)
+}
+
+func TestDoResult(t *testing.T) {
+	strategy := Fixed(10 * time.Millisecond)
+	dummyErr := errors.New("explode")
+
+	start := time.Now()
+	var i int
+	res, err := DoResult(2, strategy, func() (int, error) {
+		if i == 1 {
+			return i, nil
+		}
+
+		i++
+		return i, dummyErr
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res)
+	require.True(t, time.Since(start) > 10*time.Millisecond)
+
+	start = time.Now()
+	// add one because the first attempt counts
+	anyValue, err := DoResult(3, strategy, func() (any, error) {
+		return nil, dummyErr
+	})
+	require.Nil(t, anyValue)
 	require.Equal(t, dummyErr, err.(*ErrFailedPermanently).LastErr)
 	require.True(t, time.Since(start) > 20*time.Millisecond)
 }

--- a/op-service/client/ethclient.go
+++ b/op-service/client/ethclient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/backoff"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -15,4 +16,18 @@ func DialEthClientWithTimeout(ctx context.Context, url string, timeout time.Dura
 	defer cancel()
 
 	return ethclient.DialContext(ctxt, url)
+}
+
+// DialEthClientWithRetry attempts to dial the L1 provider using the provided
+// URL. If the dial fails, this method will retry the dial every interval seconds
+// until the context is timed out.
+func DialEthClientWithRetry(ctx context.Context, url string, strategy backoff.Strategy, maxAttempts int, timeout time.Duration) (*ethclient.Client, error) {
+	operation := func() (*ethclient.Client, error) {
+		ctxt, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		return ethclient.DialContext(ctxt, url)
+	}
+
+	return backoff.DoResult(maxAttempts, strategy, operation)
 }


### PR DESCRIPTION
**Description**

Implements a method called `DialEthClientWithRetry` as well as a new generic
`ReturnOperation` that allows the challenger and other services to dial an
eth client with retries and a specified backoff strategy.

This makes dialing eth clients more robust in the case of a networking error
or cosmic rays.

Modifications to the challenger's eth client dialing are stacked ontop of this
PR for concern separation.
