### PR TITLE
fix: Mergify Queue Conditions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,9 +1,10 @@
 queue_rules:
   - name: urgent
     queue_conditions:
-      - label = C-urgent
+      - "label=C-urgent"
   - name: default
-    queue_conditions: []
+    queue_conditions:
+      - "label!=C-urgent"
   - name: lowpriority
     queue_conditions:
       - author=dependabot[bot]

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ queue_rules:
   - name: default
     queue_conditions:
       - "label!=C-urgent"
+      - author!=dependabot[bot]
   - name: lowpriority
     queue_conditions:
       - author=dependabot[bot]


### PR DESCRIPTION
**Description**

Mergify queue conditions were not being triggered correctly.

I think what was happening is the label matching was failing for `C-urgent`.

Also, the default queue conditions included prs created by dependabot since there was no rule to exclude dependabot prs from the default queue.
