### PR TITLE
op-node: Remove Panic while Span Batch Derivation

### DIFF
--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -392,7 +392,9 @@ func (b *RawSpanBatch) derive(blockTime, genesisTimestamp uint64, chainID *big.I
 		}
 	}
 
-	b.txs.recoverV(chainID)
+	if err := b.txs.recoverV(chainID); err != nil {
+		return nil, err
+	}
 	fullTxs, err := b.txs.fullTxs(chainID)
 	if err != nil {
 		return nil, err

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -219,7 +219,8 @@ func TestSpanBatchPayload(t *testing.T) {
 	err = sb.decodePayload(r)
 	require.NoError(t, err)
 
-	sb.txs.recoverV(chainID)
+	err = sb.txs.recoverV(chainID)
+	require.NoError(t, err)
 
 	require.Equal(t, rawSpanBatch.spanBatchPayload, sb.spanBatchPayload)
 }
@@ -283,7 +284,8 @@ func TestSpanBatchTxs(t *testing.T) {
 	err = sb.decodeTxs(r)
 	require.NoError(t, err)
 
-	sb.txs.recoverV(chainID)
+	err = sb.txs.recoverV(chainID)
+	require.NoError(t, err)
 
 	require.Equal(t, rawSpanBatch.txs, sb.txs)
 }
@@ -302,7 +304,8 @@ func TestSpanBatchRoundTrip(t *testing.T) {
 	err = sb.decode(bytes.NewReader(result.Bytes()))
 	require.NoError(t, err)
 
-	sb.txs.recoverV(chainID)
+	err = sb.txs.recoverV(chainID)
+	require.NoError(t, err)
 
 	require.Equal(t, rawSpanBatch, &sb)
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Critical code path for derivation must not panic. Every expected errors must be escalated to the callers. Original span batch derivation code path had danger of panic when malicious/invalid encoded span batch was unpacked. This PR changes the dangerous behavior and appropriately escalates errors instead of throwing panic.

**Tests**

Fixed existing tests to detect expected error instead of catching panic.

