### PR TITLE
chore: Improve chain-mon docker build

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -79,26 +79,38 @@ RUN git submodule update --init --recursive
 
 RUN pnpm build
 
+FROM base as chain-mon
+WORKDIR /opt/optimism/packages/chain-mon
+ENTRYPOINT ["pnpm", "run"]
+
+# TODO keeping the rest of these here for now because they are being used
+# but we should really delete them we only need one image
 FROM base as replica-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run", "start:replica-mon"]
+ENTRYPOINT ["pnpm", "run"]
+CMD ["start:replica-mon"]
 
 FROM base as balance-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run", "start:balance-mon"]
+ENTRYPOINT ["pnpm", "run"]
+CMD ["start:balance-mon"]
 
 FROM base as drippie-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run", "start:drippie-mon"]
+ENTRYPOINT ["pnpm", "run"]
+CMD ["start:drippie-mon"]
 
 FROM base as wd-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run", "start:wd-mon"]
+ENTRYPOINT ["pnpm", "run"]
+CMD ["start:wd-mon"]
 
 FROM base as wallet-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run", "start:wallet-mon"]
+ENTRYPOINT ["pnpm", "run"]
+CMD ["start:wallet-mon"]
 
 from base as fault-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run", "start:fault-mon"]
+ENTRYPOINT ["pnpm", "run"]
+CMD ["start:fault-mon"]

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -79,38 +79,33 @@ RUN git submodule update --init --recursive
 
 RUN pnpm build
 
+ENTRYPOINT ["pnpm", "run"]
+
 FROM base as chain-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 
 # TODO keeping the rest of these here for now because they are being used
 # but we should really delete them we only need one image
 FROM base as replica-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 CMD ["start:replica-mon"]
 
 FROM base as balance-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 CMD ["start:balance-mon"]
 
 FROM base as drippie-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 CMD ["start:drippie-mon"]
 
 FROM base as wd-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 CMD ["start:wd-mon"]
 
 FROM base as wallet-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 CMD ["start:wallet-mon"]
 
 from base as fault-mon
 WORKDIR /opt/optimism/packages/chain-mon
-ENTRYPOINT ["pnpm", "run"]
 CMD ["start:fault-mon"]


### PR DESCRIPTION
- Use entrypoint and cmd in a way that makes it easier to pass in new commands
- entrypoint is pnpm run with the default command being start:foo
- Also add a new chain-mon docker image that should replace all the other ones later
- in a future pr after we update the docker builds to use chain-mon image we can delete the rest
