### PR TITLE
Dockerfiles: Run go mod download with just the go.mod and go.sum files

### DIFF
--- a/endpoint-monitor/Dockerfile
+++ b/endpoint-monitor/Dockerfile
@@ -2,17 +2,20 @@ FROM golang:1.20.7-alpine3.18 as builder
 
 RUN apk --no-cache add make jq bash git alpine-sdk
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 COPY ./endpoint-monitor /app/endpoint-monitor
 COPY ./op-service /app/op-service
 COPY ./op-node /app/op-node
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 
 COPY ./.git /app/.git
 
 WORKDIR /app/endpoint-monitor
-
-RUN go mod download
 
 RUN make build
 

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -2,17 +2,20 @@ FROM --platform=$BUILDPLATFORM golang:1.20.7-alpine3.18 as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 # build indexer with the shared go.mod & go.sum files
 COPY ./indexer /app/indexer
 COPY ./op-bindings /app/op-bindings
 COPY ./op-service /app/op-service
 COPY ./op-node /app/op-node
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 
 WORKDIR /app/indexer
-
-RUN go mod download
 
 RUN make indexer
 

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -4,20 +4,23 @@ ARG VERSION=v0.0.0
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 # build op-batcher with the shared go.mod & go.sum files
 COPY ./op-batcher /app/op-batcher
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-service /app/op-service
 COPY ./op-signer /app/op-signer
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 
 COPY ./.git /app/.git
 
 WORKDIR /app/op-batcher
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 

--- a/op-challenger/Dockerfile
+++ b/op-challenger/Dockerfile
@@ -4,6 +4,13 @@ ARG VERSION=v0.0.0
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 # build op-challenger with the shared go.mod & go.sum files
 COPY ./op-challenger /app/op-challenger
 COPY ./op-program /app/op-program
@@ -12,8 +19,6 @@ COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-service /app/op-service
 COPY ./op-signer /app/op-signer
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 COPY ./.git /app/.git
 
 # Copy cannon and its dependencies
@@ -22,8 +27,6 @@ COPY ./op-preimage /app/op-preimage
 COPY ./op-chain-ops /app/op-chain-ops
 
 WORKDIR /app/op-program
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -4,18 +4,21 @@ ARG VERSION=v0.0.0
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 # build op-node with the shared go.mod & go.sum files
 COPY ./op-node /app/op-node
 COPY ./op-chain-ops /app/op-chain-ops
 COPY ./op-service /app/op-service
 COPY ./op-bindings /app/op-bindings
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 COPY ./.git /app/.git
 
 WORKDIR /app/op-node
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 

--- a/op-program/Dockerfile
+++ b/op-program/Dockerfile
@@ -4,6 +4,13 @@ ARG VERSION=v0.0.0
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 # build op-program with the shared go.mod & go.sum files
 COPY ./op-program /app/op-program
 COPY ./op-preimage /app/op-preimage
@@ -11,13 +18,9 @@ COPY ./op-node /app/op-node
 COPY ./op-chain-ops /app/op-chain-ops
 COPY ./op-service /app/op-service
 COPY ./op-bindings /app/op-bindings
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 COPY ./.git /app/.git
 
 WORKDIR /app/op-program
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -4,19 +4,22 @@ ARG VERSION=v0.0.0
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
 
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN go mod download
+
 # build op-proposer with the shared go.mod & go.sum files
 COPY ./op-proposer /app/op-proposer
 COPY ./op-bindings /app/op-bindings
 COPY ./op-node /app/op-node
 COPY ./op-service /app/op-service
 COPY ./op-signer /app/op-signer
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
 COPY ./.git /app/.git
 
 WORKDIR /app/op-proposer
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 


### PR DESCRIPTION
**Description**

Avoids the need to re-run mod download when any source file changes and means most dockerfiles can reuse the cached layer with download already done.
