### PR TITLE
feat(indexer) fill in derived log fields

### DIFF
--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -23,17 +23,17 @@ type BlockHeader struct {
 	Number     U256
 	Timestamp  uint64
 
-	GethHeader *GethHeader `gorm:"serializer:rlp;column:rlp_bytes"`
+	RLPHeader *RLPHeader `gorm:"serializer:rlp;column:rlp_bytes"`
 }
 
-func BlockHeaderFromGethHeader(header *types.Header) BlockHeader {
+func BlockHeaderFromHeader(header *types.Header) BlockHeader {
 	return BlockHeader{
 		Hash:       header.Hash(),
 		ParentHash: header.ParentHash,
 		Number:     U256{Int: header.Number},
 		Timestamp:  header.Time,
 
-		GethHeader: (*GethHeader)(header),
+		RLPHeader: (*RLPHeader)(header),
 	}
 }
 

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -29,11 +29,11 @@ type ContractEvent struct {
 	Timestamp      uint64
 
 	// NOTE: NOT ALL THE DERIVED FIELDS ON `types.Log` ARE
-	// AVAILABLE. ONLY THE ONES LISTED ABOVE.
-	GethLog *types.Log `gorm:"serializer:rlp;column:rlp_bytes"`
+	// AVAILABLE. FIELDS LISTED ABOVE ARE FILLED IN
+	RLPLog *types.Log `gorm:"serializer:rlp;column:rlp_bytes"`
 }
 
-func ContractEventFromGethLog(log *types.Log, timestamp uint64) ContractEvent {
+func ContractEventFromLog(log *types.Log, timestamp uint64) ContractEvent {
 	eventSig := common.Hash{}
 	if len(log.Topics) > 0 {
 		eventSig = log.Topics[0]
@@ -51,16 +51,16 @@ func ContractEventFromGethLog(log *types.Log, timestamp uint64) ContractEvent {
 
 		Timestamp: timestamp,
 
-		GethLog: log,
+		RLPLog: log,
 	}
 }
 
 func (c *ContractEvent) AfterFind(tx *gorm.DB) error {
 	// Fill in some of the derived fields that are not
-	// populated when decoding the GethLog from RLP
-	c.GethLog.BlockHash = c.BlockHash
-	c.GethLog.TxHash = c.TransactionHash
-	c.GethLog.Index = uint(c.LogIndex)
+	// populated when decoding the RLPLog from RLP
+	c.RLPLog.BlockHash = c.BlockHash
+	c.RLPLog.TxHash = c.TransactionHash
+	c.RLPLog.Index = uint(c.LogIndex)
 	return nil
 }
 

--- a/indexer/database/types.go
+++ b/indexer/database/types.go
@@ -68,13 +68,13 @@ func (u256 U256) Value() (driver.Value, error) {
 	return numeric.Value()
 }
 
-type GethHeader types.Header
+type RLPHeader types.Header
 
-func (h *GethHeader) EncodeRLP(w io.Writer) error {
+func (h *RLPHeader) EncodeRLP(w io.Writer) error {
 	return types.NewBlockWithHeader((*types.Header)(h)).EncodeRLP(w)
 }
 
-func (h *GethHeader) DecodeRLP(s *rlp.Stream) error {
+func (h *RLPHeader) DecodeRLP(s *rlp.Stream) error {
 	block := new(types.Block)
 	err := block.DecodeRLP(s)
 	if err != nil {
@@ -82,14 +82,14 @@ func (h *GethHeader) DecodeRLP(s *rlp.Stream) error {
 	}
 
 	header := block.Header()
-	*h = (GethHeader)(*header)
+	*h = (RLPHeader)(*header)
 	return nil
 }
 
-func (h *GethHeader) Header() *types.Header {
+func (h *RLPHeader) Header() *types.Header {
 	return (*types.Header)(h)
 }
 
-func (h *GethHeader) Hash() common.Hash {
+func (h *RLPHeader) Hash() common.Hash {
 	return h.Header().Hash()
 }

--- a/indexer/e2e_tests/blocks_e2e_test.go
+++ b/indexer/e2e_tests/blocks_e2e_test.go
@@ -65,7 +65,7 @@ func TestE2EBlockHeaders(t *testing.T) {
 			require.Equal(t, header.Time, indexedHeader.Timestamp)
 
 			// ensure the right rlp encoding is stored. checking the hashes sufficies
-			require.Equal(t, header.Hash(), indexedHeader.GethHeader.Hash())
+			require.Equal(t, header.Hash(), indexedHeader.RLPHeader.Hash())
 		}
 	})
 
@@ -127,7 +127,7 @@ func TestE2EBlockHeaders(t *testing.T) {
 			// ensure the right rlp encoding of the contract log is stored
 			logRlp, err := rlp.EncodeToBytes(&log)
 			require.NoError(t, err)
-			contractEventRlp, err := rlp.EncodeToBytes(contractEvent.GethLog)
+			contractEventRlp, err := rlp.EncodeToBytes(contractEvent.RLPLog)
 			require.NoError(t, err)
 			require.ElementsMatch(t, logRlp, contractEventRlp)
 
@@ -146,7 +146,7 @@ func TestE2EBlockHeaders(t *testing.T) {
 
 			// ensure the right rlp encoding is stored. checking the hashes
 			// suffices as it is based on the rlp bytes of the header
-			require.Equal(t, block.Hash(), l1BlockHeader.GethHeader.Hash())
+			require.Equal(t, block.Hash(), l1BlockHeader.RLPHeader.Hash())
 		}
 	})
 }

--- a/indexer/processor/contract_events.go
+++ b/indexer/processor/contract_events.go
@@ -31,16 +31,16 @@ func NewProcessedContractEvents() *ProcessedContractEvents {
 }
 
 func (p *ProcessedContractEvents) AddLog(log *types.Log, time uint64) *database.ContractEvent {
-	contractEvent := database.ContractEventFromGethLog(log, time)
+	event := database.ContractEventFromLog(log, time)
 	emptyHash := common.Hash{}
 
-	p.events = append(p.events, &contractEvent)
-	p.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index}] = &contractEvent
-	if contractEvent.EventSignature != emptyHash { // ignore anon events
-		p.eventsBySignature[contractEvent.EventSignature] = append(p.eventsBySignature[contractEvent.EventSignature], &contractEvent)
+	p.events = append(p.events, &event)
+	p.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index}] = &event
+	if event.EventSignature != emptyHash {
+		p.eventsBySignature[event.EventSignature] = append(p.eventsBySignature[event.EventSignature], &event)
 	}
 
-	return &contractEvent
+	return &event
 }
 
 func UnpackLog(out interface{}, log *types.Log, name string, contractAbi *abi.ABI) error {

--- a/indexer/processor/cross_domain_messenger.go
+++ b/indexer/processor/cross_domain_messenger.go
@@ -40,12 +40,12 @@ type CrossDomainMessengerSentMessageEvent struct {
 
 	Value       *big.Int
 	MessageHash common.Hash
-	RawEvent    *database.ContractEvent
+	Event       *database.ContractEvent
 }
 
 type CrossDomainMessengerRelayedMessageEvent struct {
 	*bindings.CrossDomainMessengerRelayedMessage
-	RawEvent *database.ContractEvent
+	Event *database.ContractEvent
 }
 
 func CrossDomainMessengerSentMessageEvents(events *ProcessedContractEvents) ([]CrossDomainMessengerSentMessageEvent, error) {
@@ -60,7 +60,7 @@ func CrossDomainMessengerSentMessageEvents(events *ProcessedContractEvents) ([]C
 	processedSentMessageEvents := events.eventsBySignature[sentMessageEventAbi.ID]
 	crossDomainMessageEvents := make([]CrossDomainMessengerSentMessageEvent, len(processedSentMessageEvents))
 	for i, sentMessageEvent := range processedSentMessageEvents {
-		log := sentMessageEvent.GethLog
+		log := sentMessageEvent.RLPLog
 
 		var sentMsgData bindings.CrossDomainMessengerSentMessage
 		sentMsgData.Raw = *log
@@ -70,7 +70,7 @@ func CrossDomainMessengerSentMessageEvents(events *ProcessedContractEvents) ([]C
 		}
 
 		var sentMsgExtensionData bindings.CrossDomainMessengerSentMessageExtension1
-		extensionLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index + 1}].GethLog
+		extensionLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index + 1}].RLPLog
 		sentMsgExtensionData.Raw = *extensionLog
 		err = UnpackLog(&sentMsgExtensionData, extensionLog, sentMessageEventExtensionAbi.Name, crossDomainMessengerABI)
 		if err != nil {
@@ -86,7 +86,7 @@ func CrossDomainMessengerSentMessageEvents(events *ProcessedContractEvents) ([]C
 			CrossDomainMessengerSentMessage: &sentMsgData,
 			Value:                           sentMsgExtensionData.Value,
 			MessageHash:                     msgHash,
-			RawEvent:                        sentMessageEvent,
+			Event:                           sentMessageEvent,
 		}
 	}
 
@@ -103,7 +103,7 @@ func CrossDomainMessengerRelayedMessageEvents(events *ProcessedContractEvents) (
 	processedRelayedMessageEvents := events.eventsBySignature[relayedMessageEventAbi.ID]
 	crossDomainMessageEvents := make([]CrossDomainMessengerRelayedMessageEvent, len(processedRelayedMessageEvents))
 	for i, relayedMessageEvent := range processedRelayedMessageEvents {
-		log := relayedMessageEvent.GethLog
+		log := relayedMessageEvent.RLPLog
 
 		var relayedMsgData bindings.CrossDomainMessengerRelayedMessage
 		relayedMsgData.Raw = *log
@@ -114,7 +114,7 @@ func CrossDomainMessengerRelayedMessageEvents(events *ProcessedContractEvents) (
 
 		crossDomainMessageEvents[i] = CrossDomainMessengerRelayedMessageEvent{
 			CrossDomainMessengerRelayedMessage: &relayedMsgData,
-			RawEvent:                           relayedMessageEvent,
+			Event:                              relayedMessageEvent,
 		}
 	}
 

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -197,7 +197,7 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 				continue
 			}
 
-			indexedL1Headers = append(indexedL1Headers, &database.L1BlockHeader{BlockHeader: database.BlockHeaderFromGethHeader(header)})
+			indexedL1Headers = append(indexedL1Headers, &database.L1BlockHeader{BlockHeader: database.BlockHeaderFromHeader(header)})
 		}
 
 		/** Update Database **/
@@ -275,7 +275,7 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 		transactionDeposits[i] = &database.L1TransactionDeposit{
 			SourceHash:           depositTx.SourceHash,
 			L2TransactionHash:    types.NewTx(depositTx).Hash(),
-			InitiatedL1EventGUID: depositEvent.RawEvent.GUID,
+			InitiatedL1EventGUID: depositEvent.Event.GUID,
 			Version:              database.U256{Int: depositEvent.Version},
 			OpaqueData:           depositEvent.OpaqueData,
 			GasLimit:             database.U256{Int: new(big.Int).SetUint64(depositTx.Gas)},
@@ -284,7 +284,7 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 				ToAddress:   depositTx.From,
 				Amount:      database.U256{Int: depositTx.Value},
 				Data:        depositTx.Data,
-				Timestamp:   depositEvent.RawEvent.Timestamp,
+				Timestamp:   depositEvent.Event.Timestamp,
 			},
 		}
 
@@ -340,7 +340,7 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 		if withdrawal == nil {
 			// We need to ensure we are in a caught up state before claiming a missing event. Since L2 timestamps
 			// are derived from L1, we can simply compare the timestamp of this event with the latest L2 header.
-			if provenWithdrawal.RawEvent.Timestamp > latestL2Header.Timestamp {
+			if provenWithdrawal.Event.Timestamp > latestL2Header.Timestamp {
 				processLog.Warn("behind on indexed L2 withdrawals")
 				return errors.New("waiting for L2Processor to catch up")
 			} else {
@@ -349,7 +349,7 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 			}
 		}
 
-		err = db.BridgeTransactions.MarkL2TransactionWithdrawalProvenEvent(withdrawalHash, provenWithdrawal.RawEvent.GUID)
+		err = db.BridgeTransactions.MarkL2TransactionWithdrawalProvenEvent(withdrawalHash, provenWithdrawal.Event.GUID)
 		if err != nil {
 			return err
 		}
@@ -376,7 +376,7 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 			return errors.New("withdrawal missing!")
 		}
 
-		err = db.BridgeTransactions.MarkL2TransactionWithdrawalFinalizedEvent(withdrawalHash, finalizedWithdrawal.RawEvent.GUID, finalizedWithdrawal.Success)
+		err = db.BridgeTransactions.MarkL2TransactionWithdrawalFinalizedEvent(withdrawalHash, finalizedWithdrawal.Event.GUID, finalizedWithdrawal.Success)
 		if err != nil {
 			return err
 		}
@@ -399,10 +399,10 @@ func l1ProcessContractEventsBridgeCrossDomainMessages(processLog log.Logger, db 
 
 	sentMessages := make([]*database.L1BridgeMessage, len(sentMessageEvents))
 	for i, sentMessageEvent := range sentMessageEvents {
-		log := sentMessageEvent.RawEvent.GethLog
+		log := sentMessageEvent.Event.RLPLog
 
 		// extract the deposit hash from the previous TransactionDepositedEvent
-		transactionDepositedLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index - 1}].GethLog
+		transactionDepositedLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index - 1}].RLPLog
 		depositTx, err := derive.UnmarshalDepositLogEvent(transactionDepositedLog)
 		if err != nil {
 			return err
@@ -413,14 +413,14 @@ func l1ProcessContractEventsBridgeCrossDomainMessages(processLog log.Logger, db 
 			BridgeMessage: database.BridgeMessage{
 				Nonce:                database.U256{Int: sentMessageEvent.MessageNonce},
 				MessageHash:          sentMessageEvent.MessageHash,
-				SentMessageEventGUID: sentMessageEvent.RawEvent.GUID,
+				SentMessageEventGUID: sentMessageEvent.Event.GUID,
 				GasLimit:             database.U256{Int: sentMessageEvent.GasLimit},
 				Tx: database.Transaction{
 					FromAddress: sentMessageEvent.Sender,
 					ToAddress:   sentMessageEvent.Target,
 					Amount:      database.U256{Int: sentMessageEvent.Value},
 					Data:        sentMessageEvent.Message,
-					Timestamp:   sentMessageEvent.RawEvent.Timestamp,
+					Timestamp:   sentMessageEvent.Event.Timestamp,
 				},
 			},
 		}
@@ -454,7 +454,7 @@ func l1ProcessContractEventsBridgeCrossDomainMessages(processLog log.Logger, db 
 			return fmt.Errorf("missing indexed L2CrossDomainMessager mesesage: 0x%x", relayedMessage.MsgHash)
 		}
 
-		err = db.BridgeMessages.MarkRelayedL2BridgeMessage(relayedMessage.MsgHash, relayedMessage.RawEvent.GUID)
+		err = db.BridgeMessages.MarkRelayedL2BridgeMessage(relayedMessage.MsgHash, relayedMessage.Event.GUID)
 		if err != nil {
 			return err
 		}
@@ -479,11 +479,12 @@ func l1ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 
 	deposits := make([]*database.L1BridgeDeposit, len(initiatedDepositEvents))
 	for i, initiatedBridgeEvent := range initiatedDepositEvents {
-		log := initiatedBridgeEvent.RawEvent.GethLog
+		log := initiatedBridgeEvent.Event.RLPLog
 
-		// extract the deposit hash from the following TransactionDeposited event
-		transactionDepositedLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index + 1}].GethLog
-		depositTx, err := derive.UnmarshalDepositLogEvent(transactionDepositedLog)
+		// extract the deposit hash from the following TransactionDeposited event. The `BlockHash` and `LogIndex`
+		// fields are filled in for `RLPLog` which is required for `DepositTx#SourceHash` to be computed correctly
+		transactionDepositedRLPLog := events.eventByLogIndex[ProcessedContractEventLogIndexKey{log.BlockHash, log.Index + 1}].RLPLog
+		depositTx, err := derive.UnmarshalDepositLogEvent(transactionDepositedRLPLog)
 		if err != nil {
 			return err
 		}
@@ -497,7 +498,7 @@ func l1ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 				ToAddress:   initiatedBridgeEvent.To,
 				Amount:      database.U256{Int: initiatedBridgeEvent.Amount},
 				Data:        initiatedBridgeEvent.ExtraData,
-				Timestamp:   initiatedBridgeEvent.RawEvent.Timestamp,
+				Timestamp:   initiatedBridgeEvent.Event.Timestamp,
 			},
 		}
 	}

--- a/indexer/processor/l2_to_l1_message_passer.go
+++ b/indexer/processor/l2_to_l1_message_passer.go
@@ -7,7 +7,7 @@ import (
 
 type L2ToL1MessagePasserMessagePassed struct {
 	*bindings.L2ToL1MessagePasserMessagePassed
-	RawEvent *database.ContractEvent
+	Event *database.ContractEvent
 }
 
 func L2ToL1MessagePasserMessagesPassed(events *ProcessedContractEvents) ([]L2ToL1MessagePasserMessagePassed, error) {
@@ -20,7 +20,7 @@ func L2ToL1MessagePasserMessagesPassed(events *ProcessedContractEvents) ([]L2ToL
 	processedMessagePassedEvents := events.eventsBySignature[l2ToL1MessagePasserAbi.Events[eventName].ID]
 	messagesPassed := make([]L2ToL1MessagePasserMessagePassed, len(processedMessagePassedEvents))
 	for i, messagePassedEvent := range processedMessagePassedEvents {
-		log := messagePassedEvent.GethLog
+		log := messagePassedEvent.RLPLog
 
 		var messagePassed bindings.L2ToL1MessagePasserMessagePassed
 		messagePassed.Raw = *log
@@ -31,7 +31,7 @@ func L2ToL1MessagePasserMessagesPassed(events *ProcessedContractEvents) ([]L2ToL
 
 		messagesPassed[i] = L2ToL1MessagePasserMessagePassed{
 			L2ToL1MessagePasserMessagePassed: &messagePassed,
-			RawEvent:                         messagePassedEvent,
+			Event:                            messagePassedEvent,
 		}
 	}
 

--- a/indexer/processor/optimism_portal.go
+++ b/indexer/processor/optimism_portal.go
@@ -14,17 +14,17 @@ import (
 type OptimismPortalTransactionDepositEvent struct {
 	*bindings.OptimismPortalTransactionDeposited
 	DepositTx *types.DepositTx
-	RawEvent  *database.ContractEvent
+	Event     *database.ContractEvent
 }
 
 type OptimismPortalWithdrawalProvenEvent struct {
 	*bindings.OptimismPortalWithdrawalProven
-	RawEvent *database.ContractEvent
+	Event *database.ContractEvent
 }
 
 type OptimismPortalWithdrawalFinalizedEvent struct {
 	*bindings.OptimismPortalWithdrawalFinalized
-	RawEvent *database.ContractEvent
+	Event *database.ContractEvent
 }
 
 type OptimismPortalProvenWithdrawal struct {
@@ -47,7 +47,7 @@ func OptimismPortalTransactionDepositEvents(events *ProcessedContractEvents) ([]
 	processedTxDepositedEvents := events.eventsBySignature[derive.DepositEventABIHash]
 	txDeposits := make([]OptimismPortalTransactionDepositEvent, len(processedTxDepositedEvents))
 	for i, txDepositEvent := range processedTxDepositedEvents {
-		log := txDepositEvent.GethLog
+		log := txDepositEvent.RLPLog
 
 		depositTx, err := derive.UnmarshalDepositLogEvent(log)
 		if err != nil {
@@ -64,7 +64,7 @@ func OptimismPortalTransactionDepositEvents(events *ProcessedContractEvents) ([]
 		txDeposits[i] = OptimismPortalTransactionDepositEvent{
 			OptimismPortalTransactionDeposited: &txDeposit,
 			DepositTx:                          depositTx,
-			RawEvent:                           txDepositEvent,
+			Event:                              txDepositEvent,
 		}
 	}
 
@@ -81,7 +81,7 @@ func OptimismPortalWithdrawalProvenEvents(events *ProcessedContractEvents) ([]Op
 	processedWithdrawalProvenEvents := events.eventsBySignature[optimismPortalAbi.Events[eventName].ID]
 	provenEvents := make([]OptimismPortalWithdrawalProvenEvent, len(processedWithdrawalProvenEvents))
 	for i, provenEvent := range processedWithdrawalProvenEvents {
-		log := provenEvent.GethLog
+		log := provenEvent.RLPLog
 
 		var withdrawalProven bindings.OptimismPortalWithdrawalProven
 		withdrawalProven.Raw = *log
@@ -92,7 +92,7 @@ func OptimismPortalWithdrawalProvenEvents(events *ProcessedContractEvents) ([]Op
 
 		provenEvents[i] = OptimismPortalWithdrawalProvenEvent{
 			OptimismPortalWithdrawalProven: &withdrawalProven,
-			RawEvent:                       provenEvent,
+			Event:                          provenEvent,
 		}
 	}
 
@@ -109,7 +109,7 @@ func OptimismPortalWithdrawalFinalizedEvents(events *ProcessedContractEvents) ([
 	processedWithdrawalFinalizedEvents := events.eventsBySignature[optimismPortalAbi.Events[eventName].ID]
 	finalizedEvents := make([]OptimismPortalWithdrawalFinalizedEvent, len(processedWithdrawalFinalizedEvents))
 	for i, finalizedEvent := range processedWithdrawalFinalizedEvents {
-		log := finalizedEvent.GethLog
+		log := finalizedEvent.RLPLog
 
 		var withdrawalFinalized bindings.OptimismPortalWithdrawalFinalized
 		err := UnpackLog(&withdrawalFinalized, log, eventName, optimismPortalAbi)
@@ -119,7 +119,7 @@ func OptimismPortalWithdrawalFinalizedEvents(events *ProcessedContractEvents) ([
 
 		finalizedEvents[i] = OptimismPortalWithdrawalFinalizedEvent{
 			OptimismPortalWithdrawalFinalized: &withdrawalFinalized,
-			RawEvent:                          finalizedEvent,
+			Event:                             finalizedEvent,
 		}
 	}
 


### PR DESCRIPTION
Geth's `types.Log` has some derived fields that are filled in. We index some of
these useful fields, like `BlockHash` and `LogIndex`. These two fields are especially
important as a `DepositTx`'s SourceHash is computed from them.

Utilize gorm's `AfterFind` to fill in some of these fields when deserializing
`rlp_bytes` into to `types.Log` with a note that not all derived fields are present.

Rename GethLog/GethHeader to `RLPLog` and `RLPHeader` to be clear that these are solely
based on the associated RLP bytes
