### PR TITLE
cannon: Use zlib compressed base64 instead of hex for serialization

### DIFF
--- a/cannon/mipsevm/page.go
+++ b/cannon/mipsevm/page.go
@@ -47,8 +47,12 @@ func (p *Page) MarshalJSON() ([]byte, error) {
 	w := zlibWriterPool.Get().(*zlib.Writer)
 	defer zlibWriterPool.Put(w)
 	w.Reset(&out)
-	w.Write(p[:])
-	w.Close()
+	if _, err := w.Write(p[:]); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
 	return json.Marshal(out.Bytes())
 }
 

--- a/cannon/mipsevm/page.go
+++ b/cannon/mipsevm/page.go
@@ -36,12 +36,6 @@ func detectEncoding(data []byte) (string, error) {
 
 type Page [PageSize]byte
 
-func (p *Page) MarshalText() ([]byte, error) {
-	dst := make([]byte, hex.EncodedLen(len(p)))
-	hex.Encode(dst, p[:])
-	return dst, nil
-}
-
 func (p *Page) MarshalJSON() ([]byte, error) { // nosemgrep
 	var out bytes.Buffer
 	w := zlibWriterPool.Get().(*zlib.Writer)

--- a/cannon/mipsevm/page.go
+++ b/cannon/mipsevm/page.go
@@ -42,7 +42,7 @@ func (p *Page) MarshalText() ([]byte, error) {
 	return dst, nil
 }
 
-func (p *Page) MarshalJSON() ([]byte, error) {
+func (p *Page) MarshalJSON() ([]byte, error) { // nosemgrep
 	var out bytes.Buffer
 	w := zlibWriterPool.Get().(*zlib.Writer)
 	defer zlibWriterPool.Put(w)

--- a/cannon/mipsevm/page_test.go
+++ b/cannon/mipsevm/page_test.go
@@ -47,3 +47,37 @@ func TestCachedPage(t *testing.T) {
 	post5 := p.MerkleRoot()
 	require.NotEqual(t, post4, post5, "and global invalidation works regardless of changed data")
 }
+
+func TestDetectEncoding(t *testing.T) {
+	tests := []struct {
+		data []byte
+		errs bool
+		t    string
+	}{
+		{
+			data: []byte("deadbeef"),
+			errs: false,
+			t:    "hex",
+		},
+		{
+			data: []byte("c3ViamVjdAc=="),
+			errs: false,
+			t:    "base64",
+		},
+		{
+			data: []byte{0x10, 0xff, 0xe5},
+			errs: true,
+			t:    "",
+		},
+	}
+	for _, tc := range tests {
+		res, err := detectEncoding(tc.data)
+		if tc.errs {
+			require.Error(t, err)
+		} else {
+			require.Equal(t, tc.t, res)
+			require.NoError(t, err)
+		}
+
+	}
+}

--- a/cannon/mipsevm/page_test.go
+++ b/cannon/mipsevm/page_test.go
@@ -47,37 +47,3 @@ func TestCachedPage(t *testing.T) {
 	post5 := p.MerkleRoot()
 	require.NotEqual(t, post4, post5, "and global invalidation works regardless of changed data")
 }
-
-func TestDetectEncoding(t *testing.T) {
-	tests := []struct {
-		data []byte
-		errs bool
-		t    string
-	}{
-		{
-			data: []byte("deadbeef"),
-			errs: false,
-			t:    "hex",
-		},
-		{
-			data: []byte("c3ViamVjdAc=="),
-			errs: false,
-			t:    "base64",
-		},
-		{
-			data: []byte{0x10, 0xff, 0xe5},
-			errs: true,
-			t:    "",
-		},
-	}
-	for _, tc := range tests {
-		res, err := detectEncoding(tc.data)
-		if tc.errs {
-			require.Error(t, err)
-		} else {
-			require.Equal(t, tc.t, res)
-			require.NoError(t, err)
-		}
-
-	}
-}


### PR DESCRIPTION
**Description**

This changes the serialization format of state.json. It compresses the pages memory with zlib and then uses base64 encoding instead of hex encoding because base64 encoding is more compact.

This sees significant reduction in file size of snapshots. It also reduces the inuse memory caused by JSON marshalling. The sync pool of the zlib writer may slightly reduce the inuse allocations, but significantly reduces the lifetime allocations.

**Tests**

Manually tested detect snippet. Have tested the cannon binary in k8s.


