### PR TITLE
Configurable Polling Variables for Indexer

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -6,6 +6,9 @@
 ### Setup env
 The `indexer.toml` stores a set of preset environmental variables that can be used to run the indexer with the exception of the network specific `l1-rpc` and `l2-rpc` variables. The `indexer.toml` file can be ran as a default config, otherwise a custom `.toml` config can provided via the `--config` flag when running the application. An optional `l1-starting-height` value can be provided to the indexer to specify the L1 starting block height to begin indexing from. This should be ideally be an L1 block that holds a correlated L2 genesis commitment. Furthermore, this value must be less than the current L1 block height to pass validation. If no starting height value is provided and the database is empty, the indexer will begin sequentially processing from L1 genesis.
 
+### Setup polling intervals
+The indexer polls and processes batches from the L1 and L2 chains on a set interval/size. The default polling interval is 5 seconds for both chains with a default batch header size of 500. The polling frequency can be changed by setting the `l1-polling-interval` and `l2-polling-interval` values in the `indexer.toml` file. The batch header size can be changed by setting the `l1-batch-size` and `l2-batch-size` values in the `indexer.toml` file.
+
 ### Testing
 All tests can be ran by running `make test` from the `/indexer` directory.  This will run all unit and e2e tests.
 

--- a/indexer/e2e_tests/setup.go
+++ b/indexer/e2e_tests/setup.go
@@ -71,6 +71,8 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 			L2RPC: opSys.EthInstances["sequencer"].HTTPEndpoint(),
 		},
 		Chain: config.ChainConfig{
+			L1PollingInterval: 1000,
+			L2PollingInterval: 1000,
 			L1Contracts: config.L1Contracts{
 				OptimismPortalProxy:         opCfg.L1Deployments.OptimismPortalProxy,
 				L2OutputOracleProxy:         opCfg.L1Deployments.L2OutputOracleProxy,

--- a/indexer/etl/l1_etl_test.go
+++ b/indexer/etl/l1_etl_test.go
@@ -98,8 +98,11 @@ func Test_L1ETL_Construction(t *testing.T) {
 			ts := test.construction()
 
 			logger := log.NewLogger(log.DefaultCLIConfig())
+			cfg := &Config{
+				StartHeight: ts.start,
+			}
 
-			etl, err := NewL1ETL(logger, ts.db.DB, ts.client, ts.start, ts.contracts)
+			etl, err := NewL1ETL(cfg, logger, ts.db.DB, ts.client, ts.contracts)
 			test.assertion(etl, err)
 		})
 	}

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -18,7 +18,7 @@ type L2ETL struct {
 	db *database.DB
 }
 
-func NewL2ETL(log log.Logger, db *database.DB, client node.EthClient) (*L2ETL, error) {
+func NewL2ETL(cfg *Config, log log.Logger, db *database.DB, client node.EthClient) (*L2ETL, error) {
 	log = log.New("etl", "l2")
 
 	// allow predeploys to be overridable
@@ -43,6 +43,9 @@ func NewL2ETL(log log.Logger, db *database.DB, client node.EthClient) (*L2ETL, e
 
 	etlBatches := make(chan ETLBatch)
 	etl := ETL{
+		loopInterval:     cfg.LoopInterval,
+		headerBufferSize: cfg.HeaderBufferSize,
+
 		log:             log,
 		headerTraversal: node.NewHeaderTraversal(client, fromHeader),
 		ethClient:       client.GethEthClient(),

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -34,7 +35,13 @@ func NewIndexer(logger log.Logger, chainConfig config.ChainConfig, rpcsConfig co
 		return nil, err
 	}
 
-	l1Etl, err := etl.NewL1ETL(logger, db, l1EthClient, chainConfig.L1StartHeight(), chainConfig.L1Contracts)
+	l1Cfg := &etl.Config{
+		LoopInterval:     time.Duration(chainConfig.L1PollingInterval) * time.Millisecond,
+		HeaderBufferSize: uint64(chainConfig.L1HeaderBufferSize),
+		StartHeight:      chainConfig.L1StartHeight(),
+	}
+
+	l1Etl, err := etl.NewL1ETL(l1Cfg, logger, db, l1EthClient, chainConfig.L1Contracts)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +51,13 @@ func NewIndexer(logger log.Logger, chainConfig config.ChainConfig, rpcsConfig co
 		return nil, err
 	}
 
+	l2Cfg := &etl.Config{
+		LoopInterval:     time.Duration(chainConfig.L2PollingInterval) * time.Millisecond,
+		HeaderBufferSize: uint64(chainConfig.L2HeaderBufferSize),
+	}
+
 	// Currently defaults to the predeploys
-	l2Etl, err := etl.NewL2ETL(logger, db, l2EthClient)
+	l2Etl, err := etl.NewL2ETL(l2Cfg, logger, db, l2EthClient)
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/indexer.toml
+++ b/indexer/indexer.toml
@@ -1,6 +1,12 @@
 # Chain configures l1 chain addresses
 # Can configure them manually or use a preset l2 ChainId for known chains including OP Mainnet, OP Goerli, Base, Base Goerli, Zora, and Zora goerli
 [chain]
+l1-polling-interval = 0
+l1-header-buffer-size = 0
+
+l2-polling-interval = 0
+l2-header-buffer-size = 0
+
 # OP Goerli
 preset = 420
 l1-starting-height = 0


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Added support for four config variables (i.e, `l1-polling-interval`, `l2-polling-interval`, `l1-header-buffer-size`, `l2-header-buffer-size`) that provide a user fine grained control over the indexer's polling frequency and batch sizes. If these values are unset, the existing repo defaults are embedded instead. 

More specifically:
* Extended the `ChainConfig` struct to hold polling configurations
* Added an etl `Config` type that stores parameters for a L1/L2 ETL instance
* Updated dependency injection logic to build L1/L2 etl configs 
* Updated config tests to ensure polling values are properly loaded

**Tests**
Updated existing config tests to ensure that default values set when expected and don't set when unexpected. 

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #6964
