### PR TITLE
op-service,op-node,op-program: default to new standard rpc-kind with eth_getBlockReceipts support

### DIFF
--- a/op-e2e/actions/l1_replica.go
+++ b/op-e2e/actions/l1_replica.go
@@ -180,7 +180,7 @@ func (s *L1Replica) RPCClient() client.RPC {
 }
 
 func (s *L1Replica) L1Client(t Testing, cfg *rollup.Config) *sources.L1Client {
-	l1F, err := sources.NewL1Client(s.RPCClient(), s.log, nil, sources.L1ClientDefaultConfig(cfg, false, sources.RPCKindBasic))
+	l1F, err := sources.NewL1Client(s.RPCClient(), s.log, nil, sources.L1ClientDefaultConfig(cfg, false, sources.RPCKindStandard))
 	require.NoError(t, err)
 	return l1F
 }

--- a/op-e2e/actions/l1_replica_test.go
+++ b/op-e2e/actions/l1_replica_test.go
@@ -42,7 +42,7 @@ func TestL1Replica_ActL1RPCFail(gt *testing.T) {
 	// mock an RPC failure
 	replica.ActL1RPCFail(t)
 	// check RPC failure
-	l1Cl, err := sources.NewL1Client(replica.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindBasic))
+	l1Cl, err := sources.NewL1Client(replica.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindStandard))
 	require.NoError(t, err)
 	_, err = l1Cl.InfoByLabel(t.Ctx(), eth.Unsafe)
 	require.ErrorContains(t, err, "mock")

--- a/op-e2e/actions/l2_sequencer_test.go
+++ b/op-e2e/actions/l2_sequencer_test.go
@@ -21,7 +21,7 @@ func setupSequencerTest(t Testing, sd *e2eutils.SetupData, log log.Logger) (*L1M
 
 	miner := NewL1Miner(t, log, sd.L1Cfg)
 
-	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindBasic))
+	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindStandard))
 	require.NoError(t, err)
 	engine := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath)
 	l2Cl, err := sources.NewEngineClient(engine.RPCClient(), log, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))

--- a/op-e2e/actions/reorg_test.go
+++ b/op-e2e/actions/reorg_test.go
@@ -572,7 +572,7 @@ func TestRestartOpGeth(gt *testing.T) {
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 	// L1
 	miner := NewL1Miner(t, log, sd.L1Cfg)
-	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindBasic))
+	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindStandard))
 	require.NoError(t, err)
 	// Sequencer
 	seqEng := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath, dbOption)
@@ -667,7 +667,7 @@ func TestConflictingL2Blocks(gt *testing.T) {
 	altSeqEng := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath)
 	altSeqEngCl, err := sources.NewEngineClient(altSeqEng.RPCClient(), log, nil, sources.EngineClientDefaultConfig(sd.RollupCfg))
 	require.NoError(t, err)
-	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindBasic))
+	l1F, err := sources.NewL1Client(miner.RPCClient(), log, nil, sources.L1ClientDefaultConfig(sd.RollupCfg, false, sources.RPCKindStandard))
 	require.NoError(t, err)
 	altSequencer := NewL2Sequencer(t, log, l1F, altSeqEngCl, sd.RollupCfg, 0)
 	altBatcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -775,7 +775,7 @@ func configureL1(rollupNodeCfg *rollupNode.Config, l1Node EthInstance) {
 	rollupNodeCfg.L1 = &rollupNode.L1EndpointConfig{
 		L1NodeAddr:       l1EndpointConfig,
 		L1TrustRPC:       false,
-		L1RPCKind:        sources.RPCKindBasic,
+		L1RPCKind:        sources.RPCKindStandard,
 		RateLimit:        0,
 		BatchSize:        20,
 		HttpPollInterval: time.Millisecond * 100,

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -78,7 +78,7 @@ var (
 			openum.EnumString(sources.RPCProviderKinds),
 		EnvVars: prefixEnvVars("L1_RPC_KIND"),
 		Value: func() *sources.RPCProviderKind {
-			out := sources.RPCKindBasic
+			out := sources.RPCKindStandard
 			return &out
 		}(),
 	}

--- a/op-program/host/cmd/main_test.go
+++ b/op-program/host/cmd/main_test.go
@@ -210,7 +210,7 @@ func TestL1TrustRPC(t *testing.T) {
 func TestL1RPCKind(t *testing.T) {
 	t.Run("DefaultBasic", func(t *testing.T) {
 		cfg := configForArgs(t, addRequiredArgs())
-		require.Equal(t, sources.RPCKindBasic, cfg.L1RPCKind)
+		require.Equal(t, sources.RPCKindStandard, cfg.L1RPCKind)
 	})
 	for _, kind := range sources.RPCProviderKinds {
 		t.Run(kind.String(), func(t *testing.T) {

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -130,7 +130,7 @@ func NewConfig(
 		L2OutputRoot:        l2OutputRoot,
 		L2Claim:             l2Claim,
 		L2ClaimBlockNumber:  l2ClaimBlockNum,
-		L1RPCKind:           sources.RPCKindBasic,
+		L1RPCKind:           sources.RPCKindStandard,
 		IsCustomChainConfig: isCustomConfig,
 	}
 }

--- a/op-program/host/flags/flags.go
+++ b/op-program/host/flags/flags.go
@@ -86,7 +86,7 @@ var (
 			openum.EnumString(sources.RPCProviderKinds),
 		EnvVars: prefixEnvVars("L1_RPC_KIND"),
 		Value: func() *sources.RPCProviderKind {
-			out := sources.RPCKindBasic
+			out := sources.RPCKindStandard
 			return &out
 		}(),
 	}

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -52,7 +52,7 @@ var testEthClientConfig = &EthClientConfig{
 	MaxConcurrentRequests: 10,
 	TrustRPC:              false,
 	MustBePostMerge:       false,
-	RPCProviderKind:       RPCKindBasic,
+	RPCProviderKind:       RPCKindStandard,
 }
 
 func randHash() (out common.Hash) {
@@ -133,7 +133,7 @@ func TestEthClient_InfoByNumber(t *testing.T) {
 		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = rhdr
 	}).Return([]error{nil})
-	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindBasic))
+	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
 	require.NoError(t, err)
 	info, err := s.InfoByNumber(ctx, uint64(n))
 	require.NoError(t, err)
@@ -152,7 +152,7 @@ func TestEthClient_WrongInfoByNumber(t *testing.T) {
 		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = &rhdr2
 	}).Return([]error{nil})
-	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindBasic))
+	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
 	require.NoError(t, err)
 	_, err = s.InfoByNumber(ctx, uint64(n))
 	require.Error(t, err, "cannot accept the wrong block")
@@ -171,7 +171,7 @@ func TestEthClient_WrongInfoByHash(t *testing.T) {
 		"eth_getBlockByHash", []any{k, false}).Run(func(args mock.Arguments) {
 		*args[1].(**rpcHeader) = &rhdr2
 	}).Return([]error{nil})
-	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindBasic))
+	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
 	require.NoError(t, err)
 	_, err = s.InfoByHash(ctx, k)
 	require.Error(t, err, "cannot accept the wrong block")

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -51,7 +51,7 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 			MaxConcurrentRequests: 10,
 			TrustRPC:              trustRPC,
 			MustBePostMerge:       true,
-			RPCProviderKind:       RPCKindBasic,
+			RPCProviderKind:       RPCKindStandard,
 			MethodResetDuration:   time.Minute,
 		},
 		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.

--- a/op-service/sources/receipts.go
+++ b/op-service/sources/receipts.go
@@ -121,8 +121,9 @@ const (
 	RPCKindNethermind RPCProviderKind = "nethermind"
 	RPCKindDebugGeth  RPCProviderKind = "debug_geth"
 	RPCKindErigon     RPCProviderKind = "erigon"
-	RPCKindBasic      RPCProviderKind = "basic" // try only the standard most basic receipt fetching
-	RPCKindAny        RPCProviderKind = "any"   // try any method available
+	RPCKindBasic      RPCProviderKind = "basic"    // try only the standard most basic receipt fetching
+	RPCKindAny        RPCProviderKind = "any"      // try any method available
+	RPCKindStandard   RPCProviderKind = "standard" // try standard methods, including newer optimized standard RPC methods
 )
 
 var RPCProviderKinds = []RPCProviderKind{
@@ -135,6 +136,7 @@ var RPCProviderKinds = []RPCProviderKind{
 	RPCKindErigon,
 	RPCKindBasic,
 	RPCKindAny,
+	RPCKindStandard,
 }
 
 func (kind RPCProviderKind) String() string {
@@ -235,11 +237,14 @@ const (
 	//   - Alchemy: https://docs.alchemy.com/reference/eth-getblockreceipts
 	//   - Nethermind: https://docs.nethermind.io/nethermind/ethereum-client/json-rpc/parity#parity_getblockreceipts
 	ParityGetBlockReceipts
-	// EthGetBlockReceipts is a non-standard receipt fetching method in the eth namespace,
+	// EthGetBlockReceipts is a previously non-standard receipt fetching method in the eth namespace,
 	// supported by some RPC platforms.
+	// This since has been standardized in https://github.com/ethereum/execution-apis/pull/438 and adopted in Geth:
+	// https://github.com/ethereum/go-ethereum/pull/27702
 	// Available in:
 	//   - Alchemy: 500 CU total  (and deprecated)
 	//   - QuickNode: 59 credits total       (does not seem to work with block hash arg, inaccurate docs)
+	//   - Standard, incl. Geth, Besu and Reth, and Nethermind has a PR in review.
 	// Method: eth_getBlockReceipts
 	// Params:
 	//   - QuickNode: string, "quantity or tag", docs say incl. block hash, but API does not actually accept it.
@@ -296,6 +301,8 @@ func AvailableReceiptsFetchingMethods(kind RPCProviderKind) ReceiptsFetchingMeth
 		return AlchemyGetTransactionReceipts | EthGetBlockReceipts |
 			DebugGetRawReceipts | ErigonGetBlockReceiptsByBlockHash |
 			ParityGetBlockReceipts | EthGetTransactionReceiptBatch
+	case RPCKindStandard:
+		return EthGetBlockReceipts | EthGetTransactionReceiptBatch
 	default:
 		return EthGetTransactionReceiptBatch
 	}

--- a/op-service/sources/receipts_test.go
+++ b/op-service/sources/receipts_test.go
@@ -306,6 +306,16 @@ func TestEthClient_FetchReceipts(t *testing.T) {
 			setup:        fallbackCase(4, EthGetTransactionReceiptBatch),
 		},
 		{
+			name:         "standard",
+			providerKind: RPCKindStandard,
+			setup:        fallbackCase(4, EthGetBlockReceipts),
+		},
+		{
+			name:         "standard fallback",
+			providerKind: RPCKindStandard,
+			setup:        fallbackCase(4, EthGetBlockReceipts, EthGetTransactionReceiptBatch),
+		},
+		{
 			name:         "any discovers alchemy",
 			providerKind: RPCKindAny,
 			setup:        fallbackCase(4, AlchemyGetTransactionReceipts),


### PR DESCRIPTION
**Description**

`eth_getBlockReceipts` has been standard for a while now, and mostly adopted by all L1 clients. We can adopt it as a default.

We leave the "basic" rpc kind unmodified, in case anyone needs it when `eth_getBlockReceipts` is broken on their L1 RPC.

With `eth_getBlockReceipts` nodes should sync a little faster, since the method is more optimal (at least in L1 geth, where it only hydrates the receipts data once for the full block, rather than repeating the full work for the whole block per receipt call).

**Tests**

Updated unit-tests to cover the new RPC kind.

Updated op-e2e and other tests to use this as RPC kind.
