### PR TITLE
chore: Update the Mergify config labeling to use updated labels

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,6 +12,9 @@ pull_request_rules:
         - "label!=do-not-merge"
         - "label!=multiple-reviewers"
         - "label!=mergify-ignore"
+        - "label!=S-do-not-merge"
+        - "label!=S-multiple-reviewers"
+        - "label!=S-mergify-ignore"
         - "base=develop"
     actions:
       queue:
@@ -27,14 +30,14 @@ pull_request_rules:
             This PR has been added to the merge queue, and will be merged soon.
       label:
         add:
-          - on-merge-train
+          - S-on-merge-train
   - name: Remove merge train label
     conditions:
       - "queue-position = -1"
     actions:
       label:
         remove:
-          - on-merge-train
+          - S-on-merge-train
   - name: Ask to resolve conflict
     conditions:
       - conflict
@@ -43,14 +46,14 @@ pull_request_rules:
         message: Hey @{{author}}! This PR has merge conflicts. Please fix them before continuing review.
       label:
         add:
-          - conflict
+          - S-conflict
   - name: Remove conflicts label when conflicts gone
     conditions:
       - -conflict
     actions:
       label:
         remove:
-          - conflict
+          - S-conflict
   - name: Notify author when added to merge queue
     conditions:
       - "check-pending=Queue: Embarked in merge train"
@@ -87,7 +90,7 @@ pull_request_rules:
     actions:
       label:
         add:
-          - sdk
+          - M-pkg-sdk
       request_reviews:
         users:
           - roninjin10
@@ -97,7 +100,7 @@ pull_request_rules:
     actions:
       label:
         add:
-          - common-ts
+          - M-pkg-common-ts
       request_reviews:
         users:
           - roninjin10


### PR DESCRIPTION
**Description**

Updates the mergify config yaml in a backwards compatible way to use updated labels. The bot will now use the following labels:

- https://github.com/ethereum-optimism/optimism/labels/S-do-not-merge
- https://github.com/ethereum-optimism/optimism/labels/S-conflict
- https://github.com/ethereum-optimism/optimism/labels/M-multiple-reviewers
- https://github.com/ethereum-optimism/optimism/labels/M-mergify-ignore
- https://github.com/ethereum-optimism/optimism/labels/S-on-merge-train

Note, the optimism bot will still not merge if `conflict`, `do-not-merge`, or `multiple-reviewers` is a label on a pr.