### PR TITLE
op-service: Fix fetcher for proxyd

### DIFF
--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -311,5 +311,6 @@ func unusableMethod(err error) bool {
 	return strings.Contains(errText, "unsupported method") || // alchemy -32600 message
 		strings.Contains(errText, "unknown method") ||
 		strings.Contains(errText, "invalid param") ||
-		strings.Contains(errText, "is not available")
+		strings.Contains(errText, "is not available") ||
+		strings.Contains(errText, "rpc method is not whitelisted") // proxyd -32001 error code
 }


### PR DESCRIPTION
**Description**

Recognize method not available from proxyd. I used the string because proxyd returns error code -32001 which is used in other places.

**Tests**

Tested locally.
