### PR TITLE
fix(op-bindings): Add `forge clean` to make's `compile` directive

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -12,6 +12,7 @@ version:
 
 compile:
 	cd $(contracts-dir) && \
+		forge clean && \
 		pnpm build
 
 bindings: compile bindings-build


### PR DESCRIPTION
## Overview

Adds `forge clean` as a step in `op-binding`'s `compile` make directive. This is required in order to generate
a correct source map for the `MIPS` + `PreimageOracle` contracts.

### Rationale

Sometimes when there is a partial compilation, artifacts will not reflect the same source map that CI will generate.
In order to make this deterministic, both CI and local binding generation must be done with the same inputs to
the compilation pipeline with no partial compilation allowed.
