### PR TITLE
op-e2e: Minor cleanups

### DIFF
--- a/op-e2e/e2eutils/io.go
+++ b/op-e2e/e2eutils/io.go
@@ -1,0 +1,47 @@
+package e2eutils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TempDir(t *testing.T) string {
+	// Drop unusual characters (such as path separators or
+	// characters interacting with globs) from the directory name to
+	// avoid surprising os.MkdirTemp behavior.
+	// Taken from the t.TempDir() implementation in the standard library.
+	mapper := func(r rune) rune {
+		if r < utf8.RuneSelf {
+			const allowed = "!#$%&()+,-.=@^_{}~ "
+			if '0' <= r && r <= '9' ||
+				'a' <= r && r <= 'z' ||
+				'A' <= r && r <= 'Z' {
+				return r
+			}
+			if strings.ContainsRune(allowed, r) {
+				return r
+			}
+		} else if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return r
+		}
+		return -1
+	}
+
+	dir, err := os.MkdirTemp("", strings.Map(mapper, fmt.Sprintf("op-e2e-%s", t.Name())))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Logf("Error removing temp dir %s: %s", dir, err)
+		}
+	})
+
+	return dir
+}

--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -47,6 +47,7 @@ type OpGeth struct {
 	L1Head        eth.BlockInfo
 	L2Head        *eth.ExecutionPayload
 	sequenceNum   uint64
+	lgr           log.Logger
 }
 
 func NewOpGeth(t *testing.T, ctx context.Context, cfg *SystemConfig) (*OpGeth, error) {
@@ -117,11 +118,14 @@ func NewOpGeth(t *testing.T, ctx context.Context, cfg *SystemConfig) (*OpGeth, e
 		L2ChainConfig: l2Genesis.Config,
 		L1Head:        eth.BlockToInfo(l1Block),
 		L2Head:        genesisPayload,
+		lgr:           logger,
 	}, nil
 }
 
 func (d *OpGeth) Close() {
-	_ = d.node.Close()
+	if err := d.node.Close(); err != nil {
+		d.lgr.Error("error closing node", "err", err)
+	}
 	d.l2Engine.Close()
 	d.L2Client.Close()
 }


### PR DESCRIPTION
Was looking at op-e2e flakes today and found a couple of minor fixes:

- The op-e2e-ext-geth test sometimes flakes because Geth is still writing to its datadir while it's being cleaned up. You can see an example of this [here](https://app.circleci.com/pipelines/gh/ethereum-optimism/optimism/32316/workflows/3cc82541-6770-4ded-b842-05e1cd5ae0ee/jobs/1499210). This PR adds a separate mechanism to create and clean up temporary directories in E2E tests that doesn't fail the test of the directory is written to while it's being cleaned up.
- The bridge test doesn't check for iterator errors. This masks the root cause of the flakes in this test.
