### PR TITLE
fix(indexer): Fix config usage make config deps more explicit

### DIFF
--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"os"
+	"reflect"
 
 	"github.com/BurntSushi/toml"
 
-	"github.com/ethereum-optimism/optimism/indexer/processor"
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/common"
+	geth_log "github.com/ethereum/go-ethereum/log"
 	"github.com/joho/godotenv"
 )
 
@@ -17,14 +19,41 @@ type Config struct {
 	DB      DBConfig
 	API     APIConfig
 	Metrics MetricsConfig
-	Logger  log.Logger `toml:"-"`
+	Logger  log.CLIConfig
+}
+
+// fetch this via onchain config from RPCsConfig and remove from config in future
+type L1Contracts struct {
+	OptimismPortal         common.Address
+	L2OutputOracle         common.Address
+	L1CrossDomainMessenger common.Address
+	L1StandardBridge       common.Address
+	L1ERC721Bridge         common.Address
+
+	// Some more contracts -- ProxyAdmin, SystemConfig, etcc
+	// Ignore the auxiliary contracts?
+
+	// Legacy contracts? We'll add this in to index the legacy chain.
+	// Remove afterwards?
+}
+
+func (c L1Contracts) ToSlice() []common.Address {
+	fields := reflect.VisibleFields(reflect.TypeOf(c))
+	v := reflect.ValueOf(c)
+
+	contracts := make([]common.Address, len(fields))
+	for i, field := range fields {
+		contracts[i] = (v.FieldByName(field.Name).Interface()).(common.Address)
+	}
+
+	return contracts
 }
 
 // ChainConfig configures of the chain being indexed
 type ChainConfig struct {
 	// Configure known chains with the l2 chain id
 	Preset      int
-	L1Contracts processor.L1Contracts
+	L1Contracts L1Contracts
 }
 
 // RPCsConfig configures the RPC urls
@@ -55,12 +84,12 @@ type MetricsConfig struct {
 }
 
 // LoadConfig loads the `indexer.toml` config file from a given path
-func LoadConfig(path string) (Config, error) {
+func LoadConfig(logger geth_log.Logger, path string) (Config, error) {
 	if err := godotenv.Load(); err != nil {
-		log.Warn("Unable to load .env file", err)
-		log.Info("Continuing without .env file")
+		logger.Warn("Unable to load .env file", err)
+		logger.Info("Continuing without .env file")
 	} else {
-		log.Info("Loaded .env file")
+		logger.Info("Loaded .env file")
 	}
 
 	var conf Config
@@ -76,11 +105,11 @@ func LoadConfig(path string) (Config, error) {
 
 	// Decode the TOML data.
 	if _, err := toml.Decode(string(data), &conf); err != nil {
-		log.Info("Failed to decode config file", "message", err)
+		logger.Info("Failed to decode config file", "message", err)
 		return conf, err
 	}
 
-	log.Debug("Loaded config file", conf)
+	logger.Debug("Loaded config file", conf)
 
 	return conf, nil
 }

--- a/indexer/config/config_test.go
+++ b/indexer/config/config_test.go
@@ -4,10 +4,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoadConfig(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
 	tmpfile, err := os.CreateTemp("", "test.toml")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
@@ -45,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 	err = tmpfile.Close()
 	require.NoError(t, err)
 
-	conf, err := LoadConfig(tmpfile.Name())
+	conf, err := LoadConfig(logger, tmpfile.Name())
 	require.NoError(t, err)
 
 	require.Equal(t, conf.Chain.Preset, 1234)

--- a/indexer/database/db.go
+++ b/indexer/database/db.go
@@ -2,6 +2,9 @@
 package database
 
 import (
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/indexer/config"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -17,7 +20,14 @@ type DB struct {
 	BridgeTransactions BridgeTransactionsDB
 }
 
-func NewDB(dsn string) (*DB, error) {
+func NewDB(dbConfig config.DBConfig) (*DB, error) {
+	dsn := fmt.Sprintf("host=%s port=%d dbname=%s sslmode=disable", dbConfig.Host, dbConfig.Port, dbConfig.Name)
+	if dbConfig.User != "" {
+		dsn += fmt.Sprintf(" user=%s", dbConfig.User)
+	}
+	if dbConfig.Password != "" {
+		dsn += fmt.Sprintf(" password=%s", dbConfig.Password)
+	}
 	gorm, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		// The indexer will explicitly manage the transaction
 		// flow processing blocks

--- a/indexer/e2e_tests/setup.go
+++ b/indexer/e2e_tests/setup.go
@@ -13,10 +13,10 @@ import (
 	"github.com/ethereum-optimism/optimism/indexer"
 	"github.com/ethereum-optimism/optimism/indexer/config"
 	"github.com/ethereum-optimism/optimism/indexer/database"
-	"github.com/ethereum-optimism/optimism/indexer/processor"
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	op_log "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -59,7 +59,10 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 
 	// Indexer Configuration and Start
 	indexerCfg := config.Config{
-		Logger: logger,
+
+		Logger: op_log.CLIConfig{
+			Level: "warn",
+		},
 		DB: config.DBConfig{
 			Host: "127.0.0.1",
 			Port: 5432,
@@ -71,7 +74,7 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 			L2RPC: opSys.Nodes["sequencer"].HTTPEndpoint(),
 		},
 		Chain: config.ChainConfig{
-			L1Contracts: processor.L1Contracts{
+			L1Contracts: config.L1Contracts{
 				OptimismPortal:         opCfg.L1Deployments.OptimismPortalProxy,
 				L2OutputOracle:         opCfg.L1Deployments.L2OutputOracleProxy,
 				L1CrossDomainMessenger: opCfg.L1Deployments.L1CrossDomainMessengerProxy,
@@ -81,9 +84,14 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 		},
 	}
 
-	db, err := database.NewDB(fmt.Sprintf("postgres://%s@localhost:5432/%s?sslmode=disable", dbUser, dbName))
+	db, err := database.NewDB(indexerCfg.DB)
 	require.NoError(t, err)
-	indexer, err := indexer.NewIndexer(indexerCfg)
+	indexer, err := indexer.NewIndexer(
+		indexerCfg.Chain,
+		indexerCfg.RPCs,
+		db,
+		logger,
+	)
 	require.NoError(t, err)
 
 	indexerStoppedCh := make(chan interface{}, 1)

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"reflect"
 
+	"github.com/ethereum-optimism/optimism/indexer/config"
 	"github.com/ethereum-optimism/optimism/indexer/database"
 	"github.com/ethereum-optimism/optimism/indexer/node"
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
@@ -23,32 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type L1Contracts struct {
-	OptimismPortal         common.Address
-	L2OutputOracle         common.Address
-	L1CrossDomainMessenger common.Address
-	L1StandardBridge       common.Address
-	L1ERC721Bridge         common.Address
-
-	// Some more contracts -- ProxyAdmin, SystemConfig, etcc
-	// Ignore the auxiliary contracts?
-
-	// Legacy contracts? We'll add this in to index the legacy chain.
-	// Remove afterwards?
-}
-
-func (c L1Contracts) ToSlice() []common.Address {
-	fields := reflect.VisibleFields(reflect.TypeOf(c))
-	v := reflect.ValueOf(c)
-
-	contracts := make([]common.Address, len(fields))
-	for i, field := range fields {
-		contracts[i] = (v.FieldByName(field.Name).Interface()).(common.Address)
-	}
-
-	return contracts
-}
-
 type checkpointAbi struct {
 	l2OutputOracle             *abi.ABI
 	legacyStateCommitmentChain *abi.ABI
@@ -58,7 +32,7 @@ type L1Processor struct {
 	processor
 }
 
-func NewL1Processor(logger log.Logger, ethClient node.EthClient, db *database.DB, l1Contracts L1Contracts) (*L1Processor, error) {
+func NewL1Processor(logger log.Logger, ethClient node.EthClient, db *database.DB, l1Contracts config.L1Contracts) (*L1Processor, error) {
 	l1ProcessLog := logger.New("processor", "l1")
 	l1ProcessLog.Info("initializing processor")
 
@@ -107,7 +81,7 @@ func NewL1Processor(logger log.Logger, ethClient node.EthClient, db *database.DB
 	return l1Processor, nil
 }
 
-func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1Contracts, checkpointAbi checkpointAbi) ProcessFn {
+func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts config.L1Contracts, checkpointAbi checkpointAbi) ProcessFn {
 	rawEthClient := ethclient.NewClient(ethClient.RawRpcClient())
 
 	contractAddrs := l1Contracts.ToSlice()
@@ -261,7 +235,7 @@ func l1ProcessFn(processLog log.Logger, ethClient node.EthClient, l1Contracts L1
 	}
 }
 
-func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *database.DB, l1Contracts L1Contracts, events *ProcessedContractEvents) error {
+func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *database.DB, l1Contracts config.L1Contracts, events *ProcessedContractEvents) error {
 	// (1) Process New Deposits
 	portalDeposits, err := OptimismPortalTransactionDepositEvents(events)
 	if err != nil {
@@ -294,6 +268,7 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 				TransactionSourceHash: depositTx.SourceHash,
 				Tx:                    transactionDeposits[i].Tx,
 				TokenPair: database.TokenPair{
+					// TODO index eth token if it doesn't exist
 					L1TokenAddress: predeploys.LegacyERC20ETHAddr,
 					L2TokenAddress: predeploys.LegacyERC20ETHAddr,
 				},
@@ -492,7 +467,8 @@ func l1ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 		deposits[i] = &database.L1BridgeDeposit{
 			TransactionSourceHash:     depositTx.SourceHash,
 			CrossDomainMessengerNonce: &database.U256{Int: initiatedBridgeEvent.CrossDomainMessengerNonce},
-			TokenPair:                 database.TokenPair{L1TokenAddress: initiatedBridgeEvent.LocalToken, L2TokenAddress: initiatedBridgeEvent.RemoteToken},
+			// TODO index the tokens pairs if they don't exist
+			TokenPair: database.TokenPair{L1TokenAddress: initiatedBridgeEvent.LocalToken, L2TokenAddress: initiatedBridgeEvent.RemoteToken},
 			Tx: database.Transaction{
 				FromAddress: initiatedBridgeEvent.From,
 				ToAddress:   initiatedBridgeEvent.To,


### PR DESCRIPTION
This is the same pr as https://github.com/ethereum-optimism/optimism/pull/6771 but a bad rebase caused the previous one to close

**Description**

- remove literal logger from config replace with logger config
  - Inferred that this was not how it worked before because we actually need a logger before we even read the config
  - Handle this by initializing a logger with reasonable defaults first
- dependency inject the db into indexer to make the dependencies more clear
- replace using the entire config object with only the pieces of the config a service needs, this makes it more explicit
- Move l1Contracts to the config out of the indexer package
  - this blocked a future pr because it became too easy to make a circular dependency
  - the config package should rely on no other indexer code as it's the code everything else consumes to "configure it"