### PR TITLE
op-challenger: Use proof from last step

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -58,7 +58,7 @@ func ValidTraceType(value TraceType) bool {
 	return false
 }
 
-const DefaultCannonSnapshotFreq = uint(10_000)
+const DefaultCannonSnapshotFreq = uint(1_000_000_000)
 
 // Config is a well typed config that is parsed from the CLI params.
 // This also contains config options for auxiliary services.

--- a/op-challenger/fault/cannon/cannon_state.go
+++ b/op-challenger/fault/cannon/cannon_state.go
@@ -1,0 +1,23 @@
+package cannon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+)
+
+func parseState(path string) (*mipsevm.State, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open state file (%v): %w", path, err)
+	}
+	defer file.Close()
+	var state mipsevm.State
+	err = json.NewDecoder(file).Decode(&state)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mipsevm state (%v): %w", path, err)
+	}
+	return &state, nil
+}

--- a/op-challenger/fault/cannon/executor_test.go
+++ b/op-challenger/fault/cannon/executor_test.go
@@ -36,7 +36,7 @@ func TestGenerateProof(t *testing.T) {
 		l2Claim:       common.Hash{0x44},
 		l2BlockNumber: big.NewInt(3333),
 	}
-	captureExec := func(cfg config.Config, proofAt uint64) (string, string, map[string]string) {
+	captureExec := func(t *testing.T, cfg config.Config, proofAt uint64) (string, string, map[string]string) {
 		executor := NewExecutor(testlog.Logger(t, log.LvlInfo), &cfg, inputs)
 		executor.selectSnapshot = func(logger log.Logger, dir string, absolutePreState string, i uint64) (string, error) {
 			return input, nil
@@ -67,7 +67,7 @@ func TestGenerateProof(t *testing.T) {
 		cfg.CannonNetwork = "mainnet"
 		cfg.CannonRollupConfigPath = ""
 		cfg.CannonL2GenesisPath = ""
-		binary, subcommand, args := captureExec(cfg, 150_000_000)
+		binary, subcommand, args := captureExec(t, cfg, 150_000_000)
 		require.DirExists(t, filepath.Join(cfg.CannonDatadir, preimagesDir))
 		require.DirExists(t, filepath.Join(cfg.CannonDatadir, proofsDir))
 		require.DirExists(t, filepath.Join(cfg.CannonDatadir, snapsDir))
@@ -76,7 +76,7 @@ func TestGenerateProof(t *testing.T) {
 		require.Equal(t, input, args["--input"])
 		require.Contains(t, args, "--meta")
 		require.Equal(t, "", args["--meta"])
-		require.Equal(t, filepath.Join(cfg.CannonDatadir, "out.json"), args["--output"])
+		require.Equal(t, filepath.Join(cfg.CannonDatadir, finalState), args["--output"])
 		require.Equal(t, "=150000000", args["--proof-at"])
 		require.Equal(t, "=150000001", args["--stop-at"])
 		require.Equal(t, "%500", args["--snapshot-at"])
@@ -105,7 +105,7 @@ func TestGenerateProof(t *testing.T) {
 		cfg.CannonNetwork = ""
 		cfg.CannonRollupConfigPath = "rollup.json"
 		cfg.CannonL2GenesisPath = "genesis.json"
-		_, _, args := captureExec(cfg, 150_000_000)
+		_, _, args := captureExec(t, cfg, 150_000_000)
 		require.NotContains(t, args, "--network")
 		require.Equal(t, cfg.CannonRollupConfigPath, args["--rollup.config"])
 		require.Equal(t, cfg.CannonL2GenesisPath, args["--l2.genesis"])
@@ -115,7 +115,7 @@ func TestGenerateProof(t *testing.T) {
 		cfg.CannonNetwork = "mainnet"
 		cfg.CannonRollupConfigPath = "rollup.json"
 		cfg.CannonL2GenesisPath = "genesis.json"
-		_, _, args := captureExec(cfg, math.MaxUint64)
+		_, _, args := captureExec(t, cfg, math.MaxUint64)
 		// stop-at would need to be one more than the proof step which would overflow back to 0
 		// so expect that it will be omitted. We'll ultimately want cannon to execute until the program exits.
 		require.NotContains(t, args, "--stop-at")

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -33,7 +33,7 @@ func (g *FaultGameHelper) GameDuration(ctx context.Context) time.Duration {
 }
 
 func (g *FaultGameHelper) WaitForClaimCount(ctx context.Context, count int64) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	err := utils.WaitFor(ctx, time.Second, func() (bool, error) {
 		actual, err := g.game.ClaimDataLen(&bind.CallOpts{Context: ctx})

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -145,7 +145,6 @@ func TestChallengerCompleteDisputeGame(t *testing.T) {
 }
 
 func TestCannonDisputeGame(t *testing.T) {
-	t.Skip("CLI-4290: op-challenger doesn't handle trace extension correctly for cannon")
 	InitParallel(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Description**

Update the cannon trace provider to use the proof from the last step of the trace for any index beyond that point.

Generating the proof for the last step actually requires knowing how many steps are in the trace, because the proof needs to generate a Merkle proof of the memory pre-state which can't be done from the state after the step is executed. The claim hash however can be calculated from the resulting state.  So if the requested proof isn't generated by cannon, we check the final state it output and if it is prior to the index we wanted and indicates the VM is exited we record the total number of steps. If only the claim hash is required, we derive it from the final output state, if the actual proof data is required we re-execute cannon requesting the proof for the last step be generated.

Once the actual length of the trace is known, any requests for trace indices after that point are adjusted to request the proof of the last step to avoid unnecessarily re-executing.

Builds on https://github.com/ethereum-optimism/optimism/pull/6650 since that's required to make the e2e test pass in a reasonable time.

**Tests**

Updated unit tests.  e2e test now passes with challenger posting it's first counter claim! 🎉 

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4290/create-proof-at-program-exit
