### PR TITLE
op-challenger: Introduce game registry

### DIFF
--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -1,0 +1,43 @@
+package fault
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	cannonGameType   = uint8(0)
+	alphabetGameType = uint8(255)
+)
+
+type Registry interface {
+	RegisterGameType(gameType uint8, creator scheduler.PlayerCreator)
+}
+
+func RegisterGameTypes(
+	registry Registry,
+	ctx context.Context,
+	logger log.Logger,
+	m metrics.Metricer,
+	cfg *config.Config,
+	txMgr txmgr.TxManager,
+	client bind.ContractCaller) {
+	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		return NewGamePlayer(ctx, logger, m, cfg, dir, game.Proxy, txMgr, client)
+	}
+	switch cfg.TraceType {
+	case config.TraceTypeCannon:
+		registry.RegisterGameType(cannonGameType, creator)
+	case config.TraceTypeOutputCannon:
+		registry.RegisterGameType(cannonGameType, creator)
+	case config.TraceTypeAlphabet:
+		registry.RegisterGameType(alphabetGameType, creator)
+	}
+}

--- a/op-challenger/game/registry/registry.go
+++ b/op-challenger/game/registry/registry.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+)
+
+var (
+	ErrUnsupportedGameType = errors.New("unsupported game type")
+)
+
+type GameTypeRegistry struct {
+	types map[uint8]scheduler.PlayerCreator
+}
+
+func NewGameTypeRegistry() *GameTypeRegistry {
+	return &GameTypeRegistry{
+		types: make(map[uint8]scheduler.PlayerCreator),
+	}
+}
+
+func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.PlayerCreator) {
+	if _, ok := r.types[gameType]; ok {
+		panic(fmt.Errorf("duplicate creator registered for game type: %v", gameType))
+	}
+	r.types[gameType] = creator
+}
+
+func (r *GameTypeRegistry) CreatePlayer(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+	creator, ok := r.types[game.GameType]
+	if !ok {
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedGameType, game.GameType)
+	}
+	return creator(game, dir)
+}

--- a/op-challenger/game/registry/registry.go
+++ b/op-challenger/game/registry/registry.go
@@ -22,6 +22,8 @@ func NewGameTypeRegistry() *GameTypeRegistry {
 	}
 }
 
+// RegisterGameType registers a scheduler.PlayerCreator to use for a specific game type.
+// Panics if the same game type is registered multiple times, since this indicates a significant programmer error.
 func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.PlayerCreator) {
 	if _, ok := r.types[gameType]; ok {
 		panic(fmt.Errorf("duplicate creator registered for game type: %v", gameType))
@@ -29,6 +31,7 @@ func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.Pl
 	r.types[gameType] = creator
 }
 
+// CreatePlayer creates a new game player for the given game, using the specified directory for persisting data.
 func (r *GameTypeRegistry) CreatePlayer(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 	creator, ok := r.types[game.GameType]
 	if !ok {

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -1,0 +1,40 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnknownGameType(t *testing.T) {
+	registry := NewGameTypeRegistry()
+	player, err := registry.CreatePlayer(types.GameMetadata{GameType: 0}, "")
+	require.ErrorIs(t, err, ErrUnsupportedGameType)
+	require.Nil(t, player)
+}
+
+func TestKnownGameType(t *testing.T) {
+	registry := NewGameTypeRegistry()
+	expectedPlayer := &test.StubGamePlayer{}
+	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		return expectedPlayer, nil
+	}
+	registry.RegisterGameType(0, creator)
+	player, err := registry.CreatePlayer(types.GameMetadata{GameType: 0}, "")
+	require.NoError(t, err)
+	require.Same(t, expectedPlayer, player)
+}
+
+func TestPanicsOnDuplicateGameType(t *testing.T) {
+	registry := NewGameTypeRegistry()
+	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		return nil, nil
+	}
+	registry.RegisterGameType(0, creator)
+	require.Panics(t, func() {
+		registry.RegisterGameType(0, creator)
+	})
+}

--- a/op-challenger/game/scheduler/scheduler_test.go
+++ b/op-challenger/game/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -16,7 +17,7 @@ func TestSchedulerProcessesGames(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	ctx := context.Background()
 	createPlayer := func(g types.GameMetadata, dir string) (GamePlayer, error) {
-		return &stubPlayer{}, nil
+		return &test.StubGamePlayer{}, nil
 	}
 	removeExceptCalls := make(chan []common.Address)
 	disk := &trackingDiskManager{removeExceptCalls: removeExceptCalls}
@@ -44,7 +45,7 @@ func TestSchedulerProcessesGames(t *testing.T) {
 func TestReturnBusyWhenScheduleQueueFull(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	createPlayer := func(game types.GameMetadata, dir string) (GamePlayer, error) {
-		return &stubPlayer{}, nil
+		return &test.StubGamePlayer{}, nil
 	}
 	removeExceptCalls := make(chan []common.Address)
 	disk := &trackingDiskManager{removeExceptCalls: removeExceptCalls}

--- a/op-challenger/game/scheduler/test/stub_player.go
+++ b/op-challenger/game/scheduler/test/stub_player.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type StubGamePlayer struct {
+	Addr          common.Address
+	ProgressCount int
+	StatusValue   types.GameStatus
+	Dir           string
+}
+
+func (g *StubGamePlayer) ProgressGame(_ context.Context) types.GameStatus {
+	g.ProgressCount++
+	return g.StatusValue
+}
+
+func (g *StubGamePlayer) Status() types.GameStatus {
+	return g.StatusValue
+}

--- a/op-challenger/game/scheduler/worker_test.go
+++ b/op-challenger/game/scheduler/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 
@@ -24,7 +25,7 @@ func TestWorkerShouldProcessJobsUntilContextDone(t *testing.T) {
 	go progressGames(ctx, in, out, &wg, ms.ThreadActive, ms.ThreadIdle)
 
 	in <- job{
-		player: &stubPlayer{status: types.GameStatusInProgress},
+		player: &test.StubGamePlayer{StatusValue: types.GameStatusInProgress},
 	}
 	waitErr := wait.For(context.Background(), 100*time.Millisecond, func() (bool, error) {
 		return ms.activeCalls >= 1, nil
@@ -34,7 +35,7 @@ func TestWorkerShouldProcessJobsUntilContextDone(t *testing.T) {
 	require.Equal(t, ms.idleCalls, 1)
 
 	in <- job{
-		player: &stubPlayer{status: types.GameStatusDefenderWon},
+		player: &test.StubGamePlayer{StatusValue: types.GameStatusDefenderWon},
 	}
 	waitErr = wait.For(context.Background(), 100*time.Millisecond, func() (bool, error) {
 		return ms.activeCalls >= 2, nil
@@ -65,18 +66,6 @@ func (m *metricSink) ThreadActive() {
 
 func (m *metricSink) ThreadIdle() {
 	m.idleCalls++
-}
-
-type stubPlayer struct {
-	status types.GameStatus
-}
-
-func (s *stubPlayer) ProgressGame(ctx context.Context) types.GameStatus {
-	return s.status
-}
-
-func (s *stubPlayer) Status() types.GameStatus {
-	return s.status
 }
 
 func readWithTimeout[T any](t *testing.T, ch <-chan T) T {

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/loader"
-	registry2 "github.com/ethereum-optimism/optimism/op-challenger/game/registry"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/version"
@@ -94,8 +94,8 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Se
 	}
 	loader := loader.NewGameLoader(factoryContract)
 
-	registry := registry2.NewGameTypeRegistry()
-	fault.RegisterGameTypes(registry, ctx, logger, m, cfg, txMgr, l1Client)
+	gameTypeRegistry := registry.NewGameTypeRegistry()
+	fault.RegisterGameTypes(gameTypeRegistry, ctx, logger, m, cfg, txMgr, l1Client)
 
 	disk := newDiskManager(cfg.Datadir)
 	s.sched = scheduler.NewScheduler(
@@ -103,7 +103,7 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Se
 		m,
 		disk,
 		cfg.MaxConcurrency,
-		registry.CreatePlayer)
+		gameTypeRegistry.CreatePlayer)
 
 	pollClient, err := opClient.NewRPCWithClient(ctx, logger, cfg.L1EthRpc, opClient.NewBaseRPCClient(l1Client.Client()), cfg.PollInterval)
 	if err != nil {


### PR DESCRIPTION
**Description**

Introduces a game type registry that is used to create the appropriate game player based on the game type. Currently the CLI/config still only allows the user to specify one supported trace type at a time, but this sets up the code to support multiple game types once the cli and config are updated.

This also means that the challenger will now log an error if it finds games with a type it doesn't support rather than attempting to play the game anyway.

**Tests**

Added unit tests.

**Additional context**

Builds on #7662

**Metadata**

- Part of https://github.com/ethereum-optimism/client-pod/issues/100
