### PR TITLE
update 4844 code to be compatible with latest beacon node api

### DIFF
--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -134,7 +134,7 @@ func (f *fakePoS) Start() error {
 						f.log.Error("got malformed kzg commitment from engine", "commitment", commitment)
 						break
 					}
-					blobHashes = append(blobHashes, opeth.KzgToVersionedHash(*(*[48]byte)(commitment)))
+					blobHashes = append(blobHashes, opeth.KZGToVersionedHash(*(*[48]byte)(commitment)))
 				}
 				if len(blobHashes) != len(envelope.BlobsBundle.Commitments) {
 					f.log.Error("invalid or incomplete blob data", "collected", len(blobHashes), "engine", len(envelope.BlobsBundle.Commitments))

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -260,7 +260,7 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 				return nil, fmt.Errorf("cannot compute KZG proof for fast commitment verification of blob %d in tx candidate: %w", i, err)
 			}
 			sidecar.Proofs = append(sidecar.Proofs, proof)
-			blobHashes = append(blobHashes, eth.KzgToVersionedHash(commitment))
+			blobHashes = append(blobHashes, eth.KZGToVersionedHash(eth.Bytes48(commitment)))
 		}
 		log.Info("crafted blob tx sidecar")
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- Updates the code to support the latest [4844 beacon node api](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobSidecars); for example we can now fetch individual blobs by index rather than having to fetch all blobs in the block.

- Change blob verification to verify against the proof rather than recomputing the commitment.

**Tests**

Confirmed e2e 4844 test still passes.