### PR TITLE
feat(op-service): new http latency metric

### DIFF
--- a/op-service/metrics/http.go
+++ b/op-service/metrics/http.go
@@ -61,12 +61,11 @@ type PromHTTPRecorder struct {
 	HTTPResponses        *prometheus.CounterVec
 }
 
-var LatencyBuckets = []float64{.025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50}
+var LatencyBuckets = []float64{.025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100}
 
 func NewPromHTTPRecorder(r *prometheus.Registry, ns string) HTTPRecorder {
 	return &PromHTTPRecorder{
-		// nosemgrep: todos_require_linear
-		// TODO: remove this in the future when services opted in to HTTPRequestLatency
+		// TODO(INF-509): remove this in the future when services opted in to HTTPRequestLatency
 		HTTPRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: ns,
 			Name:      "http_request_duration_ms",

--- a/op-service/metrics/http.go
+++ b/op-service/metrics/http.go
@@ -65,6 +65,7 @@ var LatencyBuckets = []float64{.025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50}
 
 func NewPromHTTPRecorder(r *prometheus.Registry, ns string) HTTPRecorder {
 	return &PromHTTPRecorder{
+		// nosemgrep: todos_require_linear
 		// TODO: remove this in the future when services opted in to HTTPRequestLatency
 		HTTPRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: ns,

--- a/op-service/metrics/http.go
+++ b/op-service/metrics/http.go
@@ -44,21 +44,41 @@ func (n *noopHTTPRecorder) RecordHTTPRequest(*HTTPParams) {}
 func (n *noopHTTPRecorder) RecordHTTPResponse(*HTTPParams) {}
 
 type PromHTTPRecorder struct {
-	HTTPRequestDuration  *prometheus.HistogramVec
+	// HTTPRequestDuration is the old metric for request latency
+	// it was created with too tight buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
+	// in order to preserve backward compatibility we are keeping this metric for now
+	// and it will be removed when services opt in to HTTPRequestLatency
+	// Deprecated: HTTPRequestDuration is deprecated
+	HTTPRequestDuration *prometheus.HistogramVec
+
+	// HTTPRequestLatency measures request execution latency in *seconds*
+	// buckets are: [.025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50]
+	HTTPRequestLatency *prometheus.HistogramVec
+
 	HTTPResponseSize     *prometheus.HistogramVec
 	HTTPInflightRequests *prometheus.GaugeVec
 	HTTPRequests         *prometheus.CounterVec
 	HTTPResponses        *prometheus.CounterVec
 }
 
+var LatencyBuckets = []float64{.025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50}
+
 func NewPromHTTPRecorder(r *prometheus.Registry, ns string) HTTPRecorder {
 	return &PromHTTPRecorder{
+		// TODO: remove this in the future when services opted in to HTTPRequestLatency
 		HTTPRequestDuration: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: ns,
 			Name:      "http_request_duration_ms",
 			Help:      "Tracks HTTP request durations, in ms",
 			Buckets:   prometheus.DefBuckets,
 		}, httpLabels),
+		HTTPRequestLatency: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Name:      "http_request_latency_seconds",
+			Help:      "Tracks HTTP request execution latency, in seconds",
+			Buckets:   LatencyBuckets,
+		}, httpLabels),
+
 		HTTPResponseSize: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: ns,
 			Name:      "http_response_size",
@@ -84,8 +104,12 @@ func NewPromHTTPRecorder(r *prometheus.Registry, ns string) HTTPRecorder {
 }
 
 func (p *PromHTTPRecorder) RecordHTTPRequestDuration(params *HTTPParams, dur time.Duration) {
+	// TODO: remove this in the future when services opted in to new metric
 	p.HTTPRequestDuration.WithLabelValues(params.Method, strconv.Itoa(params.StatusCode)).
 		Observe(float64(dur.Milliseconds()))
+
+	p.HTTPRequestLatency.WithLabelValues(params.Method, strconv.Itoa(params.StatusCode)).
+		Observe(dur.Seconds())
 }
 
 func (p *PromHTTPRecorder) RecordHTTPResponseSize(params *HTTPParams, size int) {

--- a/op-service/metrics/http.go
+++ b/op-service/metrics/http.go
@@ -104,7 +104,7 @@ func NewPromHTTPRecorder(r *prometheus.Registry, ns string) HTTPRecorder {
 }
 
 func (p *PromHTTPRecorder) RecordHTTPRequestDuration(params *HTTPParams, dur time.Duration) {
-	// TODO: remove this in the future when services opted in to new metric
+	// TODO(INF-509): remove this in the future when services opted in to new metric
 	p.HTTPRequestDuration.WithLabelValues(params.Method, strconv.Itoa(params.StatusCode)).
 		Observe(float64(dur.Milliseconds()))
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Before this change, we were capturing HTTP request durations in milliseconds and used to have the default buckets for the histogram: `[.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]`. Those intervals are not expressive enough to detect significant impact to clients.

This change proposes a new metric, keeping backward compatibility with the old one.

The new metric capture HTTP request durations ("execution latency") in seconds, with more expressive buckets:  `[.025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50]`.

We'll maintain the legacy metric until all clients have migrated to the new metric in their dashboards and alerts.

**Tests**

```
go test ./...
```

**Additional context**

cc @protolambda @ajsutton 
