### PR TITLE
fix(op-challenger): Absolute Prestate Provider Refactor

### DIFF
--- a/op-challenger/game/fault/contracts/outputbisectiongame.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	methodGenesisBlockNumber = "GENESIS_BLOCK_NUMBER"
+	methodGenesisOutputRoot  = "GENESIS_OUTPUT_ROOT"
 	methodSplitDepth         = "SPLIT_DEPTH"
 	methodL2BlockNumber      = "l2BlockNumber"
 )
@@ -53,6 +54,14 @@ func (c *OutputBisectionGameContract) GetBlockRange(ctx context.Context) (presta
 	prestateBlock = results[0].GetBigInt(0).Uint64()
 	poststateBlock = results[1].GetBigInt(0).Uint64()
 	return
+}
+
+func (c *OutputBisectionGameContract) GetGenesisOutputRoot(ctx context.Context) (common.Hash, error) {
+	genesisOutputRoot, err := c.multiCaller.SingleCall(ctx, batching.BlockLatest, c.contract.Call(methodGenesisOutputRoot))
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to retrieve genesis output root: %w", err)
+	}
+	return genesisOutputRoot.GetHash(0), nil
 }
 
 func (c *OutputBisectionGameContract) GetSplitDepth(ctx context.Context) (uint64, error) {

--- a/op-challenger/game/fault/contracts/outputbisectiongame_test.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame_test.go
@@ -41,6 +41,15 @@ func TestGetSplitDepth(t *testing.T) {
 	require.Equal(t, expectedSplitDepth, splitDepth)
 }
 
+func TestGetGenesisOutputRoot(t *testing.T) {
+	stubRpc, contract := setupOutputBisectionGameTest(t)
+	expectedOutputRoot := common.HexToHash("0x1234")
+	stubRpc.SetResponse(fdgAddr, methodGenesisOutputRoot, batching.BlockLatest, nil, []interface{}{expectedOutputRoot})
+	genesisOutputRoot, err := contract.GetGenesisOutputRoot(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expectedOutputRoot, genesisOutputRoot)
+}
+
 func TestOutputBisectionGame_UpdateOracleTx(t *testing.T) {
 	t.Run("Local", func(t *testing.T) {
 		stubRpc, game := setupOutputBisectionGameTest(t)

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -129,9 +129,7 @@ func (g *GamePlayer) logGameStatus(ctx context.Context, status gameTypes.GameSta
 	g.logger.Info("Game resolved", "status", status)
 }
 
-type PrestateLoader interface {
-	GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error)
-}
+type PrestateLoader = func(ctx context.Context) (common.Hash, error)
 
 // ValidateAbsolutePrestate validates the absolute prestate of the fault game.
 func ValidateAbsolutePrestate(ctx context.Context, trace types.TraceProvider, loader PrestateLoader) error {
@@ -139,7 +137,7 @@ func ValidateAbsolutePrestate(ctx context.Context, trace types.TraceProvider, lo
 	if err != nil {
 		return fmt.Errorf("failed to get the trace provider's absolute prestate: %w", err)
 	}
-	onchainPrestate, err := loader.GetAbsolutePrestateHash(ctx)
+	onchainPrestate, err := loader(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get the onchain absolute prestate: %w", err)
 	}

--- a/op-challenger/game/fault/player_test.go
+++ b/op-challenger/game/fault/player_test.go
@@ -200,20 +200,11 @@ func (m *mockTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (com
 	return hash, nil
 }
 
-type mockLoader struct {
-	prestateError bool
-	prestate      common.Hash
-}
-
-func newMockPrestateLoader(prestateError bool, prestate common.Hash) *mockLoader {
-	return &mockLoader{
-		prestateError: prestateError,
-		prestate:      prestate,
+func newMockPrestateLoader(prestateError bool, prestate common.Hash) func(ctx context.Context) (common.Hash, error) {
+	return func(ctx context.Context) (common.Hash, error) {
+		if prestateError {
+			return common.Hash{}, mockLoaderError
+		}
+		return prestate, nil
 	}
-}
-func (m *mockLoader) GetAbsolutePrestateHash(ctx context.Context) (common.Hash, error) {
-	if m.prestateError {
-		return common.Hash{}, mockLoaderError
-	}
-	return m.prestate, nil
 }

--- a/op-challenger/game/fault/player_test.go
+++ b/op-challenger/game/fault/player_test.go
@@ -3,29 +3,19 @@ package fault
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	mockTraceProviderError = fmt.Errorf("mock trace provider error")
-	mockLoaderError        = fmt.Errorf("mock loader error")
 )
 
 func TestProgressGame_LogErrorFromAct(t *testing.T) {
 	handler, game, actor := setupProgressGameTest(t)
 	actor.actErr = errors.New("boom")
 	status := game.ProgressGame(context.Background())
-	require.Equal(t, gameTypes.GameStatusInProgress, status)
+	require.Equal(t, types.GameStatusInProgress, status)
 	require.Equal(t, 1, actor.callCount, "should perform next actions")
 	errLog := handler.FindLog(log.LvlError, "Error when acting on game")
 	require.NotNil(t, errLog, "should log error")
@@ -40,22 +30,22 @@ func TestProgressGame_LogErrorFromAct(t *testing.T) {
 func TestProgressGame_LogGameStatus(t *testing.T) {
 	tests := []struct {
 		name   string
-		status gameTypes.GameStatus
+		status types.GameStatus
 		logMsg string
 	}{
 		{
 			name:   "ChallengerWon",
-			status: gameTypes.GameStatusChallengerWon,
+			status: types.GameStatusChallengerWon,
 			logMsg: "Game resolved",
 		},
 		{
 			name:   "DefenderWon",
-			status: gameTypes.GameStatusDefenderWon,
+			status: types.GameStatusDefenderWon,
 			logMsg: "Game resolved",
 		},
 		{
 			name:   "GameInProgress",
-			status: gameTypes.GameStatusInProgress,
+			status: types.GameStatusInProgress,
 			logMsg: "Game info",
 		},
 	}
@@ -76,7 +66,7 @@ func TestProgressGame_LogGameStatus(t *testing.T) {
 }
 
 func TestDoNotActOnCompleteGame(t *testing.T) {
-	for _, status := range []gameTypes.GameStatus{gameTypes.GameStatusChallengerWon, gameTypes.GameStatusDefenderWon} {
+	for _, status := range []types.GameStatus{types.GameStatusChallengerWon, types.GameStatusDefenderWon} {
 		t.Run(status.String(), func(t *testing.T) {
 			_, game, gameState := setupProgressGameTest(t)
 			gameState.status = status
@@ -91,43 +81,6 @@ func TestDoNotActOnCompleteGame(t *testing.T) {
 			require.Equal(t, status, fetched)
 		})
 	}
-}
-
-// TestValidateAbsolutePrestate tests that the absolute prestate is validated
-// correctly by the service component.
-func TestValidateAbsolutePrestate(t *testing.T) {
-	t.Run("ValidPrestates", func(t *testing.T) {
-		prestate := []byte{0x00, 0x01, 0x02, 0x03}
-		prestateHash := crypto.Keccak256(prestate)
-		prestateHash[0] = mipsevm.VMStatusUnfinished
-		mockTraceProvider := newMockTraceProvider(false, prestate)
-		mockLoader := newMockPrestateLoader(false, common.BytesToHash(prestateHash))
-		err := ValidateAbsolutePrestate(context.Background(), mockTraceProvider, mockLoader)
-		require.NoError(t, err)
-	})
-
-	t.Run("TraceProviderErrors", func(t *testing.T) {
-		prestate := []byte{0x00, 0x01, 0x02, 0x03}
-		mockTraceProvider := newMockTraceProvider(true, prestate)
-		mockLoader := newMockPrestateLoader(false, common.BytesToHash(prestate))
-		err := ValidateAbsolutePrestate(context.Background(), mockTraceProvider, mockLoader)
-		require.ErrorIs(t, err, mockTraceProviderError)
-	})
-
-	t.Run("LoaderErrors", func(t *testing.T) {
-		prestate := []byte{0x00, 0x01, 0x02, 0x03}
-		mockTraceProvider := newMockTraceProvider(false, prestate)
-		mockLoader := newMockPrestateLoader(true, common.BytesToHash(prestate))
-		err := ValidateAbsolutePrestate(context.Background(), mockTraceProvider, mockLoader)
-		require.ErrorIs(t, err, mockLoaderError)
-	})
-
-	t.Run("PrestateMismatch", func(t *testing.T) {
-		mockTraceProvider := newMockTraceProvider(false, []byte{0x00, 0x01, 0x02, 0x03})
-		mockLoader := newMockPrestateLoader(false, common.BytesToHash([]byte{0x00}))
-		err := ValidateAbsolutePrestate(context.Background(), mockTraceProvider, mockLoader)
-		require.Error(t, err)
-	})
 }
 
 func setupProgressGameTest(t *testing.T) (*testlog.CapturingHandler, *GamePlayer, *stubGameState) {
@@ -146,7 +99,7 @@ func setupProgressGameTest(t *testing.T) (*testlog.CapturingHandler, *GamePlayer
 }
 
 type stubGameState struct {
-	status     gameTypes.GameStatus
+	status     types.GameStatus
 	claimCount uint64
 	callCount  int
 	actErr     error
@@ -158,53 +111,10 @@ func (s *stubGameState) Act(ctx context.Context) error {
 	return s.actErr
 }
 
-func (s *stubGameState) GetStatus(ctx context.Context) (gameTypes.GameStatus, error) {
+func (s *stubGameState) GetStatus(ctx context.Context) (types.GameStatus, error) {
 	return s.status, nil
 }
 
 func (s *stubGameState) GetClaimCount(ctx context.Context) (uint64, error) {
 	return s.claimCount, nil
-}
-
-type mockTraceProvider struct {
-	prestateErrors bool
-	prestate       []byte
-}
-
-func newMockTraceProvider(prestateErrors bool, prestate []byte) *mockTraceProvider {
-	return &mockTraceProvider{
-		prestateErrors: prestateErrors,
-		prestate:       prestate,
-	}
-}
-func (m *mockTraceProvider) Get(ctx context.Context, i types.Position) (common.Hash, error) {
-	panic("not implemented")
-}
-func (m *mockTraceProvider) GetStepData(ctx context.Context, i types.Position) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
-	panic("not implemented")
-}
-func (m *mockTraceProvider) AbsolutePreState(ctx context.Context) ([]byte, error) {
-	if m.prestateErrors {
-		return nil, mockTraceProviderError
-	}
-	return m.prestate, nil
-}
-func (m *mockTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (common.Hash, error) {
-	prestate, err := m.AbsolutePreState(ctx)
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	hash := common.BytesToHash(crypto.Keccak256(prestate))
-	hash[0] = mipsevm.VMStatusUnfinished
-	return hash, nil
-}
-
-func newMockPrestateLoader(prestateError bool, prestate common.Hash) func(ctx context.Context) (common.Hash, error) {
-	return func(ctx context.Context) (common.Hash, error) {
-		if prestateError {
-			return common.Hash{}, mockLoaderError
-		}
-		return prestate, nil
-	}
 }

--- a/op-challenger/game/fault/trace/alphabet/prestate.go
+++ b/op-challenger/game/fault/trace/alphabet/prestate.go
@@ -1,0 +1,30 @@
+package alphabet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	absolutePrestate = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
+)
+
+type AlphabetPrestateProvider struct{}
+
+func NewPrestateProvider() *AlphabetPrestateProvider {
+	return &AlphabetPrestateProvider{}
+}
+
+func (o *AlphabetPrestateProvider) GenesisOutputRoot(ctx context.Context) (hash common.Hash, err error) {
+	return common.Hash{}, fmt.Errorf("alphabet does not have a genesis output root")
+}
+
+func (ap *AlphabetPrestateProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	hash := common.BytesToHash(crypto.Keccak256(absolutePrestate))
+	hash[0] = mipsevm.VMStatusUnfinished
+	return hash, nil
+}

--- a/op-challenger/game/fault/trace/alphabet/prestate_test.go
+++ b/op-challenger/game/fault/trace/alphabet/prestate_test.go
@@ -1,0 +1,17 @@
+package alphabet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlphabetPrestateProvider_AbsolutePreStateCommitment_Succeeds(t *testing.T) {
+	provider := NewPrestateProvider()
+	hash, err := provider.AbsolutePreStateCommitment(context.Background())
+	require.NoError(t, err)
+	expected := common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98")
+	require.Equal(t, expected, hash)
+}

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -15,12 +15,13 @@ import (
 
 var (
 	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
-	absolutePrestate = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
 )
 
 // AlphabetTraceProvider is a [TraceProvider] that provides claims for specific
 // indices in the given trace.
 type AlphabetTraceProvider struct {
+	AlphabetPrestateProvider
+
 	state  []string
 	depth  uint64
 	maxLen uint64
@@ -29,9 +30,10 @@ type AlphabetTraceProvider struct {
 // NewTraceProvider returns a new [AlphabetProvider].
 func NewTraceProvider(state string, depth uint64) *AlphabetTraceProvider {
 	return &AlphabetTraceProvider{
-		state:  strings.Split(state, ""),
-		depth:  depth,
-		maxLen: uint64(1 << depth),
+		AlphabetPrestateProvider: *NewPrestateProvider(),
+		state:                    strings.Split(state, ""),
+		depth:                    depth,
+		maxLen:                   uint64(1 << depth),
 	}
 }
 
@@ -66,12 +68,6 @@ func (ap *AlphabetTraceProvider) Get(ctx context.Context, i types.Position) (com
 		return common.Hash{}, err
 	}
 	return alphabetStateHash(claimBytes), nil
-}
-
-func (ap *AlphabetTraceProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
-	hash := common.BytesToHash(crypto.Keccak256(absolutePrestate))
-	hash[0] = mipsevm.VMStatusUnfinished
-	return hash, nil
 }
 
 // BuildAlphabetPreimage constructs the claim bytes for the index and state item.

--- a/op-challenger/game/fault/trace/cannon/prestate.go
+++ b/op-challenger/game/fault/trace/cannon/prestate.go
@@ -1,0 +1,45 @@
+package cannon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+)
+
+type CannonPrestateProvider struct {
+	prestate string
+}
+
+func NewPrestateProvider(cfg *config.Config) *CannonPrestateProvider {
+	return &CannonPrestateProvider{
+		prestate: cfg.CannonAbsolutePreState,
+	}
+}
+
+func (p *CannonPrestateProvider) absolutePreState() ([]byte, error) {
+	state, err := parseState(p.prestate)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load absolute pre-state: %w", err)
+	}
+	return state.EncodeWitness(), nil
+}
+
+func (o *CannonPrestateProvider) GenesisOutputRoot(ctx context.Context) (hash common.Hash, err error) {
+	return common.Hash{}, fmt.Errorf("cannon does not have a genesis output root")
+}
+
+func (p *CannonPrestateProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	state, err := p.absolutePreState()
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("cannot load absolute pre-state: %w", err)
+	}
+	hash, err := mipsevm.StateWitness(state).StateHash()
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("cannot hash absolute pre-state: %w", err)
+	}
+	return hash, nil
+}

--- a/op-challenger/game/fault/trace/cannon/prestate_test.go
+++ b/op-challenger/game/fault/trace/cannon/prestate_test.go
@@ -1,0 +1,70 @@
+package cannon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func newCannonPrestateProvider(dataDir string, prestate string) *CannonPrestateProvider {
+	return &CannonPrestateProvider{
+		prestate: filepath.Join(dataDir, prestate),
+	}
+}
+
+func TestAbsolutePreStateCommitment(t *testing.T) {
+	dataDir := t.TempDir()
+
+	prestate := "state.json"
+
+	t.Run("StateUnavailable", func(t *testing.T) {
+		provider := newCannonPrestateProvider("/dir/does/not/exist", prestate)
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("InvalidStateFile", func(t *testing.T) {
+		setupPreState(t, dataDir, "invalid.json")
+		provider := newCannonPrestateProvider(dataDir, prestate)
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorContains(t, err, "invalid mipsevm state")
+	})
+
+	t.Run("ExpectedAbsolutePreState", func(t *testing.T) {
+		setupPreState(t, dataDir, "state.json")
+		provider := newCannonPrestateProvider(dataDir, prestate)
+		actual, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.NoError(t, err)
+		state := mipsevm.State{
+			Memory:         mipsevm.NewMemory(),
+			PreimageKey:    common.HexToHash("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+			PreimageOffset: 0,
+			PC:             0,
+			NextPC:         1,
+			LO:             0,
+			HI:             0,
+			Heap:           0,
+			ExitCode:       0,
+			Exited:         false,
+			Step:           0,
+			Registers:      [32]uint32{},
+		}
+		expected, err := state.EncodeWitness().StateHash()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
+func setupPreState(t *testing.T, dataDir string, filename string) {
+	srcDir := filepath.Join("test_data")
+	path := filepath.Join(srcDir, filename)
+	file, err := testData.ReadFile(path)
+	require.NoErrorf(t, err, "reading %v", path)
+	err = os.WriteFile(filepath.Join(dataDir, "state.json"), file, 0o644)
+	require.NoErrorf(t, err, "writing %v", path)
+}

--- a/op-challenger/game/fault/trace/cannon/provider_test.go
+++ b/op-challenger/game/fault/trace/cannon/provider_test.go
@@ -216,58 +216,6 @@ func TestGetStepData(t *testing.T) {
 	})
 }
 
-func TestAbsolutePreStateCommitment(t *testing.T) {
-	dataDir := t.TempDir()
-
-	prestate := "state.json"
-
-	t.Run("StateUnavailable", func(t *testing.T) {
-		provider, _ := setupWithTestData(t, "/dir/does/not/exist", prestate)
-		_, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.ErrorIs(t, err, os.ErrNotExist)
-	})
-
-	t.Run("InvalidStateFile", func(t *testing.T) {
-		setupPreState(t, dataDir, "invalid.json")
-		provider, _ := setupWithTestData(t, dataDir, prestate)
-		_, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.ErrorContains(t, err, "invalid mipsevm state")
-	})
-
-	t.Run("ExpectedAbsolutePreState", func(t *testing.T) {
-		setupPreState(t, dataDir, "state.json")
-		provider, _ := setupWithTestData(t, dataDir, prestate)
-		actual, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.NoError(t, err)
-		state := mipsevm.State{
-			Memory:         mipsevm.NewMemory(),
-			PreimageKey:    common.HexToHash("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-			PreimageOffset: 0,
-			PC:             0,
-			NextPC:         1,
-			LO:             0,
-			HI:             0,
-			Heap:           0,
-			ExitCode:       0,
-			Exited:         false,
-			Step:           0,
-			Registers:      [32]uint32{},
-		}
-		expected, err := state.EncodeWitness().StateHash()
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
-	})
-}
-
-func setupPreState(t *testing.T, dataDir string, filename string) {
-	srcDir := filepath.Join("test_data")
-	path := filepath.Join(srcDir, filename)
-	file, err := testData.ReadFile(path)
-	require.NoErrorf(t, err, "reading %v", path)
-	err = os.WriteFile(filepath.Join(dataDir, "state.json"), file, 0o644)
-	require.NoErrorf(t, err, "writing %v", path)
-}
-
 func setupTestData(t *testing.T) (string, string) {
 	srcDir := filepath.Join("test_data", "proofs")
 	entries, err := testData.ReadDir(srcDir)
@@ -290,7 +238,6 @@ func setupWithTestData(t *testing.T, dataDir string, prestate string) (*CannonTr
 		logger:    testlog.Logger(t, log.LvlInfo),
 		dir:       dataDir,
 		generator: generator,
-		prestate:  filepath.Join(dataDir, prestate),
 		gameDepth: 63,
 	}, generator
 }

--- a/op-challenger/game/fault/trace/outputs/output_alphabet.go
+++ b/op-challenger/game/fault/trace/outputs/output_alphabet.go
@@ -17,6 +17,7 @@ import (
 func NewOutputAlphabetTraceAccessor(
 	ctx context.Context,
 	logger log.Logger,
+	v AbsolutePrestateValidator,
 	m metrics.Metricer,
 	cfg *config.Config,
 	gameDepth uint64,
@@ -27,6 +28,10 @@ func NewOutputAlphabetTraceAccessor(
 	bottomDepth := gameDepth - splitDepth
 	outputProvider, err := NewTraceProvider(ctx, logger, cfg.RollupRpc, splitDepth, prestateBlock, poststateBlock)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := v(ctx, outputProvider); err != nil {
 		return nil, err
 	}
 

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/split"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -19,7 +20,7 @@ import (
 func NewOutputCannonTraceAccessor(
 	ctx context.Context,
 	logger log.Logger,
-	v AbsolutePrestateValidator,
+	prestateProvider types.PrestateProvider,
 	m metrics.Metricer,
 	cfg *config.Config,
 	l2Client cannon.L2HeaderSource,
@@ -31,14 +32,11 @@ func NewOutputCannonTraceAccessor(
 	poststateBlock uint64,
 ) (*trace.Accessor, error) {
 	bottomDepth := gameDepth - splitDepth
-	outputProvider, err := NewTraceProvider(ctx, logger, cfg.RollupRpc, splitDepth, prestateBlock, poststateBlock)
+	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, logger, cfg.RollupRpc)
 	if err != nil {
 		return nil, err
 	}
-
-	if err := v(ctx, outputProvider); err != nil {
-		return nil, err
-	}
+	outputProvider := NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, gameDepth, prestateBlock, poststateBlock)
 
 	cannonCreator := func(ctx context.Context, localContext common.Hash, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
 		logger := logger.New("pre", agreed.OutputRoot, "post", claimed.OutputRoot, "localContext", localContext)

--- a/op-challenger/game/fault/trace/outputs/output_cannon.go
+++ b/op-challenger/game/fault/trace/outputs/output_cannon.go
@@ -19,6 +19,7 @@ import (
 func NewOutputCannonTraceAccessor(
 	ctx context.Context,
 	logger log.Logger,
+	v AbsolutePrestateValidator,
 	m metrics.Metricer,
 	cfg *config.Config,
 	l2Client cannon.L2HeaderSource,
@@ -32,6 +33,10 @@ func NewOutputCannonTraceAccessor(
 	bottomDepth := gameDepth - splitDepth
 	outputProvider, err := NewTraceProvider(ctx, logger, cfg.RollupRpc, splitDepth, prestateBlock, poststateBlock)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := v(ctx, outputProvider); err != nil {
 		return nil, err
 	}
 

--- a/op-challenger/game/fault/trace/outputs/prestate.go
+++ b/op-challenger/game/fault/trace/outputs/prestate.go
@@ -1,0 +1,50 @@
+package outputs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type OutputPrestateProvider struct {
+	prestateBlock uint64
+	rollupClient  OutputRollupClient
+}
+
+func NewPrestateProvider(ctx context.Context, logger log.Logger, rollupRpc string, prestateBlock uint64) (*OutputPrestateProvider, error) {
+	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, logger, rollupRpc)
+	if err != nil {
+		return nil, err
+	}
+	return &OutputPrestateProvider{
+		prestateBlock: prestateBlock,
+		rollupClient:  rollupClient,
+	}, nil
+}
+
+func NewPrestateProviderFromInputs(logger log.Logger, rollupClient OutputRollupClient, prestateBlock uint64) *OutputPrestateProvider {
+	return &OutputPrestateProvider{
+		prestateBlock: prestateBlock,
+		rollupClient:  rollupClient,
+	}
+}
+
+func (o *OutputPrestateProvider) GenesisOutputRoot(ctx context.Context) (hash common.Hash, err error) {
+	return o.outputAtBlock(ctx, 0)
+}
+
+func (o *OutputPrestateProvider) AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error) {
+	return o.outputAtBlock(ctx, o.prestateBlock)
+}
+
+func (o *OutputPrestateProvider) outputAtBlock(ctx context.Context, block uint64) (common.Hash, error) {
+	output, err := o.rollupClient.OutputAtBlock(ctx, block)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to fetch output at block %v: %w", o.prestateBlock, err)
+	}
+	return common.Hash(output.OutputRoot), nil
+}

--- a/op-challenger/game/fault/trace/outputs/prestate_test.go
+++ b/op-challenger/game/fault/trace/outputs/prestate_test.go
@@ -1,0 +1,47 @@
+package outputs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func newOutputPrestateProvider(t *testing.T, prestateBlock uint64) (*OutputPrestateProvider, *stubRollupClient) {
+	rollupClient := stubRollupClient{
+		outputs: map[uint64]*eth.OutputResponse{
+			prestateBlock: {
+				OutputRoot: eth.Bytes32(prestateOutputRoot),
+			},
+			101: {
+				OutputRoot: eth.Bytes32(firstOutputRoot),
+			},
+			poststateBlock: {
+				OutputRoot: eth.Bytes32(poststateOutputRoot),
+			},
+		},
+	}
+	return &OutputPrestateProvider{
+		rollupClient:  &rollupClient,
+		prestateBlock: prestateBlock,
+	}, &rollupClient
+}
+
+func TestAbsolutePreStateCommitment(t *testing.T) {
+	var prestateBlock = uint64(100)
+
+	t.Run("FailedToFetchOutput", func(t *testing.T) {
+		provider, rollupClient := newOutputPrestateProvider(t, prestateBlock)
+		rollupClient.errorsOnPrestateFetch = true
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorIs(t, err, errNoOutputAtBlock)
+	})
+
+	t.Run("ReturnsCorrectPrestateOutput", func(t *testing.T) {
+		provider, _ := newOutputPrestateProvider(t, prestateBlock)
+		value, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, value, prestateOutputRoot)
+	})
+}

--- a/op-challenger/game/fault/trace/outputs/provider.go
+++ b/op-challenger/game/fault/trace/outputs/provider.go
@@ -20,6 +20,8 @@ var (
 
 var _ types.TraceProvider = (*OutputTraceProvider)(nil)
 
+type AbsolutePrestateValidator = func(ctx context.Context, provider types.TraceProvider) error
+
 type OutputRollupClient interface {
 	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
 }

--- a/op-challenger/game/fault/trace/outputs/provider.go
+++ b/op-challenger/game/fault/trace/outputs/provider.go
@@ -29,6 +29,8 @@ type OutputRollupClient interface {
 // OutputTraceProvider is a [types.TraceProvider] implementation that uses
 // output roots for given L2 Blocks as a trace.
 type OutputTraceProvider struct {
+	types.PrestateProvider
+
 	logger         log.Logger
 	rollupClient   OutputRollupClient
 	prestateBlock  uint64
@@ -41,16 +43,21 @@ func NewTraceProvider(ctx context.Context, logger log.Logger, rollupRpc string, 
 	if err != nil {
 		return nil, err
 	}
-	return NewTraceProviderFromInputs(logger, rollupClient, gameDepth, prestateBlock, poststateBlock), nil
+	prestateProvider, err := NewPrestateProvider(ctx, logger, rollupRpc, prestateBlock)
+	if err != nil {
+		return nil, err
+	}
+	return NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, gameDepth, prestateBlock, poststateBlock), nil
 }
 
-func NewTraceProviderFromInputs(logger log.Logger, rollupClient OutputRollupClient, gameDepth, prestateBlock, poststateBlock uint64) *OutputTraceProvider {
+func NewTraceProviderFromInputs(logger log.Logger, prestateProvider types.PrestateProvider, rollupClient OutputRollupClient, gameDepth, prestateBlock, poststateBlock uint64) *OutputTraceProvider {
 	return &OutputTraceProvider{
-		logger:         logger,
-		rollupClient:   rollupClient,
-		prestateBlock:  prestateBlock,
-		poststateBlock: poststateBlock,
-		gameDepth:      gameDepth,
+		PrestateProvider: prestateProvider,
+		logger:           logger,
+		rollupClient:     rollupClient,
+		prestateBlock:    prestateBlock,
+		poststateBlock:   poststateBlock,
+		gameDepth:        gameDepth,
 	}
 }
 
@@ -72,11 +79,6 @@ func (o *OutputTraceProvider) Get(ctx context.Context, pos types.Position) (comm
 		return common.Hash{}, err
 	}
 	return o.outputAtBlock(ctx, outputBlock)
-}
-
-// AbsolutePreStateCommitment returns the absolute prestate at the configured prestateBlock.
-func (o *OutputTraceProvider) AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error) {
-	return o.outputAtBlock(ctx, o.prestateBlock)
 }
 
 // GetStepData is not supported in the [OutputTraceProvider].

--- a/op-challenger/game/fault/trace/outputs/split_adapter_test.go
+++ b/op-challenger/game/fault/trace/outputs/split_adapter_test.go
@@ -131,7 +131,11 @@ func setupAdapterTest(t *testing.T, topDepth int) (split.ProviderCreator, *captu
 			},
 		},
 	}
-	topProvider := NewTraceProviderFromInputs(testlog.Logger(t, log.LvlInfo), rollupClient, uint64(topDepth), prestateBlock, poststateBlock)
+	prestateProvider := &stubPrestateProvider{
+		absolutePrestate: prestateOutputRoot,
+		genesisOutput:    firstOutputRoot,
+	}
+	topProvider := NewTraceProviderFromInputs(testlog.Logger(t, log.LvlInfo), prestateProvider, rollupClient, uint64(topDepth), prestateBlock, poststateBlock)
 	adapter := OutputRootSplitAdapter(topProvider, creator.Create)
 	return adapter, creator
 }

--- a/op-challenger/game/fault/trace/translate.go
+++ b/op-challenger/game/fault/trace/translate.go
@@ -46,4 +46,8 @@ func (p *TranslatingProvider) AbsolutePreStateCommitment(ctx context.Context) (h
 	return p.provider.AbsolutePreStateCommitment(ctx)
 }
 
+func (p *TranslatingProvider) GenesisOutputRoot(ctx context.Context) (hash common.Hash, err error) {
+	return p.provider.GenesisOutputRoot(ctx)
+}
+
 var _ types.TraceProvider = (*TranslatingProvider)(nil)

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -67,8 +67,19 @@ type TraceAccessor interface {
 	GetStepData(ctx context.Context, game Game, ref Claim, pos Position) (prestate []byte, proofData []byte, preimageData *PreimageOracleData, err error)
 }
 
+// PrestateProvider defines an interface to request the absolute prestate.
+type PrestateProvider interface {
+	// AbsolutePreStateCommitment is the commitment of the pre-image value of the trace that transitions to the trace value at index 0
+	AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error)
+
+	// GenesisOutputRoot is the output root of the provider at genesis.
+	GenesisOutputRoot(ctx context.Context) (hash common.Hash, err error)
+}
+
 // TraceProvider is a generic way to get a claim value at a specific step in the trace.
 type TraceProvider interface {
+	PrestateProvider
+
 	// Get returns the claim value at the requested index.
 	// Get(i) = Keccak256(GetPreimage(i))
 	Get(ctx context.Context, i Position) (common.Hash, error)
@@ -78,9 +89,6 @@ type TraceProvider interface {
 	// and any pre-image data that needs to be loaded into the oracle prior to execution (may be nil)
 	// The prestate returned from GetStepData for trace 10 should be the pre-image of the claim from trace 9
 	GetStepData(ctx context.Context, i Position) (prestate []byte, proofData []byte, preimageData *PreimageOracleData, err error)
-
-	// AbsolutePreStateCommitment is the commitment of the pre-image value of the trace that transitions to the trace value at index 0
-	AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error)
 }
 
 // ClaimData is the core of a claim. It must be unique inside a specific game.

--- a/op-challenger/game/fault/validate.go
+++ b/op-challenger/game/fault/validate.go
@@ -1,0 +1,44 @@
+package fault
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type HashLoader = func(ctx context.Context) (common.Hash, error)
+
+// ValidateGenesisOutputRoot validates the genesis output root of the provider.
+func ValidateGenesisOutputRoot(ctx context.Context, provider types.PrestateProvider, loader HashLoader) error {
+	providerGenesisOutputRoot, err := provider.GenesisOutputRoot(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the trace provider's genesis output root: %w", err)
+	}
+	onchainGenesisOutputRoot, err := loader(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the onchain genesis output root: %w", err)
+	}
+	if !bytes.Equal(providerGenesisOutputRoot[:], onchainGenesisOutputRoot[:]) {
+		return fmt.Errorf("provider's genesis output root does not match onchain genesis output root: Provider: %s | Chain %s", providerGenesisOutputRoot.Hex(), onchainGenesisOutputRoot.Hex())
+	}
+	return nil
+}
+
+// ValidateAbsolutePrestate validates the absolute prestate of the fault game.
+func ValidateAbsolutePrestate(ctx context.Context, provider types.PrestateProvider, loader HashLoader) error {
+	providerPrestateHash, err := provider.AbsolutePreStateCommitment(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the trace provider's absolute prestate: %w", err)
+	}
+	onchainPrestate, err := loader(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the onchain absolute prestate: %w", err)
+	}
+	if !bytes.Equal(providerPrestateHash[:], onchainPrestate[:]) {
+		return fmt.Errorf("provider's absolute prestate does not match onchain absolute prestate: Provider: %s | Chain %s", providerPrestateHash.Hex(), onchainPrestate.Hex())
+	}
+	return nil
+}

--- a/op-challenger/game/fault/validate_test.go
+++ b/op-challenger/game/fault/validate_test.go
@@ -1,0 +1,121 @@
+package fault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockProviderError     = fmt.Errorf("mock provider error")
+	mockLoaderError       = fmt.Errorf("mock loader error")
+	mockGenesisOutputRoot = common.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+)
+
+func TestValidateAbsolutePrestate(t *testing.T) {
+	t.Run("ValidPrestates", func(t *testing.T) {
+		prestate := []byte{0x00, 0x01, 0x02, 0x03}
+		prestateHash := crypto.Keccak256(prestate)
+		prestateHash[0] = mipsevm.VMStatusUnfinished
+		prestateProvider := newMockPrestateProvider(prestate, common.Hash{})
+		mockLoader := newMockPrestateLoader(false, common.BytesToHash(prestateHash))
+		err := ValidateAbsolutePrestate(context.Background(), prestateProvider, mockLoader)
+		require.NoError(t, err)
+	})
+
+	t.Run("ProviderErrors", func(t *testing.T) {
+		prestate := []byte{0x00, 0x01, 0x02, 0x03}
+		prestateProvider := newMockPrestateProvider(prestate, common.Hash{})
+		prestateProvider.prestateErrors = true
+		mockLoader := newMockPrestateLoader(false, common.BytesToHash(prestate))
+		err := ValidateAbsolutePrestate(context.Background(), prestateProvider, mockLoader)
+		require.ErrorIs(t, err, mockProviderError)
+	})
+
+	t.Run("LoaderErrors", func(t *testing.T) {
+		prestate := []byte{0x00, 0x01, 0x02, 0x03}
+		prestateProvider := newMockPrestateProvider(prestate, common.Hash{})
+		mockLoader := newMockPrestateLoader(true, common.BytesToHash(prestate))
+		err := ValidateAbsolutePrestate(context.Background(), prestateProvider, mockLoader)
+		require.ErrorIs(t, err, mockLoaderError)
+	})
+
+	t.Run("PrestateMismatch", func(t *testing.T) {
+		prestateProvider := newMockPrestateProvider([]byte{0x00, 0x01, 0x02, 0x03}, common.Hash{})
+		mockLoader := newMockPrestateLoader(false, common.BytesToHash([]byte{0x00}))
+		err := ValidateAbsolutePrestate(context.Background(), prestateProvider, mockLoader)
+		require.Error(t, err)
+	})
+}
+
+func TestValidateGenesisOutputRoot(t *testing.T) {
+	t.Run("ValidGenesisOutputRoots", func(t *testing.T) {
+		prestateProvider := newMockPrestateProvider(nil, mockGenesisOutputRoot)
+		mockLoader := newMockPrestateLoader(false, mockGenesisOutputRoot)
+		err := ValidateGenesisOutputRoot(context.Background(), prestateProvider, mockLoader)
+		require.NoError(t, err)
+	})
+
+	t.Run("ProviderErrors", func(t *testing.T) {
+		prestateProvider := newMockPrestateProvider(nil, mockGenesisOutputRoot)
+		prestateProvider.genesisErrors = true
+		mockLoader := newMockPrestateLoader(false, mockGenesisOutputRoot)
+		err := ValidateGenesisOutputRoot(context.Background(), prestateProvider, mockLoader)
+		require.ErrorIs(t, err, mockProviderError)
+	})
+
+	t.Run("LoaderErrors", func(t *testing.T) {
+		prestateProvider := newMockPrestateProvider(nil, mockGenesisOutputRoot)
+		mockLoader := newMockPrestateLoader(true, mockGenesisOutputRoot)
+		err := ValidateGenesisOutputRoot(context.Background(), prestateProvider, mockLoader)
+		require.ErrorIs(t, err, mockLoaderError)
+	})
+
+	t.Run("GenesisOutputRootMismatch", func(t *testing.T) {
+		prestateProvider := newMockPrestateProvider(nil, mockGenesisOutputRoot)
+		mockLoader := newMockPrestateLoader(false, common.BytesToHash([]byte{0x00}))
+		err := ValidateGenesisOutputRoot(context.Background(), prestateProvider, mockLoader)
+		require.Error(t, err)
+	})
+}
+
+func newMockPrestateLoader(prestateError bool, prestate common.Hash) func(ctx context.Context) (common.Hash, error) {
+	return func(ctx context.Context) (common.Hash, error) {
+		if prestateError {
+			return common.Hash{}, mockLoaderError
+		}
+		return prestate, nil
+	}
+}
+
+type mockPrestateProvider struct {
+	prestate       []byte
+	genesis        common.Hash
+	prestateErrors bool
+	genesisErrors  bool
+}
+
+func newMockPrestateProvider(prestate []byte, genesis common.Hash) *mockPrestateProvider {
+	return &mockPrestateProvider{prestate, genesis, false, false}
+}
+
+func (m *mockPrestateProvider) AbsolutePreStateCommitment(ctx context.Context) (common.Hash, error) {
+	if m.prestateErrors {
+		return common.Hash{}, mockProviderError
+	}
+	hash := common.BytesToHash(crypto.Keccak256(m.prestate))
+	hash[0] = mipsevm.VMStatusUnfinished
+	return hash, nil
+}
+
+func (m *mockPrestateProvider) GenesisOutputRoot(ctx context.Context) (common.Hash, error) {
+	if m.genesisErrors {
+		return common.Hash{}, mockProviderError
+	}
+	return m.genesis, nil
+}

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -170,7 +170,9 @@ func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, rollupEndpoin
 	h.require.NoError(err, "Failed to load l2 block number")
 	splitDepth, err := game.SPLITDEPTH(&bind.CallOpts{Context: ctx})
 	h.require.NoError(err, "Failed to load split depth")
-	provider := outputs.NewTraceProviderFromInputs(logger, rollupClient, splitDepth.Uint64(), prestateBlock.Uint64(), poststateBlock.Uint64())
+	prestateProvider, err := outputs.NewPrestateProvider(ctx, logger, rollupEndpoint, prestateBlock.Uint64())
+	h.require.NoError(err, "Failed to create prestate provider")
+	provider := outputs.NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, splitDepth.Uint64(), prestateBlock.Uint64(), poststateBlock.Uint64())
 
 	return &OutputCannonGameHelper{
 		OutputGameHelper: OutputGameHelper{


### PR DESCRIPTION
**Description**

Refactors the absolute prestate logic out of the trace provider to hoist its construction to the registry. 

Constructing the new `PrestateProvider` in the registry creator functions is more lightweight than
instantiating the trace provider and maintains separation of concerns, leaving the trace provider
construction in the trace package register functions.

This PR also splits genesis output root validation and absolute prestate commitment hash validation
logic in separate functions in a new source file with full test coverage.