### PR TITLE
feat(op-challenger): Responder bond values

### DIFF
--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
@@ -50,8 +51,11 @@ func NewGamePlayer(
 		return nil, fmt.Errorf("failed to bind the fault dispute game contract: %w", err)
 	}
 
-	loader := NewLoader(contract)
+	// todo: get bond amount from the fdg contract once the bindings are updated.
+	// bondAmount, err := bindings.FaultDisputeGameMetaData.Bond(nil)
+	bondAmount := big.NewInt(0)
 
+	loader := NewLoader(contract)
 	status, err := loader.GetGameStatus(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch game status: %w", err)
@@ -100,7 +104,7 @@ func NewGamePlayer(
 		return nil, fmt.Errorf("failed to validate absolute prestate: %w", err)
 	}
 
-	responder, err := responder.NewFaultResponder(logger, txMgr, addr)
+	responder, err := responder.NewFaultResponder(logger, txMgr, addr, bondAmount)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the responder: %w", err)
 	}

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -91,7 +91,7 @@ func (r *FaultResponder) Resolve(ctx context.Context) error {
 		return err
 	}
 
-	return r.sendTxAndWait(ctx, txData)
+	return r.sendTxAndWait(ctx, txData, big.NewInt(0))
 }
 
 // buildResolveClaimData creates the transaction data for the ResolveClaim function.
@@ -119,12 +119,13 @@ func (r *FaultResponder) ResolveClaim(ctx context.Context, claimIdx uint64) erro
 	if err != nil {
 		return err
 	}
-	return r.sendTxAndWait(ctx, txData)
+	return r.sendTxAndWait(ctx, txData, big.NewInt(0))
 }
 
 func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action) error {
 	var txData []byte
 	var err error
+	bond := big.NewInt(0)
 	switch action.Type {
 	case types.ActionTypeMove:
 		if action.IsAttack {
@@ -138,16 +139,17 @@ func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action)
 	if err != nil {
 		return err
 	}
-	return r.sendTxAndWait(ctx, txData)
+	return r.sendTxAndWait(ctx, txData, bond)
 }
 
 // sendTxAndWait sends a transaction through the [txmgr] and waits for a receipt.
 // This sets the tx GasLimit to 0, performing gas estimation online through the [txmgr].
-func (r *FaultResponder) sendTxAndWait(ctx context.Context, txData []byte) error {
+func (r *FaultResponder) sendTxAndWait(ctx context.Context, txData []byte, bond *big.Int) error {
 	receipt, err := r.txMgr.Send(ctx, txmgr.TxCandidate{
 		To:       &r.fdgAddr,
 		TxData:   txData,
 		GasLimit: 0,
+		Value:    bond,
 	})
 	if err != nil {
 		return err

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -70,6 +70,7 @@ func TestResolve(t *testing.T) {
 		err := responder.Resolve(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, 1, mockTxMgr.sends)
+		require.Equal(t, big.NewInt(0), mockTxMgr.sent[0].Value)
 	})
 }
 
@@ -104,6 +105,7 @@ func TestResolveClaim(t *testing.T) {
 		err := responder.ResolveClaim(context.Background(), 0)
 		require.NoError(t, err)
 		require.Equal(t, 1, mockTxMgr.sends)
+		require.Equal(t, big.NewInt(0), mockTxMgr.sent[0].Value)
 	})
 }
 
@@ -153,6 +155,7 @@ func TestPerformAction(t *testing.T) {
 
 		require.Len(t, mockTxMgr.sent, 1)
 		require.Equal(t, expected, mockTxMgr.sent[0].TxData)
+		require.Equal(t, big.NewInt(0), mockTxMgr.sent[0].Value)
 	})
 
 	t.Run("attack with bond", func(t *testing.T) {
@@ -197,6 +200,7 @@ func TestPerformAction(t *testing.T) {
 
 		require.Len(t, mockTxMgr.sent, 1)
 		require.Equal(t, expected, mockTxMgr.sent[0].TxData)
+		require.Equal(t, big.NewInt(0), mockTxMgr.sent[0].Value)
 	})
 
 	t.Run("defend with bond", func(t *testing.T) {
@@ -242,6 +246,7 @@ func TestPerformAction(t *testing.T) {
 
 		require.Len(t, mockTxMgr.sent, 1)
 		require.Equal(t, expected, mockTxMgr.sent[0].TxData)
+		require.Nil(t, mockTxMgr.sent[0].Value)
 	})
 }
 


### PR DESCRIPTION
**Description**

Introduces minimal bonds to the challenger's responder component.

The bond should be fetched from the fault dispute game contract once the bindings are updated. For now, we just set the value to zero.

**Tests**

Unit tests are added to the responder to check that a `TxCandidate` is produced with the `Value` set to the bond amount when a move is performed. Other tests are updated to ensure that the `TxCandidate` has a `Value` of zero otherwise.
