### PR TITLE
ci: Remove legacy labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,0 @@
----
-C-Protocol-Critical:
-  - 'packages/contracts-bedrock/**/*.sol'

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,18 +13,6 @@ pull_request_rules:
         - "label!=multiple-reviewers"
         - "label!=mergify-ignore"
         - "base=develop"
-        - or:
-          - and:
-            - "label!=SR-Risk"
-            - "label!=C-Protocol-Critical"
-          - and:
-            - "label=SR-Risk"
-            - "approved-reviews-by=maurelian"
-          - and:
-            - "label=C-Protocol-Critical"
-            - or:
-              - "approved-reviews-by=tynes"
-              - "approved-reviews-by=smartcontracts"
     actions:
       queue:
         name: default
@@ -47,28 +35,6 @@ pull_request_rules:
       label:
         remove:
           - on-merge-train
-  - name: Handle security critical PRs
-    conditions:
-      - "label=SR-Risk"
-    actions:
-      request_reviews:
-        users:
-          - "maurelian"
-      comment:
-        message: |
-          Hey there @{{author}}! You flagged this PR as security critical. To make review easier, please add a comment describing
-
-          1. The risks present in this PR.
-          2. The mitigations you have added to try and reduce those risks.
-  - name: Request protocol critical reviewers
-    conditions:
-      - label=C-Protocol-Critical
-    actions:
-      request_reviews:
-        users:
-          - tynes
-          - smartcontracts
-        random_count: 1
   - name: Ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
In the past, we used the `SR-Risk` and `C-Protocol-Critical` labels to require specific engineers to review PRs touching sensitive code:

- `SR-Risk` would tag @maurelian whenever legacy mainnet smart contracts were touched.
- `C-Protocol-Critical` would tag @tynes or @smartcontracts whenever smart contracts or `l2geth` were touched.

Since launching Bedrock, the `SR-Risk` label was removed from the `labeler` workflow, so it was never being applied. `C-Protocol-Critical` was still being applied, however it had no effect apart from blocking Mergify and pinging Mark/Kelvin unnecessarily since it is `CODEOWNERS` and not the label that prevents merge.

Given that we've started using `CODEOWNERS` and the fact that the labels were broken, this PR removes these legacy labels altogether.
