### PR TITLE
chore(contracts-bedrock): don't publish `forge-artifacts/*.t.sol` files

### DIFF
--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "files": [
     "forge-artifacts/**/*.json",
+    "!forge-artifacts/**/*.t.sol/*.json",
     "deployments/**/*.json",
     "src/**/*.sol"
   ],


### PR DESCRIPTION
**Description**

- This PR excludes `forge-artifacts/*.t.sol` files from being published.
- I discovered this when my backend project installed `@eth-optimism/sdk`, and its dependency [`@eth-optimism/contracts-bedrock`](https://www.npmjs.com/package/@eth-optimism/contracts-bedrock) was installed, adding ~400 MB to its built image size.

**Tests**

Running `npm publish --dry-run`

| Before | After |
| - | - |
| <img width="484" alt="image" src="https://github.com/ethereum-optimism/optimism/assets/31790206/607fe12f-3911-44c8-97bb-e9329b828b3d"> | <img width="484" alt="image" src="https://github.com/ethereum-optimism/optimism/assets/31790206/72bd0447-8117-43bf-9f21-5432df23e00d"> |


**Additional context**

- Tree-shaking would be my solution to the bloated image I have, but 
  1. nodeJS tree-shaking is tricky 
  2. I figured I'd open a quick PR to address this (unless I'm mistaken, and the test data is intentionally published).
- Note: this might break any downstream projects that depend on the t.sol files, but in my amateur opinion, it's unlikely
- Feel free to close if this is a non-issue