### PR TITLE
op-node: batch_decoder: Parallel tx fetching

### DIFF
--- a/op-node/cmd/batch_decoder/README.md
+++ b/op-node/cmd/batch_decoder/README.md
@@ -63,7 +63,6 @@ jq '.batches|del(.[]|.Transactions)' $CHANNEL_FILE
 
 ## Roadmap
 
-- Parallel transaction fetching (CLI-3563)
 - Pull the batches out of channels & store that information inside the ChannelWithMetadata (CLI-3565)
 	- Transaction Bytes used
 	- Total uncompressed (different from tx bytes) + compressed bytes

--- a/op-node/cmd/batch_decoder/main.go
+++ b/op-node/cmd/batch_decoder/main.go
@@ -55,6 +55,11 @@ func main() {
 					Usage:    "L1 RPC URL",
 					EnvVars:  []string{"L1_RPC"},
 				},
+				&cli.IntFlag{
+					Name:  "concurrent-requests",
+					Value: 10,
+					Usage: "Concurrency level when fetching L1",
+				},
 			},
 			Action: func(cliCtx *cli.Context) error {
 				client, err := ethclient.Dial(cliCtx.String("l1"))
@@ -74,8 +79,9 @@ func main() {
 					BatchSenders: map[common.Address]struct{}{
 						common.HexToAddress(cliCtx.String("sender")): struct{}{},
 					},
-					BatchInbox:   common.HexToAddress(cliCtx.String("inbox")),
-					OutDirectory: cliCtx.String("out"),
+					BatchInbox:         common.HexToAddress(cliCtx.String("inbox")),
+					OutDirectory:       cliCtx.String("out"),
+					ConcurrentRequests: uint64(cliCtx.Int("concurrent-requests")),
 				}
 				totalValid, totalInvalid := fetch.Batches(client, config)
 				fmt.Printf("Fetched batches in range [%v,%v). Found %v valid & %v invalid batches\n", config.Start, config.End, totalValid, totalInvalid)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Batch decoder's fetch command fetched L1 block one by one.

This PR adds `--concurrent-requests` flag to give concurrency for fetching L1 blocks for reading batch transactions.

Adjusted context timeout per requests to 10 seconds.

**Tests**

There were no tests for `batch_decoder`. Manually built and tested by comparing batch transactions between the old version and new version.
