### PR TITLE
challenger: Begin supporting new OutputBisectionGame contract

### DIFF
--- a/op-challenger/game/fault/contracts/disputegame.go
+++ b/op-challenger/game/fault/contracts/disputegame.go
@@ -1,0 +1,213 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	methodGameDuration     = "GAME_DURATION"
+	methodMaxGameDepth     = "MAX_GAME_DEPTH"
+	methodAbsolutePrestate = "ABSOLUTE_PRESTATE"
+	methodStatus           = "status"
+	methodClaimCount       = "claimDataLen"
+	methodClaim            = "claimData"
+	methodL1Head           = "l1Head"
+	methodResolve          = "resolve"
+	methodResolveClaim     = "resolveClaim"
+	methodAttack           = "attack"
+	methodDefend           = "defend"
+	methodStep             = "step"
+	methodAddLocalData     = "addLocalData"
+	methodVM               = "VM"
+)
+
+type DisputeGameContract struct {
+	multiCaller *batching.MultiCaller
+	contract    *batching.BoundContract
+}
+
+// contractProposal matches the structure for output root proposals used by the contracts.
+// It must exactly match the contract structure. The exposed API uses Proposal to decouple the contract
+// and challenger representations of the proposal data.
+type contractProposal struct {
+	Index         *big.Int
+	L2BlockNumber *big.Int
+	OutputRoot    common.Hash
+}
+
+type Proposal struct {
+	L2BlockNumber *big.Int
+	OutputRoot    common.Hash
+}
+
+func asProposal(p contractProposal) Proposal {
+	return Proposal{
+		L2BlockNumber: p.L2BlockNumber,
+		OutputRoot:    p.OutputRoot,
+	}
+}
+
+func (f *DisputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodGameDuration))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
+	}
+	return result.GetUint64(0), nil
+}
+
+func (f *DisputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodMaxGameDepth))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch max game depth: %w", err)
+	}
+	return result.GetBigInt(0).Uint64(), nil
+}
+
+func (f *DisputeGameContract) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodAbsolutePrestate))
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to fetch absolute prestate hash: %w", err)
+	}
+	return result.GetHash(0), nil
+}
+
+func (f *DisputeGameContract) GetL1Head(ctx context.Context) (common.Hash, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodL1Head))
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to fetch L1 head: %w", err)
+	}
+	return result.GetHash(0), nil
+}
+
+func (f *DisputeGameContract) GetStatus(ctx context.Context) (gameTypes.GameStatus, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodStatus))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch status: %w", err)
+	}
+	return gameTypes.GameStatusFromUint8(result.GetUint8(0))
+}
+
+func (f *DisputeGameContract) GetClaimCount(ctx context.Context) (uint64, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaimCount))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch claim count: %w", err)
+	}
+	return result.GetBigInt(0).Uint64(), nil
+}
+
+func (f *DisputeGameContract) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaim, new(big.Int).SetUint64(idx)))
+	if err != nil {
+		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
+	}
+	return f.decodeClaim(result, int(idx)), nil
+}
+
+func (f *DisputeGameContract) GetAllClaims(ctx context.Context) ([]types.Claim, error) {
+	count, err := f.GetClaimCount(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load claim count: %w", err)
+	}
+
+	calls := make([]*batching.ContractCall, count)
+	for i := uint64(0); i < count; i++ {
+		calls[i] = f.contract.Call(methodClaim, new(big.Int).SetUint64(i))
+	}
+
+	results, err := f.multiCaller.Call(ctx, batching.BlockLatest, calls...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch claim data: %w", err)
+	}
+
+	var claims []types.Claim
+	for idx, result := range results {
+		claims = append(claims, f.decodeClaim(result, idx))
+	}
+	return claims, nil
+}
+
+func (f *DisputeGameContract) vm(ctx context.Context) (*VMContract, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodVM))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch VM addr: %w", err)
+	}
+	vmAddr := result.GetAddress(0)
+	return NewVMContract(vmAddr, f.multiCaller)
+}
+
+func (f *DisputeGameContract) AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
+	call := f.contract.Call(methodAttack, new(big.Int).SetUint64(parentContractIndex), pivot)
+	return call.ToTxCandidate()
+}
+
+func (f *DisputeGameContract) DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
+	call := f.contract.Call(methodDefend, new(big.Int).SetUint64(parentContractIndex), pivot)
+	return call.ToTxCandidate()
+}
+
+func (f *DisputeGameContract) StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error) {
+	call := f.contract.Call(methodStep, new(big.Int).SetUint64(claimIdx), isAttack, stateData, proof)
+	return call.ToTxCandidate()
+}
+
+func (f *DisputeGameContract) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
+	call := f.resolveClaimCall(claimIdx)
+	_, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, call)
+	if err != nil {
+		return fmt.Errorf("failed to call resolve claim: %w", err)
+	}
+	return nil
+}
+
+func (f *DisputeGameContract) ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error) {
+	call := f.resolveClaimCall(claimIdx)
+	return call.ToTxCandidate()
+}
+
+func (f *DisputeGameContract) resolveClaimCall(claimIdx uint64) *batching.ContractCall {
+	return f.contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx))
+}
+
+func (f *DisputeGameContract) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
+	call := f.resolveCall()
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, call)
+	if err != nil {
+		return gameTypes.GameStatusInProgress, fmt.Errorf("failed to call resolve: %w", err)
+	}
+	return gameTypes.GameStatusFromUint8(result.GetUint8(0))
+}
+
+func (f *DisputeGameContract) ResolveTx() (txmgr.TxCandidate, error) {
+	call := f.resolveCall()
+	return call.ToTxCandidate()
+}
+
+func (f *DisputeGameContract) resolveCall() *batching.ContractCall {
+	return f.contract.Call(methodResolve)
+}
+
+func (f *DisputeGameContract) decodeClaim(result *batching.CallResult, contractIndex int) types.Claim {
+	parentIndex := result.GetUint32(0)
+	countered := result.GetBool(1)
+	claim := result.GetHash(2)
+	position := result.GetBigInt(3)
+	clock := result.GetBigInt(4)
+	return types.Claim{
+		ClaimData: types.ClaimData{
+			Value:    claim,
+			Position: types.NewPositionFromGIndex(position),
+		},
+		Countered:           countered,
+		Clock:               clock.Uint64(),
+		ContractIndex:       contractIndex,
+		ParentContractIndex: int(parentIndex),
+	}
+}

--- a/op-challenger/game/fault/contracts/disputegame.go
+++ b/op-challenger/game/fault/contracts/disputegame.go
@@ -29,7 +29,7 @@ const (
 	methodVM               = "VM"
 )
 
-type DisputeGameContract struct {
+type disputeGameContract struct {
 	multiCaller *batching.MultiCaller
 	contract    *batching.BoundContract
 }
@@ -55,7 +55,7 @@ func asProposal(p contractProposal) Proposal {
 	}
 }
 
-func (f *DisputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {
+func (f *disputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodGameDuration))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
@@ -63,7 +63,7 @@ func (f *DisputeGameContract) GetGameDuration(ctx context.Context) (uint64, erro
 	return result.GetUint64(0), nil
 }
 
-func (f *DisputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64, error) {
+func (f *disputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodMaxGameDepth))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch max game depth: %w", err)
@@ -71,7 +71,7 @@ func (f *DisputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64, erro
 	return result.GetBigInt(0).Uint64(), nil
 }
 
-func (f *DisputeGameContract) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
+func (f *disputeGameContract) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodAbsolutePrestate))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to fetch absolute prestate hash: %w", err)
@@ -79,7 +79,7 @@ func (f *DisputeGameContract) GetAbsolutePrestateHash(ctx context.Context) (comm
 	return result.GetHash(0), nil
 }
 
-func (f *DisputeGameContract) GetL1Head(ctx context.Context) (common.Hash, error) {
+func (f *disputeGameContract) GetL1Head(ctx context.Context) (common.Hash, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodL1Head))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to fetch L1 head: %w", err)
@@ -87,7 +87,7 @@ func (f *DisputeGameContract) GetL1Head(ctx context.Context) (common.Hash, error
 	return result.GetHash(0), nil
 }
 
-func (f *DisputeGameContract) GetStatus(ctx context.Context) (gameTypes.GameStatus, error) {
+func (f *disputeGameContract) GetStatus(ctx context.Context) (gameTypes.GameStatus, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodStatus))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch status: %w", err)
@@ -95,7 +95,7 @@ func (f *DisputeGameContract) GetStatus(ctx context.Context) (gameTypes.GameStat
 	return gameTypes.GameStatusFromUint8(result.GetUint8(0))
 }
 
-func (f *DisputeGameContract) GetClaimCount(ctx context.Context) (uint64, error) {
+func (f *disputeGameContract) GetClaimCount(ctx context.Context) (uint64, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaimCount))
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch claim count: %w", err)
@@ -103,7 +103,7 @@ func (f *DisputeGameContract) GetClaimCount(ctx context.Context) (uint64, error)
 	return result.GetBigInt(0).Uint64(), nil
 }
 
-func (f *DisputeGameContract) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
+func (f *disputeGameContract) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaim, new(big.Int).SetUint64(idx)))
 	if err != nil {
 		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
@@ -111,7 +111,7 @@ func (f *DisputeGameContract) GetClaim(ctx context.Context, idx uint64) (types.C
 	return f.decodeClaim(result, int(idx)), nil
 }
 
-func (f *DisputeGameContract) GetAllClaims(ctx context.Context) ([]types.Claim, error) {
+func (f *disputeGameContract) GetAllClaims(ctx context.Context) ([]types.Claim, error) {
 	count, err := f.GetClaimCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load claim count: %w", err)
@@ -134,7 +134,7 @@ func (f *DisputeGameContract) GetAllClaims(ctx context.Context) ([]types.Claim, 
 	return claims, nil
 }
 
-func (f *DisputeGameContract) vm(ctx context.Context) (*VMContract, error) {
+func (f *disputeGameContract) vm(ctx context.Context) (*VMContract, error) {
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodVM))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch VM addr: %w", err)
@@ -143,22 +143,22 @@ func (f *DisputeGameContract) vm(ctx context.Context) (*VMContract, error) {
 	return NewVMContract(vmAddr, f.multiCaller)
 }
 
-func (f *DisputeGameContract) AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
+func (f *disputeGameContract) AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
 	call := f.contract.Call(methodAttack, new(big.Int).SetUint64(parentContractIndex), pivot)
 	return call.ToTxCandidate()
 }
 
-func (f *DisputeGameContract) DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
+func (f *disputeGameContract) DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
 	call := f.contract.Call(methodDefend, new(big.Int).SetUint64(parentContractIndex), pivot)
 	return call.ToTxCandidate()
 }
 
-func (f *DisputeGameContract) StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error) {
+func (f *disputeGameContract) StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error) {
 	call := f.contract.Call(methodStep, new(big.Int).SetUint64(claimIdx), isAttack, stateData, proof)
 	return call.ToTxCandidate()
 }
 
-func (f *DisputeGameContract) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
+func (f *disputeGameContract) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
 	call := f.resolveClaimCall(claimIdx)
 	_, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, call)
 	if err != nil {
@@ -167,16 +167,16 @@ func (f *DisputeGameContract) CallResolveClaim(ctx context.Context, claimIdx uin
 	return nil
 }
 
-func (f *DisputeGameContract) ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error) {
+func (f *disputeGameContract) ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error) {
 	call := f.resolveClaimCall(claimIdx)
 	return call.ToTxCandidate()
 }
 
-func (f *DisputeGameContract) resolveClaimCall(claimIdx uint64) *batching.ContractCall {
+func (f *disputeGameContract) resolveClaimCall(claimIdx uint64) *batching.ContractCall {
 	return f.contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx))
 }
 
-func (f *DisputeGameContract) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
+func (f *disputeGameContract) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
 	call := f.resolveCall()
 	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, call)
 	if err != nil {
@@ -185,16 +185,16 @@ func (f *DisputeGameContract) CallResolve(ctx context.Context) (gameTypes.GameSt
 	return gameTypes.GameStatusFromUint8(result.GetUint8(0))
 }
 
-func (f *DisputeGameContract) ResolveTx() (txmgr.TxCandidate, error) {
+func (f *disputeGameContract) ResolveTx() (txmgr.TxCandidate, error) {
 	call := f.resolveCall()
 	return call.ToTxCandidate()
 }
 
-func (f *DisputeGameContract) resolveCall() *batching.ContractCall {
+func (f *disputeGameContract) resolveCall() *batching.ContractCall {
 	return f.contract.Call(methodResolve)
 }
 
-func (f *DisputeGameContract) decodeClaim(result *batching.CallResult, contractIndex int) types.Claim {
+func (f *disputeGameContract) decodeClaim(result *batching.CallResult, contractIndex int) types.Claim {
 	parentIndex := result.GetUint32(0)
 	countered := result.GetBool(1)
 	claim := result.GetHash(2)

--- a/op-challenger/game/fault/contracts/disputegame_test.go
+++ b/op-challenger/game/fault/contracts/disputegame_test.go
@@ -20,7 +20,7 @@ var (
 	oracleAddr = common.HexToAddress("0x44442842371dFC380576ebb09Ae16Cb6B6ca4444")
 )
 
-type disputeGameSetupFunc func(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameContract)
+type disputeGameSetupFunc func(t *testing.T) (*batchingTest.AbiBasedRpc, *disputeGameContract)
 
 func runCommonDisputeGameTests(t *testing.T, setup disputeGameSetupFunc) {
 	tests := []struct {
@@ -52,19 +52,19 @@ func runSimpleGettersTest(t *testing.T, setup disputeGameSetupFunc) {
 		args     []interface{}
 		result   interface{}
 		expected interface{} // Defaults to expecting the same as result
-		call     func(game *DisputeGameContract) (any, error)
+		call     func(game *disputeGameContract) (any, error)
 	}{
 		{
 			method: methodStatus,
 			result: types.GameStatusChallengerWon,
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.GetStatus(context.Background())
 			},
 		},
 		{
 			method: methodGameDuration,
 			result: uint64(5566),
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.GetGameDuration(context.Background())
 			},
 		},
@@ -72,14 +72,14 @@ func runSimpleGettersTest(t *testing.T, setup disputeGameSetupFunc) {
 			method:   methodMaxGameDepth,
 			result:   big.NewInt(128),
 			expected: uint64(128),
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.GetMaxGameDepth(context.Background())
 			},
 		},
 		{
 			method: methodAbsolutePrestate,
 			result: common.Hash{0xab},
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.GetAbsolutePrestateHash(context.Background())
 			},
 		},
@@ -87,21 +87,21 @@ func runSimpleGettersTest(t *testing.T, setup disputeGameSetupFunc) {
 			method:   methodClaimCount,
 			result:   big.NewInt(9876),
 			expected: uint64(9876),
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.GetClaimCount(context.Background())
 			},
 		},
 		{
 			method: methodL1Head,
 			result: common.Hash{0xdd, 0xbb},
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.GetL1Head(context.Background())
 			},
 		},
 		{
 			method: methodResolve,
 			result: types.GameStatusInProgress,
-			call: func(game *DisputeGameContract) (any, error) {
+			call: func(game *disputeGameContract) (any, error) {
 				return game.CallResolve(context.Background())
 			},
 		},

--- a/op-challenger/game/fault/contracts/disputegame_test.go
+++ b/op-challenger/game/fault/contracts/disputegame_test.go
@@ -1,0 +1,254 @@
+package contracts
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	fdgAddr    = common.HexToAddress("0x24112842371dFC380576ebb09Ae16Cb6B6caD7CB")
+	vmAddr     = common.HexToAddress("0x33332842371dFC380576ebb09Ae16Cb6B6c3333")
+	oracleAddr = common.HexToAddress("0x44442842371dFC380576ebb09Ae16Cb6B6ca4444")
+)
+
+type disputeGameSetupFunc func(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameContract)
+
+func runCommonDisputeGameTests(t *testing.T, setup disputeGameSetupFunc) {
+	tests := []struct {
+		name   string
+		method func(t *testing.T, setup disputeGameSetupFunc)
+	}{
+		{"SimpleGetters", runSimpleGettersTest},
+		{"GetClaim", runGetClaimTest},
+		{"GetAllClaims", runGetAllClaimsTest},
+		{"CallResolveClaim", runCallResolveClaimTest},
+		{"ResolveClaimTx", runResolveClaimTxTest},
+		{"ResolveTx", runResolveTxTest},
+		{"AttackTx", runAttackTxTest},
+		{"DefendTx", runDefendTxTest},
+		{"StepTx", runStepTxTest},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			test.method(t, setup)
+		})
+	}
+}
+
+func runSimpleGettersTest(t *testing.T, setup disputeGameSetupFunc) {
+	tests := []struct {
+		method   string
+		args     []interface{}
+		result   interface{}
+		expected interface{} // Defaults to expecting the same as result
+		call     func(game *DisputeGameContract) (any, error)
+	}{
+		{
+			method: methodStatus,
+			result: types.GameStatusChallengerWon,
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.GetStatus(context.Background())
+			},
+		},
+		{
+			method: methodGameDuration,
+			result: uint64(5566),
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.GetGameDuration(context.Background())
+			},
+		},
+		{
+			method:   methodMaxGameDepth,
+			result:   big.NewInt(128),
+			expected: uint64(128),
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.GetMaxGameDepth(context.Background())
+			},
+		},
+		{
+			method: methodAbsolutePrestate,
+			result: common.Hash{0xab},
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.GetAbsolutePrestateHash(context.Background())
+			},
+		},
+		{
+			method:   methodClaimCount,
+			result:   big.NewInt(9876),
+			expected: uint64(9876),
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.GetClaimCount(context.Background())
+			},
+		},
+		{
+			method: methodL1Head,
+			result: common.Hash{0xdd, 0xbb},
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.GetL1Head(context.Background())
+			},
+		},
+		{
+			method: methodResolve,
+			result: types.GameStatusInProgress,
+			call: func(game *DisputeGameContract) (any, error) {
+				return game.CallResolve(context.Background())
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.method, func(t *testing.T) {
+			stubRpc, game := setup(t)
+			stubRpc.SetResponse(fdgAddr, test.method, batching.BlockLatest, nil, []interface{}{test.result})
+			status, err := test.call(game)
+			require.NoError(t, err)
+			expected := test.expected
+			if expected == nil {
+				expected = test.result
+			}
+			require.Equal(t, expected, status)
+		})
+	}
+}
+
+func runGetClaimTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	idx := big.NewInt(2)
+	parentIndex := uint32(1)
+	countered := true
+	value := common.Hash{0xab}
+	position := big.NewInt(2)
+	clock := big.NewInt(1234)
+	stubRpc.SetResponse(fdgAddr, methodClaim, batching.BlockLatest, []interface{}{idx}, []interface{}{parentIndex, countered, value, position, clock})
+	status, err := game.GetClaim(context.Background(), idx.Uint64())
+	require.NoError(t, err)
+	require.Equal(t, faultTypes.Claim{
+		ClaimData: faultTypes.ClaimData{
+			Value:    value,
+			Position: faultTypes.NewPositionFromGIndex(position),
+		},
+		Countered:           true,
+		Clock:               1234,
+		ContractIndex:       int(idx.Uint64()),
+		ParentContractIndex: 1,
+	}, status)
+}
+
+func runGetAllClaimsTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	claim0 := faultTypes.Claim{
+		ClaimData: faultTypes.ClaimData{
+			Value:    common.Hash{0xaa},
+			Position: faultTypes.NewPositionFromGIndex(big.NewInt(1)),
+		},
+		Countered:           true,
+		Clock:               1234,
+		ContractIndex:       0,
+		ParentContractIndex: math.MaxUint32,
+	}
+	claim1 := faultTypes.Claim{
+		ClaimData: faultTypes.ClaimData{
+			Value:    common.Hash{0xab},
+			Position: faultTypes.NewPositionFromGIndex(big.NewInt(2)),
+		},
+		Countered:           true,
+		Clock:               4455,
+		ContractIndex:       1,
+		ParentContractIndex: 0,
+	}
+	claim2 := faultTypes.Claim{
+		ClaimData: faultTypes.ClaimData{
+			Value:    common.Hash{0xbb},
+			Position: faultTypes.NewPositionFromGIndex(big.NewInt(6)),
+		},
+		Countered:           false,
+		Clock:               7777,
+		ContractIndex:       2,
+		ParentContractIndex: 1,
+	}
+	expectedClaims := []faultTypes.Claim{claim0, claim1, claim2}
+	stubRpc.SetResponse(fdgAddr, methodClaimCount, batching.BlockLatest, nil, []interface{}{big.NewInt(int64(len(expectedClaims)))})
+	for _, claim := range expectedClaims {
+		expectGetClaim(stubRpc, claim)
+	}
+	claims, err := game.GetAllClaims(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expectedClaims, claims)
+}
+
+func runCallResolveClaimTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	stubRpc.SetResponse(fdgAddr, methodResolveClaim, batching.BlockLatest, []interface{}{big.NewInt(123)}, nil)
+	err := game.CallResolveClaim(context.Background(), 123)
+	require.NoError(t, err)
+}
+
+func runResolveClaimTxTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	stubRpc.SetResponse(fdgAddr, methodResolveClaim, batching.BlockLatest, []interface{}{big.NewInt(123)}, nil)
+	tx, err := game.ResolveClaimTx(123)
+	require.NoError(t, err)
+	stubRpc.VerifyTxCandidate(tx)
+}
+
+func runResolveTxTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	stubRpc.SetResponse(fdgAddr, methodResolve, batching.BlockLatest, nil, nil)
+	tx, err := game.ResolveTx()
+	require.NoError(t, err)
+	stubRpc.VerifyTxCandidate(tx)
+}
+
+func runAttackTxTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	value := common.Hash{0xaa}
+	stubRpc.SetResponse(fdgAddr, methodAttack, batching.BlockLatest, []interface{}{big.NewInt(111), value}, nil)
+	tx, err := game.AttackTx(111, value)
+	require.NoError(t, err)
+	stubRpc.VerifyTxCandidate(tx)
+}
+
+func runDefendTxTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	value := common.Hash{0xaa}
+	stubRpc.SetResponse(fdgAddr, methodDefend, batching.BlockLatest, []interface{}{big.NewInt(111), value}, nil)
+	tx, err := game.DefendTx(111, value)
+	require.NoError(t, err)
+	stubRpc.VerifyTxCandidate(tx)
+}
+
+func runStepTxTest(t *testing.T, setup disputeGameSetupFunc) {
+	stubRpc, game := setup(t)
+	stateData := []byte{1, 2, 3}
+	proofData := []byte{4, 5, 6, 7, 8, 9}
+	stubRpc.SetResponse(fdgAddr, methodStep, batching.BlockLatest, []interface{}{big.NewInt(111), true, stateData, proofData}, nil)
+	tx, err := game.StepTx(111, true, stateData, proofData)
+	require.NoError(t, err)
+	stubRpc.VerifyTxCandidate(tx)
+}
+
+func expectGetClaim(stubRpc *batchingTest.AbiBasedRpc, claim faultTypes.Claim) {
+	stubRpc.SetResponse(
+		fdgAddr,
+		methodClaim,
+		batching.BlockLatest,
+		[]interface{}{big.NewInt(int64(claim.ContractIndex))},
+		[]interface{}{
+			uint32(claim.ParentContractIndex),
+			claim.Countered,
+			claim.Value,
+			claim.Position.ToGIndex(),
+			big.NewInt(int64(claim.Clock)),
+		})
+}

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -17,7 +17,7 @@ const (
 )
 
 type FaultDisputeGameContract struct {
-	DisputeGameContract
+	disputeGameContract
 }
 
 func NewFaultDisputeGameContract(addr common.Address, caller *batching.MultiCaller) (*FaultDisputeGameContract, error) {
@@ -27,7 +27,7 @@ func NewFaultDisputeGameContract(addr common.Address, caller *batching.MultiCall
 	}
 
 	return &FaultDisputeGameContract{
-		DisputeGameContract: DisputeGameContract{
+		disputeGameContract: disputeGameContract{
 			multiCaller: caller,
 			contract:    batching.NewBoundContract(fdgAbi, addr),
 		},

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -7,54 +7,17 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 const (
-	methodGameDuration     = "GAME_DURATION"
-	methodMaxGameDepth     = "MAX_GAME_DEPTH"
-	methodAbsolutePrestate = "ABSOLUTE_PRESTATE"
-	methodStatus           = "status"
-	methodClaimCount       = "claimDataLen"
-	methodClaim            = "claimData"
-	methodL1Head           = "l1Head"
-	methodProposals        = "proposals"
-	methodResolve          = "resolve"
-	methodResolveClaim     = "resolveClaim"
-	methodAttack           = "attack"
-	methodDefend           = "defend"
-	methodStep             = "step"
-	methodAddLocalData     = "addLocalData"
-	methodVM               = "VM"
+	methodProposals = "proposals"
 )
 
 type FaultDisputeGameContract struct {
-	multiCaller *batching.MultiCaller
-	contract    *batching.BoundContract
-}
-
-// contractProposal matches the structure for output root proposals used by the contracts.
-// It must exactly match the contract structure. The exposed API uses Proposal to decouple the contract
-// and challenger representations of the proposal data.
-type contractProposal struct {
-	Index         *big.Int
-	L2BlockNumber *big.Int
-	OutputRoot    common.Hash
-}
-
-type Proposal struct {
-	L2BlockNumber *big.Int
-	OutputRoot    common.Hash
-}
-
-func asProposal(p contractProposal) Proposal {
-	return Proposal{
-		L2BlockNumber: p.L2BlockNumber,
-		OutputRoot:    p.OutputRoot,
-	}
+	DisputeGameContract
 }
 
 func NewFaultDisputeGameContract(addr common.Address, caller *batching.MultiCaller) (*FaultDisputeGameContract, error) {
@@ -64,41 +27,11 @@ func NewFaultDisputeGameContract(addr common.Address, caller *batching.MultiCall
 	}
 
 	return &FaultDisputeGameContract{
-		multiCaller: caller,
-		contract:    batching.NewBoundContract(fdgAbi, addr),
+		DisputeGameContract: DisputeGameContract{
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(fdgAbi, addr),
+		},
 	}, nil
-}
-
-func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodGameDuration))
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch game duration: %w", err)
-	}
-	return result.GetUint64(0), nil
-}
-
-func (f *FaultDisputeGameContract) GetMaxGameDepth(ctx context.Context) (uint64, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodMaxGameDepth))
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch max game depth: %w", err)
-	}
-	return result.GetBigInt(0).Uint64(), nil
-}
-
-func (f *FaultDisputeGameContract) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodAbsolutePrestate))
-	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to fetch absolute prestate hash: %w", err)
-	}
-	return result.GetHash(0), nil
-}
-
-func (f *FaultDisputeGameContract) GetL1Head(ctx context.Context) (common.Hash, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodL1Head))
-	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to fetch L1 head: %w", err)
-	}
-	return result.GetHash(0), nil
 }
 
 // GetProposals returns the agreed and disputed proposals
@@ -114,114 +47,7 @@ func (f *FaultDisputeGameContract) GetProposals(ctx context.Context) (Proposal, 
 	return asProposal(agreed), asProposal(disputed), nil
 }
 
-func (f *FaultDisputeGameContract) GetStatus(ctx context.Context) (gameTypes.GameStatus, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodStatus))
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch status: %w", err)
-	}
-	return gameTypes.GameStatusFromUint8(result.GetUint8(0))
-}
-
-func (f *FaultDisputeGameContract) GetClaimCount(ctx context.Context) (uint64, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaimCount))
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch claim count: %w", err)
-	}
-	return result.GetBigInt(0).Uint64(), nil
-}
-
-func (f *FaultDisputeGameContract) GetClaim(ctx context.Context, idx uint64) (types.Claim, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodClaim, new(big.Int).SetUint64(idx)))
-	if err != nil {
-		return types.Claim{}, fmt.Errorf("failed to fetch claim %v: %w", idx, err)
-	}
-	return f.decodeClaim(result, int(idx)), nil
-}
-
-func (f *FaultDisputeGameContract) GetAllClaims(ctx context.Context) ([]types.Claim, error) {
-	count, err := f.GetClaimCount(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load claim count: %w", err)
-	}
-
-	calls := make([]*batching.ContractCall, count)
-	for i := uint64(0); i < count; i++ {
-		calls[i] = f.contract.Call(methodClaim, new(big.Int).SetUint64(i))
-	}
-
-	results, err := f.multiCaller.Call(ctx, batching.BlockLatest, calls...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch claim data: %w", err)
-	}
-
-	var claims []types.Claim
-	for idx, result := range results {
-		claims = append(claims, f.decodeClaim(result, idx))
-	}
-	return claims, nil
-}
-
-func (f *FaultDisputeGameContract) vm(ctx context.Context) (*VMContract, error) {
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodVM))
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch VM addr: %w", err)
-	}
-	vmAddr := result.GetAddress(0)
-	return NewVMContract(vmAddr, f.multiCaller)
-}
-
-func (f *FaultDisputeGameContract) AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodAttack, new(big.Int).SetUint64(parentContractIndex), pivot)
-	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContract) DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodDefend, new(big.Int).SetUint64(parentContractIndex), pivot)
-	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContract) StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error) {
-	call := f.contract.Call(methodStep, new(big.Int).SetUint64(claimIdx), isAttack, stateData, proof)
-	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContract) CallResolveClaim(ctx context.Context, claimIdx uint64) error {
-	call := f.resolveClaimCall(claimIdx)
-	_, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, call)
-	if err != nil {
-		return fmt.Errorf("failed to call resolve claim: %w", err)
-	}
-	return nil
-}
-
-func (f *FaultDisputeGameContract) ResolveClaimTx(claimIdx uint64) (txmgr.TxCandidate, error) {
-	call := f.resolveClaimCall(claimIdx)
-	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContract) resolveClaimCall(claimIdx uint64) *batching.ContractCall {
-	return f.contract.Call(methodResolveClaim, new(big.Int).SetUint64(claimIdx))
-}
-
-func (f *FaultDisputeGameContract) CallResolve(ctx context.Context) (gameTypes.GameStatus, error) {
-	call := f.resolveCall()
-	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, call)
-	if err != nil {
-		return gameTypes.GameStatusInProgress, fmt.Errorf("failed to call resolve: %w", err)
-	}
-	return gameTypes.GameStatusFromUint8(result.GetUint8(0))
-}
-
-func (f *FaultDisputeGameContract) ResolveTx() (txmgr.TxCandidate, error) {
-	call := f.resolveCall()
-	return call.ToTxCandidate()
-}
-
-func (f *FaultDisputeGameContract) resolveCall() *batching.ContractCall {
-	return f.contract.Call(methodResolve)
-}
-
-func (f *FaultDisputeGameContract) UpdateOracleTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+func (f *FaultDisputeGameContract) UpdateOracleTx(ctx context.Context, claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
 	if data.IsLocal {
 		return f.addLocalDataTx(data)
 	}
@@ -248,22 +74,4 @@ func (f *FaultDisputeGameContract) addGlobalDataTx(ctx context.Context, data *ty
 		return txmgr.TxCandidate{}, err
 	}
 	return oracle.AddGlobalDataTx(data)
-}
-
-func (f *FaultDisputeGameContract) decodeClaim(result *batching.CallResult, contractIndex int) types.Claim {
-	parentIndex := result.GetUint32(0)
-	countered := result.GetBool(1)
-	claim := result.GetHash(2)
-	position := result.GetBigInt(3)
-	clock := result.GetBigInt(4)
-	return types.Claim{
-		ClaimData: types.ClaimData{
-			Value:    claim,
-			Position: types.NewPositionFromGIndex(position),
-		},
-		Countered:           countered,
-		Clock:               clock.Uint64(),
-		ContractIndex:       contractIndex,
-		ParentContractIndex: int(parentIndex),
-	}
 }

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestFaultDisputeGameContract_CommonTests(t *testing.T) {
-	runCommonDisputeGameTests(t, func(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameContract) {
+	runCommonDisputeGameTests(t, func(t *testing.T) (*batchingTest.AbiBasedRpc, *disputeGameContract) {
 		stubRpc, contract := setupFaultDisputeGameTest(t)
-		return stubRpc, &contract.DisputeGameContract
+		return stubRpc, &contract.disputeGameContract
 	})
 }
 

--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -25,7 +25,7 @@ type OutputBisectionGameContract struct {
 func NewOutputBisectionGameContract(addr common.Address, caller *batching.MultiCaller) (*OutputBisectionGameContract, error) {
 	contractAbi, err := bindings.OutputBisectionGameMetaData.GetAbi()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load fault dispute game ABI: %w", err)
+		return nil, fmt.Errorf("failed to load output bisection game ABI: %w", err)
 	}
 
 	return &OutputBisectionGameContract{
@@ -78,7 +78,7 @@ func (f *OutputBisectionGameContract) addLocalDataTx(claimIdx uint64, data *type
 	return call.ToTxCandidate()
 }
 
-func (f *disputeGameContract) addGlobalDataTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+func (f *OutputBisectionGameContract) addGlobalDataTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
 	vm, err := f.vm(ctx)
 	if err != nil {
 		return txmgr.TxCandidate{}, err

--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -1,0 +1,91 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	methodGenesisBlockNumber = "GENESIS_BLOCK_NUMBER"
+	methodSplitDepth         = "SPLIT_DEPTH"
+	methodL2BlockNumber      = "l2BlockNumber"
+)
+
+type OutputBisectionGameContract struct {
+	DisputeGameContract
+}
+
+func NewOutputBisectionGameContract(addr common.Address, caller *batching.MultiCaller) (*OutputBisectionGameContract, error) {
+	contractAbi, err := bindings.OutputBisectionGameMetaData.GetAbi()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load fault dispute game ABI: %w", err)
+	}
+
+	return &OutputBisectionGameContract{
+		DisputeGameContract: DisputeGameContract{
+			multiCaller: caller,
+			contract:    batching.NewBoundContract(contractAbi, addr),
+		},
+	}, nil
+}
+
+func (c *OutputBisectionGameContract) GetBlockRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error) {
+	results, err := c.multiCaller.Call(ctx, batching.BlockLatest,
+		c.contract.Call(methodGenesisBlockNumber),
+		c.contract.Call(methodL2BlockNumber))
+	if err != nil {
+		retErr = fmt.Errorf("failed to retrieve game block range: %w", err)
+		return
+	}
+	if len(results) != 2 {
+		retErr = fmt.Errorf("expected 2 results but got %v", len(results))
+		return
+	}
+	prestateBlock = results[0].GetBigInt(0).Uint64()
+	poststateBlock = results[1].GetBigInt(0).Uint64()
+	return
+}
+
+func (c *OutputBisectionGameContract) GetSplitDepth(ctx context.Context) (uint64, error) {
+	splitDepth, err := c.multiCaller.SingleCall(ctx, batching.BlockLatest, c.contract.Call(methodSplitDepth))
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve split depth: %w", err)
+	}
+	return splitDepth.GetBigInt(0).Uint64(), nil
+}
+
+func (f *OutputBisectionGameContract) UpdateOracleTx(ctx context.Context, claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+	if data.IsLocal {
+		return f.addLocalDataTx(claimIdx, data)
+	}
+	return f.addGlobalDataTx(ctx, data)
+}
+
+func (f *OutputBisectionGameContract) addLocalDataTx(claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+	call := f.contract.Call(
+		methodAddLocalData,
+		data.GetIdent(),
+		new(big.Int).SetUint64(claimIdx),
+		new(big.Int).SetUint64(uint64(data.OracleOffset)),
+	)
+	return call.ToTxCandidate()
+}
+
+func (f *DisputeGameContract) addGlobalDataTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+	vm, err := f.vm(ctx)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
+	oracle, err := vm.Oracle(ctx)
+	if err != nil {
+		return txmgr.TxCandidate{}, err
+	}
+	return oracle.AddGlobalDataTx(data)
+}

--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -19,7 +19,7 @@ var (
 )
 
 type OutputBisectionGameContract struct {
-	DisputeGameContract
+	disputeGameContract
 }
 
 func NewOutputBisectionGameContract(addr common.Address, caller *batching.MultiCaller) (*OutputBisectionGameContract, error) {
@@ -29,7 +29,7 @@ func NewOutputBisectionGameContract(addr common.Address, caller *batching.MultiC
 	}
 
 	return &OutputBisectionGameContract{
-		DisputeGameContract: DisputeGameContract{
+		disputeGameContract: disputeGameContract{
 			multiCaller: caller,
 			contract:    batching.NewBoundContract(contractAbi, addr),
 		},
@@ -78,7 +78,7 @@ func (f *OutputBisectionGameContract) addLocalDataTx(claimIdx uint64, data *type
 	return call.ToTxCandidate()
 }
 
-func (f *DisputeGameContract) addGlobalDataTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+func (f *disputeGameContract) addGlobalDataTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
 	vm, err := f.vm(ctx)
 	if err != nil {
 		return txmgr.TxCandidate{}, err

--- a/op-challenger/game/fault/contracts/outputbisectiongame_test.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestOutputBisectionGameContract_CommonTests(t *testing.T) {
-	runCommonDisputeGameTests(t, func(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameContract) {
+	runCommonDisputeGameTests(t, func(t *testing.T) (*batchingTest.AbiBasedRpc, *disputeGameContract) {
 		stubRpc, contract := setupOutputBisectionGameTest(t)
-		return stubRpc, &contract.DisputeGameContract
+		return stubRpc, &contract.disputeGameContract
 	})
 }
 

--- a/op-challenger/game/fault/contracts/outputbisectiongame_test.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame_test.go
@@ -13,51 +13,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFaultDisputeGameContract_CommonTests(t *testing.T) {
+func TestOutputBisectionGameContract_CommonTests(t *testing.T) {
 	runCommonDisputeGameTests(t, func(t *testing.T) (*batchingTest.AbiBasedRpc, *DisputeGameContract) {
-		stubRpc, contract := setupFaultDisputeGameTest(t)
+		stubRpc, contract := setupOutputBisectionGameTest(t)
 		return stubRpc, &contract.DisputeGameContract
 	})
 }
 
-func TestGetProposals(t *testing.T) {
-	stubRpc, game := setupFaultDisputeGameTest(t)
-	agreedIndex := big.NewInt(5)
-	agreedBlockNum := big.NewInt(6)
-	agreedRoot := common.Hash{0xaa}
-	disputedIndex := big.NewInt(7)
-	disputedBlockNum := big.NewInt(8)
-	disputedRoot := common.Hash{0xdd}
-	agreed := contractProposal{
-		Index:         agreedIndex,
-		L2BlockNumber: agreedBlockNum,
-		OutputRoot:    agreedRoot,
-	}
-	disputed := contractProposal{
-		Index:         disputedIndex,
-		L2BlockNumber: disputedBlockNum,
-		OutputRoot:    disputedRoot,
-	}
-	expectedAgreed := Proposal{
-		L2BlockNumber: agreed.L2BlockNumber,
-		OutputRoot:    agreed.OutputRoot,
-	}
-	expectedDisputed := Proposal{
-		L2BlockNumber: disputed.L2BlockNumber,
-		OutputRoot:    disputed.OutputRoot,
-	}
-	stubRpc.SetResponse(fdgAddr, methodProposals, batching.BlockLatest, []interface{}{}, []interface{}{
-		agreed, disputed,
-	})
-	actualAgreed, actualDisputed, err := game.GetProposals(context.Background())
+func TestGetBlockRange(t *testing.T) {
+	stubRpc, contract := setupOutputBisectionGameTest(t)
+	expectedStart := uint64(65)
+	expectedEnd := uint64(102)
+	stubRpc.SetResponse(fdgAddr, methodGenesisBlockNumber, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(expectedStart)})
+	stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(expectedEnd)})
+	start, end, err := contract.GetBlockRange(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, expectedAgreed, actualAgreed)
-	require.Equal(t, expectedDisputed, actualDisputed)
+	require.Equal(t, expectedStart, start)
+	require.Equal(t, expectedEnd, end)
 }
 
-func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
+func TestGetSplitDepth(t *testing.T) {
+	stubRpc, contract := setupOutputBisectionGameTest(t)
+	expectedSplitDepth := uint64(15)
+	stubRpc.SetResponse(fdgAddr, methodSplitDepth, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(expectedSplitDepth)})
+	splitDepth, err := contract.GetSplitDepth(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expectedSplitDepth, splitDepth)
+}
+
+func TestOutputBisectionGame_UpdateOracleTx(t *testing.T) {
 	t.Run("Local", func(t *testing.T) {
-		stubRpc, game := setupFaultDisputeGameTest(t)
+		stubRpc, game := setupOutputBisectionGameTest(t)
 		data := &faultTypes.PreimageOracleData{
 			IsLocal:      true,
 			LocalContext: common.Hash{0x02},
@@ -68,7 +54,7 @@ func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 		claimIdx := uint64(6)
 		stubRpc.SetResponse(fdgAddr, methodAddLocalData, batching.BlockLatest, []interface{}{
 			data.GetIdent(),
-			data.LocalContext,
+			new(big.Int).SetUint64(claimIdx),
 			new(big.Int).SetUint64(uint64(data.OracleOffset)),
 		}, nil)
 		tx, err := game.UpdateOracleTx(context.Background(), claimIdx, data)
@@ -77,7 +63,7 @@ func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 	})
 
 	t.Run("Global", func(t *testing.T) {
-		stubRpc, game := setupFaultDisputeGameTest(t)
+		stubRpc, game := setupOutputBisectionGameTest(t)
 		data := &faultTypes.PreimageOracleData{
 			IsLocal:      false,
 			OracleKey:    common.Hash{0xbc}.Bytes(),
@@ -97,8 +83,8 @@ func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 	})
 }
 
-func setupFaultDisputeGameTest(t *testing.T) (*batchingTest.AbiBasedRpc, *FaultDisputeGameContract) {
-	fdgAbi, err := bindings.FaultDisputeGameMetaData.GetAbi()
+func setupOutputBisectionGameTest(t *testing.T) (*batchingTest.AbiBasedRpc, *OutputBisectionGameContract) {
+	fdgAbi, err := bindings.OutputBisectionGameMetaData.GetAbi()
 	require.NoError(t, err)
 
 	vmAbi, err := bindings.MIPSMetaData.GetAbi()
@@ -110,7 +96,7 @@ func setupFaultDisputeGameTest(t *testing.T) (*batchingTest.AbiBasedRpc, *FaultD
 	stubRpc.AddContract(vmAddr, vmAbi)
 	stubRpc.AddContract(oracleAddr, oracleAbi)
 	caller := batching.NewMultiCaller(stubRpc, batching.DefaultBatchSize)
-	game, err := NewFaultDisputeGameContract(fdgAddr, caller)
+	game, err := NewOutputBisectionGameContract(fdgAddr, caller)
 	require.NoError(t, err)
 	return stubRpc, game
 }

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -9,10 +9,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -22,10 +20,6 @@ type GameInfo interface {
 	GetStatus(context.Context) (gameTypes.GameStatus, error)
 	GetClaimCount(context.Context) (uint64, error)
 }
-
-// gameValidator checks that the specific game instance is compatible with the configuration.
-// Typically, this is done by verifying the absolute prestate of the game matches the local absolute prestate.
-type gameValidator func(ctx context.Context, gameContract GameContract) error
 
 type GamePlayer struct {
 	act    actor
@@ -42,9 +36,12 @@ type GameContract interface {
 	GetMaxGameDepth(ctx context.Context) (uint64, error)
 }
 
-type contractCreator func(addr common.Address, caller *batching.MultiCaller) (GameContract, error)
+type gameTypeResources interface {
+	Contract() GameContract
+	CreateAccessor(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (types.TraceAccessor, error)
+}
 
-type resourceCreator func(addr common.Address, contract GameContract, gameDepth uint64, dir string) (types.TraceAccessor, gameValidator, error)
+type resourceCreator func(addr common.Address) (gameTypeResources, error)
 
 func NewGamePlayer(
 	ctx context.Context,
@@ -53,16 +50,16 @@ func NewGamePlayer(
 	dir string,
 	addr common.Address,
 	txMgr txmgr.TxManager,
-	client *ethclient.Client,
-	contractCreator contractCreator,
 	creator resourceCreator,
 ) (*GamePlayer, error) {
 	logger = logger.New("game", addr)
 
-	loader, err := contractCreator(addr, batching.NewMultiCaller(client.Client(), batching.DefaultBatchSize))
+	resources, err := creator(addr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create fault dispute game contract wrapper: %w", err)
+		return nil, fmt.Errorf("failed to create game resources: %w", err)
 	}
+
+	loader := resources.Contract()
 
 	status, err := loader.GetStatus(ctx)
 	if err != nil {
@@ -87,13 +84,9 @@ func NewGamePlayer(
 		return nil, fmt.Errorf("failed to fetch the game depth: %w", err)
 	}
 
-	accessor, validator, err := creator(addr, loader, gameDepth, dir)
+	accessor, err := resources.CreateAccessor(ctx, logger, gameDepth, dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace accessor: %w", err)
-	}
-
-	if err := validator(ctx, loader); err != nil {
-		return nil, fmt.Errorf("failed to validate absolute prestate: %w", err)
 	}
 
 	responder, err := responder.NewFaultResponder(logger, txMgr, loader)

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -40,7 +40,7 @@ func RegisterGameTypes(
 	m metrics.Metricer,
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
-	client *ethclient.Client,
+	caller *batching.MultiCaller,
 ) (CloseFunc, error) {
 	var closer CloseFunc
 	var l2Client *ethclient.Client
@@ -53,13 +53,13 @@ func RegisterGameTypes(
 		closer = l2Client.Close
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeOutputCannon) {
-		registerOutputCannon(registry, ctx, logger, m, cfg, txMgr, client, l2Client)
+		registerOutputCannon(registry, ctx, logger, m, cfg, txMgr, caller, l2Client)
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeCannon) {
-		registerCannon(registry, ctx, logger, m, cfg, txMgr, client, l2Client)
+		registerCannon(registry, ctx, logger, m, cfg, txMgr, caller, l2Client)
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeAlphabet) {
-		registerAlphabet(registry, ctx, logger, m, cfg, txMgr, client)
+		registerAlphabet(registry, ctx, logger, m, cfg, txMgr, caller)
 	}
 	return closer, nil
 }
@@ -71,34 +71,51 @@ func registerOutputCannon(
 	m metrics.Metricer,
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
-	client *ethclient.Client,
+	caller *batching.MultiCaller,
 	l2Client cannon.L2HeaderSource) {
-	// Currently still using the old fault dispute game contracts for output_cannon
-	contractCreator := func(addr common.Address, caller *batching.MultiCaller) (GameContract, error) {
-		return contracts.NewFaultDisputeGameContract(addr, caller)
-	}
-	resourceCreator := func(addr common.Address, genericContract GameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
-		logger := logger.New("game", addr)
-		contract := genericContract.(*contracts.FaultDisputeGameContract)
-		// TODO(client-pod#43): Updated contracts should expose this as the pre and post state blocks
-		agreed, disputed, err := contract.GetProposals(ctx)
+	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
+		// Currently still using the old fault dispute game contracts for output_cannon
+		// as the output bisection+cannon contract isn't being deployed.
+		contract, err := contracts.NewFaultDisputeGameContract(addr, caller)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		accessor, err := outputs.NewOutputCannonTraceAccessor(ctx, logger, m, cfg, l2Client, contract, dir, gameDepth, agreed.L2BlockNumber.Uint64(), disputed.L2BlockNumber.Uint64())
-		if err != nil {
-			return nil, nil, err
-		}
-		// TODO(client-pod#44): Validate absolute pre-state for split games
-		noopValidator := func(ctx context.Context, gameContract GameContract) error {
-			return nil
-		}
-		return accessor, noopValidator, nil
+		return &outputCannonResources{
+			m:        m,
+			cfg:      cfg,
+			l2Client: l2Client,
+			contract: contract,
+		}, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, contractCreator, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
 	}
 	registry.RegisterGameType(outputCannonGameType, playerCreator)
+}
+
+type outputCannonResources struct {
+	m        metrics.Metricer
+	cfg      *config.Config
+	l2Client cannon.L2HeaderSource
+	contract *contracts.FaultDisputeGameContract
+}
+
+func (r *outputCannonResources) Contract() GameContract {
+	return r.contract
+}
+
+func (r *outputCannonResources) CreateAccessor(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
+	// TODO(client-pod#44): Validate absolute pre-state for split games
+	// TODO(client-pod#43): Updated contracts should expose this as the pre and post state blocks
+	agreed, disputed, err := r.contract.GetProposals(ctx)
+	if err != nil {
+		return nil, err
+	}
+	accessor, err := outputs.NewOutputCannonTraceAccessor(ctx, logger, r.m, r.cfg, r.l2Client, r.contract, dir, gameDepth, agreed.L2BlockNumber.Uint64(), disputed.L2BlockNumber.Uint64())
+	if err != nil {
+		return nil, err
+	}
+	return accessor, nil
 }
 
 func registerCannon(
@@ -108,28 +125,47 @@ func registerCannon(
 	m metrics.Metricer,
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
-	client *ethclient.Client,
+	caller *batching.MultiCaller,
 	l2Client cannon.L2HeaderSource) {
-	contractCreator := func(addr common.Address, caller *batching.MultiCaller) (GameContract, error) {
-		return contracts.NewFaultDisputeGameContract(addr, caller)
-	}
-	resourceCreator := func(addr common.Address, genericContract GameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
-		logger := logger.New("game", addr)
-		contract := genericContract.(*contracts.FaultDisputeGameContract)
-		localInputs, err := cannon.FetchLocalInputs(ctx, contract, l2Client)
+	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
+		contract, err := contracts.NewFaultDisputeGameContract(addr, caller)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
+			return nil, err
 		}
-		provider := cannon.NewTraceProvider(logger, m, cfg, faultTypes.NoLocalContext, localInputs, dir, gameDepth)
-		validator := func(ctx context.Context, contract GameContract) error {
-			return ValidateAbsolutePrestate(ctx, provider, contract.(*contracts.FaultDisputeGameContract))
-		}
-		return trace.NewSimpleTraceAccessor(provider), validator, nil
+		return &cannonResources{
+			m:        m,
+			cfg:      cfg,
+			l2Client: l2Client,
+			contract: contract,
+		}, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, contractCreator, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
 	}
 	registry.RegisterGameType(cannonGameType, playerCreator)
+}
+
+type cannonResources struct {
+	m        metrics.Metricer
+	cfg      *config.Config
+	l2Client cannon.L2HeaderSource
+	contract *contracts.FaultDisputeGameContract
+}
+
+func (r *cannonResources) Contract() GameContract {
+	return r.contract
+}
+
+func (r *cannonResources) CreateAccessor(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
+	localInputs, err := cannon.FetchLocalInputs(ctx, r.contract, r.l2Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
+	}
+	provider := cannon.NewTraceProvider(logger, r.m, r.cfg, faultTypes.NoLocalContext, localInputs, dir, gameDepth)
+	if err := ValidateAbsolutePrestate(ctx, provider, r.contract); err != nil {
+		return nil, err
+	}
+	return trace.NewSimpleTraceAccessor(provider), nil
 }
 
 func registerAlphabet(
@@ -139,19 +175,36 @@ func registerAlphabet(
 	m metrics.Metricer,
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
-	client *ethclient.Client) {
-	contractCreator := func(addr common.Address, caller *batching.MultiCaller) (GameContract, error) {
-		return contracts.NewFaultDisputeGameContract(addr, caller)
-	}
-	resourceCreator := func(addr common.Address, contract GameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
-		provider := alphabet.NewTraceProvider(cfg.AlphabetTrace, gameDepth)
-		validator := func(ctx context.Context, contract GameContract) error {
-			return ValidateAbsolutePrestate(ctx, provider, contract.(*contracts.FaultDisputeGameContract))
+	caller *batching.MultiCaller) {
+	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
+		contract, err := contracts.NewFaultDisputeGameContract(addr, caller)
+		if err != nil {
+			return nil, err
 		}
-		return trace.NewSimpleTraceAccessor(provider), validator, nil
+		return &alphabetResources{
+			cfg:      cfg,
+			contract: contract,
+		}, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, contractCreator, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
 	}
 	registry.RegisterGameType(alphabetGameType, playerCreator)
+}
+
+type alphabetResources struct {
+	cfg      *config.Config
+	contract *contracts.FaultDisputeGameContract
+}
+
+func (r *alphabetResources) Contract() GameContract {
+	return r.contract
+}
+
+func (r *alphabetResources) CreateAccessor(ctx context.Context, _ log.Logger, gameDepth uint64, _ string) (faultTypes.TraceAccessor, error) {
+	provider := alphabet.NewTraceProvider(r.cfg.AlphabetTrace, gameDepth)
+	if err := ValidateAbsolutePrestate(ctx, provider, r.contract); err != nil {
+		return nil, err
+	}
+	return trace.NewSimpleTraceAccessor(provider), nil
 }

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -72,8 +73,13 @@ func registerOutputCannon(
 	txMgr txmgr.TxManager,
 	client *ethclient.Client,
 	l2Client cannon.L2HeaderSource) {
-	resourceCreator := func(addr common.Address, contract *contracts.FaultDisputeGameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
+	// Currently still using the old fault dispute game contracts for output_cannon
+	contractCreator := func(addr common.Address, caller *batching.MultiCaller) (GameContract, error) {
+		return contracts.NewFaultDisputeGameContract(addr, caller)
+	}
+	resourceCreator := func(addr common.Address, genericContract GameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
 		logger := logger.New("game", addr)
+		contract := genericContract.(*contracts.FaultDisputeGameContract)
 		// TODO(client-pod#43): Updated contracts should expose this as the pre and post state blocks
 		agreed, disputed, err := contract.GetProposals(ctx)
 		if err != nil {
@@ -84,13 +90,13 @@ func registerOutputCannon(
 			return nil, nil, err
 		}
 		// TODO(client-pod#44): Validate absolute pre-state for split games
-		noopValidator := func(ctx context.Context, gameContract *contracts.FaultDisputeGameContract) error {
+		noopValidator := func(ctx context.Context, gameContract GameContract) error {
 			return nil
 		}
 		return accessor, noopValidator, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, contractCreator, resourceCreator)
 	}
 	registry.RegisterGameType(outputCannonGameType, playerCreator)
 }
@@ -104,20 +110,24 @@ func registerCannon(
 	txMgr txmgr.TxManager,
 	client *ethclient.Client,
 	l2Client cannon.L2HeaderSource) {
-	resourceCreator := func(addr common.Address, contract *contracts.FaultDisputeGameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
+	contractCreator := func(addr common.Address, caller *batching.MultiCaller) (GameContract, error) {
+		return contracts.NewFaultDisputeGameContract(addr, caller)
+	}
+	resourceCreator := func(addr common.Address, genericContract GameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
 		logger := logger.New("game", addr)
+		contract := genericContract.(*contracts.FaultDisputeGameContract)
 		localInputs, err := cannon.FetchLocalInputs(ctx, contract, l2Client)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
 		}
 		provider := cannon.NewTraceProvider(logger, m, cfg, faultTypes.NoLocalContext, localInputs, dir, gameDepth)
-		validator := func(ctx context.Context, contract *contracts.FaultDisputeGameContract) error {
-			return ValidateAbsolutePrestate(ctx, provider, contract)
+		validator := func(ctx context.Context, contract GameContract) error {
+			return ValidateAbsolutePrestate(ctx, provider, contract.(*contracts.FaultDisputeGameContract))
 		}
 		return trace.NewSimpleTraceAccessor(provider), validator, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, contractCreator, resourceCreator)
 	}
 	registry.RegisterGameType(cannonGameType, playerCreator)
 }
@@ -130,15 +140,18 @@ func registerAlphabet(
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
 	client *ethclient.Client) {
-	resourceCreator := func(addr common.Address, contract *contracts.FaultDisputeGameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
+	contractCreator := func(addr common.Address, caller *batching.MultiCaller) (GameContract, error) {
+		return contracts.NewFaultDisputeGameContract(addr, caller)
+	}
+	resourceCreator := func(addr common.Address, contract GameContract, gameDepth uint64, dir string) (faultTypes.TraceAccessor, gameValidator, error) {
 		provider := alphabet.NewTraceProvider(cfg.AlphabetTrace, gameDepth)
-		validator := func(ctx context.Context, contract *contracts.FaultDisputeGameContract) error {
-			return ValidateAbsolutePrestate(ctx, provider, contract)
+		validator := func(ctx context.Context, contract GameContract) error {
+			return ValidateAbsolutePrestate(ctx, provider, contract.(*contracts.FaultDisputeGameContract))
 		}
 		return trace.NewSimpleTraceAccessor(provider), validator, nil
 	}
 	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, resourceCreator)
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, client, contractCreator, resourceCreator)
 	}
 	registry.RegisterGameType(alphabetGameType, playerCreator)
 }

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -21,7 +21,7 @@ type GameContract interface {
 	AttackTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error)
 	DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error)
 	StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error)
-	UpdateOracleTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error)
+	UpdateOracleTx(ctx context.Context, claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error)
 }
 
 // FaultResponder implements the [Responder] interface to send onchain transactions.
@@ -75,7 +75,7 @@ func (r *FaultResponder) ResolveClaim(ctx context.Context, claimIdx uint64) erro
 func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action) error {
 	if action.OracleData != nil {
 		r.log.Info("Updating oracle data", "key", action.OracleData.OracleKey)
-		candidate, err := r.contract.UpdateOracleTx(ctx, action.OracleData)
+		candidate, err := r.contract.UpdateOracleTx(ctx, uint64(action.ParentIdx), action.OracleData)
 		if err != nil {
 			return fmt.Errorf("failed to create pre-image oracle tx: %w", err)
 		}

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -188,6 +188,7 @@ func TestPerformAction(t *testing.T) {
 
 		require.Len(t, mockTxMgr.sent, 2)
 		require.EqualValues(t, action.OracleData, contract.updateOracleArgs)
+		require.EqualValues(t, action.ParentIdx, contract.updateOracleClaimIdx)
 		require.EqualValues(t, []interface{}{uint64(action.ParentIdx), action.IsAttack, action.PreState, action.ProofData}, contract.stepArgs)
 		// Important that the oracle is updated first
 		require.Equal(t, ([]byte)("updateOracle"), mockTxMgr.sent[0].TxData)
@@ -236,12 +237,13 @@ func (m *mockTxManager) Close() {
 }
 
 type mockContract struct {
-	calls            int
-	callFails        bool
-	attackArgs       []interface{}
-	defendArgs       []interface{}
-	stepArgs         []interface{}
-	updateOracleArgs *types.PreimageOracleData
+	calls                int
+	callFails            bool
+	attackArgs           []interface{}
+	defendArgs           []interface{}
+	stepArgs             []interface{}
+	updateOracleClaimIdx uint64
+	updateOracleArgs     *types.PreimageOracleData
 }
 
 func (m *mockContract) CallResolve(_ context.Context) (gameTypes.GameStatus, error) {
@@ -283,7 +285,8 @@ func (m *mockContract) StepTx(claimIdx uint64, isAttack bool, stateData []byte, 
 	return txmgr.TxCandidate{TxData: ([]byte)("step")}, nil
 }
 
-func (m *mockContract) UpdateOracleTx(_ context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+func (m *mockContract) UpdateOracleTx(_ context.Context, claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+	m.updateOracleClaimIdx = claimIdx
 	m.updateOracleArgs = data
 	return txmgr.TxCandidate{TxData: ([]byte)("updateOracle")}, nil
 }

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -22,7 +22,7 @@ func NewOutputCannonTraceAccessor(
 	m metrics.Metricer,
 	cfg *config.Config,
 	l2Client cannon.L2HeaderSource,
-	contract *contracts.FaultDisputeGameContract,
+	contract cannon.L1HeadSource,
 	dir string,
 	gameDepth uint64,
 	prestateBlock uint64,

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -168,7 +168,8 @@ func (s *Service) initGameLoader(cfg *config.Config) error {
 
 func (s *Service) initScheduler(ctx context.Context, cfg *config.Config) error {
 	gameTypeRegistry := registry.NewGameTypeRegistry()
-	closer, err := fault.RegisterGameTypes(gameTypeRegistry, ctx, s.logger, s.metrics, cfg, s.txMgr, s.l1Client)
+	caller := batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize)
+	closer, err := fault.RegisterGameTypes(gameTypeRegistry, ctx, s.logger, s.metrics, cfg, s.txMgr, caller)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description**

The diff makes this look bigger than it is. 😄 

Moves most of the functionality from `FaultDisputeGameContract` to `disputeGameContract` to provide the functionality common to both contract types.  `FaultDisputeGameContract` now extends it and adds just the methods specific to the older game contracts.

Introduces `OutputBisectionGameContract` which extends `disputeGameContract` and adds the output bisection specific methods.

Provide the `claimIdx` that oracle data is being used with when calling the contract since it's needed for `OutputBisectionGameContract`.  The adapters still provide a unified API to the rest of the challenger to enable code reuse.

Adjust game registration code so that the contract bindings can be different for different game types. Currently `output_cannon` games still use the old `FaultDisputeGameContract` wrapper because the new `OutputBisectionGameContract` hasn't been deployed for the cannon VM yet and e2e tests haven't been updated to handle the new contract type.

**Tests**

Added new tests for the `OutputBisectionGameContract` wrapper. Existing tests cover the refactoring.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/246
- Hooking up the new contract type is still covered by https://github.com/ethereum-optimism/client-pod/issues/43
