### PR TITLE
op-chain-ops: fix typo in canyon deploy config key

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -111,7 +111,7 @@ type DeployConfig struct {
 	L2GenesisRegolithTimeOffset *hexutil.Uint64 `json:"l2GenesisRegolithTimeOffset,omitempty"`
 	// L2GenesisCanyonTimeOffset is the number of seconds after genesis block that Canyon hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable Canyon.
-	L2GenesisCanyonTimeOffset *hexutil.Uint64 `json:"L2GenesisCanyonTimeOffset,omitempty"`
+	L2GenesisCanyonTimeOffset *hexutil.Uint64 `json:"l2GenesisCanyonTimeOffset,omitempty"`
 	// L2GenesisSpanBatchTimeOffset is the number of seconds after genesis block that Span Batch hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable SpanBatch.
 	L2GenesisSpanBatchTimeOffset *hexutil.Uint64 `json:"l2GenesisSpanBatchTimeOffset,omitempty"`


### PR DESCRIPTION
**Description**

This fixes a typo in the JSON key of the `l2GenesisCanyonTimeOffset`. It was previously upper-case, unlike all the other fields.
The devnet template config uses the lower-case name. So Canyon wasn't running on the devnet. Now it should activate at block 0x40, as defined in https://github.com/ethereum-optimism/optimism/blob/5a80dc914ba5b7723457e49dad6b22c2de9fb51c/packages/contracts-bedrock/deploy-config/devnetL1-template.json#L48

**Additional context**

Found this while adding a different deploy-config time offset value for the interop work.

