### PR TITLE
Update code examples in README

### DIFF
--- a/.changeset/wet-geese-cover.md
+++ b/.changeset/wet-geese-cover.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/web3.js-plugin': patch
+---
+
+Update code exmaples in README

--- a/packages/web3js-plugin/README.md
+++ b/packages/web3js-plugin/README.md
@@ -76,12 +76,15 @@ async estimateFees(transaction: Transaction, returnFormat?: ReturnFormat)
 
 ```typescript
 import Web3 from 'web3'
+import { OptimismPlugin } from '@eth-optimism/web3.js-plugin'
 import {
   l2StandardBridgeABI,
   l2StandardBridgeAddress,
 } from '@eth-optimism/contracts-ts'
 
 const web3 = new Web3('https://mainnet.optimism.io')
+web3.registerPlugin(new OptimismPlugin())
+
 const l2BridgeContract = new web3.eth.Contract(
   l2StandardBridgeABI,
   optimistAddress[420]
@@ -117,12 +120,15 @@ console.log(totalFee) // 26608988767659n
 
 ```typescript
 import Web3 from 'web3'
+import { OptimismPlugin } from '@eth-optimism/web3.js-plugin'
 import {
   l2StandardBridgeABI,
   l2StandardBridgeAddress,
 } from '@eth-optimism/contracts-ts'
 
 const web3 = new Web3('https://mainnet.optimism.io')
+web3.registerPlugin(new OptimismPlugin())
+
 const l2BridgeContract = new web3.eth.Contract(
   l2StandardBridgeABI,
   optimistAddress[420]

--- a/packages/web3js-plugin/README.md
+++ b/packages/web3js-plugin/README.md
@@ -28,10 +28,10 @@ yarn add @eth-optimism/web3.js-plugin
 
 ```typescript
 import Web3 from 'web3'
-import OptimismFeeEstimationPlugin from '@eth-optimism/web3.js-plugin'
+import { OptimismPlugin } from '@eth-optimism/web3.js-plugin'
 
 const web3 = new Web3('http://yourProvider.com')
-web3.registerPlugin(new OptimismFeeEstimationPlugin())
+web3.registerPlugin(new OptimismPlugin())
 ```
 
 You will now have access to the following functions under the `op` namespace, i.e. `web3.op.someMethod`


### PR DESCRIPTION
In `README`:

- Renames `OptimismFeeEstimationPlugin` to `OptimismPlugin`
- Adds plugin registration step to `estimateFees` code example