### PR TITLE
bugfix: devnet-allocs scripts multiprocess fix

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -72,30 +72,28 @@ def main():
 
 
 def deploy_contracts(paths):
-    def internal():
-        wait_up(8545)
-        wait_for_rpc_server('127.0.0.1:8545')
-        res = eth_accounts('127.0.0.1:8545')
+    wait_up(8545)
+    wait_for_rpc_server('127.0.0.1:8545')
+    res = eth_accounts('127.0.0.1:8545')
 
-        response = json.loads(res)
-        account = response['result'][0]
+    response = json.loads(res)
+    account = response['result'][0]
 
-        fqn = 'scripts/Deploy.s.sol:Deploy'
-        run_command([
-            'forge', 'script', fqn, '--sender', account,
-            '--rpc-url', 'http://127.0.0.1:8545', '--broadcast',
-            '--unlocked'
-        ], env={}, cwd=paths.contracts_bedrock_dir)
+    fqn = 'scripts/Deploy.s.sol:Deploy'
+    run_command([
+        'forge', 'script', fqn, '--sender', account,
+        '--rpc-url', 'http://127.0.0.1:8545', '--broadcast',
+        '--unlocked'
+    ], env={}, cwd=paths.contracts_bedrock_dir)
 
-        shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)
+    shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)
 
-        log.info('Syncing contracts.')
-        run_command([
-            'forge', 'script', fqn, '--sig', 'sync()',
-            '--rpc-url', 'http://127.0.0.1:8545'
-        ], env={}, cwd=paths.contracts_bedrock_dir)
+    log.info('Syncing contracts.')
+    run_command([
+        'forge', 'script', fqn, '--sig', 'sync()',
+        '--rpc-url', 'http://127.0.0.1:8545'
+    ], env={}, cwd=paths.contracts_bedrock_dir)
 
-    return internal
 
 
 def devnet_l1_genesis(paths):
@@ -105,7 +103,7 @@ def devnet_l1_genesis(paths):
         '--verbosity', '4', '--gcmode', 'archive', '--dev.gaslimit', '30000000'
     ])
 
-    forge = multiprocessing.Process(target=deploy_contracts(paths))
+    forge = multiprocessing.Process(target=deploy_contracts, args=(paths,))
     forge.start()
     forge.join()
 


### PR DESCRIPTION
python `multiprocess` only can pickle global state. Fix the script such that the arguments to `deploy_contracts` are passed explicitly vs utilizing a closure which results in trying to pickle internal state.


Currently cannot spin up devnet on macos because of this. See sample error log:
```
    File "/Users/hamdiallam/workspace/optimism/bedrock-devnet/devnet/__init__.py", line 109, in devnet_l1_genesis
    forge.start()
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/context.py", line 288, in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/opt/homebrew/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't pickle local object 'deploy_contracts.<locals>.internal'
make: *** [devnet-up] Error 1
```