### PR TITLE
op-e2e: Ignore i/o timeouts in receipts fetching

### DIFF
--- a/op-e2e/e2eutils/wait/waits.go
+++ b/op-e2e/e2eutils/wait/waits.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -52,6 +53,9 @@ func ForReceipt(ctx context.Context, client *ethclient.Client, hash common.Hash,
 			case <-ticker.C:
 				continue
 			}
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			continue
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to get receipt: %w", err)


### PR DESCRIPTION
Ignore i/o timeouts when fetching receipts. This is causing spurious failures in the indexer tests. We already have a 2 minute timeout within this method via an internal context, so there is no value in erroring out on what could (potentially) be an unrelated network failure.

If there is some other underlying error in the indexer tests, we'll be able to see that because the tests will fail with `context deadline exceeded`.
