### PR TITLE
nit(op-node): only store the needed rollup.Config fields in DataSource

### DIFF
--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -28,17 +28,17 @@ type L1TransactionFetcher interface {
 // This is not a stage in the pipeline, but a wrapper for another stage in the pipeline
 type DataSourceFactory struct {
 	log     log.Logger
-	cfg     *rollup.Config
+	dsCfg   DataSourceConfig
 	fetcher L1TransactionFetcher
 }
 
 func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1TransactionFetcher) *DataSourceFactory {
-	return &DataSourceFactory{log: log, cfg: cfg, fetcher: fetcher}
+	return &DataSourceFactory{log: log, dsCfg: DataSourceConfig{l1Signer: cfg.L1Signer(), batchInboxAddress: cfg.BatchInboxAddress}, fetcher: fetcher}
 }
 
 // OpenData returns a DataIter. This struct implements the `Next` function.
 func (ds *DataSourceFactory) OpenData(ctx context.Context, id eth.BlockID, batcherAddr common.Address) DataIter {
-	return NewDataSource(ctx, ds.log, ds.cfg, ds.fetcher, id, batcherAddr)
+	return NewDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, id, batcherAddr)
 }
 
 // DataSourceConfig regroups the mandatory rollup.Config fields needed for DataFromEVMTransactions.
@@ -65,10 +65,8 @@ type DataSource struct {
 
 // NewDataSource creates a new calldata source. It suppresses errors in fetching the L1 block if they occur.
 // If there is an error, it will attempt to fetch the result on the next call to `Next`.
-func NewDataSource(ctx context.Context, log log.Logger, cfg *rollup.Config, fetcher L1TransactionFetcher, block eth.BlockID, batcherAddr common.Address) DataIter {
+func NewDataSource(ctx context.Context, log log.Logger, dsCfg DataSourceConfig, fetcher L1TransactionFetcher, block eth.BlockID, batcherAddr common.Address) DataIter {
 	_, txs, err := fetcher.InfoAndTxsByHash(ctx, block.Hash)
-
-	dsCfg := DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress}
 
 	if err != nil {
 		return &DataSource{

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -41,8 +41,8 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, id eth.BlockID, batch
 	return NewDataSource(ctx, ds.log, ds.cfg, ds.fetcher, id, batcherAddr)
 }
 
-// minimalDataSourceConfig regroups the mandatory rollup.Config fields needed for DataFromEVMTransactions.
-type minimalDataSourceConfig struct {
+// dataSourceConfig regroups the mandatory rollup.Config fields needed for DataFromEVMTransactions.
+type dataSourceConfig struct {
 	l1Signer          types.Signer
 	batchInboxAddress common.Address
 }
@@ -56,7 +56,7 @@ type DataSource struct {
 	data []eth.Data
 	// Required to re-attempt fetching
 	id      eth.BlockID
-	cfg     minimalDataSourceConfig
+	cfg     dataSourceConfig
 	fetcher L1TransactionFetcher
 	log     log.Logger
 
@@ -71,7 +71,7 @@ func NewDataSource(ctx context.Context, log log.Logger, cfg *rollup.Config, fetc
 		return &DataSource{
 			open: false,
 			id:   block,
-			cfg: minimalDataSourceConfig{
+			cfg: dataSourceConfig{
 				l1Signer:          cfg.L1Signer(),
 				batchInboxAddress: cfg.BatchInboxAddress,
 			},

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -121,7 +121,7 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(cfg, batcherAddr, txs, testlog.Logger(t, log.LvlCrit))
+		out := DataFromEVMTransactions(cfg.L1Signer(), cfg.BatchInboxAddress, batcherAddr, txs, testlog.Logger(t, log.LvlCrit))
 		require.ElementsMatch(t, expectedData, out)
 	}
 

--- a/op-node/rollup/derive/calldata_source_test.go
+++ b/op-node/rollup/derive/calldata_source_test.go
@@ -121,7 +121,7 @@ func TestDataFromEVMTransactions(t *testing.T) {
 			}
 		}
 
-		out := DataFromEVMTransactions(cfg.L1Signer(), cfg.BatchInboxAddress, batcherAddr, txs, testlog.Logger(t, log.LvlCrit))
+		out := DataFromEVMTransactions(DataSourceConfig{cfg.L1Signer(), cfg.BatchInboxAddress}, batcherAddr, txs, testlog.Logger(t, log.LvlCrit))
 		require.ElementsMatch(t, expectedData, out)
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR implement the `op-node/rollup/derive/calldata_source.go` "TODO" comment by only storing the necessary `rollup.Config` fields in the `DataSource` struct.

**Tests**

No tests added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined data handling by introducing a new configuration structure for transaction data sourcing.
  - Enhanced the initialization process of data sources to improve efficiency and maintainability.
  - Adjusted data retrieval methods to utilize the new configuration approach, ensuring more direct and clear parameter usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->