### PR TITLE
chore(ctb): Fix delete output compiler warning

### DIFF
--- a/packages/contracts-bedrock/scripts/outputs/DeleteOutput.s.sol
+++ b/packages/contracts-bedrock/scripts/outputs/DeleteOutput.s.sol
@@ -97,7 +97,7 @@ contract DeleteOutput is SafeBuilder {
         _postCheck();
     }
 
-    function buildCalldata(address _proxyAdmin) internal view override returns (bytes memory) {
+    function buildCalldata(address) internal view override returns (bytes memory) {
         IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
 
         calls[0] = IMulticall3.Call3({


### PR DESCRIPTION
**Description**

Small chore to fix the compiler warning for the `DeleteOutput` script in contracts-bedrock by removing the parameter name.

See example output below without this fix:
<p align="center">
<img width="602" alt="Screenshot 2023-08-16 at 7 42 12 AM" src="https://github.com/ethereum-optimism/optimism/assets/21288394/c84567ec-0693-4c44-9113-180cbbdac506">
</p>

