### PR TITLE
op-upgrade: extended pause

### DIFF
--- a/op-chain-ops/cmd/op-upgrade-extended-pause/README.md
+++ b/op-chain-ops/cmd/op-upgrade-extended-pause/README.md
@@ -1,0 +1,3 @@
+# op-upgrade-extended-pause
+
+One off CLI tooling for the extended pause upgrade

--- a/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
+++ b/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
@@ -22,26 +22,96 @@ import (
 // Note that the key is the L2 chain id. This is because the L1 contracts must be specific
 // for a particular OP Stack chain and cannot currently be used by multiple chains.
 var addresses = map[uint64]superchain.ImplementationList{
-	10: {
+	// Base Sepolia
+	84532: {
 		L1CrossDomainMessenger: superchain.VersionedContract{
-			Version: "",
-			Address: superchain.Address{},
+			Version: "2.1.1",
+			Address: superchain.HexToAddress("0x442d5c024a80c34d64fed048bdc7c50dd84665c4"),
 		},
 		L1ERC721Bridge: superchain.VersionedContract{
-			Version: "",
-			Address: superchain.Address{},
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0x30e2c20c73353b8ddb6021d5636aef1b91727077"),
 		},
 		L1StandardBridge: superchain.VersionedContract{
-			Version: "",
-			Address: superchain.Address{},
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0xf71db0a6955b3edc78a267cd6441feed4ee0197b"),
 		},
 		OptimismPortal: superchain.VersionedContract{
-			Version: "",
-			Address: superchain.Address{},
+			Version: "2.1.0",
+			Address: superchain.HexToAddress("0x770d02b87e081e61ab30713b0ece6dfade792aff"),
 		},
 		SystemConfig: superchain.VersionedContract{
-			Version: "",
-			Address: superchain.Address{},
+			Version: "1.11.0",
+			Address: superchain.HexToAddress("0xf55b3dbb3bd2f2fa9236b0be6e8b9e91b819fd14"),
+		},
+	},
+	// OP Sepolia
+	11155420: {
+		L1CrossDomainMessenger: superchain.VersionedContract{
+			Version: "2.1.1",
+			Address: superchain.HexToAddress("0xc3c7e6f4ad6a593a9731a39fa883ec1999d7d873"),
+		},
+		L1ERC721Bridge: superchain.VersionedContract{
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0x532cad52e1f812eeb9c9a9571e07fef55993fefa"),
+		},
+		L1StandardBridge: superchain.VersionedContract{
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0xe19c7a2c0bb32287731ea75da9b1c836815964f1"),
+		},
+		OptimismPortal: superchain.VersionedContract{
+			Version: "2.1.0",
+			Address: superchain.HexToAddress("0x592B7D3255a8037307d23C16cC8c13a9563c8Ab1"),
+		},
+		SystemConfig: superchain.VersionedContract{
+			Version: "1.11.0",
+			Address: superchain.HexToAddress("0xce77d580e0befbb1561376a722217017651b9dbf"),
+		},
+	},
+	// Zora Sepolia
+	999999999: {
+		L1CrossDomainMessenger: superchain.VersionedContract{
+			Version: "2.1.1",
+			Address: superchain.HexToAddress("0xb74e6f01cddfc53cd48fb94e14137a0801a67ee4"),
+		},
+		L1ERC721Bridge: superchain.VersionedContract{
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0x5ff51b220049151710752ebe65d0a060020f6018"),
+		},
+		L1StandardBridge: superchain.VersionedContract{
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0xf8e25ec7ca94a960a9392c56c55b68414f5c7ded"),
+		},
+		OptimismPortal: superchain.VersionedContract{
+			Version: "2.1.0",
+			Address: superchain.HexToAddress("0xd2b5f6dfa6fdfd89327a5aa4c787a89456ef0ca8"),
+		},
+		SystemConfig: superchain.VersionedContract{
+			Version: "1.11.0",
+			Address: superchain.HexToAddress("0xaeb5f8ed2977e70f4ddacf2f603c0dcf8e561873"),
+		},
+	},
+	// PGN Sepolia
+	58008: {
+		L1CrossDomainMessenger: superchain.VersionedContract{
+			Version: "2.1.1",
+			Address: superchain.HexToAddress("0x99bb19a985e1def20d363405c5943d10e715dc12"),
+		},
+		L1ERC721Bridge: superchain.VersionedContract{
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0x89eba5aeb024534e6e1575c6bdb0f4f70d32f7da"),
+		},
+		L1StandardBridge: superchain.VersionedContract{
+			Version: "2.0.0",
+			Address: superchain.HexToAddress("0x9cde10006cac4423505864c904e2cfcf124dcaee"),
+		},
+		OptimismPortal: superchain.VersionedContract{
+			Version: "2.1.0",
+			Address: superchain.HexToAddress("0x725da050f385e52c0ae700e8c433c3636aba4592"),
+		},
+		SystemConfig: superchain.VersionedContract{
+			Version: "1.11.0",
+			Address: superchain.HexToAddress("0xd1557adfee8eda61619fc227c3dbb41fc16fc840"),
 		},
 	},
 }
@@ -54,16 +124,18 @@ func main() {
 		Usage: "Build transactions useful for upgrading the Superchain",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "l1-rpc-url",
-				Value:   "http://127.0.0.1:8545",
-				Usage:   "L1 RPC URL, the chain ID will be used to determine the superchain",
-				EnvVars: []string{"L1_RPC_URL"},
+				Name:     "l1-rpc-url",
+				Value:    "http://127.0.0.1:8545",
+				Usage:    "L1 RPC URL, the chain ID will be used to determine the superchain",
+				Required: true,
+				EnvVars:  []string{"L1_RPC_URL"},
 			},
 			&cli.StringFlag{
-				Name:    "l2-rpc-url",
-				Value:   "http://127.0.0.1:9545",
-				Usage:   "L2 RPC URL",
-				EnvVars: []string{"L2_RPC_URL"},
+				Name:     "l2-rpc-url",
+				Value:    "http://127.0.0.1:9545",
+				Usage:    "L2 RPC URL",
+				Required: true,
+				EnvVars:  []string{"L2_RPC_URL"},
 			},
 			&cli.PathFlag{
 				Name:     "deploy-config",

--- a/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
+++ b/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
@@ -18,10 +18,10 @@ import (
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
-// addresses contains the L1 addresses of the contracts that are being upgraded to.
+// deployments contains the L1 addresses of the contracts that are being upgraded to.
 // Note that the key is the L2 chain id. This is because the L1 contracts must be specific
 // for a particular OP Stack chain and cannot currently be used by multiple chains.
-var addresses = map[uint64]superchain.ImplementationList{
+var deployments = map[uint64]superchain.ImplementationList{
 	// Base Sepolia
 	84532: {
 		L1CrossDomainMessenger: superchain.VersionedContract{
@@ -175,7 +175,7 @@ func entrypoint(ctx *cli.Context) error {
 		return errors.New("Cannot create L1 client")
 	}
 	if clients.L2Client == nil {
-		return errors.New("Cannot create L1 client")
+		return errors.New("Cannot create L2 client")
 	}
 
 	l1ChainID, err := clients.L1Client.ChainID(ctx.Context)
@@ -192,7 +192,7 @@ func entrypoint(ctx *cli.Context) error {
 	// Create a batch of transactions
 	batch := safe.Batch{}
 
-	list, ok := addresses[l2ChainID.Uint64()]
+	list, ok := deployments[l2ChainID.Uint64()]
 	if !ok {
 		return fmt.Errorf("no implementations for chain ID %d", l2ChainID)
 	}

--- a/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
+++ b/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
@@ -229,7 +229,7 @@ func entrypoint(ctx *cli.Context) error {
 		return fmt.Errorf("no implementations for chain ID %d", l2ChainID)
 	}
 
-	addresses, ok := superchain.Addresses[l2ChainID.Uint64()]
+	proxyAddresses, ok := superchain.Addresses[l2ChainID.Uint64()]
 	if !ok {
 		return fmt.Errorf("no proxy addresses for chain ID %d", l2ChainID)
 	}
@@ -253,7 +253,7 @@ func entrypoint(ctx *cli.Context) error {
 	}
 
 	// Build the batch
-	if err := upgrades.L1(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+	if err := upgrades.L1(&batch, list, *proxyAddresses, config, chainConfig, clients.L1Client); err != nil {
 		return fmt.Errorf("cannot build L1 upgrade batch: %w", err)
 	}
 

--- a/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
+++ b/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"

--- a/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
+++ b/op-chain-ops/cmd/op-upgrade-extended-pause/main.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/mattn/go-isatty"
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/safe"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+)
+
+// addresses contains the L1 addresses of the contracts that are being upgraded to.
+// Note that the key is the L2 chain id. This is because the L1 contracts must be specific
+// for a particular OP Stack chain and cannot currently be used by multiple chains.
+var addresses = map[uint64]superchain.ImplementationList{
+	10: {
+		L1CrossDomainMessenger: superchain.VersionedContract{
+			Version: "",
+			Address: superchain.Address{},
+		},
+		L1ERC721Bridge: superchain.VersionedContract{
+			Version: "",
+			Address: superchain.Address{},
+		},
+		L1StandardBridge: superchain.VersionedContract{
+			Version: "",
+			Address: superchain.Address{},
+		},
+		OptimismPortal: superchain.VersionedContract{
+			Version: "",
+			Address: superchain.Address{},
+		},
+		SystemConfig: superchain.VersionedContract{
+			Version: "",
+			Address: superchain.Address{},
+		},
+	},
+}
+
+func main() {
+	log.Root().SetHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(isatty.IsTerminal(os.Stderr.Fd()))))
+
+	app := &cli.App{
+		Name:  "op-upgrade",
+		Usage: "Build transactions useful for upgrading the Superchain",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "l1-rpc-url",
+				Value:   "http://127.0.0.1:8545",
+				Usage:   "L1 RPC URL, the chain ID will be used to determine the superchain",
+				EnvVars: []string{"L1_RPC_URL"},
+			},
+			&cli.StringFlag{
+				Name:    "l2-rpc-url",
+				Value:   "http://127.0.0.1:9545",
+				Usage:   "L2 RPC URL",
+				EnvVars: []string{"L2_RPC_URL"},
+			},
+			&cli.PathFlag{
+				Name:     "deploy-config",
+				Usage:    "The path to the deploy config file",
+				Required: true,
+				EnvVars:  []string{"DEPLOY_CONFIG"},
+			},
+			&cli.PathFlag{
+				Name:    "outfile",
+				Usage:   "The file to write the output to. If not specified, output is written to stdout",
+				EnvVars: []string{"OUTFILE"},
+			},
+		},
+		Action: entrypoint,
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Crit("error op-upgrade", "err", err)
+	}
+}
+
+// entrypoint contains the main logic of the script
+func entrypoint(ctx *cli.Context) error {
+	config, err := genesis.NewDeployConfig(ctx.Path("deploy-config"))
+	if err != nil {
+		return err
+	}
+	if err := config.Check(); err != nil {
+		return fmt.Errorf("error checking deploy config: %w", err)
+	}
+
+	clients, err := clients.NewClients(ctx.String("l1-rpc-url"), ctx.String("l2-rpc-url"))
+	if err != nil {
+		return fmt.Errorf("cannot create RPC clients: %w", err)
+	}
+	if clients.L1Client == nil {
+		return errors.New("Cannot create L1 client")
+	}
+	if clients.L2Client == nil {
+		return errors.New("Cannot create L1 client")
+	}
+
+	l1ChainID, err := clients.L1Client.ChainID(ctx.Context)
+	if err != nil {
+		return fmt.Errorf("cannot fetch L1 chain ID: %w", err)
+	}
+	l2ChainID, err := clients.L2Client.ChainID(ctx.Context)
+	if err != nil {
+		return fmt.Errorf("cannot fetch L2 chain ID: %w", err)
+	}
+
+	log.Info("connected to chains", "l1-chain-id", l1ChainID, "l2-chain-id", l2ChainID)
+
+	// Create a batch of transactions
+	batch := safe.Batch{}
+
+	list, ok := addresses[l2ChainID.Uint64()]
+	if !ok {
+		return fmt.Errorf("no implementations for chain ID %d", l2ChainID)
+	}
+
+	addresses, ok := superchain.Addresses[l2ChainID.Uint64()]
+	if !ok {
+		return fmt.Errorf("no proxy addresses for chain ID %d", l2ChainID)
+	}
+
+	chainConfig, ok := superchain.OPChains[l2ChainID.Uint64()]
+	if !ok {
+		return fmt.Errorf("no chain config for chain ID %d", l2ChainID)
+	}
+
+	log.Info("Upgrading to the following versions")
+	log.Info("L1CrossDomainMessenger", "version", list.L1CrossDomainMessenger.Version, "address", list.L1CrossDomainMessenger.Address)
+	log.Info("L1ERC721Bridge", "version", list.L1ERC721Bridge.Version, "address", list.L1ERC721Bridge.Address)
+	log.Info("L1StandardBridge", "version", list.L1StandardBridge.Version, "address", list.L1StandardBridge.Address)
+	log.Info("L2OutputOracle", "version", list.L2OutputOracle.Version, "address", list.L2OutputOracle.Address)
+	log.Info("OptimismMintableERC20Factory", "version", list.OptimismMintableERC20Factory.Version, "address", list.OptimismMintableERC20Factory.Address)
+	log.Info("OptimismPortal", "version", list.OptimismPortal.Version, "address", list.OptimismPortal.Address)
+	log.Info("SystemConfig", "version", list.SystemConfig.Version, "address", list.SystemConfig.Address)
+
+	// Check just the versions that we care about
+	if err := upgrades.CheckVersionedContract(ctx.Context, list.L1CrossDomainMessenger, clients.L1Client); err != nil {
+		return fmt.Errorf("L1CrossDomainMessenger: %w", err)
+	}
+	if err := upgrades.CheckVersionedContract(ctx.Context, list.L1ERC721Bridge, clients.L1Client); err != nil {
+		return fmt.Errorf("L1ERC721Bridge: %w", err)
+	}
+	if err := upgrades.CheckVersionedContract(ctx.Context, list.L1StandardBridge, clients.L1Client); err != nil {
+		return fmt.Errorf("L1StandardBridge: %w", err)
+	}
+	if err := upgrades.CheckVersionedContract(ctx.Context, list.OptimismPortal, clients.L1Client); err != nil {
+		return fmt.Errorf("OptimismPortal: %w", err)
+	}
+	if err := upgrades.CheckVersionedContract(ctx.Context, list.SystemConfig, clients.L1Client); err != nil {
+		return fmt.Errorf("SystemConfig: %w", err)
+	}
+
+	// Build the batch
+	if err := upgrades.L1CrossDomainMessenger(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+		return fmt.Errorf("upgrading L1CrossDomainMessenger: %w", err)
+	}
+	if err := upgrades.L1ERC721Bridge(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+		return fmt.Errorf("upgrading L1ERC721Bridge: %w", err)
+	}
+	if err := upgrades.L1StandardBridge(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+		return fmt.Errorf("upgrading L1StandardBridge: %w", err)
+	}
+	if err := upgrades.OptimismPortal(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+		return fmt.Errorf("upgrading OptimismPortal: %w", err)
+	}
+	if err := upgrades.SystemConfig(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+		return fmt.Errorf("upgrading SystemConfig: %w", err)
+	}
+
+	// Write the batch to disk or stdout
+	if outfile := ctx.Path("outfile"); outfile != "" {
+		if err := writeJSON(outfile, batch); err != nil {
+			return err
+		}
+	} else {
+		data, err := json.MarshalIndent(batch, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	}
+	return nil
+}
+
+func writeJSON(outfile string, input interface{}) error {
+	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(input)
+}

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -269,22 +269,9 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	var superchainConfigGuardian common.Address
-	if config != nil {
-		superchainConfigGuardian = config.SuperchainConfigGuardian
-	} else {
-		optimismPortal, err := bindings.NewOptimismPortalCaller(common.HexToAddress(list.OptimismPortalProxy.String()), backend)
-		if err != nil {
-			return err
-		}
-		guardian, err := optimismPortal.GUARDIAN(&bind.CallOpts{})
-		if err != nil {
-			return err
-		}
-		superchainConfigGuardian = guardian
-	}
-
-	calldata, err := optimismPortalABI.Pack("initialize", common.HexToAddress(list.L2OutputOracleProxy.String()), superchainConfigGuardian, common.HexToAddress(chainConfig.SystemConfigAddr.String()), false)
+	// TODO: superchain config address
+	superchainConfig := common.Address{}
+	calldata, err := optimismPortalABI.Pack("initialize", superchainConfig)
 	if err != nil {
 		return err
 	}

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -59,8 +59,21 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 		if err != nil {
 			return err
 		}
-		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L28
-		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{31: 0xf9}, common.Hash{})
+
+		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L11-L13
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L28
+			{
+				Key:   common.Hash{31: 249},
+				Value: common.Hash{},
+			},
+		}
+
+		calldata, err := storageSetterABI.Pack("setBytes32", input)
 		if err != nil {
 			return err
 		}
@@ -112,7 +125,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 			return err
 		}
 
-		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L100-L103
+		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L100-L102
 		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{}, common.Hash{})
 		if err != nil {
 			return err
@@ -231,6 +244,11 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 		}
 
 		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L50-L51
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
 			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L55
 			{
 				Key:   common.Hash{31: 0x04},
@@ -385,6 +403,11 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		}
 
 		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L64-L65
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
 			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L72
 			{
 				Key:   common.Hash{31: 53},
@@ -457,6 +480,11 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		}
 
 		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L82-L83
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
 			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L92
 			{
 				Key:   common.Hash{31: 106},

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -21,6 +21,11 @@ const upgradeAndCall = "upgradeAndCall(address,address,bytes)"
 // storageSetterAddr represents the address of the StorageSetter contract.
 var storageSetterAddr = common.HexToAddress("0xd81f43eDBCAcb4c29a9bA38a13Ee5d79278270cC")
 
+// superchainConfigProxy refers to the address of the Sepolia superchain config proxy.
+// NOTE: this is currently hardcoded and we will need to move this to the superchain-registry
+// and have 1 deployed for each superchain target.
+var superchainConfigProxy = common.HexToAddress("0xC2Be75506d5724086DEB7245bd260Cc9753911Be")
+
 // L1 will add calls for upgrading each of the L1 contracts.
 func L1(batch *safe.Batch, implementations superchain.ImplementationList, list superchain.AddressList, config *genesis.DeployConfig, chainConfig *superchain.ChainConfig, backend bind.ContractBackend) error {
 	if err := L1CrossDomainMessenger(batch, implementations, list, config, chainConfig, backend); err != nil {
@@ -54,7 +59,8 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
@@ -93,7 +99,7 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 		return err
 	}
 
-	calldata, err := l1CrossDomainMessengerABI.Pack("initialize", common.HexToAddress(list.OptimismPortalProxy.String()))
+	calldata, err := l1CrossDomainMessengerABI.Pack("initialize", superchainConfigProxy)
 	if err != nil {
 		return err
 	}
@@ -119,7 +125,8 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
@@ -146,7 +153,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	calldata, err := l1ERC721BridgeABI.Pack("initialize", common.HexToAddress(list.L1CrossDomainMessengerProxy.String()))
+	calldata, err := l1ERC721BridgeABI.Pack("initialize", superchainConfigProxy)
 	if err != nil {
 		return err
 	}
@@ -172,7 +179,8 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
@@ -211,7 +219,7 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 		return err
 	}
 
-	calldata, err := l1StandardBridgeABI.Pack("initialize", common.HexToAddress(list.L1CrossDomainMessengerProxy.String()))
+	calldata, err := l1StandardBridgeABI.Pack("initialize", superchainConfigProxy)
 	if err != nil {
 		return err
 	}
@@ -237,7 +245,8 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
@@ -343,7 +352,8 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
@@ -396,7 +406,8 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
@@ -445,9 +456,7 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 		return err
 	}
 
-	// TODO: superchain config address
-	superchainConfig := common.Address{}
-	calldata, err := optimismPortalABI.Pack("initialize", superchainConfig)
+	calldata, err := optimismPortalABI.Pack("initialize", superchainConfigProxy)
 	if err != nil {
 		return err
 	}
@@ -473,7 +482,8 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 		return err
 	}
 
-	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+	// 2 Step Upgrade
+	{
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -18,6 +18,9 @@ import (
 // on the ProxyAdmin contract.
 const upgradeAndCall = "upgradeAndCall(address,address,bytes)"
 
+// storageSetterAddr represents the address of the StorageSetter contract.
+var storageSetterAddr = common.HexToAddress("0xd81f43eDBCAcb4c29a9bA38a13Ee5d79278270cC")
+
 // L1 will add calls for upgrading each of the L1 contracts.
 func L1(batch *safe.Batch, implementations superchain.ImplementationList, list superchain.AddressList, config *genesis.DeployConfig, chainConfig *superchain.ChainConfig, backend bind.ContractBackend) error {
 	if err := L1CrossDomainMessenger(batch, implementations, list, config, chainConfig, backend); err != nil {
@@ -51,6 +54,27 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 		return err
 	}
 
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L28
+		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{31: 0xf9}, common.Hash{})
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(list.L1CrossDomainMessengerProxy.String()),
+			storageSetterAddr,
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
+			return err
+		}
+	}
+
 	l1CrossDomainMessengerABI, err := bindings.L1CrossDomainMessengerMetaData.GetAbi()
 	if err != nil {
 		return err
@@ -80,6 +104,28 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 	proxyAdminABI, err := bindings.ProxyAdminMetaData.GetAbi()
 	if err != nil {
 		return err
+	}
+
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+
+		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L100-L103
+		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{}, common.Hash{})
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(list.L1ERC721BridgeProxy.String()),
+			storageSetterAddr,
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
+			return err
+		}
 	}
 
 	l1ERC721BridgeABI, err := bindings.L1ERC721BridgeMetaData.GetAbi()
@@ -113,24 +159,36 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 		return err
 	}
 
-	// Add in OP Mainnet specific upgrade logic here
-	if chainConfig.ChainID == 10 {
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
 		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
 		if err != nil {
 			return err
 		}
-		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{}, common.Hash{})
+
+		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L36-L37
+			{
+				Key:   common.Hash{},
+				Value: common.Hash{},
+			},
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L41
+			{
+				Key:   common.Hash{31: 0x03},
+				Value: common.Hash{},
+			},
+		}
+
+		calldata, err := storageSetterABI.Pack("setBytes32", input)
 		if err != nil {
 			return err
 		}
 		args := []any{
 			common.HexToAddress(list.L1StandardBridgeProxy.String()),
-			common.HexToAddress("0xf30CE41cA2f24D28b95Eb861553dAc2948e0157F"),
+			storageSetterAddr,
 			calldata,
 		}
 		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
-		sig := "upgradeAndCall(address,address,bytes)"
-		if err := batch.AddCall(proxyAdmin, common.Big0, sig, args, proxyAdminABI); err != nil {
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
 			return err
 		}
 	}
@@ -164,6 +222,40 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 	proxyAdminABI, err := bindings.ProxyAdminMetaData.GetAbi()
 	if err != nil {
 		return err
+	}
+
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+
+		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L55
+			{
+				Key:   common.Hash{31: 0x04},
+				Value: common.Hash{},
+			},
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L56
+			{
+				Key:   common.Hash{31: 0x05},
+				Value: common.Hash{},
+			},
+		}
+
+		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(list.L2OutputOracleProxy.String()),
+			storageSetterAddr,
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
+			return err
+		}
 	}
 
 	l2OutputOracleABI, err := bindings.L2OutputOracleMetaData.GetAbi()
@@ -233,6 +325,28 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 		return err
 	}
 
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+
+		// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L287-L289
+		calldata, err := storageSetterABI.Pack("setBytes32", common.Hash{}, common.Hash{})
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(list.OptimismMintableERC20FactoryProxy.String()),
+			storageSetterAddr,
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
+			return err
+		}
+	}
+
 	optimismMintableERC20FactoryABI, err := bindings.OptimismMintableERC20FactoryMetaData.GetAbi()
 	if err != nil {
 		return err
@@ -262,6 +376,45 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 	proxyAdminABI, err := bindings.ProxyAdminMetaData.GetAbi()
 	if err != nil {
 		return err
+	}
+
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+
+		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L72
+			{
+				Key:   common.Hash{31: 53},
+				Value: common.Hash{},
+			},
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L73
+			{
+				Key:   common.Hash{31: 54},
+				Value: common.Hash{},
+			},
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L74
+			{
+				Key:   common.Hash{31: 55},
+				Value: common.Hash{},
+			},
+		}
+
+		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(list.OptimismPortalProxy.String()),
+			storageSetterAddr,
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
+			return err
+		}
 	}
 
 	optimismPortalABI, err := bindings.OptimismPortalMetaData.GetAbi()
@@ -295,6 +448,70 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 	proxyAdminABI, err := bindings.ProxyAdminMetaData.GetAbi()
 	if err != nil {
 		return err
+	}
+
+	if chainConfig.ChainID == 10 || chainConfig.ChainID == 420 {
+		storageSetterABI, err := bindings.StorageSetterMetaData.GetAbi()
+		if err != nil {
+			return err
+		}
+
+		input := []bindings.StorageSetterSlot{
+			// https://github.com/ethereum-optimism/optimism/blob/86a96023ffd04d119296dff095d02fff79fa15de/packages/contracts-bedrock/.storage-layout#L92
+			{
+				Key:   common.Hash{31: 106},
+				Value: common.Hash{},
+			},
+			// bytes32 public constant L1_CROSS_DOMAIN_MESSENGER_SLOT = bytes32(uint256(keccak256("systemconfig.l1crossdomainmessenger")) - 1);
+			{
+				Key:   common.HexToHash("0x383f291819e6d54073bc9a648251d97421076bdd101933c0c022219ce9580636"),
+				Value: common.Hash{},
+			},
+			// bytes32 public constant L1_ERC_721_BRIDGE_SLOT = bytes32(uint256(keccak256("systemconfig.l1erc721bridge")) - 1);
+			{
+				Key:   common.HexToHash("0x46adcbebc6be8ce551740c29c47c8798210f23f7f4086c41752944352568d5a7"),
+				Value: common.Hash{},
+			},
+			// bytes32 public constant L1_STANDARD_BRIDGE_SLOT = bytes32(uint256(keccak256("systemconfig.l1standardbridge")) - 1);
+			{
+				Key:   common.HexToHash("0x9904ba90dde5696cda05c9e0dab5cbaa0fea005ace4d11218a02ac668dad6376"),
+				Value: common.Hash{},
+			},
+			// bytes32 public constant L2_OUTPUT_ORACLE_SLOT = bytes32(uint256(keccak256("systemconfig.l2outputoracle")) - 1);
+			{
+				Key:   common.HexToHash("0xe52a667f71ec761b9b381c7b76ca9b852adf7e8905da0e0ad49986a0a6871815"),
+				Value: common.Hash{},
+			},
+			// bytes32 public constant OPTIMISM_PORTAL_SLOT = bytes32(uint256(keccak256("systemconfig.optimismportal")) - 1);
+			{
+				Key:   common.HexToHash("0x4b6c74f9e688cb39801f2112c14a8c57232a3fc5202e1444126d4bce86eb19ac"),
+				Value: common.Hash{},
+			},
+			// bytes32 public constant OPTIMISM_MINTABLE_ERC20_FACTORY_SLOT = bytes32(uint256(keccak256("systemconfig.optimismmintableerc20factory")) - 1);
+			{
+				Key:   common.HexToHash("0xa04c5bb938ca6fc46d95553abf0a76345ce3e722a30bf4f74928b8e7d852320c"),
+				Value: common.Hash{},
+			},
+			// bytes32 public constant BATCH_INBOX_SLOT = bytes32(uint256(keccak256("systemconfig.batchinbox")) - 1);
+			{
+				Key:   common.HexToHash("0x71ac12829d66ee73d8d95bff50b3589745ce57edae70a3fb111a2342464dc597"),
+				Value: common.Hash{},
+			},
+		}
+
+		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		if err != nil {
+			return err
+		}
+		args := []any{
+			common.HexToAddress(chainConfig.SystemConfigAddr.String()),
+			storageSetterAddr,
+			calldata,
+		}
+		proxyAdmin := common.HexToAddress(list.ProxyAdmin.String())
+		if err := batch.AddCall(proxyAdmin, common.Big0, upgradeAndCall, args, proxyAdminABI); err != nil {
+			return err
+		}
 	}
 
 	systemConfigABI, err := bindings.SystemConfigMetaData.GetAbi()

--- a/op-chain-ops/upgrades/l1.go
+++ b/op-chain-ops/upgrades/l1.go
@@ -20,6 +20,8 @@ const (
 	upgradeAndCall = "upgradeAndCall(address,address,bytes)"
 	// upgrade represents the signature of the upgrade function on the ProxyAdmin contract.
 	upgrade = "upgrade(address,address)"
+
+	method = "setBytes32"
 )
 
 var (
@@ -85,7 +87,7 @@ func L1CrossDomainMessenger(batch *safe.Batch, implementations superchain.Implem
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return err
 		}
@@ -146,7 +148,7 @@ func L1ERC721Bridge(batch *safe.Batch, implementations superchain.Implementation
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return fmt.Errorf("setBytes32: %w", err)
 		}
@@ -212,7 +214,7 @@ func L1StandardBridge(batch *safe.Batch, implementations superchain.Implementati
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return err
 		}
@@ -283,7 +285,7 @@ func L2OutputOracle(batch *safe.Batch, implementations superchain.Implementation
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return err
 		}
@@ -367,7 +369,7 @@ func OptimismMintableERC20Factory(batch *safe.Batch, implementations superchain.
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return err
 		}
@@ -432,7 +434,7 @@ func OptimismPortal(batch *safe.Batch, implementations superchain.Implementation
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return err
 		}
@@ -533,7 +535,7 @@ func SystemConfig(batch *safe.Batch, implementations superchain.ImplementationLi
 			},
 		}
 
-		calldata, err := storageSetterABI.Pack("setBytes32", input)
+		calldata, err := storageSetterABI.Pack(method, input)
 		if err != nil {
 			return err
 		}

--- a/packages/contracts-bedrock/deploy-config/base-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/base-sepolia.json
@@ -18,7 +18,7 @@
 
   "l2OutputOracleSubmissionInterval": 120,
   "l2OutputOracleStartingBlockNumber": 0,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 1695767904,
 
   "l2OutputOracleProposer": "0x20044a0d104E9e788A0C984A2B7eAe615afD046b",
   "l2OutputOracleChallenger": "0xDa3037Ff70Ac92CD867c683BD807e5A484857405",

--- a/packages/contracts-bedrock/deploy-config/pgn-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/pgn-sepolia.json
@@ -22,7 +22,7 @@
   "l2GenesisRegolithTimeOffset": "0x0",
   "superchainConfigGuardian": "0x45eFFbD799Ab49122eeEAB75B78D9C56A187F9A7",
   "l2OutputOracleSubmissionInterval": 180,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 1685727972,
   "l2OutputOracleProposer": "0xD457799C5ba870D609f21048c67a9b11aC611BF0",
   "l2GenesisBlockGasLimit": "0x1c9c380",
   "fundDevAccounts": false,

--- a/packages/contracts-bedrock/deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia.json
@@ -14,7 +14,7 @@
   "batchSenderAddress": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
   "l2OutputOracleSubmissionInterval": 120,
   "l2OutputOracleStartingBlockNumber": 0,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 1690493568,
   "l2OutputOracleProposer": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
   "l2OutputOracleChallenger": "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301",
   "finalizationPeriodSeconds": 12,

--- a/packages/contracts-bedrock/deploy-config/zora-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/zora-sepolia.json
@@ -23,7 +23,7 @@
   "l2GenesisRegolithTimeOffset": "0x0",
   "superchainConfigGuardian": "0x45eFFbD799Ab49122eeEAB75B78D9C56A187F9A7",
   "l2OutputOracleSubmissionInterval": 180,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 1698080004,
   "l2OutputOracleStartingBlockNumber": 0,
   "l2OutputOracleProposer": "0xe8326a5839175dE7f467e66D8bB443aa70DA1c3e",
   "sequencerFeeVaultWithdrawalNetwork": 0,


### PR DESCRIPTION
**Description**

Create a one off script that can be used to generate the upgrade JSON
files. This still needs to have the addresses for each network
added in the `addresses` mapping at the top of the script. It uses
a subset of the `op-upgrade` code.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
