### PR TITLE
feat(op-challenger): Responder Preimage Oracle Data Population

### DIFF
--- a/op-challenger/fault/agent.go
+++ b/op-challenger/fault/agent.go
@@ -17,6 +17,7 @@ type Responder interface {
 	Resolve(ctx context.Context) error
 	Respond(ctx context.Context, response types.Claim) error
 	Step(ctx context.Context, stepData types.StepCallData) error
+	PopulateOracleData(ctx context.Context, data types.PreimageOracleData) error
 }
 
 type Agent struct {
@@ -131,6 +132,18 @@ func (a *Agent) step(ctx context.Context, claim types.Claim, game types.Game) er
 		a.log.Debug("Step already executed against claim", "depth", claim.Depth(), "index_at_depth", claim.IndexAtDepth(), "value", claim.Value)
 		return nil
 	}
+
+	// Uncomment these lines once the oracle loading is ready.
+	// oracleData, err := a.solver.OracleData(claim)
+	// if err != nil {
+	// 	a.log.Debug("Failed to get oracle data", "err", err)
+	// 	return nil
+	// }
+	//
+	// a.log.Info("Loading oracle data", "oracleKey", oracleData.OracleKey, "oracleData", oracleData.OracleData)
+	// if a.responder.LoadOracleData(ctx, oracleData) != nil {
+	// 	return fmt.Errorf("load oracle data: %w", err)
+	// }
 
 	a.log.Info("Attempting step", "claim_depth", claim.Depth(), "maxDepth", a.maxDepth)
 	step, err := a.solver.AttemptStep(ctx, claim, agreeWithClaimLevel)

--- a/op-challenger/fault/responder.go
+++ b/op-challenger/fault/responder.go
@@ -2,6 +2,7 @@ package fault
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
@@ -77,6 +78,52 @@ func (r *faultResponder) BuildTx(ctx context.Context, response types.Claim) ([]b
 		}
 		return txData, nil
 	}
+}
+
+// PopulateOracleData uploads the preimage oracle data into the onchain preimage oracle contract.
+func (r *faultResponder) PopulateOracleData(ctx context.Context, data types.PreimageOracleData) error {
+	var txData []byte
+	var err error
+	if data.IsLocal {
+		txData, err = r.buildLocalOracleData(data)
+		if err != nil {
+			return fmt.Errorf("local oracle tx data build: %w", err)
+		}
+	} else {
+		txData, err = r.buildGlobalOracleData(data)
+		if err != nil {
+			return fmt.Errorf("global oracle tx data build: %w", err)
+		}
+	}
+	return r.sendTxAndWait(ctx, txData)
+}
+
+// buildLocalOracleData takes the local preimage key and data
+// and creates tx data to load the key, data pair into the
+// PreimageOracle contract from the FaultDisputeGame contract call.
+//
+// Encoded call to: addLocalData(uint256 _ident, uint256 _partOffset) external
+func (r *faultResponder) buildLocalOracleData(data types.PreimageOracleData) ([]byte, error) {
+	// return r.fdgAbi.Pack(
+	// 	"addLocalData",
+	//  data.OracleKey,
+	// 	big.NewInt(0),
+	// )
+	panic("not implemented")
+}
+
+// buildGlobalOracleData takes the global preimage key and data
+// and creates tx data to load the key, data pair into the
+// PreimageOracle contract.
+//
+// Encoded call to: loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external
+func (r *faultResponder) buildGlobalOracleData(data types.PreimageOracleData) ([]byte, error) {
+	// return r.oracleAbi.Pack(
+	// 	"loadKeccak256PreimagePart",
+	// 	big.NewInt(0),
+	// 	data.OracleData,
+	// )
+	panic("not implemented")
 }
 
 // CanResolve determines if the resolve function on the fault dispute game contract

--- a/op-challenger/fault/responder.go
+++ b/op-challenger/fault/responder.go
@@ -24,19 +24,28 @@ type faultResponder struct {
 
 	fdgAddr common.Address
 	fdgAbi  *abi.ABI
+
+	preimageOracleAddr common.Address
+	preimageOracleAbi  *abi.ABI
 }
 
 // NewFaultResponder returns a new [faultResponder].
-func NewFaultResponder(logger log.Logger, txManagr txmgr.TxManager, fdgAddr common.Address) (*faultResponder, error) {
+func NewFaultResponder(logger log.Logger, txManagr txmgr.TxManager, fdgAddr common.Address, preimageOracleAddr common.Address) (*faultResponder, error) {
 	fdgAbi, err := bindings.FaultDisputeGameMetaData.GetAbi()
 	if err != nil {
 		return nil, err
 	}
+	preimageOracleAbi, err := bindings.PreimageOracleMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
 	return &faultResponder{
-		log:     logger,
-		txMgr:   txManagr,
-		fdgAddr: fdgAddr,
-		fdgAbi:  fdgAbi,
+		log:                logger,
+		txMgr:              txManagr,
+		fdgAddr:            fdgAddr,
+		fdgAbi:             fdgAbi,
+		preimageOracleAddr: preimageOracleAddr,
+		preimageOracleAbi:  preimageOracleAbi,
 	}, nil
 }
 
@@ -104,12 +113,11 @@ func (r *faultResponder) PopulateOracleData(ctx context.Context, data types.Prei
 //
 // Encoded call to: addLocalData(uint256 _ident, uint256 _partOffset) external
 func (r *faultResponder) buildLocalOracleData(data types.PreimageOracleData) ([]byte, error) {
-	// return r.fdgAbi.Pack(
-	// 	"addLocalData",
-	//  data.OracleKey,
-	// 	big.NewInt(0),
-	// )
-	panic("not implemented")
+	return r.fdgAbi.Pack(
+		"addLocalData",
+		data.OracleKey,
+		big.NewInt(0),
+	)
 }
 
 // buildGlobalOracleData takes the global preimage key and data
@@ -118,11 +126,11 @@ func (r *faultResponder) buildLocalOracleData(data types.PreimageOracleData) ([]
 //
 // Encoded call to: loadKeccak256PreimagePart(uint256 _partOffset, bytes calldata _preimage) external
 func (r *faultResponder) buildGlobalOracleData(data types.PreimageOracleData) ([]byte, error) {
-	// return r.oracleAbi.Pack(
-	// 	"loadKeccak256PreimagePart",
-	// 	big.NewInt(0),
-	// 	data.OracleData,
-	// )
+	return r.preimageOracleAbi.Pack(
+		"loadKeccak256PreimagePart",
+		big.NewInt(0),
+		data.OracleData,
+	)
 	panic("not implemented")
 }
 

--- a/op-challenger/fault/responder.go
+++ b/op-challenger/fault/responder.go
@@ -131,7 +131,6 @@ func (r *faultResponder) buildGlobalOracleData(data types.PreimageOracleData) ([
 		big.NewInt(0),
 		data.OracleData,
 	)
-	panic("not implemented")
 }
 
 // CanResolve determines if the resolve function on the fault dispute game contract

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -22,9 +23,25 @@ const (
 // PreimageOracleData encapsulates the preimage oracle data
 // to load into the onchain oracle.
 type PreimageOracleData struct {
-	IsLocal    bool
-	OracleKey  []byte
-	OracleData []byte
+	IsLocal      bool
+	OracleKey    []byte
+	OracleData   []byte
+	OracleOffset *big.Int
+}
+
+// GetIdent returns the ident for the preimage oracle data.
+func (p *PreimageOracleData) GetIdent() *big.Int {
+	return big.NewInt(int64(p.OracleData[0]))
+}
+
+// GetPartOffset returns the part offset for the preimage oracle data.
+func (p *PreimageOracleData) GetPartOffset() *big.Int {
+	panic("part offset not implemented")
+}
+
+// GetPreimage returns the preimage data.
+func (p *PreimageOracleData) GetPreimage() []byte {
+	return p.OracleData
 }
 
 // NewPreimageOracleData creates a new [PreimageOracleData] instance.


### PR DESCRIPTION
**Description**

This PR implements the methods to populate onchain preimage oracle with
local and global key-value preimage data.

Right now, data packing methods are stubbed out since this PR is blocked
by having the updated `FaultDisputeGame` and `PreimageOracle` contract 
abis in order to pack the transaction data. This is implemented in PR
#6373 which is a blocker for this to be implemented.

**Tests**

Missing tests right now since methods are stubs.

**Metadata**

Fixes CLI-4243
