### PR TITLE
bug(indexer) Chunked Batch Insertion

### DIFF
--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -77,8 +77,7 @@ func newBlocksDB(db *gorm.DB) BlocksDB {
 // L1
 
 func (db *blocksDB) StoreL1BlockHeaders(headers []L1BlockHeader) error {
-	result := db.gorm.CreateInBatches(&headers, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, headers)
 }
 
 func (db *blocksDB) L1BlockHeader(hash common.Hash) (*L1BlockHeader, error) {
@@ -115,8 +114,7 @@ func (db *blocksDB) L1LatestBlockHeader() (*L1BlockHeader, error) {
 // L2
 
 func (db *blocksDB) StoreL2BlockHeaders(headers []L2BlockHeader) error {
-	result := db.gorm.CreateInBatches(&headers, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, headers)
 }
 
 func (db *blocksDB) L2BlockHeader(hash common.Hash) (*L2BlockHeader, error) {

--- a/indexer/database/bridge_messages.go
+++ b/indexer/database/bridge_messages.go
@@ -72,8 +72,7 @@ func newBridgeMessagesDB(db *gorm.DB) BridgeMessagesDB {
  */
 
 func (db bridgeMessagesDB) StoreL1BridgeMessages(messages []L1BridgeMessage) error {
-	result := db.gorm.CreateInBatches(&messages, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, messages)
 }
 
 func (db bridgeMessagesDB) L1BridgeMessage(msgHash common.Hash) (*L1BridgeMessage, error) {
@@ -111,8 +110,7 @@ func (db bridgeMessagesDB) MarkRelayedL1BridgeMessage(messageHash common.Hash, r
  */
 
 func (db bridgeMessagesDB) StoreL2BridgeMessages(messages []L2BridgeMessage) error {
-	result := db.gorm.CreateInBatches(&messages, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, messages)
 }
 
 func (db bridgeMessagesDB) L2BridgeMessage(msgHash common.Hash) (*L2BridgeMessage, error) {

--- a/indexer/database/bridge_transactions.go
+++ b/indexer/database/bridge_transactions.go
@@ -79,9 +79,10 @@ func newBridgeTransactionsDB(db *gorm.DB) BridgeTransactionsDB {
  * Transactions deposited from L1
  */
 
+// StoreL1TransactionDeposits ... Stores a L1 tx deposit slice of arbitrary length into N chunks
+// of batchInsertSize
 func (db *bridgeTransactionsDB) StoreL1TransactionDeposits(deposits []L1TransactionDeposit) error {
-	result := db.gorm.CreateInBatches(&deposits, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, deposits)
 }
 
 func (db *bridgeTransactionsDB) L1TransactionDeposit(sourceHash common.Hash) (*L1TransactionDeposit, error) {
@@ -133,8 +134,7 @@ func (db *bridgeTransactionsDB) L1LatestBlockHeader() (*L1BlockHeader, error) {
  */
 
 func (db *bridgeTransactionsDB) StoreL2TransactionWithdrawals(withdrawals []L2TransactionWithdrawal) error {
-	result := db.gorm.CreateInBatches(&withdrawals, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, withdrawals)
 }
 
 func (db *bridgeTransactionsDB) L2TransactionWithdrawal(withdrawalHash common.Hash) (*L2TransactionWithdrawal, error) {

--- a/indexer/database/bridge_transfers.go
+++ b/indexer/database/bridge_transfers.go
@@ -91,8 +91,7 @@ func newBridgeTransfersDB(db *gorm.DB) BridgeTransfersDB {
  */
 
 func (db *bridgeTransfersDB) StoreL1BridgeDeposits(deposits []L1BridgeDeposit) error {
-	result := db.gorm.CreateInBatches(&deposits, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, deposits)
 }
 
 func (db *bridgeTransfersDB) L1BridgeDeposit(txSourceHash common.Hash) (*L1BridgeDeposit, error) {
@@ -204,8 +203,7 @@ l1_bridge_deposits.timestamp, cross_domain_message_hash, local_token_address, re
  */
 
 func (db *bridgeTransfersDB) StoreL2BridgeWithdrawals(withdrawals []L2BridgeWithdrawal) error {
-	result := db.gorm.CreateInBatches(&withdrawals, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, withdrawals)
 }
 
 func (db *bridgeTransfersDB) L2BridgeWithdrawal(txWithdrawalHash common.Hash) (*L2BridgeWithdrawal, error) {

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -109,8 +109,7 @@ func newContractEventsDB(db *gorm.DB) ContractEventsDB {
 // L1
 
 func (db *contractEventsDB) StoreL1ContractEvents(events []L1ContractEvent) error {
-	result := db.gorm.CreateInBatches(&events, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, events)
 }
 
 func (db *contractEventsDB) L1ContractEvent(uuid uuid.UUID) (*L1ContractEvent, error) {
@@ -176,8 +175,7 @@ func (db *contractEventsDB) L1LatestContractEventWithFilter(filter ContractEvent
 // L2
 
 func (db *contractEventsDB) StoreL2ContractEvents(events []L2ContractEvent) error {
-	result := db.gorm.CreateInBatches(&events, batchInsertSize)
-	return result.Error
+	return createInBatches(db.gorm, events)
 }
 
 func (db *contractEventsDB) L2ContractEvent(uuid uuid.UUID) (*L2ContractEvent, error) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
There's a bug in the indexer's database interaction logic where it can only insert batches of 3,000 rows at a time. This results in silent failures in the case where an insertion slice > 3,000 is provided (i.e, no error is returned from gorm operation). This caused a pretty nasty bug where the bridge processor was failing to correlate a cross-domain message hash on L2 with an L1 tx deposit:
```
{"bridge":"l2","from_l2_block_number":"0","lvl":"eror","msg":"missing indexed L1CrossDomainMessenger message","processor":"bridge","role":"indexer","t":"2023-10-16T16:37:18.893497-07:00","to_l2_block_number":"2165994","tx_hash":"0xd1fe53b5b2245f1079a7ae5538e1decbce800abbb04d184af4426dc65d720a22"}
{"epoch_end_number":"17839078","epoch_start_number":"17834370","err":"missing indexed L1CrossDomainMessager message. tx_hash = 0xd1fe53b5b2245f1079a7ae5538e1decbce800abbb04d184af4426dc65d720a22","lvl":"eror","msg":"failed to index l2 finalized bridge events","processor":"bridge","role":"indexer","t":"2023-10-16T16:37:18.893538-07:00"}
```
This PR introduces a common generic `createInBatches` function that does a standard batch iteration routine to ensure that the inner [gorm.BatchInsert](https://gorm.io/gen/create.html#Batch-Insert) function is only called with input slices that are <= batch_size. 

**Tests**
N/A - The existing tests should handle the < `batch_size` insertion cases. If desired, we can:
* (👌) Make `batch_size` variadic and set it to a low value for testing. (i.e, `batch_size` > element slices)
* (😅) Non-deterministically generate `batch_size` values for ensuring resiliency to different thresholds. 

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
