### PR TITLE
chore: Bump `ci-builder`'s go version

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -45,8 +45,8 @@ COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
 RUN apt-get update && \
   apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl gnupg coreutils && \
   curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
-  curl -sL https://go.dev/dl/go1.19.linux-amd64.tar.gz -o go1.19.linux-amd64.tar.gz && \
-  tar -C /usr/local/ -xzvf go1.19.linux-amd64.tar.gz && \
+  curl -sL https://go.dev/dl/go1.20.linux-amd64.tar.gz -o go1.20.linux-amd64.tar.gz && \
+  tar -C /usr/local/ -xzvf go1.20.linux-amd64.tar.gz && \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt && \
   bash nodesource_setup.sh && \
   apt-get install -y nodejs && \


### PR DESCRIPTION
## Overview

Bump's `ci-builder`'s go version from `1.19.0` -> `1.20.0` so that we can build the cannon prestate in the `op-e2e` jobs in CI.

Relevant: https://github.com/golang/go/issues/54991