### PR TITLE
contracts-bedrock: remove contracts-ts generator

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -9,7 +9,7 @@
     "src/**/*.sol"
   ],
   "scripts": {
-    "bindings": "pnpm bindings:ts && pnpm bindings:go",
+    "bindings": "pnpm bindings:go",
     "bindings:ts": "nx generate @eth-optimism/contracts-ts",
     "bindings:go": "cd ../../op-bindings && make",
     "build": "forge build",


### PR DESCRIPTION
**Description**

This should probably be a temporary change but the tooling around `contracts-ts` is broken. This removes the auto generation of the `contracts-ts` package during the bindings command in `contracts-bedrock`.

cc @roninjin10 

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
