### PR TITLE
fix(indexer): run bridge processor after completed L1ETL intervals

### DIFF
--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -148,7 +148,7 @@ func (l1Etl *L1ETL) Start(ctx context.Context) error {
 	}
 }
 
-// Notify returns a channel that'll recieve a value every time new data has
+// Notify returns a channel that'll receive a value every time new data has
 // been persisted by the L1ETL
 func (l1Etl *L1ETL) Notify() <-chan interface{} {
 	receiver := make(chan interface{})

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -59,7 +59,7 @@ func NewIndexer(logger log.Logger, db *database.DB, chainConfig config.ChainConf
 	}
 
 	// Bridge
-	bridgeProcessor, err := processors.NewBridgeProcessor(logger, db, chainConfig)
+	bridgeProcessor, err := processors.NewBridgeProcessor(logger, db, l1Etl, chainConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The bridge processor running on its own ticker was a temp solution.

Allow the bridge processor to subscribe to the L1ETL such that the bridge processor
is only fired off when new L1 state as been indexed.

Later on, we can even improve this to fire off the bridge processor when new epochs have been seen on both L1 & L2. However this is probably unnecessary and a hyper-optimization we can address after finishing everything else
