### PR TITLE
fix(contracts-bedrock): Fix job missing node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,6 +375,10 @@ jobs:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
       - check-changed:
           patterns: contracts-bedrock,op-node
+      # populate node modules from the cache
+      - run:
+          name: Install dependencies
+          command: pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: build contracts
           command: pnpm build


### PR DESCRIPTION
- eslint requires node modules so need to populate them
- since it's using --prefer-offline this is super fast

