### PR TITLE
contracts-bedrock: custom Initializable

### DIFF
--- a/packages/contracts-bedrock/src/libraries/Initializable.sol
+++ b/packages/contracts-bedrock/src/libraries/Initializable.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { Constants } from "src/libraries/Constants.sol";
+
+/// @notice Initializable is a contract that facilitates calling a function wrapped
+///         with the initializer() by the ERC-1967 admin. In practice, the admin
+///         always calls the initializer() function even in Open Zeppelin's implementation
+///         where it is permissionless to call and can only be called once. By allowing
+///         the admin to call it, the security model is the same because the admin can
+///         already call initialize to set state after changing the implementation.
+abstract contract Initializable {
+    /// @dev Emitted when the contract is called by an account that is not the owner.
+    event Unauthorized();
+
+    /// @dev A modifier that wraps a function which can only be called by
+    ///      the owner of the proxy.
+    modifier initializer() {
+        address owner;
+        assembly {
+            owner := sload(constants.PROXY_OWNER_ADDRESS)
+        }
+        if (msg.sender != owner) revert Unauthorized();
+        _;
+    }
+}


### PR DESCRIPTION
**Description**

Adds a new contract to replace the OpenZeppelin
`Initializable` contract. This contract makes the
`initializer()` modifier only callable by the
ERC1967 admin. This simplifies upgrades compared to using the OpenZeppelin `Initializable` contract because we want to be able to `reinitialize` the same account many times but don't want to worry about managing the `reinitialize` number. In practice, the admin is always calling the `initialize` function thru the `ProxyAdmin.upgradeAndCall` function.

When moving to this implementation of `Initializable`, it will require some storage layout updates to each of the contracts that used OpenZeppelin `Initializable`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
