### PR TITLE
contracts-bedrock: fix gettings started config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/getting-started.json
+++ b/packages/contracts-bedrock/deploy-config/getting-started.json
@@ -52,5 +52,7 @@
   "l2GenesisRegolithTimeOffset": "0x0",
 
   "eip1559Denominator": 50,
-  "eip1559Elasticity": 10
+  "eip1559Elasticity": 10,
+
+  "systemConfigStartBlock": 0
 }


### PR DESCRIPTION
**Description**

A new config value was added and not having it in
the deploy config will cause the deploy script
to break. This adds the new value so that the
deploy script works again.

cc @sbvegan 

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

