### PR TITLE
indexer: correct depends-on clause of docker-compose

### DIFF
--- a/indexer/docker-compose.yml
+++ b/indexer/docker-compose.yml
@@ -58,7 +58,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    depends_on:
       migrations:
         condition: service_started
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

There are duplicated `depends-on` clauses in the `indexer/docker-compose.yml`. The marshal error is reported: `mapping key "depends_on" already defined at line 58`