### PR TITLE
ci: enable codecov comments for contracts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,12 @@
-comment: false
+codecov:
+  require_ci_to_pass: false
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  flags:
+    - contracts-bedrock-tests
+
 ignore:
   - "op-e2e"
   - "**/*.t.sol"
@@ -13,6 +21,7 @@ coverage:
         threshold: 0% # coverage is not allowed to reduce vs. the PR base
         base: auto
         informational: true
+        enabled: true
     project:
       default:
         informational: true


### PR DESCRIPTION
Leaving codecov comments disabled for Go code is intentional. See https://github.com/ethereum-optimism/optimism/pull/7900 for an example of this in action.
Codecov isn't yet added to the github check. All this change sets up is codecov comments.