### PR TITLE
fix(multisig-mon): add onepass cli to dockerfile

### DIFF
--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -81,6 +81,8 @@ COPY .git/ ./.git
 COPY .gitmodules ./.gitmodules
 RUN git submodule update --init --recursive
 
+COPY --from=1password/op:2 /usr/local/bin/op /usr/local/bin/op
+
 RUN pnpm build
 
 ENTRYPOINT ["pnpm", "run"]
@@ -104,7 +106,6 @@ CMD ["start:fault-mon"]
 
 from base as multisig-mon
 WORKDIR /opt/optimism/packages/multisig-mon
-COPY --from=1password/op:2 /usr/local/bin/op /usr/local/bin/op
 CMD ["start:multisig-mon"]
 
 FROM base as replica-mon


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change adds the 1password cli to chain-mon docker file.

**Tests**

Built locally.

**Additional context**

https://github.com/ethereum-optimism/client-pod/issues/113
