### PR TITLE
contracts-bedrock: fix Deploy script

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -172,7 +172,7 @@ contract Deploy is Deployer {
             ? safeProxyFactory_ = new SafeProxyFactory()
             : safeProxyFactory_ = SafeProxyFactory(safeProxyFactory);
 
-        safeSingleton.code.length == 0 ? safeSingleton_ = new Safe() : safeSingleton_ = Safe(payable(safeSingleton_));
+        safeSingleton.code.length == 0 ? safeSingleton_ = new Safe() : safeSingleton_ = Safe(payable(safeSingleton));
 
         save("SafeProxyFactory", address(safeProxyFactory_));
         save("SafeSingleton", address(safeSingleton_));


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

In Deploy.s.sol line 175, it should be `safeSingleton_ = Safe(payable(safeSingleton))` instead of `safeSingleton_ = Safe(payable(safeSingleton_))`.

**Tests**

Manual tested using [the offical tutorial](https://stack.optimism.io/docs/build/getting-started/#)

- Before

![Screenshot 2023-10-03 at 11 16 36](https://github.com/ethereum-optimism/optimism/assets/30585557/e3c17b95-b915-4ffa-94e7-7817ac9e8f1b)


- After

![Screenshot 2023-10-03 at 11 17 37](https://github.com/ethereum-optimism/optimism/assets/30585557/d8650bdc-b510-4c08-8543-878fb9e6923c)

**Metadata**

- Fixes #7484
