### PR TITLE
fix(op-challenger): Off by 1 in block range

### DIFF
--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -48,7 +48,7 @@ func (c *OutputBisectionGameContract) GetBlockRange(ctx context.Context) (presta
 		retErr = fmt.Errorf("expected 2 results but got %v", len(results))
 		return
 	}
-	prestateBlock = results[0].GetBigInt(0).Uint64()
+	prestateBlock = results[0].GetBigInt(0).Uint64() + 1
 	poststateBlock = results[1].GetBigInt(0).Uint64()
 	return
 }

--- a/op-challenger/game/fault/contracts/outputbisectiongame_test.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame_test.go
@@ -22,13 +22,14 @@ func TestOutputBisectionGameContract_CommonTests(t *testing.T) {
 
 func TestGetBlockRange(t *testing.T) {
 	stubRpc, contract := setupOutputBisectionGameTest(t)
-	expectedStart := uint64(65)
+	genesisBlock := uint64(65)
 	expectedEnd := uint64(102)
-	stubRpc.SetResponse(fdgAddr, methodGenesisBlockNumber, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(expectedStart)})
+	stubRpc.SetResponse(fdgAddr, methodGenesisBlockNumber, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(genesisBlock)})
 	stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(expectedEnd)})
 	start, end, err := contract.GetBlockRange(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, expectedStart, start)
+	// The returned `start` is offset by 1 from the genesis block due to the dispute range being from [genesisBlockNumber+1, l2BlockNumber]
+	require.Equal(t, genesisBlock, start-1)
 	require.Equal(t, expectedEnd, end)
 }
 


### PR DESCRIPTION
## Overview

Fixes an off-by-one error in the `op-challenger`'s `GetBlockRange` function. The bisection occurs from block `[1, l2BlockNumber]`, where `l2BlockNumber` is fetched from the `l2BlockNumber()` accessor in the contract. Genesis is not considered to be disputable.