### PR TITLE
feat(op-challenger): Coordinator Prestate Validation

### DIFF
--- a/op-challenger/game/scheduler/coordinator.go
+++ b/op-challenger/game/scheduler/coordinator.go
@@ -63,7 +63,7 @@ func (c *coordinator) schedule(ctx context.Context, games []types.GameMetadata) 
 	// Otherwise, results may start being processed before all games are recorded, resulting in existing
 	// data directories potentially being deleted for games that are required.
 	for _, game := range games {
-		if j, err := c.createJob(game); err != nil {
+		if j, err := c.createJob(ctx, game); err != nil {
 			errs = append(errs, fmt.Errorf("failed to create job for game %v: %w", game.Proxy, err))
 		} else if j != nil {
 			jobs = append(jobs, *j)
@@ -96,7 +96,7 @@ func (c *coordinator) schedule(ctx context.Context, games []types.GameMetadata) 
 
 // createJob updates the state for the specified game and returns the job to enqueue for it, if any
 // Returns (nil, nil) when there is no error and no job to enqueue
-func (c *coordinator) createJob(game types.GameMetadata) (*job, error) {
+func (c *coordinator) createJob(ctx context.Context, game types.GameMetadata) (*job, error) {
 	state, ok := c.states[game.Proxy]
 	if !ok {
 		state = &gameState{}
@@ -112,7 +112,9 @@ func (c *coordinator) createJob(game types.GameMetadata) (*job, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create game player: %w", err)
 		}
-		// TODO(client-pod#325): Update coordinator to call the game player's ValidatePrestate method
+		if err := player.ValidatePrestate(ctx); err != nil {
+			return nil, fmt.Errorf("failed to validate prestate: %w", err)
+		}
 		state.player = player
 		state.status = player.Status()
 	}

--- a/op-challenger/game/scheduler/test/stub_player.go
+++ b/op-challenger/game/scheduler/test/stub_player.go
@@ -12,6 +12,11 @@ type StubGamePlayer struct {
 	ProgressCount int
 	StatusValue   types.GameStatus
 	Dir           string
+	PrestateErr   error
+}
+
+func (g *StubGamePlayer) ValidatePrestate(_ context.Context) error {
+	return g.PrestateErr
 }
 
 func (g *StubGamePlayer) ProgressGame(_ context.Context) types.GameStatus {

--- a/op-challenger/game/scheduler/types.go
+++ b/op-challenger/game/scheduler/types.go
@@ -9,6 +9,7 @@ import (
 )
 
 type GamePlayer interface {
+	ValidatePrestate(ctx context.Context) error
 	ProgressGame(ctx context.Context) types.GameStatus
 	Status() types.GameStatus
 }


### PR DESCRIPTION
**Description**

Wires up the prestate validation into the coordinator by calling the game player's `ValidatePrestate` method on instantiation.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/325
