### PR TITLE
contracts-bedrock: cleanup deploy config check

### DIFF
--- a/packages/contracts-bedrock/scripts/check-deploy-configs.sh
+++ b/packages/contracts-bedrock/scripts/check-deploy-configs.sh
@@ -11,11 +11,6 @@ CONTRACTS_BASE=$(dirname $SCRIPT_DIR)
 MONOREPO_BASE=$(dirname $(dirname $CONTRACTS_BASE))
 
 for config in $CONTRACTS_BASE/deploy-config/*.json; do
-    if grep -q "getting-started" <<< "$config"; then
-      echo "Skipping getting-started.json"
-      continue
-    fi
-
     go run $MONOREPO_BASE/op-chain-ops/cmd/check-deploy-config/main.go --path $config
     [ $? -eq 0 ]  || code=$?
 done


### PR DESCRIPTION
**Description**

Removes the special case for the deploy config check where
the `getting-started.json` was not valid JSON and would need
to be skipped by the deploy config checking script. The getting
started guide has been updated with new logic so this special case
can be removed.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
