### PR TITLE
op-e2e: Use wait for balance helper in TestMintOnRevertedDeposit

### DIFF
--- a/op-e2e/deposit_test.go
+++ b/op-e2e/deposit_test.go
@@ -2,6 +2,7 @@ package op_e2e
 
 import (
 	"context"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"math/big"
 	"testing"
 	"time"
@@ -51,14 +52,15 @@ func TestMintOnRevertedDeposit(t *testing.T) {
 	})
 
 	// Confirm balance
-	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-	endBalance, err := l2Verif.BalanceAt(ctx, fromAddr, nil)
+	ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+	endBalance, err := wait.ForBalanceChange(ctx, l2Verif, fromAddr, startBalance)
 	cancel()
 	require.Nil(t, err)
+
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	toAddrBalance, err := l2Verif.BalanceAt(ctx, toAddr, nil)
-	require.NoError(t, err)
 	cancel()
+	require.NoError(t, err)
 
 	diff := new(big.Int)
 	diff = diff.Sub(endBalance, startBalance)

--- a/op-e2e/deposit_test.go
+++ b/op-e2e/deposit_test.go
@@ -2,10 +2,11 @@ package op_e2e
 
 import (
 	"context"
-	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
Fixes flakes like https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/36744/workflows/1681df70-14fc-43b8-9db4-87beed8a75ad/jobs/1659556.
