### PR TITLE
fault-mon: fix optimism-portal address override option

### DIFF
--- a/.changeset/dry-rockets-destroy.md
+++ b/.changeset/dry-rockets-destroy.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/chain-mon': patch
+---
+
+Fixed bug with custom chains not being able to set a custom portal address

--- a/packages/chain-mon/src/fault-mon/service.ts
+++ b/packages/chain-mon/src/fault-mon/service.ts
@@ -385,7 +385,7 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
           new Date(
             (ethers.BigNumber.from(outputBlock.timestamp).toNumber() +
               this.state.faultProofWindow) *
-            1000
+              1000
           ),
           'mmmm dS, yyyy, h:MM:ss TT'
         ),

--- a/packages/chain-mon/src/fault-mon/service.ts
+++ b/packages/chain-mon/src/fault-mon/service.ts
@@ -147,11 +147,10 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
       contracts.OptimismPortal = portalAddress
 
       this.logger.info('fetching L2OutputOracle contract from OptimismPortal')
-      const opts = {
+      const portalContract = getOEContract('OptimismPortal', l2ChainId, {
         address: portalAddress,
         signerOrProvider: this.options.l1RpcProvider,
-      }
-      const portalContract = getOEContract('OptimismPortal', l2ChainId, opts)
+      })
       contracts.L2OutputOracle = await portalContract.L2_ORACLE()
     }
 
@@ -386,7 +385,7 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
           new Date(
             (ethers.BigNumber.from(outputBlock.timestamp).toNumber() +
               this.state.faultProofWindow) *
-              1000
+            1000
           ),
           'mmmm dS, yyyy, h:MM:ss TT'
         ),

--- a/packages/chain-mon/src/fault-mon/service.ts
+++ b/packages/chain-mon/src/fault-mon/service.ts
@@ -148,7 +148,7 @@ export class FaultDetector extends BaseServiceV2<Options, Metrics, State> {
 
       this.logger.info('fetching L2OutputOracle contract from OptimismPortal')
       const opts = {
-        portalAddress,
+        address: portalAddress,
         signerOrProvider: this.options.l1RpcProvider,
       }
       const portalContract = getOEContract('OptimismPortal', l2ChainId, opts)


### PR DESCRIPTION
**Description**

To run the fault-mon in the devnet, you have to specify the optimism portal address as CLI override, since it's not defined statically in the SDK (devnet setup changes too frequently for that).

However, when retrieving the output-oracle address based on an eth-call to the portal contract, it needs to get bindings to the portal. Without address-override it cannot find bindings, because the devnet chain is unknown.

The `portalAddress` variable was passed in, but becomes an unknown key. The correct option key is `address`.

Run devnet, then run something like:
```
pnpm tsx src/fault-mon/service.ts --l1rpcprovider=http://localhost:8545 --l2rpcprovider=http://localhost:9545 --optimismportaladdress="$(curl -s http://localhost:8080/addresses.json | jq -r .OptimismPortalProxy)" --port=11111
```
in the chain-mon package dir.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue allowing custom chains to set a custom portal address for improved configuration flexibility.

- **Refactor**
  - Streamlined the process of fetching the `L2OutputOracle` contract to enhance reliability and maintainability.

- **Style**
  - Minor adjustments to code formatting for better readability without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->