### PR TITLE
fix(ctb): Fix bindings:go command not found issue

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "bindings": "pnpm bindings:ts && pnpm bindings:go",
     "bindings:ts": "nx generate @eth-optimism/contracts-ts",
-    "bindings:go:no-build": "cd ../../op-bindings && make binding-build",
-    "bindings:go": "pnpm clean && pnpm build && bindings:go:no-build",
+    "bindings:go:no-build": "cd ../../op-bindings && make bindings-build",
+    "bindings:go": "pnpm clean && pnpm build && pnpm bindings:go:no-build",
     "prebuild": "./scripts/verify-foundry-install.sh",
     "build": "forge build",
     "build:differential": "go build -o ./scripts/differential-testing/differential-testing ./scripts/differential-testing",


### PR DESCRIPTION
**Description**

Fixes a `pnpm` script command which called another `pnpm` script incorrectly.