### PR TITLE
Add cannon-prestate as prereq to devnet-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ nuke: clean devnet-clean
 .PHONY: nuke
 
 devnet-up:
+	@if [ ! -e op-program/bin ]; then \
+		make cannon-prestate; \
+	fi
 	$(shell ./ops/scripts/newer-file.sh .devnet/allocs-l1.json ./packages/contracts-bedrock)
 	if [ $(.SHELLSTATUS) -ne 0 ]; then \
 		make devnet-allocs; \


### PR DESCRIPTION
The devnet-up ultimately requires the cannont-prestate target to have already executed, or the script errors out.  Consequently, for someone checking out the repo if they simply do a:

```
make && make devnet-up
```

Things still fail.  This change simply mirrors a similar check added to the e2e Makefile.