### PR TITLE
ci: install go1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -886,9 +886,9 @@ jobs:
       - run:
           name: Install latest golang
           command: |
-            wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
+            wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
             sudo rm -rf /usr/local/go
-            sudo tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.20.linux-amd64.tar.gz
             export PATH=$PATH:/usr/local/go/bin
             go version
       - run:


### PR DESCRIPTION
**Description**

Upgrade from go1.19 in CI where go is installed manually. Breaks this out of https://github.com/ethereum-optimism/optimism/pull/6412

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
