### PR TITLE
Fix Deploy script for getting-started

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -801,9 +801,12 @@ contract Deploy is Deployer {
         string memory version = oracle.version();
         console.log("L2OutputOracle version: %s", version);
 
-        ChainAssertions.checkL2OutputOracle(
-            _proxies(), cfg, cfg.l2OutputOracleStartingTimestamp(), cfg.l2OutputOracleStartingBlockNumber()
-        );
+        ChainAssertions.checkL2OutputOracle({
+            _contracts: _proxies(),
+            _cfg: cfg,
+            _l2OutputOracleStartingBlockNumber: cfg.l2OutputOracleStartingBlockNumber(),
+            _l2OutputOracleStartingTimestamp: cfg.l2OutputOracleStartingTimestamp()
+        });
 
         require(loadInitializedSlot("L2OutputOracle", true) == 1, "L2OutputOracleProxy is not initialized");
     }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR aims at fixing the [deployment stage](https://stack.optimism.io/docs/build/getting-started/#_1-deploy-the-l1-contracts) of the getting started tutorial by correctly reordering the parameters when calling `checkL2OutputOracle` in the `Deploy.s.sol` script.

**Tests**

No test have been added, but using *named arguments* when calling `checkL2OutputOracle` should prevent this from re-happening.
