### PR TITLE
fix fee bumping & blob fee estimation for blob transactions

### DIFF
--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -24,7 +24,7 @@ type L1BlobsFetcher interface {
 	BlobsByRefAndIndexedDataHashes(ctx context.Context, ref eth.L1BlockRef, dataHashes []eth.IndexedDataHash) ([]*eth.Blob, error)
 }
 
-// DataSourceFactory readers raw transactions from a given block & then filters for
+// DataSourceFactory reads raw transactions from a given block & then filters for
 // batch submitter transactions.
 // This is not a stage in the pipeline, but a wrapper for another stage in the pipeline
 type DataSourceFactory struct {
@@ -38,7 +38,7 @@ func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Transact
 	return &DataSourceFactory{log: log, cfg: cfg, fetcher: fetcher, blobsFetcher: blobsFetcher}
 }
 
-// OpenData returns a CalldataSourceImpl. This struct implements the `Next` function.
+// OpenData returns the appropriate data source for the L1 block `ref`.
 func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address) DataIter {
 	if n := ds.cfg.BlobsEnabledL1Timestamp; n != nil && *n <= ref.Time {
 		return NewBlobDataSource(ctx, ds.log, ds.cfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr)

--- a/op-service/txmgr/price_bump_test.go
+++ b/op-service/txmgr/price_bump_test.go
@@ -25,7 +25,7 @@ func (tc *priceBumpTest) run(t *testing.T) {
 	prevFC := calcGasFeeCap(big.NewInt(tc.prevBasefee), big.NewInt(tc.prevGasTip))
 	lgr := testlog.Logger(t, log.LvlCrit)
 
-	tip, fc := updateFees(big.NewInt(tc.prevGasTip), prevFC, big.NewInt(tc.newGasTip), big.NewInt(tc.newBasefee), lgr)
+	tip, fc := updateFees(big.NewInt(tc.prevGasTip), prevFC, big.NewInt(tc.newGasTip), big.NewInt(tc.newBasefee), false, lgr)
 
 	require.Equal(t, tc.expectedTip, tip.Int64(), "tip must be as expected")
 	require.Equal(t, tc.expectedFC, fc.Int64(), "fee cap must be as expected")

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -195,7 +195,7 @@ func TestSend(t *testing.T) {
 					return core.ErrNonceTooLow
 				}
 				txHash := tx.Hash()
-				backend.mine(&txHash, tx.GasFeeCap())
+				backend.mine(&txHash, tx.GasFeeCap(), nil)
 				return nil
 			}
 			backend.setTxSender(sendTx)

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -9,15 +9,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
 type sendTransactionFunc func(ctx context.Context, tx *types.Transaction) error
@@ -92,6 +96,7 @@ type gasPricer struct {
 	mineAtEpoch   int64
 	baseGasTipFee *big.Int
 	baseBaseFee   *big.Int
+	excessBlobGas uint64
 	err           error
 	mu            sync.Mutex
 }
@@ -101,24 +106,35 @@ func newGasPricer(mineAtEpoch int64) *gasPricer {
 		mineAtEpoch:   mineAtEpoch,
 		baseGasTipFee: big.NewInt(5),
 		baseBaseFee:   big.NewInt(7),
+		excessBlobGas: 100 * (params.BlobTxBlobGasPerBlob), // simulate 100 excess blobs
 	}
 }
 
 func (g *gasPricer) expGasFeeCap() *big.Int {
-	_, gasFeeCap := g.feesForEpoch(g.mineAtEpoch)
+	_, gasFeeCap, _ := g.feesForEpoch(g.mineAtEpoch)
 	return gasFeeCap
 }
 
-func (g *gasPricer) shouldMine(gasFeeCap *big.Int) bool {
-	return g.expGasFeeCap().Cmp(gasFeeCap) == 0
+func (g *gasPricer) expBlobFeeCap() *big.Int {
+	_, _, excessBlobGas := g.feesForEpoch(g.mineAtEpoch)
+	return eip4844.CalcBlobFee(excessBlobGas)
 }
 
-func (g *gasPricer) feesForEpoch(epoch int64) (*big.Int, *big.Int) {
-	epochBaseFee := new(big.Int).Mul(g.baseBaseFee, big.NewInt(epoch))
-	epochGasTipCap := new(big.Int).Mul(g.baseGasTipFee, big.NewInt(epoch))
-	epochGasFeeCap := calcGasFeeCap(epochBaseFee, epochGasTipCap)
+func (g *gasPricer) shouldMine(gasFeeCap *big.Int) bool {
+	return g.expGasFeeCap().Cmp(gasFeeCap) <= 0
+}
 
-	return epochGasTipCap, epochGasFeeCap
+func (g *gasPricer) shouldMineBlobTx(gasFeeCap, blobFeeCap *big.Int) bool {
+	return g.shouldMine(gasFeeCap) && g.expBlobFeeCap().Cmp(blobFeeCap) <= 0
+}
+
+func (g *gasPricer) feesForEpoch(epoch int64) (*big.Int, *big.Int, uint64) {
+	e := big.NewInt(epoch)
+	epochBaseFee := new(big.Int).Mul(g.baseBaseFee, e)
+	epochGasTipCap := new(big.Int).Mul(g.baseGasTipFee, e)
+	epochGasFeeCap := calcGasFeeCap(epochBaseFee, epochGasTipCap)
+	epochExcessBlobGas := g.excessBlobGas * uint64(epoch)
+	return epochGasTipCap, epochGasFeeCap, epochExcessBlobGas
 }
 
 func (g *gasPricer) basefee() *big.Int {
@@ -127,18 +143,25 @@ func (g *gasPricer) basefee() *big.Int {
 	return new(big.Int).Mul(g.baseBaseFee, big.NewInt(g.epoch))
 }
 
-func (g *gasPricer) sample() (*big.Int, *big.Int) {
+func (g *gasPricer) excessblobgas() uint64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.excessBlobGas * uint64(g.epoch)
+}
+
+func (g *gasPricer) sample() (*big.Int, *big.Int, uint64) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
 	g.epoch++
-	epochGasTipCap, epochGasFeeCap := g.feesForEpoch(g.epoch)
+	epochGasTipCap, epochGasFeeCap, epochExcessBlobGas := g.feesForEpoch(g.epoch)
 
-	return epochGasTipCap, epochGasFeeCap
+	return epochGasTipCap, epochGasFeeCap, epochExcessBlobGas
 }
 
 type minedTxInfo struct {
 	gasFeeCap   *big.Int
+	blobFeeCap  *big.Int
 	blockNumber uint64
 }
 
@@ -173,7 +196,7 @@ func (b *mockBackend) setTxSender(s sendTransactionFunc) {
 // mine records a (txHash, gasFeeCap) as confirmed. Subsequent calls to
 // TransactionReceipt with a matching txHash will result in a non-nil receipt.
 // If a nil txHash is supplied this has the effect of mining an empty block.
-func (b *mockBackend) mine(txHash *common.Hash, gasFeeCap *big.Int) {
+func (b *mockBackend) mine(txHash *common.Hash, gasFeeCap, blobFeeCap *big.Int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -181,6 +204,7 @@ func (b *mockBackend) mine(txHash *common.Hash, gasFeeCap *big.Int) {
 	if txHash != nil {
 		b.minedTxs[*txHash] = minedTxInfo{
 			gasFeeCap:   gasFeeCap,
+			blobFeeCap:  blobFeeCap,
 			blockNumber: b.blockHeight,
 		}
 	}
@@ -200,8 +224,10 @@ func (b *mockBackend) CallContract(ctx context.Context, call ethereum.CallMsg, b
 }
 
 func (b *mockBackend) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	bg := b.g.excessblobgas()
 	return &types.Header{
-		BaseFee: b.g.basefee(),
+		BaseFee:       b.g.basefee(),
+		ExcessBlobGas: &bg,
 	}, nil
 }
 
@@ -213,7 +239,7 @@ func (b *mockBackend) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (ui
 }
 
 func (b *mockBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	tip, _ := b.g.sample()
+	tip, _, _ := b.g.sample()
 	return tip, nil
 }
 
@@ -236,10 +262,10 @@ func (*mockBackend) ChainID(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(1), nil
 }
 
-// TransactionReceipt queries the mockBackend for a mined txHash. If none is
-// found, nil is returned for both return values. Otherwise, it retruns a
-// receipt containing the txHash and the gasFeeCap used in the GasUsed to make
-// the value accessible from our test framework.
+// TransactionReceipt queries the mockBackend for a mined txHash. If none is found, nil is returned
+// for both return values. Otherwise, it returns a receipt containing the txHash, the gasFeeCap
+// used in GasUsed, and the blobFeeCap in CumuluativeGasUsed to make the values accessible from our
+// test framework.
 func (b *mockBackend) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 
 	b.mu.RLock()
@@ -252,10 +278,15 @@ func (b *mockBackend) TransactionReceipt(ctx context.Context, txHash common.Hash
 
 	// Return the gas fee cap for the transaction in the GasUsed field so that
 	// we can assert the proper tx confirmed in our tests.
+	var blobFeeCap uint64
+	if txInfo.blobFeeCap != nil {
+		blobFeeCap = txInfo.blobFeeCap.Uint64()
+	}
 	return &types.Receipt{
-		TxHash:      txHash,
-		GasUsed:     txInfo.gasFeeCap.Uint64(),
-		BlockNumber: big.NewInt(int64(txInfo.blockNumber)),
+		TxHash:            txHash,
+		GasUsed:           txInfo.gasFeeCap.Uint64(),
+		CumulativeGasUsed: blobFeeCap,
+		BlockNumber:       big.NewInt(int64(txInfo.blockNumber)),
 	}, nil
 }
 
@@ -268,7 +299,7 @@ func TestTxMgrConfirmAtMinGasPrice(t *testing.T) {
 
 	gasPricer := newGasPricer(1)
 
-	gasTipCap, gasFeeCap := gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -277,7 +308,7 @@ func TestTxMgrConfirmAtMinGasPrice(t *testing.T) {
 	sendTx := func(ctx context.Context, tx *types.Transaction) error {
 		if gasPricer.shouldMine(tx.GasFeeCap()) {
 			txHash := tx.Hash()
-			h.backend.mine(&txHash, tx.GasFeeCap())
+			h.backend.mine(&txHash, tx.GasFeeCap(), nil)
 		}
 		return nil
 	}
@@ -299,7 +330,7 @@ func TestTxMgrNeverConfirmCancel(t *testing.T) {
 
 	h := newTestHarness(t)
 
-	gasTipCap, gasFeeCap := h.gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -325,7 +356,7 @@ func TestTxMgrConfirmsAtHigherGasPrice(t *testing.T) {
 
 	h := newTestHarness(t)
 
-	gasTipCap, gasFeeCap := h.gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -333,7 +364,7 @@ func TestTxMgrConfirmsAtHigherGasPrice(t *testing.T) {
 	sendTx := func(ctx context.Context, tx *types.Transaction) error {
 		if h.gasPricer.shouldMine(tx.GasFeeCap()) {
 			txHash := tx.Hash()
-			h.backend.mine(&txHash, tx.GasFeeCap())
+			h.backend.mine(&txHash, tx.GasFeeCap(), nil)
 		}
 		return nil
 	}
@@ -348,6 +379,42 @@ func TestTxMgrConfirmsAtHigherGasPrice(t *testing.T) {
 	require.Equal(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
 }
 
+// TestTxMgrConfirmsBlobTxAtMaxGasPrice asserts that Send properly returns the max gas price
+// receipt if none of the lower gas price txs were mined when attempting to send a blob tx.
+func TestTxMgrConfirmsBlobTxAtHigherGasPrice(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	gasTipCap, gasFeeCap, excessBlobGas := h.gasPricer.sample()
+	blobFeeCap := eip4844.CalcBlobFee(excessBlobGas)
+
+	tx := types.NewTx(&types.BlobTx{
+		GasTipCap:  uint256.MustFromBig(gasTipCap),
+		GasFeeCap:  uint256.MustFromBig(gasFeeCap),
+		BlobFeeCap: uint256.MustFromBig(blobFeeCap),
+	})
+	sendTx := func(ctx context.Context, tx *types.Transaction) error {
+		if h.gasPricer.shouldMineBlobTx(tx.GasFeeCap(), tx.BlobGasFeeCap()) {
+			txHash := tx.Hash()
+			h.backend.mine(&txHash, tx.GasFeeCap(), tx.BlobGasFeeCap())
+		}
+		return nil
+	}
+	h.backend.setTxSender(sendTx)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	receipt, err := h.mgr.sendTx(ctx, tx)
+	require.Nil(t, err)
+	require.NotNil(t, receipt)
+	// the fee cap for the blob tx at epoch == 3 should end up higher than the min required gas
+	// (expFeeCap()) since blob tx fee caps are bumped 100% with each epoch.
+	require.Less(t, h.gasPricer.expGasFeeCap().Uint64(), receipt.GasUsed)
+	require.Equal(t, h.gasPricer.expBlobFeeCap().Uint64(), receipt.CumulativeGasUsed)
+}
+
 // errRpcFailure is a sentinel error used in testing to fail publications.
 var errRpcFailure = errors.New("rpc failure")
 
@@ -359,7 +426,7 @@ func TestTxMgrBlocksOnFailingRpcCalls(t *testing.T) {
 
 	h := newTestHarness(t)
 
-	gasTipCap, gasFeeCap := h.gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -385,7 +452,7 @@ func TestTxMgr_CraftTx(t *testing.T) {
 	candidate := h.createTxCandidate()
 
 	// Craft the transaction.
-	gasTipCap, gasFeeCap := h.gasPricer.feesForEpoch(h.gasPricer.epoch + 1)
+	gasTipCap, gasFeeCap, _ := h.gasPricer.feesForEpoch(h.gasPricer.epoch + 1)
 	tx, err := h.mgr.craftTx(context.Background(), candidate)
 	require.Nil(t, err)
 	require.NotNil(t, tx)
@@ -456,7 +523,7 @@ func TestTxMgrOnlyOnePublicationSucceeds(t *testing.T) {
 
 	h := newTestHarness(t)
 
-	gasTipCap, gasFeeCap := h.gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -469,7 +536,7 @@ func TestTxMgrOnlyOnePublicationSucceeds(t *testing.T) {
 		}
 
 		txHash := tx.Hash()
-		h.backend.mine(&txHash, tx.GasFeeCap())
+		h.backend.mine(&txHash, tx.GasFeeCap(), nil)
 		return nil
 	}
 	h.backend.setTxSender(sendTx)
@@ -484,14 +551,14 @@ func TestTxMgrOnlyOnePublicationSucceeds(t *testing.T) {
 }
 
 // TestTxMgrConfirmsMinGasPriceAfterBumping delays the mining of the initial tx
-// with the minimum gas price, and asserts that it's receipt is returned even
+// with the minimum gas price, and asserts that its receipt is returned even
 // though if the gas price has been bumped in other goroutines.
 func TestTxMgrConfirmsMinGasPriceAfterBumping(t *testing.T) {
 	t.Parallel()
 
 	h := newTestHarness(t)
 
-	gasTipCap, gasFeeCap := h.gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -502,7 +569,7 @@ func TestTxMgrConfirmsMinGasPriceAfterBumping(t *testing.T) {
 		if h.gasPricer.shouldMine(tx.GasFeeCap()) {
 			time.AfterFunc(5*time.Second, func() {
 				txHash := tx.Hash()
-				h.backend.mine(&txHash, tx.GasFeeCap())
+				h.backend.mine(&txHash, tx.GasFeeCap(), nil)
 			})
 		}
 		return nil
@@ -523,7 +590,7 @@ func TestTxMgrDoesntAbortNonceTooLowAfterMiningTx(t *testing.T) {
 
 	h := newTestHarnessWithConfig(t, configWithNumConfs(2))
 
-	gasTipCap, gasFeeCap := h.gasPricer.sample()
+	gasTipCap, gasFeeCap, _ := h.gasPricer.sample()
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
@@ -540,9 +607,9 @@ func TestTxMgrDoesntAbortNonceTooLowAfterMiningTx(t *testing.T) {
 		// Accept and mine the actual txn we expect to confirm.
 		case h.gasPricer.shouldMine(tx.GasFeeCap()):
 			txHash := tx.Hash()
-			h.backend.mine(&txHash, tx.GasFeeCap())
+			h.backend.mine(&txHash, tx.GasFeeCap(), nil)
 			time.AfterFunc(5*time.Second, func() {
-				h.backend.mine(nil, nil)
+				h.backend.mine(nil, nil, nil)
 			})
 			return nil
 
@@ -572,7 +639,7 @@ func TestWaitMinedReturnsReceiptOnFirstSuccess(t *testing.T) {
 	// Create a tx and mine it immediately using the default backend.
 	tx := types.NewTx(&types.LegacyTx{})
 	txHash := tx.Hash()
-	h.backend.mine(&txHash, new(big.Int))
+	h.backend.mine(&txHash, new(big.Int), nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -614,7 +681,7 @@ func TestWaitMinedMultipleConfs(t *testing.T) {
 	// Create an unimined tx.
 	tx := types.NewTx(&types.LegacyTx{})
 	txHash := tx.Hash()
-	h.backend.mine(&txHash, new(big.Int))
+	h.backend.mine(&txHash, new(big.Int), nil)
 
 	receipt, err := h.mgr.waitMined(ctx, tx, NewSendState(10, time.Hour))
 	require.Equal(t, err, context.DeadlineExceeded)
@@ -624,7 +691,7 @@ func TestWaitMinedMultipleConfs(t *testing.T) {
 	defer cancel()
 
 	// Mine an empty block, tx should now be confirmed.
-	h.backend.mine(nil, nil)
+	h.backend.mine(nil, nil, nil)
 	receipt, err = h.mgr.waitMined(ctx, tx, NewSendState(10, time.Hour))
 	require.Nil(t, err)
 	require.NotNil(t, receipt)
@@ -938,7 +1005,7 @@ func TestNonceReset(t *testing.T) {
 			return core.ErrNonceTooLow
 		}
 		txHash := tx.Hash()
-		h.backend.mine(&txHash, tx.GasFeeCap())
+		h.backend.mine(&txHash, tx.GasFeeCap(), nil)
 		return nil
 	}
 	h.backend.setTxSender(sendTx)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

- set blob gas fee cap using estimates derived from current header

- make transaction resubmission handle blob txs correctly

- fix fee bump logic to account for geth's higher fee bump requirements for blob txs

**Tests**

Added unit test to confirm that blob tx fees are appropriately bumped on retries.