### PR TITLE
contracts-bedrock: testing docs

### DIFF
--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -79,3 +79,13 @@ Run the deployment with state diffs by executing: `forge script -vvv scripts/Dep
 
 All of the functions for deploying a single contract are `public` meaning that the `--sig` argument to `forge script` can be used to
 target the deployment of a single contract.
+
+### Test Setup
+
+The Solidity unit tests use the same codepaths to set up state that are used in production. The same L1 deploy script is used to deploy the L1 contracts for the in memory tests
+and the L2 state is set up using the same L2 genesis generation code that is used for production and then loaded into foundry via the `vm.loadAllocs` cheatcode. This helps
+to reduce the overhead of maintaining multiple ways to set up the state as well as give additional coverage to the "actual" way that the contracts are deployed.
+
+The L1 contract addresses are held in `deployments/hardhat/.deploy` and the L2 test state is held in a `.testdata` directory. The L1 addresses are used to create the L2 state
+and it is possible for stale addresses to be pulled into the L2 state, causing tests to fail. Stale addresses may happen if the order of the L1 deployments happen differently
+since some contracts are deployed using `CREATE`. Run `pnpm clean` and rerun the tests if they are failing for an unknown reason.


### PR DESCRIPTION
**Description**

Add some docs about how the new testing setup works as well
as the gotcha on how sometimes stale testdata can result in
the tests failing for an unknown reason.

`pnpm clean` should fix it.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the "Test Setup" section to explain the unified approach for setting up state in production and tests, reducing maintenance overhead.
	- Noted the directories for L1 contract addresses and L2 test state, with guidance on handling stale addresses to prevent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->