### PR TITLE
fix(indexer): Fix tygo check in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,6 +887,14 @@ jobs:
           name: Build
           command: make indexer
           working_directory: indexer
+      - run:
+          name: Install tygo
+          command: go install github.com/gzuidhof/tygo@latest
+          working_directory: indexer/api-ts
+      - run:
+          name: Check generated code
+          command: npm run generate && git diff --exit-code
+          working_directory: indexer/api-ts
 
   devnet:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -864,10 +864,6 @@ jobs:
           command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 4m -e "errors.As" -e "errors.Is" ./...
           working_directory: indexer
       - run:
-          name: Check generated code
-          command: npm run generate && git diff --exit-code
-          working_directory: indexer/api-ts
-      - run:
           name: install geth
           command: make install-geth
       - run:

--- a/indexer/api-ts/README.md
+++ b/indexer/api-ts/README.md
@@ -1,0 +1,1 @@
+Generated typescript types for https://github.com/ethereum-optimism/optimism/tree/develop/indexer


### PR DESCRIPTION
- install tygo before running tygo as it's not on ci builder
- add a readme to kick the ci check into running
  - Currently indexer tests are disabled unless /indexer changes