### PR TITLE
txmgr: Increase default network timeout to 10s

### DIFF
--- a/op-service/txmgr/cli.go
+++ b/op-service/txmgr/cli.go
@@ -52,7 +52,7 @@ var (
 	defaultNumConfirmations          = uint64(10)
 	defaultSafeAbortNonceTooLowCount = uint64(3)
 	defaultResubmissionTimeout       = 48 * time.Second
-	defaultNetworkTimeout            = 2 * time.Second
+	defaultNetworkTimeout            = 10 * time.Second
 	defaultTxSendTimeout             = 0 * time.Second
 	defaultTxNotInMempoolTimeout     = 2 * time.Minute
 	defaultReceiptQueryInterval      = 12 * time.Second


### PR DESCRIPTION
**Description**

Increase the default network timeout for transaction manager from 2s to 10s. Having requests time out too soon results in an increased failure rate and then the request is just retried, increasing load on the server and increasing chances of another time out.