### PR TITLE
op-e2e: Use a fixed seed to make TestMixedDeposits repeatable

### DIFF
--- a/op-e2e/system_tob_test.go
+++ b/op-e2e/system_tob_test.go
@@ -292,7 +292,7 @@ func TestMixedDepositValidity(t *testing.T) {
 	}
 
 	// Create our random provider
-	randomProvider := rand.New(rand.NewSource(time.Now().Unix()))
+	randomProvider := rand.New(rand.NewSource(1452))
 
 	// Now we create a number of deposits from each transactor
 	for i := 0; i < depositTxCount; i++ {


### PR DESCRIPTION
**Description**

Using randomness in tests makes it much more likely that they'll be flaky and since the random seed isn't captured like it would be in fuzz tests, also makes it impossible to rerun the test and understand what failed.
**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/313 
