### PR TITLE
fix: use 20.8.1 instead of 20.9.0 for bullseye slim image

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -35,7 +35,7 @@ FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest as foundr
 # we use it rather than alpine because it's not much
 # bigger and alpine is often missing packages for node applications
 # alpine is not officially supported by node.js
-FROM node:20.9.0-bullseye-slim as base
+FROM node:20.8.1-bullseye-slim as base
 
 # Base: install deps
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
- 20.9.0 is LTS but not supported by bullseye slim yet
- downgrade to 20.8.1
https://hub.docker.com/_/node/