### PR TITLE
contracts-bedrock: pseudorandom blocknumber in portal fuzz test

### DIFF
--- a/packages/contracts-bedrock/test/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/OptimismPortal.t.sol
@@ -997,6 +997,8 @@ contract OptimismPortalResourceFuzz_Test is Portal_Initializer {
         vm.assume(((_maxResourceLimit / _elasticityMultiplier) * _elasticityMultiplier) == _maxResourceLimit);
         _prevBoughtGas = uint64(bound(_prevBoughtGas, 0, _maxResourceLimit - _gasLimit));
         _blockDiff = uint8(bound(_blockDiff, 0, 3));
+        // Pick a pseudorandom block number
+        vm.roll(uint256(keccak256(abi.encode(_blockDiff))) % uint256(type(uint16).max) + uint256(_blockDiff));
 
         // Create a resource config to mock the call to the system config with
         ResourceMetering.ResourceConfig memory rcfg = ResourceMetering.ResourceConfig({


### PR DESCRIPTION
**Description**

Set a pseudorandom `block.number` when fuzzing the `OptimismPortal`
deposit transaction codepath. This is a small fix required for
the migration to using the deploy script to set up the unit tests.
This prevents underflows with computing the `_prevBlockNum` and also
adds additional converage since previously the block number was not
being set dynamically.

Breaking this out into its own smaller PR so that the deploy script
migration can be smaller.

