### PR TITLE
chore(op-node): log transaction hash in warning

### DIFF
--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -111,12 +111,12 @@ func DataFromEVMTransactions(config *rollup.Config, batcherAddr common.Address, 
 		if to := tx.To(); to != nil && *to == config.BatchInboxAddress {
 			seqDataSubmitter, err := l1Signer.Sender(tx) // optimization: only derive sender if To is correct
 			if err != nil {
-				log.Warn("tx in inbox with invalid signature", "index", j, "txHash", tx.Hash().Hex(), "err", err)
+				log.Warn("tx in inbox with invalid signature", "index", j, "txHash", tx.Hash(), "err", err)
 				continue // bad signature, ignore
 			}
 			// some random L1 user might have sent a transaction to our batch inbox, ignore them
 			if seqDataSubmitter != batcherAddr {
-				log.Warn("tx in inbox with unauthorized submitter", "index", j, "txHash", tx.Hash().Hex(), "err", err)
+				log.Warn("tx in inbox with unauthorized submitter", "index", j, "txHash", tx.Hash(), "err", err)
 				continue // not an authorized batch submitter, ignore
 			}
 			out = append(out, tx.Data())

--- a/op-node/rollup/derive/calldata_source.go
+++ b/op-node/rollup/derive/calldata_source.go
@@ -111,12 +111,12 @@ func DataFromEVMTransactions(config *rollup.Config, batcherAddr common.Address, 
 		if to := tx.To(); to != nil && *to == config.BatchInboxAddress {
 			seqDataSubmitter, err := l1Signer.Sender(tx) // optimization: only derive sender if To is correct
 			if err != nil {
-				log.Warn("tx in inbox with invalid signature", "index", j, "err", err)
+				log.Warn("tx in inbox with invalid signature", "index", j, "txHash", tx.Hash().Hex(), "err", err)
 				continue // bad signature, ignore
 			}
 			// some random L1 user might have sent a transaction to our batch inbox, ignore them
 			if seqDataSubmitter != batcherAddr {
-				log.Warn("tx in inbox with unauthorized submitter", "index", j, "err", err)
+				log.Warn("tx in inbox with unauthorized submitter", "index", j, "txHash", tx.Hash().Hex(), "err", err)
 				continue // not an authorized batch submitter, ignore
 			}
 			out = append(out, tx.Data())


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add the transaction hash in the warning log when retrieving the transactions calldata.

**Tests**

No tests were added.

**Additional context**

Implemented in response to [this comment](https://github.com/ethereum-optimism/optimism/pull/8342#discussion_r1411153899)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved logging for transactions to include the transaction hash for better traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->