### PR TITLE
fix(indexer) update withdrawal/deposit counters to use `big.Int`

### DIFF
--- a/indexer/bigint/bigint.go
+++ b/indexer/bigint/bigint.go
@@ -25,3 +25,9 @@ func Clamp(start, end *big.Int, size uint64) *big.Int {
 func Matcher(num int64) func(*big.Int) bool {
 	return func(bi *big.Int) bool { return bi.Int64() == num }
 }
+
+func WeiToETH(wei *big.Int) *big.Float {
+	f := new(big.Float)
+	f.SetString(wei.String())
+	return f.Quo(f, big.NewFloat(1e18))
+}

--- a/indexer/processors/bridge/l1_bridge_processor.go
+++ b/indexer/processors/bridge/l1_bridge_processor.go
@@ -53,8 +53,8 @@ func L1ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metrics L1M
 		}
 
 		// Convert to from wei to eth
-		mintedETH := new(big.Int).Div(mintedGWEI, big.NewInt(1e18)).Uint64()
-		metrics.RecordL1TransactionDeposits(len(transactionDeposits), int(mintedETH))
+		mintedETH, _ := bigint.WeiToETH(mintedGWEI).Float64()
+		metrics.RecordL1TransactionDeposits(len(transactionDeposits), mintedETH)
 	}
 
 	// (2) L1CrossDomainMessenger

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -16,7 +16,7 @@ var (
 type L1Metricer interface {
 	RecordLatestIndexedL1Height(height *big.Int)
 
-	RecordL1TransactionDeposits(size int, mintedETH int)
+	RecordL1TransactionDeposits(size int, mintedETH float64)
 	RecordL1ProvenWithdrawals(size int)
 	RecordL1FinalizedWithdrawals(size int)
 
@@ -30,7 +30,7 @@ type L1Metricer interface {
 type L2Metricer interface {
 	RecordLatestIndexedL2Height(height *big.Int)
 
-	RecordL2TransactionWithdrawals(size int, withdrawnETH int)
+	RecordL2TransactionWithdrawals(size int, withdrawnETH float64)
 
 	RecordL2CrossDomainSentMessages(size int)
 	RecordL2CrossDomainRelayedMessages(size int)
@@ -178,9 +178,9 @@ func (m *bridgeMetrics) RecordLatestIndexedL1Height(height *big.Int) {
 	m.latestL1Height.Set(float64(height.Uint64()))
 }
 
-func (m *bridgeMetrics) RecordL1TransactionDeposits(size, mintedETH int) {
+func (m *bridgeMetrics) RecordL1TransactionDeposits(size int, mintedETH float64) {
 	m.txDeposits.Add(float64(size))
-	m.txMintedETH.Add(float64(mintedETH))
+	m.txMintedETH.Add(mintedETH)
 }
 
 func (m *bridgeMetrics) RecordL1ProvenWithdrawals(size int) {
@@ -213,9 +213,9 @@ func (m *bridgeMetrics) RecordLatestIndexedL2Height(height *big.Int) {
 	m.latestL2Height.Set(float64(height.Uint64()))
 }
 
-func (m *bridgeMetrics) RecordL2TransactionWithdrawals(size, withdrawnETH int) {
+func (m *bridgeMetrics) RecordL2TransactionWithdrawals(size int, withdrawnETH float64) {
 	m.txWithdrawals.Add(float64(size))
-	m.txWithdrawnETH.Add(float64(withdrawnETH))
+	m.txWithdrawnETH.Add(withdrawnETH)
 }
 
 func (m *bridgeMetrics) RecordL2CrossDomainSentMessages(size int) {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
The current `RecordL1TransactionDeposits` and `RecordL2TransactionWithdrawals` take in an integer ETH amount. This amount is extracted by summating the mint value of all deposit/withdrawal txs between some block range. The values extracted from the txs are actually in `wei` instead of `eth`, resulting in `big.Int -> Uint64 -> Int` conversions to result in overflowing precision loss where the resultant integer could be a negative value. This is because `tx.value` can be `>= MAX_UINT_64`. Because of this, metric recording for the aforementioned function would cause the application to fail with the following error:

``` 
panic: counter cannot decrease in value
```

This PR remedies the value loss by:
* Tracking deposit and withdrawal values for legacy/bedrock bridge processors as `big.Int` instead of `int` 
* Converting each amount from WEI to ETH before recording with telemetry 

**Tests**
N/A

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
