### PR TITLE
op-service: Improve active seq provider

### DIFF
--- a/op-service/dial/active_l2_provider_test.go
+++ b/op-service/dial/active_l2_provider_test.go
@@ -717,14 +717,13 @@ func TestRollupProvider_HandlesManyIndexClientMismatch(t *testing.T) {
 	// secondarySequencer is inactive, but online
 	seq1.ExpectSequencerActive(false, nil)
 	seq1.MaybeClose()
-	seq1.ExpectSequencerActive(false, nil) // a non-buggy impl shouldn't need this line.
 	// tertiarySequencer can't even be dialed
 	ept.setRollupDialOutcome(2, false)
 	// after calling RollupClient, index will be set to 0, but currentRollupClient is secondarySequencer
 	rollupClient, err := rollupProvider.RollupClient(context.Background())
 	require.Error(t, err)
 	require.Nil(t, rollupClient)
-	// internal state is now inconsistent in the buggy impl.
+	// internal state would now be inconsistent in the buggy impl.
 
 	// now seq0 is dialable and active
 	ept.setRollupDialOutcome(0, true)
@@ -741,4 +740,5 @@ func TestRollupProvider_HandlesManyIndexClientMismatch(t *testing.T) {
 	rollupClient, err = rollupProvider.RollupClient(context.Background())
 	require.NoError(t, err)
 	require.Same(t, seq0, rollupClient)
+	ept.assertAllExpectations(t)
 }

--- a/op-service/dial/active_l2_provider_test.go
+++ b/op-service/dial/active_l2_provider_test.go
@@ -152,7 +152,7 @@ func TestRollupProvider_FailoverOnInactiveSequencer(t *testing.T) {
 	require.Same(t, primarySequencer, firstSequencerUsed)
 
 	primarySequencer.ExpectSequencerActive(false, nil) // become inactive after that
-	primarySequencer.ExpectClose()
+	primarySequencer.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 	secondSequencerUsed, err := rollupProvider.RollupClient(context.Background())
 	require.NoError(t, err)
@@ -180,8 +180,8 @@ func TestEndpointProvider_FailoverOnInactiveSequencer(t *testing.T) {
 
 	primarySequencer.ExpectSequencerActive(false, nil) // become inactive after that
 	secondarySequencer.ExpectSequencerActive(true, nil)
-	primarySequencer.ExpectClose()
-	ept.ethClients[0].ExpectClose() // we close the ethclient when we switch over to the next sequencer
+	primarySequencer.MaybeClose()
+	ept.ethClients[0].MaybeClose() // we close the ethclient when we switch over to the next sequencer
 	secondSequencerUsed, err := activeProvider.EthClient(context.Background())
 	require.NoError(t, err)
 	require.Same(t, ept.ethClients[1], secondSequencerUsed)
@@ -205,7 +205,7 @@ func TestRollupProvider_FailoverOnErroredSequencer(t *testing.T) {
 	require.Same(t, primarySequencer, firstSequencerUsed)
 
 	primarySequencer.ExpectSequencerActive(true, fmt.Errorf("a test error")) // error-out after that
-	primarySequencer.ExpectClose()
+	primarySequencer.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 	secondSequencerUsed, err := rollupProvider.RollupClient(context.Background())
 	require.NoError(t, err)
@@ -232,8 +232,8 @@ func TestEndpointProvider_FailoverOnErroredSequencer(t *testing.T) {
 	require.Same(t, primaryEthClient, firstSequencerUsed)
 
 	primarySequencer.ExpectSequencerActive(true, fmt.Errorf("a test error")) // error out after that
-	primarySequencer.ExpectClose()
-	primaryEthClient.ExpectClose()
+	primarySequencer.MaybeClose()
+	primaryEthClient.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 
 	secondSequencerUsed, err := activeProvider.EthClient(context.Background())
@@ -296,7 +296,7 @@ func TestRollupProvider_FailoverAndReturn(t *testing.T) {
 
 	// Primary becomes inactive, secondary active
 	primarySequencer.ExpectSequencerActive(false, nil)
-	primarySequencer.ExpectClose()
+	primarySequencer.MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 
 	// Fails over to secondary
@@ -307,7 +307,7 @@ func TestRollupProvider_FailoverAndReturn(t *testing.T) {
 	// Primary becomes active again, secondary becomes inactive
 	primarySequencer.ExpectSequencerActive(true, nil)
 	secondarySequencer.ExpectSequencerActive(false, nil)
-	secondarySequencer.ExpectClose()
+	secondarySequencer.MaybeClose()
 
 	// Should return to primary
 	thirdSequencerUsed, err := rollupProvider.RollupClient(context.Background())
@@ -330,8 +330,8 @@ func TestEndpointProvider_FailoverAndReturn(t *testing.T) {
 
 	// Primary becomes inactive, secondary active
 	primarySequencer.ExpectSequencerActive(false, nil)
-	primarySequencer.ExpectClose()
-	ept.ethClients[0].ExpectClose()
+	primarySequencer.MaybeClose()
+	ept.ethClients[0].MaybeClose()
 	secondarySequencer.ExpectSequencerActive(true, nil)
 
 	// Fails over to secondary
@@ -342,8 +342,8 @@ func TestEndpointProvider_FailoverAndReturn(t *testing.T) {
 	// Primary becomes active again, secondary becomes inactive
 	primarySequencer.ExpectSequencerActive(true, nil)
 	secondarySequencer.ExpectSequencerActive(false, nil)
-	secondarySequencer.ExpectClose()
-	ept.ethClients[1].ExpectClose()
+	secondarySequencer.MaybeClose()
+	ept.ethClients[1].MaybeClose()
 
 	// // Should return to primary
 	thirdSequencerUsed, err := endpointProvider.EthClient(context.Background())
@@ -394,7 +394,7 @@ func TestRollupProvider_SelectSecondSequencerIfFirstInactiveAtCreation(t *testin
 
 	// First sequencer is inactive, second sequencer is active
 	ept.rollupClients[0].ExpectSequencerActive(false, nil)
-	ept.rollupClients[0].ExpectClose()
+	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 
 	rollupProvider, err := ept.newActiveL2RollupProvider(0)
@@ -429,7 +429,7 @@ func TestEndpointProvider_SelectSecondSequencerIfFirstOfflineAtCreation(t *testi
 
 	// First sequencer is inactive, second sequencer is active
 	ept.rollupClients[0].ExpectSequencerActive(false, nil)
-	ept.rollupClients[0].ExpectClose()
+	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 	ept.rollupClients[1].ExpectSequencerActive(true, nil) // see comment in other tests about why we expect this twice
 
@@ -466,7 +466,7 @@ func TestRollupProvider_ConstructorErrorOnFirstSequencerOffline(t *testing.T) {
 
 	// First sequencer is dead, second sequencer is active
 	ept.rollupClients[0].ExpectSequencerActive(false, fmt.Errorf("I am offline"))
-	ept.rollupClients[0].ExpectClose()
+	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 
 	rollupProvider, err := ept.newActiveL2RollupProvider(0)
@@ -483,7 +483,7 @@ func TestEndpointProvider_ConstructorErrorOnFirstSequencerOffline(t *testing.T) 
 
 	// First sequencer is dead, second sequencer is active
 	ept.rollupClients[0].ExpectSequencerActive(false, fmt.Errorf("I am offline"))
-	ept.rollupClients[0].ExpectClose()
+	ept.rollupClients[0].MaybeClose()
 	ept.rollupClients[1].ExpectSequencerActive(true, nil)
 	ept.rollupClients[1].ExpectSequencerActive(true, nil) // see comment in other tests about why we expect this twice
 
@@ -502,7 +502,7 @@ func TestRollupProvider_FailOnAllInactiveSequencers(t *testing.T) {
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
 		sequencer.ExpectSequencerActive(false, nil)
-		sequencer.ExpectClose()
+		sequencer.MaybeClose()
 	}
 
 	_, err := ept.newActiveL2RollupProvider(0)
@@ -518,7 +518,7 @@ func TestEndpointProvider_FailOnAllInactiveSequencers(t *testing.T) {
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
 		sequencer.ExpectSequencerActive(false, nil)
-		sequencer.ExpectClose()
+		sequencer.MaybeClose()
 	}
 
 	_, err := ept.newActiveL2EndpointProvider(0)
@@ -534,7 +534,7 @@ func TestRollupProvider_FailOnAllErroredSequencers(t *testing.T) {
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
 		sequencer.ExpectSequencerActive(true, fmt.Errorf("a test error"))
-		sequencer.ExpectClose()
+		sequencer.MaybeClose()
 	}
 
 	_, err := ept.newActiveL2RollupProvider(0)
@@ -550,7 +550,7 @@ func TestEndpointProvider_FailOnAllErroredSequencers(t *testing.T) {
 	// All sequencers are inactive
 	for _, sequencer := range ept.rollupClients {
 		sequencer.ExpectSequencerActive(true, fmt.Errorf("a test error"))
-		sequencer.ExpectClose()
+		sequencer.MaybeClose()
 	}
 
 	_, err := ept.newActiveL2EndpointProvider(0)
@@ -614,7 +614,7 @@ func TestRollupProvider_ErrorWhenAllSequencersInactive(t *testing.T) {
 	// All sequencers become inactive
 	for _, sequencer := range ept.rollupClients {
 		sequencer.ExpectSequencerActive(false, nil)
-		sequencer.ExpectClose()
+		sequencer.MaybeClose()
 	}
 
 	_, err = rollupProvider.RollupClient(context.Background())
@@ -635,7 +635,7 @@ func TestEndpointProvider_ErrorWhenAllSequencersInactive(t *testing.T) {
 	// All sequencers become inactive
 	for _, sequencer := range ept.rollupClients {
 		sequencer.ExpectSequencerActive(false, nil)
-		sequencer.ExpectClose()
+		sequencer.MaybeClose()
 	}
 
 	_, err = endpointProvider.EthClient(context.Background())
@@ -712,11 +712,11 @@ func TestRollupProvider_HandlesManyIndexClientMismatch(t *testing.T) {
 
 	// primarySequencer goes down
 	seq0.ExpectSequencerActive(false, fmt.Errorf("I'm offline now"))
-	seq0.ExpectClose()
+	seq0.MaybeClose()
 	ept.setRollupDialOutcome(0, false) // primarySequencer fails to dial
 	// secondarySequencer is inactive, but online
 	seq1.ExpectSequencerActive(false, nil)
-	seq1.ExpectClose()
+	seq1.MaybeClose()
 	seq1.ExpectSequencerActive(false, nil) // a non-buggy impl shouldn't need this line.
 	// tertiarySequencer can't even be dialed
 	ept.setRollupDialOutcome(2, false)

--- a/op-service/dial/active_rollup_provider.go
+++ b/op-service/dial/active_rollup_provider.go
@@ -40,7 +40,8 @@ func NewActiveL2RollupProvider(
 	logger log.Logger,
 ) (*ActiveL2RollupProvider, error) {
 	rollupDialer := func(ctx context.Context, timeout time.Duration,
-		log log.Logger, url string) (RollupClientInterface, error) {
+		log log.Logger, url string,
+	) (RollupClientInterface, error) {
 		return DialRollupClientWithTimeout(ctx, timeout, log, url)
 	}
 	return newActiveL2RollupProvider(ctx, rollupUrls, checkDuration, networkTimeout, logger, rollupDialer)
@@ -64,22 +65,15 @@ func newActiveL2RollupProvider(
 		rollupUrls:     rollupUrls,
 		rollupDialer:   dialer,
 		clientLock:     &sync.Mutex{},
-		rollupIndex:    -1,
 	}
 	cctx, cancel := context.WithTimeout(ctx, networkTimeout)
 	defer cancel()
-	err := p.ensureClientInitialized(cctx)
-	if err != nil {
-		p.log.Warn("Error dialing initial rollup client.", "err", err)
-	}
-	_, err = p.RollupClient(cctx)
-	if err != nil {
+
+	if _, err := p.RollupClient(cctx); err != nil {
 		return nil, fmt.Errorf("setting provider rollup client: %w", err)
 	}
 	return p, nil
 }
-
-var errSeqUnset = errors.New("sequencer unset")
 
 func (p *ActiveL2RollupProvider) RollupClient(ctx context.Context) (RollupClientInterface, error) {
 	p.clientLock.Lock()
@@ -106,37 +100,46 @@ func (p *ActiveL2RollupProvider) shouldCheck() bool {
 	return time.Now().After(p.activeTimeout)
 }
 
-func (p *ActiveL2RollupProvider) ensureClientInitialized(ctx context.Context) error {
-	if p.currentRollupClient != nil {
-		return nil
-	}
-	return p.dialNextSequencer(ctx)
-}
-
 func (p *ActiveL2RollupProvider) findActiveEndpoints(ctx context.Context) error {
-	for range p.rollupUrls {
-		active, err := p.checkCurrentSequencer(ctx)
-		if errors.Is(err, errSeqUnset) {
-			log.Debug("Current sequencer unset.")
-		} else if ep := p.rollupUrls[p.rollupIndex]; err != nil {
-			p.log.Warn("Error querying active sequencer, closing connection and trying next.", "err", err, "index", p.rollupIndex, "url", ep)
+	startIdx := p.rollupIndex
+	var errs error
+	for offset := range p.rollupUrls {
+		idx := (startIdx + offset) % p.numEndpoints()
+		if offset != 0 || p.currentRollupClient == nil {
+			if err := p.dialSequencer(ctx, idx); err != nil {
+				errs = errors.Join(errs, err)
+				p.log.Warn("Error dialing next sequencer.", "err", err, "index", p.rollupIndex)
+				continue
+			}
+		}
+
+		ep := p.rollupUrls[idx]
+		if active, err := p.checkCurrentSequencer(ctx); err != nil {
+			errs = errors.Join(errs, err)
+			p.log.Warn("Error querying active sequencer, trying next.", "err", err, "index", idx, "url", ep)
 		} else if active {
-			p.log.Debug("Current sequencer active.", "index", p.rollupIndex, "url", ep)
+			if offset == 0 {
+				p.log.Debug("Current sequencer active.", "index", idx, "url", ep)
+			} else {
+				p.log.Info("Found new active sequencer.", "index", idx, "url", ep)
+			}
 			return nil
 		} else {
-			p.log.Info("Current sequencer inactive, closing connection and trying next.", "index", p.rollupIndex, "url", ep)
-		}
-		if err := p.dialNextSequencer(ctx); err != nil {
-			p.log.Warn("Error dialing next sequencer.", "err", err, "index", p.rollupIndex)
+			p.log.Info("Sequencer inactive, trying next.", "index", idx, "url", ep)
 		}
 	}
-	return fmt.Errorf("failed to find an active sequencer, tried following urls: %v", p.rollupUrls)
+
+	// TODO: We exhausted the list of sequencers, close and remove latest client?
+	//   It definitely makes all the existing tests pass, but maybe we remove
+	//   this and adjust the tests, if it makes sense.
+	if p.currentRollupClient != nil {
+		p.currentRollupClient.Close()
+		p.currentRollupClient = nil
+	}
+	return fmt.Errorf("failed to find an active sequencer, tried following urls: %v; errs: %w", p.rollupUrls, errs)
 }
 
 func (p *ActiveL2RollupProvider) checkCurrentSequencer(ctx context.Context) (bool, error) {
-	if p.currentRollupClient == nil {
-		return false, errSeqUnset
-	}
 	cctx, cancel := context.WithTimeout(ctx, p.networkTimeout)
 	defer cancel()
 	return p.currentRollupClient.SequencerActive(cctx)
@@ -146,13 +149,15 @@ func (p *ActiveL2RollupProvider) numEndpoints() int {
 	return len(p.rollupUrls)
 }
 
-func (p *ActiveL2RollupProvider) dialNextSequencer(ctx context.Context) error {
+// dialSequencer dials the sequencer for the url at the given index.
+// If successful, the currentRollupClient and rollupIndex are updated and the
+// old rollup client is closed.
+func (p *ActiveL2RollupProvider) dialSequencer(ctx context.Context, idx int) error {
 	cctx, cancel := context.WithTimeout(ctx, p.networkTimeout)
 	defer cancel()
 
-	p.rollupIndex = (p.rollupIndex + 1) % p.numEndpoints()
-	ep := p.rollupUrls[p.rollupIndex]
-	p.log.Info("Dialing next sequencer.", "index", p.rollupIndex, "url", ep)
+	ep := p.rollupUrls[idx]
+	p.log.Info("Dialing next sequencer.", "index", idx, "url", ep)
 	rollupClient, err := p.rollupDialer(cctx, p.networkTimeout, p.log, ep)
 	if err != nil {
 		return fmt.Errorf("dialing rollup client: %w", err)
@@ -160,6 +165,7 @@ func (p *ActiveL2RollupProvider) dialNextSequencer(ctx context.Context) error {
 	if p.currentRollupClient != nil {
 		p.currentRollupClient.Close()
 	}
+	p.rollupIndex = idx
 	p.currentRollupClient = rollupClient
 	return nil
 }

--- a/op-service/dial/active_rollup_provider.go
+++ b/op-service/dial/active_rollup_provider.go
@@ -128,14 +128,6 @@ func (p *ActiveL2RollupProvider) findActiveEndpoints(ctx context.Context) error 
 			p.log.Info("Sequencer inactive, trying next.", "index", idx, "url", ep)
 		}
 	}
-
-	// TODO: We exhausted the list of sequencers, close and remove latest client?
-	//   It definitely makes all the existing tests pass, but maybe we remove
-	//   this and adjust the tests, if it makes sense.
-	if p.currentRollupClient != nil {
-		p.currentRollupClient.Close()
-		p.currentRollupClient = nil
-	}
 	return fmt.Errorf("failed to find an active sequencer, tried following urls: %v; errs: %w", p.rollupUrls, errs)
 }
 

--- a/op-service/testutils/mock_eth_client.go
+++ b/op-service/testutils/mock_eth_client.go
@@ -143,6 +143,10 @@ func (m *MockEthClient) ExpectClose() {
 	m.Mock.On("Close").Once()
 }
 
+func (m *MockEthClient) MaybeClose() {
+	m.Mock.On("Close").Maybe()
+}
+
 func (m *MockEthClient) Close() {
 	m.Mock.Called()
 }

--- a/op-service/testutils/mock_rollup_client.go
+++ b/op-service/testutils/mock_rollup_client.go
@@ -63,7 +63,7 @@ func (m *MockRollupClient) ExpectClose() {
 }
 
 func (m *MockRollupClient) MaybeClose() {
-	m.Mock.On("Close").Once().Maybe()
+	m.Mock.On("Close").Maybe()
 }
 
 func (m *MockRollupClient) Close() {


### PR DESCRIPTION
- Preserve the invariant that the index and current rollup/eth client match.
- Dial at the start of the loop instead of at the end.
- Skip activity check for an index if dialing failed (`continue` loop after failed dial)
- Collect errors in a multi error.
- Improve logging.

Based on #8585 