### PR TITLE
ci: Run e2e tests when cannon changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -784,7 +784,7 @@ jobs:
     steps:
       - checkout
       - check-changed:
-          patterns: op-(.+),contracts-bedrock
+          patterns: op-(.+),cannon,contracts-bedrock
       - run:
           name: prep results dir
           command: mkdir -p /tmp/test-results


### PR DESCRIPTION
**Description**

Run e2e tests when there are changes to cannon since its used by some tests.
