### PR TITLE
ci: bump build timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,7 @@ jobs:
               $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
               -f <<parameters.docker_file>> \
               <<parameters.docker_context>>
+          no_output_timeout: 45m
       - run:
           name: Tag
           command: |


### PR DESCRIPTION
**Description**

Docker build times out in CI due to long forge compilation times.
https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/29778/workflows/2eb9b0fa-9e94-402f-8dbe-775bb6680722/jobs/1406653

Makes the timeout 45m which should be plenty, it seemed to take at least 20 minutes to build locally

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

