### PR TITLE
op-program: Support prefetching l2-transactions

### DIFF
--- a/op-program/host/prefetcher/prefetcher.go
+++ b/op-program/host/prefetcher/prefetcher.go
@@ -99,7 +99,7 @@ func (p *Prefetcher) prefetch(ctx context.Context, hint string) error {
 			return fmt.Errorf("failed to fetch L1 block %s receipts: %w", hash, err)
 		}
 		return p.storeReceipts(receipts)
-	case l2.HintL2BlockHeader:
+	case l2.HintL2BlockHeader, l2.HintL2Transactions:
 		header, txs, err := p.l2Fetcher.InfoAndTxsByHash(ctx, hash)
 		if err != nil {
 			return fmt.Errorf("failed to fetch L2 block %s: %w", hash, err)


### PR DESCRIPTION
**Description**

Add support for the `l2-transactions` hint to the prefetched.  This is only actually required in really exceptional cases where the KV store is losing previously fetched values, but it's still worth supporting all the possible hint types.

It works fine even without this support because the actual API used to request data always requests the L2 header and transactions together. The transactions are prefetched based on the `l2-header` hint and so are already present when requested and the `l2-transactions` hint is never used. The lack of support was only noticed when I was testing how op-program handled the Preimage storage being randomly deleted, so the previously fetched transaction data wasn't still available and it couldn't prefetch it again because it didn't understand the `l2-transactions` hint.

**Tests**

Added unit tests.  Exposed `PreimageOracle.LoadTransactions` method which doesn't exactly fit the usual API (takes both the block hash and the tx root hash) but makes it dramatically simpler and more realistic to test this prefetching support.

**Metadata**

- https://linear.app/optimism/issue/CLI-4379/op-program-handle-pre-images-being-deleted-unexpectedly
