### PR TITLE
chore(indexer): remove indexer all command

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -23,4 +23,4 @@ FROM alpine:3.18
 
 COPY --from=builder /app/indexer/indexer /usr/local/bin
 
-CMD ["indexer", "all", "--config", "/app/indexer/indexer.toml"]
+CMD ["indexer", "index", "--config", "/app/indexer/indexer.toml"]


### PR DESCRIPTION
In k8s repo we are adding api as a new service and the new indexer replaces the old indexer/api

- remove indexer all command
- make indexer index the default docker command so we don't have to override the command when we upgrade
