### PR TITLE
feat(indexer): index service /healthz endpoint

### DIFF
--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -38,7 +38,7 @@ func runIndexer(ctx *cli.Context) error {
 	}
 	defer db.Close()
 
-	indexer, err := indexer.NewIndexer(log, db, cfg.Chain, cfg.RPCs, cfg.Metrics)
+	indexer, err := indexer.NewIndexer(log, db, cfg.Chain, cfg.RPCs, cfg.HTTPServer, cfg.MetricsServer)
 	if err != nil {
 		log.Error("failed to create indexer", "err", err)
 		return err
@@ -63,7 +63,7 @@ func runApi(ctx *cli.Context) error {
 	defer db.Close()
 
 	api := api.NewApi(log, db.BridgeTransfers)
-	return api.Listen(ctx.Context, cfg.API.Port)
+	return api.Listen(ctx.Context, cfg.HTTPServer.Port)
 }
 
 func runAll(ctx *cli.Context) error {

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -20,11 +20,11 @@ const (
 
 // Config represents the `indexer.toml` file used to configure the indexer
 type Config struct {
-	Chain   ChainConfig   `toml:"chain"`
-	RPCs    RPCsConfig    `toml:"rpcs"`
-	DB      DBConfig      `toml:"db"`
-	API     APIConfig     `toml:"api"`
-	Metrics MetricsConfig `toml:"metrics"`
+	Chain         ChainConfig  `toml:"chain"`
+	RPCs          RPCsConfig   `toml:"rpcs"`
+	DB            DBConfig     `toml:"db"`
+	HTTPServer    ServerConfig `toml:"http"`
+	MetricsServer ServerConfig `toml:"metrics"`
 }
 
 // fetch this via onchain config from RPCsConfig and remove from config in future
@@ -96,14 +96,8 @@ type DBConfig struct {
 	Password string `toml:"password"`
 }
 
-// APIConfig configures the API server
-type APIConfig struct {
-	Host string `toml:"host"`
-	Port int    `toml:"port"`
-}
-
-// MetricsConfig configures the metrics server
-type MetricsConfig struct {
+// Configures the a server
+type ServerConfig struct {
 	Host string `toml:"host"`
 	Port int    `toml:"port"`
 }

--- a/indexer/config/config_test.go
+++ b/indexer/config/config_test.go
@@ -31,9 +31,9 @@ func TestLoadConfig(t *testing.T) {
 		port = 5432
 		user = "postgres"
 		password = "postgres"
-	  name = "indexer"
+	    name = "indexer"
 
-		[api]
+		[http]
 		host = "127.0.0.1"
 		port = 8080
 
@@ -65,10 +65,10 @@ func TestLoadConfig(t *testing.T) {
 	require.Equal(t, conf.DB.User, "postgres")
 	require.Equal(t, conf.DB.Password, "postgres")
 	require.Equal(t, conf.DB.Name, "indexer")
-	require.Equal(t, conf.API.Host, "127.0.0.1")
-	require.Equal(t, conf.API.Port, 8080)
-	require.Equal(t, conf.Metrics.Host, "127.0.0.1")
-	require.Equal(t, conf.Metrics.Port, 7300)
+	require.Equal(t, conf.HTTPServer.Host, "127.0.0.1")
+	require.Equal(t, conf.HTTPServer.Port, 8080)
+	require.Equal(t, conf.MetricsServer.Host, "127.0.0.1")
+	require.Equal(t, conf.MetricsServer.Port, 7300)
 }
 
 func TestLoadConfig_WithoutPreset(t *testing.T) {

--- a/indexer/e2e_tests/setup.go
+++ b/indexer/e2e_tests/setup.go
@@ -82,10 +82,8 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 				L1StandardBridgeProxy:       opCfg.L1Deployments.L1StandardBridgeProxy,
 			},
 		},
-		Metrics: config.MetricsConfig{
-			Host: "127.0.0.1",
-			Port: 0,
-		},
+		HTTPServer:    config.ServerConfig{Host: "127.0.0.1", Port: 0},
+		MetricsServer: config.ServerConfig{Host: "127.0.0.1", Port: 0},
 	}
 
 	db, err := database.NewDB(indexerCfg.DB)
@@ -93,7 +91,7 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 	t.Cleanup(func() { db.Close() })
 
 	indexerLog := testlog.Logger(t, log.LvlInfo).New("role", "indexer")
-	indexer, err := indexer.NewIndexer(indexerLog, db, indexerCfg.Chain, indexerCfg.RPCs, indexerCfg.Metrics)
+	indexer, err := indexer.NewIndexer(indexerLog, db, indexerCfg.Chain, indexerCfg.RPCs, indexerCfg.HTTPServer, indexerCfg.MetricsServer)
 	require.NoError(t, err)
 
 	indexerCtx, indexerStop := context.WithCancel(context.Background())

--- a/indexer/indexer.toml
+++ b/indexer/indexer.toml
@@ -28,7 +28,7 @@ user = "db_username"
 password = "db_password"
 name = "db_name"
 
-[api]
+[http]
 host = "127.0.0.1"
 port = 8080
 


### PR DESCRIPTION
The indexer is a seperate service from the api. It needs to spin up it's own HTTP server
in order to serve a /healthz endpoint

Renamed `APIConfig` to `ServerConfig` such that both `MetricsServer` and `HTTPServer`
share the same structural configuration (different toml keys, `metrics` and `http`)
