### PR TITLE
docs(ctb): Document the correct approach to defining immutable variables

### DIFF
--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -45,6 +45,18 @@ We also have the following custom tags:
 
 - Event parameters should NOT be prefixed with an underscore.
 
+#### Immutable variables
+
+Immutable variables:
+
+- should be in `SCREAMING_SNAKE_CASE`
+- should be `internal`
+- should have a hand written getter function
+
+This approach clearly indicates to the developer that the value is immutable, without exposing
+the non-standard casing to the interface. It also ensure that we don’t need to break the ABIs if
+we switch between values being in storage and immutable.
+
 #### Spacers
 
 We use spacer variables to account for old storage slots that are no longer being used.


### PR DESCRIPTION
**Description**

Adds a summary of an internally documented policy to our style guide.