### PR TITLE
ops: fix dockerfile

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y \
   g++ \
   make \
   gcc \
+  openssh-client \
   musl-dev \
   bash \
   # the following 4 deps are needed for node-hid


### PR DESCRIPTION
**Description**

Add in openssh-client to the dockerfile since some of the deps are installed via git/ssh and not having an ssh client in the image prevents it from building.

I don't think that this is a particularly secure thing to do, we should rewrite this dockerfile in a way that the dep install happens in a different image and
then the final built typescript is copied over. None of these services have private keys so I'm not super worried about this.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

