### PR TITLE
fix: add protocol version to getting-started.json

### DIFF
--- a/packages/contracts-bedrock/deploy-config/getting-started.json
+++ b/packages/contracts-bedrock/deploy-config/getting-started.json
@@ -53,5 +53,8 @@
   "eip1559Denominator": 50,
   "eip1559Elasticity": 10,
 
-  "systemConfigStartBlock": 0
+  "systemConfigStartBlock": 0,
+
+  "requiredProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "recommendedProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000"
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

getting-started.json is missing `requiredProtocolVersion` and `recommendedProtocolVersion`

.env is missing `IMPL_SALT` which is a random bytes32 hex string used for the create2 salt to enable deterministic deployment across chains.

This causes deploying contract errors on v1.1.6-rc2 if following the op stack document available at https://stack.optimism.io/docs/build/getting-started/#configure-your-network

**Tests**

I have a manual test on v1.1.6-rc2

**Before**

![image](https://github.com/ethereum-optimism/optimism/assets/4103490/2daace25-60b4-4b69-b239-ca117da7315d)

**After**

<img width="700" alt="image" src="https://github.com/ethereum-optimism/optimism/assets/4103490/48248880-43f3-4410-8c61-01db36576a5c">

You can see that this error is fixed and contracts are deployed successfully.

**Additional context**

Fix for optimism v1.1.6-rc2

<img width="445" alt="image" src="https://github.com/ethereum-optimism/optimism/assets/4103490/24b8e2ae-199a-4d6a-ad75-4d66c4a15d86">

