### PR TITLE
ci-builder: go version env var

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -39,7 +39,7 @@ ENV GO_VERSION=1.21.1
 
 # Fetch go manually, rather than using a Go base image, so we can copy the installation into the final stage
 RUN curl -sL https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz -o go$GO_VERSION.linux-amd64.tar.gz && \
-  tar -C /usr/local/ -xzvf go1.21.1.linux-amd64.tar.gz
+  tar -C /usr/local/ -xzvf go$GO_VERSION.linux-amd64.tar.gz
 
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
**Description**

Makes setting the go version via the env var `GO_VERSION` possible.
Previously it hardcoded the version that it was unpacking but used
the env var in other locations. Now setting the env var for `GO_VERSION`
will allow the user to configure whatever version they want to include
in the image.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
