### PR TITLE
contracts-bedrock: fix text coloring bug

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -97,7 +97,7 @@ contract Deploy is Deployer {
     ///         Using this helps to reduce config across networks as the implementation
     ///         addresses will be the same across networks when deployed with create2.
     function implSalt() public returns (bytes32) {
-        return keccak256(bytes(vm.envOr("IMPL_SALT", string("ether's phoenix"))));
+        return keccak256(bytes(vm.envOr("IMPL_SALT", string("ethers phoenix"))));
     }
 
     /// @notice Modifier that wraps a function in broadcasting.


### PR DESCRIPTION
**Description**

Github seems to have issues with whatever library they are using to apply colors to the code for solidity code. The `'` triggers it to think that it is in a string when it is not actually in a string because the `'` is wrapped within two `"`. Just delete the `'` to fix this issue. The create2 salt is already not completely standard but it should become standard when we finally have tooling to easily add a chain to the superchain through the deploy script, this entrypoint would deploy the proxies and initialize them to the standard implementations.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

