### PR TITLE
Sequencer fencing endpoint

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -139,6 +139,13 @@ var (
 		Required: false,
 		Value:    4,
 	}
+	SequencerFencingCheckEndpoint = &cli.StringFlag{
+		Name:     "sequencer.fencing-check-endpoint",
+		Usage:    "Optional endpoint that must return 200 when the sequencer should sequence blocks, otherwise return non-200.",
+		EnvVars:  prefixEnvVars("SEQUENCER_FENCING_CHECK_ENDPOINT"),
+		Required: false,
+		Value:    "",
+	}
 	L1EpochPollIntervalFlag = &cli.DurationFlag{
 		Name:     "l1.epoch-poll-interval",
 		Usage:    "Poll interval for retrieving new L1 epoch updates such as safe and finalized block changes. Disabled if 0 or negative.",
@@ -281,6 +288,7 @@ var optionalFlags = []cli.Flag{
 	SequencerStoppedFlag,
 	SequencerMaxSafeLagFlag,
 	SequencerL1Confs,
+	SequencerFencingCheckEndpoint,
 	L1EpochPollIntervalFlag,
 	RuntimeConfigReloadIntervalFlag,
 	RPCEnableAdmin,

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -20,4 +20,10 @@ type Config struct {
 	// SequencerMaxSafeLag is the maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
+
+	// SequencerFencingCheckEndpoint is an optional endpoint that the sequencer can check when producing a new block to ensure
+	// it has the "right" to produce this block. Useful for scenarios where you are running multiple sequencers with an election
+	// protocol and you want to validate that this sequencer is currently the leader.
+	// The sequencer will reach out to this endpoint with an HTTP GET request and should receive a 200.
+	SequencerFencingCheckEndpoint string `json:"sequencer_fencing_check_endpoint"`
 }

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -274,20 +274,20 @@ func (s *Driver) eventLoop() {
 				if err != nil {
 					s.sequencer.CancelBuildingBlock(ctx)
 					s.log.Error("failed to check fencing endpoint, unable to sequence")
-					return
+					continue
 				}
 
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
 					s.sequencer.CancelBuildingBlock(ctx)
 					s.log.Error("failed to check fencing endpoint, unable to sequence")
-					return
+					continue
 				}
 
 				if resp.StatusCode != 200 {
 					s.sequencer.CancelBuildingBlock(ctx)
 					s.log.Error("failed to check fencing endpoint, unable to sequence")
-					return
+					continue
 				}
 
 				s.log.Debug("successfully checked fencing endpoint")

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -176,11 +176,12 @@ func NewConfigPersistence(ctx *cli.Context) node.ConfigPersistence {
 
 func NewDriverConfig(ctx *cli.Context) *driver.Config {
 	return &driver.Config{
-		VerifierConfDepth:   ctx.Uint64(flags.VerifierL1Confs.Name),
-		SequencerConfDepth:  ctx.Uint64(flags.SequencerL1Confs.Name),
-		SequencerEnabled:    ctx.Bool(flags.SequencerEnabledFlag.Name),
-		SequencerStopped:    ctx.Bool(flags.SequencerStoppedFlag.Name),
-		SequencerMaxSafeLag: ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		VerifierConfDepth:             ctx.Uint64(flags.VerifierL1Confs.Name),
+		SequencerConfDepth:            ctx.Uint64(flags.SequencerL1Confs.Name),
+		SequencerEnabled:              ctx.Bool(flags.SequencerEnabledFlag.Name),
+		SequencerStopped:              ctx.Bool(flags.SequencerStoppedFlag.Name),
+		SequencerMaxSafeLag:           ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		SequencerFencingCheckEndpoint: ctx.String(flags.SequencerFencingCheckEndpoint.Name),
 	}
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds an optional fencing endpoint for block production. This provides a more fault-tolerant and consistent way to guarantee there is only one sequencer sequencing blocks at a time if you're running multiple sequencers with a consensus/election protocol.
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
