### PR TITLE
op-challenger: Use game specific data dir for cannon trace provider

### DIFF
--- a/op-challenger/fault/cannon/executor.go
+++ b/op-challenger/fault/cannon/executor.go
@@ -39,7 +39,6 @@ type Executor struct {
 	rollupConfig     string
 	l2Genesis        string
 	absolutePreState string
-	dataDir          string
 	snapshotFreq     uint
 	selectSnapshot   snapshotSelect
 	cmdExecutor      cmdExecutor
@@ -57,7 +56,6 @@ func NewExecutor(logger log.Logger, cfg *config.Config, inputs LocalGameInputs) 
 		rollupConfig:     cfg.CannonRollupConfigPath,
 		l2Genesis:        cfg.CannonL2GenesisPath,
 		absolutePreState: cfg.CannonAbsolutePreState,
-		dataDir:          cfg.CannonDatadir,
 		snapshotFreq:     cfg.CannonSnapshotFreq,
 		selectSnapshot:   findStartingSnapshot,
 		cmdExecutor:      runCmd,
@@ -71,7 +69,7 @@ func (e *Executor) GenerateProof(ctx context.Context, dir string, i uint64) erro
 		return fmt.Errorf("find starting snapshot: %w", err)
 	}
 	proofDir := filepath.Join(dir, proofsDir)
-	dataDir := filepath.Join(e.dataDir, preimagesDir)
+	dataDir := filepath.Join(dir, preimagesDir)
 	lastGeneratedState := filepath.Join(dir, finalState)
 	args := []string{
 		"run",

--- a/op-challenger/fault/cannon/executor_test.go
+++ b/op-challenger/fault/cannon/executor_test.go
@@ -22,7 +22,9 @@ const execTestCannonPrestate = "/foo/pre.json"
 func TestGenerateProof(t *testing.T) {
 	input := "starting.json"
 	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", config.TraceTypeCannon, true)
-	cfg.CannonDatadir = t.TempDir()
+	tempDir := t.TempDir()
+	dir := filepath.Join(tempDir, "gameDir")
+	cfg.CannonDatadir = tempDir
 	cfg.CannonAbsolutePreState = "pre.json"
 	cfg.CannonBin = "./bin/cannon"
 	cfg.CannonServer = "./bin/op-program"
@@ -58,7 +60,7 @@ func TestGenerateProof(t *testing.T) {
 			}
 			return nil
 		}
-		err := executor.GenerateProof(context.Background(), cfg.CannonDatadir, proofAt)
+		err := executor.GenerateProof(context.Background(), dir, proofAt)
 		require.NoError(t, err)
 		return binary, subcommand, args
 	}
@@ -68,15 +70,15 @@ func TestGenerateProof(t *testing.T) {
 		cfg.CannonRollupConfigPath = ""
 		cfg.CannonL2GenesisPath = ""
 		binary, subcommand, args := captureExec(t, cfg, 150_000_000)
-		require.DirExists(t, filepath.Join(cfg.CannonDatadir, preimagesDir))
-		require.DirExists(t, filepath.Join(cfg.CannonDatadir, proofsDir))
-		require.DirExists(t, filepath.Join(cfg.CannonDatadir, snapsDir))
+		require.DirExists(t, filepath.Join(dir, preimagesDir))
+		require.DirExists(t, filepath.Join(dir, proofsDir))
+		require.DirExists(t, filepath.Join(dir, snapsDir))
 		require.Equal(t, cfg.CannonBin, binary)
 		require.Equal(t, "run", subcommand)
 		require.Equal(t, input, args["--input"])
 		require.Contains(t, args, "--meta")
 		require.Equal(t, "", args["--meta"])
-		require.Equal(t, filepath.Join(cfg.CannonDatadir, finalState), args["--output"])
+		require.Equal(t, filepath.Join(dir, finalState), args["--output"])
 		require.Equal(t, "=150000000", args["--proof-at"])
 		require.Equal(t, "=150000001", args["--stop-at"])
 		require.Equal(t, "%500", args["--snapshot-at"])
@@ -86,9 +88,9 @@ func TestGenerateProof(t *testing.T) {
 		require.Equal(t, "--server", args[cfg.CannonServer])
 		require.Equal(t, cfg.L1EthRpc, args["--l1"])
 		require.Equal(t, cfg.CannonL2, args["--l2"])
-		require.Equal(t, filepath.Join(cfg.CannonDatadir, preimagesDir), args["--datadir"])
-		require.Equal(t, filepath.Join(cfg.CannonDatadir, proofsDir, "%d.json"), args["--proof-fmt"])
-		require.Equal(t, filepath.Join(cfg.CannonDatadir, snapsDir, "%d.json"), args["--snapshot-fmt"])
+		require.Equal(t, filepath.Join(dir, preimagesDir), args["--datadir"])
+		require.Equal(t, filepath.Join(dir, proofsDir, "%d.json"), args["--proof-fmt"])
+		require.Equal(t, filepath.Join(dir, snapsDir, "%d.json"), args["--snapshot-fmt"])
 		require.Equal(t, cfg.CannonNetwork, args["--network"])
 		require.NotContains(t, args, "--rollup.config")
 		require.NotContains(t, args, "--l2.genesis")

--- a/op-challenger/fault/cannon/provider.go
+++ b/op-challenger/fault/cannon/provider.go
@@ -64,13 +64,14 @@ func NewTraceProvider(ctx context.Context, logger log.Logger, cfg *config.Config
 	if err != nil {
 		return nil, fmt.Errorf("fetch local game inputs: %w", err)
 	}
-	return NewTraceProviderFromInputs(logger, cfg, localInputs), nil
+	return NewTraceProviderFromInputs(logger, cfg, gameAddr.Hex(), localInputs), nil
 }
 
-func NewTraceProviderFromInputs(logger log.Logger, cfg *config.Config, localInputs LocalGameInputs) *CannonTraceProvider {
+func NewTraceProviderFromInputs(logger log.Logger, cfg *config.Config, gameDirName string, localInputs LocalGameInputs) *CannonTraceProvider {
+	dir := filepath.Join(cfg.CannonDatadir, gameDirName)
 	return &CannonTraceProvider{
 		logger:    logger,
-		dir:       cfg.CannonDatadir,
+		dir:       dir,
 		prestate:  cfg.CannonAbsolutePreState,
 		generator: NewExecutor(logger, cfg, localInputs),
 	}

--- a/op-challenger/fault/cannon/provider_test.go
+++ b/op-challenger/fault/cannon/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -149,7 +150,6 @@ func TestGetStepData(t *testing.T) {
 
 func TestAbsolutePreState(t *testing.T) {
 	dataDir := t.TempDir()
-	_ = os.Mkdir(dataDir, 0o777)
 
 	prestate := "state.json"
 
@@ -187,6 +187,21 @@ func TestAbsolutePreState(t *testing.T) {
 		}
 		require.Equal(t, state.EncodeWitness(), preState)
 	})
+}
+
+func TestUseGameSpecificSubdir(t *testing.T) {
+	tempDir := t.TempDir()
+	dataDir := filepath.Join(tempDir, "data")
+	setupPreState(t, tempDir, "state.json")
+	logger := testlog.Logger(t, log.LvlInfo)
+	cfg := &config.Config{
+		CannonAbsolutePreState: filepath.Join(tempDir, "state.json"),
+		CannonDatadir:          dataDir,
+	}
+	gameDirName := "gameSubdir"
+	localInputs := LocalGameInputs{}
+	provider := NewTraceProviderFromInputs(logger, cfg, gameDirName, localInputs)
+	require.Equal(t, filepath.Join(dataDir, gameDirName), provider.dir, "should use game specific subdir")
 }
 
 func setupPreState(t *testing.T, dataDir string, filename string) {

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -170,7 +170,7 @@ func (h *FactoryHelper) StartCannonGameWithCorrectRoot(ctx context.Context, roll
 		L2Claim:       challengedOutput.OutputRoot,
 		L2BlockNumber: challengedOutput.L2BlockNumber,
 	}
-	provider := cannon.NewTraceProviderFromInputs(testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"), cfg, inputs)
+	provider := cannon.NewTraceProviderFromInputs(testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"), cfg, "correct", inputs)
 	rootClaim, err := provider.Get(ctx, math.MaxUint64)
 	h.require.NoError(err, "Compute correct root hash")
 

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -50,7 +50,6 @@ func TestMultipleAlphabetGames(t *testing.T) {
 }
 
 func TestMultipleCannonGames(t *testing.T) {
-	t.Skip("Cannon provider doesn't currently isolate different game traces")
 	InitParallel(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Description**

Modifies the cannon trace provider to use a different subdirectory per-game so the different games don't interfere with each other.

**Tests**

Added unit tests. The multiple cannon games e2e test now passes.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4130/automatically-detect-new-games
