### PR TITLE
feat(op-challenger): Abstract Claim Entry

### DIFF
--- a/op-challenger/game/fault/loader_test.go
+++ b/op-challenger/game/fault/loader_test.go
@@ -119,10 +119,6 @@ func TestLoader_FetchClaims(t *testing.T) {
 					Value:    expectedClaims[0].Claim,
 					Position: types.NewPositionFromGIndex(expectedClaims[0].Position.Uint64()),
 				},
-				Parent: types.ClaimData{
-					Value:    expectedClaims[0].Claim,
-					Position: types.NewPositionFromGIndex(expectedClaims[0].Position.Uint64()),
-				},
 				Countered:     false,
 				Clock:         uint64(0),
 				ContractIndex: 0,
@@ -134,11 +130,12 @@ func TestLoader_FetchClaims(t *testing.T) {
 				},
 				Parent: types.ClaimData{
 					Value:    expectedClaims[0].Claim,
-					Position: types.NewPositionFromGIndex(expectedClaims[1].Position.Uint64()),
+					Position: types.NewPositionFromGIndex(expectedClaims[0].Position.Uint64()),
 				},
-				Countered:     false,
-				Clock:         uint64(0),
-				ContractIndex: 1,
+				Countered:           false,
+				Clock:               uint64(0),
+				ContractIndex:       1,
+				ParentContractIndex: 0,
 			},
 			{
 				ClaimData: types.ClaimData{
@@ -146,12 +143,13 @@ func TestLoader_FetchClaims(t *testing.T) {
 					Position: types.NewPositionFromGIndex(expectedClaims[2].Position.Uint64()),
 				},
 				Parent: types.ClaimData{
-					Value:    expectedClaims[0].Claim,
-					Position: types.NewPositionFromGIndex(expectedClaims[2].Position.Uint64()),
+					Value:    expectedClaims[1].Claim,
+					Position: types.NewPositionFromGIndex(expectedClaims[1].Position.Uint64()),
 				},
-				Countered:     false,
-				Clock:         uint64(0),
-				ContractIndex: 2,
+				Countered:           false,
+				Clock:               uint64(0),
+				ContractIndex:       2,
+				ParentContractIndex: 1,
 			},
 		}, claims)
 	})
@@ -204,21 +202,23 @@ func newMockCaller() *mockCaller {
 		}{
 			{
 				Claim:     [32]byte{0x00},
-				Position:  big.NewInt(0),
+				Position:  big.NewInt(1),
 				Countered: false,
 				Clock:     big.NewInt(0),
 			},
 			{
-				Claim:     [32]byte{0x01},
-				Position:  big.NewInt(0),
-				Countered: false,
-				Clock:     big.NewInt(0),
+				Claim:       [32]byte{0x01},
+				Position:    big.NewInt(2),
+				Countered:   false,
+				Clock:       big.NewInt(0),
+				ParentIndex: 0,
 			},
 			{
-				Claim:     [32]byte{0x02},
-				Position:  big.NewInt(0),
-				Countered: false,
-				Clock:     big.NewInt(0),
+				Claim:       [32]byte{0x02},
+				Position:    big.NewInt(3),
+				Countered:   false,
+				Clock:       big.NewInt(0),
+				ParentIndex: 1,
 			},
 		},
 	}
@@ -240,7 +240,7 @@ func (m *mockCaller) ClaimData(opts *bind.CallOpts, arg0 *big.Int) (struct {
 			Clock       *big.Int
 		}{}, mockClaimDataError
 	}
-	returnClaim := m.returnClaims[m.currentIndex]
+	returnClaim := m.returnClaims[arg0.Uint64()]
 	m.currentIndex++
 	return returnClaim, nil
 }

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -56,7 +56,6 @@ func TestCalculateNextActions(t *testing.T) {
 				builder.Seq().AttackCorrect()
 			},
 		},
-
 		{
 			name:                "RespondToAllClaimsAtDisagreeingLevel",
 			agreeWithOutputRoot: true,
@@ -70,7 +69,6 @@ func TestCalculateNextActions(t *testing.T) {
 				honestClaim.Defend(common.Hash{0xdd}).ExpectAttack()
 			},
 		},
-
 		{
 			name:                "StepAtMaxDepth",
 			agreeWithOutputRoot: true,
@@ -83,7 +81,6 @@ func TestCalculateNextActions(t *testing.T) {
 				lastHonestClaim.Attack(common.Hash{0xdd}).ExpectStepAttack()
 			},
 		},
-
 		{
 			name:                "PoisonedPreState",
 			agreeWithOutputRoot: true,
@@ -113,7 +110,7 @@ func TestCalculateNextActions(t *testing.T) {
 			game := builder.Game
 			for i, claim := range game.Claims() {
 				t.Logf("Claim %v: Pos: %v TraceIdx: %v ParentIdx: %v, Countered: %v, Value: %v",
-					i, claim.Position.ToGIndex(), claim.Position.TraceIndex(maxDepth), claim.ParentContractIndex, claim.Countered, claim.Value)
+					i, claim.Position.ToGIndex().Uint64(), claim.Position.TraceIndex(maxDepth), claim.ParentContractIndex, claim.Countered, claim.Value)
 			}
 
 			solver := NewGameSolver(maxDepth, claimBuilder.CorrectTraceProvider())

--- a/op-challenger/game/fault/types/game.go
+++ b/op-challenger/game/fault/types/game.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
@@ -37,7 +39,8 @@ type Game interface {
 }
 
 type claimEntry struct {
-	ClaimData
+	GIndex              uint64
+	Value               common.Hash
 	ParentContractIndex int
 }
 
@@ -167,7 +170,8 @@ func (g *gameState) getParent(claim Claim) *extendedClaim {
 
 func makeClaimEntry(claim Claim) claimEntry {
 	return claimEntry{
-		ClaimData:           claim.ClaimData,
+		GIndex:              claim.ToGIndex().Uint64(),
+		Value:               claim.Value,
 		ParentContractIndex: claim.ParentContractIndex,
 	}
 }

--- a/op-challenger/game/fault/types/position_test.go
+++ b/op-challenger/game/fault/types/position_test.go
@@ -85,7 +85,7 @@ func TestGINConversions(t *testing.T) {
 		pos := NewPosition(test.Depth, test.IndexAtDepth)
 		require.Equal(t, pos, from)
 		to := pos.ToGIndex()
-		require.Equal(t, test.GIndex, to)
+		require.Equal(t, test.GIndex, to.Uint64())
 	}
 }
 
@@ -105,7 +105,7 @@ func TestAttack(t *testing.T) {
 		}
 		pos := NewPosition(test.Depth, test.IndexAtDepth)
 		result := pos.Attack()
-		require.Equalf(t, test.AttackGIndex, result.ToGIndex(), "Attack from GIndex %v", pos.ToGIndex())
+		require.Equalf(t, test.AttackGIndex, result.ToGIndex().Uint64(), "Attack from GIndex %v", pos.ToGIndex())
 	}
 }
 
@@ -116,6 +116,6 @@ func TestDefend(t *testing.T) {
 		}
 		pos := NewPosition(test.Depth, test.IndexAtDepth)
 		result := pos.Defend()
-		require.Equalf(t, test.DefendGIndex, result.ToGIndex(), "Defend from GIndex %v", pos.ToGIndex())
+		require.Equalf(t, test.DefendGIndex, result.ToGIndex().Uint64(), "Defend from GIndex %v", pos.ToGIndex())
 	}
 }

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var (
@@ -109,6 +110,14 @@ type Claim struct {
 	// for claims that have not made it to the contract.
 	ContractIndex       int
 	ParentContractIndex int
+}
+
+// Entry creates a hash of the claim.
+func (c *Claim) Entry() common.Hash {
+	gindex := c.ToGIndex().Bytes()
+	valueBytes := c.Value.Bytes()
+	parentContractIndex := big.NewInt(int64(c.ParentContractIndex)).Bytes()
+	return common.Hash(crypto.Keccak256(append(gindex, append(valueBytes, parentContractIndex...)...)))
 }
 
 // IsRoot returns true if this claim is the root claim.

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -119,5 +119,5 @@ func (c *Claim) IsRoot() bool {
 // DefendsParent returns true if the the claim is a defense (i.e. goes right) of the
 // parent. It returns false if the claim is an attack (i.e. goes left) of the parent.
 func (c *Claim) DefendsParent() bool {
-	return (c.IndexAtDepth() >> 1) != c.Parent.IndexAtDepth()
+	return c.Position.DefendsParent(c.Parent.IndexAtDepth())
 }

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,4 +109,36 @@ func TestDefendsParent(t *testing.T) {
 			require.Equal(t, test.expected, test.claim.DefendsParent())
 		})
 	}
+}
+
+func TestEntry(t *testing.T) {
+	defaultClaim := Claim{
+		ClaimData: ClaimData{
+			Value:    common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			Position: NewPositionFromGIndex(1),
+		},
+		ParentContractIndex: 2,
+	}
+
+	t.Run("EntriesAreEqual", func(t *testing.T) {
+		require.Equal(t, defaultClaim.Entry(), defaultClaim.Entry())
+	})
+
+	t.Run("DifferentParentContractIndices", func(t *testing.T) {
+		modified := defaultClaim
+		modified.ParentContractIndex = 3
+		require.NotEqual(t, defaultClaim.Entry(), modified.Entry())
+	})
+
+	t.Run("DifferentValues", func(t *testing.T) {
+		modified := defaultClaim
+		modified.Value = common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+		require.NotEqual(t, defaultClaim.Entry(), modified.Entry())
+	})
+
+	t.Run("DifferentPositions", func(t *testing.T) {
+		modified := defaultClaim
+		modified.Position = NewPositionFromGIndex(2)
+		require.NotEqual(t, defaultClaim.Entry(), modified.Entry())
+	})
 }


### PR DESCRIPTION
**Description**

This PR removes the unexported `claimEntry` type by exposing an `Entry` method on the claim,
returning a `common.Hash`. This allows the `Claim` itself to determine it's uniqueness and
abstracts this away from the game state.

This is stacked ontop of #7321 since it changes the `claimEntry` in order to support deep positions.

**Tests**

Unit tests around the `Entry` method, and existing game state tests capture its use.
