### PR TITLE
contracts-bedrock: remove compiler warnings in deploy script

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -121,17 +121,17 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the AddressManager
-    function deployAddressManager() public broadcast returns (address) {
+    function deployAddressManager() broadcast() public returns (address addr) {
         AddressManager manager = new AddressManager();
         require(manager.owner() == msg.sender);
 
         save("AddressManager", address(manager));
         console.log("AddressManager deployed at %s", address(manager));
-        return address(manager);
+        addr = address(manager);
     }
 
     /// @notice Deploy the ProxyAdmin
-    function deployProxyAdmin() public broadcast returns (address) {
+    function deployProxyAdmin() broadcast() public returns (address addr) {
         ProxyAdmin admin = new ProxyAdmin({
             _owner: msg.sender
         });
@@ -146,11 +146,11 @@ contract Deploy is Deployer {
 
         save("ProxyAdmin", address(admin));
         console.log("ProxyAdmin deployed at %s", address(admin));
-        return address(admin);
+        addr = address(admin);
     }
 
     /// @notice Deploy the L1StandardBridgeProxy
-    function deployL1StandardBridgeProxy() public broadcast returns (address) {
+    function deployL1StandardBridgeProxy() broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         L1ChugSplashProxy proxy = new L1ChugSplashProxy(proxyAdmin);
 
@@ -159,11 +159,11 @@ contract Deploy is Deployer {
 
         save("L1StandardBridgeProxy", address(proxy));
         console.log("L1StandardBridgeProxy deployed at %s", address(proxy));
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the L2OutputOracleProxy
-    function deployL2OutputOracleProxy() public broadcast returns (address) {
+    function deployL2OutputOracleProxy() broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -174,11 +174,11 @@ contract Deploy is Deployer {
 
         save("L2OutputOracleProxy", address(proxy));
         console.log("L2OutputOracleProxy deployed at %s", address(proxy));
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the L1CrossDomainMessengerProxy
-    function deployL1CrossDomainMessengerProxy() public broadcast returns (address) {
+    function deployL1CrossDomainMessengerProxy() broadcast() public returns (address addr) {
         AddressManager addressManager = AddressManager(mustGetAddress("AddressManager"));
         string memory contractName = "OVM_L1CrossDomainMessenger";
         ResolvedDelegateProxy proxy = new ResolvedDelegateProxy(addressManager, contractName);
@@ -186,18 +186,18 @@ contract Deploy is Deployer {
         save("L1CrossDomainMessengerProxy", address(proxy));
         console.log("L1CrossDomainMessengerProxy deployed at %s", address(proxy));
 
-        address addr = addressManager.getAddress(contractName);
-        if (addr != address(proxy)) {
+        address contractAddr = addressManager.getAddress(contractName);
+        if (contractAddr != address(proxy)) {
             addressManager.setAddress(contractName, address(proxy));
         }
 
         require(addressManager.getAddress(contractName) == address(proxy));
 
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the OptimismPortalProxy
-    function deployOptimismPortalProxy() public broadcast returns (address) {
+    function deployOptimismPortalProxy() broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -209,11 +209,11 @@ contract Deploy is Deployer {
         save("OptimismPortalProxy", address(proxy));
         console.log("OptimismPortalProxy deployed at %s", address(proxy));
 
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the OptimismMintableERC20FactoryProxy
-    function deployOptimismMintableERC20FactoryProxy() public broadcast returns (address) {
+    function deployOptimismMintableERC20FactoryProxy() broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -225,11 +225,11 @@ contract Deploy is Deployer {
         save("OptimismMintableERC20FactoryProxy", address(proxy));
         console.log("OptimismMintableERC20FactoryProxy deployed at %s", address(proxy));
 
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the L1ERC721BridgeProxy
-    function deployL1ERC721BridgeProxy() public broadcast returns (address) {
+    function deployL1ERC721BridgeProxy() broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -241,11 +241,11 @@ contract Deploy is Deployer {
         save("L1ERC721BridgeProxy", address(proxy));
         console.log("L1ERC721BridgeProxy deployed at %s", address(proxy));
 
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the SystemConfigProxy
-    function deploySystemConfigProxy() public broadcast returns (address) {
+    function deploySystemConfigProxy() broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -257,11 +257,11 @@ contract Deploy is Deployer {
         save("SystemConfigProxy", address(proxy));
         console.log("SystemConfigProxy deployed at %s", address(proxy));
 
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the DisputeGameFactoryProxy
-    function deployDisputeGameFactoryProxy() public onlyDevnet broadcast returns (address) {
+    function deployDisputeGameFactoryProxy() onlyDevnet broadcast() public returns (address addr) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -273,11 +273,11 @@ contract Deploy is Deployer {
         save("DisputeGameFactoryProxy", address(proxy));
         console.log("DisputeGameFactoryProxy deployed at %s", address(proxy));
 
-        return address(proxy);
+        addr = address(proxy);
     }
 
     /// @notice Deploy the L1CrossDomainMessenger
-    function deployL1CrossDomainMessenger() public broadcast returns (address) {
+    function deployL1CrossDomainMessenger() broadcast() public returns (address addr) {
         L1CrossDomainMessenger messenger = new L1CrossDomainMessenger();
 
         require(address(messenger.PORTAL()) == address(0));
@@ -289,11 +289,11 @@ contract Deploy is Deployer {
         save("L1CrossDomainMessenger", address(messenger));
         console.log("L1CrossDomainMessenger deployed at %s", address(messenger));
 
-        return address(messenger);
+        addr = address(messenger);
     }
 
     /// @notice Deploy the OptimismPortal
-    function deployOptimismPortal() public broadcast returns (address) {
+    function deployOptimismPortal() broadcast() public returns (address addr) {
         OptimismPortal portal = new OptimismPortal();
 
         require(address(portal.L2_ORACLE()) == address(0));
@@ -304,11 +304,11 @@ contract Deploy is Deployer {
         save("OptimismPortal", address(portal));
         console.log("OptimismPortal deployed at %s", address(portal));
 
-        return address(portal);
+        addr = address(portal);
     }
 
     /// @notice Deploy the L2OutputOracle
-    function deployL2OutputOracle() public broadcast returns (address) {
+    function deployL2OutputOracle() broadcast() public returns (address addr) {
         L2OutputOracle oracle = new L2OutputOracle({
             _submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
             _l2BlockTime: cfg.l2BlockTime(),
@@ -331,11 +331,11 @@ contract Deploy is Deployer {
         save("L2OutputOracle", address(oracle));
         console.log("L2OutputOracle deployed at %s", address(oracle));
 
-        return address(oracle);
+        addr = address(oracle);
     }
 
     /// @notice Deploy the OptimismMintableERC20Factory
-    function deployOptimismMintableERC20Factory() public broadcast returns (address) {
+    function deployOptimismMintableERC20Factory() broadcast() public returns (address addr) {
         address l1StandardBridgeProxy = mustGetAddress("L1StandardBridgeProxy");
         OptimismMintableERC20Factory factory = new OptimismMintableERC20Factory(l1StandardBridgeProxy);
 
@@ -344,47 +344,47 @@ contract Deploy is Deployer {
         save("OptimismMintableERC20Factory", address(factory));
         console.log("OptimismMintableERC20Factory deployed at %s", address(factory));
 
-        return address(factory);
+        addr = address(factory);
     }
 
     /// @notice Deploy the DisputeGameFactory
-    function deployDisputeGameFactory() public onlyDevnet broadcast returns (address) {
+    function deployDisputeGameFactory() onlyDevnet broadcast() public returns (address addr) {
         DisputeGameFactory factory = new DisputeGameFactory();
         save("DisputeGameFactory", address(factory));
         console.log("DisputeGameFactory deployed at %s", address(factory));
 
-        return address(factory);
+        addr = address(factory);
     }
 
     /// @notice Deploy the BlockOracle
-    function deployBlockOracle() public onlyDevnet broadcast returns (address) {
+    function deployBlockOracle() onlyDevnet broadcast() public returns (address addr) {
         BlockOracle oracle = new BlockOracle();
         save("BlockOracle", address(oracle));
         console.log("BlockOracle deployed at %s", address(oracle));
 
-        return address(oracle);
+        addr = address(oracle);
     }
 
     /// @notice Deploy the PreimageOracle
-    function deployPreimageOracle() public onlyDevnet broadcast returns (address) {
+    function deployPreimageOracle() onlyDevnet broadcast() public returns (address addr) {
         PreimageOracle preimageOracle = new PreimageOracle();
         save("PreimageOracle", address(preimageOracle));
         console.log("PreimageOracle deployed at %s", address(preimageOracle));
 
-        return address(preimageOracle);
+        addr = address(preimageOracle);
     }
 
     /// @notice Deploy Mips
-    function deployMips() public onlyDevnet broadcast returns (address) {
+    function deployMips() onlyDevnet broadcast() public returns (address addr) {
         MIPS mips = new MIPS(IPreimageOracle(mustGetAddress("PreimageOracle")));
         save("Mips", address(mips));
         console.log("MIPS deployed at %s", address(mips));
 
-        return address(mips);
+        addr = address(mips);
     }
 
     /// @notice Deploy the SystemConfig
-    function deploySystemConfig() public broadcast returns (address) {
+    function deploySystemConfig() broadcast() public returns (address addr) {
         SystemConfig config = new SystemConfig();
         bytes32 batcherHash = bytes32(uint256(uint160(cfg.batchSenderAddress())));
 
@@ -414,11 +414,11 @@ contract Deploy is Deployer {
         save("SystemConfig", address(config));
         console.log("SystemConfig deployed at %s", address(config));
 
-        return address(config);
+        addr = address(config);
     }
 
     /// @notice Deploy the L1StandardBridge
-    function deployL1StandardBridge() public broadcast returns (address) {
+    function deployL1StandardBridge() broadcast() public returns (address addr) {
         L1StandardBridge bridge = new L1StandardBridge();
 
         require(address(bridge.MESSENGER()) == address(0));
@@ -429,11 +429,11 @@ contract Deploy is Deployer {
         save("L1StandardBridge", address(bridge));
         console.log("L1StandardBridge deployed at %s", address(bridge));
 
-        return address(bridge);
+        addr = address(bridge);
     }
 
     /// @notice Deploy the L1ERC721Bridge
-    function deployL1ERC721Bridge() public broadcast returns (address) {
+    function deployL1ERC721Bridge() broadcast() public returns (address addr) {
         L1ERC721Bridge bridge = new L1ERC721Bridge();
 
         require(address(bridge.MESSENGER()) == address(0));
@@ -442,7 +442,7 @@ contract Deploy is Deployer {
         save("L1ERC721Bridge", address(bridge));
         console.log("L1ERC721Bridge deployed at %s", address(bridge));
 
-        return address(bridge);
+        addr = address(bridge);
     }
 
     /// @notice Transfer ownership of the address manager to the ProxyAdmin

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -46,8 +46,8 @@ contract Deploy is Deployer {
 
     /// @notice The name of the script, used to ensure the right deploy artifacts
     ///         are used.
-    function name() public pure override returns (string memory) {
-        return "Deploy";
+    function name() public pure override returns (string memory name_) {
+        name_ = "Deploy";
     }
 
     function setUp() public override {
@@ -121,17 +121,17 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the AddressManager
-    function deployAddressManager() broadcast() public returns (address addr) {
+    function deployAddressManager() broadcast() public returns (address addr_) {
         AddressManager manager = new AddressManager();
         require(manager.owner() == msg.sender);
 
         save("AddressManager", address(manager));
         console.log("AddressManager deployed at %s", address(manager));
-        addr = address(manager);
+        addr_ = address(manager);
     }
 
     /// @notice Deploy the ProxyAdmin
-    function deployProxyAdmin() broadcast() public returns (address addr) {
+    function deployProxyAdmin() broadcast() public returns (address addr_) {
         ProxyAdmin admin = new ProxyAdmin({
             _owner: msg.sender
         });
@@ -146,11 +146,11 @@ contract Deploy is Deployer {
 
         save("ProxyAdmin", address(admin));
         console.log("ProxyAdmin deployed at %s", address(admin));
-        addr = address(admin);
+        addr_ = address(admin);
     }
 
     /// @notice Deploy the L1StandardBridgeProxy
-    function deployL1StandardBridgeProxy() broadcast() public returns (address addr) {
+    function deployL1StandardBridgeProxy() broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         L1ChugSplashProxy proxy = new L1ChugSplashProxy(proxyAdmin);
 
@@ -159,11 +159,11 @@ contract Deploy is Deployer {
 
         save("L1StandardBridgeProxy", address(proxy));
         console.log("L1StandardBridgeProxy deployed at %s", address(proxy));
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the L2OutputOracleProxy
-    function deployL2OutputOracleProxy() broadcast() public returns (address addr) {
+    function deployL2OutputOracleProxy() broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -174,11 +174,11 @@ contract Deploy is Deployer {
 
         save("L2OutputOracleProxy", address(proxy));
         console.log("L2OutputOracleProxy deployed at %s", address(proxy));
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the L1CrossDomainMessengerProxy
-    function deployL1CrossDomainMessengerProxy() broadcast() public returns (address addr) {
+    function deployL1CrossDomainMessengerProxy() broadcast() public returns (address addr_) {
         AddressManager addressManager = AddressManager(mustGetAddress("AddressManager"));
         string memory contractName = "OVM_L1CrossDomainMessenger";
         ResolvedDelegateProxy proxy = new ResolvedDelegateProxy(addressManager, contractName);
@@ -193,11 +193,11 @@ contract Deploy is Deployer {
 
         require(addressManager.getAddress(contractName) == address(proxy));
 
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the OptimismPortalProxy
-    function deployOptimismPortalProxy() broadcast() public returns (address addr) {
+    function deployOptimismPortalProxy() broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -209,11 +209,11 @@ contract Deploy is Deployer {
         save("OptimismPortalProxy", address(proxy));
         console.log("OptimismPortalProxy deployed at %s", address(proxy));
 
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the OptimismMintableERC20FactoryProxy
-    function deployOptimismMintableERC20FactoryProxy() broadcast() public returns (address addr) {
+    function deployOptimismMintableERC20FactoryProxy() broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -225,11 +225,11 @@ contract Deploy is Deployer {
         save("OptimismMintableERC20FactoryProxy", address(proxy));
         console.log("OptimismMintableERC20FactoryProxy deployed at %s", address(proxy));
 
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the L1ERC721BridgeProxy
-    function deployL1ERC721BridgeProxy() broadcast() public returns (address addr) {
+    function deployL1ERC721BridgeProxy() broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -241,11 +241,11 @@ contract Deploy is Deployer {
         save("L1ERC721BridgeProxy", address(proxy));
         console.log("L1ERC721BridgeProxy deployed at %s", address(proxy));
 
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the SystemConfigProxy
-    function deploySystemConfigProxy() broadcast() public returns (address addr) {
+    function deploySystemConfigProxy() broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -257,11 +257,11 @@ contract Deploy is Deployer {
         save("SystemConfigProxy", address(proxy));
         console.log("SystemConfigProxy deployed at %s", address(proxy));
 
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the DisputeGameFactoryProxy
-    function deployDisputeGameFactoryProxy() onlyDevnet broadcast() public returns (address addr) {
+    function deployDisputeGameFactoryProxy() onlyDevnet broadcast() public returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -273,11 +273,11 @@ contract Deploy is Deployer {
         save("DisputeGameFactoryProxy", address(proxy));
         console.log("DisputeGameFactoryProxy deployed at %s", address(proxy));
 
-        addr = address(proxy);
+        addr_ = address(proxy);
     }
 
     /// @notice Deploy the L1CrossDomainMessenger
-    function deployL1CrossDomainMessenger() broadcast() public returns (address addr) {
+    function deployL1CrossDomainMessenger() broadcast() public returns (address addr_) {
         L1CrossDomainMessenger messenger = new L1CrossDomainMessenger();
 
         require(address(messenger.PORTAL()) == address(0));
@@ -289,11 +289,11 @@ contract Deploy is Deployer {
         save("L1CrossDomainMessenger", address(messenger));
         console.log("L1CrossDomainMessenger deployed at %s", address(messenger));
 
-        addr = address(messenger);
+        addr_ = address(messenger);
     }
 
     /// @notice Deploy the OptimismPortal
-    function deployOptimismPortal() broadcast() public returns (address addr) {
+    function deployOptimismPortal() broadcast() public returns (address addr_) {
         OptimismPortal portal = new OptimismPortal();
 
         require(address(portal.L2_ORACLE()) == address(0));
@@ -304,11 +304,11 @@ contract Deploy is Deployer {
         save("OptimismPortal", address(portal));
         console.log("OptimismPortal deployed at %s", address(portal));
 
-        addr = address(portal);
+        addr_ = address(portal);
     }
 
     /// @notice Deploy the L2OutputOracle
-    function deployL2OutputOracle() broadcast() public returns (address addr) {
+    function deployL2OutputOracle() broadcast() public returns (address addr_) {
         L2OutputOracle oracle = new L2OutputOracle({
             _submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
             _l2BlockTime: cfg.l2BlockTime(),
@@ -331,11 +331,11 @@ contract Deploy is Deployer {
         save("L2OutputOracle", address(oracle));
         console.log("L2OutputOracle deployed at %s", address(oracle));
 
-        addr = address(oracle);
+        addr_ = address(oracle);
     }
 
     /// @notice Deploy the OptimismMintableERC20Factory
-    function deployOptimismMintableERC20Factory() broadcast() public returns (address addr) {
+    function deployOptimismMintableERC20Factory() broadcast() public returns (address addr_) {
         address l1StandardBridgeProxy = mustGetAddress("L1StandardBridgeProxy");
         OptimismMintableERC20Factory factory = new OptimismMintableERC20Factory(l1StandardBridgeProxy);
 
@@ -344,47 +344,47 @@ contract Deploy is Deployer {
         save("OptimismMintableERC20Factory", address(factory));
         console.log("OptimismMintableERC20Factory deployed at %s", address(factory));
 
-        addr = address(factory);
+        addr_ = address(factory);
     }
 
     /// @notice Deploy the DisputeGameFactory
-    function deployDisputeGameFactory() onlyDevnet broadcast() public returns (address addr) {
+    function deployDisputeGameFactory() onlyDevnet broadcast() public returns (address addr_) {
         DisputeGameFactory factory = new DisputeGameFactory();
         save("DisputeGameFactory", address(factory));
         console.log("DisputeGameFactory deployed at %s", address(factory));
 
-        addr = address(factory);
+        addr_ = address(factory);
     }
 
     /// @notice Deploy the BlockOracle
-    function deployBlockOracle() onlyDevnet broadcast() public returns (address addr) {
+    function deployBlockOracle() onlyDevnet broadcast() public returns (address addr_) {
         BlockOracle oracle = new BlockOracle();
         save("BlockOracle", address(oracle));
         console.log("BlockOracle deployed at %s", address(oracle));
 
-        addr = address(oracle);
+        addr_ = address(oracle);
     }
 
     /// @notice Deploy the PreimageOracle
-    function deployPreimageOracle() onlyDevnet broadcast() public returns (address addr) {
+    function deployPreimageOracle() onlyDevnet broadcast() public returns (address addr_) {
         PreimageOracle preimageOracle = new PreimageOracle();
         save("PreimageOracle", address(preimageOracle));
         console.log("PreimageOracle deployed at %s", address(preimageOracle));
 
-        addr = address(preimageOracle);
+        addr_ = address(preimageOracle);
     }
 
     /// @notice Deploy Mips
-    function deployMips() onlyDevnet broadcast() public returns (address addr) {
+    function deployMips() onlyDevnet broadcast() public returns (address addr_) {
         MIPS mips = new MIPS(IPreimageOracle(mustGetAddress("PreimageOracle")));
         save("Mips", address(mips));
         console.log("MIPS deployed at %s", address(mips));
 
-        addr = address(mips);
+        addr_ = address(mips);
     }
 
     /// @notice Deploy the SystemConfig
-    function deploySystemConfig() broadcast() public returns (address addr) {
+    function deploySystemConfig() broadcast() public returns (address addr_) {
         SystemConfig config = new SystemConfig();
         bytes32 batcherHash = bytes32(uint256(uint160(cfg.batchSenderAddress())));
 
@@ -414,11 +414,11 @@ contract Deploy is Deployer {
         save("SystemConfig", address(config));
         console.log("SystemConfig deployed at %s", address(config));
 
-        addr = address(config);
+        addr_ = address(config);
     }
 
     /// @notice Deploy the L1StandardBridge
-    function deployL1StandardBridge() broadcast() public returns (address addr) {
+    function deployL1StandardBridge() broadcast() public returns (address addr_) {
         L1StandardBridge bridge = new L1StandardBridge();
 
         require(address(bridge.MESSENGER()) == address(0));
@@ -429,11 +429,11 @@ contract Deploy is Deployer {
         save("L1StandardBridge", address(bridge));
         console.log("L1StandardBridge deployed at %s", address(bridge));
 
-        addr = address(bridge);
+        addr_ = address(bridge);
     }
 
     /// @notice Deploy the L1ERC721Bridge
-    function deployL1ERC721Bridge() broadcast() public returns (address addr) {
+    function deployL1ERC721Bridge() broadcast() public returns (address addr_) {
         L1ERC721Bridge bridge = new L1ERC721Bridge();
 
         require(address(bridge.MESSENGER()) == address(0));
@@ -442,7 +442,7 @@ contract Deploy is Deployer {
         save("L1ERC721Bridge", address(bridge));
         console.log("L1ERC721Bridge deployed at %s", address(bridge));
 
-        addr = address(bridge);
+        addr_ = address(bridge);
     }
 
     /// @notice Transfer ownership of the address manager to the ProxyAdmin

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -121,7 +121,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the AddressManager
-    function deployAddressManager() broadcast() public returns (address addr_) {
+    function deployAddressManager() public broadcast returns (address addr_) {
         AddressManager manager = new AddressManager();
         require(manager.owner() == msg.sender);
 
@@ -131,7 +131,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the ProxyAdmin
-    function deployProxyAdmin() broadcast() public returns (address addr_) {
+    function deployProxyAdmin() public broadcast returns (address addr_) {
         ProxyAdmin admin = new ProxyAdmin({
             _owner: msg.sender
         });
@@ -150,7 +150,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L1StandardBridgeProxy
-    function deployL1StandardBridgeProxy() broadcast() public returns (address addr_) {
+    function deployL1StandardBridgeProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         L1ChugSplashProxy proxy = new L1ChugSplashProxy(proxyAdmin);
 
@@ -163,7 +163,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L2OutputOracleProxy
-    function deployL2OutputOracleProxy() broadcast() public returns (address addr_) {
+    function deployL2OutputOracleProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -178,7 +178,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L1CrossDomainMessengerProxy
-    function deployL1CrossDomainMessengerProxy() broadcast() public returns (address addr_) {
+    function deployL1CrossDomainMessengerProxy() public broadcast returns (address addr_) {
         AddressManager addressManager = AddressManager(mustGetAddress("AddressManager"));
         string memory contractName = "OVM_L1CrossDomainMessenger";
         ResolvedDelegateProxy proxy = new ResolvedDelegateProxy(addressManager, contractName);
@@ -197,7 +197,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the OptimismPortalProxy
-    function deployOptimismPortalProxy() broadcast() public returns (address addr_) {
+    function deployOptimismPortalProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -213,7 +213,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the OptimismMintableERC20FactoryProxy
-    function deployOptimismMintableERC20FactoryProxy() broadcast() public returns (address addr_) {
+    function deployOptimismMintableERC20FactoryProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -229,7 +229,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L1ERC721BridgeProxy
-    function deployL1ERC721BridgeProxy() broadcast() public returns (address addr_) {
+    function deployL1ERC721BridgeProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -245,7 +245,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the SystemConfigProxy
-    function deploySystemConfigProxy() broadcast() public returns (address addr_) {
+    function deploySystemConfigProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -261,7 +261,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the DisputeGameFactoryProxy
-    function deployDisputeGameFactoryProxy() onlyDevnet broadcast() public returns (address addr_) {
+    function deployDisputeGameFactoryProxy() public onlyDevnet broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
         Proxy proxy = new Proxy({
             _admin: proxyAdmin
@@ -277,7 +277,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L1CrossDomainMessenger
-    function deployL1CrossDomainMessenger() broadcast() public returns (address addr_) {
+    function deployL1CrossDomainMessenger() public broadcast returns (address addr_) {
         L1CrossDomainMessenger messenger = new L1CrossDomainMessenger();
 
         require(address(messenger.PORTAL()) == address(0));
@@ -293,7 +293,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the OptimismPortal
-    function deployOptimismPortal() broadcast() public returns (address addr_) {
+    function deployOptimismPortal() public broadcast returns (address addr_) {
         OptimismPortal portal = new OptimismPortal();
 
         require(address(portal.L2_ORACLE()) == address(0));
@@ -308,7 +308,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L2OutputOracle
-    function deployL2OutputOracle() broadcast() public returns (address addr_) {
+    function deployL2OutputOracle() public broadcast returns (address addr_) {
         L2OutputOracle oracle = new L2OutputOracle({
             _submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
             _l2BlockTime: cfg.l2BlockTime(),
@@ -335,7 +335,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the OptimismMintableERC20Factory
-    function deployOptimismMintableERC20Factory() broadcast() public returns (address addr_) {
+    function deployOptimismMintableERC20Factory() public broadcast returns (address addr_) {
         address l1StandardBridgeProxy = mustGetAddress("L1StandardBridgeProxy");
         OptimismMintableERC20Factory factory = new OptimismMintableERC20Factory(l1StandardBridgeProxy);
 
@@ -348,7 +348,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the DisputeGameFactory
-    function deployDisputeGameFactory() onlyDevnet broadcast() public returns (address addr_) {
+    function deployDisputeGameFactory() public onlyDevnet broadcast returns (address addr_) {
         DisputeGameFactory factory = new DisputeGameFactory();
         save("DisputeGameFactory", address(factory));
         console.log("DisputeGameFactory deployed at %s", address(factory));
@@ -357,7 +357,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the BlockOracle
-    function deployBlockOracle() onlyDevnet broadcast() public returns (address addr_) {
+    function deployBlockOracle() public onlyDevnet broadcast returns (address addr_) {
         BlockOracle oracle = new BlockOracle();
         save("BlockOracle", address(oracle));
         console.log("BlockOracle deployed at %s", address(oracle));
@@ -366,7 +366,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the PreimageOracle
-    function deployPreimageOracle() onlyDevnet broadcast() public returns (address addr_) {
+    function deployPreimageOracle() public onlyDevnet broadcast returns (address addr_) {
         PreimageOracle preimageOracle = new PreimageOracle();
         save("PreimageOracle", address(preimageOracle));
         console.log("PreimageOracle deployed at %s", address(preimageOracle));
@@ -375,7 +375,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy Mips
-    function deployMips() onlyDevnet broadcast() public returns (address addr_) {
+    function deployMips() public onlyDevnet broadcast returns (address addr_) {
         MIPS mips = new MIPS(IPreimageOracle(mustGetAddress("PreimageOracle")));
         save("Mips", address(mips));
         console.log("MIPS deployed at %s", address(mips));
@@ -384,7 +384,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the SystemConfig
-    function deploySystemConfig() broadcast() public returns (address addr_) {
+    function deploySystemConfig() public broadcast returns (address addr_) {
         SystemConfig config = new SystemConfig();
         bytes32 batcherHash = bytes32(uint256(uint160(cfg.batchSenderAddress())));
 
@@ -418,7 +418,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L1StandardBridge
-    function deployL1StandardBridge() broadcast() public returns (address addr_) {
+    function deployL1StandardBridge() public broadcast returns (address addr_) {
         L1StandardBridge bridge = new L1StandardBridge();
 
         require(address(bridge.MESSENGER()) == address(0));
@@ -433,7 +433,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Deploy the L1ERC721Bridge
-    function deployL1ERC721Bridge() broadcast() public returns (address addr_) {
+    function deployL1ERC721Bridge() public broadcast returns (address addr_) {
         L1ERC721Bridge bridge = new L1ERC721Bridge();
 
         require(address(bridge.MESSENGER()) == address(0));


### PR DESCRIPTION
**Description**

The only devnet modifier causes branching logic in a way where sometimes nothing is returned, triggering a compiler warning. This compiler warning can be removed by using named return args. Refactor the deploy script to use named return args to remove the compiler warnings.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

