### PR TITLE
feat(indexer): Store RLP bytes of logs/headers when indexing them

### DIFF
--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -22,6 +22,8 @@ type BlockHeader struct {
 	ParentHash common.Hash `gorm:"serializer:json"`
 	Number     U256
 	Timestamp  uint64
+
+	GethHeader *GethHeader `gorm:"serializer:rlp;column:rlp_bytes"`
 }
 
 func BlockHeaderFromGethHeader(header *types.Header) BlockHeader {
@@ -30,6 +32,8 @@ func BlockHeaderFromGethHeader(header *types.Header) BlockHeader {
 		ParentHash: header.ParentHash,
 		Number:     U256{Int: header.Number},
 		Timestamp:  header.Time,
+
+		GethHeader: (*GethHeader)(header),
 	}
 }
 

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -23,19 +23,28 @@ type ContractEvent struct {
 	EventSignature common.Hash `gorm:"serializer:json"`
 	LogIndex       uint64
 	Timestamp      uint64
+
+	GethLog *types.Log `gorm:"serializer:rlp;column:rlp_bytes"`
 }
 
 func ContractEventFromGethLog(log *types.Log, timestamp uint64) ContractEvent {
+	eventSig := common.Hash{}
+	if len(log.Topics) > 0 {
+		eventSig = log.Topics[0]
+	}
+
 	return ContractEvent{
 		GUID: uuid.New(),
 
 		BlockHash:       log.BlockHash,
 		TransactionHash: log.TxHash,
 
-		EventSignature: log.Topics[0],
+		EventSignature: eventSig,
 		LogIndex:       uint64(log.Index),
 
 		Timestamp: timestamp,
+
+		GethLog: log,
 	}
 }
 

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -16,9 +16,10 @@ import (
  */
 
 type ContractEvent struct {
-	GUID            uuid.UUID   `gorm:"primaryKey"`
-	BlockHash       common.Hash `gorm:"serializer:json"`
-	TransactionHash common.Hash `gorm:"serializer:json"`
+	GUID            uuid.UUID      `gorm:"primaryKey"`
+	BlockHash       common.Hash    `gorm:"serializer:json"`
+	ContractAddress common.Address `gorm:"serializer:json"`
+	TransactionHash common.Hash    `gorm:"serializer:json"`
 
 	EventSignature common.Hash `gorm:"serializer:json"`
 	LogIndex       uint64
@@ -37,6 +38,7 @@ func ContractEventFromGethLog(log *types.Log, timestamp uint64) ContractEvent {
 		GUID: uuid.New(),
 
 		BlockHash:       log.BlockHash,
+		ContractAddress: log.Address,
 		TransactionHash: log.TxHash,
 
 		EventSignature: eventSig,

--- a/indexer/database/rlp_serializer.go
+++ b/indexer/database/rlp_serializer.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"gorm.io/gorm/schema"
+)
+
+type RLPSerializer struct{}
+
+type RLPInterface interface {
+	rlp.Encoder
+	rlp.Decoder
+}
+
+func init() {
+	schema.RegisterSerializer("rlp", RLPSerializer{})
+}
+
+func (RLPSerializer) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue interface{}) error {
+	fieldValue := reflect.New(field.FieldType)
+	if dbValue != nil {
+		var bytes []byte
+		switch v := dbValue.(type) {
+		case []byte:
+			bytes = v
+		case string:
+			b, err := hexutil.Decode(v)
+			if err != nil {
+				return err
+			}
+			bytes = b
+		default:
+			return fmt.Errorf("unrecognized RLP bytes: %#v", dbValue)
+		}
+
+		if len(bytes) > 0 {
+			err := rlp.DecodeBytes(bytes, fieldValue.Interface())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	field.ReflectValueOf(ctx, dst).Set(fieldValue.Elem())
+	return nil
+}
+
+func (RLPSerializer) Value(ctx context.Context, field *schema.Field, dst reflect.Value, fieldValue interface{}) (interface{}, error) {
+	// Even though rlp.Encode takes an interface and will error out if the passed interface does not
+	// satisfy the interface, we check here since we also want to make sure this type satisfies the
+	// rlp.Decoder interface as well
+	i := reflect.TypeOf(new(RLPInterface)).Elem()
+	if !reflect.TypeOf(fieldValue).Implements(i) {
+		return nil, fmt.Errorf("%T does not satisfy RLP Encoder & Decoder interface", fieldValue)
+	}
+
+	rlpBytes, err := rlp.EncodeToBytes(fieldValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return hexutil.Bytes(rlpBytes).MarshalText()
+}

--- a/indexer/e2e_tests/blocks_e2e_test.go
+++ b/indexer/e2e_tests/blocks_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/stretchr/testify/require"
 )
@@ -62,6 +63,9 @@ func TestE2EBlockHeaders(t *testing.T) {
 			require.Equal(t, header.Hash(), indexedHeader.Hash)
 			require.Equal(t, header.ParentHash, indexedHeader.ParentHash)
 			require.Equal(t, header.Time, indexedHeader.Timestamp)
+
+			// ensure the right rlp encoding is stored. checking the hashes sufficies
+			require.Equal(t, header.Hash(), indexedHeader.GethHeader.Hash())
 		}
 	})
 
@@ -119,6 +123,13 @@ func TestE2EBlockHeaders(t *testing.T) {
 			require.Equal(t, log.TxHash, contractEvent.TransactionHash)
 			require.Equal(t, log.Index, uint(contractEvent.LogIndex))
 
+			// ensure the right rlp encoding of the contract log is stored
+			logRlp, err := rlp.EncodeToBytes(&log)
+			require.NoError(t, err)
+			contractEventRlp, err := rlp.EncodeToBytes(contractEvent.GethLog)
+			require.NoError(t, err)
+			require.ElementsMatch(t, logRlp, contractEventRlp)
+
 			// ensure the block is also indexed
 			block, err := testSuite.L1Client.BlockByNumber(testCtx, big.NewInt(int64(log.BlockNumber)))
 			require.NoError(t, err)
@@ -131,6 +142,10 @@ func TestE2EBlockHeaders(t *testing.T) {
 			require.Equal(t, block.ParentHash(), l1BlockHeader.ParentHash)
 			require.Equal(t, block.Number(), l1BlockHeader.Number.Int)
 			require.Equal(t, block.Time(), l1BlockHeader.Timestamp)
+
+			// ensure the right rlp encoding is stored. checking the hashes
+			// suffices as it is based on the rlp bytes of the header
+			require.Equal(t, block.Hash(), l1BlockHeader.GethHeader.Hash())
 		}
 	})
 }

--- a/indexer/e2e_tests/blocks_e2e_test.go
+++ b/indexer/e2e_tests/blocks_e2e_test.go
@@ -120,6 +120,7 @@ func TestE2EBlockHeaders(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, log.Topics[0], contractEvent.EventSignature)
 			require.Equal(t, log.BlockHash, contractEvent.BlockHash)
+			require.Equal(t, log.Address, contractEvent.ContractAddress)
 			require.Equal(t, log.TxHash, contractEvent.TransactionHash)
 			require.Equal(t, log.Index, uint(contractEvent.LogIndex))
 

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS l1_contract_events (
     -- Searchable fields
     guid             VARCHAR NOT NULL PRIMARY KEY,
 	block_hash       VARCHAR NOT NULL REFERENCES l1_block_headers(hash),
+    contract_address VARCHAR NOT NULL,
     transaction_hash VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
     event_signature  VARCHAR NOT NULL, -- bytes32(0x0) when topics are missing
@@ -49,6 +50,7 @@ CREATE TABLE IF NOT EXISTS l2_contract_events (
     -- Searchable fields
     guid             VARCHAR NOT NULL PRIMARY KEY,
 	block_hash       VARCHAR NOT NULL REFERENCES l2_block_headers(hash),
+    contract_address VARCHAR NOT NULL,
     transaction_hash VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
     event_signature  VARCHAR NOT NULL, -- bytes32(0x0) when topics are missing

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS l1_contract_events (
 	block_hash       VARCHAR NOT NULL REFERENCES l1_block_headers(hash),
     transaction_hash VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
-    event_signature  VARCHAR NOT NULL, -- Edge case anon events are 0x0
+    event_signature  VARCHAR NOT NULL, -- bytes32(0x0) when topics are missing
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0),
 
     -- Raw Data
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS l2_contract_events (
 	block_hash       VARCHAR NOT NULL REFERENCES l2_block_headers(hash),
     transaction_hash VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
-    event_signature  VARCHAR, -- Edge case of anonymous events
+    event_signature  VARCHAR NOT NULL, -- bytes32(0x0) when topics are missing
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0),
 
     -- Raw Data

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -7,18 +7,25 @@ CREATE DOMAIN UINT256 AS NUMERIC
  */
 
 CREATE TABLE IF NOT EXISTS l1_block_headers (
+    -- Searchable fields
 	hash        VARCHAR NOT NULL PRIMARY KEY,
 	parent_hash VARCHAR NOT NULL,
 	number      UINT256 NOT NULL,
-	timestamp   INTEGER NOT NULL CHECK (timestamp > 0)
+	timestamp   INTEGER NOT NULL CHECK (timestamp > 0),
+
+    -- Raw Data
+    rlp_bytes VARCHAR NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS l2_block_headers (
-    -- Block header
+    -- Searchable fields
 	hash                     VARCHAR NOT NULL PRIMARY KEY,
 	parent_hash              VARCHAR NOT NULL,
 	number                   UINT256 NOT NULL,
-	timestamp                INTEGER NOT NULL CHECK (timestamp > 0)
+	timestamp                INTEGER NOT NULL CHECK (timestamp > 0),
+
+    -- Raw Data
+    rlp_bytes VARCHAR NOT NULL
 );
 
 /** 
@@ -26,21 +33,29 @@ CREATE TABLE IF NOT EXISTS l2_block_headers (
  */
 
 CREATE TABLE IF NOT EXISTS l1_contract_events (
+    -- Searchable fields
     guid             VARCHAR NOT NULL PRIMARY KEY,
 	block_hash       VARCHAR NOT NULL REFERENCES l1_block_headers(hash),
     transaction_hash VARCHAR NOT NULL,
-    event_signature  VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
-    timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
+    event_signature  VARCHAR NOT NULL, -- Edge case anon events are 0x0
+    timestamp        INTEGER NOT NULL CHECK (timestamp > 0),
+
+    -- Raw Data
+    rlp_bytes VARCHAR NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS l2_contract_events (
+    -- Searchable fields
     guid             VARCHAR NOT NULL PRIMARY KEY,
 	block_hash       VARCHAR NOT NULL REFERENCES l2_block_headers(hash),
     transaction_hash VARCHAR NOT NULL,
-    event_signature  VARCHAR NOT NULL,
     log_index        INTEGER NOT NULL,
-    timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
+    event_signature  VARCHAR, -- Edge case of anonymous events
+    timestamp        INTEGER NOT NULL CHECK (timestamp > 0),
+
+    -- Raw Data
+    rlp_bytes VARCHAR NOT NULL
 );
 
 -- Tables that index finalization markers for L2 blocks.

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -399,10 +399,10 @@ func l1ProcessContractEventsBridgeCrossDomainMessages(processLog log.Logger, db 
 
 	sentMessages := make([]*database.L1BridgeMessage, len(sentMessageEvents))
 	for i, sentMessageEvent := range sentMessageEvents {
-		log := events.eventLog[sentMessageEvent.RawEvent.GUID]
+		log := sentMessageEvent.RawEvent.GethLog
 
 		// extract the deposit hash from the previous TransactionDepositedEvent
-		transactionDepositedLog := events.eventLog[events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index - 1}].GUID]
+		transactionDepositedLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index - 1}].GethLog
 		depositTx, err := derive.UnmarshalDepositLogEvent(transactionDepositedLog)
 		if err != nil {
 			return err
@@ -479,10 +479,10 @@ func l1ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 
 	deposits := make([]*database.L1BridgeDeposit, len(initiatedDepositEvents))
 	for i, initiatedBridgeEvent := range initiatedDepositEvents {
-		log := events.eventLog[initiatedBridgeEvent.RawEvent.GUID]
+		log := initiatedBridgeEvent.RawEvent.GethLog
 
 		// extract the deposit hash from the following TransactionDeposited event
-		transactionDepositedLog := events.eventLog[events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index + 1}].GUID]
+		transactionDepositedLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index + 1}].GethLog
 		depositTx, err := derive.UnmarshalDepositLogEvent(transactionDepositedLog)
 		if err != nil {
 			return err

--- a/indexer/processor/l2_to_l1_message_passer.go
+++ b/indexer/processor/l2_to_l1_message_passer.go
@@ -20,15 +20,19 @@ func L2ToL1MessagePasserMessagesPassed(events *ProcessedContractEvents) ([]L2ToL
 	processedMessagePassedEvents := events.eventsBySignature[l2ToL1MessagePasserAbi.Events[eventName].ID]
 	messagesPassed := make([]L2ToL1MessagePasserMessagePassed, len(processedMessagePassedEvents))
 	for i, messagePassedEvent := range processedMessagePassedEvents {
-		log := events.eventLog[messagePassedEvent.GUID]
+		log := messagePassedEvent.GethLog
 
 		var messagePassed bindings.L2ToL1MessagePasserMessagePassed
+		messagePassed.Raw = *log
 		err := UnpackLog(&messagePassed, log, eventName, l2ToL1MessagePasserAbi)
 		if err != nil {
 			return nil, err
 		}
 
-		messagesPassed[i] = L2ToL1MessagePasserMessagePassed{&messagePassed, messagePassedEvent}
+		messagesPassed[i] = L2ToL1MessagePasserMessagePassed{
+			L2ToL1MessagePasserMessagePassed: &messagePassed,
+			RawEvent:                         messagePassedEvent,
+		}
 	}
 
 	return messagesPassed, nil


### PR DESCRIPTION
Consumers of the database will likely expect to get information of logs/headers
by decoding the RLP bytes. To avoid having to make extra RPC calls to a node
node for this data, lets store those bytes alongside the indexable fields for
headers and logs


Whenever topics are missing from logs, we'll use bytes32(0x0) as the event_signature. It's not worth supporting tooling for anon events as it's impossible to determine without the contract ABI

