### PR TITLE
fix: Fix dependabot being configured to individual packages instead of monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,49 +20,10 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+      time: "16:30"
+      timezone: "America/New_York"
     open-pull-requests-limit: 10
-    labels:
-      - dependabot
-  - package-ecosystem: npm
-    directory: "/packages/chain-mon"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependabot
-  - package-ecosystem: npm
-    directory: "/packages/core-utils"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependabot
-  - package-ecosystem: npm
-    directory: "/packages/contracts-ts"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependabot
-  - package-ecosystem: npm
-    directory: "/packages/sdk"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependabot
-  - package-ecosystem: npm
-    directory: "/packages/fee-estimation"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependabot
-  - package-ecosystem: npm
-    directory: "/packages/common-ts"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+    versioning-strategy: auto
     labels:
       - dependabot
 


### PR DESCRIPTION
- dependabot was configured for individual packages instead of the monorepo
- this caused it to run on a package by package basis without updating the pnpm-lockfile
- dependabot is workspace aware you don't have to configure individual packages
