### PR TITLE
Add Delta override flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -265,6 +265,12 @@ var (
 		EnvVars: prefixEnvVars("OVERRIDE_CANYON"),
 		Hidden:  false,
 	}
+	DeltaOverrideFlag = &cli.Uint64Flag{
+		Name:    "override.delta",
+		Usage:   "Manually specify the Delta fork timestamp, overriding the bundled setting",
+		EnvVars: prefixEnvVars("OVERRIDE_DELTA"),
+		Hidden:  false,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -311,6 +317,7 @@ var optionalFlags = []cli.Flag{
 	RollupLoadProtocolVersions,
 	CanyonOverrideFlag,
 	L1RethDBPath,
+	DeltaOverrideFlag,
 }
 
 // Flags contains the list of configuration options available to the binary.

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -206,6 +206,10 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 			canyon := ctx.Uint64(flags.CanyonOverrideFlag.Name)
 			config.CanyonTime = &canyon
 		}
+		if ctx.IsSet(flags.DeltaOverrideFlag.Name) {
+			delta := ctx.Uint64(flags.DeltaOverrideFlag.Name)
+			config.DeltaTime = &delta
+		}
 
 		return config, nil
 	}
@@ -223,6 +227,10 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if ctx.IsSet(flags.CanyonOverrideFlag.Name) {
 		canyon := ctx.Uint64(flags.CanyonOverrideFlag.Name)
 		rollupConfig.CanyonTime = &canyon
+	}
+	if ctx.IsSet(flags.DeltaOverrideFlag.Name) {
+		delta := ctx.Uint64(flags.DeltaOverrideFlag.Name)
+		rollupConfig.DeltaTime = &delta
 	}
 	return &rollupConfig, nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add a hard fork activation time override flag for Delta

**Tests**

Manually tested on my local devnet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to manually set the Delta fork timestamp, enhancing configuration flexibility.

- **Enhancements**
  - Configuration handling now includes checks for the new Delta timestamp override option, allowing for custom settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->