### PR TITLE
contracts-bedrock: Add "eip1559DenominatorCanyon" to testnet's deploy config

### DIFF
--- a/packages/contracts-bedrock/deploy-config/base-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/base-sepolia.json
@@ -48,6 +48,7 @@
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
 
   "eip1559Denominator": 50,
+  "eip1559DenominatorCanyon": 250,
   "eip1559Elasticity": 10,
 
   "l2GenesisRegolithTimeOffset": "0x0",

--- a/packages/contracts-bedrock/deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia.json
@@ -37,6 +37,7 @@
   "l2GenesisBlockGasLimit": "0x1c9c380",
   "l2GenesisBlockBaseFeePerGas": "0x3b9aca00",
   "eip1559Denominator": 50,
+  "eip1559DenominatorCanyon": 250,
   "eip1559Elasticity": 6,
   "l2GenesisRegolithTimeOffset": "0x0",
   "systemConfigStartBlock": 0,

--- a/packages/contracts-bedrock/deploy-config/zora-sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/zora-sepolia.json
@@ -37,6 +37,7 @@
   "gasPriceOracleOverhead": 188,
   "gasPriceOracleScalar": 684000,
   "eip1559Denominator": 50,
+  "eip1559DenominatorCanyon": 250,
   "eip1559Elasticity": 6,
   "proxyAdminOwner": "0x45eFFbD799Ab49122eeEAB75B78D9C56A187F9A7",
   "baseFeeVaultRecipient": "0xba6fAD507A432402C64444Ed201025e060b34faB",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This pull request add `"eip1559DenominatorCanyon": 250` to testnets deploy config where eip1559Denominator is 50 and eip1559Elasticity is 10

There are chains that use different eip1559Denominator and eip1559Elasticity which remain secret which eip1559DenominatorCanyon should be used for those chains
