### PR TITLE
chore(indexer): Disable flaky indexer tests

### DIFF
--- a/ops/check-changed/main.py
+++ b/ops/check-changed/main.py
@@ -56,7 +56,11 @@ log = logging.getLogger(__name__)
 
 def main():
     patterns = sys.argv[1].split(',')
-    patterns = patterns + REBUILD_ALL_PATTERNS
+
+    # temporarily only run indexer tests if indexer is changed because the tests are flaky
+    if len(patterns) != 1 or patterns[0] != "indexer":
+      patterns = patterns + REBUILD_ALL_PATTERNS
+
 
     fp = os.path.realpath(__file__)
     monorepo_path = os.path.realpath(os.path.join(fp, '..', '..'))


### PR DESCRIPTION
- disable flaky indexer tests until we get time to debug them
- Keep running the tests if changes are directly to the indexer folder
- Update check_changed. Can remove update once tests aren't flaky again
