### PR TITLE
ci: write e2e test logs to file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -856,11 +856,16 @@ jobs:
       - run:
           name: run tests
           command: |
+            mkdir -p /testlogs
+            
             export OP_E2E_CANNON_ENABLED="<<parameters.cannon_enabled>>"
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
-            JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>>
+            JUNIT_FILE=/tmp/test-results/<<parameters.module>>_<<parameters.target>>.xml make <<parameters.target>> 2>&1 | tee /testlogs/test.log
           working_directory: <<parameters.module>>
+      - store_artifacts:
+          path: /testlogs
+          when: always
       - store_test_results:
           path: /tmp/test-results
 


### PR DESCRIPTION
Write e2e test logs to file in addition to standard output in order to make debugging easier. CCI will truncate output over 50M.

Closes https://github.com/ethereum-optimism/client-pod/issues/319
