### PR TITLE
op-challenger: Add skipped test to confirm VM status issues.

### DIFF
--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -19,7 +19,7 @@ func TestOutputAlphabetGame(t *testing.T) {
 	t.Cleanup(sys.Close)
 
 	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", "abcdexyz")
+	game := disputeGameFactory.StartOutputAlphabetGame(ctx, "sequencer", 3, "abcdexyz")
 	game.LogGameData(ctx)
 
 	opts := challenger.WithPrivKey(sys.Cfg.Secrets.Alice)


### PR DESCRIPTION
**Description**

Adds e2e tests that demonstrate cases where the honest actor is unable to counter claims correctly due to the current VM status expectations.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/336
