### PR TITLE
ci-builder: don't use nvm

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -78,18 +78,21 @@ COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
 
 COPY .nvmrc .nvmrc
 
-# not installed, unused
-# musl coreutils g++-x86-64-linux-gnu libc6-dev-amd64-cross
-#
+ENV NODE_MAJOR=18
+ENV SLITHER_VERSION=0.10.0
+
 # note: python3 package in apt is python 3.9, while base image already has python 3.11
 RUN /bin/sh -c set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends bash curl openssh-client git build-essential ca-certificates jq gnupg binutils-mips-linux-gnu; \
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash; \
-  . /root/.bashrc && nvm install && nvm use  && nvm install-latest-npm; \
+  mkdir -p /etc/apt/keyrings; \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+  apt-get update; \
+  apt-get install -y nodejs; \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt; \
   npm i -g depcheck; \
-  pip install slither-analyzer==0.9.3 capstone pyelftools; \
+  pip install slither-analyzer==$SLITHER_VERSION capstone pyelftools; \
   curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash; \
   apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
   rm -rf /var/lib/apt/lists/*; \
@@ -97,7 +100,7 @@ RUN /bin/sh -c set -eux; \
   rm -rf /root/.cache/npm;
 
 
-RUN echo "downloading pnpm and yarn" && . /root/.bashrc && npm i -g pnpm && npm i -g yarn@1 && pnpm --version && yarn --version
+RUN npm i -g pnpm && npm i -g yarn@1 && pnpm --version && yarn --version
 
 RUN svm install 0.5.17 && \
   svm install 0.8.15

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -117,9 +117,9 @@ RUN echo "downloading and verifying Codecov uploader" && \
   rm codecov
 
 # within docker use bash
-SHELL ["/bin/bash"]
+SHELL ["/bin/bash", "-c"]
 # set env to use bash
 ENV SHELL=/bin/bash
 ENV BASH=/bin/bash
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -117,16 +117,9 @@ RUN echo "downloading and verifying Codecov uploader" && \
   rm codecov
 
 # within docker use bash
-SHELL [ "/bin/bash", "-c" ]
+SHELL ["/bin/bash"]
 # set env to use bash
 ENV SHELL=/bin/bash
 ENV BASH=/bin/bash
 
-# See https://circleci.com/docs/custom-images/#adding-an-entrypoint
-# and https://circleci.com/docs/configuration-reference/#default-shell-options
-# We need a login shell for nvm to work, and need circleci to not override it back to a regular bash shell.
-LABEL com.circleci.preserve-entrypoint=true
-
-ENTRYPOINT ["/bin/bash", "--login", "-eo", "pipefail", "-c"]
-
-
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
**Description**

- Use nodesource to install nodejs. This is recommended, using nvm keeps
  the versions in lockstep but it causes a headache.
- Bump the version of slither to the latest release. Unblocks needing
  to do another release to utilize its new features.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
