### PR TITLE
chore: apply shellcheck auto fixes

### DIFF
--- a/indexer/ui/prisma.sh
+++ b/indexer/ui/prisma.sh
@@ -2,7 +2,7 @@
 
 # This script updates the prisma schema
 #
-SCRIPT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+SCRIPT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )
 
 DATABASE_URL=${DATABASE_URL:-postgresql://db_username:db_password@localhost:5434/db_name}
 PRISMA_FILE="$SCRIPT_DIR/schema.prisma"
@@ -10,21 +10,21 @@ TEMP_FILE="$SCRIPT_DIR/temp-schema.prisma"
 
 function update_prisma() {
     echo "Updating Prisma Schema..."
-    npx prisma db pull --url $DATABASE_URL --schema $PRISMA_FILE
+    npx prisma db pull --url "$DATABASE_URL" --schema "$PRISMA_FILE"
     echo "Update completed."
 }
 
 function check_prisma() {
     echo "Checking Prisma Schema..."
-    cp $PRISMA_FILE $TEMP_FILE
-    npx prisma db pull --url $DATABASE_URL --schema $TEMP_FILE
-    diff $PRISMA_FILE $TEMP_FILE > /dev/null
+    cp "$PRISMA_FILE" "$TEMP_FILE"
+    npx prisma db pull --url "$DATABASE_URL" --schema "$TEMP_FILE"
+    diff "$PRISMA_FILE" "$TEMP_FILE" > /dev/null
     if [ $? -eq 0 ]; then
         echo "Prisma Schema is up-to-date."
-        rm $TEMP_FILE
+        rm "$TEMP_FILE"
     else
         echo "Prisma Schema is not up-to-date."
-        rm $TEMP_FILE
+        rm "$TEMP_FILE"
         return 1
     fi
 }

--- a/op-chain-ops/crossdomain/testdata/trace.sh
+++ b/op-chain-ops/crossdomain/testdata/trace.sh
@@ -12,19 +12,19 @@ TRACES=$DIR/call-traces
 RECEIPTS=$DIR/receipts
 DIFFS=$DIR/state-diffs
 
-mkdir -p $TRACES
-mkdir -p $RECEIPTS
-mkdir -p $DIFFS
+mkdir -p "$TRACES"
+mkdir -p "$RECEIPTS"
+mkdir -p "$DIFFS"
 
 cast rpc \
     debug_traceTransaction \
-    $HASH \
-    '{"tracer": "callTracer"}' | jq > $TRACES/$HASH.json
+    "$HASH" \
+    '{"tracer": "callTracer"}' | jq > "$TRACES"/"$HASH".json
 
-cast receipt $HASH --json | jq > $RECEIPTS/$HASH.json
+cast receipt "$HASH" --json | jq > "$RECEIPTS"/"$HASH".json
 
 cast rpc \
     debug_traceTransaction \
-    $HASH \
-    '{"tracer": "prestateTracer"}' | jq > $DIFFS/$HASH.json
+    "$HASH" \
+    '{"tracer": "prestateTracer"}' | jq > "$DIFFS"/"$HASH".json
 

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-CHALLENGER_DIR=$(echo ${SOURCE_DIR%/*/*})
-MONOREPO_DIR=$(echo ${SOURCE_DIR%/*/*/*})
+CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
+MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
 
 # Check that the fault game address file exists
 FAULT_GAME_ADDR_FILE="$CHALLENGER_DIR/.fault-game-address"
@@ -15,23 +15,23 @@ fi
 # Charlie's Address: 0xF45B7537828CB2fffBC69996B054c2Aaf36DC778
 CHARLIE_KEY="74feb147d72bfae943e6b4e483410933d9e447d5dc47d52432dcc2c1454dabb7"
 
-DISPUTE_GAME_PROXY=$(jq -r .DisputeGameFactoryProxy $MONOREPO_DIR/.devnet/addresses.json)
-FAULT_GAME_ADDRESS=$(cat $FAULT_GAME_ADDR_FILE)
+DISPUTE_GAME_PROXY=$(jq -r .DisputeGameFactoryProxy "$MONOREPO_DIR"/.devnet/addresses.json)
+FAULT_GAME_ADDRESS=$(cat "$FAULT_GAME_ADDR_FILE")
 echo "Fault dispute game address: $FAULT_GAME_ADDRESS"
 
-DATADIR=`mktemp -d`
+DATADIR=$(mktemp -d)
 trap cleanup SIGINT
 cleanup(){
   rm -rf "${DATADIR}"
 }
 
-$CHALLENGER_DIR/bin/op-challenger \
+"$CHALLENGER_DIR"/bin/op-challenger \
   --l1-eth-rpc http://localhost:8545 \
   --trace-type="alphabet" \
   --alphabet "abcdefgh" \
   --datadir "${DATADIR}" \
-  --game-factory-address $DISPUTE_GAME_PROXY \
-  --game-allowlist $FAULT_GAME_ADDRESS \
+  --game-factory-address "$DISPUTE_GAME_PROXY" \
+  --game-allowlist "$FAULT_GAME_ADDRESS" \
   --private-key $CHARLIE_KEY \
   --num-confirmations 1 \
   --metrics.enabled --metrics.port=7304 \

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -32,7 +32,7 @@ cleanup(){
   --datadir "${DATADIR}" \
   --game-factory-address "$DISPUTE_GAME_PROXY" \
   --game-allowlist "$FAULT_GAME_ADDRESS" \
-  --private-key $CHARLIE_KEY \
+  --private-key "$CHARLIE_KEY" \
   --num-confirmations 1 \
   --metrics.enabled --metrics.port=7304 \
   --pprof.enabled --pprof.port=6064 \

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -45,10 +45,10 @@ echo " - Balance: $(cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)"
 echo "----------------------------------------------------------------"
 
 echo "Funding Charlie"
-cast send $CHARLIE_ADDRESS --value 5ether --private-key $DEVNET_SPONSOR
+cast send "$CHARLIE_ADDRESS" --value 5ether --private-key "$DEVNET_SPONSOR"
 
 echo "Funding Mallory"
-cast send $MALLORY_ADDRESS --value 5ether --private-key $DEVNET_SPONSOR
+cast send "$MALLORY_ADDRESS" --value 5ether --private-key "$DEVNET_SPONSOR"
 
 # Loop and wait until there are at least 2 outputs in the l2 output oracle
 echo "Waiting until 2 output proposals are in the l2 output oracle..."

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -3,31 +3,31 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-CHALLENGER_DIR=$(echo ${SOURCE_DIR%/*/*})
-MONOREPO_DIR=$(echo ${SOURCE_DIR%/*/*/*})
+CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
+MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
 
-cd $CHALLENGER_DIR
+cd "$CHALLENGER_DIR"
 make
 
-cd $MONOREPO_DIR
+cd "$MONOREPO_DIR"
 make devnet-clean
 make cannon-prestate
 make devnet-up
 
 DEVNET_SPONSOR="ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-DISPUTE_GAME_FACTORY=$(jq -r .DisputeGameFactoryProxy $MONOREPO_DIR/.devnet/addresses.json)
+DISPUTE_GAME_FACTORY=$(jq -r .DisputeGameFactoryProxy "$MONOREPO_DIR"/.devnet/addresses.json)
 
 echo "----------------------------------------------------------------"
 echo " Dispute Game Factory at $DISPUTE_GAME_FACTORY"
 echo "----------------------------------------------------------------"
 
-L2_OUTPUT_ORACLE_PROXY=$(jq -r .L2OutputOracleProxy $MONOREPO_DIR/.devnet/addresses.json)
+L2_OUTPUT_ORACLE_PROXY=$(jq -r .L2OutputOracleProxy "$MONOREPO_DIR"/.devnet/addresses.json)
 
 echo "----------------------------------------------------------------"
 echo " L2 Output Oracle Proxy at $L2_OUTPUT_ORACLE_PROXY"
 echo "----------------------------------------------------------------"
 
-BLOCK_ORACLE_PROXY=$(jq -r .BlockOracle $MONOREPO_DIR/.devnet/addresses.json)
+BLOCK_ORACLE_PROXY=$(jq -r .BlockOracle "$MONOREPO_DIR"/.devnet/addresses.json)
 
 echo "----------------------------------------------------------------"
 echo " Block Oracle Proxy at $BLOCK_ORACLE_PROXY"
@@ -53,7 +53,7 @@ cast send $MALLORY_ADDRESS --value 5ether --private-key $DEVNET_SPONSOR
 # Loop and wait until there are at least 2 outputs in the l2 output oracle
 echo "Waiting until 2 output proposals are in the l2 output oracle..."
 echo "NOTE: This may show errors if no output proposals are in the oracle yet."
-while [[ $(cast call $L2_OUTPUT_ORACLE_PROXY "latestOutputIndex()" | cast to-dec) -lt 2 ]]
+while [[ $(cast call "$L2_OUTPUT_ORACLE_PROXY" "latestOutputIndex()" | cast to-dec) -lt 2 ]]
 do
   echo "[BLOCK: $(cast block-number)] Waiting for output proposals..."
   sleep 2
@@ -65,4 +65,4 @@ ROOT_CLAIM=$(cast keccak $(cast abi-encode "f(uint256,uint256)" 15 122))
 # Replace the first byte of the claim with the invalid vm status indicator
 ROOT_CLAIM="0x01${ROOT_CLAIM:4}"
 
-GAME_TYPE=255 ${SOURCE_DIR}/../create_game.sh http://localhost:8545 "${DISPUTE_GAME_FACTORY}" "${ROOT_CLAIM}" --private-key "${DEVNET_SPONSOR}"
+GAME_TYPE=255 "${SOURCE_DIR}"/../create_game.sh http://localhost:8545 "${DISPUTE_GAME_FACTORY}" "${ROOT_CLAIM}" --private-key "${DEVNET_SPONSOR}"

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -32,7 +32,7 @@ cleanup(){
   --datadir "${DATADIR}" \
   --game-factory-address "$DISPUTE_GAME_PROXY" \
   --game-allowlist "$FAULT_GAME_ADDRESS" \
-  --private-key $MALLORY_KEY \
+  --private-key "$MALLORY_KEY" \
   --num-confirmations 1 \
   --metrics.enabled --metrics.port=7305 \
   --pprof.enabled --pprof.port=6065 \

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-CHALLENGER_DIR=$(echo ${SOURCE_DIR%/*/*})
-MONOREPO_DIR=$(echo ${SOURCE_DIR%/*/*/*})
+CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
+MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
 
 # Check that the fault game address file exists
 FAULT_GAME_ADDR_FILE="$CHALLENGER_DIR/.fault-game-address"
@@ -15,23 +15,23 @@ fi
 # Mallory's Address: 0x4641c704a6c743f73ee1f36C7568Fbf4b80681e4
 MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
-DISPUTE_GAME_PROXY=$(jq -r .DisputeGameFactoryProxy $MONOREPO_DIR/.devnet/addresses.json)
-FAULT_GAME_ADDRESS=$(cat $FAULT_GAME_ADDR_FILE)
+DISPUTE_GAME_PROXY=$(jq -r .DisputeGameFactoryProxy "$MONOREPO_DIR"/.devnet/addresses.json)
+FAULT_GAME_ADDRESS=$(cat "$FAULT_GAME_ADDR_FILE")
 echo "Fault dispute game address: $FAULT_GAME_ADDRESS"
 
-DATADIR=`mktemp -d`
+DATADIR=$(mktemp -d)
 trap cleanup SIGINT
 cleanup(){
   rm -rf "${DATADIR}"
 }
 
-$CHALLENGER_DIR/bin/op-challenger \
+"$CHALLENGER_DIR"/bin/op-challenger \
   --l1-eth-rpc http://localhost:8545 \
   --trace-type="alphabet" \
   --alphabet "abcdexyz" \
   --datadir "${DATADIR}" \
-  --game-factory-address $DISPUTE_GAME_PROXY \
-  --game-allowlist $FAULT_GAME_ADDRESS \
+  --game-factory-address "$DISPUTE_GAME_PROXY" \
+  --game-allowlist "$FAULT_GAME_ADDRESS" \
   --private-key $MALLORY_KEY \
   --num-confirmations 1 \
   --metrics.enabled --metrics.port=7305 \

--- a/op-challenger/scripts/create_game.sh
+++ b/op-challenger/scripts/create_game.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-CHALLENGER_DIR=$(echo ${SOURCE_DIR%/*})
-MONOREPO_DIR=$(echo ${CHALLENGER_DIR%/*})
+CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*}")
+MONOREPO_DIR=$(echo "${CHALLENGER_DIR%/*}")
 
 # ./create_game.sh <rpc-addr> <dispute-game-factory-addr> <cast signing args>
 RPC=${1:?Must specify RPC address}
@@ -33,6 +33,7 @@ echo "L2 Block Number: ${L2_BLOCK_NUM}"
 # Create a checkpoint in the block oracle to commit to the current L1 head.
 # This defines the L1 head that will be used in the dispute game.
 echo "Checkpointing the block oracle..."
+# shellcheck disable=SC2086
 L1_CHECKPOINT=$(cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${BLOCK_ORACLE_ADDR}" "checkpoint()" --json | jq -r '.logs[0].topics[1]' | cast to-dec)
 echo "L1 Checkpoint: $L1_CHECKPOINT"
 
@@ -41,9 +42,10 @@ echo "L1 Checkpoint: $L1_CHECKPOINT"
 EXTRA_DATA=$(cast abi-encode "f(uint256,uint256)" "${L2_BLOCK_NUM}" "${L1_CHECKPOINT}")
 
 echo "Initializing the game"
+# shellcheck disable=SC2086
 FAULT_GAME_DATA=$(cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${FACTORY_ADDR}" "create(uint8,bytes32,bytes) returns(address)" "${GAME_TYPE}" "${ROOT_CLAIM}" "${EXTRA_DATA}" --json)
 
 # Extract the address of the newly created game from the receipt logs.
 FAULT_GAME_ADDRESS=$(echo "${FAULT_GAME_DATA}" | jq -r '.logs[0].topics[1]' | cast parse-bytes32-address)
 echo "Fault game address: ${FAULT_GAME_ADDRESS}"
-echo "${FAULT_GAME_ADDRESS}" > $CHALLENGER_DIR/.fault-game-address
+echo "${FAULT_GAME_ADDRESS}" > "$CHALLENGER_DIR"/.fault-game-address

--- a/op-challenger/scripts/move.sh
+++ b/op-challenger/scripts/move.sh
@@ -22,4 +22,5 @@ then
 fi
 
 # Perform the move.
+# shellcheck disable=SC2086
 cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${GAME_ADDR}" "$ACTION(uint256,bytes32)" "${PARENT_INDEX}" "${CLAIM}"

--- a/op-challenger/scripts/resolve.sh
+++ b/op-challenger/scripts/resolve.sh
@@ -6,6 +6,7 @@ GAME_ADDR=${2:?Must specify game address}
 SIGNER_ARGS="${@:3}"
 
 # Perform the move.
+# shellcheck disable=SC2086
 RESULT_DATA=$(cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${GAME_ADDR}" "resolve()" --json)
 RESULT=$(echo "${RESULT_DATA}" | jq -r '.logs[0].topics[1]' | cast to-dec)
 

--- a/op-challenger/scripts/visualize.sh
+++ b/op-challenger/scripts/visualize.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 RPC="${1:?Must specify RPC address}"
 FAULT_GAME_ADDRESS="${2:?Must specify game address}"
 
-DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIR=$(echo "${DIR%/*/*}")
 cd "$DIR"/packages/contracts-bedrock
 
@@ -13,4 +13,4 @@ forge script scripts/FaultDisputeGameViz.s.sol \
   --sig "remote(address)" "$FAULT_GAME_ADDRESS" \
   --fork-url "$RPC"
 
-mv dispute_game.svg "$dir"
+mv dispute_game.svg "$DIR"

--- a/op-challenger/scripts/visualize.sh
+++ b/op-challenger/scripts/visualize.sh
@@ -6,11 +6,11 @@ RPC="${1:?Must specify RPC address}"
 FAULT_GAME_ADDRESS="${2:?Must specify game address}"
 
 DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-DIR=$(echo ${DIR%/*/*})
-cd $DIR/packages/contracts-bedrock
+DIR=$(echo "${DIR%/*/*}")
+cd "$DIR"/packages/contracts-bedrock
 
 forge script scripts/FaultDisputeGameViz.s.sol \
-  --sig "remote(address)" $FAULT_GAME_ADDRESS \
+  --sig "remote(address)" "$FAULT_GAME_ADDRESS" \
   --fork-url "$RPC"
 
 mv dispute_game.svg "$dir"

--- a/op-node/cmd/batch_decoder/script.sh
+++ b/op-node/cmd/batch_decoder/script.sh
@@ -1,3 +1,3 @@
-echo $1
-jq '.frames[] | {timestamp, inclusion_block}' $1
-jq '.batches[]|.Timestamp' $1
+echo "$1"
+jq '.frames[] | {timestamp, inclusion_block}' "$1"
+jq '.batches[]|.Timestamp' "$1"

--- a/op-service/sources/testdata/gen.sh
+++ b/op-service/sources/testdata/gen.sh
@@ -56,10 +56,10 @@ generate_test_vector() {
 
     echo "{\"name\": \"$name\"}" > "$metadata_file"
 
-    cast rpc eth_getBlockByHash $blockhash $fulltxs > $data_file
+    cast rpc eth_getBlockByHash "$blockhash" "$fulltxs" > "$data_file"
 
     # Mutate data using the provided function
-    $mutation_func "$data_file" $metadata_file
+    $mutation_func "$data_file" "$metadata_file"
 }
 
 mkdir -p data/headers

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -55,9 +55,9 @@ exec geth \
 	--nodiscover \
 	--maxpeers=1 \
 	--networkid="$CHAIN_ID" \
-	--unlock=$BLOCK_SIGNER_ADDRESS \
+	--unlock="$BLOCK_SIGNER_ADDRESS" \
 	--mine \
-	--miner.etherbase=$BLOCK_SIGNER_ADDRESS \
+	--miner.etherbase="$BLOCK_SIGNER_ADDRESS" \
 	--password="$GETH_DATA_DIR"/password \
 	--allow-insecure-unlock \
 	--rpc.allow-unprotected-txs \

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -54,7 +54,7 @@ exec geth \
 	--syncmode=full \
 	--nodiscover \
 	--maxpeers=1 \
-	--networkid=$CHAIN_ID \
+	--networkid="$CHAIN_ID" \
 	--unlock=$BLOCK_SIGNER_ADDRESS \
 	--mine \
 	--miner.etherbase=$BLOCK_SIGNER_ADDRESS \

--- a/ops-bedrock/entrypoint-l2.sh
+++ b/ops-bedrock/entrypoint-l2.sh
@@ -39,7 +39,7 @@ exec geth \
 	--syncmode=full \
 	--nodiscover \
 	--maxpeers=0 \
-	--networkid=$CHAIN_ID \
+	--networkid="$CHAIN_ID" \
 	--rpc.allow-unprotected-txs \
 	--authrpc.addr="0.0.0.0" \
 	--authrpc.port="8551" \

--- a/ops/scripts/install-foundry.sh
+++ b/ops/scripts/install-foundry.sh
@@ -26,19 +26,19 @@ echo "Created tempdir @ $TMP_DIR"
 
 # Clone the foundry repo temporarily. We do this to avoid the need for a personal access
 # token to interact with the GitHub REST API, and clean it up after we're done.
-git clone https://github.com/foundry-rs/foundry.git $TMP_DIR && cd $TMP_DIR
+git clone https://github.com/foundry-rs/foundry.git "$TMP_DIR" && cd "$TMP_DIR"
 
 # If the nightly tag exists, we can download the pre-built binaries rather than building
 # from source. Otherwise, clone the repository, check out the commit SHA, and build `forge`,
 # `cast`, `anvil`, and `chisel` from source.
 if git rev-parse "$TAG" >/dev/null 2>&1; then
   echo "Nightly tag exists! Downloading prebuilt binaries..."
-  foundryup -v $TAG
+  foundryup -v "$TAG"
 else
   echo "Nightly tag doesn't exist! Building from source..."
-  foundryup -C $SHA
+  foundryup -C "$SHA"
 fi
 
 # Remove the temporary foundry repo; Used just for checking the nightly tag's existence.
-rm -rf $TMP_DIR
+rm -rf "$TMP_DIR"
 echo "Removed tempdir @ $TMP_DIR"

--- a/ops/scripts/newer-file.sh
+++ b/ops/scripts/newer-file.sh
@@ -12,8 +12,8 @@ else
     MOD_TIME_FMT="-c %Y"
 fi
 
-FILE_1_AGE=$(stat $MOD_TIME_FMT "$1")
-FILE_2_AGE=$(stat $MOD_TIME_FMT "$2")
+FILE_1_AGE=$(stat "$MOD_TIME_FMT" "$1")
+FILE_2_AGE=$(stat "$MOD_TIME_FMT" "$2")
 
 if [ "$FILE_1_AGE" -gt "$FILE_2_AGE" ]; then
   exit 0

--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -56,9 +56,9 @@ todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+
 IFS=$'\n' # Set Internal Field Separator to newline for iteration
 for todo in $todos; do
     # Extract the text inside the parenthesis
-    FILE=$(echo $todo | awk -F':' '{print $1}')
-    LINE_NUM=$(echo $todo | awk -F':' '{print $2}')
-    ISSUE_REFERENCE=$(echo $todo | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
+    FILE=$(echo "$todo" | awk -F':' '{print $1}')
+    LINE_NUM=$(echo "$todo" | awk -F':' '{print $2}')
+    ISSUE_REFERENCE=$(echo "$todo" | sed -n 's/.*TODO(\([^)]*\)).*/\1/p')
 
     # Parse the format of the TODO comment. There are 3 supported formats:
     # * TODO(<issue_number>): <description> (Default org & repo: "ethereum-optimism/monorepo")

--- a/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
+++ b/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
@@ -30,16 +30,16 @@ cleanup() {
 # written before the solidity tests try to read it
 wait_l2_outfile() {
   i=1
-  while [ $i -le $2 ]; do
+  while [ $i -le "$2" ]; do
     i=$(($i + 1))
 
     if [ ! -f "$OUTFILE_L2" ]; then
-      sleep $1
+      sleep "$1"
       continue
     fi
 
     if [ $(du -m "$OUTFILE_L2" | cut -f1) -lt 8 ]; then
-      sleep $1
+      sleep "$1"
       continue
     fi
 
@@ -59,11 +59,11 @@ if mkdir -- "$LOCKDIR" > /dev/null 2>&1; then
   mkdir -p "$TESTDATA_DIR"
 
   if [ ! -f "$DEPLOY_ARTIFACT" ]; then
-    forge script $CONTRACTS_DIR/scripts/Deploy.s.sol:Deploy > /dev/null 2>&1
+    forge script "$CONTRACTS_DIR"/scripts/Deploy.s.sol:Deploy > /dev/null 2>&1
   fi
 
   if [ ! -f "$OUTFILE_L2" ]; then
-    go run $OP_NODE genesis l2 \
+    go run "$OP_NODE" genesis l2 \
       --deploy-config "$CONTRACTS_DIR/deploy-config/hardhat.json" \
       --l1-deployments "$DEPLOY_ARTIFACT" \
       --l1-starting-block "$L1_STARTING_BLOCK_PATH" \

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -20,7 +20,7 @@ reqenv "GS_SEQUENCER_ADDRESS"
 reqenv "L1_RPC_URL"
 
 # Get the finalized block timestamp and hash
-block=$(cast block finalized --rpc-url $L1_RPC_URL)
+block=$(cast block finalized --rpc-url "$L1_RPC_URL")
 timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
 blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
 

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -8,7 +8,7 @@ SLITHER_REPORT_BACKUP="slither-report.json.temp"
 # Get the absolute path of the parent directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
 echo "Running slither in $DIR"
-cd $DIR
+cd "$DIR"
 
 # Clean up any previous artifacts.
 # We do not check if pnpm is installed since it is used across the monorepo

--- a/packages/contracts-bedrock/scripts/verify-foundry-install.sh
+++ b/packages/contracts-bedrock/scripts/verify-foundry-install.sh
@@ -2,6 +2,7 @@
 
 if ! command -v forge &> /dev/null
 then
+  # shellcheck disable=SC2006
   echo "Is Foundry not installed? Consider installing via `curl -L https://foundry.paradigm.xyz | bash` and then running `foundryup` on a new terminal. For more context, check the installation instructions in the book: https://book.getfoundry.sh/getting-started/installation.html."
   exit 1
 fi


### PR DESCRIPTION
**Description**

Applies autofixes from [ShellCheck](https://www.shellcheck.net). To apply auto-fixes I ran the below command from the repo root: 
```sh
find . -type f -name '*.sh' -exec sh -c 'shellcheck -f diff "$1" | patch "$1"' _ {} \;
```

This PR does not add ShellCheck in CI since theres other findings that can't be auto-fixed, so ideally we'd review/fix those first.

A few additional fixes were applied manually per suggestions by @coderabbitai.

**Tests**

No tests were added. I'm not familiar with a lot of these scripts, so manual review is appreciated to make sure nothing untested broke.

**Additional context**

The autofixed code came from the following rules:
- [SC2006](https://www.shellcheck.net/wiki/SC2006):Use `$(...)` notation instead of legacy backticked `...`
- [SC2164](https://www.shellcheck.net/wiki/SC2164): Use `cd ... || exit` in case `cd` fails.
 - [SC2086](https://www.shellcheck.net/wiki/SC2086): Double quote to prevent globbing and word splitting.
     - For this one, there's a few instances of `$SIGNER_ARGS` CLI args where we do want splitting, so I disabled those inline. During review, make sure I didn't miss any other instances here

