### PR TITLE
op-challenger: Add CLI option for max concurrency

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -11,6 +11,9 @@ import (
 
 // Main is the programmatic entry-point for running op-challenger
 func Main(ctx context.Context, logger log.Logger, cfg *config.Config) error {
+	if err := cfg.Check(); err != nil {
+		return err
+	}
 	service, err := fault.NewService(ctx, logger, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create the fault service: %w", err)

--- a/op-challenger/challenger_test.go
+++ b/op-challenger/challenger_test.go
@@ -1,0 +1,17 @@
+package op_challenger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainShouldReturnErrorWhenConfigInvalid(t *testing.T) {
+	cfg := &config.Config{}
+	err := Main(context.Background(), testlog.Logger(t, log.LvlInfo), cfg)
+	require.ErrorIs(t, err, cfg.Check())
+}

--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -147,6 +147,28 @@ func TestAgreeWithProposedOutput(t *testing.T) {
 	})
 }
 
+func TestMaxConcurrency(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		expected := uint(345)
+		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--max-concurrency", "345"))
+		require.Equal(t, expected, cfg.MaxConcurrency)
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		verifyArgsInvalid(
+			t,
+			"invalid value \"abc\" for flag -max-concurrency",
+			addRequiredArgs(config.TraceTypeAlphabet, "--max-concurrency", "abc"))
+	})
+
+	t.Run("Zero", func(t *testing.T) {
+		verifyArgsInvalid(
+			t,
+			"max-concurrency must not be 0",
+			addRequiredArgs(config.TraceTypeAlphabet, "--max-concurrency", "0"))
+	})
+}
+
 func TestCannonBin(t *testing.T) {
 	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
 		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-bin"))

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,6 +17,7 @@ import (
 var (
 	ErrMissingTraceType              = errors.New("missing trace type")
 	ErrMissingDatadir                = errors.New("missing datadir")
+	ErrMaxConcurrencyZero            = errors.New("max concurrency must not be 0")
 	ErrMissingCannonL2               = errors.New("missing cannon L2")
 	ErrMissingCannonBin              = errors.New("missing cannon bin")
 	ErrMissingCannonServer           = errors.New("missing cannon server")
@@ -93,6 +95,7 @@ type Config struct {
 	GameWindow              time.Duration    // Maximum time duration to look for games to progress
 	AgreeWithProposedOutput bool             // Temporary config if we agree or disagree with the posted output
 	Datadir                 string           // Data Directory
+	MaxConcurrency          uint             // Maximum number of threads to use when progressing games
 
 	TraceType TraceType // Type of trace
 
@@ -124,6 +127,7 @@ func NewConfig(
 	return Config{
 		L1EthRpc:           l1EthRpc,
 		GameFactoryAddress: gameFactoryAddress,
+		MaxConcurrency:     uint(runtime.NumCPU()),
 
 		AgreeWithProposedOutput: agreeWithProposedOutput,
 
@@ -152,6 +156,9 @@ func (c Config) Check() error {
 	}
 	if c.Datadir == "" {
 		return ErrMissingDatadir
+	}
+	if c.MaxConcurrency == 0 {
+		return ErrMaxConcurrencyZero
 	}
 	if c.TraceType == TraceTypeCannon {
 		if c.CannonBin == "" {

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -102,6 +103,19 @@ func TestDatadirRequired(t *testing.T) {
 	config := validConfig(TraceTypeAlphabet)
 	config.Datadir = ""
 	require.ErrorIs(t, config.Check(), ErrMissingDatadir)
+}
+
+func TestMaxConcurrency(t *testing.T) {
+	t.Run("Required", func(t *testing.T) {
+		config := validConfig(TraceTypeAlphabet)
+		config.MaxConcurrency = 0
+		require.ErrorIs(t, config.Check(), ErrMaxConcurrencyZero)
+	})
+
+	t.Run("DefaultToNumberOfCPUs", func(t *testing.T) {
+		config := validConfig(TraceTypeAlphabet)
+		require.EqualValues(t, runtime.NumCPU(), config.MaxConcurrency)
+	})
 }
 
 func TestCannonL2Required(t *testing.T) {

--- a/op-challenger/fault/scheduler/scheduler.go
+++ b/op-challenger/fault/scheduler/scheduler.go
@@ -14,7 +14,7 @@ var ErrBusy = errors.New("busy scheduling previous update")
 type Scheduler struct {
 	logger         log.Logger
 	coordinator    *coordinator
-	maxConcurrency int
+	maxConcurrency uint
 	scheduleQueue  chan []common.Address
 	jobQueue       chan job
 	resultQueue    chan job
@@ -22,7 +22,7 @@ type Scheduler struct {
 	cancel         func()
 }
 
-func NewScheduler(logger log.Logger, disk DiskManager, maxConcurrency int, createPlayer PlayerCreator) *Scheduler {
+func NewScheduler(logger log.Logger, disk DiskManager, maxConcurrency uint, createPlayer PlayerCreator) *Scheduler {
 	// Size job and results queues to be fairly small so backpressure is applied early
 	// but with enough capacity to keep the workers busy
 	jobQueue := make(chan job, maxConcurrency*2)
@@ -46,7 +46,7 @@ func (s *Scheduler) Start(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 
-	for i := 0; i < s.maxConcurrency; i++ {
+	for i := uint(0); i < s.maxConcurrency; i++ {
 		s.wg.Add(1)
 		go progressGames(ctx, s.jobQueue, s.resultQueue, &s.wg)
 	}

--- a/op-challenger/fault/service.go
+++ b/op-challenger/fault/service.go
@@ -20,9 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// TODO(CLI-4342): Make this a cli option
-const maxConcurrency = 4
-
 type Loader interface {
 	FetchAbsolutePrestateHash(ctx context.Context) ([]byte, error)
 }
@@ -79,7 +76,7 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Se
 	sched := scheduler.NewScheduler(
 		logger,
 		disk,
-		maxConcurrency,
+		cfg.MaxConcurrency,
 		func(addr common.Address, dir string) (scheduler.GamePlayer, error) {
 			return NewGamePlayer(ctx, logger, cfg, dir, addr, txMgr, client)
 		})


### PR DESCRIPTION
**Description**

Adds `--max-concurrency` CLI option to op-challenger to set the maximum number of worker threads to use. Defaults the number of CPU cores.

Also adds missing call to check the config is valid.

**Tests**

Added unit tests.


**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4342/support-parallel-games
