### PR TITLE
challenger: Switch output_cannon to use the new contract type.

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -183,9 +183,6 @@ func (c Config) Check() error {
 		if c.RollupRpc == "" {
 			return ErrMissingRollupRpc
 		}
-		if c.TraceTypeEnabled(TraceTypeCannon) && (c.TraceTypeEnabled(TraceTypeOutputCannon) || c.TraceTypeEnabled(TraceTypeOutputAlphabet)) {
-			return ErrCannonAndOutputCannonConflict
-		}
 	}
 	if c.TraceTypeEnabled(TraceTypeCannon) || c.TraceTypeEnabled(TraceTypeOutputCannon) {
 		if c.CannonBin == "" {

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -34,7 +34,6 @@ var (
 	ErrCannonNetworkAndL2Genesis     = errors.New("only specify one of network or l2 genesis path")
 	ErrCannonNetworkUnknown          = errors.New("unknown cannon network")
 	ErrMissingRollupRpc              = errors.New("missing rollup rpc url")
-	ErrCannonAndOutputCannonConflict = errors.New("trace types cannon and outputCannon cannot be enabled at the same time")
 )
 
 type TraceType string
@@ -187,9 +186,6 @@ func (c Config) Check() error {
 		if c.TraceTypeEnabled(TraceTypeCannon) && (c.TraceTypeEnabled(TraceTypeOutputCannon) || c.TraceTypeEnabled(TraceTypeOutputAlphabet)) {
 			return ErrCannonAndOutputCannonConflict
 		}
-	}
-	if c.TraceTypeEnabled(TraceTypeCannon) && c.TraceTypeEnabled(TraceTypeOutputCannon) {
-		return ErrCannonAndOutputCannonConflict
 	}
 	if c.TraceTypeEnabled(TraceTypeCannon) || c.TraceTypeEnabled(TraceTypeOutputCannon) {
 		if c.CannonBin == "" {

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -146,12 +146,6 @@ func TestRollupRpcRequired_OutputAlphabet(t *testing.T) {
 	require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
 }
 
-func TestCannotEnableBothCannonAndOutputCannonTraceTypes(t *testing.T) {
-	config := validConfig(TraceTypeOutputCannon)
-	config.TraceTypes = append(config.TraceTypes, TraceTypeCannon)
-	require.ErrorIs(t, config.Check(), ErrCannonAndOutputCannonConflict)
-}
-
 func TestCannonL2Required(t *testing.T) {
 	config := validConfig(TraceTypeCannon)
 	config.CannonL2 = ""
@@ -214,7 +208,7 @@ func TestNetworkMustBeValid(t *testing.T) {
 
 func TestRequireConfigForMultipleTraceTypes(t *testing.T) {
 	cfg := validConfig(TraceTypeCannon)
-	cfg.TraceTypes = []TraceType{TraceTypeCannon, TraceTypeAlphabet}
+	cfg.TraceTypes = []TraceType{TraceTypeCannon, TraceTypeAlphabet, TraceTypeOutputCannon}
 	// Set all required options and check its valid
 	cfg.RollupRpc = validRollupRpc
 	cfg.AlphabetTrace = validAlphabetTrace
@@ -228,4 +222,9 @@ func TestRequireConfigForMultipleTraceTypes(t *testing.T) {
 	// Require alphabet specific args
 	cfg.AlphabetTrace = ""
 	require.ErrorIs(t, cfg.Check(), ErrMissingAlphabetTrace)
+	cfg.AlphabetTrace = validAlphabetTrace
+
+	// Require output cannon specific args
+	cfg.RollupRpc = ""
+	require.ErrorIs(t, cfg.Check(), ErrMissingRollupRpc)
 }

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -57,7 +56,7 @@ func RegisterGameTypes(
 		registerOutputCannon(registry, ctx, logger, m, cfg, txMgr, caller, l2Client)
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeOutputAlphabet) {
-		registerOutputAlphabet(registry, ctx, logger, m, cfg, txMgr, caller, l2Client)
+		registerOutputAlphabet(registry, ctx, logger, m, cfg, txMgr, caller)
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeCannon) {
 		registerCannon(registry, ctx, logger, m, cfg, txMgr, caller, l2Client)
@@ -75,52 +74,31 @@ func registerOutputAlphabet(
 	m metrics.Metricer,
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
-	caller *batching.MultiCaller,
-	l2Client cannon.L2HeaderSource) {
-	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
-		contract, err := contracts.NewOutputBisectionGameContract(addr, caller)
+	caller *batching.MultiCaller) {
+	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		contract, err := contracts.NewOutputBisectionGameContract(game.Proxy, caller)
 		if err != nil {
 			return nil, err
 		}
-		return &outputAlphabetResources{
-			m:        m,
-			cfg:      cfg,
-			l2Client: l2Client,
-			contract: contract,
-		}, nil
-	}
-	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
+		creator := func(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
+			// TODO(client-pod#44): Validate absolute pre-state for split games
+			prestateBlock, poststateBlock, err := contract.GetBlockRange(ctx)
+			if err != nil {
+				return nil, err
+			}
+			splitDepth, err := contract.GetSplitDepth(ctx)
+			if err != nil {
+				return nil, err
+			}
+			accessor, err := outputs.NewOutputAlphabetTraceAccessor(ctx, logger, m, cfg, gameDepth, splitDepth, prestateBlock, poststateBlock)
+			if err != nil {
+				return nil, err
+			}
+			return accessor, nil
+		}
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, contract, creator)
 	}
 	registry.RegisterGameType(outputAlphabetGameType, playerCreator)
-}
-
-type outputAlphabetResources struct {
-	m        metrics.Metricer
-	cfg      *config.Config
-	l2Client cannon.L2HeaderSource
-	contract *contracts.OutputBisectionGameContract
-}
-
-func (r *outputAlphabetResources) Contract() GameContract {
-	return r.contract
-}
-
-func (r *outputAlphabetResources) CreateAccessor(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
-	// TODO(client-pod#44): Validate absolute pre-state for split games
-	prestateBlock, poststateBlock, err := r.contract.GetBlockRange(ctx)
-	if err != nil {
-		return nil, err
-	}
-	splitDepth, err := r.contract.GetSplitDepth(ctx)
-	if err != nil {
-		return nil, err
-	}
-	accessor, err := outputs.NewOutputAlphabetTraceAccessor(ctx, logger, r.m, r.cfg, gameDepth, splitDepth, prestateBlock, poststateBlock)
-	if err != nil {
-		return nil, err
-	}
-	return accessor, nil
 }
 
 func registerOutputCannon(
@@ -132,46 +110,26 @@ func registerOutputCannon(
 	txMgr txmgr.TxManager,
 	caller *batching.MultiCaller,
 	l2Client cannon.L2HeaderSource) {
-	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
-		contract, err := contracts.NewOutputBisectionGameContract(addr, caller)
+	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		contract, err := contracts.NewOutputBisectionGameContract(game.Proxy, caller)
 		if err != nil {
 			return nil, err
 		}
-		return &outputCannonResources{
-			m:        m,
-			cfg:      cfg,
-			l2Client: l2Client,
-			contract: contract,
-		}, nil
-	}
-	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
+		creator := func(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
+			// TODO(client-pod#44): Validate absolute pre-state for split games
+			agreed, disputed, err := contract.GetBlockRange(ctx)
+			if err != nil {
+				return nil, err
+			}
+			accessor, err := outputs.NewOutputCannonTraceAccessor(ctx, logger, m, cfg, l2Client, contract, dir, gameDepth, agreed, disputed)
+			if err != nil {
+				return nil, err
+			}
+			return accessor, nil
+		}
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, contract, creator)
 	}
 	registry.RegisterGameType(outputCannonGameType, playerCreator)
-}
-
-type outputCannonResources struct {
-	m        metrics.Metricer
-	cfg      *config.Config
-	l2Client cannon.L2HeaderSource
-	contract *contracts.OutputBisectionGameContract
-}
-
-func (r *outputCannonResources) Contract() GameContract {
-	return r.contract
-}
-
-func (r *outputCannonResources) CreateAccessor(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
-	// TODO(client-pod#44): Validate absolute pre-state for split games
-	agreed, disputed, err := r.contract.GetBlockRange(ctx)
-	if err != nil {
-		return nil, err
-	}
-	accessor, err := outputs.NewOutputCannonTraceAccessor(ctx, logger, r.m, r.cfg, r.l2Client, r.contract, dir, gameDepth, agreed, disputed)
-	if err != nil {
-		return nil, err
-	}
-	return accessor, nil
 }
 
 func registerCannon(
@@ -183,45 +141,25 @@ func registerCannon(
 	txMgr txmgr.TxManager,
 	caller *batching.MultiCaller,
 	l2Client cannon.L2HeaderSource) {
-	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
-		contract, err := contracts.NewFaultDisputeGameContract(addr, caller)
+	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		contract, err := contracts.NewFaultDisputeGameContract(game.Proxy, caller)
 		if err != nil {
 			return nil, err
 		}
-		return &cannonResources{
-			m:        m,
-			cfg:      cfg,
-			l2Client: l2Client,
-			contract: contract,
-		}, nil
-	}
-	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
+		creator := func(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
+			localInputs, err := cannon.FetchLocalInputs(ctx, contract, l2Client)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
+			}
+			provider := cannon.NewTraceProvider(logger, m, cfg, faultTypes.NoLocalContext, localInputs, dir, gameDepth)
+			if err := ValidateAbsolutePrestate(ctx, provider, contract); err != nil {
+				return nil, err
+			}
+			return trace.NewSimpleTraceAccessor(provider), nil
+		}
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, contract, creator)
 	}
 	registry.RegisterGameType(cannonGameType, playerCreator)
-}
-
-type cannonResources struct {
-	m        metrics.Metricer
-	cfg      *config.Config
-	l2Client cannon.L2HeaderSource
-	contract *contracts.FaultDisputeGameContract
-}
-
-func (r *cannonResources) Contract() GameContract {
-	return r.contract
-}
-
-func (r *cannonResources) CreateAccessor(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
-	localInputs, err := cannon.FetchLocalInputs(ctx, r.contract, r.l2Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch cannon local inputs: %w", err)
-	}
-	provider := cannon.NewTraceProvider(logger, r.m, r.cfg, faultTypes.NoLocalContext, localInputs, dir, gameDepth)
-	if err := ValidateAbsolutePrestate(ctx, provider, r.contract); err != nil {
-		return nil, err
-	}
-	return trace.NewSimpleTraceAccessor(provider), nil
 }
 
 func registerAlphabet(
@@ -232,35 +170,19 @@ func registerAlphabet(
 	cfg *config.Config,
 	txMgr txmgr.TxManager,
 	caller *batching.MultiCaller) {
-	resourceCreator := func(addr common.Address) (gameTypeResources, error) {
-		contract, err := contracts.NewFaultDisputeGameContract(addr, caller)
+	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		contract, err := contracts.NewFaultDisputeGameContract(game.Proxy, caller)
 		if err != nil {
 			return nil, err
 		}
-		return &alphabetResources{
-			cfg:      cfg,
-			contract: contract,
-		}, nil
-	}
-	playerCreator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
-		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, resourceCreator)
+		creator := func(ctx context.Context, logger log.Logger, gameDepth uint64, dir string) (faultTypes.TraceAccessor, error) {
+			provider := alphabet.NewTraceProvider(cfg.AlphabetTrace, gameDepth)
+			if err := ValidateAbsolutePrestate(ctx, provider, contract); err != nil {
+				return nil, err
+			}
+			return trace.NewSimpleTraceAccessor(provider), nil
+		}
+		return NewGamePlayer(ctx, logger, m, dir, game.Proxy, txMgr, contract, creator)
 	}
 	registry.RegisterGameType(alphabetGameType, playerCreator)
-}
-
-type alphabetResources struct {
-	cfg      *config.Config
-	contract *contracts.FaultDisputeGameContract
-}
-
-func (r *alphabetResources) Contract() GameContract {
-	return r.contract
-}
-
-func (r *alphabetResources) CreateAccessor(ctx context.Context, _ log.Logger, gameDepth uint64, _ string) (faultTypes.TraceAccessor, error) {
-	provider := alphabet.NewTraceProvider(r.cfg.AlphabetTrace, gameDepth)
-	if err := ValidateAbsolutePrestate(ctx, provider, r.contract); err != nil {
-		return nil, err
-	}
-	return trace.NewSimpleTraceAccessor(provider), nil
 }

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	cannonGameType         = uint8(0)
-	outputCannonGameType   = uint8(253) // TODO(client-pod#260): Switch the output cannon game type to 1
+	outputCannonGameType   = uint8(253) // TODO(client-pod#43): Switch the output cannon game type to 1
 	outputAlphabetGameType = uint8(254)
 	alphabetGameType       = uint8(255)
 )

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -34,7 +35,7 @@ import (
 
 const alphabetGameType uint8 = 255
 const cannonGameType uint8 = 0
-const outputCannonGameType uint8 = 0 // TODO(client-pod#43): This should be a unique game type
+const outputCannonGameType uint8 = 253
 const alphabetGameDepth = 4
 
 var lastAlphabetTraceIndex = big.NewInt(1<<alphabetGameDepth - 1)
@@ -140,7 +141,10 @@ func (h *FactoryHelper) StartAlphabetGame(ctx context.Context, claimedAlphabet s
 }
 
 func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, rollupEndpoint string, rootClaim common.Hash) *OutputCannonGameHelper {
-	extraData, _, _ := h.createDisputeGameExtraData(ctx)
+	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, 30*time.Second, testlog.Logger(h.t, log.LvlInfo), rollupEndpoint)
+	h.require.NoError(err)
+
+	extraData, _ := h.createBisectionGameExtraData(ctx, rollupClient)
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
@@ -154,23 +158,20 @@ func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, rollupEndpoin
 	h.require.Len(rcpt.Logs, 1, "should have emitted a single DisputeGameCreated event")
 	createdEvent, err := h.factory.ParseDisputeGameCreated(*rcpt.Logs[0])
 	h.require.NoError(err)
-	game, err := bindings.NewFaultDisputeGame(createdEvent.DisputeProxy, h.client)
-	h.require.NoError(err)
-
-	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, 30*time.Second, testlog.Logger(h.t, log.LvlInfo), rollupEndpoint)
+	game, err := bindings.NewOutputBisectionGame(createdEvent.DisputeProxy, h.client)
 	h.require.NoError(err)
 
 	return &OutputCannonGameHelper{
-		FaultGameHelper: FaultGameHelper{
-			t:           h.t,
-			require:     h.require,
-			client:      h.client,
-			opts:        h.opts,
-			game:        game,
-			factoryAddr: h.factoryAddr,
-			addr:        createdEvent.DisputeProxy,
+		OutputGameHelper: OutputGameHelper{
+			t:            h.t,
+			require:      h.require,
+			client:       h.client,
+			opts:         h.opts,
+			game:         game,
+			factoryAddr:  h.factoryAddr,
+			addr:         createdEvent.DisputeProxy,
+			rollupClient: rollupClient,
 		},
-		rollupClient: rollupClient,
 	}
 
 }
@@ -275,6 +276,15 @@ func (h *FactoryHelper) createCannonGame(ctx context.Context, rootClaim common.H
 			addr:        createdEvent.DisputeProxy,
 		},
 	}
+}
+
+func (h *FactoryHelper) createBisectionGameExtraData(ctx context.Context, client *sources.RollupClient) (extraData []byte, l2BlockNumber uint64) {
+	syncStatus, err := client.SyncStatus(ctx)
+	h.require.NoError(err, "failed to get sync status")
+	l2BlockNumber = syncStatus.SafeL2.Number
+	extraData = make([]byte, 32)
+	binary.BigEndian.PutUint64(extraData, l2BlockNumber)
+	return
 }
 
 func (h *FactoryHelper) createDisputeGameExtraData(ctx context.Context) (extraData []byte, l1Head *big.Int, l2BlockNumber uint64) {

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -35,7 +35,7 @@ import (
 
 const alphabetGameType uint8 = 255
 const cannonGameType uint8 = 0
-const outputCannonGameType uint8 = 253
+const outputCannonGameType uint8 = 253 // TODO(client-pod#43): Switch this game type to 1
 const alphabetGameDepth = 4
 
 var lastAlphabetTraceIndex = big.NewInt(1<<alphabetGameDepth - 1)

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -2,19 +2,14 @@ package disputegame
 
 import (
 	"context"
-	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core"
 )
 
 type OutputCannonGameHelper struct {
-	FaultGameHelper
-	rollupClient *sources.RollupClient
+	OutputGameHelper
 }
 
 func (g *OutputCannonGameHelper) StartChallenger(
@@ -38,31 +33,4 @@ func (g *OutputCannonGameHelper) StartChallenger(
 		_ = c.Close()
 	})
 	return c
-}
-
-func (g *OutputCannonGameHelper) WaitForCorrectOutputRoot(ctx context.Context, claimIdx int64) {
-	g.WaitForClaimCount(ctx, claimIdx+1)
-	claim := g.getClaim(ctx, claimIdx)
-	err, blockNum := g.blockNumForClaim(ctx, claim)
-	g.require.NoError(err)
-	output, err := g.rollupClient.OutputAtBlock(ctx, blockNum)
-	g.require.NoErrorf(err, "Failed to get output at block %v", blockNum)
-	g.require.EqualValuesf(output.OutputRoot, claim.Claim, "Incorrect output root at claim %v. Expected to be from block %v", claimIdx, blockNum)
-}
-
-func (g *OutputCannonGameHelper) blockNumForClaim(ctx context.Context, claim ContractClaim) (error, uint64) {
-	proposals, err := g.game.Proposals(&bind.CallOpts{Context: ctx})
-	g.require.NoError(err, "failed to retrieve proposals")
-	prestateBlockNum := proposals.Starting.L2BlockNumber
-	disputedBlockNum := proposals.Disputed.L2BlockNumber
-	gameDepth := g.MaxDepth(ctx)
-
-	// TODO(client-pod#43): Load this from the contract
-	topDepth := gameDepth / 2
-	traceIdx := types.NewPositionFromGIndex(claim.Position).TraceIndex(int(topDepth))
-	blockNum := new(big.Int).Add(prestateBlockNum, traceIdx).Uint64() + 1
-	if blockNum > disputedBlockNum.Uint64() {
-		blockNum = disputedBlockNum.Uint64()
-	}
-	return err, blockNum
 }

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -179,11 +179,6 @@ func (g *OutputGameHelper) getClaim(ctx context.Context, claimIdx int64) Contrac
 	return claimData
 }
 
-// getClaimPosition retrieves the [types.Position] of a claim at a specific index.
-func (g *OutputGameHelper) getClaimPosition(ctx context.Context, claimIdx int64) types.Position {
-	return types.NewPositionFromGIndex(g.getClaim(ctx, claimIdx).Position)
-}
-
 func (g *OutputGameHelper) WaitForClaimAtDepth(ctx context.Context, depth int) {
 	g.waitForClaim(
 		ctx,

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -17,21 +18,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type FaultGameHelper struct {
-	t           *testing.T
-	require     *require.Assertions
-	client      *ethclient.Client
-	opts        *bind.TransactOpts
-	game        *bindings.FaultDisputeGame
-	factoryAddr common.Address
-	addr        common.Address
+const defaultTimeout = 5 * time.Minute
+
+type OutputGameHelper struct {
+	t            *testing.T
+	require      *require.Assertions
+	client       *ethclient.Client
+	opts         *bind.TransactOpts
+	game         *bindings.OutputBisectionGame
+	factoryAddr  common.Address
+	addr         common.Address
+	rollupClient *sources.RollupClient
 }
 
-func (g *FaultGameHelper) Addr() common.Address {
+func (g *OutputGameHelper) Addr() common.Address {
 	return g.addr
 }
 
-func (g *FaultGameHelper) GameDuration(ctx context.Context) time.Duration {
+func (g *OutputGameHelper) SplitDepth(ctx context.Context) int64 {
+	splitDepth, err := g.game.SPLITDEPTH(&bind.CallOpts{Context: ctx})
+	g.require.NoError(err, "failed to load split depth")
+	return splitDepth.Int64()
+}
+
+func (g *OutputGameHelper) WaitForCorrectOutputRoot(ctx context.Context, claimIdx int64) {
+	g.WaitForClaimCount(ctx, claimIdx+1)
+	claim := g.getClaim(ctx, claimIdx)
+	err, blockNum := g.blockNumForClaim(ctx, claim)
+	g.require.NoError(err)
+	output, err := g.rollupClient.OutputAtBlock(ctx, blockNum)
+	g.require.NoErrorf(err, "Failed to get output at block %v", blockNum)
+	g.require.EqualValuesf(output.OutputRoot, claim.Claim, "Incorrect output root at claim %v. Expected to be from block %v", claimIdx, blockNum)
+}
+
+func (g *OutputGameHelper) blockNumForClaim(ctx context.Context, claim ContractClaim) (error, uint64) {
+	opts := &bind.CallOpts{Context: ctx}
+	prestateBlockNum, err := g.game.GENESISBLOCKNUMBER(opts)
+	g.require.NoError(err, "failed to retrieve proposals")
+	disputedBlockNum, err := g.game.L2BlockNumber(opts)
+	g.require.NoError(err, "failed to retrieve l2 block number")
+
+	topDepth := g.SplitDepth(ctx)
+	traceIdx := types.NewPositionFromGIndex(claim.Position).TraceIndex(int(topDepth))
+	blockNum := new(big.Int).Add(prestateBlockNum, traceIdx).Uint64() + 1
+	if blockNum > disputedBlockNum.Uint64() {
+		blockNum = disputedBlockNum.Uint64()
+	}
+	return err, blockNum
+}
+
+func (g *OutputGameHelper) GameDuration(ctx context.Context) time.Duration {
 	duration, err := g.game.GAMEDURATION(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err, "failed to get game duration")
 	return time.Duration(duration) * time.Second
@@ -40,7 +76,7 @@ func (g *FaultGameHelper) GameDuration(ctx context.Context) time.Duration {
 // WaitForClaimCount waits until there are at least count claims in the game.
 // This does not check that the number of claims is exactly the specified count to avoid intermittent failures
 // where a challenger posts an additional claim before this method sees the number of claims it was waiting for.
-func (g *FaultGameHelper) WaitForClaimCount(ctx context.Context, count int64) {
+func (g *OutputGameHelper) WaitForClaimCount(ctx context.Context, count int64) {
 	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
@@ -57,13 +93,21 @@ func (g *FaultGameHelper) WaitForClaimCount(ctx context.Context, count int64) {
 	}
 }
 
-func (g *FaultGameHelper) MaxDepth(ctx context.Context) int64 {
+type ContractClaim struct {
+	ParentIndex uint32
+	Countered   bool
+	Claim       [32]byte
+	Position    *big.Int
+	Clock       *big.Int
+}
+
+func (g *OutputGameHelper) MaxDepth(ctx context.Context) int64 {
 	depth, err := g.game.MAXGAMEDEPTH(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err, "Failed to load game depth")
 	return depth.Int64()
 }
 
-func (g *FaultGameHelper) waitForClaim(ctx context.Context, errorMsg string, predicate func(claim ContractClaim) bool) {
+func (g *OutputGameHelper) waitForClaim(ctx context.Context, errorMsg string, predicate func(claim ContractClaim) bool) {
 	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
@@ -88,7 +132,7 @@ func (g *FaultGameHelper) waitForClaim(ctx context.Context, errorMsg string, pre
 	}
 }
 
-func (g *FaultGameHelper) waitForNoClaim(ctx context.Context, errorMsg string, predicate func(claim ContractClaim) bool) {
+func (g *OutputGameHelper) waitForNoClaim(ctx context.Context, errorMsg string, predicate func(claim ContractClaim) bool) {
 	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	err := wait.For(timedCtx, time.Second, func() (bool, error) {
@@ -113,13 +157,13 @@ func (g *FaultGameHelper) waitForNoClaim(ctx context.Context, errorMsg string, p
 	}
 }
 
-func (g *FaultGameHelper) GetClaimValue(ctx context.Context, claimIdx int64) common.Hash {
+func (g *OutputGameHelper) GetClaimValue(ctx context.Context, claimIdx int64) common.Hash {
 	g.WaitForClaimCount(ctx, claimIdx+1)
 	claim := g.getClaim(ctx, claimIdx)
 	return claim.Claim
 }
 
-func (g *FaultGameHelper) GetClaimPosition(ctx context.Context, claimIdx int64) types.Position {
+func (g *OutputGameHelper) GetClaimPosition(ctx context.Context, claimIdx int64) types.Position {
 	g.WaitForClaimCount(ctx, claimIdx+1)
 	claim := g.getClaim(ctx, claimIdx)
 	return types.NewPositionFromGIndex(claim.Position)
@@ -127,7 +171,7 @@ func (g *FaultGameHelper) GetClaimPosition(ctx context.Context, claimIdx int64) 
 
 // getClaim retrieves the claim data for a specific index.
 // Note that it is deliberately not exported as tests should use WaitForClaim to avoid race conditions.
-func (g *FaultGameHelper) getClaim(ctx context.Context, claimIdx int64) ContractClaim {
+func (g *OutputGameHelper) getClaim(ctx context.Context, claimIdx int64) ContractClaim {
 	claimData, err := g.game.ClaimData(&bind.CallOpts{Context: ctx}, big.NewInt(claimIdx))
 	if err != nil {
 		g.require.NoErrorf(err, "retrieve claim %v", claimIdx)
@@ -136,11 +180,11 @@ func (g *FaultGameHelper) getClaim(ctx context.Context, claimIdx int64) Contract
 }
 
 // getClaimPosition retrieves the [types.Position] of a claim at a specific index.
-func (g *FaultGameHelper) getClaimPosition(ctx context.Context, claimIdx int64) types.Position {
+func (g *OutputGameHelper) getClaimPosition(ctx context.Context, claimIdx int64) types.Position {
 	return types.NewPositionFromGIndex(g.getClaim(ctx, claimIdx).Position)
 }
 
-func (g *FaultGameHelper) WaitForClaimAtDepth(ctx context.Context, depth int) {
+func (g *OutputGameHelper) WaitForClaimAtDepth(ctx context.Context, depth int) {
 	g.waitForClaim(
 		ctx,
 		fmt.Sprintf("Could not find claim depth %v", depth),
@@ -150,7 +194,7 @@ func (g *FaultGameHelper) WaitForClaimAtDepth(ctx context.Context, depth int) {
 		})
 }
 
-func (g *FaultGameHelper) WaitForClaimAtMaxDepth(ctx context.Context, countered bool) {
+func (g *OutputGameHelper) WaitForClaimAtMaxDepth(ctx context.Context, countered bool) {
 	maxDepth := g.MaxDepth(ctx)
 	g.waitForClaim(
 		ctx,
@@ -161,7 +205,7 @@ func (g *FaultGameHelper) WaitForClaimAtMaxDepth(ctx context.Context, countered 
 		})
 }
 
-func (g *FaultGameHelper) WaitForAllClaimsCountered(ctx context.Context) {
+func (g *OutputGameHelper) WaitForAllClaimsCountered(ctx context.Context) {
 	g.waitForNoClaim(
 		ctx,
 		"Did not find all claims countered",
@@ -170,7 +214,7 @@ func (g *FaultGameHelper) WaitForAllClaimsCountered(ctx context.Context) {
 		})
 }
 
-func (g *FaultGameHelper) Resolve(ctx context.Context) {
+func (g *OutputGameHelper) Resolve(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	tx, err := g.game.Resolve(g.opts)
@@ -179,13 +223,13 @@ func (g *FaultGameHelper) Resolve(ctx context.Context) {
 	g.require.NoError(err)
 }
 
-func (g *FaultGameHelper) Status(ctx context.Context) Status {
+func (g *OutputGameHelper) Status(ctx context.Context) Status {
 	status, err := g.game.Status(&bind.CallOpts{Context: ctx})
 	g.require.NoError(err)
 	return Status(status)
 }
 
-func (g *FaultGameHelper) WaitForGameStatus(ctx context.Context, expected Status) {
+func (g *OutputGameHelper) WaitForGameStatus(ctx context.Context, expected Status) {
 	g.t.Logf("Waiting for game %v to have status %v", g.addr, expected)
 	timedCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
@@ -202,7 +246,7 @@ func (g *FaultGameHelper) WaitForGameStatus(ctx context.Context, expected Status
 	g.require.NoErrorf(err, "wait for game status. Game state: \n%v", g.gameData(ctx))
 }
 
-func (g *FaultGameHelper) WaitForInactivity(ctx context.Context, numInactiveBlocks int, untilGameEnds bool) {
+func (g *OutputGameHelper) WaitForInactivity(ctx context.Context, numInactiveBlocks int, untilGameEnds bool) {
 	g.t.Logf("Waiting for game %v to have no activity for %v blocks", g.addr, numInactiveBlocks)
 	headCh := make(chan *gethtypes.Header, 100)
 	headSub, err := g.client.SubscribeNewHead(ctx, headCh)
@@ -242,10 +286,16 @@ func (g *FaultGameHelper) WaitForInactivity(ctx context.Context, numInactiveBloc
 	}
 }
 
+// Mover is a function that either attacks or defends the claim at parentClaimIdx
+type Mover func(parentClaimIdx int64)
+
+// Stepper is a function that attempts to perform a step against the claim at parentClaimIdx
+type Stepper func(parentClaimIdx int64)
+
 // DefendRootClaim uses the supplied Mover to perform moves in an attempt to defend the root claim.
 // It is assumed that the output root being disputed is valid and that an honest op-challenger is already running.
 // When the game has reached the maximum depth it waits for the honest challenger to counter the leaf claim with step.
-func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove Mover) {
+func (g *OutputGameHelper) DefendRootClaim(ctx context.Context, performMove Mover) {
 	maxDepth := g.MaxDepth(ctx)
 	for claimCount := int64(1); claimCount < maxDepth; {
 		g.LogGameData(ctx)
@@ -267,7 +317,7 @@ func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove Mover
 // It is assumed that the output root being disputed is invalid and that an honest op-challenger is already running.
 // When the game has reached the maximum depth it calls the Stepper to attempt to counter the leaf claim.
 // Since the output root is invalid, it should not be possible for the Stepper to call step successfully.
-func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mover, attemptStep Stepper) {
+func (g *OutputGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mover, attemptStep Stepper) {
 	maxDepth := g.MaxDepth(ctx)
 	for claimCount := int64(1); claimCount < maxDepth; {
 		g.LogGameData(ctx)
@@ -289,10 +339,10 @@ func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mo
 	attemptStep(maxDepth)
 }
 
-func (g *FaultGameHelper) WaitForNewClaim(ctx context.Context, checkPoint int64) (int64, error) {
+func (g *OutputGameHelper) WaitForNewClaim(ctx context.Context, checkPoint int64) (int64, error) {
 	return g.waitForNewClaim(ctx, checkPoint, defaultTimeout)
 }
-func (g *FaultGameHelper) waitForNewClaim(ctx context.Context, checkPoint int64, timeout time.Duration) (int64, error) {
+func (g *OutputGameHelper) waitForNewClaim(ctx context.Context, checkPoint int64, timeout time.Duration) (int64, error) {
 	timedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	var newClaimLen int64
@@ -307,22 +357,26 @@ func (g *FaultGameHelper) waitForNewClaim(ctx context.Context, checkPoint int64,
 	return newClaimLen, err
 }
 
-func (g *FaultGameHelper) Attack(ctx context.Context, claimIdx int64, claim common.Hash) {
+func (g *OutputGameHelper) Attack(ctx context.Context, claimIdx int64, claim common.Hash) {
 	tx, err := g.game.Attack(g.opts, big.NewInt(claimIdx), claim)
 	g.require.NoError(err, "Attack transaction did not send")
 	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
 	g.require.NoError(err, "Attack transaction was not OK")
 }
 
-func (g *FaultGameHelper) Defend(ctx context.Context, claimIdx int64, claim common.Hash) {
+func (g *OutputGameHelper) Defend(ctx context.Context, claimIdx int64, claim common.Hash) {
 	tx, err := g.game.Defend(g.opts, big.NewInt(claimIdx), claim)
 	g.require.NoError(err, "Defend transaction did not send")
 	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
 	g.require.NoError(err, "Defend transaction was not OK")
 }
 
+type ErrWithData interface {
+	ErrorData() interface{}
+}
+
 // StepFails attempts to call step and verifies that it fails with ValidStep()
-func (g *FaultGameHelper) StepFails(claimIdx int64, isAttack bool, stateData []byte, proof []byte) {
+func (g *OutputGameHelper) StepFails(claimIdx int64, isAttack bool, stateData []byte, proof []byte) {
 	g.t.Logf("Attempting step against claim %v isAttack: %v", claimIdx, isAttack)
 	_, err := g.game.Step(g.opts, big.NewInt(claimIdx), isAttack, stateData, proof)
 	errData, ok := err.(ErrWithData)
@@ -331,16 +385,17 @@ func (g *FaultGameHelper) StepFails(claimIdx int64, isAttack bool, stateData []b
 }
 
 // ResolveClaim resolves a single subgame
-func (g *FaultGameHelper) ResolveClaim(ctx context.Context, claimIdx int64) {
+func (g *OutputGameHelper) ResolveClaim(ctx context.Context, claimIdx int64) {
 	tx, err := g.game.ResolveClaim(g.opts, big.NewInt(claimIdx))
 	g.require.NoError(err, "ResolveClaim transaction did not send")
 	_, err = wait.ForReceiptOK(ctx, g.client, tx.Hash())
 	g.require.NoError(err, "ResolveClaim transaction was not OK")
 }
 
-func (g *FaultGameHelper) gameData(ctx context.Context) string {
+func (g *OutputGameHelper) gameData(ctx context.Context) string {
 	opts := &bind.CallOpts{Context: ctx}
 	maxDepth := int(g.MaxDepth(ctx))
+	splitDepth := int(g.SplitDepth(ctx))
 	claimCount, err := g.game.ClaimDataLen(opts)
 	info := fmt.Sprintf("Claim count: %v\n", claimCount)
 	g.require.NoError(err, "Fetching claim count")
@@ -354,9 +409,10 @@ func (g *FaultGameHelper) gameData(ctx context.Context) string {
 	}
 	status, err := g.game.Status(opts)
 	g.require.NoError(err, "Load game status")
-	return fmt.Sprintf("Game %v (%v):\n%v\n", g.addr, Status(status), info)
+	return fmt.Sprintf("Game %v - %v - Split Depth: %v - Max Depth: %v:\n%v\n",
+		g.addr, Status(status), splitDepth, maxDepth, info)
 }
 
-func (g *FaultGameHelper) LogGameData(ctx context.Context) {
+func (g *OutputGameHelper) LogGameData(ctx context.Context) {
 	g.t.Log(g.gameData(ctx))
 }

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -31,12 +31,19 @@ func TestOutputCannonGame(t *testing.T) {
 	)
 
 	game.LogGameData(ctx)
-	maxDepth := game.MaxDepth(ctx)
 	// Challenger should post an output root to counter claims down to the leaf level of the top game
-	// TODO(client-pod#43): Load the depth of the top game from the contract instead of deriving it
-	for i := int64(1); i <= maxDepth/2+1; i += 2 {
+	splitDepth := game.SplitDepth(ctx)
+	for i := int64(1); i < splitDepth; i += 2 {
 		game.WaitForCorrectOutputRoot(ctx, i)
 		game.Attack(ctx, i, common.Hash{0xaa})
 		game.LogGameData(ctx)
 	}
+	game.WaitForCorrectOutputRoot(ctx, splitDepth)
+
+	// Post the first cannon output root (with 01 status code to show the output root is invalid)
+	game.Attack(ctx, splitDepth, common.Hash{0x01})
+
+	// Challenger should counter
+	game.WaitForClaimAtDepth(ctx, int(splitDepth+2))
+	game.LogGameData(ctx)
 }


### PR DESCRIPTION
**Description**

Switches the `output_cannon` trace type to use game type 253 and the new `OutputBisectionGame` contract. Enhanced the e2e test for it a little to check it progresses into the cannon trace. The e2e is still a fairly basic sanity check - we'll review and update e2e tests further in https://github.com/ethereum-optimism/client-pod/issues/262

Also we can now support `cannon` and `output_cannon` games in the same instance.

**Tests**

Updated e2e tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/260
