### PR TITLE
Add DrainOnShutdown flag to control BatchSubmitter waiting behavior

### DIFF
--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -56,6 +56,8 @@ type CLIConfig struct {
 
 	BatchType uint
 
+	DrainOnShutdown bool
+
 	TxMgrConfig      txmgr.CLIConfig
 	LogConfig        oplog.CLIConfig
 	MetricsConfig    opmetrics.CLIConfig

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -34,6 +34,7 @@ type BatcherConfig struct {
 	NetworkTimeout         time.Duration
 	PollInterval           time.Duration
 	MaxPendingTransactions uint64
+	DrainOnShutdown        bool
 }
 
 // BatcherService represents a full batch-submitter instance and its resources,
@@ -88,6 +89,7 @@ func (bs *BatcherService) initFromCLIConfig(ctx context.Context, version string,
 	bs.PollInterval = cfg.PollInterval
 	bs.MaxPendingTransactions = cfg.MaxPendingTransactions
 	bs.NetworkTimeout = cfg.TxMgrConfig.NetworkTimeout
+	bs.DrainOnShutdown = cfg.DrainOnShutdown
 
 	if err := bs.initRPCClients(ctx, cfg); err != nil {
 		return err

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -82,6 +82,13 @@ var (
 		Value:   0,
 		EnvVars: prefixEnvVars("BATCH_TYPE"),
 	}
+	DrainQueueOnShutdown = &cli.BoolFlag{
+		Name: "drainOnShutdown",
+		Usage: "Whether to drain the queue on shutdown. " +
+			"If set to false, the batcher will not wait for the underlying queue to drain when shutting down.",
+		Value:   true,
+		EnvVars: prefixEnvVars("DRAIN_ON_SHUTDOWN"),
+	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )
@@ -101,6 +108,7 @@ var optionalFlags = []cli.Flag{
 	StoppedFlag,
 	SequencerHDPathFlag,
 	BatchTypeFlag,
+	DrainQueueOnShutdown,
 }
 
 func init() {


### PR DESCRIPTION
# What
Introduces a flag, `DrainOnShutdown`, which is used by BatchSubmitter to decide not to wait for some transaction receipts.

# Why
When the BatchSubmitter is shutting down, it may be wise _not to_ wait for the underlying queue of transactions to finish being submitted, and instead the BS should just close without waiting.

There is already control logic in the BatchSubmitter which decides whether or not to wait for underlying transactions to complete before returning, during `publishStateToL1`. The logic followed prior to this PR is:
- L2 Reorg: the work is closed and the queue **IS** awaited
- Standard: the work continues and the queue **IS NOT** awaited. The BatchSubmitter handles receipts back from the Tx Manager as part of its `loop`.
- Shutdown: the work is closed and the queue **IS** awaited

With the introduction of this flag, the behavior is the same with the exception of:
- Shutdown: the work is closed and the queue **MAY BE** awaited, depending on the config setting.

By default this flag is `true` so that it does not impact standard behavior. Setting this to `false` will cause the BatchSubmitter to skip awaiting receipts, allowing it to close without depending on Tx completion.

# How
I followed the standard `config.go`, and wired in my new value wherever it was required.

# Testing
`make op-batcher` and confirmed that the flag is visible in `--help`. I will need to learn a bit more to do more testing on this.

## Also
I added some comments to `loop` and split out a common error logging stanza into a helper. This slightly changes logging messages:
- Was: `"Closed channel manager to handle L2 reorg with pending channel(s) remaining - submitting"`
- Now: `"Closed channel manager (for L2 reorg) with pending channel(s) remaining - submitting"`
This is done because the pattern and style of logging was identical in two cases, but the wording (inclusion of the reason for closing) was the only difference. Now there's an internal `close(reason string)` to remove the duplication while retaining the info.