### PR TITLE
op-challenger: Close the polling client

### DIFF
--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -228,6 +228,9 @@ func (s *Service) Stop(ctx context.Context) error {
 		s.txMgr.Close()
 	}
 
+	if s.pollClient != nil {
+		s.pollClient.Close()
+	}
 	if s.l1Client != nil {
 		s.l1Client.Close()
 	}


### PR DESCRIPTION
**Description**

When HTTP is in use a separate polling RPC client is started but was never closed.  

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/8466
