### PR TITLE
specs: 4844 blob encoding

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -507,7 +507,7 @@ Each blob in a [EIP-4844] transaction really consists of `FIELD_ELEMENTS_PER_BLO
 
 Each field element is a number in a prime field of
 `BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513`.
-This number does not represent a full `uin256`: `math.log2(BLS_MODULUS) = 254.8570894...`
+This number does not represent a full `uint256`: `math.log2(BLS_MODULUS) = 254.8570894...`
 
 The [L1 consensus-specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md)
 describe the encoding of this polynomial.

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -518,7 +518,7 @@ To save computational overhead, only `254` bits per field element are used for r
 `127` bytes of application-layer rollup data is encoded at a time, into 4 adjacent field elements of the blob:
 
 ```python
-# read(N): read N bytes from the application-layer rollup-data.
+# read(N): read the next N bytes from the application-layer rollup-data. The next read starts where the last stopped.
 # write(V): append V (one or more bytes) to the raw blob.
 bytes tailA = read(31)
 byte x = read(1)


### PR DESCRIPTION
## Background

EIP-4844: https://eips.ethereum.org/EIPS/eip-4844

Each blob-transaction carries versioned data-hashes: 32 bytes each.
These are hashes of KZG commitments: 48 bytes each.
The KZG commitments are over polynomials: `FIELD_ELEMENTS_PER_BLOB = 4096` field elements.

Each field element is a number in a prime field of `BLS_MODULUS = 52435875175126190479447740508185965837690552500527637822603658699938581184513`.
`math.log2(BLS_MODULUS) = 254.8570894...`
The problem: This is not a multiple of 8 bits.

## Efficiency

Theoretically, a blob can thus encode `math.log2(BLS_MODULUS) * 4096 / 8 = ~ 130486.8` bytes of information
Using that fractional information however, is computationally expensive and complicated:
it requires math on the field elements to preserve it.

Instead, we can also choose to only use `254` bits per element:
this gives `254*4096/8 = 130048` bytes of information, a `438` byte loss, or about `0.33%` of the blob.

Or, even more simple, use only `248` bits per element (i.e. 31 bytes):
this gives `248*4096/8 = 126976` bytes of information, a `3510` byte loss, or about `2.69%` of the blob.

## Encoding Proposal

To avoid multiplying each number into a huge integer and then factoring out the data,
for a mere `0.33%` efficiency difference, we can accept the `254` bits per element.

To avoid unnecessary bit-shifting, we can take `248` bits, and process the remaining `6` bits separately.
To pack bytes into those `6`bits, we can take groups of 4 field elements: `4 * 6 = 24` bits, or 3 bytes.

To avoid requiring all 4096 elements to be in-memory, we can encode/decode 4 field elements at a time.
This is `31 * 4 + 3 = 127` bytes of input rollup data at a time.

To avoid a lot of bit-shifting, we can set 3 of these 4 bytes with 6 bits of the data each.
And then combine the last 6 bits from the remaining 3 x 2 bits of data.

See specs change for proposed encoding details.

And then we can encode the version as a single whole byte, and the length (if we do not use the full amount of data) as the next 3 bytes. (to make it a nice 4-byte header, and since `uin16` is one byte too small to encode the length).
