### PR TITLE
:wrench: feat: Make indexer preset configurable in default indexer.toml

### DIFF
--- a/indexer/indexer.toml
+++ b/indexer/indexer.toml
@@ -3,7 +3,7 @@
 [chain]
 
 # OP Goerli
-preset = 420
+preset = $INDEXER_CHAIN_PRESET
 
 # L1 Config
 l1-polling-interval = 0


### PR DESCRIPTION
- Make default config have a configurable preset so we can easily deploy mainnet base and goerli
