### PR TITLE
contracts-bedrock: simplify CrossDomainOwnable test

### DIFF
--- a/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
@@ -26,8 +26,7 @@ contract XDomainSetter is CrossDomainOwnable {
 contract CrossDomainOwnable_Test is Test {
     XDomainSetter setter;
 
-    function setUp() public override {
-        super.setUp();
+    function setUp() public {
         setter = new XDomainSetter();
     }
 

--- a/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.15;
 // Testing utilities
 import { VmSafe } from "forge-std/Vm.sol";
 import { Test } from "forge-std/Test.sol";
-import { CommonTest, Portal_Initializer } from "test/CommonTest.t.sol";
+import { Portal_Initializer } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";

--- a/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
+++ b/packages/contracts-bedrock/test/CrossDomainOwnable.t.sol
@@ -2,17 +2,18 @@
 pragma solidity 0.8.15;
 
 // Testing utilities
-import { Vm, VmSafe } from "forge-std/Vm.sol";
+import { VmSafe } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
 import { CommonTest, Portal_Initializer } from "test/CommonTest.t.sol";
 
 // Libraries
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
 
 // Target contract dependencies
-import { AddressAliasHelper } from "../src/vendor/AddressAliasHelper.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 
 // Target contract
-import { CrossDomainOwnable } from "../src/L2/CrossDomainOwnable.sol";
+import { CrossDomainOwnable } from "src/L2/CrossDomainOwnable.sol";
 
 contract XDomainSetter is CrossDomainOwnable {
     uint256 public value;
@@ -22,7 +23,7 @@ contract XDomainSetter is CrossDomainOwnable {
     }
 }
 
-contract CrossDomainOwnable_Test is CommonTest {
+contract CrossDomainOwnable_Test is Test {
     XDomainSetter setter;
 
     function setUp() public override {


### PR DESCRIPTION
**Description**

Removes usage of `CommonTest` that are not required.
Also canonicalize the import paths. This should help
to speed up the tests slightly by reducing the amount
of execution required to run the tests.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

