### PR TITLE
Manage game data directories at the multi-game level

### DIFF
--- a/op-challenger/fault/cannon/provider.go
+++ b/op-challenger/fault/cannon/provider.go
@@ -50,7 +50,7 @@ type CannonTraceProvider struct {
 	lastProof *proofData
 }
 
-func NewTraceProvider(ctx context.Context, logger log.Logger, cfg *config.Config, l1Client bind.ContractCaller, gameAddr common.Address) (*CannonTraceProvider, error) {
+func NewTraceProvider(ctx context.Context, logger log.Logger, cfg *config.Config, l1Client bind.ContractCaller, dir string, gameAddr common.Address) (*CannonTraceProvider, error) {
 	l2Client, err := ethclient.DialContext(ctx, cfg.CannonL2)
 	if err != nil {
 		return nil, fmt.Errorf("dial l2 client %v: %w", cfg.CannonL2, err)
@@ -64,11 +64,10 @@ func NewTraceProvider(ctx context.Context, logger log.Logger, cfg *config.Config
 	if err != nil {
 		return nil, fmt.Errorf("fetch local game inputs: %w", err)
 	}
-	return NewTraceProviderFromInputs(logger, cfg, gameAddr.Hex(), localInputs), nil
+	return NewTraceProviderFromInputs(logger, cfg, localInputs, dir), nil
 }
 
-func NewTraceProviderFromInputs(logger log.Logger, cfg *config.Config, gameDirName string, localInputs LocalGameInputs) *CannonTraceProvider {
-	dir := filepath.Join(cfg.Datadir, gameDirName)
+func NewTraceProviderFromInputs(logger log.Logger, cfg *config.Config, localInputs LocalGameInputs, dir string) *CannonTraceProvider {
 	return &CannonTraceProvider{
 		logger:    logger,
 		dir:       dir,
@@ -116,10 +115,6 @@ func (p *CannonTraceProvider) AbsolutePreState(ctx context.Context) ([]byte, err
 		return nil, fmt.Errorf("cannot load absolute pre-state: %w", err)
 	}
 	return state.EncodeWitness(), nil
-}
-
-func (p *CannonTraceProvider) Cleanup() error {
-	return os.RemoveAll(p.dir)
 }
 
 // loadProof will attempt to load or generate the proof data at the specified index

--- a/op-challenger/fault/cannon/provider_test.go
+++ b/op-challenger/fault/cannon/provider_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
-	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/types"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -187,29 +186,6 @@ func TestAbsolutePreState(t *testing.T) {
 		}
 		require.Equal(t, state.EncodeWitness(), preState)
 	})
-}
-
-func TestUseGameSpecificSubdir(t *testing.T) {
-	tempDir := t.TempDir()
-	dataDir := filepath.Join(tempDir, "data")
-	setupPreState(t, tempDir, "state.json")
-	logger := testlog.Logger(t, log.LvlInfo)
-	cfg := &config.Config{
-		CannonAbsolutePreState: filepath.Join(tempDir, "state.json"),
-		Datadir:                dataDir,
-	}
-	gameDirName := "gameSubdir"
-	localInputs := LocalGameInputs{}
-	provider := NewTraceProviderFromInputs(logger, cfg, gameDirName, localInputs)
-	require.Equal(t, filepath.Join(dataDir, gameDirName), provider.dir, "should use game specific subdir")
-}
-
-func TestCleanup(t *testing.T) {
-	dataDir, prestate := setupTestData(t)
-	provider, _ := setupWithTestData(t, dataDir, prestate)
-	require.NoError(t, provider.Cleanup())
-	_, err := os.Stat(dataDir)
-	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func setupPreState(t *testing.T, dataDir string, filename string) {

--- a/op-challenger/fault/disk.go
+++ b/op-challenger/fault/disk.go
@@ -1,0 +1,30 @@
+package fault
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// diskManager coordinates
+type diskManager struct {
+	datadir string
+}
+
+func newDiskManager(dir string) *diskManager {
+	return &diskManager{datadir: dir}
+}
+
+func (d *diskManager) DirForGame(addr common.Address) string {
+	return filepath.Join(d.datadir, addr.Hex())
+}
+
+func (d *diskManager) RemoveGameData(addr common.Address) error {
+	dir := d.DirForGame(addr)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to remove dir %v: %w", dir, err)
+	}
+	return nil
+}

--- a/op-challenger/fault/disk_test.go
+++ b/op-challenger/fault/disk_test.go
@@ -14,21 +14,44 @@ func TestDiskManager_DirForGame(t *testing.T) {
 	addr := common.Address{0x53}
 	disk := newDiskManager(baseDir)
 	result := disk.DirForGame(addr)
-	require.Equal(t, filepath.Join(baseDir, addr.Hex()), result)
+	require.Equal(t, filepath.Join(baseDir, gameDirPrefix+addr.Hex()), result)
 }
 
-func TestDiskManager_RemoveGameData(t *testing.T) {
+func TestDiskManager_RemoveAllExcept(t *testing.T) {
 	baseDir := t.TempDir()
-	addr := common.Address{0x53}
+	keep := common.Address{0x53}
+	delete := common.Address{0xaa}
 	disk := newDiskManager(baseDir)
-	dir := disk.DirForGame(addr)
+	keepDir := disk.DirForGame(keep)
+	deleteDir := disk.DirForGame(delete)
 
-	require.NoError(t, os.MkdirAll(dir, 0777))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("foo"), 0644))
-	nestedDirs := filepath.Join(dir, "subdir", "deep")
-	require.NoError(t, os.MkdirAll(nestedDirs, 0777))
-	require.NoError(t, os.WriteFile(filepath.Join(nestedDirs, ".foo.txt"), []byte("foo"), 0644))
+	unexpectedFile := filepath.Join(baseDir, "file.txt")
+	require.NoError(t, os.WriteFile(unexpectedFile, []byte("test"), 0644))
+	unexpectedDir := filepath.Join(baseDir, "notagame")
+	require.NoError(t, os.MkdirAll(unexpectedDir, 0777))
+	invalidHexDir := filepath.Join(baseDir, gameDirPrefix+"0xNOPE")
+	require.NoError(t, os.MkdirAll(invalidHexDir, 0777))
 
-	require.NoError(t, disk.RemoveGameData(addr))
-	require.NoDirExists(t, dir, "should have deleted directory")
+	populateDir := func(dir string) []string {
+		require.NoError(t, os.MkdirAll(dir, 0777))
+		file1 := filepath.Join(dir, "test.txt")
+		require.NoError(t, os.WriteFile(file1, []byte("foo"), 0644))
+		nestedDirs := filepath.Join(dir, "subdir", "deep")
+		require.NoError(t, os.MkdirAll(nestedDirs, 0777))
+		file2 := filepath.Join(nestedDirs, ".foo.txt")
+		require.NoError(t, os.WriteFile(file2, []byte("foo"), 0644))
+		return []string{file1, file2}
+	}
+
+	keepFiles := populateDir(keepDir)
+	populateDir(deleteDir)
+
+	require.NoError(t, disk.RemoveAllExcept([]common.Address{keep}))
+	require.NoDirExists(t, deleteDir, "should have deleted directory")
+	for _, file := range keepFiles {
+		require.FileExists(t, file, "should have kept file for active game")
+	}
+	require.FileExists(t, unexpectedFile, "should not delete unexpected file")
+	require.DirExists(t, unexpectedDir, "should not delete unexpected dir")
+	require.DirExists(t, invalidHexDir, "should not delete dir with invalid address")
 }

--- a/op-challenger/fault/disk_test.go
+++ b/op-challenger/fault/disk_test.go
@@ -1,0 +1,34 @@
+package fault
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiskManager_DirForGame(t *testing.T) {
+	baseDir := t.TempDir()
+	addr := common.Address{0x53}
+	disk := newDiskManager(baseDir)
+	result := disk.DirForGame(addr)
+	require.Equal(t, filepath.Join(baseDir, addr.Hex()), result)
+}
+
+func TestDiskManager_RemoveGameData(t *testing.T) {
+	baseDir := t.TempDir()
+	addr := common.Address{0x53}
+	disk := newDiskManager(baseDir)
+	dir := disk.DirForGame(addr)
+
+	require.NoError(t, os.MkdirAll(dir, 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("foo"), 0644))
+	nestedDirs := filepath.Join(dir, "subdir", "deep")
+	require.NoError(t, os.MkdirAll(nestedDirs, 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDirs, ".foo.txt"), []byte("foo"), 0644))
+
+	require.NoError(t, disk.RemoveGameData(addr))
+	require.NoDirExists(t, dir, "should have deleted directory")
+}

--- a/op-challenger/fault/monitor.go
+++ b/op-challenger/fault/monitor.go
@@ -25,7 +25,7 @@ type gameSource interface {
 
 type gameDiskAllocator interface {
 	DirForGame(common.Address) string
-	RemoveGameData(common.Address) error
+	RemoveAllExcept([]common.Address) error
 }
 
 type gameMonitor struct {
@@ -97,6 +97,7 @@ func (m *gameMonitor) progressGames(ctx context.Context) error {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
 	requiredGames := make(map[common.Address]bool)
+	var keepGameData []common.Address
 	for _, game := range games {
 		if !m.allowedGame(game.Proxy) {
 			m.logger.Debug("Skipping game not on allow list", "game", game.Proxy)
@@ -109,14 +110,16 @@ func (m *gameMonitor) progressGames(ctx context.Context) error {
 			continue
 		}
 		done := player.ProgressGame(ctx)
-		if done {
-			// Remove resources on disk as soon as the game is complete to save disk space.
+		if !done {
+			// We only keep resources on disk for games that are incomplete.
+			// Games that are complete have their data removed as soon as possible to save disk space.
 			// We keep the player in memory to avoid recreating it on every update but will no longer
 			// need the resources on disk because there are no further actions required on the game.
-			if err := m.diskManager.RemoveGameData(game.Proxy); err != nil {
-				m.logger.Error("Unable to cleanup player data", "err", err)
-			}
+			keepGameData = append(keepGameData, game.Proxy)
 		}
+	}
+	if err := m.diskManager.RemoveAllExcept(keepGameData); err != nil {
+		m.logger.Error("Unable to cleanup game data", "err", err)
 	}
 	// Remove the player for any game that's no longer being returned from the list of active games
 	for addr := range m.players {

--- a/op-challenger/fault/monitor_test.go
+++ b/op-challenger/fault/monitor_test.go
@@ -18,20 +18,20 @@ func TestMonitorMinGameTimestamp(t *testing.T) {
 	t.Parallel()
 
 	t.Run("zero game window returns zero", func(t *testing.T) {
-		monitor, _, _ := setupMonitorTest(t, []common.Address{})
+		monitor, _, _, _ := setupMonitorTest(t, []common.Address{})
 		monitor.gameWindow = time.Duration(0)
 		require.Equal(t, monitor.minGameTimestamp(), uint64(0))
 	})
 
 	t.Run("non-zero game window with zero clock", func(t *testing.T) {
-		monitor, _, _ := setupMonitorTest(t, []common.Address{})
+		monitor, _, _, _ := setupMonitorTest(t, []common.Address{})
 		monitor.gameWindow = time.Minute
 		monitor.clock = clock.NewDeterministicClock(time.Unix(0, 0))
 		require.Equal(t, monitor.minGameTimestamp(), uint64(0))
 	})
 
 	t.Run("minimum computed correctly", func(t *testing.T) {
-		monitor, _, _ := setupMonitorTest(t, []common.Address{})
+		monitor, _, _, _ := setupMonitorTest(t, []common.Address{})
 		monitor.gameWindow = time.Minute
 		frozen := time.Unix(int64(time.Hour.Seconds()), 0)
 		monitor.clock = clock.NewDeterministicClock(frozen)
@@ -41,7 +41,7 @@ func TestMonitorMinGameTimestamp(t *testing.T) {
 }
 
 func TestMonitorExitsWhenContextDone(t *testing.T) {
-	monitor, _, _ := setupMonitorTest(t, []common.Address{common.Address{}})
+	monitor, _, _, _ := setupMonitorTest(t, []common.Address{{}})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	err := monitor.MonitorGames(ctx)
@@ -49,7 +49,7 @@ func TestMonitorExitsWhenContextDone(t *testing.T) {
 }
 
 func TestMonitorCreateAndProgressGameAgents(t *testing.T) {
-	monitor, source, games := setupMonitorTest(t, []common.Address{})
+	monitor, source, games, _ := setupMonitorTest(t, []common.Address{})
 
 	addr1 := common.Address{0xaa}
 	addr2 := common.Address{0xbb}
@@ -82,7 +82,7 @@ func TestMonitorCreateAndProgressGameAgents(t *testing.T) {
 func TestMonitorOnlyCreateSpecifiedGame(t *testing.T) {
 	addr1 := common.Address{0xaa}
 	addr2 := common.Address{0xbb}
-	monitor, source, games := setupMonitorTest(t, []common.Address{addr2})
+	monitor, source, games, _ := setupMonitorTest(t, []common.Address{addr2})
 
 	source.games = []FaultDisputeGame{
 		{
@@ -107,7 +107,7 @@ func TestMonitorOnlyCreateSpecifiedGame(t *testing.T) {
 func TestDeletePlayersWhenNoLongerInListOfGames(t *testing.T) {
 	addr1 := common.Address{0xaa}
 	addr2 := common.Address{0xbb}
-	monitor, source, games := setupMonitorTest(t, nil)
+	monitor, source, games, _ := setupMonitorTest(t, nil)
 
 	allGames := []FaultDisputeGame{
 		{
@@ -147,7 +147,7 @@ func TestDeletePlayersWhenNoLongerInListOfGames(t *testing.T) {
 }
 
 func TestCleanupResourcesOfCompletedGames(t *testing.T) {
-	monitor, source, games := setupMonitorTest(t, []common.Address{})
+	monitor, source, games, disk := setupMonitorTest(t, []common.Address{})
 	games.createCompleted = true
 
 	addr1 := common.Address{0xaa}
@@ -164,10 +164,11 @@ func TestCleanupResourcesOfCompletedGames(t *testing.T) {
 	require.Len(t, games.created, 1, "should create game agents")
 	require.Contains(t, games.created, addr1)
 	require.Equal(t, 1, games.created[addr1].progressCount)
-	require.Equal(t, 1, games.created[addr1].cleanupCount, "should clean up once game is done")
+	require.Contains(t, disk.gameDirExists, addr1, "should have allocated a game dir")
+	require.False(t, disk.gameDirExists[addr1], "should have then deleted the game dir")
 }
 
-func setupMonitorTest(t *testing.T, allowedGames []common.Address) (*gameMonitor, *stubGameSource, *createdGames) {
+func setupMonitorTest(t *testing.T, allowedGames []common.Address) (*gameMonitor, *stubGameSource, *createdGames, *stubDiskManager) {
 	logger := testlog.Logger(t, log.LvlDebug)
 	source := &stubGameSource{}
 	games := &createdGames{
@@ -177,8 +178,11 @@ func setupMonitorTest(t *testing.T, allowedGames []common.Address) (*gameMonitor
 	fetchBlockNum := func(ctx context.Context) (uint64, error) {
 		return 1234, nil
 	}
-	monitor := newGameMonitor(logger, time.Duration(0), clock.SystemClock, fetchBlockNum, allowedGames, source, games.CreateGame)
-	return monitor, source, games
+	disk := &stubDiskManager{
+		gameDirExists: make(map[common.Address]bool),
+	}
+	monitor := newGameMonitor(logger, time.Duration(0), clock.SystemClock, disk, fetchBlockNum, allowedGames, source, games.CreateGame)
+	return monitor, source, games, disk
 }
 
 type stubGameSource struct {
@@ -192,18 +196,13 @@ func (s *stubGameSource) FetchAllGamesAtBlock(ctx context.Context, earliest uint
 type stubGame struct {
 	addr          common.Address
 	progressCount int
-	cleanupCount  int
 	done          bool
+	dir           string
 }
 
 func (g *stubGame) ProgressGame(ctx context.Context) bool {
 	g.progressCount++
 	return g.done
-}
-
-func (g *stubGame) Cleanup() error {
-	g.cleanupCount++
-	return nil
 }
 
 type createdGames struct {
@@ -212,11 +211,29 @@ type createdGames struct {
 	created         map[common.Address]*stubGame
 }
 
-func (c *createdGames) CreateGame(addr common.Address) (gamePlayer, error) {
+func (c *createdGames) CreateGame(addr common.Address, dir string) (gamePlayer, error) {
 	if _, exists := c.created[addr]; exists {
 		c.t.Fatalf("game %v already exists", addr)
 	}
-	game := &stubGame{addr: addr, done: c.createCompleted}
+	game := &stubGame{
+		addr: addr,
+		done: c.createCompleted,
+		dir:  dir,
+	}
 	c.created[addr] = game
 	return game, nil
+}
+
+type stubDiskManager struct {
+	gameDirExists map[common.Address]bool
+}
+
+func (s *stubDiskManager) DirForGame(addr common.Address) string {
+	s.gameDirExists[addr] = true
+	return addr.Hex()
+}
+
+func (s *stubDiskManager) RemoveGameData(addr common.Address) error {
+	s.gameDirExists[addr] = false
+	return nil
 }

--- a/op-challenger/fault/player_test.go
+++ b/op-challenger/fault/player_test.go
@@ -27,24 +27,6 @@ func TestProgressGame_LogErrorFromAct(t *testing.T) {
 	require.Equal(t, uint64(1), msg.GetContextValue("claims"))
 }
 
-func TestCleanup(t *testing.T) {
-	t.Run("default cleanup", func(t *testing.T) {
-		game := &GamePlayer{
-			cleanup: func() error { return nil },
-		}
-		require.NoError(t, game.Cleanup())
-	})
-
-	t.Run("cleanup bubbles up error", func(t *testing.T) {
-		err := errors.New("wassie")
-		game := &GamePlayer{
-			cleanup: func() error { return err },
-		}
-		require.Error(t, err, game.Cleanup())
-	})
-
-}
-
 func TestProgressGame_LogGameStatus(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -73,9 +73,18 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*se
 	}
 	loader := NewGameLoader(factory)
 
-	monitor := newGameMonitor(logger, cfg.GameWindow, cl, client.BlockNumber, cfg.GameAllowlist, loader, func(addr common.Address) (gamePlayer, error) {
-		return NewGamePlayer(ctx, logger, cfg, addr, txMgr, client)
-	})
+	disk := newDiskManager(cfg.Datadir)
+	monitor := newGameMonitor(
+		logger,
+		cfg.GameWindow,
+		cl,
+		disk,
+		client.BlockNumber,
+		cfg.GameAllowlist,
+		loader,
+		func(addr common.Address, dir string) (gamePlayer, error) {
+			return NewGamePlayer(ctx, logger, cfg, dir, addr, txMgr, client)
+		})
 
 	m.RecordInfo(version.SimpleWithMeta)
 	m.RecordUp()

--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -2,6 +2,7 @@ package disputegame
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/fault/cannon"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
@@ -38,7 +39,8 @@ func (g *CannonGameHelper) CreateHonestActor(ctx context.Context, rollupCfg *rol
 	}
 	opts = append(opts, options...)
 	cfg := challenger.NewChallengerConfig(g.t, l1Endpoint, opts...)
-	provider, err := cannon.NewTraceProvider(ctx, testlog.Logger(g.t, log.LvlInfo).New("role", "CorrectTrace"), cfg, l1Client, g.addr)
+	logger := testlog.Logger(g.t, log.LvlInfo).New("role", "CorrectTrace")
+	provider, err := cannon.NewTraceProvider(ctx, logger, cfg, l1Client, filepath.Join(cfg.Datadir, "honest"), g.addr)
 	g.require.NoError(err, "create cannon trace provider")
 
 	return &HonestHelper{

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -175,7 +175,7 @@ func (h *FactoryHelper) StartCannonGameWithCorrectRoot(ctx context.Context, roll
 		L2Claim:       challengedOutput.OutputRoot,
 		L2BlockNumber: challengedOutput.L2BlockNumber,
 	}
-	provider := cannon.NewTraceProviderFromInputs(testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"), cfg, "correct", inputs)
+	provider := cannon.NewTraceProviderFromInputs(testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"), cfg, inputs, cfg.Datadir)
 	rootClaim, err := provider.Get(ctx, math.MaxUint64)
 	h.require.NoError(err, "Compute correct root hash")
 


### PR DESCRIPTION
**Description**

Modifies the approach to managing game-specific data directories so that they are managed at the `monitor` level which is multi-game aware and everything from `GamePlayer` down just uses the specific directory they are given without needing to worry about conflicts with other games.

There two advantages of this:
1. It maintains a cleaner separation of responsibilities so that the game player and trace provider are entirely focussed on a single game and not on multi-game conflicts or resource management
2. The directory deletion is self-healing. If for some reason game data isn't deleted when the game completes, it will automatically be cleaned up even if the game is no longer being returned from the factory loader because its too old etc.

**Tests**

Add unit tests for the new disk manager and updated tests for the monitor to ensure it is integrated correctly.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4343/remove-cannon-datadirs-of-completed-games
