### PR TITLE
fix(ctb): remove state diff sig from the deploy bash script.

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy.sh
+++ b/packages/contracts-bedrock/scripts/deploy.sh
@@ -7,7 +7,7 @@ if [ -n "${DEPLOY_VERIFY:-}" ]; then
 fi
 
 echo "> Deploying contracts"
-forge script -vvv scripts/Deploy.s.sol:Deploy --rpc-url "$DEPLOY_ETH_RPC_URL" --sig 'runWithStateDiff()' --broadcast --private-key "$DEPLOY_PRIVATE_KEY" $verify_flag
+forge script -vvv scripts/Deploy.s.sol:Deploy --rpc-url "$DEPLOY_ETH_RPC_URL" --broadcast --private-key "$DEPLOY_PRIVATE_KEY" $verify_flag
 
 if [ -n "${DEPLOY_GENERATE_HARDHAT_ARTIFACTS:-}" ]; then
   echo "> Generating hardhat artifacts"


### PR DESCRIPTION
**Description**

In the `deploy.sh` bash script the forge deploy command was updated to run with the sig `runWithStateDiff()`
method. This broke the subsequent hardhat artifact step since it looked for the deploy output json from
`run()` which would produce `run-latest.json`.

Since the state diff generation and check are performed with a separate, isolate forge deploy command
in the `statediff.sh` bash script, there's no need to generate the state diff when deploying with `deploy.sh`.

This pr removes the `--sig "runWithStateDiff()"` argument passed into the forge deployment in `deploy.sh`.
