### PR TITLE
op-challenger: Defer checking if we agree with a claim until after checking if we can ignore it

### DIFF
--- a/op-challenger/game/fault/solver/solver.go
+++ b/op-challenger/game/fault/solver/solver.go
@@ -35,10 +35,6 @@ func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, game type
 	if claim.Depth() == s.gameDepth {
 		return nil, types.ErrGameDepthReached
 	}
-	agree, err := s.agreeWithClaim(ctx, claim.ClaimData)
-	if err != nil {
-		return nil, err
-	}
 
 	// Before challenging this claim, first check that the move wasn't warranted.
 	// If the parent claim is on a dishonest path, then we would have moved against it anyways. So we don't move.
@@ -57,6 +53,10 @@ func (s *claimSolver) NextMove(ctx context.Context, claim types.Claim, game type
 		}
 	}
 
+	agree, err := s.agreeWithClaim(ctx, claim.ClaimData)
+	if err != nil {
+		return nil, err
+	}
 	if agree {
 		return s.defend(ctx, claim)
 	} else {


### PR DESCRIPTION
**Description**

Moves the call to check if we agree with a claim that's used to decide if we should attack or defend to after the logic that checks if we should ignore the claim entirely. Its a relatively small optimisation but may save us from running cannon to generate a proof.
