### PR TITLE
contracts-bedrock: flexible deploy script addresses

### DIFF
--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -59,6 +59,11 @@ For all information about working on and contributing to Optimism's smart contra
 The smart contracts are deployed using `foundry` with a `hardhat-deploy` compatibility layer. When the contracts are deployed,
 they will write a temp file to disk that can then be formatted into a `hardhat-deploy` style artifact by calling another script.
 
+The addresses in the `deployments` directory will be read into the script based on the backend's chain id.
+To manually define the set of addresses used in the script, set the `ADDRESSES` env var to a path on the local
+filesystem that points to a JSON file full of key value pairs where the keys are names of contracts and the
+values are addresses. This works well with the JSON files in `superchain-ops`.
+
 ### Configuration
 
 Create or modify a file `<network-name>.json` inside of the [`deploy-config`](./deploy-config/) folder.

--- a/packages/contracts-bedrock/README.md
+++ b/packages/contracts-bedrock/README.md
@@ -60,7 +60,7 @@ The smart contracts are deployed using `foundry` with a `hardhat-deploy` compati
 they will write a temp file to disk that can then be formatted into a `hardhat-deploy` style artifact by calling another script.
 
 The addresses in the `deployments` directory will be read into the script based on the backend's chain id.
-To manually define the set of addresses used in the script, set the `ADDRESSES` env var to a path on the local
+To manually define the set of addresses used in the script, set the `CONTRACT_ADDRESSES_PATH` env var to a path on the local
 filesystem that points to a JSON file full of key value pairs where the keys are names of contracts and the
 values are addresses. This works well with the JSON files in `superchain-ops`.
 

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -54,7 +54,7 @@ import { LibStateDiff } from "scripts/libraries/LibStateDiff.sol";
 ///         To add a new contract to the system, add a public function that deploys that individual contract.
 ///         Then add a call to that function inside of `run`. Be sure to call the `save` function after each
 ///         deployment so that hardhat-deploy style artifacts can be generated using a call to `sync()`.
-///         The `ADDRESSES` environment variable can be set to a path that contains a JSON file full of
+///         The `CONTRACT_ADDRESSES_PATH` environment variable can be set to a path that contains a JSON file full of
 ///         contract name to address pairs. That enables this script to be much more flexible in the way
 ///         it is used.
 contract Deploy is Deployer {
@@ -227,32 +227,6 @@ contract Deploy is Deployer {
 
         console.log("Deploying from %s", deployScript);
         console.log("Deployment context: %s", deploymentContext);
-
-        // Load addresses from a JSON file if the ADDRESSES environment variable is set.
-        // Great for loading addresses from `superchain-registry`.
-        string memory addresses = vm.envOr("ADDRESSES", string(""));
-        if (bytes(addresses).length > 0) {
-            console.log("Loading addresses from %s", addresses);
-            _loadAddresses(addresses);
-        }
-    }
-
-    /// @notice Populates the addresses to be used in a script based on a JSON file.
-    ///         The format of the JSON file is the same that it output by this script
-    ///         as well as the JSON files that contain addresses in the `superchain-ops`
-    ///         repo. The JSON key is the name of the contract and the value is an address.
-    function _loadAddresses(string memory _path) internal {
-        string[] memory commands = new string[](3);
-        commands[0] = "bash";
-        commands[1] = "-c";
-        commands[2] = string.concat("jq -cr < ", _path);
-        string memory json = string(vm.ffi(commands));
-        string[] memory keys = vm.parseJsonKeys(json, "");
-        for (uint256 i; i < keys.length; i++) {
-            string memory key = keys[i];
-            address addr = stdJson.readAddress(json, string.concat("$.", key));
-            save(key, addr);
-        }
     }
 
     /// @notice Deploy all of the L1 contracts necessary for a full Superchain with a single Op Chain.

--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -144,7 +144,6 @@ abstract contract Deployer is Script {
         }
     }
 
-
     /// @notice Call this function to sync the deployment artifacts such that
     ///         hardhat deploy style artifacts are created.
     function sync() public {

--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -116,7 +116,34 @@ abstract contract Deployer is Script {
             vm.writeJson("{}", tempDeploymentsPath);
         }
         console.log("Storing temp deployment data in %s", tempDeploymentsPath);
+
+        // Load addresses from a JSON file if the CONTRACT_ADDRESSES_PATH environment variable
+        // is set. Great for loading addresses from `superchain-registry`.
+        string memory addresses = vm.envOr("CONTRACT_ADDRESSES_PATH", string(""));
+        if (bytes(addresses).length > 0) {
+            console.log("Loading addresses from %s", addresses);
+            _loadAddresses(addresses);
+        }
     }
+
+    /// @notice Populates the addresses to be used in a script based on a JSON file.
+    ///         The format of the JSON file is the same that it output by this script
+    ///         as well as the JSON files that contain addresses in the `superchain-ops`
+    ///         repo. The JSON key is the name of the contract and the value is an address.
+    function _loadAddresses(string memory _path) internal {
+        string[] memory commands = new string[](3);
+        commands[0] = "bash";
+        commands[1] = "-c";
+        commands[2] = string.concat("jq -cr < ", _path);
+        string memory json = string(vm.ffi(commands));
+        string[] memory keys = vm.parseJsonKeys(json, "");
+        for (uint256 i; i < keys.length; i++) {
+            string memory key = keys[i];
+            address addr = stdJson.readAddress(json, string.concat("$.", key));
+            save(key, addr);
+        }
+    }
+
 
     /// @notice Call this function to sync the deployment artifacts such that
     ///         hardhat deploy style artifacts are created.


### PR DESCRIPTION
**Description**

Allow for the addresses used in the deploy script to be defined
by a JSON file at the the path defined by the `ADDRESSES` environment
variable. This makes the deploy script easy to use when it comes to
composing with the `superchain-registry`. Just set the `ADDRESSES`
env var to the path on the local filesystem that points to the
`extra/addresses/<network>/<l2>.json` file. See the
[example](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/mainnet/op.json) here.

This gives a path forward for deprecating the concept of `deployments`
in the `contracts-bedrock` package. We really only use the `deployments`
directory for getting contract addresses. We want a single source of
truth for contract addresses which is `superchain-registry`. Using this
env var allows the deploy script to easily compose with
`superchain-registry`.

`ffi` and `jq` are used instead of `vm.readFile` to break out of the
security properties that foundry uses, we do not want to need to specify
all possible directories on the filesystem as readable in the
`foundry.toml`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
