### PR TITLE
contracts-bedrock: fix pgn sepolia config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/pgn-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/pgn-sepolia.json
@@ -34,5 +34,12 @@
   "l2OutputOracleChallenger": "0x69F0FFc19504B57e9AE4B6D7694d028c3CD876F8",
   "baseFeeVaultWithdrawalNetwork": 0,
   "l1FeeVaultWithdrawalNetwork": 0,
-  "sequencerFeeVaultWithdrawalNetwork": 0
+  "sequencerFeeVaultWithdrawalNetwork": 0,
+  "l2OutputOracleStartingBlockNumber": 0,
+  "baseFeeVaultMinimumWithdrawalAmount": "0x8ac7230489e80000",
+  "l1FeeVaultMinimumWithdrawalAmount": "0x8ac7230489e80000",
+  "sequencerFeeVaultMinimumWithdrawalAmount": "0x8ac7230489e80000",
+  "systemConfigStartBlock": 0,
+  "requiredProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000001",
+  "recommendedProtocolVersion": "0x0000000000000000000000000000000000000003000000010000000000000001"
 }


### PR DESCRIPTION
**Description**

Updates the deploy config for pgn sepolia to
be conformant to the deploy config spec. Not sure why
CI is passing as the go code is supposed to check for
non compliant deploy config. It is likely because the solidity
and the go got out of sync. We could use a rethinking of how
we do deploy config. Ideally the entire thing can be simplified
now that deploy config contains op stack chain specific config,
superchain target specific config and also config values that
go into L1 and also config values that go into L2.

This change wouldn't be necessary if the lazy deploy config change
https://github.com/ethereum-optimism/optimism/issues/7711 was
implemented. It was attempted https://github.com/ethereum-optimism/optimism/pull/7776
but became stale and added a lot of overhead.

Used to deploy the `L2OutputOracle` here:
https://sepolia.etherscan.io/address/0xfae8e4695a0c96ea7ce20e1ed8d401604964315a

Using the following command:

```bash
#!/bin/bash

export IMPL_SALT="op/acc"
export DEPLOYMENT_CONTEXT=pgn-sepolia

forge script scripts/Deploy.s.sol:Deploy \
  --sig 'deployL2OutputOracle()' --rpc-url $ETH_RPC_URL \
  --private-key $PRIVATE_KEY \
  --broadcast \
  --verify
```

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

