### PR TITLE
docker: Fix golang-docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ golang-docker:
 	# We don't use a buildx builder here, and just load directly into regular docker, for convenience.
 	GIT_COMMIT=$$(git rev-parse HEAD) \
 	GIT_DATE=$$(git show -s --format='%ct') \
-	IMAGE_TAGS=$$GIT_COMMIT,latest \
+	IMAGE_TAGS=$$(git rev-parse HEAD),latest \
 	docker buildx bake \
 			--progress plain \
 			--load \
@@ -189,4 +189,3 @@ install-geth:
  			go install -v github.com/ethereum/go-ethereum/cmd/geth@$(shell cat .gethrc); \
  			echo "Installed geth!"; true)
 .PHONY: install-geth
-


### PR DESCRIPTION
**Description**

The GIT_COMMIT env var isn't available yet when setting IMAGE_TAGS - in only becomes available in the docker executable, not on the command line.  This results in `IMAGE_TAGS` being just `,latest` and then the build fails with:
```
ERROR: invalid tag "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:": invalid reference format
```

**Metadata**

- Fixes https://github.com/ethereum-optimism/developers/discussions/34
