### PR TITLE
contracts-bedrock: delete dead config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -28,7 +28,6 @@
   "proxyAdminOwner": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "finalSystemOwner": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
   "portalGuardian": "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
-  "controller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "finalizationPeriodSeconds": 2,
   "deploymentWaitConfirmations": 1,
   "fundDevAccounts": true,

--- a/packages/contracts-bedrock/deploy-config/getting-started.json
+++ b/packages/contracts-bedrock/deploy-config/getting-started.json
@@ -3,7 +3,6 @@
 
   "finalSystemOwner": "ADMIN",
   "portalGuardian": "ADMIN",
-  "controller": "ADMIN",
 
   "l1StartingBlockTag": "BLOCKHASH",
 

--- a/packages/contracts-bedrock/deploy-config/goerli.json
+++ b/packages/contracts-bedrock/deploy-config/goerli.json
@@ -3,7 +3,6 @@
 
   "finalSystemOwner": "0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f",
   "portalGuardian": "0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f",
-  "controller": "0xBc1233d0C3e6B5d53Ab455cF65A6623F6dCd7e4f",
 
   "l1StartingBlockTag": "0x6ffc1bf3754c01f6bb9fe057c1578b87a8571ce2e9be5ca14bace6eccfd336c7",
 

--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -1,7 +1,6 @@
 {
   "finalSystemOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "portalGuardian": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
-  "controller": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "proxyAdminOwner": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
   "l1StartingBlockTag": "earliest",
   "l1ChainID": 900,

--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -1,6 +1,5 @@
 {
   "finalSystemOwner": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
-  "controller": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "portalGuardian": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "l1StartingBlockTag": "0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108",
   "l1ChainID": 1,

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -14,7 +14,6 @@ contract DeployConfig is Script {
     string internal _json;
 
     address public finalSystemOwner;
-    address public controller;
     address public portalGuardian;
     uint256 public l1ChainID;
     uint256 public l2ChainID;
@@ -58,7 +57,6 @@ contract DeployConfig is Script {
         }
 
         finalSystemOwner = stdJson.readAddress(_json, "$.finalSystemOwner");
-        controller = stdJson.readAddress(_json, "$.controller");
         portalGuardian = stdJson.readAddress(_json, "$.portalGuardian");
         l1ChainID = stdJson.readUint(_json, "$.l1ChainID");
         l2ChainID = stdJson.readUint(_json, "$.l2ChainID");


### PR DESCRIPTION
**Description**

The `controller` value does nothing as part of
the deployment process. It existed as part of
the upgrade process, no chains will need upgrades
anymore and the modern deploy scripts do not use
it.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

