### PR TITLE
ci: Fix Dockerfile.packages build

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y \
   pkg-config \
   libusb-1.0-0-dev \
   libudev-dev \
+  openssh-client \
   --no-install-recommends
 
 RUN npm install pnpm --global

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -58,6 +58,9 @@ RUN apt-get update && apt-get install -y \
   openssh-client \
   --no-install-recommends
 
+# ssh is used to download pnpm dependencies from github
+RUN ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts
+
 RUN npm install pnpm --global
 
 COPY --from=foundry /usr/local/bin/forge /usr/local/bin/forge


### PR DESCRIPTION
A recent change (56e29726511fb86bb2b92ed6c88241fbee469904) replaced git HTTP references in the pnpm lock file with `git@github.com`. This forces git to clone repositories via ssh rather than https. Thus, an ssh client is now needed for the Dockerfile.packages.