### PR TITLE
Fix batcher panic on invalid configuration

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -290,8 +290,10 @@ func (bs *BatcherService) Stop(ctx context.Context) error {
 	bs.Log.Info("Stopping batcher")
 
 	var result error
-	if err := bs.driver.StopBatchSubmittingIfRunning(ctx); err != nil {
-		result = errors.Join(result, fmt.Errorf("failed to stop batch submitting: %w", err))
+	if bs.driver != nil {
+		if err := bs.driver.StopBatchSubmittingIfRunning(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to stop batch submitting: %w", err))
+		}
 	}
 
 	if bs.rpcServer != nil {
@@ -328,7 +330,7 @@ func (bs *BatcherService) Stop(ctx context.Context) error {
 
 	if result == nil {
 		bs.stopped.Store(true)
-		bs.driver.Log.Info("Batch Submitter stopped")
+		bs.Log.Info("Batch Submitter stopped")
 	}
 	return result
 }

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -203,6 +203,9 @@ type SystemConfig struct {
 	// Target L1 tx size for the batcher transactions
 	BatcherTargetL1TxSizeBytes uint64
 
+	// Max L1 tx size for the batcher transactions
+	BatcherMaxL1TxSizeBytes uint64
+
 	// SupportL1TimeTravel determines if the L1 node supports quickly skipping forward in time
 	SupportL1TimeTravel bool
 }
@@ -684,13 +687,17 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	if os.Getenv("OP_E2E_USE_SPAN_BATCH") == "true" {
 		batchType = derive.SpanBatchType
 	}
+	batcherMaxL1TxSizeBytes := cfg.BatcherMaxL1TxSizeBytes
+	if batcherMaxL1TxSizeBytes == 0 {
+		batcherMaxL1TxSizeBytes = 240_000
+	}
 	batcherCLIConfig := &bss.CLIConfig{
 		L1EthRpc:               sys.EthInstances["l1"].WSEndpoint(),
 		L2EthRpc:               sys.EthInstances["sequencer"].WSEndpoint(),
 		RollupRpc:              sys.RollupNodes["sequencer"].HTTPEndpoint(),
 		MaxPendingTransactions: 0,
 		MaxChannelDuration:     1,
-		MaxL1TxSize:            240_000,
+		MaxL1TxSize:            batcherMaxL1TxSizeBytes,
 		CompressorConfig: compressor.CLIConfig{
 			TargetL1TxSizeBytes: cfg.BatcherTargetL1TxSizeBytes,
 			TargetNumFrames:     1,

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1553,3 +1553,14 @@ func TestRequiredProtocolVersionChangeAndHalt(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("verified that op-geth closed!")
 }
+
+func TestIncorrectBatcherConfiguration(t *testing.T) {
+	InitParallel(t)
+
+	cfg := DefaultSystemConfig(t)
+	// make the batcher configuration invalid
+	cfg.BatcherMaxL1TxSizeBytes = 1
+
+	_, err := cfg.Start(t)
+	require.Error(t, err, "Expected error on invalid batcher configuration")
+}


### PR DESCRIPTION
**Description**

The batcher panics if an invalid configuration is passed. This PR fixes the `nil` access so that the actual configuration error is printed, rather than a panic.

**Tests**

Added small regression test.

**Additional context**

It can be easily repro'd using (without this PR's changes):
```
make op-batcher && bin/op-batcher --l1-eth-rpc https://example.com --l2-eth-rpc https://example.com --rollup-rpc https://example.com

INFO [10-31|12:39:25.132] Initializing Batch Submitter
INFO [10-31|12:39:25.606] Stopping batcher
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x101623288]

goroutine 1 [running]:
github.com/ethereum-optimism/optimism/op-batcher/batcher.(*BatchSubmitter).StopBatchSubmitting(0x0, {0x101ddca60, 0x14000180690})
	/Users/michaeldehoog/src/optimism/op-batcher/batcher/driver.go:114 +0x38
github.com/ethereum-optimism/optimism/op-batcher/batcher.(*BatchSubmitter).StopBatchSubmittingIfRunning(0x1?, {0x101ddca60?, 0x14000180690?})
	/Users/michaeldehoog/src/optimism/op-batcher/batcher/driver.go:105 +0x24
github.com/ethereum-optimism/optimism/op-batcher/batcher.(*BatcherService).Stop(0x140002f2800, {0x101ddca60, 0x14000180690})
	/Users/michaeldehoog/src/optimism/op-batcher/batcher/service.go:292 +0x88
github.com/ethereum-optimism/optimism/op-batcher/batcher.BatcherServiceFromCLIConfig({0x101ddca60, 0x14000180690}, {0x101b8a6d8, 0x6}, 0x2c?, {0x101de2bf8, 0x14000494540})
	/Users/michaeldehoog/src/optimism/op-batcher/batcher/service.go:74 +0x84
main.main.Main.func1(0x140003e4340, 0x1025a1a00?)
	/Users/michaeldehoog/src/optimism/op-batcher/batcher/batch_submitter.go:32 +0x15c
main.main.LifecycleCmd.lifecycleCmd.func3(0x140003e4340)
	/Users/michaeldehoog/src/optimism/op-service/cliapp/lifecycle.go:56 +0x110
github.com/urfave/cli/v2.(*Command).Run(0x1400011cdc0, 0x140003e4340, {0x140001d6000, 0x7, 0x7})
	/Users/michaeldehoog/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x730
github.com/urfave/cli/v2.(*App).RunContext(0x140000125a0, {0x101ddc788?, 0x1025a1a00}, {0x140001d6000, 0x7, 0x7})
	/Users/michaeldehoog/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x518
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/michaeldehoog/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:309
main.main()
	/Users/michaeldehoog/src/optimism/op-batcher/cmd/main.go:41 +0x4fc
```
