### PR TITLE
feat(ctb): Preserve prod game type space

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -33,27 +33,19 @@ const (
 	TraceTypeAlphabet TraceType = "alphabet"
 	TraceTypeCannon   TraceType = "cannon"
 
-	// Devnet game IDs
-	DevnetGameIDAlphabet = uint8(0)
-	DevnetGameIDCannon   = uint8(1)
+	// Mainnet games
+	CannonFaultGameID = 0
 
-	// Mainnet game IDs
-	MainnetGameIDFault = uint8(0)
+	// Devnet games
+	AlphabetFaultGameID = 255
 )
 
 var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon}
 
-// GameIdToString maps game IDs to their string representation on a per-network basis.
-var GameIdToString = map[uint64]map[uint8]string{
-	// Mainnet
-	1: {
-		MainnetGameIDFault: "fault-cannon",
-	},
-	// Devnet
-	900: {
-		DevnetGameIDAlphabet: "fault-alphabet",
-		DevnetGameIDCannon:   "fault-cannon",
-	},
+// GameIdToString maps game IDs to their string representation.
+var GameIdToString = map[uint8]string{
+	CannonFaultGameID:   "Cannon",
+	AlphabetFaultGameID: "Alphabet",
 }
 
 func (t TraceType) String() string {

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -78,8 +78,8 @@ cast call $L2_OUTPUT_ORACLE_PROXY "getL2Output(uint256)" $PRIOR_INDEX
 echo "Getting the l2 output at index $INDEX"
 cast call $L2_OUTPUT_ORACLE_PROXY "getL2Output(uint256)" $INDEX
 
-# (Alphabet) Fault game type = 0
-GAME_TYPE=0
+# (Alphabet) Fault game type = 255
+GAME_TYPE=255
 
 # Root claim commits to the entire trace.
 # Alphabet game claim construction: keccak256(abi.encode(trace_index, trace[trace_index]))

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const alphabetGameType uint8 = 0
-const cannonGameType uint8 = 1
+const alphabetGameType uint8 = 255
+const cannonGameType uint8 = 0
 const alphabetGameDepth = 4
 const lastAlphabetTraceIndex = 1<<alphabetGameDepth - 1
 

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -838,6 +838,11 @@ contract Deploy is Deployer {
                 rawGameType == 0 ? "Cannon" : "Alphabet",
                 vm.toString(rawGameType)
             );
+        } else {
+            console.log(
+                "[WARN] DisputeGameFactoryProxy: `FaultDisputeGame` implementation already set for game type: %s",
+                vm.toString(GameType.unwrap(_gameType))
+            );
         }
     }
 }


### PR DESCRIPTION
## Overview

Moves the alphabet game to game ID `255` on the devnet and the cannon game to `0`, making the game impls that will be deployed to prod have the same game IDs on devnet. Going forward, the devnet will maintain parity with prod game type values and any devnet-specific games will descend from `255`. 

**Metadata**
Closes CLI-4369
