### PR TITLE
linkcheck: Exclude vitalik.ca

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ update-op-geth:
 
 bedrock-markdown-links:
 	docker run --init -it -v `pwd`:/input lycheeverse/lychee --verbose --no-progress --exclude-loopback \
-		--exclude twitter.com --exclude explorer.optimism.io --exclude linux-mips.org \
+		--exclude twitter.com --exclude explorer.optimism.io --exclude linux-mips.org --exclude vitalik.ca \
 		--exclude-mail /input/README.md "/input/specs/**/*.md"
 
 install-geth:


### PR DESCRIPTION
**Description**

Vitalik demonstrates the problem with centralisation by running the world's least reliable web server. It's currently timing out but regular has certificate issues that cause the link checker to fail.  Given the links do tend to be stable, exclude it from the link checker to avoid the noise.