### PR TITLE
ops: fix docker-bake indexer and ci-builder target and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,9 +25,10 @@
 /ops-bedrock    @ethereum-optimism/go-reviewers
 
 # Ops
-/.circleci    @ethereum-optimism/infra-reviewers
-/.github      @ethereum-optimism/infra-reviewers
-/ops          @ethereum-optimism/infra-reviewers
+/.circleci       @ethereum-optimism/infra-reviewers
+/.github         @ethereum-optimism/infra-reviewers
+/ops             @ethereum-optimism/infra-reviewers
+/docker-bake.hcl @ethereum-optimism/infra-reviewers
 
 # Misc
 /proxyd           @ethereum-optimism/infra-reviewers

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -142,7 +142,7 @@ target "indexer" {
     GITVERSION = "${GIT_VERSION}"
   }
   platforms = split(",", PLATFORMS)
-  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/proxyd:${tag}"]
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/indexer:${tag}"]
 }
 
 target "ufm-metamask" {
@@ -177,7 +177,7 @@ type "ci-builder" {
   dockerfile = "Dockerfile"
   context = "ops/docker/ci-builder"
   platforms = split(",", PLATFORMS)
-  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/chain-mon:${tag}"]
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/ci-builder:${tag}"]
 }
 
 


### PR DESCRIPTION
**Description**

I made a stupid copy-paste mistake when defining the indexer and ci-builder targets.

Also, adding the docker-bake file to the codeowners definition, so infra-reviewers can get notified correctly about changes.

