### PR TITLE
fix(indexer): indexer config precedence

### DIFF
--- a/indexer/config/config_test.go
+++ b/indexer/config/config_test.go
@@ -141,6 +141,8 @@ func TestLoadConfigWithUnknownPreset(t *testing.T) {
 
 	logger := testlog.Logger(t, log.LvlInfo)
 	conf, err := LoadConfig(logger, tmpfile.Name())
+	require.Error(t, err)
+
 	var faultyPreset = 1234567890
 	require.Equal(t, conf.Chain.Preset, faultyPreset)
 	require.Error(t, err)
@@ -170,10 +172,87 @@ func TestLoadConfigPollingValues(t *testing.T) {
 
 	logger := testlog.Logger(t, log.LvlInfo)
 	conf, err := LoadConfig(logger, tmpfile.Name())
-
 	require.NoError(t, err)
+
 	require.Equal(t, conf.Chain.L1PollingInterval, uint(1000))
 	require.Equal(t, conf.Chain.L2PollingInterval, uint(1005))
 	require.Equal(t, conf.Chain.L1HeaderBufferSize, uint(100))
 	require.Equal(t, conf.Chain.L2HeaderBufferSize, uint(105))
+}
+
+func TestLoadedConfigPresetPrecendence(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "test_bad_preset.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	defer tmpfile.Close()
+
+	testData := `
+        [chain]
+        preset = 10  # Optimism Mainnet
+
+		# confirmation depths are explicitly set
+		l1-confirmation-depth = 50
+		l2-confirmation-depth = 100
+
+		# override a contract address
+		[chain.l1-contracts]
+		optimism-portal = "0x0000000000000000000000000000000000000001"
+
+
+        [rpcs]
+        l1-rpc = "https://l1.example.com"
+        l2-rpc = "https://l2.example.com"
+    `
+
+	data := []byte(testData)
+	err = os.WriteFile(tmpfile.Name(), data, 0644)
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	logger := testlog.Logger(t, log.LvlInfo)
+	conf, err := LoadConfig(logger, tmpfile.Name())
+	require.NoError(t, err)
+
+	// confirmation depths
+	require.Equal(t, uint(50), conf.Chain.L1ConfirmationDepth)
+	require.Equal(t, uint(100), conf.Chain.L2ConfirmationDepth)
+
+	// overriden preset conifg
+	require.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000001"), conf.Chain.L1Contracts.OptimismPortalProxy)
+}
+
+func TestLocalDevnet(t *testing.T) {
+	tmpfile, err := os.CreateTemp("", "test_user_values.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	defer tmpfile.Close()
+
+	testData := `
+        [chain]
+        preset = 901
+
+        [rpcs]
+        l1-rpc = "https://l1.example.com"
+        l2-rpc = "https://l2.example.com"
+	`
+
+	data := []byte(testData)
+	err = os.WriteFile(tmpfile.Name(), data, 0644)
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	err = tmpfile.Close()
+	require.NoError(t, err)
+
+	logger := testlog.Logger(t, log.LvlInfo)
+	conf, err := LoadConfig(logger, tmpfile.Name())
+	require.NoError(t, err)
+
+	devnetPreset, err := DevnetPreset()
+	require.NoError(t, err)
+
+	require.Equal(t, devnetPreset.ChainConfig.L1Contracts, conf.Chain.L1Contracts)
 }

--- a/indexer/config/config_test.go
+++ b/indexer/config/config_test.go
@@ -220,8 +220,9 @@ func TestLoadedConfigPresetPrecendence(t *testing.T) {
 	require.Equal(t, uint(50), conf.Chain.L1ConfirmationDepth)
 	require.Equal(t, uint(100), conf.Chain.L2ConfirmationDepth)
 
-	// overriden preset conifg
+	// preset is used but does not overwrite config
 	require.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000001"), conf.Chain.L1Contracts.OptimismPortalProxy)
+	require.Equal(t, Presets[10].ChainConfig.L1Contracts.AddressManager, conf.Chain.L1Contracts.AddressManager)
 }
 
 func TestLocalDevnet(t *testing.T) {

--- a/indexer/config/devnet.go
+++ b/indexer/config/devnet.go
@@ -3,21 +3,31 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
-var (
-	filePath           = "../.devnet/addresses.json"
-	DEVNET_L2_CHAIN_ID = 901
-)
+var DevnetPresetId = 901
 
-func GetDevnetPreset() (*Preset, error) {
-	if _, err := os.Stat(filePath); errors.Is(err, fs.ErrNotExist) {
+func DevnetPreset() (*Preset, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
 		return nil, err
 	}
 
-	content, err := os.ReadFile(filePath)
+	root, err := findMonorepoRoot(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	devnetFilepath := filepath.Join(root, ".devnet", "addresses.json")
+	if _, err := os.Stat(devnetFilepath); errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	content, err := os.ReadFile(devnetFilepath)
 	if err != nil {
 		return nil, err
 	}
@@ -27,14 +37,30 @@ func GetDevnetPreset() (*Preset, error) {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	return &Preset{
-		Name: "devnet",
-		ChainConfig: ChainConfig{
-			Preset:      DEVNET_L2_CHAIN_ID,
-			L1Contracts: l1Contracts,
-		},
+		Name:        "Local Devnet",
+		ChainConfig: ChainConfig{Preset: DevnetPresetId, L1Contracts: l1Contracts},
 	}, nil
+}
+
+// findMonorepoRoot will recursively search upwards for a go.mod file.
+// This depends on the structure of the monorepo having a go.mod file at the root.
+func findMonorepoRoot(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", err
+	}
+	for {
+		modulePath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(modulePath); err == nil {
+			return dir, nil
+		}
+		parentDir := filepath.Dir(dir)
+		// Check if we reached the filesystem root
+		if parentDir == dir {
+			break
+		}
+		dir = parentDir
+	}
+	return "", fmt.Errorf("monorepo root not found")
 }

--- a/indexer/config/presets.go
+++ b/indexer/config/presets.go
@@ -57,6 +57,22 @@ var Presets = map[int]Preset{
 			L2BedrockStartingHeight: 4061224,
 		},
 	},
+	11155420: {
+		Name: "Optimism Sepolia",
+		ChainConfig: ChainConfig{
+			Preset: 11155420,
+			L1Contracts: L1Contracts{
+				AddressManager:              common.HexToAddress("0x9bFE9c5609311DF1c011c47642253B78a4f33F4B"),
+				SystemConfigProxy:           common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
+				OptimismPortalProxy:         common.HexToAddress("0x16Fc5058F25648194471939df75CF27A2fdC48BC"),
+				L2OutputOracleProxy:         common.HexToAddress("0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F"),
+				L1CrossDomainMessengerProxy: common.HexToAddress("0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef"),
+				L1StandardBridgeProxy:       common.HexToAddress("0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1"),
+				L1ERC721BridgeProxy:         common.HexToAddress("0xd83e03D576d23C9AEab8cC44Fa98d058D2176D1f"),
+			},
+			L1StartingHeight: 4071408,
+		},
+	},
 	8453: {
 		Name: "Base",
 		ChainConfig: ChainConfig{
@@ -135,22 +151,6 @@ var Presets = map[int]Preset{
 				L1ERC721BridgeProxy:         common.HexToAddress("0x57C1C6b596ce90C0e010c358DD4Aa052404bB70F"),
 			},
 			L1StartingHeight: 8942381,
-		},
-	},
-	11155420: {
-		Name: "OP Sepolia",
-		ChainConfig: ChainConfig{
-			Preset: 11155420,
-			L1Contracts: L1Contracts{
-				AddressManager:              common.HexToAddress("0x9bFE9c5609311DF1c011c47642253B78a4f33F4B"),
-				SystemConfigProxy:           common.HexToAddress("0x034edD2A225f7f429A63E0f1D2084B9E0A93b538"),
-				OptimismPortalProxy:         common.HexToAddress("0x16Fc5058F25648194471939df75CF27A2fdC48BC"),
-				L2OutputOracleProxy:         common.HexToAddress("0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F"),
-				L1CrossDomainMessengerProxy: common.HexToAddress("0x58Cc85b8D04EA49cC6DBd3CbFFd00B4B8D6cb3ef"),
-				L1StandardBridgeProxy:       common.HexToAddress("0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1"),
-				L1ERC721BridgeProxy:         common.HexToAddress("0xd83e03D576d23C9AEab8cC44Fa98d058D2176D1f"),
-			},
-			L1StartingHeight: 4071408,
 		},
 	},
 	424: {


### PR DESCRIPTION
When utilizing a preset, any parameters set in the chain config will get overwritten.
We want to ensure that anything explictly set in the config takes precedence over
defaults via a preset
