### PR TITLE
chore(Makefile): Fix Devnet Targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,16 @@ nuke: clean devnet-clean
 	git clean -Xdf
 .PHONY: nuke
 
-devnet-up:
+pre-devnet:
 	@if ! [ -x "$(command -v geth)" ]; then \
 		make install-geth; \
 	fi
 	@if [ ! -e op-program/bin ]; then \
 		make cannon-prestate; \
 	fi
+.PHONY: pre-devnet
+
+devnet-up: pre-devnet
 	./ops/scripts/newer-file.sh .devnet/allocs-l1.json ./packages/contracts-bedrock \
 		|| make devnet-allocs
 	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=.
@@ -100,7 +103,7 @@ devnet-up:
 # alias for devnet-up
 devnet-up-deploy: devnet-up
 
-devnet-test:
+devnet-test: pre-devnet
 	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=. --test
 .PHONY: devnet-test
 
@@ -116,7 +119,7 @@ devnet-clean:
 	docker volume ls --filter name=ops-bedrock --format='{{.Name}}' | xargs -r docker volume rm
 .PHONY: devnet-clean
 
-devnet-allocs:
+devnet-allocs: pre-devnet
 	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=. --allocs
 
 devnet-logs:


### PR DESCRIPTION
**Description**

Prior to this change, the `devnet-up` command had the `install-geth` and `cannon-prestate` graceful helpers, but the `devnet-allocs` and `devnet-test` didn't. Both of these targets would then fail when `geth` isn't installed.

This PR introduces a pre-devnet hook that allows for the graceful install of any required binaries to be installed or execution to occur before devnet targets are run.