### PR TITLE
More Area Label Mergify Rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -252,8 +252,7 @@ pull_request_rules:
           - A-pkg-contracts-bedrock
   - name: Add M-docs label
     conditions:
-      - 'files~=^technical-documents/'
-      - 'files~=^specs/'
+      - 'files~=^(technical-documents|specs)\/'
       - '#label<5'
     actions:
       label:
@@ -268,9 +267,7 @@ pull_request_rules:
           - M-deletion
   - name: Add M-ci label when ci files are modified
     conditions:
-      - 'files~=^.github/'
-      - 'files~=^.circleci/'
-      - 'files~=^.husky/'
+      - 'files~=^\.(github|circleci|husky)\/'
       - '#label<5'
     actions:
       label:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -74,9 +74,17 @@ pull_request_rules:
 
           More details can be found on the `Queue: Embarked in merge train`
           check-run.
+  - name: Add A-cannon label
+    conditions:
+      - 'files~=^cannon/'
+    actions:
+      label:
+        add:
+          - A-cannon
   - name: Add A-indexer label and ecopod reviewers
     conditions:
       - 'files~=^indexer/'
+      - '#label<5'
     actions:
       label:
         add:
@@ -84,9 +92,139 @@ pull_request_rules:
       request_reviews:
         users:
           - roninjin10
+  - name: Add A-op-batcher label
+    conditions:
+      - 'files~=^op-batcher/'
+    actions:
+      label:
+        add:
+          - A-op-batcher
+  - name: Add A-op-bindings label
+    conditions:
+      - 'files~=^op-bindings/'
+    actions:
+      label:
+        add:
+          - A-op-bindings
+  - name: Add A-op-bootnode label
+    conditions:
+      - 'files~=^op-bootnode/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-bootnode
+  - name: Add A-op-chain-ops label
+    conditions:
+      - 'files~=^op-chain-ops/'
+    actions:
+      label:
+        add:
+          - A-op-chain-ops
+  - name: Add A-op-challenger label
+    conditions:
+      - 'files~=^op-challenger/'
+    actions:
+      label:
+        add:
+          - A-op-challenger
+  - name: Add A-op-e2e label
+    conditions:
+      - 'files~=^op-e2e/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-e2e
+  - name: Add A-op-exporter label
+    conditions:
+      - 'files~=^op-exporter/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-exporter
+  - name: Add A-op-heartbeat label
+    conditions:
+      - 'files~=^op-heartbeat/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-heartbeat
+  - name: Add A-op-node label
+    conditions:
+      - 'files~=^op-node/'
+    actions:
+      label:
+        add:
+          - A-op-node
+  - name: Add A-op-preimage label
+    conditions:
+      - 'files~=^op-preimage/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-preimage
+  - name: Add A-op-program label
+    conditions:
+      - 'files~=^op-program/'
+    actions:
+      label:
+        add:
+          - A-op-program
+  - name: Add A-op-proposer label
+    conditions:
+      - 'files~=^op-proposer/'
+    actions:
+      label:
+        add:
+          - A-op-proposer
+  - name: Add A-op-service label
+    conditions:
+      - 'files~=^op-service/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-service
+  - name: Add A-op-signer label
+    conditions:
+      - 'files~=^op-signer/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-signer
+  - name: Add A-op-wheel label
+    conditions:
+      - 'files~=^op-wheel/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-op-wheel
+  - name: Add A-ops-bedrock label
+    conditions:
+      - 'files~=^ops-bedrock/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-ops-bedrock
+  - name: Add A-ops label
+    conditions:
+      - 'files~=^ops/'
+      - '#label<5'
+    actions:
+      label:
+        add:
+          - A-ops
   - name: Add A-pkg-sdk label and ecopod reviewers
     conditions:
       - 'files~=^packages/sdk/'
+      - '#label<5'
     actions:
       label:
         add:
@@ -97,6 +235,7 @@ pull_request_rules:
   - name: Add A-pkg-common-ts label and ecopod reviewers
     conditions:
       - 'files~=^packages/common-ts/'
+      - '#label<5'
     actions:
       label:
         add:
@@ -104,41 +243,6 @@ pull_request_rules:
       request_reviews:
         users:
           - roninjin10
-  - name: Add A-op-node label
-    conditions:
-      - 'files~=^op-node/'
-    actions:
-      label:
-        add:
-          - A-op-node
-  - name: Add A-op-batcher label
-    conditions:
-      - 'files~=^op-batcher/'
-    actions:
-      label:
-        add:
-          - A-op-batcher
-  - name: Add A-cannon label
-    conditions:
-      - 'files~=^cannon/'
-    actions:
-      label:
-        add:
-          - A-cannon
-  - name: Add A-op-program label
-    conditions:
-      - 'files~=^op-program/'
-    actions:
-      label:
-        add:
-          - A-op-program
-  - name: Add A-op-challenger label
-    conditions:
-      - 'files~=^op-challenger/'
-    actions:
-      label:
-        add:
-          - A-op-challenger
   - name: Add A-pkg-contracts-bedrock label
     conditions:
       - 'files~=^packages/contracts-bedrock/'
@@ -150,10 +254,11 @@ pull_request_rules:
     conditions:
       - 'files~=^technical-documents/'
       - 'files~=^specs/'
+      - '#label<5'
     actions:
       label:
         add:
-          - A-pkg-contracts-bedrock
+          - M-docs
   - name: Add M-deletion label when files are removed
     conditions:
       - 'removed-files~=^/'
@@ -166,6 +271,7 @@ pull_request_rules:
       - 'files~=^.github/'
       - 'files~=^.circleci/'
       - 'files~=^.husky/'
+      - '#label<5'
     actions:
       label:
         add:


### PR DESCRIPTION
**Description**

Adds a bunch of area labels automatically.

For most areas, these will not be automatically added if there are already 5 or more labels.

Critical areas like the op-node, batcher, and proposer are labeled regardless of the label count.

Also fixes `M-ci` and `M-docs` labeling. Since the multiple file rules were not placed in a capturing group, they were mutually inclusive effectively never allowing mergify to place the `M-docs` label for either `technical-documents/` or `specs/` for example. It would require changes to both. Same with `M-ci` which is why this pr isn't labeled with `M-ci` automatically.
