### PR TITLE
Add an RPC timeout flag for the op node.

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -78,10 +79,11 @@ func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, cf
 	// setup RPC server for rollup node, hooked to the actor as backend
 	m := &testutils.TestRPCMetrics{}
 	backend := &l2VerifierBackend{verifier: rollupNode}
+	rpcTimeout := 2 * time.Second
 	apis := []rpc.API{
 		{
 			Namespace:     "optimism",
-			Service:       node.NewNodeAPI(cfg, eng, backend, log, m),
+			Service:       node.NewNodeAPI(cfg, eng, backend, rpcTimeout, log, m),
 			Public:        true,
 			Authenticated: false,
 		},

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -123,6 +123,7 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 					ListenAddr:  "127.0.0.1",
 					ListenPort:  0,
 					EnableAdmin: true,
+					RpcTimeout:  2 * time.Second,
 				},
 				L1EpochPollInterval:         time.Second * 2,
 				RuntimeConfigReloadInterval: time.Minute * 10,

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -695,6 +695,7 @@ func TestSystemP2PAltSync(t *testing.T) {
 			ListenAddr:  "127.0.0.1",
 			ListenPort:  0,
 			EnableAdmin: true,
+			RpcTimeout:  2 * time.Second,
 		},
 		P2P:                 &p2p.Prepared{HostP2P: h, EnableReqRespSync: true},
 		Metrics:             rollupNode.MetricsConfig{Enabled: false}, // no metrics server

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -67,6 +67,12 @@ var (
 		Usage:   "File path used to persist state changes made via the admin API so they persist across restarts. Disabled if not set.",
 		EnvVars: prefixEnvVars("RPC_ADMIN_STATE"),
 	}
+	RPCTimeout = &cli.DurationFlag{
+		Name:    "rpc.timeout",
+		Usage:   "Timeout for RPC requests",
+		Value:   time.Second * 2,
+		EnvVars: prefixEnvVars("RPC_TIMEOUT"),
+	}
 	L1TrustRPC = &cli.BoolFlag{
 		Name:    "l1.trustrpc",
 		Usage:   "Trust the L1 RPC, sync faster at risk of malicious/buggy RPC providing bad or inconsistent L1 data",

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -69,6 +69,7 @@ type RPCConfig struct {
 	ListenAddr  string
 	ListenPort  int
 	EnableAdmin bool
+	RpcTimout   time.Duration
 }
 
 func (cfg *RPCConfig) HttpEndpoint() string {

--- a/op-node/node/server.go
+++ b/op-node/node/server.go
@@ -28,7 +28,7 @@ type rpcServer struct {
 }
 
 func newRPCServer(ctx context.Context, rpcCfg *RPCConfig, rollupCfg *rollup.Config, l2Client l2EthClient, dr driverClient, log log.Logger, appVersion string, m metrics.Metricer) (*rpcServer, error) {
-	api := NewNodeAPI(rollupCfg, l2Client, dr, log.New("rpc", "node"), m)
+	api := NewNodeAPI(rollupCfg, l2Client, rpcCfg.RpcTimout, dr, log.New("rpc", "node"), m)
 	// TODO: extend RPC config with options for WS, IPC and HTTP RPC connections
 	endpoint := net.JoinHostPort(rpcCfg.ListenAddr, strconv.Itoa(rpcCfg.ListenPort))
 	r := &rpcServer{

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -81,6 +81,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 			ListenAddr:  ctx.String(flags.RPCListenAddr.Name),
 			ListenPort:  ctx.Int(flags.RPCListenPort.Name),
 			EnableAdmin: ctx.Bool(flags.RPCEnableAdmin.Name),
+			RpcTimout:   ctx.Duration(flags.RPCTimeout.Name),
 		},
 		Metrics: node.MetricsConfig{
 			Enabled:    ctx.Bool(flags.MetricsEnabledFlag.Name),


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR introduces a new flag named `RPCTimeout` in the op node, allowing it to wait longer for the `eth_gethProof` response.

**Additional context**

The Erigon node takes more than 10 seconds to generate the `eth_getProof` if the queried block lags more than 1M blocks behind the header. This flag allows developers to set the timeout themselves, ensuring the op-proposer functions correctly.

**Metadata**

- https://github.com/bobanetwork/v3-anchorage/pull/77
