### PR TITLE
contracts-bedrock: modern import style in tests

### DIFF
--- a/packages/contracts-bedrock/test/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/AddressAliasHelper.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { AddressAliasHelper } from "../src/vendor/AddressAliasHelper.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 contract AddressAliasHelper_applyAndUndo_Test is Test {
     /// @notice Tests that applying and then undoing an alias results in the original address.

--- a/packages/contracts-bedrock/test/AdminFaucetAuthModule.t.sol
+++ b/packages/contracts-bedrock/test/AdminFaucetAuthModule.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { AdminFaucetAuthModule } from "../src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
-import { Faucet } from "../src/periphery/faucet/Faucet.sol";
-import { FaucetHelper } from "./Helpers.sol";
+import { AdminFaucetAuthModule } from "src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
+import { Faucet } from "src/periphery/faucet/Faucet.sol";
+import { FaucetHelper } from "test/Helpers.sol";
 
 /// @title  AdminFaucetAuthModuleTest
 /// @notice Tests the AdminFaucetAuthModule contract.

--- a/packages/contracts-bedrock/test/AssetReceiver.t.sol
+++ b/packages/contracts-bedrock/test/AssetReceiver.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
-import { TestERC20 } from "./Helpers.sol";
-import { TestERC721 } from "./Helpers.sol";
-import { AssetReceiver } from "../src/periphery/AssetReceiver.sol";
+import { TestERC20 } from "test/Helpers.sol";
+import { TestERC721 } from "test/Helpers.sol";
+import { AssetReceiver } from "src/periphery/AssetReceiver.sol";
 
 contract AssetReceiver_Initializer is Test {
     address alice = address(128);

--- a/packages/contracts-bedrock/test/AttestationStation.t.sol
+++ b/packages/contracts-bedrock/test/AttestationStation.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 /* Testing utilities */
 import { Test } from "forge-std/Test.sol";
-import { AttestationStation } from "../src/periphery/op-nft/AttestationStation.sol";
+import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
 
 contract AttestationStation_Initializer is Test {
     address alice_attestor = address(128);

--- a/packages/contracts-bedrock/test/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/test/BenchmarkTest.t.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
-import "./CommonTest.t.sol";
-import { CrossDomainMessenger } from "../src/universal/CrossDomainMessenger.sol";
-import { ResourceMetering } from "../src/L1/ResourceMetering.sol";
+import "test/CommonTest.t.sol";
+import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 
 // Free function for setting the prevBaseFee param in the OptimismPortal.
 function setPrevBaseFee(Vm _vm, address _op, uint128 _prevBaseFee) {

--- a/packages/contracts-bedrock/test/Bytes.t.sol
+++ b/packages/contracts-bedrock/test/Bytes.t.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 
 // Target contract
-import { Bytes } from "../src/libraries/Bytes.sol";
+import { Bytes } from "src/libraries/Bytes.sol";
 
 contract Bytes_slice_Test is Test {
     /// @notice Tests that the `slice` function works as expected when starting from index 0.

--- a/packages/contracts-bedrock/test/CheckBalanceHigh.t.sol
+++ b/packages/contracts-bedrock/test/CheckBalanceHigh.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { CheckBalanceHigh } from "../src/periphery/drippie/dripchecks/CheckBalanceHigh.sol";
+import { CheckBalanceHigh } from "src/periphery/drippie/dripchecks/CheckBalanceHigh.sol";
 
 /// @title  CheckBalanceHighTest
 /// @notice Tests the CheckBalanceHigh contract via fuzzing both the success case

--- a/packages/contracts-bedrock/test/CheckBalanceLow.t.sol
+++ b/packages/contracts-bedrock/test/CheckBalanceLow.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { CheckBalanceLow } from "../src/periphery/drippie/dripchecks/CheckBalanceLow.sol";
+import { CheckBalanceLow } from "src/periphery/drippie/dripchecks/CheckBalanceLow.sol";
 
 /// @title  CheckBalanceLowTest
 /// @notice Tests the CheckBalanceLow contract via fuzzing both the success case

--- a/packages/contracts-bedrock/test/CheckGelatoLow.t.sol
+++ b/packages/contracts-bedrock/test/CheckGelatoLow.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { CheckGelatoLow, IGelatoTreasury } from "../src/periphery/drippie/dripchecks/CheckGelatoLow.sol";
+import { CheckGelatoLow, IGelatoTreasury } from "src/periphery/drippie/dripchecks/CheckGelatoLow.sol";
 
 /// @title  MockGelatoTreasury
 /// @notice Mocks the Gelato treasury for testing purposes. Allows arbitrary

--- a/packages/contracts-bedrock/test/CheckTrue.t.sol
+++ b/packages/contracts-bedrock/test/CheckTrue.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { CheckTrue } from "../src/periphery/drippie/dripchecks/CheckTrue.sol";
+import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";
 
 /// @title  CheckTrueTest
 /// @notice Ensures that the CheckTrue DripCheck contract always returns true.

--- a/packages/contracts-bedrock/test/Clones.t.sol
+++ b/packages/contracts-bedrock/test/Clones.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import { ClonesWithImmutableArgs } from "@cwia/ClonesWithImmutableArgs.sol";
 
-import { Clone } from "../src/libraries/Clone.sol";
+import { Clone } from "src/libraries/Clone.sol";
 
 contract ExampleClone is Clone {
     uint256 argOffset;

--- a/packages/contracts-bedrock/test/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainMessenger.t.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { Messenger_Initializer, Reverter, CallerCaller, CommonTest } from "./CommonTest.t.sol";
-import { L1CrossDomainMessenger } from "../src/L1/L1CrossDomainMessenger.sol";
+import { Messenger_Initializer, Reverter, CallerCaller, CommonTest } from "test/CommonTest.t.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 
 // Libraries
 import { Predeploys } from "../src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { Vm, VmSafe } from "forge-std/Vm.sol";
-import { CommonTest, Portal_Initializer } from "./CommonTest.t.sol";
+import { CommonTest, Portal_Initializer } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";

--- a/packages/contracts-bedrock/test/CrossDomainOwnable2.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainOwnable2.t.sol
@@ -2,11 +2,11 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest, Messenger_Initializer } from "./CommonTest.t.sol";
+import { CommonTest, Messenger_Initializer } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Hashing } from "../src/libraries/Hashing.sol";
-import { Encoding } from "../src/libraries/Encoding.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
 
 // Target contract dependencies

--- a/packages/contracts-bedrock/test/CrossDomainOwnable3.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainOwnable3.t.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest, Messenger_Initializer } from "./CommonTest.t.sol";
+import { CommonTest, Messenger_Initializer } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Hashing } from "../src/libraries/Hashing.sol";
-import { Encoding } from "../src/libraries/Encoding.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
 
 // Target contract dependencies
-import { AddressAliasHelper } from "../src/vendor/AddressAliasHelper.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 // Target contract
-import { CrossDomainOwnable3 } from "../src/L2/CrossDomainOwnable3.sol";
+import { CrossDomainOwnable3 } from "src/L2/CrossDomainOwnable3.sol";
 
 contract XDomainSetter3 is CrossDomainOwnable3 {
     uint256 public value;

--- a/packages/contracts-bedrock/test/DelayedVetoable.t.sol
+++ b/packages/contracts-bedrock/test/DelayedVetoable.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 import { DelayedVetoable } from "src/L1/DelayedVetoable.sol";
 
 contract DelayedVetoable_Init is CommonTest {

--- a/packages/contracts-bedrock/test/DeployerWhitelist.t.sol
+++ b/packages/contracts-bedrock/test/DeployerWhitelist.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract
-import { DeployerWhitelist } from "../src/legacy/DeployerWhitelist.sol";
+import { DeployerWhitelist } from "src/legacy/DeployerWhitelist.sol";
 
 contract DeployerWhitelist_Test is CommonTest {
     DeployerWhitelist list;

--- a/packages/contracts-bedrock/test/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/DisputeGameFactory.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import "../src/libraries/DisputeTypes.sol";
-import "../src/libraries/DisputeErrors.sol";
+import "src/libraries/DisputeTypes.sol";
+import "src/libraries/DisputeErrors.sol";
 
 import { Test } from "forge-std/Test.sol";
-import { DisputeGameFactory } from "../src/dispute/DisputeGameFactory.sol";
-import { IDisputeGame } from "../src/dispute/interfaces/IDisputeGame.sol";
-import { Proxy } from "../src/universal/Proxy.sol";
-import { L2OutputOracle_Initializer } from "./CommonTest.t.sol";
+import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
+import { IDisputeGame } from "src/dispute/interfaces/IDisputeGame.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { L2OutputOracle_Initializer } from "test/CommonTest.t.sol";
 
 contract DisputeGameFactory_Init is L2OutputOracle_Initializer {
     DisputeGameFactory factory;

--- a/packages/contracts-bedrock/test/Drippie.t.sol
+++ b/packages/contracts-bedrock/test/Drippie.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { Drippie } from "../src/periphery/drippie/Drippie.sol";
-import { IDripCheck } from "../src/periphery/drippie/IDripCheck.sol";
-import { CheckTrue } from "../src/periphery/drippie/dripchecks/CheckTrue.sol";
-import { SimpleStorage } from "./Helpers.sol";
+import { Drippie } from "src/periphery/drippie/Drippie.sol";
+import { IDripCheck } from "src/periphery/drippie/IDripCheck.sol";
+import { CheckTrue } from "src/periphery/drippie/dripchecks/CheckTrue.sol";
+import { SimpleStorage } from "test/Helpers.sol";
 
 /// @title  TestDrippie
 /// @notice This is a wrapper contract around Drippie used for testing.

--- a/packages/contracts-bedrock/test/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/Encoding.t.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Types } from "../src/libraries/Types.sol";
-import { LegacyCrossDomainUtils } from "../src/libraries/LegacyCrossDomainUtils.sol";
+import { Types } from "src/libraries/Types.sol";
+import { LegacyCrossDomainUtils } from "src/libraries/LegacyCrossDomainUtils.sol";
 
 // Target contract
-import { Encoding } from "../src/libraries/Encoding.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 
 contract Encoding_Test is CommonTest {
     /// @dev Tests encoding and decoding a nonce and version.

--- a/packages/contracts-bedrock/test/Faucet.t.sol
+++ b/packages/contracts-bedrock/test/Faucet.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { Faucet } from "../src/periphery/faucet/Faucet.sol";
-import { AdminFaucetAuthModule } from "../src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
-import { FaucetHelper } from "./Helpers.sol";
+import { Faucet } from "src/periphery/faucet/Faucet.sol";
+import { AdminFaucetAuthModule } from "src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
+import { FaucetHelper } from "test/Helpers.sol";
 
 contract Faucet_Initializer is Test {
     event Drip(string indexed authModule, bytes32 indexed userId, uint256 amount, address indexed recipient);

--- a/packages/contracts-bedrock/test/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/FaultDisputeGame.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { DisputeGameFactory_Init } from "./DisputeGameFactory.t.sol";
+import { DisputeGameFactory_Init } from "test/DisputeGameFactory.t.sol";
 import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
 import { FaultDisputeGame } from "src/dispute/FaultDisputeGame.sol";
 import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";

--- a/packages/contracts-bedrock/test/FeeVault.t.sol
+++ b/packages/contracts-bedrock/test/FeeVault.t.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { Bridge_Initializer } from "./CommonTest.t.sol";
-import { BaseFeeVault } from "../src/L2/BaseFeeVault.sol";
-import { StandardBridge } from "../src/universal/StandardBridge.sol";
+import { Bridge_Initializer } from "test/CommonTest.t.sol";
+import { BaseFeeVault } from "src/L2/BaseFeeVault.sol";
+import { StandardBridge } from "src/universal/StandardBridge.sol";
 
 // Libraries
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract dependencies
-import { FeeVault } from "../src/universal/FeeVault.sol";
+import { FeeVault } from "src/universal/FeeVault.sol";
 
 // Target contract
-import { L1FeeVault } from "../src/L2/L1FeeVault.sol";
+import { L1FeeVault } from "src/L2/L1FeeVault.sol";
 
 // Test the implementations of the FeeVault
 contract FeeVault_Test is Bridge_Initializer {

--- a/packages/contracts-bedrock/test/GasPriceOracle.t.sol
+++ b/packages/contracts-bedrock/test/GasPriceOracle.t.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract dependencies
-import { L1Block } from "../src/L2/L1Block.sol";
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { L1Block } from "src/L2/L1Block.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract
-import { GasPriceOracle } from "../src/L2/GasPriceOracle.sol";
+import { GasPriceOracle } from "src/L2/GasPriceOracle.sol";
 
 contract GasPriceOracle_Test is CommonTest {
     event OverheadUpdated(uint256);

--- a/packages/contracts-bedrock/test/GovernanceToken.t.sol
+++ b/packages/contracts-bedrock/test/GovernanceToken.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract
-import { GovernanceToken } from "../src/governance/GovernanceToken.sol";
+import { GovernanceToken } from "src/governance/GovernanceToken.sol";
 
 contract GovernanceToken_Test is CommonTest {
     address constant owner = address(0x1234);

--- a/packages/contracts-bedrock/test/Hashing.t.sol
+++ b/packages/contracts-bedrock/test/Hashing.t.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Types } from "../src/libraries/Types.sol";
-import { Encoding } from "../src/libraries/Encoding.sol";
-import { LegacyCrossDomainUtils } from "../src/libraries/LegacyCrossDomainUtils.sol";
+import { Types } from "src/libraries/Types.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
+import { LegacyCrossDomainUtils } from "src/libraries/LegacyCrossDomainUtils.sol";
 
 // Target contract
-import { Hashing } from "../src/libraries/Hashing.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
 
 contract Hashing_hashDepositSource_Test is CommonTest {
     /// @notice Tests that hashDepositSource returns the correct hash in a simple case.

--- a/packages/contracts-bedrock/test/Helpers.sol
+++ b/packages/contracts-bedrock/test/Helpers.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.0;
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { ERC721 } from "@rari-capital/solmate/src/tokens/ERC721.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import { OptimistInviter } from "../src/periphery/op-nft/OptimistInviter.sol";
+import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
 import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ECDSAUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
-import { AdminFaucetAuthModule } from "../src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
+import { AdminFaucetAuthModule } from "src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol";
 
 contract TestERC20 is ERC20 {
     constructor() ERC20("TEST", "TST", 18) { }

--- a/packages/contracts-bedrock/test/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L1Block.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract
-import { L1Block } from "../src/L2/L1Block.sol";
+import { L1Block } from "src/L2/L1Block.sol";
 
 contract L1BlockTest is CommonTest {
     L1Block lb;

--- a/packages/contracts-bedrock/test/L1BlockNumber.t.sol
+++ b/packages/contracts-bedrock/test/L1BlockNumber.t.sol
@@ -5,11 +5,11 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 
 // Target contract dependencies
-import { L1Block } from "../src/L2/L1Block.sol";
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { L1Block } from "src/L2/L1Block.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract
-import { L1BlockNumber } from "../src/legacy/L1BlockNumber.sol";
+import { L1BlockNumber } from "src/legacy/L1BlockNumber.sol";
 
 contract L1BlockNumberTest is Test {
     L1Block lb;

--- a/packages/contracts-bedrock/test/L1CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L1CrossDomainMessenger.t.sol
@@ -2,21 +2,21 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { Messenger_Initializer, Reverter, ConfigurableCaller } from "./CommonTest.t.sol";
-import { L2OutputOracle_Initializer } from "./L2OutputOracle.t.sol";
+import { Messenger_Initializer, Reverter, ConfigurableCaller } from "test/CommonTest.t.sol";
+import { L2OutputOracle_Initializer } from "test/L2OutputOracle.t.sol";
 
 // Libraries
-import { AddressAliasHelper } from "../src/vendor/AddressAliasHelper.sol";
-import { Predeploys } from "../src/libraries/Predeploys.sol";
-import { Hashing } from "../src/libraries/Hashing.sol";
-import { Encoding } from "../src/libraries/Encoding.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 
 // Target contract dependencies
-import { L2OutputOracle } from "../src/L1/L2OutputOracle.sol";
-import { OptimismPortal } from "../src/L1/OptimismPortal.sol";
+import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { OptimismPortal } from "src/L1/OptimismPortal.sol";
 
 // Target contract
-import { L1CrossDomainMessenger } from "../src/L1/L1CrossDomainMessenger.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 
 contract L1CrossDomainMessenger_Test is Messenger_Initializer {
     /// @dev The receiver address

--- a/packages/contracts-bedrock/test/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1ERC721Bridge.t.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { ERC721Bridge_Initializer } from "./CommonTest.t.sol";
+import { ERC721Bridge_Initializer } from "test/CommonTest.t.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 // Target contract dependencies
-import { L2ERC721Bridge } from "../src/L2/L2ERC721Bridge.sol";
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { L2ERC721Bridge } from "src/L2/L2ERC721Bridge.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract
-import { L1ERC721Bridge } from "../src/L1/L1ERC721Bridge.sol";
+import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
 
 /// @dev Test ERC721 contract.
 contract TestERC721 is ERC721 {

--- a/packages/contracts-bedrock/test/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1StandardBridge.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { Bridge_Initializer } from "./CommonTest.t.sol";
+import { Bridge_Initializer } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";

--- a/packages/contracts-bedrock/test/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2CrossDomainMessenger.t.sol
@@ -2,20 +2,20 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { Messenger_Initializer, Reverter, ConfigurableCaller } from "./CommonTest.t.sol";
+import { Messenger_Initializer, Reverter, ConfigurableCaller } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Hashing } from "../src/libraries/Hashing.sol";
-import { Encoding } from "../src/libraries/Encoding.sol";
-import { Types } from "../src/libraries/Types.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
+import { Types } from "src/libraries/Types.sol";
 
 // Target contract dependencies
-import { L2ToL1MessagePasser } from "../src/L2/L2ToL1MessagePasser.sol";
-import { AddressAliasHelper } from "../src/vendor/AddressAliasHelper.sol";
-import { L1CrossDomainMessenger } from "../src/L1/L1CrossDomainMessenger.sol";
+import { L2ToL1MessagePasser } from "src/L2/L2ToL1MessagePasser.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 
 // Target contract
-import { L2CrossDomainMessenger } from "../src/L2/L2CrossDomainMessenger.sol";
+import { L2CrossDomainMessenger } from "src/L2/L2CrossDomainMessenger.sol";
 
 contract L2CrossDomainMessenger_Test is Messenger_Initializer {
     /// @dev Receiver address for testing

--- a/packages/contracts-bedrock/test/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2ERC721Bridge.t.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { ERC721Bridge_Initializer } from "./CommonTest.t.sol";
+import { ERC721Bridge_Initializer } from "test/CommonTest.t.sol";
 
 // Target contract dependencies
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import { L1ERC721Bridge } from "../src/L1/L1ERC721Bridge.sol";
-import { OptimismMintableERC721 } from "../src/universal/OptimismMintableERC721.sol";
+import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
+import { OptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";
 
 // Target contract
-import { L2ERC721Bridge } from "../src/L2/L2ERC721Bridge.sol";
+import { L2ERC721Bridge } from "src/L2/L2ERC721Bridge.sol";
 
 contract TestERC721 is ERC721 {
     constructor() ERC721("Test", "TST") { }

--- a/packages/contracts-bedrock/test/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/L2OutputOracle.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { stdError } from "forge-std/Test.sol";
-import { L2OutputOracle_Initializer, NextImpl } from "./CommonTest.t.sol";
+import { L2OutputOracle_Initializer, NextImpl } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Types } from "src/libraries/Types.sol";

--- a/packages/contracts-bedrock/test/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2StandardBridge.t.sol
@@ -3,20 +3,20 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 // Target contract is imported by the `Bridge_Initializer`
-import { Bridge_Initializer } from "./CommonTest.t.sol";
+import { Bridge_Initializer } from "test/CommonTest.t.sol";
 import { stdStorage, StdStorage } from "forge-std/Test.sol";
-import { CrossDomainMessenger } from "../src/universal/CrossDomainMessenger.sol";
-import { L2ToL1MessagePasser } from "../src/L2/L2ToL1MessagePasser.sol";
+import { CrossDomainMessenger } from "src/universal/CrossDomainMessenger.sol";
+import { L2ToL1MessagePasser } from "src/L2/L2ToL1MessagePasser.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 // Libraries
-import { Hashing } from "../src/libraries/Hashing.sol";
-import { Types } from "../src/libraries/Types.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { Types } from "src/libraries/Types.sol";
 
 // Target contract dependencies
-import { Predeploys } from "../src/libraries/Predeploys.sol";
-import { StandardBridge } from "../src/universal/StandardBridge.sol";
-import { OptimismMintableERC20 } from "../src/universal/OptimismMintableERC20.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { StandardBridge } from "src/universal/StandardBridge.sol";
+import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 
 contract L2StandardBridge_Test is Bridge_Initializer {
     using stdStorage for StdStorage;

--- a/packages/contracts-bedrock/test/L2ToL1MessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/L2ToL1MessagePasser.t.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Types } from "../src/libraries/Types.sol";
-import { Hashing } from "../src/libraries/Hashing.sol";
+import { Types } from "src/libraries/Types.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
 
 // Target contract
-import { L2ToL1MessagePasser } from "../src/L2/L2ToL1MessagePasser.sol";
+import { L2ToL1MessagePasser } from "src/L2/L2ToL1MessagePasser.sol";
 
 contract L2ToL1MessagePasserTest is CommonTest {
     L2ToL1MessagePasser messagePasser;

--- a/packages/contracts-bedrock/test/LegacyERC20ETH.t.sol
+++ b/packages/contracts-bedrock/test/LegacyERC20ETH.t.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract dependencies
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract
-import { LegacyERC20ETH } from "../src/legacy/LegacyERC20ETH.sol";
+import { LegacyERC20ETH } from "src/legacy/LegacyERC20ETH.sol";
 
 contract LegacyERC20ETH_Test is CommonTest {
     LegacyERC20ETH eth;

--- a/packages/contracts-bedrock/test/LegacyMessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/LegacyMessagePasser.t.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Testing contract dependencies
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract
-import { LegacyMessagePasser } from "../src/legacy/LegacyMessagePasser.sol";
+import { LegacyMessagePasser } from "src/legacy/LegacyMessagePasser.sol";
 
 contract LegacyMessagePasser_Test is CommonTest {
     LegacyMessagePasser messagePasser;

--- a/packages/contracts-bedrock/test/LibClock.t.sol
+++ b/packages/contracts-bedrock/test/LibClock.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { LibClock } from "../src/dispute/lib/LibClock.sol";
-import "../src/libraries/DisputeTypes.sol";
+import "src/libraries/DisputeTypes.sol";
 
 /// @notice Tests for `LibClock`
 contract LibClock_Test is Test {

--- a/packages/contracts-bedrock/test/LibPosition.t.sol
+++ b/packages/contracts-bedrock/test/LibPosition.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { LibPosition } from "../src/dispute/lib/LibPosition.sol";
-import "../src/libraries/DisputeTypes.sol";
+import "src/libraries/DisputeTypes.sol";
 
 /// @notice Tests for `LibPosition`
 contract LibPosition_Test is Test {

--- a/packages/contracts-bedrock/test/MerkleTrie.t.sol
+++ b/packages/contracts-bedrock/test/MerkleTrie.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { CommonTest } from "./CommonTest.t.sol";
-import { MerkleTrie } from "../src/libraries/trie/MerkleTrie.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
+import { MerkleTrie } from "src/libraries/trie/MerkleTrie.sol";
 
 contract MerkleTrie_get_Test is CommonTest {
     function test_get_validProof1_succeeds() external {

--- a/packages/contracts-bedrock/test/MintManager.t.sol
+++ b/packages/contracts-bedrock/test/MintManager.t.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract dependencies
-import { GovernanceToken } from "../src/governance/GovernanceToken.sol";
+import { GovernanceToken } from "src/governance/GovernanceToken.sol";
 
 // Target contract
-import { MintManager } from "../src/governance/MintManager.sol";
+import { MintManager } from "src/governance/MintManager.sol";
 
 contract MintManager_Initializer is CommonTest {
     address constant owner = address(0x1234);

--- a/packages/contracts-bedrock/test/OptimismMintableERC20.t.sol
+++ b/packages/contracts-bedrock/test/OptimismMintableERC20.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { Bridge_Initializer } from "./CommonTest.t.sol";
-import { ILegacyMintableERC20, IOptimismMintableERC20 } from "../src/universal/IOptimismMintableERC20.sol";
+import { Bridge_Initializer } from "test/CommonTest.t.sol";
+import { ILegacyMintableERC20, IOptimismMintableERC20 } from "src/universal/IOptimismMintableERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 contract OptimismMintableERC20_Test is Bridge_Initializer {

--- a/packages/contracts-bedrock/test/OptimismMintableERC20Factory.t.sol
+++ b/packages/contracts-bedrock/test/OptimismMintableERC20Factory.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { OptimismMintableERC20 } from "../src/universal/OptimismMintableERC20.sol";
-import { Bridge_Initializer } from "./CommonTest.t.sol";
+import { OptimismMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
+import { Bridge_Initializer } from "test/CommonTest.t.sol";
 
 contract OptimismMintableTokenFactory_Test is Bridge_Initializer {
     event StandardL2TokenCreated(address indexed remoteToken, address indexed localToken);

--- a/packages/contracts-bedrock/test/OptimismMintableERC721.t.sol
+++ b/packages/contracts-bedrock/test/OptimismMintableERC721.t.sol
@@ -5,8 +5,8 @@ import { ERC721, IERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol
 import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { ERC721Bridge_Initializer } from "./CommonTest.t.sol";
-import { OptimismMintableERC721, IOptimismMintableERC721 } from "../src/universal/OptimismMintableERC721.sol";
+import { ERC721Bridge_Initializer } from "test/CommonTest.t.sol";
+import { OptimismMintableERC721, IOptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";
 
 contract OptimismMintableERC721_Test is ERC721Bridge_Initializer {
     ERC721 internal L1NFT;

--- a/packages/contracts-bedrock/test/OptimismMintableERC721Factory.t.sol
+++ b/packages/contracts-bedrock/test/OptimismMintableERC721Factory.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.15;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import { ERC721Bridge_Initializer } from "./CommonTest.t.sol";
-import { OptimismMintableERC721 } from "../src/universal/OptimismMintableERC721.sol";
-import { OptimismMintableERC721Factory } from "../src/universal/OptimismMintableERC721Factory.sol";
+import { ERC721Bridge_Initializer } from "test/CommonTest.t.sol";
+import { OptimismMintableERC721 } from "src/universal/OptimismMintableERC721.sol";
+import { OptimismMintableERC721Factory } from "src/universal/OptimismMintableERC721Factory.sol";
 
 contract OptimismMintableERC721Factory_Test is ERC721Bridge_Initializer {
     OptimismMintableERC721Factory internal factory;

--- a/packages/contracts-bedrock/test/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/OptimismPortal.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { stdError } from "forge-std/Test.sol";
-import { Portal_Initializer, CommonTest, NextImpl } from "./CommonTest.t.sol";
+import { Portal_Initializer, CommonTest, NextImpl } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Types } from "src/libraries/Types.sol";

--- a/packages/contracts-bedrock/test/Optimist.t.sol
+++ b/packages/contracts-bedrock/test/Optimist.t.sol
@@ -3,11 +3,11 @@ pragma solidity >=0.6.2 <0.9.0;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
-import { AttestationStation } from "../src/periphery/op-nft/AttestationStation.sol";
-import { Optimist } from "../src/periphery/op-nft/Optimist.sol";
-import { OptimistAllowlist } from "../src/periphery/op-nft/OptimistAllowlist.sol";
-import { OptimistInviter } from "../src/periphery/op-nft/OptimistInviter.sol";
-import { OptimistInviterHelper } from "./Helpers.sol";
+import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
+import { Optimist } from "src/periphery/op-nft/Optimist.sol";
+import { OptimistAllowlist } from "src/periphery/op-nft/OptimistAllowlist.sol";
+import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
+import { OptimistInviterHelper } from "test/Helpers.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/packages/contracts-bedrock/test/OptimistAllowlist.t.sol
+++ b/packages/contracts-bedrock/test/OptimistAllowlist.t.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
-import { AttestationStation } from "../src/periphery/op-nft/AttestationStation.sol";
-import { OptimistAllowlist } from "../src/periphery/op-nft/OptimistAllowlist.sol";
-import { OptimistInviter } from "../src/periphery/op-nft/OptimistInviter.sol";
-import { OptimistInviterHelper } from "./Helpers.sol";
-import { OptimistConstants } from "../src/periphery/op-nft/libraries/OptimistConstants.sol";
+import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
+import { OptimistAllowlist } from "src/periphery/op-nft/OptimistAllowlist.sol";
+import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
+import { OptimistInviterHelper } from "test/Helpers.sol";
+import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
 
 contract OptimistAllowlist_Initializer is Test {
     event AttestationCreated(address indexed creator, address indexed about, bytes32 indexed key, bytes val);

--- a/packages/contracts-bedrock/test/OptimistInviter.t.sol
+++ b/packages/contracts-bedrock/test/OptimistInviter.t.sol
@@ -3,13 +3,13 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
-import { AttestationStation } from "../src/periphery/op-nft/AttestationStation.sol";
-import { OptimistInviter } from "../src/periphery/op-nft/OptimistInviter.sol";
-import { Optimist } from "../src/periphery/op-nft/Optimist.sol";
+import { AttestationStation } from "src/periphery/op-nft/AttestationStation.sol";
+import { OptimistInviter } from "src/periphery/op-nft/OptimistInviter.sol";
+import { Optimist } from "src/periphery/op-nft/Optimist.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { TestERC1271Wallet } from "./Helpers.sol";
-import { OptimistInviterHelper } from "./Helpers.sol";
-import { OptimistConstants } from "../src/periphery/op-nft/libraries/OptimistConstants.sol";
+import { TestERC1271Wallet } from "test/Helpers.sol";
+import { OptimistInviterHelper } from "test/Helpers.sol";
+import { OptimistConstants } from "src/periphery/op-nft/libraries/OptimistConstants.sol";
 
 contract OptimistInviter_Initializer is Test {
     event InviteClaimed(address indexed issuer, address indexed claimer);

--- a/packages/contracts-bedrock/test/ProtocolVersions.t.sol
+++ b/packages/contracts-bedrock/test/ProtocolVersions.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";

--- a/packages/contracts-bedrock/test/Proxy.t.sol
+++ b/packages/contracts-bedrock/test/Proxy.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { Proxy } from "../src/universal/Proxy.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
 
 contract SimpleStorage {

--- a/packages/contracts-bedrock/test/ProxyAdmin.t.sol
+++ b/packages/contracts-bedrock/test/ProxyAdmin.t.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { Proxy } from "../src/universal/Proxy.sol";
-import { ProxyAdmin } from "../src/universal/ProxyAdmin.sol";
-import { SimpleStorage } from "./Proxy.t.sol";
-import { L1ChugSplashProxy } from "../src/legacy/L1ChugSplashProxy.sol";
-import { ResolvedDelegateProxy } from "../src/legacy/ResolvedDelegateProxy.sol";
-import { AddressManager } from "../src/legacy/AddressManager.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+import { SimpleStorage } from "test/Proxy.t.sol";
+import { L1ChugSplashProxy } from "src/legacy/L1ChugSplashProxy.sol";
+import { ResolvedDelegateProxy } from "src/legacy/ResolvedDelegateProxy.sol";
+import { AddressManager } from "src/legacy/AddressManager.sol";
 
 contract ProxyAdmin_Test is Test {
     address alice = address(64);

--- a/packages/contracts-bedrock/test/RLPReader.t.sol
+++ b/packages/contracts-bedrock/test/RLPReader.t.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.15;
 
 import { stdError } from "forge-std/Test.sol";
-import { CommonTest } from "./CommonTest.t.sol";
-import { RLPReader } from "../src/libraries/rlp/RLPReader.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
+import { RLPReader } from "src/libraries/rlp/RLPReader.sol";
 
 contract RLPReader_readBytes_Test is CommonTest {
     function test_readBytes_bytestring00_succeeds() external {

--- a/packages/contracts-bedrock/test/RLPWriter.t.sol
+++ b/packages/contracts-bedrock/test/RLPWriter.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { RLPWriter } from "../src/libraries/rlp/RLPWriter.sol";
-import { CommonTest } from "./CommonTest.t.sol";
+import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 contract RLPWriter_writeString_Test is CommonTest {
     function test_writeString_empty_succeeds() external {

--- a/packages/contracts-bedrock/test/ResolvedDelegateProxy.t.sol
+++ b/packages/contracts-bedrock/test/ResolvedDelegateProxy.t.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 
 // Target contract dependencies
-import { AddressManager } from "../src/legacy/AddressManager.sol";
+import { AddressManager } from "src/legacy/AddressManager.sol";
 
 // Target contract
-import { ResolvedDelegateProxy } from "../src/legacy/ResolvedDelegateProxy.sol";
+import { ResolvedDelegateProxy } from "src/legacy/ResolvedDelegateProxy.sol";
 
 contract ResolvedDelegateProxy_Test is Test {
     AddressManager internal addressManager;

--- a/packages/contracts-bedrock/test/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/ResourceMetering.t.sol
@@ -5,13 +5,13 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 
 // Libraries
-import { Constants } from "../src/libraries/Constants.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Target contract dependencies
-import { Proxy } from "../src/universal/Proxy.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 
 // Target contract
-import { ResourceMetering } from "../src/L1/ResourceMetering.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 
 contract MeterUser is ResourceMetering {
     ResourceMetering.ResourceConfig public innerConfig;

--- a/packages/contracts-bedrock/test/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/SafeCall.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Target contract
-import { SafeCall } from "../src/libraries/SafeCall.sol";
+import { SafeCall } from "src/libraries/SafeCall.sol";
 
 contract SafeCall_Test is CommonTest {
     /// @dev Tests that the `send` function succeeds.

--- a/packages/contracts-bedrock/test/Semver.t.sol
+++ b/packages/contracts-bedrock/test/Semver.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { CommonTest } from "./CommonTest.t.sol";
-import { Semver } from "../src/universal/Semver.sol";
-import { Proxy } from "../src/universal/Proxy.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
+import { Semver } from "src/universal/Semver.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 
 /// @notice Test the Semver contract that is used for semantic versioning
 ///         of various contracts.

--- a/packages/contracts-bedrock/test/SequencerFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/SequencerFeeVault.t.sol
@@ -2,17 +2,17 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { FeeVault_Initializer, Reverter } from "./CommonTest.t.sol";
-import { StandardBridge } from "../src/universal/StandardBridge.sol";
+import { FeeVault_Initializer, Reverter } from "test/CommonTest.t.sol";
+import { StandardBridge } from "src/universal/StandardBridge.sol";
 
 // Libraries
-import { Predeploys } from "../src/libraries/Predeploys.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 
 // Target contract dependencies
-import { FeeVault } from "../src/universal/FeeVault.sol";
+import { FeeVault } from "src/universal/FeeVault.sol";
 
 // Target contract
-import { SequencerFeeVault } from "../src/L2/SequencerFeeVault.sol";
+import { SequencerFeeVault } from "src/L2/SequencerFeeVault.sol";
 
 contract SequencerFeeVault_Test is FeeVault_Initializer {
     /// @dev Sets up the test suite.

--- a/packages/contracts-bedrock/test/StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/StandardBridge.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { StandardBridge } from "../src/universal/StandardBridge.sol";
-import { CommonTest } from "./CommonTest.t.sol";
-import { OptimismMintableERC20, ILegacyMintableERC20 } from "../src/universal/OptimismMintableERC20.sol";
+import { StandardBridge } from "src/universal/StandardBridge.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
+import { OptimismMintableERC20, ILegacyMintableERC20 } from "src/universal/OptimismMintableERC20.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @title StandardBridgeTester

--- a/packages/contracts-bedrock/test/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/SystemConfig.t.sol
@@ -2,17 +2,17 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { CommonTest } from "./CommonTest.t.sol";
+import { CommonTest } from "test/CommonTest.t.sol";
 
 // Libraries
-import { Constants } from "../src/libraries/Constants.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Target contract dependencies
-import { ResourceMetering } from "../src/L1/ResourceMetering.sol";
-import { Proxy } from "../src/universal/Proxy.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
+import { Proxy } from "src/universal/Proxy.sol";
 
 // Target contract
-import { SystemConfig } from "../src/L1/SystemConfig.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
 
 contract SystemConfig_Init is CommonTest {
     SystemConfig sysConf;

--- a/packages/contracts-bedrock/test/Transactor.t.sol
+++ b/packages/contracts-bedrock/test/Transactor.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.15;
 
 // Testing utilities
 import { Test } from "forge-std/Test.sol";
-import { CallRecorder } from "./Helpers.sol";
-import { Reverter } from "./Helpers.sol";
-import { Transactor } from "../src/periphery/Transactor.sol";
+import { CallRecorder } from "test/Helpers.sol";
+import { Reverter } from "test/Helpers.sol";
+import { Transactor } from "src/periphery/Transactor.sol";
 
 contract Transactor_Initializer is Test {
     address alice = address(128);

--- a/packages/contracts-bedrock/test/TransferOnion.t.sol
+++ b/packages/contracts-bedrock/test/TransferOnion.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 // Target contract
-import { TransferOnion } from "../src/periphery/TransferOnion.sol";
+import { TransferOnion } from "src/periphery/TransferOnion.sol";
 
 /// @title  TransferOnionTest
 /// @notice Test coverage of TransferOnion

--- a/packages/contracts-bedrock/test/invariants/AddressAliasHelper.t.sol
+++ b/packages/contracts-bedrock/test/invariants/AddressAliasHelper.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";
-import { AddressAliasHelper } from "../../src/vendor/AddressAliasHelper.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 contract AddressAliasHelper_Converter {
     bool public failedRoundtrip;

--- a/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Eth.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 import { StdInvariant } from "forge-std/StdInvariant.sol";
-import { Burn } from "../../src/libraries/Burn.sol";
+import { Burn } from "src/libraries/Burn.sol";
 
 contract Burn_EthBurner is StdUtils {
     Vm internal vm;

--- a/packages/contracts-bedrock/test/invariants/Burn.Gas.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Burn.Gas.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 import { StdInvariant } from "forge-std/StdInvariant.sol";
-import { Burn } from "../../src/libraries/Burn.sol";
+import { Burn } from "src/libraries/Burn.sol";
 
 contract Burn_GasBurner is StdUtils {
     Vm internal vm;

--- a/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.15;
 
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { OptimismPortal } from "../../src/L1/OptimismPortal.sol";
-import { L1CrossDomainMessenger } from "../../src/L1/L1CrossDomainMessenger.sol";
-import { Messenger_Initializer } from "../CommonTest.t.sol";
-import { Types } from "../../src/libraries/Types.sol";
-import { Predeploys } from "../../src/libraries/Predeploys.sol";
-import { Constants } from "../../src/libraries/Constants.sol";
-import { Encoding } from "../../src/libraries/Encoding.sol";
-import { Hashing } from "../../src/libraries/Hashing.sol";
+import { OptimismPortal } from "src/L1/OptimismPortal.sol";
+import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
+import { Messenger_Initializer } from "test/CommonTest.t.sol";
+import { Types } from "src/libraries/Types.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { Constants } from "src/libraries/Constants.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
 
 contract RelayActor is StdUtils {
     // Storage slot of the l2Sender

--- a/packages/contracts-bedrock/test/invariants/Encoding.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Encoding.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";
-import { Encoding } from "../../src/libraries/Encoding.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 
 contract Encoding_Converter {
     bool public failedRoundtripAToB;

--- a/packages/contracts-bedrock/test/invariants/Hashing.t.sol
+++ b/packages/contracts-bedrock/test/invariants/Hashing.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";
-import { Encoding } from "../../src/libraries/Encoding.sol";
-import { Hashing } from "../../src/libraries/Hashing.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
 
 contract Hash_CrossDomainHasher {
     bool public failedCrossDomainHashHighVersion;

--- a/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import { L2OutputOracle_Initializer } from "../CommonTest.t.sol";
-import { L2OutputOracle } from "../../src/L1/L2OutputOracle.sol";
+import { L2OutputOracle_Initializer } from "test/CommonTest.t.sol";
+import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 contract L2OutputOracle_Proposer {

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
@@ -4,15 +4,15 @@ pragma solidity 0.8.15;
 import { StdUtils } from "forge-std/Test.sol";
 import { Vm } from "forge-std/Vm.sol";
 
-import { OptimismPortal } from "../../src/L1/OptimismPortal.sol";
-import { L2OutputOracle } from "../../src/L1/L2OutputOracle.sol";
-import { AddressAliasHelper } from "../../src/vendor/AddressAliasHelper.sol";
-import { SystemConfig } from "../../src/L1/SystemConfig.sol";
-import { ResourceMetering } from "../../src/L1/ResourceMetering.sol";
-import { Constants } from "../../src/libraries/Constants.sol";
+import { OptimismPortal } from "src/L1/OptimismPortal.sol";
+import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
-import { Portal_Initializer } from "../CommonTest.t.sol";
-import { Types } from "../../src/libraries/Types.sol";
+import { Portal_Initializer } from "test/CommonTest.t.sol";
+import { Types } from "src/libraries/Types.sol";
 
 contract OptimismPortal_Depositor is StdUtils, ResourceMetering {
     Vm internal vm;

--- a/packages/contracts-bedrock/test/invariants/ResourceMetering.t.sol
+++ b/packages/contracts-bedrock/test/invariants/ResourceMetering.t.sol
@@ -6,10 +6,10 @@ import { Test } from "forge-std/Test.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { StdInvariant } from "forge-std/StdInvariant.sol";
 
-import { Arithmetic } from "../../src/libraries/Arithmetic.sol";
-import { ResourceMetering } from "../../src/L1/ResourceMetering.sol";
-import { Proxy } from "../../src/universal/Proxy.sol";
-import { Constants } from "../../src/libraries/Constants.sol";
+import { Arithmetic } from "src/libraries/Arithmetic.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 contract ResourceMetering_User is StdUtils, ResourceMetering {
     bool public failedMaxGasPerBlock;

--- a/packages/contracts-bedrock/test/invariants/SafeCall.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SafeCall.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 import { Test } from "forge-std/Test.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { Vm } from "forge-std/Vm.sol";
-import { SafeCall } from "../../src/libraries/SafeCall.sol";
+import { SafeCall } from "src/libraries/SafeCall.sol";
 
 contract SafeCall_Succeeds_Invariants is Test {
     SafeCaller_Actor actor;

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.15;
 
 import { Test } from "forge-std/Test.sol";
-import { SystemConfig } from "../../src/L1/SystemConfig.sol";
-import { Proxy } from "../../src/universal/Proxy.sol";
-import { ResourceMetering } from "../../src/L1/ResourceMetering.sol";
-import { Constants } from "../../src/libraries/Constants.sol";
+import { SystemConfig } from "src/L1/SystemConfig.sol";
+import { Proxy } from "src/universal/Proxy.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 contract SystemConfig_GasLimitLowerBound_Invariant is Test {
     struct FuzzInterface {


### PR DESCRIPTION
**Description**

Migrate to the modern import style in the tests where the
path relative from the project root is used. This makes the
code much more portable and easier to modify without the dot
dot syntax. There should be very little old relative style
imports left in the codebase if any. There are no functional
changes with this commit.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

