### PR TITLE
feat: Fix Foundry Update to reset Git Repo

### DIFF
--- a/ops/scripts/install-foundry.sh
+++ b/ops/scripts/install-foundry.sh
@@ -8,6 +8,18 @@ SHA=$(cat ./.foundryrc)
 # Check if there is a nightly tag corresponding to the `.foundryrc` commit hash
 TAG="nightly-$SHA"
 
+# If the foundry repository exists and a branch is checked out, we need to abort
+# any changes inside ~/.foundry/foundry-rs/foundry. This is because foundryup will
+# attempt to pull the latest changes from the remote repository, which will fail
+# if there are any uncommitted changes.
+if [ -d ~/.foundry/foundry-rs/foundry ]; then
+  echo "Foundry repository exists! Aborting any changes..."
+  cd ~/.foundry/foundry-rs/foundry
+  git reset --hard
+  git clean -fd
+  cd -
+fi
+
 # Create a temporary directory
 TMP_DIR=$(mktemp -d)
 echo "Created tempdir @ $TMP_DIR"


### PR DESCRIPTION
**Description**

Previously, after updating foundry with the `pnpm update:foundry` target, foundryup would install from commit using
the local cloned foundry repo in `~/.foundry/foundry-rs/foundry`. If there were uncommitted changes from a previous foundry
build, this fails since git won't checkout without committing or stashing changes.

This pr adds a graceful check to reset the local foundry repo if it exists so that foundryup doesn't fail on uncommitted changes.
