### PR TITLE
Update-contracts-ts-README.md

### DIFF
--- a/packages/contracts-ts/README.md
+++ b/packages/contracts-ts/README.md
@@ -15,11 +15,11 @@ The main entrypoint exports constants related to contracts bedrock as const. As 
 
 ```typescript
 import {
-  l2OutputOracleProxyABI,
-  l2OutputOracleAddresses,
+  l2OutputOracleABI,
+  l2OutputOracleAddress,
 } from '@eth-optimism/contracts-ts'
 
-console.log(l2OutputOracleAddresses[10], abi)
+console.log(l2OutputOracleAddress[1], l2OutputOracleABI)
 ```
 
 Addresses are also exported as an object for convenience.
@@ -27,7 +27,7 @@ Addresses are also exported as an object for convenience.
 ```typescript
 import { addresses } from '@eth-optimism/contracts-ts'
 
-console.log(addresses.l2OutputOracle[10])
+console.log(addresses.L2OutputOracle[1])
 ```
 
 #### @eth-optimism/contracts-ts/react
@@ -35,10 +35,10 @@ console.log(addresses.l2OutputOracle[10])
 - All [React hooks](https://wagmi.sh/cli/plugins/react) `@eth-optimism/contracts-ts/react`
 
 ```typescript
-import { useAddressManagerAddress } from '@eth-optimism/contracts-ts/react'
+import { useAddressManagerGetAddress } from '@eth-optimism/contracts-ts/react'
 
 const component = () => {
-  const { data, error, loading } = useAddressManagerAddress()
+  const { data, error, loading } = useAddressManagerGetAddress()
   if (loading) {
     return <div>Loading</div>
   }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The examples mentioned in the readme seem to have writing errors.

**Tests**
E:\react>node hello.js
file:///E:/react/hello.js:3
  l2OutputOracleAddresses,
  ^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: The requested module '@eth-optimism/contracts-ts' does not provide an export named 'l2OutputOracleAddresses'

E:\react>node hello.js
file:///E:/react/hello.js:3
console.log(addresses.l2OutputOracle[10])
                                    ^
TypeError: Cannot read properties of undefined (reading '10')

error app\account\page.tsx (5:59) @ useAddressManagerAddress
error TypeError: (0 , eth_optimism_contracts_ts_react__WEBPACK_IMPORTED_MODULE_1__.useAddressManagerAddress) is not a function
    at AccountPage (./app/account/page.tsx:11:128)

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
