### PR TITLE
op-chain-ops: check for protocol version config

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -352,6 +352,12 @@ func (d *DeployConfig) Check() error {
 	if d.L1BlockTime < d.L2BlockTime {
 		return fmt.Errorf("L2 block time (%d) is larger than L1 block time (%d)", d.L2BlockTime, d.L1BlockTime)
 	}
+	if d.RequiredProtocolVersion == (params.ProtocolVersion{}) {
+		return fmt.Errorf("%w: RequiredProtocolVersion cannot be empty", ErrInvalidDeployConfig)
+	}
+	if d.RecommendedProtocolVersion == (params.ProtocolVersion{}) {
+		return fmt.Errorf("%w: RecommendedProtocolVersion cannot be empty", ErrInvalidDeployConfig)
+	}
 	return nil
 }
 

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -353,10 +353,10 @@ func (d *DeployConfig) Check() error {
 		return fmt.Errorf("L2 block time (%d) is larger than L1 block time (%d)", d.L2BlockTime, d.L1BlockTime)
 	}
 	if d.RequiredProtocolVersion == (params.ProtocolVersion{}) {
-		return fmt.Errorf("%w: RequiredProtocolVersion cannot be empty", ErrInvalidDeployConfig)
+		log.Warn("RequiredProtocolVersion is empty")
 	}
 	if d.RecommendedProtocolVersion == (params.ProtocolVersion{}) {
-		return fmt.Errorf("%w: RecommendedProtocolVersion cannot be empty", ErrInvalidDeployConfig)
+		log.Warn("RecommendedProtocolVersion is empty")
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Ensures that the protocol version configs are in the deploy config
by adding them to the `Check()` function to the `DeployConfig` struct.
CI calls this function to ensure that all of the deploy configs have
set values.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Fixes https://github.com/ethereum-optimism/client-pod/issues/76