### PR TITLE
fix(indexer): Fix cli flags

### DIFF
--- a/indexer/cli/cli.go
+++ b/indexer/cli/cli.go
@@ -99,7 +99,7 @@ func (c *Cli) Run(args []string) error {
 
 func NewCli(GitVersion string, GitCommit string, GitDate string) *Cli {
 	flags := []cli.Flag{ConfigFlag}
-	flags = append(flags, log.CLIFlags("indexer")...)
+	flags = append(flags, log.CLIFlags("INDEXER")...)
 	app := &cli.App{
 		Version:     fmt.Sprintf("%s-%s", GitVersion, params.VersionWithCommit(GitCommit, GitDate)),
 		Description: "An indexer of all optimism events with a serving api layer",

--- a/indexer/cli/cli.go
+++ b/indexer/cli/cli.go
@@ -99,6 +99,7 @@ func (c *Cli) Run(args []string) error {
 
 func NewCli(GitVersion string, GitCommit string, GitDate string) *Cli {
 	flags := []cli.Flag{ConfigFlag}
+	flags = append(flags, log.CLIFlags("indexer")...)
 	app := &cli.App{
 		Version:     fmt.Sprintf("%s-%s", GitVersion, params.VersionWithCommit(GitCommit, GitDate)),
 		Description: "An indexer of all optimism events with a serving api layer",


### PR DESCRIPTION
- fixes bug where cli flags can't be parsed
- fix via adding the flags to the cli flag options
