### PR TITLE
feat(indexer): Handle process panics & config failure

### DIFF
--- a/indexer/cli/cli.go
+++ b/indexer/cli/cli.go
@@ -23,15 +23,16 @@ type Cli struct {
 }
 
 func runIndexer(ctx *cli.Context) error {
+	logger := log.NewLogger(log.ReadCLIConfig(ctx))
+
 	configPath := ctx.String(ConfigFlag.Name)
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
+		logger.Error("failed to load config", "err", err)
 		return err
 	}
 
-	// setup logger
-	cfg.Logger = log.NewLogger(log.ReadCLIConfig(ctx))
-
+	cfg.Logger = logger
 	indexer, err := indexer.NewIndexer(cfg)
 	if err != nil {
 		return err
@@ -47,17 +48,20 @@ func runIndexer(ctx *cli.Context) error {
 }
 
 func runApi(ctx *cli.Context) error {
+	logger := log.NewLogger(log.ReadCLIConfig(ctx))
+
 	configPath := ctx.String(ConfigFlag.Name)
-	conf, err := config.LoadConfig(configPath)
-
-	fmt.Println(conf)
-
+	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
-		panic(err)
+		logger.Error("failed to load config", "err", err)
+		return err
 	}
 
+	cfg.Logger = logger
+	fmt.Println(cfg)
+
 	// finish me
-	return nil
+	return err
 }
 
 var (

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -91,12 +90,12 @@ func (i *Indexer) Run(ctx context.Context) error {
 		err := start(processorCtx)
 		if err != nil {
 			i.log.Error("halting indexer on error", "err", err)
-
 			cancel()
-			errCh <- err
-		} else {
-			errCh <- errors.New("processor stopped")
 		}
+
+		// Send a value down regardless if we've received an error or halted
+		// via cancellation where err == nil
+		errCh <- err
 	}
 
 	// Kick off the processors


### PR DESCRIPTION
We gracefully close on errors. Also do the same if the the indexer process panics.

`Indexer.Run` relies on receiving an error via the error channel before returning. If the
parent context cancels, we need to still send an error message in the channel or the 
process runs indefinitely

