### PR TITLE
op-node: Fix race condition closing gossip handler.

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -601,7 +601,6 @@ func MakeSubscriber(log log.Logger, msgHandler MessageHandler) TopicSubscriber {
 }
 
 func LogTopicEvents(ctx context.Context, log log.Logger, evHandler *pubsub.TopicEventHandler) {
-	defer evHandler.Cancel()
 	for {
 		ev, err := evHandler.NextPeerEvent(ctx)
 		if err != nil {


### PR DESCRIPTION
**Description**

`LogTopicEvents` is calling `Cancel` on the event handler it logs from. This is done in a go routine but `Cancel` is not thread safe.  `Cancel` is called from the `blockTopic.Close` function anyway so the log code can simply leave it to that.

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/8488
