### PR TITLE
ops: fix entrypoint overriding behavior in circleci for nvm to work

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -119,6 +119,11 @@ SHELL [ "/bin/bash", "-c" ]
 ENV SHELL=/bin/bash
 ENV BASH=/bin/bash
 
+# See https://circleci.com/docs/custom-images/#adding-an-entrypoint
+# and https://circleci.com/docs/configuration-reference/#default-shell-options
+# We need a login shell for nvm to work, and need circleci to not override it back to a regular bash shell.
+LABEL com.circleci.preserve-entrypoint=true
+
 ENTRYPOINT ["/bin/bash", "--login", "-eo", "pipefail", "-c"]
 
 


### PR DESCRIPTION
Circleci is overriding the entrypoint fix, causing the previous issue to persist. We need to add a label to the image so that circleci doesn't mess with it.