### PR TITLE
op-batcher: Span Batch Submission

### DIFF
--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -26,8 +27,8 @@ type channel struct {
 	confirmedTransactions map[txID]eth.BlockID
 }
 
-func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, spanBatchBuilder *derive.SpanBatchBuilder) (*channel, error) {
-	cb, err := newChannelBuilder(cfg, spanBatchBuilder)
+func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, rcfg *rollup.Config) (*channel, error) {
+	cb, err := newChannelBuilder(cfg, rcfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating new channel: %w", err)
 	}

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -26,8 +26,8 @@ type channel struct {
 	confirmedTransactions map[txID]eth.BlockID
 }
 
-func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig) (*channel, error) {
-	cb, err := newChannelBuilder(cfg)
+func newChannel(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, spanBatchBuilder *derive.SpanBatchBuilder) (*channel, error) {
+	cb, err := newChannelBuilder(cfg, spanBatchBuilder)
 	if err != nil {
 		return nil, fmt.Errorf("creating new channel: %w", err)
 	}

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -121,7 +121,7 @@ type channelBuilder struct {
 	// guaranteed to be a ChannelFullError wrapping the specific reason.
 	fullErr error
 	// current channel
-	co *derive.ChannelOut
+	co derive.ChannelOut
 	// list of blocks in the channel. Saved in case the channel must be rebuilt
 	blocks []*types.Block
 	// frames data queue, to be send as txs
@@ -139,7 +139,7 @@ func newChannelBuilder(cfg ChannelConfig, spanBatchBuilder *derive.SpanBatchBuil
 	if err != nil {
 		return nil, err
 	}
-	co, err := derive.NewChannelOut(c, cfg.BatchType, spanBatchBuilder)
+	co, err := derive.NewChannelOut(cfg.BatchType, c, spanBatchBuilder)
 	if err != nil {
 		return nil, err
 	}

--- a/op-batcher/batcher/channel_builder.go
+++ b/op-batcher/batcher/channel_builder.go
@@ -58,6 +58,9 @@ type ChannelConfig struct {
 
 	// CompressorConfig contains the configuration for creating new compressors.
 	CompressorConfig compressor.Config
+
+	// BatchType indicates whether the channel uses SingularBatch or SpanBatch.
+	BatchType uint
 }
 
 // Check validates the [ChannelConfig] parameters.
@@ -81,6 +84,10 @@ func (cc *ChannelConfig) Check() error {
 	// number, making the frame size extremely large.
 	if cc.MaxFrameSize < derive.FrameV0OverHeadSize {
 		return fmt.Errorf("max frame size %d is less than the minimum 23", cc.MaxFrameSize)
+	}
+
+	if cc.BatchType > derive.SpanBatchType {
+		return fmt.Errorf("unrecognized batch type: %d", cc.BatchType)
 	}
 
 	return nil
@@ -127,12 +134,12 @@ type channelBuilder struct {
 
 // newChannelBuilder creates a new channel builder or returns an error if the
 // channel out could not be created.
-func newChannelBuilder(cfg ChannelConfig) (*channelBuilder, error) {
+func newChannelBuilder(cfg ChannelConfig, spanBatchBuilder *derive.SpanBatchBuilder) (*channelBuilder, error) {
 	c, err := cfg.CompressorConfig.NewCompressor()
 	if err != nil {
 		return nil, err
 	}
-	co, err := derive.NewChannelOut(c)
+	co, err := derive.NewChannelOut(c, cfg.BatchType, spanBatchBuilder)
 	if err != nil {
 		return nil, err
 	}
@@ -194,12 +201,12 @@ func (c *channelBuilder) AddBlock(block *types.Block) (derive.L1BlockInfo, error
 		return derive.L1BlockInfo{}, c.FullErr()
 	}
 
-	batch, l1info, err := derive.BlockToBatch(block)
+	batch, l1info, err := derive.BlockToSingularBatch(block)
 	if err != nil {
 		return l1info, fmt.Errorf("converting block to batch: %w", err)
 	}
 
-	if _, err = c.co.AddBatch(batch); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.CompressorFullErr) {
+	if _, err = c.co.AddSingularBatch(batch); errors.Is(err, derive.ErrTooManyRLPBytes) || errors.Is(err, derive.CompressorFullErr) {
 		c.setFullErr(err)
 		return l1info, c.FullErr()
 	} else if err != nil {
@@ -252,7 +259,7 @@ func (c *channelBuilder) updateDurationTimeout(l1BlockNum uint64) {
 // derived from the batch's origin L1 block. The timeout is only moved forward
 // if the derived sequencer window timeout is earlier than the currently set
 // timeout.
-func (c *channelBuilder) updateSwTimeout(batch *derive.BatchData) {
+func (c *channelBuilder) updateSwTimeout(batch *derive.SingularBatch) {
 	timeout := uint64(batch.EpochNum) + c.cfg.SeqWindowSize - c.cfg.SubSafetyMargin
 	c.updateTimeout(timeout, ErrSeqWindowClose)
 }

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -449,7 +449,7 @@ func TestChannelBuilder_OutputWrongFramePanic(t *testing.T) {
 	// to construct a single frame
 	c, err := channelConfig.CompressorConfig.NewCompressor()
 	require.NoError(t, err)
-	co, err := derive.NewChannelOut(c, derive.SingularBatchType, nil)
+	co, err := derive.NewChannelOut(derive.SingularBatchType, c, nil)
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	fn, err := co.OutputFrame(&buf, channelConfig.MaxFrameSize)

--- a/op-batcher/batcher/channel_builder_test.go
+++ b/op-batcher/batcher/channel_builder_test.go
@@ -32,6 +32,15 @@ var defaultTestChannelConfig = ChannelConfig{
 		TargetNumFrames:  1,
 		ApproxComprRatio: 0.4,
 	},
+	BatchType: derive.SingularBatchType,
+}
+
+func getSpanBatchBuilder(batchType uint) *derive.SpanBatchBuilder {
+	if batchType == derive.SpanBatchType {
+		chainId := big.NewInt(1234)
+		return derive.NewSpanBatchBuilder(uint64(0), uint64(0), chainId)
+	}
+	return nil
 }
 
 // TestChannelConfig_Check tests the [ChannelConfig] [Check] function.
@@ -158,8 +167,9 @@ func newMiniL2BlockWithNumberParent(numTx int, number *big.Int, parent common.Ha
 // addTooManyBlocks adds blocks to the channel until it hits an error,
 // which is presumably ErrTooManyRLPBytes.
 func addTooManyBlocks(cb *channelBuilder) error {
+	rng := rand.New(rand.NewSource(1234))
 	for i := 0; i < 10_000; i++ {
-		block := newMiniL2Block(100)
+		block, _ := dtest.RandomL2Block(rng, 1000)
 		_, err := cb.AddBlock(block)
 		if err != nil {
 			return err
@@ -178,7 +188,7 @@ func FuzzDurationTimeoutZeroMaxChannelDuration(f *testing.F) {
 	f.Fuzz(func(t *testing.T, l1BlockNum uint64) {
 		channelConfig := defaultTestChannelConfig
 		channelConfig.MaxChannelDuration = 0
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 		cb.timeout = 0
 		cb.updateDurationTimeout(l1BlockNum)
@@ -201,7 +211,7 @@ func FuzzChannelBuilder_DurationZero(f *testing.F) {
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig
 		channelConfig.MaxChannelDuration = maxChannelDuration
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 
 		// Whenever the timeout is set to 0, the channel builder should have a duration timeout
@@ -228,7 +238,7 @@ func FuzzDurationTimeoutMaxChannelDuration(f *testing.F) {
 		// Create the channel builder
 		channelConfig := defaultTestChannelConfig
 		channelConfig.MaxChannelDuration = maxChannelDuration
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 
 		// Whenever the timeout is greater than the l1BlockNum,
@@ -262,7 +272,7 @@ func FuzzChannelCloseTimeout(f *testing.F) {
 		channelConfig := defaultTestChannelConfig
 		channelConfig.ChannelTimeout = channelTimeout
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 
 		// Check the timeout
@@ -290,7 +300,7 @@ func FuzzChannelZeroCloseTimeout(f *testing.F) {
 		channelConfig := defaultTestChannelConfig
 		channelConfig.ChannelTimeout = channelTimeout
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 
 		// Check the timeout
@@ -317,16 +327,12 @@ func FuzzSeqWindowClose(f *testing.F) {
 		channelConfig := defaultTestChannelConfig
 		channelConfig.SeqWindowSize = seqWindowSize
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 
 		// Check the timeout
 		cb.timeout = timeout
-		cb.updateSwTimeout(derive.NewSingularBatchData(
-			derive.SingularBatch{
-				EpochNum: rollup.Epoch(epochNum),
-			},
-		))
+		cb.updateSwTimeout(&derive.SingularBatch{EpochNum: rollup.Epoch(epochNum)})
 		calculatedTimeout := epochNum + seqWindowSize - subSafetyMargin
 		if timeout > calculatedTimeout && calculatedTimeout != 0 {
 			cb.checkTimeout(calculatedTimeout)
@@ -349,16 +355,12 @@ func FuzzSeqWindowZeroTimeoutClose(f *testing.F) {
 		channelConfig := defaultTestChannelConfig
 		channelConfig.SeqWindowSize = seqWindowSize
 		channelConfig.SubSafetyMargin = subSafetyMargin
-		cb, err := newChannelBuilder(channelConfig)
+		cb, err := newChannelBuilder(channelConfig, nil)
 		require.NoError(t, err)
 
 		// Check the timeout
 		cb.timeout = 0
-		cb.updateSwTimeout(derive.NewSingularBatchData(
-			derive.SingularBatch{
-				EpochNum: rollup.Epoch(epochNum),
-			},
-		))
+		cb.updateSwTimeout(&derive.SingularBatch{EpochNum: rollup.Epoch(epochNum)})
 		calculatedTimeout := epochNum + seqWindowSize - subSafetyMargin
 		cb.checkTimeout(calculatedTimeout)
 		if cb.timeout != 0 {
@@ -367,12 +369,40 @@ func FuzzSeqWindowZeroTimeoutClose(f *testing.F) {
 	})
 }
 
+func TestChannelBuilderBatchType(t *testing.T) {
+	tests := []struct {
+		name string
+		f    func(t *testing.T, batchType uint)
+	}{
+		{"ChannelBuilder_MaxRLPBytesPerChannel", ChannelBuilder_MaxRLPBytesPerChannel},
+		{"ChannelBuilder_OutputFramesMaxFrameIndex", ChannelBuilder_OutputFramesMaxFrameIndex},
+		{"ChannelBuilder_AddBlock", ChannelBuilder_AddBlock},
+		{"ChannelBuilder_Reset", ChannelBuilder_Reset},
+		{"ChannelBuilder_PendingFrames_TotalFrames", ChannelBuilder_PendingFrames_TotalFrames},
+		{"ChannelBuilder_InputBytes", ChannelBuilder_InputBytes},
+		{"ChannelBuilder_OutputBytes", ChannelBuilder_OutputBytes},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SingularBatch", func(t *testing.T) {
+			test.f(t, derive.SingularBatchType)
+		})
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
+			test.f(t, derive.SpanBatchType)
+		})
+	}
+}
+
 // TestChannelBuilder_NextFrame tests calling NextFrame on a ChannelBuilder with only one frame
 func TestChannelBuilder_NextFrame(t *testing.T) {
 	channelConfig := defaultTestChannelConfig
 
 	// Create a new channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, nil)
 	require.NoError(t, err)
 
 	// Mock the internals of `channelBuilder.outputFrame`
@@ -412,14 +442,14 @@ func TestChannelBuilder_OutputWrongFramePanic(t *testing.T) {
 	channelConfig := defaultTestChannelConfig
 
 	// Construct a channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, nil)
 	require.NoError(t, err)
 
 	// Mock the internals of `channelBuilder.outputFrame`
 	// to construct a single frame
 	c, err := channelConfig.CompressorConfig.NewCompressor()
 	require.NoError(t, err)
-	co, err := derive.NewChannelOut(c)
+	co, err := derive.NewChannelOut(c, derive.SingularBatchType, nil)
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	fn, err := co.OutputFrame(&buf, channelConfig.MaxFrameSize)
@@ -445,7 +475,7 @@ func TestChannelBuilder_OutputFramesWorks(t *testing.T) {
 	channelConfig.MaxFrameSize = 24
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, nil)
 	require.NoError(t, err)
 	require.False(t, cb.IsFull())
 	require.Equal(t, 0, cb.PendingFrames())
@@ -480,17 +510,68 @@ func TestChannelBuilder_OutputFramesWorks(t *testing.T) {
 	}
 }
 
-// TestChannelBuilder_MaxRLPBytesPerChannel tests the [channelBuilder.OutputFrames]
+// TestChannelBuilder_OutputFramesWorks tests the [ChannelBuilder] OutputFrames is successful.
+func TestChannelBuilder_OutputFramesWorks_SpanBatch(t *testing.T) {
+	channelConfig := defaultTestChannelConfig
+	channelConfig.MaxFrameSize = 24
+	channelConfig.CompressorConfig.TargetFrameSize = 50
+	channelConfig.BatchType = derive.SpanBatchType
+
+	// Construct the channel builder
+	cb, err := newChannelBuilder(channelConfig, getSpanBatchBuilder(derive.SpanBatchType))
+	require.NoError(t, err)
+	require.False(t, cb.IsFull())
+	require.Equal(t, 0, cb.PendingFrames())
+
+	// Calling OutputFrames without having called [AddBlock]
+	// should return no error
+	require.NoError(t, cb.OutputFrames())
+
+	// There should be no ready bytes yet
+	require.Equal(t, 0, cb.co.ReadyBytes())
+
+	// fill up
+	for {
+		err = addMiniBlock(cb)
+		if err == nil {
+			require.False(t, cb.IsFull())
+			// There should be no ready bytes until the channel is full
+			require.Equal(t, cb.co.ReadyBytes(), 0)
+		} else {
+			require.ErrorIs(t, err, derive.CompressorFullErr)
+			break
+		}
+	}
+
+	require.True(t, cb.IsFull())
+	// Check how many ready bytes
+	// There should be more than the max frame size ready
+	require.Greater(t, uint64(cb.co.ReadyBytes()), channelConfig.MaxFrameSize)
+	require.Equal(t, 0, cb.PendingFrames())
+
+	// We should be able to output the frames
+	require.NoError(t, cb.OutputFrames())
+
+	// There should be many frames in the channel builder now
+	require.Greater(t, cb.PendingFrames(), 1)
+	for i := 0; i < cb.numFrames-1; i++ {
+		require.Len(t, cb.frames[i].data, int(channelConfig.MaxFrameSize))
+	}
+	require.LessOrEqual(t, len(cb.frames[len(cb.frames)-1].data), int(channelConfig.MaxFrameSize))
+}
+
+// ChannelBuilder_MaxRLPBytesPerChannel tests the [channelBuilder.OutputFrames]
 // function errors when the max RLP bytes per channel is reached.
-func TestChannelBuilder_MaxRLPBytesPerChannel(t *testing.T) {
+func ChannelBuilder_MaxRLPBytesPerChannel(t *testing.T, batchType uint) {
 	t.Parallel()
 	channelConfig := defaultTestChannelConfig
 	channelConfig.MaxFrameSize = derive.MaxRLPBytesPerChannel * 2
 	channelConfig.CompressorConfig.TargetFrameSize = derive.MaxRLPBytesPerChannel * 2
 	channelConfig.CompressorConfig.ApproxComprRatio = 1
+	channelConfig.BatchType = batchType
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, getSpanBatchBuilder(batchType))
 	require.NoError(t, err)
 
 	// Add a block that overflows the [ChannelOut]
@@ -498,61 +579,55 @@ func TestChannelBuilder_MaxRLPBytesPerChannel(t *testing.T) {
 	require.ErrorIs(t, err, derive.ErrTooManyRLPBytes)
 }
 
-// TestChannelBuilder_OutputFramesMaxFrameIndex tests the [ChannelBuilder.OutputFrames]
+// ChannelBuilder_OutputFramesMaxFrameIndex tests the [ChannelBuilder.OutputFrames]
 // function errors when the max frame index is reached.
-func TestChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T) {
+func ChannelBuilder_OutputFramesMaxFrameIndex(t *testing.T, batchType uint) {
 	channelConfig := defaultTestChannelConfig
 	channelConfig.MaxFrameSize = 24
-	channelConfig.CompressorConfig.TargetNumFrames = math.MaxInt
+	channelConfig.CompressorConfig.TargetNumFrames = 6000
 	channelConfig.CompressorConfig.TargetFrameSize = 24
-	channelConfig.CompressorConfig.ApproxComprRatio = 0
+	channelConfig.CompressorConfig.ApproxComprRatio = 1
+	channelConfig.BatchType = batchType
+
+	rng := rand.New(rand.NewSource(123))
 
 	// Continuously add blocks until the max frame index is reached
 	// This should cause the [channelBuilder.OutputFrames] function
 	// to error
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, getSpanBatchBuilder(batchType))
 	require.NoError(t, err)
 	require.False(t, cb.IsFull())
 	require.Equal(t, 0, cb.PendingFrames())
 	for {
-		lBlock := types.NewBlock(&types.Header{
-			BaseFee:    common.Big0,
-			Difficulty: common.Big0,
-			Number:     common.Big0,
-		}, nil, nil, nil, trie.NewStackTrie(nil))
-		l1InfoTx, _ := derive.L1InfoDeposit(0, eth.BlockToInfo(lBlock), eth.SystemConfig{}, false)
-		txs := []*types.Transaction{types.NewTx(l1InfoTx)}
-		a := types.NewBlock(&types.Header{
-			Number: big.NewInt(0),
-		}, txs, nil, nil, trie.NewStackTrie(nil))
+		a, _ := dtest.RandomL2Block(rng, 1)
 		_, err = cb.AddBlock(a)
-		require.NoError(t, cb.co.Flush())
 		if cb.IsFull() {
 			fullErr := cb.FullErr()
-			require.ErrorIs(t, fullErr, ErrMaxFrameIndex)
+			require.ErrorIs(t, fullErr, derive.CompressorFullErr)
 			break
 		}
 		require.NoError(t, err)
-		_ = cb.OutputFrames()
-		// Flushing so we can construct new frames
-		_ = cb.co.Flush()
 	}
+
+	_ = cb.OutputFrames()
+	require.ErrorIs(t, cb.FullErr(), ErrMaxFrameIndex)
 }
 
-// TestChannelBuilder_AddBlock tests the AddBlock function
-func TestChannelBuilder_AddBlock(t *testing.T) {
+// ChannelBuilder_AddBlock tests the AddBlock function
+func ChannelBuilder_AddBlock(t *testing.T, batchType uint) {
 	channelConfig := defaultTestChannelConfig
+	channelConfig.BatchType = batchType
 
 	// Lower the max frame size so that we can batch
-	channelConfig.MaxFrameSize = 30
+	channelConfig.MaxFrameSize = 20
 
 	// Configure the Input Threshold params so we observe a full channel
-	channelConfig.CompressorConfig.TargetFrameSize = 30
+	channelConfig.CompressorConfig.TargetFrameSize = 20
 	channelConfig.CompressorConfig.TargetNumFrames = 2
 	channelConfig.CompressorConfig.ApproxComprRatio = 1
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, getSpanBatchBuilder(batchType))
 	require.NoError(t, err)
 
 	// Add a nonsense block to the channel builder
@@ -560,7 +635,11 @@ func TestChannelBuilder_AddBlock(t *testing.T) {
 	require.NoError(t, cb.co.Flush())
 
 	// Check the fields reset in the AddBlock function
-	require.Equal(t, 74, cb.co.InputBytes())
+	expectedInputBytes := 74
+	if batchType == derive.SpanBatchType {
+		expectedInputBytes = 47
+	}
+	require.Equal(t, expectedInputBytes, cb.co.InputBytes())
 	require.Equal(t, 1, len(cb.blocks))
 	require.Equal(t, 0, len(cb.frames))
 	require.True(t, cb.IsFull())
@@ -570,14 +649,18 @@ func TestChannelBuilder_AddBlock(t *testing.T) {
 	require.ErrorIs(t, addMiniBlock(cb), derive.CompressorFullErr)
 }
 
-// TestChannelBuilder_Reset tests the [Reset] function
-func TestChannelBuilder_Reset(t *testing.T) {
+// ChannelBuilder_Reset tests the [Reset] function
+func ChannelBuilder_Reset(t *testing.T, batchType uint) {
 	channelConfig := defaultTestChannelConfig
+	channelConfig.BatchType = batchType
 
 	// Lower the max frame size so that we can batch
 	channelConfig.MaxFrameSize = 24
+	channelConfig.CompressorConfig.TargetNumFrames = 1
+	channelConfig.CompressorConfig.TargetFrameSize = 24
+	channelConfig.CompressorConfig.ApproxComprRatio = 1
 
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, getSpanBatchBuilder(batchType))
 	require.NoError(t, err)
 
 	// Add a nonsense block to the channel builder
@@ -590,20 +673,16 @@ func TestChannelBuilder_Reset(t *testing.T) {
 	// Timeout should be updated in the AddBlock internal call to `updateSwTimeout`
 	timeout := uint64(100) + cb.cfg.SeqWindowSize - cb.cfg.SubSafetyMargin
 	require.Equal(t, timeout, cb.timeout)
-	require.NoError(t, cb.fullErr)
+	require.Error(t, cb.fullErr)
 
 	// Output frames so we can set the channel builder frames
 	require.NoError(t, cb.OutputFrames())
 
-	// Add another block to increment the block count
-	require.NoError(t, addMiniBlock(cb))
-	require.NoError(t, cb.co.Flush())
-
 	// Check the fields reset in the Reset function
-	require.Equal(t, 2, len(cb.blocks))
-	require.Greater(t, len(cb.frames), 1)
+	require.Equal(t, 1, len(cb.blocks))
 	require.Equal(t, timeout, cb.timeout)
-	require.NoError(t, cb.fullErr)
+	require.Error(t, cb.fullErr)
+	require.Greater(t, len(cb.frames), 1)
 
 	// Reset the channel builder
 	require.NoError(t, cb.Reset())
@@ -622,7 +701,7 @@ func TestBuilderRegisterL1Block(t *testing.T) {
 	channelConfig := defaultTestChannelConfig
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, nil)
 	require.NoError(t, err)
 
 	// Assert params modified in RegisterL1Block
@@ -645,7 +724,7 @@ func TestBuilderRegisterL1BlockZeroMaxChannelDuration(t *testing.T) {
 	channelConfig.MaxChannelDuration = 0
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, nil)
 	require.NoError(t, err)
 
 	// Assert params modified in RegisterL1Block
@@ -666,7 +745,7 @@ func TestFramePublished(t *testing.T) {
 	channelConfig := defaultTestChannelConfig
 
 	// Construct the channel builder
-	cb, err := newChannelBuilder(channelConfig)
+	cb, err := newChannelBuilder(channelConfig, nil)
 	require.NoError(t, err)
 
 	// Let's say the block number is fed in as 100
@@ -682,7 +761,7 @@ func TestFramePublished(t *testing.T) {
 	require.Equal(t, uint64(1000), cb.timeout)
 }
 
-func TestChannelBuilder_PendingFrames_TotalFrames(t *testing.T) {
+func ChannelBuilder_PendingFrames_TotalFrames(t *testing.T, batchType uint) {
 	const tnf = 8
 	rng := rand.New(rand.NewSource(94572314))
 	require := require.New(t)
@@ -691,7 +770,8 @@ func TestChannelBuilder_PendingFrames_TotalFrames(t *testing.T) {
 	cfg.MaxFrameSize = 1000
 	cfg.CompressorConfig.TargetNumFrames = tnf
 	cfg.CompressorConfig.Kind = "shadow"
-	cb, err := newChannelBuilder(cfg)
+	cfg.BatchType = batchType
+	cb, err := newChannelBuilder(cfg, getSpanBatchBuilder(batchType))
 	require.NoError(err)
 
 	// initial builder should be empty
@@ -725,25 +805,40 @@ func TestChannelBuilder_PendingFrames_TotalFrames(t *testing.T) {
 	}
 }
 
-func TestChannelBuilder_InputBytes(t *testing.T) {
+func ChannelBuilder_InputBytes(t *testing.T, batchType uint) {
 	require := require.New(t)
 	rng := rand.New(rand.NewSource(4982432))
-	cb, _ := defaultChannelBuilderSetup(t)
+	cfg := defaultTestChannelConfig
+	cfg.BatchType = batchType
+	spanBatchBuilder := getSpanBatchBuilder(batchType)
+	cb, err := newChannelBuilder(cfg, getSpanBatchBuilder(batchType))
+	require.NoError(err)
 
 	require.Zero(cb.InputBytes())
 
 	var l int
 	for i := 0; i < 5; i++ {
 		block := newMiniL2Block(rng.Intn(32))
-		l += blockBatchRlpSize(t, block)
-
+		if batchType == derive.SingularBatchType {
+			l += blockBatchRlpSize(t, block)
+		} else {
+			singularBatch, _, err := derive.BlockToSingularBatch(block)
+			require.NoError(err)
+			spanBatchBuilder.AppendSingularBatch(singularBatch)
+			rawSpanBatch, err := spanBatchBuilder.GetRawSpanBatch()
+			require.NoError(err)
+			batch := derive.NewSpanBatchData(*rawSpanBatch)
+			var buf bytes.Buffer
+			require.NoError(batch.EncodeRLP(&buf))
+			l = buf.Len()
+		}
 		_, err := cb.AddBlock(block)
 		require.NoError(err)
 		require.Equal(cb.InputBytes(), l)
 	}
 }
 
-func TestChannelBuilder_OutputBytes(t *testing.T) {
+func ChannelBuilder_OutputBytes(t *testing.T, batchType uint) {
 	require := require.New(t)
 	rng := rand.New(rand.NewSource(9860372))
 	cfg := defaultTestChannelConfig
@@ -751,7 +846,8 @@ func TestChannelBuilder_OutputBytes(t *testing.T) {
 	cfg.MaxFrameSize = 1000
 	cfg.CompressorConfig.TargetNumFrames = 16
 	cfg.CompressorConfig.ApproxComprRatio = 1.0
-	cb, err := newChannelBuilder(cfg)
+	cfg.BatchType = batchType
+	cb, err := newChannelBuilder(cfg, getSpanBatchBuilder(batchType))
 	require.NoError(err, "newChannelBuilder")
 
 	require.Zero(cb.OutputBytes())
@@ -778,17 +874,10 @@ func TestChannelBuilder_OutputBytes(t *testing.T) {
 	require.Equal(cb.OutputBytes(), flen)
 }
 
-func defaultChannelBuilderSetup(t *testing.T) (*channelBuilder, ChannelConfig) {
-	t.Helper()
-	cfg := defaultTestChannelConfig
-	cb, err := newChannelBuilder(cfg)
-	require.NoError(t, err, "newChannelBuilder")
-	return cb, cfg
-}
-
 func blockBatchRlpSize(t *testing.T, b *types.Block) int {
 	t.Helper()
-	batch, _, err := derive.BlockToBatch(b)
+	singularBatch, _, err := derive.BlockToSingularBatch(b)
+	batch := derive.NewSingularBatchData(*singularBatch)
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	require.NoError(t, batch.EncodeRLP(&buf), "RLP-encoding batch")

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -28,11 +29,15 @@ type channelManager struct {
 	log  log.Logger
 	metr metrics.Metricer
 	cfg  ChannelConfig
+	rcfg *rollup.Config
 
 	// All blocks since the last request for new tx data.
 	blocks []*types.Block
 	// last block hash - for reorg detection
 	tip common.Hash
+
+	// last block added to channel. nil at first.
+	lastProcessedBlock *eth.L2BlockRef
 
 	// channel to write new block data to
 	currentChannel *channel
@@ -45,18 +50,21 @@ type channelManager struct {
 	closed bool
 }
 
-func NewChannelManager(log log.Logger, metr metrics.Metricer, cfg ChannelConfig) *channelManager {
+func NewChannelManager(log log.Logger, metr metrics.Metricer, cfg ChannelConfig, rcfg *rollup.Config) *channelManager {
 	return &channelManager{
-		log:        log,
-		metr:       metr,
-		cfg:        cfg,
-		txChannels: make(map[txID]*channel),
+		log:                log,
+		metr:               metr,
+		cfg:                cfg,
+		rcfg:               rcfg,
+		txChannels:         make(map[txID]*channel),
+		lastProcessedBlock: nil,
 	}
 }
 
 // Clear clears the entire state of the channel manager.
-// It is intended to be used after an L2 reorg.
-func (s *channelManager) Clear() {
+// It is intended to be used before launching op-batcher and after an L2 reorg.
+// Must set lastProcessedBlock as current L2 safe head fetched from L2 node.
+func (s *channelManager) Clear(safeHead *eth.L2BlockRef) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.log.Trace("clearing channel manager state")
@@ -66,6 +74,7 @@ func (s *channelManager) Clear() {
 	s.currentChannel = nil
 	s.channelQueue = nil
 	s.txChannels = make(map[txID]*channel)
+	s.lastProcessedBlock = safeHead
 }
 
 // TxFailed records a transaction as failed. It will attempt to resubmit the data
@@ -195,7 +204,19 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		return nil
 	}
 
-	pc, err := newChannel(s.log, s.metr, s.cfg)
+	var spanBatchBuilder *derive.SpanBatchBuilder
+	if s.cfg.BatchType == derive.SpanBatchType {
+		if s.lastProcessedBlock == nil {
+			// TODO: we can remove "lastProcessedBlock" if we change the data-builder
+			//  to append a singular-batch *with* the L2 metadata such as the L1-block-info seq-number;
+			//  this helps determine whether or not the L1 origin changed in the first block of the span,
+			//  without having to remember the last block from before the span.
+			return errors.New("last block is not initialized")
+		}
+		// Pass the current lastProcessedBlock as the parent
+		spanBatchBuilder = derive.NewSpanBatchBuilder(s.lastProcessedBlock.L1Origin.Number, s.rcfg.Genesis.L2Time, s.rcfg.L2ChainID)
+	}
+	pc, err := newChannel(s.log, s.metr, s.cfg, spanBatchBuilder)
 	if err != nil {
 		return fmt.Errorf("creating new channel: %w", err)
 	}
@@ -241,6 +262,7 @@ func (s *channelManager) processBlocks() error {
 		blocksAdded += 1
 		latestL2ref = l2BlockRefFromBlockAndL1Info(block, l1info)
 		s.metr.RecordL2BlockInChannel(block)
+		s.lastProcessedBlock = &latestL2ref
 		// current block got added but channel is now full
 		if s.currentChannel.IsFull() {
 			break

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -59,7 +59,6 @@ func NewChannelManager(log log.Logger, metr metrics.Metricer, cfg ChannelConfig,
 
 // Clear clears the entire state of the channel manager.
 // It is intended to be used before launching op-batcher and after an L2 reorg.
-// Must set lastProcessedBlock as current L2 safe head fetched from L2 node.
 func (s *channelManager) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -20,7 +21,8 @@ func TestChannelTimeout(t *testing.T) {
 	log := testlog.Logger(t, log.LvlCrit)
 	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{
 		ChannelTimeout: 100,
-	})
+	}, &rollup.Config{})
+	m.Clear(&eth.L2BlockRef{})
 
 	// Pending channel is nil so is cannot be timed out
 	require.Nil(t, m.currentChannel)
@@ -61,7 +63,8 @@ func TestChannelTimeout(t *testing.T) {
 // TestChannelNextTxData checks the nextTxData function.
 func TestChannelNextTxData(t *testing.T) {
 	log := testlog.Logger(t, log.LvlCrit)
-	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{})
+	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{}, &rollup.Config{})
+	m.Clear(&eth.L2BlockRef{})
 
 	// Nil pending channel should return EOF
 	returnedTxData, err := m.nextTxData(nil)
@@ -109,7 +112,8 @@ func TestChannelTxConfirmed(t *testing.T) {
 		// channels on confirmation. This would result in [TxConfirmed]
 		// clearing confirmed transactions, and reseting the pendingChannels map
 		ChannelTimeout: 10,
-	})
+	}, &rollup.Config{})
+	m.Clear(&eth.L2BlockRef{})
 
 	// Let's add a valid pending transaction to the channel manager
 	// So we can demonstrate that TxConfirmed's correctness
@@ -157,7 +161,8 @@ func TestChannelTxConfirmed(t *testing.T) {
 func TestChannelTxFailed(t *testing.T) {
 	// Create a channel manager
 	log := testlog.Logger(t, log.LvlCrit)
-	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{})
+	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{}, &rollup.Config{})
+	m.Clear(&eth.L2BlockRef{})
 
 	// Let's add a valid pending transaction to the channel
 	// manager so we can demonstrate correctness

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -22,7 +22,7 @@ func TestChannelTimeout(t *testing.T) {
 	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{
 		ChannelTimeout: 100,
 	}, &rollup.Config{})
-	m.Clear(&eth.L2BlockRef{})
+	m.Clear()
 
 	// Pending channel is nil so is cannot be timed out
 	require.Nil(t, m.currentChannel)
@@ -64,7 +64,7 @@ func TestChannelTimeout(t *testing.T) {
 func TestChannelNextTxData(t *testing.T) {
 	log := testlog.Logger(t, log.LvlCrit)
 	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{}, &rollup.Config{})
-	m.Clear(&eth.L2BlockRef{})
+	m.Clear()
 
 	// Nil pending channel should return EOF
 	returnedTxData, err := m.nextTxData(nil)
@@ -113,7 +113,7 @@ func TestChannelTxConfirmed(t *testing.T) {
 		// clearing confirmed transactions, and reseting the pendingChannels map
 		ChannelTimeout: 10,
 	}, &rollup.Config{})
-	m.Clear(&eth.L2BlockRef{})
+	m.Clear()
 
 	// Let's add a valid pending transaction to the channel manager
 	// So we can demonstrate that TxConfirmed's correctness
@@ -162,7 +162,7 @@ func TestChannelTxFailed(t *testing.T) {
 	// Create a channel manager
 	log := testlog.Logger(t, log.LvlCrit)
 	m := NewChannelManager(log, metrics.NoopMetrics, ChannelConfig{}, &rollup.Config{})
-	m.Clear(&eth.L2BlockRef{})
+	m.Clear()
 
 	// Let's add a valid pending transaction to the channel
 	// manager so we can demonstrate correctness

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -52,6 +52,8 @@ type CLIConfig struct {
 
 	Stopped bool
 
+	BatchType uint
+
 	TxMgrConfig      txmgr.CLIConfig
 	LogConfig        oplog.CLIConfig
 	MetricsConfig    opmetrics.CLIConfig
@@ -93,6 +95,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		MaxChannelDuration:     ctx.Uint64(flags.MaxChannelDurationFlag.Name),
 		MaxL1TxSize:            ctx.Uint64(flags.MaxL1TxSizeBytesFlag.Name),
 		Stopped:                ctx.Bool(flags.StoppedFlag.Name),
+		BatchType:              ctx.Uint(flags.BatchTypeFlag.Name),
 		TxMgrConfig:            txmgr.ReadCLIConfig(ctx),
 		LogConfig:              oplog.ReadCLIConfig(ctx),
 		MetricsConfig:          opmetrics.ReadCLIConfig(ctx),

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"io"
 	"math/big"
 	_ "net/http/pprof"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -173,6 +173,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		SubSafetyMargin:    cfg.SubSafetyMargin,
 		MaxFrameSize:       cfg.MaxL1TxSize - 1, // subtract 1 byte for version
 		CompressorConfig:   cfg.CompressorConfig.Config(),
+		BatchType:          cfg.BatchType,
 	}
 	if err := bs.Channel.Check(); err != nil {
 		return fmt.Errorf("invalid channel configuration: %w", err)

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -76,6 +76,12 @@ var (
 		Usage:   "Initialize the batcher in a stopped state. The batcher can be started using the admin_startBatcher RPC",
 		EnvVars: prefixEnvVars("STOPPED"),
 	}
+	BatchTypeFlag = &cli.UintFlag{
+		Name:    "batch-type",
+		Usage:   "The batch type. 0 for SingularBatch and 1 for SpanBatch.",
+		Value:   0,
+		EnvVars: prefixEnvVars("BATCH_TYPE"),
+	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )
@@ -94,6 +100,7 @@ var optionalFlags = []cli.Flag{
 	MaxL1TxSizeBytesFlag,
 	StoppedFlag,
 	SequencerHDPathFlag,
+	BatchTypeFlag,
 }
 
 func init() {

--- a/op-e2e/actions/garbage_channel_out.go
+++ b/op-e2e/actions/garbage_channel_out.go
@@ -61,8 +61,11 @@ type ChannelOutIface interface {
 	OutputFrame(w *bytes.Buffer, maxSize uint64) (uint16, error)
 }
 
-// Compile-time check for ChannelOutIface interface implementation for the ChannelOut type.
-var _ ChannelOutIface = (*derive.ChannelOut)(nil)
+// Compile-time check for ChannelOutIface interface implementation for the SingularChannelOut type.
+var _ ChannelOutIface = (*derive.SingularChannelOut)(nil)
+
+// Compile-time check for ChannelOutIface interface implementation for the SpanChannelOut type.
+var _ ChannelOutIface = (*derive.SpanChannelOut)(nil)
 
 // Compile-time check for ChannelOutIface interface implementation for the GarbageChannelOut type.
 var _ ChannelOutIface = (*GarbageChannelOut)(nil)

--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -140,7 +140,7 @@ func (s *L2Batcher) Buffer(t Testing) error {
 				ApproxComprRatio: 1,
 			})
 			require.NoError(t, e, "failed to create compressor")
-			ch, err = derive.NewChannelOut(c, derive.SingularBatchType, nil)
+			ch, err = derive.NewChannelOut(derive.SingularBatchType, c, nil)
 		}
 		require.NoError(t, err, "failed to create channel")
 		s.l2ChannelOut = ch

--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -140,7 +140,7 @@ func (s *L2Batcher) Buffer(t Testing) error {
 				ApproxComprRatio: 1,
 			})
 			require.NoError(t, e, "failed to create compressor")
-			ch, err = derive.NewChannelOut(c)
+			ch, err = derive.NewChannelOut(c, derive.SingularBatchType, nil)
 		}
 		require.NoError(t, err, "failed to create channel")
 		s.l2ChannelOut = ch

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	proposermetrics "github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	l2os "github.com/ethereum-optimism/optimism/op-proposer/proposer"
@@ -679,6 +680,10 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 		return nil, fmt.Errorf("unable to start l2 output submitter: %w", err)
 	}
 
+	batchType := derive.SingularBatchType
+	if os.Getenv("OP_E2E_USE_SPAN_BATCH") == "true" {
+		batchType = derive.SpanBatchType
+	}
 	batcherCLIConfig := &bss.CLIConfig{
 		L1EthRpc:               sys.EthInstances["l1"].WSEndpoint(),
 		L2EthRpc:               sys.EthInstances["sequencer"].WSEndpoint(),
@@ -698,7 +703,8 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 			Level:  log.LvlInfo,
 			Format: oplog.FormatText,
 		},
-		Stopped: sys.cfg.DisableBatcher, // Batch submitter may be enabled later
+		Stopped:   sys.cfg.DisableBatcher, // Batch submitter may be enabled later
+		BatchType: uint(batchType),
 	}
 	// Batch Submitter
 	batcher, err := bss.BatcherServiceFromCLIConfig(context.Background(), "0.0.1", batcherCLIConfig, sys.cfg.Loggers["batcher"])

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -52,7 +52,7 @@ type ChannelOut interface {
 	ID() ChannelID
 	Reset() error
 	AddBlock(*types.Block) (uint64, error)
-	AddSingularBatch(*SingularBatch) (uint64, error)
+	AddSingularBatch(*SingularBatch, uint64) (uint64, error)
 	InputBytes() int
 	ReadyBytes() int
 	Flush() error
@@ -123,11 +123,11 @@ func (co *SingularChannelOut) AddBlock(block *types.Block) (uint64, error) {
 		return 0, errors.New("already closed")
 	}
 
-	batch, _, err := BlockToSingularBatch(block)
+	batch, l1Info, err := BlockToSingularBatch(block)
 	if err != nil {
 		return 0, err
 	}
-	return co.AddSingularBatch(batch)
+	return co.AddSingularBatch(batch, l1Info.SequenceNumber)
 }
 
 // AddSingularBatch adds a batch to the channel. It returns the RLP encoded byte size
@@ -138,7 +138,7 @@ func (co *SingularChannelOut) AddBlock(block *types.Block) (uint64, error) {
 // AddSingularBatch should be used together with BlockToBatch if you need to access the
 // BatchData before adding a block to the channel. It isn't possible to access
 // the batch data with AddBlock.
-func (co *SingularChannelOut) AddSingularBatch(batch *SingularBatch) (uint64, error) {
+func (co *SingularChannelOut) AddSingularBatch(batch *SingularBatch, _ uint64) (uint64, error) {
 	if co.closed {
 		return 0, errors.New("already closed")
 	}

--- a/op-node/rollup/derive/channel_out.go
+++ b/op-node/rollup/derive/channel_out.go
@@ -91,7 +91,7 @@ func (co *SingularChannelOut) ID() ChannelID {
 
 func NewSingularChannelOut(compress Compressor) (*SingularChannelOut, error) {
 	c := &SingularChannelOut{
-		id:        ChannelID{}, // TODO: use GUID here instead of fully random data
+		id:        ChannelID{},
 		frame:     0,
 		rlpLength: 0,
 		compress:  compress,
@@ -104,7 +104,6 @@ func NewSingularChannelOut(compress Compressor) (*SingularChannelOut, error) {
 	return c, nil
 }
 
-// TODO: reuse SingularChannelOut for performance
 func (co *SingularChannelOut) Reset() error {
 	co.frame = 0
 	co.rlpLength = 0

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -29,7 +29,7 @@ func (s *nonCompressor) FullErr() error {
 }
 
 func TestChannelOutAddBlock(t *testing.T) {
-	cout, err := NewChannelOut(&nonCompressor{}, SingularBatchType, nil)
+	cout, err := NewChannelOut(SingularBatchType, &nonCompressor{}, nil)
 	require.NoError(t, err)
 
 	t.Run("returns err if first tx is not an l1info tx", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestChannelOutAddBlock(t *testing.T) {
 // max size that is below the fixed frame size overhead of 23, will return
 // an error.
 func TestOutputFrameSmallMaxSize(t *testing.T) {
-	cout, err := NewChannelOut(&nonCompressor{}, SingularBatchType, nil)
+	cout, err := NewChannelOut(SingularBatchType, &nonCompressor{}, nil)
 	require.NoError(t, err)
 
 	// Call OutputFrame with the range of small max size values that err

--- a/op-node/rollup/derive/channel_out_test.go
+++ b/op-node/rollup/derive/channel_out_test.go
@@ -29,7 +29,7 @@ func (s *nonCompressor) FullErr() error {
 }
 
 func TestChannelOutAddBlock(t *testing.T) {
-	cout, err := NewChannelOut(&nonCompressor{})
+	cout, err := NewChannelOut(&nonCompressor{}, SingularBatchType, nil)
 	require.NoError(t, err)
 
 	t.Run("returns err if first tx is not an l1info tx", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestChannelOutAddBlock(t *testing.T) {
 // max size that is below the fixed frame size overhead of 23, will return
 // an error.
 func TestOutputFrameSmallMaxSize(t *testing.T) {
-	cout, err := NewChannelOut(&nonCompressor{})
+	cout, err := NewChannelOut(&nonCompressor{}, SingularBatchType, nil)
 	require.NoError(t, err)
 
 	// Call OutputFrame with the range of small max size values that err
@@ -97,42 +97,42 @@ func TestForceCloseTxData(t *testing.T) {
 			output: "",
 		},
 		{
-			frames: []Frame{Frame{FrameNumber: 0, IsLast: false}, Frame{ID: id, FrameNumber: 1, IsLast: true}},
+			frames: []Frame{{FrameNumber: 0, IsLast: false}, {ID: id, FrameNumber: 1, IsLast: true}},
 			errors: true,
 			output: "",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 0, IsLast: false}},
+			frames: []Frame{{ID: id, FrameNumber: 0, IsLast: false}},
 			errors: false,
 			output: "00deadbeefdeadbeefdeadbeefdeadbeef00000000000001",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 0, IsLast: true}},
+			frames: []Frame{{ID: id, FrameNumber: 0, IsLast: true}},
 			errors: false,
 			output: "00",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 1, IsLast: false}},
+			frames: []Frame{{ID: id, FrameNumber: 1, IsLast: false}},
 			errors: false,
 			output: "00deadbeefdeadbeefdeadbeefdeadbeef00000000000001",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 1, IsLast: true}},
+			frames: []Frame{{ID: id, FrameNumber: 1, IsLast: true}},
 			errors: false,
 			output: "00deadbeefdeadbeefdeadbeefdeadbeef00000000000000",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 2, IsLast: true}},
+			frames: []Frame{{ID: id, FrameNumber: 2, IsLast: true}},
 			errors: false,
 			output: "00deadbeefdeadbeefdeadbeefdeadbeef00000000000000deadbeefdeadbeefdeadbeefdeadbeef00010000000000",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 1, IsLast: false}, Frame{ID: id, FrameNumber: 3, IsLast: true}},
+			frames: []Frame{{ID: id, FrameNumber: 1, IsLast: false}, {ID: id, FrameNumber: 3, IsLast: true}},
 			errors: false,
 			output: "00deadbeefdeadbeefdeadbeefdeadbeef00000000000000deadbeefdeadbeefdeadbeefdeadbeef00020000000000",
 		},
 		{
-			frames: []Frame{Frame{ID: id, FrameNumber: 1, IsLast: false}, Frame{ID: id, FrameNumber: 3, IsLast: true}, Frame{ID: id, FrameNumber: 5, IsLast: true}},
+			frames: []Frame{{ID: id, FrameNumber: 1, IsLast: false}, {ID: id, FrameNumber: 3, IsLast: true}, {ID: id, FrameNumber: 5, IsLast: true}},
 			errors: false,
 			output: "00deadbeefdeadbeefdeadbeefdeadbeef00000000000000deadbeefdeadbeefdeadbeefdeadbeef00020000000000",
 		},
@@ -152,6 +152,6 @@ func TestForceCloseTxData(t *testing.T) {
 
 func TestBlockToBatchValidity(t *testing.T) {
 	block := new(types.Block)
-	_, _, err := BlockToBatch(block)
+	_, _, err := BlockToSingularBatch(block)
 	require.ErrorContains(t, err, "has no transactions")
 }

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -493,16 +493,16 @@ func TestSpanBatchBuilder(t *testing.T) {
 		}
 		genesisTimeStamp := 1 + singularBatches[0].Timestamp - 128
 
-		parentEpoch := uint64(singularBatches[0].EpochNum)
+		var seqNum uint64 = 1
 		if originChangedBit == 1 {
-			parentEpoch -= 1
+			seqNum = 0
 		}
-		spanBatchBuilder := NewSpanBatchBuilder(parentEpoch, genesisTimeStamp, chainID)
+		spanBatchBuilder := NewSpanBatchBuilder(genesisTimeStamp, chainID)
 
 		assert.Equal(t, 0, spanBatchBuilder.GetBlockCount())
 
 		for i := 0; i < len(singularBatches); i++ {
-			spanBatchBuilder.AppendSingularBatch(singularBatches[i])
+			spanBatchBuilder.AppendSingularBatch(singularBatches[i], seqNum)
 			assert.Equal(t, i+1, spanBatchBuilder.GetBlockCount())
 			assert.Equal(t, singularBatches[0].ParentHash.Bytes()[:20], spanBatchBuilder.spanBatch.parentCheck)
 			assert.Equal(t, singularBatches[i].EpochHash.Bytes()[:20], spanBatchBuilder.spanBatch.l1OriginCheck)

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -1,0 +1,229 @@
+package derive
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type SpanChannelOut struct {
+	id ChannelID
+	// Frame ID of the next frame to emit. Increment after emitting
+	frame uint64
+	// rlpLength is the uncompressed size of the channel. Must be less than MAX_RLP_BYTES_PER_CHANNEL
+	rlpLength int
+
+	// Compressor stage. Write input data to it
+	compress Compressor
+	// closed indicates if the channel is closed
+	closed bool
+	// spanBatchBuilder contains information requires to build SpanBatch
+	spanBatchBuilder *SpanBatchBuilder
+	// reader contains compressed data for making output frames
+	reader *bytes.Buffer
+}
+
+func (co *SpanChannelOut) ID() ChannelID {
+	return co.id
+}
+
+func NewSpanChannelOut(compress Compressor, spanBatchBuilder *SpanBatchBuilder) (*SpanChannelOut, error) {
+	c := &SpanChannelOut{
+		id:               ChannelID{}, // TODO: use GUID here instead of fully random data
+		frame:            0,
+		rlpLength:        0,
+		compress:         compress,
+		spanBatchBuilder: spanBatchBuilder,
+		reader:           &bytes.Buffer{},
+	}
+	_, err := rand.Read(c.id[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// TODO: reuse ChannelOut for performance
+func (co *SpanChannelOut) Reset() error {
+	co.frame = 0
+	co.rlpLength = 0
+	co.compress.Reset()
+	co.reader.Reset()
+	co.closed = false
+	co.spanBatchBuilder.Reset()
+	_, err := rand.Read(co.id[:])
+	return err
+}
+
+// AddBlock adds a block to the channel. It returns the RLP encoded byte size
+// and an error if there is a problem adding the block. The only sentinel error
+// that it returns is ErrTooManyRLPBytes. If this error is returned, the channel
+// should be closed and a new one should be made.
+func (co *SpanChannelOut) AddBlock(block *types.Block) (uint64, error) {
+	if co.closed {
+		return 0, errors.New("already closed")
+	}
+
+	batch, _, err := BlockToSingularBatch(block)
+	if err != nil {
+		return 0, err
+	}
+	return co.AddSingularBatch(batch)
+}
+
+// AddSingularBatch adds a batch to the channel. It returns the RLP encoded byte size
+// and an error if there is a problem adding the batch. The only sentinel error
+// that it returns is ErrTooManyRLPBytes. If this error is returned, the channel
+// should be closed and a new one should be made.
+//
+// AddSingularBatch should be used together with BlockToSingularBatch if you need to access the
+// BatchData before adding a block to the channel. It isn't possible to access
+// the batch data with AddBlock.
+//
+// SingularBatch is appended to the channel's SpanBatch.
+// A channel can have only one SpanBatch. And compressed results should not be accessible until the channel is closed, since the prefix and payload can be changed.
+// So it resets channel contents and rewrites the entire SpanBatch each time, and compressed results are copied to reader after the channel is closed.
+// It makes we can only get frames once the channel is full or closed, in the case of SpanBatch.
+func (co *SpanChannelOut) AddSingularBatch(batch *SingularBatch) (uint64, error) {
+	if co.closed {
+		return 0, errors.New("already closed")
+	}
+	if co.FullErr() != nil {
+		// channel is already full
+		return 0, co.FullErr()
+	}
+	var buf bytes.Buffer
+	// Append Singular batch to its span batch builder
+	co.spanBatchBuilder.AppendSingularBatch(batch)
+	// Convert Span batch to RawSpanBatch
+	rawSpanBatch, err := co.spanBatchBuilder.GetRawSpanBatch()
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert SpanBatch into RawSpanBatch: %w", err)
+	}
+	// Encode RawSpanBatch into bytes
+	if err = rlp.Encode(&buf, NewSpanBatchData(*rawSpanBatch)); err != nil {
+		return 0, fmt.Errorf("failed to encode RawSpanBatch into bytes: %w", err)
+	}
+	// Ensure that the total size of all RLP elements is less than or equal to MAX_RLP_BYTES_PER_CHANNEL
+	if buf.Len() > MaxRLPBytesPerChannel {
+		return 0, fmt.Errorf("could not add %d bytes to channel of %d bytes, max is %d. err: %w",
+			buf.Len(), co.rlpLength, MaxRLPBytesPerChannel, ErrTooManyRLPBytes)
+	}
+	co.rlpLength = buf.Len()
+
+	if co.spanBatchBuilder.GetBlockCount() > 1 {
+		// Flush compressed data into reader to preserve current result.
+		// If the channel is full after this block is appended, we should use preserved data.
+		if err := co.compress.Flush(); err != nil {
+			return 0, fmt.Errorf("failed to flush compressor: %w", err)
+		}
+		_, err = io.Copy(co.reader, co.compress)
+		if err != nil {
+			// Must reset reader to avoid partial output
+			co.reader.Reset()
+			return 0, fmt.Errorf("failed to copy compressed data to reader: %w", err)
+		}
+	}
+
+	// Reset compressor to rewrite the entire span batch
+	co.compress.Reset()
+	// Avoid using io.Copy here, because we need all or nothing
+	written, err := co.compress.Write(buf.Bytes())
+	if co.compress.FullErr() != nil {
+		err = co.compress.FullErr()
+		if co.spanBatchBuilder.GetBlockCount() == 1 {
+			// Do not return CompressorFullErr for the first block in the batch
+			// In this case, reader must be empty. then the contents of compressor will be copied to reader when the channel is closed.
+			err = nil
+		}
+		// If there are more than one blocks in the channel, reader should have data that preserves previous compression result before adding this block.
+		// So, as a result, this block is not added to the channel and the channel will be closed.
+		return uint64(written), err
+	}
+
+	// If compressor is not full yet, reader must be reset to avoid submitting invalid frames
+	co.reader.Reset()
+	return uint64(written), err
+}
+
+// InputBytes returns the total amount of RLP-encoded input bytes.
+func (co *SpanChannelOut) InputBytes() int {
+	return co.rlpLength
+}
+
+// ReadyBytes returns the number of bytes that the channel out can immediately output into a frame.
+// Use `Flush` or `Close` to move data from the compression buffer into the ready buffer if more bytes
+// are needed. Add blocks may add to the ready buffer, but it is not guaranteed due to the compression stage.
+func (co *SpanChannelOut) ReadyBytes() int {
+	return co.reader.Len()
+}
+
+// Flush flushes the internal compression stage to the ready buffer. It enables pulling a larger & more
+// complete frame. It reduces the compression efficiency.
+func (co *SpanChannelOut) Flush() error {
+	if err := co.compress.Flush(); err != nil {
+		return err
+	}
+	if co.closed && co.ReadyBytes() == 0 && co.compress.Len() > 0 {
+		_, err := io.Copy(co.reader, co.compress)
+		if err != nil {
+			// Must reset reader to avoid partial output
+			co.reader.Reset()
+			return fmt.Errorf("failed to flush compressed data to reader: %w", err)
+		}
+	}
+	return nil
+}
+
+func (co *SpanChannelOut) FullErr() error {
+	return co.compress.FullErr()
+}
+
+func (co *SpanChannelOut) Close() error {
+	if co.closed {
+		return errors.New("already closed")
+	}
+	co.closed = true
+	if err := co.Flush(); err != nil {
+		return err
+	}
+	return co.compress.Close()
+}
+
+// OutputFrame writes a frame to w with a given max size and returns the frame
+// number.
+// Use `ReadyBytes`, `Flush`, and `Close` to modify the ready buffer.
+// Returns an error if the `maxSize` < FrameV0OverHeadSize.
+// Returns io.EOF when the channel is closed & there are no more frames.
+// Returns nil if there is still more buffered data.
+// Returns an error if it ran into an error during processing.
+func (co *SpanChannelOut) OutputFrame(w *bytes.Buffer, maxSize uint64) (uint16, error) {
+	// Check that the maxSize is large enough for the frame overhead size.
+	if maxSize < FrameV0OverHeadSize {
+		return 0, ErrMaxFrameSizeTooSmall
+	}
+
+	f := createEmptyFrame(co.id, co.frame, co.ReadyBytes(), co.closed, maxSize)
+
+	if _, err := io.ReadFull(co.reader, f.Data); err != nil {
+		return 0, err
+	}
+
+	if err := f.MarshalBinary(w); err != nil {
+		return 0, err
+	}
+
+	co.frame += 1
+	fn := f.FrameNumber
+	if f.IsLast {
+		return fn, io.EOF
+	} else {
+		return fn, nil
+	}
+}

--- a/op-node/rollup/derive/span_channel_out.go
+++ b/op-node/rollup/derive/span_channel_out.go
@@ -34,7 +34,7 @@ func (co *SpanChannelOut) ID() ChannelID {
 
 func NewSpanChannelOut(compress Compressor, spanBatchBuilder *SpanBatchBuilder) (*SpanChannelOut, error) {
 	c := &SpanChannelOut{
-		id:               ChannelID{}, // TODO: use GUID here instead of fully random data
+		id:               ChannelID{},
 		frame:            0,
 		rlpLength:        0,
 		compress:         compress,
@@ -49,7 +49,6 @@ func NewSpanChannelOut(compress Compressor, spanBatchBuilder *SpanBatchBuilder) 
 	return c, nil
 }
 
-// TODO: reuse ChannelOut for performance
 func (co *SpanChannelOut) Reset() error {
 	co.frame = 0
 	co.rlpLength = 0

--- a/op-node/rollup/derive/test/random.go
+++ b/op-node/rollup/derive/test/random.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"math/big"
 	"math/rand"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -20,4 +21,14 @@ func RandomL2Block(rng *rand.Rand, txCount int) (*types.Block, []*types.Receipt)
 		panic("L1InfoDeposit: " + err.Error())
 	}
 	return testutils.RandomBlockPrependTxs(rng, txCount, types.NewTx(l1InfoTx))
+}
+
+func RandomL2BlockWithChainId(rng *rand.Rand, txCount int, chainId *big.Int) *types.Block {
+	signer := types.NewLondonSigner(chainId)
+	block, _ := RandomL2Block(rng, 0)
+	txs := []*types.Transaction{block.Transactions()[0]} // L1 info deposit TX
+	for i := 0; i < txCount; i++ {
+		txs = append(txs, testutils.RandomTx(rng, big.NewInt(int64(rng.Uint32())), signer))
+	}
+	return block.WithBody(txs, nil)
 }

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -155,6 +155,7 @@ services:
       OP_BATCHER_PPROF_ENABLED: "true"
       OP_BATCHER_METRICS_ENABLED: "true"
       OP_BATCHER_RPC_ENABLE_ADMIN: "true"
+      OP_BATCHER_BATCH_TYPE: 0
 
   artifact-server:
     depends_on:


### PR DESCRIPTION
## Contexts

This PR contains the batcher code for [Span Batch](https://github.com/ethereum-optimism/optimism/blob/develop/specs/span-batches.md).

Please refer to the **Implementations - Batcher** and **Hard Fork Activation** sections of the Design Docs and **op-batcher** section of Implementation Design Docs for details & rationales.

This PR has a dependency on the [**Span Batch Derivation** PR](https://github.com/ethereum-optimism/optimism/pull/7289).

## Changes

- Modifications:
    - New flag: `--batch-type` : configure batch type. 0 for `SingularBatch` and 1 for `SpanBatch`. (default: 0)
    - When `--batch-type=1`:
        - For each L2 block accumulated, compress the entire batch and check if the compressed size overflows.
        - Rationale: We cannot use the compression stream for Span Batch since it changes the entire contents as each L2 block is accumulated.
    - ^ Please refer to the `op-batcher` section of Implementation Design Docs for details.
- Added unit tests.
    - ^ Please refer to the `Batch Submission` category in the Test List Sheet for each test’s details.