### PR TITLE
specs: fix broken links

### DIFF
--- a/specs/challenger.md
+++ b/specs/challenger.md
@@ -48,7 +48,7 @@ to each of the different game types. For specification of dispute game types, se
 
 ### `GameType.FAULT`
 
-> **Warning**  
+> **Warning**
 > The `FAULT` game type is not yet implemented. In the first iteration of Optimism's decentralization effort,
 > challengers will respond to `ATTESTATION` games only.
 
@@ -59,7 +59,7 @@ to each of the different game types. For specification of dispute game types, se
 
 **Events and Responses**
 
-- [`L2OutputOracle.OutputProposed`](../packages/contracts-bedrock/contracts/L1/L2OutputOracle.sol#L57-70)
+- [`L2OutputOracle.OutputProposed`](../packages/contracts-bedrock/src/L1/L2OutputOracle.sol#L57-70)
   The `L2OutputOracle` contract emits this event when a new output is proposed on the data availability
   layer. Each time an output is proposed, the Challenger should check to see if the output is equal
   the output given by the `optimism_outputAtBlock` endpoint of their `rollup-node`.
@@ -85,7 +85,7 @@ A full diagram and lifecycle of the Challenger's role in the `ATTESTATION` game 
 
 **TODO**
 
-> **Warning**  
+> **Warning**
 > The `VALIDITY` game type is not yet implemented. In the first iteration of Optimism's decentralization effort,
 > challengers will respond to `ATTESTATION` games only. A validity proof based dispute game is a possibility,
 > but fault proof based dispute games will be the primary focus of the team in the near future.

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -306,7 +306,7 @@ The contract has the following solidity interface, and can be interacted with ac
 
 A reference implementation of the L1 Attributes predeploy contract can be found in [L1Block.sol].
 
-[L1Block.sol]: ../packages/contracts-bedrock/contracts/L2/L1Block.sol
+[L1Block.sol]: ../packages/contracts-bedrock/src/L2/L1Block.sol
 
 After running `pnpm build` in the `packages/contracts` directory, the bytecode to add to the genesis
 file will be located in the `deployedBytecode` field of the build artifacts file at

--- a/specs/predeploys.md
+++ b/specs/predeploys.md
@@ -70,7 +70,7 @@ or `Bedrock`. Deprecated contracts should not be used.
 
 ## LegacyMessagePasser
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/legacy/LegacyMessagePasser.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/legacy/LegacyMessagePasser.sol)
 
 Address: `0x4200000000000000000000000000000000000000`
 
@@ -92,7 +92,7 @@ finalized.
 
 ## L2ToL1MessagePasser
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/L2ToL1MessagePasser.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol)
 
 Address: `0x4200000000000000000000000000000000000016`
 
@@ -106,7 +106,7 @@ permissionlessly removed from the L2 supply by calling the `burn()` function.
 
 ## DeployerWhitelist
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/legacy/DeployerWhitelist.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/legacy/DeployerWhitelist.sol)
 
 Address: `0x4200000000000000000000000000000000000002`
 
@@ -125,7 +125,7 @@ This contract is deprecated and its usage should be avoided.
 
 ## LegacyERC20ETH
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/legacy/LegacyERC20ETH.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/legacy/LegacyERC20ETH.sol)
 
 Address: `0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000`
 
@@ -141,7 +141,7 @@ This contract is deprecated and its usage should be avoided.
 
 ## WETH9
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/vendor/WETH9.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/vendor/WETH9.sol)
 
 Address: `0x4200000000000000000000000000000000000006`
 
@@ -151,7 +151,7 @@ deterministic address across Optimism based networks.
 
 ## L2CrossDomainMessenger
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/L2CrossDomainMessenger.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol)
 
 Address: `0x4200000000000000000000000000000000000007`
 
@@ -170,7 +170,7 @@ domain through the remote domain's `relayMessage` function.
 
 ## L2StandardBridge
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/L2StandardBridge.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2StandardBridge.sol)
 
 Address: `0x4200000000000000000000000000000000000010`
 
@@ -197,7 +197,7 @@ withdrawn to L1.
 
 ## L1BlockNumber
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/legacy/L1BlockNumber.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/legacy/L1BlockNumber.sol)
 
 Address: `0x4200000000000000000000000000000000000013`
 
@@ -210,7 +210,7 @@ L1 on L2.
 
 ## GasPriceOracle
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/GasPriceOracle.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/GasPriceOracle.sol)
 
 Address: `0x420000000000000000000000000000000000000F`
 
@@ -240,7 +240,7 @@ has been hardcoded to 6.
 
 ## L1Block
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/L1Block.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L1Block.sol)
 
 Address: `0x4200000000000000000000000000000000000015`
 
@@ -251,7 +251,7 @@ maintaining L1 context in L2. This allows for L1 state to be accessed in L2.
 
 ## ProxyAdmin
 
-[ProxyAdmin](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/universal/ProxyAdmin.sol)
+[ProxyAdmin](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/ProxyAdmin.sol)
 Address: `0x4200000000000000000000000000000000000018`
 
 The `ProxyAdmin` is the owner of all of the proxy contracts set at the
@@ -260,7 +260,7 @@ have the ability to upgrade any of the other predeploy contracts.
 
 ## SequencerFeeVault
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/SequencerFeeVault.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/SequencerFeeVault.sol)
 
 Address: `0x4200000000000000000000000000000000000011`
 
@@ -273,7 +273,7 @@ upgraded by changing its proxy's implementation key.
 
 ## OptimismMintableERC20Factory
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20Factory.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/OptimismMintableERC20Factory.sol)
 
 Address: `0x4200000000000000000000000000000000000012`
 
@@ -286,7 +286,7 @@ and burn tokens, depending on if the user is depositing from L1 to L2 or withdra
 
 ## OptimismMintableERC721Factory
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/universal/OptimismMintableERC721Factory.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/universal/OptimismMintableERC721Factory.sol)
 
 Address: `0x4200000000000000000000000000000000000017`
 
@@ -295,7 +295,7 @@ depositing native L1 NFTs into.
 
 ## BaseFeeVault
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/BaseFeeVault.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/BaseFeeVault.sol)
 
 Address: `0x4200000000000000000000000000000000000019`
 
@@ -306,7 +306,7 @@ L1.
 
 ## L1FeeVault
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/L2/L1FeeVault.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L1FeeVault.sol)
 
 Address: `0x420000000000000000000000000000000000001a`
 
@@ -316,7 +316,7 @@ withdrawn to an immutable address on L1.
 
 ## SchemaRegistry
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/EAS/SchemaRegistry.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/EAS/SchemaRegistry.sol)
 
 Address: `0x4200000000000000000000000000000000000020`
 
@@ -325,7 +325,7 @@ protocol.
 
 ## EAS
 
-[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/EAS/EAS.sol)
+[Implementation](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/EAS/EAS.sol)
 
 Address: `0x4200000000000000000000000000000000000021`
 

--- a/specs/withdrawals.md
+++ b/specs/withdrawals.md
@@ -214,5 +214,5 @@ whether or not it was 'supposed' to fail, and whether or not it should be 'repla
 minimize complexity, we have not provided any replay functionality, this may be implemented in external utility
 contracts if desired.
 
-[`WithdrawalTransaction` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/contracts/libraries/Types.sol#L76-L83
-[`OutputRootProof` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/contracts/libraries/Types.sol#L33-L38
+[`WithdrawalTransaction` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/src/libraries/Types.sol#L76-L83
+[`OutputRootProof` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/src/libraries/Types.sol#L33-L38

--- a/specs/withdrawals.md
+++ b/specs/withdrawals.md
@@ -214,5 +214,5 @@ whether or not it was 'supposed' to fail, and whether or not it should be 'repla
 minimize complexity, we have not provided any replay functionality, this may be implemented in external utility
 contracts if desired.
 
-[`WithdrawalTransaction` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/src/libraries/Types.sol#L76-L83
-[`OutputRootProof` type]: https://github.com/ethereum-optimism/optimism/blob/6c6d142d7bb95faa11066aab5d8aed7187abfe38/packages/contracts-bedrock/src/libraries/Types.sol#L33-L38
+[`WithdrawalTransaction` type]: https://github.com/ethereum-optimism/optimism/blob/08daf8dbd38c9ffdbd18fc9a211c227606cdb0ad/packages/contracts-bedrock/src/libraries/Types.sol#L62-L69
+[`OutputRootProof` type]: https://github.com/ethereum-optimism/optimism/blob/08daf8dbd38c9ffdbd18fc9a211c227606cdb0ad/packages/contracts-bedrock/src/libraries/Types.sol#L25-L30


### PR DESCRIPTION
**Description**

The contracts bedrock links broke when the package was migrated to a foundry style package.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

