### PR TITLE
contracts-bedrock: delete dead config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,16 +369,16 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - restore_cache:
-          name: Restore PNPM Package Cache
-          keys:
-            - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: contracts-bedrock,op-node
       # populate node modules from the cache
       - run:
           name: Install dependencies
           command: pnpm install --frozen-lockfile --prefer-offline
+      - run:
+          name: install deps
+          command: pnpm install
+          working_directory: packages/contracts-bedrock
       - run:
           name: build contracts
           command: pnpm build
@@ -1156,9 +1156,7 @@ workflows:
             - pnpm-monorepo
       - contracts-bedrock-tests
       - contracts-bedrock-coverage
-      - contracts-bedrock-checks:
-          requires:
-            - pnpm-monorepo
+      - contracts-bedrock-checks
       - contracts-bedrock-slither
       - contracts-bedrock-validate-spaces:
           requires:

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -31,11 +31,11 @@
     "preinstall": "npx only-allow pnpm",
     "pre-pr": "pnpm clean && pnpm gas-snapshot && pnpm storage-snapshot && pnpm semver-lock && pnpm autogen:invariant-docs && pnpm lint && (cd ../../op-bindings && make)",
     "pre-pr:full": "pnpm test && pnpm slither && pnpm validate-deploy-configs && pnpm validate-spacers && pnpm pre-pr",
-    "lint:ts:check": "eslint . --max-warnings=0",
+    "lint:ts:check": "npx eslint . --max-warnings=0",
     "lint:forge-tests:check": "npx tsx scripts/forge-test-names.ts",
     "lint:contracts:check": "pnpm lint:fix && git diff --exit-code",
     "lint:check": "pnpm lint:contracts:check && pnpm lint:ts:check",
-    "lint:ts:fix": "eslint --fix .",
+    "lint:ts:fix": "npx eslint --fix .",
     "lint:contracts:fix": "forge fmt",
     "lint:fix": "pnpm lint:contracts:fix && pnpm lint:ts:fix",
     "lint": "pnpm lint:fix && pnpm lint:check"


### PR DESCRIPTION
**Description**

Remove some cruft from CI that does nothing, the
`validate-deploy-configs.sh` script literally does nothing. We need to write a Go script that reads in a deploy config and calls `DeployConfig.Check` and asserts there are no errors. Also removes the pnpm build step as a dep for doing the contracts checks as its no
longer required.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

