### PR TITLE
fix(indexer) `op_indexer_` MetricsNamespace prefix + metric updates

### DIFF
--- a/indexer/etl/etl.go
+++ b/indexer/etl/etl.go
@@ -67,14 +67,18 @@ func (etl *ETL) Start(ctx context.Context) error {
 			if len(headers) > 0 {
 				etl.log.Info("retrying previous batch")
 			} else {
-				newHeaders, err := etl.headerTraversal.NextFinalizedHeaders(etl.headerBufferSize)
+				newHeaders, err := etl.headerTraversal.NextHeaders(etl.headerBufferSize)
 				if err != nil {
 					etl.log.Error("error querying for headers", "err", err)
 				} else if len(newHeaders) == 0 {
-					etl.log.Warn("no new headers. processor unexpectedly at head...")
+					etl.log.Warn("no new headers. etl at head?")
 				} else {
-					etl.metrics.RecordLatestHeight(etl.headerTraversal.LatestHeader().Number)
 					headers = newHeaders
+				}
+
+				latestHeader := etl.headerTraversal.LatestHeader()
+				if latestHeader != nil {
+					etl.metrics.RecordLatestHeight(latestHeader.Number)
 				}
 			}
 

--- a/indexer/etl/etl.go
+++ b/indexer/etl/etl.go
@@ -73,6 +73,7 @@ func (etl *ETL) Start(ctx context.Context) error {
 				} else if len(newHeaders) == 0 {
 					etl.log.Warn("no new headers. processor unexpectedly at head...")
 				} else {
+					etl.metrics.RecordLatestHeight(etl.headerTraversal.LatestHeader().Number)
 					headers = newHeaders
 				}
 			}

--- a/indexer/etl/l1_etl_test.go
+++ b/indexer/etl/l1_etl_test.go
@@ -62,7 +62,7 @@ func TestL1ETLConstruction(t *testing.T) {
 			},
 			assertion: func(etl *L1ETL, err error) {
 				require.NoError(t, err)
-				require.Equal(t, etl.headerTraversal.LastHeader().ParentHash, common.HexToHash("0x69"))
+				require.Equal(t, etl.headerTraversal.LastTraversedHeader().ParentHash, common.HexToHash("0x69"))
 			},
 		},
 		{
@@ -94,7 +94,7 @@ func TestL1ETLConstruction(t *testing.T) {
 			},
 			assertion: func(etl *L1ETL, err error) {
 				require.NoError(t, err)
-				header := etl.headerTraversal.LastHeader()
+				header := etl.headerTraversal.LastTraversedHeader()
 
 				require.True(t, header.Number.Cmp(big.NewInt(69)) == 0)
 			},

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -93,6 +93,7 @@ func (l2Etl *L2ETL) Start(ctx context.Context) error {
 			for i := range batch.Logs {
 				timestamp := batch.HeaderMap[batch.Logs[i].BlockHash].Time
 				l2ContractEvents[i] = database.L2ContractEvent{ContractEvent: database.ContractEventFromLog(&batch.Logs[i], timestamp)}
+				l2Etl.ETL.metrics.RecordIndexedLog(batch.Logs[i].Address)
 			}
 
 			// Continually try to persist this batch. If it fails after 10 attempts, we simply error out
@@ -115,9 +116,6 @@ func (l2Etl *L2ETL) Start(ctx context.Context) error {
 
 				l2Etl.ETL.metrics.RecordIndexedHeaders(len(l2BlockHeaders))
 				l2Etl.ETL.metrics.RecordIndexedLatestHeight(l2BlockHeaders[len(l2BlockHeaders)-1].Number)
-				if len(l2ContractEvents) > 0 {
-					l2Etl.ETL.metrics.RecordIndexedLogs(len(l2ContractEvents))
-				}
 
 				// a-ok!
 				return nil, nil

--- a/indexer/etl/metrics.go
+++ b/indexer/etl/metrics.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	MetricsNamespace string = "etl"
+	MetricsNamespace string = "op_indexer_etl"
 )
 
 type Metricer interface {

--- a/indexer/etl/metrics.go
+++ b/indexer/etl/metrics.go
@@ -51,10 +51,10 @@ func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
 		intervalFailures: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
-			Name:      "failures_total",
+			Name:      "interval_failures_total",
 			Help:      "number of times the etl encountered a failure during the processing loop",
 		}),
-		latestHeight: factory.NewCounter(prometheus.CounterOpts{
+		latestHeight: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
 			Name:      "latest_height",

--- a/indexer/etl/metrics.go
+++ b/indexer/etl/metrics.go
@@ -15,29 +15,20 @@ var (
 type Metricer interface {
 	RecordInterval() (done func(err error))
 
-	// Batch Extraction
-	RecordBatchLatestHeight(height *big.Int)
-	RecordBatchHeaders(size int)
-	RecordBatchLog(contractAddress common.Address)
-
 	// Indexed Batches
 	RecordIndexedLatestHeight(height *big.Int)
 	RecordIndexedHeaders(size int)
-	RecordIndexedLogs(size int)
+	RecordIndexedLog(contractAddress common.Address)
 }
 
 type etlMetrics struct {
 	intervalTick     prometheus.Counter
 	intervalDuration prometheus.Histogram
-
-	batchFailures     prometheus.Counter
-	batchLatestHeight prometheus.Gauge
-	batchHeaders      prometheus.Counter
-	batchLogs         *prometheus.CounterVec
+	intervalFailures prometheus.Counter
 
 	indexedLatestHeight prometheus.Gauge
 	indexedHeaders      prometheus.Counter
-	indexedLogs         prometheus.Counter
+	indexedLogs         *prometheus.CounterVec
 }
 
 func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
@@ -55,31 +46,11 @@ func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
 			Name:      "interval_seconds",
 			Help:      "duration elapsed for during the processing loop",
 		}),
-		batchFailures: factory.NewCounter(prometheus.CounterOpts{
+		intervalFailures: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
 			Name:      "failures_total",
-			Help:      "number of times the etl encountered a failure to extract a batch",
-		}),
-		batchLatestHeight: factory.NewGauge(prometheus.GaugeOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: subsystem,
-			Name:      "height",
-			Help:      "the latest block height observed by an etl interval",
-		}),
-		batchHeaders: factory.NewCounter(prometheus.CounterOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: subsystem,
-			Name:      "headers_total",
-			Help:      "number of headers observed by the etl",
-		}),
-		batchLogs: factory.NewCounterVec(prometheus.CounterOpts{
-			Namespace: MetricsNamespace,
-			Subsystem: subsystem,
-			Name:      "logs_total",
-			Help:      "number of logs observed by the etl",
-		}, []string{
-			"contract",
+			Help:      "number of times the etl encountered a failure during the processing loop",
 		}),
 		indexedLatestHeight: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,
@@ -93,11 +64,13 @@ func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
 			Name:      "indexed_headers_total",
 			Help:      "number of headers indexed by the etl",
 		}),
-		indexedLogs: factory.NewCounter(prometheus.CounterOpts{
+		indexedLogs: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
 			Name:      "indexed_logs_total",
 			Help:      "number of logs indexed by the etl",
+		}, []string{
+			"contract",
 		}),
 	}
 }
@@ -107,23 +80,10 @@ func (m *etlMetrics) RecordInterval() func(error) {
 	timer := prometheus.NewTimer(m.intervalDuration)
 	return func(err error) {
 		if err != nil {
-			m.batchFailures.Inc()
+			m.intervalFailures.Inc()
 		}
-
 		timer.ObserveDuration()
 	}
-}
-
-func (m *etlMetrics) RecordBatchLatestHeight(height *big.Int) {
-	m.batchLatestHeight.Set(float64(height.Uint64()))
-}
-
-func (m *etlMetrics) RecordBatchHeaders(size int) {
-	m.batchHeaders.Add(float64(size))
-}
-
-func (m *etlMetrics) RecordBatchLog(contractAddress common.Address) {
-	m.batchLogs.WithLabelValues(contractAddress.String()).Inc()
 }
 
 func (m *etlMetrics) RecordIndexedLatestHeight(height *big.Int) {
@@ -134,6 +94,6 @@ func (m *etlMetrics) RecordIndexedHeaders(size int) {
 	m.indexedHeaders.Add(float64(size))
 }
 
-func (m *etlMetrics) RecordIndexedLogs(size int) {
-	m.indexedLogs.Add(float64(size))
+func (m *etlMetrics) RecordIndexedLog(addr common.Address) {
+	m.indexedLogs.WithLabelValues(addr.String()).Inc()
 }

--- a/indexer/node/header_traversal.go
+++ b/indexer/node/header_traversal.go
@@ -17,8 +17,8 @@ var (
 type HeaderTraversal struct {
 	ethClient EthClient
 
-	lastHeader   *types.Header
-	latestHeader *types.Header
+	latestHeader        *types.Header
+	lastTraversedHeader *types.Header
 
 	blockConfirmationDepth *big.Int
 }
@@ -26,30 +26,37 @@ type HeaderTraversal struct {
 // NewHeaderTraversal instantiates a new instance of HeaderTraversal against the supplied rpc client.
 // The HeaderTraversal will start fetching blocks starting from the supplied header unless nil, indicating genesis.
 func NewHeaderTraversal(ethClient EthClient, fromHeader *types.Header, confDepth *big.Int) *HeaderTraversal {
-	return &HeaderTraversal{ethClient: ethClient, lastHeader: fromHeader, blockConfirmationDepth: confDepth}
+	return &HeaderTraversal{
+		ethClient:              ethClient,
+		lastTraversedHeader:    fromHeader,
+		blockConfirmationDepth: confDepth,
+	}
 }
 
 // LatestHeader returns the latest header reported by underlying eth client
+// as headers are traversed via `NextHeaders`.
 func (f *HeaderTraversal) LatestHeader() *types.Header {
 	return f.latestHeader
 }
 
-// LastHeader returns the last header traversed.
+// LastTraversedHeader returns the last header traversed.
 //   - This is useful for testing the state of the HeaderTraversal
-//   - NOTE: LastHeader may be << LatestHeader depending on the number
-//     headers traversed via `NextFinalizedHeaders`.
-func (f *HeaderTraversal) LastHeader() *types.Header {
-	return f.lastHeader
+//   - LastTraversedHeader may be << LatestHeader depending on the number
+//     headers traversed via `NextHeaders`.
+func (f *HeaderTraversal) LastTraversedHeader() *types.Header {
+	return f.lastTraversedHeader
 }
 
-// NextFinalizedHeaders retrieves the next set of headers that have been
+// NextHeaders retrieves the next set of headers that have been
 // marked as finalized by the connected client, bounded by the supplied size
-func (f *HeaderTraversal) NextFinalizedHeaders(maxSize uint64) ([]types.Header, error) {
+func (f *HeaderTraversal) NextHeaders(maxSize uint64) ([]types.Header, error) {
 	latestHeader, err := f.ethClient.BlockHeaderByNumber(nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to query latest block: %w", err)
 	} else if latestHeader == nil {
 		return nil, fmt.Errorf("latest header unreported")
+	} else {
+		f.latestHeader = latestHeader
 	}
 
 	endHeight := new(big.Int).Sub(latestHeader.Number, f.blockConfirmationDepth)
@@ -58,8 +65,8 @@ func (f *HeaderTraversal) NextFinalizedHeaders(maxSize uint64) ([]types.Header, 
 		return nil, nil
 	}
 
-	if f.lastHeader != nil {
-		cmp := f.lastHeader.Number.Cmp(endHeight)
+	if f.lastTraversedHeader != nil {
+		cmp := f.lastTraversedHeader.Number.Cmp(endHeight)
 		if cmp == 0 { // We're synced to head and there are no new headers
 			return nil, nil
 		} else if cmp > 0 {
@@ -68,8 +75,8 @@ func (f *HeaderTraversal) NextFinalizedHeaders(maxSize uint64) ([]types.Header, 
 	}
 
 	nextHeight := bigint.Zero
-	if f.lastHeader != nil {
-		nextHeight = new(big.Int).Add(f.lastHeader.Number, bigint.One)
+	if f.lastTraversedHeader != nil {
+		nextHeight = new(big.Int).Add(f.lastTraversedHeader.Number, bigint.One)
 	}
 
 	// endHeight = (nextHeight - endHeight) <= maxSize
@@ -82,13 +89,12 @@ func (f *HeaderTraversal) NextFinalizedHeaders(maxSize uint64) ([]types.Header, 
 	numHeaders := len(headers)
 	if numHeaders == 0 {
 		return nil, nil
-	} else if f.lastHeader != nil && headers[0].ParentHash != f.lastHeader.Hash() {
+	} else if f.lastTraversedHeader != nil && headers[0].ParentHash != f.lastTraversedHeader.Hash() {
 		// The indexer's state is in an irrecoverable state relative to the provider. This
 		// should never happen since the indexer is dealing with only finalized blocks.
 		return nil, ErrHeaderTraversalAndProviderMismatchedState
 	}
 
-	f.lastHeader = &headers[numHeaders-1]
-	f.latestHeader = latestHeader
+	f.lastTraversedHeader = &headers[numHeaders-1]
 	return headers, nil
 }

--- a/indexer/node/metrics.go
+++ b/indexer/node/metrics.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	MetricsNamespace = "rpc"
+	MetricsNamespace = "op_indexer_rpc"
 	batchMethod      = "<batch>"
 )
 

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -231,6 +231,9 @@ func (b *BridgeProcessor) run() error {
 
 	batchLog.Info("indexed bridge events", "latest_l1_block_number", toL1Height, "latest_l2_block_number", toL2Height)
 	b.LatestL1Header = latestEpoch.L1BlockHeader.RLPHeader.Header()
+	b.metrics.RecordLatestIndexedL1Height(b.LatestL1Header.Number)
+
 	b.LatestL2Header = latestEpoch.L2BlockHeader.RLPHeader.Header()
+	b.metrics.RecordLatestIndexedL2Height(b.LatestL2Header.Number)
 	return nil
 }

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -109,6 +109,17 @@ func (b *BridgeProcessor) run() error {
 			b.log.Error("bridge events indexed, but no observed epoch returned", "latest_bridge_l1_block_number", b.LatestL1Header.Number)
 			return errors.New("bridge events indexed, but no observed epoch returned")
 		}
+
+		latestL1Header, err := b.db.Blocks.L1LatestBlockHeader()
+		if err != nil {
+		}
+
+		latestL2Header, err := b.db.Blocks.L2LatestBlockHeader()
+		if err != nil {
+		}
+
+		b.LatestL1Header = latestL1Header.RLPHeader.Header()
+		b.LatestL2Header = latestL2Header.RLPHeader.Header()
 		b.log.Warn("no observed epochs available. waiting...")
 		return nil
 	}

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -109,17 +109,6 @@ func (b *BridgeProcessor) run() error {
 			b.log.Error("bridge events indexed, but no observed epoch returned", "latest_bridge_l1_block_number", b.LatestL1Header.Number)
 			return errors.New("bridge events indexed, but no observed epoch returned")
 		}
-
-		latestL1Header, err := b.db.Blocks.L1LatestBlockHeader()
-		if err != nil {
-		}
-
-		latestL2Header, err := b.db.Blocks.L2LatestBlockHeader()
-		if err != nil {
-		}
-
-		b.LatestL1Header = latestL1Header.RLPHeader.Header()
-		b.LatestL2Header = latestL2Header.RLPHeader.Header()
 		b.log.Warn("no observed epochs available. waiting...")
 		return nil
 	}

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	MetricsNamespace string = "bridge"
+	MetricsNamespace string = "op_indexer_bridge"
 )
 
 type L1Metricer interface {

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -83,7 +83,7 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}),
 		intervalFailures: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
-			Name:      "failures_total",
+			Name:      "interval_failures_total",
 			Help:      "number of failures encountered",
 		}),
 		latestL1Height: factory.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
Metrics by default aren't exported with a prefix. Explicitly add `op_indexer_`

Side note: ideally we'd be able to specify a global prefix when creating the registry. Will look into this later

Updates
- Bridge heights need to be updated at the end of the loop
- Consolidate on indexed data for ETL metrics. 
- Report latest height in ETL metrics