### PR TITLE
ci: ignore code coverage in script contracts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ ignore:
   - "op-bindings/bindings/*.go"
   - "**/*.t.sol"
   - "packages/contracts-bedrock/test/**/*.sol"
+  - "packages/contracts-bedrock/scripts/**/*.sol"
   - "packages/contracts-bedrock/contracts/vendor/WETH9.sol"
   - 'packages/contracts-bedrock/contracts/EAS/**/*.sol'
 coverage:


### PR DESCRIPTION
We don't/can't generate code coverage for scripts so they should be ignored from the coverage report. Otherwise, updating contract scripts will fail the coverage diff check.