### PR TITLE
feat(proxyd): ability to add additional headers to backend requests

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -139,6 +139,7 @@ type Backend struct {
 	wsURL                string
 	authUsername         string
 	authPassword         string
+	headers              map[string]string
 	client               *LimitedHTTPClient
 	dialer               *websocket.Dialer
 	maxRetries           int
@@ -167,6 +168,12 @@ func WithBasicAuth(username, password string) BackendOpt {
 	return func(b *Backend) {
 		b.authUsername = username
 		b.authPassword = password
+	}
+}
+
+func WithHeaders(headers map[string]string) BackendOpt {
+	return func(b *Backend) {
+		b.headers = headers
 	}
 }
 
@@ -534,6 +541,10 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 
 	httpReq.Header.Set("content-type", "application/json")
 	httpReq.Header.Set("X-Forwarded-For", xForwardedFor)
+
+	for name, value := range b.headers {
+		httpReq.Header.Set(name, value)
+	}
 
 	start := time.Now()
 	httpRes, err := b.client.DoLimited(httpReq)

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -83,17 +83,18 @@ type BackendOptions struct {
 }
 
 type BackendConfig struct {
-	Username         string `toml:"username"`
-	Password         string `toml:"password"`
-	RPCURL           string `toml:"rpc_url"`
-	WSURL            string `toml:"ws_url"`
-	WSPort           int    `toml:"ws_port"`
-	MaxRPS           int    `toml:"max_rps"`
-	MaxWSConns       int    `toml:"max_ws_conns"`
-	CAFile           string `toml:"ca_file"`
-	ClientCertFile   string `toml:"client_cert_file"`
-	ClientKeyFile    string `toml:"client_key_file"`
-	StripTrailingXFF bool   `toml:"strip_trailing_xff"`
+	Username         string            `toml:"username"`
+	Password         string            `toml:"password"`
+	RPCURL           string            `toml:"rpc_url"`
+	WSURL            string            `toml:"ws_url"`
+	WSPort           int               `toml:"ws_port"`
+	MaxRPS           int               `toml:"max_rps"`
+	MaxWSConns       int               `toml:"max_ws_conns"`
+	CAFile           string            `toml:"ca_file"`
+	ClientCertFile   string            `toml:"client_cert_file"`
+	ClientKeyFile    string            `toml:"client_key_file"`
+	StripTrailingXFF bool              `toml:"strip_trailing_xff"`
+	Headers          map[string]string `toml:"headers"`
 
 	ConsensusSkipPeerCountCheck bool   `toml:"consensus_skip_peer_count"`
 	ConsensusForcedCandidate    bool   `toml:"consensus_forced_candidate"`

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -130,6 +130,18 @@ func Start(config *Config) (*Server, func(), error) {
 			}
 			opts = append(opts, WithBasicAuth(cfg.Username, passwordVal))
 		}
+
+		headers := map[string]string{}
+		for headerName, headerValue := range cfg.Headers {
+			headerValue, err := ReadFromEnvOrConfig(headerValue)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			headers[headerName] = headerValue
+		}
+		opts = append(opts, WithHeaders(headers))
+
 		tlsConfig, err := configureBackendTLS(cfg)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
**Description**

- We have some backends where we would like to forward additional headers to as part of the RPC request.
- This PR adds a new property to backends `headers`.
- Any headers added to this, will be set on all requests to the backend group