### PR TITLE
contracts-bedrock: 1967 helper version

### DIFF
--- a/packages/contracts-bedrock/test/mocks/EIP1967Helper.sol
+++ b/packages/contracts-bedrock/test/mocks/EIP1967Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { Vm } from "forge-std/Vm.sol";
 import { Constants } from "src/libraries/Constants.sol";


### PR DESCRIPTION
**Description**

Use a more relaxed version for the `EIP1967Helper` contract.
This will make it much more portable.

Part of https://github.com/ethereum-optimism/optimism/pull/7928
