### PR TITLE
op-node: Hide rethDB option

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -87,6 +87,7 @@ var (
 		Usage:    "The L1 RethDB path, used to fetch receipts for L1 blocks. Only applicable when using the `reth_db` RPC kind with `l1.rpckind`.",
 		EnvVars:  prefixEnvVars("L1_RETHDB"),
 		Required: false,
+		Hidden:   true,
 	}
 	L1RPCRateLimit = &cli.Float64Flag{
 		Name:    "l1.rpc-rate-limit",

--- a/op-service/sources/receipts.go
+++ b/op-service/sources/receipts.go
@@ -138,8 +138,12 @@ var RPCProviderKinds = []RPCProviderKind{
 	RPCKindBasic,
 	RPCKindAny,
 	RPCKindStandard,
-	RPCKindRethDB,
 }
+
+// Copy of RPCProviderKinds with RethDB added to all RethDB to be used but to hide it from the flags
+var validRPCProviderKinds = func() []RPCProviderKind {
+	return append(RPCProviderKinds, RPCKindRethDB)
+}()
 
 func (kind RPCProviderKind) String() string {
 	return string(kind)
@@ -159,7 +163,7 @@ func (kind *RPCProviderKind) Clone() any {
 }
 
 func ValidRPCProviderKind(value RPCProviderKind) bool {
-	for _, k := range RPCProviderKinds {
+	for _, k := range validRPCProviderKinds {
 		if k == value {
 			return true
 		}


### PR DESCRIPTION
**Description**

If the rethDB option is used without the proper build configuration, the op-node will panic. Note that we do not have this build configuration in our releases. This hides the option to use it, but does not fully remove it. There was some duplication required to easily hide the command line flag while still being able to use it for testing purposes.

This commit should be reverted when rethDB is stable.

**Tests**

Tested flags localy.