### PR TITLE
specs: Add new fault-proof hint types

### DIFF
--- a/specs/fault-proof.md
+++ b/specs/fault-proof.md
@@ -21,13 +21,14 @@
   - [Main content](#main-content)
   - [Epilogue](#epilogue)
   - [Pre-image hinting routes](#pre-image-hinting-routes)
-    - [`l1-header <blockhash>`](#l1-header-blockhash)
+    - [`l1-block-header <blockhash>`](#l1-block-header-blockhash)
     - [`l1-transactions <blockhash>`](#l1-transactions-blockhash)
     - [`l1-receipts <blockhash>`](#l1-receipts-blockhash)
-    - [`l2-header <blockhash>`](#l2-header-blockhash)
+    - [`l2-block-header <blockhash>`](#l2-block-header-blockhash)
     - [`l2-transactions <blockhash>`](#l2-transactions-blockhash)
     - [`l2-code <codehash>`](#l2-code-codehash)
     - [`l2-state-node <nodehash>`](#l2-state-node-nodehash)
+    - [`l2-output <blockhash>`](#l2-output-blockhash)
 - [Fault Proof VM](#fault-proof-vm)
 - [Fault Proof Interactive Dispute Game](#fault-proof-interactive-dispute-game)
 
@@ -341,7 +342,7 @@ This can be exposed via a CLI, or alternative inter-process API.
 
 Every instance of `<blockhash>` in the below routes is `0x`-prefixed, lowercase, hex-encoded.
 
-#### `l1-header <blockhash>`
+#### `l1-block-header <blockhash>`
 
 Requests the host to prepare the L1 block header RLP pre-image of the block `<blockhash>`.
 
@@ -355,7 +356,7 @@ prepare the RLP pre-images of each of them, including transactions-list MPT node
 Requests the host to prepare the list of receipts of the L1 block with `<blockhash>`:
 prepare the RLP pre-images of each of them, including receipts-list MPT nodes.
 
-#### `l2-header <blockhash>`
+#### `l2-block-header <blockhash>`
 
 Requests the host to prepare the L2 block header RLP pre-image of the block `<blockhash>`.
 
@@ -371,6 +372,10 @@ Requests the host to prepare the L2 smart-contract code with the given `<codehas
 #### `l2-state-node <nodehash>`
 
 Requests the host to prepare the L2 MPT node preimage with the given `<nodehash>`.
+
+#### `l2-output <outputroot>`
+
+Requests the host to prepare the L2 Output at the l2 output root `<outputroot>`.
 
 ## Fault Proof VM
 

--- a/specs/fault-proof.md
+++ b/specs/fault-proof.md
@@ -28,7 +28,7 @@
     - [`l2-transactions <blockhash>`](#l2-transactions-blockhash)
     - [`l2-code <codehash>`](#l2-code-codehash)
     - [`l2-state-node <nodehash>`](#l2-state-node-nodehash)
-    - [`l2-output <blockhash>`](#l2-output-blockhash)
+    - [`l2-output <outputroot>`](#l2-output-outputroot)
 - [Fault Proof VM](#fault-proof-vm)
 - [Fault Proof Interactive Dispute Game](#fault-proof-interactive-dispute-game)
 
@@ -376,6 +376,7 @@ Requests the host to prepare the L2 MPT node preimage with the given `<nodehash>
 #### `l2-output <outputroot>`
 
 Requests the host to prepare the L2 Output at the l2 output root `<outputroot>`.
+The L2 Output is the preimage of a [computed output root](./proposals.md#l2-output-commitment-construction).
 
 ## Fault Proof VM
 


### PR DESCRIPTION
Adds the missing l2-output hint type and fixes the l1-block-header hint. These are already in use by the fault proof program, so the spec is out of date.