### PR TITLE
Reusable pipeline components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
 jobs:
   cannon-go-lint-and-test:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: medium
     steps:
       - checkout
@@ -92,7 +92,7 @@ jobs:
           path: /tmp/test-results
   cannon-build-test-vectors:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: medium
     steps:
       - checkout
@@ -105,7 +105,7 @@ jobs:
 
   pnpm-monorepo:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -320,7 +320,7 @@ jobs:
 
   contracts-bedrock-coverage:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -345,7 +345,7 @@ jobs:
 
   contracts-bedrock-tests:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -365,7 +365,7 @@ jobs:
 
   contracts-bedrock-checks:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -452,7 +452,7 @@ jobs:
 
   contracts-bedrock-slither:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -465,7 +465,7 @@ jobs:
 
   contracts-bedrock-validate-spaces:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - attach_workspace: { at: "." }
@@ -486,7 +486,7 @@ jobs:
 
   op-bindings-build:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -508,7 +508,7 @@ jobs:
         description: Coverage flag name
         type: string
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -537,7 +537,7 @@ jobs:
 
   contracts-ts-tests:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -559,7 +559,7 @@ jobs:
 
   sdk-next-tests:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -660,7 +660,7 @@ jobs:
 
   fuzz-op-node:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -672,7 +672,7 @@ jobs:
 
   fuzz-op-service:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -684,7 +684,7 @@ jobs:
 
   fuzz-op-chain-ops:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -696,7 +696,7 @@ jobs:
 
   fuzz-cannon:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -708,7 +708,7 @@ jobs:
 
   depcheck:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - attach_workspace: { at: "." }
@@ -751,7 +751,7 @@ jobs:
         description: Go Module Name
         type: string
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest # only used to enable codecov.
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest # only used to enable codecov.
     resource_class: xlarge
     steps:
       - checkout
@@ -779,7 +779,7 @@ jobs:
         description: The make target to execute
         type: string
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -824,7 +824,7 @@ jobs:
         type: string
         default: this-package-does-not-exist
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -852,7 +852,7 @@ jobs:
 
   indexer-tests:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
       - image: cimg/postgres:14.1
     resource_class: large
     steps:
@@ -1039,7 +1039,7 @@ jobs:
 
   go-mod-tidy:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - run:
@@ -1070,7 +1070,7 @@ jobs:
 
   check-generated-mocks-op-node:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -1081,7 +1081,7 @@ jobs:
 
   check-generated-mocks-op-service:
     docker:
-      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/ci-builder:latest
     steps:
       - checkout
       - check-changed:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ commands:
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
     parameters:
-      project_id:
+      project_number:
         type: env_var_name
-        default: GCP_PROJECT_ID
+        default: GCP_PROJECT_NUMBER
       workload_identity_pool_id:
         type: env_var_name
         default: GCP_WIP_ID
@@ -34,7 +34,7 @@ commands:
             echo $CIRCLE_OIDC_TOKEN > << parameters.oidc_token_file_path >>
             # Create a credential configuration for the generated OIDC ID Token
             gcloud iam workload-identity-pools create-cred-config \
-                "projects/${<< parameters.project_id >>}/locations/global/workloadIdentityPools/${<< parameters.workload_identity_pool_id >>}/providers/${<< parameters.workload_identity_pool_provider_id >>}"\
+                "projects/${<< parameters.project_number >>}/locations/global/workloadIdentityPools/${<< parameters.workload_identity_pool_id >>}/providers/${<< parameters.workload_identity_pool_provider_id >>}"\
                 --output-file="<< parameters.gcp_cred_config_file_path >>" \
                 --service-account="${<< parameters.service_account_email >>}" \
                 --credential-source-file=<< parameters.oidc_token_file_path >>
@@ -61,7 +61,7 @@ commands:
 jobs:
   cannon-go-lint-and-test:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: medium
     steps:
       - checkout
@@ -92,7 +92,7 @@ jobs:
           path: /tmp/test-results
   cannon-build-test-vectors:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: medium
     steps:
       - checkout
@@ -105,7 +105,7 @@ jobs:
 
   pnpm-monorepo:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -167,7 +167,7 @@ jobs:
       repo:
         description: Docker repo
         type: string
-        default: "oplabs-tools-artifacts/images"
+        default: "${GCP_ARTIFACT_REPOSITORY}/images"
     machine:
       image: ubuntu-2204:2022.07.1
       resource_class: medium
@@ -183,7 +183,7 @@ jobs:
             if [[ -v DOCKER_HUB_READ_ONLY_TOKEN ]]; then
               echo "$DOCKER_HUB_READ_ONLY_TOKEN" | docker login -u "$DOCKER_HUB_READ_ONLY_USER" --password-stdin
             fi
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
+            IMAGE_BASE="<<parameters.registry>>/${GCP_PROJECT_ID}/<<parameters.repo>>/<<parameters.docker_name>>"
             DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
             docker build --progress plain \
             $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
@@ -228,7 +228,7 @@ jobs:
       repo:
         description: Docker repo
         type: string
-        default: "oplabs-tools-artifacts/images"
+        default: "${GCP_ARTIFACT_REPOSITORY}/images"
       platforms:
         description: Platforms to build for
         type: string
@@ -250,7 +250,7 @@ jobs:
           name: Build & Publish
           command: |
             gcloud auth configure-docker <<parameters.registry>>
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
+            IMAGE_BASE="<<parameters.registry>>/${GCP_PROJECT_ID}/<<parameters.repo>>/<<parameters.docker_name>>"
             DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
             docker context create buildx-build
             docker buildx create --use buildx-build
@@ -286,7 +286,7 @@ jobs:
       repo:
         description: Docker repo
         type: string
-        default: "oplabs-tools-artifacts/images"
+        default: "${GCP_ARTIFACT_REPOSITORY}/images"
       platforms:
         description: Platforms to build for
         type: string
@@ -305,7 +305,7 @@ jobs:
       - run:
           name: Build & Publish
           command: |
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
+            IMAGE_BASE="<<parameters.registry>>/${GCP_PROJECT_ID}/<<parameters.repo>>/<<parameters.docker_name>>"
             DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
             docker context create buildx-build
             docker buildx create --use buildx-build
@@ -316,11 +316,11 @@ jobs:
       - run:
           name: Tag
           command: |
-            ./ops/scripts/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
+            ./ops/scripts/ci-docker-tag-op-stack-release.sh <<parameters.registry>>/${GCP_PROJECT_ID}/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
 
   contracts-bedrock-coverage:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -345,7 +345,7 @@ jobs:
 
   contracts-bedrock-tests:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -365,7 +365,7 @@ jobs:
 
   contracts-bedrock-checks:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -452,7 +452,7 @@ jobs:
 
   contracts-bedrock-slither:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -465,7 +465,7 @@ jobs:
 
   contracts-bedrock-validate-spaces:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - attach_workspace: { at: "." }
@@ -486,7 +486,7 @@ jobs:
 
   op-bindings-build:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -508,7 +508,7 @@ jobs:
         description: Coverage flag name
         type: string
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -537,7 +537,7 @@ jobs:
 
   contracts-ts-tests:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -559,7 +559,7 @@ jobs:
 
   sdk-next-tests:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: large
     steps:
       - checkout
@@ -660,7 +660,7 @@ jobs:
 
   fuzz-op-node:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -672,7 +672,7 @@ jobs:
 
   fuzz-op-service:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -684,7 +684,7 @@ jobs:
 
   fuzz-op-chain-ops:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -696,7 +696,7 @@ jobs:
 
   fuzz-cannon:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -708,7 +708,7 @@ jobs:
 
   depcheck:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - attach_workspace: { at: "." }
@@ -751,7 +751,7 @@ jobs:
         description: Go Module Name
         type: string
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest # only used to enable codecov.
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest # only used to enable codecov.
     resource_class: xlarge
     steps:
       - checkout
@@ -779,7 +779,7 @@ jobs:
         description: The make target to execute
         type: string
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     resource_class: xlarge
     steps:
       - checkout
@@ -824,7 +824,7 @@ jobs:
         type: string
         default: this-package-does-not-exist
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -852,7 +852,7 @@ jobs:
 
   indexer-tests:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
       - image: cimg/postgres:14.1
     resource_class: large
     steps:
@@ -1039,7 +1039,7 @@ jobs:
 
   go-mod-tidy:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - run:
@@ -1070,7 +1070,7 @@ jobs:
 
   check-generated-mocks-op-node:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
@@ -1081,7 +1081,7 @@ jobs:
 
   check-generated-mocks-op-service:
     docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+      - image: us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 GCP_ARTIFACT_REPOSITORY=oplabs-tools-artifacts
 GCP_PROJECT_ID=<>
-REPO=ethereumoptimism/optimism
+REPO=ethereum-optimism/optimism

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+GCP_ARTIFACT_REPOSITORY=oplabs-tools-artifacts
+GCP_PROJECT_ID=<>
+REPO=ethereumoptimism/optimism

--- a/.github/workflows/release-docker-canary.yml
+++ b/.github/workflows/release-docker-canary.yml
@@ -8,6 +8,8 @@ on:
         description: 'Custom Docker Image Tag (keep empty for git hash)'
         required: false
         default: '0.0.0-rc-0'
+env:
+  ORG: ethereumoptimism
 
 jobs:
   canary-publish:
@@ -68,7 +70,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: fault-mon
           push: true
-          tags: ethereumoptimism/fault-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/fault-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   balance-mon:
     name: Publish Balance Monitor Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
@@ -95,7 +100,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: balance-mon
           push: true
-          tags: ethereumoptimism/balance-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/balance-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   drippie-mon:
     name: Publish Drippie Monitor Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
@@ -122,7 +130,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: drippie-mon
           push: true
-          tags: ethereumoptimism/drippie-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/drippie-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   wd-mon:
     name: Publish Withdrawal Monitor Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
@@ -149,7 +160,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: wd-mon
           push: true
-          tags: ethereumoptimism/wd-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/wd-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   replica-mon:
     name: Publish replica-mon Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
@@ -176,7 +190,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: replica-mon
           push: true
-          tags: ethereumoptimism/replica-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/replica-mon:${{ needs.canary-publish.outputs.canary-docker-tag }}
 
   op-exporter:
     name: Publish op-exporter Version ${{ needs.canary-publish.outputs.canary-docker-tag }}
@@ -209,7 +226,7 @@ jobs:
           context: .
           file: ./op-exporter/Dockerfile=
           push: true
-          tags: ethereumoptimism/op-exporter:${{ needs.canary-publish.outputs.op-exporter }}
+          tags: ${{ env.ORG }}/op-exporter:${{ needs.canary-publish.outputs.op-exporter }}
           build-args: |
             GITDATE=${{ steps.build_args.outputs.GITDATE }}
             GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}
@@ -247,7 +264,7 @@ jobs:
           context: .
           file: ./endpoint-monitor/Dockerfile
           push: true
-          tags: ethereumoptimism/endpoint-monitor:${{ needs.canary-publish.outputs.endpoint-monitor }}
+          tags: ${{ env.ORG }}/endpoint-monitor:${{ needs.canary-publish.outputs.endpoint-monitor }}
           build-args: |
             GITDATE=${{ steps.build_args.outputs.GITDATE }}
             GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   snapshot-snapshot:
     name: Publish snapshot release to npm
-    if: github.repository == 'ethereum-optimism/optimism'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +19,16 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-
+      - name: Set current project env vars
+        run: cat .env >> $GITHUB_ENV
+      - name: Check current repo
+        run: |
+          if [ '${{github.repository}}' == ${{ env.REPO }} ]
+          then
+              exit 0
+          else
+              exit 1
+          fi
       - name: Setup
         uses: ./.github/actions/setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.repository == 'ethereum-optimism/optimism'
     # map the step outputs to job outputs
     outputs:
       fault-mon: ${{ steps.packages.outputs.fault-mon }}
@@ -37,7 +36,16 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           ref: "develop"
-
+      - name: Set current project env vars
+        run: cat .env >> $GITHUB_ENV
+      - name: Check current repo
+        run: |
+          if [ '${{github.repository}}' == ${{ env.REPO }} ]
+          then
+              exit 0
+          else
+              exit 1
+          fi
       - name: Setup
         uses: ./.github/actions/setup
 
@@ -99,7 +107,7 @@ jobs:
           context: .
           file: ./op-exporter/Dockerfile
           push: true
-          tags: ethereumoptimism/op-exporter:${{ needs.release.outputs.op-exporter }},ethereumoptimism/op-exporter:latest
+          tags: ${{ env.ORG }}/op-exporter:${{ needs.release.outputs.op-exporter }},${{ env.ORG }}/op-exporter:latest
           build-args: |
             GITDATE=${{ steps.build_args.outputs.GITDATE }}
             GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}
@@ -130,7 +138,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: fault-mon
           push: true
-          tags: ethereumoptimism/fault-mon:${{ needs.release.outputs.fault-mon }},ethereumoptimism/fault-mon:latest
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/fault-mon:${{ needs.release.outputs.fault-mon }},${{ env.ORG }}/fault-mon:latest
 
   wd-mon:
     name: Publish Withdrawal Monitor Version ${{ needs.release.outputs.wd-mon }}
@@ -157,7 +168,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: wd-mon
           push: true
-          tags: ethereumoptimism/wd-mon:${{ needs.release.outputs.wd-mon }},ethereumoptimism/wd-mon:latest
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/wd-mon:${{ needs.release.outputs.wd-mon }},${{ env.ORG }}/wd-mon:latest
 
   balance-mon:
     name: Publish Balance Monitor Version ${{ needs.release.outputs.balance-mon }}
@@ -184,7 +198,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: balance-mon
           push: true
-          tags: ethereumoptimism/balance-mon:${{ needs.release.outputs.balance-mon }},ethereumoptimism/balance-mon:latest
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/balance-mon:${{ needs.release.outputs.balance-mon }},${{ env.ORG }}/balance-mon:latest
 
   drippie-mon:
     name: Publish Drippie Monitor Version ${{ needs.release.outputs.drippie-mon }}
@@ -211,7 +228,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: drippie-mon
           push: true
-          tags: ethereumoptimism/drippie-mon:${{ needs.release.outputs.drippie-mon }},ethereumoptimism/drippie-mon:latest
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/drippie-mon:${{ needs.release.outputs.drippie-mon }},${{ env.ORG }}/drippie-mon:latest
 
   replica-mon:
     name: Publish Replica Healthcheck Version ${{ needs.release.outputs.replica-mon }}
@@ -238,7 +258,10 @@ jobs:
           file: ./ops/docker/Dockerfile.packages
           target: replica-mon
           push: true
-          tags: ethereumoptimism/replica-mon:${{ needs.release.outputs.replica-mon }},ethereumoptimism/replica-mon:latest
+          build-args:
+            - ${{ env.GCP_ARTIFACT_REPOSITORY }}
+            - ${{ env.GCP_PROJECT_ID }}
+          tags: ${{ env.ORG }}/replica-mon:${{ needs.release.outputs.replica-mon }},${{ env.ORG }}/replica-mon:latest
 
   endpoint-monitor:
     name: Publish endpoint-monitor Version ${{ needs.release.outputs.endpoint-monitor}}
@@ -271,7 +294,7 @@ jobs:
           context: .
           file: ./endpoint-monitor/Dockerfile
           push: true
-          tags: ethereumoptimism/endpoint-monitor:${{ needs.release.outputs.endpoint-monitor }},ethereumoptimism/endpoint-monitor:latest
+          tags: ${{ env.ORG }}/endpoint-monitor:${{ needs.release.outputs.endpoint-monitor }},${{ env.ORG }}/endpoint-monitor:latest
           build-args: |
             GITDATE=${{ steps.build_args.outputs.GITDATE }}
             GITCOMMIT=${{ steps.build_args.outputs.GITCOMMIT }}

--- a/ops-bedrock/Dockerfile.l2
+++ b/ops-bedrock/Dockerfile.l2
@@ -1,4 +1,6 @@
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:optimism
+ARG GCP_PROJECT_ID
+ARG GCP_ARTIFACT_REPOSITORY
+FROM us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/op-geth:optimism
 
 RUN apk add --no-cache jq
 

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -28,6 +28,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.l2
+      args:
+         - GCP_PROJECT_ID=${GCP_PROJECT_ID:-populate-manually}
+         - GCP_ARTIFACT_REPOSITORY=${GCP_ARTIFACT_REPOSITORY:-oplabs-tools-artifacts}
     ports:
       - "9545:8545"
       - "8060:6060"
@@ -47,6 +50,9 @@ services:
     build:
       context: ../
       dockerfile: ./op-node/Dockerfile
+      args:
+         - GCP_PROJECT_ID=${GCP_PROJECT_ID:-populate-manually}
+         - GCP_ARTIFACT_REPOSITORY=${GCP_ARTIFACT_REPOSITORY:-oplabs-tools-artifacts}
     command: >
       op-node
       --l1=ws://l1:8546

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -1,7 +1,8 @@
 # This Dockerfile builds all the dependencies needed by the monorepo, and should
 # be used to build any of the follow-on services
 #
-
+ARG GCP_PROJECT_ID
+ARG GCP_ARTIFACT_REPOSITORY
 # Stage 0 (named `manifests`) collects
 # dependency manifest files (`package.json` and `pnpm-lock.yaml`) which are then
 # used by stage 1 to install these dependencies
@@ -30,7 +31,7 @@ RUN mkdir manifests && \
   # .nvmrc
   cp .nvmrc ../manifests/
 
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest as foundry
+FROM us-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_ARTIFACT_REPOSITORY}/images/ci-builder:latest as foundry
 # bullseye-slim is debian based
 # we use it rather than alpine because it's not much
 # bigger and alpine is often missing packages for node applications


### PR DESCRIPTION
**Description**
This is a response to issue:
https://github.com/ethereum-optimism/optimism/issues/7075
and comment:
https://github.com/ethereum-optimism/optimism/pull/7049#issuecomment-1699839373

It includes the necessery work to migrate away from deprecated Container Registry to Artifact Registry:
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr

**Tests**

/

**Additional context**

Parameterizing the testing/image building/release pipeline that allows organizations outside of Optimisms to utilize the same pipeline flow in a forked or cloned repository. The simple explanation is that forks that work on the same codebase and pull upstream changes want to have as little conflicts as possible. 

To make this PR successful I would need the cirleCI env to be updated with 
```
GCP_ARTIFACT_REPOSITORY=oplabs-tools-artifacts
GCP_PROJECT_ID=<provide value>
```

Organizations outside of Optimism need a functioning GCP account with enabled APIs and Artifact Registry.
Link Cirleci and GCP via https://circleci.com/docs/openid-connect-tokens/ 

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/7075
