### PR TITLE
Update Mergify Labeling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - dependabot
+      - M-dependabot
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -14,7 +14,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - dependabot
+      - M-dependabot
 
   - package-ecosystem: npm
     directory: "/"
@@ -25,7 +25,7 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: auto
     labels:
-      - dependabot
+      - M-dependabot
 
   - package-ecosystem: gomod
     directory: "/"
@@ -33,4 +33,4 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     labels:
-      - dependabot
+      - M-dependabot

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,6 +12,9 @@ pull_request_rules:
         - "label!=do-not-merge"
         - "label!=multiple-reviewers"
         - "label!=mergify-ignore"
+        - "label!=M-do-not-merge"
+        - "label!=M-multiple-reviewers"
+        - "label!=M-mergify-ignore"
         - "base=develop"
     actions:
       queue:
@@ -27,14 +30,14 @@ pull_request_rules:
             This PR has been added to the merge queue, and will be merged soon.
       label:
         add:
-          - on-merge-train
+          - S-on-merge-train
   - name: Remove merge train label
     conditions:
       - "queue-position = -1"
     actions:
       label:
         remove:
-          - on-merge-train
+          - S-on-merge-train
   - name: Ask to resolve conflict
     conditions:
       - conflict
@@ -43,14 +46,14 @@ pull_request_rules:
         message: Hey @{{author}}! This PR has merge conflicts. Please fix them before continuing review.
       label:
         add:
-          - conflict
+          - S-conflict
   - name: Remove conflicts label when conflicts gone
     conditions:
       - -conflict
     actions:
       label:
         remove:
-          - conflict
+          - S-conflict
   - name: Notify author when added to merge queue
     conditions:
       - "check-pending=Queue: Embarked in merge train"
@@ -77,7 +80,7 @@ pull_request_rules:
     actions:
       label:
         add:
-          - indexer
+          - A-indexer
       request_reviews:
         users:
           - roninjin10
@@ -87,7 +90,7 @@ pull_request_rules:
     actions:
       label:
         add:
-          - sdk
+          - A-pkg-sdk
       request_reviews:
         users:
           - roninjin10
@@ -97,7 +100,7 @@ pull_request_rules:
     actions:
       label:
         add:
-          - common-ts
+          - A-pkg-common-ts
       request_reviews:
         users:
           - roninjin10


### PR DESCRIPTION
**Description**

Updates the mergify config yaml in a backwards compatible way to use updated labels.

The bot will now use the following labels.

- https://github.com/ethereum-optimism/optimism/labels/S-conflict
- https://github.com/ethereum-optimism/optimism/labels/S-on-merge-train
- https://github.com/ethereum-optimism/optimism/labels/M-do-not-merge
- https://github.com/ethereum-optimism/optimism/labels/M-multiple-reviewers
- https://github.com/ethereum-optimism/optimism/labels/M-mergify-ignore

For @roninjin10's work, the labels are updated to the following.
- https://github.com/ethereum-optimism/optimism/labels/A-pkg-sdk
- https://github.com/ethereum-optimism/optimism/labels/A-pkg-common-ts
- https://github.com/ethereum-optimism/optimism/labels/A-indexer

Note, the optimism bot will still not merge if `conflict`, `do-not-merge`,`multiple-reviewers`, or `mergify-ignore` is a label on a pr.

Also updates the dependabot to use the following tag.
- https://github.com/ethereum-optimism/optimism/labels/M-dependabot