### PR TITLE
fix(sdk): bug in supportsTokenPair

### DIFF
--- a/.changeset/good-vans-retire.md
+++ b/.changeset/good-vans-retire.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Fixed bug with tokenBridge checks throwing

--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -156,46 +156,33 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
     l1Token: AddressLike,
     l2Token: AddressLike
   ): Promise<boolean> {
-    try {
-      const contract = new Contract(
-        toAddress(l2Token),
-        optimismMintableERC20.abi,
-        this.messenger.l2Provider
-      )
-      // Don't support ETH deposits or withdrawals via this bridge.
-      if (
-        hexStringEquals(toAddress(l1Token), ethers.constants.AddressZero) ||
-        hexStringEquals(toAddress(l2Token), predeploys.OVM_ETH)
-      ) {
-        return false
-      }
-
-      // Make sure the L1 token matches.
-      const remoteL1Token = await contract.l1Token()
-
-      if (!hexStringEquals(remoteL1Token, toAddress(l1Token))) {
-        return false
-      }
-
-      // Make sure the L2 bridge matches.
-      const remoteL2Bridge = await contract.l2Bridge()
-      if (!hexStringEquals(remoteL2Bridge, this.l2Bridge.address)) {
-        return false
-      }
-
-      return true
-    } catch (err) {
-      // If the L2 token is not an L2StandardERC20, it may throw an error. If there's a call
-      // exception then we assume that the token is not supported. Other errors are thrown. Since
-      // the JSON-RPC API is not well-specified, we need to handle multiple possible error codes.
-      if (
-        !err?.message?.toString().includes('CALL_EXCEPTION') &&
-        !err?.stack?.toString().includes('execution reverted')
-      ) {
-        console.error('Unexpected error when checking bridge', err)
-      }
+    const contract = new Contract(
+      toAddress(l2Token),
+      optimismMintableERC20.abi,
+      this.messenger.l2Provider
+    )
+    // Don't support ETH deposits or withdrawals via this bridge.
+    if (
+      hexStringEquals(toAddress(l1Token), ethers.constants.AddressZero) ||
+      hexStringEquals(toAddress(l2Token), predeploys.OVM_ETH)
+    ) {
       return false
     }
+
+    // Make sure the L1 token matches.
+    const remoteL1Token = await contract.l1Token()
+
+    if (!hexStringEquals(remoteL1Token, toAddress(l1Token))) {
+      return false
+    }
+
+    // Make sure the L2 bridge matches.
+    const remoteL2Bridge = await contract.l2Bridge()
+    if (!hexStringEquals(remoteL2Bridge, this.l2Bridge.address)) {
+      return false
+    }
+
+    return true
   }
 
   public async approval(

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -490,8 +490,17 @@ export class CrossChainMessenger {
   ): Promise<IBridgeAdapter> {
     const bridges: IBridgeAdapter[] = []
     for (const bridge of Object.values(this.bridges)) {
-      if (await bridge.supportsTokenPair(l1Token, l2Token)) {
-        bridges.push(bridge)
+      try {
+        if (await bridge.supportsTokenPair(l1Token, l2Token)) {
+          bridges.push(bridge)
+        }
+      } catch (err) {
+        if (
+          !err?.message?.toString().includes('CALL_EXCEPTION') &&
+          !err?.stack?.toString().includes('execution reverted')
+        ) {
+          console.error('Unexpected error when checking bridge', err)
+        }
       }
     }
 


### PR DESCRIPTION
Fixes a bug in the supportsTokenPair where unsupported token interfaces would cause the SDK to error out. Happens because the adapters check for things that are only present in certain types of tokens. Adds a new error handling check that wraps all sub-calls to supportsTokenPair in each of the adapters so that the adapters don't need to worry about this.

Fixes #8154 