### PR TITLE
codecov: Disable posting comment on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,4 @@
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: true    # only post the comment if coverage changes
+comment: false
 ignore:
   - "op-e2e"
   - "**/*.t.sol"


### PR DESCRIPTION
**Description**

Tell codecov to stop posting a comment on PRs with the change in code coverage.  The number it posts has no relation to reality anyway. The same info is still available by checking the details of the codecov action.