### PR TITLE
ci: Add filters so op-stack-go-docker-build-release builds on tags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1488,6 +1488,11 @@ workflows:
               ignore: /.*/
       - docker-build: # just to warm up the cache (other jobs run in parallel)
           name: op-stack-go-docker-build-release
+          filters:
+            tags:
+              only: /^(proxyd|indexer|ci-builder|ufm-[a-z0-9\-]*|op-[a-z0-9\-]*)\/v.*/
+            branches:
+              ignore: /.*/
           docker_name: op-stack-go
           docker_tags: <<pipeline.git.revision>>
           platforms: "linux/amd64,linux/arm64"


### PR DESCRIPTION
**Description**

Fix release workflow config - one job was missing a filter so it didn't run on tag creation which blocked the rest of the pipeline.
