### PR TITLE
feat(op-proposer): `DisputeGameFactory` support

### DIFF
--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -26,9 +26,10 @@ import (
 )
 
 type ProposerCfg struct {
-	OutputOracleAddr  common.Address
-	ProposerKey       *ecdsa.PrivateKey
-	AllowNonFinalized bool
+	OutputOracleAddr       common.Address
+	DisputeGameFactoryAddr *common.Address
+	ProposerKey            *ecdsa.PrivateKey
+	AllowNonFinalized      bool
 }
 
 type L2Proposer struct {
@@ -49,21 +50,25 @@ type fakeTxMgr struct {
 func (f fakeTxMgr) From() common.Address {
 	return f.from
 }
+
 func (f fakeTxMgr) BlockNumber(_ context.Context) (uint64, error) {
 	panic("unimplemented")
 }
+
 func (f fakeTxMgr) Send(_ context.Context, _ txmgr.TxCandidate) (*types.Receipt, error) {
 	panic("unimplemented")
 }
+
 func (f fakeTxMgr) Close() {
 }
 
 func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Client, rollupCl *sources.RollupClient) *L2Proposer {
 	proposerConfig := proposer.ProposerConfig{
-		PollInterval:       time.Second,
-		NetworkTimeout:     time.Second,
-		L2OutputOracleAddr: cfg.OutputOracleAddr,
-		AllowNonFinalized:  cfg.AllowNonFinalized,
+		PollInterval:           time.Second,
+		NetworkTimeout:         time.Second,
+		L2OutputOracleAddr:     cfg.OutputOracleAddr,
+		DisputeGameFactoryAddr: cfg.DisputeGameFactoryAddr,
+		AllowNonFinalized:      cfg.AllowNonFinalized,
 	}
 	rollupProvider, err := dial.NewStaticL2RollupProviderFromExistingRollup(rollupCl)
 	require.NoError(t, err)

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -86,7 +86,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 	}
 
 	if cfg.OutputOracleAddr == nil {
-		panic("L2OutputOracle address must be set in op-e2e test harness. The DisputeGameFactory is not yet supported.")
+		panic("L2OutputOracle address must be set in op-e2e test harness. The DisputeGameFactory is not yet supported as a proposal destination.")
 	}
 
 	dr, err := proposer.NewL2OutputSubmitter(driverSetup)

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -26,7 +26,7 @@ import (
 )
 
 type ProposerCfg struct {
-	OutputOracleAddr       common.Address
+	OutputOracleAddr       *common.Address
 	DisputeGameFactoryAddr *common.Address
 	ProposalInterval       time.Duration
 	DisputeGameType        uint8
@@ -85,9 +85,13 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		RollupProvider: rollupProvider,
 	}
 
+	if cfg.OutputOracleAddr == nil {
+		panic("L2OutputOracle address must be set in op-e2e test harness. The DisputeGameFactory is not yet supported.")
+	}
+
 	dr, err := proposer.NewL2OutputSubmitter(driverSetup)
 	require.NoError(t, err)
-	contract, err := bindings.NewL2OutputOracleCaller(cfg.OutputOracleAddr, l1)
+	contract, err := bindings.NewL2OutputOracleCaller(*cfg.OutputOracleAddr, l1)
 	require.NoError(t, err)
 
 	address := crypto.PubkeyToAddress(cfg.ProposerKey.PublicKey)
@@ -102,7 +106,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		contract:     contract,
 		address:      address,
 		privKey:      cfg.ProposerKey,
-		contractAddr: cfg.OutputOracleAddr,
+		contractAddr: *cfg.OutputOracleAddr,
 	}
 }
 

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -29,6 +29,7 @@ type ProposerCfg struct {
 	OutputOracleAddr       common.Address
 	DisputeGameFactoryAddr *common.Address
 	ProposalInterval       time.Duration
+	DisputeGameType        uint8
 	ProposerKey            *ecdsa.PrivateKey
 	AllowNonFinalized      bool
 }
@@ -70,6 +71,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 		ProposalInterval:       cfg.ProposalInterval,
 		L2OutputOracleAddr:     cfg.OutputOracleAddr,
 		DisputeGameFactoryAddr: cfg.DisputeGameFactoryAddr,
+		DisputeGameType:        cfg.DisputeGameType,
 		AllowNonFinalized:      cfg.AllowNonFinalized,
 	}
 	rollupProvider, err := dial.NewStaticL2RollupProviderFromExistingRollup(rollupCl)

--- a/op-e2e/actions/l2_proposer.go
+++ b/op-e2e/actions/l2_proposer.go
@@ -28,6 +28,7 @@ import (
 type ProposerCfg struct {
 	OutputOracleAddr       common.Address
 	DisputeGameFactoryAddr *common.Address
+	ProposalInterval       time.Duration
 	ProposerKey            *ecdsa.PrivateKey
 	AllowNonFinalized      bool
 }
@@ -66,6 +67,7 @@ func NewL2Proposer(t Testing, log log.Logger, cfg *ProposerCfg, l1 *ethclient.Cl
 	proposerConfig := proposer.ProposerConfig{
 		PollInterval:           time.Second,
 		NetworkTimeout:         time.Second,
+		ProposalInterval:       cfg.ProposalInterval,
 		L2OutputOracleAddr:     cfg.OutputOracleAddr,
 		DisputeGameFactoryAddr: cfg.DisputeGameFactoryAddr,
 		AllowNonFinalized:      cfg.AllowNonFinalized,

--- a/op-e2e/actions/l2_proposer_test.go
+++ b/op-e2e/actions/l2_proposer_test.go
@@ -55,7 +55,7 @@ func RunProposerTest(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	}, rollupSeqCl, miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
 
 	proposer := NewL2Proposer(t, log, &ProposerCfg{
-		OutputOracleAddr:  sd.DeploymentsL1.L2OutputOracleProxy,
+		OutputOracleAddr:  &sd.DeploymentsL1.L2OutputOracleProxy,
 		ProposerKey:       dp.Secrets.Proposer,
 		AllowNonFinalized: false,
 	}, miner.EthClient(), sequencer.RollupClient())

--- a/op-e2e/actions/user_test.go
+++ b/op-e2e/actions/user_test.go
@@ -72,7 +72,7 @@ func runCrossLayerUserTest(gt *testing.T, test hardforkScheduledTest) {
 		BatcherKey:  dp.Secrets.Batcher,
 	}, seq.RollupClient(), miner.EthClient(), seqEngine.EthClient(), seqEngine.EngineClient(t, sd.RollupCfg))
 	proposer := NewL2Proposer(t, log, &ProposerCfg{
-		OutputOracleAddr:  sd.DeploymentsL1.L2OutputOracleProxy,
+		OutputOracleAddr:  &sd.DeploymentsL1.L2OutputOracleProxy,
 		ProposerKey:       dp.Secrets.Proposer,
 		AllowNonFinalized: true,
 	}, miner.EthClient(), seq.RollupClient())

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -50,6 +50,11 @@ var (
 		Usage:   "Allow the proposer to submit proposals for L2 blocks derived from non-finalized L1 blocks.",
 		EnvVars: prefixEnvVars("ALLOW_NON_FINALIZED"),
 	}
+	DisputeGameFactoryAddress = &cli.StringFlag{
+		Name:    "dgf-address",
+		Usage:   "Address of the DisputeGameFactory contract",
+		EnvVars: prefixEnvVars("DGF_ADDRESS"),
+	}
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
@@ -64,6 +69,7 @@ var optionalFlags = []cli.Flag{
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
 	L2OutputHDPathFlag,
+	DisputeGameFactoryAddress,
 }
 
 func init() {

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -60,6 +60,12 @@ var (
 		Usage:   "Interval between submitting L2 output proposals when the DGFAddress is set",
 		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
 	}
+	DisputeGameTypeFlag = &cli.UintFlag{
+		Name:    "dg-type",
+		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
+		Value:   0,
+		EnvVars: prefixEnvVars("DG_TYPE"),
+	}
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
 )
@@ -76,6 +82,7 @@ var optionalFlags = []cli.Flag{
 	L2OutputHDPathFlag,
 	DisputeGameFactoryAddressFlag,
 	ProposalIntervalFlag,
+	DisputeGameTypeFlag,
 }
 
 func init() {

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -32,13 +32,13 @@ var (
 		Usage:   "HTTP provider URL for the rollup node. A comma-separated list enables the active rollup provider.",
 		EnvVars: prefixEnvVars("ROLLUP_RPC"),
 	}
+
+	// Optional flags
 	L2OOAddressFlag = &cli.StringFlag{
 		Name:    "l2oo-address",
 		Usage:   "Address of the L2OutputOracle contract",
 		EnvVars: prefixEnvVars("L2OO_ADDRESS"),
 	}
-
-	// Optional flags
 	PollIntervalFlag = &cli.DurationFlag{
 		Name:    "poll-interval",
 		Usage:   "How frequently to poll L2 for new blocks",
@@ -50,10 +50,15 @@ var (
 		Usage:   "Allow the proposer to submit proposals for L2 blocks derived from non-finalized L1 blocks.",
 		EnvVars: prefixEnvVars("ALLOW_NON_FINALIZED"),
 	}
-	DisputeGameFactoryAddress = &cli.StringFlag{
+	DisputeGameFactoryAddressFlag = &cli.StringFlag{
 		Name:    "dgf-address",
 		Usage:   "Address of the DisputeGameFactory contract",
 		EnvVars: prefixEnvVars("DGF_ADDRESS"),
+	}
+	ProposalIntervalFlag = &cli.DurationFlag{
+		Name:    "proposal-interval",
+		Usage:   "Interval between submitting L2 output proposals when the DGFAddress is set",
+		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
 	}
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag
@@ -62,14 +67,15 @@ var (
 var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	RollupRpcFlag,
-	L2OOAddressFlag,
 }
 
 var optionalFlags = []cli.Flag{
+	L2OOAddressFlag,
 	PollIntervalFlag,
 	AllowNonFinalizedFlag,
 	L2OutputHDPathFlag,
-	DisputeGameFactoryAddress,
+	DisputeGameFactoryAddressFlag,
+	ProposalIntervalFlag,
 }
 
 func init() {

--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -54,17 +54,20 @@ var (
 		Name:    "dgf-address",
 		Usage:   "Address of the DisputeGameFactory contract",
 		EnvVars: prefixEnvVars("DGF_ADDRESS"),
+		Hidden:  true,
 	}
 	ProposalIntervalFlag = &cli.DurationFlag{
 		Name:    "proposal-interval",
 		Usage:   "Interval between submitting L2 output proposals when the DGFAddress is set",
 		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
+		Hidden:  true,
 	}
 	DisputeGameTypeFlag = &cli.UintFlag{
 		Name:    "dg-type",
 		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
 		Value:   0,
 		EnvVars: prefixEnvVars("DG_TYPE"),
+		Hidden:  true,
 	}
 	// Legacy Flags
 	L2OutputHDPathFlag = txmgr.L2OutputHDPathFlag

--- a/op-proposer/proposer/abi_test.go
+++ b/op-proposer/proposer/abi_test.go
@@ -1,6 +1,7 @@
 package proposer
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -10,24 +11,35 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
-// setupL2OutputOracle deploys the L2 Output Oracle contract to a simulated backend
-func setupL2OutputOracle() (common.Address, *bind.TransactOpts, *backends.SimulatedBackend, *bindings.L2OutputOracle, error) {
-	privateKey, err := crypto.GenerateKey()
+func simulatedBackend() (privateKey *ecdsa.PrivateKey, address common.Address, opts *bind.TransactOpts, backend *backends.SimulatedBackend, err error) {
+	privateKey, err = crypto.GenerateKey()
 	if err != nil {
-		return common.Address{}, nil, nil, nil, err
+		return nil, common.Address{}, nil, nil, err
 	}
 	from := crypto.PubkeyToAddress(privateKey.PublicKey)
-	opts, err := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))
+	opts, err = bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1337))
+	if err != nil {
+		return nil, common.Address{}, nil, nil, err
+	}
+	backend = backends.NewSimulatedBackend(core.GenesisAlloc{from: {Balance: big.NewInt(params.Ether)}}, 50_000_000)
+
+	return privateKey, from, opts, backend, nil
+}
+
+// setupL2OutputOracle deploys the L2 Output Oracle contract to a simulated backend
+func setupL2OutputOracle() (common.Address, *bind.TransactOpts, *backends.SimulatedBackend, *bindings.L2OutputOracle, error) {
+	_, from, opts, backend, err := simulatedBackend()
 	if err != nil {
 		return common.Address{}, nil, nil, nil, err
 	}
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{from: {Balance: big.NewInt(params.Ether)}}, 50_000_000)
+
 	_, _, contract, err := bindings.DeployL2OutputOracle(
 		opts,
 		backend,
@@ -44,26 +56,44 @@ func setupL2OutputOracle() (common.Address, *bind.TransactOpts, *backends.Simula
 	return from, opts, backend, contract, nil
 }
 
+// setupDisputeGameFactory deploys the DisputeGameFactory contract to a simulated backend
+func setupDisputeGameFactory() (common.Address, *bind.TransactOpts, *backends.SimulatedBackend, *bindings.DisputeGameFactory, error) {
+	_, from, opts, backend, err := simulatedBackend()
+	if err != nil {
+		return common.Address{}, nil, nil, nil, err
+	}
+
+	_, _, contract, err := bindings.DeployDisputeGameFactory(
+		opts,
+		backend,
+	)
+	if err != nil {
+		return common.Address{}, nil, nil, nil, err
+	}
+	return from, opts, backend, contract, nil
+}
+
 // TestManualABIPacking ensure that the manual ABI packing is the same as going through the bound contract.
 // We don't use the contract to transact because it does not fit our transaction management scheme, but
 // we want to make sure that we don't incorrectly create the transaction data.
 func TestManualABIPacking(t *testing.T) {
-	_, opts, _, contract, err := setupL2OutputOracle()
+	// L2OO
+	_, opts, _, l2oo, err := setupL2OutputOracle()
 	require.NoError(t, err)
 	rng := rand.New(rand.NewSource(1234))
 
-	abi, err := bindings.L2OutputOracleMetaData.GetAbi()
+	l2ooAbi, err := bindings.L2OutputOracleMetaData.GetAbi()
 	require.NoError(t, err)
 
 	output := testutils.RandomOutputResponse(rng)
 
-	txData, err := proposeL2OutputTxData(abi, output)
+	txData, err := proposeL2OutputTxData(l2ooAbi, output)
 	require.NoError(t, err)
 
 	// set a gas limit to disable gas estimation. The invariantes that the L2OO tries to uphold
 	// are not maintained in this test.
 	opts.GasLimit = 100_000
-	tx, err := contract.ProposeL2Output(
+	tx, err := l2oo.ProposeL2Output(
 		opts,
 		output.OutputRoot,
 		new(big.Int).SetUint64(output.BlockRef.Number),
@@ -72,4 +102,28 @@ func TestManualABIPacking(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, txData, tx.Data())
+
+	// DGF
+	_, opts, _, dgf, err := setupDisputeGameFactory()
+	require.NoError(t, err)
+	rng = rand.New(rand.NewSource(1234))
+
+	dgfAbi, err := bindings.DisputeGameFactoryMetaData.GetAbi()
+	require.NoError(t, err)
+
+	output = testutils.RandomOutputResponse(rng)
+
+	txData, err = proposeL2OutputDGFTxData(dgfAbi, output)
+	require.NoError(t, err)
+
+	opts.GasLimit = 100_000
+	dgfTx, err := dgf.Create(
+		opts,
+		uint8(0),
+		output.OutputRoot,
+		math.U256Bytes(new(big.Int).SetUint64(output.BlockRef.Number)),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, txData, dgfTx.Data())
 }

--- a/op-proposer/proposer/abi_test.go
+++ b/op-proposer/proposer/abi_test.go
@@ -113,7 +113,7 @@ func TestManualABIPacking(t *testing.T) {
 
 	output = testutils.RandomOutputResponse(rng)
 
-	txData, err = proposeL2OutputDGFTxData(dgfAbi, output)
+	txData, err = proposeL2OutputDGFTxData(dgfAbi, uint8(0), output)
 	require.NoError(t, err)
 
 	opts.GasLimit = 100_000

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -1,6 +1,7 @@
 package proposer
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -45,6 +46,9 @@ type CLIConfig struct {
 	MetricsConfig opmetrics.CLIConfig
 
 	PprofConfig oppprof.CLIConfig
+
+	// DGFAddress is the DisputeGameFactory contract address.
+	DGFAddress string
 }
 
 func (c *CLIConfig) Check() error {
@@ -59,6 +63,9 @@ func (c *CLIConfig) Check() error {
 	}
 	if err := c.TxMgrConfig.Check(); err != nil {
 		return err
+	}
+	if c.DGFAddress != "" && c.L2OOAddress != "" {
+		return fmt.Errorf("both the `DisputeGameFactory` and `L2OutputOracle` addresses were provided")
 	}
 	return nil
 }
@@ -78,5 +85,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		LogConfig:         oplog.ReadCLIConfig(ctx),
 		MetricsConfig:     opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:       oppprof.ReadCLIConfig(ctx),
+		DGFAddress:        ctx.String(flags.DisputeGameFactoryAddress.Name),
 	}
 }

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -52,6 +52,9 @@ type CLIConfig struct {
 
 	// ProposalInterval is the delay between submitting L2 output proposals when the DGFAddress is set.
 	ProposalInterval time.Duration
+
+	// DisputeGameType is the type of dispute game to create when submitting an output proposal.
+	DisputeGameType uint8
 }
 
 func (c *CLIConfig) Check() error {
@@ -98,5 +101,6 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		PprofConfig:       oppprof.ReadCLIConfig(ctx),
 		DGFAddress:        ctx.String(flags.DisputeGameFactoryAddressFlag.Name),
 		ProposalInterval:  ctx.Duration(flags.ProposalIntervalFlag.Name),
+		DisputeGameType:   uint8(ctx.Uint(flags.DisputeGameTypeFlag.Name)),
 	}
 }

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -1,7 +1,7 @@
 package proposer
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -72,13 +72,13 @@ func (c *CLIConfig) Check() error {
 	}
 
 	if c.DGFAddress != "" && c.L2OOAddress != "" {
-		return fmt.Errorf("both the `DisputeGameFactory` and `L2OutputOracle` addresses were provided")
+		return errors.New("both the `DisputeGameFactory` and `L2OutputOracle` addresses were provided")
 	}
 	if c.DGFAddress != "" && c.ProposalInterval == 0 {
-		return fmt.Errorf("the `DisputeGameFactory` address was provided but the `ProposalInterval` was not set")
+		return errors.New("the `DisputeGameFactory` address was provided but the `ProposalInterval` was not set")
 	}
 	if c.ProposalInterval != 0 && c.DGFAddress == "" {
-		return fmt.Errorf("the `ProposalInterval` was provided but the `DisputeGameFactory` address was not set")
+		return errors.New("the `ProposalInterval` was provided but the `DisputeGameFactory` address was not set")
 	}
 
 	return nil

--- a/op-proposer/proposer/config.go
+++ b/op-proposer/proposer/config.go
@@ -49,6 +49,9 @@ type CLIConfig struct {
 
 	// DGFAddress is the DisputeGameFactory contract address.
 	DGFAddress string
+
+	// ProposalInterval is the delay between submitting L2 output proposals when the DGFAddress is set.
+	ProposalInterval time.Duration
 }
 
 func (c *CLIConfig) Check() error {
@@ -64,9 +67,17 @@ func (c *CLIConfig) Check() error {
 	if err := c.TxMgrConfig.Check(); err != nil {
 		return err
 	}
+
 	if c.DGFAddress != "" && c.L2OOAddress != "" {
 		return fmt.Errorf("both the `DisputeGameFactory` and `L2OutputOracle` addresses were provided")
 	}
+	if c.DGFAddress != "" && c.ProposalInterval == 0 {
+		return fmt.Errorf("the `DisputeGameFactory` address was provided but the `ProposalInterval` was not set")
+	}
+	if c.ProposalInterval != 0 && c.DGFAddress == "" {
+		return fmt.Errorf("the `ProposalInterval` was provided but the `DisputeGameFactory` address was not set")
+	}
+
 	return nil
 }
 
@@ -85,6 +96,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		LogConfig:         oplog.ReadCLIConfig(ctx),
 		MetricsConfig:     opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:       oppprof.ReadCLIConfig(ctx),
-		DGFAddress:        ctx.String(flags.DisputeGameFactoryAddress.Name),
+		DGFAddress:        ctx.String(flags.DisputeGameFactoryAddressFlag.Name),
+		ProposalInterval:  ctx.Duration(flags.ProposalIntervalFlag.Name),
 	}
 }

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -449,14 +449,15 @@ func (l *L2OutputSubmitter) loopDGF(ctx context.Context) {
 
 func (l *L2OutputSubmitter) proposeOutput(ctx context.Context, output *eth.OutputResponse) {
 	cCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
 	if err := l.sendTransaction(cCtx, output); err != nil {
 		l.Log.Error("Failed to send proposal transaction",
 			"err", err,
 			"l1blocknum", output.Status.CurrentL1.Number,
 			"l1blockhash", output.Status.CurrentL1.Hash,
 			"l1head", output.Status.HeadL1.Number)
-		cancel()
+		return
 	}
 	l.Metr.RecordL2BlocksProposed(output.BlockRef)
-	cancel()
 }

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -94,7 +94,7 @@ func NewL2OutputSubmitter(setup DriverSetup) (*L2OutputSubmitter, error) {
 			cancel()
 			return nil, err
 		}
-		log.Info("Connected to DisputeGameFactory", "address", setup.Cfg.L2OutputOracleAddr, "version", version)
+		log.Info("Connected to DisputeGameFactory", "address", setup.Cfg.DisputeGameFactoryAddr, "version", version)
 
 		parsed, err := bindings.DisputeGameFactoryMetaData.GetAbi()
 		if err != nil {
@@ -300,12 +300,12 @@ func proposeL2OutputTxData(abi *abi.ABI, output *eth.OutputResponse) ([]byte, er
 }
 
 func (l *L2OutputSubmitter) ProposeL2OutputDGFTxData(output *eth.OutputResponse) ([]byte, error) {
-	return proposeL2OutputDGFTxData(l.dgfABI, output)
+	return proposeL2OutputDGFTxData(l.dgfABI, l.Cfg.DisputeGameType, output)
 }
 
 // proposeL2OutputDGFTxData creates the transaction data for the DisputeGameFactory's `create` function
-func proposeL2OutputDGFTxData(abi *abi.ABI, output *eth.OutputResponse) ([]byte, error) {
-	return abi.Pack("create", uint8(0), output.OutputRoot, math.U256Bytes(new(big.Int).SetUint64(output.BlockRef.Number)))
+func proposeL2OutputDGFTxData(abi *abi.ABI, gameType uint8, output *eth.OutputResponse) ([]byte, error) {
+	return abi.Pack("create", gameType, output.OutputRoot, math.U256Bytes(new(big.Int).SetUint64(output.BlockRef.Number)))
 }
 
 // We wait until l1head advances beyond blocknum. This is used to make sure proposal tx won't

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -111,8 +111,8 @@ func NewL2OutputSubmitter(setup DriverSetup) (*L2OutputSubmitter, error) {
 			dgfContract: dgfCaller,
 			dgfABI:      parsed,
 		}, nil
-	} else {
-		l2ooContract, err := bindings.NewL2OutputOracleCaller(setup.Cfg.L2OutputOracleAddr, setup.L1Client)
+	} else if setup.Cfg.L2OutputOracleAddr != nil {
+		l2ooContract, err := bindings.NewL2OutputOracleCaller(*setup.Cfg.L2OutputOracleAddr, setup.L1Client)
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("failed to create L2OO at address %s: %w", setup.Cfg.L2OutputOracleAddr, err)
@@ -142,6 +142,8 @@ func NewL2OutputSubmitter(setup DriverSetup) (*L2OutputSubmitter, error) {
 			l2ooContract: l2ooContract,
 			l2ooABI:      parsed,
 		}, nil
+	} else {
+		return nil, errors.New("Neither the `L2OutputOracle` nor `DisputeGameFactory` addresses were provided")
 	}
 }
 
@@ -364,7 +366,7 @@ func (l *L2OutputSubmitter) sendTransaction(ctx context.Context, output *eth.Out
 		}
 		receipt, err = l.Txmgr.Send(ctx, txmgr.TxCandidate{
 			TxData:   data,
-			To:       &l.Cfg.L2OutputOracleAddr,
+			To:       l.Cfg.L2OutputOracleAddr,
 			GasLimit: 0,
 		})
 		if err != nil {

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -15,7 +15,7 @@ import (
 // Main is the entrypoint into the L2OutputSubmitter.
 // This method returns a cliapp.LifecycleAction, to create an op-service CLI-lifecycle-managed L2Output-submitter
 func Main(version string) cliapp.LifecycleAction {
-	return func(cliCtx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+	return func(cliCtx *cli.Context, _ context.CancelCauseFunc) (cliapp.Lifecycle, error) {
 		if err := flags.CheckRequired(cliCtx); err != nil {
 			return nil, err
 		}

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -26,16 +26,16 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var (
-	ErrAlreadyStopped = errors.New("already stopped")
-)
+var ErrAlreadyStopped = errors.New("already stopped")
 
 type ProposerConfig struct {
 	// How frequently to poll L2 for new finalized outputs
 	PollInterval   time.Duration
 	NetworkTimeout time.Duration
 
-	L2OutputOracleAddr common.Address
+	L2OutputOracleAddr     common.Address
+	DisputeGameFactoryAddr *common.Address
+
 	// AllowNonFinalized enables the proposal of safe, but non-finalized L2 blocks.
 	// The L1 block-hash embedded in the proposal TX is checked and should ensure the proposal
 	// is never valid on an alternative L1 chain that would produce different L2 data.
@@ -101,6 +101,9 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 		return fmt.Errorf("failed to start pprof server: %w", err)
 	}
 	if err := ps.initL2ooAddress(cfg); err != nil {
+		return fmt.Errorf("failed to init L2ooAddress: %w", err)
+	}
+	if err := ps.initDGFAddress(cfg); err != nil {
 		return fmt.Errorf("failed to init L2ooAddress: %w", err)
 	}
 	if err := ps.initDriver(); err != nil {
@@ -200,6 +203,15 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 		return nil
 	}
 	ps.L2OutputOracleAddr = l2ooAddress
+	return nil
+}
+
+func (ps *ProposerService) initDGFAddress(cfg *CLIConfig) error {
+	l2ooAddress, err := opservice.ParseAddress(cfg.DGFAddress)
+	if err != nil {
+		return nil
+	}
+	ps.DisputeGameFactoryAddr = &l2ooAddress
 	return nil
 }
 

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -33,6 +33,9 @@ type ProposerConfig struct {
 	PollInterval   time.Duration
 	NetworkTimeout time.Duration
 
+	// How frequently to post L2 outputs when the DisputeGameFactory is configured
+	ProposalInterval time.Duration
+
 	L2OutputOracleAddr     common.Address
 	DisputeGameFactoryAddr *common.Address
 
@@ -104,7 +107,10 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 		return fmt.Errorf("failed to init L2ooAddress: %w", err)
 	}
 	if err := ps.initDGFAddress(cfg); err != nil {
-		return fmt.Errorf("failed to init L2ooAddress: %w", err)
+		return fmt.Errorf("failed to init DGF address: %w", err)
+	}
+	if err := ps.initProposalInterval(cfg); err != nil {
+		return fmt.Errorf("failed to init ProposalInterval: %w", err)
 	}
 	if err := ps.initDriver(); err != nil {
 		return fmt.Errorf("failed to init Driver: %w", err)
@@ -212,6 +218,11 @@ func (ps *ProposerService) initDGFAddress(cfg *CLIConfig) error {
 		return nil
 	}
 	ps.DisputeGameFactoryAddr = &l2ooAddress
+	return nil
+}
+
+func (ps *ProposerService) initProposalInterval(cfg *CLIConfig) error {
+	ps.ProposalInterval = cfg.ProposalInterval
 	return nil
 }
 

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -204,7 +204,7 @@ func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 	l2ooAddress, err := opservice.ParseAddress(cfg.L2OOAddress)
 	if err != nil {
-		return nil
+		return err
 	}
 	ps.L2OutputOracleAddr = &l2ooAddress
 	return nil
@@ -213,7 +213,7 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 func (ps *ProposerService) initDGF(cfg *CLIConfig) error {
 	dgfAddress, err := opservice.ParseAddress(cfg.DGFAddress)
 	if err != nil {
-		return nil
+		return err
 	}
 	ps.DisputeGameFactoryAddr = &dgfAddress
 	ps.ProposalInterval = cfg.ProposalInterval

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -211,11 +211,11 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 }
 
 func (ps *ProposerService) initDGF(cfg *CLIConfig) error {
-	l2ooAddress, err := opservice.ParseAddress(cfg.DGFAddress)
+	dgfAddress, err := opservice.ParseAddress(cfg.DGFAddress)
 	if err != nil {
 		return nil
 	}
-	ps.DisputeGameFactoryAddr = &l2ooAddress
+	ps.DisputeGameFactoryAddr = &dgfAddress
 	ps.ProposalInterval = cfg.ProposalInterval
 	ps.DisputeGameType = cfg.DisputeGameType
 	return nil

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -91,6 +91,9 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	ps.NetworkTimeout = cfg.TxMgrConfig.NetworkTimeout
 	ps.AllowNonFinalized = cfg.AllowNonFinalized
 
+	ps.initL2ooAddress(cfg)
+	ps.initDGF(cfg)
+
 	if err := ps.initRPCClients(ctx, cfg); err != nil {
 		return err
 	}
@@ -103,12 +106,6 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	}
 	if err := ps.initPProf(cfg); err != nil {
 		return fmt.Errorf("failed to start pprof server: %w", err)
-	}
-	if err := ps.initL2ooAddress(cfg); err != nil {
-		return fmt.Errorf("failed to init L2ooAddress: %w", err)
-	}
-	if err := ps.initDGF(cfg); err != nil {
-		return fmt.Errorf("failed to init DGF: %w", err)
 	}
 	if err := ps.initDriver(); err != nil {
 		return fmt.Errorf("failed to init Driver: %w", err)
@@ -201,24 +198,24 @@ func (ps *ProposerService) initMetricsServer(cfg *CLIConfig) error {
 	return nil
 }
 
-func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
+func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) {
 	l2ooAddress, err := opservice.ParseAddress(cfg.L2OOAddress)
 	if err != nil {
-		return err
+		// Return no error & set no L2OO related configuration fields.
+		return
 	}
 	ps.L2OutputOracleAddr = &l2ooAddress
-	return nil
 }
 
-func (ps *ProposerService) initDGF(cfg *CLIConfig) error {
+func (ps *ProposerService) initDGF(cfg *CLIConfig) {
 	dgfAddress, err := opservice.ParseAddress(cfg.DGFAddress)
 	if err != nil {
-		return err
+		// Return no error & set no DGF related configuration fields.
+		return
 	}
 	ps.DisputeGameFactoryAddr = &dgfAddress
 	ps.ProposalInterval = cfg.ProposalInterval
 	ps.DisputeGameType = cfg.DisputeGameType
-	return nil
 }
 
 func (ps *ProposerService) initDriver() error {

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -36,7 +36,7 @@ type ProposerConfig struct {
 	// How frequently to post L2 outputs when the DisputeGameFactory is configured
 	ProposalInterval time.Duration
 
-	L2OutputOracleAddr     common.Address
+	L2OutputOracleAddr     *common.Address
 	DisputeGameFactoryAddr *common.Address
 	DisputeGameType        uint8
 
@@ -206,7 +206,7 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 	if err != nil {
 		return nil
 	}
-	ps.L2OutputOracleAddr = l2ooAddress
+	ps.L2OutputOracleAddr = &l2ooAddress
 	return nil
 }
 

--- a/op-proposer/proposer/service.go
+++ b/op-proposer/proposer/service.go
@@ -38,6 +38,7 @@ type ProposerConfig struct {
 
 	L2OutputOracleAddr     common.Address
 	DisputeGameFactoryAddr *common.Address
+	DisputeGameType        uint8
 
 	// AllowNonFinalized enables the proposal of safe, but non-finalized L2 blocks.
 	// The L1 block-hash embedded in the proposal TX is checked and should ensure the proposal
@@ -106,11 +107,8 @@ func (ps *ProposerService) initFromCLIConfig(ctx context.Context, version string
 	if err := ps.initL2ooAddress(cfg); err != nil {
 		return fmt.Errorf("failed to init L2ooAddress: %w", err)
 	}
-	if err := ps.initDGFAddress(cfg); err != nil {
-		return fmt.Errorf("failed to init DGF address: %w", err)
-	}
-	if err := ps.initProposalInterval(cfg); err != nil {
-		return fmt.Errorf("failed to init ProposalInterval: %w", err)
+	if err := ps.initDGF(cfg); err != nil {
+		return fmt.Errorf("failed to init DGF: %w", err)
 	}
 	if err := ps.initDriver(); err != nil {
 		return fmt.Errorf("failed to init Driver: %w", err)
@@ -212,17 +210,14 @@ func (ps *ProposerService) initL2ooAddress(cfg *CLIConfig) error {
 	return nil
 }
 
-func (ps *ProposerService) initDGFAddress(cfg *CLIConfig) error {
+func (ps *ProposerService) initDGF(cfg *CLIConfig) error {
 	l2ooAddress, err := opservice.ParseAddress(cfg.DGFAddress)
 	if err != nil {
 		return nil
 	}
 	ps.DisputeGameFactoryAddr = &l2ooAddress
-	return nil
-}
-
-func (ps *ProposerService) initProposalInterval(cfg *CLIConfig) error {
 	ps.ProposalInterval = cfg.ProposalInterval
+	ps.DisputeGameType = cfg.DisputeGameType
 	return nil
 }
 


### PR DESCRIPTION
## Overview

Adds early support to the `op-proposer` to submitting outputs with the new method, creating dispute games. This can be enabled by passing the `--dgf-address` flag or setting the `DGF_ADDRESS` env var, and omitting the `l2oo-address` flag or `L2OO_ADDRESS` env var (enforced to be mutually exclusive via the `CLIConfig`'s checks).

The proposer does not currently enable this option on the devnet for any reason due to the lack of integration with the bridge.

**TODO**
- [x] New flags
- [x] Support `create` calls to the `DisputeGameFactory` contract rather than the `proposeL2Output` function in the L2OO.
- [x] Refactor the submission logic to not depend on the L2OO's `nextBlockNumber` function when the `DisputeGameFactory` is configured.
- [x] Add support for the new configuration option in the `op-e2e` helpers.

**Metadata**
closes https://github.com/ethereum-optimism/client-pod/issues/393
closes https://github.com/ethereum-optimism/client-pod/issues/332
