### PR TITLE
fix(op-challenger): Only Resolve Won Dispute Games

### DIFF
--- a/op-challenger/fault/agent_test.go
+++ b/op-challenger/fault/agent_test.go
@@ -1,0 +1,31 @@
+package fault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+)
+
+// TestShouldResolve tests the resolution logic.
+func TestShouldResolve(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+
+	t.Run("AgreeWithProposedOutput", func(t *testing.T) {
+		agent := NewAgent(nil, 0, nil, nil, nil, true, log)
+		require.False(t, agent.shouldResolve(context.Background(), types.GameStatusDefenderWon))
+		require.True(t, agent.shouldResolve(context.Background(), types.GameStatusChallengerWon))
+		require.False(t, agent.shouldResolve(context.Background(), types.GameStatusInProgress))
+	})
+
+	t.Run("DisagreeWithProposedOutput", func(t *testing.T) {
+		agent := NewAgent(nil, 0, nil, nil, nil, false, log)
+		require.True(t, agent.shouldResolve(context.Background(), types.GameStatusDefenderWon))
+		require.False(t, agent.shouldResolve(context.Background(), types.GameStatusChallengerWon))
+		require.False(t, agent.shouldResolve(context.Background(), types.GameStatusInProgress))
+	})
+}

--- a/op-challenger/fault/types/types.go
+++ b/op-challenger/fault/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,6 +33,14 @@ func (s GameStatus) String() string {
 	default:
 		return "Unknown"
 	}
+}
+
+// GameStatusFromUint8 returns a game status from the uint8 representation.
+func GameStatusFromUint8(i uint8) (GameStatus, error) {
+	if i > 2 {
+		return GameStatus(i), fmt.Errorf("invalid game status: %d", i)
+	}
+	return GameStatus(i), nil
 }
 
 // PreimageOracleData encapsulates the preimage oracle data

--- a/op-challenger/fault/types/types_test.go
+++ b/op-challenger/fault/types/types_test.go
@@ -1,10 +1,33 @@
 package types
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+var validGameStatuses = []GameStatus{
+	GameStatusInProgress,
+	GameStatusChallengerWon,
+	GameStatusDefenderWon,
+}
+
+func TestGameStatusFromUint8(t *testing.T) {
+	for _, status := range validGameStatuses {
+		t.Run(fmt.Sprintf("Valid Game Status %v", status), func(t *testing.T) {
+			parsed, err := GameStatusFromUint8(uint8(status))
+			require.NoError(t, err)
+			require.Equal(t, status, parsed)
+		})
+	}
+
+	t.Run("Invalid", func(t *testing.T) {
+		status, err := GameStatusFromUint8(3)
+		require.Error(t, err)
+		require.Equal(t, GameStatus(3), status)
+	})
+}
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Replaces PR #6744.

Only resolves dispute games which the challenger won.

In order to allow the `Agent` fault component to retrieve
the game status, the `Caller` has to be passed in during
construction by the `service.go` initialization function.

**Tests**

Introduces minimal agent unit tests for a newly exported
`ShouldResolve` method.

**Metadata**

Fixes CLI-4285
