### PR TITLE
Update predeploys.md

### DIFF
--- a/specs/predeploys.md
+++ b/specs/predeploys.md
@@ -67,6 +67,8 @@ or `Bedrock`. Deprecated contracts should not be used.
 | ProxyAdmin                    | 0x4200000000000000000000000000000000000018 | Bedrock    | No         | Yes     |
 | BaseFeeVault                  | 0x4200000000000000000000000000000000000019 | Bedrock    | No         | Yes     |
 | L1FeeVault                    | 0x420000000000000000000000000000000000001a | Bedrock    | No         | Yes     |
+| SchemaRegistry                | 0x4200000000000000000000000000000000000020 | Bedrock    | No         | Yes     |
+| EAS                           | 0x4200000000000000000000000000000000000021 | Bedrock    | No         | Yes     |
 
 ## LegacyMessagePasser
 


### PR DESCRIPTION
Added SchemaRegistry & EAS predeploy addresses to the table.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added the SchemaRegistry & EAS predeploy addresses to the table. They were listed further below but never referenced in the table.

**Tests**

No tests were provided. Just previewed the markdown :)

**Additional context**

No additional context.

**Metadata**

- Fixes #[Link to Issue]
