### PR TITLE
fix(op-e2e): Challenger Datadir Check

### DIFF
--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -179,5 +179,5 @@ func (h *Helper) VerifyNoGameDataExists(games ...GameAddr) {
 }
 
 func (h *Helper) gameDataDir(addr common.Address) string {
-	return filepath.Join(h.dir, addr.Hex())
+	return filepath.Join(h.dir, "game-"+addr.Hex())
 }


### PR DESCRIPTION
**Description**

Fixes borked ci from #6968 to add the `game-` prefix when checking data directories.
