### PR TITLE
fix(sdk): have getMessageStatus call messenger

### DIFF
--- a/.changeset/purple-melons-explain.md
+++ b/.changeset/purple-melons-explain.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Simplifies getMessageStatus to use an O(1) lookup instead of an event query

--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -667,25 +667,54 @@ export class CrossChainMessenger {
     toBlockOrBlockHash?: BlockTag
   ): Promise<MessageStatus> {
     const resolved = await this.toCrossChainMessage(message, messageIndex)
-    const receipt = await this.getMessageReceipt(
-      resolved,
-      messageIndex,
-      fromBlockOrBlockHash,
-      toBlockOrBlockHash
+    // legacy withdrawals relayed prebedrock are v1
+    const messageHashV0 = hashCrossDomainMessagev0(
+      resolved.target,
+      resolved.sender,
+      resolved.message,
+      resolved.messageNonce
+    )
+    // bedrock withdrawals are v1
+    // legacy withdrawals relayed postbedrock are v1
+    // there is no good way to differentiate between the two types of legacy
+    // so what we will check for both
+    const messageHashV1 = hashCrossDomainMessagev1(
+      resolved.messageNonce,
+      resolved.sender,
+      resolved.target,
+      resolved.value,
+      resolved.minGasLimit,
+      resolved.message
     )
 
+    // Here we want the messenger that will receive the message, not the one that sent it.
+    const messenger =
+      resolved.direction === MessageDirection.L1_TO_L2
+        ? this.contracts.l2.L2CrossDomainMessenger
+        : this.contracts.l1.L1CrossDomainMessenger
+
+    const success =
+      (await messenger.successfulMessages(messageHashV0)) ||
+      (await messenger.successfulMessages(messageHashV1))
+
+    const failure =
+      (await messenger.failedMessages(messageHashV0)) ||
+      (await messenger.failedMessages(messageHashV1))
+
     if (resolved.direction === MessageDirection.L1_TO_L2) {
-      if (receipt === null) {
-        return MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE
+      if (success) {
+        return MessageStatus.RELAYED
+      } else if (failure) {
+        return MessageStatus.FAILED_L1_TO_L2_MESSAGE
       } else {
-        if (receipt.receiptStatus === MessageReceiptStatus.RELAYED_SUCCEEDED) {
-          return MessageStatus.RELAYED
-        } else {
-          return MessageStatus.FAILED_L1_TO_L2_MESSAGE
-        }
+        return MessageStatus.UNCONFIRMED_L1_TO_L2_MESSAGE
       }
     } else {
-      if (receipt === null) {
+      if (success) {
+        return MessageStatus.RELAYED
+      } else if (failure) {
+        return MessageStatus.READY_FOR_RELAY
+      } else {
         let timestamp: number
         if (this.bedrock) {
           const output = await this.getMessageBedrockOutput(
@@ -734,12 +763,6 @@ export class CrossChainMessenger {
 
         if (timestamp + challengePeriod > latestBlock.timestamp) {
           return MessageStatus.IN_CHALLENGE_PERIOD
-        } else {
-          return MessageStatus.READY_FOR_RELAY
-        }
-      } else {
-        if (receipt.receiptStatus === MessageReceiptStatus.RELAYED_SUCCEEDED) {
-          return MessageStatus.RELAYED
         } else {
           return MessageStatus.READY_FOR_RELAY
         }

--- a/packages/sdk/test/contracts/MockMessenger.sol
+++ b/packages/sdk/test/contracts/MockMessenger.sol
@@ -8,6 +8,8 @@ contract MockMessenger is ICrossDomainMessenger {
     }
 
     uint256 public nonce;
+    mapping (bytes32 => bool) public successfulMessages;
+    mapping (bytes32 => bool) public failedMessages;
 
     // Empty function to satisfy the interface.
     function sendMessage(
@@ -81,6 +83,7 @@ contract MockMessenger is ICrossDomainMessenger {
     ) public {
         for (uint256 i = 0; i < _params.length; i++) {
             emit RelayedMessage(_params[i]);
+            successfulMessages[_params[i]] = true;
         }
     }
 
@@ -89,6 +92,7 @@ contract MockMessenger is ICrossDomainMessenger {
     ) public {
         for (uint256 i = 0; i < _params.length; i++) {
             emit FailedRelayedMessage(_params[i]);
+            failedMessages[_params[i]] = true;
         }
     }
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
getMessageStatus was previously using event queries to figure out the status of the given message. We can do the same thing by making requests directly to the messenger contracts which is more reliable because most RPC endpoints won't allow massive block ranges.x
