### PR TITLE
chore: Indexer typos fixed

### DIFF
--- a/indexer/api/api.go
+++ b/indexer/api/api.go
@@ -130,7 +130,7 @@ func (a *APIService) Addr() string {
 func (a *APIService) initDB(ctx context.Context, connector DBConnector) error {
 	db, err := connector.OpenDB(ctx, a.log)
 	if err != nil {
-		return fmt.Errorf("failed to connect to databse: %w", err)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	a.dbClose = db.Closer
 	a.bv = db.BridgeTransfers

--- a/indexer/api/config.go
+++ b/indexer/api/config.go
@@ -24,7 +24,7 @@ type DBConfigConnector struct {
 func (cfg *DBConfigConnector) OpenDB(ctx context.Context, log log.Logger) (*DB, error) {
 	db, err := database.NewDB(ctx, log, cfg.DBConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to databse: %w", err)
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 	return &DB{
 		BridgeTransfers: db.BridgeTransfers,

--- a/indexer/e2e_tests/bridge_messages_e2e_test.go
+++ b/indexer/e2e_tests/bridge_messages_e2e_test.go
@@ -66,7 +66,7 @@ func TestE2EBridgeL1CrossDomainMessenger(t *testing.T) {
 	require.Equal(t, aliceAddr, sentMessage.Tx.ToAddress)
 	require.ElementsMatch(t, calldata, sentMessage.Tx.Data)
 
-	// (2) Process RelayedMesssage on inclusion
+	// (2) Process RelayedMessage on inclusion
 	//   - We dont assert that `RelayedMessageEventGUID` is nil prior to inclusion since there isn't a
 	//   a straightforward way of pausing/resuming the processors at the right time. The codepath is the
 	//   same for L2->L1 messages which does check for this so we are still covered

--- a/indexer/etl/etl.go
+++ b/indexer/etl/etl.go
@@ -131,8 +131,8 @@ func (etl *ETL) processBatch(headers []types.Header) error {
 		batchLog.Warn("mismatch in FilterLog#ToBlock number", "queried_to_block_number", lastHeader.Number, "reported_to_block_number", logs.ToBlockHeader.Number)
 		return fmt.Errorf("mismatch in FilterLog#ToBlock number")
 	} else if logs.ToBlockHeader.Hash() != lastHeader.Hash() {
-		batchLog.Error("mismatch in FitlerLog#ToBlock block hash!!!", "queried_to_block_hash", lastHeader.Hash().String(), "reported_to_block_hash", logs.ToBlockHeader.Hash().String())
-		return fmt.Errorf("mismatch in FitlerLog#ToBlock block hash!!!")
+		batchLog.Error("mismatch in FilterLog#ToBlock block hash!!!", "queried_to_block_hash", lastHeader.Hash().String(), "reported_to_block_hash", logs.ToBlockHeader.Hash().String())
+		return fmt.Errorf("mismatch in FilterLog#ToBlock block hash!!!")
 	}
 
 	if len(logs.Logs) > 0 {

--- a/indexer/processors/contracts/cross_domain_messenger.go
+++ b/indexer/processors/contracts/cross_domain_messenger.go
@@ -91,7 +91,7 @@ func CrossDomainMessengerSentMessageEvents(chainSelector string, contractAddress
 		default:
 			// NOTE: We explicitly fail here since the presence of a new version means finalization
 			// logic needs to be updated to ensure L1 finalization can run from genesis and handle
-			// the changing version formats. Any unrelayed OVM1 messages that have been harcoded with
+			// the changing version formats. Any unrelayed OVM1 messages that have been hardcoded with
 			// the v1 hash format also need to be updated. This failure is a serving indicator
 			return nil, fmt.Errorf("expected cross domain version 0 or version 1: %d", version)
 		}

--- a/indexer/processors/contracts/legacy_ctc.go
+++ b/indexer/processors/contracts/legacy_ctc.go
@@ -39,7 +39,7 @@ func LegacyCTCDepositEvents(contractAddress common.Address, db *database.DB, fro
 			return nil, err
 		}
 
-		// Enqueued Deposits do not carry a `msg.value` amount. ETH is only minted on L2 via the L1StandardBrige
+		// Enqueued Deposits do not carry a `msg.value` amount. ETH is only minted on L2 via the L1StandardBridge
 		ctcTxDeposits[i] = LegacyCTCDepositEvent{
 			Event:    &events[i].ContractEvent,
 			GasLimit: txEnqueued.GasLimit,


### PR DESCRIPTION
Almost fixed all the typos in indexer excepted some using function/variable name typos.

Messsage->Message
databse -> database
Brige -> Bridge
harcoded -> hardcoded
Fitler -> Filter

by John Wick