### PR TITLE
fix(indexer): bridge processor detecting the right starting height

### DIFF
--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -233,7 +233,7 @@ func (db *blocksDB) LatestEpoch() (*Epoch, error) {
 	// L2 for a faster query. Per the protocol, the L2 block that starts a new epoch
 	// will have a matching timestamp with the L1 origin.
 	query := db.gorm.Table("l1_block_headers").Order("l1_block_headers.timestamp DESC")
-	query = query.Joins("INNER JOIN l2_block_headers ON l1_block_headers.timestamp = l2_block_headers.timestamp")
+	query = query.Joins("INNER JOIN l2_block_headers ON l2_block_headers.timestamp = l1_block_headers.timestamp")
 	query = query.Select("*")
 
 	var epoch Epoch

--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -44,7 +44,7 @@ func NewL1ETL(cfg Config, log log.Logger, db *database.DB, metrics Metricer, cli
 		fromHeader = latestHeader.RLPHeader.Header()
 
 	} else if cfg.StartHeight.BitLen() > 0 {
-		log.Info("no indexed state in storage, starting from supplied L1 height", "height", cfg.StartHeight.String())
+		log.Info("no indexed state starting from supplied L1 height", "height", cfg.StartHeight.String())
 		header, err := client.BlockHeaderByNumber(cfg.StartHeight)
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch starting block header: %w", err)
@@ -53,7 +53,7 @@ func NewL1ETL(cfg Config, log log.Logger, db *database.DB, metrics Metricer, cli
 		fromHeader = header
 
 	} else {
-		log.Info("no indexed state in storage, starting from L1 genesis")
+		log.Info("no indexed state, starting from genesis")
 	}
 
 	// NOTE - The use of un-buffered channel here assumes that downstream consumers


### PR DESCRIPTION
Fixes the a bug where the indexer cannot reboot since the bridge processor does not pickup
the right starting L1/L2 headers to start indexing from.

Utilize the root `l1/l2_transaction_deposits/withdrawals` bridge table, updated only by the bridge processor to
derive the latest block heights on L1/L2 that have been updated by the processor. This yields a
better solution using less LOC
