### PR TITLE
fix(ctb): Slither Triaging and Docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,11 +435,6 @@ jobs:
             pnpm snapshots:check || echo "export SNAPSHOTS_STATUS=1" >> "$BASH_ENV"
           working_directory: packages/contracts-bedrock
       - run:
-          name: slither
-          command: |
-            pnpm slither:check || echo "export SLITHER_STATUS=1" >> "$BASH_ENV"
-          working_directory: packages/contracts-bedrock
-      - run:
           name: check statuses
           command: |
             if [[ "$LINT_STATUS" -ne 0 ]]; then
@@ -466,13 +461,22 @@ jobs:
               echo "Snapshots check failed, see job output for details."
               FAILED=1
             fi
-            if [[ "$SLITHER_STATUS" -ne 0 ]]; then
-              echo "Slither check failed, see job output for details."
-              FAILED=1
-            fi
             if [[ "$FAILED" -ne 0 ]]; then
               exit 1
             fi
+
+  contracts-bedrock-slither:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    resource_class: medium
+    steps:
+      - checkout
+      - check-changed:
+          patterns: contracts-bedrock
+      - run:
+          name: slither
+          command: pnpm slither:check
+          working_directory: packages/contracts-bedrock
 
   contracts-bedrock-validate-spaces:
     docker:
@@ -1397,6 +1401,7 @@ workflows:
       - contracts-bedrock-checks:
           requires:
             - pnpm-monorepo
+      - contracts-bedrock-slither
       - contracts-bedrock-validate-spaces:
           requires:
             - pnpm-monorepo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,6 +435,11 @@ jobs:
             pnpm snapshots:check || echo "export SNAPSHOTS_STATUS=1" >> "$BASH_ENV"
           working_directory: packages/contracts-bedrock
       - run:
+          name: slither
+          command: |
+            pnpm slither:check || echo "export SLITHER_STATUS=1" >> "$BASH_ENV"
+          working_directory: packages/contracts-bedrock
+      - run:
           name: check statuses
           command: |
             if [[ "$LINT_STATUS" -ne 0 ]]; then
@@ -461,22 +466,13 @@ jobs:
               echo "Snapshots check failed, see job output for details."
               FAILED=1
             fi
+            if [[ "$SLITHER_STATUS" -ne 0 ]]; then
+              echo "Slither check failed, see job output for details."
+              FAILED=1
+            fi
             if [[ "$FAILED" -ne 0 ]]; then
               exit 1
             fi
-
-  contracts-bedrock-slither:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    resource_class: medium
-    steps:
-      - checkout
-      - check-changed:
-          patterns: contracts-bedrock
-      - run:
-          name: slither
-          command: |
-            pnpm slither:check || echo "Slither failed"
 
   contracts-bedrock-validate-spaces:
     docker:
@@ -1351,7 +1347,7 @@ jobs:
           patterns: contracts-bedrock/test/kontrol,contracts-bedrock/src/L1/OptimismPortal\.sol
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: 
+      - run:
           name: Install Docker CLI
           command: |
             # Add Docker's official GPG key:
@@ -1370,7 +1366,7 @@ jobs:
       - run:
           name: Run Kontrol Tests
           command: |
-            pnpm test:kontrol 
+            pnpm test:kontrol
           working_directory: ./packages/contracts-bedrock
       - store_artifacts:
           path: ./packages/contracts-bedrock/kontrol-results_latest.tar.gz
@@ -1401,7 +1397,6 @@ workflows:
       - contracts-bedrock-checks:
           requires:
             - pnpm-monorepo
-      - contracts-bedrock-slither
       - contracts-bedrock-validate-spaces:
           requires:
             - pnpm-monorepo

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -94,3 +94,18 @@ to reduce the overhead of maintaining multiple ways to set up the state as well 
 The L1 contract addresses are held in `deployments/hardhat/.deploy` and the L2 test state is held in a `.testdata` directory. The L1 addresses are used to create the L2 state
 and it is possible for stale addresses to be pulled into the L2 state, causing tests to fail. Stale addresses may happen if the order of the L1 deployments happen differently
 since some contracts are deployed using `CREATE`. Run `pnpm clean` and rerun the tests if they are failing for an unknown reason.
+
+### Static Analysis
+
+`contracts-bedrock` uses [slither](https://github.com/crytic/slither) as its primary static analysis tool. When opening a pr that includes changes to `contracts-bedrock`, you should
+verify that slither did not detect any new issues by running `pnpm slither:check`.
+
+If there are new issues, you should triage them.
+Run `pnpm slither:triage` to step through findings.
+You should _carefully_ walk through these findings, specifying which to triage/ignore (default is to keep all, outputting them into `slither-report.json`).
+Findings can be triaged into `slither.db.json` or kept in the `slither-report.json`.
+You should triage issues with extreme _care_ and security sign-off.
+
+After issues are triaged, or an updated slither report is generated, make sure to check in your changes to git.
+Once checked in, the changes can be verified by running `pnpm slither:check`.
+This will fail if there are issues missing from the `slither-report.json` that are _not_ triaged into `slither.db.json`.

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -4,6 +4,7 @@ set -e
 
 SLITHER_REPORT="slither-report.json"
 SLITHER_REPORT_BACKUP="slither-report.json.temp"
+SLITHER_TRIAGE_REPORT="slither.db.json"
 
 # Get the absolute path of the parent directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
@@ -44,45 +45,63 @@ if [ -e "$SLITHER_REPORT" ]; then
     echo "Created backup of previous slither report at $SLITHER_REPORT_BACKUP"
 fi
 
-# Slither's triage mode will run an 'interview' in the terminal, allowing you to review each of
-# its findings, and specify which should be ignored in future runs of slither. This will update
-# (or create) the slither.db.json file. This DB is a cleaner alternative to adding slither-disable
-# comments throughout the codebase.
-# Triage mode should only be run manually, and can be used to update the db when new findings are
-# causing a CI failure.
-# See slither.config.json for slither settings
+# Slither normal mode will run slither and put all findings in the slither-report.json file.
+# See slither.config.json for slither settings and to disable specific detectors.
 if [[ -z "$TRIAGE_MODE" ]]; then
   echo "Running slither in normal mode"
-  # Run slither and store the output in a variable to be used later
   SLITHER_OUTPUT=$(slither . 2>&1 || true)
+fi
 
-  # If slither failed to generate a report, exit with an error.
-  if [ ! -f "$SLITHER_REPORT" ]; then
-    echo "Slither output:\n$SLITHER_OUTPUT"
-    echo "Slither failed to generate a report."
-    if [ -e "$SLITHER_REPORT_BACKUP" ]; then
-        mv $SLITHER_REPORT_BACKUP $SLITHER_REPORT
-        echo "Restored previous slither report from $SLITHER_REPORT_BACKUP"
-    fi
-    echo "Exiting with error."
-    exit 1
-  fi
-
-  echo "Slither ran successfully, generating minimzed report..."
-  json=$(cat $SLITHER_REPORT)
-  updated_json=$(cat $SLITHER_REPORT | jq -r '[.results.detectors[] | .description as $description | .check as $check | .impact as $impact | .confidence as $confidence | (.elements[] | .type as $type | .name as $name | (.source_mapping | { "impact": $impact, "confidence": $confidence, "check": $check, "description": $description, "type": $type, "name": $name, start, length, filename_relative } ))]')
-  echo "$updated_json" > $SLITHER_REPORT
-  echo "Slither report stored at $DIR/$SLITHER_REPORT"
-else
+# Slither's triage mode will run an 'interview' in the terminal.
+# This allows you to review each finding, and specify which to ignore in future runs.
+# Findings to keep are output to the slither-report.json output file.
+# Checking in a json file is cleaner than adding slither-disable comments throughout the codebase.
+# See slither.config.json for slither settings and to disable specific detectors.
+if [[ ! -z "$TRIAGE_MODE" ]]; then
   echo "Running slither in triage mode"
-  slither . --triage-mode
+  SLITHER_OUTPUT=$(slither . --triage-mode --json $SLITHER_REPORT || true)
 
-  # The slither json report contains a `filename_absolute` property which includes the full
-  # local path to source code on the machine where it was generated. This property breaks
-  # cross-platform report comparisons, so it's removed here.
-  mv $SLITHER_REPORT temp-slither-report.json
-  jq 'walk(if type == "object" then del(.filename_absolute) else . end)' temp-slither-report.json > $SLITHER_REPORT
-  rm -f temp-slither-report.json
+  # If the slither report was generated successfully, and the slither triage exists, clean up the triaged output.
+  if [ -f "$SLITHER_REPORT" ] && [ -f  "$SLITHER_TRIAGE_REPORT" ]; then
+    json=$(cat $SLITHER_TRIAGE_REPORT)
+    # The following jq command selects a subset of fields in each of the slither triage report description and element objects.
+    # This significantly slims down the output json, on the order of 100 magnitudes smaller.
+    updated_json=$(cat $SLITHER_TRIAGE_REPORT | jq -r '[.[] | .id as $id | .description as $description | .check as $check | .impact as $impact | .confidence as $confidence | (.elements[] | .type as $type | .name as $name | (.source_mapping | { "id": $id, "impact": $impact, "confidence": $confidence, "check": $check, "description": $description, "type": $type, "name": $name, start, length, filename_relative } ))]')
+    echo "$updated_json" > $SLITHER_TRIAGE_REPORT
+    echo "Slither traige report updated at $DIR/$SLITHER_TRIAGE_REPORT"
+  fi
+fi
+
+# If slither failed to generate a report, exit with an error.
+if [ ! -f "$SLITHER_REPORT" ]; then
+  echo "Slither output:\n$SLITHER_OUTPUT"
+  echo "Slither failed to generate a report."
+  if [ -e "$SLITHER_REPORT_BACKUP" ]; then
+      mv $SLITHER_REPORT_BACKUP $SLITHER_REPORT
+      echo "Restored previous slither report from $SLITHER_REPORT_BACKUP"
+  fi
+  echo "Exiting with error."
+  exit 1
+fi
+
+# If slither successfully generated a report, clean up the report.
+# The following jq command selects a subset of fields in each of the slither triage report description and element objects.
+# This significantly slims down the output json, on the order of 100 magnitudes smaller.
+echo "Slither ran successfully, generating minimzed report..."
+json=$(cat $SLITHER_REPORT)
+updated_json=$(cat $SLITHER_REPORT | jq -r '[.results.detectors[] | .id as $id | .description as $description | .check as $check | .impact as $impact | .confidence as $confidence | (.elements[] | .type as $type | .name as $name | (.source_mapping | { "id": $id, "impact": $impact, "confidence": $confidence, "check": $check, "description": $description, "type": $type, "name": $name, start, length, filename_relative } ))]')
+echo "$updated_json" > $SLITHER_REPORT
+echo "Slither report stored at $DIR/$SLITHER_REPORT"
+
+# Remove any items in the slither report that are also in the slither triage report.
+# This prevents the same finding from being reported twice.
+# Iterate over the slither-report.json file and remove any items that are in the slither.db.json file
+# by matching on the id field.
+if [ -f "$SLITHER_TRIAGE_REPORT" ]; then
+  echo "Removing triaged items from slither report..."
+  jq -s '.[0] as $slither_report | .[1] as $slither_triage_report | $slither_report - ($slither_report - $slither_triage_report)' $SLITHER_REPORT $SLITHER_TRIAGE_REPORT > $SLITHER_REPORT.temp
+  mv $SLITHER_REPORT.temp $SLITHER_REPORT
+  echo "Slither report stored at $DIR/$SLITHER_REPORT"
 fi
 
 # Delete the backup of the previous slither report if it exists

--- a/packages/contracts-bedrock/slither-report.json
+++ b/packages/contracts-bedrock/slither-report.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "0b6d0d6699a3fa3c78250e527327e43538895feecaa6cfd8a1793dfcc1d20c72",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -11,6 +12,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "0b6d0d6699a3fa3c78250e527327e43538895feecaa6cfd8a1793dfcc1d20c72",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -22,6 +24,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "0b6d0d6699a3fa3c78250e527327e43538895feecaa6cfd8a1793dfcc1d20c72",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -33,6 +36,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "0d4915766a9a2117c655d6bc36e42594e95bbba8293384ec5b2c4904ff7a131f",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -44,6 +48,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "0d4915766a9a2117c655d6bc36e42594e95bbba8293384ec5b2c4904ff7a131f",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -55,6 +60,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "0d4915766a9a2117c655d6bc36e42594e95bbba8293384ec5b2c4904ff7a131f",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -66,6 +72,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "11c5e51d3a0080a2b8f208ae6ec1a4c5617c6df83441ac96c67f322294f73f2b",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -77,6 +84,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "11c5e51d3a0080a2b8f208ae6ec1a4c5617c6df83441ac96c67f322294f73f2b",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -88,6 +96,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "11c5e51d3a0080a2b8f208ae6ec1a4c5617c6df83441ac96c67f322294f73f2b",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -99,6 +108,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "1e96b3f3be5c5b827284291533d15f8b70c3f8bc774e863359baa95195e8a79c",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -110,6 +120,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "1e96b3f3be5c5b827284291533d15f8b70c3f8bc774e863359baa95195e8a79c",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -121,6 +132,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "1e96b3f3be5c5b827284291533d15f8b70c3f8bc774e863359baa95195e8a79c",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -132,6 +144,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "2792614492719714cdcff9f7f8e1c602931befa4b0b2d9e0845a2fbf3964f949",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -143,6 +156,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "2792614492719714cdcff9f7f8e1c602931befa4b0b2d9e0845a2fbf3964f949",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -154,6 +168,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "2792614492719714cdcff9f7f8e1c602931befa4b0b2d9e0845a2fbf3964f949",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -165,6 +180,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "35ba264224a7ea48dc7cd248e60c07e4aae32401690ae90b217f017e3a1b8112",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -176,6 +192,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "35ba264224a7ea48dc7cd248e60c07e4aae32401690ae90b217f017e3a1b8112",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -187,6 +204,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "35ba264224a7ea48dc7cd248e60c07e4aae32401690ae90b217f017e3a1b8112",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -198,6 +216,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "38dac452acbdd7762ba9aa67e268c249835dad01e219ff2f50d93e4533aa7c52",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -209,6 +228,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "38dac452acbdd7762ba9aa67e268c249835dad01e219ff2f50d93e4533aa7c52",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -220,6 +240,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "38dac452acbdd7762ba9aa67e268c249835dad01e219ff2f50d93e4533aa7c52",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -231,6 +252,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "39745c2ba61544fe128a7627287a023e043a087ee32100d6e0bfe5b404209670",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -242,6 +264,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "39745c2ba61544fe128a7627287a023e043a087ee32100d6e0bfe5b404209670",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -253,6 +276,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "39745c2ba61544fe128a7627287a023e043a087ee32100d6e0bfe5b404209670",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -264,6 +288,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "3f56bbd28cbf0b716ac3b0a61479a74ece176d3e2f2a53dd16994daa375a5468",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -275,6 +300,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "3f56bbd28cbf0b716ac3b0a61479a74ece176d3e2f2a53dd16994daa375a5468",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -286,6 +312,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "3f56bbd28cbf0b716ac3b0a61479a74ece176d3e2f2a53dd16994daa375a5468",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -297,6 +324,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "40da9d5df6ace4d9b107bfd175846739fa74c9a29d3b6d94d1b8ce9dfa13aa05",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -308,6 +336,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "40da9d5df6ace4d9b107bfd175846739fa74c9a29d3b6d94d1b8ce9dfa13aa05",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -319,6 +348,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "40da9d5df6ace4d9b107bfd175846739fa74c9a29d3b6d94d1b8ce9dfa13aa05",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -330,6 +360,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "4ea64b8e0080de740c9c25e7841217213a680d8680654c8c9f744be145a1431a",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -341,6 +372,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "4ea64b8e0080de740c9c25e7841217213a680d8680654c8c9f744be145a1431a",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -352,6 +384,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "4ea64b8e0080de740c9c25e7841217213a680d8680654c8c9f744be145a1431a",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -363,6 +396,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "5dbecee956931b503b0ed4fbb7be62ba5f9f64bab10ac87b3c5ba4dab3694bec",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -374,6 +408,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "5dbecee956931b503b0ed4fbb7be62ba5f9f64bab10ac87b3c5ba4dab3694bec",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -385,6 +420,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "5dbecee956931b503b0ed4fbb7be62ba5f9f64bab10ac87b3c5ba4dab3694bec",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -396,6 +432,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "5f00d9ac316494d702da33c92ba3267b0b2a5ab498b5c720e942923a75fd0f50",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -407,6 +444,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "5f00d9ac316494d702da33c92ba3267b0b2a5ab498b5c720e942923a75fd0f50",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -418,6 +456,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "5f00d9ac316494d702da33c92ba3267b0b2a5ab498b5c720e942923a75fd0f50",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -429,6 +468,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "61c6823d9d96abad705c3e29c3768a5d2ade61e6f226c9241e6f3278063ab469",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -440,6 +480,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "61c6823d9d96abad705c3e29c3768a5d2ade61e6f226c9241e6f3278063ab469",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -451,6 +492,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "61c6823d9d96abad705c3e29c3768a5d2ade61e6f226c9241e6f3278063ab469",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -462,6 +504,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "648de83c485a902ab3df50445e187c6390720ae77705d14edbcc112e4fd8fe1a",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -473,6 +516,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "648de83c485a902ab3df50445e187c6390720ae77705d14edbcc112e4fd8fe1a",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -484,6 +528,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "648de83c485a902ab3df50445e187c6390720ae77705d14edbcc112e4fd8fe1a",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -495,6 +540,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "6cf6408cd8c7aedc182552abc25970ede8e033409292304b75b62006b0ad9491",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -506,6 +552,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "6cf6408cd8c7aedc182552abc25970ede8e033409292304b75b62006b0ad9491",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -517,6 +564,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "6cf6408cd8c7aedc182552abc25970ede8e033409292304b75b62006b0ad9491",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -528,6 +576,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "98821b545d4849522091839fbd87144e6fcc256a73b9dd1817676bd127be6d8c",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -539,6 +588,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "98821b545d4849522091839fbd87144e6fcc256a73b9dd1817676bd127be6d8c",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -550,6 +600,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "98821b545d4849522091839fbd87144e6fcc256a73b9dd1817676bd127be6d8c",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -561,6 +612,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "c116aac23f49ec7d5d6574972abfbf02d56d0521ea2285dc09d239a829e7d2af",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -572,6 +624,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "c116aac23f49ec7d5d6574972abfbf02d56d0521ea2285dc09d239a829e7d2af",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -583,6 +636,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "c116aac23f49ec7d5d6574972abfbf02d56d0521ea2285dc09d239a829e7d2af",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -594,6 +648,7 @@
     "filename_relative": "src/legacy/L1ChugSplashProxy.sol"
   },
   {
+    "id": "d14996b9cc4486d4926155fb1f3d0c1ffc8be9b4af43a61074039356721c7e45",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -605,6 +660,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "d14996b9cc4486d4926155fb1f3d0c1ffc8be9b4af43a61074039356721c7e45",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -616,6 +672,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
+    "id": "d14996b9cc4486d4926155fb1f3d0c1ffc8be9b4af43a61074039356721c7e45",
     "impact": "High",
     "confidence": "Medium",
     "check": "incorrect-return",
@@ -627,28 +684,7 @@
     "filename_relative": "src/universal/Proxy.sol"
   },
   {
-    "impact": "High",
-    "confidence": "High",
-    "check": "shadowing-state",
-    "description": "EAS.__gap (src/EAS/EAS.sol#80) shadows:\n\t- EIP1271Verifier.__gap (src/EAS/eip1271/EIP1271Verifier.sol#48)\n",
-    "type": "variable",
-    "name": "__gap",
-    "start": 2496,
-    "length": 34,
-    "filename_relative": "src/EAS/EAS.sol"
-  },
-  {
-    "impact": "High",
-    "confidence": "High",
-    "check": "shadowing-state",
-    "description": "EAS.__gap (src/EAS/EAS.sol#80) shadows:\n\t- EIP1271Verifier.__gap (src/EAS/eip1271/EIP1271Verifier.sol#48)\n",
-    "type": "variable",
-    "name": "__gap",
-    "start": 1820,
-    "length": 34,
-    "filename_relative": "src/EAS/eip1271/EIP1271Verifier.sol"
-  },
-  {
+    "id": "89460308ae3bd86a612657eb7bfe28221ced6a7a7fe723ec2a19149bfc819cb5",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -660,6 +696,7 @@
     "filename_relative": "src/L1/L2OutputOracle.sol"
   },
   {
+    "id": "89460308ae3bd86a612657eb7bfe28221ced6a7a7fe723ec2a19149bfc819cb5",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -671,21 +708,23 @@
     "filename_relative": "src/L1/L2OutputOracle.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "contract",
     "name": "FaultDisputeGame",
     "start": 1080,
-    "length": 25208,
+    "length": 24930,
     "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "attack",
     "start": 2181,
@@ -693,10 +732,11 @@
     "filename_relative": "src/dispute/interfaces/IFaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "defend",
     "start": 2454,
@@ -704,10 +744,11 @@
     "filename_relative": "src/dispute/interfaces/IFaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "resolveClaim",
     "start": 4428,
@@ -715,65 +756,71 @@
     "filename_relative": "src/dispute/interfaces/IFaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "move",
-    "start": 9286,
+    "start": 9008,
     "length": 3953,
     "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "attack",
-    "start": 13283,
+    "start": 13005,
     "length": 118,
     "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "defend",
-    "start": 13445,
+    "start": 13167,
     "length": 119,
     "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "99c01b42fc96fd11586bce47c0e6edbb6697d3feda3cfe6ede5b03b79ac5af81",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-560) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#274-276)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#279-281)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract FaultDisputeGame (src/dispute/FaultDisputeGame.sol#24-557) has payable functions:\n\t - IFaultDisputeGame.attack(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#51)\n\t - IFaultDisputeGame.defend(uint256,Claim) (src/dispute/interfaces/IFaultDisputeGame.sol#56)\n\t - IFaultDisputeGame.resolveClaim(uint256) (src/dispute/interfaces/IFaultDisputeGame.sol#83)\n\t - FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t - FaultDisputeGame.attack(uint256,Claim) (src/dispute/FaultDisputeGame.sol#271-273)\n\t - FaultDisputeGame.defend(uint256,Claim) (src/dispute/FaultDisputeGame.sol#276-278)\n\t - FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "resolveClaim",
-    "start": 17388,
+    "start": 17110,
     "length": 2033,
     "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "contract",
     "name": "OutputBisectionGame",
     "start": 1092,
-    "length": 25331,
+    "length": 28651,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "attack",
     "start": 1139,
@@ -781,10 +828,11 @@
     "filename_relative": "src/dispute/interfaces/IOutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "defend",
     "start": 1412,
@@ -792,10 +840,11 @@
     "filename_relative": "src/dispute/interfaces/IOutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "resolveClaim",
     "start": 3429,
@@ -803,50 +852,55 @@
     "filename_relative": "src/dispute/interfaces/IOutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "move",
-    "start": 9135,
-    "length": 4228,
+    "start": 9840,
+    "length": 4211,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "attack",
-    "start": 13410,
+    "start": 14098,
     "length": 118,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "defend",
-    "start": 13575,
+    "start": 14263,
     "length": 119,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "a163cee00f9eadca42657b9e68feeb6933902bdb0d38f8fa1490a82a355b68dc",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
-    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-551) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#273-275)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#278-280)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\tBut does not have a function to withdraw the ether\n",
+    "description": "Contract locking ether found:\n\tContract OutputBisectionGame (src/dispute/OutputBisectionGame.sol#24-612) has payable functions:\n\t - IOutputBisectionGame.attack(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#30)\n\t - IOutputBisectionGame.defend(uint256,Claim) (src/dispute/interfaces/IOutputBisectionGame.sol#35)\n\t - IOutputBisectionGame.resolveClaim(uint256) (src/dispute/interfaces/IOutputBisectionGame.sol#62)\n\t - OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t - OutputBisectionGame.attack(uint256,Claim) (src/dispute/OutputBisectionGame.sol#284-286)\n\t - OutputBisectionGame.defend(uint256,Claim) (src/dispute/OutputBisectionGame.sol#289-291)\n\t - OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\tBut does not have a function to withdraw the ether\n",
     "type": "function",
     "name": "resolveClaim",
-    "start": 16915,
+    "start": 17921,
     "length": 2043,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "c0920fe4b6b04a2b81f69b85402d465719d06978441052f49a6582415934a1bf",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -858,6 +912,7 @@
     "filename_relative": "src/legacy/L1BlockNumber.sol"
   },
   {
+    "id": "c0920fe4b6b04a2b81f69b85402d465719d06978441052f49a6582415934a1bf",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -869,6 +924,7 @@
     "filename_relative": "src/legacy/L1BlockNumber.sol"
   },
   {
+    "id": "c0920fe4b6b04a2b81f69b85402d465719d06978441052f49a6582415934a1bf",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -880,6 +936,7 @@
     "filename_relative": "src/legacy/L1BlockNumber.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -891,6 +948,7 @@
     "filename_relative": "src/EAS/resolver/SchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -902,6 +960,7 @@
     "filename_relative": "src/EAS/resolver/ISchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -913,6 +972,7 @@
     "filename_relative": "src/EAS/resolver/ISchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -924,6 +984,7 @@
     "filename_relative": "src/EAS/resolver/ISchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -935,6 +996,7 @@
     "filename_relative": "src/EAS/resolver/ISchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -946,6 +1008,7 @@
     "filename_relative": "src/EAS/resolver/SchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -957,6 +1020,7 @@
     "filename_relative": "src/EAS/resolver/SchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -968,6 +1032,7 @@
     "filename_relative": "src/EAS/resolver/SchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -979,6 +1044,7 @@
     "filename_relative": "src/EAS/resolver/SchemaResolver.sol"
   },
   {
+    "id": "3e52f3459d6607e6494e893c33e98bfaee52639c20f8e8366a39b97d30efeb9d",
     "impact": "Medium",
     "confidence": "High",
     "check": "locked-ether",
@@ -990,39 +1056,43 @@
     "filename_relative": "src/EAS/resolver/SchemaResolver.sol"
   },
   {
+    "id": "0e1e451177ca06fd343007706a5c0c9d51f9fe188265e5d192703a2a4db433fc",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
-    "description": "Reentrancy in OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#119-183):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,uuid) == Claim.unwrap(postState.claim) (src/dispute/OutputBisectionGame.sol#176)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/OutputBisectionGame.sol#182)\n\tOutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#71) can be used in cross function reentrancies:\n\t- OutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#71)\n\t- OutputBisectionGame.claimDataLen() (src/dispute/OutputBisectionGame.sol#455-457)\n\t- OutputBisectionGame.findStartingAndDisputedOutputs(uint256) (src/dispute/OutputBisectionGame.sol#500-550)\n\t- OutputBisectionGame.findTraceAncestor(Position,uint256) (src/dispute/OutputBisectionGame.sol#483-493)\n\t- OutputBisectionGame.initialize() (src/dispute/OutputBisectionGame.sol#426-452)\n\t- OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t- OutputBisectionGame.resolve() (src/dispute/OutputBisectionGame.sol#335-347)\n\t- OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\t- OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#119-183)\n",
+    "description": "Reentrancy in FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-184):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim) (src/dispute/FaultDisputeGame.sol#177)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/FaultDisputeGame.sol#183)\n\tFaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68) can be used in cross function reentrancies:\n\t- FaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68)\n\t- FaultDisputeGame.claimDataLen() (src/dispute/FaultDisputeGame.sol#532-534)\n\t- FaultDisputeGame.findTraceAncestor(Position,uint256) (src/dispute/FaultDisputeGame.sol#546-556)\n\t- FaultDisputeGame.initialize() (src/dispute/FaultDisputeGame.sol#448-529)\n\t- FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t- FaultDisputeGame.resolve() (src/dispute/FaultDisputeGame.sol#360-369)\n\t- FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\t- FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-184)\n",
     "type": "function",
     "name": "step",
-    "start": 4835,
-    "length": 3995,
-    "filename_relative": "src/dispute/OutputBisectionGame.sol"
+    "start": 5018,
+    "length": 3685,
+    "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "0e1e451177ca06fd343007706a5c0c9d51f9fe188265e5d192703a2a4db433fc",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
-    "description": "Reentrancy in OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#119-183):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,uuid) == Claim.unwrap(postState.claim) (src/dispute/OutputBisectionGame.sol#176)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/OutputBisectionGame.sol#182)\n\tOutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#71) can be used in cross function reentrancies:\n\t- OutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#71)\n\t- OutputBisectionGame.claimDataLen() (src/dispute/OutputBisectionGame.sol#455-457)\n\t- OutputBisectionGame.findStartingAndDisputedOutputs(uint256) (src/dispute/OutputBisectionGame.sol#500-550)\n\t- OutputBisectionGame.findTraceAncestor(Position,uint256) (src/dispute/OutputBisectionGame.sol#483-493)\n\t- OutputBisectionGame.initialize() (src/dispute/OutputBisectionGame.sol#426-452)\n\t- OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t- OutputBisectionGame.resolve() (src/dispute/OutputBisectionGame.sol#335-347)\n\t- OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\t- OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#119-183)\n",
+    "description": "Reentrancy in FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-184):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim) (src/dispute/FaultDisputeGame.sol#177)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/FaultDisputeGame.sol#183)\n\tFaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68) can be used in cross function reentrancies:\n\t- FaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68)\n\t- FaultDisputeGame.claimDataLen() (src/dispute/FaultDisputeGame.sol#532-534)\n\t- FaultDisputeGame.findTraceAncestor(Position,uint256) (src/dispute/FaultDisputeGame.sol#546-556)\n\t- FaultDisputeGame.initialize() (src/dispute/FaultDisputeGame.sol#448-529)\n\t- FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t- FaultDisputeGame.resolve() (src/dispute/FaultDisputeGame.sol#360-369)\n\t- FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\t- FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-184)\n",
     "type": "node",
-    "name": "validStep = VM.step(_stateData,_proof,uuid) == Claim.unwrap(postState.claim)",
-    "start": 8388,
-    "length": 83,
-    "filename_relative": "src/dispute/OutputBisectionGame.sol"
+    "name": "validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim)",
+    "start": 8264,
+    "length": 80,
+    "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "0e1e451177ca06fd343007706a5c0c9d51f9fe188265e5d192703a2a4db433fc",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
-    "description": "Reentrancy in OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#119-183):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,uuid) == Claim.unwrap(postState.claim) (src/dispute/OutputBisectionGame.sol#176)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/OutputBisectionGame.sol#182)\n\tOutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#71) can be used in cross function reentrancies:\n\t- OutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#71)\n\t- OutputBisectionGame.claimDataLen() (src/dispute/OutputBisectionGame.sol#455-457)\n\t- OutputBisectionGame.findStartingAndDisputedOutputs(uint256) (src/dispute/OutputBisectionGame.sol#500-550)\n\t- OutputBisectionGame.findTraceAncestor(Position,uint256) (src/dispute/OutputBisectionGame.sol#483-493)\n\t- OutputBisectionGame.initialize() (src/dispute/OutputBisectionGame.sol#426-452)\n\t- OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#189-270)\n\t- OutputBisectionGame.resolve() (src/dispute/OutputBisectionGame.sol#335-347)\n\t- OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#350-400)\n\t- OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#119-183)\n",
+    "description": "Reentrancy in FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-184):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim) (src/dispute/FaultDisputeGame.sol#177)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/FaultDisputeGame.sol#183)\n\tFaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68) can be used in cross function reentrancies:\n\t- FaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68)\n\t- FaultDisputeGame.claimDataLen() (src/dispute/FaultDisputeGame.sol#532-534)\n\t- FaultDisputeGame.findTraceAncestor(Position,uint256) (src/dispute/FaultDisputeGame.sol#546-556)\n\t- FaultDisputeGame.initialize() (src/dispute/FaultDisputeGame.sol#448-529)\n\t- FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#190-268)\n\t- FaultDisputeGame.resolve() (src/dispute/FaultDisputeGame.sol#360-369)\n\t- FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#372-422)\n\t- FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-184)\n",
     "type": "node",
     "name": "parent.countered = true",
-    "start": 8800,
+    "start": 8673,
     "length": 23,
-    "filename_relative": "src/dispute/OutputBisectionGame.sol"
+    "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "1349b68c3b08ecdf27782bd74d9fecadf1739eef738171cbbba403c77a29f424",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1034,6 +1104,7 @@
     "filename_relative": "src/periphery/TransferOnion.sol"
   },
   {
+    "id": "1349b68c3b08ecdf27782bd74d9fecadf1739eef738171cbbba403c77a29f424",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1045,6 +1116,7 @@
     "filename_relative": "src/periphery/TransferOnion.sol"
   },
   {
+    "id": "1349b68c3b08ecdf27782bd74d9fecadf1739eef738171cbbba403c77a29f424",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1056,6 +1128,7 @@
     "filename_relative": "src/periphery/TransferOnion.sol"
   },
   {
+    "id": "14134bc23d372275d187f91848cac770b21d8451fa7b979380dc2ac94588945b",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1067,6 +1140,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "14134bc23d372275d187f91848cac770b21d8451fa7b979380dc2ac94588945b",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1078,6 +1152,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "14134bc23d372275d187f91848cac770b21d8451fa7b979380dc2ac94588945b",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1089,6 +1164,7 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "14134bc23d372275d187f91848cac770b21d8451fa7b979380dc2ac94588945b",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
@@ -1100,160 +1176,151 @@
     "filename_relative": "src/L1/DelayedVetoable.sol"
   },
   {
+    "id": "92534abca79638a52d5d43b56586f3d16df4fdf0139a3598bca266997377fe5f",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
-    "description": "Reentrancy in FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-187):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim) (src/dispute/FaultDisputeGame.sol#180)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/FaultDisputeGame.sol#186)\n\tFaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68) can be used in cross function reentrancies:\n\t- FaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68)\n\t- FaultDisputeGame.claimDataLen() (src/dispute/FaultDisputeGame.sol#535-537)\n\t- FaultDisputeGame.findTraceAncestor(Position,uint256) (src/dispute/FaultDisputeGame.sol#549-559)\n\t- FaultDisputeGame.initialize() (src/dispute/FaultDisputeGame.sol#451-532)\n\t- FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t- FaultDisputeGame.resolve() (src/dispute/FaultDisputeGame.sol#363-372)\n\t- FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\t- FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-187)\n",
+    "description": "Reentrancy in OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#127-194):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,Hash.unwrap(uuid)) == Claim.unwrap(postState.claim) (src/dispute/OutputBisectionGame.sol#187)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/OutputBisectionGame.sol#193)\n\tOutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#74) can be used in cross function reentrancies:\n\t- OutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#74)\n\t- OutputBisectionGame.claimDataLen() (src/dispute/OutputBisectionGame.sol#463-465)\n\t- OutputBisectionGame.findStartingAndDisputedOutputs(uint256) (src/dispute/OutputBisectionGame.sol#516-577)\n\t- OutputBisectionGame.findTraceAncestor(Position,uint256,bool) (src/dispute/OutputBisectionGame.sol#489-507)\n\t- OutputBisectionGame.initialize() (src/dispute/OutputBisectionGame.sol#437-460)\n\t- OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t- OutputBisectionGame.resolve() (src/dispute/OutputBisectionGame.sol#346-358)\n\t- OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\t- OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#127-194)\n",
     "type": "function",
     "name": "step",
-    "start": 5018,
-    "length": 3963,
-    "filename_relative": "src/dispute/FaultDisputeGame.sol"
+    "start": 5273,
+    "length": 4262,
+    "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "92534abca79638a52d5d43b56586f3d16df4fdf0139a3598bca266997377fe5f",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
-    "description": "Reentrancy in FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-187):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim) (src/dispute/FaultDisputeGame.sol#180)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/FaultDisputeGame.sol#186)\n\tFaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68) can be used in cross function reentrancies:\n\t- FaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68)\n\t- FaultDisputeGame.claimDataLen() (src/dispute/FaultDisputeGame.sol#535-537)\n\t- FaultDisputeGame.findTraceAncestor(Position,uint256) (src/dispute/FaultDisputeGame.sol#549-559)\n\t- FaultDisputeGame.initialize() (src/dispute/FaultDisputeGame.sol#451-532)\n\t- FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t- FaultDisputeGame.resolve() (src/dispute/FaultDisputeGame.sol#363-372)\n\t- FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\t- FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-187)\n",
+    "description": "Reentrancy in OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#127-194):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,Hash.unwrap(uuid)) == Claim.unwrap(postState.claim) (src/dispute/OutputBisectionGame.sol#187)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/OutputBisectionGame.sol#193)\n\tOutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#74) can be used in cross function reentrancies:\n\t- OutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#74)\n\t- OutputBisectionGame.claimDataLen() (src/dispute/OutputBisectionGame.sol#463-465)\n\t- OutputBisectionGame.findStartingAndDisputedOutputs(uint256) (src/dispute/OutputBisectionGame.sol#516-577)\n\t- OutputBisectionGame.findTraceAncestor(Position,uint256,bool) (src/dispute/OutputBisectionGame.sol#489-507)\n\t- OutputBisectionGame.initialize() (src/dispute/OutputBisectionGame.sol#437-460)\n\t- OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t- OutputBisectionGame.resolve() (src/dispute/OutputBisectionGame.sol#346-358)\n\t- OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\t- OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#127-194)\n",
     "type": "node",
-    "name": "validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim)",
-    "start": 8542,
-    "length": 80,
-    "filename_relative": "src/dispute/FaultDisputeGame.sol"
+    "name": "validStep = VM.step(_stateData,_proof,Hash.unwrap(uuid)) == Claim.unwrap(postState.claim)",
+    "start": 9080,
+    "length": 96,
+    "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "92534abca79638a52d5d43b56586f3d16df4fdf0139a3598bca266997377fe5f",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "reentrancy-no-eth",
-    "description": "Reentrancy in FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-187):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,0) == Claim.unwrap(postState.claim) (src/dispute/FaultDisputeGame.sol#180)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/FaultDisputeGame.sol#186)\n\tFaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68) can be used in cross function reentrancies:\n\t- FaultDisputeGame.claimData (src/dispute/FaultDisputeGame.sol#68)\n\t- FaultDisputeGame.claimDataLen() (src/dispute/FaultDisputeGame.sol#535-537)\n\t- FaultDisputeGame.findTraceAncestor(Position,uint256) (src/dispute/FaultDisputeGame.sol#549-559)\n\t- FaultDisputeGame.initialize() (src/dispute/FaultDisputeGame.sol#451-532)\n\t- FaultDisputeGame.move(uint256,Claim,bool) (src/dispute/FaultDisputeGame.sol#193-271)\n\t- FaultDisputeGame.resolve() (src/dispute/FaultDisputeGame.sol#363-372)\n\t- FaultDisputeGame.resolveClaim(uint256) (src/dispute/FaultDisputeGame.sol#375-425)\n\t- FaultDisputeGame.step(uint256,bool,bytes,bytes) (src/dispute/FaultDisputeGame.sol#121-187)\n",
+    "description": "Reentrancy in OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#127-194):\n\tExternal calls:\n\t- validStep = VM.step(_stateData,_proof,Hash.unwrap(uuid)) == Claim.unwrap(postState.claim) (src/dispute/OutputBisectionGame.sol#187)\n\tState variables written after the call(s):\n\t- parent.countered = true (src/dispute/OutputBisectionGame.sol#193)\n\tOutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#74) can be used in cross function reentrancies:\n\t- OutputBisectionGame.claimData (src/dispute/OutputBisectionGame.sol#74)\n\t- OutputBisectionGame.claimDataLen() (src/dispute/OutputBisectionGame.sol#463-465)\n\t- OutputBisectionGame.findStartingAndDisputedOutputs(uint256) (src/dispute/OutputBisectionGame.sol#516-577)\n\t- OutputBisectionGame.findTraceAncestor(Position,uint256,bool) (src/dispute/OutputBisectionGame.sol#489-507)\n\t- OutputBisectionGame.initialize() (src/dispute/OutputBisectionGame.sol#437-460)\n\t- OutputBisectionGame.move(uint256,Claim,bool) (src/dispute/OutputBisectionGame.sol#200-281)\n\t- OutputBisectionGame.resolve() (src/dispute/OutputBisectionGame.sol#346-358)\n\t- OutputBisectionGame.resolveClaim(uint256) (src/dispute/OutputBisectionGame.sol#361-411)\n\t- OutputBisectionGame.step(uint256,bool,bytes,bytes) (src/dispute/OutputBisectionGame.sol#127-194)\n",
     "type": "node",
     "name": "parent.countered = true",
-    "start": 8951,
+    "start": 9505,
     "length": 23,
-    "filename_relative": "src/dispute/FaultDisputeGame.sol"
+    "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "138bfe0b87067edda58ea1bb24d88b46c26dd0da82a6818486cf28b4cb185d01",
+    "impact": "Medium",
+    "confidence": "Medium",
+    "check": "tx-origin",
+    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-306) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#279)\n",
+    "type": "function",
+    "name": "relayMessage",
+    "start": 10427,
+    "length": 4822,
+    "filename_relative": "src/universal/CrossDomainMessenger.sol"
+  },
+  {
+    "id": "138bfe0b87067edda58ea1bb24d88b46c26dd0da82a6818486cf28b4cb185d01",
+    "impact": "Medium",
+    "confidence": "Medium",
+    "check": "tx-origin",
+    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-306) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#279)\n",
+    "type": "node",
+    "name": "tx.origin == Constants.ESTIMATION_ADDRESS",
+    "start": 14024,
+    "length": 41,
+    "filename_relative": "src/universal/CrossDomainMessenger.sol"
+  },
+  {
+    "id": "37ae06d1257a210b94d7ebd3a411a5e657e4fe6e09bdcb5405f76bcf5b2e6496",
+    "impact": "Medium",
+    "confidence": "Medium",
+    "check": "tx-origin",
+    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-306) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#302)\n",
+    "type": "function",
+    "name": "relayMessage",
+    "start": 10427,
+    "length": 4822,
+    "filename_relative": "src/universal/CrossDomainMessenger.sol"
+  },
+  {
+    "id": "37ae06d1257a210b94d7ebd3a411a5e657e4fe6e09bdcb5405f76bcf5b2e6496",
+    "impact": "Medium",
+    "confidence": "Medium",
+    "check": "tx-origin",
+    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-306) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#302)\n",
+    "type": "node",
+    "name": "tx.origin == Constants.ESTIMATION_ADDRESS",
+    "start": 15102,
+    "length": 41,
+    "filename_relative": "src/universal/CrossDomainMessenger.sol"
+  },
+  {
+    "id": "abea83e11d409c6cde17efdfe955c3a9f5ab92a0bc6720d631933eb091de0c77",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "tx-origin",
     "description": "OptimismPortal.finalizeWithdrawalTransaction(Types.WithdrawalTransaction) (src/L1/OptimismPortal.sol#272-355) uses tx.origin for authorization: success == false && tx.origin == Constants.ESTIMATION_ADDRESS (src/L1/OptimismPortal.sol#352)\n",
     "type": "function",
     "name": "finalizeWithdrawalTransaction",
-    "start": 13145,
+    "start": 13146,
     "length": 4841,
     "filename_relative": "src/L1/OptimismPortal.sol"
   },
   {
+    "id": "abea83e11d409c6cde17efdfe955c3a9f5ab92a0bc6720d631933eb091de0c77",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "tx-origin",
     "description": "OptimismPortal.finalizeWithdrawalTransaction(Types.WithdrawalTransaction) (src/L1/OptimismPortal.sol#272-355) uses tx.origin for authorization: success == false && tx.origin == Constants.ESTIMATION_ADDRESS (src/L1/OptimismPortal.sol#352)\n",
     "type": "node",
     "name": "success == false && tx.origin == Constants.ESTIMATION_ADDRESS",
-    "start": 17849,
+    "start": 17850,
     "length": 61,
     "filename_relative": "src/L1/OptimismPortal.sol"
   },
   {
-    "impact": "Medium",
-    "confidence": "Medium",
-    "check": "tx-origin",
-    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-302) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#275)\n",
-    "type": "function",
-    "name": "relayMessage",
-    "start": 10420,
-    "length": 4586,
-    "filename_relative": "src/universal/CrossDomainMessenger.sol"
-  },
-  {
-    "impact": "Medium",
-    "confidence": "Medium",
-    "check": "tx-origin",
-    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-302) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#275)\n",
-    "type": "node",
-    "name": "tx.origin == Constants.ESTIMATION_ADDRESS",
-    "start": 13781,
-    "length": 41,
-    "filename_relative": "src/universal/CrossDomainMessenger.sol"
-  },
-  {
-    "impact": "Medium",
-    "confidence": "Medium",
-    "check": "tx-origin",
-    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-302) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#298)\n",
-    "type": "function",
-    "name": "relayMessage",
-    "start": 10420,
-    "length": 4586,
-    "filename_relative": "src/universal/CrossDomainMessenger.sol"
-  },
-  {
-    "impact": "Medium",
-    "confidence": "Medium",
-    "check": "tx-origin",
-    "description": "CrossDomainMessenger.relayMessage(uint256,address,address,uint256,uint256,bytes) (src/universal/CrossDomainMessenger.sol#211-302) uses tx.origin for authorization: tx.origin == Constants.ESTIMATION_ADDRESS (src/universal/CrossDomainMessenger.sol#298)\n",
-    "type": "node",
-    "name": "tx.origin == Constants.ESTIMATION_ADDRESS",
-    "start": 14859,
-    "length": 41,
-    "filename_relative": "src/universal/CrossDomainMessenger.sol"
-  },
-  {
+    "id": "0369380fef18a61639eac6a12773df792e9969e7bb20eddde54ccf3a263a0987",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "uninitialized-local",
-    "description": "FaultDisputeGame.move(uint256,Claim,bool).grandparentClock (src/dispute/FaultDisputeGame.sol#218) is a local variable never initialized\n",
+    "description": "FaultDisputeGame.move(uint256,Claim,bool).grandparentClock (src/dispute/FaultDisputeGame.sol#215) is a local variable never initialized\n",
     "type": "variable",
     "name": "grandparentClock",
-    "start": 10880,
+    "start": 10602,
     "length": 22,
     "filename_relative": "src/dispute/FaultDisputeGame.sol"
   },
   {
+    "id": "b806faf2b63e910b939c5ff4b591b1109887080a010986f2af2c30787dbc2a10",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "uninitialized-local",
-    "description": "OutputBisectionGame.findStartingAndDisputedOutputs(uint256).currentDepth (src/dispute/OutputBisectionGame.sol#518) is a local variable never initialized\n",
+    "description": "OutputBisectionGame.findStartingAndDisputedOutputs(uint256).currentDepth (src/dispute/OutputBisectionGame.sol#534) is a local variable never initialized\n",
     "type": "variable",
     "name": "currentDepth",
-    "start": 24494,
+    "start": 25470,
     "length": 20,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
+    "id": "c27cc53c209fdabd18ab2c8f2cddf2053516bcaaa39122d29702ac143d835a2f",
     "impact": "Medium",
     "confidence": "Medium",
     "check": "uninitialized-local",
-    "description": "OutputBisectionGame.move(uint256,Claim,bool).grandparentClock (src/dispute/OutputBisectionGame.sol#218) is a local variable never initialized\n",
+    "description": "OutputBisectionGame.move(uint256,Claim,bool).grandparentClock (src/dispute/OutputBisectionGame.sol#229) is a local variable never initialized\n",
     "type": "variable",
     "name": "grandparentClock",
-    "start": 11025,
+    "start": 11713,
     "length": 22,
     "filename_relative": "src/dispute/OutputBisectionGame.sol"
   },
   {
-    "impact": "Medium",
-    "confidence": "Medium",
-    "check": "uninitialized-local",
-    "description": "EAS._attest(bytes32,AttestationRequestData[],address,uint256,bool).res (src/EAS/EAS.sol#403) is a local variable never initialized\n",
-    "type": "variable",
-    "name": "res",
-    "start": 16042,
-    "length": 29,
-    "filename_relative": "src/EAS/EAS.sol"
-  },
-  {
-    "impact": "Medium",
-    "confidence": "Medium",
-    "check": "uninitialized-local",
-    "description": "EAS._attest(bytes32,AttestationRequestData[],address,uint256,bool).uid (src/EAS/EAS.sol#442) is a local variable never initialized\n",
-    "type": "variable",
-    "name": "uid",
-    "start": 17694,
-    "length": 11,
-    "filename_relative": "src/EAS/EAS.sol"
-  },
-  {
+    "id": "31cd4889732cd7c264fbe798960cae4b02c6d6f07d31596ceba32a2aaf3db8f7",
     "impact": "Medium",
     "confidence": "High",
     "check": "write-after-write",
@@ -1265,32 +1332,35 @@
     "filename_relative": "src/L1/OptimismPortal.sol"
   },
   {
+    "id": "31cd4889732cd7c264fbe798960cae4b02c6d6f07d31596ceba32a2aaf3db8f7",
     "impact": "Medium",
     "confidence": "High",
     "check": "write-after-write",
     "description": "OptimismPortal.l2Sender (src/L1/OptimismPortal.sol#53) is written in both\n\tl2Sender = _tx.sender (src/L1/OptimismPortal.sol#331)\n\tl2Sender = Constants.DEFAULT_L2_SENDER (src/L1/OptimismPortal.sol#343)\n",
     "type": "node",
     "name": "l2Sender = _tx.sender",
-    "start": 16550,
+    "start": 16551,
     "length": 21,
     "filename_relative": "src/L1/OptimismPortal.sol"
   },
   {
+    "id": "31cd4889732cd7c264fbe798960cae4b02c6d6f07d31596ceba32a2aaf3db8f7",
     "impact": "Medium",
     "confidence": "High",
     "check": "write-after-write",
     "description": "OptimismPortal.l2Sender (src/L1/OptimismPortal.sol#53) is written in both\n\tl2Sender = _tx.sender (src/L1/OptimismPortal.sol#331)\n\tl2Sender = Constants.DEFAULT_L2_SENDER (src/L1/OptimismPortal.sol#343)\n",
     "type": "node",
     "name": "l2Sender = Constants.DEFAULT_L2_SENDER",
-    "start": 17344,
+    "start": 17345,
     "length": 38,
     "filename_relative": "src/L1/OptimismPortal.sol"
   },
   {
+    "id": "9ad67b006fc175893dd26d35a020a52dd8524709d87cca61212ee0e147eb992b",
     "impact": "Medium",
     "confidence": "High",
     "check": "write-after-write",
-    "description": "CrossDomainMessenger.xDomainMsgSender (src/universal/CrossDomainMessenger.sol#129) is written in both\n\txDomainMsgSender = _sender (src/universal/CrossDomainMessenger.sol#282)\n\txDomainMsgSender = Constants.DEFAULT_L2_SENDER (src/universal/CrossDomainMessenger.sol#284)\n",
+    "description": "CrossDomainMessenger.xDomainMsgSender (src/universal/CrossDomainMessenger.sol#129) is written in both\n\txDomainMsgSender = _sender (src/universal/CrossDomainMessenger.sol#286)\n\txDomainMsgSender = Constants.DEFAULT_L2_SENDER (src/universal/CrossDomainMessenger.sol#288)\n",
     "type": "variable",
     "name": "xDomainMsgSender",
     "start": 5784,
@@ -1298,24 +1368,26 @@
     "filename_relative": "src/universal/CrossDomainMessenger.sol"
   },
   {
+    "id": "9ad67b006fc175893dd26d35a020a52dd8524709d87cca61212ee0e147eb992b",
     "impact": "Medium",
     "confidence": "High",
     "check": "write-after-write",
-    "description": "CrossDomainMessenger.xDomainMsgSender (src/universal/CrossDomainMessenger.sol#129) is written in both\n\txDomainMsgSender = _sender (src/universal/CrossDomainMessenger.sol#282)\n\txDomainMsgSender = Constants.DEFAULT_L2_SENDER (src/universal/CrossDomainMessenger.sol#284)\n",
+    "description": "CrossDomainMessenger.xDomainMsgSender (src/universal/CrossDomainMessenger.sol#129) is written in both\n\txDomainMsgSender = _sender (src/universal/CrossDomainMessenger.sol#286)\n\txDomainMsgSender = Constants.DEFAULT_L2_SENDER (src/universal/CrossDomainMessenger.sol#288)\n",
     "type": "node",
     "name": "xDomainMsgSender = _sender",
-    "start": 13953,
+    "start": 14196,
     "length": 26,
     "filename_relative": "src/universal/CrossDomainMessenger.sol"
   },
   {
+    "id": "9ad67b006fc175893dd26d35a020a52dd8524709d87cca61212ee0e147eb992b",
     "impact": "Medium",
     "confidence": "High",
     "check": "write-after-write",
-    "description": "CrossDomainMessenger.xDomainMsgSender (src/universal/CrossDomainMessenger.sol#129) is written in both\n\txDomainMsgSender = _sender (src/universal/CrossDomainMessenger.sol#282)\n\txDomainMsgSender = Constants.DEFAULT_L2_SENDER (src/universal/CrossDomainMessenger.sol#284)\n",
+    "description": "CrossDomainMessenger.xDomainMsgSender (src/universal/CrossDomainMessenger.sol#129) is written in both\n\txDomainMsgSender = _sender (src/universal/CrossDomainMessenger.sol#286)\n\txDomainMsgSender = Constants.DEFAULT_L2_SENDER (src/universal/CrossDomainMessenger.sol#288)\n",
     "type": "node",
     "name": "xDomainMsgSender = Constants.DEFAULT_L2_SENDER",
-    "start": 14086,
+    "start": 14329,
     "length": 46,
     "filename_relative": "src/universal/CrossDomainMessenger.sol"
   }

--- a/packages/contracts-bedrock/slither.config.json
+++ b/packages/contracts-bedrock/slither.config.json
@@ -9,7 +9,7 @@
     "solc_disable_warnings": false,
     "disable_color": false,
     "exclude_dependencies": true,
-    "filter_paths": "(lib/|src/vendor|src/cannon/MIPS.sol)",
+    "filter_paths": "(lib/|src/vendor|src/cannon/MIPS.sol|src/EAS/EAS.sol)",
     "legacy_ast": false,
     "foundry_out_directory": "artifacts"
 }


### PR DESCRIPTION
**Description**

Prior to this PR, slither triaging was completely broken.

This PR updates the slither script to work as (now) documented in the `packages/contracts-bedrock` readme markdown.

**Updated Triaging Functionality**

To generate a slither report, slither can be run directly or in triaging mode with `pnpm slither:triage`.
This allows you to walk through slither issues and triage them into the `slither.db.json` file (currently none exists since no triaging has been done).

Once the `slither-report.json` file containing un-triaged issues and the `slither.db.json` are tracked by git,
the `pnpm slither:check` command can be run to verify that there are no additional slither issues that are not either
in the `slither-report.json` or the `slither.db.json`.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/263
