### PR TITLE
op-node: Log and set metrics after batch is derived without error

### DIFF
--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -91,9 +91,13 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 	}
 	switch batchData.GetBatchType() {
 	case SingularBatchType:
+		singularBatch, err := GetSingularBatch(batchData)
+		if err != nil {
+			return nil, err
+		}
 		cr.log.Debug("decoded singular batch from channel")
 		cr.metrics.RecordDerivedBatches("singular")
-		return GetSingularBatch(batchData)
+		return singularBatch, nil
 	case SpanBatchType:
 		if origin := cr.Origin(); !cr.cfg.IsDelta(origin.Time) {
 			// Check hard fork activation with the L1 inclusion block time instead of the L1 origin block time.
@@ -101,9 +105,13 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 			// This is just for early dropping invalid batches as soon as possible.
 			return nil, NewTemporaryError(fmt.Errorf("cannot accept span batch in L1 block %s at time %d", origin, origin.Time))
 		}
+		spanBatch, err := DeriveSpanBatch(batchData, cr.cfg.BlockTime, cr.cfg.Genesis.L2Time, cr.cfg.L2ChainID)
+		if err != nil {
+			return nil, err
+		}
 		cr.log.Debug("decoded span batch from channel")
 		cr.metrics.RecordDerivedBatches("span")
-		return DeriveSpanBatch(batchData, cr.cfg.BlockTime, cr.cfg.Genesis.L2Time, cr.cfg.L2ChainID)
+		return spanBatch, nil
 	default:
 		// error is bubbled up to user, but pipeline can skip the batch and continue after.
 		return nil, NewTemporaryError(fmt.Errorf("unrecognized batch type: %d", batchData.GetBatchType()))

--- a/op-node/rollup/derive/channel_in_reader.go
+++ b/op-node/rollup/derive/channel_in_reader.go
@@ -95,7 +95,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		if err != nil {
 			return nil, err
 		}
-		cr.log.Debug("decoded singular batch from channel")
+		singularBatch.LogContext(cr.log).Debug("decoded singular batch from channel", "stage_origin", cr.Origin())
 		cr.metrics.RecordDerivedBatches("singular")
 		return singularBatch, nil
 	case SpanBatchType:
@@ -109,7 +109,7 @@ func (cr *ChannelInReader) NextBatch(ctx context.Context) (Batch, error) {
 		if err != nil {
 			return nil, err
 		}
-		cr.log.Debug("decoded span batch from channel")
+		spanBatch.LogContext(cr.log).Debug("decoded span batch from channel", "stage_origin", cr.Origin())
 		cr.metrics.RecordDerivedBatches("span")
 		return spanBatch, nil
 	default:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

In the https://github.com/ethereum-optimism/optimism/pull/8412, I added new log messages and metrics to show which batch type is derived from channels.

Thankfully, @protolambda resolved merge conflicts for the last PR, but the unintended change was made. I think it will be better if logs and metrics are updated after the batch is derived without any errors.