### PR TITLE
fix(indexer): versioned hash database ordering

### DIFF
--- a/indexer/database/bridge_messages.go
+++ b/indexer/database/bridge_messages.go
@@ -61,7 +61,7 @@ type BridgeMessagesDB interface {
 	StoreL2BridgeMessages([]L2BridgeMessage) error
 	MarkRelayedL2BridgeMessage(common.Hash, uuid.UUID) error
 
-	StoreL2BridgeMessageV1MessageHash(common.Hash, common.Hash) error
+	StoreL2BridgeMessageV1MessageHashes([]L2BridgeMessageVersionedMessageHash) error
 }
 
 /**
@@ -141,14 +141,10 @@ func (db bridgeMessagesDB) StoreL2BridgeMessages(messages []L2BridgeMessage) err
 	return result.Error
 }
 
-func (db bridgeMessagesDB) StoreL2BridgeMessageV1MessageHash(msgHash, v1MsgHash common.Hash) error {
-	if msgHash == v1MsgHash {
-		return fmt.Errorf("message hash is equal to the v1 message: %s", msgHash)
-	}
-
+func (db bridgeMessagesDB) StoreL2BridgeMessageV1MessageHashes(versionedHashes []L2BridgeMessageVersionedMessageHash) error {
 	deduped := db.gorm.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "message_hash"}}, DoNothing: true})
-	result := deduped.Create(&L2BridgeMessageVersionedMessageHash{MessageHash: msgHash, V1MessageHash: v1MsgHash})
-	if result.Error == nil && int(result.RowsAffected) < 1 {
+	result := deduped.Create(&versionedHashes)
+	if result.Error == nil && int(result.RowsAffected) < len(versionedHashes) {
 		db.log.Warn("ignored L2 bridge v1 message hash duplicates")
 	}
 

--- a/indexer/database/bridge_messages.go
+++ b/indexer/database/bridge_messages.go
@@ -145,7 +145,7 @@ func (db bridgeMessagesDB) StoreL2BridgeMessageV1MessageHashes(versionedHashes [
 	deduped := db.gorm.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "message_hash"}}, DoNothing: true})
 	result := deduped.Create(&versionedHashes)
 	if result.Error == nil && int(result.RowsAffected) < len(versionedHashes) {
-		db.log.Warn("ignored L2 bridge v1 message hash duplicates")
+		db.log.Warn("ignored L2 bridge v1 message hash duplicates", "duplicates", len(versionedHashes)-int(result.RowsAffected))
 	}
 
 	return result.Error

--- a/indexer/processors/bridge/legacy_bridge_processor.go
+++ b/indexer/processors/bridge/legacy_bridge_processor.go
@@ -203,7 +203,7 @@ func LegacyL2ProcessInitiatedBridgeEvents(log log.Logger, db *database.DB, metri
 		}
 
 		sentMessages[logKey{sentMessage.Event.BlockHash, sentMessage.Event.LogIndex}] = sentMessageEvent{&sentMessage, withdrawalHash}
-		bridgeMessages[i] = database.L2BridgeMessage{TransactionWithdrawalHash: sentMessage.BridgeMessage.MessageHash, BridgeMessage: sentMessage.BridgeMessage}
+		bridgeMessages[i] = database.L2BridgeMessage{TransactionWithdrawalHash: withdrawalHash, BridgeMessage: sentMessage.BridgeMessage}
 		versionedMessageHashes[i] = database.L2BridgeMessageVersionedMessageHash{MessageHash: sentMessage.BridgeMessage.MessageHash, V1MessageHash: v1MessageHash}
 	}
 	if len(bridgeMessages) > 0 {


### PR DESCRIPTION
legacy processor storing the versioned hashes can only be stored **after** the messages
have been stored first due to the foreign key constraint
