### PR TITLE
op-service, op-proposer, op-batcher: Add L2EndpointProvider and its first struct, StaticL2EndpointProvider.

### DIFF
--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	"github.com/ethereum-optimism/optimism/op-proposer/proposer"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
@@ -64,13 +65,15 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		L2OutputOracleAddr: cfg.OutputOracleAddr,
 		AllowNonFinalized:  cfg.AllowNonFinalized,
 	}
+	rollupProvider, err := dial.NewStaticL2RollupProviderFromExistingRollup(rollupCl)
+	require.NoError(t, err)
 	driverSetup := proposer.DriverSetup{
-		Log:          log,
-		Metr:         metrics.NoopMetrics,
-		Cfg:          proposerConfig,
-		Txmgr:        fakeTxMgr{from: crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey)},
-		L1Client:     l1,
-		RollupClient: rollupCl,
+		Log:            log,
+		Metr:           metrics.NoopMetrics,
+		Cfg:            proposerConfig,
+		Txmgr:          fakeTxMgr{from: crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey)},
+		L1Client:       l1,
+		RollupProvider: rollupProvider,
 	}
 
 	dr, err := proposer.NewL2OutputSubmitter(driverSetup)

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
@@ -48,8 +49,8 @@ type DriverSetup struct {
 	Txmgr    txmgr.TxManager
 	L1Client L1Client
 
-	// RollupClient is used to retrieve output roots from
-	RollupClient RollupClient
+	// RollupProvider's RollupClient() is used to retrieve output roots from
+	RollupProvider dial.RollupProvider
 }
 
 // L2OutputSubmitter is responsible for proposing outputs
@@ -167,7 +168,12 @@ func (l *L2OutputSubmitter) FetchNextOutputInfo(ctx context.Context) (*eth.Outpu
 	// Fetch the current L2 heads
 	cCtx, cancel = context.WithTimeout(ctx, l.Cfg.NetworkTimeout)
 	defer cancel()
-	status, err := l.RollupClient.SyncStatus(cCtx)
+	rollupClient, err := l.RollupProvider.RollupClient(cCtx)
+	if err != nil {
+		l.Log.Error("proposer unable to get rollup client", "err", err)
+		return nil, false, err
+	}
+	status, err := rollupClient.SyncStatus(cCtx)
 	if err != nil {
 		l.Log.Error("proposer unable to get sync status", "err", err)
 		return nil, false, err
@@ -192,7 +198,13 @@ func (l *L2OutputSubmitter) FetchNextOutputInfo(ctx context.Context) (*eth.Outpu
 func (l *L2OutputSubmitter) fetchOutput(ctx context.Context, block *big.Int) (*eth.OutputResponse, bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, l.Cfg.NetworkTimeout)
 	defer cancel()
-	output, err := l.RollupClient.OutputAtBlock(ctx, block.Uint64())
+
+	rollupClient, err := l.RollupProvider.RollupClient(ctx)
+	if err != nil {
+		l.Log.Error("proposer unable to get rollup client", "err", err)
+		return nil, false, err
+	}
+	output, err := rollupClient.OutputAtBlock(ctx, block.Uint64())
 	if err != nil {
 		l.Log.Error("failed to fetch output at block %d: %w", block, err)
 		return nil, false, err

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -19,7 +19,6 @@ import (
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	oppprof "github.com/ethereum-optimism/optimism/op-service/pprof"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
-	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -49,9 +48,9 @@ type ProposerService struct {
 
 	ProposerConfig
 
-	TxManager    txmgr.TxManager
-	L1Client     *ethclient.Client
-	RollupClient *sources.RollupClient
+	TxManager      txmgr.TxManager
+	L1Client       *ethclient.Client
+	RollupProvider dial.RollupProvider
 
 	driver *L2OutputSubmitter
 
@@ -122,11 +121,11 @@ func (ps *ProposerService) initRPCClients(ctx context.Context, cfg *CLIConfig) e
 	}
 	ps.L1Client = l1Client
 
-	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, dial.DefaultDialTimeout, ps.Log, cfg.RollupRpc)
+	rollupProvider, err := dial.NewStaticL2RollupProvider(ctx, ps.Log, cfg.RollupRpc)
 	if err != nil {
-		return fmt.Errorf("failed to dial L2 rollup-client RPC: %w", err)
+		return fmt.Errorf("failed to build L2 endpoint provider: %w", err)
 	}
-	ps.RollupClient = rollupClient
+	ps.RollupProvider = rollupProvider
 	return nil
 }
 
@@ -199,12 +198,12 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 
 func (ps *ProposerService) initDriver() error {
 	driver, err := NewL2OutputSubmitter(DriverSetup{
-		Log:          ps.Log,
-		Metr:         ps.Metrics,
-		Cfg:          ps.ProposerConfig,
-		Txmgr:        ps.TxManager,
-		L1Client:     ps.L1Client,
-		RollupClient: ps.RollupClient,
+		Log:            ps.Log,
+		Metr:           ps.Metrics,
+		Cfg:            ps.ProposerConfig,
+		Txmgr:          ps.TxManager,
+		L1Client:       ps.L1Client,
+		RollupProvider: ps.RollupProvider,
 	})
 	if err != nil {
 		return err
@@ -298,8 +297,8 @@ func (ps *ProposerService) Stop(ctx context.Context) error {
 		ps.L1Client.Close()
 	}
 
-	if ps.RollupClient != nil {
-		ps.RollupClient.Close()
+	if ps.RollupProvider != nil {
+		ps.RollupProvider.Close()
 	}
 
 	if result == nil {

--- a/op-service/dial/static_l2_provider.go
+++ b/op-service/dial/static_l2_provider.go
@@ -1,0 +1,50 @@
+package dial
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// L2EndpointProvider is an interface for providing a RollupClient and l2 eth client
+// It manages the lifecycle of the RollupClient and eth client for callers
+// It does this by extending the RollupProvider interface to add the ability to get an EthClient
+type L2EndpointProvider interface {
+	RollupProvider
+	// EthClient(ctx) returns the underlying ethclient pointing to the L2 execution node
+	EthClient(ctx context.Context) (*ethclient.Client, error)
+}
+
+// StaticL2EndpointProvider is a L2EndpointProvider that always returns the same static RollupClient and eth client
+// It is meant for scenarios where a single, unchanging (L2 rollup node, L2 execution node) pair is used
+type StaticL2EndpointProvider struct {
+	StaticL2RollupProvider
+	ethClient *ethclient.Client
+}
+
+func NewStaticL2EndpointProvider(ctx context.Context, log log.Logger, ethClientUrl string, rollupClientUrl string) (*StaticL2EndpointProvider, error) {
+	ethClient, err := DialEthClientWithTimeout(ctx, DefaultDialTimeout, log, ethClientUrl)
+	if err != nil {
+		return nil, err
+	}
+	rollupProvider, err := NewStaticL2RollupProvider(ctx, log, rollupClientUrl)
+	if err != nil {
+		return nil, err
+	}
+	return &StaticL2EndpointProvider{
+		StaticL2RollupProvider: *rollupProvider,
+		ethClient:              ethClient,
+	}, nil
+}
+
+func (p *StaticL2EndpointProvider) EthClient(context.Context) (*ethclient.Client, error) {
+	return p.ethClient, nil
+}
+
+func (p *StaticL2EndpointProvider) Close() {
+	if p.ethClient != nil {
+		p.ethClient.Close()
+	}
+	p.StaticL2RollupProvider.Close()
+}

--- a/op-service/dial/static_rollup_provider.go
+++ b/op-service/dial/static_rollup_provider.go
@@ -1,0 +1,50 @@
+package dial
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// RollupProvider is an interface for providing a RollupClient
+// It manages the lifecycle of the RollupClient for callers
+type RollupProvider interface {
+	// RollupClient(ctx) returns the underlying sources.RollupClient pointing to the L2 rollup consensus node
+	RollupClient(ctx context.Context) (*sources.RollupClient, error)
+	// Close() closes the underlying client or clients
+	Close()
+}
+
+// StaticL2RollupProvider is a RollupProvider that always returns the same static RollupClient
+// It is meant for scenarios where a single, unchanging L2 rollup node is used
+type StaticL2RollupProvider struct {
+	rollupClient *sources.RollupClient
+}
+
+func NewStaticL2RollupProvider(ctx context.Context, log log.Logger, rollupClientUrl string) (*StaticL2RollupProvider, error) {
+	rollupClient, err := DialRollupClientWithTimeout(ctx, DefaultDialTimeout, log, rollupClientUrl)
+	if err != nil {
+		return nil, err
+	}
+	return &StaticL2RollupProvider{
+		rollupClient: rollupClient,
+	}, nil
+}
+
+// The NewStaticL2EndpointProviderFromExistingRollup constructor is used in e2e testing
+func NewStaticL2RollupProviderFromExistingRollup(rollupCl *sources.RollupClient) (*StaticL2RollupProvider, error) {
+	return &StaticL2RollupProvider{
+		rollupClient: rollupCl,
+	}, nil
+}
+
+func (p *StaticL2RollupProvider) RollupClient(context.Context) (*sources.RollupClient, error) {
+	return p.rollupClient, nil
+}
+
+func (p *StaticL2RollupProvider) Close() {
+	if p.rollupClient != nil {
+		p.rollupClient.Close()
+	}
+}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Towards the end of eventually adding [an active sequencer following mode to the proposer and batcher](https://github.com/ethereum-optimism/client-pod/issues/166), this PR proposes to add a new `interface` `L2EndpointProvider` in `op-service:dial`. It provides a `sources.RollupClient` and optionally a L2 `ethclient.Client`.  There is currently one struct that satisfies this interface, `StaticL2EndpointProvider`.  This PR proposes to use this `StaticL2EndpointProvider` in `op-proposer` and `op-batcher`.

In a next phase, we will add the `ActiveL2EndpointProvider` that satisfies this interface while managing clients in the background, to ensure callers are always pointing to the active sequencer.

**Tests**

Using existing test suite to detect regressions. 

**Metadata**

- Part of https://github.com/ethereum-optimism/client-pod/issues/166
