### PR TITLE
fix: Sequencer start stop test waits

### DIFF
--- a/op-e2e/e2eutils/wait/blocks.go
+++ b/op-e2e/e2eutils/wait/blocks.go
@@ -1,0 +1,66 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// BlockCaller is a subset of the [ethclient.Client] interface
+// encompassing methods that query for block information.
+type BlockCaller interface {
+	BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error)
+	BlockNumber(ctx context.Context) (uint64, error)
+}
+
+func ForBlock(ctx context.Context, client BlockCaller, n uint64) error {
+	for {
+		if ctx.Done() != nil {
+			return ctx.Err()
+		}
+		height, err := client.BlockNumber(ctx)
+		if err != nil {
+			return err
+		}
+		if height < n {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		break
+	}
+	return nil
+}
+
+func ForBlockWithTimestamp(ctx context.Context, client BlockCaller, target uint64) error {
+	_, err := AndGet(ctx, time.Second, func() (uint64, error) {
+		head, err := client.BlockByNumber(ctx, nil)
+		if err != nil {
+			return 0, err
+		}
+		return head.Time(), nil
+	}, func(actual uint64) bool {
+		return actual >= target
+	})
+	return err
+}
+
+func ForNextBlock(ctx context.Context, client BlockCaller) error {
+	current, err := client.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("get starting block number: %w", err)
+	}
+	return ForBlock(ctx, client, current+1)
+}
+
+func ForNextBlockWithTimeout(ctx context.Context, client BlockCaller, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	current, err := client.BlockNumber(ctx)
+	if err != nil {
+		return fmt.Errorf("get starting block number: %w", err)
+	}
+	return ForBlock(timeoutCtx, client, current+1)
+}

--- a/op-e2e/e2eutils/wait/waits.go
+++ b/op-e2e/e2eutils/wait/waits.go
@@ -69,43 +69,6 @@ func printDebugTrace(ctx context.Context, client *ethclient.Client, txHash commo
 	fmt.Printf("TxTrace: %v\n", trace)
 }
 
-func ForBlock(ctx context.Context, client *ethclient.Client, n uint64) error {
-	for {
-		height, err := client.BlockNumber(ctx)
-		if err != nil {
-			return err
-		}
-		if height < n {
-			time.Sleep(500 * time.Millisecond)
-			continue
-		}
-		break
-	}
-
-	return nil
-}
-
-func ForBlockWithTimestamp(ctx context.Context, client *ethclient.Client, target uint64) error {
-	_, err := AndGet(ctx, time.Second, func() (uint64, error) {
-		head, err := client.BlockByNumber(ctx, nil)
-		if err != nil {
-			return 0, err
-		}
-		return head.Time(), nil
-	}, func(actual uint64) bool {
-		return actual >= target
-	})
-	return err
-}
-
-func ForNextBlock(ctx context.Context, client *ethclient.Client) error {
-	current, err := client.BlockNumber(ctx)
-	if err != nil {
-		return fmt.Errorf("get starting block number: %w", err)
-	}
-	return ForBlock(ctx, client, current+1)
-}
-
 func For(ctx context.Context, rate time.Duration, cb func() (bool, error)) error {
 	tick := time.NewTicker(rate)
 	defer tick.Stop()

--- a/op-e2e/system_adminrpc_test.go
+++ b/op-e2e/system_adminrpc_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/node"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
@@ -34,10 +35,11 @@ func TestStopStartSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, active, "sequencer should be active")
 
-	blockBefore := latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter := latestBlock(t, l2Seq)
-	require.Greaterf(t, blockAfter, blockBefore, "Chain did not advance")
+	require.NoError(
+		t,
+		wait.ForNextBlockWithTimeout(ctx, l2Seq, time.Duration(cfg.DeployConfig.L2BlockTime+1)*2*time.Second),
+		"Chain did not advance after starting sequencer",
+	)
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -50,9 +52,9 @@ func TestStopStartSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, active, "sequencer should be inactive")
 
-	blockBefore = latestBlock(t, l2Seq)
+	blockBefore := latestBlock(t, l2Seq)
 	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter = latestBlock(t, l2Seq)
+	blockAfter := latestBlock(t, l2Seq)
 	require.Equal(t, blockAfter, blockBefore, "Chain advanced after stopping sequencer")
 
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
@@ -66,10 +68,11 @@ func TestStopStartSequencer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, active, "sequencer should be active again")
 
-	blockBefore = latestBlock(t, l2Seq)
-	time.Sleep(time.Duration(cfg.DeployConfig.L2BlockTime+1) * time.Second)
-	blockAfter = latestBlock(t, l2Seq)
-	require.Greater(t, blockAfter, blockBefore, "Chain did not advance after starting sequencer")
+	require.NoError(
+		t,
+		wait.ForNextBlockWithTimeout(ctx, l2Seq, time.Duration(cfg.DeployConfig.L2BlockTime+1)*2*time.Second),
+		"Chain did not advance after starting sequencer",
+	)
 }
 
 func TestPersistSequencerStateWhenChanged(t *testing.T) {


### PR DESCRIPTION
**Description**

`TestStopStartSequencer` is consistently flaking in ci. This PR addresses the flake inside where the chain does not advance quick enough (within the configured l2 block time) so that the check inside `TestStopStartSequencer` doesn't fail.

This fix refactors block waiting methods and uses a minimal `BlockCaller` interface for greater extensibility. It also bumps the wait time by 2x the l2 block time as opposed to 1x for latency issues. Since the block number is effectively polled every 500 milliseconds, the happy path should be hit more frequently anyways so this shouldn't slow down the testing time.