### PR TITLE
Fixing Various Mistakes and Grammatical Errors Across Documentation and Code Comments

### DIFF
--- a/docs/handbook/pr-guidelines.md
+++ b/docs/handbook/pr-guidelines.md
@@ -14,7 +14,7 @@
 
 ## Overview
 
-This document contains guidelines best practices in PRs that should be enforced as much as possible. The motivations and goals behind these best practices are:
+This document contains guidelines and best practices in PRs that should be enforced as much as possible. The motivations and goals behind these best practices are:
 
 - **Ensure thorough reviews**: By the time the PR is merged, at least one other person—because there is always at least one reviewer—should understand the PR’s changes just as well as the PR author. This helps improve security by reducing bugs and single points of failure (i.e. there should never be only one person who understands certain code).
 - **Reduce PR churn**: PRs should be quickly reviewable and mergeable without much churn (both in terms of code rewrites and comment cycles). This saves time by reducing the need for rebases due to conflicts. Similarly, too many review cycles are a burden for both PR authors and reviewers, and results in “review fatigue” where reviews become less careful and thorough, increasing the likelihood of bugs.

--- a/indexer/docs/troubleshooting.md
+++ b/indexer/docs/troubleshooting.md
@@ -20,7 +20,7 @@ Header traversal is a client abstraction that allows the indexer to sequentially
 * This error occurs when the indexer is operating on a different block state than the node. This is typically caused by network reorgs and is the result of `l1-confirmation-count` or `l2-confirmation-count` values being set too low. To resolve this issue, increase the confirmation count values and restart the indexer service.
 
 2. `the HeaderTraversal's internal state is ahead of the provider`
-* This error occurs when the indexer is operating on a block that the upstream provider does not have. This is typically occurs when resyncing upstream node services. This issue typically resolves itself once the upstream node service is fully synced. If the problem persists, please file an issue.
+* This error occurs when the indexer is operating on a block that the upstream provider does not have. This typically occurs when resyncing upstream node services. This issue typically resolves itself once the upstream node service is fully synced. If the problem persists, please file an issue.
 
 ### L1/L2 Processor Failures
 The L1 and L2 processors are responsible for processing new blocks and system txs. Processor failures can spread and contaminate other downstream processors (i.e, bridge) as well. For example, if a L2 processor misses a block and fails to index a `MessagePassed` event, the bridge processor will fail to index the corresponding `WithdrawalProven` event and halt progress. The following are some common failure modes and how to resolve them:

--- a/op-preimage/README.md
+++ b/op-preimage/README.md
@@ -1,6 +1,6 @@
 # op-preimage
 
-`op-preimage` offers simple Go bindings to interact as client or sever over the Pre-image Oracle ABI.
+`op-preimage` offers simple Go bindings to interact as client or server over the Pre-image Oracle ABI.
 
 Read more about the Preimage Oracle in the [specs](../specs/fault-proof.md).
 

--- a/op-program/README.md
+++ b/op-program/README.md
@@ -4,7 +4,7 @@ Implements a fault proof program that runs through the rollup state-transition t
 This verifiable output can then resolve a disputed output on L1.
 
 The program is designed such that it can be run in a deterministic way such that two invocations with the same input
-data wil result in not only the same output, but the same program execution trace. This allows it to be run in an
+data will result in not only the same output, but the same program execution trace. This allows it to be run in an
 on-chain VM as part of the dispute resolution process.
 
 ## Compiling

--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # Smart Contract Style Guide
 
-This document providing guidance on how we organize and write our smart contracts. For cases where
+This document provides guidance on how we organize and write our smart contracts. For cases where
 this document does not provide guidance, please refer to existing contracts for guidance,
 with priority on the `L2OutputOracle` and `OptimismPortal`.
 

--- a/packages/contracts-bedrock/STYLE_GUIDE.md
+++ b/packages/contracts-bedrock/STYLE_GUIDE.md
@@ -154,7 +154,7 @@ Test contracts should be named one of the following according to their use:
 To minimize clutter, getter functions can be grouped together into a single test contract,
   ie. `TargetContract_Getters_Test`.
 
-## Withdrawaing From Fee Vaults
+## Withdrawing From Fee Vaults
 
 See the file `scripts/FeeVaultWithdrawal.s.sol` to withdraw from the L2 fee vaults. It includes
 instructions on how to run it. `foundry` is required.

--- a/packages/contracts-ts/CODE_GEN.md
+++ b/packages/contracts-ts/CODE_GEN.md
@@ -3,7 +3,7 @@
 Summary -
 
 - This package is generated from [contracts-bedrock](../contracts-bedrock/)
-- It's version is kept in sync with contracts bedrock via the [changeset config](../../.changeset/config.json) e.g. if contracts-bedrock is `4.2.0` this package will have the same version.
+- Its version is kept in sync with contracts bedrock via the [changeset config](../../.changeset/config.json) e.g. if contracts-bedrock is `4.2.0` this package will have the same version.
 
 ## Code gen instructions
 

--- a/proxyd/README.md
+++ b/proxyd/README.md
@@ -9,7 +9,7 @@ This tool implements `proxyd`, an RPC request router and proxy. It does the foll
 5. Re-write requests and responses to enforce consensus.
 6. Load balance requests across backend services.
 7. Cache immutable responses from backends.
-8. Provides metrics the measure request latency, error rates, and the like.
+8. Provides metrics to measure request latency, error rates, and the like.
 
 
 ## Usage

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -749,7 +749,7 @@ of even benign consensus issues.
 
 The L2 block time is 2 second, meaning there is an L2 block at every 2s [time slot][time-slot].
 
-Post-[merge], it could be said the that L1 block time is 12s as that is the L1 [time slot][time-slot]. However, in
+Post-[merge], it could be said that the L1 block time is 12s as that is the L1 [time slot][time-slot]. However, in
 reality the block time is variable as some time slots might be skipped.
 
 Pre-merge, the L1 block time is variable, though it is on average 13s.

--- a/specs/predeploys.md
+++ b/specs/predeploys.md
@@ -286,7 +286,7 @@ used for depositing native L1 tokens into. These ERC20 contracts can be created 
 and implement the interface required by the `StandardBridge` to just work with deposits and withdrawals.
 
 Each ERC20 contract that is created by the `OptimismMintableERC20Factory` allows for the `L2StandardBridge` to mint
-and burn tokens, depending on if the user is depositing from L1 to L2 or withdrawaing from L2 to L1.
+and burn tokens, depending on if the user is depositing from L1 to L2 or withdrawing from L2 to L1.
 
 ## OptimismMintableERC721Factory
 

--- a/ufm-test-services/README.md
+++ b/ufm-test-services/README.md
@@ -12,9 +12,9 @@ Starting from left to right in the above diagram:
 
 1. Github Workflow files are created for each time interval Test Services should be ran
     - All Test Services that should be ran for a specific time interval (e.g. 1 hour) should be defined in the same Github Workflow file
-2. Github will run a workflow at it's specified time interval, triggering all of it's defined Test Services to run
+2. Github will run a workflow at its specified time interval, triggering all of it's defined Test Services to run
 3. `docker-compose.yml` builds and runs each Test Service, setting any environment variables that can be sourced from Github secrets
-4. Each Test Service will run it's defined tasks, generate it's metrics, and push them to an already deployed instance of Prometheus Pushgateway
+4. Each Test Service will run its defined tasks, generate its metrics, and push them to an already deployed instance of Prometheus Pushgateway
 5. An already deployed instance of Prometheus will scrape the Pushgateway for metrics
 6. An already deployed Grafana dashboard will query Prometheus for metric data to display
 
@@ -71,7 +71,7 @@ Starting from left to right in the above diagram:
             # Runs every 1 day
             0 12 * * * /usr/local/bin/docker-compose -f /path/to/docker-compose.yml --profile 1day up -d
 
-            # Runs every 7 day
+            # Runs every 7 days
             0 12 */7 * * /usr/local/bin/docker-compose -f /path/to/docker-compose.yml --profile 7day up -d
             ```
 


### PR DESCRIPTION
I've identified and corrected a series of typos and grammatical mistakes across various documentation and code comment sections. These changes are aimed at enhancing the readability and clarity of the texts:

1. *RPC Proxy Section*: Corrected a typographical error in rpc-proxy section of proxyd/README.md.

2. *Predeploys Specification*: Fixed a typo in predeploys.md, changing 'withdawaing' to 'withdrawing'.

3. *Documentation Typos*: Addressed a 'the that' typo in documentation.md.

4. *Troubleshooting Guide*: Improved clarity in the Header traversal failure subsection of indexer/docs/troubleshooting.md by removing a redundant word.

5. *PR Guidelines Document*: Inserted a missing 'and' in the PR Guidelines Document for better flow.

6. *Style Guide for Contracts*: Corrected grammatical errors in packages/contracts-bedrock/STYLE_GUIDE.md.

7. *Contracts TypeScript Code Generation*: Fixed the misuse of 'It's' in packages/contracts-ts/CODE_GEN.md.

8. *UFM Test Services README*: Addressed grammar and plurality issues in ufm-test-services/README.md.

9. *OP Program README*: Corrected the typo 'wil' to 'will' in op-program/README.md.

10. *OP Preimage README*: Fixed the typo 'sever' to 'server' in op-preimage/README.md.

Each of these changes is small but collectively they contribute to the overall quality of the project's documentation. 

Thank you for maintaining such a vital project.
