### PR TITLE
CTB: Unpause testing

### DIFF
--- a/packages/contracts-bedrock/test/ExtendedPause.t.sol
+++ b/packages/contracts-bedrock/test/ExtendedPause.t.sol
@@ -4,24 +4,37 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 
+/// @dev These tests are somewhat redundant with tests in the SuperchainConfig and other pausable contracts, however
+///      it is worthwhile to pull them into one location to ensure that the behavior is consistent.
 contract ExtendedPause_Test is CommonTest {
     /// @dev Tests that other contracts are paused when the superchain config is paused
-    ///      This test is somewhat redundant with tests in the SuperchainConfig and other pausable contracts, however
-    ///      it is worthwhile to pull them into one location to ensure that the behavior is consistent.
-    function test_pause_fullSystem_succeeds() external {
+    function test_pause_fullSystem_succeeds() public {
         assertFalse(superchainConfig.paused());
-        assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused());
 
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause("identifier");
 
+        // validate the paused state
         assertTrue(superchainConfig.paused());
-        assertEq(l1CrossDomainMessenger.paused(), superchainConfig.paused());
-
+        assertTrue(optimismPortal.paused());
+        assertTrue(l1CrossDomainMessenger.paused());
         assertTrue(l1StandardBridge.paused());
-        assertEq(l1StandardBridge.paused(), superchainConfig.paused());
-
         assertTrue(l1ERC721Bridge.paused());
-        assertEq(l1ERC721Bridge.paused(), superchainConfig.paused());
+    }
+
+    /// @dev Tests that other contracts are unpaused when the superchain config is paused and then unpaused.
+    function test_unpause_fullSystem_succeeds() external {
+        // first use the test above to pause the system
+        test_pause_fullSystem_succeeds();
+
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.unpause();
+
+        // validate the unpaused state
+        assertFalse(superchainConfig.paused());
+        assertFalse(optimismPortal.paused());
+        assertFalse(l1CrossDomainMessenger.paused());
+        assertFalse(l1StandardBridge.paused());
+        assertFalse(l1ERC721Bridge.paused());
     }
 }


### PR DESCRIPTION
Builds on #8365. 

Refactors the ExtendedPause test suite, and adds a test to validate the unpaused state.