### PR TITLE
Add config flag to set max number of concurrent L1 RPC requests.

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -814,6 +814,7 @@ func configureL1(rollupNodeCfg *rollupNode.Config, l1Node EthInstance) {
 		RateLimit:        0,
 		BatchSize:        20,
 		HttpPollInterval: time.Millisecond * 100,
+		MaxConcurrency:   10,
 	}
 }
 

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -100,6 +100,12 @@ var (
 		Required: false,
 		Hidden:   true,
 	}
+	L1RPCMaxConcurrency = &cli.IntFlag{
+		Name:    "l1.max-concurrency",
+		Usage:   "Maximum number of concurrent RPC requests to make to the L1 RPC provider.",
+		EnvVars: prefixEnvVars("L1_MAX_CONCURRENCY"),
+		Value:   10,
+	}
 	L1RPCRateLimit = &cli.Float64Flag{
 		Name:    "l1.rpc-rate-limit",
 		Usage:   "Optional self-imposed global rate-limit on L1 RPC requests, specified in requests / second. Disabled if set to 0.",
@@ -295,6 +301,7 @@ var optionalFlags = []cli.Flag{
 	L1RPCProviderKind,
 	L1RPCRateLimit,
 	L1RPCMaxBatchSize,
+	L1RPCMaxConcurrency,
 	L1HTTPPollInterval,
 	L2EngineJWTSecret,
 	VerifierL1Confs,

--- a/op-node/node/client.go
+++ b/op-node/node/client.go
@@ -151,6 +151,9 @@ type L1EndpointConfig struct {
 	// BatchSize specifies the maximum batch-size, which also applies as L1 rate-limit burst amount (if set).
 	BatchSize int
 
+	// MaxConcurrency specifies the maximum number of concurrent requests to the L1 RPC.
+	MaxConcurrency int
+
 	// HttpPollInterval specifies the interval between polling for the latest L1 block,
 	// when the RPC is detected to be an HTTP type.
 	// It is recommended to use websockets or IPC for efficient following of the changing block.
@@ -166,6 +169,9 @@ func (cfg *L1EndpointConfig) Check() error {
 	}
 	if cfg.RateLimit < 0 {
 		return fmt.Errorf("rate limit cannot be negative")
+	}
+	if cfg.MaxConcurrency < 1 {
+		return fmt.Errorf("max concurrent requests cannot be less than 1, was %d", cfg.MaxConcurrency)
 	}
 	return nil
 }
@@ -185,6 +191,7 @@ func (cfg *L1EndpointConfig) Setup(ctx context.Context, log log.Logger, rollupCf
 	}
 	rpcCfg := sources.L1ClientDefaultConfig(rollupCfg, cfg.L1TrustRPC, cfg.L1RPCKind)
 	rpcCfg.MaxRequestsPerBatch = cfg.BatchSize
+	rpcCfg.MaxConcurrentRequests = cfg.MaxConcurrency
 	return l1Node, rpcCfg, nil
 }
 

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -129,6 +129,7 @@ func NewL1EndpointConfig(ctx *cli.Context) *node.L1EndpointConfig {
 		RateLimit:        ctx.Float64(flags.L1RPCRateLimit.Name),
 		BatchSize:        ctx.Int(flags.L1RPCMaxBatchSize.Name),
 		HttpPollInterval: ctx.Duration(flags.L1HTTPPollInterval.Name),
+		MaxConcurrency:   ctx.Int(flags.L1RPCMaxConcurrency.Name),
 	}
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

As part of sync-testing #8191 in k8s, the team decided it would be useful to be able to configure the `config.MaxConcurrentRequests` passed to `LimitRPC` when making an L1 Client. See `optimism/op-service/sources/eth_client.go:NewEthClient`, around line 173 or so. 

This PR proposes to add a new flag, `L1RPCMaxConcurrentRequests`, and pass it down to this constructor. It defaults to `10`, the same value as in the default eth config. A user can also choose to use the env var `L1_MAX_CONCURRENT_RPC_REQUESTS`.

**Tests**

Will have to manually test. Question for reviewers: do we have a better testing system for this?
