### PR TITLE
chore(ci): Bump CI Builder Minor in the Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.29.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.30.0
 
 orbs:
   go: circleci/go@1.8.0


### PR DESCRIPTION
**Description**

Bumps the minor for ci-builder to use the newly-built `0.30.0` version with cheatcode-support forge.
