### PR TITLE
contracts-bedrock: fix base sepolia config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/base-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/base-sepolia.json
@@ -18,7 +18,7 @@
 
   "l2OutputOracleSubmissionInterval": 120,
   "l2OutputOracleStartingBlockNumber": 0,
-  "l2OutputOracleStartingTimestamp": -1,
+  "l2OutputOracleStartingTimestamp": 1695767904,
 
   "l2OutputOracleProposer": "0x20044a0d104E9e788A0C984A2B7eAe615afD046b",
   "l2OutputOracleChallenger": "0xDa3037Ff70Ac92CD867c683BD807e5A484857405",


### PR DESCRIPTION
**Description**

Makes the L1 starting blocknumber concrete.
See commit message in https://github.com/ethereum-optimism/optimism/pull/8515
for an explanation.

The value in the config comes from here:
https://sepolia.etherscan.io/address/0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254#readProxyContract

The contract address sourced from here:
https://github.com/base-org/contract-deployments/blob/910151eb2eed3542efbb4ccf7e38d1ed3b79d8f5/sepolia/2023-09-26-deploy/deployed/addresses.json#L10C27-L10C69

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
