### PR TITLE
build: Fix pnpm lockfile

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,0 +1,20 @@
+// This function does not modify the lockfile. It asserts that packages do not use SSH
+// when specifying git repository
+function afterAllResolved(lockfile, context) {
+  const pkgs = lockfile['packages'];
+  for (const [pkg, entry] of Object.entries(pkgs)) {
+    const repo = entry.resolution['repo'];
+    if (repo !== undefined) {
+      if (repo.startsWith('git@github.com')) {
+        throw new Error(`Invalid git ssh specification found for package ${pkg}. Ensure sure that the dependencies do not reference SSH-based git repos before running installing them`);
+      }
+    }
+  }
+  return lockfile
+}
+
+module.exports = {
+  hooks: {
+    afterAllResolved
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9639,7 +9639,7 @@ packages:
     resolution: {integrity: sha512-iNZ576iTOGcfllftB73cPB5AN+XUQAT/T8xzsILsghXC1o8gJUqe3RHlcDqagu+biFpYQ61KQrZZJza8eRSYqw==}
     deprecated: Deprecated in favor of '@metamask/eth-sig-util'
     dependencies:
-      ethereumjs-abi: git@github.com+ethereumjs/ethereumjs-abi/ee3994657fa7a427238e6ba92a84d0b529bbcde0
+      ethereumjs-abi: github.com/ethereumjs/ethereumjs-abi/ee3994657fa7a427238e6ba92a84d0b529bbcde0
       ethereumjs-util: 5.2.1
     dev: true
 
@@ -21081,8 +21081,8 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  git@github.com+ethereumjs/ethereumjs-abi/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
-    resolution: {commit: ee3994657fa7a427238e6ba92a84d0b529bbcde0, repo: git@github.com:ethereumjs/ethereumjs-abi.git, type: git}
+  github.com/ethereumjs/ethereumjs-abi/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
+    resolution: {tarball: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0}
     name: ethereumjs-abi
     version: 0.6.8
     dependencies:


### PR DESCRIPTION
Regenerates the lockfile so it no longer contains SSH git repositories.
A pnpm hook is introduced to assert during pnpm install that the lockfile does not contain SSH git repos.

We avoid using git-ssh to download packages to accommodate environments that do not have ssh keys setup for github access (ex: docker).

Note: This change will prevent dependabot from submitting PRs that include a pnpm-lock.yaml containing SSH git repos.