### PR TITLE
contracts-bedrock: label EAS predeploys in tests

### DIFF
--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -185,5 +185,7 @@ contract Setup is Deploy {
         vm.label(Predeploys.GAS_PRICE_ORACLE, "GasPriceOracle");
         vm.label(Predeploys.LEGACY_MESSAGE_PASSER, "LegacyMessagePasser");
         vm.label(Predeploys.GOVERNANCE_TOKEN, "GovernanceToken");
+        vm.label(Predeploys.EAS, "EAS");
+        vm.label(Predeploys.SCHEMA_REGISTRY, "SchemaRegistry");
     }
 }


### PR DESCRIPTION
**Description**

This commit labels the EAS and SchemaRegistry predeploy
contracts in the solidity unit tests. These contracts were
previously left out from the implementation work that labelled
all of the L2 predeploys. After a contract is labelled, it
will show up with a human readable name in the forge traces
instead of just being an address.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
