### PR TITLE
Update TestUniqueFlags to check for uniqueness in aliases

### DIFF
--- a/op-batcher/flags/flags_test.go
+++ b/op-batcher/flags/flags_test.go
@@ -26,12 +26,13 @@ func TestOptionalFlagsDontSetRequired(t *testing.T) {
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
 	for _, flag := range Flags {
-		name := flag.Names()[0]
-		if _, ok := seenCLI[name]; ok {
-			t.Errorf("duplicate flag %s", name)
-			continue
+		for _, name := range flag.Names() {
+			if _, ok := seenCLI[name]; ok {
+				t.Errorf("duplicate flag %s", name)
+				continue
+			}
+			seenCLI[name] = struct{}{}
 		}
-		seenCLI[name] = struct{}{}
 	}
 }
 

--- a/op-challenger/flags/flags_test.go
+++ b/op-challenger/flags/flags_test.go
@@ -17,12 +17,13 @@ import (
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
 	for _, flag := range Flags {
-		name := flag.Names()[0]
-		if _, ok := seenCLI[name]; ok {
-			t.Errorf("duplicate flag %s", name)
-			continue
+		for _, name := range flag.Names() {
+			if _, ok := seenCLI[name]; ok {
+				t.Errorf("duplicate flag %s", name)
+				continue
+			}
+			seenCLI[name] = struct{}{}
 		}
-		seenCLI[name] = struct{}{}
 	}
 }
 

--- a/op-node/flags/flags_test.go
+++ b/op-node/flags/flags_test.go
@@ -25,12 +25,13 @@ func TestOptionalFlagsDontSetRequired(t *testing.T) {
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
 	for _, flag := range Flags {
-		name := flag.Names()[0]
-		if _, ok := seenCLI[name]; ok {
-			t.Errorf("duplicate flag %s", name)
-			continue
+		for _, name := range flag.Names() {
+			if _, ok := seenCLI[name]; ok {
+				t.Errorf("duplicate flag %s", name)
+				continue
+			}
+			seenCLI[name] = struct{}{}
 		}
-		seenCLI[name] = struct{}{}
 	}
 }
 

--- a/op-program/host/flags/flags_test.go
+++ b/op-program/host/flags/flags_test.go
@@ -12,12 +12,13 @@ import (
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
 	for _, flag := range Flags {
-		name := flag.Names()[0]
-		if _, ok := seenCLI[name]; ok {
-			t.Errorf("duplicate flag %s", name)
-			continue
+		for _, name := range flag.Names() {
+			if _, ok := seenCLI[name]; ok {
+				t.Errorf("duplicate flag %s", name)
+				continue
+			}
+			seenCLI[name] = struct{}{}
 		}
-		seenCLI[name] = struct{}{}
 	}
 }
 

--- a/op-proposer/flags/flags_test.go
+++ b/op-proposer/flags/flags_test.go
@@ -26,12 +26,13 @@ func TestOptionalFlagsDontSetRequired(t *testing.T) {
 func TestUniqueFlags(t *testing.T) {
 	seenCLI := make(map[string]struct{})
 	for _, flag := range Flags {
-		name := flag.Names()[0]
-		if _, ok := seenCLI[name]; ok {
-			t.Errorf("duplicate flag %s", name)
-			continue
+		for _, name := range flag.Names() {
+			if _, ok := seenCLI[name]; ok {
+				t.Errorf("duplicate flag %s", name)
+				continue
+			}
+			seenCLI[name] = struct{}{}
 		}
-		seenCLI[name] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
**Description**

We previously only checked the flag name itself for duplicates, but now we are checking all of the possible flag names. These extra flag names are set via the aliases array when creating flags with urfave cli.

**Tests**

Tested locally that this test would fail if a duplicate alias was added.
