### PR TITLE
add uuid to cannon cli temporary files

### DIFF
--- a/cannon/cmd/json.go
+++ b/cannon/cmd/json.go
@@ -9,6 +9,7 @@ import (
 	"path"
 
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
+	"github.com/google/uuid"
 )
 
 func loadJSON[X any](inputPath string) (*X, error) {
@@ -33,10 +34,11 @@ func writeJSON[X any](outputPath string, value X) error {
 		return nil
 	}
 	var out io.Writer
+	var fileUUID = uuid.New()
 	finish := func() error { return nil }
 	if outputPath != "-" {
 		// Write to a tmp file but reserve the file extension if present
-		tmpPath := outputPath + "-tmp" + path.Ext(outputPath)
+		tmpPath := outputPath + "-tmp-" + fileUUID.String() + path.Ext(outputPath)
 		f, err := ioutil.OpenCompressed(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 		if err != nil {
 			return fmt.Errorf("failed to open output file: %w", err)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

When running the Cannon CLI to generate proofs from multiple processes using the same CLI input arguments, we run into a race condition where only the first command will atomically rename the file. The test script I am using to encounter the error:
```
./bin/cannon load-elf --path=./example/bin/hello.elf --out=state.json --meta=meta.json

./bin/cannon run --proof-at==0 --proof-fmt="./hello_proof-%d.json" --input=./state.json --meta=./meta.json --output=- & ./bin/cannon run --proof-at==0 --proof-fmt="./hello_proof-%d.json" --input=./state.json --meta=./meta.json --output=-
```
The output I am seeing:
```
t=2023-11-15T19:18:29-0800 lvl=info msg=processing step=0 pc=0008d1bc insn=0802346b ips=0.000 pages=282 mem="1.1 MiB" name=_rt0_mips_linux
t=2023-11-15T19:18:29-0800 lvl=info msg=processing step=0 pc=0008d1bc insn=0802346b ips=0.000 pages=282 mem="1.1 MiB" name=_rt0_mips_linux
error: failed to write proof data: failed to finish write: rename ./hello_proof-0.json-tmp.json ./hello_proof-0.json: no such file or directoryt=2023-11-15T19:18:29-0800 lvl=info msg=processing step=100,000 pc=000239f8 insn=a0680000 ips=4834684.023 pages=301 mem="1.2 MiB" name=runtime.runGCProg
```
The rename is failing because the file has already been renamed by another process.

**Tests**

No tests are added because the change is simple.

**Additional context**


**Metadata**

- Fixes #[Link to Issue]
