### PR TITLE
feat(op-challenger): Alphabet Trace Provider Local Context Loading

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -58,7 +58,7 @@ func (f *FaultDisputeGameContract) addLocalDataTx(data *types.PreimageOracleData
 	call := f.contract.Call(
 		methodAddLocalData,
 		data.GetIdent(),
-		data.LocalContext,
+		types.NoLocalContext,
 		new(big.Int).SetUint64(uint64(data.OracleOffset)),
 	)
 	return call.ToTxCandidate()

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -60,7 +60,6 @@ func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 		stubRpc, game := setupFaultDisputeGameTest(t)
 		data := &faultTypes.PreimageOracleData{
 			IsLocal:      true,
-			LocalContext: common.Hash{0x02},
 			OracleKey:    common.Hash{0xbc}.Bytes(),
 			OracleData:   []byte{1, 2, 3, 4, 5, 6, 7},
 			OracleOffset: 16,
@@ -68,7 +67,7 @@ func TestFaultDisputeGame_UpdateOracleTx(t *testing.T) {
 		claimIdx := uint64(6)
 		stubRpc.SetResponse(fdgAddr, methodAddLocalData, batching.BlockLatest, []interface{}{
 			data.GetIdent(),
-			data.LocalContext,
+			faultTypes.NoLocalContext,
 			new(big.Int).SetUint64(uint64(data.OracleOffset)),
 		}, nil)
 		tx, err := game.UpdateOracleTx(context.Background(), claimIdx, data)

--- a/op-challenger/game/fault/contracts/outputbisectiongame_test.go
+++ b/op-challenger/game/fault/contracts/outputbisectiongame_test.go
@@ -55,7 +55,6 @@ func TestOutputBisectionGame_UpdateOracleTx(t *testing.T) {
 		stubRpc, game := setupOutputBisectionGameTest(t)
 		data := &faultTypes.PreimageOracleData{
 			IsLocal:      true,
-			LocalContext: common.Hash{0x02},
 			OracleKey:    common.Hash{0xbc}.Bytes(),
 			OracleData:   []byte{1, 2, 3, 4, 5, 6, 7},
 			OracleOffset: 16,

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -179,8 +179,7 @@ func TestPerformAction(t *testing.T) {
 			PreState:  []byte{1, 2, 3},
 			ProofData: []byte{4, 5, 6},
 			OracleData: &types.PreimageOracleData{
-				IsLocal:      true,
-				LocalContext: common.Hash{0x06},
+				IsLocal: true,
 			},
 		}
 		err := responder.PerformAction(context.Background(), action)

--- a/op-challenger/game/fault/test/alphabet.go
+++ b/op-challenger/game/fault/test/alphabet.go
@@ -33,6 +33,6 @@ func (a *alphabetWithProofProvider) GetStepData(ctx context.Context, i types.Pos
 		return nil, nil, nil, err
 	}
 	traceIndex := i.TraceIndex(int(a.depth)).Uint64()
-	data := types.NewPreimageOracleData(types.NoLocalContext, []byte{byte(traceIndex)}, []byte{byte(traceIndex - 1)}, uint32(traceIndex-1))
+	data := types.NewPreimageOracleData([]byte{byte(traceIndex)}, []byte{byte(traceIndex - 1)}, uint32(traceIndex-1))
 	return preimage, []byte{byte(traceIndex - 1)}, data, nil
 }

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -16,6 +16,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+const (
+	L2ClaimBlockNumberLocalIndex = 4
+)
+
 var (
 	ErrIndexTooLarge = errors.New("index is larger than the maximum index")
 )
@@ -53,12 +57,9 @@ func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, i types.Positi
 	if traceIndex.Cmp(big.NewInt(int64(len(ap.state)))) >= 0 {
 		return ap.GetStepData(ctx, types.NewPosition(int(ap.depth), big.NewInt(int64(len(ap.state)))))
 	}
-	key := preimage.LocalIndexKey(4).PreimageKey()
-	// For alphabet output bisection, the state is the local context - that is, the
-	// pre-state l2 block number. So we can just use [ap.state] as the localContext.
-	localContext := common.HexToHash(strings.Join(ap.state, ""))
-	localContextData := types.NewPreimageOracleData(localContext, key[:], nil, 0)
-	return BuildAlphabetPreimage(traceIndex, ap.state[traceIndex.Uint64()]), []byte{}, localContextData, nil
+	key := preimage.LocalIndexKey(L2ClaimBlockNumberLocalIndex).PreimageKey()
+	preimageData := types.NewPreimageOracleData(key[:], nil, 0)
+	return BuildAlphabetPreimage(traceIndex, ap.state[traceIndex.Uint64()]), []byte{}, preimageData, nil
 }
 
 // Get returns the claim value at the given index in the trace.

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -61,9 +61,8 @@ func TestGetStepData_Succeeds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, retrieved)
 	require.Empty(t, proof)
-	localContext := common.HexToHash("abc")
-	key := preimage.LocalIndexKey(4).PreimageKey()
-	expectedLocalContextData := types.NewPreimageOracleData(localContext, key[:], nil, 0)
+	key := preimage.LocalIndexKey(L2ClaimBlockNumberLocalIndex).PreimageKey()
+	expectedLocalContextData := types.NewPreimageOracleData(key[:], nil, 0)
 	require.Equal(t, expectedLocalContextData, data)
 }
 

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -5,7 +5,10 @@ import (
 	"math/big"
 	"testing"
 
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -58,7 +61,10 @@ func TestGetStepData_Succeeds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, retrieved)
 	require.Empty(t, proof)
-	require.Nil(t, data)
+	localContext := common.HexToHash("abc")
+	key := preimage.LocalIndexKey(4).PreimageKey()
+	expectedLocalContextData := types.NewPreimageOracleData(localContext, key[:], nil, 0)
+	require.Equal(t, expectedLocalContextData, data)
 }
 
 // TestGetPreimage_TooLargeIndex_Fails tests the GetPreimage

--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -105,7 +105,7 @@ func (p *CannonTraceProvider) GetStepData(ctx context.Context, pos types.Positio
 	}
 	var oracleData *types.PreimageOracleData
 	if len(proof.OracleKey) > 0 {
-		oracleData = types.NewPreimageOracleData(p.localContext, proof.OracleKey, proof.OracleValue, proof.OracleOffset)
+		oracleData = types.NewPreimageOracleData(proof.OracleKey, proof.OracleValue, proof.OracleOffset)
 	}
 	return value, data, oracleData, nil
 }

--- a/op-challenger/game/fault/trace/cannon/provider_test.go
+++ b/op-challenger/game/fault/trace/cannon/provider_test.go
@@ -124,7 +124,7 @@ func TestGetStepData(t *testing.T) {
 
 		require.EqualValues(t, generator.proof.StateData, preimage)
 		require.EqualValues(t, generator.proof.ProofData, proof)
-		expectedData := types.NewPreimageOracleData(common.Hash{}, generator.proof.OracleKey, generator.proof.OracleValue, generator.proof.OracleOffset)
+		expectedData := types.NewPreimageOracleData(generator.proof.OracleKey, generator.proof.OracleValue, generator.proof.OracleOffset)
 		require.EqualValues(t, expectedData, data)
 	})
 

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -20,7 +20,6 @@ var (
 // to load into the onchain oracle.
 type PreimageOracleData struct {
 	IsLocal      bool
-	LocalContext common.Hash
 	OracleKey    []byte
 	OracleData   []byte
 	OracleOffset uint32
@@ -37,10 +36,9 @@ func (p *PreimageOracleData) GetPreimageWithoutSize() []byte {
 }
 
 // NewPreimageOracleData creates a new [PreimageOracleData] instance.
-func NewPreimageOracleData(lctx common.Hash, key []byte, data []byte, offset uint32) *PreimageOracleData {
+func NewPreimageOracleData(key []byte, data []byte, offset uint32) *PreimageOracleData {
 	return &PreimageOracleData{
 		IsLocal:      len(key) > 0 && key[0] == byte(1),
-		LocalContext: lctx,
 		OracleKey:    key,
 		OracleData:   data,
 		OracleOffset: offset,

--- a/op-challenger/game/fault/types/types_test.go
+++ b/op-challenger/game/fault/types/types_test.go
@@ -4,24 +4,21 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewPreimageOracleData(t *testing.T) {
 	t.Run("LocalData", func(t *testing.T) {
-		data := NewPreimageOracleData(common.Hash{0x01}, []byte{1, 2, 3}, []byte{4, 5, 6}, 7)
+		data := NewPreimageOracleData([]byte{1, 2, 3}, []byte{4, 5, 6}, 7)
 		require.True(t, data.IsLocal)
-		require.Equal(t, common.Hash{0x01}, data.LocalContext)
 		require.Equal(t, []byte{1, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
 		require.Equal(t, uint32(7), data.OracleOffset)
 	})
 
 	t.Run("GlobalData", func(t *testing.T) {
-		data := NewPreimageOracleData(common.Hash{0x01}, []byte{0, 2, 3}, []byte{4, 5, 6}, 7)
+		data := NewPreimageOracleData([]byte{0, 2, 3}, []byte{4, 5, 6}, 7)
 		require.False(t, data.IsLocal)
-		require.Equal(t, common.Hash{0x01}, data.LocalContext)
 		require.Equal(t, []byte{0, 2, 3}, data.OracleKey)
 		require.Equal(t, []byte{4, 5, 6}, data.OracleData)
 		require.Equal(t, uint32(7), data.OracleOffset)


### PR DESCRIPTION
**Description**

Loads local context into the preimage oracle by adding non-nil `PreimageOracleData` from the alphabet trace provider's
`GetStepData` method. Since the bare alphabet fault dispute game doesn't use the preimage oracle, it doesn't affect the
alphabet game to load this data into the preimage oracle. For the alphabet output bisection game, we want to load in the
local context which is the l2 block number supplied to the alphabet trace provider as the local context.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/328
