### PR TITLE
Specify CI builder image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:latest
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.27.0
 
 orbs:
   go: circleci/go@1.8.0


### PR DESCRIPTION
**Description**
This should help fix the issue that CI can easily be broken if the CI image is not compatible and helps make it possible to test the CI image.


