### PR TITLE
ci: ci-builder v0.34.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.33.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.34.0
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1
@@ -1358,22 +1358,6 @@ jobs:
           patterns: contracts-bedrock/test/kontrol,contracts-bedrock/src/L1/OptimismPortal\.sol
       - setup_remote_docker:
           docker_layer_caching: true
-      - run:
-          name: Install Docker CLI
-          command: |
-            # Add Docker's official GPG key:
-            apt-get update
-            apt-get install ca-certificates curl gnupg
-            install -m 0755 -d /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-            chmod a+r /etc/apt/keyrings/docker.gpg
-            # Add the repository to Apt sources:
-            echo \
-              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-              $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-              tee /etc/apt/sources.list.d/docker.list > /dev/null
-            apt-get update
-            apt-get install -y docker-ce-cli
       - run:
           name: Run Kontrol Tests
           command: |


### PR DESCRIPTION
**Description**

Include the `ci-builder` image built [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/36803/workflows/93e91700-4a14-4635-a4e6-e57f5001a532).
This includes the changes from https://github.com/ethereum-optimism/optimism/pull/8625.
We can remove a step from CI as mentioned in https://github.com/ethereum-optimism/optimism/issues/8529

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

