### PR TITLE
feat(proxyd): configurable IP rate limit header

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -22,9 +22,9 @@ type ServerConfig struct {
 
 	MaxUpstreamBatchSize int `toml:"max_upstream_batch_size"`
 
-	EnableRequestLog     bool `toml:"enable_request_log"`
-	MaxRequestBodyLogLen int  `toml:"max_request_body_log_len"`
-	EnablePprof          bool `toml:"enable_pprof"`
+	EnableRequestLog      bool `toml:"enable_request_log"`
+	MaxRequestBodyLogLen  int  `toml:"max_request_body_log_len"`
+	EnablePprof           bool `toml:"enable_pprof"`
 	EnableXServedByHeader bool `toml:"enable_served_by_header"`
 }
 
@@ -51,6 +51,7 @@ type RateLimitConfig struct {
 	ExemptUserAgents []string                            `toml:"exempt_user_agents"`
 	ErrorMessage     string                              `toml:"error_message"`
 	MethodOverrides  map[string]*RateLimitMethodOverride `toml:"method_overrides"`
+	IPHeaderOverride string                              `toml:"ip_header_override"`
 }
 
 type RateLimitMethodOverride struct {

--- a/proxyd/go.sum
+++ b/proxyd/go.sum
@@ -138,7 +138,6 @@ github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR was originally written by @danyalprout at Coinbase.

In their words:

We run proxyd behind Cloudflare which [appends IP's](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#x-forwarded-for). This makes it pretty easy for a client to set a fake IP's in the header and bypass the rate limits.
Would ya'll be open to a small PR making the header proxyd uses configurable? Then we can elect to use a header that's set completely by Cloudflare. (e.g. [CF-Connecting-IP](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip))


**Additional context**

See https://github.com/ethereum-optimism/developer-support/issues/284
