### PR TITLE
op-node: Channel ordering fix for canyon

### DIFF
--- a/op-node/rollup/derive/channel_bank.go
+++ b/op-node/rollup/derive/channel_bank.go
@@ -117,11 +117,12 @@ func (cb *ChannelBank) IngestFrame(f Frame) {
 // Read the raw data of the first channel, if it's timed-out or closed.
 // Read returns io.EOF if there is nothing new to read.
 func (cb *ChannelBank) Read() (data []byte, err error) {
-	// Common Code. By returning `nil,nil`, we call back into this to make sure that all timed
-	// out channels at the front of the queue will eventually be removed.
+	// Common Code pre/post canyon. Return io.EOF if no channels
 	if len(cb.channelQueue) == 0 {
 		return nil, io.EOF
 	}
+	// Return nil,nil on the first channel if it is timed out. There may be more timed out
+	// channels at the head of the queue and we want to remove them all.
 	first := cb.channelQueue[0]
 	ch := cb.channels[first]
 	timedOut := ch.OpenBlockNumber()+cb.cfg.ChannelTimeout < cb.Origin().Number
@@ -137,22 +138,23 @@ func (cb *ChannelBank) Read() (data []byte, err error) {
 	// Pre-Canyon we simply check the first index.
 	// Post-Canyon we read the entire channelQueue for the first ready channel. If no channel is
 	// available, we return `nil, io.EOF`.
+	// Canyon is activated when the first L1 block whose time >= CanyonTime, not on the L2 timestamp.
 	if !cb.cfg.IsCanyon(cb.Origin().Time) {
-		return cb.readIndex(0)
+		return cb.tryReadChannelAtIndex(0)
 	}
 
 	for i := 0; i < len(cb.channelQueue); i++ {
-		if data, err := cb.readIndex(i); err == nil {
+		if data, err := cb.tryReadChannelAtIndex(i); err == nil {
 			return data, nil
 		}
 	}
 	return nil, io.EOF
 }
 
-// readIndex attempts to read the channel at the specified index. If the channel is
+// tryReadChannelAtIndex attempts to read the channel at the specified index. If the channel is
 // not ready (or timed out), it will return io.EOF.
 // If the channel read was successful, it will remove the channel from the channelQueue.
-func (cb *ChannelBank) readIndex(i int) (data []byte, err error) {
+func (cb *ChannelBank) tryReadChannelAtIndex(i int) (data []byte, err error) {
 	chanID := cb.channelQueue[i]
 	ch := cb.channels[chanID]
 	timedOut := ch.OpenBlockNumber()+cb.cfg.ChannelTimeout < cb.Origin().Number

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -513,11 +513,14 @@ New frames for timed-out channels are dropped instead of buffered.
 
 #### Reading
 
-The channel-bank can only output data from the first opened channel.
-
 Upon reading, while the first opened channel is timed-out, remove it from the channel-bank.
 
-Once the first opened channel, if any, is not timed-out and is ready, then it is read and removed from the channel-bank.
+Prior to the Canyon network upgrade, once the first opened channel, if any, is not timed-out and is ready,
+then it is read and removed from the channel-bank. After the Canyon network upgrade, the entire channel bank
+is scanned in FIFO order (by open time) & the first ready (i.e. not timed-out) channel will be returned.
+
+The canyon behavior will activate when frames from a L1 block whose timestamp is greater than or equal to the
+canyon time first enter the channel queue.
 
 A channel is ready if:
 
@@ -534,7 +537,7 @@ a new channel is opened, tagged with the current L1 block, and appended to the c
 Frame insertion conditions:
 
 - New frames matching timed-out channels that have not yet been pruned from the channel-bank are dropped.
-- Duplicate frames (by frame number) for frames that have not yet been pruned from the channel-bank are dropped.
+- Duplicate frames (by frame number) for frames that have not been pruned from the channel-bank are dropped.
 - Duplicate closes (new frame `is_last == 1`, but the channel has already seen a closing frame and has not yet been
     pruned from the channel-bank) are dropped.
 


### PR DESCRIPTION
**Description**

This specifies & implements a new channel ordering which will activate with the canyon hard fork. Post canyon, the channel bank will read the first ready channel, rather than just the channel at the head of the channel bank queue.

**Tests**

Tests for the before & after behavior.

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/7453
