### PR TITLE
fix(indexer): remove schema/code in relation to posted checkpoints on L1

### DIFF
--- a/indexer/database/mocks.go
+++ b/indexer/database/mocks.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/stretchr/testify/mock"
@@ -53,16 +51,6 @@ func (m *MockBlocksView) L2LatestBlockHeader() (*L2BlockHeader, error) {
 	return args.Get(0).(*L2BlockHeader), args.Error(1)
 }
 
-func (m *MockBlocksView) LatestCheckpointedOutput() (*OutputProposal, error) {
-	args := m.Called()
-	return args.Get(0).(*OutputProposal), args.Error(1)
-}
-
-func (m *MockBlocksView) OutputProposal(index *big.Int) (*OutputProposal, error) {
-	args := m.Called()
-	return args.Get(0).(*OutputProposal), args.Error(1)
-}
-
 func (m *MockBlocksView) LatestEpoch() (*Epoch, error) {
 	args := m.Called()
 	return args.Get(0).(*Epoch), args.Error(1)
@@ -78,15 +66,6 @@ func (m *MockBlocksDB) StoreL1BlockHeaders(headers []L1BlockHeader) error {
 }
 
 func (m *MockBlocksDB) StoreL2BlockHeaders(headers []L2BlockHeader) error {
-	args := m.Called(headers)
-	return args.Error(1)
-}
-
-func (m *MockBlocksDB) StoreLegacyStateBatches(headers []LegacyStateBatch) error {
-	args := m.Called(headers)
-	return args.Error(1)
-}
-func (m *MockBlocksDB) StoreOutputProposals(headers []OutputProposal) error {
 	args := m.Called(headers)
 	return args.Error(1)
 }

--- a/indexer/e2e_tests/etl_e2e_test.go
+++ b/indexer/e2e_tests/etl_e2e_test.go
@@ -71,45 +71,6 @@ func TestE2EETL(t *testing.T) {
 		}
 	})
 
-	/*
-		TODO: ADD THIS BACK IN WHEN THESE MARKERS ARE INDEXED
-			t.Run("indexes L2 checkpoints", func(t *testing.T) {
-				latestOutput, err := testSuite.DB.Blocks.LatestCheckpointedOutput()
-				require.NoError(t, err)
-				require.NotNil(t, latestOutput)
-				require.GreaterOrEqual(t, latestOutput.L2BlockNumber.Int.Uint64(), uint64(9))
-
-				l2EthClient, err := node.DialEthClient(testSuite.OpSys.EthInstances["sequencer"].HTTPEndpoint())
-				require.NoError(t, err)
-
-				submissionInterval := testSuite.OpCfg.DeployConfig.L2OutputOracleSubmissionInterval
-				numOutputs := latestOutput.L2BlockNumber.Int.Uint64() / submissionInterval
-				for i := int64(0); i < int64(numOutputs); i++ {
-					blockNumber := big.NewInt((i + 1) * int64(submissionInterval))
-
-					output, err := testSuite.DB.Blocks.OutputProposal(big.NewInt(i))
-					require.NoError(t, err)
-					require.NotNil(t, output)
-					require.Equal(t, i, output.L2OutputIndex.Int.Int64())
-					require.Equal(t, blockNumber, output.L2BlockNumber.Int)
-					require.NotEmpty(t, output.L1ContractEventGUID)
-
-					// we may as well check the integrity of the output root
-					l2Block, err := testSuite.L2Client.BlockByNumber(context.Background(), blockNumber)
-					require.NoError(t, err)
-					messagePasserStorageHash, err := l2EthClient.StorageHash(predeploys.L2ToL1MessagePasserAddr, blockNumber)
-					require.NoError(t, err)
-
-					// construct and check output root
-					outputRootPreImage := [128]byte{}                                 // 4 words (first 32 are zero for version 0)
-					copy(outputRootPreImage[32:64], l2Block.Root().Bytes())           // state root
-					copy(outputRootPreImage[64:96], messagePasserStorageHash.Bytes()) // message passer storage root
-					copy(outputRootPreImage[96:128], l2Block.Hash().Bytes())          // block hash
-					require.Equal(t, crypto.Keccak256Hash(outputRootPreImage[:]), output.OutputRoot)
-				}
-			})
-	*/
-
 	t.Run("indexes L1 blocks with accompanying contract event", func(t *testing.T) {
 		l1Contracts := []common.Address{}
 		testSuite.OpCfg.L1Deployments.ForEach(func(name string, addr common.Address) { l1Contracts = append(l1Contracts, addr) })

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -77,50 +77,9 @@ CREATE INDEX IF NOT EXISTS l2_contract_events_block_hash ON l2_contract_events(b
 CREATE INDEX IF NOT EXISTS l2_contract_events_event_signature ON l2_contract_events(event_signature);
 CREATE INDEX IF NOT EXISTS l2_contract_events_contract_address ON l2_contract_events(contract_address);
 
--- Tables that index finalization markers for L2 blocks.
-
-CREATE TABLE IF NOT EXISTS legacy_state_batches (
-    index      INTEGER PRIMARY KEY,
-    root       VARCHAR NOT NULL UNIQUE,
-    size       INTEGER NOT NULL,
-    prev_total INTEGER NOT NULL,
-
-    state_batch_appended_guid VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS output_proposals (
-    output_root     VARCHAR PRIMARY KEY,
-    l2_output_index UINT256 NOT NULL UNIQUE,
-    l2_block_number UINT256 NOT NULL UNIQUE,
-
-    output_proposed_guid VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE
-);
-
-
 /**
  * BRIDGING DATA
  */
-
--- Bridged L1/L2 Tokens
-CREATE TABLE IF NOT EXISTS l1_bridged_tokens (
-    address        VARCHAR PRIMARY KEY,
-    bridge_address VARCHAR NOT NULL,
-
-    name     VARCHAR NOT NULL,
-    symbol   VARCHAR NOT NULL,
-    decimals INTEGER NOT NULL CHECK (decimals >= 0 AND decimals <= 18)
-);
-CREATE TABLE IF NOT EXISTS l2_bridged_tokens (
-    address        VARCHAR PRIMARY KEY,
-    bridge_address VARCHAR NOT NULL,
-
-    -- L1-L2 relationship is 1 to many so this is not necessarily unique
-    l1_token_address VARCHAR REFERENCES l1_bridged_tokens(address) ON DELETE CASCADE,
-
-    name     VARCHAR NOT NULL,
-    symbol   VARCHAR NOT NULL,
-    decimals INTEGER NOT NULL CHECK (decimals >= 0 AND decimals <= 18)
-);
 
 -- OptimismPortal/L2ToL1MessagePasser
 CREATE TABLE IF NOT EXISTS l1_transaction_deposits (
@@ -204,6 +163,26 @@ CREATE INDEX IF NOT EXISTS l2_bridge_messages_transaction_withdrawal_hash ON l2_
 CREATE INDEX IF NOT EXISTS l2_bridge_messages_from_address ON l2_bridge_messages(from_address);
 
 -- StandardBridge
+CREATE TABLE IF NOT EXISTS l1_bridged_tokens (
+    address        VARCHAR PRIMARY KEY,
+    bridge_address VARCHAR NOT NULL,
+
+    name     VARCHAR NOT NULL,
+    symbol   VARCHAR NOT NULL,
+    decimals INTEGER NOT NULL CHECK (decimals >= 0 AND decimals <= 18)
+);
+CREATE TABLE IF NOT EXISTS l2_bridged_tokens (
+    address        VARCHAR PRIMARY KEY,
+    bridge_address VARCHAR NOT NULL,
+
+    -- L1-L2 relationship is 1 to many so this is not necessarily unique
+    l1_token_address VARCHAR REFERENCES l1_bridged_tokens(address) ON DELETE CASCADE,
+
+    name     VARCHAR NOT NULL,
+    symbol   VARCHAR NOT NULL,
+    decimals INTEGER NOT NULL CHECK (decimals >= 0 AND decimals <= 18)
+);
+
 CREATE TABLE IF NOT EXISTS l1_bridge_deposits (
     transaction_source_hash   VARCHAR PRIMARY KEY REFERENCES l1_transaction_deposits(source_hash) ON DELETE CASCADE,
     cross_domain_message_hash VARCHAR NOT NULL UNIQUE REFERENCES l1_bridge_messages(message_hash) ON DELETE CASCADE,


### PR DESCRIPTION
We dont have an immediate use case for the schema's around the L2OutputOracle. For
this reason lets simply remove this until necessary. The events are still indexed
so these scheams can easily be bootstrapped in the future and any external parties
interested in these events can still query for them via the contract events table.
