### PR TITLE
op-challenger: Increase the default cannon snapshot frequency

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -58,7 +58,7 @@ func ValidTraceType(value TraceType) bool {
 	return false
 }
 
-const DefaultCannonSnapshotFreq = uint(10_000)
+const DefaultCannonSnapshotFreq = uint(1_000_000_000)
 
 // Config is a well typed config that is parsed from the CLI params.
 // This also contains config options for auxiliary services.


### PR DESCRIPTION
**Description**

Generating snapshots is very slow and uses a lot of disk space so they should be relatively infrequent. Performance tests showed the new value gave a good balance with about 2.5 minutes of cannon execution between each snapshot.
