### PR TITLE
op-e2e: Enable output_cannon tests

### DIFF
--- a/op-e2e/e2eutils/disputegame/output_honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_honest_helper.go
@@ -27,7 +27,7 @@ func (h *OutputHonestHelper) Attack(ctx context.Context, claimIdx int64) {
 
 	game, claim := h.loadState(ctx, claimIdx)
 	attackPos := claim.Position.Attack()
-	h.t.Logf("Attacking at position %v with g index %v", attackPos, attackPos.ToGIndex())
+	h.t.Logf("Attacking claim %v at position %v with g index %v", claimIdx, attackPos, attackPos.ToGIndex())
 	value, err := h.correctTrace.Get(ctx, game, claim, attackPos)
 	h.require.NoErrorf(err, "Get correct claim at position %v with g index %v", attackPos, attackPos.ToGIndex())
 	h.t.Log("Performing attack")

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -63,20 +63,12 @@ func TestOutputCannonGame(t *testing.T) {
 }
 
 func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
-	// TODO(client-pod#336) Reduce the number of cases and enable this tests
-	t.Skip("Contracts always require VM status to indicate the post-state output root is invalid")
 	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(outputCannonTestExecutor))
 	tests := []struct {
 		disputeL2BlockNumber uint64
 	}{
-		{1},
-		{2},
-		{3},
-		{4},
-		{5},
-		{6},
-		{7},
-		{8},
+		{7}, // Post-state output root is invalid
+		{8}, // Post-state output root is valid
 	}
 	for _, test := range tests {
 		test := test
@@ -99,8 +91,6 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 }
 
 func TestOutputCannonDisputeGame(t *testing.T) {
-	// TODO(client-pod#247): Fix and enable this.
-	t.Skip("Currently failing because of invalid pre-state")
 	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(outputCannonTestExecutor))
 
 	tests := []struct {
@@ -150,8 +140,6 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 }
 
 func TestOutputCannonDefendStep(t *testing.T) {
-	// TODO(client-pod#247): Fix and enable this.
-	t.Skip("Currently failing because of invalid pre-state")
 	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(outputCannonTestExecutor))
 
 	ctx := context.Background()

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -174,3 +174,98 @@ func TestOutputCannonDefendStep(t *testing.T) {
 	game.LogGameData(ctx)
 	require.EqualValues(t, disputegame.StatusChallengerWins, game.Status(ctx))
 }
+
+func TestOutputCannonProposedOutputRootValid(t *testing.T) {
+	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(outputCannonTestExecutor))
+	// honestStepsFail attempts to perform both an attack and defend step using the correct trace.
+	honestStepsFail := func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
+		// Attack step should fail
+		correctTrace.StepFails(ctx, parentClaimIdx, true)
+		// Defending should fail too
+		correctTrace.StepFails(ctx, parentClaimIdx, false)
+	}
+	tests := []struct {
+		// name is the name of the test
+		name string
+
+		// performMove is called to respond to each claim posted by the honest op-challenger.
+		// It should either attack or defend the claim at parentClaimIdx
+		performMove func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64)
+
+		// performStep is called once the maximum game depth is reached. It should perform a step to counter the
+		// claim at parentClaimIdx. Since the proposed output root is invalid, the step call should always revert.
+		performStep func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64)
+	}{
+		{
+			name: "AttackWithCorrectTrace",
+			performMove: func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
+				// Attack everything but oddly using the correct hash.
+				// Except the root of the cannon game must have an invalid VM status code.
+				splitDepth := game.SplitDepth(ctx)
+				if splitDepth == parentClaimIdx {
+					// TODO(client-pod#262): Verify that an attack with a valid status code is rejected
+					game.Attack(ctx, parentClaimIdx, common.Hash{0x01})
+					return
+				}
+				correctTrace.Attack(ctx, parentClaimIdx)
+			},
+			performStep: honestStepsFail,
+		},
+		{
+			name: "DefendWithCorrectTrace",
+			performMove: func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64) {
+				splitDepth := game.SplitDepth(ctx)
+				// Can only attack the root claim or the first cannon claim
+				if parentClaimIdx == 0 {
+					correctTrace.Attack(ctx, parentClaimIdx)
+					return
+				}
+				// The root of the cannon game must have an invalid VM status code
+				// Attacking ensure we're running the cannon trace between two different blocks
+				// instead of being in the trace extension of the output root bisection
+				if splitDepth == parentClaimIdx {
+					// TODO(client-pod#262): Verify that an attack with a valid status code is rejected
+					game.Attack(ctx, parentClaimIdx, common.Hash{0x01})
+					return
+				}
+				// Otherwise, defend everything using the correct hash.
+				correctTrace.Defend(ctx, parentClaimIdx)
+			},
+			performStep: honestStepsFail,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			op_e2e.InitParallel(t, op_e2e.UseExecutor(0))
+
+			ctx := context.Background()
+			sys, l1Client := startFaultDisputeSystem(t)
+			t.Cleanup(sys.Close)
+
+			disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
+			game := disputeGameFactory.StartOutputCannonGameWithCorrectRoot(ctx, "sequencer", 1)
+			correctTrace := game.CreateHonestActor(ctx, "sequencer", challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
+
+			game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+
+			// Now maliciously play the game and it should be impossible to win
+			game.ChallengeRootClaim(ctx,
+				func(parentClaimIdx int64) {
+					test.performMove(ctx, game, correctTrace, parentClaimIdx)
+				},
+				func(parentClaimIdx int64) {
+					test.performStep(ctx, game, correctTrace, parentClaimIdx)
+				})
+
+			// Time travel past when the game will be resolvable.
+			sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+			require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+
+			game.WaitForInactivity(ctx, 10, true)
+			game.LogGameData(ctx)
+			require.EqualValues(t, disputegame.StatusDefenderWins, game.Status(ctx))
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Enable the output_cannon e2e tests that have been migrated from the original cannon tests now that the fixes are in to make them pass.

Also migrates `TestOutputCannonProposedOutputRootValid` to cover a game with a valid output root and the dishonest actor is trying to disprove it by posting the correct trace values.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/247
