### PR TITLE
ci-builder: bump go version to 1.21

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update && \
   chmod +x ./rustup.sh && \
   ./rustup.sh -y
 
-COPY ./.abigenrc ./.abigenrc
-
 # Only diff from upstream docker image is this clone instead
 # of COPY. We select a specific commit to use.
 COPY ./.foundryrc ./.foundryrc
@@ -26,8 +24,6 @@ RUN source $HOME/.profile && \
   strip /opt/foundry/target/release/forge && \
   strip /opt/foundry/target/release/cast && \
   strip /opt/foundry/target/release/anvil
-
-FROM ethereum/client-go:alltools-v1.10.25 as geth
 
 FROM ghcr.io/crytic/echidna/echidna:v2.0.4 as echidna-test
 
@@ -55,6 +51,8 @@ RUN apt-get update && \
   go install gotest.tools/gotestsum@latest && \
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3 && \
   curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
+
+COPY ./.abigenrc ./.abigenrc
 
 # Install the specific version of abigen from .abigenrc
 RUN go install github.com/ethereum/go-ethereum/cmd/abigen@$(cat .abigenrc)

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -45,8 +45,8 @@ COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
 RUN apt-get update && \
   apt-get install -y bash curl openssh-client git build-essential ca-certificates jq musl gnupg coreutils && \
   curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh && \
-  curl -sL https://go.dev/dl/go1.20.linux-amd64.tar.gz -o go1.20.linux-amd64.tar.gz && \
-  tar -C /usr/local/ -xzvf go1.20.linux-amd64.tar.gz && \
+  curl -sL https://go.dev/dl/go1.21.1.linux-amd64.tar.gz -o go1.21.1.linux-amd64.tar.gz && \
+  tar -C /usr/local/ -xzvf go1.21.1.linux-amd64.tar.gz && \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt && \
   bash nodesource_setup.sh && \
   apt-get install -y nodejs && \


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Bumps the version of go in `ci-builder` to 1.21
