### PR TITLE
[4844] remove duplicate initRuntimeConfig call

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -96,9 +96,6 @@ func (n *OpNode) init(ctx context.Context, cfg *Config, snapshotLog log.Logger) 
 	if err := n.initL1BeaconAPI(ctx, cfg); err != nil {
 		return err
 	}
-	if err := n.initRuntimeConfig(ctx, cfg); err != nil {
-		return fmt.Errorf("failed to init the runtime config: %w", err)
-	}
 	if err := n.initL2(ctx, cfg, snapshotLog); err != nil {
 		return fmt.Errorf("failed to init L2: %w", err)
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

initRuntimeConfig code ended up duplicated, probably from one of the rebases, which was causing the e2e test to fail