### PR TITLE
fix(ci): Bump `ci-builder` to `v0.29.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.27.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.29.0
 
 orbs:
   go: circleci/go@1.8.0


### PR DESCRIPTION
## Overview

Bumps `ci-builder` from `v0.27.0` -> `v0.29.0` in the circleci config.