### PR TITLE
allow release pipeline for hearbeat service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1381,6 +1381,22 @@ workflows:
             branches:
               ignore: /.*/
       - docker-release:
+           name: op-heartbeat-release
+           filters:
+             tags:
+               only: /^op-heartbeat\/v.*/
+             branches:
+               ignore: /.*/
+           docker_file: op-heartbeat/Dockerfile
+           docker_name: op-heartbeat
+           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+           docker_context: .
+           platforms: "linux/amd64,linux/arm64"
+           context:
+             - oplabs-gcr-release
+           requires:
+             - hold
+      - docker-release:
           name: op-node-docker-release
           filters:
             tags:

--- a/.github/workflows/tag-service.yml
+++ b/.github/workflows/tag-service.yml
@@ -20,6 +20,7 @@ on:
         options:
           - ci-builder
           - indexer
+          - op-heartbeat
           - chain-mon
           - op-node
           - op-batcher

--- a/ops/tag-service/tag-service.py
+++ b/ops/tag-service/tag-service.py
@@ -17,7 +17,8 @@ MIN_VERSIONS = {
     'op-challenger': '0.0.4',
     'op-proposer': '0.10.14',
     'op-ufm': '0.1.0',
-    'proxyd': '3.16.0'
+    'proxyd': '3.16.0',
+    'op-heartbeat': '0.1.0'
 }
 
 VALID_BUMPS = ('major', 'minor', 'patch', 'prerelease', 'finalize-prerelease')


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I could not find a way to properly release op-heartbeat through the standard route (gh actions tag that spawns a Cirleci build).
**Tests**

We're using this in Bobanetwork as of yesterday.

**Additional context**

/

**Metadata**

/
