### PR TITLE
feat(indexer): use sql magic to coalesce eth receives with bridge transfers instead of the null-able message hash

### DIFF
--- a/indexer/database/bridge_transfers.go
+++ b/indexer/database/bridge_transfers.go
@@ -137,7 +137,7 @@ func (db *bridgeTransfersDB) L1BridgeDepositsByAddress(address common.Address, c
 	// TODO join with l1_tokens and l2_tokens
 	ethAddressString := predeploys.LegacyERC20ETHAddr.String()
 
-	// Coalesce l1 transaction deposits that are ETH receives into bridge deposits.
+	// Coalesce l1 transaction deposits that are simply ETH sends
 	ethTransactionDeposits := db.gorm.Model(&L1TransactionDeposit{})
 	ethTransactionDeposits = ethTransactionDeposits.Where(Transaction{FromAddress: address}).Where(`data = '0x' AND amount > 0`)
 	ethTransactionDeposits = ethTransactionDeposits.Joins("INNER JOIN l1_contract_events ON l1_contract_events.guid = initiated_l1_event_guid")
@@ -153,10 +153,6 @@ l1_transaction_deposits.timestamp, NULL AS cross_domain_message_hash, ? AS local
 l1_bridge_deposits.from_address, l1_bridge_deposits.to_address, l1_bridge_deposits.amount, l1_bridge_deposits.data, transaction_source_hash,
 l2_transaction_hash, l1_contract_events.transaction_hash AS l1_transaction_hash,
 l1_bridge_deposits.timestamp, cross_domain_message_hash, local_token_address, remote_token_address`)
-
-	// Since all bridge deposits share have the same primary key corresponding to the transaction
-	// deposit, we can simply order by the timestamp in the transaction deposits table which will
-	// order all deposits (bridge & transactions) uniformly
 
 	// TODO: cursoring options
 
@@ -245,7 +241,7 @@ func (db *bridgeTransfersDB) L2BridgeWithdrawalsByAddress(address common.Address
 	// TODO join with l1_tokens and l2_tokens
 	ethAddressString := predeploys.LegacyERC20ETHAddr.String()
 
-	// Coalesce l2 transaction withdrawals that are ETH receives
+	// Coalesce l2 transaction withdrawals that are simply ETH sends
 	ethTransactionWithdrawals := db.gorm.Model(&L2TransactionWithdrawal{})
 	ethTransactionWithdrawals = ethTransactionWithdrawals.Where(Transaction{FromAddress: address}).Where(`data = '0x' AND amount > 0`)
 	ethTransactionWithdrawals = ethTransactionWithdrawals.Joins("INNER JOIN l2_contract_events ON l2_contract_events.guid = l2_transaction_withdrawals.initiated_l2_event_guid")
@@ -265,10 +261,6 @@ l2_transaction_withdrawals.timestamp, NULL AS cross_domain_message_hash, ? AS lo
 l2_bridge_withdrawals.from_address, l2_bridge_withdrawals.to_address, l2_bridge_withdrawals.amount, l2_bridge_withdrawals.data, transaction_withdrawal_hash,
 l2_contract_events.transaction_hash AS l2_transaction_hash, proven_l1_events.transaction_hash AS proven_l1_transaction_hash, finalized_l1_events.transaction_hash AS finalized_l1_transaction_hash,
 l2_bridge_withdrawals.timestamp, cross_domain_message_hash, local_token_address, remote_token_address`)
-
-	// Since all bridge withdrawals share have the same primary key corresponding to the transaction
-	// withdrawal, we can simply order by the timestamp in the transaction withdrawal table which will
-	// order all deposits (bridge & transactions) uniformly
 
 	// TODO: cursoring options
 

--- a/indexer/e2e_tests/bridge_transfers_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transfers_e2e_test.go
@@ -227,6 +227,8 @@ func TestE2EBridgeTransfersOptimismPortalETHReceive(t *testing.T) {
 
 	aliceDeposits, err := testSuite.DB.BridgeTransfers.L1BridgeDepositsByAddress(aliceAddr, "", 0)
 	require.NoError(t, err)
+	require.NotNil(t, aliceDeposits)
+	require.Len(t, aliceDeposits.Deposits, 1)
 	require.Equal(t, portalDepositTx.Hash(), aliceDeposits.Deposits[0].L1TransactionHash)
 
 	deposit := aliceDeposits.Deposits[0].L1BridgeDeposit

--- a/indexer/e2e_tests/bridge_transfers_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transfers_e2e_test.go
@@ -341,7 +341,7 @@ func TestE2EBridgeTransfersStandardBridgeETHWithdrawal(t *testing.T) {
 	require.NotNil(t, crossDomainBridgeMessage.RelayedMessageEventGUID)
 }
 
-func TestE2EBridgeTransfersL2ToL1MessagePasserReceive(t *testing.T) {
+func TestE2EBridgeTransfersL2ToL1MessagePasserETHReceive(t *testing.T) {
 	testSuite := createE2ETestSuite(t)
 
 	optimismPortal, err := bindings.NewOptimismPortal(testSuite.OpCfg.L1Deployments.OptimismPortalProxy, testSuite.L1Client)
@@ -378,6 +378,7 @@ func TestE2EBridgeTransfersL2ToL1MessagePasserReceive(t *testing.T) {
 
 	aliceWithdrawals, err := testSuite.DB.BridgeTransfers.L2BridgeWithdrawalsByAddress(aliceAddr, "", 0)
 	require.NoError(t, err)
+	require.Len(t, aliceWithdrawals.Withdrawals, 1)
 	require.Equal(t, l2ToL1MessagePasserWithdrawTx.Hash().String(), aliceWithdrawals.Withdrawals[0].L2TransactionHash.String())
 
 	msgPassed, err := withdrawals.ParseMessagePassed(l2ToL1WithdrawReceipt)

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE IF NOT EXISTS l2_bridge_messages(
 -- StandardBridge
 CREATE TABLE IF NOT EXISTS l1_bridge_deposits (
     transaction_source_hash   VARCHAR PRIMARY KEY REFERENCES l1_transaction_deposits(source_hash),
-    cross_domain_message_hash VARCHAR UNIQUE REFERENCES l1_bridge_messages(message_hash),
+    cross_domain_message_hash VARCHAR NOT NULL UNIQUE REFERENCES l1_bridge_messages(message_hash),
 
     -- Deposit information
 	from_address         VARCHAR NOT NULL,

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -184,10 +184,7 @@ CREATE TABLE IF NOT EXISTS l2_bridge_messages(
 
 -- StandardBridge
 CREATE TABLE IF NOT EXISTS l1_bridge_deposits (
-    transaction_source_hash VARCHAR PRIMARY KEY REFERENCES l1_transaction_deposits(source_hash),
-
-    -- We allow the cross_domain_message_hash to be NULL-able to account
-    -- for scenarios where ETH is simply sent to the OptimismPortal contract
+    transaction_source_hash   VARCHAR PRIMARY KEY REFERENCES l1_transaction_deposits(source_hash),
     cross_domain_message_hash VARCHAR UNIQUE REFERENCES l1_bridge_messages(message_hash),
 
     -- Deposit information
@@ -201,10 +198,7 @@ CREATE TABLE IF NOT EXISTS l1_bridge_deposits (
 );
 CREATE TABLE IF NOT EXISTS l2_bridge_withdrawals (
     transaction_withdrawal_hash VARCHAR PRIMARY KEY REFERENCES l2_transaction_withdrawals(withdrawal_hash),
-
-    -- We allow the cross_domain_message_hash to be NULL-able to account for
-    -- scenarios where ETH is simply sent to the L2ToL1MessagePasser contract
-    cross_domain_message_hash VARCHAR UNIQUE REFERENCES l2_bridge_messages(message_hash),
+    cross_domain_message_hash   VARCHAR NOT NULL UNIQUE REFERENCES l2_bridge_messages(message_hash),
 
     -- Withdrawal information
 	from_address         VARCHAR NOT NULL,


### PR DESCRIPTION
As a workaround to recognize ETH receives to the OptimismPortal or L2ToL1MessagePasser contracts
as bridged ETH, we had `cross_domain_message_hash` as a nullable column in the bridge transfers
columns to represent this edge case.

Instead, let's keep the database completely seperate and solely rely on sql to coalesce the two
tables on the read-pathway. Revert `cross_domain_message_hash` to a non-nullable columns for a stronger
data model.

However, the `CrossDomainMessageHash` field in the database struct remains a pointer as an indicator for this
edge case. We can choose to change this later without needing to touch the database
