### PR TITLE
contracts-bedrock: add the nft bridge to storage lock

### DIFF
--- a/packages/contracts-bedrock/.storage-layout
+++ b/packages/contracts-bedrock/.storage-layout
@@ -92,6 +92,18 @@
 | startBlock      | uint256                                | 106  | 0      | 32    | src/L1/SystemConfig.sol:SystemConfig |
 
 =======================
+➡ src/L1/L1ERC721Bridge.sol:L1ERC721Bridge
+=======================
+
+| Name          | Type                                                             | Slot | Offset | Bytes | Contract                                 |
+|---------------|------------------------------------------------------------------|------|--------|-------|------------------------------------------|
+| _initialized  | uint8                                                            | 0    | 0      | 1     | src/L1/L1ERC721Bridge.sol:L1ERC721Bridge |
+| _initializing | bool                                                             | 0    | 1      | 1     | src/L1/L1ERC721Bridge.sol:L1ERC721Bridge |
+| messenger     | contract CrossDomainMessenger                                    | 0    | 2      | 20    | src/L1/L1ERC721Bridge.sol:L1ERC721Bridge |
+| __gap         | uint256[48]                                                      | 1    | 0      | 1536  | src/L1/L1ERC721Bridge.sol:L1ERC721Bridge |
+| deposits      | mapping(address => mapping(address => mapping(uint256 => bool))) | 49   | 0      | 32    | src/L1/L1ERC721Bridge.sol:L1ERC721Bridge |
+
+=======================
 ➡ src/legacy/DeployerWhitelist.sol:DeployerWhitelist
 =======================
 
@@ -204,6 +216,17 @@
 | Name           | Type    | Slot | Offset | Bytes | Contract                         |
 |----------------|---------|------|--------|-------|----------------------------------|
 | totalProcessed | uint256 | 0    | 0      | 32    | src/L2/L1FeeVault.sol:L1FeeVault |
+
+=======================
+➡ src/L2/L2ERC721Bridge.sol:L2ERC721Bridge
+=======================
+
+| Name          | Type                          | Slot | Offset | Bytes | Contract                                 |
+|---------------|-------------------------------|------|--------|-------|------------------------------------------|
+| _initialized  | uint8                         | 0    | 0      | 1     | src/L2/L2ERC721Bridge.sol:L2ERC721Bridge |
+| _initializing | bool                          | 0    | 1      | 1     | src/L2/L2ERC721Bridge.sol:L2ERC721Bridge |
+| messenger     | contract CrossDomainMessenger | 0    | 2      | 20    | src/L2/L2ERC721Bridge.sol:L2ERC721Bridge |
+| __gap         | uint256[48]                   | 1    | 0      | 1536  | src/L2/L2ERC721Bridge.sol:L2ERC721Bridge |
 
 =======================
 ➡ src/vendor/WETH9.sol:WETH9

--- a/packages/contracts-bedrock/scripts/storage-snapshot.sh
+++ b/packages/contracts-bedrock/scripts/storage-snapshot.sh
@@ -15,6 +15,7 @@ contracts=(
   src/L1/L2OutputOracle.sol:L2OutputOracle
   src/L1/OptimismPortal.sol:OptimismPortal
   src/L1/SystemConfig.sol:SystemConfig
+  src/L1/L1ERC721Bridge.sol:L1ERC721Bridge
   src/legacy/DeployerWhitelist.sol:DeployerWhitelist
   src/L2/L1Block.sol:L1Block
   src/legacy/L1BlockNumber.sol:L1BlockNumber
@@ -25,6 +26,7 @@ contracts=(
   src/L2/SequencerFeeVault.sol:SequencerFeeVault
   src/L2/BaseFeeVault.sol:BaseFeeVault
   src/L2/L1FeeVault.sol:L1FeeVault
+  src/L2/L2ERC721Bridge.sol:L2ERC721Bridge
   src/vendor/WETH9.sol:WETH9
   src/universal/ProxyAdmin.sol:ProxyAdmin
   src/universal/Proxy.sol:Proxy


### PR DESCRIPTION
**Description**

Adds the L1 and L2 ERC721 bridges to the storage lock file. Ensures that the tooling can make sure no slot alterations happen in the bridge

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

