### PR TITLE
ci: disable codecov comments on zero diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,9 +770,10 @@ jobs:
           key: golang-build-cache-<<parameters.module>>
           paths:
             - "/root/.cache/go-build"
-      - run:
-          name: upload coverage
-          command: codecov --verbose --clean --flags bedrock-go-tests
+      # TODO(CLI-148): Fix codecov
+      #- run:
+          #name: upload coverage
+          #command: codecov --verbose --clean --flags bedrock-go-tests
       - store_test_results:
           path: /tmp/test-results
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ codecov:
 comment:
   layout: "diff, flags, files"
   behavior: default
-  require_changes: false
+  require_changes: true
   flags:
     - contracts-bedrock-tests
 


### PR DESCRIPTION
Avoid codecov comments such as:
> We're currently processing your upload. This comment will be updated when the results are available.

when there's no diff in coverage.

This patch also disables Go codecov to avoid spurious diffs due to non-deterministic codecov reports. Go codecov will be fixed later.