### PR TITLE
feat(ci): TODO GitHub issue checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1179,7 +1179,6 @@ workflows:
       - fuzz-op-chain-ops
       - fuzz-cannon
       - bedrock-markdown
-      - todo-issues
       - go-lint:
           name: op-batcher-lint
           module: op-batcher
@@ -1514,6 +1513,15 @@ workflows:
             - oplabs-gcr
           requires:
             - hold
+
+  scheduled-todo-issues:
+    when:
+      equal: [ build_four_hours, <<pipeline.schedule.name>> ]
+    jobs:
+      - todo-issues:
+          name: todo-issue-checks
+          context:
+            - slack
 
   scheduled-fpp:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,6 +611,18 @@ jobs:
             VITE_E2E_RPC_URL_L1: http://localhost:8545
             VITE_E2E_RPC_URL_L2: http://localhost:9545
 
+  todo-issues:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    steps:
+      - checkout
+      - run:
+          name: Install ripgrep
+          command: sudo apt-get install -y ripgrep
+      - run:
+          name: Check TODO issues
+          command: ./ops/scripts/todo-checker.sh --verbose
+
   bedrock-markdown:
     machine:
       image: ubuntu-2204:2022.07.1
@@ -1167,6 +1179,7 @@ workflows:
       - fuzz-op-chain-ops
       - fuzz-cannon
       - bedrock-markdown
+      - todo-issues
       - go-lint:
           name: op-batcher-lint
           module: op-batcher

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,6 +622,10 @@ jobs:
       - run:
           name: Check TODO issues
           command: ./ops/scripts/todo-checker.sh --verbose
+      - slack/notify:
+          channel: C03N11M0BBN
+          event: fail
+          template: basic_fail_1
 
   bedrock-markdown:
     machine:

--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+set -uo pipefail
+
+# Flags
+FAIL_INVALID_FMT=false
+VERBOSE=false
+
 # Github API access token (Optional - necessary for private repositories.)
-TOKEN=""
-if [[ $TOKEN != "" ]]; then
+GH_API_TOKEN=""
+AUTH=""
+if [[ $GH_API_TOKEN != "" ]]; then
     AUTH="Authorization: token $TOKEN"
 fi
 
@@ -25,11 +32,10 @@ CYAN='\033[0;36m'
 PURPLE='\033[0;35m'
 NC='\033[0m' # No Color
 
-# Toggle strict mode; Will fail if any TODOs are found that don't match the expected
-# formats:
-# * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/client-pod")
-# * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
-# * TODO(org/repo#<issue_number>): <description>
+# Parse flags
+#
+# `--strict`: Toggle strict mode; Will fail if any TODOs are found that don't match the expected
+# `--verbose`: Toggle verbose mode; Will print out details about each TODO
 for arg in "$@"; do
   case $arg in
     --strict)
@@ -44,14 +50,21 @@ for arg in "$@"; do
 done
 
 # Use ripgrep to search for the pattern in all files within the repo
-todos=$(rg -o --no-filename --no-line-number -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
+todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
 
 # Check each TODO comment in the repo
 IFS=$'\n' # Set Internal Field Separator to newline for iteration
 for todo in $todos; do
     # Extract the text inside the parenthesis
+    FILE=$(echo $todo | awk -F':' '{print $1}')
+    LINE_NUM=$(echo $todo | awk -F':' '{print $2}')
     ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
 
+    # Parse the format of the TODO comment. There are 3 supported formats:
+    # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/client-pod")
+    # * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
+    # * TODO(org/repo#<issue_number>): <description>
+    #
     # Check if it's just a number
     if [[ $ISSUE_REFERENCE =~ ^[0-9]+$ ]]; then
         REPO_FULL="$ORG/$REPO"
@@ -65,9 +78,9 @@ for todo in $todos; do
         REPO_FULL="$ORG/${BASH_REMATCH[1]}"
         ISSUE_NUM="${BASH_REMATCH[2]}"
     else
-        if [[ $FAIL_INVALID_FMT || $VERBOSE ]]; then
-            echo -e "$YELLOW[Warning]:$NC Invalid TODO format: $todo"
-            if [[ $FAIL_INVALID_FMT ]]; then
+        if $FAIL_INVALID_FMT || $VERBOSE; then
+            echo -e "${YELLOW}[Warning]:${NC} Invalid TODO format: $todo"
+            if $FAIL_INVALID_FMT; then
                 exit 1
             fi
         fi
@@ -76,12 +89,13 @@ for todo in $todos; do
     fi
 
     # Use GitHub API to fetch issue details
-    RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$REPO_FULL/issues/$ISSUE_NUM")
+    GH_URL_PATH="$REPO_FULL/issues/$ISSUE_NUM"
+    RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$GH_URL_PATH")
 
     # Check if issue was found
     if echo "$RESPONSE" | rg -q "Not Found"; then
         if [[ $VERBOSE ]]; then
-            echo -e "$YELLOW[Warning]:$NC Issue not found: $RED$REPO_FULL/$ISSUE_NUM$NC"
+            echo -e "${YELLOW}[Warning]:${NC} Issue not found: ${RED}$REPO_FULL/$ISSUE_NUM${NC}"
         fi
         ((NOT_FOUND_COUNT++))
         continue
@@ -91,30 +105,44 @@ for todo in $todos; do
     STATE=$(echo "$RESPONSE" | jq -r .state)
 
     if [[ "$STATE" == "closed" ]]; then
-        echo -e "$RED[Error]:$NC Issue #$issue_num is closed. Please remove the TODO: $todo"
+        echo -e "${RED}[Error]:${NC} Issue #$ISSUE_NUM is closed. Please remove the TODO in ${GREEN}$FILE:$LINE_NUM${NC} referencing ${YELLOW}$ISSUE_REFERENCE${NC} (${CYAN}https://github.com/$GH_URL_PATH${NC})"
         exit 1
     fi
 
     ((OPEN_COUNT++))
     TITLE=$(echo "$RESPONSE" | jq -r .title)
-    OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE")
+    OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE|$FILE:$LINE_NUM")
 done
 
 # Print summary
 if [[ $NOT_FOUND_COUNT -gt 0 ]]; then
-    echo -e "$YELLOW[Warning]:$NC $NOT_FOUND_COUNT TODOs referred to issues that were not found."
+    echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$NOT_FOUND_COUNT${NC} TODOs referred to issues that were not found."
 fi
 if [[ $MISMATCH_COUNT -gt 0 ]]; then
-    echo -e "$YELLOW[Warning]:$NC $MISMATCH_COUNT TODOs did not match the expected pattern."
+    echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$MISMATCH_COUNT${NC} TODOs did not match the expected pattern. Run with ${RED}\`--verbose\`${NC} to show details."
 fi
 if [[ $OPEN_COUNT -gt 0 ]]; then
-    echo -e "$GREEN[Info]:$NC $OPEN_COUNT TODOs refer to issues that are still open."
-    echo -e "$GREEN[Info]:$NC Open issue details:"
-    printf "\n${PURPLE}%-59s${NC} ${GREY}|${NC} ${GREEN}%-75s${NC}\n" "Repository & Issue" "Title"
-    echo -e "$GREY------------------------------------------------------------+---------------------------------------------------------------------------$NC"
+    echo -e "${GREEN}[Info]:${NC} ${CYAN}$OPEN_COUNT${NC} TODOs refer to issues that are still open."
+    echo -e "${GREEN}[Info]:${NC} Open issue details:"
+    printf "\n${PURPLE}%-50s${NC} ${GREY}|${NC} ${GREEN}%-55s${NC} ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "Repository & Issue" "Title" "Location"
+    echo -e "$GREY$(printf '%0.s-' {1..51})+$(printf '%0.s-' {1..57})+$(printf '%0.s-' {1..31})$NC"
     for issue in "${OPEN_ISSUES[@]}"; do
-        REPO_ISSUE="${issue%|*}"
-        TITLE="${issue#*|}"
-        printf "${CYAN}%-59s${NC} ${GREY}|${NC} %-75s\n" "https://github.com/$REPO_ISSUE" "$TITLE"
+        REPO_ISSUE="https://github.com/${issue%%|*}"  # up to the first |
+        REMAINING="${issue#*|}"                       # after the first |
+        TITLE="${REMAINING%%|*}"                      # up to the second |
+        LOC="${REMAINING#*|}"                         # after the second |
+
+        # Truncate if necessary
+        if [ ${#REPO_ISSUE} -gt 47 ]; then
+            REPO_ISSUE=$(printf "%.47s..." "$REPO_ISSUE")
+        fi
+        if [ ${#TITLE} -gt 47 ]; then
+            TITLE=$(printf "%.52s..." "$TITLE")
+        fi
+        if [ ${#LOC} -gt 27 ]; then
+            LOC=$(printf "%.24s..." "$LOC")
+        fi
+
+        printf "${CYAN}%-50s${NC} ${GREY}|${NC} %-55s ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "$REPO_ISSUE" "$TITLE" "$LOC"
     done
 fi

--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -15,7 +15,7 @@ fi
 
 # Default org and repo
 ORG="ethereum-optimism"
-REPO="client-pod"
+REPO="optimism"
 
 # Counter for issues that were not found and issues that are still open.
 NOT_FOUND_COUNT=0
@@ -49,100 +49,128 @@ for arg in "$@"; do
   esac
 done
 
-# Use ripgrep to search for the pattern in all files within the repo
-todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
-
-# Check each TODO comment in the repo
-IFS=$'\n' # Set Internal Field Separator to newline for iteration
-for todo in $todos; do
-    # Extract the text inside the parenthesis
-    FILE=$(echo $todo | awk -F':' '{print $1}')
-    LINE_NUM=$(echo $todo | awk -F':' '{print $2}')
-    ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
-
-    # Parse the format of the TODO comment. There are 3 supported formats:
-    # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/client-pod")
-    # * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
-    # * TODO(org/repo#<issue_number>): <description>
-    #
-    # Check if it's just a number
-    if [[ $ISSUE_REFERENCE =~ ^[0-9]+$ ]]; then
-        REPO_FULL="$ORG/$REPO"
-        ISSUE_NUM="$ISSUE_REFERENCE"
-    # Check for org_name/repo_name#number format
-    elif [[ $ISSUE_REFERENCE =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]]; then
-        REPO_FULL="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
-        ISSUE_NUM="${BASH_REMATCH[3]}"
-    # Check for repo_name#number format
-    elif [[ $ISSUE_REFERENCE =~ ^([^#]+)#([0-9]+)$ ]]; then
-        REPO_FULL="$ORG/${BASH_REMATCH[1]}"
-        ISSUE_NUM="${BASH_REMATCH[2]}"
-    else
-        if $FAIL_INVALID_FMT || $VERBOSE; then
-            echo -e "${YELLOW}[Warning]:${NC} Invalid TODO format: $todo"
-            if $FAIL_INVALID_FMT; then
-                exit 1
-            fi
-        fi
-        ((MISMATCH_COUNT++))
-        continue
-    fi
-
-    # Use GitHub API to fetch issue details
-    GH_URL_PATH="$REPO_FULL/issues/$ISSUE_NUM"
-    RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$GH_URL_PATH")
-
-    # Check if issue was found
-    if echo "$RESPONSE" | rg -q "Not Found"; then
-        if [[ $VERBOSE ]]; then
-            echo -e "${YELLOW}[Warning]:${NC} Issue not found: ${RED}$REPO_FULL/$ISSUE_NUM${NC}"
-        fi
-        ((NOT_FOUND_COUNT++))
-        continue
-    fi
-
-    # Check issue state
-    STATE=$(echo "$RESPONSE" | jq -r .state)
-
-    if [[ "$STATE" == "closed" ]]; then
-        echo -e "${RED}[Error]:${NC} Issue #$ISSUE_NUM is closed. Please remove the TODO in ${GREEN}$FILE:$LINE_NUM${NC} referencing ${YELLOW}$ISSUE_REFERENCE${NC} (${CYAN}https://github.com/$GH_URL_PATH${NC})"
-        exit 1
-    fi
-
-    ((OPEN_COUNT++))
-    TITLE=$(echo "$RESPONSE" | jq -r .title)
-    OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE|$FILE:$LINE_NUM")
-done
-
-# Print summary
-if [[ $NOT_FOUND_COUNT -gt 0 ]]; then
-    echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$NOT_FOUND_COUNT${NC} TODOs referred to issues that were not found."
-fi
-if [[ $MISMATCH_COUNT -gt 0 ]]; then
-    echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$MISMATCH_COUNT${NC} TODOs did not match the expected pattern. Run with ${RED}\`--verbose\`${NC} to show details."
-fi
-if [[ $OPEN_COUNT -gt 0 ]]; then
-    echo -e "${GREEN}[Info]:${NC} ${CYAN}$OPEN_COUNT${NC} TODOs refer to issues that are still open."
-    echo -e "${GREEN}[Info]:${NC} Open issue details:"
-    printf "\n${PURPLE}%-50s${NC} ${GREY}|${NC} ${GREEN}%-55s${NC} ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "Repository & Issue" "Title" "Location"
-    echo -e "$GREY$(printf '%0.s-' {1..51})+$(printf '%0.s-' {1..57})+$(printf '%0.s-' {1..31})$NC"
-    for issue in "${OPEN_ISSUES[@]}"; do
-        REPO_ISSUE="https://github.com/${issue%%|*}"  # up to the first |
-        REMAINING="${issue#*|}"                       # after the first |
-        TITLE="${REMAINING%%|*}"                      # up to the second |
-        LOC="${REMAINING#*|}"                         # after the second |
-
-        # Truncate if necessary
-        if [ ${#REPO_ISSUE} -gt 47 ]; then
-            REPO_ISSUE=$(printf "%.47s..." "$REPO_ISSUE")
-        fi
-        if [ ${#TITLE} -gt 47 ]; then
-            TITLE=$(printf "%.52s..." "$TITLE")
-        fi
-        if [ ${#LOC} -gt 27 ]; then
-            LOC=$(printf "%.24s..." "$LOC")
-        fi
-
-        printf "${CYAN}%-50s${NC} ${GREY}|${NC} %-55s ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "$REPO_ISSUE" "$TITLE" "$LOC"
+spinner() {
+    local pid=$1
+    local delay=0.05
+    local spinstr='|/-\'
+    echo -n "Loading TODOs... "
+    while [ "$(ps a | awk '{print $1}' | rg $pid)" ]; do
+        local temp=${spinstr#?}
+        printf " [${GREEN}%c${NC}]  " "$spinstr"
+        local spinstr=$temp${spinstr%"$temp"}
+        sleep $delay
+        printf "\b\b\b\b\b\b"
     done
-fi
+}
+
+{
+    # Use ripgrep to search for the pattern in all files within the repo
+    todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
+
+    # Print a newline
+    echo ""
+
+    # Check each TODO comment in the repo
+    IFS=$'\n' # Set Internal Field Separator to newline for iteration
+    for todo in $todos; do
+        # Extract the text inside the parenthesis
+        FILE=$(echo $todo | awk -F':' '{print $1}')
+        LINE_NUM=$(echo $todo | awk -F':' '{print $2}')
+        ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
+
+        # Parse the format of the TODO comment. There are 3 supported formats:
+        # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/monorepo")
+        # * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
+        # * TODO(org/repo#<issue_number>): <description>
+        #
+        # Check if it's just a number
+        if [[ $ISSUE_REFERENCE =~ ^[0-9]+$ ]]; then
+            REPO_FULL="$ORG/$REPO"
+            ISSUE_NUM="$ISSUE_REFERENCE"
+        # Check for org_name/repo_name#number format
+        elif [[ $ISSUE_REFERENCE =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]]; then
+            REPO_FULL="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+            ISSUE_NUM="${BASH_REMATCH[3]}"
+        # Check for repo_name#number format
+        elif [[ $ISSUE_REFERENCE =~ ^([^#]+)#([0-9]+)$ ]]; then
+            REPO_FULL="$ORG/${BASH_REMATCH[1]}"
+            ISSUE_NUM="${BASH_REMATCH[2]}"
+        else
+            if $FAIL_INVALID_FMT || $VERBOSE; then
+                echo -e "${YELLOW}[Warning]:${NC} Invalid TODO format: $todo"
+                if $FAIL_INVALID_FMT; then
+                    exit 1
+                fi
+            fi
+            ((MISMATCH_COUNT++))
+            continue
+        fi
+
+        # Use GitHub API to fetch issue details
+        GH_URL_PATH="$REPO_FULL/issues/$ISSUE_NUM"
+        RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$GH_URL_PATH")
+
+        # Check if issue was found
+        if echo "$RESPONSE" | rg -q "Not Found"; then
+            if [[ $VERBOSE ]]; then
+                echo -e "${YELLOW}[Warning]:${NC} Issue not found: ${RED}$REPO_FULL/$ISSUE_NUM${NC}"
+            fi
+            ((NOT_FOUND_COUNT++))
+            continue
+        fi
+
+        # Check issue state
+        STATE=$(echo "$RESPONSE" | jq -r .state)
+
+        if [[ "$STATE" == "closed" ]]; then
+            echo -e "${RED}[Error]:${NC} Issue #$ISSUE_NUM is closed. Please remove the TODO in ${GREEN}$FILE:$LINE_NUM${NC} referencing ${YELLOW}$ISSUE_REFERENCE${NC} (${CYAN}https://github.com/$GH_URL_PATH${NC})"
+            exit 1
+        fi
+
+        ((OPEN_COUNT++))
+        TITLE=$(echo "$RESPONSE" | jq -r .title)
+        OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE|$FILE:$LINE_NUM")
+    done
+
+    # Print summary
+    if [[ $NOT_FOUND_COUNT -gt 0 ]]; then
+        echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$NOT_FOUND_COUNT${NC} TODOs referred to issues that were not found."
+    fi
+    if [[ $MISMATCH_COUNT -gt 0 ]]; then
+        echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$MISMATCH_COUNT${NC} TODOs did not match the expected pattern. Run with ${RED}\`--verbose\`${NC} to show details."
+    fi
+    if [[ $OPEN_COUNT -gt 0 ]]; then
+        echo -e "${GREEN}[Info]:${NC} ${CYAN}$OPEN_COUNT${NC} TODOs refer to issues that are still open."
+        echo -e "${GREEN}[Info]:${NC} Open issue details:"
+        printf "\n${PURPLE}%-50s${NC} ${GREY}|${NC} ${GREEN}%-55s${NC} ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "Repository & Issue" "Title" "Location"
+        echo -e "$GREY$(printf '%0.s-' {1..51})+$(printf '%0.s-' {1..57})+$(printf '%0.s-' {1..31})$NC"
+        for issue in "${OPEN_ISSUES[@]}"; do
+            REPO_ISSUE="https://github.com/${issue%%|*}"  # up to the first |
+            REMAINING="${issue#*|}"                       # after the first |
+            TITLE="${REMAINING%%|*}"                      # up to the second |
+            LOC="${REMAINING#*|}"                         # after the second |
+
+            # Truncate if necessary
+            if [ ${#REPO_ISSUE} -gt 47 ]; then
+                REPO_ISSUE=$(printf "%.47s..." "$REPO_ISSUE")
+            fi
+            if [ ${#TITLE} -gt 47 ]; then
+                TITLE=$(printf "%.52s..." "$TITLE")
+            fi
+            if [ ${#LOC} -gt 27 ]; then
+                LOC=$(printf "%.24s..." "$LOC")
+            fi
+
+            printf "${CYAN}%-50s${NC} ${GREY}|${NC} %-55s ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "$REPO_ISSUE" "$TITLE" "$LOC"
+        done
+    fi
+} &
+
+# Save the Process ID of the job you started in the background
+PID=$!
+
+# Start the spinner with the background job's Process ID
+spinner $PID
+
+# Wait for the background job to finish
+wait $PID

--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -7,10 +7,10 @@ FAIL_INVALID_FMT=false
 VERBOSE=false
 
 # Github API access token (Optional - necessary for private repositories.)
-GH_API_TOKEN=""
+GH_API_TOKEN="${CI_TODO_CHECKER_PAT:-""}"
 AUTH=""
 if [[ $GH_API_TOKEN != "" ]]; then
-    AUTH="Authorization: token $TOKEN"
+    AUTH="Authorization: token $GH_API_TOKEN"
 fi
 
 # Default org and repo
@@ -49,128 +49,102 @@ for arg in "$@"; do
   esac
 done
 
-spinner() {
-    local pid=$1
-    local delay=0.05
-    local spinstr='|/-\'
-    echo -n "Loading TODOs... "
-    while [ "$(ps a | awk '{print $1}' | rg $pid)" ]; do
-        local temp=${spinstr#?}
-        printf " [${GREEN}%c${NC}]  " "$spinstr"
-        local spinstr=$temp${spinstr%"$temp"}
-        sleep $delay
-        printf "\b\b\b\b\b\b"
+# Use ripgrep to search for the pattern in all files within the repo
+todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
+
+# Check each TODO comment in the repo
+IFS=$'\n' # Set Internal Field Separator to newline for iteration
+for todo in $todos; do
+    # Extract the text inside the parenthesis
+    FILE=$(echo $todo | awk -F':' '{print $1}')
+    LINE_NUM=$(echo $todo | awk -F':' '{print $2}')
+    ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
+
+    # Parse the format of the TODO comment. There are 3 supported formats:
+    # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/monorepo")
+    # * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
+    # * TODO(org/repo#<issue_number>): <description>
+    #
+    # Check if it's just a number
+    if [[ $ISSUE_REFERENCE =~ ^[0-9]+$ ]]; then
+        REPO_FULL="$ORG/$REPO"
+        ISSUE_NUM="$ISSUE_REFERENCE"
+    # Check for org_name/repo_name#number format
+    elif [[ $ISSUE_REFERENCE =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]]; then
+        REPO_FULL="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+        ISSUE_NUM="${BASH_REMATCH[3]}"
+    # Check for repo_name#number format
+    elif [[ $ISSUE_REFERENCE =~ ^([^#]+)#([0-9]+)$ ]]; then
+        REPO_FULL="$ORG/${BASH_REMATCH[1]}"
+        ISSUE_NUM="${BASH_REMATCH[2]}"
+    else
+        if $FAIL_INVALID_FMT || $VERBOSE; then
+            echo -e "${YELLOW}[Warning]:${NC} Invalid TODO format: $todo"
+            if $FAIL_INVALID_FMT; then
+                exit 1
+            fi
+        fi
+        ((MISMATCH_COUNT++))
+        continue
+    fi
+
+    # Use GitHub API to fetch issue details
+    GH_URL_PATH="$REPO_FULL/issues/$ISSUE_NUM"
+    RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$GH_URL_PATH")
+
+    # Check if issue was found
+    if echo "$RESPONSE" | rg -q "Not Found"; then
+        if [[ $VERBOSE ]]; then
+            echo -e "${YELLOW}[Warning]:${NC} Issue not found: ${RED}$REPO_FULL/$ISSUE_NUM${NC}"
+        fi
+        ((NOT_FOUND_COUNT++))
+        continue
+    fi
+
+    # Check issue state
+    STATE=$(echo "$RESPONSE" | jq -r .state)
+
+    if [[ "$STATE" == "closed" ]]; then
+        echo -e "${RED}[Error]:${NC} Issue #$ISSUE_NUM is closed. Please remove the TODO in ${GREEN}$FILE:$LINE_NUM${NC} referencing ${YELLOW}$ISSUE_REFERENCE${NC} (${CYAN}https://github.com/$GH_URL_PATH${NC})"
+        exit 1
+    fi
+
+    ((OPEN_COUNT++))
+    TITLE=$(echo "$RESPONSE" | jq -r .title)
+    OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE|$FILE:$LINE_NUM")
+done
+
+# Print summary
+if [[ $NOT_FOUND_COUNT -gt 0 ]]; then
+    echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$NOT_FOUND_COUNT${NC} TODOs referred to issues that were not found."
+fi
+if [[ $MISMATCH_COUNT -gt 0 ]]; then
+    echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$MISMATCH_COUNT${NC} TODOs did not match the expected pattern. Run with ${RED}\`--verbose\`${NC} to show details."
+fi
+if [[ $OPEN_COUNT -gt 0 ]]; then
+    echo -e "${GREEN}[Info]:${NC} ${CYAN}$OPEN_COUNT${NC} TODOs refer to issues that are still open."
+    echo -e "${GREEN}[Info]:${NC} Open issue details:"
+    printf "\n${PURPLE}%-50s${NC} ${GREY}|${NC} ${GREEN}%-55s${NC} ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "Repository & Issue" "Title" "Location"
+    echo -e "$GREY$(printf '%0.s-' {1..51})+$(printf '%0.s-' {1..57})+$(printf '%0.s-' {1..31})$NC"
+    for issue in "${OPEN_ISSUES[@]}"; do
+        REPO_ISSUE="https://github.com/${issue%%|*}"  # up to the first |
+        REMAINING="${issue#*|}"                       # after the first |
+        TITLE="${REMAINING%%|*}"                      # up to the second |
+        LOC="${REMAINING#*|}"                         # after the second |
+
+        # Truncate if necessary
+        if [ ${#REPO_ISSUE} -gt 47 ]; then
+            REPO_ISSUE=$(printf "%.47s..." "$REPO_ISSUE")
+        fi
+        if [ ${#TITLE} -gt 47 ]; then
+            TITLE=$(printf "%.52s..." "$TITLE")
+        fi
+        if [ ${#LOC} -gt 27 ]; then
+            LOC=$(printf "%.24s..." "$LOC")
+        fi
+
+        printf "${CYAN}%-50s${NC} ${GREY}|${NC} %-55s ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "$REPO_ISSUE" "$TITLE" "$LOC"
     done
-}
+fi
 
-{
-    # Use ripgrep to search for the pattern in all files within the repo
-    todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
-
-    # Print a newline
-    echo ""
-
-    # Check each TODO comment in the repo
-    IFS=$'\n' # Set Internal Field Separator to newline for iteration
-    for todo in $todos; do
-        # Extract the text inside the parenthesis
-        FILE=$(echo $todo | awk -F':' '{print $1}')
-        LINE_NUM=$(echo $todo | awk -F':' '{print $2}')
-        ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
-
-        # Parse the format of the TODO comment. There are 3 supported formats:
-        # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/monorepo")
-        # * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
-        # * TODO(org/repo#<issue_number>): <description>
-        #
-        # Check if it's just a number
-        if [[ $ISSUE_REFERENCE =~ ^[0-9]+$ ]]; then
-            REPO_FULL="$ORG/$REPO"
-            ISSUE_NUM="$ISSUE_REFERENCE"
-        # Check for org_name/repo_name#number format
-        elif [[ $ISSUE_REFERENCE =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]]; then
-            REPO_FULL="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
-            ISSUE_NUM="${BASH_REMATCH[3]}"
-        # Check for repo_name#number format
-        elif [[ $ISSUE_REFERENCE =~ ^([^#]+)#([0-9]+)$ ]]; then
-            REPO_FULL="$ORG/${BASH_REMATCH[1]}"
-            ISSUE_NUM="${BASH_REMATCH[2]}"
-        else
-            if $FAIL_INVALID_FMT || $VERBOSE; then
-                echo -e "${YELLOW}[Warning]:${NC} Invalid TODO format: $todo"
-                if $FAIL_INVALID_FMT; then
-                    exit 1
-                fi
-            fi
-            ((MISMATCH_COUNT++))
-            continue
-        fi
-
-        # Use GitHub API to fetch issue details
-        GH_URL_PATH="$REPO_FULL/issues/$ISSUE_NUM"
-        RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$GH_URL_PATH")
-
-        # Check if issue was found
-        if echo "$RESPONSE" | rg -q "Not Found"; then
-            if [[ $VERBOSE ]]; then
-                echo -e "${YELLOW}[Warning]:${NC} Issue not found: ${RED}$REPO_FULL/$ISSUE_NUM${NC}"
-            fi
-            ((NOT_FOUND_COUNT++))
-            continue
-        fi
-
-        # Check issue state
-        STATE=$(echo "$RESPONSE" | jq -r .state)
-
-        if [[ "$STATE" == "closed" ]]; then
-            echo -e "${RED}[Error]:${NC} Issue #$ISSUE_NUM is closed. Please remove the TODO in ${GREEN}$FILE:$LINE_NUM${NC} referencing ${YELLOW}$ISSUE_REFERENCE${NC} (${CYAN}https://github.com/$GH_URL_PATH${NC})"
-            exit 1
-        fi
-
-        ((OPEN_COUNT++))
-        TITLE=$(echo "$RESPONSE" | jq -r .title)
-        OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE|$FILE:$LINE_NUM")
-    done
-
-    # Print summary
-    if [[ $NOT_FOUND_COUNT -gt 0 ]]; then
-        echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$NOT_FOUND_COUNT${NC} TODOs referred to issues that were not found."
-    fi
-    if [[ $MISMATCH_COUNT -gt 0 ]]; then
-        echo -e "${YELLOW}[Warning]:${NC} ${CYAN}$MISMATCH_COUNT${NC} TODOs did not match the expected pattern. Run with ${RED}\`--verbose\`${NC} to show details."
-    fi
-    if [[ $OPEN_COUNT -gt 0 ]]; then
-        echo -e "${GREEN}[Info]:${NC} ${CYAN}$OPEN_COUNT${NC} TODOs refer to issues that are still open."
-        echo -e "${GREEN}[Info]:${NC} Open issue details:"
-        printf "\n${PURPLE}%-50s${NC} ${GREY}|${NC} ${GREEN}%-55s${NC} ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "Repository & Issue" "Title" "Location"
-        echo -e "$GREY$(printf '%0.s-' {1..51})+$(printf '%0.s-' {1..57})+$(printf '%0.s-' {1..31})$NC"
-        for issue in "${OPEN_ISSUES[@]}"; do
-            REPO_ISSUE="https://github.com/${issue%%|*}"  # up to the first |
-            REMAINING="${issue#*|}"                       # after the first |
-            TITLE="${REMAINING%%|*}"                      # up to the second |
-            LOC="${REMAINING#*|}"                         # after the second |
-
-            # Truncate if necessary
-            if [ ${#REPO_ISSUE} -gt 47 ]; then
-                REPO_ISSUE=$(printf "%.47s..." "$REPO_ISSUE")
-            fi
-            if [ ${#TITLE} -gt 47 ]; then
-                TITLE=$(printf "%.52s..." "$TITLE")
-            fi
-            if [ ${#LOC} -gt 27 ]; then
-                LOC=$(printf "%.24s..." "$LOC")
-            fi
-
-            printf "${CYAN}%-50s${NC} ${GREY}|${NC} %-55s ${GREY}|${NC} ${YELLOW}%-30s${NC}\n" "$REPO_ISSUE" "$TITLE" "$LOC"
-        done
-    fi
-} &
-
-# Save the Process ID of the job you started in the background
-PID=$!
-
-# Start the spinner with the background job's Process ID
-spinner $PID
-
-# Wait for the background job to finish
-wait $PID
+echo -e "${GREEN}[Info]:${NC} Done checking issues."

--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Github API access token (Optional - necessary for private repositories.)
+TOKEN=""
+if [[ $TOKEN != "" ]]; then
+    AUTH="Authorization: token $TOKEN"
+fi
+
+# Default org and repo
+ORG="ethereum-optimism"
+REPO="client-pod"
+
+# Counter for issues that were not found and issues that are still open.
+NOT_FOUND_COUNT=0
+MISMATCH_COUNT=0
+OPEN_COUNT=0
+declare -a OPEN_ISSUES
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+GREY='\033[1;30m'
+CYAN='\033[0;36m'
+PURPLE='\033[0;35m'
+NC='\033[0m' # No Color
+
+# Toggle strict mode; Will fail if any TODOs are found that don't match the expected
+# formats:
+# * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/client-pod")
+# * TODO(repo#<issue_number>): <description> (Default org "ethereum-optimism")
+# * TODO(org/repo#<issue_number>): <description>
+for arg in "$@"; do
+  case $arg in
+    --strict)
+    FAIL_INVALID_FMT=true
+    shift
+    ;;
+    --verbose)
+    VERBOSE=true
+    shift
+    ;;
+  esac
+done
+
+# Use ripgrep to search for the pattern in all files within the repo
+todos=$(rg -o --no-filename --no-line-number -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
+
+# Check each TODO comment in the repo
+IFS=$'\n' # Set Internal Field Separator to newline for iteration
+for todo in $todos; do
+    # Extract the text inside the parenthesis
+    ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
+
+    # Check if it's just a number
+    if [[ $ISSUE_REFERENCE =~ ^[0-9]+$ ]]; then
+        REPO_FULL="$ORG/$REPO"
+        ISSUE_NUM="$ISSUE_REFERENCE"
+    # Check for org_name/repo_name#number format
+    elif [[ $ISSUE_REFERENCE =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]]; then
+        REPO_FULL="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+        ISSUE_NUM="${BASH_REMATCH[3]}"
+    # Check for repo_name#number format
+    elif [[ $ISSUE_REFERENCE =~ ^([^#]+)#([0-9]+)$ ]]; then
+        REPO_FULL="$ORG/${BASH_REMATCH[1]}"
+        ISSUE_NUM="${BASH_REMATCH[2]}"
+    else
+        if [[ $FAIL_INVALID_FMT || $VERBOSE ]]; then
+            echo -e "$YELLOW[Warning]:$NC Invalid TODO format: $todo"
+            if [[ $FAIL_INVALID_FMT ]]; then
+                exit 1
+            fi
+        fi
+        ((MISMATCH_COUNT++))
+        continue
+    fi
+
+    # Use GitHub API to fetch issue details
+    RESPONSE=$(curl -sL -H "$AUTH" --request GET "https://api.github.com/repos/$REPO_FULL/issues/$ISSUE_NUM")
+
+    # Check if issue was found
+    if echo "$RESPONSE" | rg -q "Not Found"; then
+        if [[ $VERBOSE ]]; then
+            echo -e "$YELLOW[Warning]:$NC Issue not found: $RED$REPO_FULL/$ISSUE_NUM$NC"
+        fi
+        ((NOT_FOUND_COUNT++))
+        continue
+    fi
+
+    # Check issue state
+    STATE=$(echo "$RESPONSE" | jq -r .state)
+
+    if [[ "$STATE" == "closed" ]]; then
+        echo -e "$RED[Error]:$NC Issue #$issue_num is closed. Please remove the TODO: $todo"
+        exit 1
+    fi
+
+    ((OPEN_COUNT++))
+    TITLE=$(echo "$RESPONSE" | jq -r .title)
+    OPEN_ISSUES+=("$REPO_FULL/issues/$ISSUE_NUM|$TITLE")
+done
+
+# Print summary
+if [[ $NOT_FOUND_COUNT -gt 0 ]]; then
+    echo -e "$YELLOW[Warning]:$NC $NOT_FOUND_COUNT TODOs referred to issues that were not found."
+fi
+if [[ $MISMATCH_COUNT -gt 0 ]]; then
+    echo -e "$YELLOW[Warning]:$NC $MISMATCH_COUNT TODOs did not match the expected pattern."
+fi
+if [[ $OPEN_COUNT -gt 0 ]]; then
+    echo -e "$GREEN[Info]:$NC $OPEN_COUNT TODOs refer to issues that are still open."
+    echo -e "$GREEN[Info]:$NC Open issue details:"
+    printf "\n${PURPLE}%-59s${NC} ${GREY}|${NC} ${GREEN}%-75s${NC}\n" "Repository & Issue" "Title"
+    echo -e "$GREY------------------------------------------------------------+---------------------------------------------------------------------------$NC"
+    for issue in "${OPEN_ISSUES[@]}"; do
+        REPO_ISSUE="${issue%|*}"
+        TITLE="${issue#*|}"
+        printf "${CYAN}%-59s${NC} ${GREY}|${NC} %-75s\n" "https://github.com/$REPO_ISSUE" "$TITLE"
+    done
+fi

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bindings": "nx bindings @eth-optimism/contracts-bedrock",
     "build": "npx nx run-many --target=build",
     "test": "npx nx run-many --target=test",
+    "issues": "./ops/scripts/todo-checker.sh",
     "lint": "npx nx run-many --target=lint",
     "test:coverage": "npx nx run-many --target=test:coverage",
     "lint:ts:check": "npx nx run-many --target=lint:ts:check",


### PR DESCRIPTION
## Overview

Adds a script to `ops` that greps through the codebase for TODO comments that reference GitHub issues. If any of the issues
referenced are closed, an error is thrown, and the script exits with a non-zero exit code and an error asking the user
to remove the stale TODO comment.

The script also has several options:
* `--verbose`: Prints out warnings and a summary for issues that were either not found as well as TODO comments with invalid formats.
* `--strict`: Fails if any TODO comments are found that fit an invalid format.

### Accepted `TODO` formats
* `TODO(<issue_number>): <description>` (Default org & repo: "ethereum-optimism/optimism")
* `TODO(repo#<issue_number>): <description>` (Default org "ethereum-optimism")
* `TODO(org/repo#<issue_number>): <description>`

### Examples
<img width="1351" alt="Screenshot 2023-10-12 at 3 58 20 AM" src="https://github.com/ethereum-optimism/optimism/assets/8406232/af2c2f5e-ae2c-43d5-8fca-9816ec1243b6">
<img width="1402" alt="Screenshot 2023-10-12 at 3 58 38 AM" src="https://github.com/ethereum-optimism/optimism/assets/8406232/26edfaf9-4ef8-402d-848d-e1ce9945948c">

### TODO
- [x] Get a PAT secret for the `ethereum-optimism` organization in order for CI to be able to reference issues in `client-pod`.