### PR TITLE
ci-builder: use node version 20

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
 
 COPY .nvmrc .nvmrc
 
-ENV NODE_MAJOR=18
+ENV NODE_MAJOR=20
 ENV SLITHER_VERSION=0.10.0
 
 # note: python3 package in apt is python 3.9, while base image already has python 3.11


### PR DESCRIPTION
**Description**

node.js v20 is now LTS, this updates `ci-builder` to use
the LTS version as part of the docker image.

See https://github.com/nodesource/distributions

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

