### PR TITLE
txmgr: Add `closed` flag and behavior to SimpleTXManager

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -458,6 +458,11 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 	l.Info("Publishing transaction")
 
 	for {
+		// if the tx manager closed, give up without bumping fees or retrying
+		if m.closed.Load() {
+			l.Warn("TxManager closed, aborting transaction submission")
+			return tx, false
+		}
 		if bumpFeesImmediately {
 			newTx, err := m.increaseGasPrice(ctx, tx)
 			if err != nil {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -45,6 +45,7 @@ var (
 	two        = big.NewInt(2)
 
 	ErrBlobFeeLimit = errors.New("blob fee limit reached")
+	ErrClosed       = errors.New("transaction manager is closed")
 )
 
 // TxManager is an interface that allows callers to reliably publish txs,
@@ -119,6 +120,8 @@ type SimpleTxManager struct {
 	nonceLock sync.RWMutex
 
 	pending atomic.Int64
+
+	closed atomic.Bool
 }
 
 // NewSimpleTxManager initializes a new SimpleTxManager with the passed Config.
@@ -153,8 +156,11 @@ func (m *SimpleTxManager) BlockNumber(ctx context.Context) (uint64, error) {
 	return m.backend.BlockNumber(ctx)
 }
 
+// Close closes the underlying connection, and sets the closed flag.
+// once closed, the tx manager will refuse to send any new transactions, and may abandon pending ones.
 func (m *SimpleTxManager) Close() {
 	m.backend.Close()
+	m.closed.Store(true)
 }
 
 func (m *SimpleTxManager) txLogger(tx *types.Transaction, logGas bool) log.Logger {
@@ -195,6 +201,10 @@ type TxCandidate struct {
 //
 // NOTE: Send can be called concurrently, the nonce will be managed internally.
 func (m *SimpleTxManager) Send(ctx context.Context, candidate TxCandidate) (*types.Receipt, error) {
+	// refuse new requests if the tx manager is closed
+	if m.closed.Load() {
+		return nil, ErrClosed
+	}
 	m.metr.RecordPendingTx(m.pending.Add(1))
 	defer func() {
 		m.metr.RecordPendingTx(m.pending.Add(-1))
@@ -417,6 +427,11 @@ func (m *SimpleTxManager) sendTx(ctx context.Context, tx *types.Transaction) (*t
 			if sendState.ShouldAbortImmediately() {
 				m.txLogger(tx, false).Warn("Aborting transaction submission")
 				return nil, errors.New("aborted transaction sending")
+			}
+			// if the tx manager closed while we were waiting for the tx, give up
+			if m.closed.Load() {
+				m.txLogger(tx, false).Warn("TxManager closed, aborting transaction submission")
+				return nil, ErrClosed
 			}
 			tx = publishAndWait(tx, true)
 

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -224,6 +224,9 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 		defer cancel()
 	}
 	tx, err := retry.Do(ctx, 30, retry.Fixed(2*time.Second), func() (*types.Transaction, error) {
+		if m.closed.Load() {
+			return nil, ErrClosed
+		}
 		tx, err := m.craftTx(ctx, candidate)
 		if err != nil {
 			m.l.Warn("Failed to create a transaction, will retry", "err", err)

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -1313,7 +1313,7 @@ func TestClose(t *testing.T) {
 		}
 		if called%retries == 0 {
 			txHash := tx.Hash()
-			h.backend.mine(&txHash, tx.GasFeeCap())
+			h.backend.mine(&txHash, tx.GasFeeCap(), big.NewInt(1))
 		} else {
 			time.Sleep(10 * time.Millisecond)
 			err = core.ErrNonceTooLow
@@ -1375,7 +1375,7 @@ func TestCloseWaitingForConfirmation(t *testing.T) {
 
 	sendTx := func(ctx context.Context, tx *types.Transaction) error {
 		txHash := tx.Hash()
-		h.backend.mine(&txHash, tx.GasFeeCap())
+		h.backend.mine(&txHash, tx.GasFeeCap(), big.NewInt(1))
 		close(sendDone)
 		return nil
 	}
@@ -1393,7 +1393,7 @@ func TestCloseWaitingForConfirmation(t *testing.T) {
 	// by forcing this to happen after close, we are able to observe a closing manager waiting for confirmation
 	go func() {
 		<-closeDone
-		h.backend.mine(nil, nil)
+		h.backend.mine(nil, nil, big.NewInt(1))
 	}()
 
 	ctx := context.Background()


### PR DESCRIPTION
# What
Adds an internal flag `closed` to the SimpleTxManager, and uses that flag to stop new and ongoing work

# Why
In situations where the BatchSubmitter is shutting down, there is ongoing work traveling through the Queue, and managed internally by the TXManager itself. This internally managed work delays shutdown, sometimes by a very long time if those transactions are being hopelessly retried.

The BatchSubmitter already `Close()`s the TXManager, but that close previously did not halt any work, it only closed connection to the backend. We would like to use this signal in order to more aggressively stop the transaction submission, allowing for the Batch Submitter to shut down more directly.

# How
A new `atomic.Bool` is introduced into the SimpleTxManager. On `Close()`, this value is set to true. At several points in transaction submission, this flag is checked:
- New TX Submission on the Exported `Send` method
- During the CraftTX Retry Loop in `send`
- During the update polling loop in `sendTx`
- During the sending loop in `publishTx`
If this flag is set to true, the function returns early instead of continuing to wait or retry. In the case of the update polling in `sendTx`, waiting for confirmations takes precedence over checking the close signal, meaning transactions that should complete are awaited, while erroring or unmined transactions are abandoned.

# Tests
A new unit test has been included, demonstrating that in-flight work is cancelled early, and that new work is denied altogether.

An additional unit test has been included to show that transactions which are mined (but awaiting full confirmation) will hold the closing TxManager open until the work is complete.

# Notes and Nuance
- This should not be merged until after Canyon is settled, as abandonment of transactions has an increased *potential* for dangling frames, which can be painful.