### PR TITLE
op-challenger: cleanup service lifecycle, improve subscription ctx usage

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -312,6 +312,10 @@ func (bs *BatcherService) Stop(ctx context.Context) error {
 			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
 		}
 	}
+	if bs.TxManager != nil {
+		bs.TxManager.Close()
+	}
+
 	if bs.metricsSrv != nil {
 		if err := bs.metricsSrv.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to stop metrics server: %w", err))

--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -2,22 +2,19 @@ package op_challenger
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game"
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 )
 
-// Main is the programmatic entry-point for running op-challenger
-func Main(ctx context.Context, logger log.Logger, cfg *config.Config) error {
+// Main is the programmatic entry-point for running op-challenger with a given configuration.
+func Main(ctx context.Context, logger log.Logger, cfg *config.Config) (cliapp.Lifecycle, error) {
 	if err := cfg.Check(); err != nil {
-		return err
+		return nil, err
 	}
-	service, err := game.NewService(ctx, logger, cfg)
-	if err != nil {
-		return fmt.Errorf("failed to create the fault service: %w", err)
-	}
-
-	return service.MonitorGame(ctx)
+	srv, err := game.NewService(ctx, logger, cfg)
+	return srv, err
 }

--- a/op-challenger/challenger_test.go
+++ b/op-challenger/challenger_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestMainShouldReturnErrorWhenConfigInvalid(t *testing.T) {
 	cfg := &config.Config{}
-	err := Main(context.Background(), testlog.Logger(t, log.LvlInfo), cfg)
+	app, err := Main(context.Background(), testlog.Logger(t, log.LvlInfo), cfg)
 	require.ErrorIs(t, err, cfg.Check())
+	require.Nil(t, app)
 }

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -232,6 +232,9 @@ func (m *mockTxManager) From() common.Address {
 	return m.from
 }
 
+func (m *mockTxManager) Close() {
+}
+
 type mockContract struct {
 	calls            int
 	callFails        bool

--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
@@ -39,6 +40,7 @@ type gameMonitor struct {
 	allowedGames     []common.Address
 	l1HeadsSub       ethereum.Subscription
 	l1Source         *headSource
+	runState         sync.Mutex
 }
 
 type MinimalSubscriber interface {
@@ -126,8 +128,10 @@ func (m *gameMonitor) onNewL1Head(ctx context.Context, sig eth.L1BlockRef) {
 	}
 }
 
-func (m *gameMonitor) resubscribeFunction(ctx context.Context) event.ResubscribeErrFunc {
-	return func(innerCtx context.Context, err error) (event.Subscription, error) {
+func (m *gameMonitor) resubscribeFunction() event.ResubscribeErrFunc {
+	// The ctx is cancelled as soon as the subscription is returned,
+	// but is only used to create the subscription, and does not affect the returned subscription.
+	return func(ctx context.Context, err error) (event.Subscription, error) {
 		if err != nil {
 			m.logger.Warn("resubscribing after failed L1 subscription", "err", err)
 		}
@@ -135,18 +139,21 @@ func (m *gameMonitor) resubscribeFunction(ctx context.Context) event.Resubscribe
 	}
 }
 
-func (m *gameMonitor) MonitorGames(ctx context.Context) error {
-	m.l1HeadsSub = event.ResubscribeErr(time.Second*10, m.resubscribeFunction(ctx))
-	for {
-		select {
-		case <-ctx.Done():
-			m.l1HeadsSub.Unsubscribe()
-			return nil
-		case err, ok := <-m.l1HeadsSub.Err():
-			if !ok {
-				return err
-			}
-			m.logger.Error("L1 subscription error", "err", err)
-		}
+func (m *gameMonitor) StartMonitoring() {
+	m.runState.Lock()
+	defer m.runState.Unlock()
+	if m.l1HeadsSub != nil {
+		return // already started
 	}
+	m.l1HeadsSub = event.ResubscribeErr(time.Second*10, m.resubscribeFunction())
+}
+
+func (m *gameMonitor) StopMonitoring() {
+	m.runState.Lock()
+	defer m.runState.Unlock()
+	if m.l1HeadsSub == nil {
+		return // already stopped
+	}
+	m.l1HeadsSub.Unsubscribe()
+	m.l1HeadsSub = nil
 }

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -84,8 +84,9 @@ func TestMonitorGames(t *testing.T) {
 			cancel()
 		}()
 
-		err := monitor.MonitorGames(ctx)
-		require.NoError(t, err)
+		monitor.StartMonitoring()
+		<-ctx.Done()
+		monitor.StopMonitoring()
 		require.Len(t, sched.scheduled, 1)
 		require.Equal(t, []common.Address{addr1, addr2}, sched.scheduled[0])
 	})
@@ -129,8 +130,9 @@ func TestMonitorGames(t *testing.T) {
 			cancel()
 		}()
 
-		err := monitor.MonitorGames(ctx)
-		require.NoError(t, err)
+		monitor.StartMonitoring()
+		<-ctx.Done()
+		monitor.StopMonitoring()
 		require.NotEmpty(t, sched.scheduled) // We might get more than one update scheduled.
 		require.Equal(t, []common.Address{addr1, addr2}, sched.scheduled[0])
 	})

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault"
@@ -13,14 +18,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-challenger/version"
-	opClient "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
+	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 type Service struct {
@@ -29,101 +34,196 @@ type Service struct {
 	monitor *gameMonitor
 	sched   *scheduler.Scheduler
 
+	txMgr *txmgr.SimpleTxManager
+
+	loader *loader.GameLoader
+
+	l1Client   *ethclient.Client
+	pollClient client.RPC
+
 	pprofSrv   *httputil.HTTPServer
 	metricsSrv *httputil.HTTPServer
-}
 
-func (s *Service) Stop(ctx context.Context) error {
-	var result error
-	if s.sched != nil {
-		result = errors.Join(result, s.sched.Close())
-	}
-	if s.pprofSrv != nil {
-		result = errors.Join(result, s.pprofSrv.Stop(ctx))
-	}
-	if s.metricsSrv != nil {
-		result = errors.Join(result, s.metricsSrv.Stop(ctx))
-	}
-	return result
+	balanceMetricer io.Closer
+
+	stopped atomic.Bool
 }
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, logger log.Logger, cfg *config.Config) (*Service, error) {
-	cl := clock.SystemClock
-	m := metrics.NewMetrics()
-	txMgr, err := txmgr.NewSimpleTxManager("challenger", logger, &m.TxMetrics, cfg.TxMgrConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the transaction manager: %w", err)
-	}
-
-	l1Client, err := dial.DialEthClientWithTimeout(ctx, dial.DefaultDialTimeout, logger, cfg.L1EthRpc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial L1: %w", err)
-	}
-
 	s := &Service{
 		logger:  logger,
-		metrics: m,
+		metrics: metrics.NewMetrics(),
 	}
 
-	pprofConfig := cfg.PprofConfig
-	if pprofConfig.Enabled {
-		logger.Debug("starting pprof", "addr", pprofConfig.ListenAddr, "port", pprofConfig.ListenPort)
-		pprofSrv, err := oppprof.StartServer(pprofConfig.ListenAddr, pprofConfig.ListenPort)
-		if err != nil {
-			return nil, errors.Join(fmt.Errorf("failed to start pprof server: %w", err), s.Stop(ctx))
-		}
-		s.pprofSrv = pprofSrv
-		logger.Info("started pprof server", "addr", pprofSrv.Addr())
+	if err := s.initFromConfig(ctx, cfg); err != nil {
+		// upon initialization error we can try to close any of the service components that may have started already.
+		return nil, errors.Join(fmt.Errorf("failed to init challenger game service: %w", err), s.Stop(ctx))
 	}
-
-	metricsCfg := cfg.MetricsConfig
-	if metricsCfg.Enabled {
-		logger.Debug("starting metrics server", "addr", metricsCfg.ListenAddr, "port", metricsCfg.ListenPort)
-		metricsSrv, err := m.Start(metricsCfg.ListenAddr, metricsCfg.ListenPort)
-		if err != nil {
-			return nil, errors.Join(fmt.Errorf("failed to start metrics server: %w", err), s.Stop(ctx))
-		}
-		logger.Info("started metrics server", "addr", metricsSrv.Addr())
-		s.metricsSrv = metricsSrv
-		m.StartBalanceMetrics(ctx, logger, l1Client, txMgr.From())
-	}
-
-	factoryContract, err := contracts.NewDisputeGameFactoryContract(cfg.GameFactoryAddress, batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize))
-	if err != nil {
-		return nil, errors.Join(fmt.Errorf("failed to bind the fault dispute game factory contract: %w", err), s.Stop(ctx))
-	}
-	loader := loader.NewGameLoader(factoryContract)
-
-	gameTypeRegistry := registry.NewGameTypeRegistry()
-	fault.RegisterGameTypes(gameTypeRegistry, ctx, logger, m, cfg, txMgr, l1Client)
-
-	disk := newDiskManager(cfg.Datadir)
-	s.sched = scheduler.NewScheduler(
-		logger,
-		m,
-		disk,
-		cfg.MaxConcurrency,
-		gameTypeRegistry.CreatePlayer)
-
-	pollClient, err := opClient.NewRPCWithClient(ctx, logger, cfg.L1EthRpc, opClient.NewBaseRPCClient(l1Client.Client()), cfg.PollInterval)
-	if err != nil {
-		return nil, errors.Join(fmt.Errorf("failed to create RPC client: %w", err), s.Stop(ctx))
-	}
-	s.monitor = newGameMonitor(logger, cl, loader, s.sched, cfg.GameWindow, l1Client.BlockNumber, cfg.GameAllowlist, pollClient)
-
-	m.RecordInfo(version.SimpleWithMeta)
-	m.RecordUp()
 
 	return s, nil
 }
 
-// MonitorGame monitors the fault dispute game and attempts to progress it.
-func (s *Service) MonitorGame(ctx context.Context) error {
+func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error {
+	if err := s.initTxManager(cfg); err != nil {
+		return err
+	}
+	if err := s.initL1Client(ctx, cfg); err != nil {
+		return err
+	}
+	if err := s.initPollClient(ctx, cfg); err != nil {
+		return err
+	}
+	if err := s.initPProfServer(&cfg.PprofConfig); err != nil {
+		return err
+	}
+	if err := s.initMetricsServer(&cfg.MetricsConfig); err != nil {
+		return err
+	}
+	if err := s.initGameLoader(cfg); err != nil {
+		return err
+	}
+
+	s.initScheduler(ctx, cfg)
+	s.initMonitor(cfg)
+
+	s.metrics.RecordInfo(version.SimpleWithMeta)
+	s.metrics.RecordUp()
+	return nil
+}
+
+func (s *Service) initTxManager(cfg *config.Config) error {
+	txMgr, err := txmgr.NewSimpleTxManager("challenger", s.logger, s.metrics, cfg.TxMgrConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create the transaction manager: %w", err)
+	}
+	s.txMgr = txMgr
+	return nil
+}
+
+func (s *Service) initL1Client(ctx context.Context, cfg *config.Config) error {
+	l1Client, err := dial.DialEthClientWithTimeout(ctx, dial.DefaultDialTimeout, s.logger, cfg.L1EthRpc)
+	if err != nil {
+		return fmt.Errorf("failed to dial L1: %w", err)
+	}
+	s.l1Client = l1Client
+	return nil
+}
+
+func (s *Service) initPollClient(ctx context.Context, cfg *config.Config) error {
+	pollClient, err := client.NewRPCWithClient(ctx, s.logger, cfg.L1EthRpc, client.NewBaseRPCClient(s.l1Client.Client()), cfg.PollInterval)
+	if err != nil {
+		return fmt.Errorf("failed to create RPC client: %w", err)
+	}
+	s.pollClient = pollClient
+	return nil
+}
+
+func (s *Service) initPProfServer(cfg *oppprof.CLIConfig) error {
+	if !cfg.Enabled {
+		return nil
+	}
+	s.logger.Debug("starting pprof", "addr", cfg.ListenAddr, "port", cfg.ListenPort)
+	pprofSrv, err := oppprof.StartServer(cfg.ListenAddr, cfg.ListenPort)
+	if err != nil {
+		return fmt.Errorf("failed to start pprof server: %w", err)
+	}
+	s.pprofSrv = pprofSrv
+	s.logger.Info("started pprof server", "addr", pprofSrv.Addr())
+	return nil
+}
+
+func (s *Service) initMetricsServer(cfg *opmetrics.CLIConfig) error {
+	if !cfg.Enabled {
+		return nil
+	}
+	s.logger.Debug("starting metrics server", "addr", cfg.ListenAddr, "port", cfg.ListenPort)
+	m, ok := s.metrics.(opmetrics.RegistryMetricer)
+	if !ok {
+		return fmt.Errorf("metrics were enabled, but metricer %T does not expose registry for metrics-server", s.metrics)
+	}
+	metricsSrv, err := opmetrics.StartServer(m.Registry(), cfg.ListenAddr, cfg.ListenPort)
+	if err != nil {
+		return fmt.Errorf("failed to start metrics server: %w", err)
+	}
+	s.logger.Info("started metrics server", "addr", metricsSrv.Addr())
+	s.metricsSrv = metricsSrv
+	s.balanceMetricer = s.metrics.StartBalanceMetrics(s.logger, s.l1Client, s.txMgr.From())
+	return nil
+}
+
+func (s *Service) initGameLoader(cfg *config.Config) error {
+	factoryContract, err := contracts.NewDisputeGameFactoryContract(cfg.GameFactoryAddress,
+		batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize))
+	if err != nil {
+		return fmt.Errorf("failed to bind the fault dispute game factory contract: %w", err)
+	}
+	s.loader = loader.NewGameLoader(factoryContract)
+	return nil
+}
+
+func (s *Service) initScheduler(ctx context.Context, cfg *config.Config) {
+	gameTypeRegistry := registry.NewGameTypeRegistry()
+	fault.RegisterGameTypes(gameTypeRegistry, ctx, s.logger, s.metrics, cfg, s.txMgr, s.l1Client)
+
+	disk := newDiskManager(cfg.Datadir)
+	s.sched = scheduler.NewScheduler(s.logger, s.metrics, disk, cfg.MaxConcurrency, gameTypeRegistry.CreatePlayer)
+}
+
+func (s *Service) initMonitor(cfg *config.Config) {
+	cl := clock.SystemClock
+	s.monitor = newGameMonitor(s.logger, cl, s.loader, s.sched, cfg.GameWindow, s.l1Client.BlockNumber, cfg.GameAllowlist, s.pollClient)
+}
+
+func (s *Service) Start(ctx context.Context) error {
+	s.logger.Info("starting scheduler")
 	s.sched.Start(ctx)
-	err := s.monitor.MonitorGames(ctx)
-	// The other ctx is the close-trigger.
-	// We need to refactor Service more to allow for graceful/force-shutdown granularity.
-	err = errors.Join(err, s.Stop(context.Background()))
-	return err
+	s.logger.Info("starting monitoring")
+	s.monitor.StartMonitoring()
+	s.logger.Info("challenger game service start completed")
+	return nil
+}
+
+func (s *Service) Stopped() bool {
+	return s.stopped.Load()
+}
+
+func (s *Service) Stop(ctx context.Context) error {
+	s.logger.Info("stopping challenger game service")
+
+	var result error
+	if s.sched != nil {
+		if err := s.sched.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close scheduler: %w", err))
+		}
+	}
+	if s.monitor != nil {
+		s.monitor.StopMonitoring()
+	}
+	if s.pprofSrv != nil {
+		if err := s.pprofSrv.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close pprof server: %w", err))
+		}
+	}
+	if s.balanceMetricer != nil {
+		if err := s.balanceMetricer.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
+		}
+	}
+
+	if s.txMgr != nil {
+		s.txMgr.Close()
+	}
+
+	if s.l1Client != nil {
+		s.l1Client.Close()
+	}
+	if s.metricsSrv != nil {
+		if err := s.metricsSrv.Stop(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close metrics server: %w", err))
+		}
+	}
+	s.stopped.Store(true)
+	s.logger.Info("stopped challenger game service", "err", result)
+	return result
 }

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -1,11 +1,21 @@
 package metrics
 
 import (
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+
 	txmetrics "github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 )
 
 type NoopMetricsImpl struct {
 	txmetrics.NoopTxMetrics
+}
+
+func (i *NoopMetricsImpl) StartBalanceMetrics(l log.Logger, client *ethclient.Client, account common.Address) io.Closer {
+	return nil
 }
 
 var NoopMetrics Metricer = new(NoopMetricsImpl)

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -54,6 +54,8 @@ func (f fakeTxMgr) BlockNumber(_ context.Context) (uint64, error) {
 func (f fakeTxMgr) Send(_ context.Context, _ txmgr.TxCandidate) (*types.Receipt, error) {
 	panic("unimplemented")
 }
+func (f fakeTxMgr) Close() {
+}
 
 func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {
 	proposerConfig := proposer.ProposerConfig{

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -279,6 +279,11 @@ func (ps *ProposerService) Stop(ctx context.Context) error {
 			result = errors.Join(result, fmt.Errorf("failed to close balance metricer: %w", err))
 		}
 	}
+
+	if ps.TxManager != nil {
+		ps.TxManager.Close()
+	}
+
 	if ps.metricsSrv != nil {
 		if err := ps.metricsSrv.Stop(ctx); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to stop metrics server: %w", err))

--- a/op-service/txmgr/mocks/TxManager.go
+++ b/op-service/txmgr/mocks/TxManager.go
@@ -43,6 +43,11 @@ func (_m *TxManager) BlockNumber(ctx context.Context) (uint64, error) {
 	return r0, r1
 }
 
+// Close provides a mock function with given fields:
+func (_m *TxManager) Close() {
+	_m.Called()
+}
+
 // From provides a mock function with given fields:
 func (_m *TxManager) From() common.Address {
 	ret := _m.Called()

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -49,6 +49,9 @@ type TxManager interface {
 
 	// BlockNumber returns the most recent block number from the underlying network.
 	BlockNumber(ctx context.Context) (uint64, error)
+
+	// Close the underlying connection
+	Close()
 }
 
 // ETHBackend is the set of methods that the transaction manager uses to resubmit gas & determine
@@ -80,6 +83,8 @@ type ETHBackend interface {
 	// EstimateGas returns an estimate of the amount of gas needed to execute the given
 	// transaction against the current pending block.
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
+	// Close the underlying eth connection
+	Close()
 }
 
 // SimpleTxManager is a implementation of TxManager that performs linear fee
@@ -129,6 +134,10 @@ func (m *SimpleTxManager) From() common.Address {
 
 func (m *SimpleTxManager) BlockNumber(ctx context.Context) (uint64, error) {
 	return m.backend.BlockNumber(ctx)
+}
+
+func (m *SimpleTxManager) Close() {
+	m.backend.Close()
 }
 
 // TxCandidate is a transaction candidate that can be submitted to ask the

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -261,6 +261,9 @@ func (b *mockBackend) TransactionReceipt(ctx context.Context, txHash common.Hash
 	}, nil
 }
 
+func (b *mockBackend) Close() {
+}
+
 // TestTxMgrConfirmAtMinGasPrice asserts that Send returns the min gas price tx
 // if the tx is mined instantly.
 func TestTxMgrConfirmAtMinGasPrice(t *testing.T) {
@@ -753,6 +756,9 @@ func (b *failingBackend) PendingNonceAt(_ context.Context, _ common.Address) (ui
 
 func (b *failingBackend) ChainID(ctx context.Context) (*big.Int, error) {
 	return nil, errors.New("unimplemented")
+}
+
+func (b *failingBackend) Close() {
 }
 
 // TestWaitMinedReturnsReceiptAfterFailure asserts that WaitMined is able to


### PR DESCRIPTION
**Description**

Clean up the challenger service lifecycle:
- register interrupt signal handling immediately at `main`, and attach it as value to `ctx`, for the app lifecycle to utilize
- turn `game.Service` into a service with a lifecycle; explicit `Start` / `Stop` methods.
- Make the `game.Service` close all its initialized resources.
- Use the same pattern as batcher/proposer/op-node/indexer: init from config, and if there's an error during initialization, try to close what's left open of the service.
- Now that the challenger has a lifecycle, the test `Helper` doesn't need to maintain a channel and context, and can just stop the challenger.
- 

Improve related op-service utils:
- improve `WatchHeadChanges`: unsubscribe signals are now handled in parallel to the subscription tasks, and cancel the context internally. This way an "unsubscribe" really is an unsubscribe, and we don't also have to keep track of a long-running context that has to be closed prior to unsubscribing. The `ctx` attribute is only used for the duration of the call that creates the subscription, and does not affect the subscription after that.
- similarly, fix `PollBlockChanges` to also handle unsubscribe signals like that
- add a `Close()` method to the simple tx-manager, so services can shut down the underlying RPC client connection.

With the above op-service fixes:
- Also close the subscriptions in op-node properly, don't use the resource ctx for
- Close the tx-manager in op-proposer and op-batcher

**Tests**

No functionality changes, just cleanup. Open for suggestions to add tests where previously missing.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/7671