### PR TITLE
fix: Add chain-mon to version python script

### DIFF
--- a/ops/tag-service/tag-service.py
+++ b/ops/tag-service/tag-service.py
@@ -11,6 +11,7 @@ import semver
 # Minimum version numbers for packages migrating from legacy versioning.
 MIN_VERSIONS = {
     'ci-builder': '0.6.0',
+    'chain-mon': '0.2.2'
     'indexer': '0.5.0',
     'op-node': '0.10.14',
     'op-batcher': '0.10.14',


### PR DESCRIPTION
Fixes broken chain-mon docker tag versioning https://github.com/ethereum-optimism/optimism/actions/runs/6630154344/job/18010984270

Broken because of a python line 

```python
@click.option('--service', required=True, type=click.Choice(list(MIN_VERSIONS.keys())))
```

```
Error: Invalid value for '--service': 'chain-mon' is not one of 'ci-builder', 'indexer', 'op-node', 'op-batcher', 'op-challenger', 'op-proposer', 'op-ufm', 'proxyd', 'op-heartbeat', 'ufm-metamask'.
```
