### PR TITLE
chore: fix op-service typo

### DIFF
--- a/op-bindings/foundry/artifact.go
+++ b/op-bindings/foundry/artifact.go
@@ -9,7 +9,7 @@ import (
 
 // Artifact represents a foundry compilation artifact.
 // The Abi is specifically left as a json.RawMessage because
-// round trip marshaling/unmarshaling of the abi.ABI type
+// round trip marshaling/unmarshalling of the abi.ABI type
 // causes issues.
 type Artifact struct {
 	Abi              json.RawMessage    `json:"abi"`

--- a/op-node/rollup/derive/frame.go
+++ b/op-node/rollup/derive/frame.go
@@ -108,7 +108,7 @@ func (f *Frame) UnmarshalBinary(r ByteReader) error {
 
 // eofAsUnexpectedMissing converts an io.EOF in the error chain of err into an
 // io.ErrUnexpectedEOF. It should be used to convert intermediate io.EOF errors
-// in unmarshaling code to achieve idiomatic error behavior.
+// in unmarshalling code to achieve idiomatic error behavior.
 // Other errors are passed through unchanged.
 func eofAsUnexpectedMissing(err error) error {
 	if errors.Is(err, io.EOF) {

--- a/op-service/cliapp/lifecycle_test.go
+++ b/op-service/cliapp/lifecycle_test.go
@@ -129,7 +129,7 @@ func TestLifecycleCmd(t *testing.T) {
 	})
 	t.Run("failed init", func(t *testing.T) {
 		_, initCh, _, _, resultCh, _ := appSetup(t)
-		v := errors.New("TEST INIT ERRROR")
+		v := errors.New("TEST INIT ERROR")
 		initCh <- v
 		res := <-resultCh
 		require.ErrorIs(t, res, v)

--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -180,7 +180,7 @@ func (payload *ExecutionPayload) MarshalSSZ(w io.Writer) (n int, err error) {
 	// dynamic value 2: Transactions
 	marshalTransactions(buf[offset:offset+transactionSize], payload.Transactions)
 	offset += transactionSize
-	// dyanmic value 3: Withdrawals
+	// dynamic value 3: Withdrawals
 	if payload.Withdrawals != nil {
 		marshalWithdrawals(buf[offset:], *payload.Withdrawals)
 	}

--- a/op-service/eth/ssz_test.go
+++ b/op-service/eth/ssz_test.go
@@ -190,7 +190,7 @@ func FuzzOBP01(f *testing.F) {
 	})
 }
 
-// TestOPB01 verifies that the SSZ unmarshaling code
+// TestOPB01 verifies that the SSZ unmarshalling code
 // properly checks for the transactionOffset being larger
 // than the extraDataOffset.
 func TestOPB01(t *testing.T) {

--- a/op-service/metrics/ref_metrics.go
+++ b/op-service/metrics/ref_metrics.go
@@ -34,7 +34,7 @@ type RefMetrics struct {
 var _ RefMetricer = (*RefMetrics)(nil)
 
 // MakeRefMetrics returns a new RefMetrics, initializing its prometheus fields
-// using factory. It is supposed to be used inside the construtors of metrics
+// using factory. It is supposed to be used inside the constructors of metrics
 // structs for any op service after the full namespace and factory have been
 // setup.
 //

--- a/op-service/txmgr/send_state_test.go
+++ b/op-service/txmgr/send_state_test.go
@@ -187,5 +187,5 @@ func TestSendStateTimeoutAbort(t *testing.T) {
 func TestSendStateNoTimeoutAbortIfPublishedTx(t *testing.T) {
 	sendState := newSendStateWithTimeout(10*time.Millisecond, stepClock(20*time.Millisecond))
 	sendState.ProcessSendError(nil)
-	require.False(t, sendState.ShouldAbortImmediately(), "Should not abort if published transcation successfully")
+	require.False(t, sendState.ShouldAbortImmediately(), "Should not abort if published transaction successfully")
 }

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -239,7 +239,7 @@ func (*mockBackend) ChainID(ctx context.Context) (*big.Int, error) {
 }
 
 // TransactionReceipt queries the mockBackend for a mined txHash. If none is
-// found, nil is returned for both return values. Otherwise, it retruns a
+// found, nil is returned for both return values. Otherwise, it returns a
 // receipt containing the txHash and the gasFeeCap used in the GasUsed to make
 // the value accessible from our test framework.
 func (b *mockBackend) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {

--- a/proxyd/rpc.go
+++ b/proxyd/rpc.go
@@ -110,7 +110,7 @@ func ParseRPCRes(r io.Reader) (*RPCRes, error) {
 
 	res := new(RPCRes)
 	if err := json.Unmarshal(body, res); err != nil {
-		return nil, wrapErr(err, "error unmarshaling RPC response")
+		return nil, wrapErr(err, "error unmarshalling RPC response")
 	}
 
 	return res, nil

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -677,7 +677,7 @@ func (s *Server) isGlobalLimit(method string) bool {
 func (s *Server) rateLimitSender(ctx context.Context, req *RPCReq) error {
 	var params []string
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		log.Debug("error unmarshaling raw transaction params", "err", err, "req_Id", GetReqID(ctx))
+		log.Debug("error unmarshalling raw transaction params", "err", err, "req_Id", GetReqID(ctx))
 		return ErrParseErr
 	}
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* retruns -> returns
* transcation -> transaction
* construtors -> constructors
* unmarshaling -> unmarshalling
* dyanmic -> dynamic
* ERRROR -> ERROR
