### PR TITLE
CI: Fix proxyd store tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -882,6 +882,7 @@ jobs:
         default: this-package-does-not-exist
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
+    resource_class: medium
     steps:
       - checkout
       - check-changed:
@@ -890,14 +891,14 @@ jobs:
           name: Lint
           command: make lint
           working_directory: <<parameters.working_directory>>
-      - store_test_results:
-          path: /test-results
       - run:
           name: Test
           command: |
             mkdir -p /test-results
-            gotestsum --junitfile /test-results/tests.xml
+            gotestsum  --format=standard-verbose --junitfile /test-results/tests.xml -- -parallel=2
           working_directory: <<parameters.working_directory>>
+      - store_test_results:
+          path: /test-results
       - when:
           condition:
             equal: [ true, <<parameters.build>> ]


### PR DESCRIPTION
**Description**

Fix the location of the store tests command so now proxyd tests will be properly reported in CircleCI.

This also reduces the resource class to medium & properly sets the parallelism. The reduction from large to medium does not appear to reduce the performance.

Lastly, this uses standard-verbose format rather than the default gotestsum format for easier test log reading.

This PR was done to look into the flake that occurred in https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/35594/workflows/5d74e3ef-497f-4e7e-9452-14e12229d01b/jobs/1617049/steps. I was not able to reproduce that failure, but do not have enough logging to do so.