### PR TITLE
op-e2e: Add test for L2 transaction gossip

### DIFF
--- a/op-e2e/e2eutils/geth/peers.go
+++ b/op-e2e/e2eutils/geth/peers.go
@@ -1,0 +1,49 @@
+package geth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/stretchr/testify/require"
+)
+
+// ConnectP2P creates a p2p peer connection between node1 and node2.
+func ConnectP2P(t *testing.T, node1 *ethclient.Client, node2 *ethclient.Client) {
+	var targetInfo p2p.NodeInfo
+	require.NoError(t, node2.Client().Call(&targetInfo, "admin_nodeInfo"), "get node info")
+
+	var peerAdded bool
+	require.NoError(t, node1.Client().Call(&peerAdded, "admin_addPeer", targetInfo.Enode), "add peer")
+	require.True(t, peerAdded, "should have added peer successfully")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := wait.For(ctx, time.Second, func() (bool, error) {
+		var peerCount hexutil.Uint64
+		if err := node1.Client().Call(&peerCount, "net_peerCount"); err != nil {
+			return false, err
+		}
+		t.Logf("Peer count %v", uint64(peerCount))
+		return peerCount >= hexutil.Uint64(1), nil
+	})
+	require.NoError(t, err, "wait for a peer to be connected")
+}
+
+func WithP2P() func(ethCfg *ethconfig.Config, nodeCfg *node.Config) error {
+	return func(ethCfg *ethconfig.Config, nodeCfg *node.Config) error {
+		ethCfg.RollupDisableTxPoolGossip = false
+		nodeCfg.P2P = p2p.Config{
+			NoDiscovery: true,
+			ListenAddr:  "127.0.0.1:0",
+			MaxPeers:    10,
+		}
+		return nil
+	}
+}

--- a/op-e2e/l2_gossip_test.go
+++ b/op-e2e/l2_gossip_test.go
@@ -1,16 +1,10 @@
 package op_e2e
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,15 +12,7 @@ func TestTxGossip(t *testing.T) {
 	InitParallel(t)
 	cfg := DefaultSystemConfig(t)
 	gethOpts := []GethOption{
-		func(ethCfg *ethconfig.Config, nodeCfg *node.Config) error {
-			ethCfg.RollupDisableTxPoolGossip = false
-			nodeCfg.P2P = p2p.Config{
-				NoDiscovery: true,
-				ListenAddr:  "127.0.0.1:0",
-				MaxPeers:    10,
-			}
-			return nil
-		},
+		geth.WithP2P(),
 	}
 	cfg.GethOptions["sequencer"] = gethOpts
 	cfg.GethOptions["verifier"] = gethOpts
@@ -35,26 +21,7 @@ func TestTxGossip(t *testing.T) {
 
 	seqClient := sys.Clients["sequencer"]
 	verifClient := sys.Clients["verifier"]
-	var seqInfo p2p.NodeInfo
-	require.NoError(t, seqClient.Client().Call(&seqInfo, "admin_nodeInfo"), "get sequencer node info")
-	var verifInfo p2p.NodeInfo
-	require.NoError(t, verifClient.Client().Call(&verifInfo, "admin_nodeInfo"), "get verifier node info")
-
-	var peerAdded bool
-	require.NoError(t, verifClient.Client().Call(&peerAdded, "admin_addPeer", seqInfo.Enode), "add peer to verifier")
-	require.True(t, peerAdded, "should have added peer to verifier successfully")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	err = wait.For(ctx, time.Second, func() (bool, error) {
-		var peerCount hexutil.Uint64
-		if err := verifClient.Client().Call(&peerCount, "net_peerCount"); err != nil {
-			return false, err
-		}
-		t.Logf("Peer count %v", uint64(peerCount))
-		return peerCount >= hexutil.Uint64(1), nil
-	})
-	require.NoError(t, err, "wait for a peer to be connected")
+	geth.ConnectP2P(t, seqClient, verifClient)
 
 	// Send a transaction to the verifier and it should be gossiped to the sequencer and included in a block.
 	SendL2Tx(t, cfg, verifClient, cfg.Secrets.Alice, func(opts *TxOpts) {

--- a/op-e2e/l2_gossip_test.go
+++ b/op-e2e/l2_gossip_test.go
@@ -1,0 +1,65 @@
+package op_e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxGossip(t *testing.T) {
+	InitParallel(t)
+	cfg := DefaultSystemConfig(t)
+	gethOpts := []GethOption{
+		func(ethCfg *ethconfig.Config, nodeCfg *node.Config) error {
+			ethCfg.RollupDisableTxPoolGossip = false
+			nodeCfg.P2P = p2p.Config{
+				NoDiscovery: true,
+				ListenAddr:  "127.0.0.1:0",
+				MaxPeers:    10,
+			}
+			return nil
+		},
+	}
+	cfg.GethOptions["sequencer"] = gethOpts
+	cfg.GethOptions["verifier"] = gethOpts
+	sys, err := cfg.Start(t)
+	require.NoError(t, err, "Start system")
+
+	seqClient := sys.Clients["sequencer"]
+	verifClient := sys.Clients["verifier"]
+	var seqInfo p2p.NodeInfo
+	require.NoError(t, seqClient.Client().Call(&seqInfo, "admin_nodeInfo"), "get sequencer node info")
+	var verifInfo p2p.NodeInfo
+	require.NoError(t, verifClient.Client().Call(&verifInfo, "admin_nodeInfo"), "get verifier node info")
+
+	var peerAdded bool
+	require.NoError(t, verifClient.Client().Call(&peerAdded, "admin_addPeer", seqInfo.Enode), "add peer to verifier")
+	require.True(t, peerAdded, "should have added peer to verifier successfully")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err = wait.For(ctx, time.Second, func() (bool, error) {
+		var peerCount hexutil.Uint64
+		if err := verifClient.Client().Call(&peerCount, "net_peerCount"); err != nil {
+			return false, err
+		}
+		t.Logf("Peer count %v", uint64(peerCount))
+		return peerCount >= hexutil.Uint64(1), nil
+	})
+	require.NoError(t, err, "wait for a peer to be connected")
+
+	// Send a transaction to the verifier and it should be gossiped to the sequencer and included in a block.
+	SendL2Tx(t, cfg, verifClient, cfg.Secrets.Alice, func(opts *TxOpts) {
+		opts.ToAddr = &common.Address{0xaa}
+		opts.Value = common.Big1
+		opts.VerifyOnClients(seqClient, verifClient)
+	})
+}

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -457,7 +457,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 			ethClient = gethInst
 		} else {
 			if len(cfg.GethOptions[name]) > 0 {
-				t.Errorf("External L2 nodes do not support configuration through GethOptions")
+				t.Skip("External L2 nodes do not support configuration through GethOptions")
 			}
 			ethClient = (&ExternalRunner{
 				Name:    name,

--- a/op-e2e/tx_helper.go
+++ b/op-e2e/tx_helper.go
@@ -91,16 +91,16 @@ func SendL2Tx(t *testing.T, cfg SystemConfig, l2Client *ethclient.Client, privKe
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	err := l2Client.SendTransaction(ctx, tx)
-	require.Nil(t, err, "Sending L2 tx")
+	require.NoError(t, err, "Sending L2 tx")
 
 	receipt, err := waitForTransaction(tx.Hash(), l2Client, 10*time.Duration(cfg.DeployConfig.L2BlockTime)*time.Second)
-	require.Nil(t, err, "Waiting for L2 tx")
+	require.NoError(t, err, "Waiting for L2 tx")
 	require.Equal(t, opts.ExpectedStatus, receipt.Status, "TX should have expected status")
 
 	for i, client := range opts.VerifyClients {
 		t.Logf("Waiting for tx %v on verification client %d", tx.Hash(), i)
 		receiptVerif, err := waitForTransaction(tx.Hash(), client, 10*time.Duration(cfg.DeployConfig.L2BlockTime)*time.Second)
-		require.Nilf(t, err, "Waiting for L2 tx on verification client %d", i)
+		require.NoErrorf(t, err, "Waiting for L2 tx on verification client %d", i)
 		require.Equalf(t, receipt, receiptVerif, "Receipts should be the same on sequencer and verification client %d", i)
 	}
 	return receipt


### PR DESCRIPTION
**Description**

Adds an e2e test that verifies op-geth instances gossip transactions between each other (when enabled).

**Metadata**

- https://linear.app/optimism/issue/CLI-3593/spike-determine-future-of-hive