### PR TITLE
feat(op-challenger): OracleUpdater Component

### DIFF
--- a/op-challenger/charlie.sh
+++ b/op-challenger/charlie.sh
@@ -14,11 +14,14 @@ MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
 FAULT_GAME_ADDRESS="0x8daf17a20c9dba35f005b6324f493785d239719d"
 
+PREIMAGE_ORACLE_ADDRESS="0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+
 ./bin/op-challenger \
   --l1-eth-rpc http://localhost:8545 \
   --trace-type="alphabet" \
   --alphabet "abcdefgh" \
   --game-address $FAULT_GAME_ADDRESS \
+  --preimage-oracle-address $PREIMAGE_ORACLE_ADDRESS \
   --private-key $CHARLIE_KEY \
   --num-confirmations 1 \
   --game-depth 4 \

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -18,6 +18,7 @@ var (
 	ErrMissingAlphabetTrace          = errors.New("missing alphabet trace")
 	ErrMissingL1EthRPC               = errors.New("missing l1 eth rpc url")
 	ErrMissingGameAddress            = errors.New("missing game address")
+	ErrMissingPreimageOracleAddress  = errors.New("missing pre-image oracle address")
 	ErrMissingCannonSnapshotFreq     = errors.New("missing cannon snapshot freq")
 )
 
@@ -60,6 +61,7 @@ const DefaultCannonSnapshotFreq = uint(10_000)
 type Config struct {
 	L1EthRpc                string         // L1 RPC Url
 	GameAddress             common.Address // Address of the fault game
+	PreimageOracleAddress   common.Address // Address of the pre-image oracle
 	AgreeWithProposedOutput bool           // Temporary config if we agree or disagree with the posted output
 	GameDepth               int            // Depth of the game tree
 
@@ -82,13 +84,15 @@ type Config struct {
 func NewConfig(
 	l1EthRpc string,
 	gameAddress common.Address,
+	preimageOracleAddress common.Address,
 	traceType TraceType,
 	agreeWithProposedOutput bool,
 	gameDepth int,
 ) Config {
 	return Config{
-		L1EthRpc:    l1EthRpc,
-		GameAddress: gameAddress,
+		L1EthRpc:              l1EthRpc,
+		GameAddress:           gameAddress,
+		PreimageOracleAddress: preimageOracleAddress,
 
 		AgreeWithProposedOutput: agreeWithProposedOutput,
 		GameDepth:               gameDepth,
@@ -112,6 +116,9 @@ func (c Config) Check() error {
 		return ErrMissingTraceType
 	}
 	if c.TraceType == TraceTypeCannon {
+		if c.PreimageOracleAddress == (common.Address{}) {
+			return ErrMissingPreimageOracleAddress
+		}
 		if c.CannonBin == "" {
 			return ErrMissingCannonBin
 		}

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -11,6 +11,7 @@ import (
 var (
 	validL1EthRpc              = "http://localhost:8545"
 	validGameAddress           = common.HexToAddress("0x7bdd3b028C4796eF0EAf07d11394d0d9d8c24139")
+	validPreimageOracleAddress = common.HexToAddress("0x7bdd3b028C4796eF0EAf07d11394d0d9d8c24139")
 	validAlphabetTrace         = "abcdefgh"
 	validCannonBin             = "./bin/cannon"
 	validCannonOpProgramBin    = "./bin/op-program"
@@ -22,7 +23,7 @@ var (
 )
 
 func validConfig(traceType TraceType) Config {
-	cfg := NewConfig(validL1EthRpc, validGameAddress, traceType, agreeWithProposedOutput, gameDepth)
+	cfg := NewConfig(validL1EthRpc, validGameAddress, validPreimageOracleAddress, traceType, agreeWithProposedOutput, gameDepth)
 	switch traceType {
 	case TraceTypeAlphabet:
 		cfg.AlphabetTrace = validAlphabetTrace
@@ -71,6 +72,12 @@ func TestAlphabetTraceRequired(t *testing.T) {
 	config := validConfig(TraceTypeAlphabet)
 	config.AlphabetTrace = ""
 	require.ErrorIs(t, config.Check(), ErrMissingAlphabetTrace)
+}
+
+func TestCannonPreimageOracleAddressRequired(t *testing.T) {
+	config := validConfig(TraceTypeCannon)
+	config.PreimageOracleAddress = common.Address{}
+	require.ErrorIs(t, config.Check(), ErrMissingPreimageOracleAddress)
 }
 
 func TestCannonBinRequired(t *testing.T) {

--- a/op-challenger/fault/alphabet/updater.go
+++ b/op-challenger/fault/alphabet/updater.go
@@ -1,0 +1,27 @@
+package alphabet
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// alphabetUpdater is a [types.OracleUpdater] that exposes a
+// method to update onchain oracles with required data.
+type alphabetUpdater struct {
+	logger log.Logger
+}
+
+// NewOracleUpdater returns a new updater.
+func NewOracleUpdater(logger log.Logger) *alphabetUpdater {
+	return &alphabetUpdater{
+		logger: logger,
+	}
+}
+
+// UpdateOracle updates the oracle with the given data.
+func (u *alphabetUpdater) UpdateOracle(ctx context.Context, data types.PreimageOracleData) error {
+	u.logger.Info("alphabet oracle updater called")
+	return nil
+}

--- a/op-challenger/fault/alphabet/updater_test.go
+++ b/op-challenger/fault/alphabet/updater_test.go
@@ -1,0 +1,19 @@
+package alphabet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAlphabetUpdater tests the [alphabetUpdater].
+func TestAlphabetUpdater(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	updater := NewOracleUpdater(logger)
+	require.Nil(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{}))
+}

--- a/op-challenger/fault/cannon/executor_test.go
+++ b/op-challenger/fault/cannon/executor_test.go
@@ -19,7 +19,7 @@ const execTestCannonPrestate = "/foo/pre.json"
 
 func TestGenerateProof(t *testing.T) {
 	input := "starting.json"
-	cfg := config.NewConfig("http://localhost:8888", common.Address{0xaa}, config.TraceTypeCannon, true, 5)
+	cfg := config.NewConfig("http://localhost:8888", common.Address{0xaa}, common.Address{0xbb}, config.TraceTypeCannon, true, 5)
 	cfg.CannonDatadir = t.TempDir()
 	cfg.CannonAbsolutePreState = "pre.json"
 	cfg.CannonBin = "./bin/cannon"

--- a/op-challenger/fault/cannon/updater.go
+++ b/op-challenger/fault/cannon/updater.go
@@ -1,0 +1,59 @@
+package cannon
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// cannonUpdater is a [types.OracleUpdater] that exposes a method
+// to update onchain cannon oracles with required data.
+type cannonUpdater struct {
+	logger log.Logger
+	txMgr  txmgr.TxManager
+
+	fdgAbi  abi.ABI
+	fdgAddr common.Address
+
+	preimageOracleAbi  abi.ABI
+	preimageOracleAddr common.Address
+}
+
+// NewOracleUpdater returns a new updater.
+func NewOracleUpdater(
+	logger log.Logger,
+	txMgr txmgr.TxManager,
+	fdgAddr common.Address,
+	preimageOracleAddr common.Address,
+) (*cannonUpdater, error) {
+	fdgAbi, err := bindings.FaultDisputeGameMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	preimageOracleAbi, err := bindings.PreimageOracleMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cannonUpdater{
+		logger: logger,
+		txMgr:  txMgr,
+
+		fdgAbi:  *fdgAbi,
+		fdgAddr: fdgAddr,
+
+		preimageOracleAbi:  *preimageOracleAbi,
+		preimageOracleAddr: preimageOracleAddr,
+	}, nil
+}
+
+// UpdateOracle updates the oracle with the given data.
+func (u *cannonUpdater) UpdateOracle(ctx context.Context, data types.PreimageOracleData) error {
+	panic("oracle updates not implemented")
+}

--- a/op-challenger/fault/cannon/updater_test.go
+++ b/op-challenger/fault/cannon/updater_test.go
@@ -1,0 +1,87 @@
+package cannon
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockFdgAddress            = common.HexToAddress("0x1234")
+	mockPreimageOracleAddress = common.HexToAddress("0x12345")
+	mockSendError             = errors.New("mock send error")
+)
+
+type mockTxManager struct {
+	from      common.Address
+	sends     int
+	calls     int
+	sendFails bool
+}
+
+func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*ethtypes.Receipt, error) {
+	if m.sendFails {
+		return nil, mockSendError
+	}
+	m.sends++
+	return ethtypes.NewReceipt(
+		[]byte{},
+		false,
+		0,
+	), nil
+}
+
+func (m *mockTxManager) Call(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	if m.sendFails {
+		return nil, mockSendError
+	}
+	m.calls++
+	return []byte{}, nil
+}
+
+func (m *mockTxManager) BlockNumber(ctx context.Context) (uint64, error) {
+	panic("not implemented")
+}
+
+func (m *mockTxManager) From() common.Address {
+	return m.from
+}
+
+func newTestCannonUpdater(t *testing.T, sendFails bool) (*cannonUpdater, *mockTxManager) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	txMgr := &mockTxManager{
+		from:      mockFdgAddress,
+		sendFails: sendFails,
+	}
+	updater, err := NewOracleUpdater(logger, txMgr, mockFdgAddress, mockPreimageOracleAddress)
+	require.NoError(t, err)
+	return updater, txMgr
+}
+
+// TestCannonUpdater_UpdateOracle tests the [cannonUpdater]
+// UpdateOracle function.
+func TestCannonUpdater_UpdateOracle(t *testing.T) {
+	t.Run("succeeds", func(t *testing.T) {
+		_, _ = newTestCannonUpdater(t, false)
+		// require.Nil(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{}))
+		// require.Equal(t, 1, mockTxMgr.calls)
+	})
+
+	t.Run("send fails", func(t *testing.T) {
+		_, _ = newTestCannonUpdater(t, true)
+		// require.Error(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{}))
+		// require.Equal(t, 1, mockTxMgr.calls)
+	})
+}

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -44,6 +44,12 @@ type StepCallData struct {
 	Proof      []byte
 }
 
+// OracleUpdater is a generic interface for updating oracles.
+type OracleUpdater interface {
+	// UpdateOracle updates the oracle with the given data.
+	UpdateOracle(ctx context.Context, data PreimageOracleData) error
+}
+
 // TraceProvider is a generic way to get a claim value at a specific step in the trace.
 type TraceProvider interface {
 	// Get returns the claim value at the requested index.

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
-	openum "github.com/ethereum-optimism/optimism/op-service/enum"
-	"github.com/urfave/cli/v2"
-
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	openum "github.com/ethereum-optimism/optimism/op-service/enum"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	txmgr "github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/urfave/cli/v2"
 )
 
 const (
@@ -58,6 +59,11 @@ var (
 		Usage:   "Correct Alphabet Trace (alphabet trace type only)",
 		EnvVars: prefixEnvVars("ALPHABET"),
 	}
+	PreimageOracleAddressFlag = &cli.StringFlag{
+		Name:    "preimage-oracle-address",
+		Usage:   "Address of the Preimage Oracle contract (only required for cannon).",
+		EnvVars: prefixEnvVars("PREIMAGE_ORACLE_ADDRESS"),
+	}
 	CannonBinFlag = &cli.StringFlag{
 		Name:    "cannon-bin",
 		Usage:   "Path to cannon executable to use when generating trace data (cannon trace type only)",
@@ -103,6 +109,7 @@ var requiredFlags = []cli.Flag{
 // optionalFlags is a list of unchecked cli flags
 var optionalFlags = []cli.Flag{
 	AlphabetFlag,
+	PreimageOracleAddressFlag,
 	CannonBinFlag,
 	CannonServerFlag,
 	CannonPreStateFlag,
@@ -130,6 +137,9 @@ func CheckRequired(ctx *cli.Context) error {
 	gameType := config.TraceType(strings.ToLower(ctx.String(TraceTypeFlag.Name)))
 	switch gameType {
 	case config.TraceTypeCannon:
+		if !ctx.IsSet(PreimageOracleAddressFlag.Name) {
+			return fmt.Errorf("flag %s is required", PreimageOracleAddressFlag.Name)
+		}
 		if !ctx.IsSet(CannonBinFlag.Name) {
 			return fmt.Errorf("flag %s is required", CannonBinFlag.Name)
 		}
@@ -169,11 +179,21 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 
 	traceTypeFlag := config.TraceType(strings.ToLower(ctx.String(TraceTypeFlag.Name)))
 
+	preimageOracleAddress := common.Address{}
+	preimageOracleValue := ctx.String(PreimageOracleAddressFlag.Name)
+	if traceTypeFlag == config.TraceTypeCannon || preimageOracleValue != "" {
+		preimageOracleAddress, err = opservice.ParseAddress(preimageOracleValue)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &config.Config{
 		// Required Flags
 		L1EthRpc:                ctx.String(L1EthRpcFlag.Name),
 		TraceType:               traceTypeFlag,
 		GameAddress:             dgfAddress,
+		PreimageOracleAddress:   preimageOracleAddress,
 		AlphabetTrace:           ctx.String(AlphabetFlag.Name),
 		CannonBin:               ctx.String(CannonBinFlag.Name),
 		CannonServer:            ctx.String(CannonServerFlag.Name),

--- a/op-challenger/mallory.sh
+++ b/op-challenger/mallory.sh
@@ -14,11 +14,14 @@ MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
 FAULT_GAME_ADDRESS="0x8daf17a20c9dba35f005b6324f493785d239719d"
 
+PREIMAGE_ORACLE_ADDRESS="0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+
 ./bin/op-challenger \
   --l1-eth-rpc http://localhost:8545 \
   --trace-type="alphabet" \
   --alphabet "abcdexyz" \
   --game-address $FAULT_GAME_ADDRESS \
+  --preimage-oracle-address $PREIMAGE_ORACLE_ADDRESS \
   --private-key $MALLORY_KEY \
   --num-confirmations 1 \
   --game-depth 4 \


### PR DESCRIPTION
**Description**

This PR introduces the `OracleUpdater` interface
and stubbed implementations in the respective
`alphabet` and `cannon` component packages.

Note, very happy to change the name, couldn't think
of something cleaner off the top of my head.

This is done to decouple cannon from the abstracted
fault `Responder` component.

This PR and stack will replace #6460.

**Tests**

Unit tests are performed on the respective `cannon`
and `alphabet` oracle updater components.

**Metadata**

Fixes CLI-4243.
