### PR TITLE
feat(indexer): Throw when unknown key in toml

### DIFF
--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -153,8 +153,15 @@ func LoadConfig(log log.Logger, path string) (Config, error) {
 	data = []byte(os.ExpandEnv(string(data)))
 	log.Debug("parsed config file", "data", string(data))
 
-	if _, err := toml.Decode(string(data), &cfg); err != nil {
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
 		log.Error("failed to decode config file", "err", err)
+		return cfg, err
+	}
+
+	if len(md.Undecoded()) > 0 {
+		log.Error("unknown fields in config file", "fields", md.Undecoded())
+		err = fmt.Errorf("unknown fields in config file: %v", md.Undecoded())
 		return cfg, err
 	}
 


### PR DESCRIPTION
- Adds stricter validation of toml config to throw on unknown keys

Related to https://github.com/ethereum-optimism/mocktimism/pull/22/files#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R54-R57
