### PR TITLE
op-chain-ops: add additional assertions the `check-l2`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1522,7 +1522,7 @@ workflows:
       - cannon-build-test-vectors
       - check-values-match:
           pattern_file1: "uint8 internal constant INITIALIZER ="
-          pattern_file2: "const initializedValue ="
+          pattern_file2: "const InitializedValue ="
           file1_path: "packages/contracts-bedrock/src/libraries/Constants.sol"
           file2_path: "op-chain-ops/genesis/config.go"
   release:

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -29,7 +29,7 @@ import (
 // initialzedValue represents the `Initializable` contract value. It should be kept in
 // sync with the constant in `Constants.sol`.
 // https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/libraries/Constants.sol
-const initializedValue = 3
+const InitializedValue = 3
 
 var (
 	ErrInvalidDeployConfig     = errors.New("invalid deploy config")
@@ -726,13 +726,13 @@ func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.Storage
 		"msgNonce": 0,
 	}
 	storage["L2CrossDomainMessenger"] = state.StorageValues{
-		"_initialized":     initializedValue,
+		"_initialized":     InitializedValue,
 		"_initializing":    false,
 		"xDomainMsgSender": "0x000000000000000000000000000000000000dEaD",
 		"msgNonce":         0,
 	}
 	storage["L2StandardBridge"] = state.StorageValues{
-		"_initialized":  initializedValue,
+		"_initialized":  InitializedValue,
 		"_initializing": false,
 		"messenger":     predeploys.L2CrossDomainMessengerAddr,
 	}
@@ -767,12 +767,12 @@ func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.Storage
 	}
 	storage["L2ERC721Bridge"] = state.StorageValues{
 		"messenger":     predeploys.L2CrossDomainMessengerAddr,
-		"_initialized":  initializedValue,
+		"_initialized":  InitializedValue,
 		"_initializing": false,
 	}
 	storage["OptimismMintableERC20Factory"] = state.StorageValues{
 		"bridge":        predeploys.L2StandardBridgeAddr,
-		"_initialized":  initializedValue,
+		"_initialized":  InitializedValue,
 		"_initializing": false,
 	}
 	return storage, nil


### PR DESCRIPTION
**Description**

The `check-l2` script works against new networks but not legacy networks. We need a solution that can work against both new networks and legacy networks. This adds test coverage for new networks as `check-l2` runs in CI against the local devnet.

Add test coverage for reinitialize on L2 contracts. Also ensures that the `_initialized` value is set as expected.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
