### PR TITLE
op-chain-ops: Detect types using input.Type.T rather than string comparison

### DIFF
--- a/op-chain-ops/safe/batch_helpers.go
+++ b/op-chain-ops/safe/batch_helpers.go
@@ -141,9 +141,8 @@ func createContractInput(input abi.Argument, inputs []ContractInput) ([]Contract
 		return nil, err
 	}
 
-	// TODO: could probably do better than string comparison?
 	internalType := input.Type.String()
-	if inputType == "tuple" {
+	if input.Type.T == abi.TupleTy {
 		internalType = input.Type.TupleRawName
 	}
 


### PR DESCRIPTION
**Description**

As suggested in https://github.com/ethereum-optimism/optimism/pull/7055#discussion_r1309513283 tuple types can be detected by comparing the `Type.T` value rather than having to do a string comparison.


