### PR TITLE
op-e2e: Add call to step that verifies it is reject when matching the original claim

### DIFF
--- a/op-e2e/e2eutils/disputegame/honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/honest_helper.go
@@ -42,3 +42,18 @@ func (h *HonestHelper) Defend(ctx context.Context, claimIdx int64) {
 	h.game.require.NoErrorf(err, "Get correct claim at trace index %v", traceIdx)
 	h.game.Defend(ctx, claimIdx, value)
 }
+
+func (h *HonestHelper) StepFails(ctx context.Context, claimIdx int64, isAttack bool) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	claim := h.game.getClaim(ctx, claimIdx)
+	pos := types.NewPositionFromGIndex(claim.Position.Uint64())
+	traceIdx := pos.TraceIndex(int(h.game.MaxDepth(ctx)))
+	if !isAttack {
+		// If we're defending, then the step will be from the trace to the next one
+		traceIdx += 1
+	}
+	prestate, proofData, _, err := h.correctTrace.GetStepData(ctx, traceIdx)
+	h.require.NoError(err, "Get step data")
+	h.game.StepFails(claimIdx, isAttack, prestate, proofData)
+}

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -360,7 +360,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 	InitParallel(t)
 
 	ctx := context.Background()
-	sys, l1Client, game, correctTrace := setupDisputeGameForInvalidOutputRoot(t, common.Hash{0xab})
+	sys, l1Client, game, correctTrace := setupDisputeGameForInvalidOutputRoot(t, common.Hash{0x01, 0xab})
 	t.Cleanup(sys.Close)
 
 	maxDepth := game.MaxDepth(ctx)
@@ -385,7 +385,9 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 	game.WaitForClaimAtMaxDepth(ctx, false)
 
 	// It's on us to call step if we want to win but shouldn't be possible
-	// Need to add support for this to the helper
+	correctTrace.StepFails(ctx, maxDepth, true)
+	// Defending should fail too
+	correctTrace.StepFails(ctx, maxDepth, false)
 
 	// Time travel past when the game will be resolvable.
 	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))


### PR DESCRIPTION
**Description**

Proves that you can't counter a valid claim by using the valid trace (because the step agrees with the claim you're trying to counter). 

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/21
