### PR TITLE
op-e2e: Use callTracer when tracing failed transactions

### DIFF
--- a/op-e2e/e2eutils/wait/waits.go
+++ b/op-e2e/e2eutils/wait/waits.go
@@ -56,8 +56,11 @@ func (s *jsonRawString) UnmarshalJSON(input []byte) error {
 // printDebugTrace logs debug_traceTransaction output to aid in debugging unexpected receipt statuses
 func printDebugTrace(ctx context.Context, client *ethclient.Client, txHash common.Hash) {
 	var trace jsonRawString
-	options := map[string]any{}
-	options["enableReturnData"] = true
+	options := map[string]any{
+		"enableReturnData": true,
+		"tracer":           "callTracer",
+		"tracerConfig":     map[string]any{},
+	}
 	err := client.Client().CallContext(ctx, &trace, "debug_traceTransaction", hexutil.Bytes(txHash.Bytes()), options)
 	if err != nil {
 		fmt.Printf("TxTrace unavailable: %v\n", err)

--- a/op-e2e/geth.go
+++ b/op-e2e/geth.go
@@ -24,6 +24,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/node"
+
+	// Force-load the tracer engines to trigger registration
+	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
+	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 )
 
 var (


### PR DESCRIPTION
**Description**

Switch transaction tracing to use `callTracer`.