### PR TITLE
op-e2e: Add WaitForBlockToBeFinalized & WaitForBlocktoBeSafe

### DIFF
--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -115,7 +115,7 @@ func WaitForBlockToBeSafe(number *big.Int, client *ethclient.Client, timeout tim
 }
 
 // WaitForBlockTag polls for a block number to reach the specified tag & then returns that block at the number.
-func WaitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Duration, tag int64) (*types.Block, error) {
+func WaitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Duration, tag rpc.BlockNumber) (*types.Block, error) {
 	timeoutCh := time.After(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -107,15 +107,15 @@ func WaitForBlock(number *big.Int, client *ethclient.Client, timeout time.Durati
 }
 
 func WaitForBlockToBeFinalized(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
-	return WaitForBlockTag(number, client, timeout, int64(rpc.FinalizedBlockNumber))
+	return waitForBlockTag(number, client, timeout, int64(rpc.FinalizedBlockNumber))
 }
 
 func WaitForBlockToBeSafe(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
-	return WaitForBlockTag(number, client, timeout, int64(rpc.SafeBlockNumber))
+	return waitForBlockTag(number, client, timeout, int64(rpc.SafeBlockNumber))
 }
 
-// WaitForBlockTag polls for a block number to reach the specified tag & then returns that block at the number.
-func WaitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Duration, tag rpc.BlockNumber) (*types.Block, error) {
+// waitForBlockTag polls for a block number to reach the specified tag & then returns that block at the number.
+func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Duration, tag rpc.BlockNumber) (*types.Block, error) {
 	timeoutCh := time.After(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -124,22 +124,18 @@ func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Dur
 
 	tagBigInt := big.NewInt(tag.Int64())
 
-	for range ticker.C {
-		block, err := client.BlockByNumber(ctx, tagBigInt)
-		if err != nil {
-			return nil, err
-		}
-		if block.NumberU64() >= number.Uint64() {
-			return client.BlockByNumber(ctx, number)
-		}
-
+	for {
 		select {
+		case <-ticker.C:
+			block, err := client.BlockByNumber(ctx, tagBigInt)
+			if err != nil {
+				return nil, err
+			}
+			if block != nil && block.NumberU64() >= number.Uint64() {
+				return client.BlockByNumber(ctx, number)
+			}
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		default:
-			// Continue polling
 		}
 	}
-
-	return nil, ctx.Err() // In case the loop somehow exits without meeting the condition
 }

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -104,11 +104,11 @@ func WaitForBlock(number *big.Int, client *ethclient.Client, timeout time.Durati
 }
 
 func WaitForBlockToBeFinalized(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
-	return waitForBlockTag(number, client, timeout, int64(rpc.FinalizedBlockNumber))
+	return waitForBlockTag(number, client, timeout, rpc.FinalizedBlockNumber)
 }
 
 func WaitForBlockToBeSafe(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
-	return waitForBlockTag(number, client, timeout, int64(rpc.SafeBlockNumber))
+	return waitForBlockTag(number, client, timeout, rpc.SafeBlockNumber)
 }
 
 // waitForBlockTag polls for a block number to reach the specified tag & then returns that block at the number.
@@ -120,10 +120,11 @@ func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Dur
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
+	tagBigInt := big.NewInt(tag.Int64())
 	for {
 		select {
 		case <-ticker.C:
-			block, _ := client.BlockByNumber(ctx, big.NewInt(tag))
+			block, _ := client.BlockByNumber(ctx, tagBigInt)
 			if block.NumberU64() >= number.Uint64() {
 				return client.BlockByNumber(ctx, number)
 			}

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -81,7 +81,6 @@ func WaitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 }
 
 func WaitForBlock(number *big.Int, client *ethclient.Client, timeout time.Duration) (*types.Block, error) {
-	timeoutCh := time.After(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -100,8 +99,6 @@ func WaitForBlock(number *big.Int, client *ethclient.Client, timeout time.Durati
 			}
 		case err := <-headSub.Err():
 			return nil, fmt.Errorf("error in head subscription: %w", err)
-		case <-timeoutCh:
-			return nil, errTimeout
 		}
 	}
 }
@@ -116,7 +113,6 @@ func WaitForBlockToBeSafe(number *big.Int, client *ethclient.Client, timeout tim
 
 // waitForBlockTag polls for a block number to reach the specified tag & then returns that block at the number.
 func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Duration, tag rpc.BlockNumber) (*types.Block, error) {
-	timeoutCh := time.After(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -131,8 +127,6 @@ func waitForBlockTag(number *big.Int, client *ethclient.Client, timeout time.Dur
 			if block.NumberU64() >= number.Uint64() {
 				return client.BlockByNumber(ctx, number)
 			}
-		case <-timeoutCh:
-			return nil, errTimeout
 		}
 	}
 }

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -368,17 +368,8 @@ func TestFinalize(t *testing.T) {
 
 	l2Seq := sys.Clients["sequencer"]
 
-	// as configured in the extra geth lifecycle in testing setup
-	const finalizedDistance = 8
-	// Wait enough time for L1 to finalize and L2 to confirm its data in finalized L1 blocks
-	time.Sleep(time.Duration((finalizedDistance+6)*cfg.DeployConfig.L1BlockTime) * time.Second)
-
-	// fetch the finalizes head of geth
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	l2Finalized, err := l2Seq.BlockByNumber(ctx, big.NewInt(int64(rpc.FinalizedBlockNumber)))
-	require.NoError(t, err)
-
+	l2Finalized, err := geth.WaitForBlockToBeFinalized(big.NewInt(12), l2Seq, 1*time.Minute)
+	require.NoError(t, err, "must be able to fetch a finalized L2 block")
 	require.NotZerof(t, l2Finalized.NumberU64(), "must have finalized L2 block")
 }
 


### PR DESCRIPTION
**Description**

These helper functions simplify TestFinalize and future tests which may be waiting on actions rather than polling for actions.

