### PR TITLE
:bookmark: chore: make chainmon version match publish tag

### DIFF
--- a/packages/chain-mon/package.json
+++ b/packages/chain-mon/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@eth-optimism/chain-mon",
-  "version": "0.5.5",
+  "version": "1.0.1",
   "description": "[Optimism] Chain monitoring services",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
The versioning process on github doesn't correctly update tag