### PR TITLE
op-e2e: Update output_cannon e2e test to execute a step and resolve the game

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -7,6 +7,7 @@ import (
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -42,4 +43,25 @@ func TestOutputCannonGame(t *testing.T) {
 	// Wait for the challenger to post the first claim in the cannon trace
 	game.WaitForClaimAtDepth(ctx, int(splitDepth+1))
 	game.LogGameData(ctx)
+
+	game.Attack(ctx, splitDepth+1, common.Hash{0x00, 0xcc})
+	gameDepth := game.MaxDepth(ctx)
+	for i := splitDepth + 3; i < gameDepth; i += 2 {
+		// Wait for challenger to respond
+		game.WaitForClaimAtDepth(ctx, int(i))
+		game.LogGameData(ctx)
+
+		// Respond to push the game down to the max depth
+		game.Defend(ctx, i, common.Hash{0x00, 0xdd})
+		game.LogGameData(ctx)
+	}
+	game.LogGameData(ctx)
+
+	// Challenger should be able to call step and counter the leaf claim.
+	game.WaitForClaimAtMaxDepth(ctx, true)
+	game.LogGameData(ctx)
+
+	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 }


### PR DESCRIPTION
**Description**

Extends the existing `output_cannon` e2e test to progress all the way to the cannon leaf node and have the challenger call step to counter it.  Then confirm the game is resolved correctly in the challengers favour.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/43
