### PR TITLE
feat(op-challenger): Load the absolute prestate from cannon

### DIFF
--- a/op-challenger/Dockerfile
+++ b/op-challenger/Dockerfile
@@ -14,6 +14,11 @@ COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 COPY ./.git /app/.git
 
+# Copy cannon and its dependencies
+COPY ./cannon /app/cannon
+COPY ./op-preimage /app/op-preimage
+COPY ./op-chain-ops /app/op-chain-ops
+
 WORKDIR /app/op-challenger
 
 RUN go mod download

--- a/op-challenger/fault/alphabet/provider.go
+++ b/op-challenger/fault/alphabet/provider.go
@@ -57,8 +57,9 @@ func (ap *AlphabetTraceProvider) Get(ctx context.Context, i uint64) (common.Hash
 	return crypto.Keccak256Hash(claimBytes), nil
 }
 
-func (ap *AlphabetTraceProvider) AbsolutePreState(ctx context.Context) []byte {
-	return common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
+// AbsolutePreState returns the absolute pre-state for the alphabet trace.
+func (ap *AlphabetTraceProvider) AbsolutePreState(ctx context.Context) ([]byte, error) {
+	return common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060"), nil
 }
 
 // BuildAlphabetPreimage constructs the claim bytes for the index and state item.

--- a/op-challenger/fault/cannon/provider.go
+++ b/op-challenger/fault/cannon/provider.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -34,12 +35,14 @@ type ProofGenerator interface {
 
 type CannonTraceProvider struct {
 	dir       string
+	prestate  string
 	generator ProofGenerator
 }
 
 func NewTraceProvider(logger log.Logger, cfg *config.Config) *CannonTraceProvider {
 	return &CannonTraceProvider{
 		dir:       cfg.CannonDatadir,
+		prestate:  cfg.CannonAbsolutePreState,
 		generator: NewExecutor(logger, cfg),
 	}
 }
@@ -82,8 +85,19 @@ func (p *CannonTraceProvider) GetPreimage(ctx context.Context, i uint64) ([]byte
 	return value, data, nil
 }
 
-func (p *CannonTraceProvider) AbsolutePreState(ctx context.Context) []byte {
-	panic("absolute prestate not yet supported")
+func (p *CannonTraceProvider) AbsolutePreState(ctx context.Context) ([]byte, error) {
+	path := filepath.Join(p.dir, p.prestate)
+	file, err := os.Open(path)
+	if err != nil {
+		return []byte{}, fmt.Errorf("cannot open state file (%v): %w", path, err)
+	}
+	defer file.Close()
+	var state mipsevm.State
+	err = json.NewDecoder(file).Decode(&state)
+	if err != nil {
+		return []byte{}, fmt.Errorf("invalid mipsevm state (%v): %w", path, err)
+	}
+	return state.EncodeWitness(), nil
 }
 
 func (p *CannonTraceProvider) loadProof(ctx context.Context, i uint64) (*proofData, error) {

--- a/op-challenger/fault/cannon/test_data/invalid.json
+++ b/op-challenger/fault/cannon/test_data/invalid.json
@@ -1,0 +1,3 @@
+{
+  "preimageKey": 1
+}

--- a/op-challenger/fault/cannon/test_data/state.json
+++ b/op-challenger/fault/cannon/test_data/state.json
@@ -1,0 +1,14 @@
+{
+  "memory": [],
+  "preimageKey": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "preimageOffset": 0,
+  "pc": 0,
+  "nextPC": 1,
+  "lo": 0,
+  "hi": 0,
+  "heap": 0,
+  "exit": 0,
+  "exited": false,
+  "step": 0,
+  "registers": []
+}

--- a/op-challenger/fault/solver/solver.go
+++ b/op-challenger/fault/solver/solver.go
@@ -73,7 +73,11 @@ func (s *Solver) AttemptStep(ctx context.Context, claim types.Claim, agreeWithCl
 	var proofData []byte
 	// If we are attacking index 0, we provide the absolute pre-state, not an intermediate state
 	if index == 0 && !claimCorrect {
-		preState = s.trace.AbsolutePreState(ctx)
+		state, err := s.trace.AbsolutePreState(ctx)
+		if err != nil {
+			return StepData{}, err
+		}
+		preState = state
 	} else {
 		// If attacking, get the state just before, other get the state after
 		if !claimCorrect {

--- a/op-challenger/fault/solver/solver_test.go
+++ b/op-challenger/fault/solver/solver_test.go
@@ -113,6 +113,9 @@ func TestAttemptStep(t *testing.T) {
 
 	ctx := context.Background()
 
+	preState, err := builder.CorrectTraceProvider().AbsolutePreState(ctx)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name               string
 		claim              types.Claim
@@ -129,7 +132,7 @@ func TestAttemptStep(t *testing.T) {
 			name:               "AttackFirstTraceIndex",
 			claim:              builder.CreateLeafClaim(0, false),
 			expectAttack:       true,
-			expectPreState:     builder.CorrectTraceProvider().AbsolutePreState(ctx),
+			expectPreState:     preState,
 			expectProofData:    nil,
 			expectedOracleKey:  []byte{byte(0)},
 			expectedOracleData: []byte{byte(0)},

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -60,7 +60,7 @@ type TraceProvider interface {
 	GetPreimage(ctx context.Context, i uint64) (preimage []byte, proofData []byte, err error)
 
 	// AbsolutePreState is the pre-image value of the trace that transitions to the trace value at index 0
-	AbsolutePreState(ctx context.Context) []byte
+	AbsolutePreState(ctx context.Context) ([]byte, error)
 }
 
 // ClaimData is the core of a claim. It must be unique inside a specific game.


### PR DESCRIPTION
**Description**

Loads the absolute prestate for a fault dispute game
into the op-challenger using the `state.json` output
from cannon.

**Tests**

Cannon `AbsolutePreState` unit tests.

**Metadata**

Fixes CLI-4238
