### PR TITLE
challenger: Move DisputeGameFactory to use new approach to contract reads

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -39,7 +39,7 @@ func NewFaultDisputeGameContract(addr common.Address, caller *batching.MultiCall
 }
 
 func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {
-	result, err := f.multiCaller.SingleCallLatest(ctx, f.contract.Call(methodGameDuration))
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodGameDuration))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
 	}
@@ -47,7 +47,7 @@ func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (uint64,
 }
 
 func (f *FaultDisputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64, error) {
-	result, err := f.multiCaller.SingleCallLatest(ctx, f.contract.Call(methodMaxGameDepth))
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodMaxGameDepth))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch max game depth: %w", err)
 	}
@@ -55,7 +55,7 @@ func (f *FaultDisputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64,
 }
 
 func (f *FaultDisputeGameContract) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
-	result, err := f.multiCaller.SingleCallLatest(ctx, f.contract.Call(methodAbsolutePrestate))
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodAbsolutePrestate))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to fetch absolute prestate hash: %w", err)
 	}
@@ -63,7 +63,7 @@ func (f *FaultDisputeGameContract) GetAbsolutePrestateHash(ctx context.Context) 
 }
 
 func (f *FaultDisputeGameContract) GetStatus(ctx context.Context) (gameTypes.GameStatus, error) {
-	result, err := f.multiCaller.SingleCallLatest(ctx, f.contract.Call(methodStatus))
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodStatus))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch status: %w", err)
 	}
@@ -71,7 +71,7 @@ func (f *FaultDisputeGameContract) GetStatus(ctx context.Context) (gameTypes.Gam
 }
 
 func (f *FaultDisputeGameContract) GetClaimCount(ctx context.Context) (uint64, error) {
-	result, err := f.multiCaller.SingleCallLatest(ctx, f.contract.Call(methodClaimCount))
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaimCount))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch claim count: %w", err)
 	}
@@ -79,7 +79,7 @@ func (f *FaultDisputeGameContract) GetClaimCount(ctx context.Context) (uint64, e
 }
 
 func (f *FaultDisputeGameContract) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
-	result, err := f.multiCaller.SingleCallLatest(ctx, f.contract.Call(methodClaim, new(big.Int).SetUint64(idx)))
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaim, new(big.Int).SetUint64(idx)))
 	if err != nil {
 		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
 	}
@@ -97,7 +97,7 @@ func (f *FaultDisputeGameContract) GetAllClaims(ctx context.Context) ([]types.Cl
 		calls[i] = f.contract.Call(methodClaim, new(big.Int).SetUint64(i))
 	}
 
-	results, err := f.multiCaller.CallLatest(ctx, calls...)
+	results, err := f.multiCaller.Call(ctx, batching.BlockLatest, calls...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch claim data: %w", err)
 	}

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -65,7 +65,7 @@ func TestSimpleGetters(t *testing.T) {
 		test := test
 		t.Run(test.method, func(t *testing.T) {
 			stubRpc, game := setup(t)
-			stubRpc.SetResponse(test.method, nil, []interface{}{test.result})
+			stubRpc.SetResponse(test.method, batching.BlockLatest, nil, []interface{}{test.result})
 			status, err := test.call(game)
 			require.NoError(t, err)
 			expected := test.expected
@@ -85,7 +85,7 @@ func TestGetClaim(t *testing.T) {
 	value := common.Hash{0xab}
 	position := big.NewInt(2)
 	clock := big.NewInt(1234)
-	stubRpc.SetResponse(methodClaim, []interface{}{idx}, []interface{}{parentIndex, countered, value, position, clock})
+	stubRpc.SetResponse(methodClaim, batching.BlockLatest, []interface{}{idx}, []interface{}{parentIndex, countered, value, position, clock})
 	status, err := game.GetClaim(context.Background(), idx.Uint64())
 	require.NoError(t, err)
 	require.Equal(t, faultTypes.Claim{
@@ -133,7 +133,7 @@ func TestGetAllClaims(t *testing.T) {
 		ParentContractIndex: 1,
 	}
 	expectedClaims := []faultTypes.Claim{claim0, claim1, claim2}
-	stubRpc.SetResponse(methodClaimCount, nil, []interface{}{big.NewInt(int64(len(expectedClaims)))})
+	stubRpc.SetResponse(methodClaimCount, batching.BlockLatest, nil, []interface{}{big.NewInt(int64(len(expectedClaims)))})
 	for _, claim := range expectedClaims {
 		expectGetClaim(stubRpc, claim)
 	}
@@ -145,6 +145,7 @@ func TestGetAllClaims(t *testing.T) {
 func expectGetClaim(stubRpc *batchingTest.AbiBasedRpc, claim faultTypes.Claim) {
 	stubRpc.SetResponse(
 		methodClaim,
+		batching.BlockLatest,
 		[]interface{}{big.NewInt(int64(claim.ContractIndex))},
 		[]interface{}{
 			uint32(claim.ParentContractIndex),

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -1,0 +1,60 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	methodGameCount   = "gameCount"
+	methodGameAtIndex = "gameAtIndex"
+)
+
+type DisputeGameFactoryContract struct {
+	multiCaller *batching.MultiCaller
+	contract    *batching.BoundContract
+}
+
+func NewDisputeGameFactoryContract(addr common.Address, caller *batching.MultiCaller) (*DisputeGameFactoryContract, error) {
+	factoryAbi, err := bindings.DisputeGameFactoryMetaData.GetAbi()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load dispute game factory ABI: %w", err)
+	}
+	return &DisputeGameFactoryContract{
+		multiCaller: caller,
+		contract:    batching.NewBoundContract(factoryAbi, addr),
+	}, nil
+}
+
+func (f *DisputeGameFactoryContract) GetGameCount(ctx context.Context, blockNum uint64) (uint64, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockByNumber(blockNum), f.contract.Call(methodGameCount))
+	if err != nil {
+		return 0, fmt.Errorf("failed to load game count: %w", err)
+	}
+	return result.GetBigInt(0).Uint64(), nil
+}
+
+func (f *DisputeGameFactoryContract) GetGame(ctx context.Context, idx uint64, blockNum uint64) (types.GameMetadata, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockByNumber(blockNum), f.contract.Call(methodGameAtIndex, new(big.Int).SetUint64(idx)))
+	if err != nil {
+		return types.GameMetadata{}, fmt.Errorf("failed to load game %v: %w", idx, err)
+	}
+	return f.decodeGame(result), nil
+}
+
+func (f *DisputeGameFactoryContract) decodeGame(result *batching.CallResult) types.GameMetadata {
+	gameType := result.GetUint8(0)
+	timestamp := result.GetUint64(1)
+	proxy := result.GetAddress(2)
+	return types.GameMetadata{
+		GameType:  gameType,
+		Timestamp: timestamp,
+		Proxy:     proxy,
+	}
+}

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -1,0 +1,99 @@
+package contracts
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisputeGameFactorySimpleGetters(t *testing.T) {
+	blockNum := uint64(23)
+	tests := []struct {
+		method   string
+		args     []interface{}
+		result   interface{}
+		expected interface{} // Defaults to expecting the same as result
+		call     func(game *DisputeGameFactoryContract) (any, error)
+	}{
+		{
+			method:   methodGameCount,
+			result:   big.NewInt(9876),
+			expected: uint64(9876),
+			call: func(game *DisputeGameFactoryContract) (any, error) {
+				return game.GetGameCount(context.Background(), blockNum)
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.method, func(t *testing.T) {
+			stubRpc, factory := setupDisputeGameFactoryTest(t)
+			stubRpc.SetResponse(test.method, batching.BlockByNumber(blockNum), nil, []interface{}{test.result})
+			status, err := test.call(factory)
+			require.NoError(t, err)
+			expected := test.expected
+			if expected == nil {
+				expected = test.result
+			}
+			require.Equal(t, expected, status)
+		})
+	}
+}
+
+func TestLoadGame(t *testing.T) {
+	blockNum := uint64(23)
+	stubRpc, factory := setupDisputeGameFactoryTest(t)
+	game0 := types.GameMetadata{
+		GameType:  0,
+		Timestamp: 1234,
+		Proxy:     common.Address{0xaa},
+	}
+	game1 := types.GameMetadata{
+		GameType:  1,
+		Timestamp: 5678,
+		Proxy:     common.Address{0xbb},
+	}
+	game2 := types.GameMetadata{
+		GameType:  99,
+		Timestamp: 9988,
+		Proxy:     common.Address{0xcc},
+	}
+	expectedGames := []types.GameMetadata{game0, game1, game2}
+	for idx, expected := range expectedGames {
+		expectGetGame(stubRpc, idx, blockNum, expected)
+		actual, err := factory.GetGame(context.Background(), uint64(idx), blockNum)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+}
+
+func expectGetGame(stubRpc *batchingTest.AbiBasedRpc, idx int, blockNum uint64, game types.GameMetadata) {
+	stubRpc.SetResponse(
+		methodGameAtIndex,
+		batching.BlockByNumber(blockNum),
+		[]interface{}{big.NewInt(int64(idx))},
+		[]interface{}{
+			game.GameType,
+			game.Timestamp,
+			game.Proxy,
+		})
+}
+
+func setupDisputeGameFactoryTest(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameFactoryContract) {
+	fdgAbi, err := bindings.DisputeGameFactoryMetaData.GetAbi()
+	require.NoError(t, err)
+	address := common.HexToAddress("0x24112842371dFC380576ebb09Ae16Cb6B6caD7CB")
+
+	stubRpc := batchingTest.NewAbiBasedRpc(t, fdgAbi, address)
+	caller := batching.NewMultiCaller(stubRpc, 100)
+	factory, err := NewDisputeGameFactoryContract(address, caller)
+	require.NoError(t, err)
+	return stubRpc, factory
+}

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -47,7 +47,7 @@ func NewGamePlayer(
 	creator resourceCreator,
 ) (*GamePlayer, error) {
 	logger = logger.New("game", addr)
-	loader, err := contracts.NewFaultDisputeGameContract(addr, batching.NewMultiCaller(client.Client(), 100))
+	loader, err := contracts.NewFaultDisputeGameContract(addr, batching.NewMultiCaller(client.Client(), batching.DefaultBatchSize))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fault dispute game contract wrapper: %w", err)
 	}

--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
@@ -23,7 +22,7 @@ type blockNumberFetcher func(ctx context.Context) (uint64, error)
 
 // gameSource loads information about the games available to play
 type gameSource interface {
-	FetchAllGamesAtBlock(ctx context.Context, earliest uint64, blockNumber *big.Int) ([]types.GameMetadata, error)
+	FetchAllGamesAtBlock(ctx context.Context, earliest uint64, blockNumber uint64) ([]types.GameMetadata, error)
 }
 
 type gameScheduler interface {
@@ -101,7 +100,7 @@ func (m *gameMonitor) minGameTimestamp() uint64 {
 }
 
 func (m *gameMonitor) progressGames(ctx context.Context, blockNum uint64) error {
-	games, err := m.source.FetchAllGamesAtBlock(ctx, m.minGameTimestamp(), new(big.Int).SetUint64(blockNum))
+	games, err := m.source.FetchAllGamesAtBlock(ctx, m.minGameTimestamp(), blockNum)
 	if err != nil {
 		return fmt.Errorf("failed to load games: %w", err)
 	}

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -230,7 +230,7 @@ type stubGameSource struct {
 func (s *stubGameSource) FetchAllGamesAtBlock(
 	ctx context.Context,
 	earliest uint64,
-	blockNumber *big.Int,
+	blockNumber uint64,
 ) ([]types.GameMetadata, error) {
 	return s.games, nil
 }

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/loader"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -88,7 +89,7 @@ func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Se
 		m.StartBalanceMetrics(ctx, logger, l1Client, txMgr.From())
 	}
 
-	factoryContract, err := bindings.NewDisputeGameFactory(cfg.GameFactoryAddress, l1Client)
+	factoryContract, err := contracts.NewDisputeGameFactoryContract(cfg.GameFactoryAddress, batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize))
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("failed to bind the fault dispute game factory contract: %w", err), s.Stop(ctx))
 	}

--- a/op-service/sources/batching/call.go
+++ b/op-service/sources/batching/call.go
@@ -110,6 +110,10 @@ func (c *CallResult) GetHash(i int) common.Hash {
 	return *abi.ConvertType(c.out[i], new([32]byte)).(*[32]byte)
 }
 
+func (c *CallResult) GetAddress(i int) common.Address {
+	return *abi.ConvertType(c.out[i], new([20]byte)).(*[20]byte)
+}
+
 func (c *CallResult) GetBigInt(i int) *big.Int {
 	return *abi.ConvertType(c.out[i], new(*big.Int)).(**big.Int)
 }

--- a/op-service/sources/batching/call_test.go
+++ b/op-service/sources/batching/call_test.go
@@ -119,6 +119,13 @@ func TestCallResult_GetValues(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "GetAddress",
+			getter: func(result *CallResult, i int) interface{} {
+				return result.GetAddress(i)
+			},
+			expected: ([20]byte)(common.Address{0xaa, 0xbb, 0xcc}),
+		},
+		{
 			name: "GetHash",
 			getter: func(result *CallResult, i int) interface{} {
 				return result.GetHash(i)


### PR DESCRIPTION
**Description**

Introduce a custom contact wrapper for `DisputeGameFactory` rather than using the generated bindings.

Also introduces `batching.Block` to allow specifying which block a call should reference by label, number or hash. This custom type gives us a sane interface to geth's variety of approaches to specifying a block number, label or hash.

**Tests**

Updated existing tests.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/154
