### PR TITLE
contracts-bedrock: fix warning on _getSel, restrict to pure

### DIFF
--- a/packages/contracts-bedrock/test/Authorization.t.sol
+++ b/packages/contracts-bedrock/test/Authorization.t.sol
@@ -210,7 +210,7 @@ contract Authorization_Test is CommonTest {
     }
 
     /// @dev Computes the selector from a function signature.
-    function _getSel(string memory _name) internal returns (bytes4) {
+    function _getSel(string memory _name) internal pure returns (bytes4) {
         return bytes4(keccak256(abi.encodePacked(_name)));
     }
 


### PR DESCRIPTION
labels a function as pure