### PR TITLE
op-e2e: Use a short wait for new claim when performing all possible dishonest moves

### DIFF
--- a/op-e2e/e2eutils/disputegame/dishonest_helper.go
+++ b/op-e2e/e2eutils/disputegame/dishonest_helper.go
@@ -3,6 +3,7 @@ package disputegame
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -96,7 +97,9 @@ func (d *DishonestHelper) ExhaustDishonestClaims(ctx context.Context) {
 
 	var numClaimsSeen int64
 	for {
-		newCount, err := d.WaitForNewClaim(ctx, numClaimsSeen)
+		// Use a short timeout since we don't know the challenger will respond,
+		// and this is only designed for the alphabet game where the response should be fast.
+		newCount, err := d.waitForNewClaim(ctx, numClaimsSeen, 30*time.Second)
 		if errors.Is(err, context.DeadlineExceeded) {
 			// we assume that the honest challenger has stopped responding
 			// There's nothing to respond to.

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -304,7 +304,10 @@ func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mo
 }
 
 func (g *FaultGameHelper) WaitForNewClaim(ctx context.Context, checkPoint int64) (int64, error) {
-	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	return g.waitForNewClaim(ctx, checkPoint, defaultTimeout)
+}
+func (g *FaultGameHelper) waitForNewClaim(ctx context.Context, checkPoint int64, timeout time.Duration) (int64, error) {
+	timedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	var newClaimLen int64
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {


### PR DESCRIPTION
**Description**

The timeout is expected to be reached sometimes because the challenger has chosen not to respond, so we don't want the default long timeout. Previously it would sit idle for 5 minutes before completely and that's now reduced to just 30 seconds.  The short timeout is reasonable for the alphabet game where responses can be made very quickly - cannon is too expensive to use this particular helper with anyway.
