### PR TITLE
op-challenger: Use single L2 client instance

### DIFF
--- a/op-challenger/game/fault/trace/cannon/local.go
+++ b/op-challenger/game/fault/trace/cannon/local.go
@@ -18,8 +18,7 @@ type LocalGameInputs struct {
 	L2BlockNumber *big.Int
 }
 
-type L2DataSource interface {
-	ChainID(context.Context) (*big.Int, error)
+type L2HeaderSource interface {
 	HeaderByNumber(context.Context, *big.Int) (*ethtypes.Header, error)
 }
 
@@ -32,7 +31,7 @@ type GameInputsSource interface {
 	GetProposals(ctx context.Context) (agreed contracts.Proposal, disputed contracts.Proposal, err error)
 }
 
-func fetchLocalInputs(ctx context.Context, caller GameInputsSource, l2Client L2DataSource) (LocalGameInputs, error) {
+func fetchLocalInputs(ctx context.Context, caller GameInputsSource, l2Client L2HeaderSource) (LocalGameInputs, error) {
 	agreedOutput, claimedOutput, err := caller.GetProposals(ctx)
 	if err != nil {
 		return LocalGameInputs{}, fmt.Errorf("fetch proposals: %w", err)
@@ -40,7 +39,7 @@ func fetchLocalInputs(ctx context.Context, caller GameInputsSource, l2Client L2D
 	return fetchLocalInputsFromProposals(ctx, caller, l2Client, agreedOutput, claimedOutput)
 }
 
-func fetchLocalInputsFromProposals(ctx context.Context, caller L1HeadSource, l2Client L2DataSource, agreedOutput contracts.Proposal, claimedOutput contracts.Proposal) (LocalGameInputs, error) {
+func fetchLocalInputsFromProposals(ctx context.Context, caller L1HeadSource, l2Client L2HeaderSource, agreedOutput contracts.Proposal, claimedOutput contracts.Proposal) (LocalGameInputs, error) {
 	l1Head, err := caller.GetL1Head(ctx)
 	if err != nil {
 		return LocalGameInputs{}, fmt.Errorf("fetch L1 head: %w", err)

--- a/op-challenger/game/fault/trace/cannon/local.go
+++ b/op-challenger/game/fault/trace/cannon/local.go
@@ -31,15 +31,15 @@ type GameInputsSource interface {
 	GetProposals(ctx context.Context) (agreed contracts.Proposal, disputed contracts.Proposal, err error)
 }
 
-func fetchLocalInputs(ctx context.Context, caller GameInputsSource, l2Client L2HeaderSource) (LocalGameInputs, error) {
+func FetchLocalInputs(ctx context.Context, caller GameInputsSource, l2Client L2HeaderSource) (LocalGameInputs, error) {
 	agreedOutput, claimedOutput, err := caller.GetProposals(ctx)
 	if err != nil {
 		return LocalGameInputs{}, fmt.Errorf("fetch proposals: %w", err)
 	}
-	return fetchLocalInputsFromProposals(ctx, caller, l2Client, agreedOutput, claimedOutput)
+	return FetchLocalInputsFromProposals(ctx, caller, l2Client, agreedOutput, claimedOutput)
 }
 
-func fetchLocalInputsFromProposals(ctx context.Context, caller L1HeadSource, l2Client L2HeaderSource, agreedOutput contracts.Proposal, claimedOutput contracts.Proposal) (LocalGameInputs, error) {
+func FetchLocalInputsFromProposals(ctx context.Context, caller L1HeadSource, l2Client L2HeaderSource, agreedOutput contracts.Proposal, claimedOutput contracts.Proposal) (LocalGameInputs, error) {
 	l1Head, err := caller.GetL1Head(ctx)
 	if err != nil {
 		return LocalGameInputs{}, fmt.Errorf("fetch L1 head: %w", err)

--- a/op-challenger/game/fault/trace/cannon/local_test.go
+++ b/op-challenger/game/fault/trace/cannon/local_test.go
@@ -32,7 +32,7 @@ func TestFetchLocalInputs(t *testing.T) {
 		},
 	}
 
-	inputs, err := fetchLocalInputs(ctx, contract, l2Client)
+	inputs, err := FetchLocalInputs(ctx, contract, l2Client)
 	require.NoError(t, err)
 
 	require.Equal(t, contract.l1Head, inputs.L1Head)
@@ -62,7 +62,7 @@ func TestFetchLocalInputsFromProposals(t *testing.T) {
 		},
 	}
 
-	inputs, err := fetchLocalInputsFromProposals(ctx, contract, l2Client, agreed, claimed)
+	inputs, err := FetchLocalInputsFromProposals(ctx, contract, l2Client, agreed, claimed)
 	require.NoError(t, err)
 
 	require.Equal(t, contract.l1Head, inputs.L1Head)
@@ -91,11 +91,11 @@ type mockL2DataSource struct {
 	header  ethtypes.Header
 }
 
-func (s *mockL2DataSource) ChainID(ctx context.Context) (*big.Int, error) {
+func (s *mockL2DataSource) ChainID(_ context.Context) (*big.Int, error) {
 	return s.chainID, nil
 }
 
-func (s *mockL2DataSource) HeaderByNumber(ctx context.Context, num *big.Int) (*ethtypes.Header, error) {
+func (s *mockL2DataSource) HeaderByNumber(_ context.Context, num *big.Int) (*ethtypes.Header, error) {
 	if s.header.Number.Cmp(num) == 0 {
 		return &s.header, nil
 	}

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
@@ -56,12 +55,7 @@ type CannonTraceProvider struct {
 	lastStep uint64
 }
 
-func NewTraceProvider(ctx context.Context, logger log.Logger, m CannonMetricer, cfg *config.Config, gameContract *contracts.FaultDisputeGameContract, localContext common.Hash, dir string, gameDepth uint64) (*CannonTraceProvider, error) {
-	l2Client, err := ethclient.DialContext(ctx, cfg.CannonL2)
-	if err != nil {
-		return nil, fmt.Errorf("dial l2 client %v: %w", cfg.CannonL2, err)
-	}
-	defer l2Client.Close() // Not needed after fetching the inputs
+func NewTraceProvider(ctx context.Context, logger log.Logger, m CannonMetricer, cfg *config.Config, l2Client L2HeaderSource, gameContract *contracts.FaultDisputeGameContract, localContext common.Hash, dir string, gameDepth uint64) (*CannonTraceProvider, error) {
 	localInputs, err := fetchLocalInputs(ctx, gameContract, l2Client)
 	if err != nil {
 		return nil, fmt.Errorf("fetch local game inputs: %w", err)
@@ -74,6 +68,7 @@ func NewTraceProviderFromProposals(
 	logger log.Logger,
 	m CannonMetricer,
 	cfg *config.Config,
+	l2Client L2HeaderSource,
 	gameContract *contracts.FaultDisputeGameContract,
 	localContext common.Hash,
 	agreed contracts.Proposal,
@@ -81,11 +76,6 @@ func NewTraceProviderFromProposals(
 	dir string,
 	gameDepth uint64,
 ) (*CannonTraceProvider, error) {
-	l2Client, err := ethclient.DialContext(ctx, cfg.CannonL2)
-	if err != nil {
-		return nil, fmt.Errorf("dial l2 client %v: %w", cfg.CannonL2, err)
-	}
-	defer l2Client.Close() // Not needed after fetching the inputs
 	localInputs, err := fetchLocalInputsFromProposals(ctx, gameContract, l2Client, agreed, claimed)
 	if err != nil {
 		return nil, fmt.Errorf("fetch local game inputs: %w", err)

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,35 +54,7 @@ type CannonTraceProvider struct {
 	lastStep uint64
 }
 
-func NewTraceProvider(ctx context.Context, logger log.Logger, m CannonMetricer, cfg *config.Config, l2Client L2HeaderSource, gameContract *contracts.FaultDisputeGameContract, localContext common.Hash, dir string, gameDepth uint64) (*CannonTraceProvider, error) {
-	localInputs, err := fetchLocalInputs(ctx, gameContract, l2Client)
-	if err != nil {
-		return nil, fmt.Errorf("fetch local game inputs: %w", err)
-	}
-	return NewTraceProviderFromInputs(logger, m, cfg, localContext, localInputs, dir, gameDepth), nil
-}
-
-func NewTraceProviderFromProposals(
-	ctx context.Context,
-	logger log.Logger,
-	m CannonMetricer,
-	cfg *config.Config,
-	l2Client L2HeaderSource,
-	gameContract *contracts.FaultDisputeGameContract,
-	localContext common.Hash,
-	agreed contracts.Proposal,
-	claimed contracts.Proposal,
-	dir string,
-	gameDepth uint64,
-) (*CannonTraceProvider, error) {
-	localInputs, err := fetchLocalInputsFromProposals(ctx, gameContract, l2Client, agreed, claimed)
-	if err != nil {
-		return nil, fmt.Errorf("fetch local game inputs: %w", err)
-	}
-	return NewTraceProviderFromInputs(logger, m, cfg, localContext, localInputs, dir, gameDepth), nil
-}
-
-func NewTraceProviderFromInputs(logger log.Logger, m CannonMetricer, cfg *config.Config, localContext common.Hash, localInputs LocalGameInputs, dir string, gameDepth uint64) *CannonTraceProvider {
+func NewTraceProvider(logger log.Logger, m CannonMetricer, cfg *config.Config, localContext common.Hash, localInputs LocalGameInputs, dir string, gameDepth uint64) *CannonTraceProvider {
 	return &CannonTraceProvider{
 		logger:       logger,
 		dir:          dir,

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -21,6 +21,7 @@ func NewOutputCannonTraceAccessor(
 	logger log.Logger,
 	m metrics.Metricer,
 	cfg *config.Config,
+	l2Client cannon.L2HeaderSource,
 	contract *contracts.FaultDisputeGameContract,
 	dir string,
 	gameDepth uint64,
@@ -38,7 +39,7 @@ func NewOutputCannonTraceAccessor(
 	cannonCreator := func(ctx context.Context, localContext common.Hash, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
 		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)
 		subdir := filepath.Join(dir, localContext.Hex())
-		provider, err := cannon.NewTraceProviderFromProposals(ctx, logger, m, cfg, contract, localContext, agreed, claimed, subdir, bottomDepth)
+		provider, err := cannon.NewTraceProviderFromProposals(ctx, logger, m, cfg, l2Client, contract, localContext, agreed, claimed, subdir, bottomDepth)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create cannon trace provider: %w", err)
 		}

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -39,10 +39,11 @@ func NewOutputCannonTraceAccessor(
 	cannonCreator := func(ctx context.Context, localContext common.Hash, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
 		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)
 		subdir := filepath.Join(dir, localContext.Hex())
-		provider, err := cannon.NewTraceProviderFromProposals(ctx, logger, m, cfg, l2Client, contract, localContext, agreed, claimed, subdir, bottomDepth)
+		localInputs, err := cannon.FetchLocalInputsFromProposals(ctx, contract, l2Client, agreed, claimed)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cannon trace provider: %w", err)
+			return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
 		}
+		provider := cannon.NewTraceProvider(logger, m, cfg, localContext, localInputs, subdir, bottomDepth)
 		return provider, nil
 	}
 

--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -47,7 +47,10 @@ func (g *CannonGameHelper) CreateHonestActor(ctx context.Context, rollupCfg *rol
 	maxDepth := g.MaxDepth(ctx)
 	gameContract, err := contracts.NewFaultDisputeGameContract(g.addr, batching.NewMultiCaller(l1Client.Client(), batching.DefaultBatchSize))
 	g.require.NoError(err, "Create game contract bindings")
-	provider, err := cannon.NewTraceProvider(ctx, logger, metrics.NoopMetrics, cfg, gameContract, types.NoLocalContext, filepath.Join(cfg.Datadir, "honest"), uint64(maxDepth))
+	l2Client, err := ethclient.DialContext(ctx, cfg.CannonL2)
+	g.require.NoErrorf(err, "dial l2 client %v", cfg.CannonL2)
+	defer l2Client.Close() // Not needed after fetching the inputs
+	provider, err := cannon.NewTraceProvider(ctx, logger, metrics.NoopMetrics, cfg, l2Client, gameContract, types.NoLocalContext, filepath.Join(cfg.Datadir, "honest"), uint64(maxDepth))
 	g.require.NoError(err, "create cannon trace provider")
 
 	return &HonestHelper{

--- a/op-e2e/e2eutils/disputegame/cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/cannon_helper.go
@@ -50,8 +50,9 @@ func (g *CannonGameHelper) CreateHonestActor(ctx context.Context, rollupCfg *rol
 	l2Client, err := ethclient.DialContext(ctx, cfg.CannonL2)
 	g.require.NoErrorf(err, "dial l2 client %v", cfg.CannonL2)
 	defer l2Client.Close() // Not needed after fetching the inputs
-	provider, err := cannon.NewTraceProvider(ctx, logger, metrics.NoopMetrics, cfg, l2Client, gameContract, types.NoLocalContext, filepath.Join(cfg.Datadir, "honest"), uint64(maxDepth))
-	g.require.NoError(err, "create cannon trace provider")
+	localInputs, err := cannon.FetchLocalInputs(ctx, gameContract, l2Client)
+	g.require.NoError(err, "fetch cannon local inputs")
+	provider := cannon.NewTraceProvider(logger, metrics.NoopMetrics, cfg, types.NoLocalContext, localInputs, filepath.Join(cfg.Datadir, "honest"), uint64(maxDepth))
 
 	return &HonestHelper{
 		t:            g.t,

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -221,7 +221,7 @@ func (h *FactoryHelper) StartCannonGameWithCorrectRoot(ctx context.Context, roll
 	maxDepth, err := gameImpl.MAXGAMEDEPTH(opts)
 	h.require.NoError(err, "fetch max game depth")
 
-	provider := cannon.NewTraceProviderFromInputs(
+	provider := cannon.NewTraceProvider(
 		testlog.Logger(h.t, log.LvlInfo).New("role", "CorrectTrace"),
 		metrics.NoopMetrics,
 		cfg,


### PR DESCRIPTION
**Description**

Use a single L2 client instance of the life of challenger rather than creating a new instance every time a new cannon trace provider is created.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/237
