### PR TITLE
Optimize span batch e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1418,13 +1418,6 @@ workflows:
             - op-stack-go-lint
             - devnet-allocs
             - l1-geth-version-check
-      - go-e2e-test:
-          name: op-e2e-span-batch-tests
-          module: op-e2e
-          target: test-span-batch
-          requires:
-            - op-stack-go-lint
-            - devnet-allocs
       - op-program-compat:
           requires:
             - op-program-tests

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -23,10 +23,6 @@ test-http: pre-test
 	OP_E2E_USE_HTTP=true $(go_test) $(go_test_flags) ./...
 .PHONY: test-http
 
-test-span-batch: pre-test
-	OP_E2E_USE_SPAN_BATCH=true $(go_test) $(go_test_flags) ./...
-.PHONY: test-span-batch
-
 cannon-prestate:
 	make -C .. cannon-prestate
 .PHONY: cannon-prestate

--- a/op-e2e/actions/reorg_test.go
+++ b/op-e2e/actions/reorg_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/log"
@@ -21,8 +22,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-func setupReorgTest(t Testing, config *e2eutils.TestParams) (*e2eutils.SetupData, *e2eutils.DeployParams, *L1Miner, *L2Sequencer, *L2Engine, *L2Verifier, *L2Engine, *L2Batcher) {
+func setupReorgTest(t Testing, config *e2eutils.TestParams, spanBatchTimeOffset *hexutil.Uint64) (*e2eutils.SetupData, *e2eutils.DeployParams, *L1Miner, *L2Sequencer, *L2Engine, *L2Verifier, *L2Engine, *L2Batcher) {
 	dp := e2eutils.MakeDeployParams(t, config)
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
 
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
@@ -44,9 +46,38 @@ func setupReorgTestActors(t Testing, dp *e2eutils.DeployParams, sd *e2eutils.Set
 	return sd, dp, miner, sequencer, seqEngine, verifier, verifEngine, batcher
 }
 
-func TestReorgOrphanBlock(gt *testing.T) {
+// TestReorgBatchType run each reorg-related test case in singular batch mode and span batch mode.
+func TestReorgBatchType(t *testing.T) {
+	tests := []struct {
+		name string
+		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+	}{
+		{"ReorgOrphanBlock", ReorgOrphanBlock},
+		{"ReorgFlipFlop", ReorgFlipFlop},
+		{"DeepReorg", DeepReorg},
+		{"RestartOpGeth", RestartOpGeth},
+		{"ConflictingL2Blocks", ConflictingL2Blocks},
+		{"SyncAfterReorg", SyncAfterReorg},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SingularBatch", func(t *testing.T) {
+			test.f(t, nil)
+		})
+	}
+
+	spanBatchTimeOffset := hexutil.Uint64(0)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
+			test.f(t, &spanBatchTimeOffset)
+		})
+	}
+}
+
+func ReorgOrphanBlock(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
-	sd, _, miner, sequencer, _, verifier, verifierEng, batcher := setupReorgTest(t, defaultRollupTestParams)
+	sd, _, miner, sequencer, _, verifier, verifierEng, batcher := setupReorgTest(t, defaultRollupTestParams, spanBatchTimeOffset)
 	verifEngClient := verifierEng.EngineClient(t, sd.RollupCfg)
 
 	sequencer.ActL2PipelineFull(t)
@@ -112,9 +143,9 @@ func TestReorgOrphanBlock(gt *testing.T) {
 	require.Equal(t, verifier.L2Safe(), sequencer.L2Safe(), "verifier and sequencer see same safe L2 block, while only verifier dealt with the orphan and replay")
 }
 
-func TestReorgFlipFlop(gt *testing.T) {
+func ReorgFlipFlop(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
-	sd, _, miner, sequencer, _, verifier, verifierEng, batcher := setupReorgTest(t, defaultRollupTestParams)
+	sd, _, miner, sequencer, _, verifier, verifierEng, batcher := setupReorgTest(t, defaultRollupTestParams, spanBatchTimeOffset)
 	minerCl := miner.L1Client(t, sd.RollupCfg)
 	verifEngClient := verifierEng.EngineClient(t, sd.RollupCfg)
 	checkVerifEngine := func() {
@@ -333,7 +364,7 @@ func TestReorgFlipFlop(gt *testing.T) {
 // Verifier
 // - Unsafe head is 62
 // - Safe head is 42
-func TestDeepReorg(gt *testing.T) {
+func DeepReorg(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 
 	// Create actor and verification engine client
@@ -342,7 +373,7 @@ func TestDeepReorg(gt *testing.T) {
 		SequencerWindowSize: 20,
 		ChannelTimeout:      120,
 		L1BlockTime:         4,
-	})
+	}, spanBatchTimeOffset)
 	minerCl := miner.L1Client(t, sd.RollupCfg)
 	l2Client := seqEngine.EthClient()
 	verifEngClient := verifierEng.EngineClient(t, sd.RollupCfg)
@@ -566,9 +597,9 @@ type rpcWrapper struct {
 	client.RPC
 }
 
-// TestRestartOpGeth tests that the sequencer can restart its execution engine without rollup-node restart,
+// RestartOpGeth tests that the sequencer can restart its execution engine without rollup-node restart,
 // including recovering the finalized/safe state of L2 chain without reorging.
-func TestRestartOpGeth(gt *testing.T) {
+func RestartOpGeth(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dbPath := path.Join(t.TempDir(), "testdb")
 	dbOption := func(_ *ethconfig.Config, nodeCfg *node.Config) error {
@@ -576,6 +607,7 @@ func TestRestartOpGeth(gt *testing.T) {
 		return nil
 	}
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	jwtPath := e2eutils.WriteDefaultJWT(t)
@@ -660,12 +692,13 @@ func TestRestartOpGeth(gt *testing.T) {
 	require.Equal(t, statusBeforeRestart.SafeL2, sequencer.L2Safe(), "expecting the safe block to catch up to what it was before shutdown after syncing from L1, and not be stuck at the finalized block")
 }
 
-// TestConflictingL2Blocks tests that a second copy of the sequencer stack cannot introduce an alternative
+// ConflictingL2Blocks tests that a second copy of the sequencer stack cannot introduce an alternative
 // L2 block (compared to something already secured by the first sequencer):
 // the alt block is not synced by the verifier, in unsafe and safe sync modes.
-func TestConflictingL2Blocks(gt *testing.T) {
+func ConflictingL2Blocks(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 
@@ -772,7 +805,7 @@ func TestConflictingL2Blocks(gt *testing.T) {
 	require.Equal(t, sequencer.L2Unsafe(), altSequencer.L2Unsafe(), "and gets back in harmony with original sequencer")
 }
 
-func TestSyncAfterReorg(gt *testing.T) {
+func SyncAfterReorg(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	testingParams := e2eutils.TestParams{
 		MaxSequencerDrift:   60,
@@ -780,7 +813,7 @@ func TestSyncAfterReorg(gt *testing.T) {
 		ChannelTimeout:      2,
 		L1BlockTime:         12,
 	}
-	sd, dp, miner, sequencer, seqEngine, verifier, _, batcher := setupReorgTest(t, &testingParams)
+	sd, dp, miner, sequencer, seqEngine, verifier, _, batcher := setupReorgTest(t, &testingParams, spanBatchTimeOffset)
 	l2Client := seqEngine.EthClient()
 	log := testlog.Logger(t, log.LvlDebug)
 	addresses := e2eutils.CollectAddresses(sd, dp)

--- a/op-e2e/actions/system_config_test.go
+++ b/op-e2e/actions/system_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -19,13 +20,40 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-// TestBatcherKeyRotation tests that batcher A can operate, then be replaced with batcher B, then ignore old batcher A,
+// TestSystemConfigBatchType run each system config-related test case in singular batch mode and span batch mode.
+func TestSystemConfigBatchType(t *testing.T) {
+	tests := []struct {
+		name string
+		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+	}{
+		{"BatcherKeyRotation", BatcherKeyRotation},
+		{"GPOParamsChange", GPOParamsChange},
+		{"GasLimitChange", GasLimitChange},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SingularBatch", func(t *testing.T) {
+			test.f(t, nil)
+		})
+	}
+
+	spanBatchTimeOffset := hexutil.Uint64(0)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
+			test.f(t, &spanBatchTimeOffset)
+		})
+	}
+}
+
+// BatcherKeyRotation tests that batcher A can operate, then be replaced with batcher B, then ignore old batcher A,
 // and that the change to batcher B is reverted properly upon reorg of L1.
-func TestBatcherKeyRotation(gt *testing.T) {
+func BatcherKeyRotation(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	dp.DeployConfig.L2BlockTime = 2
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -198,11 +226,12 @@ func TestBatcherKeyRotation(gt *testing.T) {
 	require.Equal(t, sequencer.L2Unsafe(), verifier.L2Unsafe(), "verifier synced")
 }
 
-// TestGPOParamsChange tests that the GPO params can be updated to adjust fees of L2 transactions,
+// GPOParamsChange tests that the GPO params can be updated to adjust fees of L2 transactions,
 // and that the L1 data fees to the L2 transaction are applied correctly before, during and after the GPO update in L2.
-func TestGPOParamsChange(gt *testing.T) {
+func GPOParamsChange(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -326,12 +355,13 @@ func TestGPOParamsChange(gt *testing.T) {
 	require.Equal(t, "2.3", receipt.FeeScalar.String(), "2_300_000 divided by 6 decimals = float(2.3)")
 }
 
-// TestGasLimitChange tests that the gas limit can be configured to L1,
+// GasLimitChange tests that the gas limit can be configured to L1,
 // and that the L2 changes the gas limit instantly at the exact block that adopts the L1 origin with
 // the gas limit change event. And checks if a verifier node can reproduce the same gas limit change.
-func TestGasLimitChange(gt *testing.T) {
+func GasLimitChange(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)

--- a/op-e2e/actions/user_test.go
+++ b/op-e2e/actions/user_test.go
@@ -13,10 +13,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-type regolithScheduledTest struct {
-	name             string
-	regolithTime     *hexutil.Uint64
-	activateRegolith bool
+type hardforkScheduledTest struct {
+	name              string
+	regolithTime      *hexutil.Uint64
+	spanBatchTime     *hexutil.Uint64
+	activateRegolith  bool
+	activateSpanBatch bool
 }
 
 // TestCrossLayerUser tests that common actions of the CrossLayerUser actor work in various regolith configurations:
@@ -31,11 +33,18 @@ func TestCrossLayerUser(t *testing.T) {
 	zeroTime := hexutil.Uint64(0)
 	futureTime := hexutil.Uint64(20)
 	farFutureTime := hexutil.Uint64(2000)
-	tests := []regolithScheduledTest{
-		{name: "NoRegolith", regolithTime: nil, activateRegolith: false},
-		{name: "NotYetRegolith", regolithTime: &farFutureTime, activateRegolith: false},
-		{name: "RegolithAtGenesis", regolithTime: &zeroTime, activateRegolith: true},
-		{name: "RegolithAfterGenesis", regolithTime: &futureTime, activateRegolith: true},
+	tests := []hardforkScheduledTest{
+		{name: "NoRegolith", regolithTime: nil, activateRegolith: false, spanBatchTime: nil, activateSpanBatch: false},
+		{name: "NotYetRegolith", regolithTime: &farFutureTime, activateRegolith: false, spanBatchTime: nil, activateSpanBatch: false},
+		{name: "RegolithAtGenesis", regolithTime: &zeroTime, activateRegolith: true, spanBatchTime: nil, activateSpanBatch: false},
+		{name: "RegolithAfterGenesis", regolithTime: &futureTime, activateRegolith: true, spanBatchTime: nil, activateSpanBatch: false},
+		{name: "NoSpanBatch", regolithTime: &zeroTime, activateRegolith: true, spanBatchTime: nil, activateSpanBatch: false},
+		{name: "NotYetSpanBatch", regolithTime: &zeroTime, activateRegolith: true,
+			spanBatchTime: &farFutureTime, activateSpanBatch: false},
+		{name: "SpanBatchAtGenesis", regolithTime: &zeroTime, activateRegolith: true,
+			spanBatchTime: &zeroTime, activateSpanBatch: true},
+		{name: "SpanBatchAfterGenesis", regolithTime: &zeroTime, activateRegolith: true,
+			spanBatchTime: &futureTime, activateSpanBatch: true},
 	}
 	for _, test := range tests {
 		test := test // Use a fixed reference as the tests run in parallel
@@ -45,10 +54,11 @@ func TestCrossLayerUser(t *testing.T) {
 	}
 }
 
-func runCrossLayerUserTest(gt *testing.T, test regolithScheduledTest) {
+func runCrossLayerUserTest(gt *testing.T, test hardforkScheduledTest) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	dp.DeployConfig.L2GenesisRegolithTimeOffset = test.regolithTime
+	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = test.spanBatchTime
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -59,7 +59,6 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 	deployConfig.L1BlockTime = tp.L1BlockTime
 	deployConfig.L2GenesisRegolithTimeOffset = nil
 	deployConfig.L2GenesisCanyonTimeOffset = CanyonTimeOffset()
-	deployConfig.L2GenesisSpanBatchTimeOffset = SpanBatchTimeOffset()
 
 	require.NoError(t, deployConfig.Check())
 	require.Equal(t, addresses.Batcher, deployConfig.BatchSenderAddress)
@@ -184,14 +183,6 @@ func SystemConfigFromDeployConfig(deployConfig *genesis.DeployConfig) eth.System
 		Scalar:      eth.Bytes32(common.BigToHash(new(big.Int).SetUint64(deployConfig.GasPriceOracleScalar))),
 		GasLimit:    uint64(deployConfig.L2GenesisBlockGasLimit),
 	}
-}
-
-func SpanBatchTimeOffset() *hexutil.Uint64 {
-	if os.Getenv("OP_E2E_USE_SPAN_BATCH") == "true" {
-		offset := hexutil.Uint64(0)
-		return &offset
-	}
-	return nil
 }
 
 func CanyonTimeOffset() *hexutil.Uint64 {

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -684,7 +684,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	}
 
 	var batchType uint = derive.SingularBatchType
-	if os.Getenv("OP_E2E_USE_SPAN_BATCH") == "true" {
+	if cfg.DeployConfig.L2GenesisSpanBatchTimeOffset != nil && *cfg.DeployConfig.L2GenesisSpanBatchTimeOffset == hexutil.Uint64(0) {
 		batchType = derive.SpanBatchType
 	}
 	batcherMaxL1TxSizeBytes := cfg.BatcherMaxL1TxSizeBytes

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -88,7 +88,6 @@ func DefaultSystemConfig(t *testing.T) SystemConfig {
 	deployConfig := config.DeployConfig.Copy()
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	deployConfig.L2GenesisCanyonTimeOffset = e2eutils.CanyonTimeOffset()
-	deployConfig.L2GenesisSpanBatchTimeOffset = e2eutils.SpanBatchTimeOffset()
 	require.NoError(t, deployConfig.Check(), "Deploy config is invalid, do you need to run make devnet-allocs?")
 	l1Deployments := config.L1Deployments.Copy()
 	require.NoError(t, l1Deployments.Check())

--- a/op-e2e/system_fpp_test.go
+++ b/op-e2e/system_fpp_test.go
@@ -15,25 +15,42 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyL2OutputRoot(t *testing.T) {
-	testVerifyL2OutputRoot(t, false)
+	testVerifyL2OutputRoot(t, false, false)
+}
+
+func TestVerifyL2OutputRootSpanBatch(t *testing.T) {
+	testVerifyL2OutputRoot(t, false, true)
 }
 
 func TestVerifyL2OutputRootDetached(t *testing.T) {
-	testVerifyL2OutputRoot(t, true)
+	testVerifyL2OutputRoot(t, true, false)
+}
+
+func TestVerifyL2OutputRootDetachedSpanBatch(t *testing.T) {
+	testVerifyL2OutputRoot(t, true, true)
 }
 
 func TestVerifyL2OutputRootEmptyBlock(t *testing.T) {
-	testVerifyL2OutputRootEmptyBlock(t, false)
+	testVerifyL2OutputRootEmptyBlock(t, false, false)
+}
+
+func TestVerifyL2OutputRootEmptyBlockSpanBatch(t *testing.T) {
+	testVerifyL2OutputRootEmptyBlock(t, false, true)
 }
 
 func TestVerifyL2OutputRootEmptyBlockDetached(t *testing.T) {
-	testVerifyL2OutputRootEmptyBlock(t, true)
+	testVerifyL2OutputRootEmptyBlock(t, true, false)
+}
+
+func TestVerifyL2OutputRootEmptyBlockDetachedSpanBatch(t *testing.T) {
+	testVerifyL2OutputRootEmptyBlock(t, true, true)
 }
 
 // TestVerifyL2OutputRootEmptyBlock asserts that the program can verify the output root of an empty block
@@ -46,7 +63,7 @@ func TestVerifyL2OutputRootEmptyBlockDetached(t *testing.T) {
 // - reboot the batch submitter
 // - update the state root via a tx
 // - run program
-func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool) {
+func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActivated bool) {
 	InitParallel(t)
 	ctx := context.Background()
 
@@ -56,6 +73,13 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool) {
 	// Use a small sequencer window size to avoid test timeout while waiting for empty blocks
 	// But not too small to ensure that our claim and subsequent state change is published
 	cfg.DeployConfig.SequencerWindowSize = 16
+	if spanBatchActivated {
+		// Activate span batch hard fork
+		minTs := hexutil.Uint64(0)
+		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	} else {
+		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = nil
+	}
 
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")
@@ -147,13 +171,20 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool) {
 	})
 }
 
-func testVerifyL2OutputRoot(t *testing.T, detached bool) {
+func testVerifyL2OutputRoot(t *testing.T, detached bool, spanBatchActivated bool) {
 	InitParallel(t)
 	ctx := context.Background()
 
 	cfg := DefaultSystemConfig(t)
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
+	if spanBatchActivated {
+		// Activate span batch hard fork
+		minTs := hexutil.Uint64(0)
+		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	} else {
+		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = nil
+	}
 
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")


### PR DESCRIPTION
**Description**
This issue was raised in https://github.com/ethereum-optimism/optimism/pull/7867#discussion_r1375610455, and is being tracked in https://github.com/ethereum-optimism/optimism/issues/8022.

- Remove running e2e tests in span batch mode via `OP_E2E_USE_SPAN_BATCH` env variable
- Remove span batch e2e CI workflow
- Parameterize existing e2e tests related to span batch 
  - Using op-batcher and checking L2 safe head