### PR TITLE
op-batcher: fix test RNG data flake

### DIFF
--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -318,7 +318,9 @@ func ChannelManagerCloseNoPendingChannel(t *testing.T, batchType uint) {
 // new channel frames after this point.
 func ChannelManagerClosePendingChannel(t *testing.T, batchType uint) {
 	require := require.New(t)
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// The number of batch txs depends on compression of the random data, hence the static test RNG seed.
+	// Example of different RNG seed that creates less than 2 frames: 1698700588902821588
+	rng := rand.New(rand.NewSource(123))
 	log := testlog.Logger(t, log.LvlCrit)
 	m := NewChannelManager(log, metrics.NoopMetrics,
 		ChannelConfig{


### PR DESCRIPTION
**Description**

The RNG seed that generated the random block data sometimes happened to be just right to generate compressible data, which then caused the test to flake: it would only take a single frame, instead of the expected two frames, to submit the random block data.

This freezes the RNG seed, to avoid it from flaking again. And added a comment to explain the issue.
Unless we increase the test data requirements, we can't really reliably prevent compression from doing its job on the generated data, so a static RNG seed is more desirable for testing in this case.

You can try to reproduce the flake by running the test case a number of times (with the old timestamp based seed):
```

func TestFoo(t *testing.T) {
	for i := 0; i < 100; i++ {
		ChannelManagerClosePendingChannel(t, derive.SingularBatchType)
	}
}
```
Or always make it fail, with the example RNG seed mentioned in the code comment.

Fix https://github.com/ethereum-optimism/client-pod/issues/152