### PR TITLE
fix: pass in env var prefix for p2p flags

### DIFF
--- a/op-bootnode/flags/flags.go
+++ b/op-bootnode/flags/flags.go
@@ -37,7 +37,7 @@ var Flags = []cli.Flag{
 }
 
 func init() {
-	Flags = append(Flags, flags.P2pFlags...)
+	Flags = append(Flags, flags.P2PFlags(envVarPrefix)...)
 	Flags = append(Flags, opmetrics.CLIFlags(envVarPrefix)...)
 	Flags = append(Flags, oplog.CLIFlags(envVarPrefix)...)
 }

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -309,7 +309,7 @@ var optionalFlags = []cli.Flag{
 var Flags []cli.Flag
 
 func init() {
-	optionalFlags = append(optionalFlags, P2pFlags...)
+	optionalFlags = append(optionalFlags, P2PFlags(EnvVarPrefix)...)
 	optionalFlags = append(optionalFlags, oplog.CLIFlags(EnvVarPrefix)...)
 	Flags = append(requiredFlags, optionalFlags...)
 }

--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -9,343 +9,303 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 )
 
-func p2pEnv(v string) []string {
-	return prefixEnvVars("P2P_" + v)
+const p2pScoringName = "p2p.scoring"
+
+func p2pEnv(envprefix, v string) []string {
+	return []string{envprefix + "_P2P_" + v}
 }
-
-var (
-	DisableP2P = &cli.BoolFlag{
-		Name:     "p2p.disable",
-		Usage:    "Completely disable the P2P stack",
-		Required: false,
-		EnvVars:  p2pEnv("DISABLE"),
-	}
-	NoDiscovery = &cli.BoolFlag{
-		Name:     "p2p.no-discovery",
-		Usage:    "Disable Discv5 (node discovery)",
-		Required: false,
-		EnvVars:  p2pEnv("NO_DISCOVERY"),
-	}
-	Scoring = &cli.StringFlag{
-		Name:     "p2p.scoring",
-		Usage:    "Sets the peer scoring strategy for the P2P stack. Can be one of: none or light.",
-		Required: false,
-		Value:    "light",
-		EnvVars:  p2pEnv("PEER_SCORING"),
-	}
-	PeerScoring = &cli.StringFlag{
-		Name:     "p2p.scoring.peers",
-		Usage:    fmt.Sprintf("Deprecated: Use %v instead", Scoring.Name),
-		Required: false,
-		Hidden:   true,
-	}
-	PeerScoreBands = &cli.StringFlag{
-		Name:     "p2p.score.bands",
-		Usage:    "Deprecated. This option is ignored and is only present for backwards compatibility.",
-		Required: false,
-		Value:    "",
-		Hidden:   true,
-	}
-
-	// Banning Flag - whether or not we want to act on the scoring
-	Banning = &cli.BoolFlag{
-		Name:     "p2p.ban.peers",
-		Usage:    "Enables peer banning.",
-		Value:    true,
-		Required: false,
-		EnvVars:  p2pEnv("PEER_BANNING"),
-	}
-	BanningThreshold = &cli.Float64Flag{
-		Name:     "p2p.ban.threshold",
-		Usage:    "The minimum score below which peers are disconnected and banned.",
-		Required: false,
-		Value:    -100,
-		EnvVars:  p2pEnv("PEER_BANNING_THRESHOLD"),
-	}
-	BanningDuration = &cli.DurationFlag{
-		Name:     "p2p.ban.duration",
-		Usage:    "The duration that peers are banned for.",
-		Required: false,
-		Value:    1 * time.Hour,
-		EnvVars:  p2pEnv("PEER_BANNING_DURATION"),
-	}
-
-	TopicScoring = &cli.StringFlag{
-		Name:     "p2p.scoring.topics",
-		Usage:    fmt.Sprintf("Deprecated: Use %v instead", Scoring.Name),
-		Required: false,
-		Hidden:   true,
-	}
-	P2PPrivPath = &cli.StringFlag{
-		Name: "p2p.priv.path",
-		Usage: "Read the hex-encoded 32-byte private key for the peer ID from this txt file. Created if not already exists." +
-			"Important to persist to keep the same network identity after restarting, maintaining the previous advertised identity.",
-		Required:  false,
-		Value:     "opnode_p2p_priv.txt",
-		EnvVars:   p2pEnv("PRIV_PATH"),
-		TakesFile: true,
-	}
-	P2PPrivRaw = &cli.StringFlag{
-		// sometimes it may be ok to not persist the peer priv key as file, and instead pass it directly.
-		Name:     "p2p.priv.raw",
-		Usage:    "The hex-encoded 32-byte private key for the peer ID",
-		Required: false,
-		Hidden:   true,
-		Value:    "",
-		EnvVars:  p2pEnv("PRIV_RAW"),
-	}
-	ListenIP = &cli.StringFlag{
-		Name:     "p2p.listen.ip",
-		Usage:    "IP to bind LibP2P and Discv5 to",
-		Required: false,
-		Value:    "0.0.0.0",
-		EnvVars:  p2pEnv("LISTEN_IP"),
-	}
-	ListenTCPPort = &cli.UintFlag{
-		Name:     "p2p.listen.tcp",
-		Usage:    "TCP port to bind LibP2P to. Any available system port if set to 0.",
-		Required: false,
-		Value:    9222,
-		EnvVars:  p2pEnv("LISTEN_TCP_PORT"),
-	}
-	ListenUDPPort = &cli.UintFlag{
-		Name:     "p2p.listen.udp",
-		Usage:    "UDP port to bind Discv5 to. Same as TCP port if left 0.",
-		Required: false,
-		Value:    0, // can simply match the TCP libp2p port
-		EnvVars:  p2pEnv("LISTEN_UDP_PORT"),
-	}
-	AdvertiseIP = &cli.StringFlag{
-		Name:     "p2p.advertise.ip",
-		Usage:    "The IP address to advertise in Discv5, put into the ENR of the node. This may also be a hostname / domain name to resolve to an IP.",
-		Required: false,
-		// Ignored by default, nodes can discover their own external IP in the happy case,
-		// by communicating with bootnodes. Fixed IP is recommended for faster bootstrap though.
-		Value:   "",
-		EnvVars: p2pEnv("ADVERTISE_IP"),
-	}
-	AdvertiseTCPPort = &cli.UintFlag{
-		Name:     "p2p.advertise.tcp",
-		Usage:    "The TCP port to advertise in Discv5, put into the ENR of the node. Set to p2p.listen.tcp value if 0.",
-		Required: false,
-		Value:    0,
-		EnvVars:  p2pEnv("ADVERTISE_TCP"),
-	}
-	AdvertiseUDPPort = &cli.UintFlag{
-		Name:     "p2p.advertise.udp",
-		Usage:    "The UDP port to advertise in Discv5 as fallback if not determined by Discv5, put into the ENR of the node. Set to p2p.listen.udp value if 0.",
-		Required: false,
-		Value:    0,
-		EnvVars:  p2pEnv("ADVERTISE_UDP"),
-	}
-	Bootnodes = &cli.StringFlag{
-		Name:     "p2p.bootnodes",
-		Usage:    "Comma-separated base64-format ENR list. Bootnodes to start discovering other node records from.",
-		Required: false,
-		Value:    "",
-		EnvVars:  p2pEnv("BOOTNODES"),
-	}
-	StaticPeers = &cli.StringFlag{
-		Name:     "p2p.static",
-		Usage:    "Comma-separated multiaddr-format peer list. Static connections to make and maintain, these peers will be regarded as trusted.",
-		Required: false,
-		Value:    "",
-		EnvVars:  p2pEnv("STATIC"),
-	}
-	NetRestrict = &cli.StringFlag{
-		Name:     "p2p.netrestrict",
-		Usage:    "Comma-separated list of CIDR masks. P2P will only try to connect on these networks",
-		Required: false,
-		EnvVars:  p2pEnv("NETRESTRICT"),
-	}
-	HostMux = &cli.StringFlag{
-		Name:     "p2p.mux",
-		Usage:    "Comma-separated list of multiplexing protocols in order of preference. At least 1 required. Options: 'yamux','mplex'.",
-		Hidden:   true,
-		Required: false,
-		Value:    "yamux,mplex",
-		EnvVars:  p2pEnv("MUX"),
-	}
-	HostSecurity = &cli.StringFlag{
-		Name:     "p2p.security",
-		Usage:    "Comma-separated list of transport security protocols in order of preference. At least 1 required. Options: 'noise','tls'. Set to 'none' to disable.",
-		Hidden:   true,
-		Required: false,
-		Value:    "noise",
-		EnvVars:  p2pEnv("SECURITY"),
-	}
-	PeersLo = &cli.UintFlag{
-		Name:     "p2p.peers.lo",
-		Usage:    "Low-tide peer count. The node actively searches for new peer connections if below this amount.",
-		Required: false,
-		Value:    20,
-		EnvVars:  p2pEnv("PEERS_LO"),
-	}
-	PeersHi = &cli.UintFlag{
-		Name:     "p2p.peers.hi",
-		Usage:    "High-tide peer count. The node starts pruning peer connections slowly after reaching this number.",
-		Required: false,
-		Value:    30,
-		EnvVars:  p2pEnv("PEERS_HI"),
-	}
-	PeersGrace = &cli.DurationFlag{
-		Name:     "p2p.peers.grace",
-		Usage:    "Grace period to keep a newly connected peer around, if it is not misbehaving.",
-		Required: false,
-		Value:    30 * time.Second,
-		EnvVars:  p2pEnv("PEERS_GRACE"),
-	}
-	NAT = &cli.BoolFlag{
-		Name:     "p2p.nat",
-		Usage:    "Enable NAT traversal with PMP/UPNP devices to learn external IP.",
-		Required: false,
-		EnvVars:  p2pEnv("NAT"),
-	}
-	UserAgent = &cli.StringFlag{
-		Name:     "p2p.useragent",
-		Usage:    "User-agent string to share via LibP2P identify. If empty it defaults to 'optimism'.",
-		Hidden:   true,
-		Required: false,
-		Value:    "optimism",
-		EnvVars:  p2pEnv("AGENT"),
-	}
-	TimeoutNegotiation = &cli.DurationFlag{
-		Name:     "p2p.timeout.negotiation",
-		Usage:    "Negotiation timeout, time for new peer connections to share their their supported p2p protocols",
-		Hidden:   true,
-		Required: false,
-		Value:    10 * time.Second,
-		EnvVars:  p2pEnv("TIMEOUT_NEGOTIATION"),
-	}
-	TimeoutAccept = &cli.DurationFlag{
-		Name:     "p2p.timeout.accept",
-		Usage:    "Accept timeout, time for connection to be accepted.",
-		Hidden:   true,
-		Required: false,
-		Value:    10 * time.Second,
-		EnvVars:  p2pEnv("TIMEOUT_ACCEPT"),
-	}
-	TimeoutDial = &cli.DurationFlag{
-		Name:     "p2p.timeout.dial",
-		Usage:    "Dial timeout for outgoing connection requests",
-		Hidden:   true,
-		Required: false,
-		Value:    10 * time.Second,
-		EnvVars:  p2pEnv("TIMEOUT_DIAL"),
-	}
-	PeerstorePath = &cli.StringFlag{
-		Name: "p2p.peerstore.path",
-		Usage: "Peerstore database location. Persisted peerstores help recover peers after restarts. " +
-			"Set to 'memory' to never persist the peerstore. Peerstore records will be pruned / expire as necessary. " +
-			"Warning: a copy of the priv network key of the local peer will be persisted here.", // TODO: bad design of libp2p, maybe we can avoid this from happening
-		Required:  false,
-		TakesFile: true,
-		Value:     "opnode_peerstore_db",
-		EnvVars:   p2pEnv("PEERSTORE_PATH"),
-	}
-	DiscoveryPath = &cli.StringFlag{
-		Name:      "p2p.discovery.path",
-		Usage:     "Discovered ENRs are persisted in a database to recover from a restart without having to bootstrap the discovery process again. Set to 'memory' to never persist the peerstore.",
-		Required:  false,
-		TakesFile: true,
-		Value:     "opnode_discovery_db",
-		EnvVars:   p2pEnv("DISCOVERY_PATH"),
-	}
-	SequencerP2PKeyFlag = &cli.StringFlag{
-		Name:     "p2p.sequencer.key",
-		Usage:    "Hex-encoded private key for signing off on p2p application messages as sequencer.",
-		Required: false,
-		Value:    "",
-		EnvVars:  p2pEnv("SEQUENCER_KEY"),
-	}
-	GossipMeshDFlag = &cli.UintFlag{
-		Name:     "p2p.gossip.mesh.d",
-		Usage:    "Configure GossipSub topic stable mesh target count, a.k.a. desired outbound degree, number of peers to gossip to",
-		Required: false,
-		Hidden:   true,
-		Value:    p2p.DefaultMeshD,
-		EnvVars:  p2pEnv("GOSSIP_MESH_D"),
-	}
-	GossipMeshDloFlag = &cli.UintFlag{
-		Name:     "p2p.gossip.mesh.lo",
-		Usage:    "Configure GossipSub topic stable mesh low watermark, a.k.a. lower bound of outbound degree",
-		Required: false,
-		Hidden:   true,
-		Value:    p2p.DefaultMeshDlo,
-		EnvVars:  p2pEnv("GOSSIP_MESH_DLO"),
-	}
-	GossipMeshDhiFlag = &cli.UintFlag{
-		Name:     "p2p.gossip.mesh.dhi",
-		Usage:    "Configure GossipSub topic stable mesh high watermark, a.k.a. upper bound of outbound degree, additional peers will not receive gossip",
-		Required: false,
-		Hidden:   true,
-		Value:    p2p.DefaultMeshDhi,
-		EnvVars:  p2pEnv("GOSSIP_MESH_DHI"),
-	}
-	GossipMeshDlazyFlag = &cli.UintFlag{
-		Name:     "p2p.gossip.mesh.dlazy",
-		Usage:    "Configure GossipSub gossip target, a.k.a. target degree for gossip only (not messaging like p2p.gossip.mesh.d, just announcements of IHAVE",
-		Required: false,
-		Hidden:   true,
-		Value:    p2p.DefaultMeshDlazy,
-		EnvVars:  p2pEnv("GOSSIP_MESH_DLAZY"),
-	}
-	GossipFloodPublishFlag = &cli.BoolFlag{
-		Name:     "p2p.gossip.mesh.floodpublish",
-		Usage:    "Configure GossipSub to publish messages to all known peers on the topic, outside of the mesh, also see Dlazy as less aggressive alternative.",
-		Required: false,
-		Hidden:   true,
-		EnvVars:  p2pEnv("GOSSIP_FLOOD_PUBLISH"),
-	}
-	SyncReqRespFlag = &cli.BoolFlag{
-		Name:     "p2p.sync.req-resp",
-		Usage:    "Enables P2P req-resp alternative sync method, on both server and client side.",
-		Value:    true,
-		Required: false,
-		EnvVars:  p2pEnv("SYNC_REQ_RESP"),
-	}
-)
 
 // None of these flags are strictly required.
 // Some are hidden if they are too technical, or not recommended.
-var P2pFlags = []cli.Flag{
-	DisableP2P,
-	NoDiscovery,
-	P2PPrivPath,
-	P2PPrivRaw,
-	Scoring,
-	PeerScoring,
-	PeerScoreBands,
-	Banning,
-	BanningThreshold,
-	BanningDuration,
-	TopicScoring,
-	ListenIP,
-	ListenTCPPort,
-	ListenUDPPort,
-	AdvertiseIP,
-	AdvertiseTCPPort,
-	AdvertiseUDPPort,
-	Bootnodes,
-	StaticPeers,
-	NetRestrict,
-	HostMux,
-	HostSecurity,
-	PeersLo,
-	PeersHi,
-	PeersGrace,
-	NAT,
-	UserAgent,
-	TimeoutNegotiation,
-	TimeoutAccept,
-	TimeoutDial,
-	PeerstorePath,
-	DiscoveryPath,
-	SequencerP2PKeyFlag,
-	GossipMeshDFlag,
-	GossipMeshDloFlag,
-	GossipMeshDhiFlag,
-	GossipMeshDlazyFlag,
-	GossipFloodPublishFlag,
-	SyncReqRespFlag,
+func P2PFlags(envPrefix string) []cli.Flag {
+	return []cli.Flag{
+		&cli.BoolFlag{
+			Name:     "p2p.disable",
+			Usage:    "Completely disable the P2P stack",
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "DISABLE"),
+		},
+		&cli.BoolFlag{
+			Name:     "p2p.no-discovery",
+			Usage:    "Disable Discv5 (node discovery)",
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "NO_DISCOVERY"),
+		},
+		&cli.StringFlag{
+			Name:     p2pScoringName,
+			Usage:    "Sets the peer scoring strategy for the P2P stack. Can be one of: none or light.",
+			Required: false,
+			Value:    "light",
+			EnvVars:  p2pEnv(envPrefix, "PEER_SCORING"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.scoring.peers",
+			Usage:    fmt.Sprintf("Deprecated: Use %v instead", p2pScoringName),
+			Required: false,
+			Hidden:   true,
+		},
+		&cli.StringFlag{
+			Name:     "p2p.score.bands",
+			Usage:    "Deprecated. This option is ignored and is only present for backwards compatibility.",
+			Required: false,
+			Value:    "",
+			Hidden:   true,
+		},
+		&cli.BoolFlag{
+			// Banning Flag - whether or not we want to act on the scoring
+			Name:     "p2p.ban.peers",
+			Usage:    "Enables peer banning.",
+			Value:    true,
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING"),
+		},
+		&cli.Float64Flag{
+			Name:     "p2p.ban.threshold",
+			Usage:    "The minimum score below which peers are disconnected and banned.",
+			Required: false,
+			Value:    -100,
+			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING_THRESHOLD"),
+		},
+		&cli.DurationFlag{
+			Name:     "p2p.ban.duration",
+			Usage:    "The duration that peers are banned for.",
+			Required: false,
+			Value:    1 * time.Hour,
+			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING_DURATION"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.scoring.topics",
+			Usage:    fmt.Sprintf("Deprecated: Use %v instead", p2pScoringName),
+			Required: false,
+			Hidden:   true,
+		},
+		&cli.StringFlag{
+			Name: "p2p.priv.path",
+			Usage: "Read the hex-encoded 32-byte private key for the peer ID from this txt file. Created if not already exists." +
+				"Important to persist to keep the same network identity after restarting, maintaining the previous advertised identity.",
+			Required:  false,
+			Value:     "opnode_p2p_priv.txt",
+			EnvVars:   p2pEnv(envPrefix, "PRIV_PATH"),
+			TakesFile: true,
+		},
+		&cli.StringFlag{
+			// sometimes it may be ok to not persist the peer priv key as file, and instead pass it directly.
+			Name:     "p2p.priv.raw",
+			Usage:    "The hex-encoded 32-byte private key for the peer ID",
+			Required: false,
+			Hidden:   true,
+			Value:    "",
+			EnvVars:  p2pEnv(envPrefix, "PRIV_RAW"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.listen.ip",
+			Usage:    "IP to bind LibP2P and Discv5 to",
+			Required: false,
+			Value:    "0.0.0.0",
+			EnvVars:  p2pEnv(envPrefix, "LISTEN_IP"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.listen.tcp",
+			Usage:    "TCP port to bind LibP2P to. Any available system port if set to 0.",
+			Required: false,
+			Value:    9222,
+			EnvVars:  p2pEnv(envPrefix, "LISTEN_TCP_PORT"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.listen.udp",
+			Usage:    "UDP port to bind Discv5 to. Same as TCP port if left 0.",
+			Required: false,
+			Value:    0, // can simply match the TCP libp2p port
+			EnvVars:  p2pEnv(envPrefix, "LISTEN_UDP_PORT"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.advertise.ip",
+			Usage:    "The IP address to advertise in Discv5, put into the ENR of the node. This may also be a hostname / domain name to resolve to an IP.",
+			Required: false,
+			// Ignored by default, nodes can discover their own external IP in the happy case,
+			// by communicating with bootnodes. Fixed IP is recommended for faster bootstrap though.
+			Value:   "",
+			EnvVars: p2pEnv(envPrefix, "ADVERTISE_IP"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.advertise.tcp",
+			Usage:    "The TCP port to advertise in Discv5, put into the ENR of the node. Set to p2p.listen.tcp value if 0.",
+			Required: false,
+			Value:    0,
+			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_TCP"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.advertise.udp",
+			Usage:    "The UDP port to advertise in Discv5 as fallback if not determined by Discv5, put into the ENR of the node. Set to p2p.listen.udp value if 0.",
+			Required: false,
+			Value:    0,
+			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_UDP"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.bootnodes",
+			Usage:    "Comma-separated base64-format ENR list. Bootnodes to start discovering other node records from.",
+			Required: false,
+			Value:    "",
+			EnvVars:  p2pEnv(envPrefix, "BOOTNODES"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.static",
+			Usage:    "Comma-separated multiaddr-format peer list. Static connections to make and maintain, these peers will be regarded as trusted.",
+			Required: false,
+			Value:    "",
+			EnvVars:  p2pEnv(envPrefix, "STATIC"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.netrestrict",
+			Usage:    "Comma-separated list of CIDR masks. P2P will only try to connect on these networks",
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "NETRESTRICT"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.mux",
+			Usage:    "Comma-separated list of multiplexing protocols in order of preference. At least 1 required. Options: 'yamux','mplex'.",
+			Hidden:   true,
+			Required: false,
+			Value:    "yamux,mplex",
+			EnvVars:  p2pEnv(envPrefix, "MUX"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.security",
+			Usage:    "Comma-separated list of transport security protocols in order of preference. At least 1 required. Options: 'noise','tls'. Set to 'none' to disable.",
+			Hidden:   true,
+			Required: false,
+			Value:    "noise",
+			EnvVars:  p2pEnv(envPrefix, "SECURITY"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.peers.lo",
+			Usage:    "Low-tide peer count. The node actively searches for new peer connections if below this amount.",
+			Required: false,
+			Value:    20,
+			EnvVars:  p2pEnv(envPrefix, "PEERS_LO"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.peers.hi",
+			Usage:    "High-tide peer count. The node starts pruning peer connections slowly after reaching this number.",
+			Required: false,
+			Value:    30,
+			EnvVars:  p2pEnv(envPrefix, "PEERS_HI"),
+		},
+		&cli.DurationFlag{
+			Name:     "p2p.peers.grace",
+			Usage:    "Grace period to keep a newly connected peer around, if it is not misbehaving.",
+			Required: false,
+			Value:    30 * time.Second,
+			EnvVars:  p2pEnv(envPrefix, "PEERS_GRACE"),
+		},
+		&cli.BoolFlag{
+			Name:     "p2p.nat",
+			Usage:    "Enable NAT traversal with PMP/UPNP devices to learn external IP.",
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "NAT"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.useragent",
+			Usage:    "User-agent string to share via LibP2P identify. If empty it defaults to 'optimism'.",
+			Hidden:   true,
+			Required: false,
+			Value:    "optimism",
+			EnvVars:  p2pEnv(envPrefix, "AGENT"),
+		},
+		&cli.DurationFlag{
+			Name:     "p2p.timeout.negotiation",
+			Usage:    "Negotiation timeout, time for new peer connections to share their their supported p2p protocols",
+			Hidden:   true,
+			Required: false,
+			Value:    10 * time.Second,
+			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_NEGOTIATION"),
+		},
+		&cli.DurationFlag{
+			Name:     "p2p.timeout.accept",
+			Usage:    "Accept timeout, time for connection to be accepted.",
+			Hidden:   true,
+			Required: false,
+			Value:    10 * time.Second,
+			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_ACCEPT"),
+		},
+		&cli.DurationFlag{
+			Name:     "p2p.timeout.dial",
+			Usage:    "Dial timeout for outgoing connection requests",
+			Hidden:   true,
+			Required: false,
+			Value:    10 * time.Second,
+			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_DIAL"),
+		},
+		&cli.StringFlag{
+			Name: "p2p.peerstore.path",
+			Usage: "Peerstore database location. Persisted peerstores help recover peers after restarts. " +
+				"Set to 'memory' to never persist the peerstore. Peerstore records will be pruned / expire as necessary. " +
+				"Warning: a copy of the priv network key of the local peer will be persisted here.", // TODO: bad design of libp2p, maybe we can avoid this from happening
+			Required:  false,
+			TakesFile: true,
+			Value:     "opnode_peerstore_db",
+			EnvVars:   p2pEnv(envPrefix, "PEERSTORE_PATH"),
+		},
+		&cli.StringFlag{
+			Name:      "p2p.discovery.path",
+			Usage:     "Discovered ENRs are persisted in a database to recover from a restart without having to bootstrap the discovery process again. Set to 'memory' to never persist the peerstore.",
+			Required:  false,
+			TakesFile: true,
+			Value:     "opnode_discovery_db",
+			EnvVars:   p2pEnv(envPrefix, "DISCOVERY_PATH"),
+		},
+		&cli.StringFlag{
+			Name:     "p2p.sequencer.key",
+			Usage:    "Hex-encoded private key for signing off on p2p application messages as sequencer.",
+			Required: false,
+			Value:    "",
+			EnvVars:  p2pEnv(envPrefix, "SEQUENCER_KEY"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.gossip.mesh.d",
+			Usage:    "Configure GossipSub topic stable mesh target count, a.k.a. desired outbound degree, number of peers to gossip to",
+			Required: false,
+			Hidden:   true,
+			Value:    p2p.DefaultMeshD,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_D"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.gossip.mesh.lo",
+			Usage:    "Configure GossipSub topic stable mesh low watermark, a.k.a. lower bound of outbound degree",
+			Required: false,
+			Hidden:   true,
+			Value:    p2p.DefaultMeshDlo,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DLO"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.gossip.mesh.dhi",
+			Usage:    "Configure GossipSub topic stable mesh high watermark, a.k.a. upper bound of outbound degree, additional peers will not receive gossip",
+			Required: false,
+			Hidden:   true,
+			Value:    p2p.DefaultMeshDhi,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DHI"),
+		},
+		&cli.UintFlag{
+			Name:     "p2p.gossip.mesh.dlazy",
+			Usage:    "Configure GossipSub gossip target, a.k.a. target degree for gossip only (not messaging like p2p.gossip.mesh.d, just announcements of IHAVE",
+			Required: false,
+			Hidden:   true,
+			Value:    p2p.DefaultMeshDlazy,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DLAZY"),
+		},
+		&cli.BoolFlag{
+			Name:     "p2p.gossip.mesh.floodpublish",
+			Usage:    "Configure GossipSub to publish messages to all known peers on the topic, outside of the mesh, also see Dlazy as less aggressive alternative.",
+			Required: false,
+			Hidden:   true,
+			EnvVars:  p2pEnv(envPrefix, "GOSSIP_FLOOD_PUBLISH"),
+		},
+		&cli.BoolFlag{
+			Name:     "p2p.sync.req-resp",
+			Usage:    "Enables P2P req-resp alternative sync method, on both server and client side.",
+			Value:    true,
+			Required: false,
+			EnvVars:  p2pEnv(envPrefix, "SYNC_REQ_RESP"),
+		},
+	}
 }

--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -9,43 +9,83 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 )
 
-const p2pScoringName = "p2p.scoring"
-
 func p2pEnv(envprefix, v string) []string {
 	return []string{envprefix + "_P2P_" + v}
 }
+
+var (
+	DisableP2PName         = "p2p.disable"
+	NoDiscoveryName        = "p2p.no-discovery"
+	ScoringName            = "p2p.scoring"
+	PeerScoringName        = "p2p.scoring.peers"
+	PeerScoreBandsName     = "p2p.score.bands"
+	BanningName            = "p2p.ban.peers"
+	BanningThresholdName   = "p2p.ban.threshold"
+	BanningDurationName    = "p2p.ban.duration"
+	TopicScoringName       = "p2p.scoring.topics"
+	P2PPrivPathName        = "p2p.priv.path"
+	P2PPrivRawName         = "p2p.priv.raw"
+	ListenIPName           = "p2p.listen.ip"
+	ListenTCPPortName      = "p2p.listen.tcp"
+	ListenUDPPortName      = "p2p.listen.udp"
+	AdvertiseIPName        = "p2p.advertise.ip"
+	AdvertiseTCPPortName   = "p2p.advertise.tcp"
+	AdvertiseUDPPortName   = "p2p.advertise.udp"
+	BootnodesName          = "p2p.bootnodes"
+	StaticPeersName        = "p2p.static"
+	NetRestrictName        = "p2p.netrestrict"
+	HostMuxName            = "p2p.mux"
+	HostSecurityName       = "p2p.security"
+	PeersLoName            = "p2p.peers.lo"
+	PeersHiName            = "p2p.peers.hi"
+	PeersGraceName         = "p2p.peers.grace"
+	NATName                = "p2p.nat"
+	UserAgentName          = "p2p.useragent"
+	TimeoutNegotiationName = "p2p.timeout.negotiation"
+	TimeoutAcceptName      = "p2p.timeout.accept"
+	TimeoutDialName        = "p2p.timeout.dial"
+	PeerstorePathName      = "p2p.peerstore.path"
+	DiscoveryPathName      = "p2p.discovery.path"
+	SequencerP2PKeyName    = "p2p.sequencer.key"
+	GossipMeshDName        = "p2p.gossip.mesh.d"
+	GossipMeshDloName      = "p2p.gossip.mesh.lo"
+	GossipMeshDhiName      = "p2p.gossip.mesh.dhi"
+	GossipMeshDlazyName    = "p2p.gossip.mesh.dlazy"
+	GossipFloodPublishName = "p2p.gossip.mesh.floodpublish"
+	SyncReqRespName        = "p2p.sync.req-resp"
+)
 
 // None of these flags are strictly required.
 // Some are hidden if they are too technical, or not recommended.
 func P2PFlags(envPrefix string) []cli.Flag {
 	return []cli.Flag{
 		&cli.BoolFlag{
-			Name:     "p2p.disable",
+			Name:     DisableP2PName,
 			Usage:    "Completely disable the P2P stack",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "DISABLE"),
 		},
 		&cli.BoolFlag{
-			Name:     "p2p.no-discovery",
+			Name:     NoDiscoveryName,
 			Usage:    "Disable Discv5 (node discovery)",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "NO_DISCOVERY"),
 		},
 		&cli.StringFlag{
-			Name:     p2pScoringName,
+			Name:     ScoringName,
 			Usage:    "Sets the peer scoring strategy for the P2P stack. Can be one of: none or light.",
 			Required: false,
 			Value:    "light",
 			EnvVars:  p2pEnv(envPrefix, "PEER_SCORING"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.scoring.peers",
-			Usage:    fmt.Sprintf("Deprecated: Use %v instead", p2pScoringName),
+			Name:     PeerScoringName,
+			Usage:    fmt.Sprintf("Deprecated: Use %v instead", ScoringName),
 			Required: false,
 			Hidden:   true,
 		},
 		&cli.StringFlag{
-			Name:     "p2p.score.bands",
+			Name:     PeerScoreBandsName,
 			Usage:    "Deprecated. This option is ignored and is only present for backwards compatibility.",
 			Required: false,
 			Value:    "",
@@ -53,34 +93,34 @@ func P2PFlags(envPrefix string) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			// Banning Flag - whether or not we want to act on the scoring
-			Name:     "p2p.ban.peers",
+			Name:     BanningName,
 			Usage:    "Enables peer banning.",
 			Value:    true,
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING"),
 		},
 		&cli.Float64Flag{
-			Name:     "p2p.ban.threshold",
+			Name:     BanningThresholdName,
 			Usage:    "The minimum score below which peers are disconnected and banned.",
 			Required: false,
 			Value:    -100,
 			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING_THRESHOLD"),
 		},
 		&cli.DurationFlag{
-			Name:     "p2p.ban.duration",
+			Name:     BanningDurationName,
 			Usage:    "The duration that peers are banned for.",
 			Required: false,
 			Value:    1 * time.Hour,
 			EnvVars:  p2pEnv(envPrefix, "PEER_BANNING_DURATION"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.scoring.topics",
-			Usage:    fmt.Sprintf("Deprecated: Use %v instead", p2pScoringName),
+			Name:     TopicScoringName,
+			Usage:    fmt.Sprintf("Deprecated: Use %v instead", ScoringName),
 			Required: false,
 			Hidden:   true,
 		},
 		&cli.StringFlag{
-			Name: "p2p.priv.path",
+			Name: P2PPrivPathName,
 			Usage: "Read the hex-encoded 32-byte private key for the peer ID from this txt file. Created if not already exists." +
 				"Important to persist to keep the same network identity after restarting, maintaining the previous advertised identity.",
 			Required:  false,
@@ -90,7 +130,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			// sometimes it may be ok to not persist the peer priv key as file, and instead pass it directly.
-			Name:     "p2p.priv.raw",
+			Name:     P2PPrivRawName,
 			Usage:    "The hex-encoded 32-byte private key for the peer ID",
 			Required: false,
 			Hidden:   true,
@@ -98,28 +138,28 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "PRIV_RAW"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.listen.ip",
+			Name:     ListenIPName,
 			Usage:    "IP to bind LibP2P and Discv5 to",
 			Required: false,
 			Value:    "0.0.0.0",
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_IP"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.listen.tcp",
+			Name:     ListenTCPPortName,
 			Usage:    "TCP port to bind LibP2P to. Any available system port if set to 0.",
 			Required: false,
 			Value:    9222,
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_TCP_PORT"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.listen.udp",
+			Name:     ListenUDPPortName,
 			Usage:    "UDP port to bind Discv5 to. Same as TCP port if left 0.",
 			Required: false,
 			Value:    0, // can simply match the TCP libp2p port
 			EnvVars:  p2pEnv(envPrefix, "LISTEN_UDP_PORT"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.advertise.ip",
+			Name:     AdvertiseIPName,
 			Usage:    "The IP address to advertise in Discv5, put into the ENR of the node. This may also be a hostname / domain name to resolve to an IP.",
 			Required: false,
 			// Ignored by default, nodes can discover their own external IP in the happy case,
@@ -128,41 +168,41 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars: p2pEnv(envPrefix, "ADVERTISE_IP"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.advertise.tcp",
+			Name:     AdvertiseTCPPortName,
 			Usage:    "The TCP port to advertise in Discv5, put into the ENR of the node. Set to p2p.listen.tcp value if 0.",
 			Required: false,
 			Value:    0,
 			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_TCP"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.advertise.udp",
+			Name:     AdvertiseUDPPortName,
 			Usage:    "The UDP port to advertise in Discv5 as fallback if not determined by Discv5, put into the ENR of the node. Set to p2p.listen.udp value if 0.",
 			Required: false,
 			Value:    0,
 			EnvVars:  p2pEnv(envPrefix, "ADVERTISE_UDP"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.bootnodes",
+			Name:     BootnodesName,
 			Usage:    "Comma-separated base64-format ENR list. Bootnodes to start discovering other node records from.",
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "BOOTNODES"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.static",
+			Name:     StaticPeersName,
 			Usage:    "Comma-separated multiaddr-format peer list. Static connections to make and maintain, these peers will be regarded as trusted.",
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "STATIC"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.netrestrict",
+			Name:     NetRestrictName,
 			Usage:    "Comma-separated list of CIDR masks. P2P will only try to connect on these networks",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "NETRESTRICT"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.mux",
+			Name:     HostMuxName,
 			Usage:    "Comma-separated list of multiplexing protocols in order of preference. At least 1 required. Options: 'yamux','mplex'.",
 			Hidden:   true,
 			Required: false,
@@ -170,7 +210,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "MUX"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.security",
+			Name:     HostSecurityName,
 			Usage:    "Comma-separated list of transport security protocols in order of preference. At least 1 required. Options: 'noise','tls'. Set to 'none' to disable.",
 			Hidden:   true,
 			Required: false,
@@ -178,34 +218,34 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "SECURITY"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.peers.lo",
+			Name:     PeersLoName,
 			Usage:    "Low-tide peer count. The node actively searches for new peer connections if below this amount.",
 			Required: false,
 			Value:    20,
 			EnvVars:  p2pEnv(envPrefix, "PEERS_LO"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.peers.hi",
+			Name:     PeersHiName,
 			Usage:    "High-tide peer count. The node starts pruning peer connections slowly after reaching this number.",
 			Required: false,
 			Value:    30,
 			EnvVars:  p2pEnv(envPrefix, "PEERS_HI"),
 		},
 		&cli.DurationFlag{
-			Name:     "p2p.peers.grace",
+			Name:     PeersGraceName,
 			Usage:    "Grace period to keep a newly connected peer around, if it is not misbehaving.",
 			Required: false,
 			Value:    30 * time.Second,
 			EnvVars:  p2pEnv(envPrefix, "PEERS_GRACE"),
 		},
 		&cli.BoolFlag{
-			Name:     "p2p.nat",
+			Name:     NATName,
 			Usage:    "Enable NAT traversal with PMP/UPNP devices to learn external IP.",
 			Required: false,
 			EnvVars:  p2pEnv(envPrefix, "NAT"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.useragent",
+			Name:     UserAgentName,
 			Usage:    "User-agent string to share via LibP2P identify. If empty it defaults to 'optimism'.",
 			Hidden:   true,
 			Required: false,
@@ -213,7 +253,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "AGENT"),
 		},
 		&cli.DurationFlag{
-			Name:     "p2p.timeout.negotiation",
+			Name:     TimeoutNegotiationName,
 			Usage:    "Negotiation timeout, time for new peer connections to share their their supported p2p protocols",
 			Hidden:   true,
 			Required: false,
@@ -221,7 +261,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_NEGOTIATION"),
 		},
 		&cli.DurationFlag{
-			Name:     "p2p.timeout.accept",
+			Name:     TimeoutAcceptName,
 			Usage:    "Accept timeout, time for connection to be accepted.",
 			Hidden:   true,
 			Required: false,
@@ -229,7 +269,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_ACCEPT"),
 		},
 		&cli.DurationFlag{
-			Name:     "p2p.timeout.dial",
+			Name:     TimeoutDialName,
 			Usage:    "Dial timeout for outgoing connection requests",
 			Hidden:   true,
 			Required: false,
@@ -237,7 +277,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "TIMEOUT_DIAL"),
 		},
 		&cli.StringFlag{
-			Name: "p2p.peerstore.path",
+			Name: PeerstorePathName,
 			Usage: "Peerstore database location. Persisted peerstores help recover peers after restarts. " +
 				"Set to 'memory' to never persist the peerstore. Peerstore records will be pruned / expire as necessary. " +
 				"Warning: a copy of the priv network key of the local peer will be persisted here.", // TODO: bad design of libp2p, maybe we can avoid this from happening
@@ -247,7 +287,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:   p2pEnv(envPrefix, "PEERSTORE_PATH"),
 		},
 		&cli.StringFlag{
-			Name:      "p2p.discovery.path",
+			Name:      DiscoveryPathName,
 			Usage:     "Discovered ENRs are persisted in a database to recover from a restart without having to bootstrap the discovery process again. Set to 'memory' to never persist the peerstore.",
 			Required:  false,
 			TakesFile: true,
@@ -255,14 +295,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:   p2pEnv(envPrefix, "DISCOVERY_PATH"),
 		},
 		&cli.StringFlag{
-			Name:     "p2p.sequencer.key",
+			Name:     SequencerP2PKeyName,
 			Usage:    "Hex-encoded private key for signing off on p2p application messages as sequencer.",
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "SEQUENCER_KEY"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.gossip.mesh.d",
+			Name:     GossipMeshDName,
 			Usage:    "Configure GossipSub topic stable mesh target count, a.k.a. desired outbound degree, number of peers to gossip to",
 			Required: false,
 			Hidden:   true,
@@ -270,7 +310,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_D"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.gossip.mesh.lo",
+			Name:     GossipMeshDloName,
 			Usage:    "Configure GossipSub topic stable mesh low watermark, a.k.a. lower bound of outbound degree",
 			Required: false,
 			Hidden:   true,
@@ -278,7 +318,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DLO"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.gossip.mesh.dhi",
+			Name:     GossipMeshDhiName,
 			Usage:    "Configure GossipSub topic stable mesh high watermark, a.k.a. upper bound of outbound degree, additional peers will not receive gossip",
 			Required: false,
 			Hidden:   true,
@@ -286,7 +326,7 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DHI"),
 		},
 		&cli.UintFlag{
-			Name:     "p2p.gossip.mesh.dlazy",
+			Name:     GossipMeshDlazyName,
 			Usage:    "Configure GossipSub gossip target, a.k.a. target degree for gossip only (not messaging like p2p.gossip.mesh.d, just announcements of IHAVE",
 			Required: false,
 			Hidden:   true,
@@ -294,14 +334,14 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_MESH_DLAZY"),
 		},
 		&cli.BoolFlag{
-			Name:     "p2p.gossip.mesh.floodpublish",
+			Name:     GossipFloodPublishName,
 			Usage:    "Configure GossipSub to publish messages to all known peers on the topic, outside of the mesh, also see Dlazy as less aggressive alternative.",
 			Required: false,
 			Hidden:   true,
 			EnvVars:  p2pEnv(envPrefix, "GOSSIP_FLOOD_PUBLISH"),
 		},
 		&cli.BoolFlag{
-			Name:     "p2p.sync.req-resp",
+			Name:     SyncReqRespName,
 			Usage:    "Enables P2P req-resp alternative sync method, on both server and client side.",
 			Value:    true,
 			Required: false,

--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -29,7 +29,7 @@ import (
 func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) {
 	conf := &p2p.Config{}
 
-	if ctx.Bool(flags.DisableP2P.Name) {
+	if ctx.Bool(flags.DisableP2PName) {
 		conf.DisableP2P = true
 		return conf, nil
 	}
@@ -64,7 +64,7 @@ func NewConfig(ctx *cli.Context, rollupCfg *rollup.Config) (*p2p.Config, error) 
 		return nil, fmt.Errorf("failed to load banning option: %w", err)
 	}
 
-	conf.EnableReqRespSync = ctx.Bool(flags.SyncReqRespFlag.Name)
+	conf.EnableReqRespSync = ctx.Bool(flags.SyncReqRespName)
 
 	return conf, nil
 }
@@ -84,13 +84,13 @@ func validatePort(p uint) (uint16, error) {
 
 // loadScoringParams loads the peer scoring options from the CLI context.
 func loadScoringParams(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Config) error {
-	scoringLevel := ctx.String(flags.Scoring.Name)
+	scoringLevel := ctx.String(flags.ScoringName)
 	// Check old names for backwards compatibility
 	if scoringLevel == "" {
-		scoringLevel = ctx.String(flags.PeerScoring.Name)
+		scoringLevel = ctx.String(flags.PeerScoringName)
 	}
 	if scoringLevel == "" {
-		scoringLevel = ctx.String(flags.TopicScoring.Name)
+		scoringLevel = ctx.String(flags.TopicScoringName)
 	}
 	if scoringLevel != "" {
 		params, err := p2p.GetScoringParams(scoringLevel, rollupCfg)
@@ -105,14 +105,14 @@ func loadScoringParams(conf *p2p.Config, ctx *cli.Context, rollupCfg *rollup.Con
 
 // loadBanningOptions loads whether or not to ban peers from the CLI context.
 func loadBanningOptions(conf *p2p.Config, ctx *cli.Context) error {
-	conf.BanningEnabled = ctx.Bool(flags.Banning.Name)
-	conf.BanningThreshold = ctx.Float64(flags.BanningThreshold.Name)
-	conf.BanningDuration = ctx.Duration(flags.BanningDuration.Name)
+	conf.BanningEnabled = ctx.Bool(flags.BanningName)
+	conf.BanningThreshold = ctx.Float64(flags.BanningThresholdName)
+	conf.BanningDuration = ctx.Duration(flags.BanningDurationName)
 	return nil
 }
 
 func loadListenOpts(conf *p2p.Config, ctx *cli.Context) error {
-	listenIP := ctx.String(flags.ListenIP.Name)
+	listenIP := ctx.String(flags.ListenIPName)
 	if listenIP != "" { // optional
 		conf.ListenIP = net.ParseIP(listenIP)
 		if conf.ListenIP == nil {
@@ -120,11 +120,11 @@ func loadListenOpts(conf *p2p.Config, ctx *cli.Context) error {
 		}
 	}
 	var err error
-	conf.ListenTCPPort, err = validatePort(ctx.Uint(flags.ListenTCPPort.Name))
+	conf.ListenTCPPort, err = validatePort(ctx.Uint(flags.ListenTCPPortName))
 	if err != nil {
 		return fmt.Errorf("bad listen TCP port: %w", err)
 	}
-	conf.ListenUDPPort, err = validatePort(ctx.Uint(flags.ListenUDPPort.Name))
+	conf.ListenUDPPort, err = validatePort(ctx.Uint(flags.ListenUDPPortName))
 	if err != nil {
 		return fmt.Errorf("bad listen UDP port: %w", err)
 	}
@@ -132,20 +132,20 @@ func loadListenOpts(conf *p2p.Config, ctx *cli.Context) error {
 }
 
 func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
-	if ctx.Bool(flags.NoDiscovery.Name) {
+	if ctx.Bool(flags.NoDiscoveryName) {
 		conf.NoDiscovery = true
 	}
 
 	var err error
-	conf.AdvertiseTCPPort, err = validatePort(ctx.Uint(flags.AdvertiseTCPPort.Name))
+	conf.AdvertiseTCPPort, err = validatePort(ctx.Uint(flags.AdvertiseTCPPortName))
 	if err != nil {
 		return fmt.Errorf("bad advertised TCP port: %w", err)
 	}
-	conf.AdvertiseUDPPort, err = validatePort(ctx.Uint(flags.AdvertiseUDPPort.Name))
+	conf.AdvertiseUDPPort, err = validatePort(ctx.Uint(flags.AdvertiseUDPPortName))
 	if err != nil {
 		return fmt.Errorf("bad advertised UDP port: %w", err)
 	}
-	adIP := ctx.String(flags.AdvertiseIP.Name)
+	adIP := ctx.String(flags.AdvertiseIPName)
 	if adIP != "" { // optional
 		ips, err := net.LookupIP(adIP)
 		if err != nil {
@@ -163,7 +163,7 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 		}
 	}
 
-	dbPath := ctx.String(flags.DiscoveryPath.Name)
+	dbPath := ctx.String(flags.DiscoveryPathName)
 	if dbPath == "" {
 		dbPath = "opnode_discovery_db"
 	}
@@ -176,7 +176,7 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 	}
 
 	bootnodes := make([]*enode.Node, 0)
-	records := strings.Split(ctx.String(flags.Bootnodes.Name), ",")
+	records := strings.Split(ctx.String(flags.BootnodesName), ",")
 	for i, recordB64 := range records {
 		recordB64 = strings.TrimSpace(recordB64)
 		if recordB64 == "" { // ignore empty records
@@ -194,8 +194,8 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 		conf.Bootnodes = p2p.DefaultBootnodes
 	}
 
-	if ctx.IsSet(flags.NetRestrict.Name) {
-		netRestrict, err := netutil.ParseNetlist(ctx.String(flags.NetRestrict.Name))
+	if ctx.IsSet(flags.NetRestrictName) {
+		netRestrict, err := netutil.ParseNetlist(ctx.String(flags.NetRestrictName))
 		if err != nil {
 			return fmt.Errorf("failed to parse net list: %w", err)
 		}
@@ -206,7 +206,7 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 }
 
 func loadLibp2pOpts(conf *p2p.Config, ctx *cli.Context) error {
-	addrs := strings.Split(ctx.String(flags.StaticPeers.Name), ",")
+	addrs := strings.Split(ctx.String(flags.StaticPeersName), ",")
 	for i, addr := range addrs {
 		addr = strings.TrimSpace(addr)
 		if addr == "" {
@@ -219,7 +219,7 @@ func loadLibp2pOpts(conf *p2p.Config, ctx *cli.Context) error {
 		conf.StaticPeers = append(conf.StaticPeers, a)
 	}
 
-	for _, v := range strings.Split(ctx.String(flags.HostMux.Name), ",") {
+	for _, v := range strings.Split(ctx.String(flags.HostMuxName), ",") {
 		v = strings.ToLower(strings.TrimSpace(v))
 		switch v {
 		case "yamux":
@@ -231,7 +231,7 @@ func loadLibp2pOpts(conf *p2p.Config, ctx *cli.Context) error {
 		}
 	}
 
-	secArr := strings.Split(ctx.String(flags.HostSecurity.Name), ",")
+	secArr := strings.Split(ctx.String(flags.HostSecurityName), ",")
 	for _, v := range secArr {
 		v = strings.ToLower(strings.TrimSpace(v))
 		switch v {
@@ -249,16 +249,16 @@ func loadLibp2pOpts(conf *p2p.Config, ctx *cli.Context) error {
 		}
 	}
 
-	conf.PeersLo = ctx.Uint(flags.PeersLo.Name)
-	conf.PeersHi = ctx.Uint(flags.PeersHi.Name)
-	conf.PeersGrace = ctx.Duration(flags.PeersGrace.Name)
-	conf.NAT = ctx.Bool(flags.NAT.Name)
-	conf.UserAgent = ctx.String(flags.UserAgent.Name)
-	conf.TimeoutNegotiation = ctx.Duration(flags.TimeoutNegotiation.Name)
-	conf.TimeoutAccept = ctx.Duration(flags.TimeoutAccept.Name)
-	conf.TimeoutDial = ctx.Duration(flags.TimeoutDial.Name)
+	conf.PeersLo = ctx.Uint(flags.PeersLoName)
+	conf.PeersHi = ctx.Uint(flags.PeersHiName)
+	conf.PeersGrace = ctx.Duration(flags.PeersGraceName)
+	conf.NAT = ctx.Bool(flags.NATName)
+	conf.UserAgent = ctx.String(flags.UserAgentName)
+	conf.TimeoutNegotiation = ctx.Duration(flags.TimeoutNegotiationName)
+	conf.TimeoutAccept = ctx.Duration(flags.TimeoutAcceptName)
+	conf.TimeoutDial = ctx.Duration(flags.TimeoutDialName)
 
-	peerstorePath := ctx.String(flags.PeerstorePath.Name)
+	peerstorePath := ctx.String(flags.PeerstorePathName)
 	if peerstorePath == "" {
 		return errors.New("peerstore path must be specified, use 'memory' to explicitly not persist peer records")
 	}
@@ -279,11 +279,11 @@ func loadLibp2pOpts(conf *p2p.Config, ctx *cli.Context) error {
 }
 
 func loadNetworkPrivKey(ctx *cli.Context) (*crypto.Secp256k1PrivateKey, error) {
-	raw := ctx.String(flags.P2PPrivRaw.Name)
+	raw := ctx.String(flags.P2PPrivRawName)
 	if raw != "" {
 		return parsePriv(raw)
 	}
-	keyPath := ctx.String(flags.P2PPrivPath.Name)
+	keyPath := ctx.String(flags.P2PPrivPathName)
 	if keyPath == "" {
 		return nil, errors.New("no p2p private key path specified, cannot auto-generate key without path")
 	}
@@ -333,10 +333,10 @@ func parsePriv(data string) (*crypto.Secp256k1PrivateKey, error) {
 }
 
 func loadGossipOptions(conf *p2p.Config, ctx *cli.Context) error {
-	conf.MeshD = ctx.Int(flags.GossipMeshDFlag.Name)
-	conf.MeshDLo = ctx.Int(flags.GossipMeshDloFlag.Name)
-	conf.MeshDHi = ctx.Int(flags.GossipMeshDhiFlag.Name)
-	conf.MeshDLazy = ctx.Int(flags.GossipMeshDlazyFlag.Name)
-	conf.FloodPublish = ctx.Bool(flags.GossipFloodPublishFlag.Name)
+	conf.MeshD = ctx.Int(flags.GossipMeshDName)
+	conf.MeshDLo = ctx.Int(flags.GossipMeshDloName)
+	conf.MeshDHi = ctx.Int(flags.GossipMeshDhiName)
+	conf.MeshDLazy = ctx.Int(flags.GossipMeshDlazyName)
+	conf.FloodPublish = ctx.Bool(flags.GossipFloodPublishName)
 	return nil
 }

--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -15,7 +15,7 @@ import (
 
 // LoadSignerSetup loads a configuration for a Signer to be set up later
 func LoadSignerSetup(ctx *cli.Context) (p2p.SignerSetup, error) {
-	key := ctx.String(flags.SequencerP2PKeyFlag.Name)
+	key := ctx.String(flags.SequencerP2PKeyName)
 	if key != "" {
 		// Mnemonics are bad because they leak *all* keys when they leak.
 		// Unencrypted keys from file are bad because they are easy to leak (and we are not checking file permissions).


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

In #7282  bootnode metrics were enabled, but the metrics defined in P2P flag have the `OP_NODE` prefix by default. Updating so we can pass in an env var prefix.
Recommend reading the diff ignoring whitespace: https://github.com/ethereum-optimism/optimism/pull/7548/files?w=1

**Tests**

N/A

