### PR TITLE
fix(ufm): gracefully handle failed tx creation

### DIFF
--- a/op-ufm/pkg/provider/roundtrip.go
+++ b/op-ufm/pkg/provider/roundtrip.go
@@ -58,7 +58,6 @@ func (p *Provider) RoundTrip(ctx context.Context) {
 		}
 
 		tx, err := p.createTx(ctx, client, nonce)
-		nonce = tx.Nonce()
 		if err != nil {
 			log.Error("cant create tx",
 				"provider", p.name,
@@ -66,6 +65,7 @@ func (p *Provider) RoundTrip(ctx context.Context) {
 				"err", err)
 			return
 		}
+		nonce = tx.Nonce()
 
 		signedTx, err := p.sign(ctx, tx)
 		if err != nil {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This change fix a bug in which we attempted to get the nonce for a nil tx. A transaction can fail to be created if the RPC provider is experiencing errors.

