### PR TITLE
op-e2e: Assert deletion of game data in fault proof e2e tests

### DIFF
--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -26,6 +26,10 @@ type FaultGameHelper struct {
 	addr        common.Address
 }
 
+func (g *FaultGameHelper) Addr() common.Address {
+	return g.addr
+}
+
 func (g *FaultGameHelper) GameDuration(ctx context.Context) time.Duration {
 	duration, err := g.game.GAMEDURATION(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err, "failed to get game duration")

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -58,7 +58,7 @@ func TestMultipleCannonGames(t *testing.T) {
 
 	gameFactory := disputegame.NewFactoryHelper(t, ctx, sys.cfg.L1Deployments, l1Client)
 	// Start a challenger with the correct alphabet trace
-	gameFactory.StartChallenger(ctx, sys.NodeEndpoint("l1"), "TowerDefense",
+	challenger := gameFactory.StartChallenger(ctx, sys.NodeEndpoint("l1"), "TowerDefense",
 		challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg, sys.NodeEndpoint("sequencer")),
 		challenger.WithPrivKey(sys.cfg.Secrets.Alice),
 		challenger.WithAgreeProposedOutput(true),
@@ -73,6 +73,9 @@ func TestMultipleCannonGames(t *testing.T) {
 	game1Claim := game1.GetClaimValue(ctx, 1)
 	game2Claim := game2.GetClaimValue(ctx, 1)
 	require.NotEqual(t, game1Claim, game2Claim, "games should have different cannon traces")
+
+	// Check that the helper finds the game directories correctly
+	challenger.VerifyGameDataExists(game1, game2)
 
 	// Push both games down to the step function
 	maxDepth := game1.MaxDepth(ctx)
@@ -97,8 +100,9 @@ func TestMultipleCannonGames(t *testing.T) {
 
 	game1.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 	game2.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
-	game1.LogGameData(ctx)
-	game2.LogGameData(ctx)
+
+	// Check that the game directories are removed
+	challenger.VerifyNoGameDataExists(game1, game2)
 }
 
 func TestResolveDisputeGame(t *testing.T) {


### PR DESCRIPTION
**Description**

Update fault proof e2e test to confirm that game data stored on disk is deleted once the game completes.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4351/tower-defense-e2e-tests
