### PR TITLE
fix(indexer): Don't set port if there is no port

### DIFF
--- a/indexer/database/db.go
+++ b/indexer/database/db.go
@@ -38,7 +38,10 @@ type DB struct {
 func NewDB(dbConfig config.DBConfig) (*DB, error) {
 	retryStrategy := &retry.ExponentialStrategy{Min: 1000, Max: 20_000, MaxJitter: 250}
 
-	dsn := fmt.Sprintf("host=%s port=%d dbname=%s sslmode=disable", dbConfig.Host, dbConfig.Port, dbConfig.Name)
+	dsn := fmt.Sprintf("host=%s dbname=%s sslmode=disable", dbConfig.Host, dbConfig.Name)
+	if dbConfig.Port != 0 {
+		dsn += fmt.Sprintf(" port=%d", dbConfig.Port)
+	}
 	if dbConfig.User != "" {
 		dsn += fmt.Sprintf(" user=%s", dbConfig.User)
 	}


### PR DESCRIPTION
- Production instances of the indexer are unhealthy because they cannot connect to the db
- This is the same bug I fixed in the gateway https://github.com/ethereum-optimism/gateway/pull/1856A
- Fix by not setting a port if port is ""
