### PR TITLE
contracts-bedrock: update sepolia config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia.json
@@ -14,7 +14,7 @@
   "batchSenderAddress": "0x8F23BB38F531600e5d8FDDaAEC41F13FaB46E98c",
   "l2OutputOracleSubmissionInterval": 120,
   "l2OutputOracleStartingBlockNumber": 0,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 1690493568,
   "l2OutputOracleProposer": "0x49277EE36A024120Ee218127354c4a3591dc90A9",
   "l2OutputOracleChallenger": "0xfd1D2e729aE8eEe2E146c033bf4400fE75284301",
   "finalizationPeriodSeconds": 12,


### PR DESCRIPTION
**Description**

Updates the `l2OutputOracleStartingTimestamp` to a concrete value
rather than using `-1` which symbolizes "grab the latest L1 timestamp".
We often want to simplify the initial deployment but then do not want to
overwrite the value in storage when generating an upgrade transaction.
Right now `op-upgrade` uses the values in these config files. The code
enforces that it is not -1 to ensure that we do not write over the
value. The value really should be exactly the same. The state diff
tooling will be able to make assertions on this in the `superchain-ops`
post hook.

This commit simply updates the starting timestamp to the exact value
that was set on sepolia. The etherscan link can be found here:
https://sepolia.etherscan.io/address/0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F#readProxyContract

