### PR TITLE
RFP/DoNotMerge(StandardBridge): ERC20 Specific StandardBridge Extension

### DIFF
--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -145,7 +145,7 @@ abstract contract StandardBridge {
     /// @param _extraData   Extra data to be sent with the transaction. Note that the recipient will
     ///                     not be triggered with this data, but it will be emitted and can be used
     ///                     to identify the transaction.
-    function bridgeETH(uint32 _minGasLimit, bytes calldata _extraData) public payable onlyEOA {
+    function bridgeETH(uint32 _minGasLimit, bytes calldata _extraData) public payable virtual onlyEOA {
         _initiateBridgeETH(msg.sender, msg.sender, msg.value, _minGasLimit, _extraData);
     }
 
@@ -165,7 +165,7 @@ abstract contract StandardBridge {
         address _to,
         uint32 _minGasLimit,
         bytes calldata _extraData
-    ) public payable {
+    ) public payable virtual {
         _initiateBridgeETH(msg.sender, _to, msg.value, _minGasLimit, _extraData);
     }
 
@@ -304,7 +304,7 @@ abstract contract StandardBridge {
         uint256 _amount,
         uint32 _minGasLimit,
         bytes memory _extraData
-    ) internal {
+    ) internal virtual {
         require(
             msg.value == _amount,
             "StandardBridge: bridging ETH must include sufficient ETH value"

--- a/packages/contracts-bedrock/src/universal/StandardBridgeExtension.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridgeExtension.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { StandardBridge } from "./StandardBridge.sol";
+
+abstract contract StandardBridgeExtension is StandardBridge {
+    address public immutable LOCAL_TOKEN;
+    address public immutable REMOTE_TOKEN;
+
+    constructor(
+        address payable _messenger,
+        address payable _otherBridge,
+        address _localToken,
+        address _remoteToken
+    ) StandardBridge(_messenger, _otherBridge) {
+        LOCAL_TOKEN = _localToken;
+        REMOTE_TOKEN = _remoteToken;
+    }
+
+    modifier onlyERC20(address _localToken, address remoteToken) {
+        require(
+            LOCAL_TOKEN == _localToken && REMOTE_TOKEN == remoteToken,
+            "ERC20StandardBridge: can only bridge specified ERC20"
+        );
+        _;
+    }
+
+    /**
+     * Disable ETH Bridging
+     *   - (ideally we could re-route this to the official StandardBridge via the right address from SytemConfig)
+     */
+
+    function _initiateBridgeETH(
+        address _from,
+        address _to,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes memory _extraData
+    ) internal pure override {
+        revert("StandardBridgeExtensions: cannot bridge ETH using a standard bridge extension");
+    }
+
+    receive() external override payable {
+        revert("StandardBridgeExtensions: cannot bridge ETH using a standard bridge extension");
+    }
+
+    /**
+     * Bridge only the registered ERC20
+     */
+
+    /// @notice Bridge the registered ERC20 tokeen to the sender's address
+    function bridge(uint256 _amount, uint32 _minGasLimit, bytes calldata _extraData) public virtual {
+        bridgeERC20(LOCAL_TOKEN, REMOTE_TOKEN, _amount, _minGasLimit, _extraData);
+    }
+
+    /// @notice Bridge the registered ERC20 tokeen to the specified receiver's address.
+    function bridgeTo(address _to, uint256 _amount, uint32 _minGasLimit, bytes calldata _extraData) public virtual {
+        bridgeERC20To(LOCAL_TOKEN, REMOTE_TOKEN, _to, _amount, _minGasLimit, _extraData);
+    }
+
+    function bridgeERC20(
+        address _localToken,
+        address _remoteToken,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public override onlyERC20(_localToken, _remoteToken) {
+        super.bridgeERC20(_localToken, _remoteToken, _amount, _minGasLimit, _extraData);
+    }
+
+    function bridgeERC20To(
+        address _localToken,
+        address _remoteToken,
+        address _to,
+        uint256 _amount,
+        uint32 _minGasLimit,
+        bytes calldata _extraData
+    ) public override onlyERC20(_localToken, _remoteToken) {
+        super.bridgeERC20To(_localToken, _remoteToken, _to, _amount, _minGasLimit, _extraData);
+    }
+}

--- a/packages/contracts-bedrock/test/StandardBridgeExtension.t.sol
+++ b/packages/contracts-bedrock/test/StandardBridgeExtension.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { StandardBridge } from "../src/universal/StandardBridge.sol";
+import { StandardBridgeExtension } from "../src/universal/StandardBridgeExtension.sol";
+import { Bridge_Initializer, CommonTest } from "./CommonTest.t.sol";
+
+contract StandardBridgeExtensionTester is StandardBridgeExtension {
+    constructor(
+        address payable _messenger,
+        address payable _otherBridge,
+        address _localToken,
+        address _remoteToken
+    ) StandardBridgeExtension(_messenger, _otherBridge, _localToken, _remoteToken) {}
+
+    function revertIfWrongERC20(address _localToken, address _remoteToken) onlyERC20(_localToken, _remoteToken) public {}
+}
+
+contract StandardBridgeExtension_Stateless_Test is CommonTest {
+    StandardBridgeExtensionTester bridge;
+
+    function setUp() public override {
+        super.setUp();
+        bridge = new StandardBridgeExtensionTester ({
+            _messenger: payable(address(0)),
+            _otherBridge: payable(address(0)),
+            _localToken: address(0),
+            _remoteToken: address(1)
+        });
+    }
+
+    function test_revertIfWrongERC20() external {
+        // correct token pair
+        bridge.revertIfWrongERC20(address(0), address(1));
+
+        // swapped
+        vm.expectRevert();
+        bridge.revertIfWrongERC20(address(1), address(0));
+
+        vm.expectRevert();
+        bridge.bridgeERC20(address(1), address(0), 0, 0, hex"");
+
+        // just wrong
+        vm.expectRevert();
+        bridge.revertIfWrongERC20(address(1), address(2));
+
+        vm.expectRevert();
+        bridge.bridgeERC20To(address(1), address(0), address(0), 0, 0, hex"");
+    }
+
+    function test_revertWhenBridgingETH() external {
+        vm.prank(alice, alice);
+
+        // receive
+        (bool success, ) = address(bridge).call{ value: 100 }(hex"");
+        assertEq(success, false);
+
+        // bridgeETH
+        vm.expectRevert();
+        bridge.bridgeETH(0, hex"");
+        assertEq(success, false);
+
+        // bridgeETHTo
+        vm.expectRevert();
+        bridge.bridgeETHTo(address(0), 0, hex"");
+        assertEq(success, false);
+    }
+}
+
+contract StandardBridgeExtension_Test is Bridge_Initializer {
+    StandardBridgeExtensionTester bridge;
+
+    function setUp() public override {
+        super.setUp();
+        bridge = new StandardBridgeExtensionTester ({
+            _messenger: payable(L1Bridge.MESSENGER.address),
+            _otherBridge: payable(L1Bridge.OTHER_BRIDGE.address),
+            _localToken: address(L1Token),
+            _remoteToken: address(L2Token)
+        });
+    }
+
+    function test_bridge() external {
+        vm.prank(alice);
+        deal(address(L1Token), alice, 100000, true);
+        L1Token.approve(address(bridge), type(uint256).max);
+
+        // simply forwards to StandardBridge#bridgeERC20
+        bridge.bridge(100, 0, hex"");
+        vm.expectCall(
+            address(bridge),
+            abi.encodeWithSelector(StandardBridge.bridgeERC20.selector, address(L1Token), address(L2Token), 100, 0, hex"")
+        );
+        assertEq(bridge.deposits(address(L1Token), address(L2Token)), 100);
+
+        // simply forwards to StandardBridge#bridgeERC20To
+        bridge.bridgeTo(address(1), 100, 0, hex"");
+        vm.expectCall(
+            address(bridge),
+            abi.encodeWithSelector(StandardBridge.bridgeERC20To.selector, address(L1Token), address(L2Token), address(1), 100, 0, hex"")
+        );
+        assertEq(bridge.deposits(address(L1Token), address(L2Token)), 200);
+    }
+}


### PR DESCRIPTION
We want our thridparty bridge implementations to follow the StandardBridge abstraction. The StandardBridge
being an abstract class versus an interface is great since it enforces execution flow for bridging.

Here's an idea to how we can get our current third party bridges upgraded (DAI, SNX). An extension to the
StandardBridge limited to a single ERC20 token contract.

Some Extra Thoughts:
- via #6555, the StandardBridge can extract the right messenger from the SystemConfig rather than explicitly set on construction. This also allows us to route ETH sends directly to the optimism portal or deployed StandardBridge, regardless of the bridge contract it originates
     - For L1 Implementations. The L2 implementations would make use of the predeploy addresses