### PR TITLE
op-node: Use resubscriber context when watching head

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -171,10 +171,13 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 
 	// Keep subscribed to the L1 heads, which keeps the L1 maintainer pointing to the best headers to sync
 	n.l1HeadsSub = event.ResubscribeErr(time.Second*10, func(ctx context.Context, err error) (event.Subscription, error) {
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		if err != nil {
 			n.log.Warn("resubscribing after failed L1 subscription", "err", err)
 		}
-		return eth.WatchHeadChanges(n.resourcesCtx, n.l1Source, n.OnNewL1Head)
+		return eth.WatchHeadChanges(ctx, n.l1Source, n.OnNewL1Head)
 	})
 	go func() {
 		err, ok := <-n.l1HeadsSub.Err()


### PR DESCRIPTION
**Description**

The L1Heads subscription was using the `resourcesCtx` rather than the context supplied by the `ResubscribeErr` function which led to a deadlock when calling `l1HeadsSub.Unsubscribe` and prevented op-node from shutting down cleanly.

**Tests**

Manually tested shutdown.

**Additional context**

Not addressed by this, there is also a fairly long delay if you interrupt op-node shortly after it starts up because the `FindL2Heads` process has no way of being interrupted so you continue getting a bunch of `Walking back L1Block by hash` logs and op-node only exits once that completes.

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/8086
