### PR TITLE
Missing envvars setting for --override.canyon flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -254,9 +254,10 @@ var (
 		EnvVars: prefixEnvVars("ROLLUP_LOAD_PROTOCOL_VERSIONS"),
 	}
 	CanyonOverrideFlag = &cli.Uint64Flag{
-		Name:   "override.canyon",
-		Usage:  "Manually specify the Canyon fork timestamp, overriding the bundled setting",
-		Hidden: false,
+		Name:    "override.canyon",
+		Usage:   "Manually specify the Canyon fork timestamp, overriding the bundled setting",
+		EnvVars: prefixEnvVars("OVERRIDE_CANYON"),
+		Hidden:  false,
 	}
 )
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds missing envvars setting for the `--override.canyon` flag.

**Tests**

No tests added, small bugfix.

**Additional context**

We'd like to use this for our sepolia devnet which hasn't been added to the superchain registry yet. Also we use envvars rather than flags.