### PR TITLE
op-node: Span Batch Limit

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -45,6 +45,12 @@ type BatchQueue struct {
 	prev   NextBatchProvider
 	origin eth.L1BlockRef
 
+	// l1Blocks contains consecutive eth.L1BlockRef sorted by time.
+	// Every L1 origin of unsafe L2 blocks must be eventually included in l1Blocks.
+	// Batch queue's job is to ensure below two rules:
+	//  If every L2 block corresponding to single L1 block becomes safe, it will be popped from l1Blocks.
+	//  If new L2 block's L1 origin is not included in l1Blocks, fetch and push to l1Blocks.
+	// length of l1Blocks never exceeds SequencerWindowSize
 	l1Blocks []eth.L1BlockRef
 
 	// batches in order of when we've first seen them

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -236,6 +236,7 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 
 	endEpochNum := batch.GetBlockEpochNum(batch.GetBlockCount() - 1)
 	originChecked := false
+	// l1Blocks is supplied from batch queue and its length is limited to SequencerWindowSize.
 	for _, l1Block := range l1Blocks {
 		if l1Block.Number == endEpochNum {
 			if !batch.CheckOriginHash(l1Block.Hash) {

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -22,7 +22,7 @@ const DerivationVersion0 = 0
 // MaxSpanBatchFieldSize is the maximum amount of bytes that will be read from
 // a span batch to decode span batch field. This value cannot be larger than
 // MaxRLPBytesPerChannel because single batch cannot be larger than channel size.
-const MaxSpanBatchFieldSize = 10_000_000
+const MaxSpanBatchFieldSize = MaxRLPBytesPerChannel
 
 // MaxChannelBankSize is the amount of memory space, in number of bytes,
 // till the bank is pruned by removing channels,

--- a/op-node/rollup/derive/params.go
+++ b/op-node/rollup/derive/params.go
@@ -19,10 +19,10 @@ func frameSize(frame Frame) uint64 {
 
 const DerivationVersion0 = 0
 
-// MaxSpanBatchFieldSize is the maximum amount of bytes that will be read from
-// a span batch to decode span batch field. This value cannot be larger than
+// MaxSpanBatchSize is the maximum amount of bytes that will be needed
+// to decode every span batch field. This value cannot be larger than
 // MaxRLPBytesPerChannel because single batch cannot be larger than channel size.
-const MaxSpanBatchFieldSize = MaxRLPBytesPerChannel
+const MaxSpanBatchSize = MaxRLPBytesPerChannel
 
 // MaxChannelBankSize is the amount of memory space, in number of bytes,
 // till the bank is pruned by removing channels,

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -27,7 +27,7 @@ import (
 // payload := block_count ++ origin_bits ++ block_tx_counts ++ txs
 // txs := contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases
 
-var ErrTooBigSpanBatchFieldSize = errors.New("batch would cause field bytes to go over limit")
+var ErrTooBigSpanBatchSize = errors.New("span batch size limit reached")
 
 var ErrEmptySpanBatch = errors.New("span-batch must not be empty")
 
@@ -59,8 +59,8 @@ func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
 		originBitBufferLen++
 	}
 	// avoid out of memory before allocation
-	if originBitBufferLen > MaxSpanBatchFieldSize {
-		return ErrTooBigSpanBatchFieldSize
+	if originBitBufferLen > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
 	}
 	originBitBuffer := make([]byte, originBitBufferLen)
 	_, err := io.ReadFull(r, originBitBuffer)
@@ -146,9 +146,9 @@ func (bp *spanBatchPayload) decodeBlockCount(r *bytes.Reader) error {
 	if err != nil {
 		return fmt.Errorf("failed to read block count: %w", err)
 	}
-	// number of L2 block in span batch cannot be greater than MaxSpanBatchFieldSize
-	if blockCount > MaxSpanBatchFieldSize {
-		return ErrTooBigSpanBatchFieldSize
+	// number of L2 block in span batch cannot be greater than MaxSpanBatchSize
+	if blockCount > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
 	}
 	if blockCount == 0 {
 		return ErrEmptySpanBatch
@@ -166,10 +166,10 @@ func (bp *spanBatchPayload) decodeBlockTxCounts(r *bytes.Reader) error {
 		if err != nil {
 			return fmt.Errorf("failed to read block tx count: %w", err)
 		}
-		// number of txs in single L2 block cannot be greater than MaxSpanBatchFieldSize
+		// number of txs in single L2 block cannot be greater than MaxSpanBatchSize
 		// every tx will take at least single byte
-		if blockTxCount > MaxSpanBatchFieldSize {
-			return ErrTooBigSpanBatchFieldSize
+		if blockTxCount > MaxSpanBatchSize {
+			return ErrTooBigSpanBatchSize
 		}
 		blockTxCounts = append(blockTxCounts, blockTxCount)
 	}
@@ -189,13 +189,13 @@ func (bp *spanBatchPayload) decodeTxs(r *bytes.Reader) error {
 	for i := 0; i < len(bp.blockTxCounts); i++ {
 		total, overflow := math.SafeAdd(totalBlockTxCount, bp.blockTxCounts[i])
 		if overflow {
-			return ErrTooBigSpanBatchFieldSize
+			return ErrTooBigSpanBatchSize
 		}
 		totalBlockTxCount = total
 	}
-	// total number of txs in span batch cannot be greater than MaxSpanBatchFieldSize
-	if totalBlockTxCount > MaxSpanBatchFieldSize {
-		return ErrTooBigSpanBatchFieldSize
+	// total number of txs in span batch cannot be greater than MaxSpanBatchSize
+	if totalBlockTxCount > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
 	}
 	bp.txs.totalBlockTxCount = totalBlockTxCount
 	if err := bp.txs.decode(r); err != nil {
@@ -224,6 +224,14 @@ func (bp *spanBatchPayload) decodePayload(r *bytes.Reader) error {
 // decodeBytes parses data into b from data
 func (b *RawSpanBatch) decodeBytes(data []byte) error {
 	r := bytes.NewReader(data)
+	return b.decode(r)
+}
+
+// decode reads the byte encoding of SpanBatch from Reader stream
+func (b *RawSpanBatch) decode(r *bytes.Reader) error {
+	if r.Len() > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
+	}
 	if err := b.decodePrefix(r); err != nil {
 		return err
 	}
@@ -680,13 +688,13 @@ func ReadTxData(r *bytes.Reader) ([]byte, int, error) {
 		}
 	}
 	// avoid out of memory before allocation
-	s := rlp.NewStream(r, MaxSpanBatchFieldSize)
+	s := rlp.NewStream(r, MaxSpanBatchSize)
 	var txPayload []byte
 	kind, _, err := s.Kind()
 	switch {
 	case err != nil:
 		if errors.Is(err, rlp.ErrValueTooLarge) {
-			return nil, 0, ErrTooBigSpanBatchFieldSize
+			return nil, 0, ErrTooBigSpanBatchSize
 		}
 		return nil, 0, fmt.Errorf("failed to read tx RLP prefix: %w", err)
 	case kind == rlp.List:

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -529,7 +529,7 @@ func TestSpanBatchMaxTxData(t *testing.T) {
 	rng := rand.New(rand.NewSource(0x177288))
 
 	invalidTx := types.NewTx(&types.DynamicFeeTx{
-		Data: testutils.RandomData(rng, MaxSpanBatchFieldSize+1),
+		Data: testutils.RandomData(rng, MaxSpanBatchSize+1),
 	})
 
 	txEncoded, err := invalidTx.MarshalBinary()
@@ -538,7 +538,7 @@ func TestSpanBatchMaxTxData(t *testing.T) {
 	r := bytes.NewReader(txEncoded)
 	_, _, err = ReadTxData(r)
 
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }
 
 func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
@@ -547,7 +547,7 @@ func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }
 
 func TestSpanBatchMaxBlockCount(t *testing.T) {
@@ -565,7 +565,7 @@ func TestSpanBatchMaxBlockCount(t *testing.T) {
 	r := bytes.NewReader(result)
 	var sb RawSpanBatch
 	err = sb.decodeBlockCount(r)
-	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }
 
 func TestSpanBatchMaxBlockTxCount(t *testing.T) {
@@ -584,7 +584,7 @@ func TestSpanBatchMaxBlockTxCount(t *testing.T) {
 	var sb RawSpanBatch
 	sb.blockCount = rawSpanBatch.blockCount
 	err = sb.decodeBlockTxCounts(r)
-	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }
 
 func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
@@ -592,8 +592,8 @@ func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
 	chainID := big.NewInt(rng.Int63n(1000))
 
 	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
-	rawSpanBatch.blockTxCounts[0] = MaxSpanBatchFieldSize - 1
-	rawSpanBatch.blockTxCounts[1] = MaxSpanBatchFieldSize - 1
+	rawSpanBatch.blockTxCounts[0] = MaxSpanBatchSize - 1
+	rawSpanBatch.blockTxCounts[1] = MaxSpanBatchSize - 1
 	// we are sure that totalBlockTxCount will overflow on uint64
 
 	var buf bytes.Buffer
@@ -606,5 +606,5 @@ func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
 	sb.blockTxCounts = rawSpanBatch.blockTxCounts
 	err = sb.decodeTxs(r)
 
-	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -542,9 +543,68 @@ func TestSpanBatchMaxTxData(t *testing.T) {
 
 func TestSpanBatchMaxOriginBitsLength(t *testing.T) {
 	var sb RawSpanBatch
-	sb.blockCount = 0xFFFFFFFFFFFFFFFF
+	sb.blockCount = math.MaxUint64
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
 	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}
+
+func TestSpanBatchMaxBlockCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556691))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	rawSpanBatch.blockCount = math.MaxUint64
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockCount(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	err = sb.decodeBlockCount(r)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}
+
+func TestSpanBatchMaxBlockTxCount(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556692))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	rawSpanBatch.blockTxCounts[0] = math.MaxUint64
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockTxCounts(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	sb.blockCount = rawSpanBatch.blockCount
+	err = sb.decodeBlockTxCounts(r)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+}
+
+func TestSpanBatchTotalBlockTxCountNotOverflow(t *testing.T) {
+	rng := rand.New(rand.NewSource(0x77556693))
+	chainID := big.NewInt(rng.Int63n(1000))
+
+	rawSpanBatch := RandomRawSpanBatch(rng, chainID)
+	rawSpanBatch.blockTxCounts[0] = MaxSpanBatchFieldSize - 1
+	rawSpanBatch.blockTxCounts[1] = MaxSpanBatchFieldSize - 1
+	// we are sure that totalBlockTxCount will overflow on uint64
+
+	var buf bytes.Buffer
+	err := rawSpanBatch.encodeBlockTxCounts(&buf)
+	require.NoError(t, err)
+
+	result := buf.Bytes()
+	r := bytes.NewReader(result)
+	var sb RawSpanBatch
+	sb.blockTxCounts = rawSpanBatch.blockTxCounts
+	err = sb.decodeTxs(r)
+
+	require.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
 }

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -67,8 +67,8 @@ func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
 		contractCreationBitBufferLen++
 	}
 	// avoid out of memory before allocation
-	if contractCreationBitBufferLen > MaxSpanBatchFieldSize {
-		return ErrTooBigSpanBatchFieldSize
+	if contractCreationBitBufferLen > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
 	}
 	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
 	_, err := io.ReadFull(r, contractCreationBitBuffer)
@@ -190,8 +190,8 @@ func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 		yParityBitBufferLen++
 	}
 	// avoid out of memory before allocation
-	if yParityBitBufferLen > MaxSpanBatchFieldSize {
-		return ErrTooBigSpanBatchFieldSize
+	if yParityBitBufferLen > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
 	}
 	yParityBitBuffer := make([]byte, yParityBitBufferLen)
 	_, err := io.ReadFull(r, yParityBitBuffer)

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpanBatchTxsContractCreationBits(t *testing.T) {

--- a/op-node/rollup/derive/span_batch_txs_test.go
+++ b/op-node/rollup/derive/span_batch_txs_test.go
@@ -391,7 +391,7 @@ func TestSpanBatchTxsMaxContractCreationBitsLength(t *testing.T) {
 
 	r := bytes.NewReader([]byte{})
 	err := sbt.decodeContractCreationBits(r)
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }
 
 func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
@@ -400,5 +400,5 @@ func TestSpanBatchTxsMaxYParityBitsLength(t *testing.T) {
 
 	r := bytes.NewReader([]byte{})
 	err := sb.decodeOriginBits(r)
-	assert.ErrorIs(t, err, ErrTooBigSpanBatchFieldSize)
+	require.ErrorIs(t, err, ErrTooBigSpanBatchSize)
 }

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -144,10 +144,11 @@ Where:
 
 [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
 
-Every field size of span batch is limited to `MAX_SPAN_BATCH_FIELD_SIZE` (currently 10,000,000 bytes,
-equal to `MAX_RLP_BYTES_PER_CHANNEL`). There can be at least single span batch per channel, and channel size is limited
+Total size of encoded span batch is limited to `MAX_SPAN_BATCH_SIZE` (currently 10,000,000 bytes,
+equal to `MAX_RLP_BYTES_PER_CHANNEL`). Therefore every field size of span batch will be implicitly limited to
+`MAX_SPAN_BATCH_SIZE` . There can be at least single span batch per channel, and channel size is limited
 to `MAX_RLP_BYTES_PER_CHANNEL` and you may think that there is already an implicit limit. However, having an explicit
-limit for each field is helpful for several reasons. We may save computation costs by avoiding malicious input while
+limit for span batch is helpful for several reasons. We may save computation costs by avoiding malicious input while
 decoding. For example, lets say bad batcher wrote span batch which `block_count = max.Uint64`. We may early return using
 the explicit limit, not trying to consume data until EOF is reached. We can also safely preallocate memory for decoding
 because we know the upper limit of memory usage.

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -144,6 +144,14 @@ Where:
 
 [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
 
+Every field size of span batch is limited to `MAX_SPAN_BATCH_FIELD_SIZE` (currently 10,000,000 bytes,
+equal to `MAX_RLP_BYTES_PER_CHANNEL`). There can be at least single span batch per channel, and channel size is limited
+to `MAX_RLP_BYTES_PER_CHANNEL` and you may think that there is already an implicit limit. However, having an explicit
+limit for each field is helpful for several reasons. We may save computation costs by avoiding malicious input while
+decoding. For example, lets say bad batcher wrote span batch which `block_count = max.Uint64`. We may early return using
+the explicit limit, not trying to consume data until EOF is reached. We can also safely preallocate memory for decoding
+because we know the upper limit of memory usage.
+
 ## Optimization Strategies
 
 ### Truncating information and storing only necessary data


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR addresses field size limit check of span batch addressed at https://github.com/ethereum-optimism/optimism/pull/7289#discussion_r1337867641.

Updated spec to explicitly state `MAX_SPAN_BATCH_SIZE` for max span batch size.

Span batch decoding field size check:

- (Added in this PR) `block_count` cannot be larger than `MAX_SPAN_BATCH_SIZE`
- (Added in this PR) `block_tx_count` cannot be larger than `MAX_SPAN_BATCH_SIZE`
-  Length of `originBits` cannot be larger than `MAX_SPAN_BATCH_SIZE * 8`
- `total_block_tx_count` cannot be larger than `MAX_SPAN_BATCH_SIZE`
- `tx_data` cannot be larger than `MAX_SPAN_BATCH_SIZE`
- Length of `contractCreationBits` cannot be larger than `MAX_SPAN_BATCH_SIZE * 8`
- Length of `yParityBits` cannot be larger than `MAX_SPAN_BATCH_SIZE * 8`

The reason why there are multiplier `8` at some check is that there are 8 bits per byte.

**Tests**

Added tests for newly added checks:
- `TestSpanBatchMaxBlockCount`
- `TestSpanBatchMaxBlockTxCount`
- `TestSpanBatchTotalBlockTxCountNotOverflow`

**Additional context**

Branched from [ethereum-optimism:mirror-tip/span-batch-batcher](https://github.com/ethereum-optimism/optimism/tree/mirror-tip/span-batch-batcher). Must rebase because of https://github.com/ethereum-optimism/optimism/pull/7290.
