### PR TITLE
feat: e2e `op-program` execution

### DIFF
--- a/cannon/mipsevm/fuzz_evm_test.go
+++ b/cannon/mipsevm/fuzz_evm_test.go
@@ -14,7 +14,7 @@ import (
 const syscallInsn = uint32(0x00_00_00_0c)
 
 func FuzzStateSyscallBrk(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, pc uint32, step uint64, preimageOffset uint32) {
 		pc = pc & 0xFF_FF_FF_FC // align PC
 		nextPC := pc + 4
@@ -64,7 +64,7 @@ func FuzzStateSyscallBrk(f *testing.F) {
 }
 
 func FuzzStateSyscallClone(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, pc uint32, step uint64, preimageOffset uint32) {
 		pc = pc & 0xFF_FF_FF_FC // align PC
 		nextPC := pc + 4
@@ -113,7 +113,7 @@ func FuzzStateSyscallClone(f *testing.F) {
 }
 
 func FuzzStateSyscallMmap(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, addr uint32, siz uint32, heap uint32) {
 		state := &State{
 			PC:             0,
@@ -172,7 +172,7 @@ func FuzzStateSyscallMmap(f *testing.F) {
 }
 
 func FuzzStateSyscallExitGroup(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, exitCode uint8, pc uint32, step uint64) {
 		pc = pc & 0xFF_FF_FF_FC // align PC
 		nextPC := pc + 4
@@ -220,7 +220,7 @@ func FuzzStateSyscallExitGroup(f *testing.F) {
 }
 
 func FuzzStateSyscallFnctl(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, fd uint32, cmd uint32) {
 		state := &State{
 			PC:             0,
@@ -283,7 +283,7 @@ func FuzzStateSyscallFnctl(f *testing.F) {
 }
 
 func FuzzStateHintRead(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, addr uint32, count uint32) {
 		preimageData := []byte("hello world")
 		state := &State{
@@ -332,7 +332,7 @@ func FuzzStateHintRead(f *testing.F) {
 }
 
 func FuzzStatePreimageRead(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, addr uint32, count uint32, preimageOffset uint32) {
 		preimageData := []byte("hello world")
 		if preimageOffset >= uint32(len(preimageData)) {
@@ -396,7 +396,7 @@ func FuzzStatePreimageRead(f *testing.F) {
 }
 
 func FuzzStateHintWrite(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, addr uint32, count uint32) {
 		preimageData := []byte("hello world")
 		state := &State{
@@ -449,7 +449,7 @@ func FuzzStateHintWrite(f *testing.F) {
 }
 
 func FuzzStatePreimageWrite(f *testing.F) {
-	contracts, addrs := testContractsSetup(f)
+	contracts, addrs := TestContractsSetup(f)
 	f.Fuzz(func(t *testing.T, addr uint32, count uint32) {
 		preimageData := []byte("hello world")
 		state := &State{

--- a/cannon/mipsevm/test_utils.go
+++ b/cannon/mipsevm/test_utils.go
@@ -1,0 +1,75 @@
+package mipsevm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/stretchr/testify/require"
+)
+
+type MIPSEVM struct {
+	env      *vm.EVM
+	evmState *state.StateDB
+	addrs    *Addresses
+}
+
+func NewMIPSEVM(contracts *Contracts, addrs *Addresses) *MIPSEVM {
+	env, evmState := NewEVMEnv(contracts, addrs)
+	return &MIPSEVM{env, evmState, addrs}
+}
+
+func (m *MIPSEVM) SetTracer(tracer vm.EVMLogger) {
+	m.env.Config.Tracer = tracer
+}
+
+// Step is a pure function that computes the poststate from the VM state encoded in the StepWitness.
+func (m *MIPSEVM) Step(t *testing.T, stepWitness *StepWitness) []byte {
+	sender := common.Address{0x13, 0x37}
+	startingGas := uint64(30_000_000)
+
+	// we take a snapshot so we can clean up the state, and isolate the logs of this instruction run.
+	snap := m.env.StateDB.Snapshot()
+
+	if stepWitness.HasPreimage() {
+		t.Logf("reading preimage key %x at offset %d", stepWitness.PreimageKey, stepWitness.PreimageOffset)
+		poInput, err := stepWitness.EncodePreimageOracleInput()
+		require.NoError(t, err, "encode preimage oracle input")
+		_, leftOverGas, err := m.env.Call(vm.AccountRef(sender), m.addrs.Oracle, poInput, startingGas, big.NewInt(0))
+		require.NoErrorf(t, err, "evm should not fail, took %d gas", startingGas-leftOverGas)
+	}
+
+	input := stepWitness.EncodeStepInput()
+	ret, leftOverGas, err := m.env.Call(vm.AccountRef(sender), m.addrs.MIPS, input, startingGas, big.NewInt(0))
+	require.NoError(t, err, "evm should not fail")
+	require.Len(t, ret, 32, "expecting 32-byte state hash")
+	// remember state hash, to check it against state
+	postHash := common.Hash(*(*[32]byte)(ret))
+	logs := m.evmState.Logs()
+	require.Equal(t, 1, len(logs), "expecting a log with post-state")
+	evmPost := logs[0].Data
+
+	stateHash, err := StateWitness(evmPost).StateHash()
+	require.NoError(t, err, "state hash could not be computed")
+	require.Equal(t, stateHash, postHash, "logged state must be accurate")
+
+	m.env.StateDB.RevertToSnapshot(snap)
+	t.Logf("EVM step took %d gas, and returned stateHash %s", startingGas-leftOverGas, postHash)
+	return evmPost
+}
+
+func TestContractsSetup(t require.TestingT) (*Contracts, *Addresses) {
+	contracts, err := LoadContracts()
+	require.NoError(t, err)
+
+	addrs := &Addresses{
+		MIPS:         common.Address{0: 0xff, 19: 1},
+		Oracle:       common.Address{0: 0xff, 19: 2},
+		Sender:       common.Address{0x13, 0x37},
+		FeeRecipient: common.Address{0xaa},
+	}
+
+	return contracts, addrs
+}

--- a/op-e2e/e2eutils/disputegame/honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/honest_helper.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,4 +57,12 @@ func (h *HonestHelper) StepFails(ctx context.Context, claimIdx int64, isAttack b
 	prestate, proofData, _, err := h.correctTrace.GetStepData(ctx, traceIdx)
 	h.require.NoError(err, "Get step data")
 	h.game.StepFails(claimIdx, isAttack, prestate, proofData)
+}
+
+func (h *HonestHelper) Get(ctx context.Context, traceIdx uint64) (common.Hash, error) {
+	return h.correctTrace.Get(ctx, traceIdx)
+}
+
+func (h *HonestHelper) GetStepData(ctx context.Context, traceIdx uint64) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
+	return h.correctTrace.GetStepData(ctx, traceIdx)
 }


### PR DESCRIPTION
## Overview

Adds a test to execute and diff every single instruction within an `op-program` trace against the on-chain MIPS VM.