### PR TITLE
specs: rename contracts to contracts-bedrock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,9 +181,9 @@ You must have Python 3.x installed to run `slither`.
 To run `slither` locally, do:
 
 ```bash
-cd packages/contracts
+cd packages/contracts-bedrock
 pip3 install slither-analyzer
-pnpm test:slither
+pnpm slither
 ```
 
 ## Labels

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -308,9 +308,9 @@ A reference implementation of the L1 Attributes predeploy contract can be found 
 
 [L1Block.sol]: ../packages/contracts-bedrock/src/L2/L1Block.sol
 
-After running `pnpm build` in the `packages/contracts` directory, the bytecode to add to the genesis
-file will be located in the `deployedBytecode` field of the build artifacts file at
-`/packages/contracts/artifacts/contracts/L2/L1Block.sol/L1Block.json`.
+After running `pnpm build` in the `packages/contracts-bedrock` directory, the bytecode to add to 
+the genesis file will be located in the `deployedBytecode` field of the build artifacts file at
+`/packages/contracts-bedrock/forge-artifacts/L1Block.sol/L1Block.json`.
 
 ## User-Deposited Transactions
 

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -308,7 +308,7 @@ A reference implementation of the L1 Attributes predeploy contract can be found 
 
 [L1Block.sol]: ../packages/contracts-bedrock/src/L2/L1Block.sol
 
-After running `pnpm build` in the `packages/contracts-bedrock` directory, the bytecode to add to 
+After running `pnpm build` in the `packages/contracts-bedrock` directory, the bytecode to add to
 the genesis file will be located in the `deployedBytecode` field of the build artifacts file at
 `/packages/contracts-bedrock/forge-artifacts/L1Block.sol/L1Block.json`.
 

--- a/specs/meta/devnet.md
+++ b/specs/meta/devnet.md
@@ -12,7 +12,7 @@
 You can spin up a local devnet via `docker compose`.
 For convenience, we have defined `make` targets to start and stop the devnet with a single command.
 To run the devnet, you will need `docker` installed.
-Then, as a precondition, make sure that you have compiled the contracts by `cd`ing into `packages/contracts`
+Then, as a precondition, make sure that you have compiled the contracts by `cd`ing into `packages/contracts-bedrock`
 and running `pnpm i` followed by `pnpm build`. You'll only need to do this if you change the contracts in the future.
 
 Then, run the following:


### PR DESCRIPTION
**Description**

Some links don't work anymore since `contracts` was renamed to `contracts-bedrock`. This PR fixes those links.