### PR TITLE
feat(indexer): Preallocate space for a slice

### DIFF
--- a/indexer/api/routes/deposits.go
+++ b/indexer/api/routes/deposits.go
@@ -30,7 +30,7 @@ type DepositResponse struct {
 // TODO this is original spec but maybe include the l2 block info too for the relayed tx
 // FIXME make a pure function that returns a struct instead of newWithdrawalResponse
 func newDepositResponse(deposits []*database.L1BridgeDepositWithTransactionHashes) DepositResponse {
-	var items []DepositItem
+	items := make([]DepositItem, len(deposits))
 	for _, deposit := range deposits {
 		item := DepositItem{
 			Guid: deposit.L1BridgeDeposit.TransactionSourceHash.String(),

--- a/indexer/api/routes/withdrawals.go
+++ b/indexer/api/routes/withdrawals.go
@@ -43,7 +43,7 @@ type WithdrawalResponse struct {
 
 // FIXME make a pure function that returns a struct instead of newWithdrawalResponse
 func newWithdrawalResponse(withdrawals []*database.L2BridgeWithdrawalWithTransactionHashes) WithdrawalResponse {
-	var items []WithdrawalItem
+	items := make([]WithdrawalItem, len(withdrawals))
 	for _, withdrawal := range withdrawals {
 		item := WithdrawalItem{
 			Guid: withdrawal.L2BridgeWithdrawal.TransactionWithdrawalHash.String(),


### PR DESCRIPTION
Optimize mapping of db data to api response by preallocating a slice since we know it's length ahead of time
