### PR TITLE
Make shebangs more portable

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 pkg := bindings
 monorepo-base := $(shell dirname $(realpath .))

--- a/op-chain-ops/crossdomain/testdata/trace.sh
+++ b/op-chain-ops/crossdomain/testdata/trace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HASH=$1
 

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)

--- a/op-challenger/scripts/parallel.sh
+++ b/op-challenger/scripts/parallel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set -x
 

--- a/op-challenger/scripts/visualize.sh
+++ b/op-challenger/scripts/visualize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf artifacts forge-artifacts
 

--- a/packages/contracts-bedrock/scripts/verify-foundry-install.sh
+++ b/packages/contracts-bedrock/scripts/verify-foundry-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! command -v forge &> /dev/null
 then


### PR DESCRIPTION
**Description**

The `/bin/bash` binary/symlink is not available on all systems.

The new shebang works if `/usr/bin/env` exists and `bash` is in the path which should be the case for most reasonably modern systems.