### PR TITLE
Update op-e2e README.md - add missing prereq command for e2e test

### DIFF
--- a/op-e2e/README.md
+++ b/op-e2e/README.md
@@ -6,6 +6,7 @@ run the following commands from the root of the repository:
 
 ```bash
 make install-geth
+make cannon-prestate
 make devnet-allocs
 ```
 


### PR DESCRIPTION
Didn't try to figure out why this was needed but was running into an error running `make devnet-allocs` that told me to run this command before.
