### PR TITLE
op-chain-ops: option for skipping calldata encoding

### DIFF
--- a/op-chain-ops/safe/batch.go
+++ b/op-chain-ops/safe/batch.go
@@ -6,6 +6,7 @@ package safe
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -19,7 +20,12 @@ import (
 )
 
 // Batch represents a Safe tx-builder transaction.
+// SkipCalldata will skip adding the calldata to the BatchTransaction.
+// This is useful for when using the Safe UI because it prefers using
+// the raw calldata when both the calldata and ABIs with arguments are
+// present.
 type Batch struct {
+	SkipCalldata bool
 	Version      string             `json:"version"`
 	ChainID      *big.Int           `json:"chainId"`
 	CreatedAt    uint64             `json:"createdAt"`
@@ -29,7 +35,10 @@ type Batch struct {
 
 // AddCall will add a call to the batch. After a series of calls are
 // added to the batch, it can be serialized to JSON.
-func (b *Batch) AddCall(to common.Address, value *big.Int, sig string, args []any, iface abi.ABI) error {
+func (b *Batch) AddCall(to common.Address, value *big.Int, sig string, args []any, iface *abi.ABI) error {
+	if iface == nil {
+		return errors.New("abi cannot be nil")
+	}
 	// Attempt to pull out the signature from the top level methods.
 	// The abi package uses normalization that we do not want to be
 	// coupled to, so attempt to search for the raw name if the top
@@ -87,8 +96,11 @@ func (b *Batch) AddCall(to common.Address, value *big.Int, sig string, args []an
 		To:          to,
 		Value:       value,
 		Method:      contractMethod,
-		Data:        data,
 		InputValues: inputValues,
+	}
+
+	if !b.SkipCalldata {
+		batchTransaction.Data = data
 	}
 
 	b.Transactions = append(b.Transactions, batchTransaction)

--- a/op-chain-ops/safe/batch_test.go
+++ b/op-chain-ops/safe/batch_test.go
@@ -58,7 +58,7 @@ func TestBatchAddCallFinalizeWithdrawalTransaction(t *testing.T) {
 	to := common.Address{19: 0x01}
 	value := big.NewInt(222)
 
-	require.NoError(t, batch.AddCall(to, value, sig, argument, portalABI))
+	require.NoError(t, batch.AddCall(to, value, sig, argument, &portalABI))
 	require.NoError(t, batch.Check())
 	require.Equal(t, batch.Transactions[0].Signature(), "finalizeWithdrawalTransaction((uint256,address,address,uint256,uint256,bytes))")
 
@@ -89,7 +89,7 @@ func TestBatchAddCallDespositTransaction(t *testing.T) {
 		[]byte{},
 	}
 
-	require.NoError(t, batch.AddCall(to, value, sig, argument, portalABI))
+	require.NoError(t, batch.AddCall(to, value, sig, argument, &portalABI))
 	require.NoError(t, batch.Check())
 	require.Equal(t, batch.Transactions[0].Signature(), "depositTransaction(address,uint256,uint64,bool,bytes)")
 

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -63,6 +63,7 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(list.L1CrossDomainMessengerProxy.String()),
@@ -102,6 +103,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(list.L1ERC721BridgeProxy.String()),
@@ -141,6 +143,7 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(list.L1StandardBridgeProxy.String()),
@@ -219,6 +222,7 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(list.L2OutputOracleProxy.String()),
@@ -258,6 +262,7 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(list.OptimismMintableERC20FactoryProxy.String()),
@@ -315,6 +320,7 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(list.OptimismPortalProxy.String()),
@@ -434,6 +440,7 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 	if err != nil {
 		return err
 	}
+	calldata = append(initialize.ID, calldata...)
 
 	args := []any{
 		common.HexToAddress(chainConfig.SystemConfigAddr.String()),

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -72,7 +72,7 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 
@@ -111,7 +111,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 
@@ -150,7 +150,7 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 
@@ -228,7 +228,7 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 
@@ -267,7 +267,7 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 
@@ -324,7 +324,7 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 
@@ -443,7 +443,7 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 
 	proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
 	sig := "upgradeAndCall(address,address,bytes)"
-	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, *proxyAdminABI); err != nil {
+	if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Description**

Adds a field to the safe `Batch` struct so that it can optionally not include the calldata serialization in the JSON that it serializes to. This is because the Safe UI will not produce any human readable output when the JSON includes the calldata, it ignores the human readable ABI and arguments. In some cases, we may want to rely on the UI more so this gives the option to do so.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


