### PR TITLE
make usage of docker compose v2 explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Note that these environment variables significantly speed up build time.
 cd ops-bedrock
 export COMPOSE_DOCKER_CLI_BUILD=1
 export DOCKER_BUILDKIT=1
-docker-compose build
+docker compose build
 ```
 
 Source code changes can have an impact on more than one container.
@@ -127,9 +127,9 @@ Source code changes can have an impact on more than one container.
 
 ```bash
 cd ops-bedrock
-docker-compose down
-docker-compose build
-docker-compose up
+docker compose down
+docker compose build
+docker compose up
 ```
 
 **If a node process exits with exit code: 137** you may need to increase the default memory limit of docker containers
@@ -141,18 +141,18 @@ cd optimism
 pnpm clean
 pnpm build
 cd ops
-docker-compose down -v
-docker-compose build
-docker-compose up
+docker compose down -v
+docker compose build
+docker compose up
 ```
 
 #### Viewing docker container logs
 
-By default, the `docker-compose up` command will show logs from all services, and that
+By default, the `docker compose up` command will show logs from all services, and that
 can be hard to filter through. In order to view the logs from a specific service, you can run:
 
 ```bash
-docker-compose logs --follow <service name>
+docker compose logs --follow <service name>
 ```
 
 ### Running tests

--- a/Makefile
+++ b/Makefile
@@ -101,13 +101,13 @@ devnet-test:
 .PHONY: devnet-test
 
 devnet-down:
-	@(cd ./ops-bedrock && GENESIS_TIMESTAMP=$(shell date +%s) docker-compose stop)
+	@(cd ./ops-bedrock && GENESIS_TIMESTAMP=$(shell date +%s) docker compose stop)
 .PHONY: devnet-down
 
 devnet-clean:
 	rm -rf ./packages/contracts-bedrock/deployments/devnetL1
 	rm -rf ./.devnet
-	cd ./ops-bedrock && docker-compose down
+	cd ./ops-bedrock && docker compose down
 	docker image ls 'ops-bedrock*' --format='{{.Repository}}' | xargs -r docker rmi
 	docker volume ls --filter name=ops-bedrock --format='{{.Name}}' | xargs -r docker volume rm
 .PHONY: devnet-clean
@@ -116,7 +116,7 @@ devnet-allocs:
 	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=. --allocs
 
 devnet-logs:
-	@(cd ./ops-bedrock && docker-compose logs -f)
+	@(cd ./ops-bedrock && docker compose logs -f)
 	.PHONY: devnet-logs
 
 test-unit:

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -93,7 +93,7 @@ def main():
         return
 
     log.info('Building docker images')
-    run_command(['docker-compose', 'build', '--progress', 'plain'], cwd=paths.ops_bedrock_dir, env={
+    run_command(['docker', 'compose', 'build', '--progress', 'plain'], cwd=paths.ops_bedrock_dir, env={
         'PWD': paths.ops_bedrock_dir
     })
 
@@ -173,7 +173,7 @@ def devnet_deploy(paths):
         ], cwd=paths.op_node_dir)
 
     log.info('Starting L1.')
-    run_command(['docker-compose', 'up', '-d', 'l1'], cwd=paths.ops_bedrock_dir, env={
+    run_command(['docker', 'compose', 'up', '-d', 'l1'], cwd=paths.ops_bedrock_dir, env={
         'PWD': paths.ops_bedrock_dir
     })
     wait_up(8545)
@@ -196,7 +196,7 @@ def devnet_deploy(paths):
     addresses = read_json(paths.addresses_json_path)
 
     log.info('Bringing up L2.')
-    run_command(['docker-compose', 'up', '-d', 'l2'], cwd=paths.ops_bedrock_dir, env={
+    run_command(['docker', 'compose', 'up', '-d', 'l2'], cwd=paths.ops_bedrock_dir, env={
         'PWD': paths.ops_bedrock_dir
     })
     wait_up(9545)
@@ -208,7 +208,7 @@ def devnet_deploy(paths):
     log.info(f'Using batch inbox {batch_inbox_address}')
 
     log.info('Bringing up everything else.')
-    run_command(['docker-compose', 'up', '-d', 'op-node', 'op-proposer', 'op-batcher'], cwd=paths.ops_bedrock_dir, env={
+    run_command(['docker', 'compose', 'up', '-d', 'op-node', 'op-proposer', 'op-batcher'], cwd=paths.ops_bedrock_dir, env={
         'PWD': paths.ops_bedrock_dir,
         'L2OO_ADDRESS': l2_output_oracle,
         'SEQUENCER_BATCH_INBOX_ADDRESS': batch_inbox_address

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -16,7 +16,7 @@ All tests can be ran by running `make test` from the `/indexer` directory.  This
 - install docker
 - `cp example.env .env`
 - fill in .env
-- run `docker-compose up` to start the indexer vs optimism goerli network
+- run `docker compose up` to start the indexer vs optimism goerli network
 
 ### Run indexer with go
 

--- a/indexer/ui/README.md
+++ b/indexer/ui/README.md
@@ -7,7 +7,7 @@ A simple UI for exploring the indexer DB using [Prisma studio](https://www.prism
 Included in the docker-compose file as `ui` service
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 Prisma can be viewed at [localhost:5555](http://localhost:5555)

--- a/specs/meta/devnet.md
+++ b/specs/meta/devnet.md
@@ -9,9 +9,9 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-You can spin up a local devnet via `docker-compose`.
+You can spin up a local devnet via `docker compose`.
 For convenience, we have defined `make` targets to start and stop the devnet with a single command.
-To run the devnet, you will need `docker` and `docker-compose` installed.
+To run the devnet, you will need `docker` installed.
 Then, as a precondition, make sure that you have compiled the contracts by `cd`ing into `packages/contracts`
 and running `pnpm i` followed by `pnpm build`. You'll only need to do this if you change the contracts in the future.
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Since docker-compose v2, the command has changed from `docker-compose` to `docker compose` [see docs migration guide](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose)

I've switched the various references to docker-compose to make this more explicit. This also makes the package more usable since attempting to install or use docker-compose on some systems `apt`,`deb`, etc will lead to the installation of the compose v1 api which will not be compatible with this docker file (see notice  [here](https://docs.docker.com/compose/install/linux/))

If this pr is merged, these changes should be made in ethereum-optimism/optimism#6710 as well

**Tests**

N/A
