### PR TITLE
ci: solc building requires xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,7 +433,7 @@ jobs:
   contracts-bedrock-slither:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - check-changed:
@@ -446,6 +446,7 @@ jobs:
   contracts-bedrock-validate-spaces:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    resource_class: xlarge
     steps:
       - checkout
       - attach_workspace: { at: "." }
@@ -467,7 +468,7 @@ jobs:
   op-bindings-build:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - run:
@@ -876,7 +877,7 @@ jobs:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
       - image: cimg/postgres:14.1
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - check-changed:
@@ -952,6 +953,7 @@ jobs:
   devnet-allocs:
     docker:
       - image: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
**Description**

Modularize out a small change from https://github.com/ethereum-optimism/optimism/pull/7928
where any `forge build` runs oom unless at least an `xlarge` box is used
in circleci. As we have added more contracts to the repo, building the
contracts has consumed more and more CPU/memory. The deploy script is
quite large and uses a lot of memory, so adding it to our tests makes
the tests use more memory. I have not noticed the tests taking a longer
time to run locally.

We could also do a better job at encapsulating where solc builds happen
such that it only happens once and the results are cached as much as
possible. Making the boxes bigger in the meantime works, as it should
also speed up CI for the tasks where the boxes are made bigger.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

