### PR TITLE
op-challenger: Remove AbsolutePreState from TraceProvider

### DIFF
--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -129,7 +129,7 @@ func (p *CannonTraceProvider) GetStepData(ctx context.Context, pos types.Positio
 	return value, data, oracleData, nil
 }
 
-func (p *CannonTraceProvider) AbsolutePreState(ctx context.Context) ([]byte, error) {
+func (p *CannonTraceProvider) absolutePreState() ([]byte, error) {
 	state, err := parseState(p.prestate)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load absolute pre-state: %w", err)
@@ -137,8 +137,8 @@ func (p *CannonTraceProvider) AbsolutePreState(ctx context.Context) ([]byte, err
 	return state.EncodeWitness(), nil
 }
 
-func (p *CannonTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (common.Hash, error) {
-	state, err := p.AbsolutePreState(ctx)
+func (p *CannonTraceProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	state, err := p.absolutePreState()
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("cannot load absolute pre-state: %w", err)
 	}

--- a/op-challenger/game/fault/trace/cannon/provider_test.go
+++ b/op-challenger/game/fault/trace/cannon/provider_test.go
@@ -216,28 +216,28 @@ func TestGetStepData(t *testing.T) {
 	})
 }
 
-func TestAbsolutePreState(t *testing.T) {
+func TestAbsolutePreStateCommitment(t *testing.T) {
 	dataDir := t.TempDir()
 
 	prestate := "state.json"
 
 	t.Run("StateUnavailable", func(t *testing.T) {
 		provider, _ := setupWithTestData(t, "/dir/does/not/exist", prestate)
-		_, err := provider.AbsolutePreState(context.Background())
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
 		require.ErrorIs(t, err, os.ErrNotExist)
 	})
 
 	t.Run("InvalidStateFile", func(t *testing.T) {
 		setupPreState(t, dataDir, "invalid.json")
 		provider, _ := setupWithTestData(t, dataDir, prestate)
-		_, err := provider.AbsolutePreState(context.Background())
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
 		require.ErrorContains(t, err, "invalid mipsevm state")
 	})
 
 	t.Run("ExpectedAbsolutePreState", func(t *testing.T) {
 		setupPreState(t, dataDir, "state.json")
 		provider, _ := setupWithTestData(t, dataDir, prestate)
-		preState, err := provider.AbsolutePreState(context.Background())
+		actual, err := provider.AbsolutePreStateCommitment(context.Background())
 		require.NoError(t, err)
 		state := mipsevm.State{
 			Memory:         mipsevm.NewMemory(),
@@ -253,7 +253,9 @@ func TestAbsolutePreState(t *testing.T) {
 			Step:           0,
 			Registers:      [32]uint32{},
 		}
-		require.Equal(t, []byte(state.EncodeWitness()), preState)
+		expected, err := state.EncodeWitness().StateHash()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
 	})
 }
 

--- a/op-challenger/game/fault/trace/split/provider.go
+++ b/op-challenger/game/fault/trace/split/provider.go
@@ -56,11 +56,6 @@ func (s *SplitTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (ha
 	return s.bottomProvider.AbsolutePreStateCommitment(ctx)
 }
 
-// AbsolutePreState routes the AbsolutePreState request to the lowest internal [types.TraceProvider].
-func (s *SplitTraceProvider) AbsolutePreState(ctx context.Context) (preimage []byte, err error) {
-	return s.bottomProvider.AbsolutePreState(ctx)
-}
-
 // GetStepData routes the GetStepData request to the lowest internal [types.TraceProvider].
 func (s *SplitTraceProvider) GetStepData(ctx context.Context, pos types.Position) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
 	ancestorDepth, provider := s.providerForDepth(uint64(pos.Depth()))

--- a/op-challenger/game/fault/trace/split/provider_test.go
+++ b/op-challenger/game/fault/trace/split/provider_test.go
@@ -64,24 +64,6 @@ func TestAbsolutePreStateCommitment(t *testing.T) {
 	})
 }
 
-func TestAbsolutePreState(t *testing.T) {
-	t.Run("ErrorBubblesUp", func(t *testing.T) {
-		mockOutputProvider := mockTraceProvider{absolutePreStateError: mockGetError}
-		splitProvider := newSplitTraceProvider(t, nil, &mockOutputProvider, 40)
-		_, err := splitProvider.AbsolutePreState(context.Background())
-		require.ErrorIs(t, err, mockGetError)
-	})
-
-	t.Run("ReturnsCorrectPreimageData", func(t *testing.T) {
-		expectedPreimage := []byte{1, 2, 3, 4}
-		mockOutputProvider := mockTraceProvider{preImageData: expectedPreimage}
-		splitProvider := newSplitTraceProvider(t, nil, &mockOutputProvider, 40)
-		output, err := splitProvider.AbsolutePreState(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, expectedPreimage, output)
-	})
-}
-
 func TestGetStepData(t *testing.T) {
 	t.Run("ErrorBubblesUp", func(t *testing.T) {
 		mockOutputProvider := mockTraceProvider{getStepDataError: mockGetError}

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -69,9 +69,6 @@ type TraceProvider interface {
 	// The prestate returned from GetStepData for trace 10 should be the pre-image of the claim from trace 9
 	GetStepData(ctx context.Context, i Position) (prestate []byte, proofData []byte, preimageData *PreimageOracleData, err error)
 
-	// AbsolutePreState is the pre-image value of the trace that transitions to the trace value at index 0
-	AbsolutePreState(ctx context.Context) (preimage []byte, err error)
-
 	// AbsolutePreStateCommitment is the commitment of the pre-image value of the trace that transitions to the trace value at index 0
 	AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error)
 }


### PR DESCRIPTION
**Description**

Nothing actually uses `AbsolutePreState` - only `AbsolutePreStateCommitment` so we can narrow the interface and simplify code. The `TraceProvider` will internally use the absolute pre state when creating step data for the very first instruction, but there's no need to have it exposed externally.