### PR TITLE
Backport #8572: fix swapped fee/tip parameters to estimateGas

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -227,8 +227,8 @@ func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*
 		gas, err := m.backend.EstimateGas(ctx, ethereum.CallMsg{
 			From:      m.cfg.From,
 			To:        candidate.To,
-			GasFeeCap: gasFeeCap,
 			GasTipCap: gasTipCap,
+			GasFeeCap: gasFeeCap,
 			Data:      rawTx.Data,
 			Value:     rawTx.Value,
 		})
@@ -536,8 +536,8 @@ func (m *SimpleTxManager) increaseGasPrice(ctx context.Context, tx *types.Transa
 	gas, err := m.backend.EstimateGas(ctx, ethereum.CallMsg{
 		From:      m.cfg.From,
 		To:        rawTx.To,
-		GasFeeCap: bumpedTip,
-		GasTipCap: bumpedFee,
+		GasTipCap: bumpedTip,
+		GasFeeCap: bumpedFee,
 		Data:      rawTx.Data,
 	})
 	if err != nil {

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -211,6 +211,9 @@ func (b *mockBackend) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (ui
 	if b.g.err != nil {
 		return 0, b.g.err
 	}
+	if msg.GasFeeCap.Cmp(msg.GasTipCap) < 0 {
+		return 0, core.ErrTipAboveFeeCap
+	}
 	return b.g.basefee().Uint64(), nil
 }
 


### PR DESCRIPTION
**Description**

Backports #8572 to the canyon mainnet release branch.
