### PR TITLE
op-service: move mock structs closer to best-practice use of mock

### DIFF
--- a/op-service/testutils/mock_debug_client.go
+++ b/op-service/testutils/mock_debug_client.go
@@ -12,19 +12,19 @@ type MockDebugClient struct {
 }
 
 func (m *MockDebugClient) ExpectNodeByHash(hash common.Hash, res []byte, err error) {
-	m.Mock.On("NodeByHash", hash).Once().Return(res, &err)
+	m.Mock.On("NodeByHash", hash).Once().Return(res, err)
 }
 
 func (m *MockDebugClient) NodeByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	out := m.Mock.MethodCalled("NodeByHash", hash)
-	return out[0].([]byte), *out[1].(*error)
+	out := m.Mock.Called(hash)
+	return out.Get(0).([]byte), out.Error(1)
 }
 
 func (m *MockDebugClient) ExpectCodeByHash(hash common.Hash, res []byte, err error) {
-	m.Mock.On("CodeByHash", hash).Once().Return(res, &err)
+	m.Mock.On("CodeByHash", hash).Once().Return(res, err)
 }
 
 func (m *MockDebugClient) CodeByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	out := m.Mock.MethodCalled("CodeByHash", hash)
-	return out[0].([]byte), *out[1].(*error)
+	out := m.Mock.Called(hash)
+	return out.Get(0).([]byte), out.Error(1)
 }

--- a/op-service/testutils/mock_engine.go
+++ b/op-service/testutils/mock_engine.go
@@ -11,28 +11,28 @@ type MockEngine struct {
 }
 
 func (m *MockEngine) GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayload, error) {
-	out := m.Mock.MethodCalled("GetPayload", payloadId)
-	return out[0].(*eth.ExecutionPayload), *out[1].(*error)
+	out := m.Mock.Called(payloadId)
+	return out.Get(0).(*eth.ExecutionPayload), out.Error(1)
 }
 
 func (m *MockEngine) ExpectGetPayload(payloadId eth.PayloadID, payload *eth.ExecutionPayload, err error) {
-	m.Mock.On("GetPayload", payloadId).Once().Return(payload, &err)
+	m.Mock.On("GetPayload", payloadId).Once().Return(payload, err)
 }
 
 func (m *MockEngine) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	out := m.Mock.MethodCalled("ForkchoiceUpdate", state, attr)
-	return out[0].(*eth.ForkchoiceUpdatedResult), *out[1].(*error)
+	out := m.Mock.Called(state, attr)
+	return out.Get(0).(*eth.ForkchoiceUpdatedResult), out.Error(1)
 }
 
 func (m *MockEngine) ExpectForkchoiceUpdate(state *eth.ForkchoiceState, attr *eth.PayloadAttributes, result *eth.ForkchoiceUpdatedResult, err error) {
-	m.Mock.On("ForkchoiceUpdate", state, attr).Once().Return(result, &err)
+	m.Mock.On("ForkchoiceUpdate", state, attr).Once().Return(result, err)
 }
 
 func (m *MockEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload) (*eth.PayloadStatusV1, error) {
-	out := m.Mock.MethodCalled("NewPayload", payload)
-	return out[0].(*eth.PayloadStatusV1), *out[1].(*error)
+	out := m.Mock.Called(payload)
+	return out.Get(0).(*eth.PayloadStatusV1), out.Error(1)
 }
 
 func (m *MockEngine) ExpectNewPayload(payload *eth.ExecutionPayload, result *eth.PayloadStatusV1, err error) {
-	m.Mock.On("NewPayload", payload).Once().Return(result, &err)
+	m.Mock.On("NewPayload", payload).Once().Return(result, err)
 }

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -16,66 +16,66 @@ type MockEthClient struct {
 }
 
 func (m *MockEthClient) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
-	out := m.Mock.MethodCalled("InfoByHash", hash)
-	return *out[0].(*eth.BlockInfo), *out[1].(*error)
+	out := m.Mock.Called(hash)
+	return *out.Get(0).(*eth.BlockInfo), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectInfoByHash(hash common.Hash, info eth.BlockInfo, err error) {
-	m.Mock.On("InfoByHash", hash).Once().Return(&info, &err)
+	m.Mock.On("InfoByHash", hash).Once().Return(&info, err)
 }
 
 func (m *MockEthClient) InfoByNumber(ctx context.Context, number uint64) (eth.BlockInfo, error) {
-	out := m.Mock.MethodCalled("InfoByNumber", number)
-	return *out[0].(*eth.BlockInfo), *out[1].(*error)
+	out := m.Mock.Called(number)
+	return *out.Get(0).(*eth.BlockInfo), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectInfoByNumber(number uint64, info eth.BlockInfo, err error) {
-	m.Mock.On("InfoByNumber", number).Once().Return(&info, &err)
+	m.Mock.On("InfoByNumber", number).Once().Return(&info, err)
 }
 
 func (m *MockEthClient) InfoByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, error) {
-	out := m.Mock.MethodCalled("InfoByLabel", label)
-	return *out[0].(*eth.BlockInfo), *out[1].(*error)
+	out := m.Mock.Called(label)
+	return *out.Get(0).(*eth.BlockInfo), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectInfoByLabel(label eth.BlockLabel, info eth.BlockInfo, err error) {
-	m.Mock.On("InfoByLabel", label).Once().Return(&info, &err)
+	m.Mock.On("InfoByLabel", label).Once().Return(&info, err)
 }
 
 func (m *MockEthClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	out := m.Mock.MethodCalled("InfoAndTxsByHash", hash)
-	return out[0].(eth.BlockInfo), out[1].(types.Transactions), *out[2].(*error)
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(types.Transactions), out.Error(2)
 }
 
 func (m *MockEthClient) ExpectInfoAndTxsByHash(hash common.Hash, info eth.BlockInfo, transactions types.Transactions, err error) {
-	m.Mock.On("InfoAndTxsByHash", hash).Once().Return(info, transactions, &err)
+	m.Mock.On("InfoAndTxsByHash", hash).Once().Return(info, transactions, err)
 }
 
 func (m *MockEthClient) InfoAndTxsByNumber(ctx context.Context, number uint64) (eth.BlockInfo, types.Transactions, error) {
-	out := m.Mock.MethodCalled("InfoAndTxsByNumber", number)
-	return out[0].(eth.BlockInfo), out[1].(types.Transactions), *out[2].(*error)
+	out := m.Mock.Called(number)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(types.Transactions), out.Error(2)
 }
 
 func (m *MockEthClient) ExpectInfoAndTxsByNumber(number uint64, info eth.BlockInfo, transactions types.Transactions, err error) {
-	m.Mock.On("InfoAndTxsByNumber", number).Once().Return(info, transactions, &err)
+	m.Mock.On("InfoAndTxsByNumber", number).Once().Return(info, transactions, err)
 }
 
 func (m *MockEthClient) InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error) {
-	out := m.Mock.MethodCalled("InfoAndTxsByLabel", label)
-	return out[0].(eth.BlockInfo), out[1].(types.Transactions), *out[2].(*error)
+	out := m.Mock.Called(label)
+	return out.Get(0).(eth.BlockInfo), out.Get(1).(types.Transactions), out.Error(2)
 }
 
 func (m *MockEthClient) ExpectInfoAndTxsByLabel(label eth.BlockLabel, info eth.BlockInfo, transactions types.Transactions, err error) {
-	m.Mock.On("InfoAndTxsByLabel", label).Once().Return(info, transactions, &err)
+	m.Mock.On("InfoAndTxsByLabel", label).Once().Return(info, transactions, err)
 }
 
 func (m *MockEthClient) PayloadByHash(ctx context.Context, hash common.Hash) (*eth.ExecutionPayload, error) {
-	out := m.Mock.MethodCalled("PayloadByHash", hash)
-	return out[0].(*eth.ExecutionPayload), *out[1].(*error)
+	out := m.Mock.Called(hash)
+	return out.Get(0).(*eth.ExecutionPayload), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectPayloadByHash(hash common.Hash, payload *eth.ExecutionPayload, err error) {
-	m.Mock.On("PayloadByHash", hash).Once().Return(payload, &err)
+	m.Mock.On("PayloadByHash", hash).Once().Return(payload, err)
 }
 
 func (m *MockEthClient) PayloadByNumber(ctx context.Context, n uint64) (*eth.ExecutionPayload, error) {
@@ -88,43 +88,46 @@ func (m *MockEthClient) ExpectPayloadByNumber(n uint64, payload *eth.ExecutionPa
 }
 
 func (m *MockEthClient) PayloadByLabel(ctx context.Context, label eth.BlockLabel) (*eth.ExecutionPayload, error) {
-	out := m.Mock.MethodCalled("PayloadByLabel", label)
-	return out[0].(*eth.ExecutionPayload), *out[1].(*error)
+	out := m.Mock.Called(label)
+	return out.Get(0).(*eth.ExecutionPayload), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectPayloadByLabel(label eth.BlockLabel, payload *eth.ExecutionPayload, err error) {
-	m.Mock.On("PayloadByLabel", label).Once().Return(payload, &err)
+	m.Mock.On("PayloadByLabel", label).Once().Return(payload, err)
 }
 
 func (m *MockEthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
-	out := m.Mock.MethodCalled("FetchReceipts", blockHash)
-	return *out[0].(*eth.BlockInfo), out[1].(types.Receipts), *out[2].(*error)
+	out := m.Mock.Called(blockHash)
+	return *out.Get(0).(*eth.BlockInfo), out.Get(1).(types.Receipts), out.Error(2)
 }
 
 func (m *MockEthClient) ExpectFetchReceipts(hash common.Hash, info eth.BlockInfo, receipts types.Receipts, err error) {
-	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, &err)
+	m.Mock.On("FetchReceipts", hash).Once().Return(&info, receipts, err)
 }
 
 func (m *MockEthClient) GetProof(ctx context.Context, address common.Address, storage []common.Hash, blockTag string) (*eth.AccountResult, error) {
-	return m.Mock.MethodCalled("GetProof", address, storage, blockTag).Get(0).(*eth.AccountResult), nil
+	out := m.Mock.Called(address, storage, blockTag)
+	return out.Get(0).(*eth.AccountResult), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectGetProof(address common.Address, storage []common.Hash, blockTag string, result *eth.AccountResult, err error) {
-	m.Mock.On("GetProof", address, storage, blockTag).Once().Return(result, &err)
+	m.Mock.On("GetProof", address, storage, blockTag).Once().Return(result, err)
 }
 
 func (m *MockEthClient) GetStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockTag string) (common.Hash, error) {
-	return m.Mock.MethodCalled("GetStorageAt", address, storageSlot, blockTag).Get(0).(common.Hash), nil
+	out := m.Mock.Called(address, storageSlot, blockTag)
+	return out.Get(0).(common.Hash), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectGetStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockTag string, result common.Hash, err error) {
-	m.Mock.On("GetStorageAt", address, storageSlot, blockTag).Once().Return(result, &err)
+	m.Mock.On("GetStorageAt", address, storageSlot, blockTag).Once().Return(result, err)
 }
 
 func (m *MockEthClient) ReadStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockHash common.Hash) (common.Hash, error) {
-	return m.Mock.MethodCalled("ReadStorageAt", address, storageSlot, blockHash).Get(0).(common.Hash), nil
+	out := m.Mock.Called(address, storageSlot, blockHash)
+	return out.Get(0).(common.Hash), out.Error(1)
 }
 
 func (m *MockEthClient) ExpectReadStorageAt(ctx context.Context, address common.Address, storageSlot common.Hash, blockHash common.Hash, result common.Hash, err error) {
-	m.Mock.On("ReadStorageAt", address, storageSlot, blockHash).Once().Return(result, &err)
+	m.Mock.On("ReadStorageAt", address, storageSlot, blockHash).Once().Return(result, err)
 }

--- a/op-service/testutils/mock_l1.go
+++ b/op-service/testutils/mock_l1.go
@@ -12,28 +12,28 @@ type MockL1Source struct {
 }
 
 func (m *MockL1Source) L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByLabel", label)
-	return out[0].(eth.L1BlockRef), *out[1].(*error)
+	out := m.Mock.Called(label)
+	return out.Get(0).(eth.L1BlockRef), out.Error(1)
 }
 
 func (m *MockL1Source) ExpectL1BlockRefByLabel(label eth.BlockLabel, ref eth.L1BlockRef, err error) {
-	m.Mock.On("L1BlockRefByLabel", label).Once().Return(ref, &err)
+	m.Mock.On("L1BlockRefByLabel", label).Once().Return(ref, err)
 }
 
 func (m *MockL1Source) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByNumber", num)
-	return out[0].(eth.L1BlockRef), *out[1].(*error)
+	out := m.Mock.Called(num)
+	return out.Get(0).(eth.L1BlockRef), out.Error(1)
 }
 
 func (m *MockL1Source) ExpectL1BlockRefByNumber(num uint64, ref eth.L1BlockRef, err error) {
-	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, &err)
+	m.Mock.On("L1BlockRefByNumber", num).Once().Return(ref, err)
 }
 
 func (m *MockL1Source) L1BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L1BlockRef, error) {
-	out := m.Mock.MethodCalled("L1BlockRefByHash", hash)
-	return out[0].(eth.L1BlockRef), *out[1].(*error)
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.L1BlockRef), out.Error(1)
 }
 
 func (m *MockL1Source) ExpectL1BlockRefByHash(hash common.Hash, ref eth.L1BlockRef, err error) {
-	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, &err)
+	m.Mock.On("L1BlockRefByHash", hash).Once().Return(ref, err)
 }

--- a/op-service/testutils/mock_l2.go
+++ b/op-service/testutils/mock_l2.go
@@ -30,28 +30,28 @@ func (m *MockL2Client) ExpectL2BlockRefByNumber(num uint64, ref eth.L2BlockRef, 
 }
 
 func (c *MockL2Client) L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error) {
-	out := c.Mock.MethodCalled("L2BlockRefByHash", hash)
-	return out[0].(eth.L2BlockRef), *out[1].(*error)
+	out := c.Mock.Called(hash)
+	return out.Get(0).(eth.L2BlockRef), out.Error(1)
 }
 
 func (m *MockL2Client) ExpectL2BlockRefByHash(hash common.Hash, ref eth.L2BlockRef, err error) {
-	m.Mock.On("L2BlockRefByHash", hash).Once().Return(ref, &err)
+	m.Mock.On("L2BlockRefByHash", hash).Once().Return(ref, err)
 }
 
 func (m *MockL2Client) SystemConfigByL2Hash(ctx context.Context, hash common.Hash) (eth.SystemConfig, error) {
-	out := m.Mock.MethodCalled("SystemConfigByL2Hash", hash)
-	return out[0].(eth.SystemConfig), *out[1].(*error)
+	out := m.Mock.Called(hash)
+	return out.Get(0).(eth.SystemConfig), out.Error(1)
 }
 
 func (m *MockL2Client) ExpectSystemConfigByL2Hash(hash common.Hash, cfg eth.SystemConfig, err error) {
-	m.Mock.On("SystemConfigByL2Hash", hash).Once().Return(cfg, &err)
+	m.Mock.On("SystemConfigByL2Hash", hash).Once().Return(cfg, err)
 }
 
 func (m *MockL2Client) OutputV0AtBlock(ctx context.Context, blockHash common.Hash) (*eth.OutputV0, error) {
-	out := m.Mock.MethodCalled("OutputV0AtBlock", blockHash)
-	return out[0].(*eth.OutputV0), *out[1].(*error)
+	out := m.Mock.Called(blockHash)
+	return out.Get(0).(*eth.OutputV0), out.Error(1)
 }
 
 func (m *MockL2Client) ExpectOutputV0AtBlock(blockHash common.Hash, output *eth.OutputV0, err error) {
-	m.Mock.On("OutputV0AtBlock", blockHash).Once().Return(output, &err)
+	m.Mock.On("OutputV0AtBlock", blockHash).Once().Return(output, err)
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Following @sebastianst 's feedback on `mock_rollup_client.go` in #8585, this PR proposes to improve the other `mock`s in `testutils` to be closer to best-practices. Not all functions were changed: where a test relied on a particular mock implementation detail, I kept the mock the same, rather than changing the test.

**Tests**

Existing tests are used. They pass locally, want to make sure CircleCI agrees before requesting review.
