### PR TITLE
CI: Hack to move contracts-bedrock-checks out of the critical path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,10 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      # Forge heavily relies on submodules
+      - run:
+          name: git submodules
+          command: git submodule update --init --recursive
       - restore_cache:
           name: Restore PNPM Package Cache
           keys:
@@ -1287,9 +1291,9 @@ workflows:
             - pnpm-monorepo
       - contracts-bedrock-tests
       - contracts-bedrock-coverage
-      - contracts-bedrock-checks:
-          requires:
-            - pnpm-monorepo
+      - contracts-bedrock-checks # :#Disabled using the shared build from pnpm-monorepo b/c it's broken
+          # requires:
+          #   - pnpm-monorepo
       - contracts-bedrock-slither
       - contracts-bedrock-validate-spaces:
           requires:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
