### PR TITLE
README updates and package export rename

### DIFF
--- a/.changeset/strange-cheetahs-visit.md
+++ b/.changeset/strange-cheetahs-visit.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/web3.js-plugin': patch
+---
+
+Correct use of web3js-plugin to web3.js-plugin in README. Rename OptimismFeeEstimationPlugin export to OptimismPlugin

--- a/packages/web3js-plugin/README.md
+++ b/packages/web3js-plugin/README.md
@@ -1,4 +1,4 @@
-# @eth-optimism/web3js-plugin
+# @eth-optimism/web3.js-plugin
 
 This web3.js plugin adds utility functions for estimating L1 and L2 gas for OP chains by wrapping the [GasPriceOracle](../contracts-bedrock/contracts/l2/GasPriceOracle.sol) contract
 
@@ -13,22 +13,22 @@ This plugin is intended to be [registered](https://docs.web3js.org/guides/web3_p
 ### Installing the Plugin
 
 ```bash
-pnpm install @eth-optimism/web3js-plugin
+pnpm install @eth-optimism/web3.js-plugin
 ```
 
 ```bash
-npm install @eth-optimism/web3js-plugin
+npm install @eth-optimism/web3.js-plugin
 ```
 
 ```bash
-yarn add @eth-optimism/web3js-plugin
+yarn add @eth-optimism/web3.js-plugin
 ```
 
 ### Registering the Plugin
 
 ```typescript
 import Web3 from 'web3'
-import OptimismFeeEstimationPlugin from '@eth-optimism/web3js-plugin'
+import OptimismFeeEstimationPlugin from '@eth-optimism/web3.js-plugin'
 
 const web3 = new Web3('http://yourProvider.com')
 web3.registerPlugin(new OptimismFeeEstimationPlugin())
@@ -65,8 +65,8 @@ async estimateFees(transaction: Transaction, returnFormat?: ReturnFormat)
 #### Parameters
 
 - `transaction: Transaction` - An unsigned web3.js [transaction](https://docs.web3js.org/api/web3-types/interface/Transaction) object
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][1] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -168,8 +168,8 @@ async getL1Fee(transaction: Transaction, returnFormat?: ReturnFormat)
 #### Parameters
 
 - `transaction: Transaction` - An unsigned web3.js [transaction](https://docs.web3js.org/api/web3-types/interface/Transaction) object
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][1] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -235,8 +235,8 @@ async getL2Fee(transaction: Transaction, returnFormat?: ReturnFormat)
     - A web3.js [Numbers](https://docs.web3js.org/api/web3-types#Numbers)
     - A web3.js [BlockTags](https://docs.web3js.org/api/web3-types/enum/BlockTags)
     - If not provided, `BlockTags.LATEST` is used
-  - `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-    - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+  - `returnFormat?: ReturnFormat` - A web3.js [DataFormat][1] object that specifies how to format number and bytes values
+    - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -301,8 +301,8 @@ async getBaseFee(returnFormat?: ReturnFormat)
 
 #### Parameters
 
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][1] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -337,8 +337,8 @@ async getDecimals(returnFormat?: ReturnFormat)
 
 #### Parameters
 
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][3] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -373,8 +373,8 @@ async getGasPrice(returnFormat?: ReturnFormat)
 
 #### Parameters
 
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][3] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -410,8 +410,8 @@ async getL1GasUsed(transaction: Transaction, returnFormat?: ReturnFormat)
 #### Parameters
 
 - `transaction: Transaction` - An unsigned web3.js [transaction](https://docs.web3js.org/api/web3-types/interface/Transaction) object
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][3] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -470,8 +470,8 @@ async getL1BaseFee(returnFormat?: ReturnFormat)
 
 #### Parameters
 
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][3] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -506,8 +506,8 @@ async getOverhead(returnFormat?: ReturnFormat)
 
 #### Parameters
 
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][3] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -542,8 +542,8 @@ async getScalar(returnFormat?: ReturnFormat)
 
 #### Parameters
 
-- `returnFormat?: ReturnFormat` - A web3.js [DataFormat](https://docs.web3js.org/api/web3-types#DataFormat) object that specifies how to format number and bytes values
-  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT](https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT) is used which will format numbers to `BigInt`s
+- `returnFormat?: ReturnFormat` - A web3.js [DataFormat][1] object that specifies how to format number and bytes values
+  - If `returnFormat` is not provided, [DEFAULT_RETURN_FORMAT][2] is used which will format numbers to `BigInt`s
 
 #### Returns
 
@@ -592,3 +592,7 @@ console.log(version) // 1.0.0
 
 - As of version `4.0.3` of web3.js, both `input` and `data` parameters are automatically added to a transaction objects causing the gas estimations to be inflated. This was corrected in [this](https://github.com/web3/web3.js/pull/6294) PR, but has yet to be released
 - For the plugin function `getL2Fee`, you should be able to get the fee estimates using the state of the blockchain at a specified block, however, this doesn't seem to be working with web3.js and requires further investigation
+
+[1]: https://docs.web3js.org/api/web3-types#DataFormat
+[2]: https://docs.web3js.org/api/web3-types#DEFAULT_RETURN_FORMAT
+[3]: https://docs.web3js.org/api/web3-types#DataFormat

--- a/packages/web3js-plugin/src/plugin.spec.ts
+++ b/packages/web3js-plugin/src/plugin.spec.ts
@@ -8,7 +8,7 @@ import {
   optimistAddress,
 } from '@eth-optimism/contracts-ts'
 
-import { OptimismFeeEstimationPlugin } from './plugin'
+import { OptimismPlugin } from './plugin'
 
 const defaultProvider = 'https://mainnet.optimism.io'
 const provider = z
@@ -21,17 +21,17 @@ if (provider === defaultProvider)
     'Warning: Using default public provider, this could cause tests to fail due to rate limits. Set the VITE_L2_RPC_URL env to override default provider'
   )
 
-describe('OptimismFeeEstimationPlugin', () => {
+describe('OptimismPlugin', () => {
   let web3: Web3
 
   beforeAll(() => {
     web3 = new Web3(provider)
-    web3.registerPlugin(new OptimismFeeEstimationPlugin())
+    web3.registerPlugin(new OptimismPlugin())
   })
 
   test('should be registered under .op namespace', () =>
     expect(web3.op).toMatchInlineSnapshot(`
-      OptimismFeeEstimationPlugin {
+      OptimismPlugin {
         "_accountProvider": {
           "create": [Function],
           "decrypt": [Function],
@@ -62,7 +62,7 @@ describe('OptimismFeeEstimationPlugin', () => {
             Symbol(kCapture): false,
           },
           "_provider": HttpProvider {
-            "clientUrl": "https://mainnet.optimism.io",
+            "clientUrl": "https://opt-mainnet.g.alchemy.com/v2/OVlbpe9COlhG-ijOXGvL_phb5ns6p9-w",
             "httpProviderOptions": undefined,
           },
           "useRpcCallSpecification": undefined,
@@ -88,7 +88,7 @@ describe('OptimismFeeEstimationPlugin', () => {
               Symbol(kCapture): false,
             },
             "_provider": HttpProvider {
-              "clientUrl": "https://mainnet.optimism.io",
+              "clientUrl": "https://opt-mainnet.g.alchemy.com/v2/OVlbpe9COlhG-ijOXGvL_phb5ns6p9-w",
               "httpProviderOptions": undefined,
             },
             "useRpcCallSpecification": undefined,

--- a/packages/web3js-plugin/src/plugin.ts
+++ b/packages/web3js-plugin/src/plugin.ts
@@ -17,7 +17,7 @@ import {
 } from '@eth-optimism/contracts-ts'
 import { RLP } from '@ethereumjs/rlp'
 
-export class OptimismFeeEstimationPlugin extends Web3PluginBase {
+export class OptimismPlugin extends Web3PluginBase {
   public pluginNamespace = 'op'
 
   private _gasPriceOracleContract:
@@ -323,6 +323,6 @@ export class OptimismFeeEstimationPlugin extends Web3PluginBase {
 // Module Augmentation to add op namespace to root {web3} instance
 declare module 'web3' {
   interface Web3Context {
-    op: OptimismFeeEstimationPlugin
+    op: OptimismPlugin
   }
 }


### PR DESCRIPTION
- Correct use of `web3js-plugin` to `web3.js-plugin` in `README`
- Rename `OptimismFeeEstimationPlugin` export to `OptimismPlugin`