### PR TITLE
op-e2e: Wait for external clients to terminate after Kill()

### DIFF
--- a/op-e2e/external.go
+++ b/op-e2e/external.go
@@ -2,6 +2,7 @@ package op_e2e
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
 	"os"
 	"os/exec"
@@ -51,6 +52,11 @@ func (eec *ExternalEthClient) Close() error {
 	select {
 	case <-time.After(5 * time.Second):
 		eec.Session.Kill()
+		select {
+		case <-time.After(30 * time.Second):
+			return errors.New("external client failed to terminate")
+		case <-eec.Session.Exited:
+		}
 	case <-eec.Session.Exited:
 	}
 	return nil


### PR DESCRIPTION
**Description**

Fixes flaky tests where the data directory can't be deleted because the client is still writing to it. Mostly this is just because the 5 second timeout for a clean shutdown is quite short, but we don't want to waste time waiting for shutdown given the data dir is just going to be deleted anyway, so keep escalating to `Kill()` quickly, but then actually wait for the process to exit after that.
