### PR TITLE
op-program: Always close both sides of a file channel

### DIFF
--- a/op-program/io/filechan.go
+++ b/op-program/io/filechan.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"errors"
 	"io"
 	"os"
 )
@@ -41,10 +42,7 @@ func (rw *ReadWritePair) Writer() *os.File {
 }
 
 func (rw *ReadWritePair) Close() error {
-	if err := rw.r.Close(); err != nil {
-		return err
-	}
-	return rw.w.Close()
+	return errors.Join(rw.r.Close(), rw.w.Close())
 }
 
 // CreateBidirectionalChannel creates a pair of FileChannels that are connected to each other.


### PR DESCRIPTION
**Description**

Ensures the write channel is closed even if the read channel Close returns an error. Small detail and no indication its ever been a problem, but always good to ensure all resources actually get closed in all cases.