### PR TITLE
op-upgrade: add in extra logic for OP Mainnet

### DIFF
--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -113,6 +113,28 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 		return err
 	}
 
+	// Add in OP Mainnet specific upgrade logic here
+	if chainConfig.ChainID == 10 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{}, common.Hash{})
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(list.L1StandardBridgeProxy.String()),
+			common.HexToAddress("0xf30CE41cA2f24D28b95Eb861553dAc2948e0157F"),
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		sig := "upgradeAndCall(address,address,bytes)"
+		if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
+			return err
+		}
+	}
+
 	l1StandardBridgeABI, err := bindings.L1StandardBridgeMetaData.GetAbi()
 	if err != nil {
 		return err


### PR DESCRIPTION
**Description**

Adds in extra logic for `op-upgrade` that has the
special storage slot set OP Mainnet upgrade.

The 0th storage slot needs to be set to `bytes32(0)` because on OP Mainnet it is set to an address which is then interpreted as `_initialized` which then prevents initialization because it appears as the contract already being initialized, preventing the storage from being set initially.

Uses the `StorageSetter` contract defined in: https://github.com/ethereum-optimism/optimism/pull/7611
Used to create the spell in: https://github.com/ethereum-optimism/superchain-ops/pull/10
Tenderly simulation: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/35dfb460-493c-471a-89fc-1a244c9d8fe2

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
