### PR TITLE
op-node: fix ci - add test function arg

### DIFF
--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -1178,7 +1178,7 @@ func TestEngineQueue_StepPopOlderUnsafe(t *testing.T) {
 
 	prev := &fakeAttributesQueue{origin: refA}
 
-	eq := NewEngineQueue(logger, cfg, eng, metrics.NoopMetrics, prev, l1F)
+	eq := NewEngineQueue(logger, cfg, eng, metrics.NoopMetrics, prev, l1F, &sync.Config{})
 	eq.unsafeHead = refA2
 	eq.safeHead = refA0
 	eq.finalized = refA0


### PR DESCRIPTION
Fix minor Go CI issue due to manual merge of old PR, which was out of sync with later additional test.