### PR TITLE
op-challenger: Add comment to avoid confusion about what GetBlockRange returns

### DIFF
--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -36,6 +36,8 @@ func NewOutputBisectionGameContract(addr common.Address, caller *batching.MultiC
 	}, nil
 }
 
+// GetBlockRange returns the block numbers of the absolute pre-state block (typically genesis or the bedrock activation block)
+// and the post-state block (that the proposed output root is for).
 func (c *OutputBisectionGameContract) GetBlockRange(ctx context.Context) (prestateBlock uint64, poststateBlock uint64, retErr error) {
 	results, err := c.multiCaller.Call(ctx, batching.BlockLatest,
 		c.contract.Call(methodGenesisBlockNumber),


### PR DESCRIPTION
**Description**

Clarify what `GetBlockRange` returns so its clear the prestate block is "genesis" and the not the first disputable block in the game.
