### PR TITLE
op-e2e: Update cannon e2e test to execute moves down to the max depth

### DIFF
--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -27,7 +27,7 @@ func (g *CannonGameHelper) StartChallenger(ctx context.Context, rollupCfg *rollu
 			c.CannonDatadir = g.t.TempDir()
 			c.CannonServer = "../op-program/bin/op-program"
 			c.CannonAbsolutePreState = "../op-program/bin/prestate.json"
-			c.CannonSnapshotFreq = config.DefaultCannonSnapshotFreq
+			c.CannonSnapshotFreq = 10_000_000
 
 			genesisBytes, err := json.Marshal(l2Genesis)
 			g.require.NoError(err, "marshall l2 genesis config")

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -17,13 +17,12 @@ import (
 )
 
 type FaultGameHelper struct {
-	t        *testing.T
-	require  *require.Assertions
-	client   *ethclient.Client
-	opts     *bind.TransactOpts
-	game     *bindings.FaultDisputeGame
-	maxDepth int
-	addr     common.Address
+	t       *testing.T
+	require *require.Assertions
+	client  *ethclient.Client
+	opts    *bind.TransactOpts
+	game    *bindings.FaultDisputeGame
+	addr    common.Address
 }
 
 func (g *FaultGameHelper) GameDuration(ctx context.Context) time.Duration {
@@ -54,6 +53,12 @@ type ContractClaim struct {
 	Clock       *big.Int
 }
 
+func (g *FaultGameHelper) MaxDepth(ctx context.Context) int64 {
+	depth, err := g.game.MAXGAMEDEPTH(&bind.CallOpts{Context: ctx})
+	g.require.NoError(err, "Failed to load game depth")
+	return depth.Int64()
+}
+
 func (g *FaultGameHelper) WaitForClaim(ctx context.Context, predicate func(claim ContractClaim) bool) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
@@ -78,9 +83,10 @@ func (g *FaultGameHelper) WaitForClaim(ctx context.Context, predicate func(claim
 }
 
 func (g *FaultGameHelper) WaitForClaimAtMaxDepth(ctx context.Context, countered bool) {
+	maxDepth := g.MaxDepth(ctx)
 	g.WaitForClaim(ctx, func(claim ContractClaim) bool {
 		pos := types.NewPositionFromGIndex(claim.Position.Uint64())
-		return pos.Depth() == g.maxDepth && claim.Countered == countered
+		return int64(pos.Depth()) == maxDepth && claim.Countered == countered
 	})
 }
 
@@ -108,4 +114,11 @@ func (g *FaultGameHelper) WaitForGameStatus(ctx context.Context, expected Status
 		return expected == Status(status), nil
 	})
 	g.require.NoError(err, "wait for game status")
+}
+
+func (g *FaultGameHelper) Attack(ctx context.Context, claimIdx int64, claim common.Hash) {
+	tx, err := g.game.Attack(g.opts, big.NewInt(claimIdx), claim)
+	g.require.NoError(err, "Attack transaction did not send")
+	_, err = utils.WaitReceiptOK(ctx, g.client, tx.Hash())
+	g.require.NoError(err, "Attack transaction was not OK")
 }

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -22,7 +22,6 @@ import (
 const alphabetGameType uint8 = 0
 const cannonGameType uint8 = 1
 const alphabetGameDepth = 4
-const cannonGameDepth = 64
 const lastAlphabetTraceIndex = 1<<alphabetGameDepth - 1
 
 type Status uint8
@@ -109,13 +108,12 @@ func (h *FactoryHelper) StartAlphabetGame(ctx context.Context, claimedAlphabet s
 
 	return &AlphabetGameHelper{
 		FaultGameHelper: FaultGameHelper{
-			t:        h.t,
-			require:  h.require,
-			client:   h.client,
-			opts:     h.opts,
-			game:     game,
-			maxDepth: alphabetGameDepth,
-			addr:     createdEvent.DisputeProxy,
+			t:       h.t,
+			require: h.require,
+			client:  h.client,
+			opts:    h.opts,
+			game:    game,
+			addr:    createdEvent.DisputeProxy,
 		},
 		claimedAlphabet: claimedAlphabet,
 	}
@@ -143,13 +141,12 @@ func (h *FactoryHelper) StartCannonGame(ctx context.Context, rootClaim common.Ha
 
 	return &CannonGameHelper{
 		FaultGameHelper: FaultGameHelper{
-			t:        h.t,
-			require:  h.require,
-			client:   h.client,
-			opts:     h.opts,
-			game:     game,
-			maxDepth: cannonGameDepth,
-			addr:     createdEvent.DisputeProxy,
+			t:       h.t,
+			require: h.require,
+			client:  h.client,
+			opts:    h.opts,
+			game:    game,
+			addr:    createdEvent.DisputeProxy,
 		},
 	}
 }

--- a/packages/contracts-bedrock/deploy-config/devnetL1.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1.json
@@ -44,7 +44,7 @@
   "l1GenesisBlockTimestamp": "0x64c811bf",
   "l2GenesisRegolithTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x41c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
-  "faultGameMaxDepth": 4,
+  "faultGameMaxDepth": 31,
   "faultGameMaxDuration": 300,
   "systemConfigStartBlock": 0
 }


### PR DESCRIPTION
**Description**

The e2e test will now call attack on every claim the challenger makes to drive the game down to the max depth.  The final step isn't called because the depth is such that the invalid claim from the e2e would have to call step and it can't. Will follow up with tests that exercise that.

Game helper pulls the game depth from the contract instead of hard coding it.

**Tests**

Its all about the tests.

**Metadata**

- https://linear.app/optimism/issue/CLI-4306/cannon-e2e-tests
