### PR TITLE
op-chain-ops: Add scripts to check for the presence of withdrawals

### DIFF
--- a/op-chain-ops/scripts/assert_withdrawals_exist
+++ b/op-chain-ops/scripts/assert_withdrawals_exist
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -uo pipefail
+
+NUMBER=$1
+DEFAULT_RPC=http://localhost:9545
+RPC=${2:-$DEFAULT_RPC}
+
+# Run the command and store the return code
+output=$(cast block "$NUMBER" --rpc-url="$RPC" -j | jq .withdrawals -e)
+return_code=$?
+
+# Check the return code and print an error message if it's 1
+if [ $return_code -eq 1 ]; then
+    echo "Error: Withdrawals are null"
+    exit 1
+else
+    echo "Withdrawals are non-null"
+fi


### PR DESCRIPTION
**Description**

This add a simple script to check for withdrawals in the block header. This is important for verifying that Shapella has activated.

**Tests**

Tested manually against mainnet

**Metadata**

- Part of #7731 
