### PR TITLE
fix(op-challenger): PreimageOracleData Type Big Int Refactor and CI Fix

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -232,8 +232,8 @@ func (f *FaultDisputeGameContract) addLocalDataTx(data *types.PreimageOracleData
 	call := f.contract.Call(
 		methodAddLocalData,
 		data.GetIdent(),
-		new(big.Int).SetBytes(data.LocalContext.Bytes()),
-		new(big.Int).SetUint64(uint64(data.OracleOffset)),
+		data.GetLocalContextBigInt(),
+		data.GetOracleOffsetBigInt(),
 	)
 	return call.ToTxCandidate()
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -260,8 +260,8 @@ func TestUpdateOracleTx(t *testing.T) {
 		}
 		stubRpc.SetResponse(fdgAddr, methodAddLocalData, batching.BlockLatest, []interface{}{
 			data.GetIdent(),
-			new(big.Int).SetBytes(data.LocalContext.Bytes()),
-			new(big.Int).SetUint64(uint64(data.OracleOffset)),
+			data.GetLocalContextBigInt(),
+			data.GetOracleOffsetBigInt(),
 		}, nil)
 		tx, err := game.UpdateOracleTx(context.Background(), data)
 		require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestUpdateOracleTx(t *testing.T) {
 		stubRpc.SetResponse(fdgAddr, methodVM, batching.BlockLatest, nil, []interface{}{vmAddr})
 		stubRpc.SetResponse(vmAddr, methodOracle, batching.BlockLatest, nil, []interface{}{oracleAddr})
 		stubRpc.SetResponse(oracleAddr, methodLoadKeccak256PreimagePart, batching.BlockLatest, []interface{}{
-			new(big.Int).SetUint64(uint64(data.OracleOffset)),
+			data.GetOracleOffsetBigInt(),
 			data.GetPreimageWithoutSize(),
 		}, nil)
 		tx, err := game.UpdateOracleTx(context.Background(), data)

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -26,6 +26,16 @@ type PreimageOracleData struct {
 	OracleOffset uint32
 }
 
+// GetLocalContextBigInt returns the local context as a big int.
+func (p *PreimageOracleData) GetLocalContextBigInt() *big.Int {
+	return new(big.Int).SetBytes(p.LocalContext.Bytes())
+}
+
+// GetOracleOffsetBigInt returns the oracle offset as a big int.
+func (p *PreimageOracleData) GetOracleOffsetBigInt() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.OracleOffset))
+}
+
 // GetIdent returns the ident for the preimage oracle data.
 func (p *PreimageOracleData) GetIdent() *big.Int {
 	return new(big.Int).SetBytes(p.OracleKey[1:])

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -8,11 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	emptyHash = common.Hash{}
+	oneHash   = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
+	eliteHash = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000001337")
+)
+
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {
 		data := NewPreimageOracleData(common.Hash{0x01}, []byte{1, 2, 3}, []byte{4, 5, 6}, 7)
 		require.True(t, data.IsLocal)
-		require.Equal(t, uint64(1), data.LocalContext)
+		require.Equal(t, common.Hash{0x01}, data.LocalContext)
 		require.Equal(t, []byte{1, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
 		require.Equal(t, uint32(7), data.OracleOffset)
@@ -21,11 +27,49 @@ func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("GlobalData", func(t *testing.T) {
 		data := NewPreimageOracleData(common.Hash{0x01}, []byte{0, 2, 3}, []byte{4, 5, 6}, 7)
 		require.False(t, data.IsLocal)
-		require.Equal(t, uint64(1), data.LocalContext)
+		require.Equal(t, common.Hash{0x01}, data.LocalContext)
 		require.Equal(t, []byte{0, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
 		require.Equal(t, uint32(7), data.OracleOffset)
 	})
+}
+
+func TestPreimageOracleData_GetLocalContextBigInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		context  common.Hash
+		expected *big.Int
+	}{
+		{name: "LocalContext", context: oneHash, expected: new(big.Int).SetUint64(1)},
+		{name: "NoLocalContext", context: emptyHash, expected: new(big.Int).SetBytes(emptyHash.Bytes())},
+		{name: "MultiBytesLocalContext", context: eliteHash, expected: big.NewInt(0x1337)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := NewPreimageOracleData(test.context, []byte{1, 2, 3}, []byte{4, 5, 6}, 7)
+			require.Equal(t, test.expected, data.GetLocalContextBigInt())
+		})
+	}
+}
+
+func TestPreimageOracleData_GetOracleOffsetBigInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		offset   uint32
+		expected *big.Int
+	}{
+		{name: "ZeroOffset", offset: 0, expected: new(big.Int).SetUint64(0)},
+		{name: "NonZeroOffset", offset: 1, expected: new(big.Int).SetUint64(1)},
+		{name: "MaxUint32Offset", offset: 0xffffffff, expected: new(big.Int).SetUint64(0xffffffff)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := NewPreimageOracleData(common.Hash{}, []byte{1, 2, 3}, []byte{4, 5, 6}, test.offset)
+			require.Equal(t, test.expected, data.GetOracleOffsetBigInt())
+		})
+	}
 }
 
 func TestIsRootPosition(t *testing.T) {

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	emptyHash = common.Hash{}
 	oneHash   = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
 	eliteHash = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000001337")
 )
@@ -41,7 +40,7 @@ func TestPreimageOracleData_GetLocalContextBigInt(t *testing.T) {
 		expected *big.Int
 	}{
 		{name: "LocalContext", context: oneHash, expected: new(big.Int).SetUint64(1)},
-		{name: "NoLocalContext", context: emptyHash, expected: new(big.Int).SetBytes(emptyHash.Bytes())},
+		{name: "NoLocalContext", context: NoLocalContext, expected: new(big.Int).SetBytes(NoLocalContext.Bytes())},
 		{name: "MultiBytesLocalContext", context: eliteHash, expected: big.NewInt(0x1337)},
 	}
 


### PR DESCRIPTION
**Description**

Fixes CI in the parent pr #8201 (stacked ontop).

Refactors the untestable big int construction to the `PreimageOracleData` type.

**Tests**

Unit table tests surrounding the two new `PreimageOracleData` type methods.
