### PR TITLE
makefile: Update submodules recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ submodules:
 	# CI will checkout submodules on its own (and fails on these commands)
 	if [ -z "$$GITHUB_ENV" ]; then \
 		git submodule init; \
-		git submodule update; \
+		git submodule update --recursive; \
 	fi
 .PHONY: submodules
 


### PR DESCRIPTION
This is so the forge-std submodule sync also pulls in its ds-test submodule. Syncing submodules recursively avoids issues when building a fresh clone of the monorepo.