### PR TITLE
op-challenger: Remove --agree-with-proposed-output option

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -29,7 +29,6 @@ var (
 	cannonL2                = "http://example.com:9545"
 	rollupRpc               = "http://example.com:8555"
 	alphabetTrace           = "abcdefghijz"
-	agreeWithProposedOutput = "true"
 )
 
 func TestLogLevel(t *testing.T) {
@@ -49,14 +48,14 @@ func TestLogLevel(t *testing.T) {
 
 func TestDefaultCLIOptionsMatchDefaultConfig(t *testing.T) {
 	cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet))
-	defaultCfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, true, datadir, config.TraceTypeAlphabet)
+	defaultCfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, datadir, config.TraceTypeAlphabet)
 	// Add in the extra CLI options required when using alphabet trace type
 	defaultCfg.AlphabetTrace = alphabetTrace
 	require.Equal(t, defaultCfg, cfg)
 }
 
 func TestDefaultConfigIsValid(t *testing.T) {
-	cfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, true, datadir, config.TraceTypeAlphabet)
+	cfg := config.NewConfig(common.HexToAddress(gameFactoryAddressValue), l1EthRpc, datadir, config.TraceTypeAlphabet)
 	// Add in options that are required based on the specific trace type
 	// To avoid needing to specify unused options, these aren't included in the params for NewConfig
 	cfg.AlphabetTrace = alphabetTrace
@@ -166,24 +165,6 @@ func TestTxManagerFlagsSupported(t *testing.T) {
 	// Not a comprehensive list of flags, just enough to sanity check the txmgr.CLIFlags were defined
 	cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--"+txmgr.NumConfirmationsFlagName, "7"))
 	require.Equal(t, uint64(7), cfg.TxMgrConfig.NumConfirmations)
-}
-
-func TestAgreeWithProposedOutput(t *testing.T) {
-	t.Run("MustBeProvided", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag agree-with-proposed-output is required", addRequiredArgsExcept(config.TraceTypeAlphabet, "--agree-with-proposed-output"))
-	})
-	t.Run("Enabled", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--agree-with-proposed-output"))
-		require.True(t, cfg.AgreeWithProposedOutput)
-	})
-	t.Run("EnabledWithArg", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--agree-with-proposed-output=true"))
-		require.True(t, cfg.AgreeWithProposedOutput)
-	})
-	t.Run("Disabled", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--agree-with-proposed-output=false"))
-		require.False(t, cfg.AgreeWithProposedOutput)
-	})
 }
 
 func TestMaxConcurrency(t *testing.T) {
@@ -475,11 +456,10 @@ func addRequiredArgsExcept(traceType config.TraceType, name string, optionalArgs
 
 func requiredArgs(traceType config.TraceType) map[string]string {
 	args := map[string]string{
-		"--agree-with-proposed-output": agreeWithProposedOutput,
-		"--l1-eth-rpc":                 l1EthRpc,
-		"--game-factory-address":       gameFactoryAddressValue,
-		"--trace-type":                 traceType.String(),
-		"--datadir":                    datadir,
+		"--l1-eth-rpc":           l1EthRpc,
+		"--game-factory-address": gameFactoryAddressValue,
+		"--trace-type":           traceType.String(),
+		"--datadir":              datadir,
 	}
 	switch traceType {
 	case config.TraceTypeAlphabet:

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -101,14 +101,13 @@ const (
 // This also contains config options for auxiliary services.
 // It is used to initialize the challenger.
 type Config struct {
-	L1EthRpc                string           // L1 RPC Url
-	GameFactoryAddress      common.Address   // Address of the dispute game factory
-	GameAllowlist           []common.Address // Allowlist of fault game addresses
-	GameWindow              time.Duration    // Maximum time duration to look for games to progress
-	AgreeWithProposedOutput bool             // Temporary config if we agree or disagree with the posted output
-	Datadir                 string           // Data Directory
-	MaxConcurrency          uint             // Maximum number of threads to use when progressing games
-	PollInterval            time.Duration    // Polling interval for latest-block subscription when using an HTTP RPC provider
+	L1EthRpc           string           // L1 RPC Url
+	GameFactoryAddress common.Address   // Address of the dispute game factory
+	GameAllowlist      []common.Address // Allowlist of fault game addresses
+	GameWindow         time.Duration    // Maximum time duration to look for games to progress
+	Datadir            string           // Data Directory
+	MaxConcurrency     uint             // Maximum number of threads to use when progressing games
+	PollInterval       time.Duration    // Polling interval for latest-block subscription when using an HTTP RPC provider
 
 	TraceTypes []TraceType // Type of traces supported
 
@@ -137,7 +136,6 @@ type Config struct {
 func NewConfig(
 	gameFactoryAddress common.Address,
 	l1EthRpc string,
-	agreeWithProposedOutput bool,
 	datadir string,
 	supportedTraceTypes ...TraceType,
 ) Config {
@@ -146,8 +144,6 @@ func NewConfig(
 		GameFactoryAddress: gameFactoryAddress,
 		MaxConcurrency:     uint(runtime.NumCPU()),
 		PollInterval:       DefaultPollInterval,
-
-		AgreeWithProposedOutput: agreeWithProposedOutput,
 
 		TraceTypes: supportedTraceTypes,
 

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -21,11 +21,10 @@ var (
 	validDatadir               = "/tmp/data"
 	validCannonL2              = "http://localhost:9545"
 	validRollupRpc             = "http://localhost:8555"
-	agreeWithProposedOutput    = true
 )
 
 func validConfig(traceType TraceType) Config {
-	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, agreeWithProposedOutput, validDatadir, traceType)
+	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validDatadir, traceType)
 	switch traceType {
 	case TraceTypeAlphabet:
 		cfg.AlphabetTrace = validAlphabetTrace

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -50,11 +50,6 @@ var (
 		Usage:   "The trace types to support. Valid options: " + openum.EnumString(config.TraceTypes),
 		EnvVars: prefixEnvVars("TRACE_TYPE"),
 	}
-	AgreeWithProposedOutputFlag = &cli.BoolFlag{
-		Name:    "agree-with-proposed-output",
-		Usage:   "Temporary hardcoded flag if we agree or disagree with the proposed output.",
-		EnvVars: prefixEnvVars("AGREE_WITH_PROPOSED_OUTPUT"),
-	}
 	DatadirFlag = &cli.StringFlag{
 		Name:    "datadir",
 		Usage:   "Directory to store data generated as part of responding to games",
@@ -146,7 +141,6 @@ var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	FactoryAddressFlag,
 	TraceTypeFlag,
-	AgreeWithProposedOutputFlag,
 	DatadirFlag,
 }
 
@@ -285,28 +279,27 @@ func NewConfigFromCLI(ctx *cli.Context) (*config.Config, error) {
 	}
 	return &config.Config{
 		// Required Flags
-		L1EthRpc:                ctx.String(L1EthRpcFlag.Name),
-		TraceTypes:              traceTypes,
-		GameFactoryAddress:      gameFactoryAddress,
-		GameAllowlist:           allowedGames,
-		GameWindow:              ctx.Duration(GameWindowFlag.Name),
-		MaxConcurrency:          maxConcurrency,
-		PollInterval:            ctx.Duration(HTTPPollInterval.Name),
-		RollupRpc:               ctx.String(RollupRpcFlag.Name),
-		AlphabetTrace:           ctx.String(AlphabetFlag.Name),
-		CannonNetwork:           ctx.String(CannonNetworkFlag.Name),
-		CannonRollupConfigPath:  ctx.String(CannonRollupConfigFlag.Name),
-		CannonL2GenesisPath:     ctx.String(CannonL2GenesisFlag.Name),
-		CannonBin:               ctx.String(CannonBinFlag.Name),
-		CannonServer:            ctx.String(CannonServerFlag.Name),
-		CannonAbsolutePreState:  ctx.String(CannonPreStateFlag.Name),
-		Datadir:                 ctx.String(DatadirFlag.Name),
-		CannonL2:                ctx.String(CannonL2Flag.Name),
-		CannonSnapshotFreq:      ctx.Uint(CannonSnapshotFreqFlag.Name),
-		CannonInfoFreq:          ctx.Uint(CannonInfoFreqFlag.Name),
-		AgreeWithProposedOutput: ctx.Bool(AgreeWithProposedOutputFlag.Name),
-		TxMgrConfig:             txMgrConfig,
-		MetricsConfig:           metricsConfig,
-		PprofConfig:             pprofConfig,
+		L1EthRpc:               ctx.String(L1EthRpcFlag.Name),
+		TraceTypes:             traceTypes,
+		GameFactoryAddress:     gameFactoryAddress,
+		GameAllowlist:          allowedGames,
+		GameWindow:             ctx.Duration(GameWindowFlag.Name),
+		MaxConcurrency:         maxConcurrency,
+		PollInterval:           ctx.Duration(HTTPPollInterval.Name),
+		RollupRpc:              ctx.String(RollupRpcFlag.Name),
+		AlphabetTrace:          ctx.String(AlphabetFlag.Name),
+		CannonNetwork:          ctx.String(CannonNetworkFlag.Name),
+		CannonRollupConfigPath: ctx.String(CannonRollupConfigFlag.Name),
+		CannonL2GenesisPath:    ctx.String(CannonL2GenesisFlag.Name),
+		CannonBin:              ctx.String(CannonBinFlag.Name),
+		CannonServer:           ctx.String(CannonServerFlag.Name),
+		CannonAbsolutePreState: ctx.String(CannonPreStateFlag.Name),
+		Datadir:                ctx.String(DatadirFlag.Name),
+		CannonL2:               ctx.String(CannonL2Flag.Name),
+		CannonSnapshotFreq:     ctx.Uint(CannonSnapshotFreqFlag.Name),
+		CannonInfoFreq:         ctx.Uint(CannonInfoFreqFlag.Name),
+		TxMgrConfig:            txMgrConfig,
+		MetricsConfig:          metricsConfig,
+		PprofConfig:            pprofConfig,
 	}, nil
 }

--- a/op-challenger/game/fault/agent.go
+++ b/op-challenger/game/fault/agent.go
@@ -29,24 +29,22 @@ type ClaimLoader interface {
 }
 
 type Agent struct {
-	metrics                 metrics.Metricer
-	solver                  *solver.GameSolver
-	loader                  ClaimLoader
-	responder               Responder
-	maxDepth                int
-	agreeWithProposedOutput bool
-	log                     log.Logger
+	metrics   metrics.Metricer
+	solver    *solver.GameSolver
+	loader    ClaimLoader
+	responder Responder
+	maxDepth  int
+	log       log.Logger
 }
 
-func NewAgent(m metrics.Metricer, loader ClaimLoader, maxDepth int, trace types.TraceAccessor, responder Responder, agreeWithProposedOutput bool, log log.Logger) *Agent {
+func NewAgent(m metrics.Metricer, loader ClaimLoader, maxDepth int, trace types.TraceAccessor, responder Responder, log log.Logger) *Agent {
 	return &Agent{
-		metrics:                 m,
-		solver:                  solver.NewGameSolver(maxDepth, trace),
-		loader:                  loader,
-		responder:               responder,
-		maxDepth:                maxDepth,
-		agreeWithProposedOutput: agreeWithProposedOutput,
-		log:                     log,
+		metrics:   m,
+		solver:    solver.NewGameSolver(maxDepth, trace),
+		loader:    loader,
+		responder: responder,
+		maxDepth:  maxDepth,
+		log:       log,
 	}
 }
 
@@ -90,19 +88,6 @@ func (a *Agent) Act(ctx context.Context) error {
 	return nil
 }
 
-// shouldResolve returns true if the agent should resolve the game.
-// This method will return false if the game is still in progress.
-func (a *Agent) shouldResolve(status gameTypes.GameStatus) bool {
-	expected := gameTypes.GameStatusDefenderWon
-	if a.agreeWithProposedOutput {
-		expected = gameTypes.GameStatusChallengerWon
-	}
-	if expected != status {
-		a.log.Warn("Game will be lost", "expected", expected, "actual", status)
-	}
-	return expected == status
-}
-
 // tryResolve resolves the game if it is in a winning state
 // Returns true if the game is resolvable (regardless of whether it was actually resolved)
 func (a *Agent) tryResolve(ctx context.Context) bool {
@@ -113,9 +98,6 @@ func (a *Agent) tryResolve(ctx context.Context) bool {
 	status, err := a.responder.CallResolve(ctx)
 	if err != nil || status == gameTypes.GameStatusInProgress {
 		return false
-	}
-	if !a.shouldResolve(status) {
-		return true
 	}
 	a.log.Info("Resolving game")
 	if err := a.responder.Resolve(ctx); err != nil {
@@ -187,6 +169,6 @@ func (a *Agent) newGameFromContracts(ctx context.Context) (types.Game, error) {
 	if len(claims) == 0 {
 		return nil, errors.New("no claims")
 	}
-	game := types.NewGameState(a.agreeWithProposedOutput, claims, uint64(a.maxDepth))
+	game := types.NewGameState(claims, uint64(a.maxDepth))
 	return game, nil
 }

--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -18,62 +18,27 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-// TestShouldResolve tests the resolution logic.
-func TestShouldResolve(t *testing.T) {
-	t.Run("AgreeWithProposedOutput", func(t *testing.T) {
-		agent, _, _ := setupTestAgent(t, true)
-		require.False(t, agent.shouldResolve(gameTypes.GameStatusDefenderWon))
-		require.True(t, agent.shouldResolve(gameTypes.GameStatusChallengerWon))
-		require.False(t, agent.shouldResolve(gameTypes.GameStatusInProgress))
-	})
-
-	t.Run("DisagreeWithProposedOutput", func(t *testing.T) {
-		agent, _, _ := setupTestAgent(t, false)
-		require.True(t, agent.shouldResolve(gameTypes.GameStatusDefenderWon))
-		require.False(t, agent.shouldResolve(gameTypes.GameStatusChallengerWon))
-		require.False(t, agent.shouldResolve(gameTypes.GameStatusInProgress))
-	})
-}
-
 func TestDoNotMakeMovesWhenGameIsResolvable(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name                    string
-		agreeWithProposedOutput bool
-		callResolveStatus       gameTypes.GameStatus
-		shouldResolve           bool
+		name              string
+		callResolveStatus gameTypes.GameStatus
 	}{
 		{
-			name:                    "Agree_Losing",
-			agreeWithProposedOutput: true,
-			callResolveStatus:       gameTypes.GameStatusDefenderWon,
-			shouldResolve:           false,
+			name:              "DefenderWon",
+			callResolveStatus: gameTypes.GameStatusDefenderWon,
 		},
 		{
-			name:                    "Agree_Winning",
-			agreeWithProposedOutput: true,
-			callResolveStatus:       gameTypes.GameStatusChallengerWon,
-			shouldResolve:           true,
-		},
-		{
-			name:                    "Disagree_Losing",
-			agreeWithProposedOutput: false,
-			callResolveStatus:       gameTypes.GameStatusChallengerWon,
-			shouldResolve:           false,
-		},
-		{
-			name:                    "Disagree_Winning",
-			agreeWithProposedOutput: false,
-			callResolveStatus:       gameTypes.GameStatusDefenderWon,
-			shouldResolve:           true,
+			name:              "ChallengerWon",
+			callResolveStatus: gameTypes.GameStatusChallengerWon,
 		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			agent, claimLoader, responder := setupTestAgent(t, test.agreeWithProposedOutput)
+			agent, claimLoader, responder := setupTestAgent(t)
 			responder.callResolveStatus = test.callResolveStatus
 
 			require.NoError(t, agent.Act(ctx))
@@ -81,18 +46,14 @@ func TestDoNotMakeMovesWhenGameIsResolvable(t *testing.T) {
 			require.Equal(t, 1, responder.callResolveCount, "should check if game is resolvable")
 			require.Equal(t, 1, claimLoader.callCount, "should fetch claims once for resolveClaim")
 
-			if test.shouldResolve {
-				require.EqualValues(t, 1, responder.resolveCount, "should resolve winning game")
-			} else {
-				require.Zero(t, responder.resolveCount, "should not resolve losing game")
-			}
+			require.EqualValues(t, 1, responder.resolveCount, "should resolve winning game")
 		})
 	}
 }
 
 func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 	// Checks that if the game isn't resolvable, that the agent continues on to start checking claims
-	agent, claimLoader, responder := setupTestAgent(t, false)
+	agent, claimLoader, responder := setupTestAgent(t)
 	responder.callResolveErr = errors.New("game is not resolvable")
 	responder.callResolveClaimErr = errors.New("claim is not resolvable")
 	depth := 4
@@ -109,13 +70,13 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 	require.Zero(t, responder.resolveClaimCount, "should not send resolveClaim")
 }
 
-func setupTestAgent(t *testing.T, agreeWithProposedOutput bool) (*Agent, *stubClaimLoader, *stubResponder) {
+func setupTestAgent(t *testing.T) (*Agent, *stubClaimLoader, *stubResponder) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	claimLoader := &stubClaimLoader{}
 	depth := 4
 	provider := alphabet.NewTraceProvider("abcd", uint64(depth))
 	responder := &stubResponder{}
-	agent := NewAgent(metrics.NoopMetrics, claimLoader, depth, trace.NewSimpleTraceAccessor(provider), responder, agreeWithProposedOutput, logger)
+	agent := NewAgent(metrics.NoopMetrics, claimLoader, depth, trace.NewSimpleTraceAccessor(provider), responder, logger)
 	return agent, claimLoader, responder
 }
 

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/responder"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -30,11 +29,10 @@ type GameInfo interface {
 type gameValidator func(ctx context.Context, gameContract *contracts.FaultDisputeGameContract) error
 
 type GamePlayer struct {
-	act                     actor
-	agreeWithProposedOutput bool
-	loader                  GameInfo
-	logger                  log.Logger
-	status                  gameTypes.GameStatus
+	act    actor
+	loader GameInfo
+	logger log.Logger
+	status gameTypes.GameStatus
 }
 
 type resourceCreator func(addr common.Address, contract *contracts.FaultDisputeGameContract, gameDepth uint64, dir string) (types.TraceAccessor, gameValidator, error)
@@ -43,7 +41,6 @@ func NewGamePlayer(
 	ctx context.Context,
 	logger log.Logger,
 	m metrics.Metricer,
-	cfg *config.Config,
 	dir string,
 	addr common.Address,
 	txMgr txmgr.TxManager,
@@ -65,10 +62,9 @@ func NewGamePlayer(
 		logger.Info("Game already resolved", "status", status)
 		// Game is already complete so skip creating the trace provider, loading game inputs etc.
 		return &GamePlayer{
-			logger:                  logger,
-			loader:                  loader,
-			agreeWithProposedOutput: cfg.AgreeWithProposedOutput,
-			status:                  status,
+			logger: logger,
+			loader: loader,
+			status: status,
 			// Act function does nothing because the game is already complete
 			act: func(ctx context.Context) error {
 				return nil
@@ -95,13 +91,12 @@ func NewGamePlayer(
 		return nil, fmt.Errorf("failed to create the responder: %w", err)
 	}
 
-	agent := NewAgent(m, loader, int(gameDepth), accessor, responder, cfg.AgreeWithProposedOutput, logger)
+	agent := NewAgent(m, loader, int(gameDepth), accessor, responder, logger)
 	return &GamePlayer{
-		act:                     agent.Act,
-		agreeWithProposedOutput: cfg.AgreeWithProposedOutput,
-		loader:                  loader,
-		logger:                  logger,
-		status:                  status,
+		act:    agent.Act,
+		loader: loader,
+		logger: logger,
+		status: status,
 	}, nil
 }
 
@@ -139,17 +134,7 @@ func (g *GamePlayer) logGameStatus(ctx context.Context, status gameTypes.GameSta
 		g.logger.Info("Game info", "claims", claimCount, "status", status)
 		return
 	}
-	var expectedStatus gameTypes.GameStatus
-	if g.agreeWithProposedOutput {
-		expectedStatus = gameTypes.GameStatusChallengerWon
-	} else {
-		expectedStatus = gameTypes.GameStatusDefenderWon
-	}
-	if expectedStatus == status {
-		g.logger.Info("Game won", "status", status)
-	} else {
-		g.logger.Error("Game lost", "status", status)
-	}
+	g.logger.Info("Game resolved", "status", status)
 }
 
 type PrestateLoader interface {

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -90,7 +90,7 @@ func registerOutputCannon(
 		return accessor, noopValidator, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, cfg, dir, game.Proxy, txMgr, client, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, resourceCreator)
 	}
 	registry.RegisterGameType(outputCannonGameType, playerCreator)
 }
@@ -117,7 +117,7 @@ func registerCannon(
 		return trace.NewSimpleTraceAccessor(provider), validator, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, cfg, dir, game.Proxy, txMgr, client, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, resourceCreator)
 	}
 	registry.RegisterGameType(cannonGameType, playerCreator)
 }
@@ -138,7 +138,7 @@ func registerAlphabet(
 		return trace.NewSimpleTraceAccessor(provider), validator, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, cfg, dir, game.Proxy, txMgr, client, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, resourceCreator)
 	}
 	registry.RegisterGameType(alphabetGameType, playerCreator)
 }

--- a/op-challenger/game/fault/solver/game_solver.go
+++ b/op-challenger/game/fault/solver/game_solver.go
@@ -18,16 +18,24 @@ func NewGameSolver(gameDepth int, trace types.TraceAccessor) *GameSolver {
 	}
 }
 
+func (s *GameSolver) AgreeWithRootClaim(ctx context.Context, game types.Game) (bool, error) {
+	return s.claimSolver.agreeWithClaim(ctx, game, game.Claims()[0])
+}
+
 func (s *GameSolver) CalculateNextActions(ctx context.Context, game types.Game) ([]types.Action, error) {
+	agreeWithRootClaim, err := s.AgreeWithRootClaim(ctx, game)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine if root claim is correct: %w", err)
+	}
 	var errs []error
 	var actions []types.Action
 	for _, claim := range game.Claims() {
 		var action *types.Action
 		var err error
 		if uint64(claim.Depth()) == game.MaxDepth() {
-			action, err = s.calculateStep(ctx, game, claim)
+			action, err = s.calculateStep(ctx, game, agreeWithRootClaim, claim)
 		} else {
-			action, err = s.calculateMove(ctx, game, claim)
+			action, err = s.calculateMove(ctx, game, agreeWithRootClaim, claim)
 		}
 		if err != nil {
 			errs = append(errs, err)
@@ -41,11 +49,11 @@ func (s *GameSolver) CalculateNextActions(ctx context.Context, game types.Game) 
 	return actions, errors.Join(errs...)
 }
 
-func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, claim types.Claim) (*types.Action, error) {
+func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, agreeWithRootClaim bool, claim types.Claim) (*types.Action, error) {
 	if claim.Countered {
 		return nil, nil
 	}
-	if game.AgreeWithClaimLevel(claim) {
+	if game.AgreeWithClaimLevel(claim, agreeWithRootClaim) {
 		return nil, nil
 	}
 	step, err := s.claimSolver.AttemptStep(ctx, game, claim)
@@ -65,8 +73,8 @@ func (s *GameSolver) calculateStep(ctx context.Context, game types.Game, claim t
 	}, nil
 }
 
-func (s *GameSolver) calculateMove(ctx context.Context, game types.Game, claim types.Claim) (*types.Action, error) {
-	if game.AgreeWithClaimLevel(claim) {
+func (s *GameSolver) calculateMove(ctx context.Context, game types.Game, agreeWithRootClaim bool, claim types.Claim) (*types.Action, error) {
+	if game.AgreeWithClaimLevel(claim, agreeWithRootClaim) {
 		return nil, nil
 	}
 	move, err := s.claimSolver.NextMove(ctx, claim, game)

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -16,50 +16,32 @@ func TestCalculateNextActions(t *testing.T) {
 	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, maxDepth)
 
 	tests := []struct {
-		name                string
-		agreeWithOutputRoot bool
-		rootClaimCorrect    bool
-		setupGame           func(builder *faulttest.GameBuilder)
+		name             string
+		rootClaimCorrect bool
+		setupGame        func(builder *faulttest.GameBuilder)
 	}{
 		{
-			name:                "AttackRootClaim",
-			agreeWithOutputRoot: true,
+			name: "AttackRootClaim",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				builder.Seq().ExpectAttack()
 			},
 		},
 		{
-			name:                "DoNotAttackRootClaimWhenDisagreeWithOutputRoot",
-			agreeWithOutputRoot: false,
-			setupGame:           func(builder *faulttest.GameBuilder) {},
-		},
-		{
 			// Note: The fault dispute game contract should prevent a correct root claim from actually being posted
 			// But for completeness, test we ignore it so we don't get sucked into playing an unwinnable game.
-			name:                "DoNotAttackCorrectRootClaim_AgreeWithOutputRoot",
-			agreeWithOutputRoot: true,
-			rootClaimCorrect:    true,
-			setupGame:           func(builder *faulttest.GameBuilder) {},
+			name:             "DoNotAttackCorrectRootClaim_AgreeWithOutputRoot",
+			rootClaimCorrect: true,
+			setupGame:        func(builder *faulttest.GameBuilder) {},
 		},
 		{
-			// Note: The fault dispute game contract should prevent a correct root claim from actually being posted
-			// But for completeness, test we ignore it so we don't get sucked into playing an unwinnable game.
-			name:                "DoNotAttackCorrectRootClaim_DisagreeWithOutputRoot",
-			agreeWithOutputRoot: false,
-			rootClaimCorrect:    true,
-			setupGame:           func(builder *faulttest.GameBuilder) {},
-		},
-		{
-			name:                "DoNotPerformDuplicateMoves",
-			agreeWithOutputRoot: true,
+			name: "DoNotPerformDuplicateMoves",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				// Expected move has already been made.
 				builder.Seq().AttackCorrect()
 			},
 		},
 		{
-			name:                "RespondToAllClaimsAtDisagreeingLevel",
-			agreeWithOutputRoot: true,
+			name: "RespondToAllClaimsAtDisagreeingLevel",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				honestClaim := builder.Seq().AttackCorrect()
 				honestClaim.AttackCorrect().ExpectDefend()
@@ -71,8 +53,7 @@ func TestCalculateNextActions(t *testing.T) {
 			},
 		},
 		{
-			name:                "StepAtMaxDepth",
-			agreeWithOutputRoot: true,
+			name: "StepAtMaxDepth",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				lastHonestClaim := builder.Seq().
 					AttackCorrect().
@@ -83,8 +64,7 @@ func TestCalculateNextActions(t *testing.T) {
 			},
 		},
 		{
-			name:                "PoisonedPreState",
-			agreeWithOutputRoot: true,
+			name: "PoisonedPreState",
 			setupGame: func(builder *faulttest.GameBuilder) {
 				// A claim hash that has no pre-image
 				maliciousStateHash := common.Hash{0x01, 0xaa}
@@ -106,7 +86,7 @@ func TestCalculateNextActions(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			builder := claimBuilder.GameBuilder(test.agreeWithOutputRoot, test.rootClaimCorrect)
+			builder := claimBuilder.GameBuilder(test.rootClaimCorrect)
 			test.setupGame(builder)
 			game := builder.Game
 			for i, claim := range game.Claims() {

--- a/op-challenger/game/fault/solver/solver_test.go
+++ b/op-challenger/game/fault/solver/solver_test.go
@@ -160,7 +160,7 @@ func TestAttemptStep(t *testing.T) {
 	for _, tableTest := range tests {
 		tableTest := tableTest
 		t.Run(tableTest.name, func(t *testing.T) {
-			builder := claimBuilder.GameBuilder(tableTest.agreeWithOutputRoot, !tableTest.agreeWithOutputRoot)
+			builder := claimBuilder.GameBuilder(!tableTest.agreeWithOutputRoot)
 			tableTest.setupGame(builder)
 			alphabetSolver := newClaimSolver(maxDepth, trace.NewSimpleTraceAccessor(claimBuilder.CorrectTraceProvider()))
 			game := builder.Game

--- a/op-challenger/game/fault/test/game_builder.go
+++ b/op-challenger/game/fault/test/game_builder.go
@@ -8,17 +8,15 @@ import (
 )
 
 type GameBuilder struct {
-	builder             *ClaimBuilder
-	Game                types.Game
-	ExpectedActions     []types.Action
-	agreeWithOutputRoot bool
+	builder         *ClaimBuilder
+	Game            types.Game
+	ExpectedActions []types.Action
 }
 
-func (c *ClaimBuilder) GameBuilder(agreeWithOutputRoot bool, rootCorrect bool) *GameBuilder {
+func (c *ClaimBuilder) GameBuilder(rootCorrect bool) *GameBuilder {
 	return &GameBuilder{
-		builder:             c,
-		agreeWithOutputRoot: agreeWithOutputRoot,
-		Game:                types.NewGameState(agreeWithOutputRoot, []types.Claim{c.CreateRootClaim(rootCorrect)}, uint64(c.maxDepth)),
+		builder: c,
+		Game:    types.NewGameState([]types.Claim{c.CreateRootClaim(rootCorrect)}, uint64(c.maxDepth)),
 	}
 }
 
@@ -45,7 +43,7 @@ func (g *GameBuilder) SeqFrom(claim types.Claim) *GameBuilderSeq {
 func (s *GameBuilderSeq) addClaimToGame(claim *types.Claim) {
 	claim.ContractIndex = len(s.gameBuilder.Game.Claims())
 	claims := append(s.gameBuilder.Game.Claims(), *claim)
-	s.gameBuilder.Game = types.NewGameState(s.gameBuilder.agreeWithOutputRoot, claims, uint64(s.builder.maxDepth))
+	s.gameBuilder.Game = types.NewGameState(claims, uint64(s.builder.maxDepth))
 }
 
 func (s *GameBuilderSeq) AttackCorrect() *GameBuilderSeq {

--- a/op-challenger/game/fault/trace/access_test.go
+++ b/op-challenger/game/fault/trace/access_test.go
@@ -18,7 +18,7 @@ func TestAccessor_UsesSelector(t *testing.T) {
 	provider1 := test.NewAlphabetWithProofProvider(t, int(depth), nil)
 	provider2 := alphabet.NewTraceProvider("qrstuv", depth)
 	claim := types.Claim{}
-	game := types.NewGameState(true, []types.Claim{claim}, depth)
+	game := types.NewGameState([]types.Claim{claim}, depth)
 	pos1 := types.NewPositionFromGIndex(big.NewInt(4))
 	pos2 := types.NewPositionFromGIndex(big.NewInt(6))
 

--- a/op-challenger/game/fault/trace/cannon/executor_test.go
+++ b/op-challenger/game/fault/trace/cannon/executor_test.go
@@ -24,7 +24,7 @@ func TestGenerateProof(t *testing.T) {
 	input := "starting.json"
 	tempDir := t.TempDir()
 	dir := filepath.Join(tempDir, "gameDir")
-	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", true, tempDir, config.TraceTypeCannon)
+	cfg := config.NewConfig(common.Address{0xbb}, "http://localhost:8888", tempDir, config.TraceTypeCannon)
 	cfg.CannonAbsolutePreState = "pre.json"
 	cfg.CannonBin = "./bin/cannon"
 	cfg.CannonServer = "./bin/op-program"

--- a/op-challenger/game/fault/trace/split/split_test.go
+++ b/op-challenger/game/fault/trace/split/split_test.go
@@ -314,7 +314,7 @@ func setupAlphabetSplitSelector(t *testing.T) (*alphabet.AlphabetTraceProvider, 
 	selector := NewSplitProviderSelector(top, topDepth, bottomCreator)
 
 	claimBuilder := test.NewAlphabetClaimBuilder(t, topDepth+bottomDepth)
-	gameBuilder := claimBuilder.GameBuilder(true, true)
+	gameBuilder := claimBuilder.GameBuilder(true)
 	return top, selector, gameBuilder
 }
 

--- a/op-challenger/game/fault/types/game_test.go
+++ b/op-challenger/game/fault/types/game_test.go
@@ -51,7 +51,7 @@ func createTestClaims() (Claim, Claim, Claim, Claim) {
 
 func TestIsDuplicate(t *testing.T) {
 	root, top, middle, bottom := createTestClaims()
-	g := NewGameState(false, []Claim{root, top}, testMaxDepth)
+	g := NewGameState([]Claim{root, top}, testMaxDepth)
 
 	// Root + Top should be duplicates
 	require.True(t, g.IsDuplicate(root))
@@ -66,7 +66,7 @@ func TestGame_Claims(t *testing.T) {
 	// Setup the game state.
 	root, top, middle, bottom := createTestClaims()
 	expected := []Claim{root, top, middle, bottom}
-	g := NewGameState(false, expected, testMaxDepth)
+	g := NewGameState(expected, testMaxDepth)
 
 	// Validate claim pairs.
 	actual := g.Claims()
@@ -111,7 +111,7 @@ func TestGame_DefendsParent(t *testing.T) {
 		},
 		{
 			name: "RootDoesntDefend",
-			game: NewGameState(false, []Claim{
+			game: NewGameState([]Claim{
 				{
 					ClaimData: ClaimData{
 						Position: NewPositionFromGIndex(big.NewInt(0)),
@@ -145,5 +145,5 @@ func buildGameWithClaim(claimGIndex *big.Int, parentGIndex *big.Int) *gameState 
 		ContractIndex:       1,
 		ParentContractIndex: 0,
 	}
-	return NewGameState(false, []Claim{parentClaim, claim}, testMaxDepth)
+	return NewGameState([]Claim{parentClaim, claim}, testMaxDepth)
 }

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -54,12 +54,6 @@ func WithPrivKey(key *ecdsa.PrivateKey) Option {
 	}
 }
 
-func WithAgreeProposedOutput(agree bool) Option {
-	return func(c *config.Config) {
-		c.AgreeWithProposedOutput = agree
-	}
-}
-
 func WithAlphabet(alphabet string) Option {
 	return func(c *config.Config) {
 		c.TraceTypes = append(c.TraceTypes, config.TraceTypeAlphabet)
@@ -144,7 +138,7 @@ func NewChallenger(t *testing.T, ctx context.Context, l1Endpoint string, name st
 
 func NewChallengerConfig(t *testing.T, l1Endpoint string, options ...Option) *config.Config {
 	// Use the NewConfig method to ensure we pick up any defaults that are set.
-	cfg := config.NewConfig(common.Address{}, l1Endpoint, true, t.TempDir())
+	cfg := config.NewConfig(common.Address{}, l1Endpoint, t.TempDir())
 	cfg.TxMgrConfig.NumConfirmations = 1
 	cfg.TxMgrConfig.ReceiptQueryInterval = 1 * time.Second
 	if cfg.MaxConcurrency > 4 {

--- a/op-e2e/e2eutils/disputegame/alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/alphabet_helper.go
@@ -16,10 +16,7 @@ func (g *AlphabetGameHelper) StartChallenger(ctx context.Context, l1Endpoint str
 	opts := []challenger.Option{
 		challenger.WithFactoryAddress(g.factoryAddr),
 		challenger.WithGameAddress(g.addr),
-		// By default the challenger agrees with the root claim (thus disagrees with the proposed output)
-		// This can be overridden by passing in options
 		challenger.WithAlphabet(g.claimedAlphabet),
-		challenger.WithAgreeProposedOutput(false),
 	}
 	opts = append(opts, options...)
 	c := challenger.NewChallenger(g.t, ctx, l1Endpoint, name, opts...)

--- a/op-e2e/faultproofs/alphabet_test.go
+++ b/op-e2e/faultproofs/alphabet_test.go
@@ -94,13 +94,10 @@ func TestChallengerCompleteDisputeGame(t *testing.T) {
 			gameDuration := game.GameDuration(ctx)
 
 			game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "Defender",
-				challenger.WithAgreeProposedOutput(false),
 				challenger.WithPrivKey(sys.Cfg.Secrets.Mallory),
 			)
 
 			game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "Challenger",
-				// Agree with the proposed output, so disagree with the root claim
-				challenger.WithAgreeProposedOutput(true),
 				challenger.WithAlphabet(test.otherAlphabet),
 				challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 			)
@@ -137,7 +134,6 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 
 		// Start honest challenger
 		game.StartChallenger(ctx, sys.NodeEndpoint("l1"), "Challenger",
-			challenger.WithAgreeProposedOutput(!isRootCorrect),
 			challenger.WithAlphabet(disputegame.CorrectAlphabet),
 			challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 			// Ensures the challenger responds to all claims before test timeout

--- a/op-e2e/faultproofs/cannon_test.go
+++ b/op-e2e/faultproofs/cannon_test.go
@@ -38,8 +38,6 @@ func TestCannonDisputeGame(t *testing.T) {
 			game.LogGameData(ctx)
 
 			game.StartChallenger(ctx, sys.RollupConfig, sys.L2GenesisCfg, sys.NodeEndpoint("l1"), sys.NodeEndpoint("sequencer"), "Challenger",
-				// Agree with the proposed output, so disagree with the root claim
-				challenger.WithAgreeProposedOutput(true),
 				challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 			)
 
@@ -78,8 +76,6 @@ func TestCannonDefendStep(t *testing.T) {
 	l1Endpoint := sys.NodeEndpoint("l1")
 	l2Endpoint := sys.NodeEndpoint("sequencer")
 	game.StartChallenger(ctx, sys.RollupConfig, sys.L2GenesisCfg, l1Endpoint, l2Endpoint, "Challenger",
-		// Agree with the proposed output, so disagree with the root claim
-		challenger.WithAgreeProposedOutput(true),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 	)
 
@@ -214,8 +210,6 @@ func TestCannonPoisonedPostState(t *testing.T) {
 
 	// Start the honest challenger
 	game.StartChallenger(ctx, sys.RollupConfig, sys.L2GenesisCfg, l1Endpoint, l2Endpoint, "Honest",
-		// Agree with the proposed output, so disagree with the root claim
-		challenger.WithAgreeProposedOutput(true),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Bob),
 	)
 
@@ -272,8 +266,6 @@ func TestCannonChallengeWithCorrectRoot(t *testing.T) {
 	game.LogGameData(ctx)
 
 	game.StartChallenger(ctx, sys.RollupConfig, sys.L2GenesisCfg, l1Endpoint, l2Endpoint, "Challenger",
-		// Agree with the proposed output, so disagree with the root claim
-		challenger.WithAgreeProposedOutput(true),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 	)
 

--- a/op-e2e/faultproofs/multi_test.go
+++ b/op-e2e/faultproofs/multi_test.go
@@ -27,7 +27,6 @@ func TestMultipleCannonGames(t *testing.T) {
 	challenger := gameFactory.StartChallenger(ctx, sys.NodeEndpoint("l1"), "TowerDefense",
 		challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg, sys.NodeEndpoint("sequencer")),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
-		challenger.WithAgreeProposedOutput(true),
 	)
 
 	game1 := gameFactory.StartCannonGame(ctx, common.Hash{0x01, 0xaa})
@@ -88,7 +87,6 @@ func TestMultipleGameTypes(t *testing.T) {
 		challenger.WithCannon(t, sys.RollupConfig, sys.L2GenesisCfg, sys.NodeEndpoint("sequencer")),
 		challenger.WithAlphabet(disputegame.CorrectAlphabet),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
-		challenger.WithAgreeProposedOutput(true),
 	)
 
 	game1 := gameFactory.StartCannonGame(ctx, common.Hash{0x01, 0xaa})

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -27,8 +27,6 @@ func TestOutputCannonGame(t *testing.T) {
 	game.LogGameData(ctx)
 
 	game.StartChallenger(ctx, sys.RollupConfig, sys.L2GenesisCfg, rollupEndpoint, l1Endpoint, l2Endpoint, "Challenger",
-		// Agree with the proposed output, so disagree with the root claim
-		challenger.WithAgreeProposedOutput(true),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
 	)
 

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -57,8 +57,6 @@ func setupDisputeGameForInvalidOutputRoot(t *testing.T, outputRoot common.Hash) 
 
 	// Start the honest challenger
 	game.StartChallenger(ctx, sys.RollupConfig, sys.L2GenesisCfg, l1Endpoint, l2Endpoint, "Defender",
-		// Disagree with the proposed output, so agree with the (correct) root claim
-		challenger.WithAgreeProposedOutput(false),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Mallory),
 	)
 	return sys, l1Client, game, correctTrace


### PR DESCRIPTION
**Description**

The trace provider is now used to decide if the root claim is correct or not. For the FPA version of the contracts this does open up the possibility that the challenger will participate in a game it should ignore but the final result works. The new scenario is:

* An invalid output root is published
* Someone creates a game contesting that output root but with the _incorrect_ cannon trace
* Previously if the challenger had `--agree-with-proposed-output=false` it would ignore that game, but now it will attempt to defend the invalid output root because it disagrees with the root claim. If pushed all the way to calling the step function, the challenger would lose because the output  root is invalid.

Two reasons not to worry about this:
1. The new behaviour is exactly what the challenger would have done if it was configured with `--agree-with-proposed-output=true` since it would always try to counter any root claim.
2. The invalid output root would still wind up being removed if an honest actor is present because they should create a separate game disputing it with the correct cannon trace as the root claim.  op-challenger would then agree with that output root and play the game to get the invalid root removed.


As we move forward with FPAC, creating a game is how you propose a new output root so the challenger should always pick its side based on whether it agrees with it or not which is what the new code does.

** Lost Functionality **

We lost two bits of functionality with this change because deciding whether we agree with the root claim or not may be expensive:
1. When logging the game status, previously it would log "Game won" or "Game lost" at info or error level depending on the expected result.  Calculating the expected result is now more expensive so probably not something we want to incur just for that log
2. Previously the challenger would only resolve games that had its desired outcome. The resolution is done before we load the game data and decide if we agree with the output root so we don't know the expected outcome anymore. We could restore this relatively easily but our expectation is that the challenger should always get its way anyway.
  * It may be worth revisiting this to only resolve if we'd get bond payouts as part of bonds which is more economically rational anyway.  Logged https://github.com/ethereum-optimism/client-pod/issues/252 to track this.

**Tests**

Updated tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to determine agreement with the root claim in the game solver logic.

- **Bug Fixes**
  - Adjusted game state logic to correctly reflect agreement with claims based on new parameters.

- **Refactor**
  - Removed all instances of the `agreeWithProposedOutput` parameter across various components.
  - Simplified the game player's logging behavior to a unified "Game resolved" message.
  - Streamlined the challenger configuration by removing redundant options.

- **Tests**
  - Updated test cases to align with the removal of the `agreeWithProposedOutput` parameter.
  - Renamed and refactored tests to reflect changes in game solver logic.

- **Chores**
  - Cleaned up unused variables and parameters related to agreement with proposed output.

- **Documentation**
  - Updated internal documentation to reflect changes in configuration and game state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->