### PR TITLE
ci: Require cannon-go-lint-and-test to pass before merging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1224,6 +1224,7 @@ workflows:
           target: test-external-geth
       - bedrock-go-tests:
           requires:
+            - cannon-go-lint-and-test
             - op-batcher-lint
             - op-bootnode-lint
             - op-bindings-lint


### PR DESCRIPTION
**Description**

Adds `cannon-go-lint-and-test` to the dependencies for `bedrock-go-tests` which is required before merging.  Given `op-challenger` and other fault proof elements are required as part of `bedrock-go-tests` it makes sense to also include Cannon.  And we definitely want it passing before PRs can merge.


