### PR TITLE
chore: typo fix

### DIFF
--- a/indexer/api/api.go
+++ b/indexer/api/api.go
@@ -130,7 +130,7 @@ func (a *APIService) Addr() string {
 func (a *APIService) initDB(ctx context.Context, connector DBConnector) error {
 	db, err := connector.OpenDB(ctx, a.log)
 	if err != nil {
-		return fmt.Errorf("failed to connect to databse: %w", err)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	a.dbClose = db.Closer
 	a.bv = db.BridgeTransfers

--- a/indexer/api/config.go
+++ b/indexer/api/config.go
@@ -24,7 +24,7 @@ type DBConfigConnector struct {
 func (cfg *DBConfigConnector) OpenDB(ctx context.Context, log log.Logger) (*DB, error) {
 	db, err := database.NewDB(ctx, log, cfg.DBConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to databse: %w", err)
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 	return &DB{
 		BridgeTransfers: db.BridgeTransfers,

--- a/op-chain-ops/crossdomain/legacy_withdrawal.go
+++ b/op-chain-ops/crossdomain/legacy_withdrawal.go
@@ -41,7 +41,7 @@ func NewLegacyWithdrawal(msgSender, target, sender common.Address, data []byte, 
 	}
 }
 
-// Encode will serialze the Withdrawal in the legacy format so that it
+// Encode will serialize the Withdrawal in the legacy format so that it
 // is suitable for hashing. This assumes that the message is being withdrawn
 // through the standard optimism cross domain messaging system by hashing in
 // the L2CrossDomainMessenger address.

--- a/op-chain-ops/crossdomain/legacy_withdrawal_test.go
+++ b/op-chain-ops/crossdomain/legacy_withdrawal_test.go
@@ -86,7 +86,7 @@ func init() {
 	if err := readStateDiffs(); err != nil {
 		panic(err)
 	}
-	// Initialze the message passer ABI
+	// Initialize the message passer ABI
 	var err error
 	passMessage, err = abi.JSON(strings.NewReader(passMessageABI))
 	if err != nil {

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -686,7 +686,7 @@ func NewL1Deployments(path string) (*L1Deployments, error) {
 
 	var deployments L1Deployments
 	if err := json.Unmarshal(file, &deployments); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal L1 deployements: %w", err)
+		return nil, fmt.Errorf("cannot unmarshal L1 deployments: %w", err)
 	}
 
 	return &deployments, nil


### PR DESCRIPTION
Hey, the indexer typo seems already taken care of in #8571 

Few typos in op-chain-op, one of them is an error message. That's about it