### PR TITLE
fix swapped fee/tip parameters to estimateGas

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -226,8 +226,8 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		gas, err := m.backend.EstimateGas(ctx, ethereum.CallMsg{
 			From:      m.cfg.From,
 			To:        candidate.To,
-			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTipCap,
+			GasFeeCap: gasFeeCap,
 			Data:      rawTx.Data,
 			Value:     rawTx.Value,
 		})
@@ -535,8 +535,8 @@ func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transa
 	gas, err := m.backend.EstimateGas(ctx, ethereum.CallMsg{
 		From:      m.cfg.From,
 		To:        rawTx.To,
-		GasFeeCap: bumpedTip,
-		GasTipCap: bumpedFee,
+		GasTipCap: bumpedTip,
+		GasFeeCap: bumpedFee,
 		Data:      rawTx.Data,
 	})
 	if err != nil {

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -211,6 +211,9 @@ func (b *mockBackend) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (ui
 	if b.g.err != nil {
 		return 0, b.g.err
 	}
+	if msg.GasFeeCap.Cmp(msg.GasTipCap) < 0 {
+		return 0, core.ErrTipAboveFeeCap
+	}
 	return b.g.basefee().Uint64(), nil
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

fix the fact that tip & fee cap were swapped in gas limit re-estimation call, and consistently use tip->fee ordering to avoid future mixup.

**Tests**

Updated the mock backend with a check that would have caught this error.

**Additional context**

This was resulting in sporadic errors in our goerli-alpha proposer/batchers.

This bug didn't cause issues in the past because of what looks like a recent change in geth: https://github.com/ethereum/go-ethereum/pull/28462

