### PR TITLE
op-e2e: Use circleci parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,6 +778,7 @@ jobs:
       target:
         description: The make target to execute
         type: string
+    parallelism: 2
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     resource_class: xlarge

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -3,9 +3,11 @@ ifdef JUNIT_FILE
 	go_test = OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose --junitfile=$(JUNIT_FILE) --
   # Note: -parallel must be set to match the number of cores in the resource class
 	go_test_flags = -timeout=20m -parallel=8
+	go_test_target = $(go list ./... | circleci tests split --split-by=timings)
 else
 	go_test = go test
 	go_test_flags = -v
+	go_test_target = ./...
 endif
 
 test: pre-test test-ws
@@ -13,14 +15,14 @@ test: pre-test test-ws
 
 test-external-%: pre-test
 	make -C ./external_$*/
-	$(go_test) $(go_test_flags) --externalL2 ./external_$*/
+	$(go_test) $(go_test_flags) --externalL2 ./external_$*/ $(go_test_target)
 
 test-ws: pre-test
-	$(go_test) $(go_test_flags) ./...
+	$(go_test) $(go_test_flags) $(go_test_target)
 .PHONY: test-ws
 
 test-http: pre-test
-	OP_E2E_USE_HTTP=true $(go_test) $(go_test_flags) ./...
+	OP_E2E_USE_HTTP=true $(go_test) $(go_test_flags) $(go_test_target)
 .PHONY: test-ws
 
 cannon-prestate:

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -3,7 +3,7 @@ ifdef JUNIT_FILE
 	go_test = OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose --junitfile=$(JUNIT_FILE) --
   # Note: -parallel must be set to match the number of cores in the resource class
 	go_test_flags = -timeout=20m -parallel=8
-	go_test_target = $$(go list ./... | circleci tests split --split-by=timings)
+	go_test_target = $$(go test ./... -list '.*' | grep '^Test' | circleci tests split --split-by=timings)
 else
 	go_test = go test
 	go_test_flags = -v

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -3,7 +3,7 @@ ifdef JUNIT_FILE
 	go_test = OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose --junitfile=$(JUNIT_FILE) --
   # Note: -parallel must be set to match the number of cores in the resource class
 	go_test_flags = -timeout=20m -parallel=8
-	go_test_target = $(go list ./... | circleci tests split --split-by=timings)
+	go_test_target = $$(go list ./... | circleci tests split --split-by=timings)
 else
 	go_test = go test
 	go_test_flags = -v
@@ -15,14 +15,20 @@ test: pre-test test-ws
 
 test-external-%: pre-test
 	make -C ./external_$*/
-	$(go_test) $(go_test_flags) --externalL2 ./external_$*/ $(go_test_target)
+	export TESTLIST=$(go_test_target); \
+	echo "Running tests: $${TESTLIST}"; \
+	$(go_test) $(go_test_flags) --externalL2 ./external_$*/ "$${TESTLIST}"
 
 test-ws: pre-test
-	$(go_test) $(go_test_flags) $(go_test_target)
+	export TESTLIST=$(go_test_target); \
+	echo "Running tests: $${TESTLIST}"; \
+	$(go_test) $(go_test_flags) "$${TESTLIST}"
 .PHONY: test-ws
 
 test-http: pre-test
-	OP_E2E_USE_HTTP=true $(go_test) $(go_test_flags) $(go_test_target)
+	export TESTLIST=$(go_test_target); \
+	echo "Running tests: $${TESTLIST}"; \
+	OP_E2E_USE_HTTP=true $(go_test) $(go_test_flags) "$${TESTLIST}"
 .PHONY: test-ws
 
 cannon-prestate:


### PR DESCRIPTION
**Description**

Experiment with using circleci `parallelism` option to spread e2e tests across multiple executors.