### PR TITLE
monorepo: submodules makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,7 @@ golang-docker:
 .PHONY: golang-docker
 
 submodules:
-	# CI will checkout submodules on its own (and fails on these commands)
-	if [ -z "$$GITHUB_ENV" ]; then \
-		git submodule init; \
-		git submodule update --recursive; \
-	fi
+	git submodule update --init --recursive
 .PHONY: submodules
 
 op-bindings:


### PR DESCRIPTION
**Description**

Update the `submodules` recipe in the makefile.
Trying to remove ignoring the command when in CI
because it looks for a github actions env var but
we now run in circleci so its possible that its
tech debt. Will add that check back in if it breaks
ci.

Fixes https://github.com/ethereum-optimism/optimism/issues/8132

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
