### PR TITLE
op-node: Add log when the state loop returns

### DIFF
--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -169,6 +169,7 @@ func (s *Driver) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPa
 func (s *Driver) eventLoop() {
 	defer s.wg.Done()
 	s.log.Info("State loop started")
+	defer s.log.Info("State loop returned")
 
 	defer s.driverCancel()
 


### PR DESCRIPTION
**Description**

Suggested in https://github.com/ethereum-optimism/optimism/pull/8291