### PR TITLE
make shadow compressor the default compressor type

### DIFF
--- a/op-batcher/compressor/cli.go
+++ b/op-batcher/compressor/cli.go
@@ -38,7 +38,7 @@ func CLIFlags(envPrefix string) []cli.Flag {
 			Name:    KindFlagName,
 			Usage:   "The type of compressor. Valid options: " + strings.Join(KindKeys, ", "),
 			EnvVars: opservice.PrefixEnvVar(envPrefix, "COMPRESSOR"),
-			Value:   RatioKind,
+			Value:   ShadowKind,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The shadow compressor better utilizes transaction space and should be used in almost all cases, so this PR makes it the default if no specific compressor is specified.

