### PR TITLE
chore(circleci): Bump timeout from 2m to 4m in indexer lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,7 +880,7 @@ jobs:
           patterns: indexer
       - run:
           name: Lint
-          command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 2m -e "errors.As" -e "errors.Is" ./...
+          command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 4m -e "errors.As" -e "errors.Is" ./...
           working_directory: indexer
       - run:
           name: install geth


### PR DESCRIPTION
- remove timeout from lint
https://github.com/ethereum-optimism/optimism/pull/6808#discussion_r1295231513
