### PR TITLE
feat(indexer): wire up rpc client metrics

### DIFF
--- a/indexer/etl/etl.go
+++ b/indexer/etl/etl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -28,7 +27,7 @@ type ETL struct {
 	headerBufferSize uint64
 	headerTraversal  *node.HeaderTraversal
 
-	ethClient  *ethclient.Client
+	ethClient  node.EthClient
 	contracts  []common.Address
 	etlBatches chan ETLBatch
 }
@@ -103,8 +102,7 @@ func (etl *ETL) processBatch(headers []types.Header) error {
 	}
 
 	headersWithLog := make(map[common.Hash]bool, len(headers))
-	logFilter := ethereum.FilterQuery{FromBlock: firstHeader.Number, ToBlock: lastHeader.Number, Addresses: etl.contracts}
-	logs, err := etl.ethClient.FilterLogs(context.Background(), logFilter)
+	logs, err := etl.ethClient.FilterLogs(ethereum.FilterQuery{FromBlock: firstHeader.Number, ToBlock: lastHeader.Number, Addresses: etl.contracts})
 	if err != nil {
 		batchLog.Info("unable to extract logs", "err", err)
 		return err

--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -63,7 +63,7 @@ func NewL1ETL(cfg Config, log log.Logger, db *database.DB, metrics Metricer, cli
 		log:             log,
 		metrics:         metrics,
 		headerTraversal: node.NewHeaderTraversal(client, fromHeader),
-		ethClient:       client.GethEthClient(),
+		ethClient:       client,
 		contracts:       cSlice,
 		etlBatches:      etlBatches,
 	}

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -50,7 +50,7 @@ func NewL2ETL(cfg Config, log log.Logger, db *database.DB, metrics Metricer, cli
 		log:             log,
 		metrics:         metrics,
 		headerTraversal: node.NewHeaderTraversal(client, fromHeader),
-		ethClient:       client.GethEthClient(),
+		ethClient:       client,
 		contracts:       l2Contracts,
 		etlBatches:      etlBatches,
 	}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -37,7 +37,7 @@ func NewIndexer(logger log.Logger, db *database.DB, chainConfig config.ChainConf
 	metricsRegistry := metrics.NewRegistry()
 
 	// L1
-	l1EthClient, err := node.DialEthClient(rpcsConfig.L1RPC)
+	l1EthClient, err := node.DialEthClient(rpcsConfig.L1RPC, node.NewMetrics(metricsRegistry, "l1"))
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func NewIndexer(logger log.Logger, db *database.DB, chainConfig config.ChainConf
 	}
 
 	// L2 (defaults to predeploy contracts)
-	l2EthClient, err := node.DialEthClient(rpcsConfig.L2RPC)
+	l2EthClient, err := node.DialEthClient(rpcsConfig.L2RPC, node.NewMetrics(metricsRegistry, "l2"))
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/node/client.go
+++ b/indexer/node/client.go
@@ -57,8 +57,8 @@ func (c *client) FinalizedBlockHeight() (*big.Int, error) {
 	ctxwt, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
 	defer cancel()
 
-	// Local devnet is having issues with the "finalized" block tag. Switch to "latest"
-	// to iterate faster locally but this needs to be updated
+	// **NOTE** Local devnet is having issues with the "finalized" block tag. Temp switch
+	// to "latest" to iterate faster locally but this needs to be updated
 	header := new(types.Header)
 	err := c.rpc.CallContext(ctxwt, header, "eth_getBlockByNumber", "latest", false)
 	if err != nil {
@@ -222,18 +222,12 @@ func (c *rpcClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) err
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"
-	} else if number.Sign() >= 0 {
+	}
+	if number.Sign() >= 0 {
 		return hexutil.EncodeBig(number)
 	}
-
 	// It's negative.
-	if number.IsInt64() {
-		tag, _ := rpc.BlockNumber(number.Int64()).MarshalText()
-		return string(tag)
-	}
-
-	// It's negative and large, which is invalid.
-	return fmt.Sprintf("<invalid %d>", number)
+	return rpc.BlockNumber(number.Int64()).String()
 }
 
 func toFilterArg(q ethereum.FilterQuery) (interface{}, error) {

--- a/indexer/node/header_traversal.go
+++ b/indexer/node/header_traversal.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -35,7 +36,7 @@ func (f *HeaderTraversal) LastHeader() *types.Header {
 func (f *HeaderTraversal) NextFinalizedHeaders(maxSize uint64) ([]types.Header, error) {
 	finalizedBlockHeight, err := f.ethClient.FinalizedBlockHeight()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to query latest finalized height: %w", err)
 	}
 
 	if f.lastHeader != nil {
@@ -55,7 +56,7 @@ func (f *HeaderTraversal) NextFinalizedHeaders(maxSize uint64) ([]types.Header, 
 	endHeight := clampBigInt(nextHeight, finalizedBlockHeight, maxSize)
 	headers, err := f.ethClient.BlockHeadersByRange(nextHeight, endHeight)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error querying blocks by range: %w", err)
 	}
 
 	numHeaders := len(headers)

--- a/indexer/node/metrics.go
+++ b/indexer/node/metrics.go
@@ -21,8 +21,6 @@ type Metricer interface {
 }
 
 type clientMetrics struct {
-	subsystem string
-
 	rpcClientRequestsTotal          *prometheus.CounterVec
 	rpcClientRequestDurationSeconds *prometheus.HistogramVec
 	rpcClientResponsesTotal         *prometheus.CounterVec

--- a/indexer/node/metrics.go
+++ b/indexer/node/metrics.go
@@ -1,0 +1,106 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	MetricsNamespace = "rpc"
+	batchMethod      = "<batch>"
+)
+
+type Metricer interface {
+	RecordRPCClientRequest(method string) func(err error)
+	RecordRPCClientBatchRequest(b []rpc.BatchElem) func(err error)
+}
+
+type clientMetrics struct {
+	subsystem string
+
+	rpcClientRequestsTotal          *prometheus.CounterVec
+	rpcClientRequestDurationSeconds *prometheus.HistogramVec
+	rpcClientResponsesTotal         *prometheus.CounterVec
+}
+
+func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
+	factory := metrics.With(registry)
+	return &clientMetrics{
+		rpcClientRequestsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: subsystem,
+			Name:      "requests_total",
+			Help:      "Total RPC requests initiated by the RPC client",
+		}, []string{
+			"method",
+		}),
+		rpcClientRequestDurationSeconds: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: subsystem,
+			Name:      "request_duration_seconds",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			Help:      "Histogram of RPC client request durations",
+		}, []string{
+			"method",
+		}),
+		rpcClientResponsesTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: subsystem,
+			Name:      "responses_total",
+			Help:      "Total RPC request responses received by the RPC client",
+		}, []string{
+			"method",
+			"error",
+		}),
+	}
+}
+
+func (m *clientMetrics) RecordRPCClientRequest(method string) func(err error) {
+	m.rpcClientRequestsTotal.WithLabelValues(method).Inc()
+	timer := prometheus.NewTimer(m.rpcClientRequestDurationSeconds.WithLabelValues(method))
+	return func(err error) {
+		m.recordRPCClientResponse(method, err)
+		timer.ObserveDuration()
+	}
+}
+
+func (m *clientMetrics) RecordRPCClientBatchRequest(b []rpc.BatchElem) func(err error) {
+	m.rpcClientRequestsTotal.WithLabelValues(batchMethod).Add(float64(len(b)))
+	for _, elem := range b {
+		m.rpcClientRequestsTotal.WithLabelValues(elem.Method).Inc()
+	}
+
+	timer := prometheus.NewTimer(m.rpcClientRequestDurationSeconds.WithLabelValues(batchMethod))
+	return func(err error) {
+		m.recordRPCClientResponse(batchMethod, err)
+		timer.ObserveDuration()
+
+		// Record errors for individual requests
+		for _, elem := range b {
+			m.recordRPCClientResponse(elem.Method, elem.Error)
+		}
+	}
+}
+
+func (m *clientMetrics) recordRPCClientResponse(method string, err error) {
+	var errStr string
+	var rpcErr rpc.Error
+	var httpErr rpc.HTTPError
+	if err == nil {
+		errStr = "<nil>"
+	} else if errors.As(err, &rpcErr) {
+		errStr = fmt.Sprintf("rpc_%d", rpcErr.ErrorCode())
+	} else if errors.As(err, &httpErr) {
+		errStr = fmt.Sprintf("http_%d", httpErr.StatusCode)
+	} else if errors.Is(err, ethereum.NotFound) {
+		errStr = "<not found>"
+	} else {
+		errStr = "<unknown>"
+	}
+	m.rpcClientResponsesTotal.WithLabelValues(method, errStr).Inc()
+}

--- a/indexer/node/mocks.go
+++ b/indexer/node/mocks.go
@@ -3,12 +3,13 @@ package node
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/mock"
 )
+
+var _ EthClient = &MockEthClient{}
 
 type MockEthClient struct {
 	mock.Mock
@@ -39,17 +40,7 @@ func (m *MockEthClient) StorageHash(address common.Address, blockNumber *big.Int
 	return args.Get(0).(common.Hash), args.Error(1)
 }
 
-func (m *MockEthClient) GethRpcClient() *rpc.Client {
-	args := m.Called()
-	return args.Get(0).(*rpc.Client)
-}
-
-func (m *MockEthClient) GethEthClient() *ethclient.Client {
-	args := m.Called()
-
-	client, ok := args.Get(0).(*ethclient.Client)
-	if !ok {
-		return nil
-	}
-	return client
+func (m *MockEthClient) FilterLogs(query ethereum.FilterQuery) ([]types.Log, error) {
+	args := m.Called(query)
+	return args.Get(0).([]types.Log), args.Error(1)
 }


### PR DESCRIPTION
Have `node.EthClient` emit metrics.

The instrumentation method here is very similar to `op-node/client`. Once we generalize
the op-node's version of the client, we can refactor this to utilize a generalized
instrumented rpc/ethclient.
