### PR TITLE
chain-mon: Use xlarge resource class when building chainmon docker.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1827,6 +1827,7 @@ workflows:
           name: chain-mon-docker-publish
           docker_name: chain-mon
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          resource_class: xlarge
           publish: true
           context:
             - oplabs-gcr


### PR DESCRIPTION
**Description**

Use xlarge resource class when building chainmon docker. Matches what it uses for releases.

Hopefully will stop the scheduled docker publish job from failing.