### PR TITLE
ops: shared cached go docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,13 +168,42 @@ jobs:
         description: Docker repo
         type: string
         default: "oplabs-tools-artifacts/images"
+      build_args:
+        description: Docker build args
+        type: string
+        default: ""
+      load_base_image:
+        description: Load docker image as base
+        type: string
+        default: ""
+      save_image_tag:
+        description: Save docker image as
+        type: string
+        default: ""
     machine:
       image: ubuntu-2204:2022.07.1
       resource_class: medium
+      docker_layer_caching: true
     steps:
       - checkout
+      - restore_cache:
+          name: Restore docker build cache
+          key: docker-build-cache
+      - attach_workspace:
+          at: /tmp/docker_images
       - run:
           command: mkdir -p /tmp/docker_images
+      - when:
+          condition: "<<parameters.load_base_image>>"
+          steps:
+            - run:
+                name: Load OP-Stack Go base image
+                command: |
+                  docker load < "/tmp/docker_images/<<parameters.load_base_image>>.tar"
+      - run:
+          name: build args
+          command: |
+            echo "build args: <<parameters.build_args>>"
       - run:
           name: Build
           command: |
@@ -185,20 +214,30 @@ jobs:
             fi
             IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
             DOCKER_TAGS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
+            IMAGE_BASE_PREFIX="<<parameters.registry>>/<<parameters.repo>>"
+            IMAGE_BASE="$IMAGE_BASE_PREFIX/<<parameters.docker_name>>"
             docker build --progress plain \
+            <<parameters.build_args>> \
             $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
             -f <<parameters.docker_file>> \
             <<parameters.docker_context>>
-      - run:
-          name: Save
-          command: |
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-            DOCKER_LABELS=$(echo -ne <<parameters.docker_tags>> | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g")
-            echo -ne $DOCKER_LABELS | tr ' ' '\n' | xargs -I {} docker save -o /tmp/docker_images/<<parameters.docker_name>>_{}.tar $IMAGE_BASE:{}
-      - persist_to_workspace:
-          root: /tmp/docker_images
+      - when:
+          condition: "<<parameters.save_image_tag>>"
+          steps:
+            - run:
+                name: Save
+                command: |
+                  IMAGE_NAME="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>:<<parameters.save_image_tag>>"
+                  docker save -o /tmp/docker_images/<<parameters.docker_name>>.tar $IMAGE_NAME
+            - persist_to_workspace:
+                root: /tmp/docker_images
+                paths:  # only write the one file, to avoid concurrent workspace-file additions
+                  - "<<parameters.docker_name>>.tar"
+      - save_cache:
+          name: Save docker build cache
+          key: docker-build-cache
           paths:
-            - "."
+            - "/tmp/docker-build-cache"
 
   docker-publish:
     environment:
@@ -417,8 +456,8 @@ jobs:
             git diff --exit-code ./invariant-docs/*.md || echo "export INVARIANT_DOCS_STATUS=1" >> "$BASH_ENV"
           working_directory: packages/contracts-bedrock
       - run:
-          name: check deploy configs || echo "export DEPLOY_CONFIGS_STATUS=1" >> "$BASH_ENV"
-          command: pnpm validate-deploy-configs
+          name: check deploy configs
+          command: pnpm validate-deploy-configs || echo "export DEPLOY_CONFIGS_STATUS=1" >> "$BASH_ENV"
           working_directory: packages/contracts-bedrock
       - run:
           name: check statuses
@@ -675,53 +714,34 @@ jobs:
           event: fail
           template: basic_fail_1
 
-  fuzz-op-node:
+  fuzz-golang:
+    parameters:
+      package_name:
+        description: Go package name
+        type: string
+      on_changes:
+        description: changed pattern to fire fuzzer on
+        type: string
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     steps:
       - checkout
       - check-changed:
-          patterns: op-node
+          patterns: "<<parameters.package_name>>"
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          name: Restore Go build cache
+          key: golang-build-cache
       - run:
           name: Fuzz
           command: make fuzz
-          working_directory: op-node
-
-  fuzz-op-service:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    steps:
-      - checkout
-      - check-changed:
-          patterns: op-service
-      - run:
-          name: Fuzz
-          command: make fuzz
-          working_directory: op-service
-
-  fuzz-op-chain-ops:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    steps:
-      - checkout
-      - check-changed:
-          patterns: op-chain-ops,op-bindings
-      - run:
-          name: Fuzz
-          command: make fuzz
-          working_directory: op-chain-ops
-
-  fuzz-cannon:
-    docker:
-      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    steps:
-      - checkout
-      - check-changed:
-          patterns: cannon,packages/contracts-bedrock/src/cannon
-      - run:
-          name: Fuzz
-          command: make fuzz
-          working_directory: cannon
+          working_directory: "<<parameters.package_name>>"
+      - save_cache:
+          key: golang-build-cache
+          paths:
+            - "/root/.cache/go-build"
 
   depcheck:
     docker:
@@ -748,19 +768,42 @@ jobs:
           command: npx depcheck
           working_directory: packages/sdk
 
-  go-lint:
-    parameters:
-      module:
-        description: Go Module Name
-        type: string
+  l1-geth-version-check:
     docker:
-      - image: cimg/go:1.21
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     steps:
       - checkout
       - run:
-          name: run lint
-          command: make lint
-          working_directory: <<parameters.module>>
+          name: "Check L1 geth version"
+          command: ./ops/scripts/geth-version-checker.sh || (echo "geth version is wrong, update ci-builder"; false)
+
+  go-lint:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          key: golang-build-cache
+      - restore_cache:
+          key: golang-lint-cache
+      - run:
+          name: run Go linter
+          command: |
+            # Identify how many cores it defaults to
+            golangci-lint --help | grep concurrency
+            make lint-go
+          working_directory: .
+      - save_cache:
+          key: golang-build-cache
+          paths:
+            - "/root/.cache/go-build"
+      - save_cache:
+          key: golang-lint-cache
+          paths:
+            - "/root/.cache/golangci-lint"
 
   go-test:
     parameters:
@@ -772,6 +815,13 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          keys:
+            - golang-build-cache-<<parameters.module>>
+            - golang-build-cache-
       - run:
           name: prep results dir
           command: mkdir -p /tmp/test-results
@@ -781,6 +831,10 @@ jobs:
             gotestsum --format=standard-verbose --junitfile=/tmp/test-results/<<parameters.module>>.xml \
             -- -parallel=8 -coverpkg=github.com/ethereum-optimism/optimism/... -coverprofile=coverage.out ./...
           working_directory: <<parameters.module>>
+      - save_cache:
+          key: golang-build-cache-<<parameters.module>>
+          paths:
+            - "/root/.cache/go-build"
       - run:
           name: upload coverage
           command: codecov --verbose --clean --flags bedrock-go-tests
@@ -805,12 +859,16 @@ jobs:
       - run:
           name: prep results dir
           command: mkdir -p /tmp/test-results
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
-          name: install geth
-          command: make install-geth
-      - run:
-          name: git submodules
-          command: git submodule update --init --recursive
+          name: Load devnet-allocs
+          command: |
+            mkdir -p .devnet
+            cp /tmp/workspace/.devnet/allocs-l1.json .devnet/allocs-l1.json
+            cp /tmp/workspace/.devnet/addresses.json .devnet/addresses.json
+            cp /tmp/workspace/packages/contracts-bedrock/deploy-config/devnetL1.json packages/contracts-bedrock/deploy-config/devnetL1.json
+            cp -r /tmp/workspace/packages/contracts-bedrock/deployments/devnetL1 packages/contracts-bedrock/deployments/devnetL1
       - run:
           name: print go's available MIPS targets
           command: go tool dist list | grep mips
@@ -881,9 +939,6 @@ jobs:
           command: golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 4m -e "errors.As" -e "errors.Is" ./...
           working_directory: indexer
       - run:
-          name: install geth
-          command: make install-geth
-      - run:
           name: git submodules
           command: git submodule update --init --recursive
       - run:
@@ -916,6 +971,60 @@ jobs:
           name: Check generated code
           command: npm run generate && git diff --exit-code
           working_directory: indexer/api-ts
+
+  cannon-prestate:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          key: golang-build-cache
+      - restore_cache:
+          key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
+          name: Load cannon prestate cache
+      - run:
+          name: generate cannon prestate
+          command: make cannon-prestate
+      - save_cache:
+          key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
+          name: Save Cannon prestate to cache
+          paths:
+            - "op-program/bin/prestate.json"
+            - "op-program/bin/meta.json"
+            - "op-program/bin/prestate-proof.json"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "op-program/bin/prestate.json"
+            - "op-program/bin/meta.json"
+            - "op-program/bin/prestate-proof.json"
+
+  devnet-allocs:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          key: golang-build-cache
+      - run:
+          name: git submodules
+          command: git submodule update --init --recursive
+      - run:
+          name: generate devnet allocs
+          command: make devnet-allocs
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ".devnet/allocs-l1.json"
+            - ".devnet/addresses.json"
+            - "packages/contracts-bedrock/deploy-config/devnetL1.json"
+            - "packages/contracts-bedrock/deployments/devnetL1"
 
   devnet:
     machine:
@@ -968,9 +1077,37 @@ jobs:
           name: Install and build
           command: |
             pnpm install --frozen-lockfile --prefer-offline && pnpm build
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
-          name: generate cannon prestate
-          command: make cannon-prestate
+          name: Load cannon pre-state
+          command: |
+            mkdir -p op-program/bin
+            cp /tmp/workspace/op-program/bin/prestate.json op-program/bin/prestate.json
+            cp /tmp/workspace/op-program/bin/meta.json op-program/bin/meta.json
+            cp /tmp/workspace/op-program/bin/prestate-proof.json op-program/bin/prestate-proof.json
+      - run:
+          name: Load devnet-allocs
+          command: |
+            mkdir -p .devnet
+            cp /tmp/workspace/.devnet/allocs-l1.json .devnet/allocs-l1.json
+            cp /tmp/workspace/.devnet/addresses.json .devnet/addresses.json
+            cp /tmp/workspace/packages/contracts-bedrock/deploy-config/devnetL1.json packages/contracts-bedrock/deploy-config/devnetL1.json
+            cp -r /tmp/workspace/packages/contracts-bedrock/deployments/devnetL1 packages/contracts-bedrock/deployments/devnetL1
+      - run:
+          name: Load and tag docker images
+          command: |
+            IMAGE_BASE_PREFIX="us-docker.pkg.dev/oplabs-tools-artifacts/images"
+            # Load from previous docker-build job
+            docker load < "/tmp/workspace/op_stack_go.tar"
+            docker load < "/tmp/workspace/op-node.tar"
+            docker load < "/tmp/workspace/op-proposer.tar"
+            docker load < "/tmp/workspace/op-batcher.tar"
+            # rename to the tags that the docker-compose of the devnet expects
+            docker tag "$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op_stack_go:devnet"
+            docker tag "$IMAGE_BASE_PREFIX/op-node:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-node:devnet"
+            docker tag "$IMAGE_BASE_PREFIX/op-proposer:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-proposer:devnet"
+            docker tag "$IMAGE_BASE_PREFIX/op-batcher:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-batcher:devnet"
       - run:
           name: Bring up the stack
           command: make devnet-up
@@ -1054,18 +1191,50 @@ jobs:
           name: "Semgrep scan"
           command: semgrep ci
 
+  go-mod-download:
+    docker:
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    parameters:
+      file:
+        default: go.sum
+        description: The file name of checksum for restore_cache and save_cache.
+        type: string
+      key:
+        default: gomod
+        description: The key of restore_cache and save_cache.
+        type: string
+    steps:
+      - checkout
+      - restore_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Restore Go modules cache
+      - run:
+          name: Sanity check go mod cache path
+          command: test "$(go env GOMODCACHE)" == "/go/pkg/mod" # yes, it's an odd path
+      - run:
+          command: go mod download
+          name: Download Go module dependencies
+      - save_cache:
+          key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
+          name: Save Go modules cache
+          paths:
+            - "/go/pkg/mod"
+
   go-mod-tidy:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     steps:
       - checkout
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
       - run:
           name: "Go mod tidy"
           command: make mod-tidy && git diff --exit-code
 
-  bedrock-go-tests:
+  bedrock-go-tests:  # just a helper, that depends on all the actual test jobs
     docker:
-      - image: cimg/go:1.21
+      - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     resource_class: medium
     steps:
       - run: echo Done
@@ -1167,110 +1336,111 @@ workflows:
       - depcheck:
           requires:
             - pnpm-monorepo
-      - devnet
       - go-lint-test-build:
           name: proxyd-tests
           binary_name: proxyd
           working_directory: proxyd
       - indexer-tests
-      - go-lint-test-build:
-          name: op-heartbeat-tests
-          binary_name: op-heartbeat
-          working_directory: op-heartbeat
+      - l1-geth-version-check
       - semgrep-scan
-      - go-mod-tidy
-      - fuzz-op-node
-      - fuzz-op-service
-      - fuzz-op-chain-ops
-      - fuzz-cannon
+      - go-mod-download
+      - go-mod-tidy:
+          requires: ["go-mod-download"]
+      - devnet-allocs:  # devnet-allocs uses op-node genesis sub-command
+          requires:
+            - "go-mod-tidy"
+            - l1-geth-version-check
       - bedrock-markdown
-      - go-lint:
-          name: op-batcher-lint
-          module: op-batcher
-      - go-lint:
-          name: op-bootnode-lint
-          module: op-bootnode
-      - go-lint:
-          name: op-bindings-lint
-          module: op-bindings
-      - go-lint:
-          name: op-chain-ops-lint
-          module: op-chain-ops
-      - go-lint:
-          name: op-e2e-lint
-          module: op-e2e
-      - go-lint:
-          name: op-node-lint
-          module: op-node
-      - go-lint:
-          name: op-proposer-lint
-          module: op-proposer
-      - go-lint:
-          name: op-challenger-lint
-          module: op-challenger
-      - go-lint:
-          name: op-program-lint
-          module: op-program
-      - go-lint:
-          name: op-service-lint
-          module: op-service
-      - go-lint:
-          name: op-wheel-lint
-          module: op-wheel
+      - go-lint: # we combine most of the go-lint work for two reasons: (1) warm up the Go build cache, (2) reduce sum of lint time
+          name: op-stack-go-lint
+          requires: [ "go-mod-tidy" ]
+      - fuzz-golang:
+          name: op-node-fuzz
+          package_name: op-node
+          on_changes: op-node
+          requires: ["op-stack-go-lint"]
+      - fuzz-golang:
+          name: op-service-fuzz
+          package_name: op-service
+          on_changes: op-service
+          requires: ["op-stack-go-lint"]
+      - fuzz-golang:
+          name: op-chain-ops-fuzz
+          package_name: op-chain-ops
+          on_changes: op-chain-ops,op-bindings
+          requires: ["op-stack-go-lint"]
+      - fuzz-golang:
+          name: cannon-fuzz
+          package_name: cannon
+          on_changes: cannon,packages/contracts-bedrock/src/cannon
+          requires: ["op-stack-go-lint"]
+      - go-test:
+          name: op-heartbeat-tests
+          module: op-heartbeat
+          requires: [ "op-stack-go-lint" ]
       - go-test:
           name: op-batcher-tests
           module: op-batcher
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-bindings-tests
           module: op-bindings
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-chain-ops-tests
           module: op-chain-ops
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-node-tests
           module: op-node
-          # TODO: override resource class
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-proposer-tests
           module: op-proposer
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-challenger-tests
           module: op-challenger
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-program-tests
           module: op-program
+          requires: ["op-stack-go-lint"]
       - go-test:
           name: op-service-tests
           module: op-service
+          requires: ["op-stack-go-lint"]
       - go-e2e-test:
           name: op-e2e-WS-tests
           module: op-e2e
           target: test-ws
+          requires:
+            - op-stack-go-lint
+            - devnet-allocs
       - go-e2e-test:
           name: op-e2e-HTTP-tests
           module: op-e2e
           target: test-http
+          requires:
+            - op-stack-go-lint
+            - devnet-allocs
       - go-e2e-test:
           name: op-e2e-ext-geth-tests
           module: op-e2e
           target: test-external-geth
+          requires:
+            - op-stack-go-lint
+            - devnet-allocs
+            - l1-geth-version-check
       - bedrock-go-tests:
           requires:
+            - go-mod-download
             - go-mod-tidy
             - cannon-build-test-vectors
             - cannon-go-lint-and-test
             - check-generated-mocks-op-node
             - check-generated-mocks-op-service
-            - op-batcher-lint
-            - op-bootnode-lint
-            - op-bindings-lint
-            - op-chain-ops-lint
-            - op-e2e-lint
-            - op-node-lint
-            - op-proposer-lint
-            - op-challenger-lint
-            - op-program-lint
-            - op-service-lint
+            - op-stack-go-lint
             - op-batcher-tests
             - op-bindings-tests
             - op-chain-ops-tests
@@ -1284,41 +1454,80 @@ workflows:
             - op-e2e-HTTP-tests
             - op-e2e-ext-geth-tests
       - docker-build:
+          name: op-stack-go-docker-build
+          docker_file: ops/docker/op-stack-go/Dockerfile
+          docker_name: op_stack_go
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+          build_args: "--build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg GIT_DATE=$(git show -s --format='%ct')"
+          save_image_tag: <<pipeline.git.revision>> # other images builds below depend on this image, so we save it to the workspace
+      - docker-build:
           name: op-node-docker-build
           docker_file: op-node/Dockerfile
           docker_name: op-node
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          load_base_image: "op_stack_go"
           docker_context: .
+          requires: ['op-stack-go-docker-build']
+          build_args: --build-arg OP_STACK_GO_BUILDER="$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>"
+          save_image_tag: <<pipeline.git.revision>> # for devnet later
       - docker-build:
           name: op-batcher-docker-build
           docker_file: op-batcher/Dockerfile
           docker_name: op-batcher
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          load_base_image: "op_stack_go"
           docker_context: .
+          requires: ['op-stack-go-docker-build']
+          build_args: --build-arg OP_STACK_GO_BUILDER="$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>"
+          save_image_tag: <<pipeline.git.revision>> # for devnet later
       - docker-build:
           name: op-program-docker-build
           docker_file: op-program/Dockerfile
           docker_name: op-program
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          load_base_image: "op_stack_go"
           docker_context: .
+          requires: ['op-stack-go-docker-build']
+          build_args: --build-arg OP_STACK_GO_BUILDER="$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>"
       - docker-build:
           name: op-proposer-docker-build
           docker_file: op-proposer/Dockerfile
           docker_name: op-proposer
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          load_base_image: "op_stack_go"
           docker_context: .
+          requires: ['op-stack-go-docker-build']
+          build_args: --build-arg OP_STACK_GO_BUILDER="$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>"
+          save_image_tag: <<pipeline.git.revision>> # for devnet later
       - docker-build:
           name: op-challenger-docker-build
           docker_file: op-challenger/Dockerfile
           docker_name: op-challenger
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          load_base_image: "op_stack_go"
           docker_context: .
+          requires: ['op-stack-go-docker-build']
+          build_args: --build-arg OP_STACK_GO_BUILDER="$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>"
       - docker-build:
           name: op-heartbeat-docker-build
           docker_file: op-heartbeat/Dockerfile
           docker_name: op-heartbeat
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          load_base_image: "op_stack_go"
           docker_context: .
+          requires: ['op-stack-go-docker-build']
+          build_args: --build-arg OP_STACK_GO_BUILDER="$IMAGE_BASE_PREFIX/op_stack_go:<<pipeline.git.revision>>"
+      - cannon-prestate:
+          requires: ["op-stack-go-lint"]
+      - devnet:
+          requires:
+            - op-node-docker-build
+            - op-batcher-docker-build
+            - op-proposer-docker-build
+            - l1-geth-version-check
+            - devnet-allocs
+            - cannon-prestate
       - docker-build:
           name: indexer-docker-build
           docker_file: indexer/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 COMPOSEFLAGS=-d
 ITESTS_L2_HOST=http://localhost:9545
 BEDROCK_TAGS_REMOTE?=origin
+OP_STACK_GO_BUILDER?=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
 
 build: build-go build-ts
 .PHONY: build
 
 build-go: submodules op-node op-proposer op-batcher
 .PHONY: build-go
+
+lint-go:
+	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
+.PHONY: lint-go
 
 build-ts: submodules
 	if [ -n "$$NVM_DIR" ]; then \
@@ -18,6 +23,13 @@ build-ts: submodules
 
 ci-builder:
 	docker build -t ci-builder -f ops/docker/ci-builder/Dockerfile .
+
+golang-docker:
+	DOCKER_BUILDKIT=1 docker build -t op-stack-go \
+		--build-arg GIT_COMMIT=$$(git rev-parse HEAD) \
+		--build-arg GIT_DATE=$$(git show -s --format='%ct') \
+ 		-f ops/docker/op-stack-go/Dockerfile .
+.PHONY: golang-docker
 
 submodules:
 	# CI will checkout submodules on its own (and fails on these commands)
@@ -163,4 +175,10 @@ bedrock-markdown-links:
 		--exclude-mail /input/README.md "/input/specs/**/*.md"
 
 install-geth:
-	go install github.com/ethereum/go-ethereum/cmd/geth@$(shell cat .gethrc)
+	./ops/scripts/geth-version-checker.sh && \
+	 	(echo "Geth versions match, not installing geth..."; true) || \
+ 		(echo "Versions do not match, installing geth!"; \
+ 			go install -v github.com/ethereum/go-ethereum/cmd/geth@$(shell cat .gethrc); \
+ 			echo "Installed geth!"; true)
+.PHONY: install-geth
+

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -96,7 +96,9 @@ def main():
 
     log.info('Building docker images')
     run_command(['docker', 'compose', 'build', '--progress', 'plain'], cwd=paths.ops_bedrock_dir, env={
-        'PWD': paths.ops_bedrock_dir
+        'PWD': paths.ops_bedrock_dir,
+        'DOCKER_BUILDKIT': '1', # (should be available by default in later versions, but explicitly enable it anyway)
+        'COMPOSE_DOCKER_CLI_BUILD': '1'  # use the docker cache
     })
 
     log.info('Devnet starting')

--- a/cannon/Makefile
+++ b/cannon/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -19,9 +19,6 @@ elf:
 
 test: elf
 	go test -v ./...
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is"
 
 fuzz:
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzStateSyscallBrk ./mipsevm

--- a/endpoint-monitor/Makefile
+++ b/endpoint-monitor/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)

--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -1,32 +1,9 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.1-alpine3.18 as builder
-
-ARG VERSION=v0.0.0
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-WORKDIR /app
-
-RUN go mod download
-
-# build op-batcher with the shared go.mod & go.sum files
-COPY ./op-batcher /app/op-batcher
-COPY ./op-bindings /app/op-bindings
-COPY ./op-node /app/op-node
-COPY ./op-service /app/op-service
-
-COPY ./.git /app/.git
-
-WORKDIR /app/op-batcher
-
-ARG TARGETOS TARGETARCH
-
-RUN make op-batcher VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.18
 
-COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin
+COPY --from=builder /usr/local/bin/op-batcher /usr/local/bin/op-batcher
 
-ENTRYPOINT ["op-batcher"]
+CMD ["op-batcher"]

--- a/op-batcher/Dockerfile.dockerignore
+++ b/op-batcher/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-batcher/Makefile
+++ b/op-batcher/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -16,9 +16,6 @@ clean:
 test:
 	go test -v ./...
 
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-
 fuzz:
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzChannelConfig_CheckTimeout ./batcher
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzDurationZero ./batcher
@@ -33,5 +30,4 @@ fuzz:
 	op-batcher \
 	clean \
 	test \
-	lint \
 	fuzz

--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -26,9 +26,6 @@ bindings-build:
 		-package $(pkg) \
 		-monorepo-base $(monorepo-base)
 
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-
 mkdir:
 	mkdir -p $(pkg)
 

--- a/op-bootnode/Makefile
+++ b/op-bootnode/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -16,11 +16,7 @@ clean:
 test:
 	go test -v ./...
 
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-
 .PHONY: \
 	op-bootnode \
 	clean \
-	test \
-	lint
+	test

--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -6,9 +6,6 @@ check-l2:
 test:
 	go test ./...
 
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-
 fuzz:
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzEncodeDecodeWithdrawal ./crossdomain
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz=FuzzEncodeDecodeLegacyWithdrawal ./crossdomain

--- a/op-challenger/Dockerfile
+++ b/op-challenger/Dockerfile
@@ -1,56 +1,17 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.1-alpine3.18 as builder
-
-ARG VERSION=v0.0.0
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-WORKDIR /app
-
-RUN go mod download
-
-# build op-challenger with the shared go.mod & go.sum files
-COPY ./op-challenger /app/op-challenger
-COPY ./op-program /app/op-program
-COPY ./op-preimage /app/op-preimage
-COPY ./op-bindings /app/op-bindings
-COPY ./op-node /app/op-node
-COPY ./op-service /app/op-service
-COPY ./.git /app/.git
-
-# Copy cannon and its dependencies
-COPY ./cannon /app/cannon
-COPY ./op-preimage /app/op-preimage
-COPY ./op-chain-ops /app/op-chain-ops
-
-WORKDIR /app/op-program
-
-ARG TARGETOS TARGETARCH
-
-RUN make op-program-host VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
-
-WORKDIR /app/cannon
-
-ARG TARGETOS TARGETARCH
-
-RUN make cannon VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
-
-WORKDIR /app/op-challenger
-
-RUN make op-challenger VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.18
 
 # Make the bundled op-program the default cannon server
-COPY --from=builder /app/op-program/bin/op-program /usr/local/bin
+COPY --from=builder /usr/local/bin/op-program /usr/local/bin/op-program
 ENV OP_CHALLENGER_CANNON_SERVER /usr/local/bin/op-program
 
 # Make the bundled cannon the default cannon executable
-COPY --from=builder /app/cannon/bin/cannon /usr/local/bin
+COPY --from=builder /usr/local/bin/cannon /usr/local/bin/cannon
 ENV OP_CHALLENGER_CANNON_BIN /usr/local/bin/cannon
 
-COPY --from=builder /app/op-challenger/bin/op-challenger /usr/local/bin
+COPY --from=builder /usr/local/bin/op-challenger /usr/local/bin/op-challenger
 
 CMD ["op-challenger"]

--- a/op-challenger/Dockerfile.dockerignore
+++ b/op-challenger/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-challenger/Makefile
+++ b/op-challenger/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -15,9 +15,6 @@ clean:
 
 test:
 	go test -v ./...
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
 
 visualize:
 	./scripts/visualize.sh

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -51,7 +51,3 @@ clean:
 	rm -r ../.devnet
 	rm -r ../op-program/bin
 .PHONY: clean
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-.PHONY: lint

--- a/op-heartbeat/Dockerfile
+++ b/op-heartbeat/Dockerfile
@@ -1,22 +1,9 @@
-FROM golang:1.21.1-alpine3.18 as builder
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
-# build op-heartbeat with local monorepo go modules
-COPY ./op-heartbeat /app/op-heartbeat
-COPY ./op-node /app/op-node
-COPY ./op-service /app/op-service
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-COPY ./.git /app/.git
-
-WORKDIR /app/op-heartbeat
-
-RUN make op-heartbeat
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.18
 
-COPY --from=builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin
+COPY --from=builder /usr/local/bin/op-heartbeat /usr/local/bin/op-heartbeat
 
 CMD ["op-heartbeat"]

--- a/op-heartbeat/Dockerfile.dockerignore
+++ b/op-heartbeat/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-heartbeat/Makefile
+++ b/op-heartbeat/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -15,9 +15,6 @@ clean:
 
 test:
 	go test -v ./...
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
 
 .PHONY: \
 	clean \

--- a/op-node/Dockerfile
+++ b/op-node/Dockerfile
@@ -1,31 +1,9 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.1-alpine3.18 as builder
-
-ARG VERSION=v0.0.0
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-WORKDIR /app
-
-RUN go mod download
-
-# build op-node with the shared go.mod & go.sum files
-COPY ./op-node /app/op-node
-COPY ./op-chain-ops /app/op-chain-ops
-COPY ./op-service /app/op-service
-COPY ./op-bindings /app/op-bindings
-COPY ./.git /app/.git
-
-WORKDIR /app/op-node
-
-ARG TARGETOS TARGETARCH
-
-RUN make op-node VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.18
 
-COPY --from=builder /app/op-node/bin/op-node /usr/local/bin
+COPY --from=builder /usr/local/bin/op-node /usr/local/bin/op-node
 
 CMD ["op-node"]

--- a/op-node/Dockerfile.dockerignore
+++ b/op-node/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -16,9 +16,6 @@ clean:
 
 test:
 	go test -v ./...
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
 
 fuzz:
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzL1InfoRoundTrip ./rollup/derive

--- a/op-preimage/filepoller_test.go
+++ b/op-preimage/filepoller_test.go
@@ -15,9 +15,9 @@ func TestFilePoller_Read(t *testing.T) {
 	chanAPoller := NewFilePoller(ctx, chanA, time.Millisecond*100)
 
 	go func() {
-		chanB.Write([]byte("hello"))
+		_, _ = chanB.Write([]byte("hello"))
 		time.Sleep(time.Second * 1)
-		chanB.Write([]byte("world"))
+		_, _ = chanB.Write([]byte("world"))
 	}()
 	var buf [10]byte
 	n, err := chanAPoller.Read(buf[:])
@@ -34,9 +34,9 @@ func TestFilePoller_Write(t *testing.T) {
 	bufch := make(chan []byte, 1)
 	go func() {
 		var buf [10]byte
-		chanB.Read(buf[:5])
+		_, _ = chanB.Read(buf[:5])
 		time.Sleep(time.Second * 1)
-		chanB.Read(buf[5:])
+		_, _ = chanB.Read(buf[5:])
 		bufch <- buf[:]
 		close(bufch)
 	}()
@@ -59,7 +59,7 @@ func TestFilePoller_ReadCancel(t *testing.T) {
 	chanAPoller := NewFilePoller(ctx, chanA, time.Millisecond*100)
 
 	go func() {
-		chanB.Write([]byte("hello"))
+		_, _ = chanB.Write([]byte("hello"))
 		cancel()
 	}()
 	var buf [10]byte
@@ -76,7 +76,7 @@ func TestFilePoller_WriteCancel(t *testing.T) {
 
 	go func() {
 		var buf [5]byte
-		chanB.Read(buf[:])
+		_, _ = chanB.Read(buf[:])
 		cancel()
 	}()
 	// use a large buffer to overflow the kernel buffer provided to pipe(2) so the write actually blocks

--- a/op-program/Dockerfile
+++ b/op-program/Dockerfile
@@ -1,33 +1,9 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.1-alpine3.18 as builder
-
-ARG VERSION=v0.0.0
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-WORKDIR /app
-
-RUN go mod download
-
-# build op-program with the shared go.mod & go.sum files
-COPY ./op-program /app/op-program
-COPY ./op-preimage /app/op-preimage
-COPY ./op-node /app/op-node
-COPY ./op-chain-ops /app/op-chain-ops
-COPY ./op-service /app/op-service
-COPY ./op-bindings /app/op-bindings
-COPY ./.git /app/.git
-
-WORKDIR /app/op-program
-
-ARG TARGETOS TARGETARCH
-
-RUN make op-program VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.18
 
-COPY --from=builder /app/op-program/bin/op-program /usr/local/bin
+COPY --from=builder /usr/local/bin/op-program /usr/local/bin/op-program
 
 CMD ["op-program"]

--- a/op-program/Dockerfile.dockerignore
+++ b/op-program/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-program/Makefile
+++ b/op-program/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -29,9 +29,6 @@ clean:
 
 test:
 	go test -v ./...
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
 
 verify-goerli: op-program-host op-program-client
 	env GO111MODULE=on go run ./verify/cmd/goerli.go $$L1URL $$L2URL

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -1,31 +1,9 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.1-alpine3.18 as builder
-
-ARG VERSION=v0.0.0
-
-RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
-
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-WORKDIR /app
-
-RUN go mod download
-
-# build op-proposer with the shared go.mod & go.sum files
-COPY ./op-proposer /app/op-proposer
-COPY ./op-bindings /app/op-bindings
-COPY ./op-node /app/op-node
-COPY ./op-service /app/op-service
-COPY ./.git /app/.git
-
-WORKDIR /app/op-proposer
-
-ARG TARGETOS TARGETARCH
-
-RUN make op-proposer VERSION="$VERSION" GOOS=$TARGETOS GOARCH=$TARGETARCH
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 
 FROM alpine:3.18
 
-COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin
+COPY --from=builder /usr/local/bin/op-proposer /usr/local/bin/op-proposer
 
 CMD ["op-proposer"]

--- a/op-proposer/Dockerfile.dockerignore
+++ b/op-proposer/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-proposer/Makefile
+++ b/op-proposer/Makefile
@@ -1,5 +1,5 @@
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -15,9 +15,6 @@ clean:
 
 test:
 	go test -v ./...
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
 
 .PHONY: \
 	clean \

--- a/op-service/Makefile
+++ b/op-service/Makefile
@@ -1,9 +1,6 @@
 test:
 	go test -v ./...
 
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
-
 generate-mocks:
 	go generate ./...
 

--- a/op-wheel/Dockerfile
+++ b/op-wheel/Dockerfile
@@ -1,21 +1,8 @@
-FROM golang:1.21.1-alpine3.18 as builder
-
-RUN apk add --no-cache make gcc musl-dev linux-headers
-
-COPY ./op-wheel /app/op-wheel
-COPY ./op-node /app/op-node
-COPY ./op-chain-ops /app/op-chain-ops
-COPY ./op-service /app/op-service
-COPY ./op-bindings /app/op-bindings
-COPY ./go.mod /app/go.mod
-COPY ./go.sum /app/go.sum
-
-WORKDIR /app/op-wheel
-
-RUN go build -o op-wheel ./cmd/main.go
-
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+# See "make golang-docker" and /ops/docker/op-stack-go
 FROM alpine:3.18
 
-COPY --from=builder /app/op-wheel/op-wheel /usr/local/bin
+COPY --from=builder /app/op-wheel/bin/op-wheel /usr/local/bin
 
 CMD ["op-wheel"]

--- a/op-wheel/Dockerfile.dockerignore
+++ b/op-wheel/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# ignore everything but the dockerfile, the op-stack-go base image performs the build
+*

--- a/op-wheel/Makefile
+++ b/op-wheel/Makefile
@@ -1,6 +1,5 @@
-
-GITCOMMIT := $(shell git rev-parse HEAD)
-GITDATE := $(shell git show -s --format='%ct')
+GITCOMMIT ?= $(shell git rev-parse HEAD)
+GITDATE ?= $(shell git show -s --format='%ct')
 VERSION := v0.0.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
@@ -10,6 +9,3 @@ LDFLAGS := -ldflags "$(LDFLAGSSTRING)"
 
 op-wheel:
 	env GO111MODULE=on GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -v $(LDFLAGS) -o ./bin/op-wheel ./cmd
-
-lint:
-	golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -11,6 +11,16 @@ volumes:
 
 
 services:
+  op_stack_go_builder:  # Not an actual service, but builds the prerequisite go images
+    build:
+      context: ../
+      dockerfile: ops/docker/op-stack-go/Dockerfile
+      args:
+        GIT_COMMIT: "dev"
+        GIT_DATE: "0"
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:devnet
+    entrypoint: ["echo", "build complete"]
+
   l1:
     build:
       context: .
@@ -42,11 +52,15 @@ services:
 
   op-node:
     depends_on:
+      - op_stack_go_builder
       - l1
       - l2
     build:
       context: ../
       dockerfile: ./op-node/Dockerfile
+      args:
+        OP_STACK_GO_BUILDER: us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:devnet
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:devnet
     command: >
       op-node
       --l1=ws://l1:8546
@@ -85,12 +99,16 @@ services:
 
   op-proposer:
     depends_on:
+      - op_stack_go_builder
       - l1
       - l2
       - op-node
     build:
       context: ../
       dockerfile: ./op-proposer/Dockerfile
+      args:
+        OP_STACK_GO_BUILDER: us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:devnet
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:devnet
     ports:
       - "6062:6060"
       - "7302:7300"
@@ -110,12 +128,16 @@ services:
 
   op-batcher:
     depends_on:
+      - op_stack_go_builder
       - l1
       - l2
       - op-node
     build:
       context: ../
       dockerfile: ./op-batcher/Dockerfile
+      args:
+        OP_STACK_GO_BUILDER: us-docker.pkg.dev/oplabs-tools-artifacts/images/op_stack_go:devnet
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:devnet
     ports:
       - "6061:6060"
       - "7301:7300"
@@ -145,16 +167,16 @@ services:
     security_opt:
       - "no-new-privileges:true"
 
-  stateviz:
-    build:
-      context: ../
-      dockerfile: ./ops-bedrock/Dockerfile.stateviz
-    command:
-      - stateviz
-      - -addr=0.0.0.0:8080
-      - -snapshot=/op_log/snapshot.log
-      - -refresh=10s
-    ports:
-      - "9090:8080"
-    volumes:
-      - op_log:/op_log:ro
+#  stateviz:
+#    build:
+#      context: ../
+#      dockerfile: ./ops-bedrock/Dockerfile.stateviz
+#    command:
+#      - stateviz
+#      - -addr=0.0.0.0:8080
+#      - -snapshot=/op_log/snapshot.log
+#      - -refresh=10s
+#    ports:
+#      - "9090:8080"
+#    volumes:
+#      - op_log:/op_log:ro

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -1,0 +1,84 @@
+FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine3.18 as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git jq bash
+
+# We copy the go.mod/sum first, so the `go mod download` does not have to re-run if dependencies do not change.
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN echo "go mod cache: $(go env GOMODCACHE)"
+RUN echo "go build cache: $(go env GOCACHE)"
+
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go mod download
+
+# NOTE: the Dockerfile.dockerignore file effectively describes all dependencies
+COPY . /app
+
+# We avoid copying the full .git dir into the build for just some metadata.
+# Instead, specify:
+# --build-arg GIT_COMMIT=$(git rev-parse HEAD)
+# --build-arg GIT_DATE=$(git show -s --format='%ct')
+ARG GIT_COMMIT
+ARG GIT_DATE
+
+ARG CANNON_VERSION=v0.0.0
+ARG OP_PROGRAM_VERSION=v0.0.0
+
+ARG OP_HEARTBEAT_VERSION=v0.0.0
+ARG OP_WHEEL_VERSION=v0.0.0
+
+ARG OP_NODE_VERSION=v0.0.0
+ARG OP_CHALLENGER_VERSION=v0.0.0
+ARG OP_BATCHER_VERSION=v0.0.0
+ARG OP_PROPOSER_VERSION=v0.0.0
+
+
+# separate docker-builds:
+# - op-exporter
+# - op-ufm
+# - proxyd
+# - any JS/TS/smart-contract builds
+
+ARG TARGETOS TARGETARCH
+
+# Build the Go services, utilizing caches and share the many common packages.
+# The "id" defaults to the value of "target", the cache will thus be reused during this build.
+# "sharing" defaults to "shared", the cache will thus be available to other concurrent docker builds.
+
+RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
+# note: we only build the host, that's all the user needs. No Go MIPS cross-build in docker
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-host  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
+
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-heartbeat && make op-heartbeat  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_HEARTBEAT_VERSION"
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-wheel && make op-wheel  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_WHEEL_VERSION"
+
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-node && make op-node  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_NODE_VERSION"
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-challenger && make op-challenger  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_CHALLENGER_VERSION"
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-batcher && make op-batcher  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_BATCHER_VERSION"
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-proposer && make op-proposer  \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE  VERSION="$OP_PROPOSER_VERSION"
+
+
+FROM alpine:3.18
+
+COPY --from=builder /app/cannon/bin/cannon /usr/local/bin/
+COPY --from=builder /app/op-program/bin/op-program /usr/local/bin/
+
+COPY --from=builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin/
+COPY --from=builder /app/op-wheel/bin/op-wheel /usr/local/bin/
+
+COPY --from=builder /app/op-node/bin/op-node /usr/local/bin/
+COPY --from=builder /app/op-challenger/bin/op-challenger /usr/local/bin/
+COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin/
+COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin/
+
+

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -1,0 +1,19 @@
+# All the files we depend on. We are using a negative pattern to not include anything by accident.
+# node_modules, packages (contains git submodules and node modules etc.), devnet dirs etc. all add up a lot.
+*
+
+!/cannon
+!/op-batcher
+!/op-bindings
+!/op-bootnode
+!/op-chain-ops
+!/op-challenger
+!/op-heartbeat
+!/op-node
+!/op-preimage
+!/op-program
+!/op-proposer
+!/op-service
+!/op-wheel
+!/go.mod
+!/go.sum

--- a/ops/scripts/geth-version-checker.sh
+++ b/ops/scripts/geth-version-checker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Extract the version from the geth command output
+GETH_VERSION="v$(geth version | grep '^Version:' | awk '{print $2}')"
+
+# Read the version from the .gethrc file
+GETHRC_VERSION=$(cat .gethrc)
+
+# Check if GETHRC_VERSION contains a '-'. If not, append '-stable'.
+if [[ $GETHRC_VERSION != *-* ]]; then
+    GETHRC_VERSION="${GETHRC_VERSION}-stable"
+fi
+
+# Compare the versions
+if [[ "$GETH_VERSION" == "$GETHRC_VERSION" ]]; then
+    echo "Geth version $GETH_VERSION is correct!"
+    exit 0
+else
+    echo "Geth version does not match!"
+    echo "geth version: $GETH_VERSION"
+    echo ".gethrc version: $GETHRC_VERSION"
+    exit 1
+fi


### PR DESCRIPTION
**Description**

- Merge the Go Dockerfile services into one; this helps de-duplicate the Go build work, since there are so many shared Go packages. It adds very little time to the total step, with the benefit of greatly reducing computation and downloading work, and a single docker go-mod/build cache.
- The individual go services still have their own dockerfile and individual build, but simply copy the necessary binary from the above.
- Utilize the Go mod cache and Go build cache in docker builds
- Update CI to use the above docker build
- Share the docker build CI step with the devnet CI step, so the devnet does not have to re-build all docker containers, and we devnet-test exactly what was built in docker.
- The cannon pre-state is now a job that persists its results to the workspace, so it can be reused by other jobs
- The devnet-allocs is now a job that persists its results to the workspace, so it can be reused by other jobs
- The Go linting has been merged into one job: with the go caches, the go linter cache, and so many common packages to analyze it makes little sense to add different linting jobs when one suffices.
- The geth install now checks if the existing install is the right version, and doesn't re-install if it's already there and matches.

The overall CI time is still slow-ish due to the docker-caches not being fruitful CI yet; it works across jobs, but not across workflows, and the worst-case path is thus still in the 20+min range. But compute credits will be lower, so maybe we can start using more powerful/faster/expensive CI instances.

In a follow-up we can also try to do manual docker-layer caching, to save some time across workflows by putting overlay2 in the CI cache, and thus speeding up the builds a bunch.
