### PR TITLE
feat(op-challenger): Extend the Challenger Game Filtering to an Allowlist

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -105,20 +105,20 @@ func TestGameFactoryAddress(t *testing.T) {
 	})
 }
 
-func TestGameAddress(t *testing.T) {
+func TestGameAllowlist(t *testing.T) {
 	t.Run("Optional", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-address"))
+		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-allowlist"))
 		require.NoError(t, cfg.Check())
 	})
 
 	t.Run("Valid", func(t *testing.T) {
 		addr := common.Address{0xbb, 0xcc, 0xdd}
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-address", "--game-address="+addr.Hex()))
-		require.Equal(t, addr, cfg.GameAddress)
+		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-allowlist", "--game-allowlist="+addr.Hex()))
+		require.Contains(t, cfg.GameAllowlist, addr)
 	})
 
 	t.Run("Invalid", func(t *testing.T) {
-		verifyArgsInvalid(t, "invalid address: foo", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-address", "--game-address=foo"))
+		verifyArgsInvalid(t, "invalid address: foo", addRequiredArgsExcept(config.TraceTypeAlphabet, "--game-allowlist", "--game-allowlist=foo"))
 	})
 }
 

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
@@ -78,10 +79,10 @@ const DefaultCannonSnapshotFreq = uint(1_000_000_000)
 // This also contains config options for auxiliary services.
 // It is used to initialize the challenger.
 type Config struct {
-	L1EthRpc                string         // L1 RPC Url
-	GameFactoryAddress      common.Address // Address of the dispute game factory
-	GameAddress             common.Address // Address of the fault game
-	AgreeWithProposedOutput bool           // Temporary config if we agree or disagree with the posted output
+	L1EthRpc                string           // L1 RPC Url
+	GameFactoryAddress      common.Address   // Address of the dispute game factory
+	GameAllowlist           []common.Address // Allowlist of fault game addresses
+	AgreeWithProposedOutput bool             // Temporary config if we agree or disagree with the posted output
 
 	TraceType TraceType // Type of trace
 

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -3,9 +3,10 @@ package config
 import (
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
 var (
@@ -68,9 +69,9 @@ func TestGameFactoryAddressRequired(t *testing.T) {
 	require.ErrorIs(t, config.Check(), ErrMissingGameFactoryAddress)
 }
 
-func TestGameAddressNotRequired(t *testing.T) {
+func TestGameAllowlistNotRequired(t *testing.T) {
 	config := validConfig(TraceTypeCannon)
-	config.GameAddress = common.Address{}
+	config.GameAllowlist = []common.Address{}
 	require.NoError(t, config.Check())
 }
 

--- a/op-challenger/fault/monitor_test.go
+++ b/op-challenger/fault/monitor_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMonitorExitsWhenContextDone(t *testing.T) {
-	monitor, _, _ := setupMonitorTest(t, common.Address{})
+	monitor, _, _ := setupMonitorTest(t, []common.Address{common.Address{}})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	err := monitor.MonitorGames(ctx)
@@ -22,7 +22,7 @@ func TestMonitorExitsWhenContextDone(t *testing.T) {
 }
 
 func TestMonitorCreateAndProgressGameAgents(t *testing.T) {
-	monitor, source, games := setupMonitorTest(t, common.Address{})
+	monitor, source, games := setupMonitorTest(t, []common.Address{})
 
 	addr1 := common.Address{0xaa}
 	addr2 := common.Address{0xbb}
@@ -55,7 +55,7 @@ func TestMonitorCreateAndProgressGameAgents(t *testing.T) {
 func TestMonitorOnlyCreateSpecifiedGame(t *testing.T) {
 	addr1 := common.Address{0xaa}
 	addr2 := common.Address{0xbb}
-	monitor, source, games := setupMonitorTest(t, addr2)
+	monitor, source, games := setupMonitorTest(t, []common.Address{addr2})
 
 	source.games = []FaultDisputeGame{
 		{
@@ -77,7 +77,7 @@ func TestMonitorOnlyCreateSpecifiedGame(t *testing.T) {
 	require.Equal(t, 1, games.created[addr2].progressCount)
 }
 
-func setupMonitorTest(t *testing.T, allowedGame common.Address) (*gameMonitor, *stubGameSource, *createdGames) {
+func setupMonitorTest(t *testing.T, allowedGames []common.Address) (*gameMonitor, *stubGameSource, *createdGames) {
 	logger := testlog.Logger(t, log.LvlDebug)
 	source := &stubGameSource{}
 	games := &createdGames{
@@ -87,7 +87,7 @@ func setupMonitorTest(t *testing.T, allowedGame common.Address) (*gameMonitor, *
 	fetchBlockNum := func(ctx context.Context) (uint64, error) {
 		return 1234, nil
 	}
-	monitor := newGameMonitor(logger, clock.SystemClock, fetchBlockNum, allowedGame, source, games.CreateGame)
+	monitor := newGameMonitor(logger, clock.SystemClock, fetchBlockNum, allowedGames, source, games.CreateGame)
 	return monitor, source, games
 }
 

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -73,7 +73,7 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*se
 	}
 	loader := NewGameLoader(factory)
 
-	monitor := newGameMonitor(logger, cl, client.BlockNumber, cfg.GameAddress, loader, func(addr common.Address) (gamePlayer, error) {
+	monitor := newGameMonitor(logger, cl, client.BlockNumber, cfg.GameAllowlist, loader, func(addr common.Address) (gamePlayer, error) {
 		return NewGamePlayer(ctx, logger, cfg, addr, txMgr, client)
 	})
 

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -38,7 +38,10 @@ func WithFactoryAddress(addr common.Address) Option {
 
 func WithGameAddress(addr common.Address) Option {
 	return func(c *config.Config) {
-		c.GameAddress = addr
+		if c.GameAllowlist == nil {
+			c.GameAllowlist = make([]common.Address, 0)
+		}
+		c.GameAllowlist = append(c.GameAllowlist, addr)
 	}
 }
 

--- a/op-e2e/e2eutils/disputegame/alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/alphabet_helper.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type AlphabetGameHelper struct {
@@ -16,7 +18,7 @@ func (g *AlphabetGameHelper) StartChallenger(ctx context.Context, l1Endpoint str
 	opts := []challenger.Option{
 		func(c *config.Config) {
 			c.GameFactoryAddress = g.factoryAddr
-			c.GameAddress = g.addr
+			c.GameAllowlist = []common.Address{g.addr}
 			c.TraceType = config.TraceTypeAlphabet
 			// By default the challenger agrees with the root claim (thus disagrees with the proposed output)
 			// This can be overridden by passing in options


### PR DESCRIPTION
**Description**

Migrates the `--game-address` flag to a string slice allowlist called `--game-allowlist`.

This allows multiple games to be allowed by the challenger to play, with the added bonus
that the api of the challenger binary minimally changes since the allowlist can be
specified with multiple flag instantiations.
e.g. `--game-allowlist 0x0..1 --game--allowlist 0x0..2`

**Metadata**

Fixes CLI-4345
