### PR TITLE
Added TestFlagsHaveCorrespondingEnvVars pull request changes.

### DIFF
--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -63,7 +63,7 @@ func TestFlagsHaveCorrespondingEnvVars(t *testing.T) {
 			GetEnvVars() []string
 		})
 		if !ok || len(envFlag.GetEnvVars()) == 0 {
-			assert.True(t, false, "%q flag must have a corresponding env var", name)
+			t.Errorf("%q flag must have corresponding env var", name)
 		}
 	}
 }

--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -51,3 +51,16 @@ func TestBetaFlags(t *testing.T) {
 		}
 	}
 }
+
+// TestFlagsHaveCorrespondingEnvVars test that all flags have a corresponding env-var.
+func TestFlagsHaveCorrespondingEnvVars(t *testing.T) {
+	for _, flag := range Flags {
+		envFlag, ok := flag.(interface {
+			GetEnvVars() []string
+		})
+
+		if !ok || len(envFlag.GetEnvVars()) == 0 {
+			assert.True(t, false, "%q flag must have corresponding env var", flag.Names()[0])
+		}
+	}
+}

--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -54,9 +54,15 @@ func TestBetaFlags(t *testing.T) {
 
 // TestFlagsHaveCorrespondingEnvVars test that all flags have a corresponding env-var.
 func TestFlagsHaveCorrespondingEnvVars(t *testing.T) {
+	var skipFlags = map[string]bool{ // flags with no know env var
+		PeerScoringName:    true,
+		PeerScoreBandsName: true,
+		TopicScoringName:   true,
+	}
+
 	for _, flag := range Flags {
 		name := flag.Names()[0]
-		if name == PeerScoringName || name == PeerScoreBandsName || name == TopicScoringName { // skip p2p flags with no known env-vars
+		if _, skip := skipFlags[name]; skip { // skip flags with no known env-vars
 			continue
 		}
 		envFlag, ok := flag.(interface {

--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -54,7 +54,7 @@ func TestBetaFlags(t *testing.T) {
 
 // TestFlagsHaveCorrespondingEnvVars test that all flags have a corresponding env-var.
 func TestFlagsHaveCorrespondingEnvVars(t *testing.T) {
-	var skipFlags = map[string]bool{ // flags with no know env var
+	var skipFlags = map[string]bool{ // flags with no known env var
 		PeerScoringName:    true,
 		PeerScoreBandsName: true,
 		TopicScoringName:   true,

--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -55,12 +55,15 @@ func TestBetaFlags(t *testing.T) {
 // TestFlagsHaveCorrespondingEnvVars test that all flags have a corresponding env-var.
 func TestFlagsHaveCorrespondingEnvVars(t *testing.T) {
 	for _, flag := range Flags {
+		name := flag.Names()[0]
+		if name == PeerScoringName || name == PeerScoreBandsName || name == TopicScoringName { // skip p2p flags with no known env-vars
+			continue
+		}
 		envFlag, ok := flag.(interface {
 			GetEnvVars() []string
 		})
-
 		if !ok || len(envFlag.GetEnvVars()) == 0 {
-			assert.True(t, false, "%q flag must have corresponding env var", flag.Names()[0])
+			assert.True(t, false, "%q flag must have a corresponding env var", name)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This pull request addresses the issue of easily forgetting to add environment variables by introducing a dedicated test suite named TestFlagsHaveCorrespondingEnvVars. This suite specifically identifies flags without corresponding environment variables, helping to catch potential oversights.

**Tests**

I've added `TestFlagsHaveCorrespondingEnvVars` suite to validate the presence and correctness of the required environment variables. Flags which by default do not have env-vars pass.


**Additional context**

When new flags are added, environment variables can easily be forgotten and left out. This test suite emphasizes that no flag should be without its corresponding environment variables, providing an additional layer of assurance for the integrity of the codebase.


**Metadata**

- Fixes #[7976](https://github.com/ethereum-optimism/optimism/issues/7976)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Implemented a new test to ensure all relevant flags have corresponding environment variables, enhancing configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->