### PR TITLE
Support old Make version by avoiding SHELLSTATUS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,8 @@ devnet-up:
 	@if [ ! -e op-program/bin ]; then \
 		make cannon-prestate; \
 	fi
-	$(shell ./ops/scripts/newer-file.sh .devnet/allocs-l1.json ./packages/contracts-bedrock)
-	if [ $(.SHELLSTATUS) -ne 0 ]; then \
-		make devnet-allocs; \
-	fi
+	./ops/scripts/newer-file.sh .devnet/allocs-l1.json ./packages/contracts-bedrock \
+		|| make devnet-allocs
 	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=.
 .PHONY: devnet-up
 


### PR DESCRIPTION
SHELLSTATUS is only available on GNU Make 4.2 (released on 2016-05-22) and later, which is unfortunatly not installed on MacOS by default.

While I am highly annoyed that Apple is unwilling to update their Make version and don't want encourage such behaviour, the change in this commit avoids this requirement and seems even simpler than the original code.