### PR TITLE
monorepo: cleanup recent changes

### DIFF
--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -7,7 +7,7 @@ typechain
 
 # Metrics
 coverage.out
-resource-metering.csv
+.resource-metering.csv
 
 # Tests
 test-case-generator/fuzz

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,22 +444,6 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0(jsdom@22.1.0)
 
-  packages/replica-healthcheck:
-    dependencies:
-      '@eth-optimism/common-ts':
-        specifier: 0.8.3
-        version: link:../common-ts
-      '@eth-optimism/core-utils':
-        specifier: 0.12.2
-        version: link:../core-utils
-      '@ethersproject/abstract-provider':
-        specifier: ^5.7.0
-        version: 5.7.0
-    devDependencies:
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.1(@types/node@12.20.55)(typescript@5.1.6)
-
   packages/sdk:
     dependencies:
       '@eth-optimism/contracts':


### PR DESCRIPTION
**Description**

Need to gitignore the csv output with
a `.` prefix and also re-run pnpm to
build a correct lockfile.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
