### PR TITLE
contracts-bedrock: mainnet deploy config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/mainnet.json
+++ b/packages/contracts-bedrock/deploy-config/mainnet.json
@@ -38,5 +38,6 @@
   "gasPriceOracleScalar": 684000,
   "eip1559Denominator": 50,
   "eip1559Elasticity": 6,
-  "l2GenesisRegolithTimeOffset": "0x0"
+  "l2GenesisRegolithTimeOffset": "0x0",
+  "systemConfigStartBlock": 0
 }


### PR DESCRIPTION
**Description**

Updates the mainnet deploy config with the `systemConfigStartBlock`. Part of https://github.com/ethereum-optimism/optimism/pull/7607.

The deploy config is updated with the systemConfigStartBlock which should be set to the block number that the contract was initialized in. This happened in the following tx: https://etherscan.io/tx/0x76bceccd7d44656f5a129a600a6120091570b897c1d45c18cd7134cfe67c2537 which was included in block 17422444.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

