### PR TITLE
op-challenger: Pass local context into cannon provider

### DIFF
--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -41,7 +41,7 @@ func RegisterGameTypes(
 	if cfg.TraceTypeEnabled(config.TraceTypeCannon) {
 		resourceCreator := func(addr common.Address, contract *contracts.FaultDisputeGameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
 			logger := logger.New("game", addr)
-			provider, err := cannon.NewTraceProvider(ctx, logger, m, cfg, contract, dir, gameDepth)
+			provider, err := cannon.NewTraceProvider(ctx, logger, m, cfg, contract, cannon.NoLocalContext, dir, gameDepth)
 			if err != nil {
 				return nil, nil, fmt.Errorf("create cannon trace provider: %w", err)
 			}

--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -46,7 +46,7 @@ func (g *CannonGameHelper) CreateHonestActor(ctx context.Context, rollupCfg *rol
 	maxDepth := g.MaxDepth(ctx)
 	gameContract, err := contracts.NewFaultDisputeGameContract(g.addr, batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize))
 	g.require.NoError(err, "Create game contract bindings")
-	provider, err := cannon.NewTraceProvider(ctx, logger, metrics.NoopMetrics, cfg, gameContract, filepath.Join(cfg.Datadir, "honest"), uint64(maxDepth))
+	provider, err := cannon.NewTraceProvider(ctx, logger, metrics.NoopMetrics, cfg, gameContract, cannon.NoLocalContext, filepath.Join(cfg.Datadir, "honest"), uint64(maxDepth))
 	g.require.NoError(err, "create cannon trace provider")
 
 	return &HonestHelper{

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -191,6 +191,7 @@ func (h *FactoryHelper) StartCannonGameWithCorrectRoot(ctx context.Context, roll
 		testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"),
 		metrics.NoopMetrics,
 		cfg,
+		cannon.NoLocalContext,
 		inputs,
 		cfg.Datadir,
 		maxDepth.Uint64(),


### PR DESCRIPTION
**Description**

Pass local context into cannon provider to allow it to be customised by the split output trace provider.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/104 (wiring is complete - calculating the appropriate value in the split provider will fall under its issue).
