### PR TITLE
feat(op-challenger): Prestate Provider Refactor

### DIFF
--- a/op-challenger/game/fault/trace/alphabet/prestate.go
+++ b/op-challenger/game/fault/trace/alphabet/prestate.go
@@ -1,0 +1,24 @@
+package alphabet
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var absolutePrestate = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
+
+var _ types.PrestateProvider = (*AlphabetPrestateProvider)(nil)
+
+// AlphabetPrestateProvider is a stateless [PrestateProvider] that
+// uses a pre-determined, fixed pre-state hash.
+type AlphabetPrestateProvider struct{}
+
+func (ap *AlphabetPrestateProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	hash := common.BytesToHash(crypto.Keccak256(absolutePrestate))
+	hash[0] = mipsevm.VMStatusUnfinished
+	return hash, nil
+}

--- a/op-challenger/game/fault/trace/alphabet/prestate_test.go
+++ b/op-challenger/game/fault/trace/alphabet/prestate_test.go
@@ -1,0 +1,17 @@
+package alphabet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlphabetPrestateProvider_AbsolutePreStateCommitment_Succeeds(t *testing.T) {
+	provider := AlphabetPrestateProvider{}
+	hash, err := provider.AbsolutePreStateCommitment(context.Background())
+	require.NoError(t, err)
+	expected := common.HexToHash("0x03c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98")
+	require.Equal(t, expected, hash)
+}

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -15,12 +15,12 @@ import (
 
 var (
 	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
-	absolutePrestate = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
 )
 
 // AlphabetTraceProvider is a [TraceProvider] that provides claims for specific
 // indices in the given trace.
 type AlphabetTraceProvider struct {
+	AlphabetPrestateProvider
 	state  []string
 	depth  uint64
 	maxLen uint64
@@ -66,12 +66,6 @@ func (ap *AlphabetTraceProvider) Get(ctx context.Context, i types.Position) (com
 		return common.Hash{}, err
 	}
 	return alphabetStateHash(claimBytes), nil
-}
-
-func (ap *AlphabetTraceProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
-	hash := common.BytesToHash(crypto.Keccak256(absolutePrestate))
-	hash[0] = mipsevm.VMStatusUnfinished
-	return hash, nil
 }
 
 // BuildAlphabetPreimage constructs the claim bytes for the index and state item.

--- a/op-challenger/game/fault/trace/cannon/prestate.go
+++ b/op-challenger/game/fault/trace/cannon/prestate.go
@@ -1,0 +1,44 @@
+package cannon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum-optimism/optimism/op-challenger/config"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+)
+
+var _ types.PrestateProvider = (*CannonPrestateProvider)(nil)
+
+type CannonPrestateProvider struct {
+	prestate string
+}
+
+func NewPrestateProvider(cfg *config.Config) *CannonPrestateProvider {
+	return &CannonPrestateProvider{
+		prestate: cfg.CannonAbsolutePreState,
+	}
+}
+
+func (p *CannonPrestateProvider) absolutePreState() ([]byte, error) {
+	state, err := parseState(p.prestate)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load absolute pre-state: %w", err)
+	}
+	return state.EncodeWitness(), nil
+}
+
+func (p *CannonPrestateProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	state, err := p.absolutePreState()
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("cannot load absolute pre-state: %w", err)
+	}
+	hash, err := mipsevm.StateWitness(state).StateHash()
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("cannot hash absolute pre-state: %w", err)
+	}
+	return hash, nil
+}

--- a/op-challenger/game/fault/trace/cannon/prestate_test.go
+++ b/op-challenger/game/fault/trace/cannon/prestate_test.go
@@ -1,0 +1,70 @@
+package cannon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func newCannonPrestateProvider(dataDir string, prestate string) *CannonPrestateProvider {
+	return &CannonPrestateProvider{
+		prestate: filepath.Join(dataDir, prestate),
+	}
+}
+
+func TestAbsolutePreStateCommitment(t *testing.T) {
+	dataDir := t.TempDir()
+
+	prestate := "state.json"
+
+	t.Run("StateUnavailable", func(t *testing.T) {
+		provider := newCannonPrestateProvider("/dir/does/not/exist", prestate)
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("InvalidStateFile", func(t *testing.T) {
+		setupPreState(t, dataDir, "invalid.json")
+		provider := newCannonPrestateProvider(dataDir, prestate)
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorContains(t, err, "invalid mipsevm state")
+	})
+
+	t.Run("ExpectedAbsolutePreState", func(t *testing.T) {
+		setupPreState(t, dataDir, "state.json")
+		provider := newCannonPrestateProvider(dataDir, prestate)
+		actual, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.NoError(t, err)
+		state := mipsevm.State{
+			Memory:         mipsevm.NewMemory(),
+			PreimageKey:    common.HexToHash("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+			PreimageOffset: 0,
+			PC:             0,
+			NextPC:         1,
+			LO:             0,
+			HI:             0,
+			Heap:           0,
+			ExitCode:       0,
+			Exited:         false,
+			Step:           0,
+			Registers:      [32]uint32{},
+		}
+		expected, err := state.EncodeWitness().StateHash()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
+func setupPreState(t *testing.T, dataDir string, filename string) {
+	srcDir := filepath.Join("test_data")
+	path := filepath.Join(srcDir, filename)
+	file, err := testData.ReadFile(path)
+	require.NoErrorf(t, err, "reading %v", path)
+	err = os.WriteFile(filepath.Join(dataDir, "state.json"), file, 0o644)
+	require.NoErrorf(t, err, "writing %v", path)
+}

--- a/op-challenger/game/fault/trace/cannon/provider_test.go
+++ b/op-challenger/game/fault/trace/cannon/provider_test.go
@@ -216,58 +216,6 @@ func TestGetStepData(t *testing.T) {
 	})
 }
 
-func TestAbsolutePreStateCommitment(t *testing.T) {
-	dataDir := t.TempDir()
-
-	prestate := "state.json"
-
-	t.Run("StateUnavailable", func(t *testing.T) {
-		provider, _ := setupWithTestData(t, "/dir/does/not/exist", prestate)
-		_, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.ErrorIs(t, err, os.ErrNotExist)
-	})
-
-	t.Run("InvalidStateFile", func(t *testing.T) {
-		setupPreState(t, dataDir, "invalid.json")
-		provider, _ := setupWithTestData(t, dataDir, prestate)
-		_, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.ErrorContains(t, err, "invalid mipsevm state")
-	})
-
-	t.Run("ExpectedAbsolutePreState", func(t *testing.T) {
-		setupPreState(t, dataDir, "state.json")
-		provider, _ := setupWithTestData(t, dataDir, prestate)
-		actual, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.NoError(t, err)
-		state := mipsevm.State{
-			Memory:         mipsevm.NewMemory(),
-			PreimageKey:    common.HexToHash("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-			PreimageOffset: 0,
-			PC:             0,
-			NextPC:         1,
-			LO:             0,
-			HI:             0,
-			Heap:           0,
-			ExitCode:       0,
-			Exited:         false,
-			Step:           0,
-			Registers:      [32]uint32{},
-		}
-		expected, err := state.EncodeWitness().StateHash()
-		require.NoError(t, err)
-		require.Equal(t, expected, actual)
-	})
-}
-
-func setupPreState(t *testing.T, dataDir string, filename string) {
-	srcDir := filepath.Join("test_data")
-	path := filepath.Join(srcDir, filename)
-	file, err := testData.ReadFile(path)
-	require.NoErrorf(t, err, "reading %v", path)
-	err = os.WriteFile(filepath.Join(dataDir, "state.json"), file, 0o644)
-	require.NoErrorf(t, err, "writing %v", path)
-}
-
 func setupTestData(t *testing.T) (string, string) {
 	srcDir := filepath.Join("test_data", "proofs")
 	entries, err := testData.ReadDir(srcDir)

--- a/op-challenger/game/fault/trace/outputs/prestate.go
+++ b/op-challenger/game/fault/trace/outputs/prestate.go
@@ -1,0 +1,37 @@
+package outputs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var _ types.PrestateProvider = (*OutputPrestateProvider)(nil)
+
+type OutputPrestateProvider struct {
+	prestateBlock uint64
+	rollupClient  OutputRollupClient
+}
+
+func NewPrestateProvider(ctx context.Context, logger log.Logger, rollupClient OutputRollupClient, prestateBlock uint64) *OutputPrestateProvider {
+	return &OutputPrestateProvider{
+		prestateBlock: prestateBlock,
+		rollupClient:  rollupClient,
+	}
+}
+
+func (o *OutputPrestateProvider) AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error) {
+	return o.outputAtBlock(ctx, o.prestateBlock)
+}
+
+func (o *OutputPrestateProvider) outputAtBlock(ctx context.Context, block uint64) (common.Hash, error) {
+	output, err := o.rollupClient.OutputAtBlock(ctx, block)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to fetch output at block %v: %w", block, err)
+	}
+	return common.Hash(output.OutputRoot), nil
+}

--- a/op-challenger/game/fault/trace/outputs/prestate_test.go
+++ b/op-challenger/game/fault/trace/outputs/prestate_test.go
@@ -1,0 +1,47 @@
+package outputs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+func newOutputPrestateProvider(t *testing.T, prestateBlock uint64) (*OutputPrestateProvider, *stubRollupClient) {
+	rollupClient := stubRollupClient{
+		outputs: map[uint64]*eth.OutputResponse{
+			prestateBlock: {
+				OutputRoot: eth.Bytes32(prestateOutputRoot),
+			},
+			101: {
+				OutputRoot: eth.Bytes32(firstOutputRoot),
+			},
+			poststateBlock: {
+				OutputRoot: eth.Bytes32(poststateOutputRoot),
+			},
+		},
+	}
+	return &OutputPrestateProvider{
+		rollupClient:  &rollupClient,
+		prestateBlock: prestateBlock,
+	}, &rollupClient
+}
+
+func TestAbsolutePreStateCommitment(t *testing.T) {
+	var prestateBlock = uint64(100)
+
+	t.Run("FailedToFetchOutput", func(t *testing.T) {
+		provider, rollupClient := newOutputPrestateProvider(t, prestateBlock)
+		rollupClient.errorsOnPrestateFetch = true
+		_, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.ErrorIs(t, err, errNoOutputAtBlock)
+	})
+
+	t.Run("ReturnsCorrectPrestateOutput", func(t *testing.T) {
+		provider, _ := newOutputPrestateProvider(t, prestateBlock)
+		value, err := provider.AbsolutePreStateCommitment(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, value, prestateOutputRoot)
+	})
+}

--- a/op-challenger/game/fault/trace/outputs/provider_test.go
+++ b/op-challenger/game/fault/trace/outputs/provider_test.go
@@ -96,22 +96,6 @@ func TestGetBlockNumber(t *testing.T) {
 	})
 }
 
-func TestAbsolutePreStateCommitment(t *testing.T) {
-	t.Run("FailedToFetchOutput", func(t *testing.T) {
-		provider, rollupClient := setupWithTestData(t, prestateBlock, poststateBlock)
-		rollupClient.errorsOnPrestateFetch = true
-		_, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.ErrorIs(t, err, errNoOutputAtBlock)
-	})
-
-	t.Run("ReturnsCorrectPrestateOutput", func(t *testing.T) {
-		provider, _ := setupWithTestData(t, prestateBlock, poststateBlock)
-		value, err := provider.AbsolutePreStateCommitment(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, value, prestateOutputRoot)
-	})
-}
-
 func TestGetStepData(t *testing.T) {
 	provider, _ := setupWithTestData(t, prestateBlock, poststateBlock)
 	_, _, _, err := provider.GetStepData(context.Background(), types.NewPosition(1, common.Big0))

--- a/op-challenger/game/fault/trace/outputs/split_adapter_test.go
+++ b/op-challenger/game/fault/trace/outputs/split_adapter_test.go
@@ -131,7 +131,10 @@ func setupAdapterTest(t *testing.T, topDepth int) (split.ProviderCreator, *captu
 			},
 		},
 	}
-	topProvider := NewTraceProviderFromInputs(testlog.Logger(t, log.LvlInfo), rollupClient, uint64(topDepth), prestateBlock, poststateBlock)
+	prestateProvider := &stubPrestateProvider{
+		absolutePrestate: prestateOutputRoot,
+	}
+	topProvider := NewTraceProviderFromInputs(testlog.Logger(t, log.LvlInfo), prestateProvider, rollupClient, uint64(topDepth), prestateBlock, poststateBlock)
 	adapter := OutputRootSplitAdapter(topProvider, creator.Create)
 	return adapter, creator
 }
@@ -205,4 +208,16 @@ func TestCreateLocalContext(t *testing.T) {
 			require.Equal(t, crypto.Keccak256Hash(test.expected), localContext)
 		})
 	}
+}
+
+type stubPrestateProvider struct {
+	errorsOnAbsolutePrestateFetch bool
+	absolutePrestate              common.Hash
+}
+
+func (s *stubPrestateProvider) AbsolutePreStateCommitment(_ context.Context) (common.Hash, error) {
+	if s.errorsOnAbsolutePrestateFetch {
+		return common.Hash{}, errNoOutputAtBlock
+	}
+	return s.absolutePrestate, nil
 }

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -67,8 +67,16 @@ type TraceAccessor interface {
 	GetStepData(ctx context.Context, game Game, ref Claim, pos Position) (prestate []byte, proofData []byte, preimageData *PreimageOracleData, err error)
 }
 
+// PrestateProvider defines an interface to request the absolute prestate.
+type PrestateProvider interface {
+	// AbsolutePreStateCommitment is the commitment of the pre-image value of the trace that transitions to the trace value at index 0
+	AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error)
+}
+
 // TraceProvider is a generic way to get a claim value at a specific step in the trace.
 type TraceProvider interface {
+	PrestateProvider
+
 	// Get returns the claim value at the requested index.
 	// Get(i) = Keccak256(GetPreimage(i))
 	Get(ctx context.Context, i Position) (common.Hash, error)
@@ -78,9 +86,6 @@ type TraceProvider interface {
 	// and any pre-image data that needs to be loaded into the oracle prior to execution (may be nil)
 	// The prestate returned from GetStepData for trace 10 should be the pre-image of the claim from trace 9
 	GetStepData(ctx context.Context, i Position) (prestate []byte, proofData []byte, preimageData *PreimageOracleData, err error)
-
-	// AbsolutePreStateCommitment is the commitment of the pre-image value of the trace that transitions to the trace value at index 0
-	AbsolutePreStateCommitment(ctx context.Context) (hash common.Hash, err error)
 }
 
 // ClaimData is the core of a claim. It must be unique inside a specific game.

--- a/op-e2e/e2eutils/disputegame/helper.go
+++ b/op-e2e/e2eutils/disputegame/helper.go
@@ -183,7 +183,8 @@ func (h *FactoryHelper) StartOutputCannonGame(ctx context.Context, l2Node string
 	h.require.NoError(err, "Failed to load l2 block number")
 	splitDepth, err := game.SPLITDEPTH(&bind.CallOpts{Context: ctx})
 	h.require.NoError(err, "Failed to load split depth")
-	provider := outputs.NewTraceProviderFromInputs(logger, rollupClient, splitDepth.Uint64(), prestateBlock.Uint64(), poststateBlock.Uint64())
+	prestateProvider := outputs.NewPrestateProvider(ctx, logger, rollupClient, prestateBlock.Uint64())
+	provider := outputs.NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, splitDepth.Uint64(), prestateBlock.Uint64(), poststateBlock.Uint64())
 
 	return &OutputCannonGameHelper{
 		OutputGameHelper: OutputGameHelper{
@@ -231,7 +232,8 @@ func (h *FactoryHelper) StartOutputAlphabetGame(ctx context.Context, l2Node stri
 	h.require.NoError(err, "Failed to load l2 block number")
 	splitDepth, err := game.SPLITDEPTH(&bind.CallOpts{Context: ctx})
 	h.require.NoError(err, "Failed to load split depth")
-	provider := outputs.NewTraceProviderFromInputs(logger, rollupClient, splitDepth.Uint64(), prestateBlock.Uint64(), poststateBlock.Uint64())
+	prestateProvider := outputs.NewPrestateProvider(ctx, logger, rollupClient, prestateBlock.Uint64())
+	provider := outputs.NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, splitDepth.Uint64(), prestateBlock.Uint64(), poststateBlock.Uint64())
 
 	return &OutputAlphabetGameHelper{
 		OutputGameHelper: OutputGameHelper{


### PR DESCRIPTION
**Description**

Refactors the absolute prestate commitment functionality of the trace provider into its own interface called the `PrestateProvider`.

This will allow for more lightweight prestate validation since higher-up components will not need to instantiate the full trace provider to validate the absolute prestate.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/323
