### PR TITLE
feat: API example of viem decorators

### DIFF
--- a/packages/viem/.gitignore
+++ b/packages/viem/.gitignore
@@ -1,0 +1,8 @@
+artifacts
+cache
+typechain
+.deps
+.envrc
+.env 
+/dist/
+coverage

--- a/packages/viem/.prettierignore
+++ b/packages/viem/.prettierignore
@@ -1,0 +1,7 @@
+artifacts
+cache
+typechain
+.deps
+.envrc
+.env 
+/dist/

--- a/packages/viem/.prettierrc.cjs
+++ b/packages/viem/.prettierrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('../../.prettierrc.js'),
+}

--- a/packages/viem/LICENSE
+++ b/packages/viem/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Optimism
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@eth-optimism/fee-estimation",
+  "version": "0.15.2",
+  "description": "Lightweight library for doing OP-Chain gas estimation",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ethereum-optimism/optimism.git",
+    "directory": "packages/fee-estimation"
+  },
+  "homepage": "https://optimism.io",
+  "type": "module",
+  "main": "dist/estimateFees.cjs",
+  "module": "dist/estimateFees.js",
+  "exports": {
+    ".": {
+      "import": "./dist/estimateFees.js",
+      "require": "./dist/estimateFees.cjs",
+      "default": "./dist/estimateFees.js",
+      "types": "./src/estimateFees.ts"
+    }
+  },
+  "types": "src/estimateFees.ts",
+  "files": [
+    "dist/",
+    "src/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint": "prettier --check .",
+    "lint:fix": "prettier --write .",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@eth-optimism/contracts-ts": "workspace:^",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@vitest/coverage-istanbul": "^0.34.1",
+    "abitype": "^0.9.3",
+    "isomorphic-fetch": "^3.0.0",
+    "jest-dom": "link:@types/@testing-library/jest-dom",
+    "jsdom": "^22.1.0",
+    "tsup": "^7.1.0",
+    "typescript": "^5.1.6",
+    "viem": "^1.3.1",
+    "vite": "^4.4.6",
+    "vitest": "^0.33.0"
+  },
+  "peerDependencies": {
+    "viem": "^0.3.30"
+  }
+}

--- a/packages/viem/setupVitest.ts
+++ b/packages/viem/setupVitest.ts
@@ -1,0 +1,4 @@
+import fetch from 'isomorphic-fetch'
+
+// viem needs this
+global.fetch = fetch

--- a/packages/viem/src/index.spec.ts
+++ b/packages/viem/src/index.spec.ts
@@ -1,0 +1,41 @@
+import { createWalletClient, custom } from 'viem'
+import { mainnet } from 'viem/chains'
+import { describe, expect } from 'vitest'
+import { opViemWalletExtension } from 'index'
+import { optimistABI, optimistAddress } from '@eth-optimism/contracts-ts'
+
+
+describe('opViemWalletExtension', async () => {
+  // User makes their viem wallet as normal
+  // @see https://viem.sh/docs/clients/wallet.html
+  const client = createWalletClient({
+    chain: mainnet,
+    // TODO replace this with a real transport that will work in test
+    // this code is currently just to show the API
+    transport: custom((window as any).ethereum)
+  })
+
+  // To add extra OP functionality they then add our extension
+  const extendedClient = client.extend(opViemWalletExtension)
+
+  const myAddress = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+  const theirAddress = '0x420A6BF26964aF9D7eEd9e03E53415D37aA96420'
+
+  // Now they can call a contract on l2 from l1 for example using normal viem apis
+  // this api is the exact same api as the normal viem function `writeContract`
+  const l2TxHash = await extendedClient.bridgeWriteContract({
+    // Interacting with the optimist abi
+    abi: optimistABI,
+    // It's an SBT but pretend it isn't
+    functionName: 'transferFrom',
+    args: [myAddress, theirAddress, BigInt(1)],
+    address: optimistAddress[10],
+    account: myAddress,
+    chain: mainnet,
+  })
+
+  console.log(l2TxHash)
+
+  expect(/0x.+/.test(l2TxHash)).toBe(true)
+
+})

--- a/packages/viem/src/index.spec.ts
+++ b/packages/viem/src/index.spec.ts
@@ -31,6 +31,7 @@ describe('opViemWalletExtension', async () => {
     args: [myAddress, theirAddress, BigInt(1)],
     address: optimistAddress[10],
     account: myAddress,
+    // TODO modify api here make it so the chain is the destination chain instead of origin chain
     chain: mainnet,
   })
 

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -1,0 +1,46 @@
+import {
+  type Chain,
+  type Transport,
+  type Account,
+  WalletClient,
+  encodeFunctionData,
+  EncodeFunctionDataParameters
+} from 'viem'
+import { l1CrossDomainMessengerABI, l1CrossDomainMessengerAddress } from '@eth-optimism/contracts-ts'
+
+type OptimismExtended = {
+  bridgeWriteContract: WalletClient['writeContract']
+}
+
+export const opViemWalletExtension = <
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+>(client: WalletClient<transport, chain, account>) => ({
+  bridgeWriteContract: async (args) => {
+    // TODO don't hardcode this
+    const minGasLimit = 200_000
+    const message = encodeFunctionData({
+      abi: args.abi,
+      functionName: args.functionName,
+      args: args.args,
+    } as unknown as EncodeFunctionDataParameters<typeof args.abi, typeof args.functionName>)
+    const l1TxHash = await client.writeContract({
+      abi: l1CrossDomainMessengerABI,
+      // TODO currently hardcoded for OP
+      address: l1CrossDomainMessengerAddress[1],
+      functionName: 'sendMessage' as any,
+      value: args.value as any,
+      args: [
+        args.address,
+        message,
+        minGasLimit,
+      ] as any,
+    })
+    //TODO derive me using new tx hash method from core utils
+    const l2TxHash = l1TxHash
+    // TODO return both l1 and l2 tx hash instead of only l2
+    return l2TxHash
+  },
+} satisfies OptimismExtended)
+

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -17,6 +17,8 @@ export const opViemWalletExtension = <
   chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
 >(client: WalletClient<transport, chain, account>) => ({
+  // TODO move me to an action 
+  // @see https://viem.sh/docs/actions/wallet/introduction.html
   bridgeWriteContract: async (args) => {
     // TODO don't hardcode this
     const minGasLimit = 200_000
@@ -25,6 +27,7 @@ export const opViemWalletExtension = <
       functionName: args.functionName,
       args: args.args,
     } as unknown as EncodeFunctionDataParameters<typeof args.abi, typeof args.functionName>)
+    // TODO internal implementations should only rely on actions
     const l1TxHash = await client.writeContract({
       abi: l1CrossDomainMessengerABI,
       // TODO currently hardcoded for OP

--- a/packages/viem/src/vite-env.d.ts
+++ b/packages/viem/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/viem/tsconfig.json
+++ b/packages/viem/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./src",
+    "strict": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "target": "ESNext",
+    "noEmit": true
+  },
+  "include": ["./src"]
+}

--- a/packages/viem/tsup.config.ts
+++ b/packages/viem/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup'
+import packageJson from './package.json'
+
+// @see https://tsup.egoist.dev/
+export default defineConfig({
+  name: packageJson.name,
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  format: ['esm', 'cjs'],
+  splitting: false,
+  sourcemap: true,
+  clean: false,
+})

--- a/packages/viem/vite.config.ts
+++ b/packages/viem/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+// @see https://vitest.dev/config/
+export default defineConfig({
+  test: {
+    setupFiles: './setupVitest.ts',
+    environment: 'jsdom',
+    coverage: {
+      provider: 'istanbul',
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,48 @@ importers:
         specifier: ^3.22.1
         version: 3.22.1
 
+  packages/viem:
+    devDependencies:
+      '@eth-optimism/contracts-ts':
+        specifier: workspace:^
+        version: link:../contracts-ts
+      '@testing-library/jest-dom':
+        specifier: ^5.17.0
+        version: 5.17.0
+      '@testing-library/react-hooks':
+        specifier: ^8.0.1
+        version: 8.0.1(react@17.0.2)
+      '@vitest/coverage-istanbul':
+        specifier: ^0.34.1
+        version: 0.34.1(vitest@0.33.0)
+      abitype:
+        specifier: ^0.9.3
+        version: 0.9.3(typescript@5.1.6)(zod@3.22.1)
+      isomorphic-fetch:
+        specifier: ^3.0.0
+        version: 3.0.0
+      jest-dom:
+        specifier: link:@types/@testing-library/jest-dom
+        version: link:@types/@testing-library/jest-dom
+      jsdom:
+        specifier: ^22.1.0
+        version: 22.1.0
+      tsup:
+        specifier: ^7.1.0
+        version: 7.2.0(typescript@5.1.6)
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
+      viem:
+        specifier: ^1.3.1
+        version: 1.6.0(typescript@5.1.6)(zod@3.22.1)
+      vite:
+        specifier: ^4.4.6
+        version: 4.4.9(@types/node@12.20.20)
+      vitest:
+        specifier: ^0.33.0
+        version: 0.33.0(jsdom@22.1.0)
+
   packages/web3js-plugin:
     dependencies:
       '@ethereumjs/rlp':
@@ -639,29 +681,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core@7.22.9:
-    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.10
-      '@babel/generator': 7.22.9
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
-      convert-source-map: 1.9.0
-      debug: 4.3.4(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/eslint-parser@7.18.2(@babel/core@7.22.10)(eslint@8.47.0):
     resolution: {integrity: sha512-oFQYkE8SuH14+uR51JVAmdqwKYXGRjEXx7s+WiagVjqQ+HPE+nnwyF2qlVG8evUsUHmPcA+6YXMEDbIhEyQc5A==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
@@ -690,17 +709,7 @@ packages:
     resolution: {integrity: sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.19
-      jsesc: 2.5.2
-    dev: true
-
-  /@babel/generator@7.22.9:
-    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
@@ -713,20 +722,6 @@ packages:
       '@babel/compat-data': 7.22.9
       '@babel/helper-validator-option': 7.22.5
       browserslist: 4.21.10
-      lru-cache: 5.1.1
-      semver: 6.3.1
-    dev: true
-
-  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
-    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
-      '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.9
       lru-cache: 5.1.1
       semver: 6.3.1
     dev: true
@@ -746,7 +741,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-function-name@7.22.5:
@@ -754,28 +749,28 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-hoist-variables@7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-module-imports@7.22.5:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.10):
@@ -792,39 +787,25 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
     dev: true
 
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
-    dev: true
-
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-split-export-declaration@7.16.7:
     resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/helper-string-parser@7.22.5:
@@ -853,17 +834,6 @@ packages:
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.10
       '@babel/types': 7.22.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helpers@7.22.6:
-    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -897,15 +867,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.5
-    dev: true
-
-  /@babel/parser@7.22.7:
-    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/runtime@7.20.7:
@@ -926,8 +888,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.10
-      '@babel/parser': 7.22.7
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.22.10
+      '@babel/types': 7.22.10
     dev: true
 
   /@babel/traverse@7.18.2:
@@ -966,24 +928,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/traverse@7.22.8:
-    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.10
-      '@babel/generator': 7.22.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/types': 7.22.5
-      debug: 4.3.4(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/types@7.22.10:
     resolution: {integrity: sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==}
     engines: {node: '>=6.9.0'}
@@ -1005,7 +949,7 @@ packages:
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/config': 2.3.0
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -1023,7 +967,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.3:
     resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/types': 5.2.1
@@ -1126,7 +1070,7 @@ packages:
   /@changesets/get-release-plan@3.0.16:
     resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/assemble-release-plan': 5.2.3
       '@changesets/config': 2.3.0
       '@changesets/pre': 1.0.14
@@ -1142,7 +1086,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -1167,7 +1111,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -1177,7 +1121,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -1197,7 +1141,7 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -2636,7 +2580,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.20.7
+      '@babel/runtime': 7.22.6
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -4710,7 +4654,7 @@ packages:
   /@vue/compiler-core@3.2.36:
     resolution: {integrity: sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==}
     dependencies:
-      '@babel/parser': 7.22.5
+      '@babel/parser': 7.22.10
       '@vue/shared': 3.2.36
       estree-walker: 2.0.2
       source-map: 0.6.1
@@ -4748,7 +4692,7 @@ packages:
   /@vue/reactivity-transform@3.2.36:
     resolution: {integrity: sha512-Jk5o2BhpODC9XTA7o4EL8hSJ4JyrFWErLtClG3NH8wDS7ri9jBDWxI7/549T7JY9uilKsaNM+4pJASLj5dtRwA==}
     dependencies:
-      '@babel/parser': 7.22.5
+      '@babel/parser': 7.22.10
       '@vue/compiler-core': 3.2.36
       '@vue/shared': 3.2.36
       estree-walker: 2.0.2
@@ -4829,7 +4773,7 @@ packages:
       picocolors: 1.0.0
       prettier: 2.8.8
       typescript: 5.1.6
-      viem: 1.3.1(typescript@5.1.6)(zod@3.22.0)
+      viem: 1.6.0(typescript@5.1.6)(zod@3.22.0)
       wagmi: 1.0.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(viem@1.3.1)
       zod: 3.22.0
     transitivePeerDependencies:
@@ -6223,17 +6167,6 @@ packages:
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
 
-  /browserslist@4.21.9:
-    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001517
-      electron-to-chromium: 1.4.468
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.11(browserslist@4.21.9)
-    dev: true
-
   /bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
@@ -6423,10 +6356,6 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /caniuse-lite@1.0.30001517:
-    resolution: {integrity: sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==}
     dev: true
 
   /caniuse-lite@1.0.30001520:
@@ -7583,10 +7512,6 @@ packages:
     hasBin: true
     dependencies:
       jake: 10.8.7
-    dev: true
-
-  /electron-to-chromium@1.4.468:
-    resolution: {integrity: sha512-6M1qyhaJOt7rQtNti1lBA0GwclPH+oKCmsra/hkcWs5INLxfXXD/dtdnaKUYQu/pjOBP/8Osoe4mAcNvvzoFag==}
     dev: true
 
   /electron-to-chromium@1.4.491:
@@ -10564,7 +10489,7 @@ packages:
     resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': 7.22.10
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -15722,6 +15647,42 @@ packages:
       - ts-node
     dev: true
 
+  /tsup@7.2.0(typescript@5.1.6):
+    resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.1(esbuild@0.18.15)
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4(supports-color@8.1.1)
+      esbuild: 0.18.15
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.1
+      resolve-from: 5.0.0
+      rollup: 3.28.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.34.0
+      tree-kill: 1.2.2
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -16037,17 +15998,6 @@ packages:
       picocolors: 1.0.0
     dev: true
 
-  /update-browserslist-db@1.0.11(browserslist@4.21.9):
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.9
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: true
-
   /update-section@0.3.3:
     resolution: {integrity: sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==}
     dev: true
@@ -16254,30 +16204,6 @@ packages:
       - bufferutil
       - utf-8-validate
       - zod
-
-  /viem@1.3.1(typescript@5.1.6)(zod@3.22.0):
-    resolution: {integrity: sha512-Yv+y3/exrrEN4EAkVUtUuQxsjF4+3taHY2aSinJnNWtcA4fBZ+WfPJBTywcnFIa/Q5oDcQN85yqPFBbkXqWHdw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.0
-      '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
-      '@scure/bip32': 1.3.0
-      '@scure/bip39': 1.2.0
-      '@wagmi/chains': 1.6.0(typescript@5.1.6)
-      abitype: 0.9.3(typescript@5.1.6)(zod@3.22.0)
-      isomorphic-ws: 5.0.0(ws@8.12.0)
-      typescript: 5.1.6
-      ws: 8.12.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: true
 
   /viem@1.6.0(typescript@5.1.6)(zod@3.22.0):
     resolution: {integrity: sha512-ae9Twkd0q2Qlj4yYpWjb4DzYAhKY0ibEpRH8FJaTywZXNpTjFidSdBaT0CVn1BaH7O7cnX4/O47zvDUMGJD1AA==}


### PR DESCRIPTION
This is a POC of what viem based sdk would look like

## Current sdk

- bespoke API with it's own complexity and documentation
- ethers v5 based

## New sdk

- viem based
- easy to use without docs because it's api matches viem exactly
- extends viem natively
- rollup functionality that is more general than OP perhaps we upstream to viem

## Example

In this example I create a function `bridgeContractCall` which calls a contract on l2 from l1

- a reference implementation that more or less matches what a real implementation would look like
- A test that shows what using this library looks like for the user

bridgeWriteContract has the exact same API as viem's [writeContract](https://viem.sh/docs/contract/writeContract.html#writecontract). It ergonomically feels no different than calling contractCall on l2 to the developer

## What would need to happen to productionize this

- lots of TODOs in the code
- we would want to decorate a `bridgeCreateContract` method that is like creating a bridged version of `createContract`
- The action should be exported both as a standalone action and also as a client decorator matching how viem works. Users can use actions without clients (usually better code splitting this way)
- would generalize to all OP chains. Needs to be able to override options such as crossChainMessenger address
- Ideally we would add extended viem `chain` objects that include these config options for most chains
  - Ideally these are generated from on chain configs

