### PR TITLE
monorepo: add dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/ops-bedrock"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+  - package-ecosystem: npm
+    directory: "/packages/chain-mon"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+  - package-ecosystem: npm
+    directory: "/packages/core-utils"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+  - package-ecosystem: npm
+    directory: "/packages/contracts-ts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+  - package-ecosystem: npm
+    directory: "/packages/sdk"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+  - package-ecosystem: npm
+    directory: "/packages/fee-estimation"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+  - package-ecosystem: npm
+    directory: "/packages/common-ts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependabot


### PR DESCRIPTION
**Description**

Adds a dependabot.yml file from https://github.com/celestiaorg/optimism/blob/celestia-develop/.github/dependabot.yml

Based on conversation in https://github.com/ethereum-optimism/optimism/issues/5764

Co-authored-by: mjsevey@gmail.com

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

