### PR TITLE
op-service: Harden Transaction Manager

### DIFF
--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -159,7 +159,7 @@ func TestSend(t *testing.T) {
 				{sendErr: true},
 				{},
 			},
-			nonces: []uint64{0, 1, 1},
+			nonces: []uint64{0, 1},
 			total:  3 * time.Second,
 		},
 	}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/ethereum-optimism/optimism/op-service/backoff"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
@@ -175,7 +176,13 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 		ctx, cancel = context.WithTimeout(ctx, m.cfg.TxSendTimeout)
 		defer cancel()
 	}
-	tx, err := m.craftTx(ctx, candidate)
+	tx, err := backoff.Do(ctx, 30, backoff.Fixed(2*time.Second), func() (*types.Transaction, error) {
+		tx, err := m.craftTx(ctx, candidate)
+		if err != nil {
+			m.l.Warn("Failed to create a transaction, will retry", "err", err)
+		}
+		return tx, err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the tx: %w", err)
 	}


### PR DESCRIPTION
**Description**
This commit fixes a common source of errors in the transaction manager which then cause significant problems for the batcher. The transaction manager is designed to be resilient from errors when resubmitting txns or when polling for transaction receipts. It was not designed to be resilient on the initial transaction submission, and that was the root cause of several incidents.

This commit fixes this issue by wrapping `craftTx` in a retry. If there is a sustained problem for longer than the amount of retries, issues could still happen, but this will significantly reduce the number of issues.

A failure in craftTx is so harmful is because the transaction manager is wrapped in a txmgr.Queue which handles multiple in flight transactions. The queue uses an errgroup to manage concurrency and when any single txmgr.Send fails it will cancel the context & cancel the rest of the in flight sends. Because txmgr.Send could fail when creating a transaction, a transient failure would cancel multiple in flight transactions. Some of these in flight transactions would eventually land on L1 and the batcher would lose track of which frames it had submitted & thus could submit duplicate frames.

Two examples of this flow are provided in the logs. First a timeout happens in the transaction creation, then multiple transactions are cancelled via the context. Then there is a log for "aborted transaction sending". This log occurs because a transaction that was cancelled landed on L1 and the nonce of the transaction is too low. That then cancels then pending transactions again.

```
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=104,419
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:22:28+0000 lvl=warn msg="unable to publish tx"                   err="aborted transaction sending"         data_size=120,000
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=860
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:20:24+0000 lvl=warn msg="unable to publish tx"                   err="failed to create the tx: eth_signTransaction failed: Post \"--snip--\": context deadline exceeded" data_size=120,000

t=2023-07-13T16:07:37+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=104,670
t=2023-07-13T16:07:37+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:07:37+0000 lvl=warn msg="unable to publish tx"                   err="context canceled"                    data_size=120,000
t=2023-07-13T16:07:37+0000 lvl=warn msg="unable to publish tx"                   err="aborted transaction sending"         data_size=120,000
t=2023-07-13T16:05:05+0000 lvl=warn msg="unable to publish tx"                  err="context canceled" data_size=120,000
t=2023-07-13T16:05:05+0000 lvl=warn msg="unable to publish tx"                  err="context canceled" data_size=110,635
t=2023-07-13T16:05:05+0000 lvl=warn msg="unable to publish tx"                  err="context canceled" data_size=120,000
t=2023-07-13T16:05:05+0000 lvl=warn msg="unable to publish tx"                  err="context canceled" data_size=120,000
t=2023-07-13T16:05:05+0000 lvl=warn msg="unable to publish tx"                  err="failed to create the tx: failed to get gas price info: failed to fetch the suggested gas tip cap: Post \"--snip--\": context deadline exceeded" data_size=120,000
```

**Tests**

One test change for the following reason. It also depends on #6805 in order
to make sure that the context cancellation is always returned.

The context in txmgr.Send is now being checked for cancellations by the
retry package which wraps craftTx. This caused an error in one of the
txmgr queue tests. The flow of the test is that it would send a valid tx,
send an invalid tx, and then send another tx. It'd expect that the last
tx got cancelled because of the context cancellation propogation (i.e. if
one tx in the queue fails, all will fail).

Because the context is cancelled prior to the call to txmgr.Send & this
check on the context, the transaction is no longer failing in the receipt
loop, but at craftTx. This test checked that the transaction would make it
to the receipt loop (via hooking into sendTx where it recorded the nonce).

**Metadata**

- Fixes CLI-4305
