### PR TITLE
op-challenger: Add support for output_alphabet trace type

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -488,6 +488,8 @@ func requiredArgs(traceType config.TraceType) map[string]string {
 		addRequiredCannonArgs(args)
 	case config.TraceTypeOutputCannon:
 		addRequiredOutputCannonArgs(args)
+	case config.TraceTypeOutputAlphabet:
+		addRequiredOutputAlphabetArgs(args)
 	}
 	return args
 }
@@ -496,8 +498,16 @@ func addRequiredAlphabetArgs(args map[string]string) {
 	args["--alphabet"] = alphabetTrace
 }
 
+func addRequiredOutputAlphabetArgs(args map[string]string) {
+	addRequiredOutputArgs(args)
+}
+
 func addRequiredOutputCannonArgs(args map[string]string) {
 	addRequiredCannonArgs(args)
+	addRequiredOutputArgs(args)
+}
+
+func addRequiredOutputArgs(args map[string]string) {
 	args["--rollup-rpc"] = rollupRpc
 }
 

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -40,9 +40,10 @@ var (
 type TraceType string
 
 const (
-	TraceTypeAlphabet     TraceType = "alphabet"
-	TraceTypeCannon       TraceType = "cannon"
-	TraceTypeOutputCannon TraceType = "output_cannon"
+	TraceTypeAlphabet       TraceType = "alphabet"
+	TraceTypeCannon         TraceType = "cannon"
+	TraceTypeOutputCannon   TraceType = "output_cannon"
+	TraceTypeOutputAlphabet TraceType = "output_alphabet"
 
 	// Mainnet games
 	CannonFaultGameID = 0
@@ -51,7 +52,7 @@ const (
 	AlphabetFaultGameID = 255
 )
 
-var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypeOutputCannon}
+var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypeOutputCannon, TraceTypeOutputAlphabet}
 
 // GameIdToString maps game IDs to their string representation.
 var GameIdToString = map[uint8]string{
@@ -183,7 +184,7 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
-	if c.TraceTypeEnabled(TraceTypeOutputCannon) {
+	if c.TraceTypeEnabled(TraceTypeOutputCannon) || c.TraceTypeEnabled(TraceTypeOutputAlphabet) {
 		if c.RollupRpc == "" {
 			return ErrMissingRollupRpc
 		}

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -36,7 +36,7 @@ func validConfig(traceType TraceType) Config {
 		cfg.CannonL2 = validCannonL2
 		cfg.CannonNetwork = validCannonNetwork
 	}
-	if traceType == TraceTypeOutputCannon {
+	if traceType == TraceTypeOutputCannon || traceType == TraceTypeOutputAlphabet {
 		cfg.RollupRpc = validRollupRpc
 	}
 	return cfg
@@ -85,6 +85,12 @@ func TestAlphabetTraceRequired(t *testing.T) {
 	require.ErrorIs(t, config.Check(), ErrMissingAlphabetTrace)
 }
 
+func TestAlphabetTraceNotRequiredForOutputAlphabet(t *testing.T) {
+	config := validConfig(TraceTypeOutputAlphabet)
+	config.AlphabetTrace = ""
+	require.NoError(t, config.Check())
+}
+
 func TestCannonBinRequired(t *testing.T) {
 	config := validConfig(TraceTypeCannon)
 	config.CannonBin = ""
@@ -129,8 +135,14 @@ func TestHttpPollInterval(t *testing.T) {
 	})
 }
 
-func TestRollupRpcRequired(t *testing.T) {
+func TestRollupRpcRequired_OutputCannon(t *testing.T) {
 	config := validConfig(TraceTypeOutputCannon)
+	config.RollupRpc = ""
+	require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
+}
+
+func TestRollupRpcRequired_OutputAlphabet(t *testing.T) {
+	config := validConfig(TraceTypeOutputAlphabet)
 	config.RollupRpc = ""
 	require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
 }

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -230,6 +230,10 @@ func CheckRequired(ctx *cli.Context, traceTypes []config.TraceType) error {
 			if !ctx.IsSet(RollupRpcFlag.Name) {
 				return fmt.Errorf("flag %s is required", RollupRpcFlag.Name)
 			}
+		case config.TraceTypeOutputAlphabet:
+			if !ctx.IsSet(RollupRpcFlag.Name) {
+				return fmt.Errorf("flag %s is required", RollupRpcFlag.Name)
+			}
 		default:
 			return fmt.Errorf("invalid trace type. must be one of %v", config.TraceTypes)
 		}

--- a/op-challenger/game/fault/trace/outputs/alphabet/output_alphabet.go
+++ b/op-challenger/game/fault/trace/outputs/alphabet/output_alphabet.go
@@ -1,14 +1,13 @@
-package outputs
+package alphabet
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/cannon"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/split"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
@@ -16,14 +15,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-func NewOutputCannonTraceAccessor(
+func NewOutputAlphabetTraceAccessor(
 	ctx context.Context,
 	logger log.Logger,
 	m metrics.Metricer,
 	cfg *config.Config,
-	l2Client cannon.L2HeaderSource,
-	contract *contracts.FaultDisputeGameContract,
-	dir string,
 	gameDepth uint64,
 	prestateBlock uint64,
 	poststateBlock uint64,
@@ -31,23 +27,17 @@ func NewOutputCannonTraceAccessor(
 	// TODO(client-pod#43): Load depths from the contract
 	topDepth := gameDepth / 2
 	bottomDepth := gameDepth - topDepth
-	outputProvider, err := NewTraceProvider(ctx, logger, cfg.RollupRpc, topDepth, prestateBlock, poststateBlock)
+	outputProvider, err := outputs.NewTraceProvider(ctx, logger, cfg.RollupRpc, topDepth, prestateBlock, poststateBlock)
 	if err != nil {
 		return nil, err
 	}
 
 	cannonCreator := func(ctx context.Context, localContext common.Hash, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
-		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)
-		subdir := filepath.Join(dir, localContext.Hex())
-		localInputs, err := cannon.FetchLocalInputsFromProposals(ctx, contract, l2Client, agreed, claimed)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
-		}
-		provider := cannon.NewTraceProvider(logger, m, cfg, localContext, localInputs, subdir, bottomDepth)
+		provider := alphabet.NewTraceProvider(localContext.Hex(), bottomDepth)
 		return provider, nil
 	}
 
-	cache := NewProviderCache(m, "output_cannon_provider", cannonCreator)
-	selector := split.NewSplitProviderSelector(outputProvider, int(topDepth), OutputRootSplitAdapter(outputProvider, cache.GetOrCreate))
+	cache := outputs.NewProviderCache(m, "output_cannon_provider", cannonCreator)
+	selector := split.NewSplitProviderSelector(outputProvider, int(topDepth), outputs.OutputRootSplitAdapter(outputProvider, cache.GetOrCreate))
 	return trace.NewAccessor(selector), nil
 }

--- a/op-challenger/game/fault/trace/outputs/cannon/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/cannon/output_cannon.go
@@ -1,0 +1,54 @@
+package cannon
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/cannon"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/split"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func NewOutputCannonTraceAccessor(
+	ctx context.Context,
+	logger log.Logger,
+	m metrics.Metricer,
+	cfg *config.Config,
+	l2Client cannon.L2HeaderSource,
+	contract *contracts.FaultDisputeGameContract,
+	dir string,
+	gameDepth uint64,
+	prestateBlock uint64,
+	poststateBlock uint64,
+) (*trace.Accessor, error) {
+	// TODO(client-pod#43): Load depths from the contract
+	topDepth := gameDepth / 2
+	bottomDepth := gameDepth - topDepth
+	outputProvider, err := outputs.NewTraceProvider(ctx, logger, cfg.RollupRpc, topDepth, prestateBlock, poststateBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	cannonCreator := func(ctx context.Context, localContext common.Hash, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
+		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)
+		subdir := filepath.Join(dir, localContext.Hex())
+		localInputs, err := cannon.FetchLocalInputsFromProposals(ctx, contract, l2Client, agreed, claimed)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
+		}
+		provider := cannon.NewTraceProvider(logger, m, cfg, localContext, localInputs, subdir, bottomDepth)
+		return provider, nil
+	}
+
+	cache := outputs.NewProviderCache(m, "output_cannon_provider", cannonCreator)
+	selector := split.NewSplitProviderSelector(outputProvider, int(topDepth), outputs.OutputRootSplitAdapter(outputProvider, cache.GetOrCreate))
+	return trace.NewAccessor(selector), nil
+}

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -214,6 +214,7 @@ contract Deploy is Deployer {
 
         setAlphabetFaultGameImplementation();
         setCannonFaultGameImplementation();
+        setOutputAlphabetFaultGameImplementation();
 
         transferDisputeGameFactoryOwnership();
     }
@@ -876,6 +877,21 @@ contract Deploy is Deployer {
             alphabetAbsolutePrestate,
             IBigStepper(new AlphabetVM(alphabetAbsolutePrestate)),
             4 // The max game depth of the alphabet game is always 4.
+        );
+    }
+
+    /// @notice Sets the implementation for the output root -> alphabet game type in the `DisputeGameFactory`
+    function setOutputAlphabetFaultGameImplementation() public onlyDevnet broadcast {
+        DisputeGameFactory factory = DisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy"));
+
+        // Set the Alphabet FaultDisputeGame implementation in the factory.
+        Claim alphabetAbsolutePrestate = Claim.wrap(bytes32(cfg.faultGameAbsolutePrestate()));
+        _setFaultGameImplementation(
+            factory,
+            GameType.wrap(254),
+            alphabetAbsolutePrestate,
+            IBigStepper(new AlphabetVM(alphabetAbsolutePrestate)),
+            8 // The max game depth is always 4 for top half, 4 for alphabet half.
         );
     }
 


### PR DESCRIPTION
**Description**

Adds a new `output_alphabet` trace type to the challenger.  This is designed for testing to avoid the cost of generating a full canon trace for each sub-game. 

The top half of the game is the output root bisection and the bottom half is an alphabet game which uses the hex encoded local context as the definition of the correct alphabet.  This gives a unique alphabet for each sub-game that is tied to the pre and post claims in the same way as the cannon sub games would be.

Updated the contract deployment to deploy a new game type (254) for this though it currently deploys the original alphabet VM so the `step` function won't resolve correctly (but it would need the other contract changes to support split games anyway). The depth of 4 is too small to fit a split game into so we can't really just reuse the existing alphabet game.

Keen to get feedback on whether this is a viable approach on the contracts side. I think it will make it much faster to e2e test the selection of pre and post claims and how the challenger and contracts handle the split part of the game.


**Metadata**

- 
