### PR TITLE
ci: re-enable ctb codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,7 +361,7 @@ jobs:
   contracts-bedrock-coverage:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - check-changed:
@@ -372,7 +372,7 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: test and generate coverage
-          command: pnpm coverage:lcov || true
+          command: pnpm coverage:lcov
           no_output_timeout: 18m
           environment:
             FOUNDRY_PROFILE: ci

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,7 +22,7 @@ flag_management:
   individual_flags:
     - name: contracts-bedrock-tests
       paths:
-        - packages/contracts-bedrock/contracts
+        - packages/contracts-bedrock
       statuses:
         - type: patch
           target: 100%


### PR DESCRIPTION
The contracts-bedrock code coverage job used to fail due to OOM. We see a recent increase in memory usage
![image](https://github.com/ethereum-optimism/optimism/assets/3516807/838eee40-7560-4162-a1a7-46905109248a)
It's unclear why code coverage takes is taking more resources than usual. As `contract-bedrock-tests` isn't experiencing the same issue. But for now increasing the job resource class provides helps avoid OOM.

This patch also fixes the codecov.io config for ctb.