### PR TITLE
Add ability to restrict the networks that op-node discovers peers on

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -152,6 +152,13 @@ var (
 		Value:    "",
 		EnvVars:  p2pEnv("STATIC"),
 	}
+	NetRestrict = &cli.StringFlag{
+		Name:     "p2p.netrestrict",
+		Usage:    "Comma-separated list of CIDR masks. P2P will only try to connect on these networks",
+		Required: false,
+		Value:    "",
+		EnvVars:  p2pEnv("NETRESTRICT"),
+	}
 	HostMux = &cli.StringFlag{
 		Name:     "p2p.mux",
 		Usage:    "Comma-separated list of multiplexing protocols in order of preference. At least 1 required. Options: 'yamux','mplex'.",
@@ -322,6 +329,7 @@ var p2pFlags = []cli.Flag{
 	AdvertiseUDPPort,
 	Bootnodes,
 	StaticPeers,
+	NetRestrict,
 	HostMux,
 	HostSecurity,
 	PeersLo,

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/netutil"
 )
 
 func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) {
@@ -192,6 +193,13 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 	} else {
 		conf.Bootnodes = p2p.DefaultBootnodes
 	}
+
+	netRestrict, err := netutil.ParseNetlist(ctx.String(flags.NetRestrict.Name))
+	if err != nil {
+		return fmt.Errorf("failed to parse net list: %w", err)
+	}
+
+	conf.NetRestrict = netRestrict
 
 	return nil
 }

--- a/op-node/p2p/config.go
+++ b/op-node/p2p/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/netutil"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -84,6 +85,7 @@ type Config struct {
 	AdvertiseUDPPort uint16
 	Bootnodes        []*enode.Node
 	DiscoveryDB      *enode.DB
+	NetRestrict      *netutil.Netlist
 
 	StaticPeers []core.Multiaddr
 

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -97,7 +97,7 @@ func (conf *Config) Discovery(log log.Logger, rollupCfg *rollup.Config, tcpPort 
 
 	cfg := discover.Config{
 		PrivateKey:   priv,
-		NetRestrict:  nil,
+		NetRestrict:  conf.NetRestrict,
 		Bootnodes:    conf.Bootnodes,
 		Unhandled:    nil, // Not used in dv5
 		Log:          log,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This adds the ability to restrict p2p node discovery for outbound connections on op-node to the specified networks. Helpful to prevent, for example, the sequencer making outbound connections to external nodes.

**Tests**

Ran this in a testnet and confirmed external peers (not on the allowed networks list) do not get connected to, but everything in the network does.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
