### PR TITLE
ci: Configure docker auth before attempting to publish.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
 
             export REGISTRY="<<parameters.registry>>"
             export REPOSITORY="<<parameters.repo>>"
-            export IMAGE_TAGS="$(echo -ne "<<parameters.docker_tags>>" | sed "s/[^a-zA-Z0-9\n,./]/-/g")"
+            export IMAGE_TAGS="$(echo -ne "<<parameters.docker_tags>>" | sed "s/[^a-zA-Z0-9\n,]/-/g")"
             export GIT_COMMIT="$(git rev-parse HEAD)"
             export GIT_DATE="$(git show -s --format='%ct')"
             export GIT_VERSION="<<pipeline.git.tag>>"
@@ -1493,7 +1493,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: op-heartbeat
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           requires: ['op-stack-go-docker-build-release']
           platforms: "linux/amd64,linux/arm64"
           publish: true
@@ -1508,7 +1508,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: op-node
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           requires: ['op-stack-go-docker-build-release']
           platforms: "linux/amd64,linux/arm64"
           publish: true
@@ -1523,7 +1523,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: op-batcher
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           requires: ['op-stack-go-docker-build-release']
           platforms: "linux/amd64,linux/arm64"
           publish: true
@@ -1538,7 +1538,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: op-proposer
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           requires: ['op-stack-go-docker-build-release']
           platforms: "linux/amd64,linux/arm64"
           publish: true
@@ -1553,7 +1553,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: op-challenger
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           requires: ['op-stack-go-docker-build-release']
           platforms: "linux/amd64,linux/arm64"
           publish: true
@@ -1568,7 +1568,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: op-ufm
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           publish: true
           release: true
           context:
@@ -1583,7 +1583,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: proxyd
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           publish: true
           release: true
           context:
@@ -1598,7 +1598,7 @@ workflows:
             branches:
               ignore: /.*/
           docker_name: indexer
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
+          docker_tags: <<pipeline.git.revision>>
           publish: true
           release: true
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
 
             export REGISTRY="<<parameters.registry>>"
             export REPOSITORY="<<parameters.repo>>"
-            export IMAGE_TAGS="$(echo -ne "<<parameters.docker_tags>>" | sed "s/[^a-zA-Z0-9\n,]/-/g")"
+            export IMAGE_TAGS="$(echo -ne "<<parameters.docker_tags>>" | sed "s/[^a-zA-Z0-9\n,./]/-/g")"
             export GIT_COMMIT="$(git rev-parse HEAD)"
             export GIT_DATE="$(git show -s --format='%ct')"
             export GIT_VERSION="<<pipeline.git.tag>>"
@@ -272,20 +272,6 @@ jobs:
                 root: /tmp/docker_images
                 paths:  # only write the one file, to avoid concurrent workspace-file additions
                   - "<<parameters.docker_name>>.tar"
-      - when:
-          condition: "<<parameters.publish>>"
-          steps:
-            - run:
-                name: Publish
-                command: |
-                  gcloud auth configure-docker <<parameters.registry>>
-                  IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-                  # tags, without the '-t ' here, so we can loop over them
-                  DOCKER_TAGS="$(echo -ne "<<parameters.docker_tags>>" | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n]/-/g" | sed -e "s|^|${IMAGE_BASE}:|")"
-                  for docker_image_tag in $DOCKER_TAGS; do
-                    docker image push $docker_image_tag
-                  done
-                no_output_timeout: 45m
       - when:
           condition: "<<parameters.release>>"
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,7 @@ jobs:
 
             DOCKER_OUTPUT_DESTINATION=""
             if [ "<<parameters.publish>>" == "true" ]; then
+              gcloud auth configure-docker <<parameters.registry>>
               echo "Building for platforms $PLATFORMS and then publishing to registry"
               DOCKER_OUTPUT_DESTINATION="--push"
               if [ "<<parameters.save_image_tag>>" != "" ]; then


### PR DESCRIPTION
**Description**

The docker buildx step now does the initial publish (only when configured to as part of release or publish pipelines) and so it needs to have the gcloud config setup for docker before that happens, not just before the extra tags are published.
