### PR TITLE
feat(op-challenger): Wire Up the LocalContext

### DIFF
--- a/op-challenger/game/fault/test/alphabet.go
+++ b/op-challenger/game/fault/test/alphabet.go
@@ -33,6 +33,6 @@ func (a *alphabetWithProofProvider) GetStepData(ctx context.Context, i types.Pos
 		return nil, nil, nil, err
 	}
 	traceIndex := i.TraceIndex(int(a.depth)).Uint64()
-	data := types.NewPreimageOracleData([]byte{byte(traceIndex)}, []byte{byte(traceIndex - 1)}, uint32(traceIndex-1))
+	data := types.NewPreimageOracleData(0, []byte{byte(traceIndex)}, []byte{byte(traceIndex - 1)}, uint32(traceIndex-1))
 	return preimage, []byte{byte(traceIndex - 1)}, data, nil
 }

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -123,7 +123,8 @@ func (p *CannonTraceProvider) GetStepData(ctx context.Context, pos types.Positio
 	}
 	var oracleData *types.PreimageOracleData
 	if len(proof.OracleKey) > 0 {
-		oracleData = types.NewPreimageOracleData(proof.OracleKey, proof.OracleValue, proof.OracleOffset)
+		// TODO(client-pod#104): Replace the LocalContext `0` argument below with the correct local context.
+		oracleData = types.NewPreimageOracleData(0, proof.OracleKey, proof.OracleValue, proof.OracleOffset)
 	}
 	return value, data, oracleData, nil
 }

--- a/op-challenger/game/fault/trace/cannon/provider_test.go
+++ b/op-challenger/game/fault/trace/cannon/provider_test.go
@@ -124,7 +124,7 @@ func TestGetStepData(t *testing.T) {
 
 		require.EqualValues(t, generator.proof.StateData, preimage)
 		require.EqualValues(t, generator.proof.ProofData, proof)
-		expectedData := types.NewPreimageOracleData(generator.proof.OracleKey, generator.proof.OracleValue, generator.proof.OracleOffset)
+		expectedData := types.NewPreimageOracleData(0, generator.proof.OracleKey, generator.proof.OracleValue, generator.proof.OracleOffset)
 		require.EqualValues(t, expectedData, data)
 	})
 

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -33,9 +33,10 @@ func (p *PreimageOracleData) GetPreimageWithoutSize() []byte {
 }
 
 // NewPreimageOracleData creates a new [PreimageOracleData] instance.
-func NewPreimageOracleData(key []byte, data []byte, offset uint32) *PreimageOracleData {
+func NewPreimageOracleData(lctx uint64, key []byte, data []byte, offset uint32) *PreimageOracleData {
 	return &PreimageOracleData{
 		IsLocal:      len(key) > 0 && key[0] == byte(1),
+		LocalContext: lctx,
 		OracleKey:    key,
 		OracleData:   data,
 		OracleOffset: offset,

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -9,16 +9,18 @@ import (
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {
-		data := NewPreimageOracleData([]byte{1, 2, 3}, []byte{4, 5, 6}, 7)
+		data := NewPreimageOracleData(1, []byte{1, 2, 3}, []byte{4, 5, 6}, 7)
 		require.True(t, data.IsLocal)
+		require.Equal(t, uint64(1), data.LocalContext)
 		require.Equal(t, []byte{1, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
 		require.Equal(t, uint32(7), data.OracleOffset)
 	})
 
 	t.Run("GlobalData", func(t *testing.T) {
-		data := NewPreimageOracleData([]byte{0, 2, 3}, []byte{4, 5, 6}, 7)
+		data := NewPreimageOracleData(1, []byte{0, 2, 3}, []byte{4, 5, 6}, 7)
 		require.False(t, data.IsLocal)
+		require.Equal(t, uint64(1), data.LocalContext)
 		require.Equal(t, []byte{0, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
 		require.Equal(t, uint32(7), data.OracleOffset)


### PR DESCRIPTION
**Description**

Begins to wire up the `LocalContext` in the challenger's `PreimageOracleData`.
