### PR TITLE
ctb/superchain config set bool

### DIFF
--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -61,14 +61,14 @@ contract SuperchainConfig is Initializable, ISemver {
     /// @param _identifier (Optional) A string to identify provenance of the pause transaction.
     function pause(string memory _identifier) external {
         require(msg.sender == guardian(), "SuperchainConfig: only guardian can pause");
-        Storage.setUint(PAUSED_SLOT, 1);
+        Storage.setBool(PAUSED_SLOT, true);
         emit Paused(_identifier);
     }
 
     /// @notice Unpauses withdrawals.
     function unpause() external {
         require(msg.sender == guardian(), "SuperchainConfig: only guardian can unpause");
-        Storage.setUint(PAUSED_SLOT, 0);
+        Storage.setBool(PAUSED_SLOT, false);
         emit Unpaused();
     }
 

--- a/packages/contracts-bedrock/src/libraries/Storage.sol
+++ b/packages/contracts-bedrock/src/libraries/Storage.sol
@@ -58,12 +58,31 @@ library Storage {
 
     /// @notice Stores a bytes32 value in an arbitrary storage slot, `_slot`.
     /// @param _slot The storage slot to store the address in.
-    /// @param _value The protocol version to store
+    /// @param _value The bytes32 value to store.
     /// @dev WARNING! This function must be used cautiously, as it allows for overwriting values
     ///      in arbitrary storage slots.
     function setBytes32(bytes32 _slot, bytes32 _value) internal {
         assembly {
             sstore(_slot, _value)
+        }
+    }
+
+    /// @notice Stores a bool value in an arbitrary storage slot, `_slot`.
+    /// @param _slot The storage slot to store the bool in.
+    /// @param _value The bool value to store
+    /// @dev WARNING! This function must be used cautiously, as it allows for overwriting values
+    ///      in arbitrary storage slots.
+    function setBool(bytes32 _slot, bool _value) internal {
+        assembly {
+            sstore(_slot, _value)
+        }
+    }
+
+    /// @notice Returns a bool stored in an arbitrary storage slot.
+    /// @param _slot The storage slot to retrieve the bool from.
+    function getBool(bytes32 _slot) internal view returns (bool value_) {
+        assembly {
+            value_ := sload(_slot)
         }
     }
 }

--- a/packages/contracts-bedrock/src/universal/StorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/StorageSetter.sol
@@ -16,8 +16,8 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
 
     /// @notice Stores a bytes32 `_value` at `_slot`. Any storage slots that
     ///         are packed should be set through this interface.
@@ -34,8 +34,8 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Retrieves a bytes32 value from `_slot`.
-    function getBytes32(bytes32 _slot) external view returns (bytes32) {
-        return Storage.getBytes32(_slot);
+    function getBytes32(bytes32 _slot) external view returns (bytes32 value_) {
+        value_ = Storage.getBytes32(_slot);
     }
 
     /// @notice Stores a uint256 `_value` at `_slot`.
@@ -44,8 +44,8 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Retrieves a uint256 value from `_slot`.
-    function getUint(bytes32 _slot) external view returns (uint256) {
-        return Storage.getUint(_slot);
+    function getUint(bytes32 _slot) external view returns (uint256 value_) {
+        value_ = Storage.getUint(_slot);
     }
 
     /// @notice Stores an address `_value` at `_slot`.
@@ -54,7 +54,17 @@ contract StorageSetter is ISemver {
     }
 
     /// @notice Retrieves an address value from `_slot`.
-    function getAddress(bytes32 _slot) external view returns (address) {
-        return Storage.getAddress(_slot);
+    function getAddress(bytes32 _slot) external view returns (address addr_) {
+        addr_ = Storage.getAddress(_slot);
+    }
+
+    /// @notice Stores a bool `_value` at `_slot`.
+    function setBool(bytes32 _slot, bool _value) public {
+        Storage.setBool(_slot, _value);
+    }
+
+    /// @notice Retrieves a bool value from `_slot`.
+    function getBool(bytes32 _slot) external view returns (bool value_) {
+        value_ = Storage.getBool(_slot);
     }
 }

--- a/packages/contracts-bedrock/test/libraries/Storage.t.sol
+++ b/packages/contracts-bedrock/test/libraries/Storage.t.sol
@@ -40,6 +40,12 @@ contract Storage_Roundtrip_Test is Test {
         assertEq(hash, vm.load(address(setter), slot));
     }
 
+    function test_setGetBool_succeeds(bytes32 slot, bool value) external {
+        setter.setBool(slot, value);
+        assertEq(setter.getBool(slot), value);
+        assertEq(value, vm.load(address(setter), slot) == bytes32(uint256(1)));
+    }
+
     /// @dev All keys must be unique in the input so deduplication is required.
     function testFuzz_setGetBytes32Multi_succeeds(StorageSetter.Slot[] calldata _slots) external {
         for (uint256 i; i < _slots.length; i++) {


### PR DESCRIPTION
**Description**

Make the `SuperchainConfig` easier to audit by increasing type safety

- contracts-bedrock: add bool getter/setter to `Storage.sol`
- contracts-bedrock: simplify storage setting in SuperchainConfig

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

