### PR TITLE
op-service/backoff: Refactor to use time.Duration instead of float/int.

### DIFF
--- a/op-node/sources/sync_client.go
+++ b/op-node/sources/sync_client.go
@@ -131,9 +131,9 @@ func (s *SyncClient) eventLoop() {
 	s.log.Info("Starting sync client event loop")
 
 	backoffStrategy := &backoff.ExponentialStrategy{
-		Min:       1000,
-		Max:       20_000,
-		MaxJitter: 250,
+		Min:       1000 * time.Millisecond,
+		Max:       20_000 * time.Millisecond,
+		MaxJitter: 250 * time.Millisecond,
 	}
 
 	for {

--- a/op-service/backoff/strategies_test.go
+++ b/op-service/backoff/strategies_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestExponential(t *testing.T) {
 	strategy := &ExponentialStrategy{
-		Min:       3000,
-		Max:       10000,
+		Min:       3000 * time.Millisecond,
+		Max:       10000 * time.Millisecond,
 		MaxJitter: 0,
 	}
 
-	durations := []int{4, 5, 7, 10, 10}
+	durations := []time.Duration{4, 5, 7, 10, 10}
 	for i, dur := range durations {
-		require.Equal(t, time.Millisecond*time.Duration(dur*1000), strategy.Duration(i))
+		require.Equal(t, dur*time.Second, strategy.Duration(i))
 	}
 }


### PR DESCRIPTION
changed backoff/strategies.go and backoff/strategies_test.go, only types and a function changed

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

No features added. Just refactored backoff package to allow only types from time.Duration on time related variables. 

**Tests**

Only modified a single test to use time.Duration instead of int.

**Metadata**

- Fixes #[6730](https://github.com/ethereum-optimism/optimism/issues/6730#issuecomment-1678950667)
