### PR TITLE
bugfix(indexer) index the mint field of the l1 deposit transactions and not the value field

### DIFF
--- a/indexer/e2e_tests/bridge_transactions_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transactions_e2e_test.go
@@ -36,7 +36,7 @@ func TestE2EBridgeTransactionsOptimismPortalDeposits(t *testing.T) {
 	l1Opts.Value = big.NewInt(params.Ether)
 
 	// In the same deposit transaction, transfer, 0.5ETH to Bob. We do this to ensure we're only indexing
-	// bridged funds from the source address versus any transferred value to a recepient in the same L2 transaction
+	// bridged funds from the source address versus any transferred value to a recipient in the same L2 transaction
 	depositTx, err := optimismPortal.DepositTransaction(l1Opts, bobAddr, big.NewInt(params.Ether/2), 100_000, false, calldata)
 	require.NoError(t, err)
 	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())

--- a/indexer/e2e_tests/bridge_transactions_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transactions_e2e_test.go
@@ -26,6 +26,7 @@ func TestE2EBridgeTransactionsOptimismPortalDeposits(t *testing.T) {
 	optimismPortal, err := bindings.NewOptimismPortal(testSuite.OpCfg.L1Deployments.OptimismPortalProxy, testSuite.L1Client)
 	require.NoError(t, err)
 
+	bobAddr := testSuite.OpCfg.Secrets.Addresses().Bob
 	aliceAddr := testSuite.OpCfg.Secrets.Addresses().Alice
 
 	// attach 1 ETH to the deposit and random calldata
@@ -34,7 +35,9 @@ func TestE2EBridgeTransactionsOptimismPortalDeposits(t *testing.T) {
 	require.NoError(t, err)
 	l1Opts.Value = big.NewInt(params.Ether)
 
-	depositTx, err := optimismPortal.DepositTransaction(l1Opts, aliceAddr, l1Opts.Value, 100_000, false, calldata)
+	// In the same deposit transaction, transfer, 0.5ETH to Bob. We do this to ensure we're only indexing
+	// bridged funds from the source address versus any transferred value to a recepient in the same L2 transaction
+	depositTx, err := optimismPortal.DepositTransaction(l1Opts, bobAddr, big.NewInt(params.Ether/2), 100_000, false, calldata)
 	require.NoError(t, err)
 	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
 	require.NoError(t, err)
@@ -57,7 +60,7 @@ func TestE2EBridgeTransactionsOptimismPortalDeposits(t *testing.T) {
 	require.Equal(t, uint64(100_000), deposit.GasLimit.Uint64())
 	require.Equal(t, uint64(params.Ether), deposit.Tx.Amount.Uint64())
 	require.Equal(t, aliceAddr, deposit.Tx.FromAddress)
-	require.Equal(t, aliceAddr, deposit.Tx.ToAddress)
+	require.Equal(t, bobAddr, deposit.Tx.ToAddress)
 	require.ElementsMatch(t, calldata, deposit.Tx.Data)
 
 	event, err := testSuite.DB.ContractEvents.L1ContractEvent(deposit.InitiatedL1EventGUID)

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -92,7 +92,10 @@ CREATE TABLE IF NOT EXISTS l1_transaction_deposits (
     l2_transaction_hash     VARCHAR NOT NULL UNIQUE,
     initiated_l1_event_guid VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE,
 
-    -- transaction data
+    -- transaction data. NOTE: `to_address` is the recipient of funds transferred in value field of the
+    -- L2 deposit transaction and not the amount minted on L1 from the source address. Hence the `amount`
+    -- column in this table does NOT indiciate the amount transferred to the recipient but instead funds
+    -- bridged from L1 into `from_address`.
     from_address VARCHAR NOT NULL,
     to_address   VARCHAR NOT NULL,
 

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -95,7 +95,11 @@ CREATE TABLE IF NOT EXISTS l1_transaction_deposits (
     -- transaction data
     from_address VARCHAR NOT NULL,
     to_address   VARCHAR NOT NULL,
+
+    -- This refers to the amount MINTED on L2 (msg.value of the L1 transaction). Important distinction from
+    -- the `value` field of the deposit transaction which simply is the value transferred to specified recipient.
     amount       UINT256 NOT NULL,
+
     gas_limit    UINT256 NOT NULL,
     data         VARCHAR NOT NULL,
     timestamp    INTEGER NOT NULL CHECK (timestamp > 0)

--- a/indexer/processors/contracts/optimism_portal.go
+++ b/indexer/processors/contracts/optimism_portal.go
@@ -71,7 +71,7 @@ func OptimismPortalTransactionDepositEvents(contractAddress common.Address, db *
 			Tx: database.Transaction{
 				FromAddress: txDeposit.From,
 				ToAddress:   txDeposit.To,
-				Amount:      depositTx.Value,
+				Amount:      depositTx.Mint,
 				Data:        depositTx.Data,
 				Timestamp:   transactionDepositEvents[i].Timestamp,
 			},


### PR DESCRIPTION
We currently index the value field of the l1 deposit receipt which is different than
the amount of ETH bridged over from L1. What we want to index is the mint field which
is the amount bridged over (msg.value).
