### PR TITLE
Fix typos in README.md

### DIFF
--- a/op-e2e/external_geth/README.md
+++ b/op-e2e/external_geth/README.md
@@ -29,7 +29,7 @@ the binary to be rebuilt before executing the tests.
 ## Arguments
 
 *--config <path>* The config path is a required argument, it points to a JSON
-file which contains details of the L2 environment to bring up (including the
+file that contains details of the L2 environment to bring up (including the
 `genesis.json` path, the chain ID, the JWT path, and a ready file path).  See
 the data structures in `op-e2e/external/config.go` for more details.
 
@@ -53,7 +53,7 @@ details.
 
 ## Generalization
 
-This shim is included to help document an demonstrate the usage of the
+This shim is included to help document and demonstrate the usage of the
 external ethereum process e2e test execution.  It is configured to execute in
 CI to help ensure that the tests remain compatible with external clients.
 

--- a/op-e2e/external_geth/README.md
+++ b/op-e2e/external_geth/README.md
@@ -53,7 +53,7 @@ details.
 
 ## Generalization
 
-This shim is included to help document and demonstrate the usage of the
+This shim is included to help document and demonstrates the usage of the
 external ethereum process e2e test execution.  It is configured to execute in
 CI to help ensure that the tests remain compatible with external clients.
 


### PR DESCRIPTION
Fixed a typo and recommend a change for better clarity:

1-Original: file which contains details of the L2 environment to bring up (including the
Suggested: file that contains details of the L2 environment to bring up (including the (I changed "which" to "that" for better flow)

2-Original: is included to help document an demonstrate the usage of the
Suggested: is included to help document and demonstrate the usage of the (I fixed a small typo, change "an" to "and")

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A clear and concise description of the features you're adding in this pull request.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
