### PR TITLE
monorepo: make devnet-up just works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,7 +922,7 @@ jobs:
           working_directory: indexer
       - run:
           name: git submodules
-          command: git submodule update --init --recursive
+          command: make submodules
       - run:
           name: generate cannon prestate
           command: make cannon-prestate
@@ -997,7 +997,7 @@ jobs:
           key: golang-build-cache
       - run:
           name: git submodules
-          command: git submodule update --init --recursive
+          command: make submodules
       - run:
           name: generate devnet allocs
           command: make devnet-allocs
@@ -1056,7 +1056,7 @@ jobs:
             npm i pnpm --global
       - run:
           name: git submodules
-          command: git submodule update --init --recursive
+          command: make submodules
       - run:
           name: Install and build
           command: |

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ nuke: clean devnet-clean
 	git clean -Xdf
 .PHONY: nuke
 
-pre-devnet:
+pre-devnet: submodules
 	@if ! [ -x "$(command -v geth)" ]; then \
 		make install-geth; \
 	fi


### PR DESCRIPTION
**Description**

Ensure that the submodules exist as part of the
`make devnet-up` command. This enables somebody
to clone the repo and run a single command to bring
up the entire devnet without needing to worry about
running any other commands. Also replace some calls
in the CI to use `make` instead of `git` directly
for when installing the submodules.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
