### PR TITLE
op-challenger: Don't progress completed games

### DIFF
--- a/op-challenger/fault/caller.go
+++ b/op-challenger/fault/caller.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type FaultDisputeGameCaller interface {
@@ -26,7 +25,7 @@ func NewFaultCaller(caller FaultDisputeGameCaller) *FaultCaller {
 	}
 }
 
-func NewFaultCallerFromBindings(fdgAddr common.Address, client *ethclient.Client) (*FaultCaller, error) {
+func NewFaultCallerFromBindings(fdgAddr common.Address, client bind.ContractCaller) (*FaultCaller, error) {
 	caller, err := bindings.NewFaultDisputeGameCaller(fdgAddr, client)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description**

Don't attempt to perform any actions on games that are already completed. Avoids quite a few calls to the game contract and in particular avoids recreating cannon trace outputs to check if we agree with claims or not.

Still doesn't actually clean up resources on disk for completed games but does remove them from memory. Cleaning up resources on disk is under a separate ticket.

Since there's a not-insignificant cost to creating a `GamePlayer` (it has to load the local game inputs, checks the absolute prestate etc), the players are kept in memory until they are considered too old and not returned from the game factory loader (https://github.com/ethereum-optimism/optimism/pull/6927 will exclude old games from that).

**Tests**

Updated unit tests.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4370/stop-attempting-to-progress-completed-games
