### PR TITLE
chore: Update Cannon Readme and Contracts Paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - checkout
       - check-changed:
-          patterns: cannon,packages/contracts-bedrock/contracts/cannon
+          patterns: cannon,packages/contracts-bedrock/src/cannon
       - run:
           name: prep Cannon results dir
           command: mkdir -p /tmp/test-results
@@ -723,7 +723,7 @@ jobs:
     steps:
       - checkout
       - check-changed:
-          patterns: cannon,packages/contracts-bedrock/contracts/cannon
+          patterns: cannon,packages/contracts-bedrock/src/cannon
       - run:
           name: Fuzz
           command: make fuzz

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The primary development branch is [`develop`](https://github.com/ethereum-optimi
 `develop` contains the most up-to-date software that remains backwards compatible with the latest experimental [network deployments](https://community.optimism.io/docs/useful-tools/networks/).
 If you're making a backwards compatible change, please direct your pull request towards `develop`.
 
-**Changes to contracts within `packages/contracts-bedrock/contracts` are usually NOT considered backwards compatible and SHOULD be made against a release candidate branch**.
+**Changes to contracts within `packages/contracts-bedrock/src` are usually NOT considered backwards compatible and SHOULD be made against a release candidate branch**.
 Some exceptions to this rule exist for cases in which we absolutely must deploy some new contract after a release candidate branch has already been fully deployed.
 If you're changing or adding a contract and you're unsure about which branch to make a PR into, default to using the latest release candidate branch.
 See below for info about release candidate branches.
@@ -120,7 +120,7 @@ See below for info about release candidate branches.
 ### Release candidate branches
 
 Branches marked `release/X.X.X` are **release candidate branches**.
-Changes that are not backwards compatible and all changes to contracts within `packages/contracts-bedrock/contracts` MUST be directed towards a release candidate branch.
+Changes that are not backwards compatible and all changes to contracts within `packages/contracts-bedrock/src` MUST be directed towards a release candidate branch.
 Release candidates are merged into `develop` and then into `master` once they've been fully deployed.
 We may sometimes have more than one active `release/X.X.X` branch if we're in the middle of a deployment.
 See table in the **Active Branches** section above to find the right branch to target.

--- a/cannon/README.md
+++ b/cannon/README.md
@@ -39,25 +39,25 @@ make cannon
 # Note:
 #  - The L2 RPC is an archive L2 node on OP goerli.
 #  - The L1 RPC is a non-archive RPC, also change `--l1.rpckind` to reflect the correct L1 RPC type.
-./bin/cannon run
---pprof.cpu
---info-at '%10000000'
---proof-at never
---input ./state.json
---
-../op-program/bin/op-program
---l2 http://127.0.0.1:8745
---l1 http://127.0.0.1:8645
---l1.trustrpc
---l1.rpckind debug_geth
---log.format terminal
---l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816
---network goerli
---l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab
---l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9
---l2.blocknumber 8813570
---datadir /tmp/fpp-database
---server
+./bin/cannon run \
+    --pprof.cpu \
+    --info-at '%10000000' \
+    --proof-at never \
+    --input ./state.json \
+    -- \
+    ../op-program/bin/op-program \
+    --network goerli \
+    --l1.trustrpc \
+    --l1.rpckind debug_geth \
+    --l1 http://127.0.0.1:8645 \
+    --l2 http://127.0.0.1:8745 \
+    --l1.head 0x204f815790ca3bb43526ad60ebcc64784ec809bdc3550e82b54a0172f981efab \
+    --l2.head 0xedc79de4d616a9100fdd42192224580daee81ea3d6303de8089d48a6c1bf4816 \
+    --l2.claim 0x530658ab1b1b3ff4829731fc8d5955f0e6b8410db2cd65b572067ba58df1f2b9 \
+    --l2.blocknumber 8813570 \
+    --datadir /tmp/fpp-database \
+    --log.format terminal \
+    --server
 
 # Add --proof-at '=12345' (or pick other pattern, see --help)
 # to pick a step to build a proof for (e.g. exact step, every N steps, etc.)
@@ -72,7 +72,7 @@ The Cannon contracts:
 - `PreimageOracle.sol`: implements the pre-image oracle ABI, to support the instruction execution pre-image requests.
 
 The smart-contracts are integrated into the Optimism monorepo contracts:
-[`../packages/contracts-bedrock/contracts/cannon`](../packages/contracts-bedrock/contracts/cannon)
+[`../packages/contracts-bedrock/src/cannon`](../packages/contracts-bedrock/src/cannon)
 
 ## `mipsevm`
 


### PR DESCRIPTION
**Description**

Updates the cannon readme to allow for an easy copy
paste of the cannon binary command into bash.

Updates references from `contracts-bedrock/contracts`
to the updated `contracts-bedrock/src` directory.
