### PR TITLE
op-e2e: Use sequencer to verify deposit behaviour in TestMintOnRevertedDeposit

### DIFF
--- a/op-e2e/deposit_test.go
+++ b/op-e2e/deposit_test.go
@@ -16,13 +16,13 @@ import (
 func TestMintOnRevertedDeposit(t *testing.T) {
 	InitParallel(t)
 	cfg := DefaultSystemConfig(t)
-
+	delete(cfg.Nodes, "verifier")
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")
 	defer sys.Close()
 
 	l1Client := sys.Clients["l1"]
-	l2Verif := sys.Clients["verifier"]
+	l2Verif := sys.Clients["sequencer"]
 
 	// create signer
 	aliceKey := cfg.Secrets.Alice

--- a/op-e2e/tx_helper.go
+++ b/op-e2e/tx_helper.go
@@ -47,7 +47,9 @@ func SendDepositTx(t *testing.T, cfg SystemConfig, l1Client *ethclient.Client, l
 	reconstructedDep, err := derive.UnmarshalDepositLogEvent(l1Receipt.Logs[0])
 	require.NoError(t, err, "Could not reconstruct L2 Deposit")
 	tx = types.NewTx(reconstructedDep)
-	l2Receipt, err := geth.WaitForTransaction(tx.Hash(), l2Client, 10*time.Duration(cfg.DeployConfig.L2BlockTime)*time.Second)
+	// Use a long wait because the l2Client may not be configured to receive gossip from the sequencer
+	// so has to wait for the batcher to submit and then import those blocks from L1.
+	l2Receipt, err := geth.WaitForTransaction(tx.Hash(), l2Client, 60*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, l2Opts.ExpectedStatus, l2Receipt.Status, "l2 transaction status")
 	return l2Receipt


### PR DESCRIPTION
**Description**

Makes the test faster and use fewer resources. How deposit mints are handled doesn't need to use a separate verifier node.

Extend the timeout for deposit transactions to be reflected on L2 to avoid flakiness when the L2 client isn't receiving gossip from the sequencer.

https://github.com/ethereum-optimism/client-pod/issues/221