### PR TITLE
contracts-bedrock: better comment for deployer `name()(string)`

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -52,7 +52,7 @@ import "src/libraries/DisputeTypes.sol";
 contract Deploy is Deployer {
     DeployConfig cfg;
 
-    /// @inheritdoc
+    /// @inheritdoc Deployer
     function name() public pure override returns (string memory name_) {
         name_ = "Deploy";
     }

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -52,8 +52,7 @@ import "src/libraries/DisputeTypes.sol";
 contract Deploy is Deployer {
     DeployConfig cfg;
 
-    /// @notice The name of the script, used to ensure the right deploy artifacts
-    ///         are used.
+    /// @inheritdoc
     function name() public pure override returns (string memory name_) {
         name_ = "Deploy";
     }

--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -163,6 +163,8 @@ abstract contract Deployer is Script {
 
     /// @notice Returns the name of the deployment script. Children contracts
     ///         must implement this to ensure that the deploy artifacts can be found.
+    ///         This should be the same as the name of the script and is used as the file
+    ///         name inside of the `broadcast` directory when looking up deployment artifacts.
     function name() public pure virtual returns (string memory);
 
     /// @notice Returns all of the deployments done in the current context.


### PR DESCRIPTION
**Description**

Updates the comment for the `name()(string)` function that is
abstract on the `Deployer` contract. It should be more obvious
why the function exists now.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
