### PR TITLE
contracts-bedrock: add protocol versions to hh deploy config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/hardhat.json
+++ b/packages/contracts-bedrock/deploy-config/hardhat.json
@@ -39,5 +39,7 @@
   "eip1559Denominator": 50,
   "eip1559Elasticity": 10,
   "l2GenesisRegolithTimeOffset": "0x0",
-  "systemConfigStartBlock": 0
+  "systemConfigStartBlock": 0,
+  "requiredProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "recommendedProtocolVersion": "0x0000000000000000000000000000000000000000000000000000000000000000"
 }


### PR DESCRIPTION
**Description**

Adds the two new protocol versions config values to the `hardhat` deploy config. This ensures that the config is up to date and can be consumed by the tests.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

