### PR TITLE
op-challenger: Detect already resolved games at startup

### DIFF
--- a/op-challenger/game/fault/player_test.go
+++ b/op-challenger/game/fault/player_test.go
@@ -157,7 +157,7 @@ func setupProgressGameTest(t *testing.T, agreeWithProposedRoot bool) (*testlog.C
 	logger.SetHandler(handler)
 	gameState := &stubGameState{claimCount: 1}
 	game := &GamePlayer{
-		agent:                   gameState,
+		act:                     gameState.Act,
 		agreeWithProposedOutput: agreeWithProposedRoot,
 		loader:                  gameState,
 		logger:                  logger,


### PR DESCRIPTION
**Description**

Avoids regenerating the cannon traces when performing an initial move at startup if the game is already resolved.


**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4386/dont-try-to-play-already-resolved-games-at-startup
