### PR TITLE
Update to golang 1.20.7 and alpine 3.18

### DIFF
--- a/endpoint-monitor/Dockerfile
+++ b/endpoint-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.9-alpine3.16 as builder
+FROM golang:1.20.7-alpine3.18 as builder
 
 RUN apk --no-cache add make jq bash git alpine-sdk
 
@@ -16,7 +16,7 @@ RUN go mod download
 
 RUN make build
 
-FROM alpine:3.16
+FROM alpine:3.18
 RUN apk --no-cache add ca-certificates
 
 RUN addgroup -S app && adduser -S app -G app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/optimism
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
@@ -18,7 +18,7 @@ RUN go mod download
 
 RUN make indexer
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/indexer/indexer /usr/local/bin
 

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 ARG VERSION=v0.0.0
 
@@ -23,7 +23,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-batcher VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin
 

--- a/op-batcher/compressor/shadow_compressor_test.go
+++ b/op-batcher/compressor/shadow_compressor_test.go
@@ -3,8 +3,8 @@ package compressor_test
 import (
 	"bytes"
 	"compress/zlib"
+	"crypto/rand"
 	"io"
-	"math/rand"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/compressor"

--- a/op-chain-ops/state/memory_db_test.go
+++ b/op-chain-ops/state/memory_db_test.go
@@ -48,7 +48,8 @@ func TestCode(t *testing.T) {
 		require.Nil(t, pre)
 
 		code := make([]byte, rand.Intn(1024))
-		crand.Read(code)
+		_, err := crand.Read(code)
+		require.NoError(t, err)
 
 		db.SetCode(addr, code)
 

--- a/op-chain-ops/state/memory_db_test.go
+++ b/op-chain-ops/state/memory_db_test.go
@@ -1,6 +1,7 @@
 package state_test
 
 import (
+	crand "crypto/rand"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -47,7 +48,7 @@ func TestCode(t *testing.T) {
 		require.Nil(t, pre)
 
 		code := make([]byte, rand.Intn(1024))
-		rand.Read(code)
+		crand.Read(code)
 
 		db.SetCode(addr, code)
 

--- a/op-challenger/Dockerfile
+++ b/op-challenger/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.0-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 ARG VERSION=v0.0.0
 
@@ -27,7 +27,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-challenger VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.15
+FROM alpine:3.18
 
 COPY --from=builder /app/op-challenger/bin/op-challenger /usr/local/bin
 

--- a/op-exporter/Dockerfile
+++ b/op-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.9-alpine3.16 as builder
+FROM golang:1.20.7-alpine3.18 as builder
 
 # build from root of repo
 COPY ./op-exporter /app
@@ -7,7 +7,7 @@ WORKDIR /app/
 RUN apk --no-cache add make bash jq git
 RUN make build
 
-FROM alpine:3.16
+FROM alpine:3.18
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /app/op-exporter /usr/local/bin/

--- a/op-exporter/go.mod
+++ b/op-exporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/optimism/op-exporter
 
-go 1.18
+go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.10.17

--- a/op-heartbeat/Dockerfile
+++ b/op-heartbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.9-alpine3.16 as builder
+FROM golang:1.20.7-alpine3.18 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
@@ -15,7 +15,7 @@ WORKDIR /app/op-heartbeat
 
 RUN make op-heartbeat
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin
 

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 ARG VERSION=v0.0.0
 
@@ -21,7 +21,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-node VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/op-node/bin/op-node /usr/local/bin
 

--- a/op-node/rollup/derive/l1_block_info_test.go
+++ b/op-node/rollup/derive/l1_block_info_test.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	crand "crypto/rand"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -97,7 +98,7 @@ func TestParseL1InfoDepositTxData(t *testing.T) {
 		info := testutils.MakeBlockInfo(nil)(rng)
 		depTx, err := L1InfoDeposit(randomSeqNr(rng), info, randomL1Cfg(rng, info), false)
 		require.NoError(t, err)
-		_, err = rand.Read(depTx.Data[0:4])
+		_, err = crand.Read(depTx.Data[0:4])
 		require.NoError(t, err)
 		_, err = L1InfoDepositTxData(depTx.Data)
 		require.ErrorContains(t, err, "function signature")

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -2,8 +2,8 @@ package sources
 
 import (
 	"context"
+	crand "crypto/rand"
 	"math/big"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -56,7 +56,7 @@ var testEthClientConfig = &EthClientConfig{
 }
 
 func randHash() (out common.Hash) {
-	rand.Read(out[:])
+	crand.Read(out[:])
 	return out
 }
 

--- a/op-node/sources/eth_client_test.go
+++ b/op-node/sources/eth_client_test.go
@@ -56,7 +56,7 @@ var testEthClientConfig = &EthClientConfig{
 }
 
 func randHash() (out common.Hash) {
-	crand.Read(out[:])
+	_, _ = crand.Read(out[:])
 	return out
 }
 

--- a/op-program/Dockerfile
+++ b/op-program/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 ARG VERSION=v0.0.0
 
@@ -23,7 +23,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-program VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/op-program/bin/op-program /usr/local/bin
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.9-alpine3.16 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 ARG VERSION=v0.0.0
 
@@ -22,7 +22,7 @@ ARG TARGETOS TARGETARCH
 
 RUN make op-proposer VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin
 

--- a/op-wheel/Dockerfile
+++ b/op-wheel/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.9-alpine3.16 as builder
+FROM golang:1.20.7-alpine3.18 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
@@ -14,7 +14,7 @@ WORKDIR /app/op-wheel
 
 RUN go build -o op-wheel ./cmd/main.go
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=builder /app/op-wheel/op-wheel /usr/local/bin
 

--- a/packages/contracts-bedrock/test-case-generator/go.mod
+++ b/packages/contracts-bedrock/test-case-generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/optimism/packages/contracts-bedrock/ctb-test-case-generator
 
-go 1.19
+go 1.20
 
 require github.com/ethereum/go-ethereum v1.10.26
 

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethereum-optimism/optimism/proxyd
 
-go 1.18
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.0


### PR DESCRIPTION
**Description**

Updates docker images to use go 1.20.7 and use alpine 3.18 as a base.
