### PR TITLE
feat(proxyd): add weighting feature to node selection

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -691,10 +691,10 @@ func sortBatchRPCResponse(req []*RPCReq, res []*RPCRes) {
 }
 
 type BackendGroup struct {
-	Name               string
-	Backends           []*Backend
-	UseWeightedRouting bool
-	Consensus          *ConsensusPoller
+	Name            string
+	Backends        []*Backend
+	WeightedRouting bool
+	Consensus       *ConsensusPoller
 }
 
 func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool) ([]*RPCRes, string, error) {
@@ -750,7 +750,7 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 			}
 		}
 		rpcReqs = rewrittenReqs
-	} else if bg.UseWeightedRouting {
+	} else if bg.WeightedRouting {
 		backends = randomizeFirstBackendByWeight(backends)
 	}
 
@@ -820,7 +820,7 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 }
 
 func randomizeFirstBackendByWeight(backends []*Backend) []*Backend {
-	if len(backends) == 0 {
+	if len(backends) <= 1 {
 		return backends
 	}
 
@@ -916,7 +916,7 @@ func (bg *BackendGroup) loadBalancedConsensusGroup() []*Backend {
 		backendsDegraded[i], backendsDegraded[j] = backendsDegraded[j], backendsDegraded[i]
 	})
 
-	if bg.UseWeightedRouting {
+	if bg.WeightedRouting {
 		backendsHealthy = randomizeFirstBackendByWeight(backendsHealthy)
 		backendsDegraded = randomizeFirstBackendByWeight(backendsDegraded)
 	}

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -2,7 +2,6 @@ package proxyd
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -18,119 +17,5 @@ func TestStripXFF(t *testing.T) {
 	for _, test := range tests {
 		actual := stripXFF(test.in)
 		assert.Equal(t, test.out, actual)
-	}
-}
-
-func TestCreateBackendGroup(t *testing.T) {
-	unweightedOne := &Backend{
-		Name:   "one",
-		weight: 0,
-	}
-
-	unweightedTwo := &Backend{
-		Name:   "two",
-		weight: 0,
-	}
-
-	weightedOne := &Backend{
-		Name:   "one",
-		weight: 1,
-	}
-
-	weightedTwo := &Backend{
-		Name:   "two",
-		weight: 1,
-	}
-
-	tests := []struct {
-		name            string
-		backends        []*Backend
-		weightedRouting bool
-		expectError     bool
-	}{
-		{
-			name:            "weighting disabled",
-			backends:        []*Backend{unweightedOne, unweightedTwo},
-			weightedRouting: false,
-			expectError:     false,
-		},
-		{
-			name:            "weighting enabled -- all nodes have weight",
-			backends:        []*Backend{weightedOne, weightedTwo},
-			weightedRouting: true,
-			expectError:     false,
-		},
-		{
-			name:            "weighting enabled -- some nodes have weight",
-			backends:        []*Backend{weightedOne, unweightedTwo},
-			weightedRouting: true,
-			expectError:     false,
-		},
-		{
-			name:            "weighting enabled -- no nodes have weight",
-			backends:        []*Backend{unweightedOne, unweightedTwo},
-			weightedRouting: true,
-			expectError:     true,
-		},
-	}
-
-	for _, test := range tests {
-		result, err := NewBackendGroup(test.name, test.backends, test.weightedRouting)
-
-		if test.expectError {
-			require.Error(t, err)
-		} else {
-			require.NoError(t, err)
-			assert.Equal(t, test.name, result.Name)
-			assert.Equal(t, test.backends, test.backends)
-			assert.Equal(t, test.weightedRouting, test.weightedRouting)
-		}
-	}
-
-}
-
-func TestMoveIndexToStart(t *testing.T) {
-	one := &Backend{
-		Name: "one",
-	}
-
-	two := &Backend{
-		Name: "two",
-	}
-
-	three := &Backend{
-		Name: "three",
-	}
-
-	tests := []struct {
-		choice *Backend
-		input  []*Backend
-		output []*Backend
-	}{
-		{
-			choice: one,
-			input:  []*Backend{one, two, three},
-			output: []*Backend{one, two, three},
-		},
-		{
-			choice: two,
-			input:  []*Backend{one, two, three},
-			output: []*Backend{two, one, three},
-		},
-		{
-			choice: three,
-			input:  []*Backend{one, two},
-			output: []*Backend{one, two},
-		},
-		{
-			choice: one,
-			input:  []*Backend{one},
-			output: []*Backend{one},
-		},
-	}
-
-	for _, test := range tests {
-		result := moveBackendToStart(test.choice, test.input)
-		assert.Equal(t, test.output, result)
 	}
 }

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -19,3 +19,52 @@ func TestStripXFF(t *testing.T) {
 		assert.Equal(t, test.out, actual)
 	}
 }
+
+func TestMoveIndexToStart(t *testing.T) {
+	backends := []*Backend{
+		{
+			Name: "node1",
+		},
+		{
+			Name: "node1",
+		},
+		{
+			Name: "node1",
+		},
+	}
+
+	tests := []struct {
+		index int
+		out   []*Backend
+	}{
+		{
+			index: 0,
+			out: []*Backend{
+				backends[0],
+				backends[1],
+				backends[2],
+			},
+		},
+		{
+			index: 1,
+			out: []*Backend{
+				backends[1],
+				backends[0],
+				backends[2],
+			},
+		},
+		{
+			index: 2,
+			out: []*Backend{
+				backends[2],
+				backends[0],
+				backends[1],
+			},
+		},
+	}
+
+	for _, test := range tests {
+		result := moveIndexToStart(backends, test.index)
+		assert.Equal(t, test.out, result)
+	}
+}

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -98,12 +98,16 @@ type BackendConfig struct {
 	ConsensusSkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`
+
+	Weight int `toml:"weight"`
 }
 
 type BackendsConfig map[string]*BackendConfig
 
 type BackendGroupConfig struct {
 	Backends []string `toml:"backends"`
+
+	UseWeightedRouting bool `toml:"weighted_routing"`
 
 	ConsensusAware        bool   `toml:"consensus_aware"`
 	ConsensusAsyncHandler string `toml:"consensus_handler"`

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -95,11 +95,11 @@ type BackendConfig struct {
 	ClientKeyFile    string `toml:"client_key_file"`
 	StripTrailingXFF bool   `toml:"strip_trailing_xff"`
 
+	Weight int `toml:"weight"`
+
 	ConsensusSkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`
 	ConsensusReceiptsTarget     string `toml:"consensus_receipts_target"`
-
-	Weight int `toml:"weight"`
 }
 
 type BackendsConfig map[string]*BackendConfig
@@ -107,7 +107,7 @@ type BackendsConfig map[string]*BackendConfig
 type BackendGroupConfig struct {
 	Backends []string `toml:"backends"`
 
-	UseWeightedRouting bool `toml:"weighted_routing"`
+	WeightedRouting bool `toml:"weighted_routing"`
 
 	ConsensusAware        bool   `toml:"consensus_aware"`
 	ConsensusAsyncHandler string `toml:"consensus_handler"`

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -12,13 +12,13 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v1.0.2
-	github.com/mroth/weightedrand/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/redis/go-redis/v9 v9.2.1
 	github.com/rs/cors v1.10.1
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+	github.com/xaionaro-go/weightedshuffle v0.0.0-20211213010739-6a74fbc7d24a
 	golang.org/x/sync v0.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/proxyd/go.mod
+++ b/proxyd/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v1.0.2
+	github.com/mroth/weightedrand/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/redis/go-redis/v9 v9.2.1

--- a/proxyd/go.sum
+++ b/proxyd/go.sum
@@ -143,8 +143,6 @@ github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQth
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
-github.com/mroth/weightedrand/v2 v2.1.0 h1:o1ascnB1CIVzsqlfArQQjeMy1U0NcIbBO5rfd5E/OeU=
-github.com/mroth/weightedrand/v2 v2.1.0/go.mod h1:f2faGsfOGOwc1p94wzHKKZyTpcJUW7OJ/9U4yfiNAOU=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
@@ -200,6 +198,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/xaionaro-go/weightedshuffle v0.0.0-20211213010739-6a74fbc7d24a h1:WS5nQycV+82Ndezq0UcMcGVG416PZgcJPqI/bLM824A=
+github.com/xaionaro-go/weightedshuffle v0.0.0-20211213010739-6a74fbc7d24a/go.mod h1:0KAUfC65le2kMu4fnBxm7Xj3PkQ3MBpJbF5oMmqufBc=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=

--- a/proxyd/go.sum
+++ b/proxyd/go.sum
@@ -143,6 +143,8 @@ github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQth
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+github.com/mroth/weightedrand/v2 v2.1.0 h1:o1ascnB1CIVzsqlfArQQjeMy1U0NcIbBO5rfd5E/OeU=
+github.com/mroth/weightedrand/v2 v2.1.0/go.mod h1:f2faGsfOGOwc1p94wzHKKZyTpcJUW7OJ/9U4yfiNAOU=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -175,11 +175,12 @@ func Start(config *Config) (*Server, func(), error) {
 			}
 			backends = append(backends, backendsByName[bName])
 		}
-		group := &BackendGroup{
-			Name:            bgName,
-			WeightedRouting: bg.WeightedRouting,
-			Backends:        backends,
+
+		group, err := NewBackendGroup(bgName, backends, bg.WeightedRouting)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error creating backend group %s: %w", bgName, err)
 		}
+
 		backendGroups[bgName] = group
 	}
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -176,12 +176,11 @@ func Start(config *Config) (*Server, func(), error) {
 			backends = append(backends, backendsByName[bName])
 		}
 
-		group, err := NewBackendGroup(bgName, backends, bg.WeightedRouting)
-		if err != nil {
-			return nil, nil, fmt.Errorf("error creating backend group %s: %w", bgName, err)
+		backendGroups[bgName] = &BackendGroup{
+			Name:            bgName,
+			Backends:        backends,
+			WeightedRouting: bg.WeightedRouting,
 		}
-
-		backendGroups[bgName] = group
 	}
 
 	var wsBackendGroup *BackendGroup

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -176,9 +176,9 @@ func Start(config *Config) (*Server, func(), error) {
 			backends = append(backends, backendsByName[bName])
 		}
 		group := &BackendGroup{
-			Name:               bgName,
-			UseWeightedRouting: bg.UseWeightedRouting,
-			Backends:           backends,
+			Name:            bgName,
+			WeightedRouting: bg.WeightedRouting,
+			Backends:        backends,
 		}
 		backendGroups[bgName] = group
 	}

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -144,6 +144,7 @@ func Start(config *Config) (*Server, func(), error) {
 		opts = append(opts, WithProxydIP(os.Getenv("PROXYD_IP")))
 		opts = append(opts, WithConsensusSkipPeerCountCheck(cfg.ConsensusSkipPeerCountCheck))
 		opts = append(opts, WithConsensusForcedCandidate(cfg.ConsensusForcedCandidate))
+		opts = append(opts, WithWeight(cfg.Weight))
 
 		receiptsTarget, err := ReadFromEnvOrConfig(cfg.ConsensusReceiptsTarget)
 		if err != nil {
@@ -175,8 +176,9 @@ func Start(config *Config) (*Server, func(), error) {
 			backends = append(backends, backendsByName[bName])
 		}
 		group := &BackendGroup{
-			Name:     bgName,
-			Backends: backends,
+			Name:               bgName,
+			UseWeightedRouting: bg.UseWeightedRouting,
+			Backends:           backends,
 		}
 		backendGroups[bgName] = group
 	}


### PR DESCRIPTION
### Description
Today we have two modes for backend groups (default and consensus), which have differing ways of selecting which backend  to forward requests to.

This PR adds the ability (behind a flag) to enable weighted routing. The goal is to send different %'s of traffic to each backend.

#### Today

**Default:** Use the first backend node defined in the configuration. ([one](https://github.com/ethereum-optimism/optimism/blob/develop/proxyd/backend.go#L696), [two](https://github.com/ethereum-optimism/optimism/blob/58c8b1f401ad447ee35685ab78f1c4e9cd93efe4/proxyd/proxyd.go#L170-L175)). On failure go through the backends in order they are defined in the backend group config. The outcome of this is the first backend defined receives all requests, except when it fails.

**Consensus:** Order the nodes by `[shuffle(healthyNodes)..., shuffle(degreadedNodes)...]`. Then iterate through this list. ([reference](https://github.com/ethereum-optimism/optimism/blob/develop/proxyd/backend.go#L854-L877)). This results in an approximately equal distribution of requests.

#### With Weighted Routing

```
[backends]
[backends.node]
...
weight = 5

[backends.node2]
...
weight = 10

[backend_groups]
[backend_groups.node]
weighted_routing = true
backends = ["node", "node2"]
```

**Default:** For the first request attempt, select a backend at random based on it's weight. i.e. send 1/3 of the requests to `node` and 2/3 of the requests to `node2`. In the event of a failure requests are routed to backends in order (excluding the selected backend).

**Consensus:** Shuffle backends ordered by healthy then degraded status. However order the first node of the healthy + degraded sections based on weight. e.g.

`[weightedHealthyNode, shuffle(otherHealthyNodes)..., weightedDegradedNode, shuffle(otherDegradedNodes)...]`

Assuming low rates of failure, these should result in distributing traffic based on the backend weights.