### PR TITLE
op-e2e: Un-skip TestCannonChallengeWithCorrectRoot

### DIFF
--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/deployer"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -174,6 +175,9 @@ func (h *FactoryHelper) StartCannonGameWithCorrectRoot(ctx context.Context, roll
 	provider := cannon.NewTraceProviderFromInputs(testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"), metrics.NoopMetrics, cfg, inputs, cfg.Datadir)
 	rootClaim, err := provider.Get(ctx, math.MaxUint64)
 	h.require.NoError(err, "Compute correct root hash")
+	// Override the VM status to claim the root is invalid
+	// Otherwise creating the game will fail
+	rootClaim[0] = mipsevm.VMStatusInvalid
 
 	game := h.createCannonGame(ctx, l2BlockNumber, l1Head, rootClaim)
 	honestHelper := &HonestHelper{

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -434,7 +434,6 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 }
 
 func TestCannonChallengeWithCorrectRoot(t *testing.T) {
-	t.Skip("Not currently handling this case as the correct approach will change when output root bisection is added")
 	InitParallel(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Description**

With the VM status change, `TestCannonChallengeWithCorrectRoot` now passes so long as the helper is updated to change the vm status in the root claim to incorrectly claim the root is invalid.  The root claim is then correctly challenged by the honest actor.

Also improves the error messages in a couple of cases when tests fail so they include the current game state.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/16
