### PR TITLE
fix(op-challenger): Standardizes Package Nomenclature

### DIFF
--- a/op-challenger/fault/alphabet/provider.go
+++ b/op-challenger/fault/alphabet/provider.go
@@ -15,28 +15,28 @@ var (
 	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
 )
 
-// AlphabetProvider is a [TraceProvider] that provides claims for specific
+// AlphabetTraceProvider is a [TraceProvider] that provides claims for specific
 // indices in the given trace.
-type AlphabetProvider struct {
+type AlphabetTraceProvider struct {
 	state  []string
 	maxLen uint64
 }
 
-// NewAlphabetProvider returns a new [AlphabetProvider].
-func NewAlphabetProvider(state string, depth uint64) *AlphabetProvider {
-	return &AlphabetProvider{
+// NewTraceProvider returns a new [AlphabetProvider].
+func NewTraceProvider(state string, depth uint64) *AlphabetTraceProvider {
+	return &AlphabetTraceProvider{
 		state:  strings.Split(state, ""),
 		maxLen: uint64(1 << depth),
 	}
 }
 
 // GetOracleData should not return any preimage oracle data for the alphabet provider.
-func (p *AlphabetProvider) GetOracleData(ctx context.Context, i uint64) (*types.PreimageOracleData, error) {
+func (p *AlphabetTraceProvider) GetOracleData(ctx context.Context, i uint64) (*types.PreimageOracleData, error) {
 	return &types.PreimageOracleData{}, nil
 }
 
 // GetPreimage returns the preimage for the given hash.
-func (ap *AlphabetProvider) GetPreimage(ctx context.Context, i uint64) ([]byte, []byte, error) {
+func (ap *AlphabetTraceProvider) GetPreimage(ctx context.Context, i uint64) ([]byte, []byte, error) {
 	// The index cannot be larger than the maximum index as computed by the depth.
 	if i >= ap.maxLen {
 		return nil, nil, ErrIndexTooLarge
@@ -49,7 +49,7 @@ func (ap *AlphabetProvider) GetPreimage(ctx context.Context, i uint64) ([]byte, 
 }
 
 // Get returns the claim value at the given index in the trace.
-func (ap *AlphabetProvider) Get(ctx context.Context, i uint64) (common.Hash, error) {
+func (ap *AlphabetTraceProvider) Get(ctx context.Context, i uint64) (common.Hash, error) {
 	claimBytes, _, err := ap.GetPreimage(ctx, i)
 	if err != nil {
 		return common.Hash{}, err
@@ -57,7 +57,7 @@ func (ap *AlphabetProvider) Get(ctx context.Context, i uint64) (common.Hash, err
 	return crypto.Keccak256Hash(claimBytes), nil
 }
 
-func (ap *AlphabetProvider) AbsolutePreState(ctx context.Context) []byte {
+func (ap *AlphabetTraceProvider) AbsolutePreState(ctx context.Context) []byte {
 	return common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
 }
 

--- a/op-challenger/fault/alphabet/provider_test.go
+++ b/op-challenger/fault/alphabet/provider_test.go
@@ -17,7 +17,7 @@ func alphabetClaim(index uint64, letter string) common.Hash {
 // TestAlphabetProvider_Get_ClaimsByTraceIndex tests the [fault.AlphabetProvider] Get function.
 func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	// Create a new alphabet provider.
-	canonicalProvider := NewAlphabetProvider("abcdefgh", uint64(3))
+	canonicalProvider := NewTraceProvider("abcdefgh", uint64(3))
 
 	// Build a list of traces.
 	traces := []struct {
@@ -59,7 +59,7 @@ func FuzzIndexToBytes(f *testing.F) {
 // TestGetPreimage_Succeeds tests the GetPreimage function
 // returns the correct pre-image for a index.
 func TestGetPreimage_Succeeds(t *testing.T) {
-	ap := NewAlphabetProvider("abc", 2)
+	ap := NewTraceProvider("abc", 2)
 	expected := BuildAlphabetPreimage(0, "a'")
 	retrieved, proof, err := ap.GetPreimage(context.Background(), uint64(0))
 	require.NoError(t, err)
@@ -70,14 +70,14 @@ func TestGetPreimage_Succeeds(t *testing.T) {
 // TestGetPreimage_TooLargeIndex_Fails tests the GetPreimage
 // function errors if the index is too large.
 func TestGetPreimage_TooLargeIndex_Fails(t *testing.T) {
-	ap := NewAlphabetProvider("abc", 2)
+	ap := NewTraceProvider("abc", 2)
 	_, _, err := ap.GetPreimage(context.Background(), 4)
 	require.ErrorIs(t, err, ErrIndexTooLarge)
 }
 
 // TestGet_Succeeds tests the Get function.
 func TestGet_Succeeds(t *testing.T) {
-	ap := NewAlphabetProvider("abc", 2)
+	ap := NewTraceProvider("abc", 2)
 	claim, err := ap.Get(context.Background(), 0)
 	require.NoError(t, err)
 	expected := alphabetClaim(0, "a")
@@ -87,7 +87,7 @@ func TestGet_Succeeds(t *testing.T) {
 // TestGet_IndexTooLarge tests the Get function with an index
 // greater than the number of indices: 2^depth - 1.
 func TestGet_IndexTooLarge(t *testing.T) {
-	ap := NewAlphabetProvider("abc", 2)
+	ap := NewTraceProvider("abc", 2)
 	_, err := ap.Get(context.Background(), 4)
 	require.ErrorIs(t, err, ErrIndexTooLarge)
 }
@@ -95,7 +95,7 @@ func TestGet_IndexTooLarge(t *testing.T) {
 // TestGet_Extends tests the Get function with an index that is larger
 // than the trace, but smaller than the maximum depth.
 func TestGet_Extends(t *testing.T) {
-	ap := NewAlphabetProvider("abc", 2)
+	ap := NewTraceProvider("abc", 2)
 	claim, err := ap.Get(context.Background(), 3)
 	require.NoError(t, err)
 	expected := alphabetClaim(2, "c")

--- a/op-challenger/fault/cannon/provider.go
+++ b/op-challenger/fault/cannon/provider.go
@@ -37,7 +37,7 @@ type CannonTraceProvider struct {
 	generator ProofGenerator
 }
 
-func NewCannonTraceProvider(logger log.Logger, cfg *config.Config) *CannonTraceProvider {
+func NewTraceProvider(logger log.Logger, cfg *config.Config) *CannonTraceProvider {
 	return &CannonTraceProvider{
 		dir:       cfg.CannonDatadir,
 		generator: NewExecutor(logger, cfg),

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -56,9 +56,9 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*se
 	var trace types.TraceProvider
 	switch cfg.TraceType {
 	case config.TraceTypeCannon:
-		trace = cannon.NewCannonTraceProvider(logger, cfg)
+		trace = cannon.NewTraceProvider(logger, cfg)
 	case config.TraceTypeAlphabet:
-		trace = alphabet.NewAlphabetProvider(cfg.AlphabetTrace, uint64(cfg.GameDepth))
+		trace = alphabet.NewTraceProvider(cfg.AlphabetTrace, uint64(cfg.GameDepth))
 	default:
 		return nil, fmt.Errorf("unsupported trace type: %v", cfg.TraceType)
 	}

--- a/op-challenger/fault/test/alphabet.go
+++ b/op-challenger/fault/test/alphabet.go
@@ -10,7 +10,7 @@ import (
 
 func NewAlphabetWithProofProvider(t *testing.T, maxDepth int, oracleError error) *alphabetWithProofProvider {
 	return &alphabetWithProofProvider{
-		alphabet.NewAlphabetProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth)),
+		alphabet.NewTraceProvider("abcdefghijklmnopqrstuvwxyz", uint64(maxDepth)),
 		oracleError,
 	}
 }
@@ -21,12 +21,12 @@ func NewAlphabetClaimBuilder(t *testing.T, maxDepth int) *ClaimBuilder {
 }
 
 type alphabetWithProofProvider struct {
-	*alphabet.AlphabetProvider
+	*alphabet.AlphabetTraceProvider
 	OracleError error
 }
 
 func (a *alphabetWithProofProvider) GetPreimage(ctx context.Context, i uint64) ([]byte, []byte, error) {
-	preimage, _, err := a.AlphabetProvider.GetPreimage(ctx, i)
+	preimage, _, err := a.AlphabetTraceProvider.GetPreimage(ctx, i)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -67,7 +67,7 @@ func NewFactoryHelper(t *testing.T, ctx context.Context, client *ethclient.Clien
 func (h *FactoryHelper) StartAlphabetGame(ctx context.Context, claimedAlphabet string) *FaultGameHelper {
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
-	trace := alphabet.NewAlphabetProvider(claimedAlphabet, 4)
+	trace := alphabet.NewTraceProvider(claimedAlphabet, 4)
 	rootClaim, err := trace.Get(ctx, lastAlphabetTraceIndex)
 	h.require.NoError(err, "get root claim")
 	tx, err := h.factory.Create(h.opts, faultGameType, rootClaim, alphaExtraData)


### PR DESCRIPTION
**Description**

Small PR to clean up/standardize the identifiers
used in the challenger's fault package components.
