### PR TITLE
op-e2e: Split e2e tests into two executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,6 +779,12 @@ jobs:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
     resource_class: xlarge
+    # Note: Tests are split between runs manually.
+    # Tests default to run on the first executor but can be moved to the second with:
+    # InitParallel(t, UseExecutor(1))
+    # Any tests assigned to an executor greater than the number available automatically use the last executor.
+    # Executor indexes start from 0
+    parallelism: 2
     steps:
       - checkout
       - check-changed:

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -559,9 +559,6 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 
 func TestCannonChallengeWithCorrectRoot(t *testing.T) {
 	InitParallel(t, UsesCannon, UseExecutor(0))
-	if true {
-		return
-	}
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMultipleCannonGames(t *testing.T) {
-	InitParallel(t, UsesCannon, UseExecutor(1))
+	InitParallel(t, UsesCannon, UseExecutor(0))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -78,7 +78,7 @@ func TestMultipleCannonGames(t *testing.T) {
 }
 
 func TestMultipleGameTypes(t *testing.T) {
-	InitParallel(t, UsesCannon, UseExecutor(1))
+	InitParallel(t, UsesCannon, UseExecutor(0))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -370,7 +370,7 @@ func TestCannonDefendStep(t *testing.T) {
 }
 
 func TestCannonProposedOutputRootInvalid(t *testing.T) {
-	InitParallel(t, UsesCannon, UseExecutor(1))
+	InitParallel(t, UsesCannon, UseExecutor(0))
 	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
 	honestStepsFail := func(ctx context.Context, game *disputegame.CannonGameHelper, correctTrace *disputegame.HonestHelper, parentClaimIdx int64) {
 		// Attack step should fail
@@ -421,7 +421,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			InitParallel(t, UseExecutor(1))
+			InitParallel(t, UseExecutor(0))
 
 			ctx := context.Background()
 			sys, l1Client, game, correctTrace := setupDisputeGameForInvalidOutputRoot(t, test.outputRoot)
@@ -448,7 +448,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 }
 
 func TestCannonPoisonedPostState(t *testing.T) {
-	InitParallel(t, UsesCannon, UseExecutor(1))
+	InitParallel(t, UsesCannon, UseExecutor(0))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -558,7 +558,7 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 }
 
 func TestCannonChallengeWithCorrectRoot(t *testing.T) {
-	InitParallel(t, UsesCannon, UseExecutor(1))
+	InitParallel(t, UsesCannon, UseExecutor(0))
 	if true {
 		return
 	}

--- a/op-e2e/faultproof_test.go
+++ b/op-e2e/faultproof_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMultipleCannonGames(t *testing.T) {
-	InitParallel(t, UsesCannon)
+	InitParallel(t, UsesCannon, UseExecutor(1))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -78,7 +78,7 @@ func TestMultipleCannonGames(t *testing.T) {
 }
 
 func TestMultipleGameTypes(t *testing.T) {
-	InitParallel(t, UsesCannon)
+	InitParallel(t, UsesCannon, UseExecutor(1))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -113,7 +113,7 @@ func TestMultipleGameTypes(t *testing.T) {
 }
 
 func TestChallengerCompleteDisputeGame(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, UseExecutor(1))
 
 	tests := []struct {
 		name              string
@@ -182,7 +182,7 @@ func TestChallengerCompleteDisputeGame(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			InitParallel(t)
+			InitParallel(t, UseExecutor(1))
 
 			ctx := context.Background()
 			sys, l1Client := startFaultDisputeSystem(t)
@@ -219,7 +219,7 @@ func TestChallengerCompleteDisputeGame(t *testing.T) {
 }
 
 func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
-	InitParallel(t)
+	InitParallel(t, UseExecutor(1))
 
 	testCase := func(t *testing.T, isRootCorrect bool) {
 		ctx := context.Background()
@@ -267,17 +267,17 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 	}
 
 	t.Run("RootCorrect", func(t *testing.T) {
-		InitParallel(t)
+		InitParallel(t, UseExecutor(1))
 		testCase(t, true)
 	})
 	t.Run("RootIncorrect", func(t *testing.T) {
-		InitParallel(t)
+		InitParallel(t, UseExecutor(1))
 		testCase(t, false)
 	})
 }
 
 func TestCannonDisputeGame(t *testing.T) {
-	InitParallel(t, UsesCannon)
+	InitParallel(t, UsesCannon, UseExecutor(1))
 
 	tests := []struct {
 		name             string
@@ -290,7 +290,7 @@ func TestCannonDisputeGame(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			InitParallel(t)
+			InitParallel(t, UseExecutor(1))
 
 			ctx := context.Background()
 			sys, l1Client := startFaultDisputeSystem(t)
@@ -328,7 +328,7 @@ func TestCannonDisputeGame(t *testing.T) {
 }
 
 func TestCannonDefendStep(t *testing.T) {
-	InitParallel(t, UsesCannon)
+	InitParallel(t, UsesCannon, UseExecutor(1))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -370,7 +370,7 @@ func TestCannonDefendStep(t *testing.T) {
 }
 
 func TestCannonProposedOutputRootInvalid(t *testing.T) {
-	InitParallel(t, UsesCannon)
+	InitParallel(t, UsesCannon, UseExecutor(1))
 	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
 	honestStepsFail := func(ctx context.Context, game *disputegame.CannonGameHelper, correctTrace *disputegame.HonestHelper, parentClaimIdx int64) {
 		// Attack step should fail
@@ -421,7 +421,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			InitParallel(t)
+			InitParallel(t, UseExecutor(1))
 
 			ctx := context.Background()
 			sys, l1Client, game, correctTrace := setupDisputeGameForInvalidOutputRoot(t, test.outputRoot)
@@ -448,7 +448,7 @@ func TestCannonProposedOutputRootInvalid(t *testing.T) {
 }
 
 func TestCannonPoisonedPostState(t *testing.T) {
-	InitParallel(t, UsesCannon)
+	InitParallel(t, UsesCannon, UseExecutor(1))
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -558,8 +558,10 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 }
 
 func TestCannonChallengeWithCorrectRoot(t *testing.T) {
-	InitParallel(t, UsesCannon)
-
+	InitParallel(t, UsesCannon, UseExecutor(1))
+	if true {
+		return
+	}
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)

--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -9,7 +9,7 @@ import (
 var enableParallelTesting bool = os.Getenv("OP_E2E_DISABLE_PARALLEL") != "true"
 
 type testopts struct {
-	executor int
+	executor uint64
 }
 
 func InitParallel(t *testing.T, args ...func(t *testing.T, opts *testopts)) {
@@ -37,13 +37,13 @@ func UsesCannon(t *testing.T, opts *testopts) {
 // InitParallel(t, UseExecutor(1))
 // Any tests assigned to an executor greater than the number available automatically use the last executor.
 // Executor indexes start from 0
-func UseExecutor(assignedIdx int) func(t *testing.T, opts *testopts) {
+func UseExecutor(assignedIdx uint64) func(t *testing.T, opts *testopts) {
 	return func(t *testing.T, opts *testopts) {
 		opts.executor = assignedIdx
 	}
 }
 
-func checkExecutor(t *testing.T, assignedIdx int) {
+func checkExecutor(t *testing.T, assignedIdx uint64) {
 	envTotal := os.Getenv("CIRCLE_NODE_TOTAL")
 	envIdx := os.Getenv("CIRCLE_NODE_INDEX")
 	if envTotal == "" || envIdx == "" {
@@ -51,11 +51,11 @@ func checkExecutor(t *testing.T, assignedIdx int) {
 		t.Logf("Running test. Test splitting not in use.")
 		return
 	}
-	total, err := strconv.Atoi(envTotal)
+	total, err := strconv.ParseUint(envTotal, 10, 0)
 	if err != nil {
 		t.Fatalf("Could not parse CIRCLE_NODE_TOTAL env var %v: %v", envTotal, err)
 	}
-	idx, err := strconv.Atoi(envIdx)
+	idx, err := strconv.ParseUint(envIdx, 10, 0)
 	if err != nil {
 		t.Fatalf("Could not parse CIRCLE_NODE_INDEX env var %v: %v", envIdx, err)
 	}

--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -2,23 +2,70 @@ package op_e2e
 
 import (
 	"os"
+	"strconv"
 	"testing"
 )
 
 var enableParallelTesting bool = os.Getenv("OP_E2E_DISABLE_PARALLEL") != "true"
 
-func InitParallel(t *testing.T, opts ...func(t *testing.T)) {
+type testopts struct {
+	executor int
+}
+
+func InitParallel(t *testing.T, args ...func(t *testing.T, opts *testopts)) {
 	t.Helper()
 	if enableParallelTesting {
 		t.Parallel()
 	}
-	for _, opt := range opts {
-		opt(t)
+
+	opts := &testopts{}
+	for _, arg := range args {
+		arg(t, opts)
 	}
+	checkExecutor(t, opts.executor)
 }
 
-func UsesCannon(t *testing.T) {
+func UsesCannon(t *testing.T, opts *testopts) {
 	if os.Getenv("OP_E2E_CANNON_ENABLED") == "false" {
 		t.Skip("Skipping cannon test")
 	}
+}
+
+//	UseExecutor allows manually splitting tests between circleci executors
+//
+// Tests default to run on the first executor but can be moved to the second with:
+// InitParallel(t, UseExecutor(1))
+// Any tests assigned to an executor greater than the number available automatically use the last executor.
+// Executor indexes start from 0
+func UseExecutor(assignedIdx int) func(t *testing.T, opts *testopts) {
+	return func(t *testing.T, opts *testopts) {
+		opts.executor = assignedIdx
+	}
+}
+
+func checkExecutor(t *testing.T, assignedIdx int) {
+	envTotal := os.Getenv("CIRCLE_NODE_TOTAL")
+	envIdx := os.Getenv("CIRCLE_NODE_INDEX")
+	if envTotal == "" || envIdx == "" {
+		// Not using test splitting, so ignore assigned executor
+		t.Logf("Running test. Test splitting not in use.")
+		return
+	}
+	total, err := strconv.Atoi(envTotal)
+	if err != nil {
+		t.Fatalf("Could not parse CIRCLE_NODE_TOTAL env var %v: %v", envTotal, err)
+	}
+	idx, err := strconv.Atoi(envIdx)
+	if err != nil {
+		t.Fatalf("Could not parse CIRCLE_NODE_INDEX env var %v: %v", envIdx, err)
+	}
+	if assignedIdx >= total && idx == total-1 {
+		t.Logf("Running test. Current executor (%v) is the last executor and assigned executor (%v) >= total executors (%v).", idx, assignedIdx, total)
+		return
+	}
+	if idx == assignedIdx {
+		t.Logf("Running test. Assigned executor (%v) matches current executor (%v) of total (%v)", assignedIdx, idx, total)
+		return
+	}
+	t.Skipf("Skipping test. Assigned executor %v, current executor %v of total %v", assignedIdx, idx, total)
 }


### PR DESCRIPTION
**Description**

Uses circleci `parallelism` option to start two parallel executors for each e2e job. Tests are split between executors manually using the `UseExecutor` option to `InitParallel`.  The `go test` invocation still executes every test, but we skip the ones that shouldn't have been run on this executor.

This is primitive but effective...  Ideally we'd use `circleci test split` to allocate individual test methods intelligently based on the time they last took to execute but there's a fair bit of complexity to getting that to work correctly with `go test` and having the test names match up correctly with the junit xml generated by `gotestsum`. It would be good to move to that in the future, but the primitive approach can give us a quick win now and significantly reduce CI build times.  We'll just have to rebalance things manually as the e2e tests change to keep the two executors roughly evenly loaded.

The initial approach allocates the fault proof tests to the second executor but this will be wildly out of balance for http and external-geth tests because the cannon tests are skipped. But it's a starting point to get an idea of the run times and the e2e-ws-tests are currently our longest running tests by quite a way and will benefit from this.

To ensure all tests run even if we screw up the configuration:
* No tests are skipped if the env vars CircleCI sets when running multiple executors aren't set
* All tests fail if the env vars are set but can't be parsed to a uint.
* Tests default to the 0 executor if not set
* Tests that assign themselves to an executor that doesn't exist (ie >= executor count) run on the last executor.