### PR TITLE
Change the version of "op-node"

### DIFF
--- a/op-node/Makefile
+++ b/op-node/Makefile
@@ -1,6 +1,6 @@
 GITCOMMIT ?= $(shell git rev-parse HEAD)
 GITDATE ?= $(shell git show -s --format='%ct')
-VERSION := v0.0.0
+VERSION := v1.3.0
 
 LDFLAGSSTRING +=-X main.GitCommit=$(GITCOMMIT)
 LDFLAGSSTRING +=-X main.GitDate=$(GITDATE)

--- a/op-node/version/version.go
+++ b/op-node/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	Version = "v0.10.14"
+	Version = "v1.3.0"
 	Meta    = "dev"
 )


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Since the version of op-node changed to v1.3.0, it should be printed in `v1.3.0`. But it is still `v0.0.0` or `v0.10.14`.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
```sh
root@b14471fb02d2:/app# ./op-node --version
op-node version v1.3.0-8c2f0795-1699002925
```
```sh
➜  op-node git:(develop) ✗ ./bin/op-node --version
op-node version v1.3.0-dev
```