### PR TITLE
op-e2e: Automatically close System at the end of the test

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -27,6 +27,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
+var (
+	ErrAlreadyStopped = errors.New("already stopped")
+)
+
 type BatcherConfig struct {
 	NetworkTimeout         time.Duration
 	PollInterval           time.Duration
@@ -285,7 +289,7 @@ func (bs *BatcherService) Kill() error {
 // If the provided ctx is cancelled, the stopping is forced, i.e. the batching work is killed non-gracefully.
 func (bs *BatcherService) Stop(ctx context.Context) error {
 	if bs.stopped.Load() {
-		return errors.New("already stopped")
+		return ErrAlreadyStopped
 	}
 	bs.Log.Info("Stopping batcher")
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -30,6 +30,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
+var (
+	ErrAlreadyClosed = errors.New("node is already closed")
+)
+
 type OpNode struct {
 	log        log.Logger
 	appVersion string
@@ -553,7 +557,7 @@ func (n *OpNode) RuntimeConfig() ReadonlyRuntimeConfig {
 // If the provided ctx is expired, the node will accelerate the stop where possible, but still fully close.
 func (n *OpNode) Stop(ctx context.Context) error {
 	if n.closed.Load() {
-		return errors.New("node is already closed")
+		return ErrAlreadyClosed
 	}
 
 	var result *multierror.Error

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -26,6 +26,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+var (
+	ErrAlreadyStopped = errors.New("already stopped")
+)
+
 type ProposerConfig struct {
 	// How frequently to poll L2 for new finalized outputs
 	PollInterval   time.Duration
@@ -252,7 +256,7 @@ func (ps *ProposerService) Kill() error {
 // See driver.StopL2OutputSubmitting to temporarily stop the L2Output submitter.
 func (ps *ProposerService) Stop(ctx context.Context) error {
 	if ps.stopped.Load() {
-		return errors.New("already stopped")
+		return ErrAlreadyStopped
 	}
 	ps.Log.Info("Stopping Proposer")
 


### PR DESCRIPTION
**Description**

Use `t.Cleanup` to ensure that every `System` instance is stopped when the test completes.  `System.Close` is safe to call multiple times so we don't have issues if the test also calls `defer sys.Close()`, stops the system manually or if startup fails part way through.

Also fails the test if any of the system components return an error when closed.
