### PR TITLE
contracts-bedrock: make `implSalt()` internal

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -97,7 +97,7 @@ contract Deploy is Deployer {
     /// @notice The create2 salt used for deployment of the contract implementations.
     ///         Using this helps to reduce config across networks as the implementation
     ///         addresses will be the same across networks when deployed with create2.
-    function implSalt() public returns (bytes32) {
+    function implSalt() internal returns (bytes32) {
         return keccak256(bytes(vm.envOr("IMPL_SALT", string("ethers phoenix"))));
     }
 


### PR DESCRIPTION
**Description**

There is no reason for the `implSalt` method on the deploy
script to be public, so make it internal. This reduces the external
abi of the deploy script to prevent accidental leaky abstractions.

Co-authored-by: @mds1
