### PR TITLE
ci-builder: add docker-ce-cli

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -95,8 +95,11 @@ RUN /bin/sh -c set -eux; \
   mkdir -p /etc/apt/keyrings; \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \
+  chmod a+r /etc/apt/keyrings/docker.gpg; \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null; \
   apt-get update; \
-  apt-get install -y nodejs; \
+  apt-get install -y nodejs docker-ce-cli; \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt; \
   npm i -g depcheck; \
   pip install slither-analyzer==$SLITHER_VERSION capstone pyelftools; \


### PR DESCRIPTION
**Description**

Allows for https://github.com/ethereum-optimism/optimism/blob/e6e7fd267e19f3497e0ff4e1c30a3675cbe05e52/.circleci/config.yml#L1362
to be removed from the CI so that `docker-ce-cli` is built into the
`ci-builder` image and it doesn't need to be installed in each run of
CI.

Closes https://github.com/ethereum-optimism/optimism/issues/8529

I built the image locally and it was able to build to completion.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
