### PR TITLE
CI: Set STRICT_DEPLOYMENT=false for gas snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
           name: gas snapshot
           command: |
             forge --version
-            pnpm gas-snapshot --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
+            STRICT_DEPLOYMENT=false pnpm gas-snapshot --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock


### PR DESCRIPTION
This is attempting to reduce the flakiness of the gas snaphots tests & fix the following logged issue:


```
FAIL. Reason: Setup failed: Misconfigured networks:  != 31337] setUp() (gas: 0)
```