### PR TITLE
fix(op-node): git commit print

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -95,7 +95,7 @@ def main():
         return
 
     git_commit = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
-    git_date = subprocess.run(['git', 'show', '-s', "--format='%ct'"], capture_output=True, text=True).stdout.strip()
+    git_date = subprocess.run(['git', 'show', '-s', "--format=%ct"], capture_output=True, text=True).stdout.strip()
 
     log.info(f'Building docker images for git commit {git_commit} ({git_date})')
     run_command(['docker', 'compose', 'build', '--progress', 'plain',

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -94,8 +94,13 @@ def main():
         devnet_l1_genesis(paths)
         return
 
-    log.info('Building docker images')
-    run_command(['docker', 'compose', 'build', '--progress', 'plain'], cwd=paths.ops_bedrock_dir, env={
+    git_commit = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
+    git_date = subprocess.run(['git', 'show', '-s', "--format='%ct'"], capture_output=True, text=True).stdout.strip()
+
+    log.info(f'Building docker images for git commit {git_commit} ({git_date})')
+    run_command(['docker', 'compose', 'build', '--progress', 'plain',
+                 '--build-arg', f'GIT_COMMIT={git_commit}', '--build-arg', f'GIT_DATE={git_date}'],
+                cwd=paths.ops_bedrock_dir, env={
         'PWD': paths.ops_bedrock_dir,
         'DOCKER_BUILDKIT': '1', # (should be available by default in later versions, but explicitly enable it anyway)
         'COMPOSE_DOCKER_CLI_BUILD': '1'  # use the docker cache

--- a/op-challenger/cmd/main.go
+++ b/op-challenger/cmd/main.go
@@ -24,7 +24,11 @@ var (
 var VersionWithMeta = func() string {
 	v := version.Version
 	if GitCommit != "" {
-		v += "-" + GitCommit[:8]
+		if len(GitCommit) >= 8 {
+			v += "-" + GitCommit[:8]
+		} else {
+			v += "-" + GitCommit
+		}
 	}
 	if GitDate != "" {
 		v += "-" + GitDate

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -31,10 +31,12 @@ var (
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
 	v := version.Version
-	if len(GitCommit) >= 8 {
-		v += "-" + GitCommit[:8]
-	} else {
-		v += "-" + GitCommit
+	if GitCommit != "" {
+		if len(GitCommit) >= 8 {
+			v += "-" + GitCommit[:8]
+		} else {
+			v += "-" + GitCommit
+		}
 	}
 	if GitDate != "" {
 		v += "-" + GitDate

--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -31,8 +31,10 @@ var (
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
 	v := version.Version
-	if GitCommit != "" {
+	if len(GitCommit) >= 8 {
 		v += "-" + GitCommit[:8]
+	} else {
+		v += "-" + GitCommit
 	}
 	if GitDate != "" {
 		v += "-" + GitDate

--- a/op-program/host/cmd/main.go
+++ b/op-program/host/cmd/main.go
@@ -21,7 +21,11 @@ var (
 var VersionWithMeta = func() string {
 	v := version.Version
 	if GitCommit != "" {
-		v += "-" + GitCommit[:8]
+		if len(GitCommit) >= 8 {
+			v += "-" + GitCommit[:8]
+		} else {
+			v += "-" + GitCommit
+		}
 	}
 	if GitDate != "" {
 		v += "-" + GitDate


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When running `make devnet-up` on the develop branch, I encountered `panic: runtime error: slice bounds out of range [:8] with length 3`. I found the issue to be in a print statement within op-node's main.go. On the develop branch, `GitCommit` has a value of `"dev"`. 

**Tests**

Tested on my machine that `make devnet-up` now works.

**Additional context**


**Metadata**


