### PR TITLE
op-proposer: Changes for nilaway

### DIFF
--- a/op-proposer/proposer/abi_test.go
+++ b/op-proposer/proposer/abi_test.go
@@ -19,6 +19,9 @@ import (
 // setupL2OutputOracle deploys the L2 Output Oracle contract to a simulated backend
 func setupL2OutputOracle() (common.Address, *bind.TransactOpts, *backends.SimulatedBackend, *bindings.L2OutputOracle, error) {
 	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		return common.Address{}, nil, nil, nil, err
+	}
 	from := crypto.PubkeyToAddress(privateKey.PublicKey)
 	if err != nil {
 		return common.Address{}, nil, nil, nil, err

--- a/op-service/httputil/server.go
+++ b/op-service/httputil/server.go
@@ -41,7 +41,9 @@ func StartHTTPServer(addr string, handler http.Handler, opts ...HTTPOption) (*HT
 	for _, opt := range opts {
 		if err := opt(out); err != nil {
 			srvCancel()
-			return nil, errors.Join(fmt.Errorf("failed to apply HTTP option: %w", err), listener.Close())
+			return nil, fmt.Errorf("failed to apply HTTP option: %w", err)
+			// TODO: nilaway cannot handle errors.Join for some reason.
+			// return nil, errors.Join(fmt.Errorf("failed to apply HTTP option: %w", err), listener.Close())
 		}
 	}
 	go func() {

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -22,20 +23,37 @@ func NewRollupClient(rpc client.RPC) *RollupClient {
 
 func (r *RollupClient) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error) {
 	var output *eth.OutputResponse
+	// If you provide `nil` to rpc.CallContext, it will return `nil` so we have to check the returned value
+	// (even though we know it is not nil) to satisfy nilaway
 	err := r.rpc.CallContext(ctx, &output, "optimism_outputAtBlock", hexutil.Uint64(blockNum))
-	return output, err
+	if err != nil {
+		return nil, err
+	} else if output == nil {
+		return nil, errors.New("nil result from RPC call")
+	}
+	return output, nil
 }
 
 func (r *RollupClient) SyncStatus(ctx context.Context) (*eth.SyncStatus, error) {
 	var output *eth.SyncStatus
 	err := r.rpc.CallContext(ctx, &output, "optimism_syncStatus")
-	return output, err
+	if err != nil {
+		return nil, err
+	} else if output == nil {
+		return nil, errors.New("nil result from RPC call")
+	}
+	return output, nil
 }
 
 func (r *RollupClient) RollupConfig(ctx context.Context) (*rollup.Config, error) {
 	var output *rollup.Config
 	err := r.rpc.CallContext(ctx, &output, "optimism_rollupConfig")
-	return output, err
+	if err != nil {
+		return nil, err
+	} else if output == nil {
+		return nil, errors.New("nil result from RPC call")
+	}
+	return output, nil
 }
 
 func (r *RollupClient) Version(ctx context.Context) (string, error) {


### PR DESCRIPTION
**Description**

This fixes nilaway issues for the op-proposer.
There was one legit issue & several false positives.
1. Nilaway could not handle errors.Join.
2. rpc.CallContext would return (nil, nil) if nil was passed in.
3. A legit issue with not checking an error in a test.

**Additional context**

I've been playing around with [nilaway](https://github.com/uber-go/nilaway). The op-node and op-batcher have many more flags. I've noticed that they show up a lot in testing code or in convoluted batcher code. I think the signal is a little lower than I initially hoped for.