### PR TITLE
Bindings and metadata overwrite warning

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -7,6 +7,8 @@ contracts-list := ./artifacts.json
 log-level := info
 ETHERSCAN_APIKEY_ETH ?=
 ETHERSCAN_APIKEY_OP ?=
+RPC_URL_ETH ?=
+RPC_URL_OP ?=
 
 all: version mkdir bindings
 
@@ -36,7 +38,9 @@ bindgen-generate-all:
 		--source-maps-list MIPS,PreimageOracle \
 		--forge-artifacts $(contracts-dir)/forge-artifacts \
 		--etherscan.apikey.eth $(ETHERSCAN_APIKEY_ETH) \
-		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP)
+		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP) \
+		--rpc.url.eth $(RPC_URL_ETH) \
+		--rpc.url.op $(RPC_URL_OP)
 
 bindgen-local: compile bindgen-generate-local
 
@@ -60,7 +64,9 @@ bindgen-remote:
 		--log.level $(log-level) \
 		remote \
 		--etherscan.apikey.eth $(ETHERSCAN_APIKEY_ETH) \
-		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP)
+		--etherscan.apikey.op $(ETHERSCAN_APIKEY_OP) \
+		--rpc.url.eth $(RPC_URL_ETH) \
+		--rpc.url.op $(RPC_URL_OP)
 
 mkdir:
 	mkdir -p $(pkg)

--- a/op-bindings/bindgen/generator_remote.go
+++ b/op-bindings/bindgen/generator_remote.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/etherscan"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type bindGenGeneratorRemote struct {
@@ -14,6 +15,10 @@ type bindGenGeneratorRemote struct {
 	contractDataClients struct {
 		eth contractDataClient
 		op  contractDataClient
+	}
+	rpcClients struct {
+		eth *ethclient.Client
+		op  *ethclient.Client
 	}
 	tempArtifactsDir string
 }

--- a/op-bindings/bindgen/main.go
+++ b/op-bindings/bindgen/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/etherscan"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli/v2"
 )
@@ -170,6 +171,13 @@ func parseConfigRemote(logger log.Logger, c *cli.Context) (bindGenGeneratorRemot
 
 	generator.contractDataClients.eth = etherscan.NewEthereumClient(c.String(EtherscanApiKeyEthFlagName))
 	generator.contractDataClients.op = etherscan.NewOptimismClient(c.String(EtherscanApiKeyOpFlagName))
+
+	if generator.rpcClients.eth, err = ethclient.Dial(c.String(RpcUrlEthFlagName)); err != nil {
+		return bindGenGeneratorRemote{}, fmt.Errorf("error initializing Ethereum client: %w", err)
+	}
+	if generator.rpcClients.op, err = ethclient.Dial(c.String(RpcUrlOpFlagName)); err != nil {
+		return bindGenGeneratorRemote{}, fmt.Errorf("error initializing Optimism client: %w", err)
+	}
 	return generator, nil
 }
 
@@ -219,6 +227,16 @@ func remoteFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:     EtherscanApiKeyOpFlagName,
 			Usage:    "API key to make queries to Etherscan for Optimism",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     RpcUrlEthFlagName,
+			Usage:    "RPC URL (with API key if required) to query Ethereum",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     RpcUrlOpFlagName,
+			Usage:    "RPC URL (with API key if required) to query Optimism",
 			Required: true,
 		},
 	}


### PR DESCRIPTION
This PR adds a check for an existing bindings and metadata output files before overwriting them with newly generated files. The rationale for this mitigation: if the bindings for a contract already exist, compare them against newly generated outputs. If they differ, return an error to be handled manually