### PR TITLE
bugfix(indexer) uint256 sql domain check constraint

### DIFF
--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -3,7 +3,12 @@ DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'uint256') THEN
         CREATE DOMAIN UINT256 AS NUMERIC
-            CHECK (VALUE >= 0 AND VALUE < 2^256 and SCALE(VALUE) = 0);
+            CHECK (VALUE >= 0 AND VALUE < POWER(CAST(2 AS NUMERIC), CAST(256 AS NUMERIC)) AND SCALE(VALUE) = 0);
+    ELSE
+        -- To remain backwards compatible, drop the old constraint and re-add.
+        ALTER DOMAIN UINT256 DROP CONSTRAINT uint256_check;
+        ALTER DOMAIN UINT256 ADD
+            CHECK (VALUE >= 0 AND VALUE < POWER(CAST(2 AS NUMERIC), CAST(256 AS NUMERIC)) AND SCALE(VALUE) = 0);
     END IF;
 END $$;
 


### PR DESCRIPTION
The domain constrant set the upper bound using doubles. Postgres computes
this using scientific notion resulting the max value being much less than 2^256-1. To fix this,
we explicitly cast the values as numerics in the POW function for precision.

Not a huge issues as most numbers the indexer will see are <<<< 2^256. Ironically this
issue helped surface the bug fixed in #7585
