### PR TITLE
ci: Notify slack when semgrep or docker publish fails on develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,19 @@ commands:
             cd ops/check-changed
             pip3 install -r requirements.txt
             python3 main.py "<<parameters.patterns>>"
+  notify-failures-on-develop:
+    description: "Notify Slack"
+    parameters:
+      channel:
+        type: string
+        default: C03N11M0BBN
+    steps:
+      - slack/notify:
+          channel: << parameters.channel >>
+          event: fail
+          template: basic_fail_1
+          branch_pattern: develop
+
 jobs:
   cannon-go-lint-and-test:
     docker:
@@ -260,6 +273,10 @@ jobs:
               <<parameters.docker_name>>
 
           no_output_timeout: 45m
+      - when:
+          condition: "<<parameters.publish>>"
+          steps:
+            - notify-failures-on-develop
       - when:
           condition: "<<parameters.save_image_tag>>"
           steps:
@@ -585,10 +602,7 @@ jobs:
       - run:
           name: Check TODO issues
           command: ./ops/scripts/todo-checker.sh --verbose
-      - slack/notify:
-          channel: C03N11M0BBN
-          event: fail
-          template: basic_fail_1
+      - notify-failures-on-develop
 
   bedrock-markdown:
     machine:
@@ -632,10 +646,8 @@ jobs:
           name: link lint
           command: |
             make bedrock-markdown-links
-      - slack/notify:
+      - notify-failures-on-develop:
           channel: C055R639XT9 #notify-link-check
-          event: fail
-          template: basic_fail_1
 
   fuzz-golang:
     parameters:
@@ -1114,6 +1126,7 @@ jobs:
       - run:
           name: "Semgrep scan"
           command: semgrep ci
+      - notify-failures-on-develop
 
   go-mod-download:
     docker:
@@ -1173,10 +1186,7 @@ jobs:
           command: |
             make verify-goerli
           working_directory: op-program
-      - slack/notify:
-          channel: C03N11M0BBN
-          event: fail
-          template: basic_fail_1
+      - notify-failures-on-develop
 
   op-program-compat:
     docker:
@@ -1672,6 +1682,7 @@ workflows:
           platforms: "linux/amd64,linux/arm64"
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: op-node-docker-publish
           docker_name: op-node
@@ -1681,6 +1692,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: op-batcher-docker-publish
           docker_name: op-batcher
@@ -1690,6 +1702,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: op-program-docker-publish
           docker_name: op-program
@@ -1699,6 +1712,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: op-proposer-docker-publish
           docker_name: op-proposer
@@ -1708,6 +1722,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: op-challenger-docker-publish
           docker_name: op-challenger
@@ -1717,6 +1732,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: op-heartbeat-docker-publish
           docker_name: op-heartbeat
@@ -1726,6 +1742,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: indexer-docker-publish
           docker_name: indexer
@@ -1733,6 +1750,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
           platforms: "linux/amd64,linux/arm64"
       - docker-build:
           name: chain-mon-docker-publish
@@ -1741,6 +1759,7 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack
       - docker-build:
           name: ufm-metamask-docker-publish
           docker_name: ufm-metamask
@@ -1748,3 +1767,4 @@ workflows:
           publish: true
           context:
             - oplabs-gcr
+            - slack


### PR DESCRIPTION
**Description**

Adds a slack notification step to semgrep and docker publishing. Will only notify when there is a failure and the job is running on the `develop` branch.  This picks up the regular scheduled docker jobs as well as when semgrep starts failing on develop branch.
