### PR TITLE
feat(cannon): Proof PreimageOffset Field

### DIFF
--- a/cannon/README.md
+++ b/cannon/README.md
@@ -39,25 +39,24 @@ make cannon
 # Note:
 #  - The L2 RPC is an archive L2 node on OP goerli.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
-./bin/cannon run
---pprof.cpu
---info-at '%10000000'
---proof-at never
---input ./state.json
---
-../op-program/bin/op-program
---l2 http://127.0.0.1:8745
---l1 http://127.0.0.1:8645
---l1.trustrpc
---l1.rpckind debug_geth
---log.format terminal
---l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816
---network goerli
---l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab
---l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9
---l2.blocknumber 8813570
---datadir /tmp/fpp-database
---server
+./bin/cannon run \
+  --pprof.cpu \
+  --info-at '%10000000' \
+  --proof-at never \
+  --input ./state.json \
+  -- ../op-program/bin/op-program \
+  --l2 http://127.0.0.1:8745 \
+  --l1 http://127.0.0.1:8645 \
+  --l1.trustrpc \
+  --l1.rpckind debug_geth \
+  --log.format terminal \
+  --network goerli \
+  --l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab \
+  --l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816 \
+  --l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9 \
+  --l2.blocknumber 8813570 \
+  --datadir /tmp/fpp-database \
+  --server
 
 # Add --proof-at '=12345' (or pick other pattern, see --help)
 # to pick a step to build a proof for (e.g. exact step, every N steps, etc.)

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -39,24 +39,25 @@ make cannon
 # Note:
 #  - The L2 RPC is an archive L2 node on OP goerli.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
-./bin/cannon run \
-  --pprof.cpu \
-  --info-at '%10000000' \
-  --proof-at never \
-  --input ./state.json \
-  -- ../op-program/bin/op-program \
-  --l2 http://127.0.0.1:8745 \
-  --l1 http://127.0.0.1:8645 \
-  --l1.trustrpc \
-  --l1.rpckind debug_geth \
-  --log.format terminal \
-  --network goerli \
-  --l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab \
-  --l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816 \
-  --l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9 \
-  --l2.blocknumber 8813570 \
-  --datadir /tmp/fpp-database \
-  --server
+./bin/cannon run
+--pprof.cpu
+--info-at '%10000000'
+--proof-at never
+--input ./state.json
+--
+../op-program/bin/op-program
+--l2 http://127.0.0.1:8745
+--l1 http://127.0.0.1:8645
+--l1.trustrpc
+--l1.rpckind debug_geth
+--log.format terminal
+--l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816
+--network goerli
+--l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab
+--l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9
+--l2.blocknumber 8813570
+--datadir /tmp/fpp-database
+--server
 
 # Add --proof-at '=12345' (or pick other pattern, see --help)
 # to pick a step to build a proof for (e.g. exact step, every N steps, etc.)

--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -91,8 +91,9 @@ type Proof struct {
 	StateData hexutil.Bytes `json:"state-data"`
 	ProofData hexutil.Bytes `json:"proof-data"`
 
-	OracleKey   hexutil.Bytes `json:"oracle-key,omitempty"`
-	OracleValue hexutil.Bytes `json:"oracle-value,omitempty"`
+	OracleKey    hexutil.Bytes `json:"oracle-key,omitempty"`
+	OracleValue  hexutil.Bytes `json:"oracle-value,omitempty"`
+	OracleOffset uint32        `json:"oracle-offset,omitempty"`
 
 	StepInput   hexutil.Bytes `json:"step-input"`
 	OracleInput hexutil.Bytes `json:"oracle-input"`
@@ -304,7 +305,7 @@ func Run(ctx *cli.Context) error {
 		}
 
 		if snapshotAt(state) {
-			if err := writeJSON[*mipsevm.State](fmt.Sprintf(snapshotFmt, step), state, false); err != nil {
+			if err := writeJSON(fmt.Sprintf(snapshotFmt, step), state, false); err != nil {
 				return fmt.Errorf("failed to write state snapshot: %w", err)
 			}
 		}
@@ -332,8 +333,9 @@ func Run(ctx *cli.Context) error {
 				proof.OracleInput = inp
 				proof.OracleKey = witness.PreimageKey[:]
 				proof.OracleValue = witness.PreimageValue
+				proof.OracleOffset = witness.PreimageOffset
 			}
-			if err := writeJSON[*Proof](fmt.Sprintf(proofFmt, step), proof, true); err != nil {
+			if err := writeJSON(fmt.Sprintf(proofFmt, step), proof, true); err != nil {
 				return fmt.Errorf("failed to write proof data: %w", err)
 			}
 		} else {
@@ -344,7 +346,7 @@ func Run(ctx *cli.Context) error {
 		}
 	}
 
-	if err := writeJSON[*mipsevm.State](ctx.Path(RunOutputFlag.Name), state, true); err != nil {
+	if err := writeJSON(ctx.Path(RunOutputFlag.Name), state, true); err != nil {
 		return fmt.Errorf("failed to write state output: %w", err)
 	}
 	return nil


### PR DESCRIPTION
**Description**

This PR adds a new `PreimageOffset` field to cannon's
`Proof` object which is required for the challenger
to construct valid preimage oracle update calls.

**Metadata**

Fixes CLI-4320
