### PR TITLE
feat(op-challenger): Cannon OracleUpdater Tx Crafting

### DIFF
--- a/op-challenger/fault/cannon/provider.go
+++ b/op-challenger/fault/cannon/provider.go
@@ -21,11 +21,12 @@ const (
 )
 
 type proofData struct {
-	ClaimValue  hexutil.Bytes `json:"post"`
-	StateData   hexutil.Bytes `json:"state-data"`
-	ProofData   hexutil.Bytes `json:"proof-data"`
-	OracleKey   hexutil.Bytes `json:"oracle-key,omitempty"`
-	OracleValue hexutil.Bytes `json:"oracle-value,omitempty"`
+	ClaimValue   hexutil.Bytes `json:"post"`
+	StateData    hexutil.Bytes `json:"state-data"`
+	ProofData    hexutil.Bytes `json:"proof-data"`
+	OracleKey    hexutil.Bytes `json:"oracle-key,omitempty"`
+	OracleValue  hexutil.Bytes `json:"oracle-value,omitempty"`
+	OracleOffset uint32        `json:"oracle-offset,omitempty"`
 }
 
 type ProofGenerator interface {
@@ -52,7 +53,7 @@ func (p *CannonTraceProvider) GetOracleData(ctx context.Context, i uint64) (*typ
 	if err != nil {
 		return nil, err
 	}
-	data := types.NewPreimageOracleData(proof.OracleKey, proof.OracleValue)
+	data := types.NewPreimageOracleData(proof.OracleKey, proof.OracleValue, proof.OracleOffset)
 	return &data, nil
 }
 

--- a/op-challenger/fault/cannon/updater.go
+++ b/op-challenger/fault/cannon/updater.go
@@ -2,6 +2,8 @@ package cannon
 
 import (
 	"context"
+	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
@@ -9,14 +11,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 // cannonUpdater is a [types.OracleUpdater] that exposes a method
 // to update onchain cannon oracles with required data.
 type cannonUpdater struct {
-	logger log.Logger
-	txMgr  txmgr.TxManager
+	log   log.Logger
+	txMgr txmgr.TxManager
 
 	fdgAbi  abi.ABI
 	fdgAddr common.Address
@@ -42,8 +45,8 @@ func NewOracleUpdater(
 	}
 
 	return &cannonUpdater{
-		logger: logger,
-		txMgr:  txMgr,
+		log:   logger,
+		txMgr: txMgr,
 
 		fdgAbi:  *fdgAbi,
 		fdgAddr: fdgAddr,
@@ -55,5 +58,67 @@ func NewOracleUpdater(
 
 // UpdateOracle updates the oracle with the given data.
 func (u *cannonUpdater) UpdateOracle(ctx context.Context, data types.PreimageOracleData) error {
-	panic("oracle updates not implemented")
+	if data.IsLocal {
+		return u.sendLocalOracleData(ctx, data)
+	}
+	return u.sendGlobalOracleData(ctx, data)
+}
+
+// sendLocalOracleData sends the local oracle data to the [txmgr].
+func (u *cannonUpdater) sendLocalOracleData(ctx context.Context, data types.PreimageOracleData) error {
+	txData, err := u.buildLocalOracleData(data)
+	if err != nil {
+		return fmt.Errorf("local oracle tx data build: %w", err)
+	}
+	return u.sendTxAndWait(ctx, u.fdgAddr, txData)
+}
+
+// sendGlobalOracleData sends the global oracle data to the [txmgr].
+func (u *cannonUpdater) sendGlobalOracleData(ctx context.Context, data types.PreimageOracleData) error {
+	txData, err := u.buildGlobalOracleData(data)
+	if err != nil {
+		return fmt.Errorf("global oracle tx data build: %w", err)
+	}
+	return u.sendTxAndWait(ctx, u.fdgAddr, txData)
+}
+
+// buildLocalOracleData takes the local preimage key and data
+// and creates tx data to load the key, data pair into the
+// PreimageOracle contract from the FaultDisputeGame contract call.
+func (u *cannonUpdater) buildLocalOracleData(data types.PreimageOracleData) ([]byte, error) {
+	return u.fdgAbi.Pack(
+		"addLocalData",
+		data.OracleKey,
+		big.NewInt(0),
+	)
+}
+
+// buildGlobalOracleData takes the global preimage key and data
+// and creates tx data to load the key, data pair into the
+// PreimageOracle contract.
+func (u *cannonUpdater) buildGlobalOracleData(data types.PreimageOracleData) ([]byte, error) {
+	return u.preimageOracleAbi.Pack(
+		"loadKeccak256PreimagePart",
+		big.NewInt(0),
+		data.OracleData,
+	)
+}
+
+// sendTxAndWait sends a transaction through the [txmgr] and waits for a receipt.
+// This sets the tx GasLimit to 0, performing gas estimation online through the [txmgr].
+func (u *cannonUpdater) sendTxAndWait(ctx context.Context, addr common.Address, txData []byte) error {
+	receipt, err := u.txMgr.Send(ctx, txmgr.TxCandidate{
+		To:       &addr,
+		TxData:   txData,
+		GasLimit: 0,
+	})
+	if err != nil {
+		return err
+	}
+	if receipt.Status == ethtypes.ReceiptStatusFailed {
+		u.log.Error("Responder tx successfully published but reverted", "tx_hash", receipt.TxHash)
+	} else {
+		u.log.Debug("Responder tx successfully published", "tx_hash", receipt.TxHash)
+	}
+	return nil
 }

--- a/op-challenger/fault/cannon/updater.go
+++ b/op-challenger/fault/cannon/updater.go
@@ -66,7 +66,7 @@ func (u *cannonUpdater) UpdateOracle(ctx context.Context, data types.PreimageOra
 
 // sendLocalOracleData sends the local oracle data to the [txmgr].
 func (u *cannonUpdater) sendLocalOracleData(ctx context.Context, data types.PreimageOracleData) error {
-	txData, err := u.buildLocalOracleData(data)
+	txData, err := u.BuildLocalOracleData(data)
 	if err != nil {
 		return fmt.Errorf("local oracle tx data build: %w", err)
 	}
@@ -75,32 +75,32 @@ func (u *cannonUpdater) sendLocalOracleData(ctx context.Context, data types.Prei
 
 // sendGlobalOracleData sends the global oracle data to the [txmgr].
 func (u *cannonUpdater) sendGlobalOracleData(ctx context.Context, data types.PreimageOracleData) error {
-	txData, err := u.buildGlobalOracleData(data)
+	txData, err := u.BuildGlobalOracleData(data)
 	if err != nil {
 		return fmt.Errorf("global oracle tx data build: %w", err)
 	}
 	return u.sendTxAndWait(ctx, u.fdgAddr, txData)
 }
 
-// buildLocalOracleData takes the local preimage key and data
+// BuildLocalOracleData takes the local preimage key and data
 // and creates tx data to load the key, data pair into the
 // PreimageOracle contract from the FaultDisputeGame contract call.
-func (u *cannonUpdater) buildLocalOracleData(data types.PreimageOracleData) ([]byte, error) {
+func (u *cannonUpdater) BuildLocalOracleData(data types.PreimageOracleData) ([]byte, error) {
 	return u.fdgAbi.Pack(
 		"addLocalData",
-		data.OracleKey,
-		big.NewInt(0),
+		data.GetIdent(),
+		big.NewInt(int64(data.OracleOffset)),
 	)
 }
 
-// buildGlobalOracleData takes the global preimage key and data
+// BuildGlobalOracleData takes the global preimage key and data
 // and creates tx data to load the key, data pair into the
 // PreimageOracle contract.
-func (u *cannonUpdater) buildGlobalOracleData(data types.PreimageOracleData) ([]byte, error) {
+func (u *cannonUpdater) BuildGlobalOracleData(data types.PreimageOracleData) ([]byte, error) {
 	return u.preimageOracleAbi.Pack(
 		"loadKeccak256PreimagePart",
-		big.NewInt(0),
-		data.OracleData,
+		big.NewInt(int64(data.OracleOffset)),
+		data.GetPreimageWithoutSize(),
 	)
 }
 

--- a/op-challenger/fault/cannon/updater_test.go
+++ b/op-challenger/fault/cannon/updater_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
@@ -13,6 +14,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/stretchr/testify/require"
@@ -25,14 +27,15 @@ var (
 )
 
 type mockTxManager struct {
-	from      common.Address
-	sends     int
-	calls     int
-	sendFails bool
+	from        common.Address
+	sends       int
+	failedSends int
+	sendFails   bool
 }
 
 func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (*ethtypes.Receipt, error) {
 	if m.sendFails {
+		m.failedSends++
 		return nil, mockSendError
 	}
 	m.sends++
@@ -44,11 +47,7 @@ func (m *mockTxManager) Send(ctx context.Context, candidate txmgr.TxCandidate) (
 }
 
 func (m *mockTxManager) Call(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
-	if m.sendFails {
-		return nil, mockSendError
-	}
-	m.calls++
-	return []byte{}, nil
+	panic("not implemented")
 }
 
 func (m *mockTxManager) BlockNumber(ctx context.Context) (uint64, error) {
@@ -74,14 +73,68 @@ func newTestCannonUpdater(t *testing.T, sendFails bool) (*cannonUpdater, *mockTx
 // UpdateOracle function.
 func TestCannonUpdater_UpdateOracle(t *testing.T) {
 	t.Run("succeeds", func(t *testing.T) {
-		_, _ = newTestCannonUpdater(t, false)
-		// require.Nil(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{}))
-		// require.Equal(t, 1, mockTxMgr.calls)
+		updater, mockTxMgr := newTestCannonUpdater(t, false)
+		require.Nil(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{
+			OracleData: common.Hex2Bytes("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		}))
+		require.Equal(t, 1, mockTxMgr.sends)
 	})
 
 	t.Run("send fails", func(t *testing.T) {
-		_, _ = newTestCannonUpdater(t, true)
-		// require.Error(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{}))
-		// require.Equal(t, 1, mockTxMgr.calls)
+		updater, mockTxMgr := newTestCannonUpdater(t, true)
+		require.Error(t, updater.UpdateOracle(context.Background(), types.PreimageOracleData{
+			OracleData: common.Hex2Bytes("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		}))
+		require.Equal(t, 1, mockTxMgr.failedSends)
 	})
+}
+
+// TestCannonUpdater_BuildLocalOracleData tests the [cannonUpdater]
+// builds a valid tx candidate for a local oracle update.
+func TestCannonUpdater_BuildLocalOracleData(t *testing.T) {
+	updater, _ := newTestCannonUpdater(t, false)
+	oracleData := types.PreimageOracleData{
+		OracleKey:    common.Hex2Bytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		OracleData:   common.Hex2Bytes("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		OracleOffset: 7,
+	}
+
+	txData, err := updater.BuildLocalOracleData(oracleData)
+	require.NoError(t, err)
+
+	var addLocalDataBytes4 = crypto.Keccak256([]byte("addLocalData(uint256,uint256)"))[:4]
+
+	// Pack the tx data manually.
+	var expected []byte
+	expected = append(expected, addLocalDataBytes4...)
+	expected = append(expected, common.Hex2Bytes("00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")...)
+	expected = append(expected, common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000007")...)
+
+	require.Equal(t, expected, txData)
+}
+
+// TestCannonUpdater_BuildGlobalOracleData tests the [cannonUpdater]
+// builds a valid tx candidate for a global oracle update.
+func TestCannonUpdater_BuildGlobalOracleData(t *testing.T) {
+	updater, _ := newTestCannonUpdater(t, false)
+	oracleData := types.PreimageOracleData{
+		OracleKey:    common.Hex2Bytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		OracleData:   common.Hex2Bytes("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+		OracleOffset: 7,
+	}
+
+	txData, err := updater.BuildGlobalOracleData(oracleData)
+	require.NoError(t, err)
+
+	var loadKeccak256PreimagePartBytes4 = crypto.Keccak256([]byte("loadKeccak256PreimagePart(uint256,bytes)"))[:4]
+
+	// Pack the tx data manually.
+	var expected []byte
+	expected = append(expected, loadKeccak256PreimagePartBytes4...)
+	expected = append(expected, common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000007")...)
+	expected = append(expected, common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000040")...)
+	expected = append(expected, common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000018")...)
+	expected = append(expected, common.Hex2Bytes("cccccccccccccccccccccccccccccccccccccccccccccccc0000000000000000")...)
+
+	require.Equal(t, expected, txData)
 }

--- a/op-challenger/fault/test/alphabet.go
+++ b/op-challenger/fault/test/alphabet.go
@@ -37,6 +37,6 @@ func (a *alphabetWithProofProvider) GetOracleData(ctx context.Context, i uint64)
 	if a.OracleError != nil {
 		return &types.PreimageOracleData{}, a.OracleError
 	}
-	data := types.NewPreimageOracleData([]byte{byte(i)}, []byte{byte(i)})
+	data := types.NewPreimageOracleData([]byte{byte(i)}, []byte{byte(i)}, uint32(i))
 	return &data, nil
 }

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -23,22 +23,34 @@ const (
 // PreimageOracleData encapsulates the preimage oracle data
 // to load into the onchain oracle.
 type PreimageOracleData struct {
-	IsLocal    bool
-	OracleKey  []byte
-	OracleData []byte
+	IsLocal      bool
+	OracleKey    []byte
+	OracleData   []byte
+	OracleOffset uint32
+}
+
+// GetType returns the type for the preimage oracle data.
+func (p *PreimageOracleData) GetType() *big.Int {
+	return big.NewInt(int64(p.OracleKey[0]))
 }
 
 // GetIdent returns the ident for the preimage oracle data.
 func (p *PreimageOracleData) GetIdent() *big.Int {
-	return big.NewInt(int64(p.OracleData[0]))
+	return big.NewInt(0).SetBytes(p.OracleKey[1:])
+}
+
+// GetPreimageWithoutSize returns the preimage for the preimage oracle data.
+func (p *PreimageOracleData) GetPreimageWithoutSize() []byte {
+	return p.OracleData[8:]
 }
 
 // NewPreimageOracleData creates a new [PreimageOracleData] instance.
-func NewPreimageOracleData(key []byte, data []byte) PreimageOracleData {
+func NewPreimageOracleData(key []byte, data []byte, offset uint32) PreimageOracleData {
 	return PreimageOracleData{
-		IsLocal:    len(key) > 0 && key[0] == byte(1),
-		OracleKey:  key,
-		OracleData: data,
+		IsLocal:      len(key) > 0 && key[0] == byte(1),
+		OracleKey:    key,
+		OracleData:   data,
+		OracleOffset: offset,
 	}
 }
 

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -25,6 +26,11 @@ type PreimageOracleData struct {
 	IsLocal    bool
 	OracleKey  []byte
 	OracleData []byte
+}
+
+// GetIdent returns the ident for the preimage oracle data.
+func (p *PreimageOracleData) GetIdent() *big.Int {
+	return big.NewInt(int64(p.OracleData[0]))
 }
 
 // NewPreimageOracleData creates a new [PreimageOracleData] instance.

--- a/op-challenger/fault/types/types_test.go
+++ b/op-challenger/fault/types/types_test.go
@@ -8,16 +8,18 @@ import (
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {
-		data := NewPreimageOracleData([]byte{1, 2, 3}, []byte{4, 5, 6})
+		data := NewPreimageOracleData([]byte{1, 2, 3}, []byte{4, 5, 6}, 7)
 		require.True(t, data.IsLocal)
 		require.Equal(t, []byte{1, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
+		require.Equal(t, uint32(7), data.OracleOffset)
 	})
 
 	t.Run("GlobalData", func(t *testing.T) {
-		data := NewPreimageOracleData([]byte{0, 2, 3}, []byte{4, 5, 6})
+		data := NewPreimageOracleData([]byte{0, 2, 3}, []byte{4, 5, 6}, 7)
 		require.False(t, data.IsLocal)
 		require.Equal(t, []byte{0, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
+		require.Equal(t, uint32(7), data.OracleOffset)
 	})
 }


### PR DESCRIPTION
**Description**

This PR continues the stack to replace #6460.

It updates the cannon `OracleUpdater` component
to dispatch on local vs global preimage oracle
data, build the tx, and send it through the tx
manager.

**Tests**

Unit tests around the cannon `OracleUpdater`
implementation.

**Metadata**

Fixes CLI-4243.
