### PR TITLE
 Add Metadata Store to Extended Peerstore 

### DIFF
--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/p2p/store"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -333,6 +334,23 @@ func TestDiscovery(t *testing.T) {
 			peersOfB = append(peersOfB, c.RemotePeer())
 		}
 	}
+
+	// For each node, check that they have recorded metadata about the other nodes during discovery
+	for _, n1 := range []*NodeP2P{nodeA, nodeB, nodeC} {
+		eps, ok := n1.Host().Peerstore().(store.ExtendedPeerstore)
+		require.True(t, ok)
+		for _, n2 := range []*NodeP2P{nodeA, nodeB, nodeC} {
+			if n1 == n2 {
+				continue
+			}
+			md, err := eps.GetPeerMetadata(n2.Host().ID())
+			require.NoError(t, err)
+			// we don't scrutinize the ENR itself, just that it exists
+			require.NotEmpty(t, md.ENR)
+			require.Equal(t, uint64(901), md.OPStackID)
+		}
+	}
+
 }
 
 // Most tests should use mocknets instead of using the actual local host network

--- a/op-node/p2p/rpc_server.go
+++ b/op-node/p2p/rpc_server.go
@@ -115,6 +115,10 @@ func dumpPeer(id peer.ID, nw network.Network, pstore peerstore.Peerstore, connMg
 		if dat, err := eps.GetPeerScores(id); err == nil {
 			info.PeerScores = dat
 		}
+		if md, err := eps.GetPeerMetadata(id); err == nil {
+			info.ENR = md.ENR
+			info.ChainID = md.OPStackID
+		}
 	}
 	if dat, err := pstore.Get(id, "ProtocolVersion"); err == nil {
 		protocolVersion, ok := dat.(string)
@@ -126,12 +130,6 @@ func dumpPeer(id peer.ID, nw network.Network, pstore peerstore.Peerstore, connMg
 		agentVersion, ok := dat.(string)
 		if ok {
 			info.UserAgent = agentVersion
-		}
-	}
-	if dat, err := pstore.Get(id, "ENR"); err == nil {
-		enodeData, ok := dat.(*enode.Node)
-		if ok {
-			info.ENR = enodeData.String()
 		}
 	}
 	// include the /p2p/ address component in all of the addresses for convenience of the API user.
@@ -151,12 +149,6 @@ func dumpPeer(id peer.ID, nw network.Network, pstore peerstore.Peerstore, connMg
 	for _, c := range nw.ConnsToPeer(id) {
 		info.Direction = c.Stat().Direction
 		break
-	}
-	if dat, err := pstore.Get(id, "optimismChainID"); err == nil {
-		chID, ok := dat.(uint64)
-		if ok {
-			info.ChainID = chID
-		}
 	}
 	info.Latency = pstore.LatencyEWMA(id)
 	if connMgr != nil {

--- a/op-node/p2p/store/iface.go
+++ b/op-node/p2p/store/iface.go
@@ -120,6 +120,13 @@ type IPBanStore interface {
 	GetIPBanExpiration(ip net.IP) (time.Time, error)
 }
 
+type MetadataStore interface {
+	// SetPeerMetadata sets the metadata for the specified peer
+	SetPeerMetadata(id peer.ID, md PeerMetadata) (PeerMetadata, error)
+	// GetPeerMetadata returns the metadata for the specified peer
+	GetPeerMetadata(id peer.ID) (PeerMetadata, error)
+}
+
 // ExtendedPeerstore defines a type-safe API to work with additional peer metadata based on a libp2p peerstore.Peerstore
 type ExtendedPeerstore interface {
 	peerstore.Peerstore
@@ -127,4 +134,5 @@ type ExtendedPeerstore interface {
 	peerstore.CertifiedAddrBook
 	PeerBanStore
 	IPBanStore
+	MetadataStore
 }

--- a/op-node/p2p/store/mdbook.go
+++ b/op-node/p2p/store/mdbook.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/ethereum/go-ethereum/log"
+	ds "github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+const (
+	mdCacheSize        = 100
+	mdRecordExpiration = time.Hour * 24 * 7
+)
+
+var metadataBase = ds.NewKey("/peers/md")
+
+// LastUpdate requires atomic update operations. Use the helper functions SetLastUpdated and LastUpdated to modify and access this field.
+type metadataRecord struct {
+	LastUpdate   int64        `json:"lastUpdate"` // unix timestamp in seconds
+	PeerMetadata PeerMetadata `json:"peerMetadata"`
+}
+
+type PeerMetadata struct {
+	ENR       string `json:"enr"`
+	OPStackID uint64 `json:"opStackID"`
+}
+
+func (m *metadataRecord) SetLastUpdated(t time.Time) {
+	atomic.StoreInt64(&m.LastUpdate, t.Unix())
+}
+
+func (m *metadataRecord) LastUpdated() time.Time {
+	return time.Unix(atomic.LoadInt64(&m.LastUpdate), 0)
+}
+
+func (m *metadataRecord) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(m)
+}
+
+func (m *metadataRecord) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, m)
+}
+
+type metadataBook struct {
+	book *recordsBook[peer.ID, *metadataRecord]
+}
+
+func newMetadataRecord() *metadataRecord {
+	return new(metadataRecord)
+}
+
+func newMetadataBook(ctx context.Context, logger log.Logger, clock clock.Clock, store ds.Batching) (*metadataBook, error) {
+	book, err := newRecordsBook[peer.ID, *metadataRecord](ctx, logger, clock, store, mdCacheSize, mdRecordExpiration, metadataBase, newMetadataRecord, peerIDKey)
+	if err != nil {
+		return nil, err
+	}
+	return &metadataBook{book: book}, nil
+}
+
+func (m *metadataBook) startGC() {
+	m.book.startGC()
+}
+
+func (m *metadataBook) GetPeerMetadata(id peer.ID) (PeerMetadata, error) {
+	record, err := m.book.getRecord(id)
+	// If the record is not found, return an empty PeerMetadata
+	if err == UnknownRecordErr {
+		return PeerMetadata{}, nil
+	}
+	if err != nil {
+		return PeerMetadata{}, err
+	}
+	return record.PeerMetadata, nil
+}
+
+// Apply simply overwrites the record with the new one.
+// presently, metadata is only collected during peering, so this is fine.
+// if in the future this data can be updated or expanded, this function will need to be updated.
+func (md *metadataRecord) Apply(rec *metadataRecord) {
+	*rec = *md
+}
+
+func (m *metadataBook) SetPeerMetadata(id peer.ID, md PeerMetadata) (PeerMetadata, error) {
+	rec := newMetadataRecord()
+	rec.PeerMetadata = md
+	rec.SetLastUpdated(m.book.clock.Now())
+	v, err := m.book.SetRecord(id, rec)
+	return v.PeerMetadata, err
+}
+
+func (m *metadataBook) Close() {
+	m.book.Close()
+}


### PR DESCRIPTION
# What
Extended Peer Store now includes a Metadata Book, which tracks data about the peer.

The Metadata Book stores two pieces of data
- `ENR` string
- `ChainID`uint64.

# Why
We thought this information was already loaded to the Peerstore, as we had been attempting to load it during `dumpPeers`, which is used to collect peer info for the caller. However, it was found when calling the RPC command `opp2p_peers` that these values would never be loaded. After investigation, it turns out we never recorded the data.

The first implementation in this PR used the peerstore's metadata store directly to hold this data, but it was found to not prune as we would like. This implementation extends the Extended store to hold this data in a way consistent with the rest of our record keeping.

# How
During the discovery process, the ENR and ChainID are available. If the store can be an Extended Store, we call `SetPeerMetadata` for the peer. This is accomplished using the existing pattern of writing a *Book, and extending the Extended Store's interface to use the new books' functions. It will also log a warning when the MD can't be recorded.

When `dumpPeer` is used to collect information about the peer, the `GetPeerMetadata` function of the extended store is used to retrieve the values it holds, which are then attached to the info structure.

# Testing
Additional requirements were added to the only test I could find which uses the DiscoveryProcess. Once the nodes in the test have finished peering, a new set of checks run to confirm the ENR and ChainID are available for each peer, from each node.

I also manually tested this, running on Sepolia and confirming that my peers now have the expected ChainID and ENR. I used the following command:
```
cast rpc opp2p_peers 'true' --rpc-url http://localhost:8547 | jq
```

# Nuance and Notes
- **Only peers added through Discovery will see this improvement**. This is due to the nature of our peering -- outgoing connections are selected based on ChainID (and hence we have the value to save). However, *incoming* connections are assumed to be pre-filtered by the peer, meaning we never ask for the ENR or ChainID. @protolambda and I discussed extending the peering behavior to optimistically share and enforce these values. This would not prevent dishonest actors from sharing the wrong ChainID, but it would allow for a more consistent UX (if all peers have this value) and would mitigate blast radius for some bugs in the peering process.
  - I'd like to cut this as a nice-to-have ticket
- The internal key name "optimismChainID" has been changed to "opStackID". This was based on some feedback from Proto that the old name misrepresents opStacks as "optimism chains", which I agree with.