### PR TITLE
:lock: feat: Improve security of CI by not running scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -952,7 +952,6 @@ jobs:
       - run:
           name: Install node_modules
           command: pnpm install:ci
-          working_directory: indexer/api-ts
       - run:
           name: Install tygo
           command: go install github.com/gzuidhof/tygo@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
             - "node_modules"
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --offline
+          command: pnpm install:ci:offline
       - run:
           name: print forge version
           command: forge --version
@@ -367,7 +367,7 @@ jobs:
       # populate node modules from the cache
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       - run:
           name: print forge version
           command: forge --version
@@ -399,7 +399,7 @@ jobs:
       # populate node modules from the cache
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       # Note: this step needs to come first because one of the later steps modifies the cache & forces a contracts rebuild
       - run:
           name: semver lock
@@ -493,7 +493,7 @@ jobs:
       - attach_workspace: { at: "." }
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       - check-changed:
           patterns: contracts-bedrock
       - run:
@@ -539,7 +539,7 @@ jobs:
       # populate node modules from the cache
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       - run:
           name: Lint
           command: pnpm lint && git diff --exit-code
@@ -568,7 +568,7 @@ jobs:
       # populate node modules from the cache
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       - run:
           name: Check generated and build
           command: pnpm generate:check
@@ -590,7 +590,7 @@ jobs:
       # populate node modules from the cache
       - run:
           name: Install dependencies
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       - run:
           name: anvil-l1
           background: true
@@ -654,7 +654,7 @@ jobs:
             npm i pnpm --global
       - run:
           name: pnpm dev deps
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
       - run:
           name: specs toc
           command: pnpm lint:specs:toc && git diff --exit-code ./specs
@@ -674,7 +674,7 @@ jobs:
       - run:
           name: Install node_modules
           command: |
-            pnpm install --frozen-lockfile --prefer-offline
+            pnpm install:ci
       - run:
           name: Lint check
           command: |
@@ -859,7 +859,7 @@ jobs:
           name: run tests
           command: |
             mkdir -p /testlogs
-            
+
             export OP_E2E_CANNON_ENABLED="<<parameters.cannon_enabled>>"
             # Note: We don't use circle CI test splits because we need to split by test name, not by package. There is an additional
             # constraint that gotestsum does not currently (nor likely will) accept files from different pacakges when building.
@@ -951,7 +951,7 @@ jobs:
           working_directory: indexer
       - run:
           name: Install node_modules
-          command: pnpm install --frozen-lockfile --prefer-offline
+          command: pnpm install:ci
           working_directory: indexer/api-ts
       - run:
           name: Install tygo
@@ -1068,7 +1068,7 @@ jobs:
       - run:
           name: Install and build
           command: |
-            pnpm install --frozen-lockfile --prefer-offline && pnpm build
+            pnpm install:ci && pnpm build
       - attach_workspace:
           at: /tmp/workspace
       - run:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,10 +19,10 @@ runs:
 
     - name: Install node dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm install:ci
     - name: Derive appropriate SHAs for base and head for `nx affected` commands
       uses: nrwl/nx-set-shas@v3
-      with: 
+      with:
         main-branch-name: "develop"
     - run: |
         echo "nx using following shas:"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-ts: submodules
 	if [ -n "$$NVM_DIR" ]; then \
 		. $$NVM_DIR/nvm.sh && nvm use; \
 	fi
-	pnpm install
+	pnpm install:ci
 	pnpm build
 .PHONY: build-ts
 

--- a/ops/docker/Dockerfile.packages
+++ b/ops/docker/Dockerfile.packages
@@ -73,7 +73,7 @@ WORKDIR /opt/optimism
 COPY --from=manifests /tmp/manifests  ./
 COPY *.json ./
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install:ci
 
 COPY ./packages ./packages
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build": "npx nx run-many --target=build",
     "test": "npx nx run-many --target=test",
     "issues": "./ops/scripts/todo-checker.sh",
+    "install:ci": "pnpm install --ignore-scripts --frozen-lockfile && pnpm postinstall && pnpm rebuild nx",
+    "install:ci:offline": "pnpm install --ignore-scripts --offline --frozen-lockfile && pnpm postinstall && pnpm rebuild nx",
     "lint": "npx nx run-many --target=lint",
     "test:coverage": "npx nx run-many --target=test:coverage",
     "lint:ts:check": "npx nx run-many --target=lint:ts:check",

--- a/ufm-test-services/metamask/Dockerfile
+++ b/ufm-test-services/metamask/Dockerfile
@@ -17,7 +17,7 @@ RUN if [ "$METAMASK_PLAYWRIGHT_RUN_HEADLESS" != "false" ]; then \
 
 # Copy necessary files and directories
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY tests /app/tests/
 COPY playwright.config.ts /app/
 COPY start.sh /app/


### PR DESCRIPTION
NPM packages can run arbitrary scripts when installed. To improve security in CI pass in --ignore-scripts flags.

Developers locally can also choose to use `npm install:ci` if they want the same assurances locally too.

Nx requires a post install script to run so we explicitly run it via running `pnpm rebuild nx`. If any other packages require a postinstall scripts we should do the same. This makes it so we never are accidentally introducing a new script we didn't realize is running.