### PR TITLE
fix(indexer): bridge starting height marker

### DIFF
--- a/indexer/database/bridge_transactions.go
+++ b/indexer/database/bridge_transactions.go
@@ -133,10 +133,10 @@ func (db *bridgeTransactionsDB) L1LatestFinalizedBlockHeader() (*L1BlockHeader, 
 	provenQuery = provenQuery.Order("l1_contract_events.timestamp DESC").Select("l1_contract_events.*")
 
 	finalizedQuery := db.gorm.Table("l2_transaction_withdrawals").Order("timestamp DESC").Limit(1)
-	finalizedQuery = finalizedQuery.Joins("INNER JOIN l1_contract_events ON l1_contract_events.guid = l2_transaction_withdrawals.proven_l1_event_guid")
+	finalizedQuery = finalizedQuery.Joins("INNER JOIN l1_contract_events ON l1_contract_events.guid = l2_transaction_withdrawals.finalized_l1_event_guid")
 	finalizedQuery = finalizedQuery.Select("l1_contract_events.*")
 
-	relayedQuery := db.gorm.Table("l2_bridge_messages").Order("timestamp DESC")
+	relayedQuery := db.gorm.Table("l2_bridge_messages").Order("timestamp DESC").Limit(1)
 	relayedQuery = relayedQuery.Joins("INNER JOIN l1_contract_events ON l1_contract_events.guid = l2_bridge_messages.relayed_message_event_guid")
 	relayedQuery = relayedQuery.Select("l1_contract_events.*")
 
@@ -227,49 +227,22 @@ func (db *bridgeTransactionsDB) MarkL2TransactionWithdrawalFinalizedEvent(withdr
 }
 
 func (db *bridgeTransactionsDB) L2LatestBlockHeader() (*L2BlockHeader, error) {
-	// L2: Latest Withdrawal, Latest L2 Header of indexed deposit epoch
-	var latestWithdrawalHeader, latestL2DepositHeader *L2BlockHeader
+	// L2: Latest Withdrawal
+	l2Query := db.gorm.Table("l2_transaction_withdrawals").Order("timestamp DESC")
+	l2Query = l2Query.Joins("INNER JOIN l2_contract_events ON l2_contract_events.guid = l2_transaction_withdrawals.initiated_l2_event_guid")
+	l2Query = l2Query.Joins("INNER JOIN l2_block_headers ON l2_block_headers.hash = l2_contract_events.block_hash")
+	l2Query = l2Query.Select("l2_block_headers.*")
 
-	var withdrawHeader L2BlockHeader
-	withdrawalQuery := db.gorm.Table("l2_transaction_withdrawals").Order("timestamp DESC").Limit(1)
-	withdrawalQuery = withdrawalQuery.Joins("INNER JOIN l2_contract_events ON l2_contract_events.guid = l2_transaction_withdrawals.initiated_l2_event_guid")
-	withdrawalQuery = withdrawalQuery.Joins("INNER JOIN l2_block_headers ON l2_block_headers.hash = l2_contract_events.block_hash")
-	result := withdrawalQuery.Select("l2_block_headers.*").Take(&withdrawHeader)
-	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, result.Error
-	} else if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		latestWithdrawalHeader = &withdrawHeader
-	}
-
-	// Check for any deposits that may have been included after the latest withdrawal. However, since the bridge
-	// processor only inserts entries when the corresponding epoch has been indexed on both L1 and L2, we can
-	// simply look for the latest L2 block with at <= time of the latest L1 deposit.
-	var l1Deposit L1TransactionDeposit
-	result = db.gorm.Table("l1_transaction_deposits").Order("timestamp DESC").Limit(1).Take(&l1Deposit)
-	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, result.Error
-	} else if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		var l2DepositHeader L2BlockHeader
-		result := db.gorm.Table("l2_block_headers").Order("timestamp DESC").Limit(1).Where("timestamp <= ?", l1Deposit.Tx.Timestamp).Take(&l2DepositHeader)
-		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, result.Error
-		} else if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			latestL2DepositHeader = &l2DepositHeader
+	var l2Header L2BlockHeader
+	result := l2Query.Take(&l2Header)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
 		}
+		return nil, result.Error
 	}
 
-	// compare
-	if latestWithdrawalHeader == nil {
-		return latestL2DepositHeader, nil
-	} else if latestL2DepositHeader == nil {
-		return latestWithdrawalHeader, nil
-	}
-
-	if latestWithdrawalHeader.Timestamp >= latestL2DepositHeader.Timestamp {
-		return latestWithdrawalHeader, nil
-	} else {
-		return latestL2DepositHeader, nil
-	}
+	return &l2Header, nil
 }
 
 func (db *bridgeTransactionsDB) L2LatestFinalizedBlockHeader() (*L2BlockHeader, error) {

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -95,7 +95,6 @@ func NewMetrics(registry *prometheus.Registry) Metricer {
 		}),
 		latestHeight: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,
-			Subsystem: "l1",
 			Name:      "height",
 			Help:      "the latest processed l1 block height",
 		}, []string{


### PR DESCRIPTION
Now that the bridge independently operates on L1 & L2. The starting height from
L2 processing should only take into account the latest withdrawal and not account
for deposits that have occured on L1. This will cause the L2 bridge processor to
potentially skip blocks if the L2 worker has been behind L1
