### PR TITLE
chore: Remove unecessary flag

### DIFF
--- a/indexer/cli/cli.go
+++ b/indexer/cli/cli.go
@@ -72,15 +72,6 @@ var (
 		Usage:   "path to config file",
 		EnvVars: []string{"INDEXER_CONFIG"},
 	}
-	// Not used yet.  Use this flag to run legacy app instead
-	// Remove me after indexer is released
-	IndexerRefreshFlag = &cli.BoolFlag{
-		Name:    "indexer-refresh",
-		Value:   false,
-		Aliases: []string{"i"},
-		Usage:   "run new unreleased indexer by passing in flag",
-		EnvVars: []string{"INDEXER_REFRESH"},
-	}
 )
 
 // make a instance method on Cli called Run that runs cli

--- a/indexer/example.env
+++ b/indexer/example.env
@@ -2,8 +2,5 @@
 INDEXER_L1_ETH_RPC=FILL_ME_IN
 INDEXER_L2_ETH_RPC=FILL_ME_IN
 
-# temporary env variable to enable to new indexer
-INDEXER_REFRESH=1
-
 # Fill in to use prisma studio ui with a db other than the default
 # DATABASE_URL=FILL_ME_IN


### PR DESCRIPTION
- not going to use this flag as it adds a lot of extra work to configuring deployments. Instead we just keep old indexer running for a week or so while migrating gateway
