### PR TITLE
fix(cli): shutdown cleanly on interrupts

### DIFF
--- a/endpoint-monitor/cmd/main.go
+++ b/endpoint-monitor/cmd/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 
@@ -20,6 +22,13 @@ var (
 func main() {
 	oplog.SetupDefaults()
 
+	// Invoke cancel when an interrupt is received.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		opio.BlockOnInterrupts()
+		cancel()
+	}()
+
 	app := cli.NewApp()
 	app.Flags = endpointMonitor.CLIFlags("ENDPOINT_MONITOR")
 	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
@@ -28,7 +37,7 @@ func main() {
 	app.Description = ""
 
 	app.Action = endpointMonitor.Main(Version)
-	err := app.Run(os.Args)
+	err := app.RunContext(ctx, os.Args)
 	if err != nil {
 		log.Crit("Application failed", "message", err)
 	}

--- a/endpoint-monitor/endpoint_monitor.go
+++ b/endpoint-monitor/endpoint_monitor.go
@@ -16,7 +16,6 @@ import (
 
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
-	"github.com/ethereum-optimism/optimism/op-service/opio"
 )
 
 var (
@@ -57,7 +56,11 @@ func Main(version string) func(cliCtx *cli.Context) error {
 				l.Error("failed to stop metrics server", "err", err)
 			}
 		}()
-		opio.BlockOnInterrupts()
+
+		select {
+		case <-cliCtx.Done():
+			l.Info("shutting down op-endpoint-monitor")
+		}
 
 		return nil
 	}

--- a/op-batcher/batcher/batch_submitter.go
+++ b/op-batcher/batcher/batch_submitter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/rpc"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/opio"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 )
@@ -104,7 +103,10 @@ func Main(version string, cliCtx *cli.Context) error {
 	m.RecordInfo(version)
 	m.RecordUp()
 
-	opio.BlockOnInterrupts()
+	select {
+	case <-cliCtx.Done():
+		l.Info("shutting down op-batcher")
+	}
 	if err := server.Stop(); err != nil {
 		l.Error("Error shutting down http server: %w", err)
 	}

--- a/op-bootnode/cmd/main.go
+++ b/op-bootnode/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -9,10 +10,18 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bootnode/bootnode"
 	"github.com/ethereum-optimism/optimism/op-bootnode/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 )
 
 func main() {
 	oplog.SetupDefaults()
+
+	// Invoke cancel when an interrupt is received.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		opio.BlockOnInterrupts()
+		cancel()
+	}()
 
 	app := cli.NewApp()
 	app.Flags = flags.Flags
@@ -21,7 +30,7 @@ func main() {
 	app.Description = "Broadcasts incoming P2P peers to each other, enabling peer bootstrapping."
 	app.Action = bootnode.Main
 
-	err := app.Run(os.Args)
+	err := app.RunContext(ctx, os.Args)
 	if err != nil {
 		log.Crit("Application failed", "message", err)
 	}

--- a/op-heartbeat/cmd/main.go
+++ b/op-heartbeat/cmd/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	heartbeat "github.com/ethereum-optimism/optimism/op-heartbeat"
 	"github.com/ethereum-optimism/optimism/op-heartbeat/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 )
@@ -20,6 +22,13 @@ var (
 func main() {
 	oplog.SetupDefaults()
 
+	// Invoke cancel when an interrupt is received.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		opio.BlockOnInterrupts()
+		cancel()
+	}()
+
 	app := cli.NewApp()
 	app.Flags = flags.Flags
 	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
@@ -27,7 +36,7 @@ func main() {
 	app.Usage = "Heartbeat recorder"
 	app.Description = "Service that records opt-in heartbeats from op nodes"
 	app.Action = heartbeat.Main(app.Version)
-	err := app.Run(os.Args)
+	err := app.RunContext(ctx, os.Args)
 	if err != nil {
 		log.Crit("Application failed", "message", err)
 	}

--- a/op-heartbeat/service.go
+++ b/op-heartbeat/service.go
@@ -8,11 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -47,14 +44,10 @@ func Main(version string) func(ctx *cli.Context) error {
 			l.Crit("error starting application", "err", err)
 		}
 
-		doneCh := make(chan os.Signal, 1)
-		signal.Notify(doneCh, []os.Signal{
-			os.Interrupt,
-			os.Kill,
-			syscall.SIGTERM,
-			syscall.SIGQUIT,
-		}...)
-		<-doneCh
+		select {
+		case <-cliCtx.Done():
+			l.Info("shutting down op-heartbeat")
+		}
 		return srv.Stop(context.Background())
 	}
 }

--- a/op-program/client/cmd/main.go
+++ b/op-program/client/cmd/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"os"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli"
 
+	"github.com/ethereum-optimism/optimism/op-node/cmd/doc"
 	"github.com/ethereum-optimism/optimism/op-program/client"
+	cldr "github.com/ethereum-optimism/optimism/op-program/client/driver"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 )
 
 func main() {
@@ -18,5 +24,41 @@ func main() {
 		Color:  false,
 	})
 	oplog.SetGlobalLogHandler(logger.GetHandler())
-	client.Main(logger)
+
+	// Invoke cancel when an interrupt is received.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		opio.BlockOnInterrupts()
+		cancel()
+	}()
+
+	app := cli.NewApp()
+	app.Name = "op-program"
+	app.Action = curryMain(logger)
+	app.Commands = []*cli.Command{
+		{
+			Name:        "doc",
+			Subcommands: doc.Subcommands,
+		},
+	}
+
+	err := app.RunContext(ctx, os.Args)
+	if err != nil {
+		if errors.Is(err, cldr.ErrClaimNotValid) {
+			log.Error("Claim is invalid", "err", err)
+			os.Exit(1)
+		} else if err != nil {
+			log.Error("Program failed", "err", err)
+			os.Exit(2)
+		}
+	} else {
+		log.Info("Claim successfully verified")
+		os.Exit(0)
+	}
+}
+
+func curryMain(logger log.Logger) func(ctx *cli.Context) error {
+	return func(ctx *cli.Context) error {
+		return client.Main(ctx, logger)
+	}
 }

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -30,14 +30,13 @@ type L2Source struct {
 	*sources.DebugClient
 }
 
-func Main(logger log.Logger, cfg *config.Config) error {
+func Main(ctx context.Context, logger log.Logger, cfg *config.Config) error {
 	if err := cfg.Check(); err != nil {
 		return fmt.Errorf("invalid config: %w", err)
 	}
 	opservice.ValidateEnvVars(flags.EnvVarPrefix, flags.Flags, logger)
 	cfg.Rollup.LogDescription(logger, chaincfg.L2ChainIDToNetworkDisplayName)
 
-	ctx := context.Background()
 	if cfg.ServerMode {
 		preimageChan := cl.CreatePreimageChannel()
 		hinterChan := cl.CreateHinterChannel()

--- a/op-proposer/cmd/main.go
+++ b/op-proposer/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -22,6 +24,13 @@ var (
 
 func main() {
 	oplog.SetupDefaults()
+
+	// Invoke cancel when an interrupt is received.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		opio.BlockOnInterrupts()
+		cancel()
+	}()
 
 	app := cli.NewApp()
 	app.Flags = cliapp.ProtectFlags(flags.Flags)
@@ -37,7 +46,7 @@ func main() {
 		},
 	}
 
-	err := app.Run(os.Args)
+	err := app.RunContext(ctx, os.Args)
 	if err != nil {
 		log.Crit("Application failed", "message", err)
 	}

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
-	"github.com/ethereum-optimism/optimism/op-service/opio"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
@@ -113,7 +112,10 @@ func Main(version string, cliCtx *cli.Context) error {
 	m.RecordInfo(version)
 	m.RecordUp()
 
-	opio.BlockOnInterrupts()
+	select {
+	case <-cliCtx.Done():
+		l.Info("shutting down L2 Output Submitter")
+	}
 
 	return nil
 }


### PR DESCRIPTION
**Description**

This commit updates main entry points to feed-in a context from the top level, and adds an easy cancel upon interrupt signals. The change allows graceful shutdowns on future features as long as the feature utilizes the context.
A clear and concise description of the features you're adding in this pull request.

**Tests**

No test added. More than glad to add one with some guidance.

**Metadata**

- Fixes #6742 
