### PR TITLE
op-challenger: Updated for the revised resolution

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/solver"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -18,6 +19,8 @@ import (
 type Responder interface {
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	Resolve(ctx context.Context) error
+	CallResolveClaim(ctx context.Context, claimIdx int64) error
+	ResolveClaim(ctx context.Context, claimIdx int64) error
 	PerformAction(ctx context.Context, action types.Action) error
 }
 
@@ -112,6 +115,10 @@ func (a *Agent) shouldResolve(status gameTypes.GameStatus) bool {
 // tryResolve resolves the game if it is in a winning state
 // Returns true if the game is resolvable (regardless of whether it was actually resolved)
 func (a *Agent) tryResolve(ctx context.Context) bool {
+	if err := a.resolveClaims(ctx); err != nil {
+		a.log.Error("Failed to resolve claims", "err", err)
+		return false
+	}
 	status, err := a.responder.CallResolve(ctx)
 	if err != nil || status == gameTypes.GameStatusInProgress {
 		return false
@@ -124,6 +131,41 @@ func (a *Agent) tryResolve(ctx context.Context) bool {
 		a.log.Error("Failed to resolve the game", "err", err)
 	}
 	return true
+}
+
+func (a *Agent) resolveClaims(ctx context.Context) error {
+	claims, err := a.loader.FetchClaims(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch claims: %w", err)
+	}
+	if len(claims) == 0 {
+		return nil
+	}
+
+	var resolvableClaims []int64
+	for _, claim := range claims {
+		a.log.Debug("checking if claim is resolvable", "claimIdx", claim.ContractIndex)
+		if err := a.responder.CallResolveClaim(ctx, int64(claim.ContractIndex)); err == nil {
+			a.log.Info("Resolving claim", "claimIdx", claim.ContractIndex)
+			resolvableClaims = append(resolvableClaims, int64(claim.ContractIndex))
+		}
+	}
+	a.log.Info("Resolving claims", "numClaims", len(resolvableClaims))
+
+	var wg sync.WaitGroup
+	wg.Add(len(resolvableClaims))
+	for _, claimIdx := range resolvableClaims {
+		claimIdx := claimIdx
+		go func() {
+			defer wg.Done()
+			err := a.responder.ResolveClaim(ctx, claimIdx)
+			if err != nil {
+				a.log.Error("Failed to resolve claim", "err", err)
+			}
+		}()
+	}
+	wg.Wait()
+	return nil
 }
 
 // newGameFromContracts initializes a new game state from the state in the contract

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -177,12 +177,12 @@ func (a *Agent) resolveClaims(ctx context.Context) error {
 	for {
 		err := a.tryResolveClaims(ctx)
 		switch err {
-		case err:
-			return err
 		case errNoResolvableClaims:
 			return nil
-		default:
+		case nil:
 			continue
+		default:
+			return err
 		}
 	}
 }

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -141,7 +141,7 @@ func (a *Agent) tryResolveClaims(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch claims: %w", err)
 	}
 	if len(claims) == 0 {
-		return nil
+		return errNoResolvableClaims
 	}
 
 	var resolvableClaims []int64

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -19,8 +19,8 @@ import (
 type Responder interface {
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	Resolve(ctx context.Context) error
-	CallResolveClaim(ctx context.Context, claimIdx int64) error
-	ResolveClaim(ctx context.Context, claimIdx int64) error
+	CallResolveClaim(ctx context.Context, claimIdx uint64) error
+	ResolveClaim(ctx context.Context, claimIdx uint64) error
 	PerformAction(ctx context.Context, action types.Action) error
 }
 
@@ -145,7 +145,7 @@ func (a *Agent) resolveClaims(ctx context.Context) error {
 	var resolvableClaims []int64
 	for _, claim := range claims {
 		a.log.Debug("checking if claim is resolvable", "claimIdx", claim.ContractIndex)
-		if err := a.responder.CallResolveClaim(ctx, int64(claim.ContractIndex)); err == nil {
+		if err := a.responder.CallResolveClaim(ctx, uint64(claim.ContractIndex)); err == nil {
 			a.log.Info("Resolving claim", "claimIdx", claim.ContractIndex)
 			resolvableClaims = append(resolvableClaims, int64(claim.ContractIndex))
 		}
@@ -158,7 +158,7 @@ func (a *Agent) resolveClaims(ctx context.Context) error {
 		claimIdx := claimIdx
 		go func() {
 			defer wg.Done()
-			err := a.responder.ResolveClaim(ctx, claimIdx)
+			err := a.responder.ResolveClaim(ctx, uint64(claimIdx))
 			if err != nil {
 				a.log.Error("Failed to resolve claim", "err", err)
 			}

--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -77,7 +77,7 @@ func TestDoNotMakeMovesWhenGameIsResolvable(t *testing.T) {
 			require.NoError(t, agent.Act(ctx))
 
 			require.Equal(t, 1, responder.callResolveCount, "should check if game is resolvable")
-			require.Zero(t, claimLoader.callCount, "should not fetch claims for resolvable game")
+			require.Equal(t, 1, claimLoader.callCount, "should fetch claims once for resolveClaim")
 
 			if test.shouldResolve {
 				require.EqualValues(t, 1, responder.resolveCount, "should resolve winning game")
@@ -92,6 +92,7 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 	// Checks that if the game isn't resolvable, that the agent continues on to start checking claims
 	agent, claimLoader, responder := setupTestAgent(t, false)
 	responder.callResolveErr = errors.New("game is not resolvable")
+	responder.callResolveClaimErr = errors.New("claim is not resolvable")
 	depth := 4
 	claimBuilder := test.NewClaimBuilder(t, depth, alphabet.NewTraceProvider("abcdefg", uint64(depth)))
 
@@ -101,7 +102,9 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 
 	require.NoError(t, agent.Act(context.Background()))
 
-	require.EqualValues(t, 1, claimLoader.callCount, "should load claims for unresolvable game")
+	require.EqualValues(t, 2, claimLoader.callCount, "should load claims for unresolvable game")
+	require.EqualValues(t, responder.callResolveClaimCount, 1, "should check if claim is resolvable")
+	require.Zero(t, responder.resolveClaimCount, "should not send resolveClaim")
 }
 
 func setupTestAgent(t *testing.T, agreeWithProposedOutput bool) (*Agent, *stubClaimLoader, *stubResponder) {
@@ -132,6 +135,10 @@ type stubResponder struct {
 
 	resolveCount int
 	resolveErr   error
+
+	callResolveClaimCount int
+	callResolveClaimErr   error
+	resolveClaimCount     int
 }
 
 func (s *stubResponder) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
@@ -144,8 +151,18 @@ func (s *stubResponder) Resolve(ctx context.Context) error {
 	return s.resolveErr
 }
 
+func (s *stubResponder) CallResolveClaim(ctx context.Context, clainIdx int64) error {
+	s.callResolveClaimCount++
+	return s.callResolveClaimErr
+}
+
+func (s *stubResponder) ResolveClaim(ctx context.Context, clainIdx int64) error {
+	s.resolveClaimCount++
+	return nil
+}
+
 func (s *stubResponder) PerformAction(ctx context.Context, response types.Action) error {
-	panic("Not implemented")
+	return nil
 }
 
 type stubUpdater struct {

--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -151,12 +151,12 @@ func (s *stubResponder) Resolve(ctx context.Context) error {
 	return s.resolveErr
 }
 
-func (s *stubResponder) CallResolveClaim(ctx context.Context, clainIdx int64) error {
+func (s *stubResponder) CallResolveClaim(ctx context.Context, clainIdx uint64) error {
 	s.callResolveClaimCount++
 	return s.callResolveClaimErr
 }
 
-func (s *stubResponder) ResolveClaim(ctx context.Context, clainIdx int64) error {
+func (s *stubResponder) ResolveClaim(ctx context.Context, clainIdx uint64) error {
 	s.resolveClaimCount++
 	return nil
 }

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -95,13 +95,13 @@ func (r *FaultResponder) Resolve(ctx context.Context) error {
 }
 
 // buildResolveClaimData creates the transaction data for the ResolveClaim function.
-func (r *FaultResponder) buildResolveClaimData(ctx context.Context, claimIdx int64) ([]byte, error) {
+func (r *FaultResponder) buildResolveClaimData(ctx context.Context, claimIdx uint64) ([]byte, error) {
 	return r.fdgAbi.Pack("resolveClaim", big.NewInt(int64(claimIdx)))
 }
 
 // CallResolveClaim determines if the resolveClaim function on the fault dispute game contract
 // would succeed.
-func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx int64) error {
+func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
 	txData, err := r.buildResolveClaimData(ctx, claimIdx)
 	if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx int64) e
 }
 
 // ResolveClaim executes a resolveClaim transaction to resolve a fault dispute game.
-func (r *FaultResponder) ResolveClaim(ctx context.Context, claimIdx int64) error {
+func (r *FaultResponder) ResolveClaim(ctx context.Context, claimIdx uint64) error {
 	txData, err := r.buildResolveClaimData(ctx, claimIdx)
 	if err != nil {
 		return err

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -94,6 +94,34 @@ func (r *FaultResponder) Resolve(ctx context.Context) error {
 	return r.sendTxAndWait(ctx, txData)
 }
 
+// buildResolveClaimData creates the transaction data for the ResolveClaim function.
+func (r *FaultResponder) buildResolveClaimData(ctx context.Context, claimIdx int64) ([]byte, error) {
+	return r.fdgAbi.Pack("resolveClaim", big.NewInt(int64(claimIdx)))
+}
+
+// CallResolveClaim determines if the resolveClaim function on the fault dispute game contract
+// would succeed.
+func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx int64) error {
+	txData, err := r.buildResolveClaimData(ctx, claimIdx)
+	if err != nil {
+		return err
+	}
+	_, err = r.txMgr.Call(ctx, ethereum.CallMsg{
+		To:   &r.fdgAddr,
+		Data: txData,
+	}, nil)
+	return err
+}
+
+// ResolveClaim executes a resolveClaim transaction to resolve a fault dispute game.
+func (r *FaultResponder) ResolveClaim(ctx context.Context, claimIdx int64) error {
+	txData, err := r.buildResolveClaimData(ctx, claimIdx)
+	if err != nil {
+		return err
+	}
+	return r.sendTxAndWait(ctx, txData)
+}
+
 func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action) error {
 	var txData []byte
 	var err error

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -73,6 +73,40 @@ func TestResolve(t *testing.T) {
 	})
 }
 
+func TestCallResolveClaim(t *testing.T) {
+	t.Run("SendFails", func(t *testing.T) {
+		responder, mockTxMgr := newTestFaultResponder(t)
+		mockTxMgr.callFails = true
+		err := responder.CallResolveClaim(context.Background(), 0)
+		require.ErrorIs(t, err, mockCallError)
+		require.Equal(t, 0, mockTxMgr.calls)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		responder, mockTxMgr := newTestFaultResponder(t)
+		err := responder.CallResolveClaim(context.Background(), 0)
+		require.NoError(t, err)
+		require.Equal(t, 1, mockTxMgr.calls)
+	})
+}
+
+func TestResolveClaim(t *testing.T) {
+	t.Run("SendFails", func(t *testing.T) {
+		responder, mockTxMgr := newTestFaultResponder(t)
+		mockTxMgr.sendFails = true
+		err := responder.ResolveClaim(context.Background(), 0)
+		require.ErrorIs(t, err, mockSendError)
+		require.Equal(t, 0, mockTxMgr.sends)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		responder, mockTxMgr := newTestFaultResponder(t)
+		err := responder.ResolveClaim(context.Background(), 0)
+		require.NoError(t, err)
+		require.Equal(t, 1, mockTxMgr.sends)
+	})
+}
+
 // TestRespond tests the [Responder.Respond] method.
 func TestPerformAction(t *testing.T) {
 	t.Run("send fails", func(t *testing.T) {

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -48,7 +48,6 @@ func TestCalculateNextActions(t *testing.T) {
 			rootClaimCorrect:    true,
 			setupGame:           func(builder *faulttest.GameBuilder) {},
 		},
-
 		{
 			name:                "DoNotPerformDuplicateMoves",
 			agreeWithOutputRoot: true,
@@ -93,16 +92,15 @@ func TestCalculateNextActions(t *testing.T) {
 				maliciousStateHash := common.Hash{0x01, 0xaa}
 
 				// Dishonest actor counters their own claims to set up a situation with an invalid prestate
-				// The honest actor should attack all claims that support the root claim (disagree with the output root)
-				builder.Seq().ExpectAttack(). // This expected action is the winning move.
-								Attack(maliciousStateHash).
-								Defend(maliciousStateHash).ExpectAttack().
-								Attack(maliciousStateHash).
-								Attack(maliciousStateHash).ExpectStepAttack()
-
-				// The attempt to step against our malicious leaf node will fail because the pre-state won't match our
-				// malicious state hash. However, it is the very first expected action, attacking the root claim with
-				// the correct hash that wins the game since it will be the left-most uncountered claim.
+				// The honest actor should ignore path created by the dishonest actor, only supporting its own attack on the root claim
+				honestMove := builder.Seq().AttackCorrect() // This expected action is the winning move.
+				dishonestMove := honestMove.Attack(maliciousStateHash)
+				// The expected action by the honest actor
+				dishonestMove.ExpectAttack()
+				// The honest actor will ignore this poisoned path
+				dishonestMove.
+					Defend(maliciousStateHash).
+					Attack(maliciousStateHash)
 			},
 		},
 	}

--- a/op-challenger/game/fault/solver/rules.go
+++ b/op-challenger/game/fault/solver/rules.go
@@ -13,7 +13,6 @@ var rules = []actionRule{
 	parentMustExist,
 	onlyStepAtMaxDepth,
 	onlyMoveBeforeMaxDepth,
-	onlyCounterClaimsAtDisagreeingLevels,
 	doNotDuplicateExistingMoves,
 	doNotDefendRootClaim,
 }
@@ -57,20 +56,12 @@ func onlyMoveBeforeMaxDepth(game types.Game, action types.Action) error {
 	return nil
 }
 
-func onlyCounterClaimsAtDisagreeingLevels(game types.Game, action types.Action) error {
-	parentClaim := game.Claims()[action.ParentIdx]
-	if game.AgreeWithClaimLevel(parentClaim) {
-		return fmt.Errorf("countering a claim at depth %v that supports our view of the root", parentClaim.Position.Depth())
-	}
-	return nil
-}
-
 func doNotDuplicateExistingMoves(game types.Game, action types.Action) error {
 	newClaimData := types.ClaimData{
 		Value:    action.Value,
 		Position: resultingPosition(game, action),
 	}
-	if game.IsDuplicate(newClaimData) {
+	if game.IsDuplicate(types.Claim{ClaimData: newClaimData, ParentContractIndex: action.ParentIdx}) {
 		return fmt.Errorf("creating duplicate claim at %v with value %v", newClaimData.Position.ToGIndex(), newClaimData.Value)
 	}
 	return nil

--- a/op-challenger/game/fault/solver/solver.go
+++ b/op-challenger/game/fault/solver/solver.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	ErrStepNonLeafNode = errors.New("cannot step on non-leaf claims")
-	ErrStepAgreedClaim = errors.New("cannot step on claims we agree with")
+	ErrStepNonLeafNode       = errors.New("cannot step on non-leaf claims")
+	ErrStepAgreedClaim       = errors.New("cannot step on claims we agree with")
+	ErrStepIgnoreInvalidPath = errors.New("cannot step on claims that dispute invalid paths")
 )
 
 // claimSolver uses a [TraceProvider] to determine the moves to make in a dispute game.
@@ -30,10 +31,7 @@ func newClaimSolver(gameDepth int, traceProvider types.TraceProvider) *claimSolv
 }
 
 // NextMove returns the next move to make given the current state of the game.
-func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, agreeWithClaimLevel bool) (*types.Claim, error) {
-	if agreeWithClaimLevel {
-		return nil, nil
-	}
+func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, game types.Game) (*types.Claim, error) {
 	if claim.Depth() == s.gameDepth {
 		return nil, types.ErrGameDepthReached
 	}
@@ -41,6 +39,24 @@ func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, agreeWith
 	if err != nil {
 		return nil, err
 	}
+
+	// Before challenging this claim, first check that the move wasn't warranted.
+	// If the parent claim is on a dishonest path, then we would have moved against it anyways. So we don't move.
+	// Avoiding dishonest paths ensures that there's always a valid claim available to support ours during step.
+	if !claim.IsRoot() {
+		parent, err := game.GetParent(claim)
+		if err != nil {
+			return nil, err
+		}
+		agreeWithParent, err := s.agreeWithClaimPath(ctx, game, parent)
+		if err != nil {
+			return nil, err
+		}
+		if !agreeWithParent {
+			return nil, nil
+		}
+	}
+
 	if agree {
 		return s.defend(ctx, claim)
 	} else {
@@ -58,13 +74,25 @@ type StepData struct {
 
 // AttemptStep determines what step should occur for a given leaf claim.
 // An error will be returned if the claim is not at the max depth.
-func (s *claimSolver) AttemptStep(ctx context.Context, claim types.Claim, agreeWithClaimLevel bool) (StepData, error) {
+// Returns ErrStepIgnoreInvalidPath if the claim disputes an invalid path
+func (s *claimSolver) AttemptStep(ctx context.Context, game types.Game, claim types.Claim) (StepData, error) {
 	if claim.Depth() != s.gameDepth {
 		return StepData{}, ErrStepNonLeafNode
 	}
-	if agreeWithClaimLevel {
-		return StepData{}, ErrStepAgreedClaim
+
+	// Step only on claims that dispute a valid path
+	parent, err := game.GetParent(claim)
+	if err != nil {
+		return StepData{}, err
 	}
+	parentValid, err := s.agreeWithClaimPath(ctx, game, parent)
+	if err != nil {
+		return StepData{}, err
+	}
+	if !parentValid {
+		return StepData{}, ErrStepIgnoreInvalidPath
+	}
+
 	claimCorrect, err := s.agreeWithClaim(ctx, claim.ClaimData)
 	if err != nil {
 		return StepData{}, err
@@ -141,4 +169,27 @@ func (s *claimSolver) traceAtPosition(ctx context.Context, p types.Position) (co
 	index := p.TraceIndex(s.gameDepth)
 	hash, err := s.trace.Get(ctx, index)
 	return hash, err
+}
+
+// agreeWithClaimPath returns true if the every other claim in the path to root is correct according to the internal [TraceProvider].
+func (s *claimSolver) agreeWithClaimPath(ctx context.Context, game types.Game, claim types.Claim) (bool, error) {
+	agree, err := s.agreeWithClaim(ctx, claim.ClaimData)
+	if err != nil {
+		return false, err
+	}
+	if !agree {
+		return false, nil
+	}
+	if claim.IsRoot() || claim.Parent.IsRootPosition() {
+		return true, nil
+	}
+	parent, err := game.GetParent(claim)
+	if err != nil {
+		return false, err
+	}
+	grandParent, err := game.GetParent(parent)
+	if err != nil {
+		return false, err
+	}
+	return s.agreeWithClaimPath(ctx, game, grandParent)
 }

--- a/op-challenger/game/fault/solver/solver_test.go
+++ b/op-challenger/game/fault/solver/solver_test.go
@@ -2,206 +2,171 @@ package solver
 
 import (
 	"context"
-	"errors"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
+	faulttest "github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNextMove(t *testing.T) {
-	maxDepth := 4
-	builder := test.NewAlphabetClaimBuilder(t, maxDepth)
-	tests := []struct {
-		name           string
-		claim          types.Claim
-		agreeWithLevel bool
-		expectedErr    error
-		expectedMove   func(claim types.Claim, correct bool) types.Claim
-	}{
-		{
-			name:           "AgreeWithLevel_CorrectRoot",
-			claim:          builder.CreateRootClaim(true),
-			agreeWithLevel: true,
-		},
-		{
-			name:           "AgreeWithLevel_IncorrectRoot",
-			claim:          builder.CreateRootClaim(false),
-			agreeWithLevel: true,
-		},
-		{
-			name:           "AgreeWithLevel_EvenDepth",
-			claim:          builder.Seq(false).Attack(false).Get(),
-			agreeWithLevel: true,
-		},
-		{
-			name:           "AgreeWithLevel_OddDepth",
-			claim:          builder.Seq(false).Attack(false).Defend(false).Get(),
-			agreeWithLevel: true,
-		},
-		{
-			name:  "Root_CorrectValue",
-			claim: builder.CreateRootClaim(true),
-		},
-		{
-			name:         "Root_IncorrectValue",
-			claim:        builder.CreateRootClaim(false),
-			expectedMove: builder.AttackClaim,
-		},
-		{
-			name:         "NonRoot_AgreeWithParentAndClaim",
-			claim:        builder.Seq(true).Attack(true).Get(),
-			expectedMove: builder.DefendClaim,
-		},
-		{
-			name:         "NonRoot_AgreeWithParentDisagreeWithClaim",
-			claim:        builder.Seq(true).Attack(false).Get(),
-			expectedMove: builder.AttackClaim,
-		},
-		{
-			name:         "NonRoot_DisagreeWithParentAgreeWithClaim",
-			claim:        builder.Seq(false).Attack(true).Get(),
-			expectedMove: builder.DefendClaim,
-		},
-		{
-			name:         "NonRoot_DisagreeWithParentAndClaim",
-			claim:        builder.Seq(false).Attack(false).Get(),
-			expectedMove: builder.AttackClaim,
-		},
-		{
-			name:        "ErrorWhenClaimIsLeaf_Correct",
-			claim:       builder.CreateLeafClaim(4, true),
-			expectedErr: types.ErrGameDepthReached,
-		},
-		{
-			name:        "ErrorWhenClaimIsLeaf_Incorrect",
-			claim:       builder.CreateLeafClaim(6, false),
-			expectedErr: types.ErrGameDepthReached,
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			solver := newClaimSolver(maxDepth, builder.CorrectTraceProvider())
-			move, err := solver.NextMove(context.Background(), test.claim, test.agreeWithLevel)
-			if test.expectedErr == nil {
-				require.NoError(t, err)
-			} else {
-				require.ErrorIs(t, err, test.expectedErr)
-			}
-			if test.expectedMove == nil {
-				require.Nil(t, move)
-			} else {
-				expected := test.expectedMove(test.claim, true)
-				require.Equal(t, &expected, move)
-			}
-		})
-	}
-}
-
 func TestAttemptStep(t *testing.T) {
 	maxDepth := 3
-	builder := test.NewAlphabetClaimBuilder(t, maxDepth)
+	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, maxDepth)
 
 	// Last accessible leaf is the second last trace index
 	// The root node is used for the last trace index and can only be attacked.
 	lastLeafTraceIndex := uint64(1<<maxDepth - 2)
-
-	errProvider := errors.New("provider error")
-
 	ctx := context.Background()
 
 	tests := []struct {
-		name               string
-		claim              types.Claim
-		agreeWithLevel     bool
-		expectedErr        error
-		expectAttack       bool
-		expectPreState     []byte
-		expectProofData    []byte
-		expectedOracleData *types.PreimageOracleData
+		name                string
+		agreeWithOutputRoot bool
+		expectedErr         error
+		expectAttack        bool
+		expectPreState      []byte
+		expectProofData     []byte
+		expectedOracleData  *types.PreimageOracleData
+		setupGame           func(builder *faulttest.GameBuilder)
 	}{
 		{
 			name:               "AttackFirstTraceIndex",
-			claim:              builder.CreateLeafClaim(0, false),
 			expectAttack:       true,
-			expectPreState:     builder.CorrectPreState(0),
-			expectProofData:    builder.CorrectProofData(0),
-			expectedOracleData: builder.CorrectOracleData(0),
+			expectPreState:     claimBuilder.CorrectPreState(0),
+			expectProofData:    claimBuilder.CorrectProofData(0),
+			expectedOracleData: claimBuilder.CorrectOracleData(0),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					Attack(common.Hash{0xaa}).
+					AttackCorrect().
+					Attack(common.Hash{0xbb})
+			},
 		},
 		{
 			name:               "DefendFirstTraceIndex",
-			claim:              builder.CreateLeafClaim(0, true),
 			expectAttack:       false,
-			expectPreState:     builder.CorrectPreState(1),
-			expectProofData:    builder.CorrectProofData(1),
-			expectedOracleData: builder.CorrectOracleData(1),
+			expectPreState:     claimBuilder.CorrectPreState(1),
+			expectProofData:    claimBuilder.CorrectProofData(1),
+			expectedOracleData: claimBuilder.CorrectOracleData(1),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					Attack(common.Hash{0xaa}).
+					AttackCorrect().
+					AttackCorrect()
+			},
 		},
 		{
 			name:               "AttackMiddleTraceIndex",
-			claim:              builder.CreateLeafClaim(4, false),
 			expectAttack:       true,
-			expectPreState:     builder.CorrectPreState(4),
-			expectProofData:    builder.CorrectProofData(4),
-			expectedOracleData: builder.CorrectOracleData(4),
+			expectPreState:     claimBuilder.CorrectPreState(4),
+			expectProofData:    claimBuilder.CorrectProofData(4),
+			expectedOracleData: claimBuilder.CorrectOracleData(4),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().
+					DefendCorrect().
+					Attack(common.Hash{0xaa})
+			},
 		},
 		{
 			name:               "DefendMiddleTraceIndex",
-			claim:              builder.CreateLeafClaim(4, true),
 			expectAttack:       false,
-			expectPreState:     builder.CorrectPreState(5),
-			expectProofData:    builder.CorrectProofData(5),
-			expectedOracleData: builder.CorrectOracleData(5),
+			expectPreState:     claimBuilder.CorrectPreState(5),
+			expectProofData:    claimBuilder.CorrectProofData(5),
+			expectedOracleData: claimBuilder.CorrectOracleData(5),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().
+					DefendCorrect().
+					AttackCorrect()
+			},
 		},
 		{
 			name:               "AttackLastTraceIndex",
-			claim:              builder.CreateLeafClaim(lastLeafTraceIndex, false),
 			expectAttack:       true,
-			expectPreState:     builder.CorrectPreState(lastLeafTraceIndex),
-			expectProofData:    builder.CorrectProofData(lastLeafTraceIndex),
-			expectedOracleData: builder.CorrectOracleData(lastLeafTraceIndex),
+			expectPreState:     claimBuilder.CorrectPreState(lastLeafTraceIndex),
+			expectProofData:    claimBuilder.CorrectProofData(lastLeafTraceIndex),
+			expectedOracleData: claimBuilder.CorrectOracleData(lastLeafTraceIndex),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().
+					DefendCorrect().
+					Defend(common.Hash{0xaa})
+			},
 		},
 		{
 			name:               "DefendLastTraceIndex",
-			claim:              builder.CreateLeafClaim(lastLeafTraceIndex, true),
 			expectAttack:       false,
-			expectPreState:     builder.CorrectPreState(lastLeafTraceIndex + 1),
-			expectProofData:    builder.CorrectProofData(lastLeafTraceIndex + 1),
-			expectedOracleData: builder.CorrectOracleData(lastLeafTraceIndex + 1),
+			expectPreState:     claimBuilder.CorrectPreState(lastLeafTraceIndex + 1),
+			expectProofData:    claimBuilder.CorrectProofData(lastLeafTraceIndex + 1),
+			expectedOracleData: claimBuilder.CorrectOracleData(lastLeafTraceIndex + 1),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().
+					DefendCorrect().
+					DefendCorrect()
+			},
 		},
 		{
-			name:        "CannotStepNonLeaf",
-			claim:       builder.Seq(false).Attack(false).Get(),
-			expectedErr: ErrStepNonLeafNode,
+			name: "CannotStepNonLeaf",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().AttackCorrect().AttackCorrect()
+			},
+			expectedErr:         ErrStepNonLeafNode,
+			agreeWithOutputRoot: true,
 		},
 		{
-			name:           "CannotStepAgreedNode",
-			claim:          builder.Seq(false).Attack(false).Get(),
-			agreeWithLevel: true,
-			expectedErr:    ErrStepNonLeafNode,
+			name: "CannotStepAgreedNode",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().
+					Attack(common.Hash{0xaa}).
+					AttackCorrect()
+			},
+			expectedErr:         ErrStepIgnoreInvalidPath,
+			agreeWithOutputRoot: true,
 		},
 		{
-			name:           "CannotStepAgreedNode",
-			claim:          builder.Seq(false).Attack(false).Get(),
-			agreeWithLevel: true,
-			expectedErr:    ErrStepNonLeafNode,
+			name: "CannotStepInvalidPath",
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					Attack(common.Hash{0xaa}).
+					Attack(common.Hash{0xbb}).
+					Attack(common.Hash{0xcc})
+			},
+			expectedErr:         ErrStepIgnoreInvalidPath,
+			agreeWithOutputRoot: true,
+		},
+		{
+			name:               "CannotStepNearlyValidPath",
+			expectAttack:       true,
+			expectPreState:     claimBuilder.CorrectPreState(4),
+			expectProofData:    claimBuilder.CorrectProofData(4),
+			expectedOracleData: claimBuilder.CorrectOracleData(4),
+			setupGame: func(builder *faulttest.GameBuilder) {
+				builder.Seq().
+					AttackCorrect().
+					DefendCorrect().
+					DefendCorrect()
+			},
+			expectedErr:         ErrStepIgnoreInvalidPath,
+			agreeWithOutputRoot: true,
 		},
 	}
 
 	for _, tableTest := range tests {
 		tableTest := tableTest
 		t.Run(tableTest.name, func(t *testing.T) {
-			alphabetProvider := test.NewAlphabetWithProofProvider(t, maxDepth, nil)
-			if errors.Is(tableTest.expectedErr, errProvider) {
-				alphabetProvider = test.NewAlphabetWithProofProvider(t, maxDepth, errProvider)
-			}
-			builder = test.NewClaimBuilder(t, maxDepth, alphabetProvider)
-			alphabetSolver := newClaimSolver(maxDepth, builder.CorrectTraceProvider())
-			step, err := alphabetSolver.AttemptStep(ctx, tableTest.claim, tableTest.agreeWithLevel)
+			builder := claimBuilder.GameBuilder(tableTest.agreeWithOutputRoot, !tableTest.agreeWithOutputRoot)
+			tableTest.setupGame(builder)
+			alphabetSolver := newClaimSolver(maxDepth, claimBuilder.CorrectTraceProvider())
+			game := builder.Game
+			claims := game.Claims()
+			lastClaim := claims[len(claims)-1]
+			step, err := alphabetSolver.AttemptStep(ctx, game, lastClaim)
 			if tableTest.expectedErr == nil {
 				require.NoError(t, err)
-				require.Equal(t, tableTest.claim, step.LeafClaim)
+				require.Equal(t, lastClaim, step.LeafClaim)
 				require.Equal(t, tableTest.expectAttack, step.IsAttack)
 				require.Equal(t, tableTest.expectPreState, step.PreState)
 				require.Equal(t, tableTest.expectProofData, step.ProofData)

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -79,12 +79,13 @@ func (c *ClaimBuilder) claim(idx uint64, correct bool) common.Hash {
 
 func (c *ClaimBuilder) CreateRootClaim(correct bool) types.Claim {
 	value := c.claim((1<<c.maxDepth)-1, correct)
-	return types.Claim{
+	claim := types.Claim{
 		ClaimData: types.ClaimData{
 			Value:    value,
 			Position: types.NewPosition(0, 0),
 		},
 	}
+	return claim
 }
 
 func (c *ClaimBuilder) CreateLeafClaim(traceIndex uint64, correct bool) types.Claim {

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -68,6 +68,12 @@ func WithAlphabet(alphabet string) Option {
 	}
 }
 
+func WithPollInterval(pollInterval time.Duration) Option {
+	return func(c *config.Config) {
+		c.PollInterval = pollInterval
+	}
+}
+
 func WithCannon(
 	t *testing.T,
 	rollupCfg *rollup.Config,
@@ -98,7 +104,7 @@ func WithCannon(
 }
 
 func NewChallenger(t *testing.T, ctx context.Context, l1Endpoint string, name string, options ...Option) *Helper {
-	log := testlog.Logger(t, log.LvlInfo).New("role", name)
+	log := testlog.Logger(t, log.LvlDebug).New("role", name)
 	log.Info("Creating challenger", "l1", l1Endpoint)
 	cfg := NewChallengerConfig(t, l1Endpoint, options...)
 

--- a/op-e2e/e2eutils/disputegame/alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/alphabet_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,4 +33,13 @@ func (g *AlphabetGameHelper) StartChallenger(ctx context.Context, l1Endpoint str
 		_ = c.Close()
 	})
 	return c
+}
+
+func (g *AlphabetGameHelper) CreateHonestActor(ctx context.Context, alphabetTrace string, depth uint64) *HonestHelper {
+	return &HonestHelper{
+		t:            g.t,
+		require:      g.require,
+		game:         &g.FaultGameHelper,
+		correctTrace: alphabet.NewTraceProvider(alphabetTrace, depth),
+	}
 }

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -309,8 +309,6 @@ func (g *FaultGameHelper) WaitForNewClaim(ctx context.Context, checkPoint int64)
 
 func (g *FaultGameHelper) Attack(ctx context.Context, claimIdx int64, claim common.Hash) {
 	tx, err := g.game.Attack(g.opts, big.NewInt(claimIdx), claim)
-	g.LogGameData(ctx)
-	g.t.Logf("Attack. claim: %v. claimIdx: %d", claim, claimIdx)
 	g.require.NoError(err, "Attack transaction did not send")
 	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
 	g.require.NoError(err, "Attack transaction was not OK")

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -2,16 +2,19 @@ package disputegame
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
@@ -130,6 +133,10 @@ func (g *FaultGameHelper) getClaim(ctx context.Context, claimIdx int64) Contract
 	return claimData
 }
 
+func (g *FaultGameHelper) GetClaimUnsafe(ctx context.Context, claimIdx int64) ContractClaim {
+	return g.getClaim(ctx, claimIdx)
+}
+
 func (g *FaultGameHelper) WaitForClaimAtDepth(ctx context.Context, depth int) {
 	g.waitForClaim(
 		ctx,
@@ -169,6 +176,12 @@ func (g *FaultGameHelper) Resolve(ctx context.Context) {
 	g.require.NoError(err)
 }
 
+func (g *FaultGameHelper) Status(ctx context.Context) Status {
+	status, err := g.game.Status(&bind.CallOpts{Context: ctx})
+	g.require.NoError(err)
+	return Status(status)
+}
+
 func (g *FaultGameHelper) WaitForGameStatus(ctx context.Context, expected Status) {
 	g.t.Logf("Waiting for game %v to have status %v", g.addr, expected)
 	timedCtx, cancel := context.WithTimeout(ctx, time.Minute)
@@ -184,6 +197,46 @@ func (g *FaultGameHelper) WaitForGameStatus(ctx context.Context, expected Status
 		return expected == Status(status), nil
 	})
 	g.require.NoErrorf(err, "wait for game status. Game state: \n%v", g.gameData(ctx))
+}
+
+func (g *FaultGameHelper) WaitForInactivity(ctx context.Context, numInactiveBlocks int, untilGameEnds bool) {
+	g.t.Logf("Waiting for game %v to have no activity for %v blocks", g.addr, numInactiveBlocks)
+	headCh := make(chan *gethtypes.Header, 100)
+	headSub, err := g.client.SubscribeNewHead(ctx, headCh)
+	g.require.NoError(err)
+	defer headSub.Unsubscribe()
+
+	var lastActiveBlock uint64
+	for {
+		if untilGameEnds && g.Status(ctx) != StatusInProgress {
+			break
+		}
+		select {
+		case head := <-headCh:
+			if lastActiveBlock == 0 {
+				lastActiveBlock = head.Number.Uint64()
+				continue
+			} else if lastActiveBlock+uint64(numInactiveBlocks) < head.Number.Uint64() {
+				return
+			}
+			block, err := g.client.BlockByNumber(ctx, head.Number)
+			g.require.NoError(err)
+			numActions := 0
+			for _, tx := range block.Transactions() {
+				if tx.To().Hex() == g.addr.Hex() {
+					numActions++
+				}
+			}
+			if numActions != 0 {
+				g.t.Logf("Game %v has %v actions in block %d. Resetting inactivity timeout", g.addr, numActions, block.NumberU64())
+				lastActiveBlock = head.Number.Uint64()
+			}
+		case err := <-headSub.Err():
+			g.require.NoError(err)
+		case <-ctx.Done():
+			g.require.Fail("Context canceled", ctx.Err())
+		}
+	}
 }
 
 // Mover is a function that either attacks or defends the claim at parentClaimIdx
@@ -239,9 +292,27 @@ func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mo
 	attemptStep(maxDepth)
 }
 
+func (g *FaultGameHelper) WaitForNewClaim(ctx context.Context, checkPoint int64) (int64, error) {
+	timedCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	var newClaimLen int64
+	err := wait.For(timedCtx, time.Second, func() (bool, error) {
+		actual, err := g.game.ClaimDataLen(&bind.CallOpts{Context: ctx})
+		if err != nil {
+			return false, err
+		}
+		newClaimLen = actual.Int64()
+		return actual.Cmp(big.NewInt(checkPoint)) > 0, nil
+	})
+	return newClaimLen, err
+}
+
 func (g *FaultGameHelper) Attack(ctx context.Context, claimIdx int64, claim common.Hash) {
 	tx, err := g.game.Attack(g.opts, big.NewInt(claimIdx), claim)
+	g.LogGameData(ctx)
+	g.t.Logf("Attack. claim: %v. claimIdx: %d", claim, claimIdx)
 	g.require.NoError(err, "Attack transaction did not send")
+	g.t.Logf("Attack tx: %x. claim: %v. claimIdx: %d", tx.Hash(), claim, claimIdx)
 	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
 	g.require.NoError(err, "Attack transaction was not OK")
 }
@@ -266,6 +337,33 @@ func (g *FaultGameHelper) StepFails(claimIdx int64, isAttack bool, stateData []b
 	g.require.Equal("0xfb4e40dd", errData.ErrorData(), "Revert reason should be abi encoded ValidStep()")
 }
 
+// ResolveClaim resolves a single subgame
+func (g *FaultGameHelper) ResolveClaim(ctx context.Context, claimIdx int64) {
+	tx, err := g.game.ResolveClaim(g.opts, big.NewInt(claimIdx))
+	g.require.NoError(err, "ResolveClaim transaction did not send")
+	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
+	g.require.NoError(err, "ResolveClaim transaction was not OK")
+}
+
+// ResolveAllClaims resolves all subgames
+// This function does not resolve the game. That's the responsibility of challengers
+func (g *FaultGameHelper) ResolveAllClaims(ctx context.Context) {
+	loader := fault.NewLoader(g.game)
+	claims, err := loader.FetchClaims(ctx)
+	g.require.NoError(err, "Failed to fetch claims")
+	subgames := make(map[int]bool)
+	for i := len(claims) - 1; i > 0; i-- {
+		subgames[claims[i].ParentContractIndex] = true
+		// Subgames containing only one node are implicitly resolved
+		// i.e. uncountered and claims at MAX_DEPTH
+		if !subgames[i] {
+			continue
+		}
+		g.ResolveClaim(ctx, int64(i))
+	}
+	g.ResolveClaim(ctx, 0)
+}
+
 func (g *FaultGameHelper) gameData(ctx context.Context) string {
 	opts := &bind.CallOpts{Context: ctx}
 	maxDepth := int(g.MaxDepth(ctx))
@@ -277,8 +375,8 @@ func (g *FaultGameHelper) gameData(ctx context.Context) string {
 		g.require.NoErrorf(err, "Fetch claim %v", i)
 
 		pos := types.NewPositionFromGIndex(claim.Position.Uint64())
-		info = info + fmt.Sprintf("%v - Position: %v, Depth: %v, IndexAtDepth: %v Trace Index: %v, Value: %v, Countered: %v\n",
-			i, claim.Position.Int64(), pos.Depth(), pos.IndexAtDepth(), pos.TraceIndex(maxDepth), common.Hash(claim.Claim).Hex(), claim.Countered)
+		info = info + fmt.Sprintf("%v - Position: %v, Depth: %v, IndexAtDepth: %v Trace Index: %v, Value: %v, Countered: %v, ParentIndex: %v\n",
+			i, claim.Position.Int64(), pos.Depth(), pos.IndexAtDepth(), pos.TraceIndex(maxDepth), common.Hash(claim.Claim).Hex(), claim.Countered, claim.ParentIndex)
 	}
 	status, err := g.game.Status(opts)
 	g.require.NoError(err, "Load game status")
@@ -287,4 +385,107 @@ func (g *FaultGameHelper) gameData(ctx context.Context) string {
 
 func (g *FaultGameHelper) LogGameData(ctx context.Context) {
 	g.t.Log(g.gameData(ctx))
+}
+
+type dishonestClaim struct {
+	ParentIndex int64
+	IsAttack    bool
+	Valid       bool
+}
+type DishonestHelper struct {
+	*FaultGameHelper
+	*HonestHelper
+	claims   map[dishonestClaim]bool
+	defender bool
+}
+
+func NewDishonestHelper(g *FaultGameHelper, correctTrace *HonestHelper, defender bool) *DishonestHelper {
+	return &DishonestHelper{g, correctTrace, make(map[dishonestClaim]bool), defender}
+}
+
+func (t *DishonestHelper) Attack(ctx context.Context, claimIndex int64) {
+	c := dishonestClaim{claimIndex, true, false}
+	if t.claims[c] {
+		return
+	}
+	t.claims[c] = true
+	t.FaultGameHelper.Attack(ctx, claimIndex, common.Hash{byte(claimIndex)})
+}
+
+func (t *DishonestHelper) Defend(ctx context.Context, claimIndex int64) {
+	c := dishonestClaim{claimIndex, false, false}
+	if t.claims[c] {
+		return
+	}
+	t.claims[c] = true
+	t.FaultGameHelper.Defend(ctx, claimIndex, common.Hash{byte(claimIndex)})
+}
+
+func (t *DishonestHelper) AttackCorrect(ctx context.Context, claimIndex int64) {
+	c := dishonestClaim{claimIndex, true, true}
+	if t.claims[c] {
+		return
+	}
+	t.claims[c] = true
+	t.HonestHelper.Attack(ctx, claimIndex)
+}
+
+func (t *DishonestHelper) DefendCorrect(ctx context.Context, claimIndex int64) {
+	c := dishonestClaim{claimIndex, false, true}
+	if t.claims[c] {
+		return
+	}
+	t.claims[c] = true
+	t.HonestHelper.Defend(ctx, claimIndex)
+}
+
+// ExhaustDishonestClaims makes all possible significant moves (mod honest challenger's) in a game.
+// It is very inefficient and should NOT be used on games with large depths
+func (d *DishonestHelper) ExhaustDishonestClaims(ctx context.Context) {
+	depth := d.MaxDepth(ctx)
+
+	move := func(claimIndex int64, claimData ContractClaim) {
+		// dishonest level, valid attack
+		// dishonest level, invalid attack
+		// dishonest level, valid defense
+		// dishonest level, invalid defense
+		// honest level, invalid attack
+		// honest level, invalid defense
+
+		pos := types.NewPositionFromGIndex(claimData.Position.Uint64())
+		if int64(pos.Depth()) == depth {
+			return
+		}
+
+		d.LogGameData(ctx)
+		d.FaultGameHelper.t.Logf("Dishonest moves against claimIndex %d", claimIndex)
+		agreeWithLevel := d.defender == (pos.Depth()%2 == 0)
+		if !agreeWithLevel {
+			d.AttackCorrect(ctx, claimIndex)
+			if claimIndex != 0 {
+				d.DefendCorrect(ctx, claimIndex)
+			}
+		}
+		d.Attack(ctx, claimIndex)
+		if claimIndex != 0 {
+			d.Defend(ctx, claimIndex)
+		}
+	}
+
+	var numClaimsSeen int64
+	for {
+		newCount, err := d.WaitForNewClaim(ctx, numClaimsSeen)
+		if errors.Is(err, context.DeadlineExceeded) {
+			// we assume that the honest challenger has stopped responding
+			// There's nothing to respond to.
+			break
+		}
+		d.FaultGameHelper.require.NoError(err)
+
+		for i := numClaimsSeen; i < newCount; i++ {
+			claimData := d.getClaim(ctx, numClaimsSeen)
+			move(numClaimsSeen, claimData)
+			numClaimsSeen++
+		}
+	}
 }

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -312,7 +312,6 @@ func (g *FaultGameHelper) Attack(ctx context.Context, claimIdx int64, claim comm
 	g.LogGameData(ctx)
 	g.t.Logf("Attack. claim: %v. claimIdx: %d", claim, claimIdx)
 	g.require.NoError(err, "Attack transaction did not send")
-	g.t.Logf("Attack tx: %x. claim: %v. claimIdx: %d", tx.Hash(), claim, claimIdx)
 	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
 	g.require.NoError(err, "Attack transaction was not OK")
 }


### PR DESCRIPTION
Follow up to #7061 to update op-challenger behavior.

A couple notes:
- The resolver actor is built into the game player actor. This will be useful later when the op-challenger keeps track of its bonded claims. Such that it can avoid resolving subgames it did not participate in. In any case, the op-e2e contains helper functions for claim resolution if we decide to separate resolver actions from the challenger.
- Multiple resolve actors may create the issue highlighted [here](https://github.com/ethereum-optimism/client-pod/issues/61). This will be fixed in a later PR.