### PR TITLE
[txmgr] Avoid incrementing the nonce if tx signing fails

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -265,6 +265,8 @@ func (m *SimpleTxManager) signWithNextNonce(ctx context.Context, rawTx *types.Dy
 	}
 
 	rawTx.Nonce = *m.nonce
+	ctx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
+	defer cancel()
 	tx, err := m.cfg.Signer(ctx, m.cfg.From, types.NewTx(rawTx))
 	if err != nil {
 		// decrement the nonce, so we can retry signing with the same nonce next time


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
#5398 had a bug that incremented the nonce every time `craftTx` is called, even if it fails. #7250 fixed the issue if gas estimation fails, but not if the sign tx call fails.

This PR moves the sign call into `signWithNextNonce`, and avoids incrementing the nonce if the sign call fails.

**Tests**
Added regression test.

**Additional context**
We saw a batcher halt on Base mainnet because our signer infra was briefly unavailable. This caused the txmgr to submit txs with incremented nonces, which meant the L1 nodes ignored them (i.e. nonce was too high).