### PR TITLE
chore: Remove version pin on `foundryup` in devnet job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -989,7 +989,7 @@ jobs:
           command: |
             curl -L https://foundry.paradigm.xyz | bash
             source $HOME/.bashrc
-            foundryup --version nightly-aa257c2fb50814dfc5da4b3688cd3b95b5e3844d
+            foundryup
             echo 'export PATH=$HOME/.foundry/bin:$PATH' >> $BASH_ENV
             source $HOME/.bashrc
             forge --version


### PR DESCRIPTION
# Overview

Upstream fix for `foundryup` has been merged (https://github.com/foundry-rs/foundry/pull/6155), can remove the explicit pin in the `devnet` job.