### PR TITLE
txmgr: Do not update nonce on failed gas estimate

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -211,14 +211,8 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 	}
 	gasFeeCap := calcGasFeeCap(basefee, gasTipCap)
 
-	nonce, err := m.nextNonce(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	rawTx := &types.DynamicFeeTx{
 		ChainID:   m.chainID,
-		Nonce:     nonce,
 		To:        candidate.To,
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -246,6 +240,13 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		}
 		rawTx.Gas = gas
 	}
+
+	// Avoid bumping the nonce if the gas estimation fails.
+	nonce, err := m.nextNonce(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rawTx.Nonce = nonce
 
 	ctx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
 	defer cancel()


### PR DESCRIPTION
The nonce is irrelevant for gas estimation. So we shouldn't bump the txmgr nonce counter when `EstimateGas` fails. Otherwise, a subsequent successful gas estimation will use an incorrect nonce.

fixes https://github.com/ethereum-optimism/client-pod/issues/56