### PR TITLE
chore: apply manual shellcheck fixes

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2002

--- a/indexer/ui/prisma.sh
+++ b/indexer/ui/prisma.sh
@@ -18,8 +18,8 @@ function check_prisma() {
     echo "Checking Prisma Schema..."
     cp "$PRISMA_FILE" "$TEMP_FILE"
     npx prisma db pull --url "$DATABASE_URL" --schema "$TEMP_FILE"
-    diff "$PRISMA_FILE" "$TEMP_FILE" > /dev/null
-    if [ $? -eq 0 ]; then
+
+    if diff "$PRISMA_FILE" "$TEMP_FILE" > /dev/null; then
         echo "Prisma Schema is up-to-date."
         rm "$TEMP_FILE"
     else

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CHALLENGER_DIR=$("${SOURCE_DIR%/*/*}")
-MONOREPO_DIR=$("${SOURCE_DIR%/*/*/*}")
+CHALLENGER_DIR="${SOURCE_DIR%/*/*}"
+MONOREPO_DIR="${SOURCE_DIR%/*/*/*}"
 
 # Check that the fault game address file exists
 FAULT_GAME_ADDR_FILE="$CHALLENGER_DIR/.fault-game-address"

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
 MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
 

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
-MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
+CHALLENGER_DIR=$("${SOURCE_DIR%/*/*}")
+MONOREPO_DIR=$("${SOURCE_DIR%/*/*/*}")
 
 # Check that the fault game address file exists
 FAULT_GAME_ADDR_FILE="$CHALLENGER_DIR/.fault-game-address"

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
 MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
 
@@ -34,10 +34,10 @@ echo " Block Oracle Proxy at $BLOCK_ORACLE_PROXY"
 echo "----------------------------------------------------------------"
 
 CHARLIE_ADDRESS="0xF45B7537828CB2fffBC69996B054c2Aaf36DC778"
-CHARLIE_KEY="74feb147d72bfae943e6b4e483410933d9e447d5dc47d52432dcc2c1454dabb7"
+# CHARLIE_KEY="74feb147d72bfae943e6b4e483410933d9e447d5dc47d52432dcc2c1454dabb7"
 
 MALLORY_ADDRESS="0x4641c704a6c743f73ee1f36C7568Fbf4b80681e4"
-MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
+# MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
 echo "----------------------------------------------------------------"
 echo " - Fetching balance of the sponsor"
@@ -61,7 +61,7 @@ done
 
 # Root claim commits to the entire trace.
 # Alphabet game claim construction: keccak256(abi.encode(trace_index, trace[trace_index]))
-ROOT_CLAIM=$(cast keccak $(cast abi-encode "f(uint256,uint256)" 15 122))
+ROOT_CLAIM=$(cast keccak "$(cast abi-encode "f(uint256,uint256)" 15 122)")
 # Replace the first byte of the claim with the invalid vm status indicator
 ROOT_CLAIM="0x01${ROOT_CLAIM:4}"
 

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
-MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
+CHALLENGER_DIR="${SOURCE_DIR%/*/*}"
+MONOREPO_DIR="${SOURCE_DIR%/*/*/*}"
 
 cd "$CHALLENGER_DIR"
 make

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -34,10 +34,7 @@ echo " Block Oracle Proxy at $BLOCK_ORACLE_PROXY"
 echo "----------------------------------------------------------------"
 
 CHARLIE_ADDRESS="0xF45B7537828CB2fffBC69996B054c2Aaf36DC778"
-# CHARLIE_KEY="74feb147d72bfae943e6b4e483410933d9e447d5dc47d52432dcc2c1454dabb7"
-
 MALLORY_ADDRESS="0x4641c704a6c743f73ee1f36C7568Fbf4b80681e4"
-# MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
 
 echo "----------------------------------------------------------------"
 echo " - Fetching balance of the sponsor"

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CHALLENGER_DIR=$("${SOURCE_DIR%/*/*}")
-MONOREPO_DIR=$("${SOURCE_DIR%/*/*/*}")
+CHALLENGER_DIR="${SOURCE_DIR%/*/*}"
+MONOREPO_DIR="${SOURCE_DIR%/*/*/*}"
 
 # Check that the fault game address file exists
 FAULT_GAME_ADDR_FILE="$CHALLENGER_DIR/.fault-game-address"

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
 MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
 

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
-MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
+CHALLENGER_DIR=$("${SOURCE_DIR%/*/*}")
+MONOREPO_DIR=$("${SOURCE_DIR%/*/*/*}")
 
 # Check that the fault game address file exists
 FAULT_GAME_ADDR_FILE="$CHALLENGER_DIR/.fault-game-address"

--- a/op-challenger/scripts/create_game.sh
+++ b/op-challenger/scripts/create_game.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*}")
-MONOREPO_DIR=$(echo "${CHALLENGER_DIR%/*}")
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CHALLENGER_DIR="${SOURCE_DIR%/*}"
 
 # ./create_game.sh <rpc-addr> <dispute-game-factory-addr> <cast signing args>
 RPC=${1:?Must specify RPC address}
 FACTORY_ADDR=${2:?Must specify factory address}
 ROOT_CLAIM=${3:?Must specify root claim}
-SIGNER_ARGS="${@:4}"
+SIGNER_ARGS=("${@:4}")
 
 # Default to Cannon Fault game type
 GAME_TYPE=${GAME_TYPE:-0}
@@ -33,8 +32,7 @@ echo "L2 Block Number: ${L2_BLOCK_NUM}"
 # Create a checkpoint in the block oracle to commit to the current L1 head.
 # This defines the L1 head that will be used in the dispute game.
 echo "Checkpointing the block oracle..."
-# shellcheck disable=SC2086
-L1_CHECKPOINT=$(cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${BLOCK_ORACLE_ADDR}" "checkpoint()" --json | jq -r '.logs[0].topics[1]' | cast to-dec)
+L1_CHECKPOINT=$(cast send --rpc-url "${RPC}" "${SIGNER_ARGS[@]}" "${BLOCK_ORACLE_ADDR}" "checkpoint()" --json | jq -r '.logs[0].topics[1]' | cast to-dec)
 echo "L1 Checkpoint: $L1_CHECKPOINT"
 
 # Fault dispute game extra data is calculated as follows.
@@ -42,8 +40,7 @@ echo "L1 Checkpoint: $L1_CHECKPOINT"
 EXTRA_DATA=$(cast abi-encode "f(uint256,uint256)" "${L2_BLOCK_NUM}" "${L1_CHECKPOINT}")
 
 echo "Initializing the game"
-# shellcheck disable=SC2086
-FAULT_GAME_DATA=$(cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${FACTORY_ADDR}" "create(uint8,bytes32,bytes) returns(address)" "${GAME_TYPE}" "${ROOT_CLAIM}" "${EXTRA_DATA}" --json)
+FAULT_GAME_DATA=$(cast send --rpc-url "${RPC}" "${SIGNER_ARGS[@]}" "${FACTORY_ADDR}" "create(uint8,bytes32,bytes) returns(address)" "${GAME_TYPE}" "${ROOT_CLAIM}" "${EXTRA_DATA}" --json)
 
 # Extract the address of the newly created game from the receipt logs.
 FAULT_GAME_ADDRESS=$(echo "${FAULT_GAME_DATA}" | jq -r '.logs[0].topics[1]' | cast parse-bytes32-address)

--- a/op-challenger/scripts/list_claims.sh
+++ b/op-challenger/scripts/list_claims.sh
@@ -11,10 +11,9 @@ echo "Claim count: ${COUNT}"
 for i in $(seq 0 "${COUNT}")
 do
   CLAIM=$(cast call --rpc-url "${RPC}" "${GAME_ADDR}" 'claimData(uint256) returns(uint32 parentIndex, bool countered, bytes32 claim, uint128 position, uint128 clock)' "${i}")
-  SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
-  IFS=$'\n'      # Change IFS to newline char
-  CLAIM=($CLAIM) # split the string into an array by the same name
-  IFS=$SAVEIFS   # Restore original IFS
+  # Use read -ra to safely split the string into an array named CLAIM, assuming
+  # data is newline-separated.
+  IFS=$'\n' read -ra CLAIM <<< "$CLAIM"
 
   echo "${i}  Parent: ${CLAIM[0]} Countered: ${CLAIM[1]} Claim: ${CLAIM[2]} Position: ${CLAIM[3]} Clock ${CLAIM[4]}"
 done

--- a/op-challenger/scripts/list_claims.sh
+++ b/op-challenger/scripts/list_claims.sh
@@ -11,9 +11,11 @@ echo "Claim count: ${COUNT}"
 for i in $(seq 0 "${COUNT}")
 do
   CLAIM=$(cast call --rpc-url "${RPC}" "${GAME_ADDR}" 'claimData(uint256) returns(uint32 parentIndex, bool countered, bytes32 claim, uint128 position, uint128 clock)' "${i}")
-  # Use read -ra to safely split the string into an array named CLAIM, assuming
-  # data is newline-separated.
-  IFS=$'\n' read -ra CLAIM <<< "$CLAIM"
+  SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
+  IFS=$'\n'      # Change IFS to newline char
+  # shellcheck disable=SC2206
+  CLAIM=($CLAIM) # split the string into an array by the same name
+  IFS=$SAVEIFS # Restore original IFS
 
   echo "${i}  Parent: ${CLAIM[0]} Countered: ${CLAIM[1]} Claim: ${CLAIM[2]} Position: ${CLAIM[3]} Clock ${CLAIM[4]}"
 done

--- a/op-challenger/scripts/list_games.sh
+++ b/op-challenger/scripts/list_games.sh
@@ -15,11 +15,9 @@ fi
 for i in $(seq 0 "${COUNT}")
 do
   GAME=$(cast call --rpc-url "${RPC}" "${FACTORY_ADDR}" 'gameAtIndex(uint256) returns(uint8, uint64, address)' "${i}")
-
-  SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
-  IFS=$'\n'      # Change IFS to newline char
-  GAME=($GAME) # split the string into an array by the same name
-  IFS=$SAVEIFS   # Restore original IFS
+  # Use read -ra to safely split the string into an array named GAME, assuming
+  # data is newline-separated.
+  IFS=$'\n' read -ra GAME <<< "$GAME"
 
   GAME_ADDR="${GAME[2]}"
   CLAIMS=$(cast call --rpc-url "${RPC}" "${GAME_ADDR}" "claimDataLen() returns(uint256)")

--- a/op-challenger/scripts/list_games.sh
+++ b/op-challenger/scripts/list_games.sh
@@ -15,9 +15,11 @@ fi
 for i in $(seq 0 "${COUNT}")
 do
   GAME=$(cast call --rpc-url "${RPC}" "${FACTORY_ADDR}" 'gameAtIndex(uint256) returns(uint8, uint64, address)' "${i}")
-  # Use read -ra to safely split the string into an array named GAME, assuming
-  # data is newline-separated.
-  IFS=$'\n' read -ra GAME <<< "$GAME"
+  SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
+  IFS=$'\n'      # Change IFS to newline char
+  # shellcheck disable=SC2206
+  GAME=($GAME) # split the string into an array by the same name
+  IFS=$SAVEIFS   # Restore original IFS
 
   GAME_ADDR="${GAME[2]}"
   CLAIMS=$(cast call --rpc-url "${RPC}" "${GAME_ADDR}" "claimDataLen() returns(uint256)")

--- a/op-challenger/scripts/move.sh
+++ b/op-challenger/scripts/move.sh
@@ -6,7 +6,8 @@ GAME_ADDR=${2:?Must specify game address}
 ACTION=${3:?Must specify attack or defend}
 PARENT_INDEX=${4:?Must specify parent index. Use latest to counter the latest claim added to the game.}
 CLAIM=${5:?Must specify claim hash}
-SIGNER_ARGS="${@:6}"
+SIGNER_ARGS=("${@:6}")
+
 
 if [[ "${ACTION}" != "attack" && "${ACTION}" != "defend" ]]
 then
@@ -22,5 +23,4 @@ then
 fi
 
 # Perform the move.
-# shellcheck disable=SC2086
-cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${GAME_ADDR}" "$ACTION(uint256,bytes32)" "${PARENT_INDEX}" "${CLAIM}"
+cast send --rpc-url "${RPC}" "${SIGNER_ARGS[@]}" "${GAME_ADDR}" "$ACTION(uint256,bytes32)" "${PARENT_INDEX}" "${CLAIM}"

--- a/op-challenger/scripts/resolve.sh
+++ b/op-challenger/scripts/resolve.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 RPC=${1:?Must specify RPC URL}
 GAME_ADDR=${2:?Must specify game address}
-SIGNER_ARGS="${@:3}"
+SIGNER_ARGS=("${@:3}")
 
 # Perform the move.
 # shellcheck disable=SC2086
-RESULT_DATA=$(cast send --rpc-url "${RPC}" ${SIGNER_ARGS} "${GAME_ADDR}" "resolve()" --json)
+RESULT_DATA=$(cast send --rpc-url "${RPC}" "${SIGNER_ARGS[@]}" "${GAME_ADDR}" "resolve()" --json)
 RESULT=$(echo "${RESULT_DATA}" | jq -r '.logs[0].topics[1]' | cast to-dec)
 
 if [[ "${RESULT}" == "0" ]]

--- a/op-challenger/scripts/visualize.sh
+++ b/op-challenger/scripts/visualize.sh
@@ -6,7 +6,7 @@ RPC="${1:?Must specify RPC address}"
 FAULT_GAME_ADDRESS="${2:?Must specify game address}"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DIR=$(echo "${DIR%/*/*}")
+DIR="${DIR%/*/*}"
 cd "$DIR"/packages/contracts-bedrock
 
 forge script scripts/FaultDisputeGameViz.s.sol \

--- a/op-node/cmd/batch_decoder/script.sh
+++ b/op-node/cmd/batch_decoder/script.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "$1"
 jq '.frames[] | {timestamp, inclusion_block}' "$1"
 jq '.batches[]|.Timestamp' "$1"

--- a/op-service/sources/testdata/gen.sh
+++ b/op-service/sources/testdata/gen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$SOURCE_DIR"
 export ETH_RPC_URL=https://ethereum-goerli-rpc.allthatnode.com
 

--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -1,6 +1,6 @@
 FROM ethereum/client-go:v1.13.5
 
-RUN apk add --no-cache jq
+RUN apk add --no-cache jq bash
 
 COPY entrypoint-l1.sh /entrypoint.sh
 

--- a/ops-bedrock/Dockerfile.l1
+++ b/ops-bedrock/Dockerfile.l1
@@ -6,4 +6,4 @@ COPY entrypoint-l1.sh /entrypoint.sh
 
 VOLUME ["/db"]
 
-ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -14,9 +14,9 @@ WS_PORT="${WS_PORT:-8546}"
 
 if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
 	echo "$GETH_KEYSTORE_DIR missing, running account import"
-	echo -n "pwd" > "$GETH_DATA_DIR"/password
-	echo -n "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
-	geth account import \
+	printf "%s" "pwd" > "$GETH_DATA_DIR"/password
+  printf "%s" "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
+  geth account import \
 		--datadir="$GETH_DATA_DIR" \
 		--password="$GETH_DATA_DIR"/password \
 		"$GETH_DATA_DIR"/block-signer-key

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -14,7 +14,7 @@ WS_PORT="${WS_PORT:-8546}"
 
 if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
 	echo "$GETH_KEYSTORE_DIR missing, running account import"
-	printf "%s" "$(pwd)" > "$GETH_DATA_DIR"/password
+	printf "%s" "pwd" > "$GETH_DATA_DIR"/password
   printf "%s" "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
   geth account import \
 		--datadir="$GETH_DATA_DIR" \

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -14,7 +14,7 @@ WS_PORT="${WS_PORT:-8546}"
 
 if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
 	echo "$GETH_KEYSTORE_DIR missing, running account import"
-	printf "%s" "pwd" > "$GETH_DATA_DIR"/password
+	printf "%s" "$(pwd)" > "$GETH_DATA_DIR"/password
   printf "%s" "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
   geth account import \
 		--datadir="$GETH_DATA_DIR" \

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -14,8 +14,8 @@ WS_PORT="${WS_PORT:-8546}"
 
 if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
 	echo "$GETH_KEYSTORE_DIR missing, running account import"
-	echo -n "%s" "pwd" > "$GETH_DATA_DIR"/password
-  echo -n "%s" "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
+	echo -n "pwd" > "$GETH_DATA_DIR"/password
+  echo -n "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
   geth account import \
 		--datadir="$GETH_DATA_DIR" \
 		--password="$GETH_DATA_DIR"/password \

--- a/ops-bedrock/entrypoint-l1.sh
+++ b/ops-bedrock/entrypoint-l1.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -exu
 
 VERBOSITY=${GETH_VERBOSITY:-3}
@@ -14,8 +14,8 @@ WS_PORT="${WS_PORT:-8546}"
 
 if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
 	echo "$GETH_KEYSTORE_DIR missing, running account import"
-	printf "%s" "pwd" > "$GETH_DATA_DIR"/password
-  printf "%s" "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
+	echo -n "%s" "pwd" > "$GETH_DATA_DIR"/password
+  echo -n "%s" "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
   geth account import \
 		--datadir="$GETH_DATA_DIR" \
 		--password="$GETH_DATA_DIR"/password \

--- a/packages/contracts-bedrock/scripts/check-deploy-configs.sh
+++ b/packages/contracts-bedrock/scripts/check-deploy-configs.sh
@@ -12,7 +12,7 @@ MONOREPO_BASE=$(dirname "$(dirname "$CONTRACTS_BASE")")
 
 for config in "$CONTRACTS_BASE"/deploy-config/*.json; do
     # shellcheck disable=SC2086
-    if ! go run "$MONOREPO_BASE/op-chain-ops/cmd/check-deploy-config/main.go" --path $config; then
+    if ! go run "$MONOREPO_BASE/op-chain-ops/cmd/check-deploy-config/main.go" --path "$config"; then
         code=1
     fi
 done

--- a/packages/contracts-bedrock/scripts/check-deploy-configs.sh
+++ b/packages/contracts-bedrock/scripts/check-deploy-configs.sh
@@ -4,7 +4,7 @@
 # It should check all configs and return a non-zero exit code if any of them are invalid.
 # getting-started.json isn't valid JSON so its skipped.
 
-code=$?
+code=0
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 CONTRACTS_BASE=$(dirname "$SCRIPT_DIR")

--- a/packages/contracts-bedrock/scripts/check-deploy-configs.sh
+++ b/packages/contracts-bedrock/scripts/check-deploy-configs.sh
@@ -7,12 +7,14 @@
 code=$?
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-CONTRACTS_BASE=$(dirname $SCRIPT_DIR)
-MONOREPO_BASE=$(dirname $(dirname $CONTRACTS_BASE))
+CONTRACTS_BASE=$(dirname "$SCRIPT_DIR")
+MONOREPO_BASE=$(dirname "$(dirname "$CONTRACTS_BASE")")
 
-for config in $CONTRACTS_BASE/deploy-config/*.json; do
-    go run $MONOREPO_BASE/op-chain-ops/cmd/check-deploy-config/main.go --path $config
-    [ $? -eq 0 ]  || code=$?
+for config in "$CONTRACTS_BASE"/deploy-config/*.json; do
+    # shellcheck disable=SC2086
+    if ! go run "$MONOREPO_BASE/op-chain-ops/cmd/check-deploy-config/main.go" --path $config; then
+        code=1
+    fi
 done
 
 exit $code

--- a/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
+++ b/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
@@ -31,7 +31,7 @@ cleanup() {
 wait_l2_outfile() {
   i=1
   while [ $i -le "$2" ]; do
-    i=$(($i + 1))
+    i=$((i + 1))
 
     if [ ! -f "$OUTFILE_L2" ]; then
       sleep "$1"

--- a/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
+++ b/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
@@ -38,7 +38,7 @@ wait_l2_outfile() {
       continue
     fi
 
-    if [ $(du -m "$OUTFILE_L2" | cut -f1) -lt 8 ]; then
+    if [ "$(du -m "$OUTFILE_L2" | cut -f1)" -lt 8 ]; then
       sleep "$1"
       continue
     fi

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -73,7 +73,8 @@ fi
 
 # If slither failed to generate a report, exit with an error.
 if [ ! -f "$SLITHER_REPORT" ]; then
-  printf "Slither output:\n%s\n" "$SLITHER_OUTPUT"
+  echo "Slither output:"
+  echo "$SLITHER_OUTPUT"
   echo "Slither failed to generate a report."
   if [ -e "$SLITHER_REPORT_BACKUP" ]; then
       mv $SLITHER_REPORT_BACKUP $SLITHER_REPORT

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -63,7 +63,6 @@ if [[ ! -z "$TRIAGE_MODE" ]]; then
 
   # If the slither report was generated successfully, and the slither triage exists, clean up the triaged output.
   if [ -f "$SLITHER_REPORT" ] && [ -f  "$SLITHER_TRIAGE_REPORT" ]; then
-    json=$(cat $SLITHER_TRIAGE_REPORT)
     # The following jq command selects a subset of fields in each of the slither triage report description and element objects.
     # This significantly slims down the output json, on the order of 100 magnitudes smaller.
     updated_json=$(cat $SLITHER_TRIAGE_REPORT | jq -r '[.[] | .id as $id | .description as $description | .check as $check | .impact as $impact | .confidence as $confidence | (.elements[] | .type as $type | .name as $name | (.source_mapping | { "id": $id, "impact": $impact, "confidence": $confidence, "check": $check, "description": $description, "type": $type, "name": $name, start, length, filename_relative } ))]')
@@ -74,7 +73,7 @@ fi
 
 # If slither failed to generate a report, exit with an error.
 if [ ! -f "$SLITHER_REPORT" ]; then
-  echo "Slither output:\n$SLITHER_OUTPUT"
+  printf "Slither output:\n%s\n" "$SLITHER_OUTPUT"
   echo "Slither failed to generate a report."
   if [ -e "$SLITHER_REPORT_BACKUP" ]; then
       mv $SLITHER_REPORT_BACKUP $SLITHER_REPORT
@@ -88,7 +87,6 @@ fi
 # The following jq command selects a subset of fields in each of the slither triage report description and element objects.
 # This significantly slims down the output json, on the order of 100 magnitudes smaller.
 echo "Slither ran successfully, generating minimzed report..."
-json=$(cat $SLITHER_REPORT)
 updated_json=$(cat $SLITHER_REPORT | jq -r '[.results.detectors[] | .id as $id | .description as $description | .check as $check | .impact as $impact | .confidence as $confidence | (.elements[] | .type as $type | .name as $name | (.source_mapping | { "id": $id, "impact": $impact, "confidence": $confidence, "check": $check, "description": $description, "type": $type, "name": $name, start, length, filename_relative } ))]')
 echo "$updated_json" > $SLITHER_REPORT
 echo "Slither report stored at $DIR/$SLITHER_REPORT"

--- a/packages/contracts-bedrock/scripts/slither.sh
+++ b/packages/contracts-bedrock/scripts/slither.sh
@@ -57,7 +57,7 @@ fi
 # Findings to keep are output to the slither-report.json output file.
 # Checking in a json file is cleaner than adding slither-disable comments throughout the codebase.
 # See slither.config.json for slither settings and to disable specific detectors.
-if [[ ! -z "$TRIAGE_MODE" ]]; then
+if [[ -n "$TRIAGE_MODE" ]]; then
   echo "Running slither in triage mode"
   SLITHER_OUTPUT=$(slither . --triage-mode --json $SLITHER_REPORT || true)
 

--- a/packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh
+++ b/packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh
@@ -15,7 +15,7 @@ SCRIPT_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 notif "Script Home: $SCRIPT_HOME"
 blank_line
 
-# Set Run Directory <root>/packages/contracts-bedrock 
+# Set Run Directory <root>/packages/contracts-bedrock
 WORKSPACE_DIR=$( cd "${SCRIPT_HOME}/../../.." >/dev/null 2>&1 && pwd )
 notif "Run Directory: ${WORKSPACE_DIR}"
 blank_line
@@ -31,6 +31,7 @@ export KONTROL_RELEASE=${KONTROLRC}
 #############
 kontrol_build() {
     notif "Kontrol Build"
+    # shellcheck disable=SC2086
     docker_exec kontrol build                       \
                         --verbose                   \
                         --require ${lemmas}         \
@@ -40,6 +41,7 @@ kontrol_build() {
 
 kontrol_prove() {
     notif "Kontrol Prove"
+    # shellcheck disable=SC2086
     docker_exec kontrol prove                              \
                         --max-depth ${max_depth}           \
                         --max-iterations ${max_iterations} \
@@ -85,12 +87,12 @@ dump_log_results(){
   notif "Copying Tests Results to Host"
   docker cp ${CONTAINER_NAME}:/home/user/workspace/results.tar.gz "${RESULTS_LOG}"
   if [ -f "${RESULTS_LOG}" ]; then
-    cp "${RESULTS_LOG}" kontrol-results_latest.tar.gz 
+    cp "${RESULTS_LOG}" kontrol-results_latest.tar.gz
   else
     notif "Results Log: ${RESULTS_LOG} not found, did not pull from container."
   fi
   blank_line
-  
+
   notif "Dump RUN Logs"
   RUN_LOG="run-kontrol-$(date +'%Y-%m-%d-%H-%M-%S').log"
   docker logs ${CONTAINER_NAME} > "${RUN_LOG}"


### PR DESCRIPTION

**Description**

Follow-up to https://github.com/ethereum-optimism/optimism/pull/8487 which applies fixes that shellcheck could not apply manually. To find these issues I ran the following command:

```sh
find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path './packages/contracts-bedrock/lib/*' -not -path './.husky/_/husky.sh' -exec sh -c 'echo "Checking $1"; shellcheck "$1"' _ {} \;
```

That command logs the name of each file checked because one file reported `shellcheck: (Array.!): undefined array element` with no indication of which file it was from, so the extra logging helped track it down (it was `./packages/contracts-bedrock/scripts/check-deploy-configs.sh`)

This also adds a `.shellcheckrc` file to configure shellcheck. For now it just disables the [SC2002: Useless `cat`](https://www.shellcheck.net/wiki/SC2002) check—it's a purely stylistic check that doesn't affect correctness, and IMO is easier to read than the alternative syntaxes.

Below is the full shellcheck output against develop, which can be used to find the shellcheck rule for any of the changes here.

<details><summary>Expand to see shellcheck output</summary>
Checking ./ops-bedrock/entrypoint-l1.sh

In ./ops-bedrock/entrypoint-l1.sh line 9:
CHAIN_ID=$(cat "$GENESIS_FILE_PATH" | jq -r .config.chainId)
               ^------------------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.


In ./ops-bedrock/entrypoint-l1.sh line 17:
	echo -n "pwd" > "$GETH_DATA_DIR"/password
             ^-- SC3037 (warning): In POSIX sh, echo flags are undefined.


In ./ops-bedrock/entrypoint-l1.sh line 18:
	echo -n "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
             ^-- SC3037 (warning): In POSIX sh, echo flags are undefined.

For more information:
  https://www.shellcheck.net/wiki/SC3037 -- In POSIX sh, echo flags are undef...
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...
Checking ./ops-bedrock/op-batcher-entrypoint.sh
Checking ./ops-bedrock/entrypoint-l2.sh

In ./ops-bedrock/entrypoint-l2.sh line 8:
CHAIN_ID=$(cat "$GENESIS_FILE_PATH" | jq -r .config.chainId)
               ^------------------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

For more information:
  https://www.shellcheck.net/wiki/SC2002 -- Useless cat. Consider 'cmd < file...
Checking ./op-service/rethdb-reader/headgen.sh
Checking ./op-service/sources/testdata/gen.sh

In ./op-service/sources/testdata/gen.sh line 4:
SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
                ^----------------------------^ SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
Checking ./ufm-test-services/metamask/start.sh
Checking ./proxyd/entrypoint.sh
Checking ./op-chain-ops/crossdomain/testdata/trace.sh
Checking ./op-ufm/entrypoint.sh
Checking ./op-node/cmd/batch_decoder/script.sh

In ./op-node/cmd/batch_decoder/script.sh line 1:
echo "$1"
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
Checking ./packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh

In ./packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh line 38:
                        ${rekompile}
                        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
                        "${rekompile}"


In ./packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh line 49:
                        ${reinit}                          \
                        ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
                        "${reinit}"                          \


In ./packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh line 50:
                        ${bug_report}                      \
                        ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
                        "${bug_report}"                      \


In ./packages/contracts-bedrock/test/kontrol/kontrol/run-kontrol.sh line 53:
                        ${tests}                           \
                        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
                        "${tests}"                           \

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
Checking ./packages/contracts-bedrock/scripts/slither.sh

In ./packages/contracts-bedrock/scripts/slither.sh line 60:
if [[ ! -z "$TRIAGE_MODE" ]]; then
      ^-- SC2236 (style): Use -n instead of ! -z.


In ./packages/contracts-bedrock/scripts/slither.sh line 77:
  echo "Slither output:\n$SLITHER_OUTPUT"
       ^-- SC2028 (info): echo may not expand escape sequences. Use printf.


In ./packages/contracts-bedrock/scripts/slither.sh line 91:
json=$(cat $SLITHER_REPORT)
^--^ SC2034 (warning): json appears unused. Verify use (or export if used externally).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- json appears unused. Verify use (...
  https://www.shellcheck.net/wiki/SC2028 -- echo may not expand escape sequen...
  https://www.shellcheck.net/wiki/SC2236 -- Use -n instead of ! -z.
Checking ./packages/contracts-bedrock/scripts/check-deploy-configs.sh
shellcheck: (Array.!): undefined array element
Checking ./packages/contracts-bedrock/scripts/check-snapshots.sh
Checking ./packages/contracts-bedrock/scripts/generate-l2-genesis.sh

In ./packages/contracts-bedrock/scripts/generate-l2-genesis.sh line 34:
    i=$(($i + 1))
         ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.


In ./packages/contracts-bedrock/scripts/generate-l2-genesis.sh line 41:
    if [ $(du -m "$OUTFILE_L2" | cut -f1) -lt 8 ]; then
         ^-- SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2004 -- $/${} is unnecessary on arithmeti...
Checking ./packages/contracts-bedrock/scripts/getting-started/versions.sh
Checking ./packages/contracts-bedrock/scripts/getting-started/config.sh
Checking ./packages/contracts-bedrock/scripts/getting-started/wallets.sh
Checking ./packages/contracts-bedrock/scripts/deploy.sh
Checking ./packages/contracts-bedrock/scripts/statediff.sh
Checking ./packages/contracts-bedrock/scripts/verify-foundry-install.sh
Checking ./ops/scripts/geth-version-checker.sh
Checking ./ops/scripts/ci-match-values-between-files.sh
Checking ./ops/scripts/newer-file.sh
Checking ./ops/scripts/install-foundry.sh
Checking ./ops/scripts/todo-checker.sh
Checking ./ops/scripts/ci-docker-tag-op-stack-release.sh
Checking ./op-challenger/scripts/list_games.sh

In ./op-challenger/scripts/list_games.sh line 21:
  GAME=($GAME) # split the string into an array by the same name
        ^---^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.

For more information:
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
Checking ./op-challenger/scripts/move.sh

In ./op-challenger/scripts/move.sh line 9:
SIGNER_ARGS="${@:6}"
            ^------^ SC2124 (warning): Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.

For more information:
  https://www.shellcheck.net/wiki/SC2124 -- Assigning an array to a string! A...
Checking ./op-challenger/scripts/parallel.sh
Checking ./op-challenger/scripts/list_claims.sh

In ./op-challenger/scripts/list_claims.sh line 16:
  CLAIM=($CLAIM) # split the string into an array by the same name
         ^----^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.

For more information:
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
Checking ./op-challenger/scripts/alphabet/mallory.sh

In ./op-challenger/scripts/alphabet/mallory.sh line 4:
SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
                ^----------------------------^ SC2046 (warning): Quote this to prevent word splitting.


In ./op-challenger/scripts/alphabet/mallory.sh line 5:
CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
               ^--------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.


In ./op-challenger/scripts/alphabet/mallory.sh line 6:
MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
             ^----------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2116 -- Useless echo? Instead of 'cmd $(e...
Checking ./op-challenger/scripts/alphabet/charlie.sh

In ./op-challenger/scripts/alphabet/charlie.sh line 4:
SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
                ^----------------------------^ SC2046 (warning): Quote this to prevent word splitting.


In ./op-challenger/scripts/alphabet/charlie.sh line 5:
CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
               ^--------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.


In ./op-challenger/scripts/alphabet/charlie.sh line 6:
MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
             ^----------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2116 -- Useless echo? Instead of 'cmd $(e...
Checking ./op-challenger/scripts/alphabet/init_game.sh

In ./op-challenger/scripts/alphabet/init_game.sh line 5:
SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
                ^----------------------------^ SC2046 (warning): Quote this to prevent word splitting.


In ./op-challenger/scripts/alphabet/init_game.sh line 6:
CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*/*}")
               ^--------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.


In ./op-challenger/scripts/alphabet/init_game.sh line 7:
MONOREPO_DIR=$(echo "${SOURCE_DIR%/*/*/*}")
             ^----------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.


In ./op-challenger/scripts/alphabet/init_game.sh line 37:
CHARLIE_KEY="74feb147d72bfae943e6b4e483410933d9e447d5dc47d52432dcc2c1454dabb7"
^---------^ SC2034 (warning): CHARLIE_KEY appears unused. Verify use (or export if used externally).


In ./op-challenger/scripts/alphabet/init_game.sh line 40:
MALLORY_KEY="28d7045146193f5f4eeb151c4843544b1b0d30a7ac1680c845a416fac65a7715"
^---------^ SC2034 (warning): MALLORY_KEY appears unused. Verify use (or export if used externally).


In ./op-challenger/scripts/alphabet/init_game.sh line 64:
ROOT_CLAIM=$(cast keccak $(cast abi-encode "f(uint256,uint256)" 15 122))
                         ^-- SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- CHARLIE_KEY appears unused. Verif...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2116 -- Useless echo? Instead of 'cmd $(e...
Checking ./op-challenger/scripts/resolve.sh

In ./op-challenger/scripts/resolve.sh line 6:
SIGNER_ARGS="${@:3}"
            ^------^ SC2124 (warning): Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.

For more information:
  https://www.shellcheck.net/wiki/SC2124 -- Assigning an array to a string! A...
Checking ./op-challenger/scripts/create_game.sh

In ./op-challenger/scripts/create_game.sh line 4:
SOURCE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
                ^----------------------------^ SC2046 (warning): Quote this to prevent word splitting.


In ./op-challenger/scripts/create_game.sh line 5:
CHALLENGER_DIR=$(echo "${SOURCE_DIR%/*}")
               ^------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.


In ./op-challenger/scripts/create_game.sh line 6:
MONOREPO_DIR=$(echo "${CHALLENGER_DIR%/*}")
^----------^ SC2034 (warning): MONOREPO_DIR appears unused. Verify use (or export if used externally).
             ^----------------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.


In ./op-challenger/scripts/create_game.sh line 12:
SIGNER_ARGS="${@:4}"
            ^------^ SC2124 (warning): Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- MONOREPO_DIR appears unused. Veri...
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2124 -- Assigning an array to a string! A...
Checking ./op-challenger/scripts/visualize.sh

In ./op-challenger/scripts/visualize.sh line 9:
DIR=$(echo "${DIR%/*/*}")
    ^-------------------^ SC2116 (style): Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.

For more information:
  https://www.shellcheck.net/wiki/SC2116 -- Useless echo? Instead of 'cmd $(e...
Checking ./indexer/ui/prisma.sh

In ./indexer/ui/prisma.sh line 22:
    if [ $? -eq 0 ]; then
         ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.

For more information:
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...

</details>

**Tests**

No tests were added. I'm not familiar with a lot of these scripts, so manual review is appreciated to make sure nothing untested broke.

**Additional context**

Now that all shellcheck issues are resolved, we can add it to CI in a future PR. If this reveals rules we don't like we can add them to the `.shellcheckrc` file


