### PR TITLE
fix(fm-test-services): Use lockfile in docker test

### DIFF
--- a/ufm-test-services/metamask/Dockerfile
+++ b/ufm-test-services/metamask/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /app
 # Update PATH
 ENV PATH /app/node_modules/.bin:$PATH
 
+RUN npm i -g pnpm
+
 RUN if [ "$METAMASK_PLAYWRIGHT_RUN_HEADLESS" != "false" ]; then \
         apt-get update && \
         apt-get install -y xvfb && \
@@ -14,8 +16,8 @@ RUN if [ "$METAMASK_PLAYWRIGHT_RUN_HEADLESS" != "false" ]; then \
     fi
 
 # Copy necessary files and directories
-COPY package.json /app/
-RUN npm install
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
+RUN pnpm install --frozen-lockfile
 COPY tests /app/tests/
 COPY playwright.config.ts /app/
 COPY start.sh /app/


### PR DESCRIPTION
Use the lockfile in test build to make test more determinstic
