### PR TITLE
ci-builder: include solc 0.8.19

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -103,7 +103,8 @@ RUN /bin/sh -c set -eux; \
 RUN npm i -g pnpm && npm i -g yarn@1 && pnpm --version && yarn --version
 
 RUN svm install 0.5.17 && \
-  svm install 0.8.15
+  svm install 0.8.15 && \
+  svm install 0.8.19
 
 RUN echo "downloading and verifying Codecov uploader" && \
   curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import && \


### PR DESCRIPTION
**Description**

The other 2 compiler versions are included in `ci-builder` so we should
also include `0.8.19`. This will save us from needing to download the
compiler in CI many times.

The following lines are logged in CI:

```
3[2K[⠆]3[2Ktalling solc version 0.8.19[⠰]3[2Ktalling solc version 0.8.19[⠔] Installing solc version 0.8.19
3[2K[⠒]3[2Kcessfully installed solc 0.8.19[⠑] Successfully installed solc 0.8.19
```

These lines are not logged for the other 2 solc versions that are
included in `ci-builder` because they are already downloaded.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
