### PR TITLE
op-node: on fetching error, accurately report the L1 block that it fails at

### DIFF
--- a/op-node/rollup/derive/l1_traversal.go
+++ b/op-node/rollup/derive/l1_traversal.go
@@ -73,7 +73,7 @@ func (l1t *L1Traversal) AdvanceL1Block(ctx context.Context) error {
 	// Parse L1 receipts of the given block and update the L1 system configuration
 	_, receipts, err := l1t.l1Blocks.FetchReceipts(ctx, nextL1Origin.Hash)
 	if err != nil {
-		return NewTemporaryError(fmt.Errorf("failed to fetch receipts of L1 block %s for L1 sysCfg update: %w", origin, err))
+		return NewTemporaryError(fmt.Errorf("failed to fetch receipts of L1 block %s (parent: %s) for L1 sysCfg update: %w", nextL1Origin, origin, err))
 	}
 	if err := UpdateSystemConfigWithL1Receipts(&l1t.sysCfg, receipts, l1t.cfg); err != nil {
 		// the sysCfg changes should always be formatted correctly.


### PR DESCRIPTION
**Description**

The error was logging the parent block reference as if it's the current block that failed, while the parent was already successfully fetched.

In the case of the earlier goerli network issue, it was reporting an issue with `0xdc6cd3bd7c41f7e2cf0d7986edf89718cb99ada79fe9fed87c436e79d2a52875:9876474` expecting 67 transactions, but `9876474` is actually the parent block of the one that failed and has 92 as expected. It is block `9876475` that has the 67 transactions that the inner error says it expected, while getting 0 from the L1 RPC.
So the op-node was behaving correctly, but reporting the error badly.
