### PR TITLE
op-e2e: move global logger init, detach from tests

### DIFF
--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -3,12 +3,6 @@ package op_e2e
 import (
 	"os"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
 var enableParallelTesting bool = os.Getenv("OP_E2E_DISABLE_PARALLEL") != "true"
@@ -18,12 +12,4 @@ func InitParallel(t *testing.T) {
 	if enableParallelTesting {
 		t.Parallel()
 	}
-	lvl := log.Lvl(config.EthNodeVerbosity)
-	if lvl < log.LvlCrit {
-		log.Root().SetHandler(log.DiscardHandler())
-	} else if lvl > log.LvlTrace { // clip to trace level
-		lvl = log.LvlTrace
-	}
-	h := testlog.Handler(t, lvl, log.TerminalFormat(false)) // some CI logs do not handle colors well
-	oplog.SetGlobalLogHandler(h)
 }


### PR DESCRIPTION
For #6734 the e2e logger was updated, but the global logger usage for tests was invalid; parallel tests fight over the global logger and if a test finishes before the next test uses it, it causes a test-failure.

This fixes that by moving the global logger init to the op-e2e init function that first configures the log level. After the options are parsed, it applies it to the global logger, once.

Output is written to stdout, and although slightly messy with test-logs in between, will not conflict or cause test-failures anymore.
