### PR TITLE
op-e2e: Disable cannon tests for external geth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,6 +772,10 @@ jobs:
       target:
         description: The make target to execute
         type: string
+      cannon_enabled:
+        description: Whether to include cannon tests
+        default: true
+        type: boolean
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     resource_class: xlarge
@@ -797,7 +801,8 @@ jobs:
           command: go tool dist list | grep mips
       - run:
           name: run tests
-          command:
+          command: |
+            export OP_E2E_CANNON_ENABLED="<<parameters.cannon_enabled>>"
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
             JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>>
@@ -1361,6 +1366,7 @@ workflows:
           name: op-e2e-HTTP-tests
           module: op-e2e
           target: test-http
+          cannon_enabled: false
           requires:
             - op-stack-go-lint
             - devnet-allocs
@@ -1368,6 +1374,7 @@ workflows:
           name: op-e2e-ext-geth-tests
           module: op-e2e
           target: test-external-geth
+          cannon_enabled: false
           requires:
             - op-stack-go-lint
             - devnet-allocs

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMultipleCannonGames(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -78,7 +78,7 @@ func TestMultipleCannonGames(t *testing.T) {
 }
 
 func TestMultipleGameTypes(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -277,7 +277,7 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 }
 
 func TestCannonDisputeGame(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 
 	tests := []struct {
 		name             string
@@ -328,7 +328,7 @@ func TestCannonDisputeGame(t *testing.T) {
 }
 
 func TestCannonDefendStep(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -370,7 +370,7 @@ func TestCannonDefendStep(t *testing.T) {
 }
 
 func TestCannonProposedOutputRootInvalid(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
 	honestStepsFail := func(ctx context.Context, game *disputegame.CannonGameHelper, correctTrace *disputegame.HonestHelper, parentClaimIdx int64) {
 		// Attack step should fail
@@ -448,7 +448,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 }
 
 func TestCannonPoisonedPostState(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -558,7 +558,7 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 }
 
 func TestCannonChallengeWithCorrectRoot(t *testing.T) {
-	InitParallel(t, SkipIfHTTP)
+	InitParallel(t, UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)

--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -17,8 +17,8 @@ func InitParallel(t *testing.T, opts ...func(t *testing.T)) {
 	}
 }
 
-func SkipIfHTTP(t *testing.T) {
-	if UseHTTP() {
-		t.Skip("Skipping test because HTTP connection is in use")
+func UsesCannon(t *testing.T) {
+	if os.Getenv("OP_E2E_CANNON_ENABLED") == "false" {
+		t.Skip("Skipping cannon test")
 	}
 }


### PR DESCRIPTION
**Description**

Moves choice of running cannon tests to a separate env var rather so it is possible to run cannon tests with HTTP when desired.

Should shave another couple of minutes off CI runtime. The alphabet tests still ensure the challenger works and cannon only works with geth as it requires access to `debug_dbGet` so this also makes it easier for alt clients to disable the cannon tests which won't work with their client.
