### PR TITLE
Usage of 'Immutable' for variables storing keccak hashes

### DIFF
--- a/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
+++ b/packages/contracts-bedrock/src/periphery/faucet/authmodules/AdminFaucetAuthModule.sol
@@ -14,7 +14,7 @@ contract AdminFaucetAuthModule is IFaucetAuthModule, EIP712 {
     address public immutable ADMIN;
 
     /// @notice EIP712 typehash for the Proof type.
-    bytes32 public constant PROOF_TYPEHASH = keccak256("Proof(address recipient,bytes32 nonce,bytes32 id)");
+    bytes32 public immutable PROOF_TYPEHASH = keccak256("Proof(address recipient,bytes32 nonce,bytes32 id)");
 
     /// @notice Struct that represents a proof that verifies the admin.
     /// @custom:field recipient Address that will be receiving the faucet funds.


### PR DESCRIPTION
**Description**

Replaced 'constant' with 'immutable' on the basis of these two links -> [1st](https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#change-constant-to-immutable-for-keccak-variables) and [2nd](https://github.com/ethereum/solidity/issues/9232#issuecomment-646131646)
This seems more effective.

**Tests**

No tests added cuz it wasn't necessary!