### PR TITLE
op-e2e: Increase gas limit when creating dispute games.

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -106,8 +106,16 @@ func (h *FactoryHelper) StartAlphabetGame(ctx context.Context, claimedAlphabet s
 	extraData := make([]byte, 64)
 	binary.BigEndian.PutUint64(extraData[24:], l2BlockNumber)
 	binary.BigEndian.PutUint64(extraData[56:], l1Head.Uint64())
+	h.opts.NoSend = true
 	tx, err := h.factory.Create(h.opts, alphabetGameType, rootClaim, extraData)
+	h.require.NoError(err, "create fault dispute game (estimate gas)")
+
+	// Now send with increased gas. This provides a buffer if the output oracle search is now more expensive
+	h.opts.NoSend = false
+	h.opts.GasLimit = tx.Gas() * 2
+	tx, err = h.factory.Create(h.opts, alphabetGameType, rootClaim, extraData)
 	h.require.NoError(err, "create fault dispute game")
+	h.opts.GasLimit = 0
 	rcpt, err := wait.ForReceiptOK(ctx, h.client, tx.Hash())
 	h.require.NoError(err, "wait for create fault dispute game receipt to be OK")
 	h.require.Len(rcpt.Logs, 1, "should have emitted a single DisputeGameCreated event")
@@ -191,8 +199,16 @@ func (h *FactoryHelper) createCannonGame(ctx context.Context, l2BlockNumber uint
 	extraData := make([]byte, 64)
 	binary.BigEndian.PutUint64(extraData[24:], l2BlockNumber)
 	binary.BigEndian.PutUint64(extraData[56:], l1Head.Uint64())
+	h.opts.NoSend = true
 	tx, err := h.factory.Create(h.opts, cannonGameType, rootClaim, extraData)
+	h.require.NoError(err, "create fault dispute game (estimate gas)")
+
+	// Now send with increased gas. This provides a buffer if the output oracle search is now more expensive
+	h.opts.NoSend = false
+	h.opts.GasLimit = tx.Gas() * 2
+	tx, err = h.factory.Create(h.opts, cannonGameType, rootClaim, extraData)
 	h.require.NoError(err, "create fault dispute game")
+	h.opts.GasLimit = 0
 	rcpt, err := wait.ForReceiptOK(ctx, h.client, tx.Hash())
 	h.require.NoError(err, "wait for create fault dispute game receipt to be OK")
 	h.require.Len(rcpt.Logs, 1, "should have emitted a single DisputeGameCreated event")


### PR DESCRIPTION
**Description**

Manually double the gas limit when creating fault dispute games. Tests were flaky because this tx sometimes ran out of gas. We believe this occurred when a new output root was posted between estimating the gas and actually executing the transaction on chain, causing the search to use more gas.