### PR TITLE
op-node: Span batch Unprotected Tx Handling + Logic Error Fix

### DIFF
--- a/op-node/rollup/derive/batch_test.go
+++ b/op-node/rollup/derive/batch_test.go
@@ -30,15 +30,24 @@ func RandomRawSpanBatch(rng *rand.Rand, chainId *big.Int) *RawSpanBatch {
 	}
 	var blockTxCounts []uint64
 	totalblockTxCounts := uint64(0)
-	for i := 0; i < int(blockCount); i++ {
+
+	blockTxCounts = append(blockTxCounts, 4)
+	totalblockTxCounts += 4
+	for i := 1; i < int(blockCount); i++ {
 		blockTxCount := uint64(rng.Intn(16))
 		blockTxCounts = append(blockTxCounts, blockTxCount)
 		totalblockTxCounts += blockTxCount
 	}
-	signer := types.NewLondonSigner(chainId)
+	londonSigner := types.NewLondonSigner(chainId)
 	var txs [][]byte
 	for i := 0; i < int(totalblockTxCounts); i++ {
-		tx := testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), signer)
+		var tx *types.Transaction
+		// ensure unprotected txs are included
+		if i < 4 || testutils.RandomBool(rng) {
+			tx = testutils.RandomLegacyTxNotProtected(rng)
+		} else {
+			tx = testutils.RandomTx(rng, new(big.Int).SetUint64(rng.Uint64()), londonSigner)
+		}
 		rawTx, err := tx.MarshalBinary()
 		if err != nil {
 			panic("MarshalBinary:" + err.Error())

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -26,7 +26,7 @@ import (
 // spanBatch := SpanBatchType ++ prefix ++ payload
 // prefix := rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check
 // payload := block_count ++ origin_bits ++ block_tx_counts ++ txs
-// txs := contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases
+// txs := contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits
 
 var ErrTooBigSpanBatchSize = errors.New("span batch size limit reached")
 

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -41,7 +41,7 @@ type spanBatchPrefix struct {
 
 type spanBatchPayload struct {
 	blockCount    uint64        // Number of L2 block in the span
-	originBits    *big.Int      // Bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
+	originBits    *big.Int      // Standard span-batch bitlist of blockCount bits. Each bit indicates if the L1 origin is changed at the L2 block.
 	blockTxCounts []uint64      // List of transaction counts for each L2 block
 	txs           *spanBatchTxs // Transactions encoded in SpanBatch specs
 }
@@ -58,34 +58,12 @@ func (b *RawSpanBatch) GetBatchType() int {
 }
 
 // decodeOriginBits parses data into bp.originBits
-// originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
-	originBitBufferLen := bp.blockCount / 8
-	if bp.blockCount%8 != 0 {
-		originBitBufferLen++
-	}
-	// avoid out of memory before allocation
-	if originBitBufferLen > MaxSpanBatchSize {
-		return ErrTooBigSpanBatchSize
-	}
-	originBitBuffer := make([]byte, originBitBufferLen)
-	_, err := io.ReadFull(r, originBitBuffer)
+	bits, err := decodeSpanBatchBits(r, bp.blockCount)
 	if err != nil {
-		return fmt.Errorf("failed to read origin bits: %w", err)
+		return fmt.Errorf("failed to decode origin bits: %w", err)
 	}
-	originBits := new(big.Int)
-	for i := 0; i < int(bp.blockCount); i += 8 {
-		end := i + 8
-		if end > int(bp.blockCount) {
-			end = int(bp.blockCount)
-		}
-		bits := originBitBuffer[i/8]
-		for j := i; j < end; j++ {
-			bit := uint((bits >> (j - i)) & 1)
-			originBits.SetBit(originBits, j, bit)
-		}
-	}
-	bp.originBits = originBits
+	bp.originBits = bits
 	return nil
 }
 
@@ -293,26 +271,9 @@ func (bp *spanBatchPrefix) encodePrefix(w io.Writer) error {
 }
 
 // encodeOriginBits encodes bp.originBits
-// originBits is bitlist right-padded to a multiple of 8 bits
 func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
-	originBitBufferLen := bp.blockCount / 8
-	if bp.blockCount%8 != 0 {
-		originBitBufferLen++
-	}
-	originBitBuffer := make([]byte, originBitBufferLen)
-	for i := 0; i < int(bp.blockCount); i += 8 {
-		end := i + 8
-		if end > int(bp.blockCount) {
-			end = int(bp.blockCount)
-		}
-		var bits uint = 0
-		for j := i; j < end; j++ {
-			bits |= bp.originBits.Bit(j) << (j - i)
-		}
-		originBitBuffer[i/8] = byte(bits)
-	}
-	if _, err := w.Write(originBitBuffer); err != nil {
-		return fmt.Errorf("cannot write origin bits: %w", err)
+	if err := encodeSpanBatchBits(w, bp.blockCount, bp.originBits); err != nil {
+		return fmt.Errorf("failed to encode origin bits: %w", err)
 	}
 	return nil
 }

--- a/op-node/rollup/derive/span_batch.go
+++ b/op-node/rollup/derive/span_batch.go
@@ -76,7 +76,7 @@ func (bp *spanBatchPayload) decodeOriginBits(r *bytes.Reader) error {
 	originBits := new(big.Int)
 	for i := 0; i < int(bp.blockCount); i += 8 {
 		end := i + 8
-		if end < int(bp.blockCount) {
+		if end > int(bp.blockCount) {
 			end = int(bp.blockCount)
 		}
 		bits := originBitBuffer[i/8]
@@ -302,7 +302,7 @@ func (bp *spanBatchPayload) encodeOriginBits(w io.Writer) error {
 	originBitBuffer := make([]byte, originBitBufferLen)
 	for i := 0; i < int(bp.blockCount); i += 8 {
 		end := i + 8
-		if end < int(bp.blockCount) {
+		if end > int(bp.blockCount) {
 			end = int(bp.blockCount)
 		}
 		var bits uint = 0

--- a/op-node/rollup/derive/span_batch_test.go
+++ b/op-node/rollup/derive/span_batch_test.go
@@ -447,9 +447,10 @@ func TestSpanBatchToSingularBatch(t *testing.T) {
 
 func TestSpanBatchReadTxData(t *testing.T) {
 	cases := []spanBatchTxTest{
-		{"legacy tx", 32, testutils.RandomLegacyTx},
-		{"access list tx", 32, testutils.RandomAccessListTx},
-		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx},
+		{"unprotected legacy tx", 32, testutils.RandomLegacyTx, false},
+		{"legacy tx", 32, testutils.RandomLegacyTx, true},
+		{"access list tx", 32, testutils.RandomAccessListTx, true},
+		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx, true},
 	}
 
 	for i, testCase := range cases {
@@ -457,6 +458,9 @@ func TestSpanBatchReadTxData(t *testing.T) {
 			rng := rand.New(rand.NewSource(int64(0x109550 + i)))
 			chainID := new(big.Int).SetUint64(rng.Uint64())
 			signer := types.NewLondonSigner(chainID)
+			if !testCase.protected {
+				signer = types.HomesteadSigner{}
+			}
 
 			var rawTxs [][]byte
 			var txs []*types.Transaction

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -12,16 +12,18 @@ import (
 )
 
 type spanBatchTxTest struct {
-	name   string
-	trials int
-	mkTx   func(rng *rand.Rand, signer types.Signer) *types.Transaction
+	name      string
+	trials    int
+	mkTx      func(rng *rand.Rand, signer types.Signer) *types.Transaction
+	protected bool
 }
 
 func TestSpanBatchTxConvert(t *testing.T) {
 	cases := []spanBatchTxTest{
-		{"legacy tx", 32, testutils.RandomLegacyTx},
-		{"access list tx", 32, testutils.RandomAccessListTx},
-		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx},
+		{"unprotected legacy tx", 32, testutils.RandomLegacyTx, false},
+		{"legacy tx", 32, testutils.RandomLegacyTx, true},
+		{"access list tx", 32, testutils.RandomAccessListTx, true},
+		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx, true},
 	}
 
 	for i, testCase := range cases {
@@ -29,6 +31,9 @@ func TestSpanBatchTxConvert(t *testing.T) {
 			rng := rand.New(rand.NewSource(int64(0x1331 + i)))
 			chainID := big.NewInt(rng.Int63n(1000))
 			signer := types.NewLondonSigner(chainID)
+			if !testCase.protected {
+				signer = types.HomesteadSigner{}
+			}
 
 			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
 				tx := testCase.mkTx(rng, signer)
@@ -54,9 +59,10 @@ func TestSpanBatchTxConvert(t *testing.T) {
 
 func TestSpanBatchTxRoundTrip(t *testing.T) {
 	cases := []spanBatchTxTest{
-		{"legacy tx", 32, testutils.RandomLegacyTx},
-		{"access list tx", 32, testutils.RandomAccessListTx},
-		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx},
+		{"unprotected legacy tx", 32, testutils.RandomLegacyTx, false},
+		{"legacy tx", 32, testutils.RandomLegacyTx, true},
+		{"access list tx", 32, testutils.RandomAccessListTx, true},
+		{"dynamic fee tx", 32, testutils.RandomDynamicFeeTx, true},
 	}
 
 	for i, testCase := range cases {
@@ -64,6 +70,9 @@ func TestSpanBatchTxRoundTrip(t *testing.T) {
 			rng := rand.New(rand.NewSource(int64(0x1332 + i)))
 			chainID := big.NewInt(rng.Int63n(1000))
 			signer := types.NewLondonSigner(chainID)
+			if !testCase.protected {
+				signer = types.HomesteadSigner{}
+			}
 
 			for txIdx := 0; txIdx < testCase.trials; txIdx++ {
 				tx := testCase.mkTx(rng, signer)

--- a/op-node/rollup/derive/span_batch_txs.go
+++ b/op-node/rollup/derive/span_batch_txs.go
@@ -48,7 +48,7 @@ func (btx *spanBatchTxs) encodeContractCreationBits(w io.Writer) error {
 	contractCreationBitBuffer := make([]byte, contractCreationBitBufferLen)
 	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
 		end := i + 8
-		if end < int(btx.totalBlockTxCount) {
+		if end > int(btx.totalBlockTxCount) {
 			end = int(btx.totalBlockTxCount)
 		}
 		var bits uint = 0
@@ -81,7 +81,7 @@ func (btx *spanBatchTxs) decodeContractCreationBits(r *bytes.Reader) error {
 	contractCreationBits := new(big.Int)
 	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
 		end := i + 8
-		if end < int(btx.totalBlockTxCount) {
+		if end > int(btx.totalBlockTxCount) {
 			end = int(btx.totalBlockTxCount)
 		}
 		bits := contractCreationBitBuffer[i/8]
@@ -173,7 +173,7 @@ func (btx *spanBatchTxs) encodeYParityBits(w io.Writer) error {
 	yParityBitBuffer := make([]byte, yParityBitBufferLen)
 	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
 		end := i + 8
-		if end < int(btx.totalBlockTxCount) {
+		if end > int(btx.totalBlockTxCount) {
 			end = int(btx.totalBlockTxCount)
 		}
 		var bits uint = 0
@@ -260,7 +260,7 @@ func (btx *spanBatchTxs) decodeYParityBits(r *bytes.Reader) error {
 	yParityBits := new(big.Int)
 	for i := 0; i < int(btx.totalBlockTxCount); i += 8 {
 		end := i + 8
-		if end < int(btx.totalBlockTxCount) {
+		if end > int(btx.totalBlockTxCount) {
 			end = int(btx.totalBlockTxCount)
 		}
 		bits := yParityBitBuffer[i/8]

--- a/op-node/rollup/derive/span_batch_util.go
+++ b/op-node/rollup/derive/span_batch_util.go
@@ -1,0 +1,60 @@
+package derive
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+)
+
+// decodeSpanBatchBits decodes a standard span-batch bitlist.
+// The bitlist is encoded as big-endian integer, left-padded with zeroes to a multiple of 8 bits.
+// The encoded bitlist cannot be longer than MaxSpanBatchSize.
+func decodeSpanBatchBits(r *bytes.Reader, bitLength uint64) (*big.Int, error) {
+	// Round up, ensure enough bytes when number of bits is not a multiple of 8.
+	// Alternative of (L+7)/8 is not overflow-safe.
+	bufLen := bitLength / 8
+	if bitLength%8 != 0 {
+		bufLen++
+	}
+	// avoid out of memory before allocation
+	if bufLen > MaxSpanBatchSize {
+		return nil, ErrTooBigSpanBatchSize
+	}
+	buf := make([]byte, bufLen)
+	_, err := io.ReadFull(r, buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bits: %w", err)
+	}
+	out := new(big.Int)
+	out.SetBytes(buf)
+	// We read the correct number of bytes, but there may still be trailing bits
+	if l := uint64(out.BitLen()); l > bitLength {
+		return nil, fmt.Errorf("bitfield has %d bits, but expected no more than %d", l, bitLength)
+	}
+	return out, nil
+}
+
+// encodeSpanBatchBits encodes a standard span-batch bitlist.
+// The bitlist is encoded as big-endian integer, left-padded with zeroes to a multiple of 8 bits.
+// The encoded bitlist cannot be longer than MaxSpanBatchSize.
+func encodeSpanBatchBits(w io.Writer, bitLength uint64, bits *big.Int) error {
+	if l := uint64(bits.BitLen()); l > bitLength {
+		return fmt.Errorf("bitfield is larger than bitLength: %d > %d", l, bitLength)
+	}
+	// Round up, ensure enough bytes when number of bits is not a multiple of 8.
+	// Alternative of (L+7)/8 is not overflow-safe.
+	bufLen := bitLength / 8
+	if bitLength%8 != 0 { // rounding up this way is safe against overflows
+		bufLen++
+	}
+	if bufLen > MaxSpanBatchSize {
+		return ErrTooBigSpanBatchSize
+	}
+	buf := make([]byte, bufLen)
+	bits.FillBytes(buf) // zero-extended, big-endian
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("cannot write bits: %w", err)
+	}
+	return nil
+}

--- a/op-service/testutils/random.go
+++ b/op-service/testutils/random.go
@@ -157,6 +157,10 @@ func RandomTx(rng *rand.Rand, baseFee *big.Int, signer types.Signer) *types.Tran
 	return tx
 }
 
+func RandomLegacyTxNotProtected(rng *rand.Rand) *types.Transaction {
+	return RandomLegacyTx(rng, types.HomesteadSigner{})
+}
+
 func RandomLegacyTx(rng *rand.Rand, signer types.Signer) *types.Transaction {
 	key := InsecureRandomKey(rng)
 	txData := &types.LegacyTx{

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -208,7 +208,7 @@ not risking codebase with gnarly custom encoding/decoding implementations.
 
 ### Store `y_parity` and `protected_bit` instead of `v`
 
-Only legacy type transactions can be optionally protected. If protected([EIP-155]), `v = 2 * ChainID + y_parity`.
+Only legacy type transactions can be optionally protected. If protected([EIP-155]), `v = 2 * ChainID + 35 + y_parity`.
 Else, `v = 27 + y_parity`. For other types of transactions, `v = y_parity`.
 We store `y_parity`, which is single bit per L2 transaction.
 We store `protected_bit`, which is single bit per L2 legacy type transactions to indicate that tx is protected.

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -86,6 +86,9 @@ Notation:
 
 [protobuf spec]: https://protobuf.dev/programming-guides/encoding/#varints
 
+Standard bitlists, in the context of span-batches, are encoded as big-endian integers,
+left-padded with zeroes to the next multiple of 8 bits.
+
 Where:
 
 - `prefix = rel_timestamp ++ l1_origin_num ++ parent_check ++ l1_origin_check`
@@ -98,15 +101,15 @@ Where:
     The hash is truncated to 20 bytes for efficiency, i.e. `span_end.l1_origin.hash[:20]`.
 - `payload = block_count ++ origin_bits ++ block_tx_counts ++ txs`:
   - `block_count`: `uvarint` number of L2 blocks. This is at least 1, empty span batches are invalid.
-  - `origin_bits`: bitlist of `block_count` bits, right-padded to a multiple of 8 bits:
+  - `origin_bits`: standard bitlist of `block_count` bits:
     1 bit per L2 block, indicating if the L1 origin changed this L2 block.
   - `block_tx_counts`: for each block, a `uvarint` of `len(block.transactions)`.
   - `txs`: L2 transactions which is reorganized and encoded as below.
 - `txs = contract_creation_bits ++ y_parity_bits ++
         tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits`
-  - `contract_creation_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
+  - `contract_creation_bits`: standard bitlist of `sum(block_tx_counts)` bits:
     1 bit per L2 transactions, indicating if transaction is a contract creation transaction.
-  - `y_parity_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
+  - `y_parity_bits`: standard bitlist of `sum(block_tx_counts)` bits:
     1 bit per L2 transactions, indicating the y parity value when recovering transaction sender address.
   - `tx_sigs`: concatenated list of transaction signatures
     - `r` is encoded as big-endian `uint256`
@@ -122,7 +125,7 @@ Where:
     - `legacy`: `gasLimit`
     - `1`: ([EIP-2930]): `gasLimit`
     - `2`: ([EIP-1559]): `gas_limit`
-  - `protected_bits`: bit list of length of number of legacy transactions, right-padded to a multiple of 8 bits,
+  - `protected_bits`: standard bitlist of length of number of legacy transactions:
     1 bit per L2 legacy transactions, indicating if transacion is protected([EIP-155]) or not.
 
 Introduce version `2` to the [batch-format](./derivation.md#batch-format) table:

--- a/specs/span-batches.md
+++ b/specs/span-batches.md
@@ -16,7 +16,7 @@
   - [`Chain ID` removal from initial specs](#chain-id-removal-from-initial-specs)
   - [Reorganization of constant length transaction fields](#reorganization-of-constant-length-transaction-fields)
   - [RLP encoding for only variable length fields](#rlp-encoding-for-only-variable-length-fields)
-  - [Store `y_parity` instead of `v`](#store-y_parity-instead-of-v)
+  - [Store `y_parity` and `protected_bit` instead of `v`](#store-y_parity-and-protected_bit-instead-of-v)
   - [Adjust `txs` Data Layout for Better Compression](#adjust-txs-data-layout-for-better-compression)
   - [`fee_recipients` Encoding Scheme](#fee_recipients-encoding-scheme)
 - [How derivation works with Span Batch?](#how-derivation-works-with-span-batch)
@@ -102,7 +102,8 @@ Where:
     1 bit per L2 block, indicating if the L1 origin changed this L2 block.
   - `block_tx_counts`: for each block, a `uvarint` of `len(block.transactions)`.
   - `txs`: L2 transactions which is reorganized and encoded as below.
-- `txs = contract_creation_bits ++ y_parity_bits ++ tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases`
+- `txs = contract_creation_bits ++ y_parity_bits ++
+        tx_sigs ++ tx_tos ++ tx_datas ++ tx_nonces ++ tx_gases ++ protected_bits`
   - `contract_creation_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
     1 bit per L2 transactions, indicating if transaction is a contract creation transaction.
   - `y_parity_bits`: bit list of `sum(block_tx_counts)` bits, right-padded to a multiple of 8 bits,
@@ -121,6 +122,8 @@ Where:
     - `legacy`: `gasLimit`
     - `1`: ([EIP-2930]): `gasLimit`
     - `2`: ([EIP-1559]): `gas_limit`
+  - `protected_bits`: bit list of length of number of legacy transactions, right-padded to a multiple of 8 bits,
+    1 bit per L2 legacy transactions, indicating if transacion is protected([EIP-155]) or not.
 
 Introduce version `2` to the [batch-format](./derivation.md#batch-format) table:
 
@@ -146,6 +149,8 @@ Where:
 [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
 
 [EIP-1559]: https://eips.ethereum.org/EIPS/eip-1559
+
+[EIP-155]: https://eips.ethereum.org/EIPS/eip-155
 
 Total size of encoded span batch is limited to `MAX_SPAN_BATCH_SIZE` (currently 10,000,000 bytes,
 equal to `MAX_RLP_BYTES_PER_CHANNEL`). Therefore every field size of span batch will be implicitly limited to
@@ -201,10 +206,12 @@ Our goal is to find the sweet spot on code complexity - span batch size tradeoff
 I decided that using RLP for all variable length fields will be the best option,
 not risking codebase with gnarly custom encoding/decoding implementations.
 
-### Store `y_parity` instead of `v`
+### Store `y_parity` and `protected_bit` instead of `v`
 
-For legacy type transactions, `v = 2 * ChainID + y_parity`. For other types of transactions, `v = y_parity`.
-We may only store `y_parity`, which is single bit per L2 transaction.
+Only legacy type transactions can be optionally protected. If protected([EIP-155]), `v = 2 * ChainID + y_parity`.
+Else, `v = 27 + y_parity`. For other types of transactions, `v = y_parity`.
+We store `y_parity`, which is single bit per L2 transaction.
+We store `protected_bit`, which is single bit per L2 legacy type transactions to indicate that tx is protected.
 
 This optimization will benefit more when ratio between number of legacy type transactions over number of transactions
 excluding deposit tx is higher.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
This PR fixes two critical errors.

1. Span batch Unprotected Tx

Span batch did not encode/decode correctly for L2 transactions which is not protected(signed with homestead signer), causing L2 unsafe block reorg.
Example input:
```
0xf86280830f42418252089400000000000000000000000030bd3402deadbeef01801ca048543f9148389fc09f9c37092a255a9550f6748d6fee3d6e066c92f56199f0e1a02003e0128eece7c6ee59d13a9856964c7252034558fe5551b309f033d4d3efb5
```
Example output(after upper tx encoded and is written to L1, then decoded by derivation):
```
0xf86480830f42418252089400000000000000000000000030bd3402deadbeef018082072ea048543f9148389fc09f9c37092a255a9550f6748d6fee3d6e066c92f56199f0e1a02003e0128eece7c6ee59d13a9856964c7252034558fe5551b309f033d4d3efb5
```
This discrepancy was caused because span batch encoding always assumed that legacy transaction will be always protected. THIS IS WRONG. `v` value was originally `28` but after enc/dec, it becomes `1838 = 901 * 2 + 35 + 1`. A disaster!

Therefore, we do have to store bits whether legacy tx is protected or not. All other tx types(access list, eip1559) is always protected. Added `protected_bits` field. Please refer to the updated specs for the details. This may affect span batch performance, but not much because it adds single bit per L2 legacy transactions.

2. Wrong Inequality

Found out while self reviewing. If window is larger than span, must truncate.

**Tests**

Ensured than non-protected tx are included at span batch.
Added unit tests for new methods.
Updated unit tests to handle newly added field in span batch txs.


