### PR TITLE
op-chain-ops. op-e2e: L1 dencun support

### DIFF
--- a/op-chain-ops/deployer/deployer.go
+++ b/op-chain-ops/deployer/deployer.go
@@ -70,6 +70,8 @@ func NewBackendWithGenesisTimestamp(ts uint64, shanghai bool) *backends.Simulate
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
 		GrayGlacierBlock:    big.NewInt(0),
+		ShanghaiTime:        nil,
+		CancunTime:          nil,
 		// Activated proof of stake. We manually build/commit blocks in the simulator anyway,
 		// and the timestamp verification of PoS is not against the wallclock,
 		// preventing blocks from getting stuck temporarily in the future-blocks queue, decreasing setup time a lot.

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -217,6 +217,9 @@ type DeployConfig struct {
 	// RequiredProtocolVersion indicates the protocol version that
 	// nodes are recommended to adopt, to stay in sync with the network.
 	RecommendedProtocolVersion params.ProtocolVersion `json:"recommendedProtocolVersion"`
+
+	// When Cancun activates. Relative to L1 genesis.
+	L1CancunTimeOffset *uint64 `json:"l1CancunTimeOffset,omitempty"`
 }
 
 // Copy will deeply copy the DeployConfig. This does a JSON roundtrip to copy

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -64,6 +64,7 @@ func NewL2Genesis(config *DeployConfig, block *types.Block) (*core.Genesis, erro
 		RegolithTime:                  config.RegolithTime(block.Time()),
 		CanyonTime:                    config.CanyonTime(block.Time()),
 		ShanghaiTime:                  config.CanyonTime(block.Time()),
+		CancunTime:                    nil, // no Dencun on L2 yet.
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator:       eip1559Denom,
 			EIP1559Elasticity:        eip1559Elasticity,
@@ -134,6 +135,8 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
 		GrayGlacierBlock:    big.NewInt(0),
+		ShanghaiTime:        nil,
+		CancunTime:          nil,
 	}
 
 	extraData := make([]byte, 0)
@@ -167,6 +170,10 @@ func NewL1Genesis(config *DeployConfig) (*core.Genesis, error) {
 	timestamp := config.L1GenesisBlockTimestamp
 	if timestamp == 0 {
 		timestamp = hexutil.Uint64(time.Now().Unix())
+	}
+	if !config.L1UseClique && config.L1CancunTimeOffset != nil {
+		cancunTime := uint64(timestamp) + *config.L1CancunTimeOffset
+		chainConfig.CancunTime = &cancunTime
 	}
 
 	return &core.Genesis{

--- a/op-e2e/actions/l1_replica.go
+++ b/op-e2e/actions/l1_replica.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool/blobpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
@@ -51,6 +52,11 @@ func NewL1Replica(t Testing, log log.Logger, genesis *core.Genesis) *L1Replica {
 		NetworkId:                 genesis.Config.ChainID.Uint64(),
 		Genesis:                   genesis,
 		RollupDisableTxPoolGossip: true,
+		BlobPool: blobpool.Config{
+			Datadir:   t.TempDir(),
+			Datacap:   blobpool.DefaultConfig.Datacap,
+			PriceBump: blobpool.DefaultConfig.PriceBump,
+		},
 	}
 	nodeCfg := &node.Config{
 		Name:        "l1-geth",

--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -1,0 +1,194 @@
+package fakebeacon
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// FakeBeacon presents a beacon-node in testing, without leading any chain-building.
+// This merely serves a fake beacon API, and holds on to blocks,
+// to complement the actual block-building to happen in testing (e.g. through the fake consensus geth module).
+type FakeBeacon struct {
+	log log.Logger
+
+	// directory to store blob contents in after the blobs are persisted in a block
+	blobsDir  string
+	blobsLock sync.Mutex
+
+	beaconSrv         *http.Server
+	beaconAPIListener net.Listener
+
+	genesisTime uint64
+	blockTime   uint64
+}
+
+func NewBeacon(log log.Logger, blobsDir string, genesisTime uint64, blockTime uint64) *FakeBeacon {
+	return &FakeBeacon{
+		log:         log,
+		blobsDir:    blobsDir,
+		genesisTime: genesisTime,
+		blockTime:   blockTime,
+	}
+}
+
+func (f *FakeBeacon) Start(addr string) error {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to open tcp listener for http beacon api server: %w", err)
+	}
+	f.beaconAPIListener = listener
+
+	mux := new(http.ServeMux)
+	mux.HandleFunc("/eth/v1/beacon/genesis", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(&eth.APIGenesisResponse{Data: eth.ReducedGenesisData{GenesisTime: eth.Uint64String(f.genesisTime)}})
+		if err != nil {
+			f.log.Error("genesis handler err", "err", err)
+		}
+	})
+	mux.HandleFunc("/eth/v1/config/spec", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(&eth.APIConfigResponse{Data: eth.ReducedConfigData{SecondsPerSlot: eth.Uint64String(f.blockTime)}})
+		if err != nil {
+			f.log.Error("config handler err", "err", err)
+		}
+	})
+	mux.HandleFunc("/eth/v1/beacon/blob_sidecars/", func(w http.ResponseWriter, r *http.Request) {
+		blockID := strings.TrimPrefix(r.URL.Path, "/eth/v1/beacon/blob_sidecars/")
+		slot, err := strconv.ParseUint(blockID, 10, 64)
+		if err != nil {
+			f.log.Error("could not parse block id from request", "url", r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		bundle, err := f.LoadBlobsBundle(slot)
+		if err != nil {
+			f.log.Error("failed to load blobs bundle", "slot", slot)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		query := r.URL.Query()
+		rawIndices := query["indices"]
+		indices := make([]int, 0, len(bundle.Blobs))
+		if len(rawIndices) == 0 {
+			// request is for all blobs
+			for i := range bundle.Blobs {
+				indices = append(indices, i)
+			}
+		} else {
+			for _, raw := range rawIndices {
+				ix, err := strconv.ParseUint(raw, 10, 64)
+				if err != nil {
+					f.log.Error("could not parse index from request", "url", r.URL)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				indices = append(indices, int(ix))
+			}
+		}
+
+		var mockBeaconBlockRoot [32]byte
+		mockBeaconBlockRoot[0] = 42
+		binary.LittleEndian.PutUint64(mockBeaconBlockRoot[32-8:], slot)
+		sidecars := make([]*eth.BlobSidecar, len(indices))
+		for i, ix := range indices {
+			if ix < 0 || ix >= len(bundle.Blobs) {
+				f.log.Error("blob index from request is out of range", "url", r.URL)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			sidecars[i] = &eth.BlobSidecar{
+				BlockRoot:     mockBeaconBlockRoot,
+				Slot:          eth.Uint64String(slot),
+				Index:         eth.Uint64String(i),
+				KZGCommitment: eth.Bytes48(bundle.Commitments[ix]),
+				KZGProof:      eth.Bytes48(bundle.Proofs[ix]),
+			}
+			copy(sidecars[i].Blob[:], bundle.Blobs[ix])
+		}
+		if err := json.NewEncoder(w).Encode(&eth.APIGetBlobSidecarsResponse{Data: sidecars}); err != nil {
+			f.log.Error("blobs handler err", "err", err)
+		}
+	})
+	f.beaconSrv = &http.Server{
+		Handler:           mux,
+		ReadTimeout:       time.Second * 20,
+		ReadHeaderTimeout: time.Second * 20,
+		WriteTimeout:      time.Second * 20,
+		IdleTimeout:       time.Second * 20,
+	}
+	go func() {
+		if err := f.beaconSrv.Serve(f.beaconAPIListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			f.log.Error("failed to start fake-pos beacon server for blobs testing", "err", err)
+		}
+	}()
+	return nil
+}
+
+func (f *FakeBeacon) StoreBlobsBundle(slot uint64, bundle *engine.BlobsBundleV1) error {
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		return fmt.Errorf("failed to encode blobs bundle of slot %d: %w", slot, err)
+	}
+
+	f.blobsLock.Lock()
+	defer f.blobsLock.Unlock()
+	bundlePath := fmt.Sprintf("blobs_bundle_%d.json", slot)
+	if err := os.MkdirAll(f.blobsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create dir for blob storage: %w", err)
+	}
+	err = os.WriteFile(filepath.Join(f.blobsDir, bundlePath), data, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to write blobs bundle of slot %d: %w", slot, err)
+	}
+	return nil
+}
+
+func (f *FakeBeacon) LoadBlobsBundle(slot uint64) (*engine.BlobsBundleV1, error) {
+	f.blobsLock.Lock()
+	defer f.blobsLock.Unlock()
+	bundlePath := fmt.Sprintf("blobs_bundle_%d.json", slot)
+	data, err := os.ReadFile(filepath.Join(f.blobsDir, bundlePath))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("no blobs bundle found for slot %d (%q): %w", slot, bundlePath, ethereum.NotFound)
+		} else {
+			return nil, fmt.Errorf("failed to read blobs bundle of slot %d (%q): %w", slot, bundlePath, err)
+		}
+	}
+	var out engine.BlobsBundleV1
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("failed to decode blobs bundle of slot %d (%q): %w", slot, bundlePath, err)
+	}
+	return &out, nil
+}
+
+func (f *FakeBeacon) Close() error {
+	var out error
+	if f.beaconSrv != nil {
+		out = errors.Join(out, f.beaconSrv.Close())
+	}
+	if f.beaconAPIListener != nil {
+		out = errors.Join(out, f.beaconAPIListener.Close())
+	}
+	return out
+}
+
+func (f *FakeBeacon) BeaconAddr() string {
+	return "http://" + f.beaconAPIListener.Addr().String()
+}

--- a/op-e2e/e2eutils/geth/geth.go
+++ b/op-e2e/e2eutils/geth/geth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool/blobpool"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/catalyst"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
@@ -21,10 +22,15 @@ import (
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 )
 
-func InitL1(chainID uint64, blockTime uint64, genesis *core.Genesis, c clock.Clock, opts ...GethOption) (*node.Node, *eth.Ethereum, error) {
+func InitL1(chainID uint64, blockTime uint64, genesis *core.Genesis, c clock.Clock, blobPoolDir string, beaconSrv Beacon, opts ...GethOption) (*node.Node, *eth.Ethereum, error) {
 	ethConfig := &ethconfig.Config{
 		NetworkId: chainID,
 		Genesis:   genesis,
+		BlobPool: blobpool.Config{
+			Datadir:   blobPoolDir,
+			Datacap:   blobpool.DefaultConfig.Datacap,
+			PriceBump: blobpool.DefaultConfig.PriceBump,
+		},
 	}
 	nodeConfig := &node.Config{
 		Name:        "l1-geth",
@@ -53,6 +59,7 @@ func InitL1(chainID uint64, blockTime uint64, genesis *core.Genesis, c clock.Clo
 		finalizedDistance: 8,
 		safeDistance:      4,
 		engineAPI:         catalyst.NewConsensusAPI(l1Eth),
+		beacon:            beaconSrv,
 	})
 
 	return l1Node, l1Eth, nil

--- a/op-e2e/external.go
+++ b/op-e2e/external.go
@@ -24,6 +24,8 @@ type ExternalRunner struct {
 	BinPath string
 	Genesis *core.Genesis
 	JWTPath string
+	// 4844: a datadir specifically for tx-pool blobs
+	BlobPoolPath string
 }
 
 type ExternalEthClient struct {

--- a/op-service/eth/blob.go
+++ b/op-service/eth/blob.go
@@ -1,0 +1,68 @@
+package eth
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const (
+	BlobSize        = 4096 * 32
+	MaxBlobDataSize = 4096*31 - 4
+)
+
+type Blob [BlobSize]byte
+
+func (b *Blob) KZGBlob() *kzg4844.Blob {
+	return (*kzg4844.Blob)(b)
+}
+
+func (b *Blob) UnmarshalJSON(text []byte) error {
+	return hexutil.UnmarshalFixedJSON(reflect.TypeOf(b), text, b[:])
+}
+
+func (b *Blob) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("Bytes32", text, b[:])
+}
+
+func (b *Blob) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(b[:]).MarshalText()
+}
+
+func (b *Blob) String() string {
+	return hexutil.Encode(b[:])
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (b *Blob) TerminalString() string {
+	return fmt.Sprintf("%x..%x", b[:3], b[BlobSize-3:])
+}
+
+func (b *Blob) ComputeKZGCommitment() (kzg4844.Commitment, error) {
+	return kzg4844.BlobToCommitment(*b.KZGBlob())
+}
+
+// KZGToVersionedHash computes the "blob hash" (a.k.a. versioned-hash) of a blob-commitment, as used in a blob-tx.
+// We implement it here because it is unfortunately not (currently) exposed by geth.
+func KZGToVersionedHash(commitment kzg4844.Commitment) (out common.Hash) {
+	// EIP-4844 spec:
+	//	def kzg_to_versioned_hash(commitment: KZGCommitment) -> VersionedHash:
+	//		return VERSIONED_HASH_VERSION_KZG + sha256(commitment)[1:]
+	h := sha256.New()
+	h.Write(commitment[:])
+	_ = h.Sum(out[:0])
+	out[0] = params.BlobTxHashVersion
+	return out
+}
+
+// VerifyBlobProof verifies that the given blob and proof corresponds to the given commitment,
+// returning error if the verification fails.
+func VerifyBlobProof(blob *Blob, commitment kzg4844.Commitment, proof kzg4844.Proof) error {
+	return kzg4844.VerifyBlobProof(*blob.KZGBlob(), commitment, proof)
+}

--- a/op-service/eth/blobs_api.go
+++ b/op-service/eth/blobs_api.go
@@ -1,0 +1,30 @@
+package eth
+
+type BlobSidecar struct {
+	BlockRoot     Bytes32      `json:"block_root"`
+	Slot          Uint64String `json:"slot"`
+	Blob          Blob         `json:"blob"`
+	Index         Uint64String `json:"index"`
+	KZGCommitment Bytes48      `json:"kzg_commitment"`
+	KZGProof      Bytes48      `json:"kzg_proof"`
+}
+
+type APIGetBlobSidecarsResponse struct {
+	Data []*BlobSidecar `json:"data"`
+}
+
+type ReducedGenesisData struct {
+	GenesisTime Uint64String `json:"genesis_time"`
+}
+
+type APIGenesisResponse struct {
+	Data ReducedGenesisData `json:"data"`
+}
+
+type ReducedConfigData struct {
+	SecondsPerSlot Uint64String `json:"SECONDS_PER_SLOT"`
+}
+
+type APIConfigResponse struct {
+	Data ReducedConfigData `json:"data"`
+}

--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -94,3 +94,11 @@ func (id L2BlockRef) ParentID() BlockID {
 		Number: n,
 	}
 }
+
+// IndexedDataHash represents a data-hash that commits to a single blob confirmed in a block.
+// The index helps us avoid unnecessary blob to data-hash conversions to find the right content in a sidecar.
+type IndexedDataHash struct {
+	Index    uint64      // absolute index in the block, a.k.a. position in sidecar blobs array
+	DataHash common.Hash // hash of the blob, used for consistency checks
+	// Might add tx index and/or tx hash here later, depending on blobs API design
+}

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -316,4 +317,45 @@ type SystemConfig struct {
 	// GasLimit identifies the L2 block gas limit
 	GasLimit uint64 `json:"gasLimit"`
 	// More fields can be added for future SystemConfig versions.
+}
+
+type Bytes48 [48]byte
+
+func (b *Bytes48) UnmarshalJSON(text []byte) error {
+	return hexutil.UnmarshalFixedJSON(reflect.TypeOf(b), text, b[:])
+}
+
+func (b *Bytes48) UnmarshalText(text []byte) error {
+	return hexutil.UnmarshalFixedText("Bytes32", text, b[:])
+}
+
+func (b Bytes48) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(b[:]).MarshalText()
+}
+
+func (b Bytes48) String() string {
+	return hexutil.Encode(b[:])
+}
+
+// TerminalString implements log.TerminalStringer, formatting a string for console
+// output during logging.
+func (b Bytes48) TerminalString() string {
+	return fmt.Sprintf("%x..%x", b[:3], b[45:])
+}
+
+// Uint64String is a decimal string representation of an uint64, for usage in the Beacon API JSON encoding
+type Uint64String uint64
+
+func (v Uint64String) MarshalText() (out []byte, err error) {
+	out = strconv.AppendUint(out, uint64(v), 10)
+	return
+}
+
+func (v *Uint64String) UnmarshalText(b []byte) error {
+	n, err := strconv.ParseUint(string(b), 0, 64)
+	if err != nil {
+		return err
+	}
+	*v = Uint64String(n)
+	return nil
 }


### PR DESCRIPTION
**Description**

This PR adds deploy-config support for a `l1CancunTimeOffset` to configure a L1 with Dencun hardfork.

This updates the existing `TestDencunL1Fork` action-test from @EvanJRichard to use the deploy-config to configure the hardfork.

Additionally, this PR adds:
- `TestDencunL1ForkAtGenesis`: an action test like the above, but with the hardfork activated at genesis. This doesn't work without the deploy-config approach, since modifying the cancun hardfork time after computing the genesis block hashes would break the chain setup. (can't build on a genesis block with mismatching blockhash).
- `TestSystemE2EDencunAtGenesis`: to verify that the e2e test can run with a L1 Dencun chain.

The L1 dencun chain in the full e2e setup is supported by the fake beacon-API and blob-storage, attached to an updated version of the fake proof-of-stake block-builder that we use for op-e2e. This has been cherry-picked from the 4844 branch.

This PR supersedes #8104; this avoids the regressions that were introduced in that PR, by building on latest `develop` and the new rebased `eip4844` branch: The #8104 PR was based on an older version of the `eip4844` branch, and erroneously pulled in old content from develop that the `eip4844` was based on, that had since already been fixed on develop. The old eip4844 branch can be found at `eip4844-old`.

Note: this pulls in more of the API typing additions from the eip4844 branch, to support the 4844 e2e test, but does not support 4844 as DA yet.

Fixes https://github.com/ethereum-optimism/client-pod/issues/156