### PR TITLE
feat(op-node): Clean up L2OO Caller

### DIFF
--- a/indexer/integration_tests/bedrock_test.go
+++ b/indexer/integration_tests/bedrock_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
@@ -208,7 +209,7 @@ func TestBedrockIndexer(t *testing.T) {
 		require.Nil(t, wd.BedrockFinalizedTxHash)
 
 		// Finalize withdrawal
-		err = withdrawals.WaitForFinalizationPeriod(e2eutils.TimeoutCtx(t, 30*time.Second), l1Client, cfg.L1Deployments.OptimismPortalProxy, proveReceipt.BlockNumber)
+		err = withdrawals.WaitForFinalizationPeriod(e2eutils.TimeoutCtx(t, 30*time.Second), l1Client, proveReceipt.BlockNumber, config.L1Deployments.L2OutputOracleProxy)
 		require.Nil(t, err)
 		finReceipt := op_e2e.FinalizeWithdrawal(t, cfg, l1Client, cfg.Secrets.Alice, wdReceipt, wdParams)
 

--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -676,7 +676,7 @@ func TestMixedWithdrawalValidity(t *testing.T) {
 				// Wait for finalization and then create the Finalized Withdrawal Transaction
 				ctx, cancel = context.WithTimeout(context.Background(), 45*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 				defer cancel()
-				err = withdrawals.WaitForFinalizationPeriod(ctx, l1Client, cfg.L1Deployments.OptimismPortalProxy, header.Number)
+				err = withdrawals.WaitForFinalizationPeriod(ctx, l1Client, header.Number, cfg.L1Deployments.L2OutputOracleProxy)
 				require.Nil(t, err)
 
 				// Finalize withdrawal

--- a/op-e2e/withdrawal_helper.go
+++ b/op-e2e/withdrawal_helper.go
@@ -145,7 +145,7 @@ func FinalizeWithdrawal(t *testing.T, cfg SystemConfig, l1Client *ethclient.Clie
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	defer cancel()
 
-	err := withdrawals.WaitForFinalizationPeriod(ctx, l1Client, config.L1Deployments.OptimismPortalProxy, withdrawalProofReceipt.BlockNumber)
+	err := withdrawals.WaitForFinalizationPeriod(ctx, l1Client, withdrawalProofReceipt.BlockNumber, config.L1Deployments.L2OutputOracleProxy)
 	require.Nil(t, err)
 
 	opts, err := bind.NewKeyedTransactorWithChainID(privKey, cfg.L1ChainIDBig())


### PR DESCRIPTION
**Description**

Removes de-duplicated L2OO caller creation code.

This PR changes the `WaitForFinalizationPeriod` function and calling references to use the `L2OutputOracle` proxy address directly as opposed to using the `OptimismPortal` proxy and querying its storage for the l2oo address. Essentially, removes an unnecessary step now that L1Deployments are made available through the `op-e2e` config. 
