### PR TITLE
feat(ci-builder): Slither-analyzer Docker Image

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -30,6 +30,8 @@ RUN strip /root/.foundry/bin/forge && \
 
 FROM --platform=linux/amd64 ghcr.io/crytic/echidna/echidna:v2.0.4 as echidna-test
 
+FROM --platform=linux/amd64 ghcr.io/trailofbits/eth-security-toolbox:latest as slither
+
 FROM --platform=linux/amd64 debian:bullseye-slim as go-build
 
 RUN apt-get update && apt-get install -y curl ca-certificates


### PR DESCRIPTION
**Description**

Adds the trail of bits `eth-security-toolbox` [docker image](https://github.com/crytic/slither?tab=readme-ov-file#using-docker) as a dependency to the `ci-builder` so `slither` can be used in circleci jobs.
