### PR TITLE
contracts-bedrock: update solidity deploy config

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.0;
 import { Script } from "forge-std/Script.sol";
 import { console2 as console } from "forge-std/console2.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-import { Executables } from "./Executables.sol";
-import { Chains } from "./Chains.sol";
+import { Executables } from "scripts/Executables.sol";
+import { Chains } from "scripts/Chains.sol";
 
 /// @title DeployConfig
 /// @notice Represents the configuration required to deploy the system. It is expected
@@ -33,8 +33,11 @@ contract DeployConfig is Script {
     uint256 public finalizationPeriodSeconds;
     address public proxyAdminOwner;
     address public baseFeeVaultRecipient;
+    uint256 public baseFeeVaultMinimumWithdrawalAmount;
     address public l1FeeVaultRecipient;
+    uint256 public l1FeeVaultMinimumWithdrawalAmount;
     address public sequencerFeeVaultRecipient;
+    uint256 public sequencerFeeVaultMinimumWithdrawalAmount;
     string public governanceTokenName;
     string public governanceTokenSymbol;
     address public governanceTokenOwner;
@@ -79,8 +82,11 @@ contract DeployConfig is Script {
         finalizationPeriodSeconds = stdJson.readUint(_json, "$.finalizationPeriodSeconds");
         proxyAdminOwner = stdJson.readAddress(_json, "$.proxyAdminOwner");
         baseFeeVaultRecipient = stdJson.readAddress(_json, "$.baseFeeVaultRecipient");
+        baseFeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.baseFeeVaultMinimumWithdrawalAmount");
         l1FeeVaultRecipient = stdJson.readAddress(_json, "$.l1FeeVaultRecipient");
+        l1FeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.l1FeeVaultMinimumWithdrawalAmount");
         sequencerFeeVaultRecipient = stdJson.readAddress(_json, "$.sequencerFeeVaultRecipient");
+        sequencerFeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.sequencerFeeVaultMinimumWithdrawalAmount");
         governanceTokenName = stdJson.readString(_json, "$.governanceTokenName");
         governanceTokenSymbol = stdJson.readString(_json, "$.governanceTokenSymbol");
         governanceTokenOwner = stdJson.readAddress(_json, "$.governanceTokenOwner");


### PR DESCRIPTION
**Description**

Updates the solidity deploy config with extra configuration
that was not previously required to be read in solidity but
it exists in the Go code. These particular config values are
used to build the L2 genesis state. We will read in these values
as part of https://github.com/ethereum-optimism/optimism/pull/7928.
They were previously not used in solidity. The Go deploy config
check does ensure that they exist.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

