### PR TITLE
feat(indexer) cli & client touchups

### DIFF
--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -49,6 +49,7 @@ func runIndexer(ctx *cli.Context) error {
 		return err
 	}
 
+	log.Info("running indexer...")
 	return indexer.Run(ctx.Context)
 }
 
@@ -68,12 +69,13 @@ func runApi(ctx *cli.Context) error {
 	}
 	defer db.Close()
 
+	log.Info("running api...")
 	api := api.NewApi(log, db.BridgeTransfers, cfg.HTTPServer, cfg.MetricsServer)
 	return api.Run(ctx.Context)
 }
 
 func runMigrations(ctx *cli.Context) error {
-	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "api")
+	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "migrations")
 	oplog.SetGlobalLogHandler(log.GetHandler())
 	cfg, err := config.LoadConfig(log, ctx.String(ConfigFlag.Name))
 	migrationsDir := ctx.String(MigrationsFlag.Name)
@@ -89,6 +91,7 @@ func runMigrations(ctx *cli.Context) error {
 	}
 	defer db.Close()
 
+	log.Info("running migrations...")
 	return db.ExecuteSQLMigration(migrationsDir)
 }
 

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -164,7 +164,7 @@ func LoadConfig(log log.Logger, path string) (Config, error) {
 			return cfg, err
 		}
 
-		log.Info("loaded local devnet preset")
+		log.Info("detected preset", "preset", DevnetPresetId, "name", preset.Name)
 		cfg.Chain = preset.ChainConfig
 	} else if cfg.Chain.Preset != 0 {
 		preset, ok := Presets[cfg.Chain.Preset]
@@ -191,25 +191,21 @@ func LoadConfig(log log.Logger, path string) (Config, error) {
 	// Defaults for any unset options
 
 	if cfg.Chain.L1PollingInterval == 0 {
-		log.Info("setting default L1 polling interval", "interval", defaultLoopInterval)
 		cfg.Chain.L1PollingInterval = defaultLoopInterval
 	}
 
 	if cfg.Chain.L2PollingInterval == 0 {
-		log.Info("setting default L2 polling interval", "interval", defaultLoopInterval)
 		cfg.Chain.L2PollingInterval = defaultLoopInterval
 	}
 
 	if cfg.Chain.L1HeaderBufferSize == 0 {
-		log.Info("setting default L1 header buffer", "size", defaultHeaderBufferSize)
 		cfg.Chain.L1HeaderBufferSize = defaultHeaderBufferSize
 	}
 
 	if cfg.Chain.L2HeaderBufferSize == 0 {
-		log.Info("setting default L2 header buffer", "size", defaultHeaderBufferSize)
 		cfg.Chain.L2HeaderBufferSize = defaultHeaderBufferSize
 	}
 
-	log.Info("loaded config", "config", cfg.Chain)
+	log.Info("loaded chain config", "config", cfg.Chain)
 	return cfg, nil
 }

--- a/indexer/node/client_test.go
+++ b/indexer/node/client_test.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialEthClientUnavailable(t *testing.T) {
+	listener, err := net.Listen("tcp4", ":0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	a := listener.Addr().String()
+	parts := strings.Split(a, ":")
+	addr := fmt.Sprintf("http://localhost:%s", parts[1])
+
+	metrics := &clientMetrics{}
+
+	// available
+	_, err = DialEthClient(addr, metrics)
+	require.NoError(t, err)
+
+	// :0 requests a new unbound port
+	_, err = DialEthClient("http://localhost:0", metrics)
+	require.Error(t, err)
+
+	// Fail open if we don't recognize the scheme
+	_, err = DialEthClient("mailto://example.com", metrics)
+	require.Error(t, err)
+}


### PR DESCRIPTION
- Fix Migrations log role
- Reduce noisy default config log since chainConfig is already logged
- Emit command being run
- `node.DailEthClient` tests for connectivity to failfast rather than have the indexer repeatedly use a failed client
    - Eventaully, this will fully leverage op-service/client after a op-node client metrics refactor
