### PR TITLE
fix: string encode error TS2345

### DIFF
--- a/packages/common-ts/src/base-service/base-service-v2.ts
+++ b/packages/common-ts/src/base-service/base-service-v2.ts
@@ -336,7 +336,8 @@ export abstract class BaseServiceV2<
       app.use(
         bodyParser.json({
           verify: (req, res, buf, encoding) => {
-            ;(req as any).rawBody = buf?.toString(encoding || 'utf8') || ''
+            ;(req as any).rawBody =
+              buf?.toString((encoding as BufferEncoding) || 'utf8') || ''
           },
           ...(this.params.bodyParserParams ?? {}),
         })


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

forge: 0.2.0 (6ac22df 2023-10-25T00:28:01.119427000Z)
nvm: 18.17.1


When running `make build-ts`, the below error reported:

```
✖  nx run @eth-optimism/common-ts:build
       > @eth-optimism/common-ts@0.8.7 build /Users/keroro520/gopath/src/github.com/s7v7nislands/optimism/packages/common-ts
       > tsc -p tsconfig.json

       src/base-service/base-service-v2.ts(339,51): error TS2345: Argument of type 'string' is not assignable to parameter of type 'BufferEncoding'.
        ELIFECYCLE  Command failed with exit code 2.
```