### PR TITLE
EIP4844: Add single minimal e2e test.

### DIFF
--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -138,7 +138,7 @@ func (f *fakePoS) Start() error {
 					tim.Stop()
 					return nil
 				}
-				envelope, err := f.engineAPI.GetPayloadV2(*res.PayloadID)
+				envelope, err := f.engineAPI.GetPayloadV3(*res.PayloadID)
 				if err != nil {
 					f.log.Error("failed to finish building L1 block", "err", err)
 					continue
@@ -178,7 +178,7 @@ func (f *fakePoS) Start() error {
 						continue
 					}
 				}
-				if _, err := f.engineAPI.ForkchoiceUpdatedV2(engine.ForkchoiceStateV1{
+				if _, err := f.engineAPI.ForkchoiceUpdatedV3(engine.ForkchoiceStateV1{
 					HeadBlockHash:      envelope.ExecutionPayload.BlockHash,
 					SafeBlockHash:      safe.Hash(),
 					FinalizedBlockHash: finalized.Hash(),

--- a/op-e2e/e2eutils/transactions/blobs.go
+++ b/op-e2e/e2eutils/transactions/blobs.go
@@ -1,0 +1,42 @@
+package transactions
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/holiman/uint256"
+)
+
+var (
+	emptyBlob          = kzg4844.Blob{}
+	emptyBlobCommit, _ = kzg4844.BlobToCommitment(emptyBlob)
+	emptyBlobProof, _  = kzg4844.ComputeBlobProof(emptyBlob, emptyBlobCommit)
+)
+
+// with thanks to fjl
+// https://github.com/ethereum/go-ethereum/commit/2a6beb6a39d7cb3c5906dd4465d65da6efcc73cd
+func CreateEmptyBlobTx(key *ecdsa.PrivateKey, withSidecar bool, chainID uint64) *types.BlobTx {
+	sidecar := &types.BlobTxSidecar{
+		Blobs:       []kzg4844.Blob{emptyBlob},
+		Commitments: []kzg4844.Commitment{emptyBlobCommit},
+		Proofs:      []kzg4844.Proof{emptyBlobProof},
+	}
+	blobTx := &types.BlobTx{
+		ChainID:    uint256.NewInt(chainID),
+		Nonce:      0,
+		GasTipCap:  uint256.NewInt(2200000000000),
+		GasFeeCap:  uint256.NewInt(5000000000000),
+		Gas:        25000,
+		To:         common.Address{0x03, 0x04, 0x05},
+		Value:      uint256.NewInt(99),
+		Data:       make([]byte, 50),
+		BlobFeeCap: uint256.NewInt(150000000000),
+		BlobHashes: sidecar.BlobHashes(),
+	}
+	if withSidecar {
+		blobTx.Sidecar = sidecar
+	}
+	return blobTx
+}

--- a/op-e2e/e2eutils/transactions/blobs.go
+++ b/op-e2e/e2eutils/transactions/blobs.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-var (
 	emptyBlob          kzg4844.Blob
 	emptyBlobCommit    kzg4844.Commitment
 	emptyBlobProof     kzg4844.Proof

--- a/op-e2e/e2eutils/transactions/blobs.go
+++ b/op-e2e/e2eutils/transactions/blobs.go
@@ -10,9 +10,24 @@ import (
 )
 
 var (
-	emptyBlob          = kzg4844.Blob{}
-	emptyBlobCommit, _ = kzg4844.BlobToCommitment(emptyBlob)
-	emptyBlobProof, _  = kzg4844.ComputeBlobProof(emptyBlob, emptyBlobCommit)
+var (
+	emptyBlob          kzg4844.Blob
+	emptyBlobCommit    kzg4844.Commitment
+	emptyBlobProof     kzg4844.Proof
+)
+
+func init() {
+	var err error
+	emptyBlob = kzg4844.Blob{}
+	emptyBlobCommit, err = kzg4844.BlobToCommitment(emptyBlob)
+	if err != nil {
+		panic("failed to create empty blob commitment: " + err.Error())
+	}
+	emptyBlobProof, err = kzg4844.ComputeBlobProof(emptyBlob, emptyBlobCommit)
+	if err != nil {
+		panic("failed to create empty blob proof: " + err.Error())
+	}
+}
 )
 
 // with thanks to fjl

--- a/op-e2e/e2eutils/transactions/blobs.go
+++ b/op-e2e/e2eutils/transactions/blobs.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	emptyBlob          kzg4844.Blob
-	emptyBlobCommit    kzg4844.Commitment
-	emptyBlobProof     kzg4844.Proof
+	emptyBlob       kzg4844.Blob
+	emptyBlobCommit kzg4844.Commitment
+	emptyBlobProof  kzg4844.Proof
 )
 
 func init() {
@@ -27,7 +27,6 @@ func init() {
 		panic("failed to create empty blob proof: " + err.Error())
 	}
 }
-)
 
 // with thanks to fjl
 // https://github.com/ethereum/go-ethereum/commit/2a6beb6a39d7cb3c5906dd4465d65da6efcc73cd

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -200,7 +200,7 @@ func TestSystemE2EDencunAtGenesisWithBlobs(t *testing.T) {
 	// Wait for transaction on L1
 	blockContainsBlob, err := geth.WaitForTransaction(tx.Hash(), l1Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for blob tx on L1")
-	// end sending blob-contraining txns on l1
+	// end sending blob-containing txns on l1
 	l2Client := sys.Clients["sequencer"]
 	finalizedBlock, err := gethutils.WaitForL1OriginOnL2(blockContainsBlob.BlockNumber.Uint64(), l2Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L1 origin of blob tx on L2")

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -187,8 +187,8 @@ func TestSystemE2EDencunAtGenesisWithBlobs(t *testing.T) {
 	defer sys.Close()
 
 	// send a blob-containing txn on l1
-	ethPrivKey := sys.cfg.Secrets.Alice
-	txData := transactions.CreateEmptyBlobTx(ethPrivKey, true, sys.cfg.L1ChainIDBig().Uint64())
+	ethPrivKey := sys.Cfg.Secrets.Alice
+	txData := transactions.CreateEmptyBlobTx(ethPrivKey, true, sys.Cfg.L1ChainIDBig().Uint64())
 	tx := types.MustSignNewTx(ethPrivKey, types.LatestSignerForChainID(cfg.L1ChainIDBig()), txData)
 	// send blob-containing txn
 	sendCtx, sendCancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -201,7 +201,8 @@ func TestSystemE2EDencunAtGenesisWithBlobs(t *testing.T) {
 	blockContainsBlob, err := geth.WaitForTransaction(tx.Hash(), l1Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for blob tx on L1")
 	// end sending blob-contraining txns on l1
-	finalizedBlock, err := gethutils.WaitForL1OriginOnL2(blockContainsBlob.BlockNumber.Uint64(), l1Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
+	l2Client := sys.Clients["sequencer"]
+	finalizedBlock, err := gethutils.WaitForL1OriginOnL2(blockContainsBlob.BlockNumber.Uint64(), l2Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L1 origin of blob tx on L2")
 	finalizationTimeout := 30 * time.Duration(cfg.DeployConfig.L1BlockTime) * time.Second
 	_, err = gethutils.WaitForBlockToBeFinalized(finalizedBlock.Header().Number, l1Client, finalizationTimeout)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -205,17 +205,8 @@ func TestSystemE2EDencunAtGenesisWithBlobs(t *testing.T) {
 	finalizedBlock, err := gethutils.WaitForL1OriginOnL2(blockContainsBlob.BlockNumber.Uint64(), l2Client, 30*time.Duration(cfg.DeployConfig.L1BlockTime)*time.Second)
 	require.Nil(t, err, "Waiting for L1 origin of blob tx on L2")
 	finalizationTimeout := 30 * time.Duration(cfg.DeployConfig.L1BlockTime) * time.Second
-	_, err = gethutils.WaitForBlockToBeFinalized(finalizedBlock.Header().Number, l1Client, finalizationTimeout)
-	require.Nil(t, err, "Waiting for blob block to be finalized on L1")
-
-	// fetch the finalized head of geth
-	finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer finalizeCancel()
-	l2Seq := sys.Clients["sequencer"]
-	l2Finalized, err := l2Seq.BlockByNumber(finalizeCtx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
-	require.NoError(t, err)
-
-	require.NotZerof(t, l2Finalized.NumberU64(), "must have finalized L2 block")
+	_, err = gethutils.WaitForBlockToBeSafe(finalizedBlock.Header().Number, l2Client, finalizationTimeout)
+	require.Nil(t, err, "Waiting for safety of L2 block")
 }
 
 // TestSystemE2E sets up a L1 Geth node, a rollup node, and a L2 geth node and then confirms that L1 deposits are reflected on L2.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

As an intermediate step to https://github.com/ethereum-optimism/optimism/pull/8104 and therefore https://github.com/ethereum-optimism/optimism/pull/7349, this PR aims to add a minimal system test that starts a Cancun-compatible L1, sends a blob-containing transaction on that L1, and ensures the L2 can finalize against that L1.

**Tests**

The test is called `TestSystemE2EDencunAtGenesisWithBlobs` in `system_test.go`.

**Metadata**
Builds on top of #8131 


