### PR TITLE
contracts-bedrock: visibility into flake

### DIFF
--- a/packages/contracts-bedrock/.gas-snapshot
+++ b/packages/contracts-bedrock/.gas-snapshot
@@ -140,7 +140,7 @@ GasBenchMark_L1StandardBridge_Finalize:test_finalizeETHWithdrawal_benchmark() (g
 GasBenchMark_L2OutputOracle:test_proposeL2Output_benchmark() (gas: 88797)
 GasBenchMark_OptimismPortal:test_depositTransaction_benchmark() (gas: 68320)
 GasBenchMark_OptimismPortal:test_depositTransaction_benchmark_1() (gas: 68973)
-GasBenchMark_OptimismPortal:test_proveWithdrawalTransaction_benchmark() (gas: 143295)
+GasBenchMark_OptimismPortal:test_proveWithdrawalTransaction_benchmark() (gas: 143303)
 GasPriceOracle_Test:test_baseFee_succeeds() (gas: 8348)
 GasPriceOracle_Test:test_decimals_succeeds() (gas: 6234)
 GasPriceOracle_Test:test_gasPrice_succeeds() (gas: 8340)

--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -88,7 +88,10 @@ abstract contract Deployer is Script {
         string memory chainIdPath = string.concat(deploymentsDir, "/.chainId");
         try vm.readFile(chainIdPath) returns (string memory localChainId) {
             if (vm.envOr("STRICT_DEPLOYMENT", true)) {
-                require(vm.parseUint(localChainId) == chainId, "Misconfigured networks");
+                require(
+                    vm.parseUint(localChainId) == chainId,
+                    string.concat("Misconfigured networks: ", localChainId, " != ", vm.toString(chainId))
+                );
             }
         } catch {
             vm.writeFile(chainIdPath, vm.toString(chainId));


### PR DESCRIPTION
**Description**

A flake in CI was introduced when https://github.com/ethereum-optimism/optimism/pull/7928
was merged. It is probably due to a race condition when reading a file
from disk. Is there a way to have foundry only do something once for the
entire test suite? Tried moving things to the constructor instead of
`setUp` but that did not work. Ideally we do not need to read the file
from disk for each contract deployed, this adds a lot of overhead.
A solution around this is to refactor the way that the deploy script
works or to add in the env var that will skip the check that sometimes
fails.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
