### PR TITLE
op-challenger: Fix recording of last step index

### DIFF
--- a/op-challenger/game/fault/trace/cannon/provider_test.go
+++ b/op-challenger/game/fault/trace/cannon/provider_test.go
@@ -158,20 +158,16 @@ func TestGetStepData(t *testing.T) {
 			Exited: true,
 		}
 		generator.proof = &proofData{
-			ClaimValue:   common.Hash{0xaa},
-			StateData:    []byte{0xbb},
-			ProofData:    []byte{0xcc},
-			OracleKey:    common.Hash{0xdd}.Bytes(),
-			OracleValue:  []byte{0xdd},
-			OracleOffset: 10,
+			ClaimValue: common.Hash{0xaa},
+			StateData:  []byte{0xbb},
+			ProofData:  []byte{0xcc},
 		}
 		preimage, proof, data, err := provider.GetStepData(context.Background(), 7000)
 		require.NoError(t, err)
-		require.Contains(t, generator.generated, 10, "should have tried to generate the proof")
+		require.Empty(t, generator.generated, "should not have to generate the proof again")
 
-		witness := generator.finalState.EncodeWitness()
-		require.EqualValues(t, witness, preimage)
-		require.Equal(t, []byte{}, proof)
+		require.EqualValues(t, initGenerator.finalState.EncodeWitness(), preimage)
+		require.Empty(t, proof)
 		require.Nil(t, data)
 	})
 


### PR DESCRIPTION
**Description**

The cannon trace provider was writing the wrong final step to disk causing it to execute the final segment after startup when it shouldn't need to.

* Record the same last step value to disk as we store in memory (should be one less than the final state Step value).
* Write the proof for the last step to disk to avoid needing to regenerate it even once. The final proof is built from the final state and was previously stored only in memory but is now written to disk.


**Tests**

Updated unit tests to actually confirm the executor is not executed.