### PR TITLE
ci: use bash login-style shell to activate nvm and source bashrc

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -113,3 +113,12 @@ RUN echo "downloading and verifying Codecov uploader" && \
   chmod +x /usr/local/bin/codecov  && \
   rm codecov
 
+# within docker use bash
+SHELL [ "/bin/bash", "-c" ]
+# set env to use bash
+ENV SHELL=/bin/bash
+ENV BASH=/bin/bash
+
+ENTRYPOINT ["/bin/bash", "--login", "-eo", "pipefail", "-c"]
+
+


### PR DESCRIPTION
CircleCI was not sourcing the bashrc

https://circleci.com/docs/configuration-reference/#default-shell-options