### PR TITLE
fix: Missing geth Check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ nuke: clean devnet-clean
 .PHONY: nuke
 
 devnet-up:
+	@if ! command -v geth &> /dev/null; then \
+    	echo "\ngeth binary not found in path.\nPlease run 'make install-geth' to install geth before spinning up the devnet.\n" && exit 1; \
+	fi
 	@if [ ! -e op-program/bin ]; then \
 		make cannon-prestate; \
 	fi


### PR DESCRIPTION
**Description**

As detailed in #6976, when the `geth` binary is missing, the `make devnet-up` command fails with a very verbose error message.

This pr adds an explicit check to the `devnet-up` Makefile target to check that the `geth` command is present in the user's path,
pretty-printing a simple error to run `make install-geth` before running `devnet-up`. Feedback was given _not_ to quitely install
`geth` if missing.

Original error output:

```bash
$ make devnet-up

[INFO|08-23-2023 10:41:20] Devnet starting
[INFO|08-23-2023 10:41:20] Generating L1 genesis.
[INFO|08-23-2023 10:41:20] Generating L1 genesis state
Traceback (most recent call last):
  File "/Users/soyboy/Desktop/optimism/./bedrock-devnet/main.py", line 9, in <module>
    main()
  File "/Users/soyboy/Desktop/optimism/./bedrock-devnet/main.py", line 5, in main
    devnet.main()
  File "/Users/soyboy/Desktop/optimism/bedrock-devnet/devnet/__init__.py", line 101, in main
    devnet_deploy(paths)
  File "/Users/soyboy/Desktop/optimism/bedrock-devnet/devnet/__init__.py", line 158, in devnet_deploy
    devnet_l1_genesis(paths)
  File "/Users/soyboy/Desktop/optimism/bedrock-devnet/devnet/__init__.py", line 131, in devnet_l1_genesis
    geth = subprocess.Popen([
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'geth'
make: *** [devnet-up] Error 1
soyboy@soyboys-MacBook-Air optimism %
```

New error output when `geth` is missing:

```bash
$ make devnet-up

geth binary not found in path.
Please run 'make install-geth' to install geth before spinning up the devnet.

make: *** [devnet-up] Error 1
```

**Metadata**

Fixes #6976.
