### PR TITLE
feat(ctb): Refactor `SemverLock`

### DIFF
--- a/packages/contracts-bedrock/scripts/SemverLock.s.sol
+++ b/packages/contracts-bedrock/scripts/SemverLock.s.sol
@@ -53,13 +53,12 @@ contract SemverLock is Script {
             // Parse the artifact to get the contract's initcode hash.
             bytes memory initCode = vm.getCode(string.concat(artifactsDir, "/", contractName, ".sol/", fileName));
 
-            // Serialize the source hash in JSON.
-            string memory j = vm.serializeBytes32(out, _files[i], keccak256(abi.encodePacked(fileContents, initCode)));
+            // Serialize the initcode hash + sourcecode hash in JSON.
+            vm.serializeBytes32(_files[i], "initCodeHash", keccak256(initCode));
+            string memory obj = vm.serializeBytes32(_files[i], "sourceCodeHash", keccak256(bytes(fileContents)));
 
-            // If this is the last file, set the output.
-            if (i == _files.length - 1) {
-                out = j;
-            }
+            // Serialize the map from the file name -> initcode hash + sourcecode hash in JSON.
+            out = vm.serializeString("", _files[i], obj);
         }
 
         // Write the semver lockfile.

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -1,40 +1,154 @@
 {
-  "src/EAS/EAS.sol": "0x850a0eb089d5a01f489c7239f5b9a1b09120afb1bc80239268215c2dfe1de26c",
-  "src/EAS/SchemaRegistry.sol": "0x5ee1a0c3b2bf1eb5edb53fb0967cf13856be546f0f16fe7acdc3e4f286db6831",
-  "src/L1/DelayedVetoable.sol": "0x276c6276292095e6aa37a70008cf4e0d1cbcc020dbc9107459bbc72ab5ed744f",
-  "src/L1/L1CrossDomainMessenger.sol": "0x941099109e18dcfb8ddd51432a55077a7d075c008332e4107dbabf1473ebfa63",
-  "src/L1/L1ERC721Bridge.sol": "0x0e57251c77c052cec3a537b1dd4bb30eaff083a9d2b7bfb4cff342641ffd690d",
-  "src/L1/L1StandardBridge.sol": "0xc63b9a99a8e61321930a848c67d950a26356343e12e4376a2b12e03e44e8d8da",
-  "src/L1/L2OutputOracle.sol": "0xbc8acf3cdf2ea6107e2f9fad37e68a8f039f289d88b2ce002920c9ae00310450",
-  "src/L1/OptimismPortal.sol": "0x0b86047802c87795d2bf8f2c68a8accff18966564a836197dcdf81573405f7db",
-  "src/L1/ProtocolVersions.sol": "0x6401853c57ca29e8e9bb38173b5ac9f0856395a325324a08eeb965cc831f0419",
-  "src/L1/SuperchainConfig.sol": "0x316e49c6d1d34d3172916015a049039d04364aabe0f0ddfa29472354a1fe6ea9",
-  "src/L1/SystemConfig.sol": "0xc24454da676297e0cd718ebf017933c5b1084e389e78ebe2a69d31053ea2f051",
-  "src/L2/BaseFeeVault.sol": "0xe36f9be65c910694e60a14f266f9b6569f01b4ddd74fa0557305eb83e7e9d112",
-  "src/L2/GasPriceOracle.sol": "0x88efffbd40f8d012d700a5d7fde0d92266f65e9d7006cd8f034bacaa036d0eb2",
-  "src/L2/L1Block.sol": "0x1ed9aa36036ded00a0383692eca81a22f668d64e22af973559d2ccefc86825c0",
-  "src/L2/L1FeeVault.sol": "0x6a7a9a262c0a4c9781d812ea343f984944a8dd2b45bc1967dfcc3805c0053518",
-  "src/L2/L2CrossDomainMessenger.sol": "0xb7def88517877533e36bee7b6d1739d986e04d22ecef07991e2f6252e02e50c5",
-  "src/L2/L2ERC721Bridge.sol": "0x2efc8615a1f4c0e7508df68def345b958b9815f8ddc5b4945e8c0f97962a4de8",
-  "src/L2/L2StandardBridge.sol": "0x7471e1d246ae3642995677f220045d70feeafc863dc640ce0c9891fd336d20dd",
-  "src/L2/L2ToL1MessagePasser.sol": "0xafc710b4d320ef450586d96a61cbd58cac814cb3b0c4fdc280eace3efdcdf321",
-  "src/L2/SequencerFeeVault.sol": "0x883e434a69b4789997a4a9a32060dbbd2e12db6f1970927f1310820336119575",
-  "src/Safe/LivenessGuard.sol": "0xa08460138c22a337f8f5d3a17e02beffe8136c4dba58935cc5c9c2d7ffe1222c",
-  "src/Safe/LivenessModule.sol": "0x45621d74ea464c75064f9194261d29d47552cf4a9c4f4b3a733f5df5803fc0dd",
-  "src/dispute/BlockOracle.sol": "0x7e724b1ee0116dfd744f556e6237af449c2f40c6426d6f1462ae2a47589283bb",
-  "src/dispute/DisputeGameFactory.sol": "0xfdfa141408d7f8de7e230ff4bef088e30d0e4d569ca743d60d292abdd21ff270",
-  "src/dispute/FaultDisputeGame.sol": "0x7ac7553a47d96a4481a6b95363458bed5f160112b647829c4defc134fa178d9a",
-  "src/dispute/OutputBisectionGame.sol": "0x16714c8660bf704d255ebb3fe08eb72caf4a890c43ea74fa1109df95194af760",
-  "src/legacy/DeployerWhitelist.sol": "0x0a6840074734c9d167321d3299be18ef911a415e4c471fa92af7d6cfaa8336d4",
-  "src/legacy/L1BlockNumber.sol": "0x20d83a636c5e2067fca8c0ed505b295174e6eddb25960d8705e6b6fea8e77fa6",
-  "src/legacy/LegacyMessagePasser.sol": "0x80f355c9710af586f58cf6a86d1925e0073d1e504d0b3d814284af1bafe4dece",
-  "src/periphery/op-nft/AttestationStation.sol": "0x067b29fe24734c121469c1cb2e9b2602ddabb9e07792338b766cab341776cd78",
-  "src/periphery/op-nft/Optimist.sol": "0x128113cd97433987220f25b59d883d5ee7e70ff2214a536c0df3d892e13287fc",
-  "src/periphery/op-nft/OptimistAllowlist.sol": "0x12e5d0a79c8c05cfd41be8a1bcbd5c889652182a723aeb5eccb35e0ee2a5b6c0",
-  "src/periphery/op-nft/OptimistInviter.sol": "0xe5353f882475396ca8c3c0f8905baf3450697612ee6ac1d7053a80f6e1ecdd3b",
-  "src/universal/OptimismMintableERC20.sol": "0x099bea9f5d2f0a827f87485a4e51b8055981f6d84a0e974d226ba6d8ed5ba73d",
-  "src/universal/OptimismMintableERC20Factory.sol": "0x6dff4744e9f84f0c0c548584ae44cfc58bfeedc3ed35ba48ee948448d65cb3d9",
-  "src/universal/OptimismMintableERC721.sol": "0x4c73bf8474fa7eb091796a4db7e57bc5f26d50a3d1cfcb78d5efa47ced5ced2b",
-  "src/universal/OptimismMintableERC721Factory.sol": "0x935fd97018b6ef10fa813d9d43ab7a77c80885f7a8d7feb430097645cb2abd2c",
-  "src/universal/StorageSetter.sol": "0x394ec39ef24b44f54549deec6183cace8eea2e5313cde8d5a6e0411a481c5953"
+  "src/EAS/EAS.sol": {
+    "initCodeHash": "0x1a097f352425b503a28c795dbfd390f2bc330e9c1f8a27bd26cf243b6c703499",
+    "sourceCodeHash": "0x23287e96b00c31ab57b05090525afdebf8e45ca09253a21b95052cf7d94e071b"
+  },
+  "src/EAS/SchemaRegistry.sol": {
+    "initCodeHash": "0xf4c3155413be4a4ebaaba66b9f9daaf12db7b090afdea739dfb8a543df357289",
+    "sourceCodeHash": "0x2ed7a2d6d66839fb3d207952f44b001bce349334adc40ce66d0503ce64e48548"
+  },
+  "src/L1/DelayedVetoable.sol": {
+    "initCodeHash": "0xd33130a4cf4db0cbfe07ed20cf910a619562c7560e575e45d20e3db88bb9ccfd",
+    "sourceCodeHash": "0x0c2f8fdc6130397f84d5867000110ef5ee864946cbc159f9b78665c29333b4f7"
+  },
+  "src/L1/L1CrossDomainMessenger.sol": {
+    "initCodeHash": "0x2e30441e86771fb65dac0dd021fa5bab8b6b4b224386594b76cc2bfc5146832f",
+    "sourceCodeHash": "0x508ac7c5628d226f5e3ec6593f6c28aab969f70223c678eb0e870155d24b1da4"
+  },
+  "src/L1/L1ERC721Bridge.sol": {
+    "initCodeHash": "0xb9d7955f46b634725a57269f7004ee638850a4d3ecd20ae2d6fdcd4694430a75",
+    "sourceCodeHash": "0x76ab62d44cf4efdc1db7042e75738b6d187682b0bdfb4160f5d0dc09eab55b4f"
+  },
+  "src/L1/L1StandardBridge.sol": {
+    "initCodeHash": "0xf925378da0e620f9ebcf8a2b6ee1989a2a527d933903398d7da53a88a550dcd6",
+    "sourceCodeHash": "0x540dbe1d8961c7b1eece7eb4bd29631b5a743b1ea9bad6983a6c6b20572bd9d7"
+  },
+  "src/L1/L2OutputOracle.sol": {
+    "initCodeHash": "0x2c79bc6708742cdf21ca8d134227dab60fe908028aee2255192950f531fa548e",
+    "sourceCodeHash": "0xb99ee58a672ed59f6bf529a618d4949f198bfda7c65664c9b2a2657070756c69"
+  },
+  "src/L1/OptimismPortal.sol": {
+    "initCodeHash": "0xc79a302dde8780d8c640e9311a8f5f8959f05b42a60a6c869fb2c2c5a54f9062",
+    "sourceCodeHash": "0x8fe20e758082efde3a87ffc9d7570fd9237a2defd6a0b42f2fd8b4f260b8a1bf"
+  },
+  "src/L1/ProtocolVersions.sol": {
+    "initCodeHash": "0x72cd467e8bcf019c02675d72ab762e088bcc9cc0f1a4e9f587fa4589f7fdd1b8",
+    "sourceCodeHash": "0xbd56a23cd3221cb9d25029e80cd9f2afe2c615ae9c0b3956bf6ed373b8b805b6"
+  },
+  "src/L1/SuperchainConfig.sol": {
+    "initCodeHash": "0xb7d34a360315d7cd920dfae9688a279f82c0608e3e3fe839d50e17f5fe50b65f",
+    "sourceCodeHash": "0x22d8de384a5261335ba734ef4af221b0e360b6228531560811188d22b555e926"
+  },
+  "src/L1/SystemConfig.sol": {
+    "initCodeHash": "0x7662ba203d662cf433b3e44b85fdd6f4d5b39d77eb88156200d15b6bc8f15bc4",
+    "sourceCodeHash": "0x04ce779f3bf7463af5e633f76f2c712e73a8ade75c9ef3624ae59a761d279156"
+  },
+  "src/L2/BaseFeeVault.sol": {
+    "initCodeHash": "0x2744d34573be83206d1b75d049d18a7bb37f9058e68c0803e5008c46b0dc2474",
+    "sourceCodeHash": "0xd787bd2a192ba5025fa0a8de2363af66a8de20de226e411bdb576adb64636cd0"
+  },
+  "src/L2/GasPriceOracle.sol": {
+    "initCodeHash": "0x6e235d82993606ca4d19b523096678b3cb13bad7a140567dd4f42de2cf0a2b8e",
+    "sourceCodeHash": "0x6dd53c5d8164eb2c96c3e210d0b667a24daa674056c9b75ac1f93433b7e737fa"
+  },
+  "src/L2/L1Block.sol": {
+    "initCodeHash": "0x280927b73942e7d00c6170b15c0b1e087da0be3adf5a63a59d3a71ad64b33685",
+    "sourceCodeHash": "0x50e1aae72b91da2d288bbd0b7ffb693b13bd375962d9c1ac0d8b47a913520fd9"
+  },
+  "src/L2/L1FeeVault.sol": {
+    "initCodeHash": "0x2744d34573be83206d1b75d049d18a7bb37f9058e68c0803e5008c46b0dc2474",
+    "sourceCodeHash": "0x3a94f273937d8908fb37dd2c495a6a0b9c3941fe68ccea51723f84eb343ba225"
+  },
+  "src/L2/L2CrossDomainMessenger.sol": {
+    "initCodeHash": "0x83c8e1eb0dca6061998a14f561f02952350b8bbf56542b7229e611de0338a6b1",
+    "sourceCodeHash": "0x167f90f8b75e6ae2d5326d5245384d1ec9dd28222e78388b9e9b11aea8da7348"
+  },
+  "src/L2/L2ERC721Bridge.sol": {
+    "initCodeHash": "0x8c7dc436d8150514bca8a322e3e45e53fb98a6c1f0f22d6a9ba6cf1f479e0e56",
+    "sourceCodeHash": "0x448b01aa8e9e79782766134290d54a3557135c9d39357bfbbf1d2672687518ac"
+  },
+  "src/L2/L2StandardBridge.sol": {
+    "initCodeHash": "0x6dbd834196fc887100a05aa9b730bf2a29982d6c793ae4d770d96f7c15699c17",
+    "sourceCodeHash": "0x26f070902aa1b8b421060aae222ae251515f794833c458a4ed19ef0a4472003b"
+  },
+  "src/L2/L2ToL1MessagePasser.sol": {
+    "initCodeHash": "0x08bbede75cd6dfd076903b8f04d24f82fa7881576c135825098778632e37eebc",
+    "sourceCodeHash": "0x8388b9b8075f31d580fed815b66b45394e40fb1a63cd8cda2272d2c390fc908c"
+  },
+  "src/L2/SequencerFeeVault.sol": {
+    "initCodeHash": "0xd62e193d89b1661d34031227a45ce1eade9c2a89b0bd7f362f511d03cceef294",
+    "sourceCodeHash": "0xa304b4b556162323d69662b4dd9a1d073d55ec661494465489bb67f1e465e7b3"
+  },
+  "src/Safe/LivenessGuard.sol": {
+    "initCodeHash": "0x16ec47f0888391638814047a1735dbac849b48e256b2e20182bbb3186d950a3c",
+    "sourceCodeHash": "0x9633cea9b66077e222f470439fe3e9a31f3e33b4f7a5618374c44310fd234b24"
+  },
+  "src/Safe/LivenessModule.sol": {
+    "initCodeHash": "0x0da844fb4dd22f252ff631524f01f45edf43bca7558fe45f71d711b79af01742",
+    "sourceCodeHash": "0x1afb1d392e8f6a58ff86ea7f648e0d1756d4ba8d0d964279d58a390deaa53b7e"
+  },
+  "src/dispute/BlockOracle.sol": {
+    "initCodeHash": "0x183ce41fb2842c9853f08955ddd91e345126028fad64e07ed14f593cbf9c88bc",
+    "sourceCodeHash": "0xabbfe0def64318b467e098bb518100a4cbf7ad4e803d13fbb187f25df35de8dd"
+  },
+  "src/dispute/DisputeGameFactory.sol": {
+    "initCodeHash": "0x84a15994d275bea8a96af83a46849e74eb573aa579db86350b6fe358bd61ec57",
+    "sourceCodeHash": "0x64290a5d8138c46d2ecd308e3ef62ba04663049cce8a271b9a686ddd2e630391"
+  },
+  "src/dispute/FaultDisputeGame.sol": {
+    "initCodeHash": "0xc4c2fe17a1e9c82c924b0ac3dbd6512850a19b55125eca14c2636cc4adb9cc67",
+    "sourceCodeHash": "0x1d0cacaf259aff7802aae91a793e3c7234a4d063614cf9c72176fb04738e7c97"
+  },
+  "src/dispute/OutputBisectionGame.sol": {
+    "initCodeHash": "0xc5ac9d76d7c46ccc073f3e5d74a78253bf2f627b04af9b2e3c86803c44890075",
+    "sourceCodeHash": "0x68df25016fa101a9d40e5d00f839dd053e7b5aa0c73c06c61d483cdfda0be124"
+  },
+  "src/legacy/DeployerWhitelist.sol": {
+    "initCodeHash": "0x8de80fb23b26dd9d849f6328e56ea7c173cd9e9ce1f05c9beea559d1720deb3d",
+    "sourceCodeHash": "0xb518a9f56136a910f2450098b4823c9982f93883fe4a9ef6f6b0a89355965d38"
+  },
+  "src/legacy/L1BlockNumber.sol": {
+    "initCodeHash": "0xd586c4f93caf1753e53fcdc05eb547c1f3a69afda2904ae9f9d851b73e1c9c1d",
+    "sourceCodeHash": "0x2a42b124a918a987da60934d9059a72d4fe13dba2609b9f80146f9c8a3fc8293"
+  },
+  "src/legacy/LegacyMessagePasser.sol": {
+    "initCodeHash": "0x024ff54be1762f8946c6dc1796517bd5e622349a26a908f78a31872969f10369",
+    "sourceCodeHash": "0x31f66f771d912ed4fe06c166f4b1c44d9f2bce8537ab42271c3900360966999f"
+  },
+  "src/periphery/op-nft/AttestationStation.sol": {
+    "initCodeHash": "0xf9b8ff2ecdcaca2b1521a96f0ebaea2d77aeb986ff1b9b7d82fb0cbc63f9169a",
+    "sourceCodeHash": "0x81ba07ca8d0bedf3b0d0ff054d68fcc6dca52a4da0ca5c8624cee92f20a87c37"
+  },
+  "src/periphery/op-nft/Optimist.sol": {
+    "initCodeHash": "0x468354be7d17863a587b1f1daf220c17697e57c76cba8e0082d7afec4aafea49",
+    "sourceCodeHash": "0x3ceeaab5b013968b226b3c97e202a3af4946590763b2002d1bc36ae8776c78fe"
+  },
+  "src/periphery/op-nft/OptimistAllowlist.sol": {
+    "initCodeHash": "0xbe1a89f077473c298ce96be5eb5e5a0ec97968f24c7ef843e1f9fee1c57087e4",
+    "sourceCodeHash": "0x077967c4c1b99396481c91464237e696f12974c864470b2ef39ffa3756a58ac0"
+  },
+  "src/periphery/op-nft/OptimistInviter.sol": {
+    "initCodeHash": "0xefc67e1be541adfc92f9a5bef36746477299f5e76a4601c12f802af52fb02253",
+    "sourceCodeHash": "0x323f707d4cebc38f59f9241098a1d7e5e790ffcaf1719065edabf4cb794ac745"
+  },
+  "src/universal/OptimismMintableERC20.sol": {
+    "initCodeHash": "0x7c6e1cf86cf8622d8beceafa3610ff88eceb3b0fafff0491bfa26a7b876c4d9a",
+    "sourceCodeHash": "0x52737b23e99bf79dd2c23196b3298e80aa41f740efc6adc7916e696833eb546a"
+  },
+  "src/universal/OptimismMintableERC20Factory.sol": {
+    "initCodeHash": "0x786f4d03cf19cf3af728966a8b22385e178e2021f20b410032c195bbc57e1e7c",
+    "sourceCodeHash": "0x723c294abec447081df4a87104e9ae6c0a1f14cc76499be734008d850eae3a0f"
+  },
+  "src/universal/OptimismMintableERC721.sol": {
+    "initCodeHash": "0xb400f430acf4d65bee9635e4935a6e1e3a0284fc50aea40ad8b7818dc826f31c",
+    "sourceCodeHash": "0xd4bb4d1e16f545976302109ab0234ae785afa52de820553d67ebd9f147e4b994"
+  },
+  "src/universal/OptimismMintableERC721Factory.sol": {
+    "initCodeHash": "0x5504069cb1377405bf5c6f1b37ea02057fdb452cf85922cc83dffd5390cad7da",
+    "sourceCodeHash": "0x89cab3bfb4a6a6146336585216c78f20733219ac6973e7fc1cb49c43c060662d"
+  },
+  "src/universal/StorageSetter.sol": {
+    "initCodeHash": "0xb579792cbef7a862d60190712b3b5bc6b5ec8e2d0d4cc75a4ca9980490e3c238",
+    "sourceCodeHash": "0xc5d4a62bcb4dfe1844c72d40b21375769004e9dc76f6f293ee1ecb35abe58a92"
+  }
 }


### PR DESCRIPTION
## Overview

Breaks out the semver lock hash in `contracts-bedrock` into two separate hashes: the sourcecode hash & the initcode hash.

By the [style guide](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/STYLE_GUIDE.md#versioning):
1. A patch bump should occur when the source changes, but the initcode hash does not.
2. A minor bump should occur when the source + initcode hash changes, but there are no breaking changes to the interface.
3. A major bump should occur when there are breaking changes to the interface or large changes to the security model.

This extra granularity allows for reviewers to more easily assess whether or not the semver bump in smart contract PRs is appropriate for the changes. Previously, the single hash of `sourceCode ++ initCode` required a more in-depth analysis of the changes to determine if the bump was appropriate.
