### PR TITLE
op-challenger: Spike for how to support parallel game playing

### DIFF
--- a/op-challenger/fault/disk.go
+++ b/op-challenger/fault/disk.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/exp/slices"
 )
 
@@ -15,11 +16,15 @@ const gameDirPrefix = "game-"
 
 // diskManager coordinates the storage of game data on disk.
 type diskManager struct {
+	logger  log.Logger
 	datadir string
 }
 
-func newDiskManager(dir string) *diskManager {
-	return &diskManager{datadir: dir}
+func newDiskManager(logger log.Logger, dir string) *diskManager {
+	return &diskManager{
+		logger:  logger,
+		datadir: dir,
+	}
 }
 
 func (d *diskManager) DirForGame(addr common.Address) string {
@@ -49,7 +54,10 @@ func (d *diskManager) RemoveAllExcept(keep []common.Address) error {
 			// Preserve data for games we should keep.
 			continue
 		}
-		errs = append(errs, os.RemoveAll(filepath.Join(d.datadir, entry.Name())))
+
+		path := filepath.Join(d.datadir, entry.Name())
+		d.logger.Info("Deleting game data", "game", addr, "dir", path)
+		errs = append(errs, os.RemoveAll(path))
 	}
 	return errors.Join(errs...)
 }

--- a/op-challenger/fault/disk_test.go
+++ b/op-challenger/fault/disk_test.go
@@ -5,14 +5,16 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDiskManager_DirForGame(t *testing.T) {
 	baseDir := t.TempDir()
 	addr := common.Address{0x53}
-	disk := newDiskManager(baseDir)
+	disk := newDiskManager(testlog.Logger(t, log.LvlInfo), baseDir)
 	result := disk.DirForGame(addr)
 	require.Equal(t, filepath.Join(baseDir, gameDirPrefix+addr.Hex()), result)
 }
@@ -21,7 +23,7 @@ func TestDiskManager_RemoveAllExcept(t *testing.T) {
 	baseDir := t.TempDir()
 	keep := common.Address{0x53}
 	delete := common.Address{0xaa}
-	disk := newDiskManager(baseDir)
+	disk := newDiskManager(testlog.Logger(t, log.LvlInfo), baseDir)
 	keepDir := disk.DirForGame(keep)
 	deleteDir := disk.DirForGame(delete)
 

--- a/op-challenger/fault/monitor.go
+++ b/op-challenger/fault/monitor.go
@@ -2,6 +2,7 @@ package fault
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -11,11 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type gamePlayer interface {
-	ProgressGame(ctx context.Context) bool
-}
-
-type playerCreator func(address common.Address, dir string) (gamePlayer, error)
 type blockNumberFetcher func(ctx context.Context) (uint64, error)
 
 // gameSource loads information about the games available to play
@@ -31,35 +27,30 @@ type gameDiskAllocator interface {
 type gameMonitor struct {
 	logger           log.Logger
 	clock            clock.Clock
-	diskManager      gameDiskAllocator
+	scheduler        *GameScheduler
 	source           gameSource
 	gameWindow       time.Duration
-	createPlayer     playerCreator
 	fetchBlockNumber blockNumberFetcher
 	allowedGames     []common.Address
-	players          map[common.Address]gamePlayer
 }
 
 func newGameMonitor(
 	logger log.Logger,
 	gameWindow time.Duration,
 	cl clock.Clock,
-	disk gameDiskAllocator,
+	scheduler *GameScheduler,
 	fetchBlockNumber blockNumberFetcher,
 	allowedGames []common.Address,
 	source gameSource,
-	createGame playerCreator,
 ) *gameMonitor {
 	return &gameMonitor{
 		logger:           logger,
 		clock:            cl,
-		diskManager:      disk,
+		scheduler:        scheduler,
 		source:           source,
 		gameWindow:       gameWindow,
-		createPlayer:     createGame,
 		fetchBlockNumber: fetchBlockNumber,
 		allowedGames:     allowedGames,
-		players:          make(map[common.Address]gamePlayer),
 	}
 }
 
@@ -92,52 +83,15 @@ func (m *gameMonitor) progressGames(ctx context.Context, blockNum uint64) error 
 	if err != nil {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
-	requiredGames := make(map[common.Address]bool)
-	var keepGameData []common.Address
+	var gamesToPlay []common.Address
 	for _, game := range games {
 		if !m.allowedGame(game.Proxy) {
 			m.logger.Debug("Skipping game not on allow list", "game", game.Proxy)
 			continue
 		}
-		requiredGames[game.Proxy] = true
-		player, err := m.fetchOrCreateGamePlayer(game)
-		if err != nil {
-			m.logger.Error("Error while progressing game", "game", game.Proxy, "err", err)
-			continue
-		}
-		done := player.ProgressGame(ctx)
-		if !done {
-			// We only keep resources on disk for games that are incomplete.
-			// Games that are complete have their data removed as soon as possible to save disk space.
-			// We keep the player in memory to avoid recreating it on every update but will no longer
-			// need the resources on disk because there are no further actions required on the game.
-			keepGameData = append(keepGameData, game.Proxy)
-		}
+		gamesToPlay = append(gamesToPlay, game.Proxy)
 	}
-	if err := m.diskManager.RemoveAllExcept(keepGameData); err != nil {
-		m.logger.Error("Unable to cleanup game data", "err", err)
-	}
-	// Remove the player for any game that's no longer being returned from the list of active games
-	for addr := range m.players {
-		if _, ok := requiredGames[addr]; ok {
-			// Game still required
-			continue
-		}
-		delete(m.players, addr)
-	}
-	return nil
-}
-
-func (m *gameMonitor) fetchOrCreateGamePlayer(gameData FaultDisputeGame) (gamePlayer, error) {
-	if player, ok := m.players[gameData.Proxy]; ok {
-		return player, nil
-	}
-	player, err := m.createPlayer(gameData.Proxy, m.diskManager.DirForGame(gameData.Proxy))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create game player %v: %w", gameData.Proxy, err)
-	}
-	m.players[gameData.Proxy] = player
-	return player, nil
+	return m.scheduler.ProgressCurrentGames(ctx, gamesToPlay)
 }
 
 func (m *gameMonitor) MonitorGames(ctx context.Context) error {
@@ -156,7 +110,9 @@ func (m *gameMonitor) MonitorGames(ctx context.Context) error {
 			}
 			if nextBlockNum > blockNum {
 				blockNum = nextBlockNum
-				if err := m.progressGames(ctx, nextBlockNum); err != nil {
+				if err := m.progressGames(ctx, nextBlockNum); errors.Is(err, ErrBusy) {
+					m.logger.Debug("Skipping game update as scheduler is busy", "err", err)
+				} else if err != nil {
 					m.logger.Error("Failed to progress games", "err", err)
 				}
 			}

--- a/op-challenger/fault/scheduler.go
+++ b/op-challenger/fault/scheduler.go
@@ -1,0 +1,210 @@
+package fault
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/exp/slices"
+)
+
+var ErrBusy = errors.New("scheduler busy processing previous updates")
+
+type gamePlayer interface {
+	ProgressGame(ctx context.Context) bool
+}
+
+type playerCreator func(address common.Address, dir string) (gamePlayer, error)
+
+type job struct {
+	gameAddr     common.Address
+	player       gamePlayer
+	gameResolved bool
+}
+
+type gameState struct {
+	scheduled bool
+	resolved  bool
+	player    gamePlayer
+}
+
+type GameScheduler struct {
+	wg             sync.WaitGroup
+	cancel         func()
+	logger         log.Logger
+	maxConcurrency int
+	scheduleQueue  chan []common.Address
+	runQueue       chan *job
+	resultQueue    chan *job
+
+	// Only safe to access from coordinatorLoop
+	gameState    map[common.Address]*gameState
+	disk         *diskManager
+	createPlayer playerCreator
+}
+
+func NewGameScheduler(logger log.Logger, disk *diskManager, createPlayer playerCreator, maxConcurrency int) *GameScheduler {
+	return &GameScheduler{
+		logger:         logger,
+		maxConcurrency: maxConcurrency,
+		// Only one pending list of games to schedule.
+		// When full, we just skip a new chain head and will schedule new games on the next block.
+		scheduleQueue: make(chan []common.Address, 1),
+
+		// TODO: Work out sizing for these queues
+		// Currently keeping them relatively small. Big enough to keep the workers busy
+		// but small enough to create backpressure so we don't fetch more games if we haven't
+		// finished processing the previous batch as we'll just skip them all since the previous update is pending.
+		runQueue:     make(chan *job, maxConcurrency*2),
+		resultQueue:  make(chan *job, maxConcurrency*2),
+		gameState:    make(map[common.Address]*gameState),
+		disk:         disk,
+		createPlayer: createPlayer,
+	}
+}
+
+func (s *GameScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	// Start coordinator
+	s.wg.Add(1)
+	go s.coordinatorLoop(ctx)
+
+	// Start workers
+	for i := 0; i < s.maxConcurrency; i++ {
+		s.wg.Add(1)
+		go s.workerLoop(ctx)
+	}
+}
+
+func (s *GameScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *GameScheduler) ProgressCurrentGames(ctx context.Context, games []common.Address) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.scheduleQueue <- games:
+		return nil
+	default:
+		// If the queue is full, skip this head update
+		// TODO: Might want to remove this so the monitor is blocked and doesn't move on to poll the factory again
+		// On the other hand, skipping this update might mean we get new games from a later update...
+		return ErrBusy
+	}
+}
+
+func (s *GameScheduler) coordinatorLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case games := <-s.scheduleQueue:
+			s.coordinateScheduling(ctx, games)
+		case j := <-s.resultQueue:
+			s.coordinateResult(j)
+		}
+	}
+}
+
+func (s *GameScheduler) coordinateScheduling(ctx context.Context, games []common.Address) {
+	// Remove existing game states that aren't in the list of addresses as those games have expired
+	for addr, state := range s.gameState {
+		if !slices.Contains(games, addr) && !state.scheduled {
+			delete(s.gameState, addr)
+		}
+	}
+
+	// Update the game state for all games and create jobs for those that need to be played
+	// We need to ensure all required games are tracked before we start executing any or we might delete
+	// some files on disk right after startup because we get a result before all current games are added to the state
+	var jobs []*job
+	for _, addr := range games {
+		state, ok := s.gameState[addr]
+		if !ok {
+
+			state = &gameState{}
+			s.gameState[addr] = state
+		}
+		if state.scheduled {
+			s.logger.Debug("Game update already scheduled, skipping", "game", addr)
+			continue
+		}
+		if state.resolved {
+			s.logger.Debug("Game already resolved, skipping update", "game", addr)
+			continue
+		}
+		// Create the player separate to the gameState to ensure that the game state is present
+		// even if creating the player fails. Otherwise, existing game data may be deleted because
+		// of temporary problems requesting data
+		if state.player == nil {
+			player, err := s.createPlayer(addr, s.disk.DirForGame(addr))
+			if err != nil {
+				s.logger.Error("Could not create player for game", "game", addr, "err", err)
+				continue
+			}
+			state.player = player
+		}
+		state.scheduled = true
+		jobs = append(jobs, &job{
+			gameAddr: addr,
+			player:   state.player,
+		})
+	}
+	for _, j := range jobs {
+		select {
+		case <-ctx.Done():
+			return
+
+		case s.runQueue <- j:
+
+		// Process incoming results to avoid deadlock because the runQueue is full.
+		case j := <-s.resultQueue:
+			s.coordinateResult(j)
+		}
+	}
+}
+
+func (s *GameScheduler) coordinateResult(j *job) {
+	state, ok := s.gameState[j.gameAddr]
+	if !ok {
+		s.logger.Error("Got result for untracked game", "game", j.gameAddr)
+		return
+	}
+	state.resolved = j.gameResolved
+	state.scheduled = false
+
+	// Delete resources for any games that aren't currently scheduled and are resolved
+	var keepData []common.Address
+	for addr, state := range s.gameState {
+		if !state.scheduled && state.resolved {
+			// We can delete games that have been resolved and aren't scheduled to run.
+			continue
+		}
+		keepData = append(keepData, addr)
+	}
+	if err := s.disk.RemoveAllExcept(keepData); err != nil {
+		s.logger.Error("Unable to cleanup game data", "err", err)
+	}
+}
+
+func (s *GameScheduler) workerLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case j := <-s.runQueue:
+			j.gameResolved = j.player.ProgressGame(ctx)
+			select {
+			case <-ctx.Done():
+				return
+			case s.resultQueue <- j:
+			}
+		}
+	}
+}

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -47,7 +47,7 @@ func (g *FaultGameHelper) WaitForClaimCount(ctx context.Context, count int64) {
 		g.t.Log("Waiting for claim count", "current", actual, "expected", count, "game", g.addr)
 		return actual.Cmp(big.NewInt(count)) == 0, nil
 	})
-	g.require.NoErrorf(err, "Did not find expected claim count %v", count)
+	g.require.NoErrorf(err, "Did not find expected claim count %v for game %v", count, g.addr)
 }
 
 type ContractClaim struct {


### PR DESCRIPTION
**Description**

Putting this up for visibility but it's definitely not ready to merge. I think the e2e tests will pass (actually looks like there's either a bug or a race condition with deleting the files) so it seems to work but unit tests haven't been updated and the new game scheduler is still completely untested. The wiring isn't all in place either - most notably the goroutines spawned aren't ever stopped.

The design will likely have to change to make things more testable but this is a useful spike to work through how parallel game execution can work.

There's a few properties we want to preserve when operating in parallel:

* The game-specific code shouldn't need to deal with concurrency. The multi-game coordination should ensure that only one thread is ever progressing a game at a time
* There needs to be a limit on the number of concurrent games played
* Delete files on disk once a game is resolved
* Avoid recreating the `gamePlayer` for games (as it requires a bunch of calls to load game inputs even if the game is resolved)
* It shouldn't wait for all games to finishes progressing before moving on to handle later updates. For example game A might need to generate the initial trace and so could take an hour to complete its update. If at the same time game B can perform its next move quickly because the snapshots are available, game B might be able to perform multiple moves by the time game A generates its trace.

Will get this documented in comments for the final implementation, but the high level design here is:

* The monitor component periodically loads the list of games and filters them with the allow list like it does today.
* The monitor then submits the games to play as a batch to the `GameScheduler`
* The `GameScheduler` routes those games to its single "coordinator" thread which tracks the game state and controls when files are deleted.
* The coordinator updates state to remove any games it was tracking that are not in the current list (as they've expired and are no longer relevant). It filters out any games that already have an update job in flight, then queues the others to be updated in a channel
* A configurable number of "worker" threads read from the channel of games to update and they call the existing `ProgressGame` method that goes off into the single-game area of code.
* The worker thread sends the result of the update (whether the game is resolved or not) back to the coordinator thread via a channel
* The coordinator processes those results and updates the game state. It then deletes the files for any games that are resolved and not currently scheduled for an update.




**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- https://linear.app/optimism/issue/CLI-4342/support-parallel-games
