### PR TITLE
op-node: remove beta prefix from rollup.load-protocol-versions and rollup.halt flags

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -243,13 +243,13 @@ var (
 			"Available networks: %s", strings.Join(chaincfg.BetaAvailableNetworks(), ", ")),
 		EnvVars: prefixEnvVars("BETA_EXTRA_NETWORKS"),
 	}
-	BetaRollupHalt = &cli.StringFlag{
-		Name:    "beta.rollup.halt",
+	RollupHalt = &cli.StringFlag{
+		Name:    "rollup.halt",
 		Usage:   "Beta feature: opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled onchain in L1",
 		EnvVars: prefixEnvVars("BETA_ROLLUP_HALT"),
 	}
-	BetaRollupLoadProtocolVersions = &cli.BoolFlag{
-		Name:    "beta.rollup.load-protocol-versions",
+	RollupLoadProtocolVersions = &cli.BoolFlag{
+		Name:    "rollup.load-protocol-versions",
 		Usage:   "Beta feature: load protocol versions from the superchain L1 ProtocolVersions contract (if available), and report in logs and metrics",
 		EnvVars: prefixEnvVars("BETA_ROLLUP_LOAD_PROTOCOL_VERSIONS"),
 	}
@@ -300,8 +300,8 @@ var optionalFlags = []cli.Flag{
 	L2EngineSyncEnabled,
 	SkipSyncStartCheck,
 	BetaExtraNetworks,
-	BetaRollupHalt,
-	BetaRollupLoadProtocolVersions,
+	RollupHalt,
+	RollupLoadProtocolVersions,
 	CanyonOverrideFlag,
 }
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -245,12 +245,12 @@ var (
 	}
 	RollupHalt = &cli.StringFlag{
 		Name:    "rollup.halt",
-		Usage:   "Beta feature: opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled onchain in L1",
+		Usage:   "Opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled onchain in L1",
 		EnvVars: prefixEnvVars("BETA_ROLLUP_HALT"),
 	}
 	RollupLoadProtocolVersions = &cli.BoolFlag{
 		Name:    "rollup.load-protocol-versions",
-		Usage:   "Beta feature: load protocol versions from the superchain L1 ProtocolVersions contract (if available), and report in logs and metrics",
+		Usage:   "Load protocol versions from the superchain L1 ProtocolVersions contract (if available), and report in logs and metrics",
 		EnvVars: prefixEnvVars("BETA_ROLLUP_LOAD_PROTOCOL_VERSIONS"),
 	}
 	CanyonOverrideFlag = &cli.Uint64Flag{

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -36,7 +36,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, err
 	}
 
-	if !ctx.Bool(flags.BetaRollupLoadProtocolVersions.Name) {
+	if !ctx.Bool(flags.RollupLoadProtocolVersions.Name) {
 		log.Info("Not opted in to ProtocolVersions signal loading, disabling ProtocolVersions contract now.")
 		rollupConfig.ProtocolVersionsAddress = common.Address{}
 	}
@@ -66,7 +66,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 
 	syncConfig := NewSyncConfig(ctx)
 
-	haltOption := ctx.String(flags.BetaRollupHalt.Name)
+	haltOption := ctx.String(flags.RollupHalt.Name)
 	if haltOption == "none" {
 		haltOption = ""
 	}


### PR DESCRIPTION
**Description**

This functionality is going out of beta, into regular release-candidate and release cycle.
