### PR TITLE
op-chain-ops: Fix flaky TestCode

### DIFF
--- a/op-chain-ops/state/memory_db_test.go
+++ b/op-chain-ops/state/memory_db_test.go
@@ -52,7 +52,11 @@ func TestCode(t *testing.T) {
 		db.SetCode(addr, code)
 
 		post := db.GetCode(addr)
-		require.Equal(t, post, code)
+		if len(code) == 0 {
+			require.Nil(t, post)
+		} else {
+			require.Equal(t, post, code)
+		}
 
 		size := db.GetCodeSize(addr)
 		require.Equal(t, size, len(code))


### PR DESCRIPTION
**Description**

If getting an empty code value in the state DB, geth returns `nil`, not an empty array. This is funcationally equivalent if you are checking the length, but not the same if you expect to get the same object out that you put in. This now checks for this special case & prevents the test from flaking.

This can be tested by running `go test ./state -count=10 -run=TestCode` in the op-chain-ops folder. Without this change the test will fail, with this change it will now pass.
