### PR TITLE
op-e2e: Wait for game data to be deleted

### DIFF
--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -102,7 +102,7 @@ func TestMultipleCannonGames(t *testing.T) {
 	game2.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 
 	// Check that the game directories are removed
-	challenger.VerifyNoGameDataExists(game1, game2)
+	challenger.WaitForGameDataDeletion(ctx, game1, game2)
 }
 
 func TestResolveDisputeGame(t *testing.T) {


### PR DESCRIPTION
**Description**

Fixes a race condition which could cause flaky e2e tests. The challenger should delete game data _after_ the game is resolved but that takes time and happens asynchronously so it's important for the e2e test to wait rather than just doing a one-off check if the data has been deleted.