### PR TITLE
Span Batch Hard Fork Activation Rule Update 

### DIFF
--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -47,7 +47,7 @@ func CheckBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Block
 			log.Error("failed type assertion to SpanBatch")
 			return BatchDrop
 		}
-		if !cfg.IsSpanBatch(batch.Batch.GetTimestamp()) {
+		if !cfg.IsSpanBatch(batch.Batch.GetTimestamp()) || !cfg.IsSpanBatch(batch.L1InclusionBlock.Time) {
 			log.Warn("received SpanBatch before SpanBatch hard fork")
 			return BatchDrop
 		}

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -47,10 +47,6 @@ func CheckBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Block
 			log.Error("failed type assertion to SpanBatch")
 			return BatchDrop
 		}
-		if !cfg.IsSpanBatch(batch.Batch.GetTimestamp()) || !cfg.IsSpanBatch(batch.L1InclusionBlock.Time) {
-			log.Warn("received SpanBatch before SpanBatch hard fork")
-			return BatchDrop
-		}
 		return checkSpanBatch(ctx, cfg, log, l1Blocks, l2SafeHead, spanBatch, batch.L1InclusionBlock, l2Fetcher)
 	default:
 		log.Warn("Unrecognized batch type: %d", batch.Batch.GetBatchType())
@@ -181,6 +177,20 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 	}
 	epoch := l1Blocks[0]
 
+	startEpochNum := uint64(batch.GetStartEpochNum())
+	batchOrigin := epoch
+	if startEpochNum == batchOrigin.Number+1 {
+		if len(l1Blocks) < 2 {
+			log.Info("eager batch wants to advance epoch, but could not without more L1 blocks", "current_epoch", epoch.ID())
+			return BatchUndecided
+		}
+		batchOrigin = l1Blocks[1]
+	}
+	if !cfg.IsSpanBatch(batchOrigin.Time) {
+		log.Warn("received SpanBatch with L1 origin before SpanBatch hard fork")
+		return BatchDrop
+	}
+
 	nextTimestamp := l2SafeHead.Time + cfg.BlockTime
 
 	if batch.GetTimestamp() > nextTimestamp {
@@ -219,8 +229,6 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 		log.Warn("ignoring batch with mismatching parent hash", "parent_block", parentBlock.Hash)
 		return BatchDrop
 	}
-
-	startEpochNum := uint64(batch.GetStartEpochNum())
 
 	// Filter out batches that were included too late.
 	if startEpochNum+cfg.SeqWindowSize < l1InclusionBlock.Number {

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -711,6 +711,33 @@ func TestValidBatch(t *testing.T) {
 				}),
 			},
 			Expected:      BatchUndecided,
+			ExpectedLog:   "eager batch wants to advance epoch, but could not without more L1 blocks",
+			SpanBatchTime: &minTs,
+		},
+		{
+			Name:       "insufficient L1 info for eager derivation - long span",
+			L1Blocks:   []eth.L1BlockRef{l1A}, // don't know about l1B yet
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: NewSpanBatch([]*SingularBatch{
+					{
+						ParentHash:   l2A3.ParentHash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2A3.Time,
+						Transactions: nil,
+					},
+					{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
+				}),
+			},
+			Expected:      BatchUndecided,
 			ExpectedLog:   "need more l1 blocks to check entire origins of span batch",
 			SpanBatchTime: &minTs,
 		},
@@ -1413,7 +1440,7 @@ func TestValidBatch(t *testing.T) {
 					Transactions: []hexutil.Bytes{randTxData},
 				},
 			},
-			SpanBatchTime: &l2A2.Time,
+			SpanBatchTime: &l1B.Time,
 			Expected:      BatchAccept,
 		},
 		{
@@ -1432,8 +1459,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			SpanBatchTime: &l2A2.Time,
+			SpanBatchTime: &l1B.Time,
 			Expected:      BatchDrop,
+			ExpectedLog:   "received SpanBatch with L1 origin before SpanBatch hard fork",
 		},
 		{
 			Name:       "singular batch after hard fork",
@@ -1449,7 +1477,7 @@ func TestValidBatch(t *testing.T) {
 					Transactions: []hexutil.Bytes{randTxData},
 				},
 			},
-			SpanBatchTime: &l2A0.Time,
+			SpanBatchTime: &l1A.Time,
 			Expected:      BatchAccept,
 		},
 		{
@@ -1468,7 +1496,7 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			SpanBatchTime: &l2A0.Time,
+			SpanBatchTime: &l1A.Time,
 			Expected:      BatchAccept,
 		},
 	}

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -99,6 +99,9 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		return singularBatch, nil
 	case SpanBatchType:
 		if origin := cr.Origin(); !cr.cfg.IsSpanBatch(origin.Time) {
+			// Check hard fork activation with the L1 inclusion block time instead of the L1 origin block time.
+			// Therefore, even if the batch passed this rule, it can be dropped in the batch queue.
+			// This is just for early dropping invalid batches as soon as possible.
 			return nil, NewTemporaryError(fmt.Errorf("cannot accept span batch in L1 block %s at time %d", origin, origin.Time))
 		}
 		rawSpanBatch, ok := batchData.inner.(*RawSpanBatch)

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -9,7 +9,7 @@
 
 - [Introduction](#introduction)
 - [Span batch format](#span-batch-format)
-- [Span batch Hard Fork Rule](#span-batch-hard-fork-rule)
+- [Span batch Activation Rule](#span-batch-activation-rule)
 - [Optimization Strategies](#optimization-strategies)
   - [Truncating information and storing only necessary data](#truncating-information-and-storing-only-necessary-data)
   - [`tx_data_headers` removal from initial specs](#tx_data_headers-removal-from-initial-specs)
@@ -154,13 +154,13 @@ decoding. For example, lets say bad batcher wrote span batch which `block_count 
 the explicit limit, not trying to consume data until EOF is reached. We can also safely preallocate memory for decoding
 because we know the upper limit of memory usage.
 
-## Span batch Hard Fork Rule
+## Span batch Activation Rule
 
-Span batch hard fork is activated based on timestamp.
+The span batch upgrade is activated based on timestamp.
 
-Activation Rule: `upgradeNumber != null && x >= upgradeTime`
+Activation Rule: `upgradeTime != null && span_start.l1_origin.timestamp >= upgradeTime`
 
-`x == span_start.l1_origin.timestamp`, which is the L1 origin block timestamp of the first block in the span.
+`span_start.l1_origin.timestamp` is the L1 origin block timestamp of the first block in the span batch.
 This rule ensures that every chain activity regarding this span batch is done after the hard fork.
 i.e. Every block in the span is created, submitted to the L1, and derived from the L1 after the hard fork.
 
@@ -272,6 +272,13 @@ Rules are enforced with the [contextual definitions](./derivation.md#batch-queue
 
 Span-batch rules, in validation order:
 
+- `batch_origin` is determined like with singular batches:
+  - `batch.epoch_num == epoch.number+1`:
+    - If `next_epoch` is not known -> `undecided`:
+      i.e. a batch that changes the L1 origin cannot be processed until we have the L1 origin data.
+    - If known, then define `batch_origin` as `next_epoch`
+- `batch_origin.timestamp < span_batch_upgrade_timestamp` -> `drop`:
+  i.e. enforce the [span batch upgrade activation rule](#span-batch-activation-rule).
 - `batch.start_timestamp > next_timestamp` -> `future`: i.e. the batch must be ready to process.
 - `batch.start_timestamp < next_timestamp` -> `drop`: i.e. the batch must not be too old.
 - `batch.parent_check != safe_l2_head.hash[:20]` -> `drop`: i.e. the checked part of the parent hash must be equal

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -9,6 +9,7 @@
 
 - [Introduction](#introduction)
 - [Span batch format](#span-batch-format)
+- [Span batch Hard Fork Rule](#span-batch-hard-fork-rule)
 - [Optimization Strategies](#optimization-strategies)
   - [Truncating information and storing only necessary data](#truncating-information-and-storing-only-necessary-data)
   - [`tx_data_headers` removal from initial specs](#tx_data_headers-removal-from-initial-specs)
@@ -152,6 +153,20 @@ limit for span batch is helpful for several reasons. We may save computation cos
 decoding. For example, lets say bad batcher wrote span batch which `block_count = max.Uint64`. We may early return using
 the explicit limit, not trying to consume data until EOF is reached. We can also safely preallocate memory for decoding
 because we know the upper limit of memory usage.
+
+## Span batch Hard Fork Rule
+
+Span batch hard fork is activated based on timestamp.
+
+Activation Rule: `x != null && x >= upgradeTime && y != null && y >= upgradeTime`
+
+Let `inclusion_block` be the L1 block when the span batch was first fully derived.
+
+`x == span_start.timestamp`, which is the timestamp of first L2 block timestamp derived from span batch.
+
+`y == inclusion_block.timestamp`, which is the timestamp of L1 block when span batch was first fully derived.
+We need this additional check because span batch hard fork is a derivation update, and
+`x` becomes dependent of the hard fork(we must run span batch decoding to find `x`).
 
 ## Optimization Strategies
 

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -158,15 +158,11 @@ because we know the upper limit of memory usage.
 
 Span batch hard fork is activated based on timestamp.
 
-Activation Rule: `x != null && x >= upgradeTime && y != null && y >= upgradeTime`
+Activation Rule: `upgradeNumber != null && x >= upgradeTime`
 
-Let `inclusion_block` be the L1 block when the span batch was first fully derived.
-
-`x == span_start.timestamp`, which is the timestamp of first L2 block timestamp derived from span batch.
-
-`y == inclusion_block.timestamp`, which is the timestamp of L1 block when span batch was first fully derived.
-We need this additional check because span batch hard fork is a derivation update, and
-`x` becomes dependent of the hard fork(we must run span batch decoding to find `x`).
+`x == span_start.l1_origin.timestamp`, which is the L1 origin block timestamp of the first block in the span.
+This rule ensures that every chain activity regarding this span batch is done after the hard fork.
+i.e. Every block in the span is created, submitted to the L1, and derived from the L1 after the hard fork.
 
 ## Optimization Strategies
 

--- a/specs/superchain-upgrades.md
+++ b/specs/superchain-upgrades.md
@@ -199,7 +199,10 @@ and are then retrieved from the superchain target configuration.
 
 ### L2 Block-number based activation (deprecated)
 
-Activation rule: `x != null && x >= upgradeNumber`
+Activation rule: `upgradeNumber != null && block.number >= upgradeNumber`
+
+Starting at, and including, the L2 `block` with `block.number >= upgradeNumber`, the upgrade rules apply.
+If the upgrade block-number `upgradeNumber` is not specified in the configuration, the upgrade is ignored.
 
 This block number based method has commonly been used in L1 up until the Bellatrix/Paris upgrade, a.k.a. The Merge,
 which was upgraded through special rules.
@@ -207,21 +210,18 @@ which was upgraded through special rules.
 This method is not superchain-compatible, as the activation-parameter is chain-specific
 (different chains may have different block-heights at the same moment in time).
 
-Starting at, and including, the L2 `block` with `block.number == x`, the upgrade rules apply.
-If the upgrade block-number `x` is not specified in the configuration, the upgrade is ignored.
-
 This applies to the L2 block number, not to the L1-origin block number.
 This means that an L2 upgrade may be inactive, and then active, without changing the L1-origin.
 
 ### L2 Block-timestamp based activation
 
-Activation rule: `x != null && x >= upgradeTime`
+Activation rule: `upgradeTime != null && block.timestamp >= upgradeTime`
+
+Starting at, and including, the L2 `block` with `block.timestamp >= upgradeTime`, the upgrade rules apply.
+If the upgrade block-timestamp `upgradeTime` is not specified in the configuration, the upgrade is ignored.
 
 This is the preferred superchain upgrade activation-parameter type:
 it is synchronous between all L2 chains and compatible with post-Merge timestamp-based chain upgrades in L1.
-
-Starting at, and including, the L2 `block` with `block.timestamp == x`, the upgrade rules apply.
-If the upgrade block-timestamp `x` is not specified in the configuration, the upgrade is ignored.
 
 This applies to the L2 block timestamp, not to the L1-origin block timestamp.
 This means that an L2 upgrade may be inactive, and then active, without changing the L1-origin.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

This diff fixes subset of https://github.com/ethereum-optimism/optimism/pull/7289#issuecomment-1756315597
> In the batch-checking function we need to review the hardfork activation conditions,
and update the specs as well, so the span-batches activate at the right moment (w.r.t. L1 inclusion and L2 block time)
This should be added to the span-batch derivation specs, and then referenced as a feature of Canyon,
in the superchain-upgrades spec document.

1. Added span batch hardfork spec.
2. Harden span batch hardfork check using L1 inclusion block time.

**Additional context**

We may update [superchain-upgrades spec](https://github.com/testinprod-io/optimism/blob/develop/specs/superchain-upgrades.md#activation-rules) in the separate PR, resolving below sentence.
> This should be added to the span-batch derivation specs, and then referenced as a feature of Canyon,

in the superchain-upgrades spec document.

Base branch will be changed to develop when https://github.com/ethereum-optimism/optimism/pull/7621 is merged in develop branch.
