### PR TITLE
fix(indexer) bridge event correlation

### DIFF
--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -30,6 +30,8 @@ var (
 func runIndexer(ctx *cli.Context) error {
 	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "indexer")
 	oplog.SetGlobalLogHandler(log.GetHandler())
+	log.Info("running indexer...")
+
 	cfg, err := config.LoadConfig(log, ctx.String(ConfigFlag.Name))
 	if err != nil {
 		log.Error("failed to load config", "err", err)
@@ -49,13 +51,14 @@ func runIndexer(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Info("running indexer...")
 	return indexer.Run(ctx.Context)
 }
 
 func runApi(ctx *cli.Context) error {
 	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "api")
 	oplog.SetGlobalLogHandler(log.GetHandler())
+	log.Info("running api...")
+
 	cfg, err := config.LoadConfig(log, ctx.String(ConfigFlag.Name))
 	if err != nil {
 		log.Error("failed to load config", "err", err)
@@ -69,7 +72,6 @@ func runApi(ctx *cli.Context) error {
 	}
 	defer db.Close()
 
-	log.Info("running api...")
 	api := api.NewApi(log, db.BridgeTransfers, cfg.HTTPServer, cfg.MetricsServer)
 	return api.Run(ctx.Context)
 }
@@ -77,6 +79,8 @@ func runApi(ctx *cli.Context) error {
 func runMigrations(ctx *cli.Context) error {
 	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "migrations")
 	oplog.SetGlobalLogHandler(log.GetHandler())
+	log.Info("running migrations...")
+
 	cfg, err := config.LoadConfig(log, ctx.String(ConfigFlag.Name))
 	migrationsDir := ctx.String(MigrationsFlag.Name)
 	if err != nil {
@@ -89,9 +93,8 @@ func runMigrations(ctx *cli.Context) error {
 		log.Error("failed to connect to database", "err", err)
 		return err
 	}
-	defer db.Close()
 
-	log.Info("running migrations...")
+	defer db.Close()
 	return db.ExecuteSQLMigration(migrationsDir)
 }
 

--- a/indexer/database/contract_events.go
+++ b/indexer/database/contract_events.go
@@ -144,7 +144,7 @@ func (db *contractEventsDB) L1ContractEventsWithFilter(filter ContractEvent, fro
 	query := db.gorm.Table("l1_contract_events").Where(&filter)
 	query = query.Joins("INNER JOIN l1_block_headers ON l1_contract_events.block_hash = l1_block_headers.hash")
 	query = query.Where("l1_block_headers.number >= ? AND l1_block_headers.number <= ?", fromHeight, toHeight)
-	query = query.Order("l1_block_headers.number ASC").Select("l1_contract_events.*")
+	query = query.Order("l1_block_headers.number ASC, l1_contract_events.log_index ASC").Select("l1_contract_events.*")
 
 	// NOTE: We use `Find` here instead of `Scan` since `Scan` doesn't not support
 	// model hooks like `ContractEvent#AfterFind`. Functionally they are the same
@@ -211,7 +211,7 @@ func (db *contractEventsDB) L2ContractEventsWithFilter(filter ContractEvent, fro
 	query := db.gorm.Table("l2_contract_events").Where(&filter)
 	query = query.Joins("INNER JOIN l2_block_headers ON l2_contract_events.block_hash = l2_block_headers.hash")
 	query = query.Where("l2_block_headers.number >= ? AND l2_block_headers.number <= ?", fromHeight, toHeight)
-	query = query.Order("l2_block_headers.number ASC").Select("l2_contract_events.*")
+	query = query.Order("l2_block_headers.number ASC, l2_contract_events.log_index ASC").Select("l2_contract_events.*")
 
 	// NOTE: We use `Find` here instead of `Scan` since `Scan` doesn't not support
 	// model hooks like `ContractEvent#AfterFind`. Functionally they are the same

--- a/indexer/database/serializers/bytes.go
+++ b/indexer/database/serializers/bytes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"gorm.io/gorm/schema"
@@ -70,5 +71,5 @@ func (BytesSerializer) Value(ctx context.Context, field *schema.Field, dst refle
 	}
 
 	hexStr := hexutil.Encode(fieldBytes.Bytes())
-	return hexStr, nil
+	return strings.ToLower(hexStr), nil
 }

--- a/indexer/database/serializers/rlp.go
+++ b/indexer/database/serializers/rlp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -52,5 +53,5 @@ func (RLPSerializer) Value(ctx context.Context, field *schema.Field, dst reflect
 	}
 
 	hexStr := hexutil.Encode(rlpBytes)
-	return hexStr, nil
+	return strings.ToLower(hexStr), nil
 }

--- a/indexer/processors/bridge/l1_bridge_processor.go
+++ b/indexer/processors/bridge/l1_bridge_processor.go
@@ -28,11 +28,16 @@ func L1ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L1M
 		log.Info("detected transaction deposits", "size", len(optimismPortalTxDeposits))
 	}
 
+	totalDepositAmount := 0
 	portalDeposits := make(map[logKey]*contracts.OptimismPortalTransactionDepositEvent, len(optimismPortalTxDeposits))
 	transactionDeposits := make([]database.L1TransactionDeposit, len(optimismPortalTxDeposits))
 	for i := range optimismPortalTxDeposits {
 		depositTx := optimismPortalTxDeposits[i]
 		portalDeposits[logKey{depositTx.Event.BlockHash, depositTx.Event.LogIndex}] = &depositTx
+		if len(depositTx.Tx.Data) == 0 {
+			totalDepositAmount = totalDepositAmount + int(depositTx.Tx.Amount.Uint64())
+		}
+
 		transactionDeposits[i] = database.L1TransactionDeposit{
 			SourceHash:           depositTx.DepositTx.SourceHash,
 			L2TransactionHash:    types.NewTx(depositTx.DepositTx).Hash(),
@@ -46,6 +51,7 @@ func L1ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L1M
 			return err
 		}
 		metrics.RecordL1TransactionDeposits(len(transactionDeposits))
+		metrics.RecordL1InitiatedBridgeTransfers(database.ETHTokenPair.LocalTokenAddress, totalDepositAmount)
 	}
 
 	// (2) L1CrossDomainMessenger
@@ -115,8 +121,8 @@ func L1ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L1M
 			return fmt.Errorf("correlated events tx hash mismatch")
 		}
 
-		initiatedBridge.BridgeTransfer.CrossDomainMessageHash = &sentMessage.BridgeMessage.MessageHash
 		bridgedTokens[initiatedBridge.BridgeTransfer.TokenPair.LocalTokenAddress]++
+		initiatedBridge.BridgeTransfer.CrossDomainMessageHash = &sentMessage.BridgeMessage.MessageHash
 		bridgeDeposits[i] = database.L1BridgeDeposit{
 			TransactionSourceHash: portalDeposit.DepositTx.SourceHash,
 			BridgeTransfer:        initiatedBridge.BridgeTransfer,
@@ -177,23 +183,29 @@ func L1ProcessFinalizedBridgeEvents(log log.Logger, db *database.DB, metrics L1M
 		log.Info("detected finalized withdrawals", "size", len(finalizedWithdrawals))
 	}
 
+	totalWithdrawalAmount := 0
 	for i := range finalizedWithdrawals {
-		finalized := finalizedWithdrawals[i]
-		withdrawal, err := db.BridgeTransactions.L2TransactionWithdrawal(finalized.WithdrawalHash)
+		finalizedWithdrawal := finalizedWithdrawals[i]
+		withdrawal, err := db.BridgeTransactions.L2TransactionWithdrawal(finalizedWithdrawal.WithdrawalHash)
 		if err != nil {
 			return err
 		} else if withdrawal == nil {
-			log.Error("missing indexed withdrawal on finalization event!", "tx_hash", finalized.Event.TransactionHash.String())
-			return fmt.Errorf("missing indexed withdrawal on finalization! tx_hash: %s", finalized.Event.TransactionHash.String())
+			log.Error("missing indexed withdrawal on finalization event!", "tx_hash", finalizedWithdrawal.Event.TransactionHash.String())
+			return fmt.Errorf("missing indexed withdrawal on finalization! tx_hash: %s", finalizedWithdrawal.Event.TransactionHash.String())
 		}
 
-		if err = db.BridgeTransactions.MarkL2TransactionWithdrawalFinalizedEvent(finalized.WithdrawalHash, finalized.Event.GUID, finalized.Success); err != nil {
-			log.Error("failed to mark withdrawal as finalized", "err", err, "tx_hash", finalized.Event.TransactionHash.String())
+		if len(withdrawal.Tx.Data) == 0 {
+			totalWithdrawalAmount = totalWithdrawalAmount + int(withdrawal.Tx.Amount.Int64())
+		}
+
+		if err = db.BridgeTransactions.MarkL2TransactionWithdrawalFinalizedEvent(finalizedWithdrawal.WithdrawalHash, finalizedWithdrawal.Event.GUID, finalizedWithdrawal.Success); err != nil {
+			log.Error("failed to mark withdrawal as finalized", "err", err, "tx_hash", finalizedWithdrawal.Event.TransactionHash.String())
 			return err
 		}
 	}
 	if len(finalizedWithdrawals) > 0 {
 		metrics.RecordL1FinalizedWithdrawals(len(finalizedWithdrawals))
+		metrics.RecordL1FinalizedBridgeTransfers(database.ETHTokenPair.LocalTokenAddress, totalWithdrawalAmount)
 	}
 
 	// (3) L1CrossDomainMessenger

--- a/indexer/processors/bridge/l2_bridge_processor.go
+++ b/indexer/processors/bridge/l2_bridge_processor.go
@@ -28,14 +28,14 @@ func L2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 		log.Info("detected transaction withdrawals", "size", len(l2ToL1MPMessagesPassed))
 	}
 
-	totalWithdrawalAmount := 0
+	l2ToL1WithdrawalAmount := 0
 	messagesPassed := make(map[logKey]*contracts.L2ToL1MessagePasserMessagePassed, len(l2ToL1MPMessagesPassed))
 	transactionWithdrawals := make([]database.L2TransactionWithdrawal, len(l2ToL1MPMessagesPassed))
 	for i := range l2ToL1MPMessagesPassed {
 		messagePassed := l2ToL1MPMessagesPassed[i]
 		messagesPassed[logKey{messagePassed.Event.BlockHash, messagePassed.Event.LogIndex}] = &messagePassed
 		if len(messagePassed.Tx.Data) == 0 {
-			totalWithdrawalAmount = totalWithdrawalAmount + int(messagePassed.Tx.Amount.Int64())
+			l2ToL1WithdrawalAmount = l2ToL1WithdrawalAmount + int(messagePassed.Tx.Amount.Int64())
 		}
 
 		transactionWithdrawals[i] = database.L2TransactionWithdrawal{
@@ -50,8 +50,7 @@ func L2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 		if err := db.BridgeTransactions.StoreL2TransactionWithdrawals(transactionWithdrawals); err != nil {
 			return err
 		}
-
-		metrics.RecordL2InitiatedBridgeTransfers(database.ETHTokenPair.LocalTokenAddress, totalWithdrawalAmount)
+		metrics.RecordL2InitiatedBridgeTransfers(database.ETHTokenPair.LocalTokenAddress, l2ToL1WithdrawalAmount)
 		metrics.RecordL2TransactionWithdrawals(len(transactionWithdrawals))
 	}
 

--- a/indexer/processors/bridge/l2_bridge_processor.go
+++ b/indexer/processors/bridge/l2_bridge_processor.go
@@ -68,6 +68,9 @@ func L2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 		if !ok {
 			log.Error("expected MessagePassedEvent preceding SentMessage", "tx_hash", sentMessage.Event.TransactionHash.String())
 			return fmt.Errorf("expected MessagePassedEvent preceding SentMessage. tx_hash = %s", sentMessage.Event.TransactionHash.String())
+		} else if messagePassed.Event.TransactionHash != sentMessage.Event.TransactionHash {
+			log.Error("correlated events tx hash mismatch", "withdraw_tx_hash", messagePassed.Event.TransactionHash.String(), "message_tx_hash", sentMessage.Event.TransactionHash.String())
+			return fmt.Errorf("correlated events tx hash mismatch")
 		}
 
 		bridgeMessages[i] = database.L2BridgeMessage{TransactionWithdrawalHash: messagePassed.WithdrawalHash, BridgeMessage: sentMessage.BridgeMessage}
@@ -93,16 +96,23 @@ func L2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 	for i := range initiatedBridges {
 		initiatedBridge := initiatedBridges[i]
 
-		// extract the cross domain message hash & deposit source hash from the following events
+		// extract the cross domain message hash & withdraw hash from the following events
 		messagePassed, ok := messagesPassed[logKey{initiatedBridge.Event.BlockHash, initiatedBridge.Event.LogIndex + 1}]
 		if !ok {
 			log.Error("expected MessagePassed following BridgeInitiated event", "tx_hash", initiatedBridge.Event.TransactionHash.String())
 			return fmt.Errorf("expected MessagePassed following BridgeInitiated event. tx_hash = %s", initiatedBridge.Event.TransactionHash.String())
+		} else if messagePassed.Event.TransactionHash != initiatedBridge.Event.TransactionHash {
+			log.Error("correlated events tx hash mismatch", "withdraw_tx_hash", messagePassed.Event.TransactionHash.String(), "bridge_tx_hash", initiatedBridge.Event.TransactionHash.String())
+			return fmt.Errorf("correlated events tx hash mismatch")
 		}
+
 		sentMessage, ok := sentMessages[logKey{initiatedBridge.Event.BlockHash, initiatedBridge.Event.LogIndex + 2}]
 		if !ok {
-			log.Error("expected SentMessage following MessagePassed event", "tx_hash", initiatedBridge.Event.TransactionHash.String())
-			return fmt.Errorf("expected SentMessage following MessagePassed event. tx_hash = %s", initiatedBridge.Event.TransactionHash.String())
+			log.Error("expected SentMessage following BridgeInitiated event", "tx_hash", initiatedBridge.Event.TransactionHash.String())
+			return fmt.Errorf("expected SentMessage following BridgeInitiated event. tx_hash = %s", initiatedBridge.Event.TransactionHash.String())
+		} else if sentMessage.Event.TransactionHash != initiatedBridge.Event.TransactionHash {
+			log.Error("correlated events tx hash mismatch", "message_tx_hash", sentMessage.Event.TransactionHash.String(), "bridge_tx_hash", initiatedBridge.Event.TransactionHash.String())
+			return fmt.Errorf("correlated events tx hash mismatch")
 		}
 
 		initiatedBridge.BridgeTransfer.CrossDomainMessageHash = &sentMessage.BridgeMessage.MessageHash
@@ -180,6 +190,9 @@ func L2ProcessFinalizedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 		if !ok {
 			log.Error("expected RelayedMessage following BridgeFinalized event", "tx_hash", finalizedBridge.Event.TransactionHash.String())
 			return fmt.Errorf("expected RelayedMessage following BridgeFinalized event. tx_hash = %s", finalizedBridge.Event.TransactionHash.String())
+		} else if relayedMessage.Event.TransactionHash != finalizedBridge.Event.TransactionHash {
+			log.Error("correlated events tx hash mismatch", "message_tx_hash", relayedMessage.Event.TransactionHash.String(), "bridge_tx_hash", finalizedBridge.Event.TransactionHash.String())
+			return fmt.Errorf("correlated events tx hash mismatch")
 		}
 
 		// Since the message hash is computed from the relayed message, this ensures the withdrawal fields must match

--- a/indexer/processors/bridge/l2_bridge_processor.go
+++ b/indexer/processors/bridge/l2_bridge_processor.go
@@ -28,15 +28,13 @@ func L2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 		log.Info("detected transaction withdrawals", "size", len(l2ToL1MPMessagesPassed))
 	}
 
-	l2ToL1WithdrawalAmount := 0
+	withdrawnETH := 0
 	messagesPassed := make(map[logKey]*contracts.L2ToL1MessagePasserMessagePassed, len(l2ToL1MPMessagesPassed))
 	transactionWithdrawals := make([]database.L2TransactionWithdrawal, len(l2ToL1MPMessagesPassed))
 	for i := range l2ToL1MPMessagesPassed {
 		messagePassed := l2ToL1MPMessagesPassed[i]
 		messagesPassed[logKey{messagePassed.Event.BlockHash, messagePassed.Event.LogIndex}] = &messagePassed
-		if len(messagePassed.Tx.Data) == 0 {
-			l2ToL1WithdrawalAmount = l2ToL1WithdrawalAmount + int(messagePassed.Tx.Amount.Int64())
-		}
+		withdrawnETH = withdrawnETH + int(messagePassed.Tx.Amount.Int64())
 
 		transactionWithdrawals[i] = database.L2TransactionWithdrawal{
 			WithdrawalHash:       messagePassed.WithdrawalHash,
@@ -50,8 +48,7 @@ func L2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L2M
 		if err := db.BridgeTransactions.StoreL2TransactionWithdrawals(transactionWithdrawals); err != nil {
 			return err
 		}
-		metrics.RecordL2InitiatedBridgeTransfers(database.ETHTokenPair.LocalTokenAddress, l2ToL1WithdrawalAmount)
-		metrics.RecordL2TransactionWithdrawals(len(transactionWithdrawals))
+		metrics.RecordL2TransactionWithdrawals(len(transactionWithdrawals), withdrawnETH)
 	}
 
 	// (2) L2CrossDomainMessenger

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -116,7 +116,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		txWithdrawnETH: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Name:      "tx_withdrawn_eth",
-			Help:      "amount of eth withdrawan from l2",
+			Help:      "amount of eth withdrawn from l2",
 		}),
 		provenWithdrawals: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -16,7 +16,7 @@ var (
 type L1Metricer interface {
 	RecordLatestIndexedL1Height(height *big.Int)
 
-	RecordL1TransactionDeposits(size int)
+	RecordL1TransactionDeposits(size int, mintedETH int)
 	RecordL1ProvenWithdrawals(size int)
 	RecordL1FinalizedWithdrawals(size int)
 
@@ -30,7 +30,7 @@ type L1Metricer interface {
 type L2Metricer interface {
 	RecordLatestIndexedL2Height(height *big.Int)
 
-	RecordL2TransactionWithdrawals(size int)
+	RecordL2TransactionWithdrawals(size int, withdrawnETH int)
 
 	RecordL2CrossDomainSentMessages(size int)
 	RecordL2CrossDomainRelayedMessages(size int)
@@ -55,7 +55,9 @@ type bridgeMetrics struct {
 	latestL2Height prometheus.Gauge
 
 	txDeposits           prometheus.Counter
+	txMintedETH          prometheus.Counter
 	txWithdrawals        prometheus.Counter
+	txWithdrawnETH       prometheus.Counter
 	provenWithdrawals    prometheus.Counter
 	finalizedWithdrawals prometheus.Counter
 
@@ -101,10 +103,20 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 			Name:      "tx_deposits",
 			Help:      "number of processed transactions deposited from l1",
 		}),
+		txMintedETH: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Name:      "tx_minted_eth",
+			Help:      "amount of eth bridged from l1",
+		}),
 		txWithdrawals: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Name:      "tx_withdrawals",
 			Help:      "number of processed transactions withdrawn from l2",
+		}),
+		txWithdrawnETH: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Name:      "tx_withdrawn_eth",
+			Help:      "amount of eth withdrawan from l2",
 		}),
 		provenWithdrawals: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
@@ -166,8 +178,9 @@ func (m *bridgeMetrics) RecordLatestIndexedL1Height(height *big.Int) {
 	m.latestL1Height.Set(float64(height.Uint64()))
 }
 
-func (m *bridgeMetrics) RecordL1TransactionDeposits(size int) {
+func (m *bridgeMetrics) RecordL1TransactionDeposits(size, mintedETH int) {
 	m.txDeposits.Add(float64(size))
+	m.txMintedETH.Add(float64(mintedETH))
 }
 
 func (m *bridgeMetrics) RecordL1ProvenWithdrawals(size int) {
@@ -200,8 +213,9 @@ func (m *bridgeMetrics) RecordLatestIndexedL2Height(height *big.Int) {
 	m.latestL2Height.Set(float64(height.Uint64()))
 }
 
-func (m *bridgeMetrics) RecordL2TransactionWithdrawals(size int) {
+func (m *bridgeMetrics) RecordL2TransactionWithdrawals(size, withdrawnETH int) {
 	m.txWithdrawals.Add(float64(size))
+	m.txWithdrawnETH.Add(float64(withdrawnETH))
 }
 
 func (m *bridgeMetrics) RecordL2CrossDomainSentMessages(size int) {


### PR DESCRIPTION
The bridge processor relies on event ordering to correlate the different layers of the bridge.
Because of this, it is very important that the database returns an ordered list of events.

When the block number matches, the ordering must follow the log index. The database only ordered
by block number which can result in errors


- Assert tx hash matches when correlated events as a sanity check


## Non-related changes
- Add direct non-standardbridge ETH inflows & outflow to the bridge metrics
- `hex.Encode` utilizes low case characters, a-f. However lets explicitly lowercase the hex string to not rely on this assumption
