### PR TITLE
feat(op-challenger): Output Bisection Game Genesis Output Root Fetching

### DIFF
--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	methodGenesisBlockNumber = "GENESIS_BLOCK_NUMBER"
+	methodGenesisOutputRoot  = "GENESIS_OUTPUT_ROOT"
 	methodSplitDepth         = "SPLIT_DEPTH"
 	methodL2BlockNumber      = "l2BlockNumber"
 )
@@ -53,6 +54,14 @@ func (c *OutputBisectionGameContract) GetBlockRange(ctx context.Context) (presta
 	prestateBlock = results[0].GetBigInt(0).Uint64()
 	poststateBlock = results[1].GetBigInt(0).Uint64()
 	return
+}
+
+func (c *OutputBisectionGameContract) GetGenesisOutputRoot(ctx context.Context) (common.Hash, error) {
+	genesisOutputRoot, err := c.multiCaller.SingleCall(ctx, batching.BlockLatest, c.contract.Call(methodGenesisOutputRoot))
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to retrieve genesis output root: %w", err)
+	}
+	return genesisOutputRoot.GetHash(0), nil
 }
 
 func (c *OutputBisectionGameContract) GetSplitDepth(ctx context.Context) (uint64, error) {

--- a/op-challenger/game/fault/contracts/outputbisectiongame_test.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame_test.go
@@ -41,6 +41,15 @@ func TestGetSplitDepth(t *testing.T) {
 	require.Equal(t, expectedSplitDepth, splitDepth)
 }
 
+func TestGetGenesisOutputRoot(t *testing.T) {
+	stubRpc, contract := setupOutputBisectionGameTest(t)
+	expectedOutputRoot := common.HexToHash("0x1234")
+	stubRpc.SetResponse(fdgAddr, methodGenesisOutputRoot, batching.BlockLatest, nil, []interface{}{expectedOutputRoot})
+	genesisOutputRoot, err := contract.GetGenesisOutputRoot(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expectedOutputRoot, genesisOutputRoot)
+}
+
 func TestOutputBisectionGame_UpdateOracleTx(t *testing.T) {
 	t.Run("Local", func(t *testing.T) {
 		stubRpc, game := setupOutputBisectionGameTest(t)


### PR DESCRIPTION
**Descriptions**

Adds support for genesis output root fetching to the op-challenger contracts.

**Metadata**

Makes progress on https://github.com/ethereum-optimism/client-pod/issues/259
