### PR TITLE
op-chain-ops: extended pause 2 step upgrades

### DIFF
--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -59,8 +59,21 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 		if err != nil {
 			return err
 		}
-		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L28
-		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{31: 0xf9}, common.Hash{})
+
+		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L11-L13
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L28
+			{
+				Key:   common.Hash{31: 249},
+				Value: common.Hash{},
+			},
+		}
+
+		calldata, err := storageSetterABI.Pack("setBytes32", input)
 		if err != nil {
 			return err
 		}
@@ -112,7 +125,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 			return err
 		}
 
-		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L100-L103
+		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L100-L102
 		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{}, common.Hash{})
 		if err != nil {
 			return err
@@ -231,6 +244,11 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 		}
 
 		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L50-L51
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
 			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L55
 			{
 				Key:   common.Hash{31: 0x04},
@@ -385,6 +403,11 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		}
 
 		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L64-L65
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
 			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L72
 			{
 				Key:   common.Hash{31: 53},
@@ -470,6 +493,11 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		}
 
 		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L82-L83
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
 			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L92
 			{
 				Key:   common.Hash{31: 106},


### PR DESCRIPTION
**Description**

The new storage setter contract with ability to set multiple
slots in a single call is deployed at [0xd81f43eDBCAcb4c29a9bA38a13Ee5d79278270cC](https://etherscan.io/address/0xd81f43edbcacb4c29a9ba38a13ee5d79278270cc#code).
It was deployed with create2 and should also be on goerli + sepolia and
ay other chain that has a superchain deployed on it.

Manual calls to `upgradeAndCall` are made. There isn't a great way to
support multiple upgrades at a time within `op-upgrade` so adopting a
"release" model where `op-upgrade` supports building a single version to
another single version makes the most sense. It is too difficult given
the current abstractions to build something that supports any upgrade to
any upgrade arbitrarily. This sort of system is certainly possible to
build but we would need to think more about the abstractions.

One thing is this does not support a reverse upgrade aka downgrade.

Each storage slot that was set as part of the upgrade to MCP is removed
using the `StorageSetter` contract. A link to the storage layout file
is included for each call to `setStorage`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
