### PR TITLE
feat(indexer): Make DB configurable in config.toml

### DIFF
--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -25,7 +25,7 @@ var (
 )
 
 func runIndexer(ctx *cli.Context) error {
-	logger := log.NewLogger(log.ReadCLIConfig(ctx))
+	logger := log.NewLogger(log.ReadCLIConfig(ctx)).New("role", "indexer")
 	cfg, err := config.LoadConfig(logger, ctx.String(ConfigFlag.Name))
 	if err != nil {
 		logger.Error("failed to load config", "err", err)
@@ -53,7 +53,7 @@ func runIndexer(ctx *cli.Context) error {
 }
 
 func runApi(ctx *cli.Context) error {
-	logger := log.NewLogger(log.ReadCLIConfig(ctx))
+	logger := log.NewLogger(log.ReadCLIConfig(ctx)).New("role", "api")
 	cfg, err := config.LoadConfig(logger, ctx.String(ConfigFlag.Name))
 	if err != nil {
 		logger.Error("failed to load config", "err", err)

--- a/indexer/indexer.toml
+++ b/indexer/indexer.toml
@@ -10,11 +10,15 @@ l1-rpc = "${INDEXER_RPC_URL_L1}"
 l2-rpc = "${INDEXER_RPC_URL_L2}"
 
 [db]
-host = "postgres"
+host = "$INDEXER_DB_HOST"
+# this port may be problematic once we depoly
+# the DATABASE_URL looks like this for previous services and didn't include a port
+# DATABASE_URL="postgresql://${INDEXER_DB_USER}:${INDEXER_DB_PASS}@localhost/${INDEXER_DB_NAME}?host=${INDEXER_DB_HOST}"
+# If not problematic delete these comments
 port = 5432
-user = "db_username"
-password = "db_password"
-name = "db_name"
+user = "$INDEXER_DB_USER"
+password = "$INDEXER_DB_PASS"
+name = "$INDEXER_DB_NAME"
 
 [api]
 host = "127.0.0.1"


### PR DESCRIPTION
Make db configurable in the default toml file. Use the same env variables the old indexer used for easy migration
