### PR TITLE
op-challenger: fixes latestBlockNumber signature and ROOT_CLAIM length

### DIFF
--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -63,6 +63,6 @@ done
 # Alphabet game claim construction: keccak256(abi.encode(trace_index, trace[trace_index]))
 ROOT_CLAIM=$(cast keccak $(cast abi-encode "f(uint256,uint256)" 15 122))
 # Replace the first byte of the claim with the invalid vm status indicator
-ROOT_CLAIM="0x01${ROOT_CLAIM:4:60}"
+ROOT_CLAIM="0x01${ROOT_CLAIM:4}"
 
 GAME_TYPE=255 ${SOURCE_DIR}/../create_game.sh http://localhost:8545 "${DISPUTE_GAME_FACTORY}" "${ROOT_CLAIM}" --private-key "${DEVNET_SPONSOR}"

--- a/op-challenger/scripts/create_game.sh
+++ b/op-challenger/scripts/create_game.sh
@@ -27,7 +27,7 @@ BLOCK_ORACLE_ADDR=$(cast call --rpc-url "${RPC}" "${GAME_IMPL_ADDR}" 'BLOCK_ORAC
 echo "Block Oracle: ${BLOCK_ORACLE_ADDR}"
 
 # Get the L2 block number of the latest output proposal. This is the proposal that will be disputed by the created game.
-L2_BLOCK_NUM=$(cast call --rpc-url "${RPC}" "${L2OO_ADDR}" 'latestBlockNumber() public view returns (uint256)')
+L2_BLOCK_NUM=$(cast call --rpc-url "${RPC}" "${L2OO_ADDR}" 'latestBlockNumber() returns(uint256)')
 echo "L2 Block Number: ${L2_BLOCK_NUM}"
 
 # Create a checkpoint in the block oracle to commit to the current L1 head.


### PR DESCRIPTION
**Description**
Two issues were found while running the `op-challenger && make alphabet` command with foundry `0.2.0`. Those issues prevent users from playing Alphabet's bisection game: 
1. The `public view` parameters in `latestBlockNumber()` found in `op-challenger/scripts/create_game.sh` were causing `cast call` to fail.
2. The slicing of `ROOT_CLAIM` in `op-challenger/scripts/alphabet/init_game.sh` was yielding less than 32 bytes.   

**Tests**
Executed the existing scripts in `op-challenger && make alphabet` successfully using foundry's toolset version `0.2.0`.
