### PR TITLE
fix: Remove unused contexts

### DIFF
--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -95,14 +95,14 @@ func (r *FaultResponder) Resolve(ctx context.Context) error {
 }
 
 // buildResolveClaimData creates the transaction data for the ResolveClaim function.
-func (r *FaultResponder) buildResolveClaimData(ctx context.Context, claimIdx uint64) ([]byte, error) {
+func (r *FaultResponder) buildResolveClaimData(claimIdx uint64) ([]byte, error) {
 	return r.fdgAbi.Pack("resolveClaim", big.NewInt(int64(claimIdx)))
 }
 
 // CallResolveClaim determines if the resolveClaim function on the fault dispute game contract
 // would succeed.
 func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
-	txData, err := r.buildResolveClaimData(ctx, claimIdx)
+	txData, err := r.buildResolveClaimData(claimIdx)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (r *FaultResponder) CallResolveClaim(ctx context.Context, claimIdx uint64) 
 
 // ResolveClaim executes a resolveClaim transaction to resolve a fault dispute game.
 func (r *FaultResponder) ResolveClaim(ctx context.Context, claimIdx uint64) error {
-	txData, err := r.buildResolveClaimData(ctx, claimIdx)
+	txData, err := r.buildResolveClaimData(claimIdx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Descriptions**

Removes unused context parameters in some responder methods.
