### PR TITLE
op-node: chaosnet config, superchain-registry update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230921190252-f29074de9e36
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231001123245-7b48d3818686
 	github.com/ethereum/go-ethereum v1.13.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-chi/chi/v5 v5.0.10

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
 github.com/ethereum-optimism/op-geth v1.101301.0-rc.2 h1:CoZuN0uuEqoXlKu3iirnGlfsO1nKcIvvbyFZqUVmYN4=
 github.com/ethereum-optimism/op-geth v1.101301.0-rc.2/go.mod h1:N++/klTCpY0UAU9tXFOyOEtvkjgHlNZkzzXm5I/1kzM=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230921190252-f29074de9e36 h1:HGDz8DcAkHvZy+iPnBa8yr4MdLqKpb7oAks01P08JOg=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230921190252-f29074de9e36/go.mod h1:q0u2UbyOr1q/y94AgMOj/V8b1KO05ZwILTR/qKt7Auo=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231001123245-7b48d3818686 h1:f57hd8G96c8ORWd4ameFpveSnHcb0hA2D1VatviwoDc=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231001123245-7b48d3818686/go.mod h1:q0u2UbyOr1q/y94AgMOj/V8b1KO05ZwILTR/qKt7Auo=
 github.com/ethereum/c-kzg-4844 v0.3.1 h1:sR65+68+WdnMKxseNWxSJuAv2tsUrihTpVBTfM/U5Zg=
 github.com/ethereum/c-kzg-4844 v0.3.1/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -25,6 +25,7 @@ const (
 	zoraGoerli  = 999
 	zoraMainnet = 7777777
 	labsDevnet  = 997
+	chaosnet    = 888
 )
 
 // LoadOPStackRollupConfig loads the rollup configuration of the requested chain ID from the superchain-registry.
@@ -69,6 +70,8 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		regolithTime = 1679079600
 	case labsDevnet:
 		regolithTime = 1677984480
+	case chaosnet:
+		regolithTime = 1692156862
 	}
 
 	cfg := &Config{
@@ -102,7 +105,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address
 		cfg.ProtocolVersionsAddress = common.Address(*superChain.Config.ProtocolVersionsAddr)
 	}
-	if chainID == labsDevnet {
+	if chainID == labsDevnet || chainID == chaosnet {
 		cfg.ChannelTimeout = 120
 		cfg.MaxSequencerDrift = 1200
 	}


### PR DESCRIPTION
**Description**

- Update superchain-registry to include chaosnet config.
- Add chaosnet config exceptions: regolith time, and custom channel timeout / seq time drift like devnet.

Before merging: also pull in https://github.com/ethereum-optimism/op-geth/pull/145