### PR TITLE
op-e2e: Deduplicate blocks for alt sync test

### DIFF
--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -592,6 +592,10 @@ func TestSystemRPCAltSync(t *testing.T) {
 		opts.VerifyOnClients(l2Verif)
 	})
 
+	// Sometimes we get duplicate blocks on the sequencer which makes this test flaky
+	published = slices.Compact(published)
+	received = slices.Compact(received)
+
 	// Verify that the tx was received via RPC sync (P2P is disabled)
 	require.Contains(t, received, eth.BlockID{Hash: receiptSeq.BlockHash, Number: receiptSeq.BlockNumber.Uint64()}.String())
 


### PR DESCRIPTION
**Description**

Sometimes when TestSystemRPCAltSync there are duplicates in the received list. We trim those to make this test more reliable.

Example Flake [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/30041/workflows/5653dd58-17da-4557-8bd2-818d6bea2e56/jobs/1417679/tests)

Selected Logs
```
    system_test.go:600: 
        	Error Trace:	/root/project/op-e2e/system_test.go:600
        	Error:      	elements differ
        	            	
        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (string) (len=68) "0x47945cdb1ca8648e6e1c92d8ebfd2748defe6ebafb9a6c022d417d971d747e25:1"
        	            	}
        	            	
        	            	
        	            	extra elements in list B:
        	            	([]interface {}) (len=1) {
        	            	 (string) (len=69) "0x087726fbcf239e2e0f0b75b9482dc246c98323e992f3b1b6caa1b0cce34b705a:10"
        	            	}
        	            	
        	            	
        	            	listA:
        	            	([]string) (len=10) {
        	            	 (string) (len=68) "0x47945cdb1ca8648e6e1c92d8ebfd2748defe6ebafb9a6c022d417d971d747e25:1",
        	            	 (string) (len=68) "0x47945cdb1ca8648e6e1c92d8ebfd2748defe6ebafb9a6c022d417d971d747e25:1",
        	            	 (string) (len=68) "0x3500b4553e2efa702cc1b147e10698c3a072ab0b84eaf6b0c86d8c51d2c4aae5:2",
        	            	 (string) (len=68) "0x45ce58592957f3ebf1f586cd929e0c9df9ec8dcdc40f58e6bc1af309854428e8:3",
        	            	 (string) (len=68) "0x596b0bc4dd2033fcabb8fdade3dba17d388ae2639dcf936118087a4200d79beb:4",
        	            	 (string) (len=68) "0x0422d5044e9af39a29a31f0f57725a1b0ed83c6b314df943a5cf22a748c1da7c:5",
        	            	 (string) (len=68) "0x7bea4815e2e6f4ab46f3f1f8e5d0c7281ca2dba13fb573569d911fc6c24e1c51:6",
        	            	 (string) (len=68) "0x72c6affcfeb401bffc67b8a7cfdcc939690033ea7e61a7505f7ef01f1c645f46:7",
        	            	 (string) (len=68) "0xde96feec852bd6aff8f4508446268dd472534c676a8c7c4160e94b80bfffe9f0:8",
        	            	 (string) (len=68) "0x5b6475ef9ce412627ee3e698bdfd4cbd32604ecfc2062cb012c45feea315958d:9"
        	            	}
        	            	
        	            	
        	            	listB:
        	            	([]string) (len=10) {
        	            	 (string) (len=68) "0x47945cdb1ca8648e6e1c92d8ebfd2748defe6ebafb9a6c022d417d971d747e25:1",
        	            	 (string) (len=68) "0x3500b4553e2efa702cc1b147e10698c3a072ab0b84eaf6b0c86d8c51d2c4aae5:2",
        	            	 (string) (len=68) "0x45ce58592957f3ebf1f586cd929e0c9df9ec8dcdc40f58e6bc1af309854428e8:3",
        	            	 (string) (len=68) "0x596b0bc4dd2033fcabb8fdade3dba17d388ae2639dcf936118087a4200d79beb:4",
        	            	 (string) (len=68) "0x0422d5044e9af39a29a31f0f57725a1b0ed83c6b314df943a5cf22a748c1da7c:5",
        	            	 (string) (len=68) "0x7bea4815e2e6f4ab46f3f1f8e5d0c7281ca2dba13fb573569d911fc6c24e1c51:6",
        	            	 (string) (len=68) "0x72c6affcfeb401bffc67b8a7cfdcc939690033ea7e61a7505f7ef01f1c645f46:7",
        	            	 (string) (len=68) "0xde96feec852bd6aff8f4508446268dd472534c676a8c7c4160e94b80bfffe9f0:8",
        	            	 (string) (len=68) "0x5b6475ef9ce412627ee3e698bdfd4cbd32604ecfc2062cb012c45feea315958d:9",
        	            	 (string) (len=69) "0x087726fbcf239e2e0f0b75b9482dc246c98323e992f3b1b6caa1b0cce34b705a:10"
        	            	}
        	Test:       	TestSystemRPCAltSync
```
