### PR TITLE
op-e2e: Specify correct l2 block number when create dispute games

### DIFF
--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -21,6 +21,7 @@ func TestResolveDisputeGame(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys.cfg.L1Deployments, l1Client)
+
 	game := disputeGameFactory.StartAlphabetGame(ctx, "zyxwvut")
 	require.NotNil(t, game)
 	gameDuration := game.GameDuration(ctx)


### PR DESCRIPTION
**Description**

Should fix flakiness when creating games as the previous hard coded block number may not have had suitable outputs published.


**Metadata**

- https://linear.app/optimism/issue/CLI-4306/cannon-e2e-tests
