### PR TITLE
rethdb_reader: opaque ffi and better error reporting

### DIFF
--- a/op-service/rethdb-reader/README.md
+++ b/op-service/rethdb-reader/README.md
@@ -51,13 +51,13 @@ functions. Currently, the only exported functions pertain to reading fully hydra
  * as well as an error status that is compatible with FFI.
  *
  * # Safety
- * - When the `error` field is false, the `data` pointer is guaranteed to be valid.
- * - When the `error` field is true, the `data` pointer is guaranteed to be null.
+ * - When the `error` field is null, the `data` pointer is guaranteed to be valid.
+ * - When the `error` field is non-null, the `data` pointer is guaranteed to be null.
  */
 typedef struct ReceiptsResult {
   uint32_t *data;
   uintptr_t data_len;
-  bool error;
+  int8_t *error;
 } ReceiptsResult;
 
 /**
@@ -67,17 +67,41 @@ typedef struct ReceiptsResult {
  * - All possible nil pointer dereferences are checked, and the function will return a
  *   failing [ReceiptsResult] if any are found.
  */
-struct ReceiptsResult rdb_read_receipts(const uint8_t *block_hash,
-                                        uintptr_t block_hash_len,
-                                        const char *db_path);
+struct ReceiptsResult *rdb_read_receipts(const uint8_t *block_hash,
+                                         uintptr_t block_hash_len,
+                                         const char *db_path);
 
 /**
- * Free a string that was allocated in Rust and passed to C.
+ * Free a ReceiptsResult that was allocated in Rust and passed to C.
  *
  * # Safety
  * - All possible nil pointer dereferences are checked.
  */
-void rdb_free_string(char *string);
+void rdb_free_receipts(struct ReceiptsResult *res);
+
+/**
+ * Return the data from a ReceiptsResult.
+ *
+ * # Safety
+ * - All possible nil pointer dereferences are checked.
+ */
+const char *rdb_get_receipts_data(struct ReceiptsResult *res);
+
+/**
+ * Return the length of the data from a ReceiptsResult.
+ *
+ * # Safety
+ * - All possible nil pointer dereferences are checked.
+ */
+uintptr_t rdb_get_receipts_data_len(struct ReceiptsResult *res);
+
+/**
+ * Return the error string, if it exists, from a ReceiptsResult.
+ *
+ * # Safety
+ * - All possible nil pointer dereferences are checked.
+ */
+const char *rdb_get_receipts_error(struct ReceiptsResult *res);
 ```
 
 [rust-toolchain]: https://rustup.rs/

--- a/op-service/rethdb-reader/src/lib.rs
+++ b/op-service/rethdb-reader/src/lib.rs
@@ -78,9 +78,9 @@ pub unsafe extern "C" fn rdb_get_receipts_data_len(res: *mut ReceiptsResult) -> 
 /// - All possible nil pointer dereferences are checked.
 #[no_mangle]
 pub unsafe extern "C" fn rdb_get_receipts_error(res: *mut ReceiptsResult) -> *const c_char {
-    if res.is_null() {
-        return std::ptr::null();
-    }
-    let res = &*res;
-    res.error as *const c_char
+    res.as_ref().map_or_else(std::ptr::null, |res| {
+        res.error
+            .as_ref()
+            .map_or_else(std::ptr::null, |e| e as *const c_char)
+    })
 }

--- a/op-service/rethdb-reader/src/lib.rs
+++ b/op-service/rethdb-reader/src/lib.rs
@@ -67,14 +67,9 @@ pub unsafe extern "C" fn rdb_get_receipts_data(res: *mut ReceiptsResult) -> *con
 /// - All possible nil pointer dereferences are checked.
 #[no_mangle]
 pub unsafe extern "C" fn rdb_get_receipts_data_len(res: *mut ReceiptsResult) -> usize {
-    if res.is_null() {
-        return 0;
-    }
-    let res = &*res;
-    if res.error.is_null() {
-        return 0;
-    }
-    res.data_len
+    res.as_ref().map_or(0, |res| {
+        res.error.is_null().then_some(0).unwrap_or(res.data_len)
+    })
 }
 
 /// Return the error string, if it exists, from a ReceiptsResult.

--- a/op-service/rethdb-reader/src/lib.rs
+++ b/op-service/rethdb-reader/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use receipts::{read_receipts_inner, ReceiptsResult};
+use std::ffi::CString;
 use std::os::raw::c_char;
 
 mod receipts;
@@ -15,19 +16,76 @@ pub unsafe extern "C" fn rdb_read_receipts(
     block_hash: *const u8,
     block_hash_len: usize,
     db_path: *const c_char,
-) -> ReceiptsResult {
-    read_receipts_inner(block_hash, block_hash_len, db_path).unwrap_or(ReceiptsResult::fail())
+) -> *mut ReceiptsResult {
+    let res = read_receipts_inner(block_hash, block_hash_len, db_path);
+    match res {
+        Ok(res) => Box::into_raw(Box::new(res)),
+        Err(err) => Box::into_raw(Box::new(ReceiptsResult::fail(err.to_string()))),
+    }
 }
 
-/// Free a string that was allocated in Rust and passed to C.
+/// Free a ReceiptsResult that was allocated in Rust and passed to C.
 ///
 /// # Safety
 /// - All possible nil pointer dereferences are checked.
 #[no_mangle]
-pub unsafe extern "C" fn rdb_free_string(string: *mut c_char) {
-    // Convert the raw pointer back to a CString and let it go out of scope,
+pub unsafe extern "C" fn rdb_free_receipts(res: *mut ReceiptsResult) {
+    // Convert the raw pointer back to a ReceiptResult and let it go out of scope,
     // which will deallocate the memory.
-    if !string.is_null() {
-        let _ = std::ffi::CString::from_raw(string);
+    if !res.is_null() {
+        if !(*res).data.is_null() {
+            // Same deal with the data string
+            let _ = CString::from_raw((*res).data as *mut c_char);
+        }
+        if !(*res).error.is_null() {
+            // Same deal with the error string
+            let _ = CString::from_raw((*res).error);
+        }
+        let _ = Box::from_raw(res);
     }
+}
+
+/// Return the data from a ReceiptsResult.
+///
+/// # Safety
+/// - All possible nil pointer dereferences are checked.
+#[no_mangle]
+pub unsafe extern "C" fn rdb_get_receipts_data(res: *mut ReceiptsResult) -> *const c_char {
+    if res.is_null() {
+        return std::ptr::null();
+    }
+    let res = &*res;
+    if res.error.is_null() {
+        return std::ptr::null();
+    }
+    res.data as *const c_char
+}
+
+/// Return the length of the data from a ReceiptsResult.
+///
+/// # Safety
+/// - All possible nil pointer dereferences are checked.
+#[no_mangle]
+pub unsafe extern "C" fn rdb_get_receipts_data_len(res: *mut ReceiptsResult) -> usize {
+    if res.is_null() {
+        return 0;
+    }
+    let res = &*res;
+    if res.error.is_null() {
+        return 0;
+    }
+    res.data_len
+}
+
+/// Return the error string, if it exists, from a ReceiptsResult.
+///
+/// # Safety
+/// - All possible nil pointer dereferences are checked.
+#[no_mangle]
+pub unsafe extern "C" fn rdb_get_receipts_error(res: *mut ReceiptsResult) -> *const c_char {
+    if res.is_null() {
+        return std::ptr::null();
+    }
+    let res = &*res;
+    res.error as *const c_char
 }

--- a/op-service/rethdb-reader/src/lib.rs
+++ b/op-service/rethdb-reader/src/lib.rs
@@ -51,14 +51,12 @@ pub unsafe extern "C" fn rdb_free_receipts(res: *mut ReceiptsResult) {
 /// - All possible nil pointer dereferences are checked.
 #[no_mangle]
 pub unsafe extern "C" fn rdb_get_receipts_data(res: *mut ReceiptsResult) -> *const c_char {
-    if res.is_null() {
-        return std::ptr::null();
-    }
-    let res = &*res;
-    if res.error.is_null() {
-        return std::ptr::null();
-    }
-    res.data as *const c_char
+    res.as_ref().map_or(std::ptr::null(), |res| {
+        res.error
+            .is_null()
+            .then_some(std::ptr::null())
+            .unwrap_or_else(|| res.data as *const c_char)
+    })
 }
 
 /// Return the length of the data from a ReceiptsResult.


### PR DESCRIPTION
Refactors the rethdb_reader ffi to use opaque objects. This is generally good practice as it better forwards-compatibility against updates to the ffi object. But more importantly, this lets us add additional non-owning pointers such as error strings that can be deallocated in one function.
Otherwise, the user will have to make multiple calls to deallocate the memory of the receipts buffer and the error string. The error string provides more detailed information to users in the event of a receipt fetching error.