### PR TITLE
monorepo: delete dead solidity linter

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,25 +1,10 @@
 module.exports = {
   $schema: 'http://json.schemastore.org/prettierrc',
-  plugins: ['prettier-plugin-solidity'],
+  plugins: [],
   trailingComma: 'es5',
   tabWidth: 2,
   semi: false,
   singleQuote: true,
   arrowParens: 'always',
-  overrides: [
-    {
-      files: '*.sol',
-      options: {
-        // These options are native to Prettier.
-        printWidth: 100,
-        tabWidth: 4,
-        useTabs: false,
-        singleQuote: false,
-        bracketSpacing: true,
-        // These options are specific to the Solidity Plugin
-        explicitTypes: 'always',
-        compiler: '>=0.8.15',
-      },
-    },
-  ],
+  overrides: [],
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "nyc": "^15.1.0",
     "patch-package": "^8.0.0",
     "prettier": "^2.8.0",
-    "prettier-plugin-solidity": "^1.2.0",
     "rimraf": "^5.0.5",
     "ts-mocha": "^10.0.0",
     "typescript": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       prettier:
         specifier: ^2.8.0
         version: 2.8.8
-      prettier-plugin-solidity:
-        specifier: ^1.2.0
-        version: 1.2.0(prettier@2.8.8)
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -3409,12 +3406,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /@solidity-parser/parser@0.16.2:
-    resolution: {integrity: sha512-PI9NfoA3P8XK2VBkK5oIfRgKDsicwDZfkVq9ZTBCQYGOP1N2owgY2dyLGyU5/J/hQs8KRk55kdmvTLjy3Mu3vg==}
-    dependencies:
-      antlr4ts: 0.5.0-alpha.4
-    dev: true
-
   /@stablelib/aead@1.0.1:
     resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
 
@@ -5559,10 +5550,6 @@ packages:
   /ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
     dev: false
-
-  /antlr4ts@0.5.0-alpha.4:
-    resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
-    dev: true
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -12099,18 +12086,6 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier-plugin-solidity@1.2.0(prettier@2.8.8):
-    resolution: {integrity: sha512-fgxcUZpVAP+LlRfy5JI5oaAkXGkmsje2VJ5krv/YMm+rcTZbIUwFguSw5f+WFuttMjpDm6wB4UL7WVkArEfiVA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      prettier: '>=2.3.0'
-    dependencies:
-      '@solidity-parser/parser': 0.16.2
-      prettier: 2.8.8
-      semver: 7.5.4
-      solidity-comments-extractor: 0.0.7
-    dev: true
-
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -13089,10 +13064,6 @@ packages:
       tmp: 0.0.33
     transitivePeerDependencies:
       - debug
-    dev: true
-
-  /solidity-comments-extractor@0.0.7:
-    resolution: {integrity: sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==}
     dev: true
 
   /sonic-boom@2.8.0:


### PR DESCRIPTION
**Description**

`forge fmt` is used by the repo now instead of
prettier for linting the solidity code. We
should delete dead deps that are not used.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
