### PR TITLE
op-node: Default to no netrestrict instead of allow none

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -156,7 +156,6 @@ var (
 		Name:     "p2p.netrestrict",
 		Usage:    "Comma-separated list of CIDR masks. P2P will only try to connect on these networks",
 		Required: false,
-		Value:    "",
 		EnvVars:  p2pEnv("NETRESTRICT"),
 	}
 	HostMux = &cli.StringFlag{

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -194,12 +194,13 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 		conf.Bootnodes = p2p.DefaultBootnodes
 	}
 
-	netRestrict, err := netutil.ParseNetlist(ctx.String(flags.NetRestrict.Name))
-	if err != nil {
-		return fmt.Errorf("failed to parse net list: %w", err)
+	if ctx.IsSet(flags.NetRestrict.Name) {
+		netRestrict, err := netutil.ParseNetlist(ctx.String(flags.NetRestrict.Name))
+		if err != nil {
+			return fmt.Errorf("failed to parse net list: %w", err)
+		}
+		conf.NetRestrict = netRestrict
 	}
-
-	conf.NetRestrict = netRestrict
 
 	return nil
 }


### PR DESCRIPTION
**Description**

When p2p.netrestrict was not set, the empty string was being used as the list of allowed nodes, thus preventing any peers from connecting.  Now if netrestrict is not set, the `conf.NetRestrict` is left as nil meaning that all peers are allowed.

