### PR TITLE
op-challenger: Delete game files when complete

### DIFF
--- a/op-challenger/fault/monitor.go
+++ b/op-challenger/fault/monitor.go
@@ -13,6 +13,7 @@ import (
 
 type gamePlayer interface {
 	ProgressGame(ctx context.Context) bool
+	Cleanup() error
 }
 
 type playerCreator func(address common.Address) (gamePlayer, error)
@@ -78,7 +79,15 @@ func (m *gameMonitor) progressGames(ctx context.Context) error {
 			m.logger.Error("Error while progressing game", "game", game.Proxy, "err", err)
 			continue
 		}
-		player.ProgressGame(ctx)
+		done := player.ProgressGame(ctx)
+		if done {
+			// Remove resources on disk as soon as the game is complete to save disk space.
+			// We keep the player in memory to avoid recreating it on every update but will no longer
+			// need the resources on disk because there are no further actions required on the game.
+			if err := player.Cleanup(); err != nil {
+				m.logger.Error("Unable to cleanup player data", "err", err)
+			}
+		}
 	}
 	// Remove the player for any game that's no longer being returned from the list of active games
 	for addr := range m.players {


### PR DESCRIPTION
**Description**

Once a dispute game is resolved, cleanup its files from disk to save disk space.

**Tests**

Updated monitor unit tests.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4374/wire-cleanup-into-the-monitor-component
