### PR TITLE
devnet: bump go-ethereum to v1.13.4

### DIFF
--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.13.3
+FROM ethereum/client-go:v1.13.4
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
**Description**

Bumps the local devnet to use the latest release of geth for L1.

https://github.com/ethereum/go-ethereum/releases/tag/v1.13.4

