### PR TITLE
op-program: Fix fpp-verify by actually setting the datadir

### DIFF
--- a/op-program/verify/cmd/goerli.go
+++ b/op-program/verify/cmd/goerli.go
@@ -98,7 +98,7 @@ func Run(l1RpcUrl string, l1RpcKind string, l2RpcUrl string, l2OracleAddr common
 	l1Head := l1HeadBlock.Hash()
 
 	if dataDir == "" {
-		dataDir, err := os.MkdirTemp("", "oracledata")
+		dataDir, err = os.MkdirTemp("", "oracledata")
 		if err != nil {
 			return fmt.Errorf("create temp dir: %w", err)
 		}


### PR DESCRIPTION
**Description**

Fix `fpp-verify` - when a data dir wasn't specified, a temp one was created but assigned to an overridden variable instead of the original.
