### PR TITLE
Only Resolve Won Dispute Games

### DIFF
--- a/op-challenger/fault/abi_test.go
+++ b/op-challenger/fault/abi_test.go
@@ -4,8 +4,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +11,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 )
 
 // setupFaultDisputeGame deploys the FaultDisputeGame contract to a simulated backend
@@ -26,7 +27,10 @@ func setupFaultDisputeGame() (common.Address, *bind.TransactOpts, *backends.Simu
 	if err != nil {
 		return common.Address{}, nil, nil, nil, err
 	}
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{from: {Balance: big.NewInt(params.Ether)}}, 50_000_000)
+	backend := backends.NewSimulatedBackend(
+		core.GenesisAlloc{from: {Balance: big.NewInt(params.Ether)}},
+		50_000_000,
+	)
 
 	blockHashOracle, _, _, err := bindings.DeployBlockOracle(opts, backend)
 	if err != nil {
@@ -55,7 +59,7 @@ func TestBuildFaultDefendData(t *testing.T) {
 	_, opts, _, contract, err := setupFaultDisputeGame()
 	require.NoError(t, err)
 
-	responder, _ := newTestFaultResponder(t, false)
+	responder, _ := newTestFaultResponder(t)
 
 	data, err := responder.buildFaultDefendData(1, [32]byte{0x02, 0x03})
 	require.NoError(t, err)
@@ -72,7 +76,7 @@ func TestBuildFaultAttackData(t *testing.T) {
 	_, opts, _, contract, err := setupFaultDisputeGame()
 	require.NoError(t, err)
 
-	responder, _ := newTestFaultResponder(t, false)
+	responder, _ := newTestFaultResponder(t)
 
 	data, err := responder.buildFaultAttackData(1, [32]byte{0x02, 0x03})
 	require.NoError(t, err)
@@ -89,7 +93,7 @@ func TestBuildFaultStepData(t *testing.T) {
 	_, opts, _, contract, err := setupFaultDisputeGame()
 	require.NoError(t, err)
 
-	responder, _ := newTestFaultResponder(t, false)
+	responder, _ := newTestFaultResponder(t)
 
 	data, err := responder.buildStepTxData(types.StepCallData{
 		ClaimIndex: 2,

--- a/op-challenger/fault/agent_test.go
+++ b/op-challenger/fault/agent_test.go
@@ -1,0 +1,30 @@
+package fault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+)
+
+// TestAgent_ShouldResolve tests the [Agent] resolution logic.
+func TestAgent_ShouldResolve(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+
+	t.Run("AgreeWithProposedOutput", func(t *testing.T) {
+		agent := NewAgent(nil, 0, nil, nil, nil, true, log)
+		require.False(t, agent.ShouldResolve(context.Background(), uint8(2)))
+		require.True(t, agent.ShouldResolve(context.Background(), uint8(1)))
+		require.False(t, agent.ShouldResolve(context.Background(), uint8(0)))
+	})
+
+	t.Run("DisagreeWithProposedOutput", func(t *testing.T) {
+		agent := NewAgent(nil, 0, nil, nil, nil, false, log)
+		require.True(t, agent.ShouldResolve(context.Background(), uint8(2)))
+		require.False(t, agent.ShouldResolve(context.Background(), uint8(1)))
+		require.False(t, agent.ShouldResolve(context.Background(), uint8(0)))
+	})
+}

--- a/op-challenger/fault/utils.go
+++ b/op-challenger/fault/utils.go
@@ -1,0 +1,24 @@
+package fault
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type LogBuilder struct {
+	ctx []interface{}
+}
+
+// NewLogBuilder creates a new [logBuilder] instance.
+func NewLogBuilder() *LogBuilder {
+	return &LogBuilder{}
+}
+
+// With adds a new [key, value] pair to the context.
+func (l *LogBuilder) With(key string, value interface{}) {
+	l.ctx = append(l.ctx, key, value)
+}
+
+// Build returns the new [log.Logger] with the built context.
+func (l *LogBuilder) Build() log.Logger {
+	return log.New(l.ctx...)
+}

--- a/op-challenger/fault/utils_test.go
+++ b/op-challenger/fault/utils_test.go
@@ -1,0 +1,57 @@
+package fault
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type testHandler struct {
+	entries []log.Record
+}
+
+func (t *testHandler) Log(r *log.Record) error {
+	t.entries = append(t.entries, *r)
+	return nil
+}
+
+// TestLogBuilder_With tests that the [LogBuilder.With] method works as expected.
+func TestLogBuilder_With(t *testing.T) {
+	t.Run("SinglePair_Succeeds", func(t *testing.T) {
+		builder := NewLogBuilder()
+		builder.With("key", "value")
+		logger := builder.Build()
+		handler := &testHandler{}
+		logger.SetHandler(handler)
+		logger.Info("test")
+		assert.Equal(t, 1, len(handler.entries))
+		assert.Equal(t, "key", handler.entries[0].Ctx[0])
+		assert.Equal(t, "value", handler.entries[0].Ctx[1])
+	})
+
+	t.Run("MultiplePairs_Succeed", func(t *testing.T) {
+		builder := NewLogBuilder()
+		builder.With("key", "value")
+		builder.With("key2", "value2")
+		logger := builder.Build()
+		handler := &testHandler{}
+		logger.SetHandler(handler)
+		logger.Info("test")
+		assert.Equal(t, 1, len(handler.entries))
+		assert.Equal(t, "key", handler.entries[0].Ctx[0])
+		assert.Equal(t, "value", handler.entries[0].Ctx[1])
+		assert.Equal(t, "key2", handler.entries[0].Ctx[2])
+		assert.Equal(t, "value2", handler.entries[0].Ctx[3])
+	})
+
+	t.Run("NoContext_Succeeds", func(t *testing.T) {
+		builder := NewLogBuilder()
+		logger := builder.Build()
+		handler := &testHandler{}
+		logger.SetHandler(handler)
+		logger.Info("test")
+		assert.Equal(t, 1, len(handler.entries))
+		assert.Equal(t, 0, len(handler.entries[0].Ctx))
+	})
+}

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -231,6 +231,10 @@ func TestCannonDisputeGame(t *testing.T) {
 			sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
 			require.NoError(t, wait.ForNextBlock(ctx, l1Client))
 
+			// Manually resolve the game since the "honest actor" is the defender
+			// and won't call resolve.
+			game.Resolve(ctx)
+
 			game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 			game.LogGameData(ctx)
 		})


### PR DESCRIPTION
**Description**

Only resolves dispute games which the challenger won.

In order to allow the `Agent` fault component to retrieve
the game status, the `Caller` has to be passed in during
construction by the `service.go` initialization function.

**Tests**

Introduces minimal agent unit tests for a newly exported
`ShouldResolve` method.

**Metadata**

Fixes CLI-4285
