### PR TITLE
contracts-bedrock: fix contracts flake in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: run tests
-          command: pnpm test
+          command: STRICT_DEPLOYMENT=false pnpm test
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock


### PR DESCRIPTION
**Description**

Adds a `STRICT_DEPLOYMENT=false` env var to the CI for the foundry tests. There is a race condition with it reading files from disk. The deploy process needs to get config from disk and when all of the foundry tests run in parallel, sometimes particular tests will think the files do not exist.

Ideally we can figure out a way to express to foundry "do something only once" and then checkpoint the state, kind of like a meta `setUp` but this doesn't seem to be possible, `setUp` is called many times.
