### PR TITLE
feat(op-challenger): Split Trace Provider

### DIFF
--- a/op-challenger/game/fault/trace/split/provider.go
+++ b/op-challenger/game/fault/trace/split/provider.go
@@ -1,0 +1,78 @@
+package split
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	GetStepDataErr = fmt.Errorf("GetStepData not supported")
+	NoProvidersErr = fmt.Errorf("no trace providers configured")
+)
+
+// todo(refcell): the Get method traceIndex is update to be a Position so we have the depth
+// var _ types.TraceProvider = (*SplitTraceProvider)(nil)
+
+// SplitTraceProvider is a [types.TraceProvider] implementation that
+// routes requests to the correct internal trace provider based on the
+// depth of the requested trace.
+type SplitTraceProvider struct {
+	logger     log.Logger
+	providers  []types.TraceProvider
+	depthTiers []uint64
+}
+
+func NewTraceProvider(logger log.Logger, providers []types.TraceProvider, depthTiers []uint64) *SplitTraceProvider {
+	return &SplitTraceProvider{
+		logger:     logger,
+		providers:  providers,
+		depthTiers: depthTiers,
+	}
+}
+
+func (s *SplitTraceProvider) providerForDepth(depth uint64) types.TraceProvider {
+	for i, tier := range s.depthTiers {
+		if depth <= tier {
+			return s.providers[i]
+		}
+	}
+	return s.providers[len(s.providers)-1]
+}
+
+// Get routes the Get request to the internal [types.TraceProvider] that
+// that serves the trace index at the depth.
+func (s *SplitTraceProvider) Get(ctx context.Context, pos types.Position) (common.Hash, error) {
+	if len(s.providers) == 0 {
+		return common.Hash{}, NoProvidersErr
+	}
+	return s.providerForDepth(uint64(pos.Depth())).Get(ctx, pos.TraceIndex(pos.Depth()))
+}
+
+// AbsolutePreStateCommitment returns the absolute prestate from the lowest internal [types.TraceProvider]
+func (s *SplitTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error) {
+	if len(s.providers) == 0 {
+		return common.Hash{}, NoProvidersErr
+	}
+	return s.providers[len(s.providers)-1].AbsolutePreStateCommitment(ctx)
+}
+
+// AbsolutePreState routes the AbsolutePreState request to the lowest internal [types.TraceProvider].
+func (s *SplitTraceProvider) AbsolutePreState(ctx context.Context) (preimage []byte, err error) {
+	if len(s.providers) == 0 {
+		return nil, NoProvidersErr
+	}
+	return s.providers[len(s.providers)-1].AbsolutePreState(ctx)
+}
+
+// GetStepData routes the GetStepData request to the lowest internal [types.TraceProvider].
+func (s *SplitTraceProvider) GetStepData(ctx context.Context, i uint64) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
+	if len(s.providers) == 0 {
+		return nil, nil, nil, NoProvidersErr
+	}
+	return s.providers[len(s.providers)-1].GetStepData(ctx, i)
+}

--- a/op-challenger/game/fault/trace/split/provider.go
+++ b/op-challenger/game/fault/trace/split/provider.go
@@ -63,10 +63,10 @@ func (s *SplitTraceProvider) AbsolutePreState(ctx context.Context) (preimage []b
 
 // GetStepData routes the GetStepData request to the lowest internal [types.TraceProvider].
 func (s *SplitTraceProvider) GetStepData(ctx context.Context, pos types.Position) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
-	ancestorDepth, _ := s.providerForDepth(uint64(pos.Depth()))
+	ancestorDepth, provider := s.providerForDepth(uint64(pos.Depth()))
 	relativePosition, err := pos.RelativeToAncestorAtDepth(ancestorDepth)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return s.bottomProvider.GetStepData(ctx, relativePosition)
+	return provider.GetStepData(ctx, relativePosition)
 }

--- a/op-challenger/game/fault/trace/split/provider.go
+++ b/op-challenger/game/fault/trace/split/provider.go
@@ -15,8 +15,7 @@ var (
 	NoProvidersErr = fmt.Errorf("no trace providers configured")
 )
 
-// todo(refcell): the Get method traceIndex is update to be a Position so we have the depth
-// var _ types.TraceProvider = (*SplitTraceProvider)(nil)
+var _ types.TraceProvider = (*SplitTraceProvider)(nil)
 
 // SplitTraceProvider is a [types.TraceProvider] implementation that
 // routes requests to the correct internal trace provider based on the
@@ -56,8 +55,7 @@ func (s *SplitTraceProvider) Get(ctx context.Context, pos types.Position) (commo
 	}
 	reduced, provider := s.providerForDepth(uint64(pos.Depth()))
 	localizedPosition := pos.Localize(reduced)
-	// todo(refcell): we should just pass the localized position once `Get` is updated to accept a Position
-	return provider.Get(ctx, localizedPosition.ToGIndex())
+	return provider.Get(ctx, localizedPosition)
 }
 
 // AbsolutePreStateCommitment returns the absolute prestate from the lowest internal [types.TraceProvider]
@@ -77,7 +75,7 @@ func (s *SplitTraceProvider) AbsolutePreState(ctx context.Context) (preimage []b
 }
 
 // GetStepData routes the GetStepData request to the lowest internal [types.TraceProvider].
-func (s *SplitTraceProvider) GetStepData(ctx context.Context, i uint64) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
+func (s *SplitTraceProvider) GetStepData(ctx context.Context, i types.Position) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
 	if len(s.providers) == 0 {
 		return nil, nil, nil, NoProvidersErr
 	}

--- a/op-challenger/game/fault/trace/split/provider_test.go
+++ b/op-challenger/game/fault/trace/split/provider_test.go
@@ -1,0 +1,146 @@
+package split
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockGetError   = fmt.Errorf("mock get error")
+	mockOutput     = common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	mockCommitment = common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+)
+
+func TestGet(t *testing.T) {
+	t.Run("ErrorBubblesUp", func(t *testing.T) {
+		mockOutputProvider := mockTraceProvider{getError: mockGetError}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&mockOutputProvider},
+			depthTiers: []uint64{40, 20},
+		}
+		_, err := splitProvider.Get(context.Background(), types.NewPosition(1, 0))
+		require.ErrorIs(t, err, mockGetError)
+	})
+
+	t.Run("ReturnsCorrectOutput", func(t *testing.T) {
+		mockOutputProvider := mockTraceProvider{getOutput: mockOutput}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&mockOutputProvider},
+			depthTiers: []uint64{40, 20},
+		}
+		output, err := splitProvider.Get(context.Background(), types.NewPosition(1, 0))
+		require.NoError(t, err)
+		require.Equal(t, mockOutput, output)
+	})
+
+	t.Run("ReturnsCorrectOutputWithMultipleProviders", func(t *testing.T) {
+		firstOutputProvider := mockTraceProvider{}
+		secondOutputProvider := mockTraceProvider{getOutput: mockOutput}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&firstOutputProvider, &secondOutputProvider},
+			depthTiers: []uint64{40, 20},
+		}
+		output, err := splitProvider.Get(context.Background(), types.NewPosition(41, 0))
+		require.NoError(t, err)
+		require.Equal(t, mockOutput, output)
+	})
+}
+
+func TestAbsolutePreStateCommitment(t *testing.T) {
+	t.Run("ErrorBubblesUp", func(t *testing.T) {
+		mockOutputProvider := mockTraceProvider{absolutePreStateCommitmentError: mockGetError}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&mockOutputProvider},
+			depthTiers: []uint64{40, 20},
+		}
+		_, err := splitProvider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorIs(t, err, mockGetError)
+	})
+
+	t.Run("ReturnsCorrectOutput", func(t *testing.T) {
+		mockOutputProvider := mockTraceProvider{absolutePreStateCommitment: mockCommitment}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&mockOutputProvider},
+			depthTiers: []uint64{40, 20},
+		}
+		output, err := splitProvider.AbsolutePreStateCommitment(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, mockCommitment, output)
+	})
+}
+
+func TestAbsolutePreState(t *testing.T) {
+	t.Run("ErrorBubblesUp", func(t *testing.T) {
+		mockOutputProvider := mockTraceProvider{absolutePreStateError: mockGetError}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&mockOutputProvider},
+			depthTiers: []uint64{40},
+		}
+		_, err := splitProvider.AbsolutePreState(context.Background())
+		require.ErrorIs(t, err, mockGetError)
+	})
+}
+
+func TestGetStepData(t *testing.T) {
+	t.Run("ErrorBubblesUp", func(t *testing.T) {
+		mockOutputProvider := mockTraceProvider{getStepDataError: mockGetError}
+		splitProvider := SplitTraceProvider{
+			logger:     testlog.Logger(t, log.LvlInfo),
+			providers:  []types.TraceProvider{&mockOutputProvider},
+			depthTiers: []uint64{40},
+		}
+		_, _, _, err := splitProvider.GetStepData(context.Background(), 0)
+		require.ErrorIs(t, err, mockGetError)
+	})
+}
+
+type mockTraceProvider struct {
+	getOutput                       common.Hash
+	getError                        error
+	absolutePreStateCommitmentError error
+	absolutePreStateCommitment      common.Hash
+	absolutePreStateError           error
+	getStepDataError                error
+}
+
+func (m *mockTraceProvider) Get(ctx context.Context, i uint64) (common.Hash, error) {
+	if m.getError != nil {
+		return common.Hash{}, m.getError
+	}
+	return m.getOutput, nil
+}
+
+func (m *mockTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error) {
+	if m.absolutePreStateCommitmentError != nil {
+		return common.Hash{}, m.absolutePreStateCommitmentError
+	}
+	return m.absolutePreStateCommitment, nil
+}
+
+func (m *mockTraceProvider) AbsolutePreState(ctx context.Context) (preimage []byte, err error) {
+	if m.absolutePreStateError != nil {
+		return []byte{}, m.absolutePreStateError
+	}
+	return []byte{}, nil
+}
+
+func (m *mockTraceProvider) GetStepData(ctx context.Context, i uint64) ([]byte, []byte, *types.PreimageOracleData, error) {
+	if m.getStepDataError != nil {
+		return nil, nil, nil, m.getStepDataError
+	}
+	return nil, nil, nil, nil
+}

--- a/op-challenger/game/fault/trace/split/provider_test.go
+++ b/op-challenger/game/fault/trace/split/provider_test.go
@@ -23,9 +23,9 @@ func TestGet(t *testing.T) {
 	t.Run("ErrorBubblesUp", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{getError: mockGetError}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&mockOutputProvider},
-			depthTiers: []uint64{40, 20},
+			logger:      testlog.Logger(t, log.LvlInfo),
+			topProvider: &mockOutputProvider,
+			topDepth:    40,
 		}
 		_, err := splitProvider.Get(context.Background(), types.NewPosition(1, 0))
 		require.ErrorIs(t, err, mockGetError)
@@ -34,9 +34,9 @@ func TestGet(t *testing.T) {
 	t.Run("ReturnsCorrectOutput", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{getOutput: mockOutput}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&mockOutputProvider},
-			depthTiers: []uint64{40, 20},
+			logger:      testlog.Logger(t, log.LvlInfo),
+			topProvider: &mockOutputProvider,
+			topDepth:    40,
 		}
 		output, err := splitProvider.Get(context.Background(), types.NewPosition(6, 3))
 		require.NoError(t, err)
@@ -45,12 +45,13 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("ReturnsCorrectOutputWithMultipleProviders", func(t *testing.T) {
-		firstOutputProvider := mockTraceProvider{}
-		secondOutputProvider := mockTraceProvider{getOutput: mockOutput}
+		topProvider := mockTraceProvider{}
+		bottomProvider := mockTraceProvider{getOutput: mockOutput}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&firstOutputProvider, &secondOutputProvider},
-			depthTiers: []uint64{40, 20},
+			logger:         testlog.Logger(t, log.LvlInfo),
+			topProvider:    &topProvider,
+			bottomProvider: &bottomProvider,
+			topDepth:       40,
 		}
 		output, err := splitProvider.Get(context.Background(), types.NewPosition(42, 17))
 		require.NoError(t, err)
@@ -63,9 +64,9 @@ func TestAbsolutePreStateCommitment(t *testing.T) {
 	t.Run("ErrorBubblesUp", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{absolutePreStateCommitmentError: mockGetError}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&mockOutputProvider},
-			depthTiers: []uint64{40, 20},
+			logger:         testlog.Logger(t, log.LvlInfo),
+			bottomProvider: &mockOutputProvider,
+			topDepth:       40,
 		}
 		_, err := splitProvider.AbsolutePreStateCommitment(context.Background())
 		require.ErrorIs(t, err, mockGetError)
@@ -74,9 +75,9 @@ func TestAbsolutePreStateCommitment(t *testing.T) {
 	t.Run("ReturnsCorrectOutput", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{absolutePreStateCommitment: mockCommitment}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&mockOutputProvider},
-			depthTiers: []uint64{40, 20},
+			logger:         testlog.Logger(t, log.LvlInfo),
+			bottomProvider: &mockOutputProvider,
+			topDepth:       40,
 		}
 		output, err := splitProvider.AbsolutePreStateCommitment(context.Background())
 		require.NoError(t, err)
@@ -88,9 +89,9 @@ func TestAbsolutePreState(t *testing.T) {
 	t.Run("ErrorBubblesUp", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{absolutePreStateError: mockGetError}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&mockOutputProvider},
-			depthTiers: []uint64{40},
+			logger:         testlog.Logger(t, log.LvlInfo),
+			bottomProvider: &mockOutputProvider,
+			topDepth:       40,
 		}
 		_, err := splitProvider.AbsolutePreState(context.Background())
 		require.ErrorIs(t, err, mockGetError)
@@ -101,9 +102,9 @@ func TestGetStepData(t *testing.T) {
 	t.Run("ErrorBubblesUp", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{getStepDataError: mockGetError}
 		splitProvider := SplitTraceProvider{
-			logger:     testlog.Logger(t, log.LvlInfo),
-			providers:  []types.TraceProvider{&mockOutputProvider},
-			depthTiers: []uint64{40},
+			logger:         testlog.Logger(t, log.LvlInfo),
+			bottomProvider: &mockOutputProvider,
+			topDepth:       40,
 		}
 		_, _, _, err := splitProvider.GetStepData(context.Background(), types.NewPosition(0, 0))
 		require.ErrorIs(t, err, mockGetError)

--- a/op-challenger/game/fault/trace/split/provider_test.go
+++ b/op-challenger/game/fault/trace/split/provider_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -105,7 +105,7 @@ func TestGetStepData(t *testing.T) {
 			providers:  []types.TraceProvider{&mockOutputProvider},
 			depthTiers: []uint64{40},
 		}
-		_, _, _, err := splitProvider.GetStepData(context.Background(), 0)
+		_, _, _, err := splitProvider.GetStepData(context.Background(), types.NewPosition(0, 0))
 		require.ErrorIs(t, err, mockGetError)
 	})
 }
@@ -119,11 +119,11 @@ type mockTraceProvider struct {
 	getStepDataError                error
 }
 
-func (m *mockTraceProvider) Get(ctx context.Context, i uint64) (common.Hash, error) {
+func (m *mockTraceProvider) Get(ctx context.Context, pos types.Position) (common.Hash, error) {
 	if m.getError != nil {
 		return common.Hash{}, m.getError
 	}
-	return common.BytesToHash([]byte{byte(i)}), nil
+	return common.BytesToHash([]byte{byte(pos.ToGIndex())}), nil
 }
 
 func (m *mockTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error) {
@@ -140,7 +140,7 @@ func (m *mockTraceProvider) AbsolutePreState(ctx context.Context) (preimage []by
 	return []byte{}, nil
 }
 
-func (m *mockTraceProvider) GetStepData(ctx context.Context, i uint64) ([]byte, []byte, *types.PreimageOracleData, error) {
+func (m *mockTraceProvider) GetStepData(ctx context.Context, pos types.Position) ([]byte, []byte, *types.PreimageOracleData, error) {
 	if m.getStepDataError != nil {
 		return nil, nil, nil, m.getStepDataError
 	}

--- a/op-challenger/game/fault/trace/split/provider_test.go
+++ b/op-challenger/game/fault/trace/split/provider_test.go
@@ -27,7 +27,7 @@ func TestGet(t *testing.T) {
 		require.ErrorIs(t, err, mockGetError)
 	})
 
-	t.Run("ReturnsCorrectOutput", func(t *testing.T) {
+	t.Run("ReturnsCorrectOutputFromTopProvider", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{getOutput: mockOutput}
 		splitProvider := newSplitTraceProvider(t, &mockOutputProvider, &mockTraceProvider{}, 40)
 		output, err := splitProvider.Get(context.Background(), types.NewPosition(6, 3))

--- a/op-challenger/game/fault/trace/split/provider_test.go
+++ b/op-challenger/game/fault/trace/split/provider_test.go
@@ -29,7 +29,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("ReturnsCorrectOutput", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{getOutput: mockOutput}
-		splitProvider := newSplitTraceProvider(t, &mockOutputProvider, nil, 40)
+		splitProvider := newSplitTraceProvider(t, &mockOutputProvider, &mockTraceProvider{}, 40)
 		output, err := splitProvider.Get(context.Background(), types.NewPosition(6, 3))
 		require.NoError(t, err)
 		expectedGIndex := types.NewPosition(6, 3).ToGIndex()

--- a/op-challenger/game/fault/types/position.go
+++ b/op-challenger/game/fault/types/position.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	PositionDepthTooSmall = errors.New("Position depth is too small")
+	ErrPositionDepthTooSmall = errors.New("Position depth is too small")
 )
 
 // Position is a golang wrapper around the dispute game Position type.
@@ -36,7 +36,7 @@ func (p Position) MoveRight() Position {
 // [ancestor] is the depth of the subtree root node.
 func (p Position) RelativeToAncestorAtDepth(ancestor uint64) (Position, error) {
 	if ancestor > uint64(p.depth) {
-		return Position{}, PositionDepthTooSmall
+		return Position{}, ErrPositionDepthTooSmall
 	}
 	newPosDepth := uint64(p.depth) - ancestor
 	nodesAtDepth := 1 << newPosDepth

--- a/op-challenger/game/fault/types/position.go
+++ b/op-challenger/game/fault/types/position.go
@@ -1,6 +1,13 @@
 package types
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	PositionDepthTooSmall = errors.New("Position depth is too small")
+)
 
 // Position is a golang wrapper around the dispute game Position type.
 type Position struct {
@@ -25,13 +32,16 @@ func (p Position) MoveRight() Position {
 	}
 }
 
-// Localize returns a new position for a subtree.
-// reduced is the number of levels to reduce the depth by.
-func (p Position) Localize(reduced uint64) Position {
-	newPosDepth := uint64(p.depth) - reduced
+// RelativeToAncestorAtDepth returns a new position for a subtree.
+// [ancestor] is the depth of the subtree root node.
+func (p Position) RelativeToAncestorAtDepth(ancestor uint64) (Position, error) {
+	if ancestor > uint64(p.depth) {
+		return Position{}, PositionDepthTooSmall
+	}
+	newPosDepth := uint64(p.depth) - ancestor
 	nodesAtDepth := 1 << newPosDepth
 	newIndexAtDepth := p.indexAtDepth % nodesAtDepth
-	return NewPosition(int(newPosDepth), newIndexAtDepth)
+	return NewPosition(int(newPosDepth), newIndexAtDepth), nil
 }
 
 func (p Position) Depth() int {

--- a/op-challenger/game/fault/types/position.go
+++ b/op-challenger/game/fault/types/position.go
@@ -25,6 +25,15 @@ func (p Position) MoveRight() Position {
 	}
 }
 
+// Localize returns a new position for a subtree.
+// reduced is the number of levels to reduce the depth by.
+func (p Position) Localize(reduced uint64) Position {
+	newPosDepth := uint64(p.depth) - reduced
+	nodesAtDepth := 1 << newPosDepth
+	newIndexAtDepth := p.indexAtDepth % nodesAtDepth
+	return NewPosition(int(newPosDepth), newIndexAtDepth)
+}
+
 func (p Position) Depth() int {
 	return p.depth
 }

--- a/op-challenger/game/fault/types/position_test.go
+++ b/op-challenger/game/fault/types/position_test.go
@@ -119,3 +119,19 @@ func TestDefend(t *testing.T) {
 		require.Equalf(t, test.DefendGIndex, result.ToGIndex(), "Defend from GIndex %v", pos.ToGIndex())
 	}
 }
+
+func TestRelativeToAncestorAtDepth(t *testing.T) {
+	t.Run("ErrorsForDeepAncestor", func(t *testing.T) {
+		pos := NewPosition(1, 1)
+		_, err := pos.RelativeToAncestorAtDepth(2)
+		require.ErrorIs(t, err, PositionDepthTooSmall)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		pos := NewPosition(2, 1)
+		expectedRelativePosition := NewPosition(1, 1)
+		relativePosition, err := pos.RelativeToAncestorAtDepth(1)
+		require.NoError(t, err)
+		require.Equal(t, expectedRelativePosition, relativePosition)
+	})
+}

--- a/op-challenger/game/fault/types/position_test.go
+++ b/op-challenger/game/fault/types/position_test.go
@@ -124,7 +124,7 @@ func TestRelativeToAncestorAtDepth(t *testing.T) {
 	t.Run("ErrorsForDeepAncestor", func(t *testing.T) {
 		pos := NewPosition(1, 1)
 		_, err := pos.RelativeToAncestorAtDepth(2)
-		require.ErrorIs(t, err, PositionDepthTooSmall)
+		require.ErrorIs(t, err, ErrPositionDepthTooSmall)
 	})
 
 	t.Run("Success", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Introduces the Split Trace Provider that routes requests to its underlying trace providers
based on the game depth of the positions in the requests.

**Tests**

Unit tests around the split trace provider methods.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/43
