### PR TITLE
op-challenger: Include the op-program host binary in docker image.

### DIFF
--- a/op-challenger/Dockerfile
+++ b/op-challenger/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
 # build op-challenger with the shared go.mod & go.sum files
 COPY ./op-challenger /app/op-challenger
+COPY ./op-program /app/op-program
+COPY ./op-preimage /app/op-preimage
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-service /app/op-service
@@ -19,16 +21,25 @@ COPY ./cannon /app/cannon
 COPY ./op-preimage /app/op-preimage
 COPY ./op-chain-ops /app/op-chain-ops
 
-WORKDIR /app/op-challenger
+WORKDIR /app/op-program
 
 RUN go mod download
 
 ARG TARGETOS TARGETARCH
 
+RUN make op-program-host VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+
+WORKDIR /app/op-challenger
+
 RUN make op-challenger VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 FROM alpine:3.18
 
+# Make the bundled op-program the default cannon server
+ENV OP_CHALLENGER_CANNON_SERVER /usr/local/bin/op-program
+
 COPY --from=builder /app/op-challenger/bin/op-challenger /usr/local/bin
+
+COPY --from=builder /app/op-program/bin/op-program /usr/local/bin
 
 CMD ["op-challenger"]


### PR DESCRIPTION
**Description**

Avoids the need to manually specify the op-program binary to run as the cannon pre-image server. The default value is set as an env var in the docker image so that it becomes the default but can still be overridden with `--cannon-server` if users want to use a different server implementation.

**Tests**

Manually tested.

**Metadata**

- Fixes https://linear.app/optimism/issue/CLI-4387/build-op-program-server-binary-into-op-challenger-docker-image
