### PR TITLE
op-e2e: Improve e2e test for span batches

### DIFF
--- a/op-e2e/actions/l2_batcher.go
+++ b/op-e2e/actions/l2_batcher.go
@@ -44,6 +44,9 @@ type BatcherCfg struct {
 	BatcherKey *ecdsa.PrivateKey
 
 	GarbageCfg *GarbageChannelCfg
+
+	ForceSubmitSingularBatch bool
+	ForceSubmitSpanBatch     bool
 }
 
 type L2BlockRefs interface {
@@ -157,7 +160,13 @@ func (s *L2Batcher) Buffer(t Testing) error {
 
 			var batchType uint = derive.SingularBatchType
 			var spanBatchBuilder *derive.SpanBatchBuilder = nil
-			if s.rollupCfg.IsDelta(block.Time()) {
+
+			if s.l2BatcherCfg.ForceSubmitSingularBatch && s.l2BatcherCfg.ForceSubmitSpanBatch {
+				t.Fatalf("ForceSubmitSingularBatch and ForceSubmitSpanBatch cannot be set to true at the same time")
+			} else if s.l2BatcherCfg.ForceSubmitSingularBatch {
+				// use SingularBatchType
+			} else if s.l2BatcherCfg.ForceSubmitSpanBatch || s.rollupCfg.IsDelta(block.Time()) {
+				// If both ForceSubmitSingularBatch and ForceSubmitSpanbatch are false, use SpanBatch automatically if Delta HF is activated.
 				batchType = derive.SpanBatchType
 				spanBatchBuilder = derive.NewSpanBatchBuilder(s.rollupCfg.Genesis.L2Time, s.rollupCfg.L2ChainID)
 			}

--- a/op-e2e/actions/span_batch_test.go
+++ b/op-e2e/actions/span_batch_test.go
@@ -586,3 +586,143 @@ func TestSpanBatchLowThroughputChain(gt *testing.T) {
 	require.Equal(t, verifier.L2Unsafe(), verifier.L2Safe())
 	require.Equal(t, sequencer.L2Safe(), verifier.L2Safe())
 }
+
+func TestBatchEquivalence(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	log := testlog.Logger(t, log.LvlError)
+
+	p := &e2eutils.TestParams{
+		MaxSequencerDrift:   20, // larger than L1 block time we simulate in this test (12)
+		SequencerWindowSize: 24,
+		ChannelTimeout:      20,
+		L1BlockTime:         12,
+	}
+	// Delta activated deploy config
+	dp := e2eutils.MakeDeployParams(t, p)
+	minTs := hexutil.Uint64(0)
+	dp.DeployConfig.L2GenesisDeltaTimeOffset = &minTs
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+
+	// Delta deactivated deploy config
+	//dp2 := e2eutils.MakeDeployParams(t, p)
+	//dp2.DeployConfig.L2GenesisDeltaTimeOffset = nil
+	//sd2 := sd
+	//sd2.RollupCfg.Genesis = sd.RollupCfg.Genesis
+	rcfg2 := *sd.RollupCfg
+	rcfg2.DeltaTime = nil
+	sd2 := &e2eutils.SetupData{
+		L1Cfg:         sd.L1Cfg,
+		L2Cfg:         sd.L2Cfg,
+		RollupCfg:     &rcfg2,
+		DeploymentsL1: sd.DeploymentsL1,
+	}
+
+	// Setup sequencer
+	miner, seqEngine, sequencer := setupSequencerTest(t, sd, log)
+	rollupSeqCl := sequencer.RollupClient()
+	seqEngCl := seqEngine.EthClient()
+
+	// Setup Delta activated verifier
+	_, verifier := setupVerifier(t, sd, log, miner.L1Client(t, sd.RollupCfg), &sync.Config{})
+
+	// Setup Delta deactivated verifier
+	_, verifier2 := setupVerifier(t, sd2, log, miner.L1Client(t, sd2.RollupCfg), &sync.Config{})
+
+	// Setup Delta activated batcher
+	batcher := NewL2Batcher(log, sd.RollupCfg, &BatcherCfg{
+		MinL1TxSize: 0,
+		MaxL1TxSize: 128_000,
+		BatcherKey:  dp.Secrets.Batcher,
+	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
+
+	// Setup Delta deactivated batcher
+	batcher2 := NewL2Batcher(log, sd2.RollupCfg, &BatcherCfg{
+		MinL1TxSize: 0,
+		MaxL1TxSize: 128_000,
+		BatcherKey:  dp.Secrets.Batcher,
+	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd2.RollupCfg))
+
+	const numTestUsers = 5
+	var privKeys [numTestUsers]*ecdsa.PrivateKey
+	var addrs [numTestUsers]common.Address
+	for i := 0; i < numTestUsers; i++ {
+		// Create a new test account
+		privateKey, err := dp.Secrets.Wallet.PrivateKey(accounts.Account{
+			URL: accounts.URL{
+				Path: fmt.Sprintf("m/44'/60'/0'/0/%d", 10+i),
+			},
+		})
+		privKeys[i] = privateKey
+		addr := crypto.PubkeyToAddress(privateKey.PublicKey)
+		require.NoError(t, err)
+		addrs[i] = addr
+	}
+
+	miner.ActEmptyBlock(t)
+	sequencer.ActL1HeadSignal(t)
+	sequencer.ActL2PipelineFull(t)
+	totalTxCount := 0
+	// Build random blocks
+	for sequencer.derivation.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
+		sequencer.ActL2StartBlock(t)
+		// fill the block with random number of L2 txs
+		for j := 0; j < rand.Intn(3); j++ {
+			userIdx := totalTxCount % numTestUsers
+			signer := types.LatestSigner(sd.L2Cfg.Config)
+			data := make([]byte, rand.Intn(100))
+			_, err := crand.Read(data[:]) // fill with random bytes
+			require.NoError(t, err)
+			gas, err := core.IntrinsicGas(data, nil, false, true, true, false)
+			require.NoError(t, err)
+			baseFee := seqEngine.l2Chain.CurrentBlock().BaseFee
+			nonce, err := seqEngCl.PendingNonceAt(t.Ctx(), addrs[userIdx])
+			require.NoError(t, err)
+			tx := types.MustSignNewTx(privKeys[userIdx], signer, &types.DynamicFeeTx{
+				ChainID:   sd.L2Cfg.Config.ChainID,
+				Nonce:     nonce,
+				GasTipCap: big.NewInt(2 * params.GWei),
+				GasFeeCap: new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(2)), big.NewInt(2*params.GWei)),
+				Gas:       gas,
+				To:        &dp.Addresses.Bob,
+				Value:     big.NewInt(0),
+				Data:      data,
+			})
+			require.NoError(gt, seqEngCl.SendTransaction(t.Ctx(), tx))
+			seqEngine.ActL2IncludeTx(addrs[userIdx])(t)
+			totalTxCount += 1
+		}
+		sequencer.ActL2EndBlock(t)
+	}
+
+	// Submit SpanBatch
+	batcher.ActSubmitAll(t)
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
+	miner.ActL1EndBlock(t)
+
+	// Run derivation pipeline for verifiers
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+	verifier2.ActL1HeadSignal(t)
+	verifier2.ActL2PipelineFull(t)
+
+	// Delta activated verifier must be synced
+	require.Equal(t, verifier.L2Safe(), sequencer.L2Unsafe())
+	// Delta deactivated verifier could not derive SpanBatch
+	require.Equal(t, verifier2.L2Safe().Number, uint64(0))
+
+	// Submit SingularBatches
+	batcher2.ActSubmitAll(t)
+	miner.ActL1StartBlock(12)(t)
+	miner.ActL1IncludeTx(dp.Addresses.Batcher)(t)
+	miner.ActL1EndBlock(t)
+
+	// Run derivation pipeline for verifiers
+	verifier.ActL1HeadSignal(t)
+	verifier.ActL2PipelineFull(t)
+	verifier2.ActL1HeadSignal(t)
+	verifier2.ActL2PipelineFull(t)
+
+	// Delta deactivated verifier must be synced
+	require.Equal(t, verifier.L2Safe(), verifier2.L2Safe())
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds new e2e tests for span batches as discussed in [the testing plan](https://github.com/ethereum-optimism/optimism/issues/7731#issuecomment-1769787171) & failure modes discussion

**New test cases**
- `TestHardforkMiddleOfSpanBatch`: The behavior when the span batch starts prior to the fork activating and is completed after the fork activates.
- `TestMixOfBatchesAfterHardfork`: The behavior when there is a mix of singular batches and span batches after hard fork.
- `TestBatchEquivalence`: Batch submission and derivation pipeline work equivalently for both singular batch and span batch. i.e. generates the same blocks as a result of derivation.

**New checks**
- Check if the derivation pipeline generates same blocks as the unsafe blocks, i.e. there's no reorg during span batch derivation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Implemented new tests to ensure system stability and correct behavior during and after the Delta hardfork, with a focus on batch submissions and block confirmations.

- **Documentation**
  - Updated test documentation to reflect new scenarios and expected outcomes for system behavior during hardfork conditions.

- **Chores**
  - Enhanced configuration structures to support new testing scenarios, ensuring thorough evaluation of system resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->