### PR TITLE
op-program: Recreate preimage data dir if required

### DIFF
--- a/op-program/host/kvstore/disk_test.go
+++ b/op-program/host/kvstore/disk_test.go
@@ -1,9 +1,24 @@
 package kvstore
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
 
 func TestDiskKV(t *testing.T) {
 	tmp := t.TempDir() // automatically removed by testing cleanup
 	kv := NewDiskKV(tmp)
 	kvTest(t, kv)
+}
+
+func TestCreateMissingDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "data")
+	kv := NewDiskKV(dir)
+	val := []byte{1, 2, 3, 4}
+	key := crypto.Keccak256Hash(val)
+	require.NoError(t, kv.Put(key, val))
 }


### PR DESCRIPTION
**Description**

op-program pre-image storage now handles the whole data directory being removed unexpectedly by recreating it when needed.

**Tests**

Added unit tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/15
