### PR TITLE
Revert: Claim Count Metrics

### DIFF
--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -30,7 +30,6 @@ type ClaimLoader interface {
 
 type Agent struct {
 	metrics                 metrics.Metricer
-	fdgAddr                 common.Address
 	solver                  *solver.GameSolver
 	loader                  ClaimLoader
 	responder               Responder
@@ -40,10 +39,9 @@ type Agent struct {
 	log                     log.Logger
 }
 
-func NewAgent(m metrics.Metricer, addr common.Address, loader ClaimLoader, maxDepth int, trace types.TraceProvider, responder Responder, updater types.OracleUpdater, agreeWithProposedOutput bool, log log.Logger) *Agent {
+func NewAgent(m metrics.Metricer, loader ClaimLoader, maxDepth int, trace types.TraceProvider, responder Responder, updater types.OracleUpdater, agreeWithProposedOutput bool, log log.Logger) *Agent {
 	return &Agent{
 		metrics:                 m,
-		fdgAddr:                 addr,
 		solver:                  solver.NewGameSolver(maxDepth, trace),
 		loader:                  loader,
 		responder:               responder,
@@ -198,7 +196,6 @@ func (a *Agent) newGameFromContracts(ctx context.Context) (types.Game, error) {
 	if len(claims) == 0 {
 		return nil, errors.New("no claims")
 	}
-	a.metrics.RecordGameClaimCount(a.fdgAddr.String(), len(claims))
 	game := types.NewGameState(a.agreeWithProposedOutput, claims[0], uint64(a.maxDepth))
 	if err := game.PutAll(claims[1:]); err != nil {
 		return nil, fmt.Errorf("failed to load claims into the local state: %w", err)

--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -10,11 +10,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
-	"github.com/ethereum-optimism/optimism/op-node/testlog"
-
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
 )
 
 // TestShouldResolve tests the resolution logic.
@@ -111,12 +110,11 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 func setupTestAgent(t *testing.T, agreeWithProposedOutput bool) (*Agent, *stubClaimLoader, *stubResponder) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	claimLoader := &stubClaimLoader{}
-	addr := common.HexToAddress("0x1234")
 	depth := 4
 	trace := alphabet.NewTraceProvider("abcd", uint64(depth))
 	responder := &stubResponder{}
 	updater := &stubUpdater{}
-	agent := NewAgent(metrics.NoopMetrics, addr, claimLoader, depth, trace, responder, updater, agreeWithProposedOutput, logger)
+	agent := NewAgent(metrics.NoopMetrics, claimLoader, depth, trace, responder, updater, agreeWithProposedOutput, logger)
 	return agent, claimLoader, responder
 }
 

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -106,7 +106,7 @@ func NewGamePlayer(
 	}
 
 	return &GamePlayer{
-		act:                     NewAgent(m, addr, loader, int(gameDepth), provider, responder, updater, cfg.AgreeWithProposedOutput, logger).Act,
+		act:                     NewAgent(m, loader, int(gameDepth), provider, responder, updater, cfg.AgreeWithProposedOutput, logger).Act,
 		agreeWithProposedOutput: cfg.AgreeWithProposedOutput,
 		loader:                  loader,
 		logger:                  logger,

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -25,8 +25,6 @@ type Metricer interface {
 	RecordGameMove()
 	RecordCannonExecutionTime(t float64)
 
-	RecordGameClaimCount(addr string, count int)
-
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 
 	RecordGameUpdateScheduled()
@@ -54,8 +52,6 @@ type Metrics struct {
 	steps prometheus.Counter
 
 	cannonExecutionTime prometheus.Histogram
-
-	gameClaimCount prometheus.GaugeVec
 
 	trackedGames  prometheus.GaugeVec
 	inflightGames prometheus.Gauge
@@ -110,13 +106,6 @@ func NewMetrics() *Metrics {
 			Buckets: append(
 				[]float64{1.0, 10.0},
 				prometheus.ExponentialBuckets(30.0, 2.0, 14)...),
-		}),
-		gameClaimCount: *factory.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: Namespace,
-			Name:      "game_claim_count",
-			Help:      "Number of claims in the game",
-		}, []string{
-			"game_address",
 		}),
 		trackedGames: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -188,10 +177,6 @@ func (m *Metrics) IncIdleExecutors() {
 
 func (m *Metrics) DecIdleExecutors() {
 	m.executors.WithLabelValues("idle").Dec()
-}
-
-func (m *Metrics) RecordGameClaimCount(addr string, count int) {
-	m.gameClaimCount.With(prometheus.Labels{"game_address": addr}).Set(float64(count))
 }
 
 func (m *Metrics) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -27,5 +27,3 @@ func (*NoopMetricsImpl) IncActiveExecutors() {}
 func (*NoopMetricsImpl) DecActiveExecutors() {}
 func (*NoopMetricsImpl) IncIdleExecutors()   {}
 func (*NoopMetricsImpl) DecIdleExecutors()   {}
-
-func (*NoopMetricsImpl) RecordGameClaimCount(addr string, count int) {}


### PR DESCRIPTION
**Description**

Reverts https://github.com/ethereum-optimism/optimism/pull/7264/ because the new game claim count metric uses an unbounded label value (the game address). This will create a new prometheus time series for every game the challenger touches. This is explicitly recommended against by prometheus: https://prometheus.io/docs/practices/naming/#labels

This reverts commit eb76a0db06214985940265e4a2fae6da91436fce, reversing changes made to b15e3ffea35eb877a13910dececa84e40ca4b9a3.