### PR TITLE
op-e2e: Extract helper for sending transactions with padded gas limit

### DIFF
--- a/op-e2e/e2eutils/transactions/gas.go
+++ b/op-e2e/e2eutils/transactions/gas.go
@@ -1,0 +1,30 @@
+package transactions
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// TxBuilder creates and sends a transaction using the supplied bind.TransactOpts.
+// Returns the created transaction and any error reported.
+type TxBuilder func(opts *bind.TransactOpts) (*types.Transaction, error)
+
+// PadGasEstimate multiplies the gas estimate for a transaction by the specified paddingFactor before sending the
+// actual transaction. Useful for cases where the gas required is variable.
+// The builder will be invoked twice, first with NoSend=true to estimate the gas and the second time with
+// NoSend=false and GasLimit including the requested padding.
+func PadGasEstimate(opts *bind.TransactOpts, paddingFactor float64, builder TxBuilder) (*types.Transaction, error) {
+	// Take a copy of the opts to avoid mutating the original
+	o := *opts
+	o.NoSend = true
+	tx, err := builder(&o)
+	if err != nil {
+		return nil, fmt.Errorf("failed to estimate gas: %w", err)
+	}
+	gas := float64(tx.Gas()) * paddingFactor
+	o.GasLimit = uint64(gas)
+	o.NoSend = false
+	return builder(&o)
+}


### PR DESCRIPTION
**Description**

Extract a helper method to pad the transaction gas limit. Avoids duplicating boilerplate code between the dispute game and deposit tx helpers which both need to pad the estimate.

