### PR TITLE
feat(interop): eoa postie daemon

### DIFF
--- a/indexer/node/client.go
+++ b/indexer/node/client.go
@@ -32,6 +32,8 @@ const (
 )
 
 type EthClient interface {
+	ChainID() (*big.Int, error)
+
 	BlockHeaderByNumber(*big.Int) (*types.Header, error)
 	BlockHeaderByHash(common.Hash) (*types.Header, error)
 	BlockHeadersByRange(*big.Int, *big.Int) ([]types.Header, error)
@@ -73,6 +75,20 @@ func DialEthClient(ctx context.Context, rpcUrl string, metrics Metricer) (EthCli
 	}
 
 	return &clnt{rpc: NewRPC(rpcClient, metrics)}, nil
+}
+
+// ChainID retrieves the chain id associated with the rpc connection
+func (c *clnt) ChainID() (*big.Int, error) {
+	ctxwt, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
+	defer cancel()
+
+	var result hexutil.Big
+	err := c.rpc.CallContext(ctxwt, &result, "eth_chainId")
+	if err != nil {
+		return nil, err
+	}
+
+	return (*big.Int)(&result), nil
 }
 
 // BlockHeaderByHash retrieves the block header attributed to the supplied hash

--- a/indexer/node/client.go
+++ b/indexer/node/client.go
@@ -77,6 +77,10 @@ func DialEthClient(ctx context.Context, rpcUrl string, metrics Metricer) (EthCli
 	return &clnt{rpc: NewRPC(rpcClient, metrics)}, nil
 }
 
+func FromRPCClient(rpc *rpc.Client, metrics Metricer) EthClient {
+	return &clnt{rpc: NewRPC(rpc, metrics)}
+}
+
 // ChainID retrieves the chain id associated with the rpc connection
 func (c *clnt) ChainID() (*big.Int, error) {
 	ctxwt, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)

--- a/indexer/node/mocks.go
+++ b/indexer/node/mocks.go
@@ -16,6 +16,11 @@ type MockEthClient struct {
 	mock.Mock
 }
 
+func (m *MockEthClient) ChainID() (*big.Int, error) {
+	args := m.Called()
+	return args.Get(0).(*big.Int), args.Error(1)
+}
+
 func (m *MockEthClient) BlockHeaderByNumber(number *big.Int) (*types.Header, error) {
 	args := m.Called(number)
 	return args.Get(0).(*types.Header), args.Error(1)

--- a/interop/cmd/cli.go
+++ b/interop/cmd/cli.go
@@ -2,28 +2,112 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
 
+	"github.com/BurntSushi/toml"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 
+	"github.com/ethereum-optimism/optimism/indexer/node"
 	"github.com/ethereum-optimism/optimism/interop"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
 )
+
+var configFlag = &cli.StringFlag{
+	Name:    "config",
+	Value:   "./postie.toml",
+	Aliases: []string{"c"},
+	Usage:   "path to config file",
+	EnvVars: []string{"INTEROP_POSTIE_CONFIG"},
+}
 
 func newCli() *cli.App {
 	flags := oplog.CLIFlags("INTEROP_POSTIE")
+	flags = append(flags, configFlag)
+
 	return &cli.App{
-		Description: "",
+		Name: "interop",
 		Commands: []*cli.Command{
 			{
-				Name:   "interop-postie",
-				Flags:  flags,
-				Action: cliapp.LifecycleCmd(runPostie),
+				Name:        "postie",
+				Description: "daemon that watches connected chains relative to the destination chain for inbox updates",
+				Flags:       flags,
+				Action:      cliapp.LifecycleCmd(runPostie),
 			},
 		},
 	}
 }
 
-func runPostie(cli *cli.Context, shutdown context.CancelCauseFunc) (cliapp.Lifecycle, error) {
-	return interop.NewPostie(), nil
+func runPostie(ctx *cli.Context, shutdown context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "postie")
+	metricsRegistry := metrics.NewRegistry()
+
+	/** Load Config **/
+
+	var cfg struct {
+		PrivateKey string `toml:"private-key"`
+
+		DestinationChainRPC string   `toml:"destination-rpc"`
+		ConnectedChainRPCs  []string `toml:"connected-rpcs"`
+
+		UpdateIntervalMinutes int64 `toml:"update-interval-minutes"`
+	}
+
+	log.Info("reading config")
+	data, err := os.ReadFile(ctx.String(configFlag.Name))
+	if err != nil {
+		return nil, fmt.Errorf("unable to read conifg: %w", err)
+	}
+
+	data = []byte(os.ExpandEnv(string(data)))
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode config file: %w", err)
+	} else if len(md.Undecoded()) > 0 {
+		return nil, fmt.Errorf("unknown fields in config file: %s", md.Undecoded())
+	}
+
+	/** Setup Key & Clients **/
+
+	if len(cfg.PrivateKey) >= 2 && strings.ToLower(cfg.PrivateKey)[:2] == "0x" {
+		cfg.PrivateKey = cfg.PrivateKey[2:]
+	}
+
+	postieSecret, err := crypto.HexToECDSA(cfg.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create ecdsa key from provided private key: %w", err)
+	}
+
+	connectedClients := make([]node.EthClient, len(cfg.ConnectedChainRPCs))
+	for i, rpcUrl := range cfg.ConnectedChainRPCs {
+		clnt, err := node.DialEthClient(context.Background(), rpcUrl, node.NewMetrics(metricsRegistry, ""))
+		if err != nil {
+			return nil, fmt.Errorf("unable to dial client %s: %w", rpcUrl, err)
+		}
+		connectedClients[i] = clnt
+	}
+
+	if !client.IsURLAvailable(cfg.DestinationChainRPC) {
+		return nil, fmt.Errorf("address unavailable (%s)", cfg.DestinationChainRPC)
+	}
+	destinationClient, err := ethclient.Dial(cfg.DestinationChainRPC)
+	if err != nil {
+		return nil, fmt.Errorf("unable to dial client %s: %w", cfg.DestinationChainRPC, err)
+	}
+
+	/** Start the Postie Daemon **/
+
+	return interop.NewPostie(log, interop.PostieConfig{
+		Postie:           postieSecret,
+		DestinationChain: destinationClient,
+		ConnectedChains:  connectedClients,
+		UpdateInterval:   time.Duration(cfg.UpdateIntervalMinutes) * time.Minute,
+	})
 }

--- a/interop/cmd/cli.go
+++ b/interop/cmd/cli.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/interop"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+func newCli() *cli.App {
+	flags := oplog.CLIFlags("INTEROP_POSTIE")
+	return &cli.App{
+		Description: "",
+		Commands: []*cli.Command{
+			{
+				Name:   "interop-postie",
+				Flags:  flags,
+				Action: cliapp.LifecycleCmd(runPostie),
+			},
+		},
+	}
+}
+
+func runPostie(cli *cli.Context, shutdown context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	return interop.NewPostie(), nil
+}

--- a/interop/cmd/main.go
+++ b/interop/cmd/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/opio"
+)
+
+func main() {
+	oplog.SetupDefaults()
+
+	cli := newCli()
+	ctx := opio.WithInterruptBlocker(context.Background())
+	if err := cli.RunContext(ctx, os.Args); err != nil {
+		log.Error("application failed", "err", err)
+		os.Exit(1)
+	}
+}

--- a/interop/e2e_tests/postie_test.go
+++ b/interop/e2e_tests/postie_test.go
@@ -1,11 +1,48 @@
 package e2e_tests
 
-import "testing"
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
 
-func TestPostie(t *testing.T) {
-	_ = createE2ETestSuite(t)
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
 
-	for {
-		// just looping to make sure postie logs look good for now
-	}
+func TestPostieStorageRootUpdates(t *testing.T) {
+	testSuite := createE2ETestSuite(t)
+
+	// wait for the first storage root of chain B to change
+	var oldStorageRoot common.Hash
+	require.NoError(t, wait.For(context.Background(), time.Second/2, func() (bool, error) {
+		oldStorageRoot = testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB)
+		return oldStorageRoot != common.Hash{}, nil
+	}))
+
+	// initiate an message on chain B
+	// NOTE: the destination chain does not matter for now as postie will update for any change
+	outbox, err := bindings.NewCrossL2Outbox(predeploys.CrossL2OutboxAddr, testSuite.OpSysB.Clients["sequencer"])
+	require.NoError(t, err)
+
+	sender, senderAddr := testSuite.OpCfg.Secrets.Bob, testSuite.OpCfg.Secrets.Addresses().Bob
+	senderOpts, err := bind.NewKeyedTransactorWithChainID(sender, big.NewInt(int64(testSuite.ChainIdB)))
+	require.NoError(t, err)
+	senderOpts.Value = big.NewInt(params.Ether / 2)
+
+	tx, err := outbox.InitiateMessage(senderOpts, common.BigToHash(big.NewInt(int64(testSuite.ChainIdA))), senderAddr, big.NewInt(25_000), []byte{})
+	require.NoError(t, err)
+
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.OpSysB.Clients["sequencer"], tx.Hash())
+	require.NoError(t, err)
+
+	// wait for a changed root
+	require.NoError(t, wait.For(context.Background(), time.Second/2, func() (bool, error) {
+		return testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB) != oldStorageRoot, nil
+	}))
 }

--- a/interop/e2e_tests/postie_test.go
+++ b/interop/e2e_tests/postie_test.go
@@ -1,0 +1,11 @@
+package e2e_tests
+
+import "testing"
+
+func TestPostie(t *testing.T) {
+	_ = createE2ETestSuite(t)
+
+	for {
+		// just looping to make sure postie logs look good for now
+	}
+}

--- a/interop/e2e_tests/postie_test.go
+++ b/interop/e2e_tests/postie_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/indexer/node"
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
@@ -45,4 +47,68 @@ func TestPostieStorageRootUpdates(t *testing.T) {
 	require.NoError(t, wait.For(context.Background(), time.Second/2, func() (bool, error) {
 		return testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB) != oldStorageRoot, nil
 	}))
+
+	clnt := node.FromRPCClient(testSuite.OpSysB.RawClients["sequencer"], node.NewMetrics(metrics.NewRegistry(), ""))
+	root, err := clnt.StorageHash(predeploys.CrossL2OutboxAddr, nil)
+	require.NoError(t, err)
+	require.Equal(t, root, testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB))
+
+	inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.OpSysA.Clients["sequencer"])
+	require.NoError(t, err)
+
+	includedRoot, err := inbox.Roots(&bind.CallOpts{}, common.BigToHash(big.NewInt(int64(testSuite.ChainIdB))), root)
+	require.NoError(t, err)
+	require.True(t, includedRoot)
+}
+
+func TestPostieInboxRelay(t *testing.T) {
+	testSuite := createE2ETestSuite(t)
+
+	// wait for the first storage root of chain B to change
+	var oldStorageRoot common.Hash
+	require.NoError(t, wait.For(context.Background(), time.Second/2, func() (bool, error) {
+		oldStorageRoot = testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB)
+		return oldStorageRoot != common.Hash{}, nil
+	}))
+
+	outbox, err := bindings.NewCrossL2Outbox(predeploys.CrossL2OutboxAddr, testSuite.OpSysB.Clients["sequencer"])
+	require.NoError(t, err)
+
+	// Transfer 0.5 ETH from Bob's account from Chain B -> A
+	sender, senderAddr := testSuite.OpCfg.Secrets.Bob, testSuite.OpCfg.Secrets.Addresses().Bob
+	senderOpts, _ := bind.NewKeyedTransactorWithChainID(sender, big.NewInt(int64(testSuite.ChainIdB)))
+	senderOpts.Value = big.NewInt(params.Ether / 2)
+	tx, err := outbox.InitiateMessage(senderOpts, common.BigToHash(big.NewInt(int64(testSuite.ChainIdA))), senderAddr, big.NewInt(25_000), []byte{})
+	require.NoError(t, err)
+
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.OpSysB.Clients["sequencer"], tx.Hash())
+	require.NoError(t, err)
+
+	require.NoError(t, wait.For(context.Background(), time.Second/2, func() (bool, error) {
+		return testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB) != oldStorageRoot, nil
+	}))
+
+	// Relay this message onto chain A
+	inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, testSuite.OpSysA.Clients["sequencer"])
+	require.NoError(t, err)
+
+	senderOpts, _ = bind.NewKeyedTransactorWithChainID(sender, big.NewInt(int64(testSuite.ChainIdA)))
+	tx, err = inbox.RunCrossL2Message(senderOpts,
+		bindings.TypesSuperchainMessage{
+			Nonce:       big.NewInt(0), // first message
+			SourceChain: common.BigToHash(big.NewInt(int64(testSuite.ChainIdB))),
+			TargetChain: common.BigToHash(big.NewInt(int64(testSuite.ChainIdA))),
+			From:        senderAddr,
+			To:          senderAddr,
+			GasLimit:    big.NewInt(25_000),
+			Data:        []byte{},
+			Value:       big.NewInt(params.Ether / 2),
+		},
+		testSuite.PostieA.OutboxStorageRoot(testSuite.ChainIdB),
+		[]byte{}, // TODO: proof is ignored for now. no validation yet
+	)
+	require.NoError(t, err)
+
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.OpSysA.Clients["sequencer"], tx.Hash())
+	require.NoError(t, err)
 }

--- a/interop/e2e_tests/setup.go
+++ b/interop/e2e_tests/setup.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -21,11 +22,13 @@ type E2ETestSuite struct {
 
 	OpCfg *op_e2e.SystemConfig
 
-	OpSysA  *op_e2e.System
-	PostieA *interop.Postie
+	ChainIdA uint64
+	OpSysA   *op_e2e.System
+	PostieA  *interop.Postie
 
-	OpSysB  *op_e2e.System
-	PostieB *interop.Postie
+	ChainIdB uint64
+	OpSysB   *op_e2e.System
+	PostieB  *interop.Postie
 }
 
 func createE2ETestSuite(t *testing.T) E2ETestSuite {
@@ -47,6 +50,9 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 	// NOTE: These two L2s will not settle on the same L1 local network which
 	// is fine for now because this prototype does not care about L1 state and
 	// L1 liquidity is still seperate per L2 chain.
+	interopAtGenesis := hexutil.Uint64(0)
+	opCfg.DeployConfig.L2GenesisInteropTimeOffset = &interopAtGenesis
+	opCfg.DeployConfig.SuperchainPostie = &opCfg.Secrets.Addresses().Alice
 
 	opCfg.DeployConfig.L2ChainID = 901
 	opSysA, err := opCfg.Start(t)
@@ -57,16 +63,16 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 	require.NoError(t, err)
 
 	postieCfgA := interop.PostieConfig{
-		Postie:           opSysA.Cfg.Secrets.SysCfgOwner, // setup the right private key
+		Postie:           opCfg.Secrets.Alice,
 		DestinationChain: opSysA.Clients["sequencer"],
-		ConnectedChains:  []node.EthClient{node.FromRPCClient(opSysB.RawClients["sequencer"], node.NewMetrics(m, "a"))},
-		UpdateInterval:   10 * time.Second,
+		ConnectedChains:  []node.EthClient{node.FromRPCClient(opSysB.RawClients["sequencer"], node.NewMetrics(m, "b"))},
+		UpdateInterval:   6 * time.Duration(opCfg.DeployConfig.L2BlockTime) * time.Second, // every ~6 blocks
 	}
 	postieCfgB := interop.PostieConfig{
-		Postie:           opSysB.Cfg.Secrets.SysCfgOwner, // setup the right private key
+		Postie:           opCfg.Secrets.Alice,
 		DestinationChain: opSysB.Clients["sequencer"],
-		ConnectedChains:  []node.EthClient{node.FromRPCClient(opSysA.RawClients["sequencer"], node.NewMetrics(m, "b"))},
-		UpdateInterval:   10 * time.Second,
+		ConnectedChains:  []node.EthClient{node.FromRPCClient(opSysA.RawClients["sequencer"], node.NewMetrics(m, "a"))},
+		UpdateInterval:   6 * time.Duration(opCfg.DeployConfig.L2BlockTime) * time.Second, // every ~6 blocks
 	}
 
 	log := testlog.Logger(t, log.LvlInfo).New("role", "postie")
@@ -87,10 +93,12 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 		t:     t,
 		OpCfg: &opCfg,
 
-		OpSysA:  opSysA,
-		PostieA: postieA,
+		ChainIdA: 901,
+		OpSysA:   opSysA,
+		PostieA:  postieA,
 
-		OpSysB:  opSysB,
-		PostieB: postieB,
+		ChainIdB: 902,
+		OpSysB:   opSysB,
+		PostieB:  postieB,
 	}
 }

--- a/interop/e2e_tests/setup.go
+++ b/interop/e2e_tests/setup.go
@@ -1,0 +1,96 @@
+package e2e_tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/indexer/node"
+	"github.com/ethereum-optimism/optimism/interop"
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+type E2ETestSuite struct {
+	t *testing.T
+
+	OpCfg *op_e2e.SystemConfig
+
+	OpSysA  *op_e2e.System
+	PostieA *interop.Postie
+
+	OpSysB  *op_e2e.System
+	PostieB *interop.Postie
+}
+
+func createE2ETestSuite(t *testing.T) E2ETestSuite {
+	m := metrics.NewRegistry()
+
+	// Rollup System Configuration. Unless specified,
+	// omit logs emitted by the various components. Maybe
+	// we can eventually dump these logs to a temp file
+	log.Root().SetHandler(log.DiscardHandler())
+	opCfg := op_e2e.DefaultSystemConfig(t)
+	if len(os.Getenv("ENABLE_ROLLUP_LOGS")) == 0 {
+		t.Log("set env 'ENABLE_ROLLUP_LOGS' to show rollup logs")
+		for name, logger := range opCfg.Loggers {
+			t.Logf("discarding logs for %s", name)
+			logger.SetHandler(log.DiscardHandler())
+		}
+	}
+
+	// NOTE: These two L2s will not settle on the same L1 local network which
+	// is fine for now because this prototype does not care about L1 state and
+	// L1 liquidity is still seperate per L2 chain.
+
+	opCfg.DeployConfig.L2ChainID = 901
+	opSysA, err := opCfg.Start(t)
+	require.NoError(t, err)
+
+	opCfg.DeployConfig.L2ChainID = 902
+	opSysB, err := opCfg.Start(t)
+	require.NoError(t, err)
+
+	postieCfgA := interop.PostieConfig{
+		Postie:           opSysA.Cfg.Secrets.SysCfgOwner, // setup the right private key
+		DestinationChain: opSysA.Clients["sequencer"],
+		ConnectedChains:  []node.EthClient{node.FromRPCClient(opSysB.RawClients["sequencer"], node.NewMetrics(m, "a"))},
+		UpdateInterval:   10 * time.Second,
+	}
+	postieCfgB := interop.PostieConfig{
+		Postie:           opSysB.Cfg.Secrets.SysCfgOwner, // setup the right private key
+		DestinationChain: opSysB.Clients["sequencer"],
+		ConnectedChains:  []node.EthClient{node.FromRPCClient(opSysA.RawClients["sequencer"], node.NewMetrics(m, "b"))},
+		UpdateInterval:   10 * time.Second,
+	}
+
+	log := testlog.Logger(t, log.LvlInfo).New("role", "postie")
+
+	postieA, err := interop.NewPostie(log.New("chain", "a"), postieCfgA)
+	require.NoError(t, err)
+
+	postieB, err := interop.NewPostie(log.New("chain", "b"), postieCfgB)
+	require.NoError(t, err)
+
+	require.NoError(t, postieA.Start(context.Background()))
+	t.Cleanup(func() { require.NoError(t, postieA.Stop(context.Background())) })
+
+	require.NoError(t, postieB.Start(context.Background()))
+	t.Cleanup(func() { require.NoError(t, postieB.Stop(context.Background())) })
+
+	return E2ETestSuite{
+		t:     t,
+		OpCfg: &opCfg,
+
+		OpSysA:  opSysA,
+		PostieA: postieA,
+
+		OpSysB:  opSysB,
+		PostieB: postieB,
+	}
+}

--- a/interop/postie.go
+++ b/interop/postie.go
@@ -1,0 +1,36 @@
+package interop
+
+import (
+	"context"
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+var (
+	CrossL2Outbox = common.HexToAddress("")
+)
+
+type PostieConfig struct {
+	Postie          *ecdsa.PrivateKey
+	ConnectedChains []ethclient.Client
+}
+
+type Postie struct{}
+
+func NewPostie() *Postie {
+	return &Postie{}
+}
+
+func (p *Postie) Start(ctx context.Context) error {
+	return nil
+}
+
+func (p *Postie) Stop(ctx context.Context) error {
+	return nil
+}
+
+func (p *Postie) Stopped() bool {
+	return false
+}

--- a/interop/postie.go
+++ b/interop/postie.go
@@ -43,6 +43,8 @@ type Postie struct {
 }
 
 func NewPostie(log log.Logger, cfg PostieConfig) (*Postie, error) {
+	log.Info("configuring postie...")
+
 	connectedChains := map[uint64]node.EthClient{}
 	for _, clnt := range cfg.ConnectedChains {
 		chainIdBig, err := clnt.ChainID()
@@ -50,8 +52,8 @@ func NewPostie(log log.Logger, cfg PostieConfig) (*Postie, error) {
 			return nil, fmt.Errorf("unable to retrieve chain id: %w", err)
 		}
 
-		chainId := chainIdBig.Uint64()
-		connectedChains[chainId] = clnt
+		log.Info("connected outbox", "id", chainIdBig)
+		connectedChains[chainIdBig.Uint64()] = clnt
 	}
 
 	destChainId, err := cfg.DestinationChain.ChainID(context.Background())
@@ -114,8 +116,12 @@ func (p *Postie) Stopped() bool {
 	return p.stopped.Load()
 }
 
+func (p *Postie) OutboxStorageRoot(chainId uint64) common.Hash {
+	return p.outboxStorageRoots[chainId]
+}
+
 func (p *Postie) tick(_ context.Context) {
-	p.log.Info("checking outboxes")
+	p.log.Info("checking outboxes...")
 
 	// NOTE: There are some potential lifecycle isssues casued by the delay between
 	// tx submission and inclusion that would cause repeated mail delivery. As long as
@@ -126,13 +132,15 @@ func (p *Postie) tick(_ context.Context) {
 
 		outboxStorageRoot, err := clnt.StorageHash(predeploys.CrossL2OutboxAddr, nil)
 		if err != nil {
-			p.log.Error("unable to fetch outbox storage root", "chain_id", chainId, "err", err)
+			p.log.Error("unable to fetch outbox storage root", "id", chainId, "err", err)
 		}
 
 		if outboxStorageRoot == oldStorageRoot {
-			p.log.Info("no change in state", "chain_id", chainId)
+			p.log.Info("no change in state", "id", chainId)
 		} else {
-			p.log.Info("detected new outbox storage root", "chain_id", chainId, "root", outboxStorageRoot.String(), "old_root", oldStorageRoot.String())
+			// NOTE: With the single-outbox design, we technically should be checking for a change that
+			// contains a message specific to the destination. For the prototype, we'll just always update
+			p.log.Info("detected new outbox storage root", "id", chainId, "root", outboxStorageRoot.String(), "old_root", oldStorageRoot.String())
 			mail = append(mail, bindings.InboxEntry{Chain: common.BigToHash(big.NewInt(int64(chainId))), Output: outboxStorageRoot})
 		}
 	}
@@ -151,6 +159,7 @@ func (p *Postie) tick(_ context.Context) {
 		// inclusion should be guaranteed, this is fine
 		for _, mail := range mail {
 			chainId := new(big.Int).SetBytes(mail.Chain[:]).Uint64()
+			p.log.Info("updated chain", "id", chainId)
 			p.outboxStorageRoots[chainId] = mail.Output
 		}
 	}

--- a/interop/postie.toml
+++ b/interop/postie.toml
@@ -1,0 +1,11 @@
+# Postie Private Key
+private-key = "0xabc"
+
+# Interval for mail updates
+update-interval-minutes = 3
+
+# Destination Chain where inbox updates will be delivered
+destination-rpc = "http://localhost:9545"
+
+# List of Connected Chains watched for updates
+connected-rpcs = ["http://localhost:9646", "http://localhost:9747"]

--- a/packages/contracts-bedrock/src/interop/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/interop/CrossL2Inbox.sol
@@ -34,7 +34,7 @@ contract CrossL2Inbox is ISemver {
     /// @notice Address of the cross L2 account which initiated a call in this cross L2 message.
     ///         If the of this variable is the default L2 sender address, then we are NOT inside of
     ///         a call to runCrossL2Transaction.
-    address public crossL2Sender;
+    address public crossL2Sender = Constants.DEFAULT_L2_SENDER;
 
     /// @notice Source chain identifier from where the cross L2 call originated. Empty if not in a call.
     bytes32 public messageSourceChain;


### PR DESCRIPTION
EOA driven postie daemon that monitors storage root changes of connected chains
and delivers them to the destination chain on some interval.

Important to note that for a bidirectional channels, there would be two instances
of this deamon on each end of the channel

Closes ethereum-optimism/interop#22
Closes ethereum-optimism/interop#21
