### PR TITLE
op-e2e: Disable cannon tests when using HTTP instead of WS

### DIFF
--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMultipleCannonGames(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -78,7 +78,7 @@ func TestMultipleCannonGames(t *testing.T) {
 }
 
 func TestMultipleGameTypes(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -277,7 +277,7 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 }
 
 func TestCannonDisputeGame(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 
 	tests := []struct {
 		name             string
@@ -328,7 +328,7 @@ func TestCannonDisputeGame(t *testing.T) {
 }
 
 func TestCannonDefendStep(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -370,7 +370,7 @@ func TestCannonDefendStep(t *testing.T) {
 }
 
 func TestCannonProposedOutputRootInvalid(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
 	honestStepsFail := func(ctx context.Context, game *disputegame.CannonGameHelper, correctTrace *disputegame.HonestHelper, parentClaimIdx int64) {
 		// Attack step should fail
@@ -448,7 +448,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 }
 
 func TestCannonPoisonedPostState(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -558,7 +558,7 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 }
 
 func TestCannonChallengeWithCorrectRoot(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, SkipIfHTTP)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)

--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -7,9 +7,18 @@ import (
 
 var enableParallelTesting bool = os.Getenv("OP_E2E_DISABLE_PARALLEL") != "true"
 
-func InitParallel(t *testing.T) {
+func InitParallel(t *testing.T, opts ...func(t *testing.T)) {
 	t.Helper()
 	if enableParallelTesting {
 		t.Parallel()
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+}
+
+func SkipIfHTTP(t *testing.T) {
+	if UseHTTP() {
+		t.Skip("Skipping test because HTTP connection is in use")
 	}
 }

--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -102,7 +102,7 @@ func NewOpGeth(t *testing.T, ctx context.Context, cfg *SystemConfig) (*OpGeth, e
 	)
 	require.Nil(t, err)
 
-	l2Client, err := ethclient.Dial(node.HTTPEndpoint())
+	l2Client, err := ethclient.Dial(selectEndpoint(node))
 	require.Nil(t, err)
 
 	genesisPayload, err := eth.BlockAsPayload(l2GenesisBlock, cfg.DeployConfig.CanyonTime(l2GenesisBlock.Time()))

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -758,9 +758,12 @@ func (sys *System) newMockNetPeer() (host.Host, error) {
 	return sys.Mocknet.AddPeerWithPeerstore(p, eps)
 }
 
+func UseHTTP() bool {
+	return os.Getenv("OP_E2E_USE_HTTP") == "true"
+}
+
 func selectEndpoint(node EthInstance) string {
-	useHTTP := os.Getenv("OP_E2E_USE_HTTP") == "true"
-	if useHTTP {
+	if UseHTTP() {
 		log.Info("using HTTP client")
 		return node.HTTPEndpoint()
 	}
@@ -785,9 +788,8 @@ type WSOrHTTPEndpoint interface {
 }
 
 func configureL2(rollupNodeCfg *rollupNode.Config, l2Node WSOrHTTPEndpoint, jwtSecret [32]byte) {
-	useHTTP := os.Getenv("OP_E2E_USE_HTTP") == "true"
 	l2EndpointConfig := l2Node.WSAuthEndpoint()
-	if useHTTP {
+	if UseHTTP() {
 		l2EndpointConfig = l2Node.HTTPAuthEndpoint()
 	}
 


### PR DESCRIPTION
**Description**

Fault dispute tests take longer to execute when polling with HTTP so disable the longer running cannon tests on HTTP. Cannon itself is unaffected by the connection type and the challenger is tested with HTTP via the alphabet game tests.

Should shave a few minutes off total CI time since op-e2e-HTTP-tests is currently the longest running task.

Introduces varargs options to the `InitParallel` call that every e2e test makes so it's really simple to add future options like this while keeping the tests really simple.