### PR TITLE
fix(indexer) simplify standard bridge finalization check

### DIFF
--- a/indexer/processors/bridge/legacy_bridge_processor.go
+++ b/indexer/processors/bridge/legacy_bridge_processor.go
@@ -330,10 +330,12 @@ func LegacyL1ProcessFinalizedBridgeEvents(log log.Logger, db *database.DB, metri
 		log.Warn("skipped pre-regensis relayed L2CrossDomainMessenger withdrawals", "size", skippedPreRegenesisMessages)
 	}
 
-	// (2) L2StandardBridge -- no-op for now as there's nothing actionable to do here besides
-	// santiy checks which is not important for legacy code. Not worth extra code pre-bedrock.
-	// The message status is already tracked via the relayed bridge messed through the cross domain messenger.
-	//  - NOTE: This means we dont increment metrics for finalized bridge transfers
+	// (2) L1StandardBridge
+	// 	- Nothing actionable on the database. Since the StandardBridge is layered ontop of the
+	// CrossDomainMessenger, there's no need for any sanity or invariant checks as the previous step
+	// ensures a relayed message (finalized bridge) can be linked with a sent message (initiated bridge).
+
+	//  - NOTE: Ignoring metrics for pre-bedrock transfers
 
 	// a-ok!
 	return nil
@@ -372,10 +374,12 @@ func LegacyL2ProcessFinalizedBridgeEvents(log log.Logger, db *database.DB, metri
 		metrics.RecordL2CrossDomainRelayedMessages(len(crossDomainRelayedMessages))
 	}
 
-	// (2) L2StandardBridge -- no-op for now as there's nothing actionable to do here besides
-	// santiy checks which is not important for legacy code. Not worth the extra code pre-bedorck.
-	// The message status is already tracked via the relayed bridge messed through the cross domain messenger.
-	//  - NOTE: This means we dont increment metrics for finalized bridge transfers
+	// (2) L2StandardBridge
+	// 	- Nothing actionable on the database. Since the StandardBridge is layered ontop of the
+	// CrossDomainMessenger, there's no need for any sanity or invariant checks as the previous step
+	// ensures a relayed message (finalized bridge) can be linked with a sent message (initiated bridge).
+
+	//  - NOTE: Ignoring metrics for pre-bedrock transfers
 
 	// a-ok!
 	return nil


### PR DESCRIPTION
Since the StandardBridge is layered on top of the CrossDomainMessenger, we don't necessarily
need to ensure the L1 deposit exists when reading in the standard bridge finalization event
as the underlying messages are already linked.

The reason for this simplification is because we cannot rely on event ordering between
`RelayedMessage` and `BridgeFinalized`. This is because of the execution of:
```
 bool success = SafeCall.call(_to, gasleft(), _amount, hex"");
 require(success, "StandardBridge: ETH transfer failed");
```

If `_to` is a smart contract, `receive()` can be implemented such that arbitrary events are emitted
such as the Safe contract, sitting in between the relayed and bridge finalized events

**The previous invariant check is a nice-to-have but not worth the extra effort to handle these scenarios**
