### PR TITLE
L1 contract deploy: add support for customization of the IMPL_SALT

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -47,11 +47,6 @@ import "src/libraries/DisputeTypes.sol";
 contract Deploy is Deployer {
     DeployConfig cfg;
 
-    /// @notice The create2 salt used for deployment of the contract implementations.
-    ///         Using this helps to reduce config across networks as the implementation
-    ///         addresses will be the same across networks when deployed with create2.
-    bytes32 constant IMPL_SALT = keccak256(bytes("ether's phoenix"));
-
     /// @notice The name of the script, used to ensure the right deploy artifacts
     ///         are used.
     function name() public pure override returns (string memory name_) {
@@ -90,6 +85,13 @@ contract Deploy is Deployer {
 
         transferProxyAdminOwnership();
         transferDisputeGameFactoryOwnership();
+    }
+
+    /// @notice The create2 salt used for deployment of the contract implementations.
+    ///         Using this helps to reduce config across networks as the implementation
+    ///         addresses will be the same across networks when deployed with create2.
+    function implSalt() public returns (bytes32) {
+        return keccak256(bytes(vm.envOr("IMPL_SALT", string("ether's phoenix"))));
     }
 
     /// @notice Modifier that wraps a function in broadcasting.
@@ -327,7 +329,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the L1CrossDomainMessenger
     function deployL1CrossDomainMessenger() public broadcast returns (address addr_) {
-        L1CrossDomainMessenger messenger = new L1CrossDomainMessenger{ salt: IMPL_SALT }();
+        L1CrossDomainMessenger messenger = new L1CrossDomainMessenger{ salt: implSalt() }();
 
         require(address(messenger.PORTAL()) == address(0));
         require(address(messenger.portal()) == address(0));
@@ -343,7 +345,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the OptimismPortal
     function deployOptimismPortal() public broadcast returns (address addr_) {
-        OptimismPortal portal = new OptimismPortal{ salt: IMPL_SALT }();
+        OptimismPortal portal = new OptimismPortal{ salt: implSalt() }();
 
         require(address(portal.L2_ORACLE()) == address(0));
         require(portal.GUARDIAN() == address(0));
@@ -358,7 +360,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the L2OutputOracle
     function deployL2OutputOracle() public broadcast returns (address addr_) {
-        L2OutputOracle oracle = new L2OutputOracle{ salt: IMPL_SALT }({
+        L2OutputOracle oracle = new L2OutputOracle{ salt: implSalt() }({
             _submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
             _l2BlockTime: cfg.l2BlockTime(),
             _finalizationPeriodSeconds: cfg.finalizationPeriodSeconds()
@@ -385,7 +387,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the OptimismMintableERC20Factory
     function deployOptimismMintableERC20Factory() public broadcast returns (address addr_) {
-        OptimismMintableERC20Factory factory = new OptimismMintableERC20Factory{ salt: IMPL_SALT }();
+        OptimismMintableERC20Factory factory = new OptimismMintableERC20Factory{ salt: implSalt() }();
 
         require(factory.BRIDGE() == address(0));
         require(factory.bridge() == address(0));
@@ -398,7 +400,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the DisputeGameFactory
     function deployDisputeGameFactory() public onlyDevnet broadcast returns (address addr_) {
-        DisputeGameFactory factory = new DisputeGameFactory{ salt: IMPL_SALT }();
+        DisputeGameFactory factory = new DisputeGameFactory{ salt: implSalt() }();
         save("DisputeGameFactory", address(factory));
         console.log("DisputeGameFactory deployed at %s", address(factory));
 
@@ -407,7 +409,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the BlockOracle
     function deployBlockOracle() public onlyDevnet broadcast returns (address addr_) {
-        BlockOracle oracle = new BlockOracle{ salt: IMPL_SALT }();
+        BlockOracle oracle = new BlockOracle{ salt: implSalt() }();
         save("BlockOracle", address(oracle));
         console.log("BlockOracle deployed at %s", address(oracle));
 
@@ -416,7 +418,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the ProtocolVersions
     function deployProtocolVersions() public onlyTestnetOrDevnet broadcast returns (address addr_) {
-        ProtocolVersions versions = new ProtocolVersions{ salt: IMPL_SALT }();
+        ProtocolVersions versions = new ProtocolVersions{ salt: implSalt() }();
         save("ProtocolVersions", address(versions));
         console.log("ProtocolVersions deployed at %s", address(versions));
 
@@ -425,7 +427,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the PreimageOracle
     function deployPreimageOracle() public onlyDevnet broadcast returns (address addr_) {
-        PreimageOracle preimageOracle = new PreimageOracle{ salt: IMPL_SALT }();
+        PreimageOracle preimageOracle = new PreimageOracle{ salt: implSalt() }();
         save("PreimageOracle", address(preimageOracle));
         console.log("PreimageOracle deployed at %s", address(preimageOracle));
 
@@ -434,7 +436,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy Mips
     function deployMips() public onlyDevnet broadcast returns (address addr_) {
-        MIPS mips = new MIPS{ salt: IMPL_SALT }(IPreimageOracle(mustGetAddress("PreimageOracle")));
+        MIPS mips = new MIPS{ salt: implSalt() }(IPreimageOracle(mustGetAddress("PreimageOracle")));
         save("Mips", address(mips));
         console.log("MIPS deployed at %s", address(mips));
 
@@ -443,7 +445,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the SystemConfig
     function deploySystemConfig() public broadcast returns (address addr_) {
-        SystemConfig config = new SystemConfig{ salt: IMPL_SALT }();
+        SystemConfig config = new SystemConfig{ salt: implSalt() }();
 
         require(config.owner() == address(0xdEaD));
         require(config.overhead() == 0);
@@ -476,7 +478,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the L1StandardBridge
     function deployL1StandardBridge() public broadcast returns (address addr_) {
-        L1StandardBridge bridge = new L1StandardBridge{ salt: IMPL_SALT }();
+        L1StandardBridge bridge = new L1StandardBridge{ salt: implSalt() }();
 
         require(address(bridge.MESSENGER()) == address(0));
         require(address(bridge.messenger()) == address(0));
@@ -491,7 +493,7 @@ contract Deploy is Deployer {
 
     /// @notice Deploy the L1ERC721Bridge
     function deployL1ERC721Bridge() public broadcast returns (address addr_) {
-        L1ERC721Bridge bridge = new L1ERC721Bridge{ salt: IMPL_SALT }();
+        L1ERC721Bridge bridge = new L1ERC721Bridge{ salt: implSalt() }();
 
         require(address(bridge.MESSENGER()) == address(0));
         require(bridge.OTHER_BRIDGE() == Predeploys.L2_ERC721_BRIDGE);


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Currently any new L2 chain using this repo's Deploy script has to edit the hardcoded `IMPL_SALT` variable to be able to deploy to an L1 chain that has already been deployed to, otherwise the script will fail with:
```
    ├─ [0] → new OptimismPortal@0x8Cfa294bD0c6F63cD65d492bdB754eAcf684D871
    │   └─ ← 21596 bytes of code
    └─ ← "EvmError: Revert"
```
because the contract is already deployed.

This PR lets one customize the salt using the `IMPL_SALT` environment variable.

**Tests**
Tested locally using a forge simulation.

**Additional context**
We are trying to bootstrap our sepolia chain and running into this.