### PR TITLE
fix(indexer) metrics exception which recording skipped ovm1 events

### DIFF
--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -1,4 +1,3 @@
-
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'uint256') THEN
@@ -57,13 +56,14 @@ CREATE TABLE IF NOT EXISTS l1_contract_events (
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0),
 
     -- Raw Data
-    rlp_bytes VARCHAR NOT NULL
+    rlp_bytes VARCHAR NOT NULL,
+
+    UNIQUE(block_hash, log_index)
 );
 CREATE INDEX IF NOT EXISTS l1_contract_events_timestamp ON l1_contract_events(timestamp);
 CREATE INDEX IF NOT EXISTS l1_contract_events_block_hash ON l1_contract_events(block_hash);
 CREATE INDEX IF NOT EXISTS l1_contract_events_event_signature ON l1_contract_events(event_signature);
 CREATE INDEX IF NOT EXISTS l1_contract_events_contract_address ON l1_contract_events(contract_address);
-ALTER TABLE l1_contract_events ADD UNIQUE (block_hash, log_index);
 
 CREATE TABLE IF NOT EXISTS l2_contract_events (
     -- Searchable fields
@@ -76,13 +76,14 @@ CREATE TABLE IF NOT EXISTS l2_contract_events (
     timestamp        INTEGER NOT NULL CHECK (timestamp > 0),
 
     -- Raw Data
-    rlp_bytes VARCHAR NOT NULL
+    rlp_bytes VARCHAR NOT NULL,
+
+    UNIQUE(block_hash, log_index)
 );
 CREATE INDEX IF NOT EXISTS l2_contract_events_timestamp ON l2_contract_events(timestamp);
 CREATE INDEX IF NOT EXISTS l2_contract_events_block_hash ON l2_contract_events(block_hash);
 CREATE INDEX IF NOT EXISTS l2_contract_events_event_signature ON l2_contract_events(event_signature);
 CREATE INDEX IF NOT EXISTS l2_contract_events_contract_address ON l2_contract_events(contract_address);
-ALTER TABLE l2_contract_events ADD UNIQUE (block_hash, log_index);
 
 /**
  * BRIDGING DATA

--- a/indexer/processors/bridge/metrics.go
+++ b/indexer/processors/bridge/metrics.go
@@ -227,11 +227,11 @@ func (m *bridgeMetrics) RecordL1CrossDomainRelayedMessages(size int) {
 }
 
 func (m *bridgeMetrics) RecordL1SkippedOVM1ProvenWithdrawals(size int) {
-	m.skippedOVM1Withdrawals.WithLabelValues("stage", "proven").Add(float64(size))
+	m.skippedOVM1Withdrawals.WithLabelValues("proven").Add(float64(size))
 }
 
 func (m *bridgeMetrics) RecordL1SkippedOVM1FinalizedWithdrawals(size int) {
-	m.skippedOVM1Withdrawals.WithLabelValues("stage", "finalized").Add(float64(size))
+	m.skippedOVM1Withdrawals.WithLabelValues("finalized").Add(float64(size))
 }
 
 func (m *bridgeMetrics) RecordL1SkippedOVM1CrossDomainRelayedMessages(size int) {


### PR DESCRIPTION
Mismatch in label values for the `skippedOVM1Withdrawals` metrics
