### PR TITLE
cleanup: delete lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,0 @@
-{
-  "npmClient": "pnpm",
-  "useWorkspaces": true,
-  "version": "independent",
-  "packages": [
-    "packages/*"
-  ]
-}


### PR DESCRIPTION
**Description**

There are no other references to lerna in the repository, this is leftover from when lerna was used. We now use pnpm. This commit deletes `lerna.json` at the root of the repo.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
