### PR TITLE
chore(proxyd): remove -race from make tests

### DIFF
--- a/proxyd/Makefile
+++ b/proxyd/Makefile
@@ -13,7 +13,7 @@ fmt:
 .PHONY: fmt
 
 test:
-	go test -race -v ./...
+	go test -v ./...
 .PHONY: test
 
 lint:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Remove `-race` from Makefile test target
