### PR TITLE
op-node: handle EL node without genesis state

### DIFF
--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -204,7 +204,11 @@ func (dp *DerivationPipeline) Step(ctx context.Context) error {
 			dp.resetting += 1
 			return nil
 		} else if err != nil {
-			return fmt.Errorf("stage %d failed resetting: %w", dp.resetting, err)
+			if errors.Is(err, sync.UnavailableStateErr) {
+				dp.resetting = len(dp.stages) // continue with just the engine stage, the rest is not going to be initialized.
+			} else {
+				return fmt.Errorf("stage %d failed resetting: %w", dp.resetting, err)
+			}
 		} else {
 			return nil
 		}

--- a/op-node/rollup/sync/start_test.go
+++ b/op-node/rollup/sync/start_test.go
@@ -26,7 +26,8 @@ func (c *syncStartTestCase) generateFakeL2(t *testing.T) (*testutils.FakeChainSo
 	log := testlog.Logger(t, log.LvlError)
 	chain := testutils.NewFakeChainSource([]string{c.L1, c.NewL1}, []string{c.L2}, int(c.GenesisL1Num), log)
 	chain.SetL2Head(len(c.L2) - 1)
-	genesis := testutils.FakeGenesis(c.GenesisL1, c.GenesisL2, int(c.GenesisL1Num))
+	genesisL1, genesisL2ID := testutils.FakeGenesis(c.GenesisL1, c.GenesisL2, int(c.GenesisL1Num))
+	genesis := rollup.Genesis{L1: genesisL1, L2: genesisL2ID}
 	chain.ReorgL1()
 	for i := 0; i < len(c.NewL1)-1; i++ {
 		chain.AdvanceL1()

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
 )
 
 func randConfig() *Config {
@@ -200,6 +201,13 @@ func TestRegolithActivation(t *testing.T) {
 type mockL2Client struct {
 	chainID *big.Int
 	Hash    common.Hash
+}
+
+func (m *mockL2Client) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
+	return &testutils.MockBlockInfo{ // just the basic block-info for the rollup config genesis validation
+		InfoHash: m.Hash,
+		InfoNum:  100,
+	}, nil
 }
 
 func (m *mockL2Client) ChainID(context.Context) (*big.Int, error) {

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -127,6 +128,8 @@ type PayloadID = engine.PayloadID
 type ExecutionPayloadEnvelope struct {
 	ExecutionPayload *ExecutionPayload `json:"executionPayload"`
 }
+
+var PreMergePayloadErr = errors.New("block is pre-merge")
 
 type ExecutionPayload struct {
 	ParentHash    common.Hash     `json:"parentHash"`

--- a/op-service/sources/l2_client.go
+++ b/op-service/sources/l2_client.go
@@ -50,9 +50,10 @@ func L2ClientDefaultConfig(config *rollup.Config, trustRPC bool) *L2ClientConfig
 			MaxRequestsPerBatch:   20, // TODO: tune batch param
 			MaxConcurrentRequests: 10,
 			TrustRPC:              trustRPC,
-			MustBePostMerge:       true,
 			RPCProviderKind:       RPCKindStandard,
 			MethodResetDuration:   time.Minute,
+			// don't enforce post-merge if the chain has pre-bedrock history.
+			MustBePostMerge: config.Genesis.L2.Number == 0,
 		},
 		// Not bounded by span, to cover find-sync-start range fully for speedy recovery after errors.
 		L2BlockRefsCacheSize: fullSpan,

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -128,19 +128,19 @@ func (hdr *rpcHeader) checkPostMerge() error {
 	// TODO: the genesis block has a non-zero difficulty number value.
 	// Either this block needs to change, or we special case it. This is not valid w.r.t. EIP-3675.
 	if hdr.Number != 0 && (*big.Int)(&hdr.Difficulty).Cmp(common.Big0) != 0 {
-		return fmt.Errorf("post-merge block header requires zeroed difficulty field, but got: %s", &hdr.Difficulty)
+		return fmt.Errorf("%w: post-merge block header requires zeroed difficulty field, but got: %s", eth.PreMergePayloadErr, &hdr.Difficulty)
 	}
 	if hdr.Nonce != (types.BlockNonce{}) {
-		return fmt.Errorf("post-merge block header requires zeroed block nonce field, but got: %s", hdr.Nonce)
+		return fmt.Errorf("%w: post-merge block header requires zeroed block nonce field, but got: %s", eth.PreMergePayloadErr, hdr.Nonce)
 	}
 	if hdr.BaseFee == nil {
-		return fmt.Errorf("post-merge block header requires EIP-1559 basefee field, but got %s", hdr.BaseFee)
+		return fmt.Errorf("%w: post-merge block header requires EIP-1559 basefee field, but got %s", eth.PreMergePayloadErr, hdr.BaseFee)
 	}
 	if len(hdr.Extra) > 32 {
-		return fmt.Errorf("post-merge block header requires 32 or less bytes of extra data, but got %d", len(hdr.Extra))
+		return fmt.Errorf("%w: post-merge block header requires 32 or less bytes of extra data, but got %d", eth.PreMergePayloadErr, len(hdr.Extra))
 	}
 	if hdr.UncleHash != types.EmptyUncleHash {
-		return fmt.Errorf("post-merge block header requires uncle hash to be of empty uncle list, but got %s", hdr.UncleHash)
+		return fmt.Errorf("%w: post-merge block header requires uncle hash to be of empty uncle list, but got %s", eth.PreMergePayloadErr, hdr.UncleHash)
 	}
 	return nil
 }

--- a/op-service/testutils/fake_chain.go
+++ b/op-service/testutils/fake_chain.go
@@ -10,15 +10,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber int) rollup.Genesis {
-	return rollup.Genesis{
-		L1: fakeID(l1, uint64(l1GenesisNumber)),
-		L2: fakeID(l2, 0),
-	}
+func FakeGenesis(l1 rune, l2 rune, l1GenesisNumber int) (l1ID, l2ID eth.BlockID) {
+	return fakeID(l1, uint64(l1GenesisNumber)), fakeID(l2, 0)
 }
 
 func fakeID(id rune, num uint64) eth.BlockID {


### PR DESCRIPTION
This enables an end-user to start a full-node without legacy data-dir, by handling the case where the genesis-block is present in the EL, but the genesis state is not.

To handle it, we detect the state is unavailable, and force the engine-queue in a state where it can relay the unsafe payload headers and trigger sync, but not do anything else till syncing completes.

Once completed, the engine-queue snaps (no pun intended) out of this state by simply returning a "reset error", to enter regular block derivation.

To handle the legacy block-header fetching, the post-merge header-validation requirement has to be relaxed (we can do so conditionally on the rollup config, to avoid introducing any legacy edge-cases to other new chains).

And then there are some minor test updates + op-program oracle update, so the new extended L2 chain interface is covered.

This relies on the op-geth https://github.com/ethereum-optimism/op-geth/pull/182 changes in to fully function.

Tested this on home-lab with an op-goerli snap-sync, with path-DB scheme and pebble-DB. This is very experimental.
We should add an e2e test that covers the unavailable-state syncing case.
