### PR TITLE
[DRAFT] Log the duration of derivation pipeline calls down to L1 ethclient

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -61,7 +61,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	if l2Parent.L1Origin.Number != epoch.Number {
 		start := time.Now()
 		info, receipts, err := ba.l1.FetchReceipts(ctx, epoch.Hash)
-		log.Debug("FetchingAttributesBuilder:PreparePayloadAttributes: called ba.l1.FetchReceipts.", "duration", time.Since(start))
+		log.Debug("derivation fetcher performance info", "stage", "FetchingAttribtuesBuilder", "caller", "PreparePayloadAttributes", "method", "FetchReceipts", "duration", time.Since(start))
 		if err != nil {
 			return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and receipts: %w", err))
 		}

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -90,7 +90,7 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		}
 		start := time.Now()
 		info, err := ba.l1.InfoByHash(ctx, epoch.Hash)
-		log.Debug("FetchingAttributesBuilder:PreparePayloadAttributes: called ba.l1.InfoByHash.", "duration", time.Since(start))
+		log.Debug("derivation fetcher performance info", "stage", "FetchingAttribtuesBuilder", "caller", "PreparePayloadAttributes", "method", "InfoByHash", "duration", time.Since(start))
 		if err != nil {
 			return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info: %w", err))
 		}

--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -3,10 +3,12 @@ package derive
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -57,7 +59,9 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	// case we need to fetch all transaction receipts from the L1 origin block so we can scan for
 	// user deposits.
 	if l2Parent.L1Origin.Number != epoch.Number {
+		start := time.Now()
 		info, receipts, err := ba.l1.FetchReceipts(ctx, epoch.Hash)
+		log.Debug("FetchingAttributesBuilder:PreparePayloadAttributes: called ba.l1.FetchReceipts.", "duration", time.Since(start))
 		if err != nil {
 			return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info and receipts: %w", err))
 		}
@@ -84,7 +88,9 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 		if l2Parent.L1Origin.Hash != epoch.Hash {
 			return nil, NewResetError(fmt.Errorf("cannot create new block with L1 origin %s in conflict with L1 origin %s", epoch, l2Parent.L1Origin))
 		}
+		start := time.Now()
 		info, err := ba.l1.InfoByHash(ctx, epoch.Hash)
+		log.Debug("FetchingAttributesBuilder:PreparePayloadAttributes: called ba.l1.InfoByHash.", "duration", time.Since(start))
 		if err != nil {
 			return nil, NewTemporaryError(fmt.Errorf("failed to fetch L1 block info: %w", err))
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR proposes to add very simple duration logging of the derivation pipeline's `PreparePayloadAttributes` calls down to the l1 `EthClient`. It does not need to be merged at this time, so it is left as a draft at time of writing.

**Additional context**

#8191 

