### PR TITLE
op-node: static-peers list local-peer check and flag description update

### DIFF
--- a/op-node/flags/p2p_flags.go
+++ b/op-node/flags/p2p_flags.go
@@ -189,8 +189,9 @@ func P2PFlags(envPrefix string) []cli.Flag {
 			EnvVars:  p2pEnv(envPrefix, "BOOTNODES"),
 		},
 		&cli.StringFlag{
-			Name:     StaticPeersName,
-			Usage:    "Comma-separated multiaddr-format peer list. Static connections to make and maintain, these peers will be regarded as trusted.",
+			Name: StaticPeersName,
+			Usage: "Comma-separated multiaddr-format peer list. Static connections to make and maintain, these peers will be regarded as trusted. " +
+				"Addresses of the local peer are ignored. Duplicate/Alternative addresses for the same peer all apply, but only a single connection per peer is maintained.",
 			Required: false,
 			Value:    "",
 			EnvVars:  p2pEnv(envPrefix, "STATIC"),

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -236,7 +236,7 @@ func (conf *Config) Host(log log.Logger, reporter metrics.Reporter, metrics Host
 			return nil, fmt.Errorf("bad peer address: %w", err)
 		}
 		if addr.ID == h.ID() {
-			log.Info("Static-peer list contains address of local peer, ignoring the address.", "address", addr)
+			log.Info("Static-peer list contains address of local peer, ignoring the address.", "peer_id", addr.ID, "addrs", addr.Addrs)
 			continue
 		}
 		staticPeers = append(staticPeers, addr)

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -229,13 +229,17 @@ func (conf *Config) Host(log log.Logger, reporter metrics.Reporter, metrics Host
 		return nil, err
 	}
 
-	staticPeers := make([]*peer.AddrInfo, len(conf.StaticPeers))
-	for i, peerAddr := range conf.StaticPeers {
+	staticPeers := make([]*peer.AddrInfo, 0, len(conf.StaticPeers))
+	for _, peerAddr := range conf.StaticPeers {
 		addr, err := peer.AddrInfoFromP2pAddr(peerAddr)
 		if err != nil {
 			return nil, fmt.Errorf("bad peer address: %w", err)
 		}
-		staticPeers[i] = addr
+		if addr.ID == h.ID() {
+			log.Info("Static-peer list contains address of local peer, ignoring the address.", "address", addr)
+			continue
+		}
+		staticPeers = append(staticPeers, addr)
 	}
 
 	out := &extraHost{

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
@@ -139,12 +140,22 @@ func TestP2PFull(t *testing.T) {
 	confB.StaticPeers, err = peer.AddrInfoToP2pAddrs(&peer.AddrInfo{ID: hostA.ID(), Addrs: hostA.Addrs()})
 	require.NoError(t, err)
 
+	// Add address of host B itself, it shouldn't connect or cause issues.
+	idB, err := peer.IDFromPublicKey(confB.Priv.GetPublic())
+	require.NoError(t, err)
+	altAddrB, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/12345/p2p/" + idB.String())
+	require.NoError(t, err)
+	confB.StaticPeers = append(confB.StaticPeers, altAddrB)
+
 	logB := testlog.Logger(t, log.LvlError).New("host", "B")
 
 	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
+
+	require.True(t, nodeB.IsStatic(hostA.ID()), "node A must be static peer of node B")
+	require.False(t, nodeB.IsStatic(hostB.ID()), "node B must not be static peer of node B itself")
 
 	select {
 	case <-time.After(time.Second):


### PR DESCRIPTION
Don't try to connect to the local peer itself.
Emits an info log when skipping it, to help debug any configuration issue, if any.
Also updates the flag-description to reflect the peer-behavior, and a related edge-case of duplicate/alternative addresses of the same peer.
