### PR TITLE
Add deployed bytecode retrieval mitigation

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -7,6 +7,8 @@ contracts-list := ./artifacts.json
 log-level := info
 ETHERSCAN_APIKEY_ETH ?=
 ETHERSCAN_APIKEY_OP ?=
+RPC_URL_ETH ?=
+RPC_URL_OP ?=
 
 all: version mkdir bindings
 
@@ -36,7 +38,9 @@ bindgen-generate-all:
 		--source-maps-list MIPS,PreimageOracle \
 		--forge-artifacts $(contracts-dir)/forge-artifacts \
 		--etherscan.apikey.eth $(ETHERSCAN_APIKEY_ETH) \
-		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP)
+		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP) \
+		--rpc.url.eth $(RPC_URL_ETH) \
+		--rpc.url.op $(RPC_URL_OP)
 
 bindgen-local: compile bindgen-generate-local
 
@@ -60,7 +64,9 @@ bindgen-remote:
 		--log.level $(log-level) \
 		remote \
 		--etherscan.apikey.eth $(ETHERSCAN_APIKEY_ETH) \
-		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP)
+		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP) \
+		--rpc.url.eth $(RPC_URL_ETH) \
+		--rpc.url.op $(RPC_URL_OP)
 
 mkdir:
 	mkdir -p $(pkg)

--- a/op-bindings/bindgen/generator_remote.go
+++ b/op-bindings/bindgen/generator_remote.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/etherscan"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type bindGenGeneratorRemote struct {
@@ -14,6 +15,10 @@ type bindGenGeneratorRemote struct {
 	contractDataClients struct {
 		eth contractDataClient
 		op  contractDataClient
+	}
+	rpcClients struct {
+		eth *ethclient.Client
+		op  *ethclient.Client
 	}
 	tempArtifactsDir string
 }

--- a/op-bindings/bindgen/main.go
+++ b/op-bindings/bindgen/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/etherscan"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 )
@@ -170,6 +171,13 @@ func parseConfigRemote(logger log.Logger, c *cli.Context) (bindGenGeneratorRemot
 
 	generator.contractDataClients.eth = etherscan.NewEthereumClient(c.String(EtherscanApiKeyEthFlagName))
 	generator.contractDataClients.op = etherscan.NewOptimismClient(c.String(EtherscanApiKeyOpFlagName))
+
+	if generator.rpcClients.eth, err = ethclient.Dial(c.String(RpcUrlEthFlagName)); err != nil {
+		return bindGenGeneratorRemote{}, fmt.Errorf("error initializing Ethereum client: %w", err)
+	}
+	if generator.rpcClients.op, err = ethclient.Dial(c.String(RpcUrlOpFlagName)); err != nil {
+		return bindGenGeneratorRemote{}, fmt.Errorf("error initializing Optimism client: %w", err)
+	}
 	return generator, nil
 }
 
@@ -219,6 +227,16 @@ func remoteFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:     EtherscanApiKeyOpFlagName,
 			Usage:    "API key to make queries to Etherscan for Optimism",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     RpcUrlEthFlagName,
+			Usage:    "RPC URL (with API key if required) to query Ethereum",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     RpcUrlOpFlagName,
+			Usage:    "RPC URL (with API key if required) to query Optimism",
 			Required: true,
 		},
 	}


### PR DESCRIPTION
This PR will query OP mainnet for the contract's deployed bytecode and compare it to the bytecode sourced from ETH mainnet. Because the added contracts from #8281 are all deterministically deployed, the address for the contracts are the same across networks. The thinking of the this mitigation is: if the deployed bytecode on chain A differ from B, then there _might_ be a chain specific consideration that's not accounted for and may affect the validity of using ETH mainnet's deployed bytecode on any OP chain