### PR TITLE
contracts-bedrock: update base sepolia l1StartingBlockTag

### DIFF
--- a/packages/contracts-bedrock/deploy-config/base-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/base-sepolia.json
@@ -1,7 +1,7 @@
 {
   "finalSystemOwner": "0x608081689Fe46936fB2fBDF7552CbB1D80ad4822",
 
-  "l1StartingBlockTag": "safe",
+  "l1StartingBlockTag": "0x85b50d136c509037b2256180c9f911ac5bf9c39b057f94981c9c611efb0fcf02",
 
   "l1ChainID": 11155111,
   "l2ChainID": 84532,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Update base sepolia deploy config l1StartingBlockTag from safe to 0x85b50d136c509037b2256180c9f911ac5bf9c39b057f94981c9c611efb0fcf02 to match with l2OutputOracleStartingTimestamp 1695767904

**Additional context**

Etherscan link for block: https://sepolia.etherscan.io/block/4370837

**Metadata**

- Additional Fix for #8519
