### PR TITLE
devnet: Disable delta in devnet by default

### DIFF
--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -44,7 +44,7 @@
   "eip1559Elasticity": 6,
   "l1GenesisBlockTimestamp": "0x64c811bf",
   "l2GenesisRegolithTimeOffset": "0x0",
-  "l2GenesisDeltaTimeOffset": "0x0",
+  "l2GenesisDeltaTimeOffset": null,
   "l2GenesisCanyonTimeOffset": "0x40",
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -45,7 +45,7 @@
   "l1GenesisBlockTimestamp": "0x64c811bf",
   "l2GenesisRegolithTimeOffset": "0x0",
   "l2GenesisDeltaTimeOffset": null,
-  "l2GenesisCanyonTimeOffset": "0x40",
+  "l2GenesisCanyonTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,
   "faultGameMaxDuration": 1200,


### PR DESCRIPTION
**Description**

Change `devnetL1-template.json` to disable the delta hard fork by default.  Previously it was enabled at genesis which is before canyon activates.  These defaults are used as the basis for e2e tests so span batches were being enabled in all tests instead of just the ones that specifically tested them.

When we change this default we will need to adjust the e2e tests to ensure we have a set of tests specifically testing the singular batches.
