### PR TITLE
op-challenger: Include game address in error message instead of listing all games

### DIFF
--- a/op-challenger/game/scheduler/coordinator.go
+++ b/op-challenger/game/scheduler/coordinator.go
@@ -62,7 +62,7 @@ func (c *coordinator) schedule(ctx context.Context, games []common.Address) erro
 	// data directories potentially being deleted for games that are required.
 	for _, addr := range games {
 		if j, err := c.createJob(addr); err != nil {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("failed to create job for game %v: %w", addr, err))
 		} else if j != nil {
 			jobs = append(jobs, *j)
 			c.m.RecordGameUpdateScheduled()
@@ -85,7 +85,9 @@ func (c *coordinator) schedule(ctx context.Context, games []common.Address) erro
 
 	// Finally, enqueue the jobs
 	for _, j := range jobs {
-		errs = append(errs, c.enqueueJob(ctx, j))
+		if err := c.enqueueJob(ctx, j); err != nil {
+			errs = append(errs, fmt.Errorf("failed to enqueue job for game %v: %w", j.addr, err))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/op-challenger/game/scheduler/scheduler.go
+++ b/op-challenger/game/scheduler/scheduler.go
@@ -101,7 +101,7 @@ func (s *Scheduler) loop(ctx context.Context) {
 			return
 		case games := <-s.scheduleQueue:
 			if err := s.coordinator.schedule(ctx, games); err != nil {
-				s.logger.Error("Failed to schedule game updates", "games", games, "err", err)
+				s.logger.Error("Failed to schedule game updates", "err", err)
 			}
 		case j := <-s.resultQueue:
 			if err := s.coordinator.processResult(j); err != nil {


### PR DESCRIPTION
**Description**

When there's an error scheduling a game update, the coordinator continues trying to schedule all games, but was then reporting the single game error with a log message that listed all games.  Change this to include the game address in the specific error message and not attach the full list of games.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/55
