### PR TITLE
fix(ctb): readd type field to storageLayout snapshot

### DIFF
--- a/packages/contracts-bedrock/scripts/generate-snapshots.ts
+++ b/packages/contracts-bedrock/scripts/generate-snapshots.ts
@@ -48,6 +48,7 @@ type AbiSpecStorageLayoutEntry = {
   slot: number
   offset: number
   bytes: number
+  type: string
 }
 const sortKeys = (obj: any) => {
   if (typeof obj !== 'object' || obj === null) {
@@ -122,6 +123,7 @@ const main = async () => {
           bytes: typ.numberOfBytes,
           offset: storageEntry.offset,
           slot: storageEntry.slot,
+          type: typ.label,
         })
       }
 

--- a/packages/contracts-bedrock/snapshots/storageLayout/AddressManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/AddressManager.json
@@ -3,12 +3,14 @@
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "addresses",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(bytes32 => address)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/AssetReceiver.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/AssetReceiver.json
@@ -3,6 +3,7 @@
     "bytes": "20",
     "label": "owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/AttestationStation.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/AttestationStation.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "attestations",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => mapping(address => mapping(bytes32 => bytes)))"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/BaseFeeVault.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/BaseFeeVault.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "totalProcessed",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/BlockOracle.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/BlockOracle.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "blocks",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(uint256 => struct BlockOracle.BlockInfo)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/CrossDomainMessengerLegacySpacer0.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/CrossDomainMessengerLegacySpacer0.json
@@ -3,6 +3,7 @@
     "bytes": "20",
     "label": "spacer_0_0_20",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/CrossDomainMessengerLegacySpacer1.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/CrossDomainMessengerLegacySpacer1.json
@@ -3,54 +3,63 @@
     "bytes": "1600",
     "label": "spacer_1_0_1600",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256[50]"
   },
   {
     "bytes": "20",
     "label": "spacer_51_0_20",
     "offset": 0,
-    "slot": "50"
+    "slot": "50",
+    "type": "address"
   },
   {
     "bytes": "1568",
     "label": "spacer_52_0_1568",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "uint256[49]"
   },
   {
     "bytes": "1",
     "label": "spacer_101_0_1",
     "offset": 0,
-    "slot": "100"
+    "slot": "100",
+    "type": "bool"
   },
   {
     "bytes": "1568",
     "label": "spacer_102_0_1568",
     "offset": 0,
-    "slot": "101"
+    "slot": "101",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "spacer_151_0_32",
     "offset": 0,
-    "slot": "150"
+    "slot": "150",
+    "type": "uint256"
   },
   {
     "bytes": "1568",
     "label": "spacer_152_0_1568",
     "offset": 0,
-    "slot": "151"
+    "slot": "151",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "spacer_201_0_32",
     "offset": 0,
-    "slot": "200"
+    "slot": "200",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "32",
     "label": "spacer_202_0_32",
     "offset": 0,
-    "slot": "201"
+    "slot": "201",
+    "type": "mapping(bytes32 => bool)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/DelayedVetoable.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/DelayedVetoable.json
@@ -3,12 +3,14 @@
     "bytes": "32",
     "label": "_delay",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "_queuedAt",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(bytes32 => uint256)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/DeployerWhitelist.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/DeployerWhitelist.json
@@ -3,12 +3,14 @@
     "bytes": "20",
     "label": "owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "whitelist",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => bool)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/DisputeGameFactory.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/DisputeGameFactory.json
@@ -3,48 +3,56 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[50]"
   },
   {
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "address"
   },
   {
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "gameImpls",
     "offset": 0,
-    "slot": "101"
+    "slot": "101",
+    "type": "mapping(GameType => contract IDisputeGame)"
   },
   {
     "bytes": "32",
     "label": "_disputeGames",
     "offset": 0,
-    "slot": "102"
+    "slot": "102",
+    "type": "mapping(Hash => GameId)"
   },
   {
     "bytes": "32",
     "label": "_disputeGameList",
     "offset": 0,
-    "slot": "103"
+    "slot": "103",
+    "type": "GameId[]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/Drippie.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/Drippie.json
@@ -3,12 +3,14 @@
     "bytes": "20",
     "label": "owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "drips",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(string => struct Drippie.DripState)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/EAS.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/EAS.json
@@ -3,36 +3,42 @@
     "bytes": "32",
     "label": "_nonces",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "_db",
     "offset": 0,
-    "slot": "50"
+    "slot": "50",
+    "type": "mapping(bytes32 => struct Attestation)"
   },
   {
     "bytes": "32",
     "label": "_timestamps",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "mapping(bytes32 => uint64)"
   },
   {
     "bytes": "32",
     "label": "_revocationsOffchain",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "mapping(address => mapping(bytes32 => uint64))"
   },
   {
     "bytes": "1504",
     "label": "__gap",
     "offset": 0,
-    "slot": "53"
+    "slot": "53",
+    "type": "uint256[47]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/Faucet.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/Faucet.json
@@ -3,18 +3,21 @@
     "bytes": "32",
     "label": "modules",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(contract IFaucetAuthModule => struct Faucet.ModuleConfig)"
   },
   {
     "bytes": "32",
     "label": "timeouts",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(contract IFaucetAuthModule => mapping(bytes32 => uint256))"
   },
   {
     "bytes": "32",
     "label": "nonces",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "mapping(bytes32 => mapping(bytes32 => bool))"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/FaultDisputeGame.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/FaultDisputeGame.json
@@ -3,54 +3,63 @@
     "bytes": "8",
     "label": "createdAt",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "Timestamp"
   },
   {
     "bytes": "1",
     "label": "status",
     "offset": 8,
-    "slot": "0"
+    "slot": "0",
+    "type": "enum GameStatus"
   },
   {
     "bytes": "20",
     "label": "bondManager",
     "offset": 9,
-    "slot": "0"
+    "slot": "0",
+    "type": "contract IBondManager"
   },
   {
     "bytes": "32",
     "label": "l1Head",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "Hash"
   },
   {
     "bytes": "32",
     "label": "claimData",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "struct IFaultDisputeGame.ClaimData[]"
   },
   {
     "bytes": "128",
     "label": "proposals",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "struct IFaultDisputeGame.OutputProposals"
   },
   {
     "bytes": "32",
     "label": "claims",
     "offset": 0,
-    "slot": "7"
+    "slot": "7",
+    "type": "mapping(ClaimHash => bool)"
   },
   {
     "bytes": "32",
     "label": "subgames",
     "offset": 0,
-    "slot": "8"
+    "slot": "8",
+    "type": "mapping(uint256 => uint256[])"
   },
   {
     "bytes": "1",
     "label": "subgameAtRootResolved",
     "offset": 0,
-    "slot": "9"
+    "slot": "9",
+    "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/GovernanceToken.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/GovernanceToken.json
@@ -3,66 +3,77 @@
     "bytes": "32",
     "label": "_balances",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "_allowances",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => mapping(address => uint256))"
   },
   {
     "bytes": "32",
     "label": "_totalSupply",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "_name",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_symbol",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_nonces",
     "offset": 0,
-    "slot": "5"
+    "slot": "5",
+    "type": "mapping(address => struct Counters.Counter)"
   },
   {
     "bytes": "32",
     "label": "_PERMIT_TYPEHASH_DEPRECATED_SLOT",
     "offset": 0,
-    "slot": "6"
+    "slot": "6",
+    "type": "bytes32"
   },
   {
     "bytes": "32",
     "label": "_delegates",
     "offset": 0,
-    "slot": "7"
+    "slot": "7",
+    "type": "mapping(address => address)"
   },
   {
     "bytes": "32",
     "label": "_checkpoints",
     "offset": 0,
-    "slot": "8"
+    "slot": "8",
+    "type": "mapping(address => struct ERC20Votes.Checkpoint[])"
   },
   {
     "bytes": "32",
     "label": "_totalSupplyCheckpoints",
     "offset": 0,
-    "slot": "9"
+    "slot": "9",
+    "type": "struct ERC20Votes.Checkpoint[]"
   },
   {
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "10"
+    "slot": "10",
+    "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1Block.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1Block.json
@@ -3,48 +3,56 @@
     "bytes": "8",
     "label": "number",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint64"
   },
   {
     "bytes": "8",
     "label": "timestamp",
     "offset": 8,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint64"
   },
   {
     "bytes": "32",
     "label": "basefee",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "hash",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "bytes32"
   },
   {
     "bytes": "8",
     "label": "sequenceNumber",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "uint64"
   },
   {
     "bytes": "32",
     "label": "batcherHash",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "bytes32"
   },
   {
     "bytes": "32",
     "label": "l1FeeOverhead",
     "offset": 0,
-    "slot": "5"
+    "slot": "5",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "l1FeeScalar",
     "offset": 0,
-    "slot": "6"
+    "slot": "6",
+    "type": "uint256"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1CrossDomainMessenger.json
@@ -3,108 +3,126 @@
     "bytes": "20",
     "label": "spacer_0_0_20",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "1",
     "label": "_initialized",
     "offset": 20,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 21,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "1600",
     "label": "spacer_1_0_1600",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[50]"
   },
   {
     "bytes": "20",
     "label": "spacer_51_0_20",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "address"
   },
   {
     "bytes": "1568",
     "label": "spacer_52_0_1568",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "uint256[49]"
   },
   {
     "bytes": "1",
     "label": "spacer_101_0_1",
     "offset": 0,
-    "slot": "101"
+    "slot": "101",
+    "type": "bool"
   },
   {
     "bytes": "1568",
     "label": "spacer_102_0_1568",
     "offset": 0,
-    "slot": "102"
+    "slot": "102",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "spacer_151_0_32",
     "offset": 0,
-    "slot": "151"
+    "slot": "151",
+    "type": "uint256"
   },
   {
     "bytes": "1568",
     "label": "spacer_152_0_1568",
     "offset": 0,
-    "slot": "152"
+    "slot": "152",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "spacer_201_0_32",
     "offset": 0,
-    "slot": "201"
+    "slot": "201",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "32",
     "label": "spacer_202_0_32",
     "offset": 0,
-    "slot": "202"
+    "slot": "202",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "32",
     "label": "successfulMessages",
     "offset": 0,
-    "slot": "203"
+    "slot": "203",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "20",
     "label": "xDomainMsgSender",
     "offset": 0,
-    "slot": "204"
+    "slot": "204",
+    "type": "address"
   },
   {
     "bytes": "30",
     "label": "msgNonce",
     "offset": 0,
-    "slot": "205"
+    "slot": "205",
+    "type": "uint240"
   },
   {
     "bytes": "32",
     "label": "failedMessages",
     "offset": 0,
-    "slot": "206"
+    "slot": "206",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "1408",
     "label": "__gap",
     "offset": 0,
-    "slot": "207"
+    "slot": "207",
+    "type": "uint256[44]"
   },
   {
     "bytes": "20",
     "label": "superchainConfig",
     "offset": 0,
-    "slot": "251"
+    "slot": "251",
+    "type": "contract SuperchainConfig"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1ERC721Bridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1ERC721Bridge.json
@@ -3,12 +3,14 @@
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "deposits",
     "offset": 0,
-    "slot": "49"
+    "slot": "49",
+    "type": "mapping(address => mapping(address => mapping(uint256 => bool)))"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1FeeVault.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1FeeVault.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "totalProcessed",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
@@ -3,24 +3,28 @@
     "bytes": "20",
     "label": "spacer_0_0_20",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "20",
     "label": "spacer_1_0_20",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "deposits",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "mapping(address => mapping(address => uint256))"
   },
   {
     "bytes": "1504",
     "label": "__gap",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "uint256[47]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L2CrossDomainMessenger.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L2CrossDomainMessenger.json
@@ -3,102 +3,119 @@
     "bytes": "20",
     "label": "spacer_0_0_20",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "1",
     "label": "_initialized",
     "offset": 20,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 21,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "1600",
     "label": "spacer_1_0_1600",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[50]"
   },
   {
     "bytes": "20",
     "label": "spacer_51_0_20",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "address"
   },
   {
     "bytes": "1568",
     "label": "spacer_52_0_1568",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "uint256[49]"
   },
   {
     "bytes": "1",
     "label": "spacer_101_0_1",
     "offset": 0,
-    "slot": "101"
+    "slot": "101",
+    "type": "bool"
   },
   {
     "bytes": "1568",
     "label": "spacer_102_0_1568",
     "offset": 0,
-    "slot": "102"
+    "slot": "102",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "spacer_151_0_32",
     "offset": 0,
-    "slot": "151"
+    "slot": "151",
+    "type": "uint256"
   },
   {
     "bytes": "1568",
     "label": "spacer_152_0_1568",
     "offset": 0,
-    "slot": "152"
+    "slot": "152",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "spacer_201_0_32",
     "offset": 0,
-    "slot": "201"
+    "slot": "201",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "32",
     "label": "spacer_202_0_32",
     "offset": 0,
-    "slot": "202"
+    "slot": "202",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "32",
     "label": "successfulMessages",
     "offset": 0,
-    "slot": "203"
+    "slot": "203",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "20",
     "label": "xDomainMsgSender",
     "offset": 0,
-    "slot": "204"
+    "slot": "204",
+    "type": "address"
   },
   {
     "bytes": "30",
     "label": "msgNonce",
     "offset": 0,
-    "slot": "205"
+    "slot": "205",
+    "type": "uint240"
   },
   {
     "bytes": "32",
     "label": "failedMessages",
     "offset": 0,
-    "slot": "206"
+    "slot": "206",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "1408",
     "label": "__gap",
     "offset": 0,
-    "slot": "207"
+    "slot": "207",
+    "type": "uint256[44]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L2ERC721Bridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L2ERC721Bridge.json
@@ -3,6 +3,7 @@
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256[49]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L2OutputOracle.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L2OutputOracle.json
@@ -3,30 +3,35 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "32",
     "label": "startingBlockNumber",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "startingTimestamp",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "l2Outputs",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "struct Types.OutputProposal[]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L2StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L2StandardBridge.json
@@ -3,24 +3,28 @@
     "bytes": "20",
     "label": "spacer_0_0_20",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "20",
     "label": "spacer_1_0_20",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "deposits",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "mapping(address => mapping(address => uint256))"
   },
   {
     "bytes": "1504",
     "label": "__gap",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "uint256[47]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L2ToL1MessagePasser.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L2ToL1MessagePasser.json
@@ -3,12 +3,14 @@
     "bytes": "32",
     "label": "sentMessages",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "30",
     "label": "msgNonce",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint240"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/LegacyERC20ETH.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/LegacyERC20ETH.json
@@ -3,30 +3,35 @@
     "bytes": "32",
     "label": "_balances",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "_allowances",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => mapping(address => uint256))"
   },
   {
     "bytes": "32",
     "label": "_totalSupply",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "_name",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_symbol",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "string"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/LegacyMessagePasser.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/LegacyMessagePasser.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "sentMessages",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(bytes32 => bool)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/LegacyMintableERC20.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/LegacyMintableERC20.json
@@ -3,42 +3,49 @@
     "bytes": "32",
     "label": "_balances",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "_allowances",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => mapping(address => uint256))"
   },
   {
     "bytes": "32",
     "label": "_totalSupply",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "_name",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_symbol",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "string"
   },
   {
     "bytes": "20",
     "label": "l1Token",
     "offset": 0,
-    "slot": "5"
+    "slot": "5",
+    "type": "address"
   },
   {
     "bytes": "20",
     "label": "l2Bridge",
     "offset": 0,
-    "slot": "6"
+    "slot": "6",
+    "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/LivenessGuard.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/LivenessGuard.json
@@ -3,12 +3,14 @@
     "bytes": "32",
     "label": "lastLive",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "64",
     "label": "ownersBefore",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "struct EnumerableSet.AddressSet"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/MintManager.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/MintManager.json
@@ -3,12 +3,14 @@
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "mintPermittedAfter",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismMintableERC20.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismMintableERC20.json
@@ -3,30 +3,35 @@
     "bytes": "32",
     "label": "_balances",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "_allowances",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => mapping(address => uint256))"
   },
   {
     "bytes": "32",
     "label": "_totalSupply",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "_name",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_symbol",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "string"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismMintableERC721.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismMintableERC721.json
@@ -3,66 +3,77 @@
     "bytes": "32",
     "label": "_name",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_symbol",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_owners",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "mapping(uint256 => address)"
   },
   {
     "bytes": "32",
     "label": "_balances",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "_tokenApprovals",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "mapping(uint256 => address)"
   },
   {
     "bytes": "32",
     "label": "_operatorApprovals",
     "offset": 0,
-    "slot": "5"
+    "slot": "5",
+    "type": "mapping(address => mapping(address => bool))"
   },
   {
     "bytes": "32",
     "label": "_ownedTokens",
     "offset": 0,
-    "slot": "6"
+    "slot": "6",
+    "type": "mapping(address => mapping(uint256 => uint256))"
   },
   {
     "bytes": "32",
     "label": "_ownedTokensIndex",
     "offset": 0,
-    "slot": "7"
+    "slot": "7",
+    "type": "mapping(uint256 => uint256)"
   },
   {
     "bytes": "32",
     "label": "_allTokens",
     "offset": 0,
-    "slot": "8"
+    "slot": "8",
+    "type": "uint256[]"
   },
   {
     "bytes": "32",
     "label": "_allTokensIndex",
     "offset": 0,
-    "slot": "9"
+    "slot": "9",
+    "type": "mapping(uint256 => uint256)"
   },
   {
     "bytes": "32",
     "label": "baseTokenURI",
     "offset": 0,
-    "slot": "10"
+    "slot": "10",
+    "type": "string"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismMintableERC721Factory.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismMintableERC721Factory.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "isOptimismMintableERC721",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => bool)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal.json
@@ -3,54 +3,63 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "32",
     "label": "params",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "struct ResourceMetering.ResourceParams"
   },
   {
     "bytes": "1536",
     "label": "__gap",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint256[48]"
   },
   {
     "bytes": "20",
     "label": "l2Sender",
     "offset": 0,
-    "slot": "50"
+    "slot": "50",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "finalizedWithdrawals",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "mapping(bytes32 => bool)"
   },
   {
     "bytes": "32",
     "label": "provenWithdrawals",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "mapping(bytes32 => struct OptimismPortal.ProvenWithdrawal)"
   },
   {
     "bytes": "1",
     "label": "spacer_53_0_1",
     "offset": 0,
-    "slot": "53"
+    "slot": "53",
+    "type": "bool"
   },
   {
     "bytes": "20",
     "label": "superchainConfig",
     "offset": 1,
-    "slot": "53"
+    "slot": "53",
+    "type": "contract SuperchainConfig"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/Optimist.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/Optimist.json
@@ -3,72 +3,84 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[50]"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "uint256[50]"
   },
   {
     "bytes": "32",
     "label": "_name",
     "offset": 0,
-    "slot": "101"
+    "slot": "101",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_symbol",
     "offset": 0,
-    "slot": "102"
+    "slot": "102",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "_owners",
     "offset": 0,
-    "slot": "103"
+    "slot": "103",
+    "type": "mapping(uint256 => address)"
   },
   {
     "bytes": "32",
     "label": "_balances",
     "offset": 0,
-    "slot": "104"
+    "slot": "104",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "_tokenApprovals",
     "offset": 0,
-    "slot": "105"
+    "slot": "105",
+    "type": "mapping(uint256 => address)"
   },
   {
     "bytes": "32",
     "label": "_operatorApprovals",
     "offset": 0,
-    "slot": "106"
+    "slot": "106",
+    "type": "mapping(address => mapping(address => bool))"
   },
   {
     "bytes": "1408",
     "label": "__gap",
     "offset": 0,
-    "slot": "107"
+    "slot": "107",
+    "type": "uint256[44]"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "151"
+    "slot": "151",
+    "type": "uint256[50]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimistInviter.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimistInviter.json
@@ -3,48 +3,56 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "32",
     "label": "_HASHED_NAME",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "bytes32"
   },
   {
     "bytes": "32",
     "label": "_HASHED_VERSION",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "bytes32"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "uint256[50]"
   },
   {
     "bytes": "32",
     "label": "commitmentTimestamps",
     "offset": 0,
-    "slot": "53"
+    "slot": "53",
+    "type": "mapping(bytes32 => uint256)"
   },
   {
     "bytes": "32",
     "label": "usedNonces",
     "offset": 0,
-    "slot": "54"
+    "slot": "54",
+    "type": "mapping(address => mapping(bytes32 => bool))"
   },
   {
     "bytes": "32",
     "label": "inviteCounts",
     "offset": 0,
-    "slot": "55"
+    "slot": "55",
+    "type": "mapping(address => uint256)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OutputBisectionGame.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OutputBisectionGame.json
@@ -3,54 +3,63 @@
     "bytes": "8",
     "label": "createdAt",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "Timestamp"
   },
   {
     "bytes": "8",
     "label": "resolvedAt",
     "offset": 8,
-    "slot": "0"
+    "slot": "0",
+    "type": "Timestamp"
   },
   {
     "bytes": "1",
     "label": "status",
     "offset": 16,
-    "slot": "0"
+    "slot": "0",
+    "type": "enum GameStatus"
   },
   {
     "bytes": "20",
     "label": "bondManager",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "contract IBondManager"
   },
   {
     "bytes": "32",
     "label": "l1Head",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "Hash"
   },
   {
     "bytes": "32",
     "label": "claimData",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "struct IOutputBisectionGame.ClaimData[]"
   },
   {
     "bytes": "32",
     "label": "claims",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "mapping(ClaimHash => bool)"
   },
   {
     "bytes": "32",
     "label": "subgames",
     "offset": 0,
-    "slot": "5"
+    "slot": "5",
+    "type": "mapping(uint256 => uint256[])"
   },
   {
     "bytes": "1",
     "label": "subgameAtRootResolved",
     "offset": 0,
-    "slot": "6"
+    "slot": "6",
+    "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/PreimageOracle.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/PreimageOracle.json
@@ -3,18 +3,21 @@
     "bytes": "32",
     "label": "preimageLengths",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(bytes32 => uint256)"
   },
   {
     "bytes": "32",
     "label": "preimageParts",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(bytes32 => mapping(uint256 => bytes32))"
   },
   {
     "bytes": "32",
     "label": "preimagePartOk",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "mapping(bytes32 => mapping(uint256 => bool))"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/ProtocolVersions.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ProtocolVersions.json
@@ -3,30 +3,35 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[50]"
   },
   {
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "address"
   },
   {
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "uint256[49]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/ProxyAdmin.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ProxyAdmin.json
@@ -3,30 +3,35 @@
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   },
   {
     "bytes": "32",
     "label": "proxyType",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => enum ProxyAdmin.ProxyType)"
   },
   {
     "bytes": "32",
     "label": "implementationName",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "mapping(address => string)"
   },
   {
     "bytes": "20",
     "label": "addressManager",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "contract AddressManager"
   },
   {
     "bytes": "1",
     "label": "upgrading",
     "offset": 20,
-    "slot": "3"
+    "slot": "3",
+    "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/ResolvedDelegateProxy.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ResolvedDelegateProxy.json
@@ -3,12 +3,14 @@
     "bytes": "32",
     "label": "implementationName",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(address => string)"
   },
   {
     "bytes": "32",
     "label": "addressManager",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "mapping(address => contract AddressManager)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/SchemaRegistry.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SchemaRegistry.json
@@ -3,12 +3,14 @@
     "bytes": "32",
     "label": "_registry",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "mapping(bytes32 => struct SchemaRecord)"
   },
   {
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[49]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/SequencerFeeVault.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SequencerFeeVault.json
@@ -3,6 +3,7 @@
     "bytes": "32",
     "label": "totalProcessed",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/SuperchainConfig.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SuperchainConfig.json
@@ -3,12 +3,14 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json
@@ -3,60 +3,70 @@
     "bytes": "1",
     "label": "_initialized",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint8"
   },
   {
     "bytes": "1",
     "label": "_initializing",
     "offset": 1,
-    "slot": "0"
+    "slot": "0",
+    "type": "bool"
   },
   {
     "bytes": "1600",
     "label": "__gap",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "uint256[50]"
   },
   {
     "bytes": "20",
     "label": "_owner",
     "offset": 0,
-    "slot": "51"
+    "slot": "51",
+    "type": "address"
   },
   {
     "bytes": "1568",
     "label": "__gap",
     "offset": 0,
-    "slot": "52"
+    "slot": "52",
+    "type": "uint256[49]"
   },
   {
     "bytes": "32",
     "label": "overhead",
     "offset": 0,
-    "slot": "101"
+    "slot": "101",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "scalar",
     "offset": 0,
-    "slot": "102"
+    "slot": "102",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "batcherHash",
     "offset": 0,
-    "slot": "103"
+    "slot": "103",
+    "type": "bytes32"
   },
   {
     "bytes": "8",
     "label": "gasLimit",
     "offset": 0,
-    "slot": "104"
+    "slot": "104",
+    "type": "uint64"
   },
   {
     "bytes": "32",
     "label": "_resourceConfig",
     "offset": 0,
-    "slot": "105"
+    "slot": "105",
+    "type": "struct ResourceMetering.ResourceConfig"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/Transactor.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/Transactor.json
@@ -3,6 +3,7 @@
     "bytes": "20",
     "label": "owner",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "address"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/TransferOnion.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/TransferOnion.json
@@ -3,12 +3,14 @@
     "bytes": "32",
     "label": "_status",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "uint256"
   },
   {
     "bytes": "32",
     "label": "shell",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "bytes32"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/WETH9.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/WETH9.json
@@ -3,30 +3,35 @@
     "bytes": "32",
     "label": "name",
     "offset": 0,
-    "slot": "0"
+    "slot": "0",
+    "type": "string"
   },
   {
     "bytes": "32",
     "label": "symbol",
     "offset": 0,
-    "slot": "1"
+    "slot": "1",
+    "type": "string"
   },
   {
     "bytes": "1",
     "label": "decimals",
     "offset": 0,
-    "slot": "2"
+    "slot": "2",
+    "type": "uint8"
   },
   {
     "bytes": "32",
     "label": "balanceOf",
     "offset": 0,
-    "slot": "3"
+    "slot": "3",
+    "type": "mapping(address => uint256)"
   },
   {
     "bytes": "32",
     "label": "allowance",
     "offset": 0,
-    "slot": "4"
+    "slot": "4",
+    "type": "mapping(address => mapping(address => uint256))"
   }
 ]


### PR DESCRIPTION
The type should be present in the storage layout to detect type changes to a variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the contract snapshot generation with additional type information for improved clarity and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->