### PR TITLE
feat(indexer): simplify bridging schemas via local/remote naming & simplify tx deposits table

### DIFF
--- a/indexer/api/routes/deposits.go
+++ b/indexer/api/routes/deposits.go
@@ -48,7 +48,7 @@ func newDepositResponse(deposits []*database.L1BridgeDepositWithTransactionHashe
 			Amount: deposit.L1BridgeDeposit.Tx.Amount.Int.String(),
 			L1Token: TokenInfo{
 				ChainId:  1,
-				Address:  deposit.L1BridgeDeposit.TokenPair.L1TokenAddress.String(),
+				Address:  deposit.L1BridgeDeposit.TokenPair.LocalTokenAddress.String(),
 				Name:     "TODO",
 				Symbol:   "TODO",
 				Decimals: 420,
@@ -58,7 +58,7 @@ func newDepositResponse(deposits []*database.L1BridgeDepositWithTransactionHashe
 			},
 			L2Token: TokenInfo{
 				ChainId:  10,
-				Address:  deposit.L1BridgeDeposit.TokenPair.L2TokenAddress.String(),
+				Address:  deposit.L1BridgeDeposit.TokenPair.RemoteTokenAddress.String(),
 				Name:     "TODO",
 				Symbol:   "TODO",
 				Decimals: 420,

--- a/indexer/api/routes/withdrawals.go
+++ b/indexer/api/routes/withdrawals.go
@@ -73,7 +73,7 @@ func newWithdrawalResponse(withdrawals []*database.L2BridgeWithdrawalWithTransac
 			WithdrawalState: "COMPLETE", // TODO
 			L1Token: TokenInfo{
 				ChainId:  1,
-				Address:  withdrawal.L2BridgeWithdrawal.TokenPair.L1TokenAddress.String(),
+				Address:  withdrawal.L2BridgeWithdrawal.TokenPair.RemoteTokenAddress.String(),
 				Name:     "Example", // TODO
 				Symbol:   "EXAMPLE", // TODO
 				Decimals: 18,        // TODO
@@ -83,7 +83,7 @@ func newWithdrawalResponse(withdrawals []*database.L2BridgeWithdrawalWithTransac
 			},
 			L2Token: TokenInfo{
 				ChainId:  10,
-				Address:  withdrawal.L2BridgeWithdrawal.TokenPair.L2TokenAddress.String(),
+				Address:  withdrawal.L2BridgeWithdrawal.TokenPair.LocalTokenAddress.String(),
 				Name:     "Example", // TODO
 				Symbol:   "EXAMPLE", // TODO
 				Decimals: 18,        // TODO

--- a/indexer/database/bridge_transactions.go
+++ b/indexer/database/bridge_transactions.go
@@ -24,21 +24,16 @@ type Transaction struct {
 }
 
 type L1TransactionDeposit struct {
-	SourceHash        common.Hash `gorm:"serializer:json;primaryKey"`
-	L2TransactionHash common.Hash `gorm:"serializer:json"`
-
+	SourceHash           common.Hash `gorm:"serializer:json;primaryKey"`
+	L2TransactionHash    common.Hash `gorm:"serializer:json"`
 	InitiatedL1EventGUID uuid.UUID
-
-	Version    U256
-	OpaqueData hexutil.Bytes `gorm:"serializer:json"`
 
 	Tx       Transaction `gorm:"embedded"`
 	GasLimit U256
 }
 
 type L2TransactionWithdrawal struct {
-	WithdrawalHash common.Hash `gorm:"serializer:json;primaryKey"`
-
+	WithdrawalHash       common.Hash `gorm:"serializer:json;primaryKey"`
 	Nonce                U256
 	InitiatedL2EventGUID uuid.UUID
 

--- a/indexer/database/bridge_transfers.go
+++ b/indexer/database/bridge_transfers.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	ETHTokenPair = TokenPair{L1TokenAddress: predeploys.LegacyERC20ETHAddr, L2TokenAddress: predeploys.LegacyERC20ETHAddr}
+	ETHTokenPair = TokenPair{LocalTokenAddress: predeploys.LegacyERC20ETHAddr, RemoteTokenAddress: predeploys.LegacyERC20ETHAddr}
 )
 
 /**
@@ -18,8 +18,8 @@ var (
  */
 
 type TokenPair struct {
-	L1TokenAddress common.Address `gorm:"serializer:json"`
-	L2TokenAddress common.Address `gorm:"serializer:json"`
+	LocalTokenAddress  common.Address `gorm:"serializer:json"`
+	RemoteTokenAddress common.Address `gorm:"serializer:json"`
 }
 
 type BridgeTransfer struct {

--- a/indexer/e2e_tests/bridge_transactions_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transactions_e2e_test.go
@@ -59,9 +59,6 @@ func TestE2EBridgeTransactionsOptimismPortalDeposits(t *testing.T) {
 	require.Equal(t, aliceAddr, deposit.Tx.ToAddress)
 	require.ElementsMatch(t, calldata, deposit.Tx.Data)
 
-	require.Equal(t, depositInfo.Version.Uint64(), deposit.Version.Int.Uint64())
-	require.ElementsMatch(t, depositInfo.OpaqueData, deposit.OpaqueData)
-
 	event, err := testSuite.DB.ContractEvents.L1ContractEvent(deposit.InitiatedL1EventGUID)
 	require.NoError(t, err)
 	require.NotNil(t, event)

--- a/indexer/e2e_tests/bridge_transfers_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transfers_e2e_test.go
@@ -55,8 +55,8 @@ func TestE2EBridgeTransfersStandardBridgeETHDeposit(t *testing.T) {
 
 	deposit := aliceDeposits[0].L1BridgeDeposit
 	require.Equal(t, depositInfo.DepositTx.SourceHash, deposit.TransactionSourceHash)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.L1TokenAddress)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.L2TokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.LocalTokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.RemoteTokenAddress)
 	require.Equal(t, big.NewInt(params.Ether), deposit.Tx.Amount.Int)
 	require.Equal(t, aliceAddr, deposit.Tx.FromAddress)
 	require.Equal(t, aliceAddr, deposit.Tx.ToAddress)
@@ -114,8 +114,8 @@ func TestE2EBridgeTransfersOptimismPortalETHReceive(t *testing.T) {
 
 	deposit := aliceDeposits[0].L1BridgeDeposit
 	require.Equal(t, depositInfo.DepositTx.SourceHash, deposit.TransactionSourceHash)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.L1TokenAddress)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.L2TokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.LocalTokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, deposit.TokenPair.RemoteTokenAddress)
 	require.Equal(t, big.NewInt(params.Ether), deposit.Tx.Amount.Int)
 	require.Equal(t, aliceAddr, deposit.Tx.FromAddress)
 	require.Equal(t, aliceAddr, deposit.Tx.ToAddress)
@@ -185,8 +185,8 @@ func TestE2EBridgeTransfersStandardBridgeETHWithdrawal(t *testing.T) {
 
 	withdrawal := aliceWithdrawals[0].L2BridgeWithdrawal
 	require.Equal(t, withdrawalHash, withdrawal.TransactionWithdrawalHash)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.L1TokenAddress)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.L2TokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.LocalTokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.RemoteTokenAddress)
 	require.Equal(t, big.NewInt(params.Ether), withdrawal.Tx.Amount.Int)
 	require.Equal(t, aliceAddr, withdrawal.Tx.FromAddress)
 	require.Equal(t, aliceAddr, withdrawal.Tx.ToAddress)
@@ -268,8 +268,8 @@ func TestE2EBridgeTransfersL2ToL1MessagePasserReceive(t *testing.T) {
 
 	withdrawal := aliceWithdrawals[0].L2BridgeWithdrawal
 	require.Equal(t, withdrawalHash, withdrawal.TransactionWithdrawalHash)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.L1TokenAddress)
-	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.L2TokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.LocalTokenAddress)
+	require.Equal(t, predeploys.LegacyERC20ETHAddr, withdrawal.TokenPair.RemoteTokenAddress)
 	require.Equal(t, big.NewInt(params.Ether), withdrawal.Tx.Amount.Int)
 	require.Equal(t, aliceAddr, withdrawal.Tx.FromAddress)
 	require.Equal(t, aliceAddr, withdrawal.Tx.ToAddress)

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -116,10 +116,6 @@ CREATE TABLE IF NOT EXISTS l1_transaction_deposits (
 
     initiated_l1_event_guid VARCHAR NOT NULL REFERENCES l1_contract_events(guid),
 
-    -- OptimismPortal specific
-    version     UINT256 NOT NULL,
-    opaque_data VARCHAR NOT NULL,
-
     -- transaction data
     from_address VARCHAR NOT NULL,
     to_address   VARCHAR NOT NULL,
@@ -197,8 +193,8 @@ CREATE TABLE IF NOT EXISTS l1_bridge_deposits (
     -- Deposit information
 	from_address     VARCHAR NOT NULL,
 	to_address       VARCHAR NOT NULL,
-    l1_token_address VARCHAR NOT NULL, -- REFERENCES l1_tokens(address), uncomment me in future pr
-    l2_token_address VARCHAR NOT NULL, -- REFERENCES l2_tokens(address), uncomment me in future pr
+	local_token_address VARCHAR NOT NULL, -- REFERENCES l1_tokens(address), uncomment me in future pr
+	remote_token_address VARCHAR NOT NULL, -- REFERENCES l2_tokens(address), uncomment me in future pr
 	amount           UINT256 NOT NULL,
 	data             VARCHAR NOT NULL,
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0)
@@ -213,8 +209,8 @@ CREATE TABLE IF NOT EXISTS l2_bridge_withdrawals (
     -- Withdrawal information
 	from_address     VARCHAR NOT NULL,
 	to_address       VARCHAR NOT NULL,
-    l1_token_address VARCHAR NOT NULL, -- REFERENCES l1_tokens(address), uncomment me in future pr
-    l2_token_address VARCHAR NOT NULL, -- REFERENCES l2_tokens(address), uncomment me in future pr
+	local_token_address VARCHAR NOT NULL, -- REFERENCES l1_tokens(address), uncomment me in future pr
+	remote_token_address VARCHAR NOT NULL, -- REFERENCES l2_tokens(address), uncomment me in future pr
 	amount           UINT256 NOT NULL,
 	data             VARCHAR NOT NULL,
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0)

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -209,8 +209,8 @@ CREATE TABLE IF NOT EXISTS l2_bridge_withdrawals (
     -- Withdrawal information
 	from_address     VARCHAR NOT NULL,
 	to_address       VARCHAR NOT NULL,
-	local_token_address VARCHAR NOT NULL, -- REFERENCES l1_tokens(address), uncomment me in future pr
-	remote_token_address VARCHAR NOT NULL, -- REFERENCES l2_tokens(address), uncomment me in future pr
+	local_token_address VARCHAR NOT NULL, -- REFERENCES l2_tokens(address), uncomment me in future pr
+	remote_token_address VARCHAR NOT NULL, -- REFERENCES l1_tokens(address), uncomment me in future pr
 	amount           UINT256 NOT NULL,
 	data             VARCHAR NOT NULL,
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0)

--- a/indexer/processor/l1_processor.go
+++ b/indexer/processor/l1_processor.go
@@ -249,8 +249,6 @@ func l1ProcessContractEventsBridgeTransactions(processLog log.Logger, db *databa
 			SourceHash:           depositTx.SourceHash,
 			L2TransactionHash:    types.NewTx(depositTx).Hash(),
 			InitiatedL1EventGUID: depositEvent.Event.GUID,
-			Version:              database.U256{Int: depositEvent.Version},
-			OpaqueData:           depositEvent.OpaqueData,
 			GasLimit:             database.U256{Int: new(big.Int).SetUint64(depositTx.Gas)},
 			Tx: database.Transaction{
 				FromAddress: depositTx.From,
@@ -465,7 +463,7 @@ func l1ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 			BridgeTransfer: database.BridgeTransfer{
 				CrossDomainMessageHash: &initiatedBridgeEvent.CrossDomainMessageHash,
 				// TODO index the tokens pairs if they don't exist
-				TokenPair: database.TokenPair{L1TokenAddress: initiatedBridgeEvent.LocalToken, L2TokenAddress: initiatedBridgeEvent.RemoteToken},
+				TokenPair: database.TokenPair{LocalTokenAddress: initiatedBridgeEvent.LocalToken, RemoteTokenAddress: initiatedBridgeEvent.RemoteToken},
 				Tx: database.Transaction{
 					FromAddress: initiatedBridgeEvent.From,
 					ToAddress:   initiatedBridgeEvent.To,
@@ -506,7 +504,7 @@ func l1ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 		// sanity check on the bridge fields
 		if finalizedWithdrawalEvent.From != withdrawal.Tx.FromAddress || finalizedWithdrawalEvent.To != withdrawal.Tx.ToAddress ||
 			finalizedWithdrawalEvent.Amount.Cmp(withdrawal.Tx.Amount.Int) != 0 || !bytes.Equal(finalizedWithdrawalEvent.ExtraData, withdrawal.Tx.Data) ||
-			finalizedWithdrawalEvent.LocalToken != withdrawal.TokenPair.L1TokenAddress || finalizedWithdrawalEvent.RemoteToken != withdrawal.TokenPair.L2TokenAddress {
+			finalizedWithdrawalEvent.LocalToken != withdrawal.TokenPair.LocalTokenAddress || finalizedWithdrawalEvent.RemoteToken != withdrawal.TokenPair.RemoteTokenAddress {
 			processLog.Crit("bridge finalization fields mismatch with initiated fields!", "tx_withdrawal_hash", withdrawal.TransactionWithdrawalHash, "cross_domain_message_hash", withdrawal.CrossDomainMessageHash)
 		}
 	}

--- a/indexer/processor/l2_processor.go
+++ b/indexer/processor/l2_processor.go
@@ -355,7 +355,7 @@ func l2ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 			TransactionWithdrawalHash: msgPassedEvent.WithdrawalHash,
 			BridgeTransfer: database.BridgeTransfer{
 				CrossDomainMessageHash: &initiatedBridgeEvent.CrossDomainMessageHash,
-				TokenPair:              database.TokenPair{L1TokenAddress: initiatedBridgeEvent.LocalToken, L2TokenAddress: initiatedBridgeEvent.RemoteToken},
+				TokenPair:              database.TokenPair{LocalTokenAddress: initiatedBridgeEvent.LocalToken, RemoteTokenAddress: initiatedBridgeEvent.RemoteToken},
 				Tx: database.Transaction{
 					FromAddress: initiatedBridgeEvent.From,
 					ToAddress:   initiatedBridgeEvent.To,
@@ -398,7 +398,7 @@ func l2ProcessContractEventsStandardBridge(processLog log.Logger, db *database.D
 		// sanity check on the bridge fields
 		if finalizedDepositEvent.From != deposit.Tx.FromAddress || finalizedDepositEvent.To != deposit.Tx.ToAddress ||
 			finalizedDepositEvent.Amount.Cmp(deposit.Tx.Amount.Int) != 0 || !bytes.Equal(finalizedDepositEvent.ExtraData, deposit.Tx.Data) ||
-			finalizedDepositEvent.LocalToken != deposit.TokenPair.L1TokenAddress || finalizedDepositEvent.RemoteToken != deposit.TokenPair.L2TokenAddress {
+			finalizedDepositEvent.LocalToken != deposit.TokenPair.LocalTokenAddress || finalizedDepositEvent.RemoteToken != deposit.TokenPair.RemoteTokenAddress {
 			processLog.Error("bridge finalization fields mismatch with initiated fields!", "tx_source_hash", deposit.TransactionSourceHash, "cross_domain_message_hash", deposit.CrossDomainMessageHash)
 			return errors.New("bridge tx mismatch")
 		}


### PR DESCRIPTION
In order to not switch on "l1" or "l2". For bridging data, lets also
adopt the Local/Remote naming. The table contraints can enforce that
the local/remote addresses are either l1 or l2 when we get around to it.


Now that we index rlp bytes, the version & opaque fields in tx deposits
dont need to be individual columns. Someone can just decode the bytes to
get them
