### PR TITLE
contracts-bedrock: virtual setup in deploy script

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -58,7 +58,7 @@ contract Deploy is Deployer {
         name_ = "Deploy";
     }
 
-    function setUp() public override {
+    function setUp() public virtual override {
         super.setUp();
 
         string memory path = string.concat(vm.projectRoot(), "/deploy-config/", deploymentContext, ".json");


### PR DESCRIPTION
**Description**

Makes the `setUp` function virtual in the deploy script.
Part of https://github.com/ethereum-optimism/optimism/pull/7928
