### PR TITLE
op-e2e: Wait for transactions to be ready to include in ActL2IncludeTx

### DIFF
--- a/op-e2e/actions/l2_batcher_test.go
+++ b/op-e2e/actions/l2_batcher_test.go
@@ -464,7 +464,7 @@ func TestBigL2Txs(gt *testing.T) {
 				Value:     big.NewInt(0),
 				Data:      data,
 			})
-			engine.ActSendTx(t, tx)
+			require.NoError(gt, cl.SendTransaction(t.Ctx(), tx))
 			engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
 		}
 		sequencer.ActL2EndBlock(t)

--- a/op-e2e/actions/l2_batcher_test.go
+++ b/op-e2e/actions/l2_batcher_test.go
@@ -464,7 +464,7 @@ func TestBigL2Txs(gt *testing.T) {
 				Value:     big.NewInt(0),
 				Data:      data,
 			})
-			require.NoError(gt, cl.SendTransaction(t.Ctx(), tx))
+			engine.ActSendTx(t, tx)
 			engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
 		}
 		sequencer.ActL2EndBlock(t)
@@ -504,7 +504,7 @@ func TestBigL2Txs(gt *testing.T) {
 			if miner.l1GasPool.Gas() < tx.Gas() { // fill the L1 block with batcher txs until we run out of gas
 				break
 			}
-			log.Info("including batcher tx", "nonce", tx)
+			log.Info("including batcher tx", "nonce", tx.Nonce())
 			miner.IncludeTx(t, tx)
 			txs = txs[1:]
 		}

--- a/op-e2e/actions/l2_engine.go
+++ b/op-e2e/actions/l2_engine.go
@@ -168,6 +168,13 @@ func (e *L2Engine) ActL2RPCFail(t Testing) {
 	e.failL2RPC = errors.New("mock L2 RPC error")
 }
 
+// ActSendTx adds a transaction to the tx pool and ensures any required promotion to the pending tx queue is complete
+// before returning.
+func (e *L2Engine) ActSendTx(t Testing, tx *types.Transaction) {
+	err := errors.Join(e.eth.TxPool().Add([]*types.Transaction{tx}, true, true)...)
+	require.NoError(t, err, "Add tx to pool")
+}
+
 // ActL2IncludeTx includes the next transaction from the given address in the block that is being built
 func (e *L2Engine) ActL2IncludeTx(from common.Address) Action {
 	return func(t Testing) {

--- a/op-e2e/e2eutils/wait/blocks.go
+++ b/op-e2e/e2eutils/wait/blocks.go
@@ -1,0 +1,66 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// BlockCaller is a subset of the [ethclient.Client] interface
+// encompassing methods that query for block information.
+type BlockCaller interface {
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	BlockNumber(ctx context.Context) (uint64, error)
+}
+
+func ForBlock(ctx context.Context, client BlockCaller, n uint64) error {
+	for {
+		if ctx.Done() != nil {
+			return ctx.Err()
+		}
+		height, err := client.BlockNumber(ctx)
+		if err != nil {
+			return err
+		}
+		if height < n {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		break
+	}
+	return nil
+}
+
+func ForBlockWithTimestamp(ctx context.Context, client BlockCaller, target uint64) error {
+	_, err := AndGet(ctx, time.Second, func() (uint64, error) {
+		head, err := client.BlockByNumber(ctx, nil)
+		if err != nil {
+			return 0, err
+		}
+		return head.Time(), nil
+	}, func(actual uint64) bool {
+		return actual >= target
+	})
+	return err
+}
+
+func ForNextBlock(ctx context.Context, client BlockCaller) error {
+	current, err := client.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("get starting block number: %w", err)
+	}
+	return ForBlock(ctx, client, current+1)
+}
+
+func ForNextBlockWithTimeout(ctx context.Context, client BlockCaller, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	current, err := client.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("get starting block number: %w", err)
+	}
+	return ForBlock(timeoutCtx, client, current+1)
+}

--- a/op-e2e/e2eutils/wait/blocks.go
+++ b/op-e2e/e2eutils/wait/blocks.go
@@ -49,18 +49,11 @@ func ForBlockWithTimestamp(ctx context.Context, client BlockCaller, target uint6
 
 func ForNextBlock(ctx context.Context, client BlockCaller) error {
 	current, err := client.BlockNumber(ctx)
+	// Long timeout so we don't have to care what the block time is. If the test passes this will complete early anyway.
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
 	if err != nil {
 		return fmt.Errorf("get starting block number: %w", err)
 	}
 	return ForBlock(ctx, client, current+1)
-}
-
-func ForNextBlockWithTimeout(ctx context.Context, client BlockCaller, timeout time.Duration) error {
-	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	current, err := client.BlockNumber(ctx)
-	if err != nil {
-		return fmt.Errorf("get starting block number: %w", err)
-	}
-	return ForBlock(timeoutCtx, client, current+1)
 }

--- a/op-e2e/e2eutils/wait/waits.go
+++ b/op-e2e/e2eutils/wait/waits.go
@@ -69,43 +69,6 @@ func printDebugTrace(ctx context.Context, client *ethclient.Client, txHash commo
 	fmt.Printf("TxTrace: %v\n", trace)
 }
 
-func ForBlock(ctx context.Context, client *ethclient.Client, n uint64) error {
-	for {
-		height, err := client.BlockNumber(ctx)
-		if err != nil {
-			return err
-		}
-		if height < n {
-			time.Sleep(500 * time.Millisecond)
-			continue
-		}
-		break
-	}
-
-	return nil
-}
-
-func ForBlockWithTimestamp(ctx context.Context, client *ethclient.Client, target uint64) error {
-	_, err := AndGet(ctx, time.Second, func() (uint64, error) {
-		head, err := client.BlockByNumber(ctx, nil)
-		if err != nil {
-			return 0, err
-		}
-		return head.Time(), nil
-	}, func(actual uint64) bool {
-		return actual >= target
-	})
-	return err
-}
-
-func ForNextBlock(ctx context.Context, client *ethclient.Client) error {
-	current, err := client.BlockNumber(ctx)
-	if err != nil {
-		return fmt.Errorf("get starting block number: %w", err)
-	}
-	return ForBlock(ctx, client, current+1)
-}
-
 func For(ctx context.Context, rate time.Duration, cb func() (bool, error)) error {
 	tick := time.NewTicker(rate)
 	defer tick.Stop()

--- a/op-e2e/system_adminrpc_test.go
+++ b/op-e2e/system_adminrpc_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
@@ -34,10 +35,11 @@ func TestStopStartSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, active, "sequencer should be active")
 
-	blockBefore := latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter := latestBlock(t, l2Seq)
-	require.Greaterf(t, blockAfter, blockBefore, "Chain did not advance")
+	require.NoError(
+		t,
+		wait.ForNextBlockWithTimeout(ctx, l2Seq, time.Duration(cfg.DeployConfig.L2BlockTime+1)*2*time.Second),
+		"Chain did not advance after starting sequencer",
+	)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -50,9 +52,9 @@ func TestStopStartSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, active, "sequencer should be inactive")
 
-	blockBefore = latestBlock(t, l2Seq)
+	blockBefore := latestBlock(t, l2Seq)
 	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter = latestBlock(t, l2Seq)
+	blockAfter := latestBlock(t, l2Seq)
 	require.Equal(t, blockAfter, blockBefore, "Chain advanced after stopping sequencer")
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
@@ -66,10 +68,11 @@ func TestStopStartSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, active, "sequencer should be active again")
 
-	blockBefore = latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter = latestBlock(t, l2Seq)
-	require.Greater(t, blockAfter, blockBefore, "Chain did not advance after starting sequencer")
+	require.NoError(
+		t,
+		wait.ForNextBlockWithTimeout(ctx, l2Seq, time.Duration(cfg.DeployConfig.L2BlockTime+1)*2*time.Second),
+		"Chain did not advance after starting sequencer",
+	)
 }
 
 func TestPersistSequencerStateWhenChanged(t *testing.T) {

--- a/op-e2e/system_adminrpc_test.go
+++ b/op-e2e/system_adminrpc_test.go
@@ -37,7 +37,7 @@ func TestStopStartSequencer(t *testing.T) {
 
 	require.NoError(
 		t,
-		wait.ForNextBlockWithTimeout(ctx, l2Seq, time.Duration(cfg.DeployConfig.L2BlockTime+1)*2*time.Second),
+		wait.ForNextBlock(ctx, l2Seq),
 		"Chain did not advance after starting sequencer",
 	)
 
@@ -70,7 +70,7 @@ func TestStopStartSequencer(t *testing.T) {
 
 	require.NoError(
 		t,
-		wait.ForNextBlockWithTimeout(ctx, l2Seq, time.Duration(cfg.DeployConfig.L2BlockTime+1)*2*time.Second),
+		wait.ForNextBlock(ctx, l2Seq),
 		"Chain did not advance after starting sequencer",
 	)
 }


### PR DESCRIPTION
**Description**

Theory on the source of flakiness:
The test adds the transaction to the pool by calling `eth_sendRawTransaction` which winds up in `[api_backend` `SendTx`](https://github.com/ethereum-optimism/op-geth/blob/c06ca1374da9aafee1f2ff2ab44816b4cf78b11b/eth/api_backend.go#L289-L311). Importantly when it calls `txPool.Add` it specifies `sync: false`. The net result is that the tx is added to the pool’s `queue` initially (the unprocessable transactions) and then [calls `requestPromoteExecutables` to schedule an evaluation of which transactions can be promoted asynchronously](https://github.com/ethereum-optimism/op-geth/blob/8737298ff823f5a8397ac6533a8a227a4662b5d9/core/txpool/legacypool/legacypool.go#L1026-L1030).  Because `sync` is false, it does *not* wait for that promotion to complete.

If the test proceeds and reaches the point in `ActL2IncludeTx` where it retrieves transactions before the promotion completes, it will get the new transaction in the unprocessable list and thus fail.

This avoids that async process by calling `Add` on the tx pool directly and setting `sync=true` to ensure any promotion has completed before the method returns.