### PR TITLE
op-service,op-node: track proxyd debug info

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -100,6 +100,12 @@ var (
 		EnvVars: prefixEnvVars("L1_HTTP_POLL_INTERVAL"),
 		Value:   time.Second * 12,
 	}
+	L1ProxydDebug = &cli.BoolFlag{
+		Name:    "l1.proxyd-debug",
+		Usage:   "Capture proxyd debug data on RPC requests, and report it on RPC errors",
+		EnvVars: prefixEnvVars("L1_PROXYD_DEBUG"),
+	}
+
 	L2EngineJWTSecret = &cli.StringFlag{
 		Name:        "l2.jwt-secret",
 		Usage:       "Path to JWT secret key. Keys are 32 bytes, hex encoded in a file. A new key will be generated if left empty.",
@@ -275,6 +281,7 @@ var optionalFlags = []cli.Flag{
 	L1RPCRateLimit,
 	L1RPCMaxBatchSize,
 	L1HTTPPollInterval,
+	L1ProxydDebug,
 	L2EngineJWTSecret,
 	VerifierL1Confs,
 	SequencerEnabledFlag,

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -124,6 +124,7 @@ func NewL1EndpointConfig(ctx *cli.Context) *node.L1EndpointConfig {
 		RateLimit:        ctx.Float64(flags.L1RPCRateLimit.Name),
 		BatchSize:        ctx.Int(flags.L1RPCMaxBatchSize.Name),
 		HttpPollInterval: ctx.Duration(flags.L1HTTPPollInterval.Name),
+		ProxydDebug:      ctx.Bool(flags.L1ProxydDebug.Name),
 	}
 }
 

--- a/op-service/httputil/interceptor.go
+++ b/op-service/httputil/interceptor.go
@@ -1,0 +1,83 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+)
+
+// HTTPInterceptorFunc is a function expression of HTTPInterceptor for convenience
+type HTTPInterceptorFunc func(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error)
+
+func (fn HTTPInterceptorFunc) Intercept(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error) {
+	return fn(req, inner)
+}
+
+// HTTPInterceptor intercepts HTTP requests, allows the interceptor to run the inner round-tripper,
+// and then return the response.
+type HTTPInterceptor interface {
+	Intercept(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error)
+}
+
+type interceptorChain struct {
+	insp  HTTPInterceptor
+	inner http.RoundTripper
+}
+
+func (ic interceptorChain) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	return ic.insp.Intercept(req, ic.inner)
+}
+
+type interceptorContextValue struct {
+	insp  HTTPInterceptor
+	inner HTTPInterceptor
+}
+
+func (ic interceptorContextValue) Intercept(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error) {
+	if ic.inner == nil {
+		return ic.insp.Intercept(req, inner)
+	}
+	v := interceptorChain{
+		insp:  ic.inner,
+		inner: inner,
+	}
+	return ic.insp.Intercept(req, &v)
+}
+
+type interceptorKeyType struct{}
+
+var interceptorKey = interceptorKeyType{}
+
+// NewInterceptorContext adds an HTTPInterceptor to the context.
+// The http interceptor of the parent context, of any, will run as the inner http.RoundTripper to the interceptor.
+// I.e. HTTP interceptors can be chained together.
+func NewInterceptorContext(ctx context.Context, interceptor HTTPInterceptor) context.Context {
+	val := interceptorContextValue{
+		insp:  interceptor,
+		inner: InterceptorFromContext(ctx),
+	}
+	return context.WithValue(ctx, interceptorKey, val)
+}
+
+func InterceptorFromContext(ctx context.Context) HTTPInterceptor {
+	insp := ctx.Value(interceptorKey)
+	if insp == nil {
+		return nil
+	}
+	return insp.(HTTPInterceptor)
+}
+
+// InterceptorRoundTripper wraps a http.RoundTripper and intercepts the HTTP requests,
+// and passes them through the HTTPInterceptor attached to the request context, if any.
+type InterceptorRoundTripper struct {
+	Inner http.RoundTripper
+}
+
+func (ir InterceptorRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	v := req.Context().Value(interceptorKey)
+	if v == nil {
+		return ir.Inner.RoundTrip(req)
+	} else {
+		interceptor := v.(interceptorContextValue)
+		return interceptor.Intercept(req, ir.Inner)
+	}
+}

--- a/op-service/httputil/interceptor_test.go
+++ b/op-service/httputil/interceptor_test.go
@@ -1,0 +1,83 @@
+package httputil
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHTTPTransport struct {
+	resp *http.Response
+	err  error
+}
+
+func (f *fakeHTTPTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	return f.resp, f.err
+}
+
+func TestHTTPInterceptor(t *testing.T) {
+	out := "start"
+	basic := HTTPInterceptorFunc(func(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error) {
+		out += " " + req.Header.Get("X_TEST_PRE")
+		resp, err = inner.RoundTrip(req)
+		out += " " + resp.Header.Get("X_TEST_POST")
+		return
+	})
+	req := &http.Request{Header: make(http.Header)}
+	req.Header.Set("X_TEST_PRE", "foo")
+
+	resp := &http.Response{Header: make(http.Header), Body: io.NopCloser(bytes.NewReader([]byte{}))}
+	resp.Header.Set("X_TEST_POST", "bar")
+
+	inner := &fakeHTTPTransport{resp: resp, err: nil}
+
+	got, err := basic.Intercept(req, inner)
+	require.NoError(t, err)
+	_ = got.Body.Close() // Make lint happy
+	require.Equal(t, resp, got)
+
+	require.Equal(t, "start foo bar", out)
+}
+
+func TestNestedContextHTTPInterceptor(t *testing.T) {
+	out := "start"
+	foo := HTTPInterceptorFunc(func(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error) {
+		out += " " + req.Header.Get("X_TEST_PRE_FOO")
+		resp, err = inner.RoundTrip(req)
+		out += " " + resp.Header.Get("X_TEST_POST_FOO")
+		return
+	})
+	bar := HTTPInterceptorFunc(func(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error) {
+		out += " " + req.Header.Get("X_TEST_PRE_BAR")
+		resp, err = inner.RoundTrip(req)
+		out += " " + resp.Header.Get("X_TEST_POST_BAR")
+		return
+	})
+
+	ctx := context.Background()
+	ctx = NewInterceptorContext(ctx, foo)
+	ctx = NewInterceptorContext(ctx, bar)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "test", bytes.NewReader([]byte{}))
+	require.NoError(t, err)
+	req.Header.Set("X_TEST_PRE_FOO", "pre-foo")
+	req.Header.Set("X_TEST_PRE_BAR", "pre-bar")
+
+	resp := &http.Response{Header: make(http.Header), Body: io.NopCloser(bytes.NewReader([]byte{})), StatusCode: 200}
+	resp.Header.Set("X_TEST_POST_FOO", "post-foo")
+	resp.Header.Set("X_TEST_POST_BAR", "post-bar")
+
+	inner := &fakeHTTPTransport{resp: resp, err: nil}
+
+	cl := &http.Client{Transport: InterceptorRoundTripper{Inner: inner}}
+	got, err := cl.Do(req)
+	require.NoError(t, err)
+	_ = got.Body.Close()
+	require.Equal(t, 200, got.StatusCode)
+
+	require.Equal(t, "start pre-bar pre-foo post-foo post-bar", out)
+}

--- a/op-service/httputil/proxyd_inspector.go
+++ b/op-service/httputil/proxyd_inspector.go
@@ -1,0 +1,28 @@
+package httputil
+
+import (
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// ProxydInspector implements a HTTPInterceptor to monitor cache headers in HTTP responses.
+type ProxydInspector struct {
+	ServedBy          string
+	ProxydCacheStatus string
+}
+
+var _ HTTPInterceptor = (*ProxydInspector)(nil)
+
+func (chi *ProxydInspector) Intercept(req *http.Request, inner http.RoundTripper) (resp *http.Response, err error) {
+	resp, err = inner.RoundTrip(req)
+	if resp != nil {
+		chi.ServedBy = resp.Header.Get("X-Served-By")
+		chi.ProxydCacheStatus = resp.Header.Get("X-Proxyd-Cache-Status")
+	}
+	return
+}
+
+func (chi *ProxydInspector) LogContext(logger log.Logger) log.Logger {
+	return logger.New("served_by", chi.ServedBy, "proxyd_cache_status", chi.ProxydCacheStatus)
+}


### PR DESCRIPTION
**Description**

Introduces an "HTTP Interceptor"; a bit of an anti-pattern, but it allows us to modify/inspect HTTP requests by the underlying HTTP client of the geth RPC.

With the websocket RPC it might capture the initial WS upgrade, if connecting from HTTP endpoint with upgrade. Untested.

This allows us to track Proxyd HTTP headers, and implement more future RPC-debugging utils (many services use RPC but hae little insight in the underlying server data).

This intercepting of the requests/responses should not be used for control-flow, but can provide very valuable debug information.

If we make interceptor support the default, perhaps we can implement HTTP metrics and more, to attach to all Json RPC clients.

This implements a new `--l1.proxyd-debug` flag that enables the intercepting & error logging.

**Tests**
TODO: this is quite experimental still. We should add some op-e2e tests maybe. I did add unit-tests for the HTTP interceptor.

**Additional context**

Feature request by @felipe-op 
