### PR TITLE
Change output cannon game type to 1

### DIFF
--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	cannonGameType         = uint8(0)
-	outputCannonGameType   = uint8(253) // TODO(client-pod#43): Switch the output cannon game type to 1
+	outputCannonGameType   = uint8(1)
 	outputAlphabetGameType = uint8(254)
 	alphabetGameType       = uint8(255)
 )

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -35,7 +35,7 @@ import (
 
 const alphabetGameType uint8 = 255
 const cannonGameType uint8 = 0
-const outputCannonGameType uint8 = 253 // TODO(client-pod#43): Switch this game type to 1
+const outputCannonGameType uint8 = 1
 const alphabetGameDepth = 4
 
 var lastAlphabetTraceIndex = big.NewInt(1<<alphabetGameDepth - 1)

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -1024,7 +1024,7 @@ contract Deploy is Deployer {
         // Set the Cannon FaultDisputeGame implementation in the factory.
         _setFaultGameImplementation({
             _factory: factory,
-            _gameType: GameTypes.FAULT,
+            _gameType: GameTypes.CANNON,
             _absolutePrestate: loadMipsAbsolutePrestate(),
             _faultVm: IBigStepper(mustGetAddress("Mips")),
             _maxGameDepth: cfg.faultGameMaxDepth()
@@ -1130,13 +1130,13 @@ contract Deploy is Deployer {
 
         uint8 rawGameType = GameType.unwrap(_gameType);
         string memory gameTypeString;
-        if (rawGameType == 0) {
+        if (rawGameType == GameType.unwrap(GameTypes.CANNON)) {
             gameTypeString = "Cannon";
-        } else if (rawGameType == 253) {
+        } else if (rawGameType == GameType.unwrap(GameTypes.OUTPUT_CANNON)) {
             gameTypeString = "OutputBisectionCannon";
-        } else if (rawGameType == 254) {
+        } else if (rawGameType == GameType.unwrap(GameTypes.OUTPUT_ALPHABET)) {
             gameTypeString = "OutputBisectionAlphabet";
-        } else if (rawGameType == 255) {
+        } else if (rawGameType == GameType.unwrap(GameTypes.ALPHABET)) {
             gameTypeString = "Alphabet";
         } else {
             gameTypeString = "Unknown";

--- a/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
+++ b/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
@@ -79,17 +79,11 @@ enum GameStatus
 /// @title GameTypes
 /// @notice A library that defines the IDs of games that can be played.
 library GameTypes {
-    /// @dev The game will use a `IDisputeGame` implementation that utilizes fault proofs.
-    GameType internal constant FAULT = GameType.wrap(0);
-
-    /// @dev The game will use a `IDisputeGame` implementation that utilizes validity proofs.
-    GameType internal constant VALIDITY = GameType.wrap(1);
-
-    /// @dev The game will use a `IDisputeGame` implementation that utilizes attestation proofs.
-    GameType internal constant ATTESTATION = GameType.wrap(2);
+    /// @dev A dispute game type the uses the cannon vm.
+    GameType internal constant CANNON = GameType.wrap(0);
 
     /// @dev A dispute game type that performs output bisection and then uses the cannon vm.
-    GameType internal constant OUTPUT_CANNON = GameType.wrap(253);
+    GameType internal constant OUTPUT_CANNON = GameType.wrap(1);
 
     /// @dev A dispute game type that performs output bisection and then uses an alphabet vm.
     ///      Note intended for production use.

--- a/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
+++ b/packages/contracts-bedrock/test/dispute/DisputeGameFactory.t.sol
@@ -116,17 +116,17 @@ contract DisputeGameFactory_Create_Test is DisputeGameFactory_Init {
 contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_Init {
     /// @dev Tests that the `setImplementation` function properly sets the implementation for a given `GameType`.
     function test_setImplementation_succeeds() public {
-        // There should be no implementation for the `GameTypes.FAULT` enum value, it has not been set.
-        assertEq(address(factory.gameImpls(GameTypes.FAULT)), address(0));
+        // There should be no implementation for the `GameTypes.CANNON` enum value, it has not been set.
+        assertEq(address(factory.gameImpls(GameTypes.CANNON)), address(0));
 
         vm.expectEmit(true, true, true, true, address(factory));
-        emit ImplementationSet(address(1), GameTypes.FAULT);
+        emit ImplementationSet(address(1), GameTypes.CANNON);
 
-        // Set the implementation for the `GameTypes.FAULT` enum value.
-        factory.setImplementation(GameTypes.FAULT, IDisputeGame(address(1)));
+        // Set the implementation for the `GameTypes.CANNON` enum value.
+        factory.setImplementation(GameTypes.CANNON, IDisputeGame(address(1)));
 
-        // Ensure that the implementation for the `GameTypes.FAULT` enum value is set.
-        assertEq(address(factory.gameImpls(GameTypes.FAULT)), address(1));
+        // Ensure that the implementation for the `GameTypes.CANNON` enum value is set.
+        assertEq(address(factory.gameImpls(GameTypes.CANNON)), address(1));
     }
 
     /// @dev Tests that the `setImplementation` function reverts when called by a non-owner.
@@ -134,7 +134,7 @@ contract DisputeGameFactory_SetImplementation_Test is DisputeGameFactory_Init {
         // Ensure that the `setImplementation` function reverts when called by a non-owner.
         vm.prank(address(0));
         vm.expectRevert("Ownable: caller is not the owner");
-        factory.setImplementation(GameTypes.FAULT, IDisputeGame(address(1)));
+        factory.setImplementation(GameTypes.CANNON, IDisputeGame(address(1)));
     }
 }
 

--- a/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
+++ b/packages/contracts-bedrock/test/dispute/FaultDisputeGame.t.sol
@@ -152,7 +152,7 @@ contract FaultDisputeGame_Test is FaultDisputeGame_Init {
         if (vmStatus == 1 || vmStatus == 2) rootClaim = changeClaimStatus(rootClaim, VMStatuses.VALID);
 
         vm.expectRevert(abi.encodeWithSelector(UnexpectedRootClaim.selector, rootClaim));
-        factory.create(GameTypes.FAULT, rootClaim, extraData);
+        factory.create(GameTypes.CANNON, rootClaim, extraData);
     }
 
     /// @dev Tests that the game is initialized with the correct data.


### PR DESCRIPTION
**Description**

* Change OUTPUT_CANNON game type to code 1.
* Renames the FAULT game type to CANNON.
* Removes the VALIDITY and ATTESTATION game types.
* Use constants when selecting game type string.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/43
