### PR TITLE
contracts-bedrock: fail on warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,8 @@ jobs:
           command: forge --version
       - run:
           name: Build monorepo
+          environment:
+            FOUNDRY_PROFILE: ci
           command: pnpm build
       - persist_to_workspace:
           root: "."

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -55,7 +55,7 @@ ignore = ['src/vendor/WETH9.sol']
 
 [profile.ci]
 deny_warnings = true
-fuzz = { runs = 12 }
+fuzz = { runs = 512 }
 
 ################################################################
 #                         PROFILE: LITE                        #

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -55,6 +55,7 @@ ignore = ['src/vendor/WETH9.sol']
 
 [profile.ci.fuzz]
 runs = 512
+deny_warnings = true
 
 ################################################################
 #                         PROFILE: LITE                        #

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -53,9 +53,9 @@ ignore = ['src/vendor/WETH9.sol']
 #                         PROFILE: CI                          #
 ################################################################
 
-[profile.ci.fuzz]
-runs = 512
+[profile.ci]
 deny_warnings = true
+fuzz = { runs = 12 }
 
 ################################################################
 #                         PROFILE: LITE                        #

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -812,7 +812,6 @@ contract Deploy is Deployer {
     /// @notice Initialize the L1ERC721Bridge
     function initializeL1ERC721Bridge() public broadcast {
         console.log("Upgrading and initializing L1ERC721Bridge proxy");
-        ProxyAdmin proxyAdmin = ProxyAdmin(mustGetAddress("ProxyAdmin"));
         address l1ERC721BridgeProxy = mustGetAddress("L1ERC721BridgeProxy");
         address l1ERC721Bridge = mustGetAddress("L1ERC721Bridge");
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");


### PR DESCRIPTION
**Description**

We currently have no compiler warnings in the contracts. We should maintain that by failing in CI.

I've restricted this setting to the CI profile, to not create headaches during local development. 