### PR TITLE
op-e2e: allow external processes to skip tests

### DIFF
--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -13,7 +13,7 @@ test: pre-test test-ws
 
 test-external-%: pre-test
 	make -C ./external_$*/
-	$(go_test) $(go_test_flags) --externalL2 ./external_$*/shim
+	$(go_test) $(go_test_flags) --externalL2 ./external_$*/
 
 test-ws: pre-test
 	$(go_test) $(go_test_flags) ./...

--- a/op-e2e/external/config.go
+++ b/op-e2e/external/config.go
@@ -1,8 +1,11 @@
 package external
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
+	"testing"
 )
 
 type Config struct {
@@ -39,4 +42,27 @@ type Endpoints struct {
 	WSEndpoint       string `json:"ws_endpoint"`
 	HTTPAuthEndpoint string `json:"http_auth_endpoint"`
 	WSAuthEndpoint   string `json:"ws_auth_endpoint"`
+}
+
+type TestParms struct {
+	// SkipTests is a map from test name to skip message.  The skip message may
+	// be arbitrary, but the test name should match the skipped test (either
+	// base, or a sub-test) exactly.  Precisely, the skip name must match rune for
+	// rune starting with the first rune.  If the skip name does not match all
+	// runes, the first mismatched rune must be a '/'.
+	SkipTests map[string]string `json:"skip_tests"`
+}
+
+func (tp TestParms) SkipIfNecessary(t *testing.T) {
+	if len(tp.SkipTests) == 0 {
+		return
+	}
+	var base bytes.Buffer
+	for _, name := range strings.Split(t.Name(), "/") {
+		base.WriteString(name)
+		if msg, ok := tp.SkipTests[base.String()]; ok {
+			t.Skip(msg)
+		}
+		base.WriteRune('/')
+	}
 }

--- a/op-e2e/external_geth/README.md
+++ b/op-e2e/external_geth/README.md
@@ -41,6 +41,16 @@ process and looks for the lines indicating that the HTTP server and Auth HTTP
 server have started up.  It then reads the ports which were allocated (because
 the requested ports were passed in as ephemeral via the CLI arguments).
 
+## Skipping tests
+
+Although ideally, all tests would be structured such that they may execute
+either with an in-process op-geth or with an extra-process ethereum client,
+this is not always the case.  You may optionally create a `test_parms.json`
+file in the `external_<your-client>` directory, as there is in the
+`external_geth` directory which specifies a map of tests to skip, and
+accompanying skip text.  See the `op-e2e/external/config.go` file for more
+details.
+
 ## Generalization
 
 This shim is included to help document an demonstrate the usage of the

--- a/op-e2e/external_geth/test_parms.json
+++ b/op-e2e/external_geth/test_parms.json
@@ -1,0 +1,5 @@
+{
+  "skip_tests":{
+    "TestPendingGasLimit":"This test requires directly modifying go structures and cannot be implemented with flags"
+  }
+}

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -45,23 +44,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if config.ExternalL2Nodes != "" {
-		fmt.Println("Running tests with external L2 process adapter at ", config.ExternalL2Nodes)
-		shimPath, err := filepath.Abs(config.ExternalL2Nodes)
-		if err != nil {
-			fmt.Printf("Could not compute abs of externalL2Nodes shim: %s\n", err)
-			os.Exit(2)
-		}
-		// We convert the passed in path to an absolute path, as it simplifies
-		// the path handling logic for the rest of the testing
-		config.ExternalL2Nodes = shimPath
-
-		_, err = os.Stat(config.ExternalL2Nodes)
-		if err != nil {
-			fmt.Printf("Failed to stat externalL2Nodes path: %s\n", err)
-			os.Exit(3)
-		}
-
+	if config.ExternalL2Shim != "" {
+		fmt.Println("Running tests with external L2 process adapter at ", config.ExternalL2Shim)
 		// As these are integration tests which launch many other processes, the
 		// default parallelism makes the tests flaky.  This change aims to
 		// reduce the flakiness of these tests.
@@ -273,13 +257,6 @@ func TestPendingGasLimit(t *testing.T) {
 	InitParallel(t)
 
 	cfg := DefaultSystemConfig(t)
-	if cfg.ExternalL2Nodes != "" {
-		// Some eth clients such as Erigon don't currently build blocks until
-		// they receive the engine call which includes the gas limit.  After we
-		// provide a mechanism for external clients to advertise test support we
-		// should enable for those which support it.
-		t.Skip()
-	}
 
 	// configure the L2 gas limit to be high, and the pending gas limits to be lower for resource saving.
 	cfg.DeployConfig.L2GenesisBlockGasLimit = 30_000_000


### PR DESCRIPTION
Certain existing e2e tests are not adaptable to external binary testing. Although it's better for tests to be able to execute against both an in-process geth or an extra-process arbitrary ethereum client, the current state of the tests does not allow this in all cases.

This change allows for external binaries to specify a set of test names to be skipped, including a skip message for why they are skipped.  The set is specified as a JSON map in a new optional file `test_parms.json` which can be created in the external adapter folder.

Prior to this change, the external process was indicated only by a path to a `shim` binary.  This change now instead asks that the external test be specified by directory, wherein a `shim` binary must exist, and this new file `test_params.json` may exist.  Other approaches are of course possible, such as allowing the JSON file to be specified via a command flag, but it seemed better to simply establish a convention for expected paths for these external tests to satisfy.

There actually is a single test which already has a `t.Skip()` based on the presence of the external L2 flag.  I'd though these were all removed in the last PR, but this one actually is required for an external op-geth.  So, this skip has been converted to the new method and acts as a nice test that it is working.