### PR TITLE
:technologist: feat: Add never-connect-to-cloud to nx.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "develop",
+  "neverConnectToCloud": true,
   "affected": {
     "defaultBase": "develop"
   },


### PR DESCRIPTION
@protolambda mentioend not liking that IP address leaks when running nx. This is from connecting nx cloud which we aren't actually taking advantage of. It's currently unused (with exception of myself) by CI and the team

Because other developers likely feel the same way about using nx cloud add setting to make it not connect to nx cloud.

Also add a $schema property. This simply allows editors to strongly type the json file