### PR TITLE
Support optional whitespace in XFF Header

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1170,6 +1170,6 @@ func RecordBatchRPCForward(ctx context.Context, backendName string, reqs []*RPCR
 }
 
 func stripXFF(xff string) string {
-	ipList := strings.Split(xff, ", ")
+	ipList := strings.Split(xff, ",")
 	return strings.TrimSpace(ipList[0])
 }

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -1,0 +1,21 @@
+package proxyd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStripXFF(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{"1.2.3, 4.5.6, 7.8.9", "1.2.3"},
+		{"1.2.3,4.5.6", "1.2.3"},
+		{" 1.2.3 , 4.5.6 ", "1.2.3"},
+	}
+
+	for _, test := range tests {
+		actual := stripXFF(test.in)
+		assert.Equal(t, test.out, actual)
+	}
+}


### PR DESCRIPTION
**Description**
In XFF headers the whitespace around the commas is [optional](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#syntax).

This PR updates `stripXFF` to support the optional whitespace case along with the `, ` case.