### PR TITLE
feat: Multiple Mergify Queues

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: urgent
     queue_conditions:
-      - label = urgent
+      - label = C-urgent
   - name: default
     conditions: []
   - name: lowpriority

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,12 @@
 queue_rules:
+  - name: urgent
+    queue_conditions:
+      - label = urgent
   - name: default
     conditions: []
+  - name: lowpriority
+    conditions:
+      - author=dependabot[bot]
 
 pull_request_rules:
   - name: Automatic merge on approval

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,9 +3,9 @@ queue_rules:
     queue_conditions:
       - label = C-urgent
   - name: default
-    conditions: []
+    queue_conditions: []
   - name: lowpriority
-    conditions:
+    queue_conditions:
       - author=dependabot[bot]
 
 pull_request_rules:


### PR DESCRIPTION
**Description**

Updates the mergify ruleset to use 3 queues as opposed to 1.

The three queues (in decreasing priority) are: `urgent`, `default`, and `lowpriority`.

By default, pull requests are added to the `default` queue. Pull requests made by `dependabot` will be added to the `lowpriority` queue. When the https://github.com/ethereum-optimism/optimism/labels/C-urgent label is added to a pull request, it is added to the `urgent` queue.

In sum, the processing of queues is done in the order they are defined. So the `urgent` queue is processed before the
`default` queue, which in turn is processed before the `lowpriority` queue.

**On Queue Interruption**

By introducing multiple queues, interruption is supported whereby a pull request added to the `default` queue will _interrupt_
pull requests in the `lowpriority` queue, effectively "jumping" ahead and will be merged before `lowpriority` prs.

Better explained by the mergify docs:

> By default, when a pull request enters a queue that has a higher precedence over the one currently being processed, the processing of the current queue gets interrupted, and the higher precedence queue takes over. This ensures that your most critical pull requests are processed as soon as possible, regardless of what else is happening.

To learn more about merge queues, see the [mergify docs](https://docs.mergify.com/merge-queue/multi).
