### PR TITLE
(fix)indexer: add timestamp to op-indexer withdrawals response

### DIFF
--- a/indexer/api/routes/withdrawals.go
+++ b/indexer/api/routes/withdrawals.go
@@ -16,6 +16,7 @@ func newWithdrawalResponse(withdrawals *database.L2BridgeWithdrawalsResponse) mo
 		item := models.WithdrawalItem{
 			Guid:                 withdrawal.L2BridgeWithdrawal.TransactionWithdrawalHash.String(),
 			L2BlockHash:          withdrawal.L2BlockHash.String(),
+			Timestamp:            withdrawal.L2BridgeWithdrawal.Tx.Timestamp,
 			From:                 withdrawal.L2BridgeWithdrawal.Tx.FromAddress.String(),
 			To:                   withdrawal.L2BridgeWithdrawal.Tx.ToAddress.String(),
 			TransactionHash:      withdrawal.L2TransactionHash.String(),


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

add l2 transaction timestamp to op indexer withdrawals response (currently missing)