### PR TITLE
chore(cannon): Remove `StepInput` and `OracleInput` from `Proof`

### DIFF
--- a/cannon/cmd/run.go
+++ b/cannon/cmd/run.go
@@ -94,9 +94,6 @@ type Proof struct {
 	OracleKey    hexutil.Bytes `json:"oracle-key,omitempty"`
 	OracleValue  hexutil.Bytes `json:"oracle-value,omitempty"`
 	OracleOffset uint32        `json:"oracle-offset,omitempty"`
-
-	StepInput   hexutil.Bytes `json:"step-input"`
-	OracleInput hexutil.Bytes `json:"oracle-input"`
 }
 
 type rawHint string
@@ -348,14 +345,8 @@ func Run(ctx *cli.Context) error {
 				Post:      postStateHash,
 				StateData: witness.State,
 				ProofData: witness.MemProof,
-				StepInput: witness.EncodeStepInput(0),
 			}
 			if witness.HasPreimage() {
-				inp, err := witness.EncodePreimageOracleInput(0)
-				if err != nil {
-					return fmt.Errorf("failed to encode pre-image oracle input: %w", err)
-				}
-				proof.OracleInput = inp
 				proof.OracleKey = witness.PreimageKey[:]
 				proof.OracleValue = witness.PreimageValue
 				proof.OracleOffset = witness.PreimageOffset


### PR DESCRIPTION
## Overview

Removes the `StepInput` and `OracleInput` from the `Proof` data that is written to disk. No existing consumer of this data relies on the `StepInput` or `OracleInput` being present, and removing them will reduce the size of the data written to disk + reduce runtime overhead of abi-encoding this data within Cannon's run loop.
