### PR TITLE
op-chain-ops: skip extra json serialization

### DIFF
--- a/op-chain-ops/safe/batch.go
+++ b/op-chain-ops/safe/batch.go
@@ -25,7 +25,7 @@ import (
 // the raw calldata when both the calldata and ABIs with arguments are
 // present.
 type Batch struct {
-	SkipCalldata bool
+	SkipCalldata bool               `json:"-"`
 	Version      string             `json:"version"`
 	ChainID      *big.Int           `json:"chainId"`
 	CreatedAt    uint64             `json:"createdAt"`


### PR DESCRIPTION
**Description**

Ignore JSON serialization of the skip calldata field as it is meant to be a helper for the implementation and should not be included in the serialized JSON.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
