### PR TITLE
feat(indexer): use contiguous slice of memory

### DIFF
--- a/indexer/api/api_test.go
+++ b/indexer/api/api_test.go
@@ -56,7 +56,7 @@ func (mbv *MockBridgeTransfersView) L2BridgeWithdrawalWithFilter(filter database
 
 func (mbv *MockBridgeTransfersView) L1BridgeDepositsByAddress(address common.Address, cursor string, limit int) (*database.L1BridgeDepositsResponse, error) {
 	return &database.L1BridgeDepositsResponse{
-		Deposits: []*database.L1BridgeDepositWithTransactionHashes{
+		Deposits: []database.L1BridgeDepositWithTransactionHashes{
 			{
 				L1BridgeDeposit:   deposit,
 				L1TransactionHash: common.HexToHash("0x123"),
@@ -67,7 +67,7 @@ func (mbv *MockBridgeTransfersView) L1BridgeDepositsByAddress(address common.Add
 
 func (mbv *MockBridgeTransfersView) L2BridgeWithdrawalsByAddress(address common.Address, cursor string, limit int) (*database.L2BridgeWithdrawalsResponse, error) {
 	return &database.L2BridgeWithdrawalsResponse{
-		Withdrawals: []*database.L2BridgeWithdrawalWithTransactionHashes{
+		Withdrawals: []database.L2BridgeWithdrawalWithTransactionHashes{
 			{
 				L2BridgeWithdrawal: withdrawal,
 				L2TransactionHash:  common.HexToHash("0x789"),

--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -82,11 +82,11 @@ type BlocksView interface {
 type BlocksDB interface {
 	BlocksView
 
-	StoreL1BlockHeaders([]*L1BlockHeader) error
-	StoreL2BlockHeaders([]*L2BlockHeader) error
+	StoreL1BlockHeaders([]L1BlockHeader) error
+	StoreL2BlockHeaders([]L2BlockHeader) error
 
-	StoreLegacyStateBatches([]*LegacyStateBatch) error
-	StoreOutputProposals([]*OutputProposal) error
+	StoreLegacyStateBatches([]LegacyStateBatch) error
+	StoreOutputProposals([]OutputProposal) error
 }
 
 /**
@@ -103,17 +103,17 @@ func newBlocksDB(db *gorm.DB) BlocksDB {
 
 // L1
 
-func (db *blocksDB) StoreL1BlockHeaders(headers []*L1BlockHeader) error {
+func (db *blocksDB) StoreL1BlockHeaders(headers []L1BlockHeader) error {
 	result := db.gorm.Create(&headers)
 	return result.Error
 }
 
-func (db *blocksDB) StoreLegacyStateBatches(stateBatches []*LegacyStateBatch) error {
+func (db *blocksDB) StoreLegacyStateBatches(stateBatches []LegacyStateBatch) error {
 	result := db.gorm.Create(stateBatches)
 	return result.Error
 }
 
-func (db *blocksDB) StoreOutputProposals(outputs []*OutputProposal) error {
+func (db *blocksDB) StoreOutputProposals(outputs []OutputProposal) error {
 	result := db.gorm.Create(outputs)
 	return result.Error
 }
@@ -179,7 +179,7 @@ func (db *blocksDB) OutputProposal(index *big.Int) (*OutputProposal, error) {
 
 // L2
 
-func (db *blocksDB) StoreL2BlockHeaders(headers []*L2BlockHeader) error {
+func (db *blocksDB) StoreL2BlockHeaders(headers []L2BlockHeader) error {
 	result := db.gorm.Create(&headers)
 	return result.Error
 }

--- a/indexer/database/bridge_messages.go
+++ b/indexer/database/bridge_messages.go
@@ -47,10 +47,10 @@ type BridgeMessagesView interface {
 type BridgeMessagesDB interface {
 	BridgeMessagesView
 
-	StoreL1BridgeMessages([]*L1BridgeMessage) error
+	StoreL1BridgeMessages([]L1BridgeMessage) error
 	MarkRelayedL1BridgeMessage(common.Hash, uuid.UUID) error
 
-	StoreL2BridgeMessages([]*L2BridgeMessage) error
+	StoreL2BridgeMessages([]L2BridgeMessage) error
 	MarkRelayedL2BridgeMessage(common.Hash, uuid.UUID) error
 }
 
@@ -70,7 +70,7 @@ func newBridgeMessagesDB(db *gorm.DB) BridgeMessagesDB {
  * Arbitrary Messages Sent from L1
  */
 
-func (db bridgeMessagesDB) StoreL1BridgeMessages(messages []*L1BridgeMessage) error {
+func (db bridgeMessagesDB) StoreL1BridgeMessages(messages []L1BridgeMessage) error {
 	result := db.gorm.Create(&messages)
 	return result.Error
 }
@@ -109,7 +109,7 @@ func (db bridgeMessagesDB) MarkRelayedL1BridgeMessage(messageHash common.Hash, r
  * Arbitrary Messages Sent from L2
  */
 
-func (db bridgeMessagesDB) StoreL2BridgeMessages(messages []*L2BridgeMessage) error {
+func (db bridgeMessagesDB) StoreL2BridgeMessages(messages []L2BridgeMessage) error {
 	result := db.gorm.Create(&messages)
 	return result.Error
 }

--- a/indexer/database/bridge_transactions.go
+++ b/indexer/database/bridge_transactions.go
@@ -53,9 +53,9 @@ type BridgeTransactionsView interface {
 type BridgeTransactionsDB interface {
 	BridgeTransactionsView
 
-	StoreL1TransactionDeposits([]*L1TransactionDeposit) error
+	StoreL1TransactionDeposits([]L1TransactionDeposit) error
 
-	StoreL2TransactionWithdrawals([]*L2TransactionWithdrawal) error
+	StoreL2TransactionWithdrawals([]L2TransactionWithdrawal) error
 	MarkL2TransactionWithdrawalProvenEvent(common.Hash, uuid.UUID) error
 	MarkL2TransactionWithdrawalFinalizedEvent(common.Hash, uuid.UUID, bool) error
 }
@@ -76,7 +76,7 @@ func newBridgeTransactionsDB(db *gorm.DB) BridgeTransactionsDB {
  * Transactions deposited from L1
  */
 
-func (db *bridgeTransactionsDB) StoreL1TransactionDeposits(deposits []*L1TransactionDeposit) error {
+func (db *bridgeTransactionsDB) StoreL1TransactionDeposits(deposits []L1TransactionDeposit) error {
 	result := db.gorm.Create(&deposits)
 	return result.Error
 }
@@ -98,7 +98,7 @@ func (db *bridgeTransactionsDB) L1TransactionDeposit(sourceHash common.Hash) (*L
  * Transactions withdrawn from L2
  */
 
-func (db *bridgeTransactionsDB) StoreL2TransactionWithdrawals(withdrawals []*L2TransactionWithdrawal) error {
+func (db *bridgeTransactionsDB) StoreL2TransactionWithdrawals(withdrawals []L2TransactionWithdrawal) error {
 	result := db.gorm.Create(&withdrawals)
 	return result.Error
 }

--- a/indexer/database/bridge_transfers.go
+++ b/indexer/database/bridge_transfers.go
@@ -68,8 +68,8 @@ type BridgeTransfersView interface {
 type BridgeTransfersDB interface {
 	BridgeTransfersView
 
-	StoreL1BridgeDeposits([]*L1BridgeDeposit) error
-	StoreL2BridgeWithdrawals([]*L2BridgeWithdrawal) error
+	StoreL1BridgeDeposits([]L1BridgeDeposit) error
+	StoreL2BridgeWithdrawals([]L2BridgeWithdrawal) error
 }
 
 /**
@@ -88,7 +88,7 @@ func newBridgeTransfersDB(db *gorm.DB) BridgeTransfersDB {
  * Tokens Bridged (Deposited) from L1
  */
 
-func (db *bridgeTransfersDB) StoreL1BridgeDeposits(deposits []*L1BridgeDeposit) error {
+func (db *bridgeTransfersDB) StoreL1BridgeDeposits(deposits []L1BridgeDeposit) error {
 	result := db.gorm.Create(&deposits)
 	return result.Error
 }
@@ -122,7 +122,7 @@ func (db *bridgeTransfersDB) L1BridgeDepositWithFilter(filter BridgeTransfer) (*
 }
 
 type L1BridgeDepositsResponse struct {
-	Deposits    []*L1BridgeDepositWithTransactionHashes
+	Deposits    []L1BridgeDepositWithTransactionHashes
 	Cursor      string
 	HasNextPage bool
 }
@@ -150,7 +150,7 @@ l1_transaction_deposits.l2_transaction_hash`)
 
 	filteredQuery := depositsQuery.Where(&Transaction{FromAddress: address}).Order("l1_bridge_deposits.transaction_source_hash DESC").Limit(limit + 1)
 
-	deposits := []*L1BridgeDepositWithTransactionHashes{}
+	deposits := []L1BridgeDepositWithTransactionHashes{}
 	result := filteredQuery.Scan(&deposits)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -183,7 +183,7 @@ l1_transaction_deposits.l2_transaction_hash`)
  * Tokens Bridged (Withdrawn) from L2
  */
 
-func (db *bridgeTransfersDB) StoreL2BridgeWithdrawals(withdrawals []*L2BridgeWithdrawal) error {
+func (db *bridgeTransfersDB) StoreL2BridgeWithdrawals(withdrawals []L2BridgeWithdrawal) error {
 	result := db.gorm.Create(&withdrawals)
 	return result.Error
 }
@@ -217,7 +217,7 @@ func (db *bridgeTransfersDB) L2BridgeWithdrawalWithFilter(filter BridgeTransfer)
 }
 
 type L2BridgeWithdrawalsResponse struct {
-	Withdrawals []*L2BridgeWithdrawalWithTransactionHashes
+	Withdrawals []L2BridgeWithdrawalWithTransactionHashes
 	Cursor      string
 	HasNextPage bool
 }
@@ -247,7 +247,7 @@ finalized_l1_contract_events.transaction_hash AS finalized_l1_transaction_hash`)
 
 	filteredQuery := withdrawalsQuery.Where(&Transaction{FromAddress: address}).Order("l2_bridge_withdrawals.timestamp DESC").Limit(limit + 1)
 
-	withdrawals := []*L2BridgeWithdrawalWithTransactionHashes{}
+	withdrawals := []L2BridgeWithdrawalWithTransactionHashes{}
 	result := filteredQuery.Scan(&withdrawals)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -90,8 +90,8 @@ type ContractEventsView interface {
 type ContractEventsDB interface {
 	ContractEventsView
 
-	StoreL1ContractEvents([]*L1ContractEvent) error
-	StoreL2ContractEvents([]*L2ContractEvent) error
+	StoreL1ContractEvents([]L1ContractEvent) error
+	StoreL2ContractEvents([]L2ContractEvent) error
 }
 
 /**
@@ -108,7 +108,7 @@ func newContractEventsDB(db *gorm.DB) ContractEventsDB {
 
 // L1
 
-func (db *contractEventsDB) StoreL1ContractEvents(events []*L1ContractEvent) error {
+func (db *contractEventsDB) StoreL1ContractEvents(events []L1ContractEvent) error {
 	result := db.gorm.Create(&events)
 	return result.Error
 }
@@ -175,7 +175,7 @@ func (db *contractEventsDB) L1LatestContractEventWithFilter(filter ContractEvent
 
 // L2
 
-func (db *contractEventsDB) StoreL2ContractEvents(events []*L2ContractEvent) error {
+func (db *contractEventsDB) StoreL2ContractEvents(events []L2ContractEvent) error {
 	result := db.gorm.Create(&events)
 	return result.Error
 }

--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -77,10 +77,10 @@ func (l1Etl *L1ETL) Start(ctx context.Context) error {
 		// Index incoming batches
 		case batch := <-l1Etl.etlBatches:
 			// Pull out only L1 blocks that have emitted a log ( <= batch.Headers )
-			l1BlockHeaders := make([]*database.L1BlockHeader, 0, len(batch.Headers))
+			l1BlockHeaders := make([]database.L1BlockHeader, 0, len(batch.Headers))
 			for i := range batch.Headers {
 				if _, ok := batch.HeadersWithLog[batch.Headers[i].Hash()]; ok {
-					l1BlockHeaders = append(l1BlockHeaders, &database.L1BlockHeader{BlockHeader: database.BlockHeaderFromHeader(&batch.Headers[i])})
+					l1BlockHeaders = append(l1BlockHeaders, database.L1BlockHeader{BlockHeader: database.BlockHeaderFromHeader(&batch.Headers[i])})
 				}
 			}
 
@@ -89,10 +89,10 @@ func (l1Etl *L1ETL) Start(ctx context.Context) error {
 				continue
 			}
 
-			l1ContractEvents := make([]*database.L1ContractEvent, len(batch.Logs))
+			l1ContractEvents := make([]database.L1ContractEvent, len(batch.Logs))
 			for i := range batch.Logs {
 				timestamp := batch.HeaderMap[batch.Logs[i].BlockHash].Time
-				l1ContractEvents[i] = &database.L1ContractEvent{ContractEvent: database.ContractEventFromLog(&batch.Logs[i], timestamp)}
+				l1ContractEvents[i] = database.L1ContractEvent{ContractEvent: database.ContractEventFromLog(&batch.Logs[i], timestamp)}
 			}
 
 			// Continually try to persist this batch. If it fails after 10 attempts, we simply error out

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -67,15 +67,15 @@ func (l2Etl *L2ETL) Start(ctx context.Context) error {
 		// Index incoming batches
 		case batch := <-l2Etl.etlBatches:
 			// We're indexing every L2 block.
-			l2BlockHeaders := make([]*database.L2BlockHeader, len(batch.Headers))
+			l2BlockHeaders := make([]database.L2BlockHeader, len(batch.Headers))
 			for i := range batch.Headers {
-				l2BlockHeaders[i] = &database.L2BlockHeader{BlockHeader: database.BlockHeaderFromHeader(&batch.Headers[i])}
+				l2BlockHeaders[i] = database.L2BlockHeader{BlockHeader: database.BlockHeaderFromHeader(&batch.Headers[i])}
 			}
 
-			l2ContractEvents := make([]*database.L2ContractEvent, len(batch.Logs))
+			l2ContractEvents := make([]database.L2ContractEvent, len(batch.Logs))
 			for i := range batch.Logs {
 				timestamp := batch.HeaderMap[batch.Logs[i].BlockHash].Time
-				l2ContractEvents[i] = &database.L2ContractEvent{ContractEvent: database.ContractEventFromLog(&batch.Logs[i], timestamp)}
+				l2ContractEvents[i] = database.L2ContractEvent{ContractEvent: database.ContractEventFromLog(&batch.Logs[i], timestamp)}
 			}
 
 			// Continually try to persist this batch. If it fails after 5 attempts, we simply error out


### PR DESCRIPTION
Golang slices are passed by reference and different stages of the indexer
often manipulates/transforms many slices of memory. Lets use slices of
non-pointers wherever possible which should yield better performance
