### PR TITLE
Rename span batch hard fork to delta hard fork

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -112,9 +112,9 @@ type DeployConfig struct {
 	// L2GenesisCanyonTimeOffset is the number of seconds after genesis block that Canyon hard fork activates.
 	// Set it to 0 to activate at genesis. Nil to disable Canyon.
 	L2GenesisCanyonTimeOffset *hexutil.Uint64 `json:"l2GenesisCanyonTimeOffset,omitempty"`
-	// L2GenesisSpanBatchTimeOffset is the number of seconds after genesis block that Span Batch hard fork activates.
-	// Set it to 0 to activate at genesis. Nil to disable SpanBatch.
-	L2GenesisSpanBatchTimeOffset *hexutil.Uint64 `json:"l2GenesisSpanBatchTimeOffset,omitempty"`
+	// L2GenesisDeltaTimeOffset is the number of seconds after genesis block that Delta hard fork activates.
+	// Set it to 0 to activate at genesis. Nil to disable Delta.
+	L2GenesisDeltaTimeOffset *hexutil.Uint64 `json:"l2GenesisDeltaTimeOffset,omitempty"`
 	// L2GenesisBlockExtraData is configurable extradata. Will default to []byte("BEDROCK") if left unspecified.
 	L2GenesisBlockExtraData []byte `json:"l2GenesisBlockExtraData"`
 	// ProxyAdminOwner represents the owner of the ProxyAdmin predeploy on L2.
@@ -459,12 +459,12 @@ func (d *DeployConfig) CanyonTime(genesisTime uint64) *uint64 {
 	return &v
 }
 
-func (d *DeployConfig) SpanBatchTime(genesisTime uint64) *uint64 {
-	if d.L2GenesisSpanBatchTimeOffset == nil {
+func (d *DeployConfig) DeltaTime(genesisTime uint64) *uint64 {
+	if d.L2GenesisDeltaTimeOffset == nil {
 		return nil
 	}
 	v := uint64(0)
-	if offset := *d.L2GenesisSpanBatchTimeOffset; offset > 0 {
+	if offset := *d.L2GenesisDeltaTimeOffset; offset > 0 {
 		v = genesisTime + uint64(offset)
 	}
 	return &v
@@ -508,7 +508,7 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Block, l2GenesisBlockHas
 		L1SystemConfigAddress:  d.SystemConfigProxy,
 		RegolithTime:           d.RegolithTime(l1StartBlock.Time()),
 		CanyonTime:             d.CanyonTime(l1StartBlock.Time()),
-		SpanBatchTime:          d.SpanBatchTime(l1StartBlock.Time()),
+		DeltaTime:              d.DeltaTime(l1StartBlock.Time()),
 	}, nil
 }
 

--- a/op-e2e/actions/blocktime_test.go
+++ b/op-e2e/actions/blocktime_test.go
@@ -17,7 +17,7 @@ import (
 func TestBlockTimeBatchType(t *testing.T) {
 	tests := []struct {
 		name string
-		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+		f    func(gt *testing.T, deltaTimeOffset *hexutil.Uint64)
 	}{
 		{"BatchInLastPossibleBlocks", BatchInLastPossibleBlocks},
 		{"LargeL1Gaps", LargeL1Gaps},
@@ -29,11 +29,11 @@ func TestBlockTimeBatchType(t *testing.T) {
 		})
 	}
 
-	spanBatchTimeOffset := hexutil.Uint64(0)
+	deltaTimeOffset := hexutil.Uint64(0)
 	for _, test := range tests {
 		test := test
 		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
-			test.f(t, &spanBatchTimeOffset)
+			test.f(t, &deltaTimeOffset)
 		})
 	}
 }
@@ -43,10 +43,10 @@ func TestBlockTimeBatchType(t *testing.T) {
 // where there are also no other batches included in the sequence
 // window.
 // This is a regression test against the bug fixed in PR #4566
-func BatchInLastPossibleBlocks(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func BatchInLastPossibleBlocks(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	dp.DeployConfig.SequencerWindowSize = 4
 	dp.DeployConfig.L2BlockTime = 2
 
@@ -154,14 +154,14 @@ func BatchInLastPossibleBlocks(gt *testing.T, spanBatchTimeOffset *hexutil.Uint6
 // Then it generates 3 more L1 blocks.
 // At this point it can verify that the batches where properly generated.
 // Note: It batches submits when possible.
-func LargeL1Gaps(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func LargeL1Gaps(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	dp.DeployConfig.L1BlockTime = 4
 	dp.DeployConfig.L2BlockTime = 2
 	dp.DeployConfig.SequencerWindowSize = 4
 	dp.DeployConfig.MaxSequencerDrift = 32
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 

--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -157,7 +157,7 @@ func (s *L2Batcher) Buffer(t Testing) error {
 
 			var batchType uint = derive.SingularBatchType
 			var spanBatchBuilder *derive.SpanBatchBuilder = nil
-			if s.rollupCfg.IsSpanBatch(block.Time()) {
+			if s.rollupCfg.IsDelta(block.Time()) {
 				batchType = derive.SpanBatchType
 				spanBatchBuilder = derive.NewSpanBatchBuilder(s.rollupCfg.Genesis.L2Time, s.rollupCfg.L2ChainID)
 			}

--- a/op-e2e/actions/l2_proposer_test.go
+++ b/op-e2e/actions/l2_proposer_test.go
@@ -19,7 +19,7 @@ import (
 func TestProposerBatchType(t *testing.T) {
 	tests := []struct {
 		name string
-		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+		f    func(gt *testing.T, deltaTimeOffset *hexutil.Uint64)
 	}{
 		{"RunProposerTest", RunProposerTest},
 	}
@@ -30,19 +30,19 @@ func TestProposerBatchType(t *testing.T) {
 		})
 	}
 
-	spanBatchTimeOffset := hexutil.Uint64(0)
+	deltaTimeOffset := hexutil.Uint64(0)
 	for _, test := range tests {
 		test := test
 		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
-			test.f(t, &spanBatchTimeOffset)
+			test.f(t, &deltaTimeOffset)
 		})
 	}
 }
 
-func RunProposerTest(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func RunProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)

--- a/op-e2e/actions/span_batch_test.go
+++ b/op-e2e/actions/span_batch_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDropSpanBatchBeforeHardfork tests behavior of op-node before SpanBatch hardfork.
-// op-node must drop SpanBatch before SpanBatch hardfork.
+// TestDropSpanBatchBeforeHardfork tests behavior of op-node before Delta hardfork.
+// op-node must drop SpanBatch before Delta hardfork.
 func TestDropSpanBatchBeforeHardfork(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	p := &e2eutils.TestParams{
@@ -34,8 +34,8 @@ func TestDropSpanBatchBeforeHardfork(gt *testing.T) {
 		L1BlockTime:         12,
 	}
 	dp := e2eutils.MakeDeployParams(t, p)
-	// do not activate SpanBatch hardfork for verifier
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = nil
+	// do not activate Delta hardfork for verifier
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = nil
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlError)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -44,8 +44,8 @@ func TestDropSpanBatchBeforeHardfork(gt *testing.T) {
 	rollupSeqCl := sequencer.RollupClient()
 	dp2 := e2eutils.MakeDeployParams(t, p)
 	minTs := hexutil.Uint64(0)
-	// activate SpanBatch hardfork for batcher. so batcher will submit SpanBatches to L1.
-	dp2.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// activate Delta hardfork for batcher. so batcher will submit SpanBatches to L1.
+	dp2.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	sd2 := e2eutils.Setup(t, dp2, defaultAlloc)
 	batcher := NewL2Batcher(log, sd2.RollupCfg, &BatcherCfg{
 		MinL1TxSize: 0,
@@ -114,8 +114,8 @@ func TestDropSpanBatchBeforeHardfork(gt *testing.T) {
 	require.ErrorIs(t, err, ethereum.NotFound)
 }
 
-// TestAcceptSingularBatchAfterHardfork tests behavior of op-node after SpanBatch hardfork.
-// op-node must accept SingularBatch after SpanBatch hardfork.
+// TestAcceptSingularBatchAfterHardfork tests behavior of op-node after Delta hardfork.
+// op-node must accept SingularBatch after Delta hardfork.
 func TestAcceptSingularBatchAfterHardfork(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	p := &e2eutils.TestParams{
@@ -127,8 +127,8 @@ func TestAcceptSingularBatchAfterHardfork(gt *testing.T) {
 	minTs := hexutil.Uint64(0)
 	dp := e2eutils.MakeDeployParams(t, p)
 
-	// activate SpanBatch hardfork for verifier.
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// activate Delta hardfork for verifier.
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlError)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -137,8 +137,8 @@ func TestAcceptSingularBatchAfterHardfork(gt *testing.T) {
 	rollupSeqCl := sequencer.RollupClient()
 	dp2 := e2eutils.MakeDeployParams(t, p)
 
-	// not activate SpanBatch hardfork for batcher
-	dp2.DeployConfig.L2GenesisSpanBatchTimeOffset = nil
+	// not activate Delta hardfork for batcher
+	dp2.DeployConfig.L2GenesisDeltaTimeOffset = nil
 	sd2 := e2eutils.Setup(t, dp2, defaultAlloc)
 	batcher := NewL2Batcher(log, sd2.RollupCfg, &BatcherCfg{
 		MinL1TxSize: 0,
@@ -213,8 +213,8 @@ func TestSpanBatchEmptyChain(gt *testing.T) {
 	}
 	dp := e2eutils.MakeDeployParams(t, p)
 	minTs := hexutil.Uint64(0)
-	// Activate SpanBatch hardfork
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// Activate Delta hardfork
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlError)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -270,8 +270,8 @@ func TestSpanBatchLowThroughputChain(gt *testing.T) {
 	}
 	dp := e2eutils.MakeDeployParams(t, p)
 	minTs := hexutil.Uint64(0)
-	// Activate SpanBatch hardfork
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// Activate Delta hardfork
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlError)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)

--- a/op-e2e/actions/sync_test.go
+++ b/op-e2e/actions/sync_test.go
@@ -27,7 +27,7 @@ import (
 func TestSyncBatchType(t *testing.T) {
 	tests := []struct {
 		name string
-		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+		f    func(gt *testing.T, deltaTimeOffset *hexutil.Uint64)
 	}{
 		{"DerivationWithFlakyL1RPC", DerivationWithFlakyL1RPC},
 		{"FinalizeWhileSyncing", FinalizeWhileSyncing},
@@ -39,19 +39,19 @@ func TestSyncBatchType(t *testing.T) {
 		})
 	}
 
-	spanBatchTimeOffset := hexutil.Uint64(0)
+	deltaTimeOffset := hexutil.Uint64(0)
 	for _, test := range tests {
 		test := test
 		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
-			test.f(t, &spanBatchTimeOffset)
+			test.f(t, &deltaTimeOffset)
 		})
 	}
 }
 
-func DerivationWithFlakyL1RPC(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func DerivationWithFlakyL1RPC(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlError) // mute all the temporary derivation errors that we forcefully create
 	_, _, miner, sequencer, _, verifier, _, batcher := setupReorgTestActors(t, dp, sd, log)
@@ -88,10 +88,10 @@ func DerivationWithFlakyL1RPC(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64
 	require.Equal(t, sequencer.L2Unsafe(), verifier.L2Safe(), "verifier is synced")
 }
 
-func FinalizeWhileSyncing(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func FinalizeWhileSyncing(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlError) // mute all the temporary derivation errors that we forcefully create
 	_, _, miner, sequencer, _, verifier, _, batcher := setupReorgTestActors(t, dp, sd, log)
@@ -207,8 +207,8 @@ func TestInvalidPayloadInSpanBatch(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	minTs := hexutil.Uint64(0)
-	// Activate SpanBatch hardfork
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// Activate Delta hardfork
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	dp.DeployConfig.L2BlockTime = 2
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlInfo)
@@ -330,8 +330,8 @@ func TestSpanBatchAtomicity_Consolidation(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	minTs := hexutil.Uint64(0)
-	// Activate SpanBatch hardfork
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// Activate Delta hardfork
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	dp.DeployConfig.L2BlockTime = 2
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlInfo)
@@ -389,8 +389,8 @@ func TestSpanBatchAtomicity_ForceAdvance(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	minTs := hexutil.Uint64(0)
-	// Activate SpanBatch hardfork
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+	// Activate Delta hardfork
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	dp.DeployConfig.L2BlockTime = 2
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlInfo)

--- a/op-e2e/actions/system_config_test.go
+++ b/op-e2e/actions/system_config_test.go
@@ -24,7 +24,7 @@ import (
 func TestSystemConfigBatchType(t *testing.T) {
 	tests := []struct {
 		name string
-		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+		f    func(gt *testing.T, deltaTimeOffset *hexutil.Uint64)
 	}{
 		{"BatcherKeyRotation", BatcherKeyRotation},
 		{"GPOParamsChange", GPOParamsChange},
@@ -37,23 +37,23 @@ func TestSystemConfigBatchType(t *testing.T) {
 		})
 	}
 
-	spanBatchTimeOffset := hexutil.Uint64(0)
+	deltaTimeOffset := hexutil.Uint64(0)
 	for _, test := range tests {
 		test := test
 		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
-			test.f(t, &spanBatchTimeOffset)
+			test.f(t, &deltaTimeOffset)
 		})
 	}
 }
 
 // BatcherKeyRotation tests that batcher A can operate, then be replaced with batcher B, then ignore old batcher A,
 // and that the change to batcher B is reverted properly upon reorg of L1.
-func BatcherKeyRotation(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func BatcherKeyRotation(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	dp.DeployConfig.L2BlockTime = 2
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -228,10 +228,10 @@ func BatcherKeyRotation(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 
 // GPOParamsChange tests that the GPO params can be updated to adjust fees of L2 transactions,
 // and that the L1 data fees to the L2 transaction are applied correctly before, during and after the GPO update in L2.
-func GPOParamsChange(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func GPOParamsChange(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
@@ -358,10 +358,10 @@ func GPOParamsChange(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
 // GasLimitChange tests that the gas limit can be configured to L1,
 // and that the L2 changes the gas limit instantly at the exact block that adopts the L1 origin with
 // the gas limit change event. And checks if a verifier node can reproduce the same gas limit change.
-func GasLimitChange(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func GasLimitChange(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)

--- a/op-e2e/actions/user_test.go
+++ b/op-e2e/actions/user_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 type hardforkScheduledTest struct {
-	name              string
-	regolithTime      *hexutil.Uint64
-	spanBatchTime     *hexutil.Uint64
-	activateRegolith  bool
-	activateSpanBatch bool
+	name             string
+	regolithTime     *hexutil.Uint64
+	deltaTime        *hexutil.Uint64
+	activateRegolith bool
+	activateDelta    bool
 }
 
 // TestCrossLayerUser tests that common actions of the CrossLayerUser actor work in various regolith configurations:
@@ -34,17 +34,17 @@ func TestCrossLayerUser(t *testing.T) {
 	futureTime := hexutil.Uint64(20)
 	farFutureTime := hexutil.Uint64(2000)
 	tests := []hardforkScheduledTest{
-		{name: "NoRegolith", regolithTime: nil, activateRegolith: false, spanBatchTime: nil, activateSpanBatch: false},
-		{name: "NotYetRegolith", regolithTime: &farFutureTime, activateRegolith: false, spanBatchTime: nil, activateSpanBatch: false},
-		{name: "RegolithAtGenesis", regolithTime: &zeroTime, activateRegolith: true, spanBatchTime: nil, activateSpanBatch: false},
-		{name: "RegolithAfterGenesis", regolithTime: &futureTime, activateRegolith: true, spanBatchTime: nil, activateSpanBatch: false},
-		{name: "NoSpanBatch", regolithTime: &zeroTime, activateRegolith: true, spanBatchTime: nil, activateSpanBatch: false},
-		{name: "NotYetSpanBatch", regolithTime: &zeroTime, activateRegolith: true,
-			spanBatchTime: &farFutureTime, activateSpanBatch: false},
-		{name: "SpanBatchAtGenesis", regolithTime: &zeroTime, activateRegolith: true,
-			spanBatchTime: &zeroTime, activateSpanBatch: true},
-		{name: "SpanBatchAfterGenesis", regolithTime: &zeroTime, activateRegolith: true,
-			spanBatchTime: &futureTime, activateSpanBatch: true},
+		{name: "NoRegolith", regolithTime: nil, activateRegolith: false, deltaTime: nil, activateDelta: false},
+		{name: "NotYetRegolith", regolithTime: &farFutureTime, activateRegolith: false, deltaTime: nil, activateDelta: false},
+		{name: "RegolithAtGenesis", regolithTime: &zeroTime, activateRegolith: true, deltaTime: nil, activateDelta: false},
+		{name: "RegolithAfterGenesis", regolithTime: &futureTime, activateRegolith: true, deltaTime: nil, activateDelta: false},
+		{name: "NoDelta", regolithTime: &zeroTime, activateRegolith: true, deltaTime: nil, activateDelta: false},
+		{name: "NotYetDelta", regolithTime: &zeroTime, activateRegolith: true,
+			deltaTime: &farFutureTime, activateDelta: false},
+		{name: "DeltaAtGenesis", regolithTime: &zeroTime, activateRegolith: true,
+			deltaTime: &zeroTime, activateDelta: true},
+		{name: "DeltaAfterGenesis", regolithTime: &zeroTime, activateRegolith: true,
+			deltaTime: &futureTime, activateDelta: true},
 	}
 	for _, test := range tests {
 		test := test // Use a fixed reference as the tests run in parallel
@@ -58,7 +58,7 @@ func runCrossLayerUserTest(gt *testing.T, test hardforkScheduledTest) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	dp.DeployConfig.L2GenesisRegolithTimeOffset = test.regolithTime
-	dp.DeployConfig.L2GenesisSpanBatchTimeOffset = test.spanBatchTime
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = test.deltaTime
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
 

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -158,7 +158,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 		L1SystemConfigAddress:  deployConf.SystemConfigProxy,
 		RegolithTime:           deployConf.RegolithTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 		CanyonTime:             deployConf.CanyonTime(uint64(deployConf.L1GenesisBlockTimestamp)),
-		SpanBatchTime:          deployConf.SpanBatchTime(uint64(deployConf.L1GenesisBlockTimestamp)),
+		DeltaTime:              deployConf.DeltaTime(uint64(deployConf.L1GenesisBlockTimestamp)),
 	}
 
 	require.NoError(t, rollupCfg.Check())

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -433,7 +433,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 			L1SystemConfigAddress:   cfg.DeployConfig.SystemConfigProxy,
 			RegolithTime:            cfg.DeployConfig.RegolithTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			CanyonTime:              cfg.DeployConfig.CanyonTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
-			SpanBatchTime:           cfg.DeployConfig.SpanBatchTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
+			DeltaTime:               cfg.DeployConfig.DeltaTime(uint64(cfg.DeployConfig.L1GenesisBlockTimestamp)),
 			ProtocolVersionsAddress: cfg.L1Deployments.ProtocolVersionsProxy,
 		}
 	}
@@ -700,7 +700,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	sys.L2OutputSubmitter = proposer
 
 	var batchType uint = derive.SingularBatchType
-	if cfg.DeployConfig.L2GenesisSpanBatchTimeOffset != nil && *cfg.DeployConfig.L2GenesisSpanBatchTimeOffset == hexutil.Uint64(0) {
+	if cfg.DeployConfig.L2GenesisDeltaTimeOffset != nil && *cfg.DeployConfig.L2GenesisDeltaTimeOffset == hexutil.Uint64(0) {
 		batchType = derive.SpanBatchType
 	}
 	batcherMaxL1TxSizeBytes := cfg.BatcherMaxL1TxSizeBytes

--- a/op-e2e/system_fpp_test.go
+++ b/op-e2e/system_fpp_test.go
@@ -74,11 +74,11 @@ func testVerifyL2OutputRootEmptyBlock(t *testing.T, detached bool, spanBatchActi
 	// But not too small to ensure that our claim and subsequent state change is published
 	cfg.DeployConfig.SequencerWindowSize = 16
 	if spanBatchActivated {
-		// Activate span batch hard fork
+		// Activate delta hard fork
 		minTs := hexutil.Uint64(0)
-		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+		cfg.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	} else {
-		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = nil
+		cfg.DeployConfig.L2GenesisDeltaTimeOffset = nil
 	}
 
 	sys, err := cfg.Start(t)
@@ -179,11 +179,11 @@ func testVerifyL2OutputRoot(t *testing.T, detached bool, spanBatchActivated bool
 	// We don't need a verifier - just the sequencer is enough
 	delete(cfg.Nodes, "verifier")
 	if spanBatchActivated {
-		// Activate span batch hard fork
+		// Activate delta hard fork
 		minTs := hexutil.Uint64(0)
-		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = &minTs
+		cfg.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
 	} else {
-		cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = nil
+		cfg.DeployConfig.L2GenesisDeltaTimeOffset = nil
 	}
 
 	sys, err := cfg.Start(t)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -50,7 +50,7 @@ import (
 func TestSystemBatchType(t *testing.T) {
 	tests := []struct {
 		name string
-		f    func(gt *testing.T, spanBatchTimeOffset *hexutil.Uint64)
+		f    func(gt *testing.T, deltaTimeOffset *hexutil.Uint64)
 	}{
 		{"StopStartBatcher", StopStartBatcher},
 	}
@@ -61,11 +61,11 @@ func TestSystemBatchType(t *testing.T) {
 		})
 	}
 
-	spanBatchTimeOffset := hexutil.Uint64(0)
+	deltaTimeOffset := hexutil.Uint64(0)
 	for _, test := range tests {
 		test := test
 		t.Run(test.name+"_SpanBatch", func(t *testing.T) {
-			test.f(t, &spanBatchTimeOffset)
+			test.f(t, &deltaTimeOffset)
 		})
 	}
 }
@@ -1256,11 +1256,11 @@ func TestFees(t *testing.T) {
 	require.Equal(t, balanceDiff, totalFee, "balances should add up")
 }
 
-func StopStartBatcher(t *testing.T, spanBatchTimeOffset *hexutil.Uint64) {
+func StopStartBatcher(t *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	InitParallel(t)
 
 	cfg := DefaultSystemConfig(t)
-	cfg.DeployConfig.L2GenesisSpanBatchTimeOffset = spanBatchTimeOffset
+	cfg.DeployConfig.L2GenesisDeltaTimeOffset = deltaTimeOffset
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")
 	defer sys.Close()

--- a/op-node/rollup/derive/batch.go
+++ b/op-node/rollup/derive/batch.go
@@ -26,7 +26,7 @@ var encodeBufferPool = sync.Pool{
 const (
 	// SingularBatchType is the first version of Batch format, representing a single L2 block.
 	SingularBatchType = 0
-	// SpanBatchType is the Batch version used after SpanBatch hard fork, representing a span of L2 blocks.
+	// SpanBatchType is the Batch version used after Delta hard fork, representing a span of L2 blocks.
 	SpanBatchType = 1
 )
 

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -73,7 +73,7 @@ func buildSpanBatches(t *testing.T, parent *eth.L2BlockRef, singularBatches []*S
 	return spanBatches
 }
 
-func getSpanBatchTime(batchType int) *uint64 {
+func getDeltaTime(batchType int) *uint64 {
 	minTs := uint64(0)
 	if batchType == SpanBatchType {
 		return &minTs
@@ -182,7 +182,7 @@ func BatchQueueNewOrigin(t *testing.T, batchType int) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     2,
-		SpanBatchTime:     getSpanBatchTime(batchType),
+		DeltaTime:         getDeltaTime(batchType),
 	}
 
 	input := &fakeBatchQueueInput{
@@ -243,7 +243,7 @@ func BatchQueueEager(t *testing.T, batchType int) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
-		SpanBatchTime:     getSpanBatchTime(batchType),
+		DeltaTime:         getDeltaTime(batchType),
 		L2ChainID:         chainId,
 	}
 
@@ -321,7 +321,7 @@ func BatchQueueInvalidInternalAdvance(t *testing.T, batchType int) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     2,
-		SpanBatchTime:     getSpanBatchTime(batchType),
+		DeltaTime:         getDeltaTime(batchType),
 		L2ChainID:         chainId,
 	}
 
@@ -440,7 +440,7 @@ func BatchQueueMissing(t *testing.T, batchType int) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     2,
-		SpanBatchTime:     getSpanBatchTime(batchType),
+		DeltaTime:         getDeltaTime(batchType),
 		L2ChainID:         chainId,
 	}
 
@@ -557,7 +557,7 @@ func BatchQueueAdvancedEpoch(t *testing.T, batchType int) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
-		SpanBatchTime:     getSpanBatchTime(batchType),
+		DeltaTime:         getDeltaTime(batchType),
 		L2ChainID:         chainId,
 	}
 
@@ -644,7 +644,7 @@ func BatchQueueShuffle(t *testing.T, batchType int) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
-		SpanBatchTime:     getSpanBatchTime(batchType),
+		DeltaTime:         getDeltaTime(batchType),
 		L2ChainID:         chainId,
 	}
 
@@ -742,7 +742,7 @@ func TestBatchQueueOverlappingSpanBatch(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
-		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		DeltaTime:         getDeltaTime(SpanBatchType),
 		L2ChainID:         chainId,
 	}
 
@@ -847,7 +847,7 @@ func TestBatchQueueComplex(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
-		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		DeltaTime:         getDeltaTime(SpanBatchType),
 		L2ChainID:         chainId,
 	}
 
@@ -965,7 +965,7 @@ func TestBatchQueueResetSpan(t *testing.T) {
 		BlockTime:         2,
 		MaxSequencerDrift: 600,
 		SeqWindowSize:     30,
-		SpanBatchTime:     getSpanBatchTime(SpanBatchType),
+		DeltaTime:         getDeltaTime(SpanBatchType),
 		L2ChainID:         chainId,
 	}
 

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -186,8 +186,8 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 		}
 		batchOrigin = l1Blocks[1]
 	}
-	if !cfg.IsSpanBatch(batchOrigin.Time) {
-		log.Warn("received SpanBatch with L1 origin before SpanBatch hard fork")
+	if !cfg.IsDelta(batchOrigin.Time) {
+		log.Warn("received SpanBatch with L1 origin before Delta hard fork")
 		return BatchDrop
 	}
 

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -29,7 +29,7 @@ type ValidBatchTestCase struct {
 	Expected       BatchValidity
 	ExpectedLog    string // log message that must be included
 	NotExpectedLog string // log message that must not be included
-	SpanBatchTime  *uint64
+	DeltaTime      *uint64
 }
 
 type TestLogHandler struct {
@@ -54,7 +54,7 @@ func TestValidBatch(t *testing.T) {
 		SeqWindowSize:     4,
 		MaxSequencerDrift: 6,
 		// other config fields are ignored and can be left empty.
-		SpanBatchTime: nil,
+		DeltaTime: nil,
 	}
 
 	rng := rand.New(rand.NewSource(1234))
@@ -584,9 +584,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided,
-			ExpectedLog:   "missing L1 block input, cannot proceed with batch checking",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided,
+			ExpectedLog: "missing L1 block input, cannot proceed with batch checking",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "future timestamp",
@@ -604,9 +604,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchFuture,
-			ExpectedLog:   "received out-of-order batch for future processing after next batch",
-			SpanBatchTime: &minTs,
+			Expected:    BatchFuture,
+			ExpectedLog: "received out-of-order batch for future processing after next batch",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "misaligned timestamp",
@@ -624,9 +624,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "span batch has no new blocks after safe head",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "span batch has no new blocks after safe head",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "invalid parent block hash",
@@ -644,9 +644,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "ignoring batch with mismatching parent hash",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "ignoring batch with mismatching parent hash",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequence window expired",
@@ -664,9 +664,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch was included too late, sequence window expired",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch was included too late, sequence window expired",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "epoch too old, but good parent hash and timestamp", // repeat of now outdated l2A3 data
@@ -690,9 +690,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "dropped batch, epoch is too old",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "dropped batch, epoch is too old",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "insufficient L1 info for eager derivation",
@@ -710,9 +710,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided,
-			ExpectedLog:   "eager batch wants to advance epoch, but could not without more L1 blocks",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided,
+			ExpectedLog: "eager batch wants to advance epoch, but could not without more L1 blocks",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "insufficient L1 info for eager derivation - long span",
@@ -737,9 +737,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided,
-			ExpectedLog:   "need more l1 blocks to check entire origins of span batch",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided,
+			ExpectedLog: "need more l1 blocks to check entire origins of span batch",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "epoch too new",
@@ -757,9 +757,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch is for future epoch too far ahead, while it has the next timestamp, so it must be invalid",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch is for future epoch too far ahead, while it has the next timestamp, so it must be invalid",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "epoch hash wrong",
@@ -777,9 +777,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch is for different L1 chain, epoch hash does not match",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch is for different L1 chain, epoch hash does not match",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "epoch hash wrong - long span",
@@ -804,9 +804,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch is for different L1 chain, epoch hash does not match",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch is for different L1 chain, epoch hash does not match",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on same epoch with non-empty txs",
@@ -824,9 +824,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on same epoch with non-empty txs - long span",
@@ -851,9 +851,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on changing epoch with non-empty txs",
@@ -871,9 +871,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch exceeded sequencer time drift, sequencer must adopt new L1 origin to include transactions again",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on same epoch with empty txs and late next epoch",
@@ -891,8 +891,8 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchAccept, // accepted because empty & preserving L2 time invariant
-			SpanBatchTime: &minTs,
+			Expected:  BatchAccept, // accepted because empty & preserving L2 time invariant
+			DeltaTime: &minTs,
 		},
 		{
 			Name:       "sequencer time drift on changing epoch with empty txs",
@@ -918,7 +918,7 @@ func TestValidBatch(t *testing.T) {
 				}),
 			},
 			Expected:       BatchAccept, // accepted because empty & still advancing epoch
-			SpanBatchTime:  &minTs,
+			DeltaTime:      &minTs,
 			NotExpectedLog: "continuing with empty batch before late L1 block to preserve L2 time invariant",
 		},
 		{
@@ -937,9 +937,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided, // we have to wait till the next epoch is in sight to check the time
-			ExpectedLog:   "without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided, // we have to wait till the next epoch is in sight to check the time
+			ExpectedLog: "without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on same epoch with empty txs and no next epoch in sight yet - long span",
@@ -964,9 +964,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided, // we have to wait till the next epoch is in sight to check the time
-			ExpectedLog:   "without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided, // we have to wait till the next epoch is in sight to check the time
+			ExpectedLog: "without the next L1 origin we cannot determine yet if this empty batch that exceeds the time drift is still valid",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on same epoch with empty txs and but in-sight epoch that invalidates it",
@@ -984,9 +984,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop, // dropped because it could have advanced the epoch to B
-			ExpectedLog:   "batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop, // dropped because it could have advanced the epoch to B
+			ExpectedLog: "batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "sequencer time drift on same epoch with empty txs and but in-sight epoch that invalidates it - long span",
@@ -1011,9 +1011,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop, // dropped because it could have advanced the epoch to B
-			ExpectedLog:   "batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop, // dropped because it could have advanced the epoch to B
+			ExpectedLog: "batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "empty tx included",
@@ -1033,9 +1033,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "transaction data must not be empty, but found empty tx",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "transaction data must not be empty, but found empty tx",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "deposit tx included",
@@ -1055,9 +1055,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "sequencers may not embed any deposits into batch data, but found tx that has one",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "sequencers may not embed any deposits into batch data, but found tx that has one",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "valid batch same epoch",
@@ -1075,8 +1075,8 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchAccept,
-			SpanBatchTime: &minTs,
+			Expected:  BatchAccept,
+			DeltaTime: &minTs,
 		},
 		{
 			Name:       "valid batch changing epoch",
@@ -1094,8 +1094,8 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchAccept,
-			SpanBatchTime: &minTs,
+			Expected:  BatchAccept,
+			DeltaTime: &minTs,
 		},
 		{
 			Name:       "batch with L2 time before L1 time",
@@ -1113,9 +1113,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "block timestamp is less than L1 origin timestamp",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "block timestamp is less than L1 origin timestamp",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "batch with L2 time before L1 time - long span",
@@ -1140,9 +1140,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "block timestamp is less than L1 origin timestamp",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "block timestamp is less than L1 origin timestamp",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "valid overlapping batch",
@@ -1167,8 +1167,8 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchAccept,
-			SpanBatchTime: &minTs,
+			Expected:  BatchAccept,
+			DeltaTime: &minTs,
 		},
 		{
 			Name:       "longer overlapping batch",
@@ -1200,8 +1200,8 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchAccept,
-			SpanBatchTime: &minTs,
+			Expected:  BatchAccept,
+			DeltaTime: &minTs,
 		},
 		{
 			Name:       "fully overlapping batch",
@@ -1226,9 +1226,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "span batch has no new blocks after safe head",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "span batch has no new blocks after safe head",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "overlapping batch with invalid parent hash",
@@ -1253,9 +1253,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "ignoring batch with mismatching parent hash",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "ignoring batch with mismatching parent hash",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "overlapping batch with invalid origin number",
@@ -1280,9 +1280,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "overlapped block's L1 origin number does not match",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "overlapped block's L1 origin number does not match",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "overlapping batch with invalid tx",
@@ -1307,9 +1307,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "overlapped block's tx count does not match",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "overlapped block's tx count does not match",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "overlapping batch l2 fetcher error",
@@ -1341,9 +1341,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided,
-			ExpectedLog:   "failed to fetch L2 block",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided,
+			ExpectedLog: "failed to fetch L2 block",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "short block time",
@@ -1368,9 +1368,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch has misaligned timestamp, block time is too short",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch has misaligned timestamp, block time is too short",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "misaligned batch",
@@ -1395,9 +1395,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchDrop,
-			ExpectedLog:   "batch has misaligned timestamp, not overlapped exactly",
-			SpanBatchTime: &minTs,
+			Expected:    BatchDrop,
+			ExpectedLog: "batch has misaligned timestamp, not overlapped exactly",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "failed to fetch overlapping block payload",
@@ -1422,9 +1422,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			Expected:      BatchUndecided,
-			ExpectedLog:   "failed to fetch L2 block payload",
-			SpanBatchTime: &minTs,
+			Expected:    BatchUndecided,
+			ExpectedLog: "failed to fetch L2 block payload",
+			DeltaTime:   &minTs,
 		},
 		{
 			Name:       "singular batch before hard fork",
@@ -1440,8 +1440,8 @@ func TestValidBatch(t *testing.T) {
 					Transactions: []hexutil.Bytes{randTxData},
 				},
 			},
-			SpanBatchTime: &l1B.Time,
-			Expected:      BatchAccept,
+			DeltaTime: &l1B.Time,
+			Expected:  BatchAccept,
 		},
 		{
 			Name:       "span batch before hard fork",
@@ -1459,9 +1459,9 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			SpanBatchTime: &l1B.Time,
-			Expected:      BatchDrop,
-			ExpectedLog:   "received SpanBatch with L1 origin before SpanBatch hard fork",
+			DeltaTime:   &l1B.Time,
+			Expected:    BatchDrop,
+			ExpectedLog: "received SpanBatch with L1 origin before Delta hard fork",
 		},
 		{
 			Name:       "singular batch after hard fork",
@@ -1477,8 +1477,8 @@ func TestValidBatch(t *testing.T) {
 					Transactions: []hexutil.Bytes{randTxData},
 				},
 			},
-			SpanBatchTime: &l1A.Time,
-			Expected:      BatchAccept,
+			DeltaTime: &l1A.Time,
+			Expected:  BatchAccept,
 		},
 		{
 			Name:       "span batch after hard fork",
@@ -1496,8 +1496,8 @@ func TestValidBatch(t *testing.T) {
 					},
 				}),
 			},
-			SpanBatchTime: &l1A.Time,
-			Expected:      BatchAccept,
+			DeltaTime: &l1A.Time,
+			Expected:  BatchAccept,
 		},
 	}
 
@@ -1535,8 +1535,8 @@ func TestValidBatch(t *testing.T) {
 	runTestCase := func(t *testing.T, testCase ValidBatchTestCase) {
 		ctx := context.Background()
 		rcfg := defaultConf
-		if testCase.SpanBatchTime != nil {
-			rcfg.SpanBatchTime = testCase.SpanBatchTime
+		if testCase.DeltaTime != nil {
+			rcfg.DeltaTime = testCase.DeltaTime
 		}
 		validity := CheckBatch(ctx, &rcfg, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, &l2Client)
 		require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
@@ -1608,9 +1608,9 @@ func TestValidBatch(t *testing.T) {
 				},
 			}),
 		},
-		Expected:      BatchDrop,
-		ExpectedLog:   "overlapped block's transaction does not match",
-		SpanBatchTime: &minTs,
+		Expected:    BatchDrop,
+		ExpectedLog: "overlapped block's transaction does not match",
+		DeltaTime:   &minTs,
 	}
 
 	t.Run(differentTxtestCase.Name, func(t *testing.T) {
@@ -1651,9 +1651,9 @@ func TestValidBatch(t *testing.T) {
 				},
 			}),
 		},
-		Expected:      BatchDrop,
-		ExpectedLog:   "failed to extract L2BlockRef from execution payload",
-		SpanBatchTime: &minTs,
+		Expected:    BatchDrop,
+		ExpectedLog: "failed to extract L2BlockRef from execution payload",
+		DeltaTime:   &minTs,
 	}
 
 	t.Run(invalidTxTestCase.Name, func(t *testing.T) {

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -98,7 +98,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		}
 		return singularBatch, nil
 	case SpanBatchType:
-		if origin := cr.Origin(); !cr.cfg.IsSpanBatch(origin.Time) {
+		if origin := cr.Origin(); !cr.cfg.IsDelta(origin.Time) {
 			// Check hard fork activation with the L1 inclusion block time instead of the L1 origin block time.
 			// Therefore, even if the batch passed this rule, it can be dropped in the batch queue.
 			// This is just for early dropping invalid batches as soon as possible.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -75,11 +75,13 @@ type Config struct {
 	// Active if RegolithTime != nil && L2 block timestamp >= *RegolithTime, inactive otherwise.
 	RegolithTime *uint64 `json:"regolith_time,omitempty"`
 
-	// CanyonTime  sets the activation time of the next network upgrade.
+	// CanyonTime sets the activation time of the next network upgrade.
 	// Active if CanyonTime != nil && L2 block timestamp >= *CanyonTime, inactive otherwise.
 	CanyonTime *uint64 `json:"canyon_time,omitempty"`
 
-	SpanBatchTime *uint64 `json:"span_batch_time,omitempty"`
+	// DeltaTime sets the activation time of the next network upgrade.
+	// Active if DeltaTime != nil && L2 block timestamp >= *DeltaTime, inactive otherwise.
+	DeltaTime *uint64 `json:"delta_time,omitempty"`
 
 	// Note: below addresses are part of the block-derivation process,
 	// and required to be the same network-wide to stay in consensus.
@@ -274,8 +276,9 @@ func (c *Config) IsCanyon(timestamp uint64) bool {
 	return c.CanyonTime != nil && timestamp >= *c.CanyonTime
 }
 
-func (c *Config) IsSpanBatch(timestamp uint64) bool {
-	return c.SpanBatchTime != nil && timestamp >= *c.SpanBatchTime
+// IsDelta returns true if the Delta hardfork is active at or past the given timestamp.
+func (c *Config) IsDelta(timestamp uint64) bool {
+	return c.DeltaTime != nil && timestamp >= *c.DeltaTime
 }
 
 // Description outputs a banner describing the important parts of rollup configuration in a human-readable form.
@@ -306,7 +309,7 @@ func (c *Config) Description(l2Chains map[string]string) string {
 	banner += "Post-Bedrock Network Upgrades (timestamp based):\n"
 	banner += fmt.Sprintf("  - Regolith: %s\n", fmtForkTimeOrUnset(c.RegolithTime))
 	banner += fmt.Sprintf("  - Canyon: %s\n", fmtForkTimeOrUnset(c.CanyonTime))
-	banner += fmt.Sprintf("  - SpanBatch: %s\n", fmtForkTimeOrUnset(c.SpanBatchTime))
+	banner += fmt.Sprintf("  - Delta: %s\n", fmtForkTimeOrUnset(c.DeltaTime))
 	// Report the protocol version
 	banner += fmt.Sprintf("Node supports up to OP-Stack Protocol Version: %s\n", OPStackSupport)
 	return banner
@@ -333,7 +336,7 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l2_block_number", c.Genesis.L2.Number, "l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number, "regolith_time", fmtForkTimeOrUnset(c.RegolithTime),
 		"canyon_time", fmtForkTimeOrUnset(c.CanyonTime),
-		"span_batch_time", fmtForkTimeOrUnset(c.SpanBatchTime),
+		"delta_time", fmtForkTimeOrUnset(c.DeltaTime),
 	)
 }
 

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -44,7 +44,7 @@
   "eip1559Elasticity": 6,
   "l1GenesisBlockTimestamp": "0x64c811bf",
   "l2GenesisRegolithTimeOffset": "0x0",
-  "l2GenesisSpanBatchTimeOffset": "0x0",
+  "l2GenesisDeltaTimeOffset": "0x0",
   "l2GenesisCanyonTimeOffset": "0x40",
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Span batch will be included in delta hardfork. Therefore, rename span batch hard fork to delta hard fork. Delta hard fork configuration is introduced.

**Tests**

No newly added testcases.

**Additional context**

Span batch issue tracker: https://github.com/ethereum-optimism/optimism/issues/7454



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renamed and updated hard fork activation from "Span Batch" to "Delta" for improved clarity.

- **Refactor**
  - Updated internal logic to reflect the terminology change from "Span Batch" to "Delta" across various components.

- **Tests**
  - Modified test suites to align with the new "Delta" hard fork terminology and configuration.

- **Documentation**
  - Adjusted comments and documentation to match the new naming conventions.

- **Bug Fixes**
  - Ensured consistent behavior across the application following the renaming of the hard fork.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->