### PR TITLE
Revert "cannon: Use atomic write pattern to avoid leaving partially written files"

### DIFF
--- a/cannon/cmd/json.go
+++ b/cannon/cmd/json.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 )
@@ -30,20 +29,13 @@ func loadJSON[X any](inputPath string) (*X, error) {
 
 func writeJSON[X any](outputPath string, value X, outIfEmpty bool) error {
 	var out io.Writer
-	finish := func() error { return nil }
 	if outputPath != "" {
-		// Write to a tmp file but reserve the file extension if present
-		tmpPath := outputPath + "-tmp" + path.Ext(outputPath)
-		f, err := ioutil.OpenCompressed(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+		f, err := ioutil.OpenCompressed(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 		if err != nil {
 			return fmt.Errorf("failed to open output file: %w", err)
 		}
 		defer f.Close()
 		out = f
-		finish = func() error {
-			// Rename the file into place as atomically as the OS will allow
-			return os.Rename(tmpPath, outputPath)
-		}
 	} else if outIfEmpty {
 		out = os.Stdout
 	} else {
@@ -56,9 +48,6 @@ func writeJSON[X any](outputPath string, value X, outIfEmpty bool) error {
 	_, err := out.Write([]byte{'\n'})
 	if err != nil {
 		return fmt.Errorf("failed to append new-line: %w", err)
-	}
-	if err := finish(); err != nil {
-		return fmt.Errorf("failed to finish write: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Reverts ethereum-optimism/optimism#7201

This breaks op-e2e on develop for some reason. op-cannon is not tagged as a dependency for op-e2e so the op-e2e test suite did not run in #7201 prior to merging.