### PR TITLE
improve naming consistency of Config struct variables

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -48,7 +48,7 @@ type BatcherService struct {
 	RollupConfig *rollup.Config
 
 	// Channel builder parameters
-	Channel ChannelConfig
+	ChannelConfig ChannelConfig
 
 	driver *BatchSubmitter
 
@@ -90,7 +90,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	if err := bs.initRPCClients(ctx, cfg); err != nil {
 		return err
 	}
-	if err := bs.initRollupCfg(ctx); err != nil {
+	if err := bs.initRollupConfig(ctx); err != nil {
 		return fmt.Errorf("failed to load rollup config: %w", err)
 	}
 	if err := bs.initChannelConfig(cfg); err != nil {
@@ -153,12 +153,12 @@ func (bs *BatcherService) initBalanceMonitor(cfg *CLIConfig) {
 	}
 }
 
-func (bs *BatcherService) initRollupCfg(ctx context.Context) error {
-	rollupCfg, err := bs.RollupNode.RollupConfig(ctx)
+func (bs *BatcherService) initRollupConfig(ctx context.Context) error {
+	rollupConfig, err := bs.RollupNode.RollupConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve rollup config: %w", err)
 	}
-	bs.RollupConfig = rollupCfg
+	bs.RollupConfig = rollupConfig
 	if err := bs.RollupConfig.Check(); err != nil {
 		return fmt.Errorf("invalid rollup config: %w", err)
 	}
@@ -166,7 +166,7 @@ func (bs *BatcherService) initRollupCfg(ctx context.Context) error {
 }
 
 func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
-	bs.Channel = ChannelConfig{
+	bs.ChannelConfig = ChannelConfig{
 		SeqWindowSize:      bs.RollupConfig.SeqWindowSize,
 		ChannelTimeout:     bs.RollupConfig.ChannelTimeout,
 		MaxChannelDuration: cfg.MaxChannelDuration,
@@ -175,7 +175,7 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		CompressorConfig:   cfg.CompressorConfig.Config(),
 		BatchType:          cfg.BatchType,
 	}
-	if err := bs.Channel.Check(); err != nil {
+	if err := bs.ChannelConfig.Check(); err != nil {
 		return fmt.Errorf("invalid channel configuration: %w", err)
 	}
 	return nil
@@ -225,15 +225,15 @@ func (bs *BatcherService) initMetricsServer(cfg *CLIConfig) error {
 
 func (bs *BatcherService) initDriver() {
 	bs.driver = NewBatchSubmitter(DriverSetup{
-		Log:          bs.Log,
-		Metr:         bs.Metrics,
-		RollupCfg:    bs.RollupConfig,
-		Cfg:          bs.BatcherConfig,
-		Txmgr:        bs.TxManager,
-		L1Client:     bs.L1Client,
-		L2Client:     bs.L2Client,
-		RollupClient: bs.RollupNode,
-		Channel:      bs.Channel,
+		Log:           bs.Log,
+		Metr:          bs.Metrics,
+		RollupConfig:  bs.RollupConfig,
+		Config:        bs.BatcherConfig,
+		Txmgr:         bs.TxManager,
+		L1Client:      bs.L1Client,
+		L2Client:      bs.L2Client,
+		RollupClient:  bs.RollupNode,
+		ChannelConfig: bs.ChannelConfig,
 	})
 }
 


### PR DESCRIPTION
This is a simple PR that consistently names all public config variable names within the batcher as "*Config".  (The inconsistencies caused me a bit of confusion when trying to understand this code.)

