### PR TITLE
op-proposer: Enable default Admin RPC

### DIFF
--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -37,6 +37,7 @@ type Metrics struct {
 
 	opmetrics.RefMetrics
 	txmetrics.TxMetrics
+	opmetrics.RPCMetrics
 
 	info prometheus.GaugeVec
 	up   prometheus.Gauge
@@ -60,6 +61,7 @@ func NewMetrics(procName string) *Metrics {
 
 		RefMetrics: opmetrics.MakeRefMetrics(ns, factory),
 		TxMetrics:  txmetrics.MakeTxMetrics(ns, factory),
+		RPCMetrics: opmetrics.MakeRPCMetrics(ns, factory),
 
 		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -106,6 +106,10 @@ func Main(version string, cliCtx *cli.Context) error {
 
 	rpcCfg := cfg.RPCConfig
 	server := oprpc.NewServer(rpcCfg.ListenAddr, rpcCfg.ListenPort, version, oprpc.WithLogger(l))
+	if rpcCfg.EnableAdmin {
+		server.AddAPI(oprpc.ToGethAdminAPI(oprpc.NewCommonAdminAPI(&m.RPCMetrics, l)))
+		l.Info("Admin RPC enabled")
+	}
 	if err := server.Start(); err != nil {
 		return fmt.Errorf("error starting RPC server: %w", err)
 	}

--- a/op-service/rpc/api.go
+++ b/op-service/rpc/api.go
@@ -7,7 +7,15 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 )
+
+func ToGethAdminAPI(api *CommonAdminAPI) rpc.API {
+	return rpc.API{
+		Namespace: "admin",
+		Service:   api,
+	}
+}
 
 type CommonAdminAPI struct {
 	M   metrics.RPCMetricer

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     ports:
       - "6062:6060"
       - "7302:7300"
+      - "6546:8545"
     environment:
       OP_PROPOSER_L1_ETH_RPC: http://l1:8545
       OP_PROPOSER_ROLLUP_RPC: http://op-node:8545
@@ -105,6 +106,7 @@ services:
       OP_PROPOSER_PPROF_ENABLED: "true"
       OP_PROPOSER_METRICS_ENABLED: "true"
       OP_PROPOSER_ALLOW_NON_FINALIZED: "true"
+      OP_PROPOSER_RPC_ENABLE_ADMIN: "true"
 
   op-batcher:
     depends_on:


### PR DESCRIPTION
**Description**

This allows the admin RPC to change the log level of the proposer while it is running.


