### PR TITLE
contracts-bedrock: fix implementation salt

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -47,7 +47,7 @@ contract Deploy is Deployer {
     /// @notice The create2 salt used for deployment of the contract implementations.
     ///         Using this helps to reduce config across networks as the implementation
     ///         addresses will be the same across networks when deployed with create2.
-    bytes32 constant IMPL_SALT = bytes32("ether's phoenix");
+    bytes32 constant IMPL_SALT = keccak256(bytes("ether's phoenix"));
 
     /// @notice The name of the script, used to ensure the right deploy artifacts
     ///         are used.


### PR DESCRIPTION
**Description**

Updates the implementation salt. Without this change, the deployments fail on Goerli. They work on the devnet so something must be different between the devnet and the live network. This change will ensure that there is less config to manage in the superchain registry by having a canonical address for each semver version.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

