### PR TITLE
op-challenger: Unsubscribe from l1 heads on shutdown

### DIFF
--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -141,6 +141,7 @@ func (m *gameMonitor) MonitorGames(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			m.l1HeadsSub.Unsubscribe()
 			return nil
 		case err, ok := <-m.l1HeadsSub.Err():
 			if !ok {

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -100,7 +100,8 @@ func TestMonitorGames(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			waitErr := wait.For(context.Background(), 100*time.Millisecond, func() (bool, error) {
+			// Wait for the subscription to be created
+			waitErr := wait.For(context.Background(), 5*time.Second, func() (bool, error) {
 				return mockHeadSource.sub != nil, nil
 			})
 			require.NoError(t, waitErr)


### PR DESCRIPTION
**Description**

Avoids leaving a background function running that could trigger logging. This was causing flaky tests.

Also bumped up the wait timeout for the subscription to be initiated because 100ms is way too short. It will only wait that long if the subscription isn't made and the test will then fail so no harm in having it be longer.