### PR TITLE
op-node: Skip L2 Genesis Check when EL syncing

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -320,7 +320,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return fmt.Errorf("failed to create Engine client: %w", err)
 	}
 
-	if err := cfg.Rollup.ValidateL2Config(ctx, n.l2Source); err != nil {
+	if err := cfg.Rollup.ValidateL2Config(ctx, n.l2Source, cfg.Sync.SyncMode == sync.ELSync); err != nil {
 		return err
 	}
 

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -128,13 +128,17 @@ func (cfg *Config) ValidateL1Config(ctx context.Context, client L1Client) error 
 }
 
 // ValidateL2Config checks L2 config variables for errors.
-func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client) error {
+func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client, skipL2GenesisBlockHash bool) error {
 	// Validate the L2 Client Chain ID
 	if err := cfg.CheckL2ChainID(ctx, client); err != nil {
 		return err
 	}
 
-	// Validate the Rollup L2 Genesis Blockhash
+	// Validate the Rollup L2 Genesis Blockhash if requested
+	// We skip this when doing EL sync
+	if skipL2GenesisBlockHash {
+		return nil
+	}
 	if err := cfg.CheckL2GenesisBlockHash(ctx, client); err != nil {
 		return err
 	}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -134,8 +134,7 @@ func (cfg *Config) ValidateL2Config(ctx context.Context, client L2Client, skipL2
 		return err
 	}
 
-	// Validate the Rollup L2 Genesis Blockhash if requested
-	// We skip this when doing EL sync
+	// Validate the Rollup L2 Genesis Blockhash if requested. We skip this when doing EL sync
 	if skipL2GenesisBlockHash {
 		return nil
 	}

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -219,7 +219,7 @@ func TestValidateL2Config(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient)
+	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
 	assert.NoError(t, err)
 }
 
@@ -229,10 +229,10 @@ func TestValidateL2ConfigInvalidChainIdFails(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x01}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient)
+	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
 	assert.Error(t, err)
 	config.L2ChainID = big.NewInt(99)
-	err = config.ValidateL2Config(context.TODO(), &mockClient)
+	err = config.ValidateL2Config(context.TODO(), &mockClient, false)
 	assert.Error(t, err)
 }
 
@@ -242,11 +242,24 @@ func TestValidateL2ConfigInvalidGenesisHashFails(t *testing.T) {
 	config.Genesis.L2.Number = 100
 	config.Genesis.L2.Hash = [32]byte{0x00}
 	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
-	err := config.ValidateL2Config(context.TODO(), &mockClient)
+	err := config.ValidateL2Config(context.TODO(), &mockClient, false)
 	assert.Error(t, err)
 	config.Genesis.L2.Hash = [32]byte{0x02}
-	err = config.ValidateL2Config(context.TODO(), &mockClient)
+	err = config.ValidateL2Config(context.TODO(), &mockClient, false)
 	assert.Error(t, err)
+}
+
+func TestValidateL2ConfigInvalidGenesisHashSkippedWhenRequested(t *testing.T) {
+	config := randConfig()
+	config.L2ChainID = big.NewInt(100)
+	config.Genesis.L2.Number = 100
+	config.Genesis.L2.Hash = [32]byte{0x00}
+	mockClient := mockL2Client{chainID: big.NewInt(100), Hash: common.Hash{0x01}}
+	err := config.ValidateL2Config(context.TODO(), &mockClient, true)
+	assert.NoError(t, err)
+	config.Genesis.L2.Hash = [32]byte{0x02}
+	err = config.ValidateL2Config(context.TODO(), &mockClient, true)
+	assert.NoError(t, err)
 }
 
 func TestCheckL2ChainID(t *testing.T) {


### PR DESCRIPTION
**Description**

This is done because the transition block does not exist in a geth when
performing a snap sync and the actual genesis block header is pre-london
which breaks all of our fetching code.

This change is required for snap sync to work without downloading a datadir on transitioned networks.

**Tests**

Tested that this works with an empty datadir on goerli.


**Metadata***

* Fixes https://github.com/ethereum-optimism/client-pod/issues/376
