### PR TITLE
:bug: fix: remove git dep from docker build

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -10,8 +10,6 @@ COPY ./op-node /app/op-node
 COPY ./go.mod /app/go.mod
 COPY ./go.sum /app/go.sum
 
-COPY ./.git /app/.git
-
 WORKDIR /app/indexer
 
 RUN go mod download


### PR DESCRIPTION
- Git is unused
- Including it makes some builds like render.com fail
