### PR TITLE
ci: Add additional CI tasks that weren't previously required as bedrock-go-tests dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1224,7 +1224,11 @@ workflows:
           target: test-external-geth
       - bedrock-go-tests:
           requires:
+            - go-mod-tidy
+            - cannon-build-test-vectors
             - cannon-go-lint-and-test
+            - check-generated-mocks-op-node
+            - check-generated-mocks-op-service
             - op-batcher-lint
             - op-bootnode-lint
             - op-bindings-lint
@@ -1238,6 +1242,7 @@ workflows:
             - op-batcher-tests
             - op-bindings-tests
             - op-chain-ops-tests
+            - op-heartbeat-tests
             - op-node-tests
             - op-proposer-tests
             - op-challenger-tests
@@ -1245,6 +1250,7 @@ workflows:
             - op-service-tests
             - op-e2e-WS-tests
             - op-e2e-HTTP-tests
+            - op-e2e-ext-geth-tests
       - docker-build:
           name: op-node-docker-build
           docker_file: op-node/Dockerfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1142,7 +1142,7 @@ workflows:
           working_directory: proxyd
       - indexer-tests
       - go-lint-test-build:
-          name: op-heartbeat tests
+          name: op-heartbeat-tests
           binary_name: op-heartbeat
           working_directory: op-heartbeat
       - semgrep-scan


### PR DESCRIPTION
**Description**

Adds a number of additional CI jobs to the list of dependencies for `bedrock-go-tests`. `bedrock-go-tests` is marked as required to merge in GitHub config so if any of its dependencies fail, merging is blocked.  Without this these tasks can fail and mergify will still automatically merge the PR, potentially breaking the `develop` branch.