### PR TITLE
op-program: Verify loaded preimage matches requested key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - checkout
       - check-changed:
-          patterns: cannon,packages/contracts-bedrock/src/cannon
+          patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage
       - run:
           name: prep Cannon results dir
           command: mkdir -p /tmp/test-results

--- a/op-preimage/verifier.go
+++ b/op-preimage/verifier.go
@@ -1,0 +1,35 @@
+package preimage
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+)
+
+var (
+	ErrIncorrectData      = errors.New("incorrect data")
+	ErrUnsupportedKeyType = errors.New("unsupported key type")
+)
+
+// WithVerification wraps the supplied source to verify that the returned data is a valid pre-image for the key.
+func WithVerification(source PreimageGetter) PreimageGetter {
+	return func(key [32]byte) ([]byte, error) {
+		data, err := source(key)
+		if err != nil {
+			return nil, err
+		}
+
+		switch KeyType(key[0]) {
+		case LocalKeyType:
+			return data, nil
+		case Keccak256KeyType:
+			hash := Keccak256(data)
+			if !slices.Equal(hash[1:], key[1:]) {
+				return nil, fmt.Errorf("%w for key %v, hash: %v data: %x", ErrIncorrectData, key, hash, data)
+			}
+			return data, nil
+		default:
+			return nil, fmt.Errorf("%w: %v", ErrUnsupportedKeyType, key[0])
+		}
+	}
+}

--- a/op-preimage/verifier_test.go
+++ b/op-preimage/verifier_test.go
@@ -1,0 +1,81 @@
+package preimage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithVerification(t *testing.T) {
+	validData := []byte{1, 2, 3, 4, 5, 6}
+	keccak256Key := Keccak256Key(Keccak256(validData))
+	anError := errors.New("boom")
+
+	tests := []struct {
+		name         string
+		key          Key
+		data         []byte
+		err          error
+		expectedErr  error
+		expectedData []byte
+	}{
+		{
+			name:         "LocalKey NoVerification",
+			key:          LocalIndexKey(1),
+			data:         []byte{4, 3, 5, 7, 3},
+			expectedData: []byte{4, 3, 5, 7, 3},
+		},
+		{
+			name:         "Keccak256 Valid",
+			key:          keccak256Key,
+			data:         validData,
+			expectedData: validData,
+		},
+		{
+			name:        "Keccak256 Error",
+			key:         keccak256Key,
+			data:        validData,
+			err:         anError,
+			expectedErr: anError,
+		},
+		{
+			name:        "Keccak256 InvalidData",
+			key:         keccak256Key,
+			data:        []byte{6, 7, 8},
+			expectedErr: ErrIncorrectData,
+		},
+		{
+			name:        "EmptyData",
+			key:         keccak256Key,
+			data:        []byte{},
+			expectedErr: ErrIncorrectData,
+		},
+		{
+			name:        "UnknownKey",
+			key:         invalidKey([32]byte{0xaa}),
+			data:        []byte{},
+			expectedErr: ErrUnsupportedKeyType,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			source := WithVerification(func(key [32]byte) ([]byte, error) {
+				return test.data, test.err
+			})
+			actual, err := source(test.key.PreimageKey())
+			require.ErrorIs(t, err, test.expectedErr)
+			require.Equal(t, test.expectedData, actual)
+		})
+	}
+}
+
+type invalidKey [32]byte
+
+func (k invalidKey) PreimageKey() (out [32]byte) {
+	out = k            // copy the source hash
+	out[0] = byte(254) // apply invalid prefix
+	return
+}

--- a/op-program/host/host.go
+++ b/op-program/host/host.go
@@ -174,7 +174,7 @@ func PreimageServer(ctx context.Context, logger log.Logger, cfg *config.Config, 
 
 	localPreimageSource := kvstore.NewLocalPreimageSource(cfg)
 	splitter := kvstore.NewPreimageSourceSplitter(localPreimageSource.Get, getPreimage)
-	preimageGetter := splitter.Get
+	preimageGetter := preimage.WithVerification(splitter.Get)
 
 	serverDone = launchOracleServer(logger, preimageChannel, preimageGetter)
 	hinterDone = routeHints(logger, hintChannel, hinter)


### PR DESCRIPTION
**Description**

Verify loaded preimage matches requested key. Avoids errors in the preimage oracle (e.g. disk faults) from silently resulting in invalid execution. Verification is performed on data regardless of the original source (ie both fetched and cached data is verified).

I've added the function that adds verification to the `op-preimage` module but open to feedback if that's the wrong place.  It is an entirely optional wrapper so seems useful to have it in the more reusable module.

**Tests**

Added unit tests for the verification.