### PR TITLE
Move entire game playing strategy into solver module

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -17,8 +17,7 @@ import (
 type Responder interface {
 	CallResolve(ctx context.Context) (gameTypes.GameStatus, error)
 	Resolve(ctx context.Context) error
-	Respond(ctx context.Context, response types.Claim) error
-	Step(ctx context.Context, stepData types.StepCallData) error
+	PerformAction(ctx context.Context, action solver.Action) error
 }
 
 type ClaimLoader interface {
@@ -27,7 +26,7 @@ type ClaimLoader interface {
 
 type Agent struct {
 	metrics                 metrics.Metricer
-	solver                  *solver.Solver
+	solver                  *solver.GameSolver
 	loader                  ClaimLoader
 	responder               Responder
 	updater                 types.OracleUpdater
@@ -39,7 +38,7 @@ type Agent struct {
 func NewAgent(m metrics.Metricer, loader ClaimLoader, maxDepth int, trace types.TraceProvider, responder Responder, updater types.OracleUpdater, agreeWithProposedOutput bool, log log.Logger) *Agent {
 	return &Agent{
 		metrics:                 m,
-		solver:                  solver.NewSolver(maxDepth, trace),
+		solver:                  solver.NewGameSolver(maxDepth, trace),
 		loader:                  loader,
 		responder:               responder,
 		updater:                 updater,
@@ -58,16 +57,34 @@ func (a *Agent) Act(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("create game from contracts: %w", err)
 	}
-	// Create counter claims
-	for _, claim := range game.Claims() {
-		if err := a.move(ctx, claim, game); err != nil && !errors.Is(err, types.ErrGameDepthReached) {
-			log.Error("Failed to move", "err", err)
-		}
+
+	// Calculate the actions to take
+	actions, err := a.solver.CalculateNextActions(ctx, game)
+	if err != nil {
+		log.Error("Failed to calculate all required moves", "err", err)
 	}
-	// Step on all leaf claims
-	for _, claim := range game.Claims() {
-		if err := a.step(ctx, claim, game); err != nil {
-			log.Error("Failed to step", "err", err)
+
+	// Perform the actions
+	for _, action := range actions {
+		log := a.log.New("action", action.Type, "is_attack", action.IsAttack, "parent", action.ParentIdx, "value", action.Value)
+
+		if action.OracleData != nil {
+			a.log.Info("Updating oracle data", "oracleKey", action.OracleData.OracleKey, "oracleData", action.OracleData.OracleData)
+			if err := a.updater.UpdateOracle(ctx, action.OracleData); err != nil {
+				return fmt.Errorf("failed to load oracle data: %w", err)
+			}
+		}
+
+		switch action.Type {
+		case solver.ActionTypeMove:
+			a.metrics.RecordGameMove()
+		case solver.ActionTypeStep:
+			a.metrics.RecordGameStep()
+		}
+		log.Info("Performing action")
+		err := a.responder.PerformAction(ctx, action)
+		if err != nil {
+			log.Error("Action failed", "err", err)
 		}
 	}
 	return nil
@@ -117,69 +134,4 @@ func (a *Agent) newGameFromContracts(ctx context.Context) (types.Game, error) {
 		return nil, fmt.Errorf("failed to load claims into the local state: %w", err)
 	}
 	return game, nil
-}
-
-// move determines & executes the next move given a claim
-func (a *Agent) move(ctx context.Context, claim types.Claim, game types.Game) error {
-	nextMove, err := a.solver.NextMove(ctx, claim, game.AgreeWithClaimLevel(claim))
-	if err != nil {
-		return fmt.Errorf("execute next move: %w", err)
-	}
-	if nextMove == nil {
-		a.log.Debug("No next move")
-		return nil
-	}
-	move := *nextMove
-	log := a.log.New("is_defend", move.DefendsParent(), "depth", move.Depth(), "index_at_depth", move.IndexAtDepth(),
-		"value", move.Value, "trace_index", move.TraceIndex(a.maxDepth),
-		"parent_value", claim.Value, "parent_trace_index", claim.TraceIndex(a.maxDepth))
-	if game.IsDuplicate(move) {
-		log.Debug("Skipping duplicate move")
-		return nil
-	}
-	a.metrics.RecordGameMove()
-	log.Info("Performing move")
-	return a.responder.Respond(ctx, move)
-}
-
-// step determines & executes the next step against a leaf claim through the responder
-func (a *Agent) step(ctx context.Context, claim types.Claim, game types.Game) error {
-	if claim.Depth() != a.maxDepth {
-		return nil
-	}
-
-	agreeWithClaimLevel := game.AgreeWithClaimLevel(claim)
-	if agreeWithClaimLevel {
-		a.log.Debug("Agree with leaf claim, skipping step", "claim_depth", claim.Depth(), "maxDepth", a.maxDepth)
-		return nil
-	}
-
-	if claim.Countered {
-		a.log.Debug("Step already executed against claim", "depth", claim.Depth(), "index_at_depth", claim.IndexAtDepth(), "value", claim.Value)
-		return nil
-	}
-
-	a.log.Info("Attempting step", "claim_depth", claim.Depth(), "maxDepth", a.maxDepth)
-	step, err := a.solver.AttemptStep(ctx, claim, agreeWithClaimLevel)
-	if err != nil {
-		return fmt.Errorf("attempt step: %w", err)
-	}
-
-	if step.OracleData != nil {
-		a.log.Info("Updating oracle data", "oracleKey", step.OracleData.OracleKey, "oracleData", step.OracleData.OracleData)
-		if err := a.updater.UpdateOracle(ctx, step.OracleData); err != nil {
-			return fmt.Errorf("failed to load oracle data: %w", err)
-		}
-	}
-
-	a.log.Info("Performing step", "is_attack", step.IsAttack,
-		"depth", step.LeafClaim.Depth(), "index_at_depth", step.LeafClaim.IndexAtDepth(), "value", step.LeafClaim.Value)
-	a.metrics.RecordGameStep()
-	callData := types.StepCallData{
-		ClaimIndex: uint64(step.LeafClaim.ContractIndex),
-		IsAttack:   step.IsAttack,
-		StateData:  step.PreState,
-		Proof:      step.ProofData,
-	}
-	return a.responder.Step(ctx, callData)
 }

--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/solver"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -144,11 +145,7 @@ func (s *stubResponder) Resolve(ctx context.Context) error {
 	return s.resolveErr
 }
 
-func (s *stubResponder) Respond(ctx context.Context, response types.Claim) error {
-	panic("Not implemented")
-}
-
-func (s *stubResponder) Step(ctx context.Context, stepData types.StepCallData) error {
+func (s *stubResponder) PerformAction(ctx context.Context, response solver.Action) error {
 	panic("Not implemented")
 }
 

--- a/op-challenger/game/fault/responder/abi_test.go
+++ b/op-challenger/game/fault/responder/abi_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
@@ -94,12 +93,7 @@ func TestBuildFaultStepData(t *testing.T) {
 
 	resp, _ := newTestFaultResponder(t)
 
-	data, err := resp.buildStepTxData(types.StepCallData{
-		ClaimIndex: 2,
-		IsAttack:   false,
-		StateData:  []byte{0x01},
-		Proof:      []byte{0x02},
-	})
+	data, err := resp.buildStepTxData(2, false, []byte{0x01}, []byte{0x02})
 	require.NoError(t, err)
 
 	opts.GasLimit = 100_000

--- a/op-challenger/game/fault/solver/game_solver.go
+++ b/op-challenger/game/fault/solver/game_solver.go
@@ -1,0 +1,107 @@
+package solver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ActionType string
+
+const (
+	ActionTypeMove ActionType = "move"
+	ActionTypeStep ActionType = "step"
+)
+
+func (a ActionType) String() string {
+	return string(a)
+}
+
+type Action struct {
+	Type      ActionType
+	ParentIdx int
+	IsAttack  bool
+
+	// Moves
+	Value common.Hash
+
+	// Steps
+	PreState   []byte
+	ProofData  []byte
+	OracleData *types.PreimageOracleData
+}
+
+type GameSolver struct {
+	claimSolver *claimSolver
+	gameDepth   int
+}
+
+func NewGameSolver(gameDepth int, trace types.TraceProvider) *GameSolver {
+	return &GameSolver{
+		claimSolver: newClaimSolver(gameDepth, trace),
+		gameDepth:   gameDepth,
+	}
+}
+
+func (s *GameSolver) CalculateNextActions(ctx context.Context, game types.Game) ([]Action, error) {
+	var errs []error
+	var actions []Action
+	for _, claim := range game.Claims() {
+		var action *Action
+		var err error
+		if claim.Depth() == s.gameDepth {
+			action, err = s.calculateStep(ctx, game, claim)
+		} else {
+			action, err = s.calculateMove(ctx, game, claim)
+		}
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if action == nil {
+			continue
+		}
+		actions = append(actions, *action)
+	}
+	return actions, errors.Join(errs...)
+}
+
+func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, claim types.Claim) (*Action, error) {
+	if claim.Countered {
+		return nil, nil
+	}
+	if game.AgreeWithClaimLevel(claim) {
+		return nil, nil
+	}
+	step, err := s.claimSolver.AttemptStep(ctx, claim, game.AgreeWithClaimLevel(claim))
+	if err != nil {
+		return nil, err
+	}
+	return &Action{
+		Type:       ActionTypeStep,
+		ParentIdx:  step.LeafClaim.ContractIndex,
+		IsAttack:   step.IsAttack,
+		PreState:   step.PreState,
+		ProofData:  step.ProofData,
+		OracleData: step.OracleData,
+	}, nil
+}
+
+func (s *GameSolver) calculateMove(ctx context.Context, game types.Game, claim types.Claim) (*Action, error) {
+	move, err := s.claimSolver.NextMove(ctx, claim, game.AgreeWithClaimLevel(claim))
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate next move for claim index %v: %w", claim.ContractIndex, err)
+	}
+	if move == nil || game.IsDuplicate(*move) {
+		return nil, nil
+	}
+	return &Action{
+		Type:      ActionTypeMove,
+		IsAttack:  !move.DefendsParent(),
+		ParentIdx: move.ParentContractIndex,
+		Value:     move.Value,
+	}, nil
+}

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -1,0 +1,187 @@
+package solver
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	faulttest "github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+type actionMaker func(game types.Game) Action
+
+func TestCalculateNextActions(t *testing.T) {
+	maxDepth := 4
+	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, maxDepth)
+
+	attackClaim := func(parentIdx int) actionMaker {
+		return func(game types.Game) Action {
+			parentClaim := game.Claims()[parentIdx]
+			return Action{
+				Type:      ActionTypeMove,
+				ParentIdx: parentIdx,
+				IsAttack:  true,
+				Value:     claimBuilder.CorrectClaimAtPosition(parentClaim.Position.Attack()),
+			}
+		}
+	}
+	defendClaim := func(parentIdx int) actionMaker {
+		return func(game types.Game) Action {
+			parentClaim := game.Claims()[parentIdx]
+			return Action{
+				Type:      ActionTypeMove,
+				ParentIdx: parentIdx,
+				IsAttack:  false,
+				Value:     claimBuilder.CorrectClaimAtPosition(parentClaim.Position.Defend()),
+			}
+		}
+	}
+	stepAttack := func(parentIdx int) actionMaker {
+		return func(game types.Game) Action {
+			parentClaim := game.Claims()[parentIdx]
+			traceIdx := parentClaim.Position.TraceIndex(maxDepth)
+			return Action{
+				Type:       ActionTypeStep,
+				ParentIdx:  parentIdx,
+				IsAttack:   true,
+				PreState:   claimBuilder.CorrectPreState(traceIdx),
+				ProofData:  claimBuilder.CorrectProofData(traceIdx),
+				OracleData: claimBuilder.CorrectOracleData(traceIdx),
+			}
+		}
+	}
+	stepDefend := func(parentIdx int) actionMaker {
+		return func(game types.Game) Action {
+			parentClaim := game.Claims()[parentIdx]
+			traceIdx := parentClaim.Position.TraceIndex(maxDepth) + 1
+			return Action{
+				Type:       ActionTypeStep,
+				ParentIdx:  parentIdx,
+				IsAttack:   false,
+				PreState:   claimBuilder.CorrectPreState(traceIdx),
+				ProofData:  claimBuilder.CorrectProofData(traceIdx),
+				OracleData: claimBuilder.CorrectOracleData(traceIdx),
+			}
+		}
+	}
+
+	tests := []struct {
+		name                string
+		agreeWithOutputRoot bool
+		rootClaimCorrect    bool
+		setupGame           func(builder *faulttest.GameBuilder)
+		expectedActions     []actionMaker
+	}{
+		{
+			name:                "AttackRootClaim",
+			agreeWithOutputRoot: true,
+			setupGame:           func(builder *faulttest.GameBuilder) {},
+			expectedActions: []actionMaker{
+				attackClaim(0),
+			},
+		},
+		{
+			name:                "DoNotAttackRootClaimWhenDisagreeWithOutputRoot",
+			agreeWithOutputRoot: false,
+			setupGame:           func(builder *faulttest.GameBuilder) {},
+			expectedActions:     nil,
+		},
+		{
+			// Note: The fault dispute game contract should prevent a correct root claim from actually being posted
+			// But for completeness, test we ignore it so we don't get sucked into playing an unwinnable game.
+			name:                "DoNotAttackCorrectRootClaim_AgreeWithOutputRoot",
+			agreeWithOutputRoot: true,
+			rootClaimCorrect:    true,
+			setupGame:           func(builder *faulttest.GameBuilder) {},
+			expectedActions:     nil,
+		},
+		{
+			// Note: The fault dispute game contract should prevent a correct root claim from actually being posted
+			// But for completeness, test we ignore it so we don't get sucked into playing an unwinnable game.
+			name:                "DoNotAttackCorrectRootClaim_DisagreeWithOutputRoot",
+			agreeWithOutputRoot: false,
+			rootClaimCorrect:    true,
+			setupGame:           func(builder *faulttest.GameBuilder) {},
+			expectedActions:     nil,
+		},
+
+		{
+			name:                "DoNotPerformDuplicateMoves",
+			agreeWithOutputRoot: true,
+			setupGame: func(builder *faulttest.GameBuilder) {
+				// Expected move has already been made.
+				builder.Seq().AttackCorrect()
+			},
+			expectedActions: nil,
+		},
+
+		{
+			name:                "RespondToAllClaimsAtDisagreeingLevel",
+			agreeWithOutputRoot: true,
+			setupGame: func(builder *faulttest.GameBuilder) {
+				honestClaim := builder.Seq().AttackCorrect() // 1
+				honestClaim.AttackCorrect()                  // 2
+				honestClaim.DefendCorrect()                  // 3
+				honestClaim.Attack(common.Hash{0xaa})        // 4
+				honestClaim.Attack(common.Hash{0xbb})        // 5
+				honestClaim.Defend(common.Hash{0xcc})        // 6
+				honestClaim.Defend(common.Hash{0xdd})        // 7
+			},
+			expectedActions: []actionMaker{
+				// Defend the correct claims
+				defendClaim(2),
+				defendClaim(3),
+
+				// Attack the incorrect claims
+				attackClaim(4),
+				attackClaim(5),
+				attackClaim(6),
+				attackClaim(7),
+			},
+		},
+
+		{
+			name:                "StepAtMaxDepth",
+			agreeWithOutputRoot: true,
+			setupGame: func(builder *faulttest.GameBuilder) {
+				lastHonestClaim := builder.Seq().
+					AttackCorrect(). // 1 - Honest
+					AttackCorrect(). // 2 - Dishonest
+					DefendCorrect()  // 3 - Honest
+				lastHonestClaim.AttackCorrect()           // 4 - Dishonest
+				lastHonestClaim.Attack(common.Hash{0xdd}) // 5 - Dishonest
+			},
+			expectedActions: []actionMaker{
+				stepDefend(4),
+				stepAttack(5),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			builder := claimBuilder.GameBuilder(test.agreeWithOutputRoot, test.rootClaimCorrect)
+			test.setupGame(builder)
+			game := builder.Game
+			for i, claim := range game.Claims() {
+				t.Logf("Claim %v: Pos: %v ParentIdx: %v, Countered: %v, Value: %v", i, claim.Position.ToGIndex(), claim.ParentContractIndex, claim.Countered, claim.Value)
+			}
+
+			solver := NewGameSolver(maxDepth, claimBuilder.CorrectTraceProvider())
+			actions, err := solver.CalculateNextActions(context.Background(), game)
+			require.NoError(t, err)
+			for i, action := range actions {
+				t.Logf("Move %v: Type: %v, ParentIdx: %v, Attack: %v, Value: %v, PreState: %v, ProofData: %v",
+					i, action.Type, action.ParentIdx, action.IsAttack, action.Value, hex.EncodeToString(action.PreState), hex.EncodeToString(action.ProofData))
+			}
+			require.Len(t, actions, len(test.expectedActions))
+			for i, action := range test.expectedActions {
+				require.Containsf(t, actions, action(game), "Expected claim %v missing", i)
+			}
+		})
+	}
+}

--- a/op-challenger/game/fault/solver/solver.go
+++ b/op-challenger/game/fault/solver/solver.go
@@ -15,22 +15,22 @@ var (
 	ErrStepAgreedClaim = errors.New("cannot step on claims we agree with")
 )
 
-// Solver uses a [TraceProvider] to determine the moves to make in a dispute game.
-type Solver struct {
+// claimSolver uses a [TraceProvider] to determine the moves to make in a dispute game.
+type claimSolver struct {
 	trace     types.TraceProvider
 	gameDepth int
 }
 
-// NewSolver creates a new [Solver] using the provided [TraceProvider].
-func NewSolver(gameDepth int, traceProvider types.TraceProvider) *Solver {
-	return &Solver{
+// newClaimSolver creates a new [claimSolver] using the provided [TraceProvider].
+func newClaimSolver(gameDepth int, traceProvider types.TraceProvider) *claimSolver {
+	return &claimSolver{
 		traceProvider,
 		gameDepth,
 	}
 }
 
 // NextMove returns the next move to make given the current state of the game.
-func (s *Solver) NextMove(ctx context.Context, claim types.Claim, agreeWithClaimLevel bool) (*types.Claim, error) {
+func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, agreeWithClaimLevel bool) (*types.Claim, error) {
 	if agreeWithClaimLevel {
 		return nil, nil
 	}
@@ -58,7 +58,7 @@ type StepData struct {
 
 // AttemptStep determines what step should occur for a given leaf claim.
 // An error will be returned if the claim is not at the max depth.
-func (s *Solver) AttemptStep(ctx context.Context, claim types.Claim, agreeWithClaimLevel bool) (StepData, error) {
+func (s *claimSolver) AttemptStep(ctx context.Context, claim types.Claim, agreeWithClaimLevel bool) (StepData, error) {
 	if claim.Depth() != s.gameDepth {
 		return StepData{}, ErrStepNonLeafNode
 	}
@@ -100,7 +100,7 @@ func (s *Solver) AttemptStep(ctx context.Context, claim types.Claim, agreeWithCl
 }
 
 // attack returns a response that attacks the claim.
-func (s *Solver) attack(ctx context.Context, claim types.Claim) (*types.Claim, error) {
+func (s *claimSolver) attack(ctx context.Context, claim types.Claim) (*types.Claim, error) {
 	position := claim.Attack()
 	value, err := s.traceAtPosition(ctx, position)
 	if err != nil {
@@ -114,7 +114,7 @@ func (s *Solver) attack(ctx context.Context, claim types.Claim) (*types.Claim, e
 }
 
 // defend returns a response that defends the claim.
-func (s *Solver) defend(ctx context.Context, claim types.Claim) (*types.Claim, error) {
+func (s *claimSolver) defend(ctx context.Context, claim types.Claim) (*types.Claim, error) {
 	if claim.IsRoot() {
 		return nil, nil
 	}
@@ -131,13 +131,13 @@ func (s *Solver) defend(ctx context.Context, claim types.Claim) (*types.Claim, e
 }
 
 // agreeWithClaim returns true if the claim is correct according to the internal [TraceProvider].
-func (s *Solver) agreeWithClaim(ctx context.Context, claim types.ClaimData) (bool, error) {
+func (s *claimSolver) agreeWithClaim(ctx context.Context, claim types.ClaimData) (bool, error) {
 	ourValue, err := s.traceAtPosition(ctx, claim.Position)
 	return bytes.Equal(ourValue[:], claim.Value[:]), err
 }
 
 // traceAtPosition returns the [common.Hash] from internal [TraceProvider] at the given [Position].
-func (s *Solver) traceAtPosition(ctx context.Context, p types.Position) (common.Hash, error) {
+func (s *claimSolver) traceAtPosition(ctx context.Context, p types.Position) (common.Hash, error) {
 	index := p.TraceIndex(s.gameDepth)
 	hash, err := s.trace.Get(ctx, index)
 	return hash, err

--- a/op-challenger/game/fault/solver/solver_test.go
+++ b/op-challenger/game/fault/solver/solver_test.go
@@ -1,11 +1,10 @@
-package solver_test
+package solver
 
 import (
 	"context"
 	"errors"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/solver"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/stretchr/testify/require"
@@ -84,7 +83,7 @@ func TestNextMove(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			solver := solver.NewSolver(maxDepth, builder.CorrectTraceProvider())
+			solver := newClaimSolver(maxDepth, builder.CorrectTraceProvider())
 			move, err := solver.NextMove(context.Background(), test.claim, test.agreeWithLevel)
 			if test.expectedErr == nil {
 				require.NoError(t, err)
@@ -174,19 +173,19 @@ func TestAttemptStep(t *testing.T) {
 		{
 			name:        "CannotStepNonLeaf",
 			claim:       builder.Seq(false).Attack(false).Get(),
-			expectedErr: solver.ErrStepNonLeafNode,
+			expectedErr: ErrStepNonLeafNode,
 		},
 		{
 			name:           "CannotStepAgreedNode",
 			claim:          builder.Seq(false).Attack(false).Get(),
 			agreeWithLevel: true,
-			expectedErr:    solver.ErrStepNonLeafNode,
+			expectedErr:    ErrStepNonLeafNode,
 		},
 		{
 			name:           "CannotStepAgreedNode",
 			claim:          builder.Seq(false).Attack(false).Get(),
 			agreeWithLevel: true,
-			expectedErr:    solver.ErrStepNonLeafNode,
+			expectedErr:    ErrStepNonLeafNode,
 		},
 	}
 
@@ -198,7 +197,7 @@ func TestAttemptStep(t *testing.T) {
 				alphabetProvider = test.NewAlphabetWithProofProvider(t, maxDepth, errProvider)
 			}
 			builder = test.NewClaimBuilder(t, maxDepth, alphabetProvider)
-			alphabetSolver := solver.NewSolver(maxDepth, builder.CorrectTraceProvider())
+			alphabetSolver := newClaimSolver(maxDepth, builder.CorrectTraceProvider())
 			step, err := alphabetSolver.AttemptStep(ctx, tableTest.claim, tableTest.agreeWithLevel)
 			if tableTest.expectedErr == nil {
 				require.NoError(t, err)
@@ -212,7 +211,7 @@ func TestAttemptStep(t *testing.T) {
 				require.Equal(t, tableTest.expectedOracleData.OracleOffset, step.OracleData.OracleOffset)
 			} else {
 				require.ErrorIs(t, err, tableTest.expectedErr)
-				require.Equal(t, solver.StepData{}, step)
+				require.Equal(t, StepData{}, step)
 			}
 		})
 	}

--- a/op-challenger/game/fault/test/claim_builder.go
+++ b/op-challenger/game/fault/test/claim_builder.go
@@ -38,6 +38,13 @@ func (c *ClaimBuilder) CorrectClaim(idx uint64) common.Hash {
 	return value
 }
 
+// CorrectClaimAtPosition returns the canonical claim at a specified position
+func (c *ClaimBuilder) CorrectClaimAtPosition(pos types.Position) common.Hash {
+	value, err := c.correct.Get(context.Background(), pos.TraceIndex(c.maxDepth))
+	c.require.NoError(err)
+	return value
+}
+
 // CorrectPreState returns the pre-state (not hashed) required to execute the valid step at the specified trace index
 func (c *ClaimBuilder) CorrectPreState(idx uint64) []byte {
 	preimage, _, _, err := c.correct.GetStepData(context.Background(), idx)
@@ -102,7 +109,20 @@ func (c *ClaimBuilder) AttackClaim(claim types.Claim, correct bool) types.Claim 
 			Value:    c.claim(pos.TraceIndex(c.maxDepth), correct),
 			Position: pos,
 		},
-		Parent: claim.ClaimData,
+		Parent:              claim.ClaimData,
+		ParentContractIndex: claim.ContractIndex,
+	}
+}
+
+func (c *ClaimBuilder) AttackClaimWithValue(claim types.Claim, value common.Hash) types.Claim {
+	pos := claim.Position.Attack()
+	return types.Claim{
+		ClaimData: types.ClaimData{
+			Value:    value,
+			Position: pos,
+		},
+		Parent:              claim.ClaimData,
+		ParentContractIndex: claim.ContractIndex,
 	}
 }
 
@@ -113,6 +133,19 @@ func (c *ClaimBuilder) DefendClaim(claim types.Claim, correct bool) types.Claim 
 			Value:    c.claim(pos.TraceIndex(c.maxDepth), correct),
 			Position: pos,
 		},
-		Parent: claim.ClaimData,
+		Parent:              claim.ClaimData,
+		ParentContractIndex: claim.ContractIndex,
+	}
+}
+
+func (c *ClaimBuilder) DefendClaimWithValue(claim types.Claim, value common.Hash) types.Claim {
+	pos := claim.Position.Defend()
+	return types.Claim{
+		ClaimData: types.ClaimData{
+			Value:    value,
+			Position: pos,
+		},
+		Parent:              claim.ClaimData,
+		ParentContractIndex: claim.ContractIndex,
 	}
 }

--- a/op-challenger/game/fault/test/game_builder.go
+++ b/op-challenger/game/fault/test/game_builder.go
@@ -1,0 +1,76 @@
+package test
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type GameBuilder struct {
+	builder *ClaimBuilder
+	Game    types.Game
+}
+
+func (c *ClaimBuilder) GameBuilder(agreeWithOutputRoot bool, rootCorrect bool) *GameBuilder {
+	return &GameBuilder{
+		builder: c,
+		Game:    types.NewGameState(agreeWithOutputRoot, c.CreateRootClaim(rootCorrect), uint64(c.maxDepth)),
+	}
+}
+
+type GameBuilderSeq struct {
+	builder   *ClaimBuilder
+	lastClaim types.Claim
+	game      types.Game
+}
+
+func (g *GameBuilder) Seq() *GameBuilderSeq {
+	return &GameBuilderSeq{
+		builder:   g.builder,
+		game:      g.Game,
+		lastClaim: g.Game.Claims()[0],
+	}
+}
+
+func (s *GameBuilderSeq) AttackCorrect() *GameBuilderSeq {
+	claim := s.builder.AttackClaim(s.lastClaim, true)
+	claim.ContractIndex = len(s.game.Claims())
+	s.builder.require.NoError(s.game.Put(claim))
+	return &GameBuilderSeq{
+		builder:   s.builder,
+		game:      s.game,
+		lastClaim: claim,
+	}
+}
+
+func (s *GameBuilderSeq) Attack(value common.Hash) *GameBuilderSeq {
+	claim := s.builder.AttackClaimWithValue(s.lastClaim, value)
+	claim.ContractIndex = len(s.game.Claims())
+	s.builder.require.NoError(s.game.Put(claim))
+	return &GameBuilderSeq{
+		builder:   s.builder,
+		game:      s.game,
+		lastClaim: claim,
+	}
+}
+
+func (s *GameBuilderSeq) DefendCorrect() *GameBuilderSeq {
+	claim := s.builder.DefendClaim(s.lastClaim, true)
+	claim.ContractIndex = len(s.game.Claims())
+	s.builder.require.NoError(s.game.Put(claim))
+	return &GameBuilderSeq{
+		builder:   s.builder,
+		game:      s.game,
+		lastClaim: claim,
+	}
+}
+
+func (s *GameBuilderSeq) Defend(value common.Hash) *GameBuilderSeq {
+	claim := s.builder.DefendClaimWithValue(s.lastClaim, value)
+	claim.ContractIndex = len(s.game.Claims())
+	s.builder.require.NoError(s.game.Put(claim))
+	return &GameBuilderSeq{
+		builder:   s.builder,
+		game:      s.game,
+		lastClaim: claim,
+	}
+}


### PR DESCRIPTION
**Description**

Introduces GameSolver which evaluates the overall game state and decides all actions to take. Agent now uses GameSolver so that it has no knowledge of the game playing strategy.  The existing `Solver` is now `ClaimSolver` and still exists to decide how to respond to a specific claim, but `GameSolver` controls the iteration of claims, decisions around whether we agree with a game depth and whether potential moves are duplicates etc.


**Tests**

This logic was poorly testing in Agent, and is easier to test now its in GameSolver. Some initial unit tests are added using a new `GameBuilder` that makes it easy for unit tests to build up a specific game state.  
 
**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/7174