### PR TITLE
fix(ci): Pin nightly commit in `foundry` for devnet job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -989,7 +989,7 @@ jobs:
           command: |
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
-            foundryup
+            foundryup --version nightly-aa257c2fb50814dfc5da4b3688cd3b95b5e3844d
             echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
             source $HOME/.bashrc
             forge --version


### PR DESCRIPTION
## Overview

The `foundryup` script is currently broken for the [pinned nightly release](https://github.com/foundry-rs/foundry/releases/tag/nightly). 

It's currently trying to append a sha hash of the nightly commit for the default `nightly` build tag, where there is none (see: [here](https://github.com/foundry-rs/foundry/blob/master/foundryup/foundryup#L86-L92)). For now, we can just pin the `devnet` CI job's version to a newer `nightly` build to get the prebuilt binaries in the job.