### PR TITLE
ci: Remove duplicate build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ jobs:
           paths:
             - "packages/**/dist"
             - "packages/contracts-bedrock/forge-artifacts"
+            - "packages/contracts-bedrock/scripts/go-ffi/go-ffi"
 
   docker-build:
     environment:
@@ -359,10 +360,6 @@ jobs:
       - run:
           name: Install dependencies
           command: pnpm install --frozen-lockfile --prefer-offline
-      - run:
-          name: build contracts
-          command: pnpm build
-          working_directory: packages/contracts-bedrock
       - run:
           name: lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,8 +363,17 @@ jobs:
           patterns: contracts-bedrock,op-node
       # populate node modules from the cache
       - run:
+          name: look for cached artifacts
+          command: |
+            ls artifacts
+            ls lib
+            ls forge-artifacts
+            ls cache
+          working_directory: packages/contracts-bedrock
+      - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: |
+            pnpm install --frozen-lockfile --prefer-offline
       - run:
           name: lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,12 @@ jobs:
           root: "."
           paths:
             - "packages/**/dist"
+            - "packages/contracts-bedrock/cache"
+            - "packages/contracts-bedrock/artifacts"
             - "packages/contracts-bedrock/forge-artifacts"
-            - "packages/contracts-bedrock/scripts/go-ffi/go-ffi"
+            - "packages/contracts-bedrock/tsconfig.tsbuildinfo"
+            - "packages/contracts-bedrock/tsconfig.build.tsbuildinfo"
+            - "packages/contracts-bedrock/scripts/go-ffi"
 
   docker-build:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,7 @@ jobs:
             - "packages/contracts-bedrock/forge-artifacts"
             - "packages/contracts-bedrock/tsconfig.tsbuildinfo"
             - "packages/contracts-bedrock/tsconfig.build.tsbuildinfo"
+            - "packages/contracts-bedrock/lib"
             - "packages/contracts-bedrock/scripts/go-ffi"
 
   docker-build:
@@ -373,7 +374,7 @@ jobs:
           name: gas snapshot
           command: |
             forge --version
-            pnpm gas-snapshot:no-build --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
+            pnpm gas-snapshot --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
           name: gas snapshot
           command: |
             forge --version
-            pnpm gas-snapshot --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
+            pnpm gas-snapshot:no-build --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -31,6 +31,7 @@
     "slither:triage": "TRIAGE_MODE=1 ./scripts/slither.sh",
     "clean": "rm -rf ./artifacts ./forge-artifacts ./cache ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo ./scripts/go-ffi/go-ffi",
     "preinstall": "npx only-allow pnpm",
+    "install": "forge install",
     "pre-pr:no-build": "pnpm gas-snapshot:no-build && pnpm storage-snapshot && pnpm semver-lock && pnpm autogen:invariant-docs && pnpm lint && pnpm bindings:go",
     "pre-pr": "pnpm clean && pnpm build:go-ffi && pnpm build && pnpm pre-pr:no-build",
     "pre-pr:full": "pnpm test && pnpm slither && pnpm validate-deploy-configs && pnpm validate-spacers && pnpm pre-pr",


### PR DESCRIPTION
**Description**

`contracts-bedrock-checks` is running `pnpm build` which should be handled by the `pnpm-monorepo` job that precedes it. 

