### PR TITLE
ci: Build monorepo on op-node change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
           name: git submodules
           command: make submodules
       - check-changed:
-          patterns: op-chain-ops,packages/
+          patterns: op-chain-ops,packages/,op-node
       - restore_cache:
           name: Restore PNPM Package Cache
           keys:


### PR DESCRIPTION
Rebased version of #8213 

Fixes an issue where the pnpm-monorepo job would not build due to `check-changed`, but downstream jobs like `contracts-bedrock-test` would. This causes the contracts to be rebuilt on the downstream jobs and causes OOMs and spurious test flakes.
