### PR TITLE
op-node: Span Batch Derivation

### DIFF
--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -322,11 +322,11 @@ func FuzzSeqWindowClose(f *testing.F) {
 
 		// Check the timeout
 		cb.timeout = timeout
-		cb.updateSwTimeout(&derive.BatchData{
-			BatchV1: derive.BatchV1{
+		cb.updateSwTimeout(derive.NewSingularBatchData(
+			derive.SingularBatch{
 				EpochNum: rollup.Epoch(epochNum),
 			},
-		})
+		))
 		calculatedTimeout := epochNum + seqWindowSize - subSafetyMargin
 		if timeout > calculatedTimeout && calculatedTimeout != 0 {
 			cb.checkTimeout(calculatedTimeout)
@@ -354,11 +354,11 @@ func FuzzSeqWindowZeroTimeoutClose(f *testing.F) {
 
 		// Check the timeout
 		cb.timeout = 0
-		cb.updateSwTimeout(&derive.BatchData{
-			BatchV1: derive.BatchV1{
+		cb.updateSwTimeout(derive.NewSingularBatchData(
+			derive.SingularBatch{
 				EpochNum: rollup.Epoch(epochNum),
 			},
-		})
+		))
 		calculatedTimeout := epochNum + seqWindowSize - subSafetyMargin
 		cb.checkTimeout(calculatedTimeout)
 		if cb.timeout != 0 {

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -109,6 +109,9 @@ type DeployConfig struct {
 	// L2GenesisRegolithTimeOffset is the number of seconds after genesis block that Regolith hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable regolith.
 	L2GenesisRegolithTimeOffset *hexutil.Uint64 `json:"l2GenesisRegolithTimeOffset,omitempty"`
+	// L2GenesisSpanBatchTimeOffset is the number of seconds after genesis block that Span Batch hard fork activates.
+	// Set it to 0 to activate at genesis. Nil to disable SpanBatch.
+	L2GenesisSpanBatchTimeOffset *hexutil.Uint64 `json:"l2GenesisSpanBatchTimeOffset,omitempty"`
 	// L2GenesisBlockExtraData is configurable extradata. Will default to []byte("BEDROCK") if left unspecified.
 	L2GenesisBlockExtraData []byte `json:"l2GenesisBlockExtraData"`
 	// ProxyAdminOwner represents the owner of the ProxyAdmin predeploy on L2.
@@ -441,6 +444,17 @@ func (d *DeployConfig) RegolithTime(genesisTime uint64) *uint64 {
 	return &v
 }
 
+func (d *DeployConfig) SpanBatchTime(genesisTime uint64) *uint64 {
+	if d.L2GenesisSpanBatchTimeOffset == nil {
+		return nil
+	}
+	v := uint64(0)
+	if offset := *d.L2GenesisSpanBatchTimeOffset; offset > 0 {
+		v = genesisTime + uint64(offset)
+	}
+	return &v
+}
+
 // RollupConfig converts a DeployConfig to a rollup.Config
 func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHash common.Hash, l2GenesisBlockNumber uint64) (*rollup.Config, error) {
 	if d.OptimismPortalProxy == (common.Address{}) {
@@ -478,6 +492,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 		DepositContractAddress: d.OptimismPortalProxy,
 		L1SystemConfigAddress:  d.SystemConfigProxy,
 		RegolithTime:           d.RegolithTime(l1StartBlock.Time()),
+		SpanBatchTime:          d.SpanBatchTime(l1StartBlock.Time()),
 	}, nil
 }
 

--- a/op-e2e/actions/garbage_channel_out.go
+++ b/op-e2e/actions/garbage_channel_out.go
@@ -253,7 +253,7 @@ func blockToBatch(block *types.Block) (*derive.BatchData, error) {
 	}
 
 	return &derive.BatchData{
-		BatchV1: derive.BatchV1{
+		SingularBatch: derive.SingularBatch{
 			ParentHash:   block.ParentHash(),
 			EpochNum:     rollup.Epoch(l1Info.Number),
 			EpochHash:    l1Info.BlockHash,

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -58,6 +58,7 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 	deployConfig.ChannelTimeout = tp.ChannelTimeout
 	deployConfig.L1BlockTime = tp.L1BlockTime
 	deployConfig.L2GenesisRegolithTimeOffset = nil
+	deployConfig.L2GenesisSpanBatchTimeOffset = SpanBatchTimeOffset()
 
 	require.NoError(t, deployConfig.Check())
 	require.Equal(t, addresses.Batcher, deployConfig.BatchSenderAddress)
@@ -156,6 +157,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		DepositContractAddress: deployConf.OptimismPortalProxy,
 		L1SystemConfigAddress:  deployConf.SystemConfigProxy,
 		RegolithTime:           deployConf.RegolithTime(uint64(deployConf.L1GenesisBlockTimestamp)),
+		SpanBatchTime:          deployConf.SpanBatchTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 	}
 
 	require.NoError(t, rollupCfg.Check())
@@ -180,4 +182,12 @@ func SystemConfigFromDeployConfig(deployConfig *genesis.DeployConfig) eth.System
 		Scalar:      eth.Bytes32(common.BigToHash(new(big.Int).SetUint64(deployConfig.GasPriceOracleScalar))),
 		GasLimit:    uint64(deployConfig.L2GenesisBlockGasLimit),
 	}
+}
+
+func SpanBatchTimeOffset() *hexutil.Uint64 {
+	if os.Getenv("OP_E2E_USE_SPAN_BATCH") == "true" {
+		offset := hexutil.Uint64(0)
+		return &offset
+	}
+	return nil
 }

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -85,6 +85,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 	require.NoError(t, err)
 	deployConfig := config.DeployConfig.Copy()
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
+	deployConfig.L2GenesisSpanBatchTimeOffset = e2eutils.SpanBatchTimeOffset()
 	require.NoError(t, deployConfig.Check(), "Deploy config is invalid, do you need to run make devnet-allocs?")
 	l1Deployments := config.L1Deployments.Copy()
 	require.NoError(t, l1Deployments.Check())
@@ -418,6 +419,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 			DepositContractAddress:  cfg.DeployConfig.OptimismPortalProxy,
 			L1SystemConfigAddress:   cfg.DeployConfig.SystemConfigProxy,
 			RegolithTime:            cfg.DeployConfig.RegolithTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
+			SpanBatchTime:           cfg.DeployConfig.SpanBatchTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			ProtocolVersionsAddress: cfg.L1Deployments.ProtocolVersionsProxy,
 		}
 	}

--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -16,12 +16,12 @@ import (
 )
 
 type ChannelWithMetadata struct {
-	ID             derive.ChannelID    `json:"id"`
-	IsReady        bool                `json:"is_ready"`
-	InvalidFrames  bool                `json:"invalid_frames"`
-	InvalidBatches bool                `json:"invalid_batches"`
-	Frames         []FrameWithMetadata `json:"frames"`
-	Batches        []derive.BatchV1    `json:"batches"`
+	ID             derive.ChannelID       `json:"id"`
+	IsReady        bool                   `json:"is_ready"`
+	InvalidFrames  bool                   `json:"invalid_frames"`
+	InvalidBatches bool                   `json:"invalid_batches"`
+	Frames         []FrameWithMetadata    `json:"frames"`
+	Batches        []derive.SingularBatch `json:"batches"`
 }
 
 type FrameWithMetadata struct {
@@ -100,7 +100,7 @@ func processFrames(id derive.ChannelID, frames []FrameWithMetadata) ChannelWithM
 		}
 	}
 
-	var batches []derive.BatchV1
+	var batches []derive.SingularBatch
 	invalidBatches := false
 	if ch.IsReady() {
 		br, err := derive.BatchReader(ch.Reader(), eth.L1BlockRef{})
@@ -110,7 +110,7 @@ func processFrames(id derive.ChannelID, frames []FrameWithMetadata) ChannelWithM
 					fmt.Printf("Error reading batch for channel %v. Err: %v\n", id.String(), err)
 					invalidBatches = true
 				} else {
-					batches = append(batches, batch.Batch.BatchV1)
+					batches = append(batches, batch.Batch.SingularBatch)
 				}
 			}
 		} else {

--- a/op-node/cmd/batch_decoder/reassemble/reassemble.go
+++ b/op-node/cmd/batch_decoder/reassemble/reassemble.go
@@ -103,14 +103,14 @@ func processFrames(id derive.ChannelID, frames []FrameWithMetadata) ChannelWithM
 	var batches []derive.SingularBatch
 	invalidBatches := false
 	if ch.IsReady() {
-		br, err := derive.BatchReader(ch.Reader(), eth.L1BlockRef{})
+		br, err := derive.BatchReader(ch.Reader())
 		if err == nil {
 			for batch, err := br(); err != io.EOF; batch, err = br() {
 				if err != nil {
 					fmt.Printf("Error reading batch for channel %v. Err: %v\n", id.String(), err)
 					invalidBatches = true
 				} else {
-					batches = append(batches, batch.Batch.SingularBatch)
+					batches = append(batches, batch.SingularBatch)
 				}
 			}
 		} else {

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -32,7 +32,7 @@ type AttributesQueue struct {
 	config  *rollup.Config
 	builder AttributesBuilder
 	prev    *BatchQueue
-	batch   *BatchData
+	batch   *SingularBatch
 }
 
 func NewAttributesQueue(log log.Logger, cfg *rollup.Config, builder AttributesBuilder, prev *BatchQueue) *AttributesQueue {
@@ -71,7 +71,7 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, l2SafeHead eth.L2
 
 // createNextAttributes transforms a batch into a payload attributes. This sets `NoTxPool` and appends the batched transactions
 // to the attributes transaction list
-func (aq *AttributesQueue) createNextAttributes(ctx context.Context, batch *BatchData, l2SafeHead eth.L2BlockRef) (*eth.PayloadAttributes, error) {
+func (aq *AttributesQueue) createNextAttributes(ctx context.Context, batch *SingularBatch, l2SafeHead eth.L2BlockRef) (*eth.PayloadAttributes, error) {
 	// sanity check parent hash
 	if batch.ParentHash != l2SafeHead.Hash {
 		return nil, NewResetError(fmt.Errorf("valid batch has bad parent hash %s, expected %s", batch.ParentHash, l2SafeHead.Hash))

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -42,13 +42,13 @@ func TestAttributesQueue(t *testing.T) {
 	safeHead.L1Origin = l1Info.ID()
 	safeHead.Time = l1Info.InfoTime
 
-	batch := &BatchData{BatchV1{
+	batch := NewSingularBatchData(SingularBatch{
 		ParentHash:   safeHead.Hash,
 		EpochNum:     rollup.Epoch(l1Info.InfoNum),
 		EpochHash:    l1Info.InfoHash,
 		Timestamp:    safeHead.Time + cfg.BlockTime,
 		Transactions: []eth.Data{eth.Data("foobar"), eth.Data("example")},
-	}}
+	})
 
 	parentL1Cfg := eth.SystemConfig{
 		BatcherAddr: common.Address{42},

--- a/op-node/rollup/derive/attributes_queue_test.go
+++ b/op-node/rollup/derive/attributes_queue_test.go
@@ -42,13 +42,13 @@ func TestAttributesQueue(t *testing.T) {
 	safeHead.L1Origin = l1Info.ID()
 	safeHead.Time = l1Info.InfoTime
 
-	batch := NewSingularBatchData(SingularBatch{
+	batch := SingularBatch{
 		ParentHash:   safeHead.Hash,
 		EpochNum:     rollup.Epoch(l1Info.InfoNum),
 		EpochHash:    l1Info.InfoHash,
 		Timestamp:    safeHead.Time + cfg.BlockTime,
 		Transactions: []eth.Data{eth.Data("foobar"), eth.Data("example")},
-	})
+	}
 
 	parentL1Cfg := eth.SystemConfig{
 		BatcherAddr: common.Address{42},
@@ -80,7 +80,7 @@ func TestAttributesQueue(t *testing.T) {
 
 	aq := NewAttributesQueue(testlog.Logger(t, log.LvlError), cfg, attrBuilder, nil)
 
-	actual, err := aq.createNextAttributes(context.Background(), batch, safeHead)
+	actual, err := aq.createNextAttributes(context.Background(), &batch, safeHead)
 
 	require.NoError(t, err)
 	require.Equal(t, attrs, *actual)

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -7,48 +7,44 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // Batch format
 // first byte is type followed by bytestring.
 //
-// BatchV1Type := 0
-// batchV1 := BatchV1Type ++ RLP([epoch, timestamp, transaction_list]
-//
 // An empty input is not a valid batch.
 //
 // Note: the type system is based on L1 typed transactions.
-
+//
 // encodeBufferPool holds temporary encoder buffers for batch encoding
 var encodeBufferPool = sync.Pool{
 	New: func() any { return new(bytes.Buffer) },
 }
 
 const (
-	BatchV1Type = iota
+	// SingularBatchType is the first version of Batch format, representing a single L2 block.
+	SingularBatchType = iota
+	// SpanBatchType is the Batch version used after SpanBatch hard fork, representing a span of L2 blocks.
+	SpanBatchType
 )
 
-type BatchV1 struct {
-	ParentHash common.Hash  // parent L2 block hash
-	EpochNum   rollup.Epoch // aka l1 num
-	EpochHash  common.Hash  // block hash
-	Timestamp  uint64
-	// no feeRecipient address input, all fees go to a L2 contract
-	Transactions []hexutil.Bytes
+// Batch contains information to build one or multiple L2 blocks.
+// Batcher converts L2 blocks into Batch and writes encoded bytes to Channel.
+// Derivation pipeline decodes Batch from Channel, and converts to one or multiple payload attributes.
+type Batch interface {
+	GetBatchType() int
+	GetTimestamp() uint64
+	LogContext(log.Logger) log.Logger
 }
 
+// BatchData is a composition type that contains raw data of each batch version.
+// It has encoding & decoding methods to implement typed encoding.
 type BatchData struct {
-	BatchV1
-	// batches may contain additional data with new upgrades
-}
-
-func (b *BatchV1) Epoch() eth.BlockID {
-	return eth.BlockID{Hash: b.EpochHash, Number: uint64(b.EpochNum)}
+	BatchType int
+	SingularBatch
+	RawSpanBatch
 }
 
 // EncodeRLP implements rlp.Encoder
@@ -69,9 +65,18 @@ func (b *BatchData) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// encodeTyped encodes batch type and payload for each batch type.
 func (b *BatchData) encodeTyped(buf *bytes.Buffer) error {
-	buf.WriteByte(BatchV1Type)
-	return rlp.Encode(buf, &b.BatchV1)
+	switch b.BatchType {
+	case SingularBatchType:
+		buf.WriteByte(SingularBatchType)
+		return rlp.Encode(buf, &b.SingularBatch)
+	case SpanBatchType:
+		buf.WriteByte(byte(b.BatchType))
+		return b.RawSpanBatch.encode(buf)
+	default:
+		return fmt.Errorf("unrecognized batch type: %d", b.BatchType)
+	}
 }
 
 // DecodeRLP implements rlp.Decoder
@@ -94,14 +99,35 @@ func (b *BatchData) UnmarshalBinary(data []byte) error {
 	return b.decodeTyped(data)
 }
 
+// decodeTyped decodes batch type and payload for each batch type.
 func (b *BatchData) decodeTyped(data []byte) error {
 	if len(data) == 0 {
 		return fmt.Errorf("batch too short")
 	}
 	switch data[0] {
-	case BatchV1Type:
-		return rlp.DecodeBytes(data[1:], &b.BatchV1)
+	case SingularBatchType:
+		b.BatchType = SingularBatchType
+		return rlp.DecodeBytes(data[1:], &b.SingularBatch)
+	case SpanBatchType:
+		b.BatchType = int(data[0])
+		return b.RawSpanBatch.decodeBytes(data[1:])
 	default:
 		return fmt.Errorf("unrecognized batch type: %d", data[0])
+	}
+}
+
+// NewSingularBatchData creates new BatchData with SingularBatch
+func NewSingularBatchData(singularBatch SingularBatch) *BatchData {
+	return &BatchData{
+		BatchType:     SingularBatchType,
+		SingularBatch: singularBatch,
+	}
+}
+
+// NewSpanBatchData creates new BatchData with SpanBatch
+func NewSpanBatchData(spanBatch RawSpanBatch) *BatchData {
+	return &BatchData{
+		BatchType:    SpanBatchType,
+		RawSpanBatch: spanBatch,
 	}
 }

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -243,15 +243,15 @@ batchLoop:
 	// batch to ensure that we at least have one batch per epoch.
 	if nextTimestamp < nextEpoch.Time || firstOfEpoch {
 		bq.log.Info("Generating next batch", "epoch", epoch, "timestamp", nextTimestamp)
-		return &BatchData{
-			BatchV1{
+		return NewSingularBatchData(
+			SingularBatch{
 				ParentHash:   l2SafeHead.Hash,
 				EpochNum:     rollup.Epoch(epoch.Number),
 				EpochHash:    epoch.Hash,
 				Timestamp:    nextTimestamp,
 				Transactions: nil,
 			},
-		}, nil
+		), nil
 	}
 
 	// At this point we have auto generated every batch for the current epoch

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -78,7 +78,7 @@ func (bq *BatchQueue) popNextBatch(safeL2Head eth.L2BlockRef) *SingularBatch {
 	return nextBatch
 }
 
-func (bq *BatchQueue) advanceEpoch(nextBatch *SingularBatch) {
+func (bq *BatchQueue) advanceEpochMaybe(nextBatch *SingularBatch) {
 	if nextBatch.GetEpochNum() == rollup.Epoch(bq.l1Blocks[0].Number)+1 {
 		// Advance epoch if necessary
 		bq.l1Blocks = bq.l1Blocks[1:]
@@ -89,7 +89,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 	if len(bq.nextSpan) > 0 {
 		// If there are cached singular batches, pop first one and return.
 		nextBatch := bq.popNextBatch(safeL2Head)
-		bq.advanceEpoch(nextBatch)
+		bq.advanceEpochMaybe(nextBatch)
 		return nextBatch, nil
 	}
 
@@ -169,7 +169,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 		return nil, NewCriticalError(fmt.Errorf("unrecognized batch type: %d", batch.GetBatchType()))
 	}
 
-	bq.advanceEpoch(nextBatch)
+	bq.advanceEpochMaybe(nextBatch)
 	return nextBatch, nil
 }
 

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -29,7 +29,12 @@ import (
 
 type NextBatchProvider interface {
 	Origin() eth.L1BlockRef
-	NextBatch(ctx context.Context) (*BatchData, error)
+	NextBatch(ctx context.Context) (Batch, error)
+}
+
+type SafeBlockFetcher interface {
+	L2BlockRefByNumber(context.Context, uint64) (eth.L2BlockRef, error)
+	PayloadByNumber(context.Context, uint64) (*eth.ExecutionPayload, error)
 }
 
 // BatchQueue contains a set of batches for every L1 block.
@@ -42,16 +47,22 @@ type BatchQueue struct {
 
 	l1Blocks []eth.L1BlockRef
 
-	// batches in order of when we've first seen them, grouped by L2 timestamp
-	batches map[uint64][]*BatchWithL1InclusionBlock
+	// batches in order of when we've first seen them
+	batches []*BatchWithL1InclusionBlock
+
+	// nextSpan is cached SingularBatches derived from SpanBatch
+	nextSpan []*SingularBatch
+
+	l2 SafeBlockFetcher
 }
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.
-func NewBatchQueue(log log.Logger, cfg *rollup.Config, prev NextBatchProvider) *BatchQueue {
+func NewBatchQueue(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l2 SafeBlockFetcher) *BatchQueue {
 	return &BatchQueue{
 		log:    log,
 		config: cfg,
 		prev:   prev,
+		l2:     l2,
 	}
 }
 
@@ -59,7 +70,29 @@ func (bq *BatchQueue) Origin() eth.L1BlockRef {
 	return bq.prev.Origin()
 }
 
-func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) (*BatchData, error) {
+func (bq *BatchQueue) popNextBatch(safeL2Head eth.L2BlockRef) *SingularBatch {
+	nextBatch := bq.nextSpan[0]
+	bq.nextSpan = bq.nextSpan[1:]
+	// Must set ParentHash before return. we can use safeL2Head because the parentCheck is verified in CheckBatch().
+	nextBatch.ParentHash = safeL2Head.Hash
+	return nextBatch
+}
+
+func (bq *BatchQueue) advanceEpoch(nextBatch *SingularBatch) {
+	if nextBatch.GetEpochNum() == rollup.Epoch(bq.l1Blocks[0].Number)+1 {
+		// Advance epoch if necessary
+		bq.l1Blocks = bq.l1Blocks[1:]
+	}
+}
+
+func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) (*SingularBatch, error) {
+	if len(bq.nextSpan) > 0 {
+		// If there are cached singular batches, pop first one and return.
+		nextBatch := bq.popNextBatch(safeL2Head)
+		bq.advanceEpoch(nextBatch)
+		return nextBatch, nil
+	}
+
 	// Note: We use the origin that we will have to determine if it's behind. This is important
 	// because it's the future origin that gets saved into the l1Blocks array.
 	// We always update the origin of this stage if it is not the same so after the update code
@@ -89,7 +122,7 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 	} else if err != nil {
 		return nil, err
 	} else if !originBehind {
-		bq.AddBatch(batch, safeL2Head)
+		bq.AddBatch(ctx, batch, safeL2Head)
 	}
 
 	// Skip adding data unless we are up to date with the origin, but do fully
@@ -111,43 +144,70 @@ func (bq *BatchQueue) NextBatch(ctx context.Context, safeL2Head eth.L2BlockRef) 
 	} else if err != nil {
 		return nil, err
 	}
-	return batch, nil
+
+	var nextBatch *SingularBatch
+	switch batch.GetBatchType() {
+	case SingularBatchType:
+		singularBatch, ok := batch.(*SingularBatch)
+		if !ok {
+			return nil, NewCriticalError(errors.New("failed type assertion to SingularBatch"))
+		}
+		nextBatch = singularBatch
+	case SpanBatchType:
+		spanBatch, ok := batch.(*SpanBatch)
+		if !ok {
+			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
+		}
+		// If next batch is SpanBatch, convert it to SingularBatches.
+		singularBatches, err := spanBatch.GetSingularBatches(bq.l1Blocks, safeL2Head)
+		if err != nil {
+			return nil, NewCriticalError(err)
+		}
+		bq.nextSpan = singularBatches
+		nextBatch = bq.popNextBatch(safeL2Head)
+	default:
+		return nil, NewCriticalError(fmt.Errorf("unrecognized batch type: %d", batch.GetBatchType()))
+	}
+
+	bq.advanceEpoch(nextBatch)
+	return nextBatch, nil
 }
 
 func (bq *BatchQueue) Reset(ctx context.Context, base eth.L1BlockRef, _ eth.SystemConfig) error {
 	// Copy over the Origin from the next stage
 	// It is set in the engine queue (two stages away) such that the L2 Safe Head origin is the progress
 	bq.origin = base
-	bq.batches = make(map[uint64][]*BatchWithL1InclusionBlock)
+	bq.batches = []*BatchWithL1InclusionBlock{}
 	// Include the new origin as an origin to build on
 	// Note: This is only for the initialization case. During normal resets we will later
 	// throw out this block.
 	bq.l1Blocks = bq.l1Blocks[:0]
 	bq.l1Blocks = append(bq.l1Blocks, base)
+	bq.nextSpan = bq.nextSpan[:0]
 	return io.EOF
 }
 
-func (bq *BatchQueue) AddBatch(batch *BatchData, l2SafeHead eth.L2BlockRef) {
+func (bq *BatchQueue) AddBatch(ctx context.Context, batch Batch, l2SafeHead eth.L2BlockRef) {
 	if len(bq.l1Blocks) == 0 {
-		panic(fmt.Errorf("cannot add batch with timestamp %d, no origin was prepared", batch.Timestamp))
+		panic(fmt.Errorf("cannot add batch with timestamp %d, no origin was prepared", batch.GetTimestamp()))
 	}
 	data := BatchWithL1InclusionBlock{
 		L1InclusionBlock: bq.origin,
 		Batch:            batch,
 	}
-	validity := CheckBatch(bq.config, bq.log, bq.l1Blocks, l2SafeHead, &data)
+	validity := CheckBatch(ctx, bq.config, bq.log, bq.l1Blocks, l2SafeHead, &data, bq.l2)
 	if validity == BatchDrop {
 		return // if we do drop the batch, CheckBatch will log the drop reason with WARN level.
 	}
-	bq.log.Debug("Adding batch", "batch_timestamp", batch.Timestamp, "parent_hash", batch.ParentHash, "batch_epoch", batch.Epoch(), "txs", len(batch.Transactions))
-	bq.batches[batch.Timestamp] = append(bq.batches[batch.Timestamp], &data)
+	batch.LogContext(bq.log).Debug("Adding batch")
+	bq.batches = append(bq.batches, &data)
 }
 
 // deriveNextBatch derives the next batch to apply on top of the current L2 safe head,
 // following the validity rules imposed on consecutive batches,
 // based on currently available buffered batch and L1 origin information.
 // If no batch can be derived yet, then (nil, io.EOF) is returned.
-func (bq *BatchQueue) deriveNextBatch(ctx context.Context, outOfData bool, l2SafeHead eth.L2BlockRef) (*BatchData, error) {
+func (bq *BatchQueue) deriveNextBatch(ctx context.Context, outOfData bool, l2SafeHead eth.L2BlockRef) (Batch, error) {
 	if len(bq.l1Blocks) == 0 {
 		return nil, NewCriticalError(errors.New("cannot derive next batch, no origin was prepared"))
 	}
@@ -170,19 +230,15 @@ func (bq *BatchQueue) deriveNextBatch(ctx context.Context, outOfData bool, l2Saf
 	// Go over all batches, in order of inclusion, and find the first batch we can accept.
 	// We filter in-place by only remembering the batches that may be processed in the future, or those we are undecided on.
 	var remaining []*BatchWithL1InclusionBlock
-	candidates := bq.batches[nextTimestamp]
 batchLoop:
-	for i, batch := range candidates {
-		validity := CheckBatch(bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch)
+	for i, batch := range bq.batches {
+		validity := CheckBatch(ctx, bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch, bq.l2)
 		switch validity {
 		case BatchFuture:
-			return nil, NewCriticalError(fmt.Errorf("found batch with timestamp %d marked as future batch, but expected timestamp %d", batch.Batch.Timestamp, nextTimestamp))
+			remaining = append(remaining, batch)
+			continue
 		case BatchDrop:
-			bq.log.Warn("dropping batch",
-				"batch_timestamp", batch.Batch.Timestamp,
-				"parent_hash", batch.Batch.ParentHash,
-				"batch_epoch", batch.Batch.Epoch(),
-				"txs", len(batch.Batch.Transactions),
+			batch.Batch.LogContext(bq.log).Warn("dropping batch",
 				"l2_safe_head", l2SafeHead.ID(),
 				"l2_safe_head_time", l2SafeHead.Time,
 			)
@@ -191,29 +247,20 @@ batchLoop:
 			nextBatch = batch
 			// don't keep the current batch in the remaining items since we are processing it now,
 			// but retain every batch we didn't get to yet.
-			remaining = append(remaining, candidates[i+1:]...)
+			remaining = append(remaining, bq.batches[i+1:]...)
 			break batchLoop
 		case BatchUndecided:
-			remaining = append(remaining, batch)
-			bq.batches[nextTimestamp] = remaining
+			remaining = append(remaining, bq.batches[i:]...)
+			bq.batches = remaining
 			return nil, io.EOF
 		default:
 			return nil, NewCriticalError(fmt.Errorf("unknown batch validity type: %d", validity))
 		}
 	}
-	// clean up if we remove the final batch for this timestamp
-	if len(remaining) == 0 {
-		delete(bq.batches, nextTimestamp)
-	} else {
-		bq.batches[nextTimestamp] = remaining
-	}
+	bq.batches = remaining
 
 	if nextBatch != nil {
-		// advance epoch if necessary
-		if nextBatch.Batch.EpochNum == rollup.Epoch(epoch.Number)+1 {
-			bq.l1Blocks = bq.l1Blocks[1:]
-		}
-		bq.log.Info("Found next batch", "epoch", epoch, "batch_epoch", nextBatch.Batch.EpochNum, "batch_timestamp", nextBatch.Batch.Timestamp)
+		nextBatch.Batch.LogContext(bq.log).Info("Found next batch")
 		return nextBatch.Batch, nil
 	}
 
@@ -243,15 +290,13 @@ batchLoop:
 	// batch to ensure that we at least have one batch per epoch.
 	if nextTimestamp < nextEpoch.Time || firstOfEpoch {
 		bq.log.Info("Generating next batch", "epoch", epoch, "timestamp", nextTimestamp)
-		return NewSingularBatchData(
-			SingularBatch{
-				ParentHash:   l2SafeHead.Hash,
-				EpochNum:     rollup.Epoch(epoch.Number),
-				EpochHash:    epoch.Hash,
-				Timestamp:    nextTimestamp,
-				Transactions: nil,
-			},
-		), nil
+		return &SingularBatch{
+			ParentHash:   l2SafeHead.Hash,
+			EpochNum:     rollup.Epoch(epoch.Number),
+			EpochHash:    epoch.Hash,
+			Timestamp:    nextTimestamp,
+			Transactions: nil,
+		}, nil
 	}
 
 	// At this point we have auto generated every batch for the current epoch

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -48,13 +48,13 @@ func mockHash(time uint64, layer uint8) common.Hash {
 func b(timestamp uint64, epoch eth.L1BlockRef) *BatchData {
 	rng := rand.New(rand.NewSource(int64(timestamp)))
 	data := testutils.RandomData(rng, 20)
-	return &BatchData{BatchV1{
+	return NewSingularBatchData(SingularBatch{
 		ParentHash:   mockHash(timestamp-2, 2),
 		Timestamp:    timestamp,
 		EpochNum:     rollup.Epoch(epoch.Number),
 		EpochHash:    epoch.Hash,
 		Transactions: []hexutil.Bytes{data},
-	}}
+	})
 }
 
 func L1Chain(l1Times []uint64) []eth.L1BlockRef {
@@ -331,7 +331,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(12))
-	require.Empty(t, b.BatchV1.Transactions)
+	require.Empty(t, b.SingularBatch.Transactions)
 	require.Equal(t, rollup.Epoch(0), b.EpochNum)
 	safeHead.Number += 1
 	safeHead.Time += 2
@@ -341,7 +341,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(14))
-	require.Empty(t, b.BatchV1.Transactions)
+	require.Empty(t, b.SingularBatch.Transactions)
 	require.Equal(t, rollup.Epoch(0), b.EpochNum)
 	safeHead.Number += 1
 	safeHead.Time += 2
@@ -367,6 +367,6 @@ func TestBatchQueueMissing(t *testing.T) {
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(18))
-	require.Empty(t, b.BatchV1.Transactions)
+	require.Empty(t, b.SingularBatch.Transactions)
 	require.Equal(t, rollup.Epoch(1), b.EpochNum)
 }

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -3,9 +3,13 @@ package derive
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
+	"math/big"
 	"math/rand"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -20,7 +24,7 @@ import (
 
 type fakeBatchQueueInput struct {
 	i       int
-	batches []*BatchData
+	batches []Batch
 	errors  []error
 	origin  eth.L1BlockRef
 }
@@ -29,7 +33,7 @@ func (f *fakeBatchQueueInput) Origin() eth.L1BlockRef {
 	return f.origin
 }
 
-func (f *fakeBatchQueueInput) NextBatch(ctx context.Context) (*BatchData, error) {
+func (f *fakeBatchQueueInput) NextBatch(ctx context.Context) (Batch, error) {
 	if f.i >= len(f.batches) {
 		return nil, io.EOF
 	}
@@ -45,16 +49,74 @@ func mockHash(time uint64, layer uint8) common.Hash {
 	return hash
 }
 
-func b(timestamp uint64, epoch eth.L1BlockRef) *BatchData {
+func b(chainId *big.Int, timestamp uint64, epoch eth.L1BlockRef) *SingularBatch {
 	rng := rand.New(rand.NewSource(int64(timestamp)))
-	data := testutils.RandomData(rng, 20)
-	return NewSingularBatchData(SingularBatch{
+	signer := types.NewLondonSigner(chainId)
+	tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+	txData, _ := tx.MarshalBinary()
+	return &SingularBatch{
 		ParentHash:   mockHash(timestamp-2, 2),
 		Timestamp:    timestamp,
 		EpochNum:     rollup.Epoch(epoch.Number),
 		EpochHash:    epoch.Hash,
-		Transactions: []hexutil.Bytes{data},
-	})
+		Transactions: []hexutil.Bytes{txData},
+	}
+}
+
+func buildSpanBatches(t *testing.T, parent *eth.L2BlockRef, singularBatches []*SingularBatch, blockCounts []int, chainId *big.Int) []Batch {
+	var spanBatches []Batch
+	idx := 0
+	for _, count := range blockCounts {
+		span := NewSpanBatch(singularBatches[idx : idx+count])
+		spanBatches = append(spanBatches, span)
+		idx += count
+	}
+	return spanBatches
+}
+
+func getSpanBatchTime(batchType int) *uint64 {
+	minTs := uint64(0)
+	if batchType == SpanBatchType {
+		return &minTs
+	}
+	return nil
+}
+
+func l1InfoDepositTx(t *testing.T, l1BlockNum uint64) hexutil.Bytes {
+	l1Info := L1BlockInfo{
+		Number:  l1BlockNum,
+		BaseFee: big.NewInt(0),
+	}
+	infoData, err := l1Info.MarshalBinary()
+	require.NoError(t, err)
+	depositTx := &types.DepositTx{
+		Data: infoData,
+	}
+	txData, err := types.NewTx(depositTx).MarshalBinary()
+	require.NoError(t, err)
+	return txData
+}
+
+func singularBatchToPayload(t *testing.T, batch *SingularBatch, blockNumber uint64) eth.ExecutionPayload {
+	txs := []hexutil.Bytes{l1InfoDepositTx(t, uint64(batch.EpochNum))}
+	txs = append(txs, batch.Transactions...)
+	return eth.ExecutionPayload{
+		BlockHash:    mockHash(batch.Timestamp, 2),
+		ParentHash:   batch.ParentHash,
+		BlockNumber:  hexutil.Uint64(blockNumber),
+		Timestamp:    hexutil.Uint64(batch.Timestamp),
+		Transactions: txs,
+	}
+}
+
+func singularBatchToBlockRef(t *testing.T, batch *SingularBatch, blockNumber uint64) eth.L2BlockRef {
+	return eth.L2BlockRef{
+		Hash:       mockHash(batch.Timestamp, 2),
+		Number:     blockNumber,
+		ParentHash: batch.ParentHash,
+		Time:       batch.Timestamp,
+		L1Origin:   eth.BlockID{Hash: batch.EpochHash, Number: uint64(batch.EpochNum)},
+	}
 }
 
 func L1Chain(l1Times []uint64) []eth.L1BlockRef {
@@ -73,10 +135,37 @@ func L1Chain(l1Times []uint64) []eth.L1BlockRef {
 	return out
 }
 
-// TestBatchQueueNewOrigin tests that the batch queue properly saves the new origin
+func TestBatchQueue(t *testing.T) {
+	tests := []struct {
+		name string
+		f    func(t *testing.T, batchType int)
+	}{
+		{"BatchQueueNewOrigin", BatchQueueNewOrigin},
+		{"BatchQueueEager", BatchQueueEager},
+		{"BatchQueueInvalidInternalAdvance", BatchQueueInvalidInternalAdvance},
+		{"BatchQueueMissing", BatchQueueMissing},
+		{"BatchQueueAdvancedEpoch", BatchQueueAdvancedEpoch},
+		{"BatchQueueShuffle", BatchQueueShuffle},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SingularBatch", func(t *testing.T) {
+			test.f(t, SingularBatchType)
+		})
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
+			test.f(t, SpanBatchType)
+		})
+	}
+}
+
+// BatchQueueNewOrigin tests that the batch queue properly saves the new origin
 // when the safehead's origin is ahead of the pipeline's origin (as is after a reset).
 // This issue was fixed in https://github.com/ethereum-optimism/optimism/pull/3694
-func TestBatchQueueNewOrigin(t *testing.T) {
+func BatchQueueNewOrigin(t *testing.T, batchType int) {
 	log := testlog.Logger(t, log.LvlCrit)
 	l1 := L1Chain([]uint64{10, 15, 20, 25})
 	safeHead := eth.L2BlockRef{
@@ -94,15 +183,16 @@ func TestBatchQueueNewOrigin(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     2,
+		SpanBatchTime:     getSpanBatchTime(batchType),
 	}
 
 	input := &fakeBatchQueueInput{
-		batches: []*BatchData{nil},
+		batches: []Batch{nil},
 		errors:  []error{io.EOF},
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	require.Equal(t, []eth.L1BlockRef{l1[0]}, bq.l1Blocks)
 
@@ -133,11 +223,12 @@ func TestBatchQueueNewOrigin(t *testing.T) {
 	require.Equal(t, l1[2], bq.origin)
 }
 
-// TestBatchQueueEager adds a bunch of contiguous batches and asserts that
+// BatchQueueEager adds a bunch of contiguous batches and asserts that
 // enough calls to `NextBatch` return all of those batches.
-func TestBatchQueueEager(t *testing.T) {
+func BatchQueueEager(t *testing.T, batchType int) {
 	log := testlog.Logger(t, log.LvlCrit)
 	l1 := L1Chain([]uint64{10, 20, 30})
+	chainId := big.NewInt(1234)
 	safeHead := eth.L2BlockRef{
 		Hash:           mockHash(10, 2),
 		Number:         0,
@@ -153,41 +244,69 @@ func TestBatchQueueEager(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(batchType),
+		L2ChainID:         chainId,
 	}
 
-	batches := []*BatchData{b(12, l1[0]), b(14, l1[0]), b(16, l1[0]), b(18, l1[0]), b(20, l1[0]), b(22, l1[0]), b(24, l1[1]), nil}
-	errors := []error{nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		b(cfg.L2ChainID, 12, l1[0]),
+		b(cfg.L2ChainID, 14, l1[0]),
+		b(cfg.L2ChainID, 16, l1[0]),
+		b(cfg.L2ChainID, 18, l1[0]),
+		b(cfg.L2ChainID, 20, l1[0]),
+		b(cfg.L2ChainID, 22, l1[0]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == SpanBatchType {
+		spanBlockCounts := []int{1, 2, 3}
+		inputErrors = []error{nil, nil, nil, io.EOF}
+		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+		inputBatches = append(inputBatches, nil)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
 
 	input := &fakeBatchQueueInput{
-		batches: batches,
-		errors:  errors,
+		batches: inputBatches,
+		errors:  inputErrors,
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	// Advance the origin
 	input.origin = l1[1]
 
-	for i := 0; i < len(batches); i++ {
+	for i := 0; i < len(expectedOutputBatches); i++ {
 		b, e := bq.NextBatch(context.Background(), safeHead)
-		require.ErrorIs(t, e, errors[i])
-		require.Equal(t, batches[i], b)
-
-		if b != nil {
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutputBatches[i])
+		} else {
+			require.Equal(t, expectedOutputBatches[i], b)
 			safeHead.Number += 1
-			safeHead.Time += 2
+			safeHead.Time += cfg.BlockTime
 			safeHead.Hash = mockHash(b.Timestamp, 2)
 			safeHead.L1Origin = b.Epoch()
 		}
 	}
 }
 
-// TestBatchQueueInvalidInternalAdvance asserts that we do not miss an epoch when generating batches.
+// BatchQueueInvalidInternalAdvance asserts that we do not miss an epoch when generating batches.
 // This is a regression test for CLI-3378.
-func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
+func BatchQueueInvalidInternalAdvance(t *testing.T, batchType int) {
 	log := testlog.Logger(t, log.LvlTrace)
 	l1 := L1Chain([]uint64{10, 15, 20, 25, 30})
+	chainId := big.NewInt(1234)
 	safeHead := eth.L2BlockRef{
 		Hash:           mockHash(10, 2),
 		Number:         0,
@@ -203,27 +322,54 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     2,
+		SpanBatchTime:     getSpanBatchTime(batchType),
+		L2ChainID:         chainId,
 	}
 
-	batches := []*BatchData{b(12, l1[0]), b(14, l1[0]), b(16, l1[0]), b(18, l1[0]), b(20, l1[0]), b(22, l1[0]), nil}
-	errors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		b(cfg.L2ChainID, 12, l1[0]),
+		b(cfg.L2ChainID, 14, l1[0]),
+		b(cfg.L2ChainID, 16, l1[0]),
+		b(cfg.L2ChainID, 18, l1[0]),
+		b(cfg.L2ChainID, 20, l1[0]),
+		b(cfg.L2ChainID, 22, l1[0]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == SpanBatchType {
+		spanBlockCounts := []int{1, 2, 3}
+		inputErrors = []error{nil, nil, nil, io.EOF}
+		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+		inputBatches = append(inputBatches, nil)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
 
 	input := &fakeBatchQueueInput{
-		batches: batches,
-		errors:  errors,
+		batches: inputBatches,
+		errors:  inputErrors,
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	// Load continuous batches for epoch 0
-	for i := 0; i < len(batches); i++ {
+	for i := 0; i < len(expectedOutputBatches); i++ {
 		b, e := bq.NextBatch(context.Background(), safeHead)
-		require.ErrorIs(t, e, errors[i])
-		require.Equal(t, batches[i], b)
-
-		if b != nil {
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutputBatches[i])
+		} else {
+			require.Equal(t, expectedOutputBatches[i], b)
 			safeHead.Number += 1
 			safeHead.Time += 2
 			safeHead.Hash = mockHash(b.Timestamp, 2)
@@ -276,9 +422,10 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 
 }
 
-func TestBatchQueueMissing(t *testing.T) {
+func BatchQueueMissing(t *testing.T, batchType int) {
 	log := testlog.Logger(t, log.LvlCrit)
 	l1 := L1Chain([]uint64{10, 15, 20, 25})
+	chainId := big.NewInt(1234)
 	safeHead := eth.L2BlockRef{
 		Hash:           mockHash(10, 2),
 		Number:         0,
@@ -294,30 +441,49 @@ func TestBatchQueueMissing(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     2,
+		SpanBatchTime:     getSpanBatchTime(batchType),
+		L2ChainID:         chainId,
 	}
 
-	// The batches at 18 and 20 are skipped to stop 22 from being eagerly processed.
+	// The inputBatches at 18 and 20 are skipped to stop 22 from being eagerly processed.
 	// This test checks that batch timestamp 12 & 14 are created, 16 is used, and 18 is advancing the epoch.
-	// Due to the large sequencer time drift 16 is perfectly valid to have epoch 0 as origin.
-	batches := []*BatchData{b(16, l1[0]), b(22, l1[1])}
-	errors := []error{nil, nil}
+	// Due to the large sequencer time drift 16 is perfectly valid to have epoch 0 as origin.a
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		b(cfg.L2ChainID, 16, l1[0]),
+		b(cfg.L2ChainID, 22, l1[1]),
+	}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil}
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == SpanBatchType {
+		spanBlockCounts := []int{1, 1}
+		inputErrors = []error{nil, nil, nil, io.EOF}
+		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
 
 	input := &fakeBatchQueueInput{
-		batches: batches,
-		errors:  errors,
+		batches: inputBatches,
+		errors:  inputErrors,
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
-	for i := 0; i < len(batches); i++ {
+	for i := 0; i < len(expectedOutputBatches); i++ {
 		b, e := bq.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, e, NotEnoughData)
 		require.Nil(t, b)
 	}
 
-	// advance origin. Underlying stage still has no more batches
+	// advance origin. Underlying stage still has no more inputBatches
 	// This is not enough to auto advance yet
 	input.origin = l1[1]
 	b, e := bq.NextBatch(context.Background(), safeHead)
@@ -331,7 +497,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(12))
-	require.Empty(t, b.SingularBatch.Transactions)
+	require.Empty(t, b.Transactions)
 	require.Equal(t, rollup.Epoch(0), b.EpochNum)
 	safeHead.Number += 1
 	safeHead.Time += 2
@@ -341,7 +507,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(14))
-	require.Empty(t, b.SingularBatch.Transactions)
+	require.Empty(t, b.Transactions)
 	require.Equal(t, rollup.Epoch(0), b.EpochNum)
 	safeHead.Number += 1
 	safeHead.Time += 2
@@ -350,7 +516,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	// Check for the inputted batch at t = 16
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
-	require.Equal(t, b, batches[0])
+	require.Equal(t, b, expectedOutputBatches[0])
 	require.Equal(t, rollup.Epoch(0), b.EpochNum)
 	safeHead.Number += 1
 	safeHead.Time += 2
@@ -367,6 +533,387 @@ func TestBatchQueueMissing(t *testing.T) {
 	b, e = bq.NextBatch(context.Background(), safeHead)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(18))
-	require.Empty(t, b.SingularBatch.Transactions)
+	require.Empty(t, b.Transactions)
 	require.Equal(t, rollup.Epoch(1), b.EpochNum)
+}
+
+// BatchQueueAdvancedEpoch tests that batch queue derives consecutive valid batches with advancing epochs.
+// Batch queue's l1blocks list should be updated along epochs.
+func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		b(cfg.L2ChainID, 6, l1[1]),
+		b(cfg.L2ChainID, 8, l1[1]),
+		b(cfg.L2ChainID, 10, l1[1]),
+		b(cfg.L2ChainID, 12, l1[2]),
+		b(cfg.L2ChainID, 14, l1[2]),
+		b(cfg.L2ChainID, 16, l1[2]),
+		b(cfg.L2ChainID, 18, l1[3]),
+		b(cfg.L2ChainID, 20, l1[3]),
+		b(cfg.L2ChainID, 22, l1[3]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == SpanBatchType {
+		spanBlockCounts := []int{2, 2, 2, 3}
+		inputErrors = []error{nil, nil, nil, nil, io.EOF}
+		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+		inputBatches = append(inputBatches, nil)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		b, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
+			require.Equal(t, bq.l1Blocks[0].Number, uint64(b.EpochNum))
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
+// BatchQueueShuffle tests batch queue can reorder shuffled valid batches
+func BatchQueueShuffle(t *testing.T, batchType int) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(batchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		b(cfg.L2ChainID, 6, l1[1]),
+		b(cfg.L2ChainID, 8, l1[1]),
+		b(cfg.L2ChainID, 10, l1[1]),
+		b(cfg.L2ChainID, 12, l1[2]),
+		b(cfg.L2ChainID, 14, l1[2]),
+		b(cfg.L2ChainID, 16, l1[2]),
+		b(cfg.L2ChainID, 18, l1[3]),
+		b(cfg.L2ChainID, 20, l1[3]),
+		b(cfg.L2ChainID, 22, l1[3]),
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := expectedOutputErrors
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	if batchType == SpanBatchType {
+		spanBlockCounts := []int{2, 2, 2, 3}
+		inputErrors = []error{nil, nil, nil, nil, io.EOF}
+		inputBatches = buildSpanBatches(t, &safeHead, expectedOutputBatches, spanBlockCounts, chainId)
+	} else {
+		for _, singularBatch := range expectedOutputBatches {
+			inputBatches = append(inputBatches, singularBatch)
+		}
+	}
+
+	// Shuffle the order of input batches
+	rand.Shuffle(len(inputBatches), func(i, j int) {
+		inputBatches[i], inputBatches[j] = inputBatches[j], inputBatches[i]
+	})
+	inputBatches = append(inputBatches, nil)
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	bq := NewBatchQueue(log, cfg, input, nil)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		var b *SingularBatch
+		var e error
+		for j := 0; j < len(expectedOutputBatches); j++ {
+			// Multiple NextBatch() executions may be required because the order of input is shuffled
+			b, e = bq.NextBatch(context.Background(), safeHead)
+			if !errors.Is(e, NotEnoughData) {
+				break
+			}
+		}
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
+			require.Equal(t, bq.l1Blocks[0].Number, uint64(b.EpochNum))
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
+func TestBatchQueueOverlappingSpanBatch(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1 := L1Chain([]uint64{10, 20, 30})
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(10, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           10,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		b(cfg.L2ChainID, 12, l1[0]),
+		b(cfg.L2ChainID, 14, l1[0]),
+		b(cfg.L2ChainID, 16, l1[0]),
+		b(cfg.L2ChainID, 18, l1[0]),
+		b(cfg.L2ChainID, 20, l1[0]),
+		b(cfg.L2ChainID, 22, l1[0]),
+		nil,
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil, nil, nil, io.EOF}
+
+	// batches will be returned by fakeBatchQueueInput
+	var inputBatches []Batch
+	batchSize := 3
+	for i := 0; i < len(expectedOutputBatches)-batchSize; i++ {
+		inputBatches = append(inputBatches, NewSpanBatch(expectedOutputBatches[i:i+batchSize]))
+	}
+	inputBatches = append(inputBatches, nil)
+
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[0],
+	}
+
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	for i, batch := range expectedOutputBatches {
+		if batch != nil {
+			blockRef := singularBatchToBlockRef(t, batch, uint64(i+1))
+			payload := singularBatchToPayload(t, batch, uint64(i+1))
+			l2Client.Mock.On("L2BlockRefByNumber", uint64(i+1)).Times(9999).Return(blockRef, &nilErr)
+			l2Client.Mock.On("PayloadByNumber", uint64(i+1)).Times(9999).Return(&payload, &nilErr)
+		}
+	}
+
+	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
+	// Advance the origin
+	input.origin = l1[1]
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		b, e := bq.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutputBatches[i])
+		} else {
+			require.Equal(t, expectedOutputBatches[i], b)
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
+}
+
+func TestBatchQueueComplex(t *testing.T) {
+	log := testlog.Logger(t, log.LvlCrit)
+	l1 := L1Chain([]uint64{0, 6, 12, 18, 24}) // L1 block time: 6s
+	chainId := big.NewInt(1234)
+	safeHead := eth.L2BlockRef{
+		Hash:           mockHash(4, 2),
+		Number:         0,
+		ParentHash:     common.Hash{},
+		Time:           4,
+		L1Origin:       l1[0].ID(),
+		SequenceNumber: 0,
+	}
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 10,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     30,
+		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		L2ChainID:         chainId,
+	}
+
+	// expected output of BatchQueue.NextBatch()
+	expectedOutputBatches := []*SingularBatch{
+		// 3 L2 blocks per L1 block
+		b(cfg.L2ChainID, 6, l1[1]),
+		b(cfg.L2ChainID, 8, l1[1]),
+		b(cfg.L2ChainID, 10, l1[1]),
+		b(cfg.L2ChainID, 12, l1[2]),
+		b(cfg.L2ChainID, 14, l1[2]),
+		b(cfg.L2ChainID, 16, l1[2]),
+		b(cfg.L2ChainID, 18, l1[3]),
+		b(cfg.L2ChainID, 20, l1[3]),
+		b(cfg.L2ChainID, 22, l1[3]),
+	}
+	// expected error of BatchQueue.NextBatch()
+	expectedOutputErrors := []error{nil, nil, nil, nil, nil, nil, nil, nil, nil, io.EOF}
+	// errors will be returned by fakeBatchQueueInput.NextBatch()
+	inputErrors := []error{nil, nil, nil, nil, nil, nil, io.EOF}
+	// batches will be returned by fakeBatchQueueInput
+	inputBatches := []Batch{
+		NewSpanBatch(expectedOutputBatches[0:2]), // 6, 8
+		expectedOutputBatches[2],                 // 10
+		NewSpanBatch(expectedOutputBatches[1:4]), // 8, 10, 12
+		expectedOutputBatches[4],                 // 14
+		NewSpanBatch(expectedOutputBatches[4:6]), // 14, 16
+		NewSpanBatch(expectedOutputBatches[6:9]), // 18, 20, 22
+	}
+
+	// Shuffle the order of input batches
+	rand.Shuffle(len(inputBatches), func(i, j int) {
+		inputBatches[i], inputBatches[j] = inputBatches[j], inputBatches[i]
+	})
+
+	inputBatches = append(inputBatches, nil)
+
+	// ChannelInReader origin number
+	inputOriginNumber := 2
+	input := &fakeBatchQueueInput{
+		batches: inputBatches,
+		errors:  inputErrors,
+		origin:  l1[inputOriginNumber],
+	}
+
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	for i, batch := range expectedOutputBatches {
+		if batch != nil {
+			blockRef := singularBatchToBlockRef(t, batch, uint64(i+1))
+			payload := singularBatchToPayload(t, batch, uint64(i+1))
+			l2Client.Mock.On("L2BlockRefByNumber", uint64(i+1)).Times(9999).Return(blockRef, &nilErr)
+			l2Client.Mock.On("PayloadByNumber", uint64(i+1)).Times(9999).Return(&payload, &nilErr)
+		}
+	}
+
+	bq := NewBatchQueue(log, cfg, input, &l2Client)
+	_ = bq.Reset(context.Background(), l1[1], eth.SystemConfig{})
+
+	for i := 0; i < len(expectedOutputBatches); i++ {
+		expectedOutput := expectedOutputBatches[i]
+		if expectedOutput != nil && uint64(expectedOutput.EpochNum) == l1[inputOriginNumber].Number {
+			// Advance ChannelInReader origin if needed
+			inputOriginNumber += 1
+			input.origin = l1[inputOriginNumber]
+		}
+		var b *SingularBatch
+		var e error
+		for j := 0; j < len(expectedOutputBatches); j++ {
+			// Multiple NextBatch() executions may be required because the order of input is shuffled
+			b, e = bq.NextBatch(context.Background(), safeHead)
+			if !errors.Is(e, NotEnoughData) {
+				break
+			}
+		}
+		require.ErrorIs(t, e, expectedOutputErrors[i])
+		if b == nil {
+			require.Nil(t, expectedOutput)
+		} else {
+			require.Equal(t, expectedOutput, b)
+			require.Equal(t, bq.l1Blocks[0].Number, uint64(b.EpochNum))
+			safeHead.Number += 1
+			safeHead.Time += cfg.BlockTime
+			safeHead.Hash = mockHash(b.Timestamp, 2)
+			safeHead.L1Origin = b.Epoch()
+		}
+	}
 }

--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -1,18 +1,148 @@
 package derive
 
 import (
+	"bytes"
+	"math/big"
+	"math/rand"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
+func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
+	blockCount := uint64(1 + rng.Int()&0xFF)
+	originBits := new(big.Int)
+	for i := 0; i < int(blockCount); i++ {
+		bit := uint(0)
+		if testutils.RandomBool(rng) {
+			bit = uint(1)
+		}
+		originBits.SetBit(originBits, i, bit)
+	}
+	var blockTxCounts []uint64
+	totalblockTxCounts := uint64(0)
+	for i := 0; i < int(blockCount); i++ {
+		blockTxCount := uint64(rng.Intn(16))
+		blockTxCounts = append(blockTxCounts, blockTxCount)
+		totalblockTxCounts += blockTxCount
+	}
+	signer := types.NewLondonSigner(chainId)
+	var txs [][]byte
+	for i := 0; i < int(totalblockTxCounts); i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		rawTx, err := tx.MarshalBinary()
+		if err != nil {
+			panic("MarshalBinary:" + err.Error())
+		}
+		txs = append(txs, rawTx)
+	}
+	spanBatchTxs, err := newSpanBatchTxs(txs, chainId)
+	if err != nil {
+		panic(err.Error())
+	}
+	rawSpanBatch := RawSpanBatch{
+		spanBatchPrefix: spanBatchPrefix{
+			relTimestamp:  uint64(rng.Uint32()),
+			l1OriginNum:   rng.Uint64(),
+			parentCheck:   testutils.RandomData(rng, 20),
+			l1OriginCheck: testutils.RandomData(rng, 20),
+		},
+		spanBatchPayload: spanBatchPayload{
+			blockCount:    blockCount,
+			originBits:    originBits,
+			blockTxCounts: blockTxCounts,
+			txs:           spanBatchTxs,
+		},
+	}
+	return &rawSpanBatch
+}
+
+func RandomSingularBatch(rng *rand.Rand, txCount int, chainID *big.Int) *SingularBatch {
+	signer := types.NewLondonSigner(chainID)
+	baseFee := big.NewInt(rng.Int63n(300_000_000_000))
+	txsEncoded := make([]hexutil.Bytes, 0, txCount)
+	// force each tx to have equal chainID
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, baseFee, signer)
+		txEncoded, err := tx.MarshalBinary()
+		if err != nil {
+			panic("tx Marshal binary" + err.Error())
+		}
+		txsEncoded = append(txsEncoded, hexutil.Bytes(txEncoded))
+	}
+	return &SingularBatch{
+		ParentHash:   testutils.RandomHash(rng),
+		EpochNum:     rollup.Epoch(1 + rng.Int63n(100_000_000)),
+		EpochHash:    testutils.RandomHash(rng),
+		Timestamp:    uint64(rng.Int63n(2_000_000_000)),
+		Transactions: txsEncoded,
+	}
+}
+
+func RandomValidConsecutiveSingularBatches(rng *rand.Rand, chainID *big.Int) []*SingularBatch {
+	blockCount := 2 + rng.Intn(128)
+	l2BlockTime := uint64(2)
+
+	var singularBatches []*SingularBatch
+	for i := 0; i < blockCount; i++ {
+		singularBatch := RandomSingularBatch(rng, 1+rng.Intn(8), chainID)
+		singularBatches = append(singularBatches, singularBatch)
+	}
+	l1BlockNum := rng.Uint64()
+	// make sure oldest timestamp is large enough
+	singularBatches[0].Timestamp += 256
+	for i := 0; i < blockCount; i++ {
+		originChangedBit := rng.Intn(2)
+		if originChangedBit == 1 {
+			l1BlockNum++
+			singularBatches[i].EpochHash = testutils.RandomHash(rng)
+		} else if i > 0 {
+			singularBatches[i].EpochHash = singularBatches[i-1].EpochHash
+		}
+		singularBatches[i].EpochNum = rollup.Epoch(l1BlockNum)
+		if i > 0 {
+			singularBatches[i].Timestamp = singularBatches[i-1].Timestamp + l2BlockTime
+		}
+	}
+	return singularBatches
+}
+
+func mockL1Origin(rng *rand.Rand, rawSpanBatch *RawSpanBatch, singularBatches []*SingularBatch) []eth.L1BlockRef {
+	safeHeadOrigin := testutils.RandomBlockRef(rng)
+	safeHeadOrigin.Hash = singularBatches[0].EpochHash
+	safeHeadOrigin.Number = uint64(singularBatches[0].EpochNum)
+
+	l1Origins := []eth.L1BlockRef{safeHeadOrigin}
+	originBitSum := uint64(0)
+	for i := 0; i < int(rawSpanBatch.blockCount); i++ {
+		if rawSpanBatch.originBits.Bit(i) == 1 {
+			l1Origin := testutils.NextRandomRef(rng, l1Origins[originBitSum])
+			originBitSum++
+			l1Origin.Hash = singularBatches[i].EpochHash
+			l1Origin.Number = uint64(singularBatches[i].EpochNum)
+			l1Origins = append(l1Origins, l1Origin)
+		}
+	}
+	return l1Origins
+}
+
 func TestBatchRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xdeadbeef))
+	blockTime := uint64(2)
+	genesisTimestamp := uint64(0)
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
 	batches := []*BatchData{
 		{
-			BatchV1: BatchV1{
+			SingularBatch: SingularBatch{
 				ParentHash:   common.Hash{},
 				EpochNum:     0,
 				Timestamp:    0,
@@ -20,13 +150,18 @@ func TestBatchRoundTrip(t *testing.T) {
 			},
 		},
 		{
-			BatchV1: BatchV1{
+			SingularBatch: SingularBatch{
 				ParentHash:   common.Hash{31: 0x42},
 				EpochNum:     1,
 				Timestamp:    1647026951,
 				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},
 			},
 		},
+		NewSingularBatchData(*RandomSingularBatch(rng, 5, chainID)),
+		NewSingularBatchData(*RandomSingularBatch(rng, 7, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
 	}
 
 	for i, batch := range batches {
@@ -35,6 +170,58 @@ func TestBatchRoundTrip(t *testing.T) {
 		var dec BatchData
 		err = dec.UnmarshalBinary(enc)
 		assert.NoError(t, err)
+		if dec.BatchType == SpanBatchType {
+			_, err := dec.RawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)
+	}
+}
+
+func TestBatchRoundTripRLP(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbeefdead))
+	blockTime := uint64(2)
+	genesisTimestamp := uint64(0)
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	batches := []*BatchData{
+		{
+			SingularBatch: SingularBatch{
+				ParentHash:   common.Hash{},
+				EpochNum:     0,
+				Timestamp:    0,
+				Transactions: []hexutil.Bytes{},
+			},
+		},
+		{
+			SingularBatch: SingularBatch{
+				ParentHash:   common.Hash{31: 0x42},
+				EpochNum:     1,
+				Timestamp:    1647026951,
+				Transactions: []hexutil.Bytes{[]byte{0, 0, 0}, []byte{0x76, 0xfd, 0x7c}},
+			},
+		},
+		NewSingularBatchData(*RandomSingularBatch(rng, 5, chainID)),
+		NewSingularBatchData(*RandomSingularBatch(rng, 7, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+		NewSpanBatchData(*RandomRawSpanBatch(rng, chainID)),
+	}
+
+	for i, batch := range batches {
+		var buf bytes.Buffer
+		err := batch.EncodeRLP(&buf)
+		assert.NoError(t, err)
+		result := buf.Bytes()
+		var dec BatchData
+		r := bytes.NewReader(result)
+		s := rlp.NewStream(r, 0)
+		err = dec.DecodeRLP(s)
+		assert.NoError(t, err)
+		if dec.BatchType == SpanBatchType {
+			_, err := dec.RawSpanBatch.derive(blockTime, genesisTimestamp, chainID)
+			assert.NoError(t, err)
+		}
 		assert.Equal(t, batch, &dec, "Batch not equal test case %v", i)
 	}
 }

--- a/op-node/rollup/derive/batch_tob_test.go
+++ b/op-node/rollup/derive/batch_tob_test.go
@@ -10,6 +10,7 @@ import (
 
 // FuzzBatchRoundTrip executes a fuzz test similar to TestBatchRoundTrip, which tests that arbitrary BatchData will be
 // encoded and decoded without loss of its original values.
+// Does not test span batch because fuzzer is not aware structure of span batch.
 func FuzzBatchRoundTrip(f *testing.F) {
 	f.Fuzz(func(t *testing.T, fuzzedData []byte) {
 		// Create our fuzzer wrapper to generate complex values
@@ -19,6 +20,10 @@ func FuzzBatchRoundTrip(f *testing.F) {
 		// Create our batch data from fuzzed data
 		var batchData BatchData
 		typeProvider.Fuzz(&batchData)
+
+		// force batchdata to only contain singular batch
+		batchData.BatchType = SingularBatchType
+		batchData.RawSpanBatch = RawSpanBatch{}
 
 		// Encode our batch data
 		enc, err := batchData.MarshalBinary()

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -1,6 +1,9 @@
 package derive
 
 import (
+	"bytes"
+	"context"
+
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -9,7 +12,7 @@ import (
 
 type BatchWithL1InclusionBlock struct {
 	L1InclusionBlock eth.L1BlockRef
-	Batch            *BatchData
+	Batch            Batch
 }
 
 type BatchValidity uint8
@@ -28,14 +31,37 @@ const (
 // CheckBatch checks if the given batch can be applied on top of the given l2SafeHead, given the contextual L1 blocks the batch was included in.
 // The first entry of the l1Blocks should match the origin of the l2SafeHead. One or more consecutive l1Blocks should be provided.
 // In case of only a single L1 block, the decision whether a batch is valid may have to stay undecided.
-func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock) BatchValidity {
+func CheckBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef,
+	l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l2Fetcher SafeBlockFetcher) BatchValidity {
+	switch batch.Batch.GetBatchType() {
+	case SingularBatchType:
+		singularBatch, ok := batch.Batch.(*SingularBatch)
+		if !ok {
+			log.Error("failed type assertion to SingularBatch")
+			return BatchDrop
+		}
+		return checkSingularBatch(cfg, log, l1Blocks, l2SafeHead, singularBatch, batch.L1InclusionBlock)
+	case SpanBatchType:
+		spanBatch, ok := batch.Batch.(*SpanBatch)
+		if !ok {
+			log.Error("failed type assertion to SpanBatch")
+			return BatchDrop
+		}
+		if !cfg.IsSpanBatch(batch.Batch.GetTimestamp()) {
+			log.Warn("received SpanBatch before SpanBatch hard fork")
+			return BatchDrop
+		}
+		return checkSpanBatch(ctx, cfg, log, l1Blocks, l2SafeHead, spanBatch, batch.L1InclusionBlock, l2Fetcher)
+	default:
+		log.Warn("unrecognized batch type: %d", batch.Batch.GetBatchType())
+		return BatchDrop
+	}
+}
+
+// checkSingularBatch implements SingularBatch validation rule.
+func checkSingularBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *SingularBatch, l1InclusionBlock eth.L1BlockRef) BatchValidity {
 	// add details to the log
-	log = log.New(
-		"batch_timestamp", batch.Batch.Timestamp,
-		"parent_hash", batch.Batch.ParentHash,
-		"batch_epoch", batch.Batch.Epoch(),
-		"txs", len(batch.Batch.Transactions),
-	)
+	log = batch.LogContext(log)
 
 	// sanity check we have consistent inputs
 	if len(l1Blocks) == 0 {
@@ -45,36 +71,36 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 	epoch := l1Blocks[0]
 
 	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
-	if batch.Batch.Timestamp > nextTimestamp {
+	if batch.Timestamp > nextTimestamp {
 		log.Trace("received out-of-order batch for future processing after next batch", "next_timestamp", nextTimestamp)
 		return BatchFuture
 	}
-	if batch.Batch.Timestamp < nextTimestamp {
+	if batch.Timestamp < nextTimestamp {
 		log.Warn("dropping batch with old timestamp", "min_timestamp", nextTimestamp)
 		return BatchDrop
 	}
 
 	// dependent on above timestamp check. If the timestamp is correct, then it must build on top of the safe head.
-	if batch.Batch.ParentHash != l2SafeHead.Hash {
+	if batch.ParentHash != l2SafeHead.Hash {
 		log.Warn("ignoring batch with mismatching parent hash", "current_safe_head", l2SafeHead.Hash)
 		return BatchDrop
 	}
 
 	// Filter out batches that were included too late.
-	if uint64(batch.Batch.EpochNum)+cfg.SeqWindowSize < batch.L1InclusionBlock.Number {
+	if uint64(batch.EpochNum)+cfg.SeqWindowSize < l1InclusionBlock.Number {
 		log.Warn("batch was included too late, sequence window expired")
 		return BatchDrop
 	}
 
 	// Check the L1 origin of the batch
 	batchOrigin := epoch
-	if uint64(batch.Batch.EpochNum) < epoch.Number {
+	if uint64(batch.EpochNum) < epoch.Number {
 		log.Warn("dropped batch, epoch is too old", "minimum", epoch.ID())
 		// batch epoch too old
 		return BatchDrop
-	} else if uint64(batch.Batch.EpochNum) == epoch.Number {
+	} else if uint64(batch.EpochNum) == epoch.Number {
 		// Batch is sticking to the current epoch, continue.
-	} else if uint64(batch.Batch.EpochNum) == epoch.Number+1 {
+	} else if uint64(batch.EpochNum) == epoch.Number+1 {
 		// With only 1 l1Block we cannot look at the next L1 Origin.
 		// Note: This means that we are unable to determine validity of a batch
 		// without more information. In this case we should bail out until we have
@@ -90,19 +116,19 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 		return BatchDrop
 	}
 
-	if batch.Batch.EpochHash != batchOrigin.Hash {
+	if batch.EpochHash != batchOrigin.Hash {
 		log.Warn("batch is for different L1 chain, epoch hash does not match", "expected", batchOrigin.ID())
 		return BatchDrop
 	}
 
-	if batch.Batch.Timestamp < batchOrigin.Time {
-		log.Warn("batch timestamp is less than L1 origin timestamp", "l2_timestamp", batch.Batch.Timestamp, "l1_timestamp", batchOrigin.Time, "origin", batchOrigin.ID())
+	if batch.Timestamp < batchOrigin.Time {
+		log.Warn("batch timestamp is less than L1 origin timestamp", "l2_timestamp", batch.Timestamp, "l1_timestamp", batchOrigin.Time, "origin", batchOrigin.ID())
 		return BatchDrop
 	}
 
 	// Check if we ran out of sequencer time drift
-	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Batch.Timestamp > max {
-		if len(batch.Batch.Transactions) == 0 {
+	if max := batchOrigin.Time + cfg.MaxSequencerDrift; batch.Timestamp > max {
+		if len(batch.Transactions) == 0 {
 			// If the sequencer is co-operating by producing an empty batch,
 			// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.
 			// We only check batches that do not advance the epoch, to ensure epoch advancement regardless of time drift is allowed.
@@ -112,7 +138,7 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 					return BatchUndecided
 				}
 				nextOrigin := l1Blocks[1]
-				if batch.Batch.Timestamp >= nextOrigin.Time { // check if the next L1 origin could have been adopted
+				if batch.Timestamp >= nextOrigin.Time { // check if the next L1 origin could have been adopted
 					log.Info("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid")
 					return BatchDrop
 				} else {
@@ -128,7 +154,7 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 	}
 
 	// We can do this check earlier, but it's a more intensive one, so we do this last.
-	for i, txBytes := range batch.Batch.Transactions {
+	for i, txBytes := range batch.Transactions {
 		if len(txBytes) == 0 {
 			log.Warn("transaction data must not be empty, but found empty tx", "tx_index", i)
 			return BatchDrop
@@ -136,6 +162,207 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 		if txBytes[0] == types.DepositTxType {
 			log.Warn("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", i)
 			return BatchDrop
+		}
+	}
+
+	return BatchAccept
+}
+
+// checkSpanBatch implements SpanBatch validation rule.
+func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
+	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher) BatchValidity {
+	// add details to the log
+	log = batch.LogContext(log)
+
+	// sanity check we have consistent inputs
+	if len(l1Blocks) == 0 {
+		log.Warn("missing L1 block input, cannot proceed with batch checking")
+		return BatchUndecided
+	}
+	epoch := l1Blocks[0]
+
+	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
+
+	if batch.GetTimestamp() > nextTimestamp {
+		log.Trace("received out-of-order batch for future processing after next batch", "next_timestamp", nextTimestamp)
+		return BatchFuture
+	}
+	if batch.GetBlockTimestamp(batch.GetBlockCount()-1) < nextTimestamp {
+		log.Warn("span batch has no new blocks after safe head")
+		return BatchDrop
+	}
+
+	// finding parent block of the span batch.
+	// if the span batch does not overlap the current safe chain, parentBLock should be l2SafeHead.
+	parentNum := l2SafeHead.Number
+	parentBlock := l2SafeHead
+	if batch.GetTimestamp() < nextTimestamp {
+		if batch.GetTimestamp() > l2SafeHead.Time {
+			// batch timestamp cannot be between safe head and next timestamp
+			log.Warn("batch has misaligned timestamp")
+			return BatchDrop
+		}
+		if (l2SafeHead.Time-batch.GetTimestamp())%cfg.BlockTime != 0 {
+			log.Warn("batch has misaligned timestamp")
+			return BatchDrop
+		}
+		parentNum = l2SafeHead.Number - (l2SafeHead.Time-batch.GetTimestamp())/cfg.BlockTime - 1
+		var err error
+		parentBlock, err = l2Fetcher.L2BlockRefByNumber(ctx, parentNum)
+		if err != nil {
+			log.Error("failed to fetch L2 block", "number", parentNum, "err", err)
+			// unable to validate the batch for now. retry later.
+			return BatchUndecided
+		}
+	}
+	if !batch.CheckParentHash(parentBlock.Hash) {
+		log.Warn("ignoring batch with mismatching parent hash", "parent_block", parentBlock.Hash)
+		return BatchDrop
+	}
+
+	startEpochNum := uint64(batch.GetStartEpochNum())
+
+	// Filter out batches that were included too late.
+	if startEpochNum+cfg.SeqWindowSize < l1InclusionBlock.Number {
+		log.Warn("batch was included too late, sequence window expired")
+		return BatchDrop
+	}
+
+	// Check the L1 origin of the batch
+	if startEpochNum > parentBlock.L1Origin.Number+1 {
+		log.Warn("batch is for future epoch too far ahead, while it has the next timestamp, so it must be invalid", "current_epoch", epoch.ID())
+		return BatchDrop
+	}
+
+	endEpochNum := batch.GetBlockEpochNum(batch.GetBlockCount() - 1)
+	originChecked := false
+	for _, l1Block := range l1Blocks {
+		if l1Block.Number == endEpochNum {
+			if !batch.CheckOriginHash(l1Block.Hash) {
+				log.Warn("batch is for different L1 chain, epoch hash does not match", "expected", l1Block.Hash)
+				return BatchDrop
+			}
+			originChecked = true
+			break
+		}
+	}
+	if !originChecked {
+		log.Info("need more l1 blocks to check entire origins of span batch")
+		return BatchUndecided
+	}
+
+	if startEpochNum < parentBlock.L1Origin.Number {
+		log.Warn("dropped batch, epoch is too old", "minimum", parentBlock.ID())
+		return BatchDrop
+	}
+
+	originIdx := 0
+	originAdvanced := false
+	if startEpochNum == parentBlock.L1Origin.Number+1 {
+		originAdvanced = true
+	}
+
+	for i := 0; i < batch.GetBlockCount(); i++ {
+		if batch.GetBlockTimestamp(i) <= l2SafeHead.Time {
+			continue
+		}
+		var l1Origin eth.L1BlockRef
+		for j := originIdx; j < len(l1Blocks); j++ {
+			if batch.GetBlockEpochNum(i) == l1Blocks[j].Number {
+				l1Origin = l1Blocks[j]
+				originIdx = j
+				break
+			}
+
+		}
+		if i > 0 {
+			originAdvanced = false
+			if batch.GetBlockEpochNum(i) > batch.GetBlockEpochNum(i-1) {
+				originAdvanced = true
+			}
+		}
+		blockTimestamp := batch.GetBlockTimestamp(i)
+		if blockTimestamp < l1Origin.Time {
+			log.Warn("block timestamp is less than L1 origin timestamp", "l2_timestamp", blockTimestamp, "l1_timestamp", l1Origin.Time, "origin", l1Origin.ID())
+			return BatchDrop
+		}
+
+		// Check if we ran out of sequencer time drift
+		if max := l1Origin.Time + cfg.MaxSequencerDrift; blockTimestamp > max {
+			if len(batch.GetBlockTransactions(i)) == 0 {
+				// If the sequencer is co-operating by producing an empty batch,
+				// then allow the batch if it was the right thing to do to maintain the L2 time >= L1 time invariant.
+				// We only check batches that do not advance the epoch, to ensure epoch advancement regardless of time drift is allowed.
+				if !originAdvanced {
+					if originIdx+1 >= len(l1Blocks) {
+						log.Info("without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid")
+						return BatchUndecided
+					}
+					if blockTimestamp >= l1Blocks[originIdx+1].Time { // check if the next L1 origin could have been adopted
+						log.Info("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid")
+						return BatchDrop
+					} else {
+						log.Info("continuing with empty batch before late L1 block to preserve L2 time invariant")
+					}
+				}
+			} else {
+				// If the sequencer is ignoring the time drift rule, then drop the batch and force an empty batch instead,
+				// as the sequencer is not allowed to include anything past this point without moving to the next epoch.
+				log.Warn("batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again", "max_time", max)
+				return BatchDrop
+			}
+		}
+
+		for i, txBytes := range batch.GetBlockTransactions(i) {
+			if len(txBytes) == 0 {
+				log.Warn("transaction data must not be empty, but found empty tx", "tx_index", i)
+				return BatchDrop
+			}
+			if txBytes[0] == types.DepositTxType {
+				log.Warn("sequencers may not embed any deposits into batch data, but found tx that has one", "tx_index", i)
+				return BatchDrop
+			}
+		}
+	}
+
+	// Check overlapped blocks
+	if batch.GetTimestamp() < nextTimestamp {
+		for i := uint64(0); i < l2SafeHead.Number-parentNum; i++ {
+			safeBlockNum := parentNum + i + 1
+			safeBlockPayload, err := l2Fetcher.PayloadByNumber(ctx, safeBlockNum)
+			if err != nil {
+				log.Error("failed to fetch L2 block payload", "number", parentNum, "err", err)
+				// unable to validate the batch for now. retry later.
+				return BatchUndecided
+			}
+			safeBlockTxs := safeBlockPayload.Transactions
+			batchTxs := batch.GetBlockTransactions(int(i))
+			// execution payload has deposit TXs, but batch does not.
+			depositCount := 0
+			for _, tx := range safeBlockTxs {
+				if tx[0] == types.DepositTxType {
+					depositCount++
+				}
+			}
+			if len(safeBlockTxs)-depositCount != len(batchTxs) {
+				log.Warn("overlapped block's tx count does not match", "safeBlockTxs", len(safeBlockTxs), "batchTxs", len(batchTxs))
+				return BatchDrop
+			}
+			for j := 0; j < len(batchTxs); j++ {
+				if !bytes.Equal(safeBlockTxs[j+depositCount], batchTxs[j]) {
+					log.Warn("overlapped block's transaction does not match")
+					return BatchDrop
+				}
+			}
+			safeBlockRef, err := PayloadToBlockRef(safeBlockPayload, &cfg.Genesis)
+			if err != nil {
+				log.Error("failed to extract L2BlockRef from execution payload", "hash", safeBlockPayload.BlockHash, "err", err)
+				return BatchDrop
+			}
+			if safeBlockRef.L1Origin.Number != batch.GetBlockEpochNum(int(i)) {
+				log.Warn("overlapped block's L1 origin number does not match")
+				return BatchDrop
+			}
 		}
 	}
 

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -174,13 +174,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2A1.ParentHash,
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A1.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchUndecided,
 		},
@@ -190,13 +190,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2A1.ParentHash,
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A1.Time + 1, // 1 too high
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchFuture,
 		},
@@ -206,13 +206,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2A1.ParentHash,
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A0.Time, // repeating the same time
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -222,13 +222,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2A1.ParentHash,
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A1.Time - 1, // block time is 2, so this is 1 too low
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -238,13 +238,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   testutils.RandomHash(rng),
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A1.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -254,13 +254,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1F, // included in 5th block after epoch of batch, while seq window is 4
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2A1.ParentHash,
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A1.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -270,13 +270,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2B0, // we already moved on to B
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2B0.Hash,                          // build on top of safe head to continue
 					EpochNum:     rollup.Epoch(l2A3.L1Origin.Number), // epoch A is no longer valid
 					EpochHash:    l2A3.L1Origin.Hash,
 					Timestamp:    l2B0.Time + conf.BlockTime, // pass the timestamp check to get too epoch check
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -286,13 +286,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2B0.ParentHash,
 					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
 					EpochHash:    l2B0.L1Origin.Hash,
 					Timestamp:    l2B0.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchUndecided,
 		},
@@ -302,13 +302,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1D,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2B0.ParentHash,
 					EpochNum:     rollup.Epoch(l1C.Number), // invalid, we need to adopt epoch B before C
 					EpochHash:    l1C.Hash,
 					Timestamp:    l2B0.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -318,13 +318,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2B0.ParentHash,
 					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
 					EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
 					Timestamp:    l2B0.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -334,13 +334,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+				Batch: NewSingularBatchData(SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
 					ParentHash:   l2A4.ParentHash,
 					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
 					EpochHash:    l2A4.L1Origin.Hash,
 					Timestamp:    l2A4.Time,
 					Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -350,13 +350,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2X0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1Z,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2Y0.ParentHash,
 					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
 					EpochHash:    l2Y0.L1Origin.Hash,
 					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
 					Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -366,13 +366,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1BLate,
-				Batch: &BatchData{BatchV1{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
+				Batch: NewSingularBatchData(SingularBatch{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
 					ParentHash:   l2A4.ParentHash,
 					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
 					EpochHash:    l2A4.L1Origin.Hash,
 					Timestamp:    l2A4.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchAccept, // accepted because empty & preserving L2 time invariant
 		},
@@ -382,13 +382,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2X0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1Z,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash:   l2Y0.ParentHash,
 					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
 					EpochHash:    l2Y0.L1Origin.Hash,
 					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchAccept, // accepted because empty & still advancing epoch
 		},
@@ -398,13 +398,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+				Batch: NewSingularBatchData(SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
 					ParentHash:   l2A4.ParentHash,
 					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
 					EpochHash:    l2A4.L1Origin.Hash,
 					Timestamp:    l2A4.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
 		},
@@ -414,13 +414,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: &BatchData{BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+				Batch: NewSingularBatchData(SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
 					ParentHash:   l2A4.ParentHash,
 					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
 					EpochHash:    l2A4.L1Origin.Hash,
 					Timestamp:    l2A4.Time,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop, // dropped because it could have advanced the epoch to B
 		},
@@ -430,7 +430,7 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash: l2A1.ParentHash,
 					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:  l2A1.L1Origin.Hash,
@@ -438,7 +438,7 @@ func TestValidBatch(t *testing.T) {
 					Transactions: []hexutil.Bytes{
 						[]byte{}, // empty tx data
 					},
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -448,7 +448,7 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash: l2A1.ParentHash,
 					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:  l2A1.L1Origin.Hash,
@@ -456,7 +456,7 @@ func TestValidBatch(t *testing.T) {
 					Transactions: []hexutil.Bytes{
 						[]byte{types.DepositTxType, 0}, // piece of data alike to a deposit
 					},
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},
@@ -466,7 +466,7 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash: l2A1.ParentHash,
 					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:  l2A1.L1Origin.Hash,
@@ -475,7 +475,7 @@ func TestValidBatch(t *testing.T) {
 						[]byte{0x02, 0x42, 0x13, 0x37},
 						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
 					},
-				}},
+				}),
 			},
 			Expected: BatchAccept,
 		},
@@ -485,7 +485,7 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: &BatchData{BatchV1{
+				Batch: NewSingularBatchData(SingularBatch{
 					ParentHash: l2B0.ParentHash,
 					EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
 					EpochHash:  l2B0.L1Origin.Hash,
@@ -494,7 +494,7 @@ func TestValidBatch(t *testing.T) {
 						[]byte{0x02, 0x42, 0x13, 0x37},
 						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
 					},
-				}},
+				}),
 			},
 			Expected: BatchAccept,
 		},
@@ -504,13 +504,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A2,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV1{ // we build l2B0', which starts a new epoch too early
+				Batch: NewSingularBatchData(SingularBatch{ // we build l2B0', which starts a new epoch too early
 					ParentHash:   l2A2.Hash,
 					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
 					EpochHash:    l2B0.L1Origin.Hash,
 					Timestamp:    l2A2.Time + conf.BlockTime,
 					Transactions: nil,
-				}},
+				}),
 			},
 			Expected: BatchDrop,
 		},

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -1,6 +1,9 @@
 package derive
 
 import (
+	"context"
+	"errors"
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -24,10 +27,19 @@ type ValidBatchTestCase struct {
 	Expected   BatchValidity
 }
 
+type SpanBatchHardForkTestCase struct {
+	Name          string
+	L1Blocks      []eth.L1BlockRef
+	L2SafeHead    eth.L2BlockRef
+	Batch         BatchWithL1InclusionBlock
+	Expected      BatchValidity
+	SpanBatchTime uint64
+}
+
 var HashA = common.Hash{0x0a}
 var HashB = common.Hash{0x0b}
 
-func TestValidBatch(t *testing.T) {
+func TestValidSingularBatch(t *testing.T) {
 	conf := rollup.Config{
 		Genesis: rollup.Genesis{
 			L2Time: 31, // a genesis time that itself does not align to make it more interesting
@@ -174,12 +186,521 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
+				Batch: &SingularBatch{
 					ParentHash:   l2A1.ParentHash,
 					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
 					EpochHash:    l2A1.L1Origin.Hash,
 					Timestamp:    l2A1.Time,
 					Transactions: nil,
+				},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "future timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time + 1, // 1 too high
+					Transactions: nil,
+				},
+			},
+			Expected: BatchFuture,
+		},
+		{
+			Name:       "old timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A0.Time, // repeating the same time
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "misaligned timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time - 1, // block time is 2, so this is 1 too low
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "invalid parent block hash",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash:   testutils.RandomHash(rng),
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequence window expired",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D, l1E, l1F},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1F, // included in 5th block after epoch of batch, while seq window is 4
+				Batch: &SingularBatch{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch too old, but good parent hash and timestamp", // repeat of now outdated l2A3 data
+			L1Blocks:   []eth.L1BlockRef{l1B, l1C, l1D},
+			L2SafeHead: l2B0, // we already moved on to B
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &SingularBatch{
+					ParentHash:   l2B0.Hash,                          // build on top of safe head to continue
+					EpochNum:     rollup.Epoch(l2A3.L1Origin.Number), // epoch A is no longer valid
+					EpochHash:    l2A3.L1Origin.Hash,
+					Timestamp:    l2B0.Time + conf.BlockTime, // pass the timestamp check to get too epoch check
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "insufficient L1 info for eager derivation",
+			L1Blocks:   []eth.L1BlockRef{l1A}, // don't know about l1B yet
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &SingularBatch{
+					ParentHash:   l2B0.ParentHash,
+					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:    l2B0.L1Origin.Hash,
+					Timestamp:    l2B0.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "epoch too new",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1D,
+				Batch: &SingularBatch{
+					ParentHash:   l2B0.ParentHash,
+					EpochNum:     rollup.Epoch(l1C.Number), // invalid, we need to adopt epoch B before C
+					EpochHash:    l1C.Hash,
+					Timestamp:    l2B0.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch hash wrong",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &SingularBatch{
+					ParentHash:   l2B0.ParentHash,
+					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
+					Timestamp:    l2B0.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on same epoch with non-empty txs",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+					ParentHash:   l2A4.ParentHash,
+					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+					EpochHash:    l2A4.L1Origin.Hash,
+					Timestamp:    l2A4.Time,
+					Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on changing epoch with non-empty txs",
+			L1Blocks:   []eth.L1BlockRef{l1X, l1Y, l1Z},
+			L2SafeHead: l2X0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1Z,
+				Batch: &SingularBatch{
+					ParentHash:   l2Y0.ParentHash,
+					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+					EpochHash:    l2Y0.L1Origin.Hash,
+					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+					Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and late next epoch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1BLate},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1BLate,
+				Batch: &SingularBatch{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
+					ParentHash:   l2A4.ParentHash,
+					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+					EpochHash:    l2A4.L1Origin.Hash,
+					Timestamp:    l2A4.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchAccept, // accepted because empty & preserving L2 time invariant
+		},
+		{
+			Name:       "sequencer time drift on changing epoch with empty txs",
+			L1Blocks:   []eth.L1BlockRef{l1X, l1Y, l1Z},
+			L2SafeHead: l2X0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1Z,
+				Batch: &SingularBatch{
+					ParentHash:   l2Y0.ParentHash,
+					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+					EpochHash:    l2Y0.L1Origin.Hash,
+					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+					Transactions: nil,
+				},
+			},
+			Expected: BatchAccept, // accepted because empty & still advancing epoch
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and no next epoch in sight yet",
+			L1Blocks:   []eth.L1BlockRef{l1A},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+					ParentHash:   l2A4.ParentHash,
+					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+					EpochHash:    l2A4.L1Origin.Hash,
+					Timestamp:    l2A4.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and but in-sight epoch that invalidates it",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+					ParentHash:   l2A4.ParentHash,
+					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+					EpochHash:    l2A4.L1Origin.Hash,
+					Timestamp:    l2A4.Time,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop, // dropped because it could have advanced the epoch to B
+		},
+		{
+			Name:       "empty tx included",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash: l2A1.ParentHash,
+					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:  l2A1.L1Origin.Hash,
+					Timestamp:  l2A1.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{}, // empty tx data
+					},
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "deposit tx included",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash: l2A1.ParentHash,
+					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:  l2A1.L1Origin.Hash,
+					Timestamp:  l2A1.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{types.DepositTxType, 0}, // piece of data alike to a deposit
+					},
+				},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "valid batch same epoch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash: l2A1.ParentHash,
+					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:  l2A1.L1Origin.Hash,
+					Timestamp:  l2A1.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{0x02, 0x42, 0x13, 0x37},
+						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+					},
+				},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "valid batch changing epoch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &SingularBatch{
+					ParentHash: l2B0.ParentHash,
+					EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:  l2B0.L1Origin.Hash,
+					Timestamp:  l2B0.Time,
+					Transactions: []hexutil.Bytes{
+						[]byte{0x02, 0x42, 0x13, 0x37},
+						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+					},
+				},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "batch with L2 time before L1 time",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{ // we build l2B0', which starts a new epoch too early
+					ParentHash:   l2A2.Hash,
+					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+					EpochHash:    l2B0.L1Origin.Hash,
+					Timestamp:    l2A2.Time + conf.BlockTime,
+					Transactions: nil,
+				},
+			},
+			Expected: BatchDrop,
+		},
+	}
+
+	// Log level can be increased for debugging purposes
+	logger := testlog.Logger(t, log.LvlError)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ctx := context.Background()
+			validity := CheckBatch(ctx, &conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, nil)
+			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
+		})
+	}
+}
+
+func TestValidSpanBatch(t *testing.T) {
+	minTs := uint64(0)
+	conf := rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 31, // a genesis time that itself does not align to make it more interesting
+		},
+		BlockTime:         2,
+		SeqWindowSize:     4,
+		MaxSequencerDrift: 6,
+		SpanBatchTime:     &minTs,
+		// other config fields are ignored and can be left empty.
+	}
+
+	rng := rand.New(rand.NewSource(1234))
+	chainId := new(big.Int).SetUint64(rng.Uint64())
+	signer := types.NewLondonSigner(chainId)
+	randTx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+	randTxData, _ := randTx.MarshalBinary()
+	l1A := testutils.RandomBlockRef(rng)
+	l1B := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1A.Number + 1,
+		ParentHash: l1A.Hash,
+		Time:       l1A.Time + 7,
+	}
+	l1C := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1B.Number + 1,
+		ParentHash: l1B.Hash,
+		Time:       l1B.Time + 7,
+	}
+	l1D := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1C.Number + 1,
+		ParentHash: l1C.Hash,
+		Time:       l1C.Time + 7,
+	}
+	l1E := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1D.Number + 1,
+		ParentHash: l1D.Hash,
+		Time:       l1D.Time + 7,
+	}
+	l1F := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1E.Number + 1,
+		ParentHash: l1E.Hash,
+		Time:       l1E.Time + 7,
+	}
+
+	l2A0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         100,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           l1A.Time,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 0,
+	}
+
+	l2A1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A0.Number + 1,
+		ParentHash:     l2A0.Hash,
+		Time:           l2A0.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 1,
+	}
+
+	l2A2 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A1.Number + 1,
+		ParentHash:     l2A1.Hash,
+		Time:           l2A1.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 2,
+	}
+
+	l2A3 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A2.Number + 1,
+		ParentHash:     l2A2.Hash,
+		Time:           l2A2.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 3,
+	}
+
+	l2B0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A3.Number + 1,
+		ParentHash:     l2A3.Hash,
+		Time:           l2A3.Time + conf.BlockTime, // 8 seconds larger than l1A0, 1 larger than origin
+		L1Origin:       l1B.ID(),
+		SequenceNumber: 0,
+	}
+
+	l1X := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     42,
+		ParentHash: testutils.RandomHash(rng),
+		Time:       10_000,
+	}
+	l1Y := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1X.Number + 1,
+		ParentHash: l1X.Hash,
+		Time:       l1X.Time + 12,
+	}
+	l1Z := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1Y.Number + 1,
+		ParentHash: l1Y.Hash,
+		Time:       l1Y.Time + 12,
+	}
+	l2X0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         1000,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           10_000 + 12 + 6 - 1, // add one block, and you get ahead of next l1 block by more than the drift
+		L1Origin:       l1X.ID(),
+		SequenceNumber: 0,
+	}
+	l2Y0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2X0.Number + 1,
+		ParentHash:     l2X0.Hash,
+		Time:           l2X0.Time + conf.BlockTime, // exceeds sequencer time drift, forced to be empty block
+		L1Origin:       l1Y.ID(),
+		SequenceNumber: 0,
+	}
+
+	l2A4 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A3.Number + 1,
+		ParentHash:     l2A3.Hash,
+		Time:           l2A3.Time + conf.BlockTime, // 4*2 = 8, higher than seq time drift
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 4,
+	}
+
+	l1BLate := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1A.Number + 1,
+		ParentHash: l1A.Hash,
+		Time:       l2A4.Time + 1, // too late for l2A4 to adopt yet
+	}
+
+	testCases := []ValidBatchTestCase{
+		{
+			Name:       "missing L1 info",
+			L1Blocks:   []eth.L1BlockRef{},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchUndecided,
@@ -190,12 +711,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2A1.ParentHash,
-					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:    l2A1.L1Origin.Hash,
-					Timestamp:    l2A1.Time + 1, // 1 too high
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time + 1, // 1 too high
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchFuture,
@@ -206,12 +729,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2A1.ParentHash,
-					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:    l2A1.L1Origin.Hash,
-					Timestamp:    l2A0.Time, // repeating the same time
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A0.Time, // repeating the same time
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -222,12 +747,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2A1.ParentHash,
-					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:    l2A1.L1Origin.Hash,
-					Timestamp:    l2A1.Time - 1, // block time is 2, so this is 1 too low
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time - 1, // block time is 2, so this is 1 too low
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -238,12 +765,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   testutils.RandomHash(rng),
-					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:    l2A1.L1Origin.Hash,
-					Timestamp:    l2A1.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   testutils.RandomHash(rng),
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -253,13 +782,15 @@ func TestValidBatch(t *testing.T) {
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D, l1E, l1F},
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1F, // included in 5th block after epoch of batch, while seq window is 4
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2A1.ParentHash,
-					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:    l2A1.L1Origin.Hash,
-					Timestamp:    l2A1.Time,
-					Transactions: nil,
+				L1InclusionBlock: l1F,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -270,12 +801,20 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2B0, // we already moved on to B
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2B0.Hash,                          // build on top of safe head to continue
-					EpochNum:     rollup.Epoch(l2A3.L1Origin.Number), // epoch A is no longer valid
-					EpochHash:    l2A3.L1Origin.Hash,
-					Timestamp:    l2B0.Time + conf.BlockTime, // pass the timestamp check to get too epoch check
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2B0.Hash,                          // build on top of safe head to continue
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number), // epoch A is no longer valid
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2B0.Time + conf.BlockTime, // pass the timestamp check to get too epoch check
+						Transactions: nil,
+					},
+					{
+						EpochNum:     rollup.Epoch(l1B.Number),
+						EpochHash:    l1B.Hash, // pass the l1 origin check
+						Timestamp:    l2B0.Time + conf.BlockTime*2,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -286,12 +825,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2B0.ParentHash,
-					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
-					EpochHash:    l2B0.L1Origin.Hash,
-					Timestamp:    l2B0.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchUndecided,
@@ -302,12 +843,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1D,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2B0.ParentHash,
-					EpochNum:     rollup.Epoch(l1C.Number), // invalid, we need to adopt epoch B before C
-					EpochHash:    l1C.Hash,
-					Timestamp:    l2B0.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l1C.Number), // invalid, we need to adopt epoch B before C
+						EpochHash:    l1C.Hash,
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -318,12 +861,39 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2B0.ParentHash,
-					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
-					EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
-					Timestamp:    l2B0.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch hash wrong - long span",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // valid batch
+						ParentHash:   l2A3.ParentHash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l1A.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -334,12 +904,39 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
-					ParentHash:   l2A4.ParentHash,
-					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
-					EpochHash:    l2A4.L1Origin.Hash,
-					Timestamp:    l2A4.Time,
-					Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: []hexutil.Bytes{randTxData},
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on same epoch with non-empty txs - long span",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // valid batch
+						ParentHash:   l2A3.ParentHash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: []hexutil.Bytes{randTxData},
+					},
+					{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: []hexutil.Bytes{randTxData},
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -350,12 +947,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2X0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1Z,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2Y0.ParentHash,
-					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
-					EpochHash:    l2Y0.L1Origin.Hash,
-					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
-					Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2Y0.ParentHash,
+						EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+						EpochHash:    l2Y0.L1Origin.Hash,
+						Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+						Transactions: []hexutil.Bytes{randTxData},
+					},
 				}),
 			},
 			Expected: BatchDrop,
@@ -366,12 +965,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1BLate,
-				Batch: NewSingularBatchData(SingularBatch{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
-					ParentHash:   l2A4.ParentHash,
-					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
-					EpochHash:    l2A4.L1Origin.Hash,
-					Timestamp:    l2A4.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchAccept, // accepted because empty & preserving L2 time invariant
@@ -382,12 +983,14 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2X0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1Z,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash:   l2Y0.ParentHash,
-					EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
-					EpochHash:    l2Y0.L1Origin.Hash,
-					Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2Y0.ParentHash,
+						EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+						EpochHash:    l2Y0.L1Origin.Hash,
+						Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchAccept, // accepted because empty & still advancing epoch
@@ -398,12 +1001,39 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
-					ParentHash:   l2A4.ParentHash,
-					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
-					EpochHash:    l2A4.L1Origin.Hash,
-					Timestamp:    l2A4.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and no next epoch in sight yet - long span",
+			L1Blocks:   []eth.L1BlockRef{l1A},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // valid batch
+						ParentHash:   l2A3.ParentHash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+					{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
@@ -414,12 +1044,39 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: NewSingularBatchData(SingularBatch{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
-					ParentHash:   l2A4.ParentHash,
-					EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
-					EpochHash:    l2A4.L1Origin.Hash,
-					Timestamp:    l2A4.Time,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop, // dropped because it could have advanced the epoch to B
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and but in-sight epoch that invalidates it - long span",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // valid batch
+						ParentHash:   l2A3.ParentHash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+					{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop, // dropped because it could have advanced the epoch to B
@@ -430,13 +1087,15 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash: l2A1.ParentHash,
-					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:  l2A1.L1Origin.Hash,
-					Timestamp:  l2A1.Time,
-					Transactions: []hexutil.Bytes{
-						[]byte{}, // empty tx data
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash: l2A1.ParentHash,
+						EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:  l2A1.L1Origin.Hash,
+						Timestamp:  l2A1.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{}, // empty tx data
+						},
 					},
 				}),
 			},
@@ -448,13 +1107,15 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash: l2A1.ParentHash,
-					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:  l2A1.L1Origin.Hash,
-					Timestamp:  l2A1.Time,
-					Transactions: []hexutil.Bytes{
-						[]byte{types.DepositTxType, 0}, // piece of data alike to a deposit
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash: l2A1.ParentHash,
+						EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:  l2A1.L1Origin.Hash,
+						Timestamp:  l2A1.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{types.DepositTxType, 0}, // piece of data alike to a deposit
+						},
 					},
 				}),
 			},
@@ -466,14 +1127,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A0,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash: l2A1.ParentHash,
-					EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
-					EpochHash:  l2A1.L1Origin.Hash,
-					Timestamp:  l2A1.Time,
-					Transactions: []hexutil.Bytes{
-						[]byte{0x02, 0x42, 0x13, 0x37},
-						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: []hexutil.Bytes{randTxData},
 					},
 				}),
 			},
@@ -485,14 +1145,13 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1C,
-				Batch: NewSingularBatchData(SingularBatch{
-					ParentHash: l2B0.ParentHash,
-					EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
-					EpochHash:  l2B0.L1Origin.Hash,
-					Timestamp:  l2B0.Time,
-					Transactions: []hexutil.Bytes{
-						[]byte{0x02, 0x42, 0x13, 0x37},
-						[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2B0.Time,
+						Transactions: []hexutil.Bytes{randTxData},
 					},
 				}),
 			},
@@ -504,24 +1163,396 @@ func TestValidBatch(t *testing.T) {
 			L2SafeHead: l2A2,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
-				Batch: NewSingularBatchData(SingularBatch{ // we build l2B0', which starts a new epoch too early
-					ParentHash:   l2A2.Hash,
-					EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
-					EpochHash:    l2B0.L1Origin.Hash,
-					Timestamp:    l2A2.Time + conf.BlockTime,
-					Transactions: nil,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // we build l2B0, which starts a new epoch too early
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2A2.Time + conf.BlockTime,
+						Transactions: nil,
+					},
 				}),
 			},
 			Expected: BatchDrop,
+		},
+		{
+			Name:       "batch with L2 time before L1 time - long span",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A1,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{ // valid batch
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+					{ // we build l2B0, which starts a new epoch too early
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2A2.Time + conf.BlockTime,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "valid overlapping batch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "longer overlapping batch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A0.Hash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "fully overlapping batch",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A0.Hash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "overlapping batch with invalid parent hash",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A0.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "overlapping batch with invalid origin number",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number) + 1,
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "overlapping batch with invalid tx",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: []hexutil.Bytes{randTxData},
+					},
+					{
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "overlapping batch l2 fetcher error",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A1,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A0.ParentHash,
+						EpochNum:     rollup.Epoch(l2A0.L1Origin.Number),
+						EpochHash:    l2A0.L1Origin.Hash,
+						Timestamp:    l2A0.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A0.Hash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2A1.Hash,
+						EpochNum:     rollup.Epoch(l2A2.L1Origin.Number),
+						EpochHash:    l2A2.L1Origin.Hash,
+						Timestamp:    l2A2.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected: BatchUndecided,
 		},
 	}
 
 	// Log level can be increased for debugging purposes
 	logger := testlog.Logger(t, log.LvlError)
 
+	l2Client := testutils.MockL2Client{}
+	var nilErr error
+	// will be return error for block #99 (parent of l2A0)
+	tempErr := errors.New("temp error")
+	l2Client.Mock.On("L2BlockRefByNumber", l2A0.Number-1).Times(9999).Return(eth.L2BlockRef{}, &tempErr)
+	l2Client.Mock.On("PayloadByNumber", l2A0.Number-1).Times(9999).Return(nil, &tempErr)
+
+	// make payloads for L2 blocks and set as expected return value of MockL2Client
+	for _, l2Block := range []eth.L2BlockRef{l2A0, l2A1, l2A2, l2A3, l2A4, l2B0} {
+		l2Client.ExpectL2BlockRefByNumber(l2Block.Number, l2Block, nil)
+		txData := l1InfoDepositTx(t, l2Block.L1Origin.Number)
+		payload := eth.ExecutionPayload{
+			ParentHash:   l2Block.ParentHash,
+			BlockNumber:  hexutil.Uint64(l2Block.Number),
+			Timestamp:    hexutil.Uint64(l2Block.Time),
+			BlockHash:    l2Block.Hash,
+			Transactions: []hexutil.Bytes{txData},
+		}
+		l2Client.Mock.On("L2BlockRefByNumber", l2Block.Number).Times(9999).Return(l2Block, &nilErr)
+		l2Client.Mock.On("PayloadByNumber", l2Block.Number).Times(9999).Return(&payload, &nilErr)
+	}
+
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch)
+			ctx := context.Background()
+			validity := CheckBatch(ctx, &conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, &l2Client)
+			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
+		})
+	}
+}
+
+func TestSpanBatchHardFork(t *testing.T) {
+	minTs := uint64(0)
+	conf := rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 31, // a genesis time that itself does not align to make it more interesting
+		},
+		BlockTime:         2,
+		SeqWindowSize:     4,
+		MaxSequencerDrift: 6,
+		SpanBatchTime:     &minTs,
+		// other config fields are ignored and can be left empty.
+	}
+
+	rng := rand.New(rand.NewSource(1234))
+	chainId := new(big.Int).SetUint64(rng.Uint64())
+	signer := types.NewLondonSigner(chainId)
+	randTx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+	randTxData, _ := randTx.MarshalBinary()
+	l1A := testutils.RandomBlockRef(rng)
+	l1B := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1A.Number + 1,
+		ParentHash: l1A.Hash,
+		Time:       l1A.Time + 7,
+	}
+
+	l2A0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         100,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           l1A.Time,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 0,
+	}
+
+	l2A1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A0.Number + 1,
+		ParentHash:     l2A0.Hash,
+		Time:           l2A0.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 1,
+	}
+
+	testCases := []SpanBatchHardForkTestCase{
+		{
+			Name:       "singular batch before hard fork",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: []hexutil.Bytes{randTxData},
+				},
+			},
+			SpanBatchTime: l2A1.Time + 2,
+			Expected:      BatchAccept,
+		},
+		{
+			Name:       "span batch before hard fork",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: []hexutil.Bytes{randTxData},
+					},
+				}),
+			},
+			SpanBatchTime: l2A1.Time + 2,
+			Expected:      BatchDrop,
+		},
+		{
+			Name:       "singular batch after hard fork",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &SingularBatch{
+					ParentHash:   l2A1.ParentHash,
+					EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+					EpochHash:    l2A1.L1Origin.Hash,
+					Timestamp:    l2A1.Time,
+					Transactions: []hexutil.Bytes{randTxData},
+				},
+			},
+			SpanBatchTime: l2A1.Time - 2,
+			Expected:      BatchAccept,
+		},
+		{
+			Name:       "span batch after hard fork",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: []hexutil.Bytes{randTxData},
+					},
+				}),
+			},
+			SpanBatchTime: l2A1.Time - 2,
+			Expected:      BatchAccept,
+		},
+	}
+
+	// Log level can be increased for debugging purposes
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			rcfg := conf
+			rcfg.SpanBatchTime = &testCase.SpanBatchTime
+			ctx := context.Background()
+			validity := CheckBatch(ctx, &rcfg, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, nil)
 			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
 		})
 	}

--- a/op-node/rollup/derive/channel.go
+++ b/op-node/rollup/derive/channel.go
@@ -144,7 +144,7 @@ func (ch *Channel) Reader() io.Reader {
 
 // BatchReader provides a function that iteratively consumes batches from the reader.
 // The L1Inclusion block is also provided at creation time.
-func BatchReader(r io.Reader, l1InclusionBlock eth.L1BlockRef) (func() (BatchWithL1InclusionBlock, error), error) {
+func BatchReader(r io.Reader) (func() (*BatchData, error), error) {
 	// Setup decompressor stage + RLP reader
 	zr, err := zlib.NewReader(r)
 	if err != nil {
@@ -152,11 +152,11 @@ func BatchReader(r io.Reader, l1InclusionBlock eth.L1BlockRef) (func() (BatchWit
 	}
 	rlpReader := rlp.NewStream(zr, MaxRLPBytesPerChannel)
 	// Read each batch iteratively
-	return func() (BatchWithL1InclusionBlock, error) {
-		ret := BatchWithL1InclusionBlock{
-			L1InclusionBlock: l1InclusionBlock,
+	return func() (*BatchData, error) {
+		batchData := BatchData{}
+		if err = rlpReader.Decode(&batchData); err != nil {
+			return nil, err
 		}
-		err := rlpReader.Decode(&ret.Batch)
-		return ret, err
+		return &batchData, nil
 	}, nil
 }

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/ethereum/go-ethereum/log"
-
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // ChannelInReader reads a batch from the channel
@@ -16,8 +16,9 @@ import (
 // must be tagged with an L1 inclusion block to be passed to the batch queue.
 type ChannelInReader struct {
 	log log.Logger
+	cfg *rollup.Config
 
-	nextBatchFn func() (BatchWithL1InclusionBlock, error)
+	nextBatchFn func() (*BatchData, error)
 
 	prev *ChannelBank
 
@@ -27,9 +28,10 @@ type ChannelInReader struct {
 var _ ResettableStage = (*ChannelInReader)(nil)
 
 // NewChannelInReader creates a ChannelInReader, which should be Reset(origin) before use.
-func NewChannelInReader(log log.Logger, prev *ChannelBank, metrics Metrics) *ChannelInReader {
+func NewChannelInReader(log log.Logger, cfg *rollup.Config, prev *ChannelBank, metrics Metrics) *ChannelInReader {
 	return &ChannelInReader{
 		log:     log,
+		cfg:     cfg,
 		prev:    prev,
 		metrics: metrics,
 	}
@@ -41,7 +43,7 @@ func (cr *ChannelInReader) Origin() eth.L1BlockRef {
 
 // TODO: Take full channel for better logging
 func (cr *ChannelInReader) WriteChannel(data []byte) error {
-	if f, err := BatchReader(bytes.NewBuffer(data), cr.Origin()); err == nil {
+	if f, err := BatchReader(bytes.NewBuffer(data)); err == nil {
 		cr.nextBatchFn = f
 		cr.metrics.RecordChannelInputBytes(len(data))
 		return nil
@@ -60,7 +62,7 @@ func (cr *ChannelInReader) NextChannel() {
 // NextBatch pulls out the next batch from the channel if it has it.
 // It returns io.EOF when it cannot make any more progress.
 // It will return a temporary error if it needs to be called again to advance some internal state.
-func (cr *ChannelInReader) NextBatch(ctx context.Context) (*BatchData, error) {
+func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 	if cr.nextBatchFn == nil {
 		if data, err := cr.prev.NextData(ctx); err == io.EOF {
 			return nil, io.EOF
@@ -75,7 +77,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (*BatchData, error) {
 
 	// TODO: can batch be non nil while err == io.EOF
 	// This depends on the behavior of rlp.Stream
-	batch, err := cr.nextBatchFn()
+	batchData, err := cr.nextBatchFn()
 	if err == io.EOF {
 		cr.NextChannel()
 		return nil, NotEnoughData
@@ -84,7 +86,16 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (*BatchData, error) {
 		cr.NextChannel()
 		return nil, NotEnoughData
 	}
-	return batch.Batch, nil
+	if batchData.BatchType == SingularBatchType {
+		return &batchData.SingularBatch, nil
+	} else {
+		// If the batch type is Span batch, derive block inputs from RawSpanBatch.
+		spanBatch, err := batchData.RawSpanBatch.derive(cr.cfg.BlockTime, cr.cfg.Genesis.L2Time, cr.cfg.L2ChainID)
+		if err != nil {
+			return nil, err
+		}
+		return spanBatch, nil
+	}
 }
 
 func (cr *ChannelInReader) Reset(ctx context.Context, _ eth.L1BlockRef, _ eth.SystemConfig) error {

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -238,15 +238,15 @@ func BlockToBatch(block *types.Block) (*BatchData, L1BlockInfo, error) {
 		return nil, l1Info, fmt.Errorf("could not parse the L1 Info deposit: %w", err)
 	}
 
-	return &BatchData{
-		BatchV1{
+	return NewSingularBatchData(
+		SingularBatch{
 			ParentHash:   block.ParentHash(),
 			EpochNum:     rollup.Epoch(l1Info.Number),
 			EpochHash:    l1Info.BlockHash,
 			Timestamp:    block.Time(),
 			Transactions: opaqueTxs,
 		},
-	}, l1Info, nil
+	), l1Info, nil
 }
 
 // ForceCloseTxData generates the transaction data for a transaction which will force close

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -35,6 +35,7 @@ type Engine interface {
 	PayloadByNumber(context.Context, uint64) (*eth.ExecutionPayload, error)
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 	L2BlockRefByHash(ctx context.Context, l2Hash common.Hash) (eth.L2BlockRef, error)
+	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 	SystemConfigL2Fetcher
 }
 

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -19,6 +19,11 @@ func frameSize(frame Frame) uint64 {
 
 const DerivationVersion0 = 0
 
+// MaxSpanBatchFieldSize is the maximum amount of bytes that will be read from
+// a span batch to decode span batch field. This value cannot be larger than
+// MaxRLPBytesPerChannel because single batch cannot be larger than channel size.
+const MaxSpanBatchFieldSize = 10_000_000
+
 // MaxChannelBankSize is the amount of memory space, in number of bytes,
 // till the bank is pruned by removing channels,
 // starting with the oldest channel.

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -89,8 +89,8 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher, metrics)
-	chInReader := NewChannelInReader(log, bank, metrics)
-	batchQueue := NewBatchQueue(log, cfg, chInReader)
+	chInReader := NewChannelInReader(log, cfg, bank, metrics)
+	batchQueue := NewBatchQueue(log, cfg, chInReader, engine)
 	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, engine)
 	attributesQueue := NewAttributesQueue(log, cfg, attrBuilder, batchQueue)
 

--- a/op-node/rollup/derive/singular_batch.go
+++ b/op-node/rollup/derive/singular_batch.go
@@ -1,0 +1,53 @@
+package derive
+
+import (
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// Batch format
+//
+// SingularBatchType := 0
+// singularBatch := SingularBatchType ++ RLP([epoch, timestamp, transaction_list]
+
+// SingularBatch is an implementation of Batch interface, containing the input to build one L2 block.
+type SingularBatch struct {
+	ParentHash   common.Hash  // parent L2 block hash
+	EpochNum     rollup.Epoch // aka l1 num
+	EpochHash    common.Hash  // l1 block hash
+	Timestamp    uint64
+	Transactions []hexutil.Bytes
+}
+
+// GetBatchType returns its batch type (batch_version)
+func (b *SingularBatch) GetBatchType() int {
+	return SingularBatchType
+}
+
+// GetTimestamp returns its block timestamp
+func (b *SingularBatch) GetTimestamp() uint64 {
+	return b.Timestamp
+}
+
+// GetEpochNum returns its epoch number (L1 origin block number)
+func (b *SingularBatch) GetEpochNum() rollup.Epoch {
+	return b.EpochNum
+}
+
+// LogContext creates a new log context that contains information of the batch
+func (b *SingularBatch) LogContext(log log.Logger) log.Logger {
+	return log.New(
+		"batch_timestamp", b.Timestamp,
+		"parent_hash", b.ParentHash,
+		"batch_epoch", b.Epoch(),
+		"txs", len(b.Transactions),
+	)
+}
+
+// Epoch returns a BlockID of its L1 origin.
+func (b *SingularBatch) Epoch() eth.BlockID {
+	return eth.BlockID{Hash: b.EpochHash, Number: uint64(b.EpochNum)}
+}

--- a/op-node/rollup/derive/singular_batch_test.go
+++ b/op-node/rollup/derive/singular_batch_test.go
@@ -1,0 +1,21 @@
+package derive
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingularBatchForBatchInterface(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x543331))
+	chainID := big.NewInt(rng.Int63n(1000))
+	txCount := 1 + rng.Intn(8)
+
+	singularBatch := RandomSingularBatch(rng, txCount, chainID)
+
+	assert.Equal(t, SingularBatchType, singularBatch.GetBatchType())
+	assert.Equal(t, singularBatch.Timestamp, singularBatch.GetTimestamp())
+	assert.Equal(t, singularBatch.EpochNum, singularBatch.GetEpochNum())
+}

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -1,0 +1,670 @@
+package derive
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"sort"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Batch format
+//
+// SpanBatchType := 1
+// spanBatch := SpanBatchType ++ prefix ++ payload
+// prefix := rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check
+// payload := payload = block_count ++ origin_bits ++ block_tx_counts ++ txs
+// txs = contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases
+
+var ErrTooBigSpanBatchFieldSize = errors.New("batch would cause field bytes to go over limit")
+
+type spanBatchPrefix struct {
+	relTimestamp  uint64 // Relative timestamp of the first block
+	l1OriginNum   uint64 // L1 origin number
+	parentCheck   []byte // First 20 bytes of the first block's parent hash
+	l1OriginCheck []byte // First 20 bytes of the last block's L1 origin hash
+}
+
+type spanBatchPayload struct {
+	blockCount    uint64        // Number of L2 block in the span
+	originBits    *big.Int      // Bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
+	blockTxCounts []uint64      // List of transaction counts for each L2 block
+	txs           *spanBatchTxs // Transactions encoded in SpanBatch specs
+}
+
+// RawSpanBatch is another representation of SpanBatch, that encodes data according to SpanBatch specs.
+type RawSpanBatch struct {
+	spanBatchPrefix
+	spanBatchPayload
+}
+
+// decodeOriginBits parses data into bp.originBits
+// originBits is bitlist right-padded to a multiple of 8 bits
+func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
+	originBitBufferLen := bp.blockCount / 8
+	if bp.blockCount%8 != 0 {
+		originBitBufferLen++
+	}
+	// avoid out of memory before allocation
+	if originBitBufferLen > MaxSpanBatchFieldSize {
+		return ErrTooBigSpanBatchFieldSize
+	}
+	originBitBuffer := make([]byte, originBitBufferLen)
+	_, err := io.ReadFull(r, originBitBuffer)
+	if err != nil {
+		return fmt.Errorf("failed to read origin bits: %w", err)
+	}
+	originBits := new(big.Int)
+	for i := 0; i < int(bp.blockCount); i += 8 {
+		end := i + 8
+		if end < int(bp.blockCount) {
+			end = int(bp.blockCount)
+		}
+		bits := originBitBuffer[i/8]
+		for j := i; j < end; j++ {
+			bit := uint((bits >> (j - i)) & 1)
+			originBits.SetBit(originBits, j, bit)
+		}
+	}
+	bp.originBits = originBits
+	return nil
+}
+
+// decodeRelTimestamp parses data into bp.relTimestamp
+func (bp *spanBatchPrefix) decodeRelTimestamp(r *bytes.Reader) error {
+	relTimestamp, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read rel timestamp: %w", err)
+	}
+	bp.relTimestamp = relTimestamp
+	return nil
+}
+
+// decodeL1OriginNum parses data into bp.l1OriginNum
+func (bp *spanBatchPrefix) decodeL1OriginNum(r *bytes.Reader) error {
+	L1OriginNum, err := binary.ReadUvarint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read l1 origin num: %w", err)
+	}
+	bp.l1OriginNum = L1OriginNum
+	return nil
+}
+
+// decodeParentCheck parses data into bp.parentCheck
+func (bp *spanBatchPrefix) decodeParentCheck(r *bytes.Reader) error {
+	bp.parentCheck = make([]byte, 20)
+	_, err := io.ReadFull(r, bp.parentCheck)
+	if err != nil {
+		return fmt.Errorf("failed to read parent check: %w", err)
+	}
+	return nil
+}
+
+// decodeL1OriginCheck parses data into bp.decodeL1OriginCheck
+func (bp *spanBatchPrefix) decodeL1OriginCheck(r *bytes.Reader) error {
+	bp.l1OriginCheck = make([]byte, 20)
+	_, err := io.ReadFull(r, bp.l1OriginCheck)
+	if err != nil {
+		return fmt.Errorf("failed to read l1 origin check: %w", err)
+	}
+	return nil
+}
+
+// decodePrefix parses data into bp.spanBatchPrefix
+func (bp *spanBatchPrefix) decodePrefix(r *bytes.Reader) error {
+	if err := bp.decodeRelTimestamp(r); err != nil {
+		return err
+	}
+	if err := bp.decodeL1OriginNum(r); err != nil {
+		return err
+	}
+	if err := bp.decodeParentCheck(r); err != nil {
+		return err
+	}
+	if err := bp.decodeL1OriginCheck(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodeBlockCount parses data into bp.blockCount
+func (bp *spanBatchPayload) decodeBlockCount(r *bytes.Reader) error {
+	blockCount, err := binary.ReadUvarint(r)
+	bp.blockCount = blockCount
+	if err != nil {
+		return fmt.Errorf("failed to read block count: %w", err)
+	}
+	return nil
+}
+
+// decodeBlockTxCounts parses data into bp.blockTxCounts
+// and sets bp.txs.totalBlockTxCount as sum(bp.blockTxCounts)
+func (bp *spanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
+	var blockTxCounts []uint64
+	for i := 0; i < int(bp.blockCount); i++ {
+		blockTxCount, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read block tx count: %w", err)
+		}
+		blockTxCounts = append(blockTxCounts, blockTxCount)
+	}
+	bp.blockTxCounts = blockTxCounts
+	return nil
+}
+
+// decodeTxs parses data into bp.txs
+func (bp *spanBatchPayload) decodeTxs(r *bytes.Reader) error {
+	if bp.txs == nil {
+		bp.txs = &spanBatchTxs{}
+	}
+	if bp.blockTxCounts == nil {
+		return errors.New("failed to read txs: blockTxCounts not set")
+	}
+	totalBlockTxCount := uint64(0)
+	for i := 0; i < len(bp.blockTxCounts); i++ {
+		totalBlockTxCount += bp.blockTxCounts[i]
+	}
+	bp.txs.totalBlockTxCount = totalBlockTxCount
+	if err := bp.txs.decode(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodePayload parses data into bp.spanBatchPayload
+func (bp *spanBatchPayload) decodePayload(r *bytes.Reader) error {
+	if err := bp.decodeBlockCount(r); err != nil {
+		return err
+	}
+	if err := bp.decodeOriginBits(r); err != nil {
+		return err
+	}
+	if err := bp.decodeBlockTxCounts(r); err != nil {
+		return err
+	}
+	if err := bp.decodeTxs(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// decodeBytes parses data into b from data
+func (b *RawSpanBatch) decodeBytes(data []byte) error {
+	r := bytes.NewReader(data)
+	if err := b.decodePrefix(r); err != nil {
+		return err
+	}
+	if err := b.decodePayload(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encodeRelTimestamp encodes bp.relTimestamp
+func (bp *spanBatchPrefix) encodeRelTimestamp(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], bp.relTimestamp)
+	if _, err := w.Write(buf[:n]); err != nil {
+		return fmt.Errorf("cannot write rel timestamp: %w", err)
+	}
+	return nil
+}
+
+// encodeL1OriginNum encodes bp.l1OriginNum
+func (bp *spanBatchPrefix) encodeL1OriginNum(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], bp.l1OriginNum)
+	if _, err := w.Write(buf[:n]); err != nil {
+		return fmt.Errorf("cannot write l1 origin number: %w", err)
+	}
+	return nil
+}
+
+// encodeParentCheck encodes bp.parentCheck
+func (bp *spanBatchPrefix) encodeParentCheck(w io.Writer) error {
+	if _, err := w.Write(bp.parentCheck); err != nil {
+		return fmt.Errorf("cannot write parent check: %w", err)
+	}
+	return nil
+}
+
+// encodeL1OriginCheck encodes bp.l1OriginCheck
+func (bp *spanBatchPrefix) encodeL1OriginCheck(w io.Writer) error {
+	if _, err := w.Write(bp.l1OriginCheck); err != nil {
+		return fmt.Errorf("cannot write l1 origin check: %w", err)
+	}
+	return nil
+}
+
+// encodePrefix encodes spanBatchPrefix
+func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
+	if err := bp.encodeRelTimestamp(w); err != nil {
+		return err
+	}
+	if err := bp.encodeL1OriginNum(w); err != nil {
+		return err
+	}
+	if err := bp.encodeParentCheck(w); err != nil {
+		return err
+	}
+	if err := bp.encodeL1OriginCheck(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encodeOriginBits encodes bp.originBits
+// originBits is bitlist right-padded to a multiple of 8 bits
+func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
+	originBitBufferLen := bp.blockCount / 8
+	if bp.blockCount%8 != 0 {
+		originBitBufferLen++
+	}
+	originBitBuffer := make([]byte, originBitBufferLen)
+	for i := 0; i < int(bp.blockCount); i += 8 {
+		end := i + 8
+		if end < int(bp.blockCount) {
+			end = int(bp.blockCount)
+		}
+		var bits uint = 0
+		for j := i; j < end; j++ {
+			bits |= bp.originBits.Bit(j) << (j - i)
+		}
+		originBitBuffer[i/8] = byte(bits)
+	}
+	if _, err := w.Write(originBitBuffer); err != nil {
+		return fmt.Errorf("cannot write origin bits: %w", err)
+	}
+	return nil
+}
+
+// encodeBlockCount encodes bp.blockCount
+func (bp *spanBatchPayload) encodeBlockCount(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], bp.blockCount)
+	if _, err := w.Write(buf[:n]); err != nil {
+		return fmt.Errorf("cannot write block count: %w", err)
+	}
+	return nil
+}
+
+// encodeBlockTxCounts encodes bp.blockTxCounts
+func (bp *spanBatchPayload) encodeBlockTxCounts(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	for _, blockTxCount := range bp.blockTxCounts {
+		n := binary.PutUvarint(buf[:], blockTxCount)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write block tx count: %w", err)
+		}
+	}
+	return nil
+}
+
+// encodeTxs encodes bp.txs
+func (bp *spanBatchPayload) encodeTxs(w io.Writer) error {
+	if bp.txs == nil {
+		return errors.New("cannot write txs: txs not set")
+	}
+	if err := bp.txs.encode(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encodePayload encodes spanBatchPayload
+func (bp *spanBatchPayload) encodePayload(w io.Writer) error {
+	if err := bp.encodeBlockCount(w); err != nil {
+		return err
+	}
+	if err := bp.encodeOriginBits(w); err != nil {
+		return err
+	}
+	if err := bp.encodeBlockTxCounts(w); err != nil {
+		return err
+	}
+	if err := bp.encodeTxs(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encode writes the byte encoding of SpanBatch to Writer stream
+func (b *RawSpanBatch) encode(w io.Writer) error {
+	if err := b.encodePrefix(w); err != nil {
+		return err
+	}
+	if err := b.encodePayload(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// encodeBytes returns the byte encoding of SpanBatch
+func (b *RawSpanBatch) encodeBytes() ([]byte, error) {
+	buf := encodeBufferPool.Get().(*bytes.Buffer)
+	defer encodeBufferPool.Put(buf)
+	buf.Reset()
+	if err := b.encode(buf); err != nil {
+		return []byte{}, err
+	}
+	return buf.Bytes(), nil
+}
+
+// derive converts RawSpanBatch into SpanBatch, which has a list of spanBatchElement.
+// We need chain config constants to derive values for making payload attributes.
+func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainID *big.Int) (*SpanBatch, error) {
+	blockOriginNums := make([]uint64, b.blockCount)
+	l1OriginBlockNumber := b.l1OriginNum
+	for i := int(b.blockCount) - 1; i >= 0; i-- {
+		blockOriginNums[i] = l1OriginBlockNumber
+		if b.originBits.Bit(i) == 1 && i > 0 {
+			l1OriginBlockNumber--
+		}
+	}
+
+	b.txs.recoverV(chainID)
+	fullTxs, err := b.txs.fullTxs(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	spanBatch := SpanBatch{
+		parentCheck:   b.parentCheck,
+		l1OriginCheck: b.l1OriginCheck,
+	}
+	txIdx := 0
+	for i := 0; i < int(b.blockCount); i++ {
+		batch := spanBatchElement{}
+		batch.Timestamp = genesisTimestamp + b.relTimestamp + blockTime*uint64(i)
+		batch.EpochNum = rollup.Epoch(blockOriginNums[i])
+		for j := 0; j < int(b.blockTxCounts[i]); j++ {
+			batch.Transactions = append(batch.Transactions, fullTxs[txIdx])
+			txIdx++
+		}
+		spanBatch.batches = append(spanBatch.batches, &batch)
+	}
+	return &spanBatch, nil
+}
+
+// spanBatchElement is a derived form of input to build a L2 block.
+// similar to SingularBatch, but does not have ParentHash and EpochHash
+// because Span batch spec does not contain parent hash and epoch hash of every block in the span.
+type spanBatchElement struct {
+	EpochNum     rollup.Epoch // aka l1 num
+	Timestamp    uint64
+	Transactions []hexutil.Bytes
+}
+
+// singularBatchToElement converts a SingularBatch to a spanBatchElement
+func singularBatchToElement(singularBatch *SingularBatch) *spanBatchElement {
+	return &spanBatchElement{
+		EpochNum:     singularBatch.EpochNum,
+		Timestamp:    singularBatch.Timestamp,
+		Transactions: singularBatch.Transactions,
+	}
+}
+
+// SpanBatch is an implementation of Batch interface,
+// containing the input to build a span of L2 blocks in derived form (spanBatchElement)
+type SpanBatch struct {
+	parentCheck   []byte              // First 20 bytes of the first block's parent hash
+	l1OriginCheck []byte              // First 20 bytes of the last block's L1 origin hash
+	batches       []*spanBatchElement // List of block input in derived form
+}
+
+// GetBatchType returns its batch type (batch_version)
+func (b *SpanBatch) GetBatchType() int {
+	return SpanBatchType
+}
+
+// GetTimestamp returns timestamp of the first block in the span
+func (b *SpanBatch) GetTimestamp() uint64 {
+	return b.batches[0].Timestamp
+}
+
+// LogContext creates a new log context that contains information of the batch
+func (b *SpanBatch) LogContext(log log.Logger) log.Logger {
+	return log.New(
+		"batch_timestamp", b.batches[0].Timestamp,
+		"parent_check", hexutil.Encode(b.parentCheck),
+		"origin_check", hexutil.Encode(b.l1OriginCheck),
+		"start_epoch_number", b.GetStartEpochNum(),
+		"end_epoch_number", b.GetBlockEpochNum(len(b.batches)-1),
+		"block_count", len(b.batches),
+	)
+}
+
+// GetStartEpochNum returns epoch number(L1 origin block number) of the first block in the span
+func (b *SpanBatch) GetStartEpochNum() rollup.Epoch {
+	return b.batches[0].EpochNum
+}
+
+// CheckOriginHash checks if the l1OriginCheck matches the first 20 bytes of given hash, probably L1 block hash from the current canonical L1 chain.
+func (b *SpanBatch) CheckOriginHash(hash common.Hash) bool {
+	return bytes.Equal(b.l1OriginCheck, hash.Bytes()[:20])
+}
+
+// CheckParentHash checks if the parentCheck matches the first 20 bytes of given hash, probably the current L2 safe head.
+func (b *SpanBatch) CheckParentHash(hash common.Hash) bool {
+	return bytes.Equal(b.parentCheck, hash.Bytes()[:20])
+}
+
+// GetBlockEpochNum returns the epoch number(L1 origin block number) of the block at the given index in the span.
+func (b *SpanBatch) GetBlockEpochNum(i int) uint64 {
+	return uint64(b.batches[i].EpochNum)
+}
+
+// GetBlockTimestamp returns the timestamp of the block at the given index in the span.
+func (b *SpanBatch) GetBlockTimestamp(i int) uint64 {
+	return b.batches[i].Timestamp
+}
+
+// GetBlockTransactions returns the encoded transactions of the block at the given index in the span.
+func (b *SpanBatch) GetBlockTransactions(i int) []hexutil.Bytes {
+	return b.batches[i].Transactions
+}
+
+// GetBlockCount returns the number of blocks in the span
+func (b *SpanBatch) GetBlockCount() int {
+	return len(b.batches)
+}
+
+// AppendSingularBatch appends a SingularBatch into the span batch
+// updates l1OriginCheck or parentCheck if needed.
+func (b *SpanBatch) AppendSingularBatch(singularBatch *SingularBatch) {
+	if len(b.batches) == 0 {
+		b.parentCheck = singularBatch.ParentHash.Bytes()[:20]
+	}
+	b.batches = append(b.batches, singularBatchToElement(singularBatch))
+	b.l1OriginCheck = singularBatch.EpochHash.Bytes()[:20]
+}
+
+// ToRawSpanBatch merges SingularBatch List and initialize single RawSpanBatch
+func (b *SpanBatch) ToRawSpanBatch(originChangedBit uint, genesisTimestamp uint64, chainID *big.Int) (*RawSpanBatch, error) {
+	if len(b.batches) == 0 {
+		return nil, errors.New("cannot merge empty singularBatch list")
+	}
+	raw := RawSpanBatch{}
+	// Sort by timestamp of L2 block
+	sort.Slice(b.batches, func(i, j int) bool {
+		return b.batches[i].Timestamp < b.batches[j].Timestamp
+	})
+	// spanBatchPrefix
+	span_start := b.batches[0]
+	span_end := b.batches[len(b.batches)-1]
+	raw.relTimestamp = span_start.Timestamp - genesisTimestamp
+	raw.l1OriginNum = uint64(span_end.EpochNum)
+	raw.parentCheck = make([]byte, 20)
+	copy(raw.parentCheck, b.parentCheck)
+	raw.l1OriginCheck = make([]byte, 20)
+	copy(raw.l1OriginCheck, b.l1OriginCheck)
+	// spanBatchPayload
+	raw.blockCount = uint64(len(b.batches))
+	raw.originBits = new(big.Int)
+	raw.originBits.SetBit(raw.originBits, 0, originChangedBit)
+	for i := 1; i < len(b.batches); i++ {
+		bit := uint(0)
+		if b.batches[i-1].EpochNum < b.batches[i].EpochNum {
+			bit = 1
+		}
+		raw.originBits.SetBit(raw.originBits, i, bit)
+	}
+	var blockTxCounts []uint64
+	var txs [][]byte
+	for _, batch := range b.batches {
+		blockTxCount := uint64(len(batch.Transactions))
+		blockTxCounts = append(blockTxCounts, blockTxCount)
+		for _, rawTx := range batch.Transactions {
+			txs = append(txs, rawTx)
+		}
+	}
+	raw.blockTxCounts = blockTxCounts
+	stxs, err := newSpanBatchTxs(txs, chainID)
+	if err != nil {
+		return nil, err
+	}
+	raw.txs = stxs
+	return &raw, nil
+}
+
+// GetSingularBatches converts spanBatchElements after L2 safe head to SingularBatches.
+// Since spanBatchElement does not contain EpochHash, set EpochHash from the given L1 blocks.
+// The result SingularBatches do not contain ParentHash yet. It must be set by BatchQueue.
+func (b *SpanBatch) GetSingularBatches(l1Origins []eth.L1BlockRef, l2SafeHead eth.L2BlockRef) ([]*SingularBatch, error) {
+	var singularBatches []*SingularBatch
+	originIdx := 0
+	for _, batch := range b.batches {
+		if batch.Timestamp <= l2SafeHead.Time {
+			continue
+		}
+		singularBatch := SingularBatch{
+			EpochNum:     batch.EpochNum,
+			Timestamp:    batch.Timestamp,
+			Transactions: batch.Transactions,
+		}
+		originFound := false
+		for i := originIdx; i < len(l1Origins); i++ {
+			if l1Origins[i].Number == uint64(batch.EpochNum) {
+				originIdx = i
+				singularBatch.EpochHash = l1Origins[i].Hash
+				originFound = true
+				break
+			}
+		}
+		if !originFound {
+			return nil, fmt.Errorf("unable to find L1 origin for the epoch number: %d", batch.EpochNum)
+		}
+		singularBatches = append(singularBatches, &singularBatch)
+	}
+	return singularBatches, nil
+}
+
+// NewSpanBatch converts given singularBatches into spanBatchElements, and creates a new SpanBatch.
+func NewSpanBatch(singularBatches []*SingularBatch) *SpanBatch {
+	if len(singularBatches) == 0 {
+		return &SpanBatch{}
+	}
+	spanBatch := SpanBatch{
+		parentCheck:   singularBatches[0].ParentHash.Bytes()[:20],
+		l1OriginCheck: singularBatches[len(singularBatches)-1].EpochHash.Bytes()[:20],
+	}
+	for _, singularBatch := range singularBatches {
+		spanBatch.batches = append(spanBatch.batches, singularBatchToElement(singularBatch))
+	}
+	return &spanBatch
+}
+
+// SpanBatchBuilder is a utility type to build a SpanBatch by adding a SingularBatch one by one.
+// makes easier to stack SingularBatches and convert to RawSpanBatch for encoding.
+type SpanBatchBuilder struct {
+	parentEpoch      uint64
+	genesisTimestamp uint64
+	chainID          *big.Int
+	spanBatch        *SpanBatch
+}
+
+func NewSpanBatchBuilder(parentEpoch uint64, genesisTimestamp uint64, chainID *big.Int) *SpanBatchBuilder {
+	return &SpanBatchBuilder{
+		parentEpoch:      parentEpoch,
+		genesisTimestamp: genesisTimestamp,
+		chainID:          chainID,
+		spanBatch:        &SpanBatch{},
+	}
+}
+
+func (b *SpanBatchBuilder) AppendSingularBatch(singularBatch *SingularBatch) {
+	b.spanBatch.AppendSingularBatch(singularBatch)
+}
+
+func (b *SpanBatchBuilder) GetRawSpanBatch() (*RawSpanBatch, error) {
+	originChangedBit := 0
+	if uint64(b.spanBatch.GetStartEpochNum()) != b.parentEpoch {
+		originChangedBit = 1
+	}
+	raw, err := b.spanBatch.ToRawSpanBatch(uint(originChangedBit), b.genesisTimestamp, b.chainID)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func (b *SpanBatchBuilder) GetBlockCount() int {
+	return len(b.spanBatch.batches)
+}
+
+func (b *SpanBatchBuilder) Reset() {
+	b.spanBatch = &SpanBatch{}
+}
+
+// ReadTxData reads raw RLP tx data from reader and returns txData and txType
+func ReadTxData(r *bytes.Reader) ([]byte, int, error) {
+	var txData []byte
+	offset, err := r.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to seek tx reader: %w", err)
+	}
+	b, err := r.ReadByte()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read tx initial byte: %w", err)
+	}
+	txType := byte(0)
+	if int(b) <= 0x7F {
+		// EIP-2718: non legacy tx so write tx type
+		txType = byte(b)
+		txData = append(txData, txType)
+	} else {
+		// legacy tx: seek back single byte to read prefix again
+		_, err = r.Seek(offset, io.SeekStart)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to seek tx reader: %w", err)
+		}
+	}
+	// avoid out of memory before allocation
+	s := rlp.NewStream(r, MaxSpanBatchFieldSize)
+	var txPayload []byte
+	kind, _, err := s.Kind()
+	switch {
+	case err != nil:
+		if errors.Is(err, rlp.ErrValueTooLarge) {
+			return nil, 0, ErrTooBigSpanBatchFieldSize
+		}
+		return nil, 0, fmt.Errorf("failed to read tx RLP prefix: %w", err)
+	case kind == rlp.List:
+		if txPayload, err = s.Raw(); err != nil {
+			return nil, 0, fmt.Errorf("failed to read tx RLP payload: %w", err)
+		}
+	default:
+		return nil, 0, errors.New("tx RLP prefix type must be list")
+	}
+	txData = append(txData, txPayload...)
+	return txData, int(txType), nil
+}

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -1,0 +1,514 @@
+package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanBatchForBatchInterface(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x5432177))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+	blockCount := len(singularBatches)
+	safeL2Head := testutils.RandomL2BlockRef(rng)
+	safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+
+	spanBatch := NewSpanBatch(singularBatches)
+
+	// check interface method implementations except logging
+	assert.Equal(t, SpanBatchType, spanBatch.GetBatchType())
+	assert.Equal(t, singularBatches[0].Timestamp, spanBatch.GetTimestamp())
+	assert.Equal(t, singularBatches[0].EpochNum, spanBatch.GetStartEpochNum())
+	assert.True(t, spanBatch.CheckOriginHash(singularBatches[blockCount-1].EpochHash))
+	assert.True(t, spanBatch.CheckParentHash(singularBatches[0].ParentHash))
+}
+
+func TestSpanBatchOriginBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77665544))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	blockCount := rawSpanBatch.blockCount
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeOriginBits(&buf)
+	assert.NoError(t, err)
+
+	// originBit field is fixed length: single bit
+	originBitBufferLen := blockCount / 8
+	if blockCount%8 != 0 {
+		originBitBufferLen++
+	}
+	assert.Equal(t, buf.Len(), int(originBitBufferLen))
+
+	result := buf.Bytes()
+	var sb RawSpanBatch
+	sb.blockCount = blockCount
+	r := bytes.NewReader(result)
+	err = sb.decodeOriginBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.originBits, sb.originBits)
+}
+
+func TestSpanBatchPrefix(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44775566))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	// only compare prefix
+	rawSpanBatch.spanBatchPayload = spanBatchPayload{}
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodePrefix(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodePrefix(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch, &sb)
+}
+
+func TestSpanBatchRelTimestamp(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44775566))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeRelTimestamp(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeRelTimestamp(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.relTimestamp, sb.relTimestamp)
+}
+
+func TestSpanBatchL1OriginNum(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556688))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeL1OriginNum(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeL1OriginNum(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.l1OriginNum, sb.l1OriginNum)
+}
+
+func TestSpanBatchParentCheck(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556689))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeParentCheck(&buf)
+	assert.NoError(t, err)
+
+	// parent check field is fixed length: 20 bytes
+	assert.Equal(t, buf.Len(), 20)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeParentCheck(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.parentCheck, sb.parentCheck)
+}
+
+func TestSpanBatchL1OriginCheck(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556690))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeL1OriginCheck(&buf)
+	assert.NoError(t, err)
+
+	// l1 origin check field is fixed length: 20 bytes
+	assert.Equal(t, buf.Len(), 20)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeL1OriginCheck(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.l1OriginCheck, sb.l1OriginCheck)
+}
+
+func TestSpanBatchPayload(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodePayload(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	err = sb.decodePayload(r)
+	assert.NoError(t, err)
+
+	sb.txs.recoverV(chainID)
+
+	assert.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
+}
+
+func TestSpanBatchBlockCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockCount(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	err = sb.decodeBlockCount(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.blockCount, sb.blockCount)
+}
+
+func TestSpanBatchBlockTxCounts(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556692))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockTxCounts(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	sb.blockCount = rawSpanBatch.blockCount
+	err = sb.decodeBlockTxCounts(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rawSpanBatch.blockTxCounts, sb.blockTxCounts)
+}
+
+func TestSpanBatchTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556693))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeTxs(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+
+	sb.blockTxCounts = rawSpanBatch.blockTxCounts
+	err = sb.decodeTxs(r)
+	assert.NoError(t, err)
+
+	sb.txs.recoverV(chainID)
+
+	assert.Equal(t, rawSpanBatch.txs, sb.txs)
+}
+
+func TestSpanBatchRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556694))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	result, err := rawSpanBatch.encodeBytes()
+	assert.NoError(t, err)
+
+	var sb RawSpanBatch
+	err = sb.decodeBytes(result)
+	assert.NoError(t, err)
+
+	sb.txs.recoverV(chainID)
+
+	assert.Equal(t, rawSpanBatch, &sb)
+}
+
+func TestSpanBatchDerive(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab0bab0))
+
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+	l2BlockTime := uint64(2)
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		spanBatchDerived, err := rawSpanBatch.derive(l2BlockTime, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		blockCount := len(singularBatches)
+		assert.Equal(t, safeL2Head.Hash.Bytes()[:20], spanBatchDerived.parentCheck)
+		assert.Equal(t, singularBatches[blockCount-1].Epoch().Hash.Bytes()[:20], spanBatchDerived.l1OriginCheck)
+		assert.Equal(t, len(singularBatches), int(rawSpanBatch.blockCount))
+
+		for i := 1; i < len(singularBatches); i++ {
+			assert.Equal(t, spanBatchDerived.batches[i].Timestamp, spanBatchDerived.batches[i-1].Timestamp+l2BlockTime)
+		}
+
+		for i := 0; i < len(singularBatches); i++ {
+			assert.Equal(t, singularBatches[i].EpochNum, spanBatchDerived.batches[i].EpochNum)
+			assert.Equal(t, singularBatches[i].Timestamp, spanBatchDerived.batches[i].Timestamp)
+			assert.Equal(t, singularBatches[i].Transactions, spanBatchDerived.batches[i].Transactions)
+		}
+	}
+}
+
+func TestSpanBatchAppend(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x44337711))
+
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+	// initialize empty span batch
+	spanBatch := NewSpanBatch([]*SingularBatch{})
+
+	L := 2
+	for i := 0; i < L; i++ {
+		spanBatch.AppendSingularBatch(singularBatches[i])
+	}
+	// initialize with two singular batches
+	spanBatch2 := NewSpanBatch(singularBatches[:L])
+
+	assert.Equal(t, spanBatch, spanBatch2)
+}
+
+func TestSpanBatchMerge(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73314433))
+
+	genesisTimeStamp := rng.Uint64()
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		blockCount := len(singularBatches)
+
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		// check span batch prefix
+		assert.Equal(t, rawSpanBatch.relTimestamp, singularBatches[0].Timestamp-genesisTimeStamp, "invalid relative timestamp")
+		assert.Equal(t, rollup.Epoch(rawSpanBatch.l1OriginNum), singularBatches[blockCount-1].EpochNum)
+		assert.Equal(t, rawSpanBatch.parentCheck, singularBatches[0].ParentHash.Bytes()[:20], "invalid parent check")
+		assert.Equal(t, rawSpanBatch.l1OriginCheck, singularBatches[blockCount-1].EpochHash.Bytes()[:20], "invalid l1 origin check")
+
+		// check span batch payload
+		assert.Equal(t, int(rawSpanBatch.blockCount), len(singularBatches))
+		assert.Equal(t, rawSpanBatch.originBits.Bit(0), originChangedBit)
+		for i := 1; i < blockCount; i++ {
+			if rawSpanBatch.originBits.Bit(i) == 1 {
+				assert.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum+1)
+			} else {
+				assert.Equal(t, singularBatches[i].EpochNum, singularBatches[i-1].EpochNum)
+			}
+		}
+		for i := 0; i < len(singularBatches); i++ {
+			txCount := len(singularBatches[i].Transactions)
+			assert.Equal(t, txCount, int(rawSpanBatch.blockTxCounts[i]))
+		}
+
+		// check invariants
+		endEpochNum := rawSpanBatch.l1OriginNum
+		assert.Equal(t, endEpochNum, uint64(singularBatches[blockCount-1].EpochNum))
+
+		// we do not check txs field because it has to be derived to be compared
+	}
+}
+
+func TestSpanBatchToSingularBatch(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab0bab1))
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		safeL2Head.Time = singularBatches[0].Timestamp - 2
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		l1Origins := mockL1Origin(rng, rawSpanBatch, singularBatches)
+
+		singularBatches2, err := spanBatch.GetSingularBatches(l1Origins, safeL2Head)
+		assert.NoError(t, err)
+
+		// GetSingularBatches does not fill in parent hash of singular batches
+		// empty out parent hash for comparison
+		for i := 0; i < len(singularBatches); i++ {
+			singularBatches[i].ParentHash = common.Hash{}
+		}
+		// check parent hash is empty
+		for i := 0; i < len(singularBatches2); i++ {
+			assert.Equal(t, singularBatches2[i].ParentHash, common.Hash{})
+		}
+
+		assert.Equal(t, singularBatches, singularBatches2)
+	}
+}
+
+func TestSpanBatchReadTxData(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x109550))
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	txCount := 64
+
+	signer := types.NewLondonSigner(chainID)
+	var rawTxs [][]byte
+	var txs []*types.Transaction
+	m := make(map[byte]int)
+	for i := 0; i < txCount; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		rawTx, err := tx.MarshalBinary()
+		assert.NoError(t, err)
+		rawTxs = append(rawTxs, rawTx)
+		txs = append(txs, tx)
+	}
+
+	for i := 0; i < txCount; i++ {
+		r := bytes.NewReader(rawTxs[i])
+		_, txType, err := ReadTxData(r)
+		assert.NoError(t, err)
+		assert.Equal(t, int(txs[i].Type()), txType)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+func TestSpanBatchReadTxDataInvalid(t *testing.T) {
+	dummy, err := rlp.EncodeToBytes("dummy")
+	assert.NoError(t, err)
+
+	// test non list rlp decoding
+	r := bytes.NewReader(dummy)
+	_, _, err = ReadTxData(r)
+	assert.ErrorContains(t, err, "tx RLP prefix type must be list")
+}
+
+func TestSpanBatchBuilder(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xbab1bab1))
+	chainID := new(big.Int).SetUint64(rng.Uint64())
+
+	for originChangedBit := 0; originChangedBit < 2; originChangedBit++ {
+		singularBatches := RandomValidConsecutiveSingularBatches(rng, chainID)
+		safeL2Head := testutils.RandomL2BlockRef(rng)
+		if originChangedBit == 0 {
+			safeL2Head.Hash = common.BytesToHash(singularBatches[0].ParentHash[:])
+		}
+		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
+
+		parentEpoch := uint64(singularBatches[0].EpochNum)
+		if originChangedBit == 1 {
+			parentEpoch -= 1
+		}
+		spanBatchBuilder := NewSpanBatchBuilder(parentEpoch, genesisTimeStamp, chainID)
+
+		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
+
+		for i := 0; i < len(singularBatches); i++ {
+			spanBatchBuilder.AppendSingularBatch(singularBatches[i])
+			assert.Equal(t, i+1, spanBatchBuilder.GetBlockCount())
+			assert.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck)
+			assert.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck)
+		}
+
+		rawSpanBatch, err := spanBatchBuilder.GetRawSpanBatch()
+		assert.NoError(t, err)
+
+		// compare with rawSpanBatch not using spanBatchBuilder
+		spanBatch := NewSpanBatch(singularBatches)
+		originChangedBit := uint(originChangedBit)
+		rawSpanBatch2, err := spanBatch.ToRawSpanBatch(originChangedBit, genesisTimeStamp, chainID)
+		assert.NoError(t, err)
+
+		assert.Equal(t, rawSpanBatch2, rawSpanBatch)
+
+		spanBatchBuilder.Reset()
+		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
+	}
+}
+
+func TestSpanBatchMaxTxData(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x177288))
+
+	invalidTx := types.NewTx(&types.DynamicFeeTx{
+		Data: testutils.RandomData(rng, MaxSpanBatchFieldSize+1),
+	})
+
+	txEncoded, err := invalidTx.MarshalBinary()
+	assert.NoError(t, err)
+
+	r := bytes.NewReader(txEncoded)
+	_, _, err = ReadTxData(r)
+
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}
+
+func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
+	var sb RawSpanBatch
+	sb.blockCount = 0xFFFFFFFFFFFFFFFF
+
+	r := bytes.NewReader([]byte{})
+	err := sb.decodeOriginBits(r)
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}

--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -1,0 +1,253 @@
+package derive
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type spanBatchTxData interface {
+	txType() byte // returns the type ID
+}
+
+type spanBatchTx struct {
+	inner spanBatchTxData
+}
+
+type spanBatchLegacyTxData struct {
+	Value    *big.Int // wei amount
+	GasPrice *big.Int // wei per gas
+	Data     []byte
+}
+
+func (txData *spanBatchLegacyTxData) txType() byte { return types.LegacyTxType }
+
+type spanBatchAccessListTxData struct {
+	Value      *big.Int // wei amount
+	GasPrice   *big.Int // wei per gas
+	Data       []byte
+	AccessList types.AccessList // EIP-2930 access list
+}
+
+func (txData *spanBatchAccessListTxData) txType() byte { return types.AccessListTxType }
+
+type spanBatchDynamicFeeTxData struct {
+	Value      *big.Int
+	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
+	Data       []byte
+	AccessList types.AccessList
+}
+
+func (txData *spanBatchDynamicFeeTxData) txType() byte { return types.DynamicFeeTxType }
+
+// Type returns the transaction type.
+func (tx *spanBatchTx) Type() uint8 {
+	return tx.inner.txType()
+}
+
+// encodeTyped writes the canonical encoding of a typed transaction to w.
+func (tx *spanBatchTx) encodeTyped(w *bytes.Buffer) error {
+	w.WriteByte(tx.Type())
+	return rlp.Encode(w, tx.inner)
+}
+
+// MarshalBinary returns the canonical encoding of the transaction.
+// For legacy transactions, it returns the RLP encoding. For EIP-2718 typed
+// transactions, it returns the type and payload.
+func (tx *spanBatchTx) MarshalBinary() ([]byte, error) {
+	if tx.Type() == types.LegacyTxType {
+		return rlp.EncodeToBytes(tx.inner)
+	}
+	var buf bytes.Buffer
+	err := tx.encodeTyped(&buf)
+	return buf.Bytes(), err
+}
+
+// EncodeRLP implements rlp.Encoder
+func (tx *spanBatchTx) EncodeRLP(w io.Writer) error {
+	if tx.Type() == types.LegacyTxType {
+		return rlp.Encode(w, tx.inner)
+	}
+	// It's an EIP-2718 typed TX envelope.
+	buf := encodeBufferPool.Get().(*bytes.Buffer)
+	defer encodeBufferPool.Put(buf)
+	buf.Reset()
+	if err := tx.encodeTyped(buf); err != nil {
+		return err
+	}
+	return rlp.Encode(w, buf.Bytes())
+}
+
+// setDecoded sets the inner transaction after decoding.
+func (tx *spanBatchTx) setDecoded(inner spanBatchTxData, size uint64) {
+	tx.inner = inner
+}
+
+// decodeTyped decodes a typed transaction from the canonical format.
+func (tx *spanBatchTx) decodeTyped(b []byte) (spanBatchTxData, error) {
+	if len(b) <= 1 {
+		return nil, errors.New("typed transaction too short")
+	}
+	switch b[0] {
+	case types.AccessListTxType:
+		var inner spanBatchAccessListTxData
+		err := rlp.DecodeBytes(b[1:], &inner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode spanBatchAccessListTxData: %w", err)
+		}
+		return &inner, nil
+	case types.DynamicFeeTxType:
+		var inner spanBatchDynamicFeeTxData
+		err := rlp.DecodeBytes(b[1:], &inner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode spanBatchDynamicFeeTxData: %w", err)
+		}
+		return &inner, nil
+	default:
+		return nil, types.ErrTxTypeNotSupported
+	}
+}
+
+// DecodeRLP implements rlp.Decoder
+func (tx *spanBatchTx) DecodeRLP(s *rlp.Stream) error {
+	kind, size, err := s.Kind()
+	switch {
+	case err != nil:
+		return err
+	case kind == rlp.List:
+		// It's a legacy transaction.
+		var inner spanBatchLegacyTxData
+		err = s.Decode(&inner)
+		if err != nil {
+			return fmt.Errorf("failed to decode spanBatchLegacyTxData: %w", err)
+		}
+		tx.setDecoded(&inner, rlp.ListSize(size))
+		return nil
+	default:
+		// It's an EIP-2718 typed TX envelope.
+		var b []byte
+		if b, err = s.Bytes(); err != nil {
+			return err
+		}
+		inner, err := tx.decodeTyped(b)
+		if err != nil {
+			return err
+		}
+		tx.setDecoded(inner, uint64(len(b)))
+		return nil
+	}
+}
+
+// UnmarshalBinary decodes the canonical encoding of transactions.
+// It supports legacy RLP transactions and EIP2718 typed transactions.
+func (tx *spanBatchTx) UnmarshalBinary(b []byte) error {
+	if len(b) > 0 && b[0] > 0x7f {
+		// It's a legacy transaction.
+		var data spanBatchLegacyTxData
+		err := rlp.DecodeBytes(b, &data)
+		if err != nil {
+			return fmt.Errorf("failed to decode spanBatchLegacyTxData: %w", err)
+		}
+		tx.setDecoded(&data, uint64(len(b)))
+		return nil
+	}
+	// It's an EIP2718 typed transaction envelope.
+	inner, err := tx.decodeTyped(b)
+	if err != nil {
+		return err
+	}
+	tx.setDecoded(inner, uint64(len(b)))
+	return nil
+}
+
+// convertToFullTx takes values and convert spanBatchTx to types.Transaction
+func (tx *spanBatchTx) convertToFullTx(nonce, gas uint64, to *common.Address, chainID, V, R, S *big.Int) (*types.Transaction, error) {
+	var inner types.TxData
+	switch tx.Type() {
+	case types.LegacyTxType:
+		batchTxInner := tx.inner.(*spanBatchLegacyTxData)
+		inner = &types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: batchTxInner.GasPrice,
+			Gas:      gas,
+			To:       to,
+			Value:    batchTxInner.Value,
+			Data:     batchTxInner.Data,
+			V:        V,
+			R:        R,
+			S:        S,
+		}
+	case types.AccessListTxType:
+		batchTxInner := tx.inner.(*spanBatchAccessListTxData)
+		inner = &types.AccessListTx{
+			ChainID:    chainID,
+			Nonce:      nonce,
+			GasPrice:   batchTxInner.GasPrice,
+			Gas:        gas,
+			To:         to,
+			Value:      batchTxInner.Value,
+			Data:       batchTxInner.Data,
+			AccessList: batchTxInner.AccessList,
+			V:          V,
+			R:          R,
+			S:          S,
+		}
+	case types.DynamicFeeTxType:
+		batchTxInner := tx.inner.(*spanBatchDynamicFeeTxData)
+		inner = &types.DynamicFeeTx{
+			ChainID:    chainID,
+			Nonce:      nonce,
+			GasTipCap:  batchTxInner.GasTipCap,
+			GasFeeCap:  batchTxInner.GasFeeCap,
+			Gas:        gas,
+			To:         to,
+			Value:      batchTxInner.Value,
+			Data:       batchTxInner.Data,
+			AccessList: batchTxInner.AccessList,
+			V:          V,
+			R:          R,
+			S:          S,
+		}
+	default:
+		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
+	}
+	return types.NewTx(inner), nil
+}
+
+// newSpanBatchTx converts types.Transaction to spanBatchTx
+func newSpanBatchTx(tx types.Transaction) (*spanBatchTx, error) {
+	var inner spanBatchTxData
+	switch tx.Type() {
+	case types.LegacyTxType:
+		inner = &spanBatchLegacyTxData{
+			GasPrice: tx.GasPrice(),
+			Value:    tx.Value(),
+			Data:     tx.Data(),
+		}
+	case types.AccessListTxType:
+		inner = &spanBatchAccessListTxData{
+			GasPrice:   tx.GasPrice(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+		}
+	case types.DynamicFeeTxType:
+		inner = &spanBatchDynamicFeeTxData{
+			GasTipCap:  tx.GasTipCap(),
+			GasFeeCap:  tx.GasFeeCap(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+		}
+	default:
+		return nil, fmt.Errorf("invalid tx type: %d", tx.Type())
+	}
+	return &spanBatchTx{inner: inner}, nil
+}

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -1,0 +1,150 @@
+package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanBatchTxConvert(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1331))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	m := make(map[byte]int)
+	for i := 0; i < 32; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		v, r, s := tx.RawSignatureValues()
+		sbtx, err := newSpanBatchTx(*tx)
+		assert.NoError(t, err)
+
+		tx2, err := sbtx.convertToFullTx(tx.Nonce(), tx.Gas(), tx.To(), chainID, v, r, s)
+		assert.NoError(t, err)
+
+		// compare after marshal because we only need inner field of transaction
+		txEncoded, err := tx.MarshalBinary()
+		assert.NoError(t, err)
+		tx2Encoded, err := tx2.MarshalBinary()
+		assert.NoError(t, err)
+
+		assert.Equal(t, txEncoded, tx2Encoded)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+func TestSpanBatchTxRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1332))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	m := make(map[byte]int)
+	for i := 0; i < 32; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		sbtx, err := newSpanBatchTx(*tx)
+		assert.NoError(t, err)
+
+		sbtxEncoded, err := sbtx.MarshalBinary()
+		assert.NoError(t, err)
+
+		var sbtx2 spanBatchTx
+		err = sbtx2.UnmarshalBinary(sbtxEncoded)
+		assert.NoError(t, err)
+
+		assert.Equal(t, sbtx, &sbtx2)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+func TestSpanBatchTxRoundTripRLP(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1333))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	m := make(map[byte]int)
+	for i := 0; i < 32; i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		m[tx.Type()] += 1
+		sbtx, err := newSpanBatchTx(*tx)
+		assert.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = sbtx.EncodeRLP(&buf)
+		assert.NoError(t, err)
+
+		result := buf.Bytes()
+		var sbtx2 spanBatchTx
+		r := bytes.NewReader(result)
+		rlpReader := rlp.NewStream(r, 0)
+		err = sbtx2.DecodeRLP(rlpReader)
+		assert.NoError(t, err)
+
+		assert.Equal(t, sbtx, &sbtx2)
+	}
+	// make sure every tx type is tested
+	assert.Positive(t, m[types.LegacyTxType])
+	assert.Positive(t, m[types.AccessListTxType])
+	assert.Positive(t, m[types.DynamicFeeTxType])
+}
+
+type spanBatchDummyTxData struct{}
+
+func (txData *spanBatchDummyTxData) txType() byte { return types.DepositTxType }
+func TestSpanBatchTxInvalidTxType(t *testing.T) {
+	// span batch never contain deposit tx
+	depositTx := types.NewTx(&types.DepositTx{})
+	_, err := newSpanBatchTx(*depositTx)
+	assert.ErrorContains(t, err, "invalid tx type")
+
+	var sbtx spanBatchTx
+	sbtx.inner = &spanBatchDummyTxData{}
+	_, err = sbtx.convertToFullTx(0, 0, nil, nil, nil, nil, nil)
+	assert.ErrorContains(t, err, "invalid tx type")
+}
+
+func TestSpanBatchTxDecodeInvalid(t *testing.T) {
+	var sbtx spanBatchTx
+	_, err := sbtx.decodeTyped([]byte{})
+	assert.EqualError(t, err, "typed transaction too short")
+
+	tx := types.NewTx(&types.LegacyTx{})
+	txEncoded, err := tx.MarshalBinary()
+	assert.NoError(t, err)
+
+	// legacy tx is not typed tx
+	_, err = sbtx.decodeTyped(txEncoded)
+	assert.EqualError(t, err, types.ErrTxTypeNotSupported.Error())
+
+	tx2 := types.NewTx(&types.AccessListTx{})
+	tx2Encoded, err := tx2.MarshalBinary()
+	assert.NoError(t, err)
+
+	tx2Encoded[0] = types.DynamicFeeTxType
+	_, err = sbtx.decodeTyped(tx2Encoded)
+	assert.ErrorContains(t, err, "failed to decode spanBatchDynamicFeeTxData")
+
+	tx3 := types.NewTx(&types.DynamicFeeTx{})
+	tx3Encoded, err := tx3.MarshalBinary()
+	assert.NoError(t, err)
+
+	tx3Encoded[0] = types.AccessListTxType
+	_, err = sbtx.decodeTyped(tx3Encoded)
+	assert.ErrorContains(t, err, "failed to decode spanBatchAccessListTxData")
+
+	invalidLegacyTxDecoded := []byte{0xFF, 0xFF}
+	err = sbtx.UnmarshalBinary(invalidLegacyTxDecoded)
+	assert.ErrorContains(t, err, "failed to decode spanBatchLegacyTxData")
+}

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -1,0 +1,475 @@
+package derive
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+type spanBatchTxs struct {
+	// this field must be manually set
+	totalBlockTxCount uint64
+
+	// 7 fields
+	contractCreationBits *big.Int
+	yParityBits          *big.Int
+	txSigs               []spanBatchSignature
+	txNonces             []uint64
+	txGases              []uint64
+	txTos                []common.Address
+	txDatas              []hexutil.Bytes
+
+	txTypes []int
+}
+
+type spanBatchSignature struct {
+	v uint64
+	r *uint256.Int
+	s *uint256.Int
+}
+
+// contractCreationBits is bitlist right-padded to a multiple of 8 bits
+func (btx *spanBatchTxs) encodeContractCreationBits(w io.Writer) error {
+	contractCreationBitBufferLen := btx.totalBlockTxCount / 8
+	if btx.totalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
+	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.totalBlockTxCount) {
+			end = int(btx.totalBlockTxCount)
+		}
+		var bits uint = 0
+		for j := i; j < end; j++ {
+			bits |= btx.contractCreationBits.Bit(j) << (j - i)
+		}
+		contractCreationBitBuffer[i/8] = byte(bits)
+	}
+	if _, err := w.Write(contractCreationBitBuffer); err != nil {
+		return fmt.Errorf("cannot write contract creation bits: %w", err)
+	}
+	return nil
+}
+
+// contractCreationBits is bitlist right-padded to a multiple of 8 bits
+func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
+	contractCreationBitBufferLen := btx.totalBlockTxCount / 8
+	if btx.totalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	// avoid out of memory before allocation
+	if contractCreationBitBufferLen > MaxSpanBatchFieldSize {
+		return ErrTooBigSpanBatchFieldSize
+	}
+	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
+	_, err := io.ReadFull(r, contractCreationBitBuffer)
+	if err != nil {
+		return fmt.Errorf("failed to read contract creation bits: %w", err)
+	}
+	contractCreationBits := new(big.Int)
+	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.totalBlockTxCount) {
+			end = int(btx.totalBlockTxCount)
+		}
+		bits := contractCreationBitBuffer[i/8]
+		for j := i; j < end; j++ {
+			bit := uint((bits >> (j - i)) & 1)
+			contractCreationBits.SetBit(contractCreationBits, j, bit)
+		}
+	}
+	btx.contractCreationBits = contractCreationBits
+	return nil
+}
+
+func (btx *spanBatchTxs) contractCreationCount() uint64 {
+	if btx.contractCreationBits == nil {
+		panic("contract creation bits not set")
+	}
+	var result uint64 = 0
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		bit := btx.contractCreationBits.Bit(i)
+		if bit == 1 {
+			result++
+		}
+	}
+	return result
+}
+
+// yParityBits is bitlist right-padded to a multiple of 8 bits
+func (btx *spanBatchTxs) encodeYParityBits(w io.Writer) error {
+	yParityBitBufferLen := btx.totalBlockTxCount / 8
+	if btx.totalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	yParityBitBuffer := make([]byte, yParityBitBufferLen)
+	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.totalBlockTxCount) {
+			end = int(btx.totalBlockTxCount)
+		}
+		var bits uint = 0
+		for j := i; j < end; j++ {
+			bits |= btx.yParityBits.Bit(j) << (j - i)
+		}
+		yParityBitBuffer[i/8] = byte(bits)
+	}
+	if _, err := w.Write(yParityBitBuffer); err != nil {
+		return fmt.Errorf("cannot write y parity bits: %w", err)
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) encodeTxSigsRS(w io.Writer) error {
+	for _, txSig := range btx.txSigs {
+		rBuf := txSig.r.Bytes32()
+		if _, err := w.Write(rBuf[:]); err != nil {
+			return fmt.Errorf("cannot write tx sig r: %w", err)
+		}
+		sBuf := txSig.s.Bytes32()
+		if _, err := w.Write(sBuf[:]); err != nil {
+			return fmt.Errorf("cannot write tx sig s: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) encodeTxNonces(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	for _, txNonce := range btx.txNonces {
+		n := binary.PutUvarint(buf[:], txNonce)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx nonce: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) encodeTxGases(w io.Writer) error {
+	var buf [binary.MaxVarintLen64]byte
+	for _, txGas := range btx.txGases {
+		n := binary.PutUvarint(buf[:], txGas)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return fmt.Errorf("cannot write tx gas: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) encodeTxTos(w io.Writer) error {
+	for _, txTo := range btx.txTos {
+		if _, err := w.Write(txTo.Bytes()); err != nil {
+			return fmt.Errorf("cannot write tx to address: %w", err)
+		}
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) encodeTxDatas(w io.Writer) error {
+	for _, txData := range btx.txDatas {
+		if _, err := w.Write(txData); err != nil {
+			return fmt.Errorf("cannot write tx data: %w", err)
+		}
+	}
+	return nil
+}
+
+// yParityBits is bitlist right-padded to a multiple of 8 bits
+func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
+	yParityBitBufferLen := btx.totalBlockTxCount / 8
+	if btx.totalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	// avoid out of memory before allocation
+	if yParityBitBufferLen > MaxSpanBatchFieldSize {
+		return ErrTooBigSpanBatchFieldSize
+	}
+	yParityBitBuffer := make([]byte, yParityBitBufferLen)
+	_, err := io.ReadFull(r, yParityBitBuffer)
+	if err != nil {
+		return fmt.Errorf("failed to read y parity bits: %w", err)
+	}
+	yParityBits := new(big.Int)
+	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
+		end := i + 8
+		if end < int(btx.totalBlockTxCount) {
+			end = int(btx.totalBlockTxCount)
+		}
+		bits := yParityBitBuffer[i/8]
+		for j := i; j < end; j++ {
+			bit := uint((bits >> (j - i)) & 1)
+			yParityBits.SetBit(yParityBits, j, bit)
+		}
+	}
+	btx.yParityBits = yParityBits
+	return nil
+}
+
+func (btx *spanBatchTxs) decodeTxSigsRS(r *bytes.Reader) error {
+	var txSigs []spanBatchSignature
+	var sigBuffer [32]byte
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		var txSig spanBatchSignature
+		_, err := io.ReadFull(r, sigBuffer[:])
+		if err != nil {
+			return fmt.Errorf("failed to read tx sig r: %w", err)
+		}
+		txSig.r, _ = uint256.FromBig(new(big.Int).SetBytes(sigBuffer[:]))
+		_, err = io.ReadFull(r, sigBuffer[:])
+		if err != nil {
+			return fmt.Errorf("failed to read tx sig s: %w", err)
+		}
+		txSig.s, _ = uint256.FromBig(new(big.Int).SetBytes(sigBuffer[:]))
+		txSigs = append(txSigs, txSig)
+	}
+	btx.txSigs = txSigs
+	return nil
+}
+
+func (btx *spanBatchTxs) decodeTxNonces(r *bytes.Reader) error {
+	var txNonces []uint64
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		txNonce, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx nonce: %w", err)
+		}
+		txNonces = append(txNonces, txNonce)
+	}
+	btx.txNonces = txNonces
+	return nil
+}
+
+func (btx *spanBatchTxs) decodeTxGases(r *bytes.Reader) error {
+	var txGases []uint64
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		txGas, err := binary.ReadUvarint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read tx gas: %w", err)
+		}
+		txGases = append(txGases, txGas)
+	}
+	btx.txGases = txGases
+	return nil
+}
+
+func (btx *spanBatchTxs) decodeTxTos(r *bytes.Reader) error {
+	var txTos []common.Address
+	txToBuffer := make([]byte, common.AddressLength)
+	contractCreationCount := btx.contractCreationCount()
+	for i := 0; i < int(btx.totalBlockTxCount-contractCreationCount); i++ {
+		_, err := io.ReadFull(r, txToBuffer)
+		if err != nil {
+			return fmt.Errorf("failed to read tx to address: %w", err)
+		}
+		txTos = append(txTos, common.BytesToAddress(txToBuffer))
+	}
+	btx.txTos = txTos
+	return nil
+}
+
+func (btx *spanBatchTxs) decodeTxDatas(r *bytes.Reader) error {
+	var txDatas []hexutil.Bytes
+	var txTypes []int
+	// Do not need txDataHeader because RLP byte stream already includes length info
+	for i := 0; i < int(btx.totalBlockTxCount); i++ {
+		txData, txType, err := ReadTxData(r)
+		if err != nil {
+			return err
+		}
+		txDatas = append(txDatas, txData)
+		txTypes = append(txTypes, txType)
+	}
+	btx.txDatas = txDatas
+	btx.txTypes = txTypes
+	return nil
+}
+
+func (btx *spanBatchTxs) recoverV(chainID *big.Int) {
+	if len(btx.txTypes) != len(btx.txSigs) {
+		panic("tx type length and tx sigs length mismatch")
+	}
+	for idx, txType := range btx.txTypes {
+		bit := uint64(btx.yParityBits.Bit(idx))
+		var v uint64
+		switch txType {
+		case types.LegacyTxType:
+			// EIP155
+			v = chainID.Uint64()*2 + 35 + bit
+		case types.AccessListTxType:
+			v = bit
+		case types.DynamicFeeTxType:
+			v = bit
+		default:
+			panic(fmt.Sprintf("invalid tx type: %d", txType))
+		}
+		btx.txSigs[idx].v = v
+	}
+}
+
+func (btx *spanBatchTxs) encode(w io.Writer) error {
+	if err := btx.encodeContractCreationBits(w); err != nil {
+		return err
+	}
+	if err := btx.encodeYParityBits(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxSigsRS(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxTos(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxDatas(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxNonces(w); err != nil {
+		return err
+	}
+	if err := btx.encodeTxGases(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) decode(r *bytes.Reader) error {
+	if err := btx.decodeContractCreationBits(r); err != nil {
+		return err
+	}
+	if err := btx.decodeYParityBits(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxSigsRS(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxTos(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxDatas(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxNonces(r); err != nil {
+		return err
+	}
+	if err := btx.decodeTxGases(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (btx *spanBatchTxs) fullTxs(chainID *big.Int) ([][]byte, error) {
+	var txs [][]byte
+	toIdx := 0
+	for idx := 0; idx < int(btx.totalBlockTxCount); idx++ {
+		var stx spanBatchTx
+		if err := stx.UnmarshalBinary(btx.txDatas[idx]); err != nil {
+			return nil, err
+		}
+		nonce := btx.txNonces[idx]
+		gas := btx.txGases[idx]
+		var to *common.Address = nil
+		bit := btx.contractCreationBits.Bit(idx)
+		if bit == 0 {
+			if len(btx.txTos) <= toIdx {
+				return nil, errors.New("tx to not enough")
+			}
+			to = &btx.txTos[toIdx]
+			toIdx++
+		}
+		v := new(big.Int).SetUint64(btx.txSigs[idx].v)
+		r := btx.txSigs[idx].r.ToBig()
+		s := btx.txSigs[idx].s.ToBig()
+		tx, err := stx.convertToFullTx(nonce, gas, to, chainID, v, r, s)
+		if err != nil {
+			return nil, err
+		}
+		encodedTx, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, encodedTx)
+	}
+	return txs, nil
+}
+
+func convertVToYParity(v uint64, txType int) uint {
+	var yParityBit uint
+	switch txType {
+	case types.LegacyTxType:
+		// EIP155: v = 2 * chainID + 35 + yParity
+		// v - 35 = yParity (mod 2)
+		yParityBit = uint((v - 35) & 1)
+	case types.AccessListTxType:
+		yParityBit = uint(v)
+	case types.DynamicFeeTxType:
+		yParityBit = uint(v)
+	default:
+		panic(fmt.Sprintf("invalid tx type: %d", txType))
+	}
+	return yParityBit
+}
+
+func newSpanBatchTxs(txs [][]byte, chainID *big.Int) (*spanBatchTxs, error) {
+	totalBlockTxCount := uint64(len(txs))
+	var txSigs []spanBatchSignature
+	var txTos []common.Address
+	var txNonces []uint64
+	var txGases []uint64
+	var txDatas []hexutil.Bytes
+	var txTypes []int
+	contractCreationBits := new(big.Int)
+	yParityBits := new(big.Int)
+	for idx := 0; idx < int(totalBlockTxCount); idx++ {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(txs[idx]); err != nil {
+			return nil, errors.New("failed to decode tx")
+		}
+		var txSig spanBatchSignature
+		v, r, s := tx.RawSignatureValues()
+		R, _ := uint256.FromBig(r)
+		S, _ := uint256.FromBig(s)
+		txSig.v = v.Uint64()
+		txSig.r = R
+		txSig.s = S
+		txSigs = append(txSigs, txSig)
+		contractCreationBit := uint(1)
+		if tx.To() != nil {
+			txTos = append(txTos, *tx.To())
+			contractCreationBit = uint(0)
+		}
+		contractCreationBits.SetBit(contractCreationBits, idx, contractCreationBit)
+		yParityBit := convertVToYParity(txSig.v, int(tx.Type()))
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
+		txNonces = append(txNonces, tx.Nonce())
+		txGases = append(txGases, tx.Gas())
+		stx, err := newSpanBatchTx(tx)
+		if err != nil {
+			return nil, err
+		}
+		txData, err := stx.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		txDatas = append(txDatas, txData)
+		txTypes = append(txTypes, int(tx.Type()))
+	}
+	return &spanBatchTxs{
+		totalBlockTxCount:    totalBlockTxCount,
+		contractCreationBits: contractCreationBits,
+		yParityBits:          yParityBits,
+		txSigs:               txSigs,
+		txNonces:             txNonces,
+		txGases:              txGases,
+		txTos:                txTos,
+		txDatas:              txDatas,
+		txTypes:              txTypes,
+	}, nil
+}

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -1,0 +1,404 @@
+package derive
+
+import (
+	"bytes"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanBatchTxsContractCreationBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234567))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	contractCreationBits := rawSpanBatch.txs.contractCreationBits
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeContractCreationBits(&buf)
+	assert.NoError(t, err)
+
+	// contractCreationBit field is fixed length: single bit
+	contractCreationBitBufferLen := totalBlockTxCount / 8
+	if totalBlockTxCount%8 != 0 {
+		contractCreationBitBufferLen++
+	}
+	assert.Equal(t, buf.Len(), int(contractCreationBitBufferLen))
+
+	result := buf.Bytes()
+	sbt.contractCreationBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeContractCreationBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, contractCreationBits, sbt.contractCreationBits)
+}
+
+func TestSpanBatchTxsContractCreationCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+
+	contractCreationBits := rawSpanBatch.txs.contractCreationBits
+	contractCreationCount := rawSpanBatch.txs.contractCreationCount()
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeContractCreationBits(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.contractCreationBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeContractCreationBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, contractCreationCount, sbt.contractCreationCount())
+}
+
+func TestSpanBatchTxsYParityBits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x7331))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	yParityBits := rawSpanBatch.txs.yParityBits
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.yParityBits = yParityBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeYParityBits(&buf)
+	assert.NoError(t, err)
+
+	// yParityBit field is fixed length: single bit
+	yParityBitBufferLen := totalBlockTxCount / 8
+	if totalBlockTxCount%8 != 0 {
+		yParityBitBufferLen++
+	}
+	assert.Equal(t, buf.Len(), int(yParityBitBufferLen))
+
+	result := buf.Bytes()
+	sbt.yParityBits = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeYParityBits(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, yParityBits, sbt.yParityBits)
+}
+
+func TestSpanBatchTxsTxSigs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73311337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txSigs := rawSpanBatch.txs.txSigs
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txSigs = txSigs
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxSigsRS(&buf)
+	assert.NoError(t, err)
+
+	// txSig field is fixed length: 32 byte + 32 byte = 64 byte
+	assert.Equal(t, buf.Len(), 64*int(totalBlockTxCount))
+
+	result := buf.Bytes()
+	sbt.txSigs = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxSigsRS(r)
+	assert.NoError(t, err)
+
+	// v field is not set
+	for i := 0; i < int(totalBlockTxCount); i++ {
+		assert.Equal(t, txSigs[i].r, sbt.txSigs[i].r)
+		assert.Equal(t, txSigs[i].s, sbt.txSigs[i].s)
+	}
+}
+
+func TestSpanBatchTxsTxNonces(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x123456))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txNonces := rawSpanBatch.txs.txNonces
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txNonces = txNonces
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxNonces(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txNonces = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxNonces(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txNonces, sbt.txNonces)
+}
+
+func TestSpanBatchTxsTxGases(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x12345))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txGases := rawSpanBatch.txs.txGases
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+	sbt.txGases = txGases
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxGases(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txGases = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxGases(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txGases, sbt.txGases)
+}
+
+func TestSpanBatchTxsTxTos(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x54321))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txTos := rawSpanBatch.txs.txTos
+	contractCreationBits := rawSpanBatch.txs.contractCreationBits
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.txTos = txTos
+	// creation bits and block tx count must be se to decode tos
+	sbt.contractCreationBits = contractCreationBits
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxTos(&buf)
+	assert.NoError(t, err)
+
+	// to field is fixed length: 20 bytes
+	assert.Equal(t, buf.Len(), 20*len(txTos))
+
+	result := buf.Bytes()
+	sbt.txTos = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxTos(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txTos, sbt.txTos)
+}
+
+func TestSpanBatchTxsTxDatas(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x1234))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	txDatas := rawSpanBatch.txs.txDatas
+	txTypes := rawSpanBatch.txs.txTypes
+	totalBlockTxCount := rawSpanBatch.txs.totalBlockTxCount
+
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = totalBlockTxCount
+
+	sbt.txDatas = txDatas
+
+	var buf bytes.Buffer
+	err := sbt.encodeTxDatas(&buf)
+	assert.NoError(t, err)
+
+	result := buf.Bytes()
+	sbt.txDatas = nil
+	sbt.txTypes = nil
+
+	r := bytes.NewReader(result)
+	err = sbt.decodeTxDatas(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, txDatas, sbt.txDatas)
+	assert.Equal(t, txTypes, sbt.txTypes)
+}
+
+func TestSpanBatchTxsRecoverV(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x123))
+
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+	totalblockTxCount := rng.Intn(100)
+
+	var spanBatchTxs spanBatchTxs
+	var txTypes []int
+	var txSigs []spanBatchSignature
+	var originalVs []uint64
+	yParityBits := new(big.Int)
+	for idx := 0; idx < totalblockTxCount; idx++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		txTypes = append(txTypes, int(tx.Type()))
+		var txSig spanBatchSignature
+		v, r, s := tx.RawSignatureValues()
+		// Do not fill in txSig.V
+		txSig.r, _ = uint256.FromBig(r)
+		txSig.s, _ = uint256.FromBig(s)
+		txSigs = append(txSigs, txSig)
+		originalVs = append(originalVs, v.Uint64())
+		yParityBit := convertVToYParity(v.Uint64(), int(tx.Type()))
+		yParityBits.SetBit(yParityBits, idx, yParityBit)
+	}
+
+	spanBatchTxs.yParityBits = yParityBits
+	spanBatchTxs.txSigs = txSigs
+	spanBatchTxs.txTypes = txTypes
+	// recover txSig.v
+	spanBatchTxs.recoverV(chainID)
+
+	var recoveredVs []uint64
+	for _, txSig := range spanBatchTxs.txSigs {
+		recoveredVs = append(recoveredVs, txSig.v)
+	}
+
+	assert.Equal(t, originalVs, recoveredVs, "recovered v mismatch")
+}
+
+func TestSpanBatchTxsRoundTrip(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x73311337))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	for i := 0; i < 4; i++ {
+		rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+		sbt := rawSpanBatch.txs
+		totalBlockTxCount := sbt.totalBlockTxCount
+
+		var buf bytes.Buffer
+		err := sbt.encode(&buf)
+		assert.NoError(t, err)
+
+		result := buf.Bytes()
+		r := bytes.NewReader(result)
+
+		var sbt2 spanBatchTxs
+		sbt2.totalBlockTxCount = totalBlockTxCount
+		err = sbt2.decode(r)
+		assert.NoError(t, err)
+		sbt2.recoverV(chainID)
+
+		assert.Equal(t, sbt, &sbt2)
+	}
+}
+
+func TestSpanBatchTxsRoundTripFullTxs(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x13377331))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	for i := 0; i < 4; i++ {
+		totalblockTxCounts := uint64(1 + rng.Int()&0xFF)
+		var txs [][]byte
+		for i := 0; i < int(totalblockTxCounts); i++ {
+			tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+			rawTx, err := tx.MarshalBinary()
+			assert.NoError(t, err)
+			txs = append(txs, rawTx)
+		}
+		sbt, err := newSpanBatchTxs(txs, chainID)
+		assert.NoError(t, err)
+
+		txs2, err := sbt.fullTxs(chainID)
+		assert.NoError(t, err)
+
+		assert.Equal(t, txs, txs2)
+	}
+}
+
+func TestSpanBatchTxsRecoverVInvalidTxType(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	rng := rand.New(rand.NewSource(0x321))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	var sbt spanBatchTxs
+
+	sbt.txTypes = []int{types.DepositTxType}
+	sbt.txSigs = []spanBatchSignature{{v: 0, r: nil, s: nil}}
+	sbt.yParityBits = new(big.Int)
+
+	// expect panic
+	sbt.recoverV(chainID)
+}
+
+func TestSpanBatchTxsFullTxNotEnoughTxTos(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x13572468))
+	chainID := big.NewInt(rng.Int63n(1000))
+	signer := types.NewLondonSigner(chainID)
+
+	totalblockTxCounts := uint64(1 + rng.Int()&0xFF)
+	var txs [][]byte
+	for i := 0; i < int(totalblockTxCounts); i++ {
+		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		rawTx, err := tx.MarshalBinary()
+		assert.NoError(t, err)
+		txs = append(txs, rawTx)
+	}
+	sbt, err := newSpanBatchTxs(txs, chainID)
+	assert.NoError(t, err)
+
+	// drop single to field
+	sbt.txTos = sbt.txTos[:len(sbt.txTos)-2]
+
+	_, err = sbt.fullTxs(chainID)
+	assert.EqualError(t, err, "tx to not enough")
+}
+
+func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
+	var sbt spanBatchTxs
+	sbt.totalBlockTxCount = 0xFFFFFFFFFFFFFFFF
+
+	r := bytes.NewReader([]byte{})
+	err := sbt.decodeContractCreationBits(r)
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}
+
+func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
+	var sb RawSpanBatch
+	sb.blockCount = 0xFFFFFFFFFFFFFFFF
+
+	r := bytes.NewReader([]byte{})
+	err := sb.decodeOriginBits(r)
+	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -79,6 +79,8 @@ type Config struct {
 	// Active if CanyonTime != nil && L2 block timestamp >= *CanyonTime, inactive otherwise.
 	CanyonTime *uint64 `json:"canyon_time,omitempty"`
 
+	SpanBatchTime *uint64 `json:"span_batch_time,omitempty"`
+
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
 
@@ -268,6 +270,10 @@ func (c *Config) IsCanyon(timestamp uint64) bool {
 	return c.CanyonTime != nil && timestamp >= *c.CanyonTime
 }
 
+func (c *Config) IsSpanBatch(timestamp uint64) bool {
+	return c.SpanBatchTime != nil && timestamp >= *c.SpanBatchTime
+}
+
 // Description outputs a banner describing the important parts of rollup configuration in a human-readable form.
 // Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain with if not unknown.
 // The config should be config.Check()-ed before creating a description.
@@ -296,6 +302,7 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += "Post-Bedrock Network Upgrades (timestamp based):\n"
 	banner += fmt.Sprintf("  - Regolith: %s\n", fmtForkTimeOrUnset(c.RegolithTime))
 	banner += fmt.Sprintf("  - Canyon: %s\n", fmtForkTimeOrUnset(c.CanyonTime))
+	banner += fmt.Sprintf("  - SpanBatch: %s\n", fmtForkTimeOrUnset(c.SpanBatchTime))
 	// Report the protocol version
 	banner += fmt.Sprintf("Node supports up to OP-Stack Protocol Version: %s\n", OPStackSupport)
 	return banner
@@ -321,7 +328,9 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l1_network", networkL1, "l2_start_time", c.Genesis.L2Time, "l2_block_hash", c.Genesis.L2.Hash.String(),
 		"l2_block_number", c.Genesis.L2.Number, "l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number, "regolith_time", fmtForkTimeOrUnset(c.RegolithTime),
-		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime))
+		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime),
+		"span_batch_time", fmtForkTimeOrUnset(c.SpanBatchTime),
+	)
 }
 
 func fmtForkTimeOrUnset(v *uint64) string {

--- a/op-node/testutils/mock_l2.go
+++ b/op-node/testutils/mock_l2.go
@@ -3,9 +3,8 @@ package testutils
 import (
 	"context"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type MockL2Client struct {
@@ -13,7 +12,8 @@ type MockL2Client struct {
 }
 
 func (c *MockL2Client) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	return c.Mock.MethodCalled("L2BlockRefByLabel", label).Get(0).(eth.L2BlockRef), nil
+	out := c.Mock.MethodCalled("L2BlockRefByLabel", label)
+	return out[0].(eth.L2BlockRef), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByLabel(label eth.BlockLabel, ref eth.L2BlockRef, err error) {
@@ -21,7 +21,8 @@ func (m *MockL2Client) ExpectL2BlockRefByLabel(label eth.BlockLabel, ref eth.L2B
 }
 
 func (c *MockL2Client) L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error) {
-	return c.Mock.MethodCalled("L2BlockRefByNumber", num).Get(0).(eth.L2BlockRef), nil
+	out := c.Mock.MethodCalled("L2BlockRefByNumber", num)
+	return out[0].(eth.L2BlockRef), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, err error) {
@@ -29,7 +30,8 @@ func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, 
 }
 
 func (c *MockL2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
-	return c.Mock.MethodCalled("L2BlockRefByHash", hash).Get(0).(eth.L2BlockRef), nil
+	out := c.Mock.MethodCalled("L2BlockRefByHash", hash)
+	return out[0].(eth.L2BlockRef), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockRef, err error) {
@@ -37,7 +39,8 @@ func (m *MockL2Client) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockR
 }
 
 func (m *MockL2Client) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
-	return m.Mock.MethodCalled("SystemConfigByL2Hash", hash).Get(0).(eth.SystemConfig), nil
+	out := m.Mock.MethodCalled("SystemConfigByL2Hash", hash)
+	return out[0].(eth.SystemConfig), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectSystemConfigByL2Hash(hash common.Hash, cfg eth.SystemConfig, err error) {
@@ -45,7 +48,8 @@ func (m *MockL2Client) ExpectSystemConfigByL2Hash(hash common.Hash, cfg eth.Syst
 }
 
 func (m *MockL2Client) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
-	return m.Mock.MethodCalled("OutputV0AtBlock", blockHash).Get(0).(*eth.OutputV0), nil
+	out := m.Mock.MethodCalled("OutputV0AtBlock", blockHash)
+	return out[0].(*eth.OutputV0), *out[1].(*error)
 }
 
 func (m *MockL2Client) ExpectOutputV0AtBlock(blockHash common.Hash, output *eth.OutputV0, err error) {

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -105,6 +105,14 @@ func (o *OracleEngine) L2BlockRefByHash(ctx context.Context, l2Hash common.Hash)
 	return derive.L2BlockToBlockRef(block, &o.rollupCfg.Genesis)
 }
 
+func (o *OracleEngine) L2BlockRefByNumber(ctx context.Context, n uint64) (eth.L2BlockRef, error) {
+	hash := o.backend.GetCanonicalHash(n)
+	if hash == (common.Hash{}) {
+		return eth.L2BlockRef{}, ErrNotFound
+	}
+	return o.L2BlockRefByHash(ctx, hash)
+}
+
 func (o *OracleEngine) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
 	payload, err := o.PayloadByHash(ctx, hash)
 	if err != nil {

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -43,6 +43,7 @@
   "eip1559Elasticity": 6,
   "l1GenesisBlockTimestamp": "0x64c811bf",
   "l2GenesisRegolithTimeOffset": "0x0",
+  "l2GenesisSpanBatchTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,
   "faultGameMaxDuration": 1200,


### PR DESCRIPTION
## Contexts

This PR contains the derivation code for [Span Batch](https://github.com/ethereum-optimism/optimism/blob/develop/specs/span-batches.md).

Please refer to the **Implementations - Derivation** and **Hard Fork Activation** sections of the Design Docs and **op-node** section of Implementation Design Docs for details & rationales.

This PR has a dependency on the [**Span Batch Type, Encoding, and Decoding** PR](https://github.com/ethereum-optimism/optimism/pull/7288).

## Changes

- Modifications:
    - Modify **ChannelReader** to decode both **SingularBatch** and **SpanBatch**.
    - Verify if the processing batch’s timestamp matches the expected batch type by **spanBatchTime** at **BatchQueue**.
    - **BatchQueue** splits a **SpanBatch** to multiple **SingularBatch**-es.
    - Leave the rest of the derivation stages as-is by passing **SingularBatches**.
    - ^ Please refer to the `op-node` section of Implementation Design Docs for details.
- Added unit tests.
    - ^ Please refer to the `Derivation` category in the Test List Sheet for each test’s details.