### PR TITLE
op-service/txmgr: Bump fees by at least 1 wei

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -604,9 +604,14 @@ func (m *SimpleTxManager) checkLimits(tip, basefee, bumpedTip, bumpedFee *big.In
 }
 
 // calcThresholdValue returns x * priceBumpPercent / 100
+// It guarantees that x is increased by at least 1
 func calcThresholdValue(x *big.Int) *big.Int {
 	threshold := new(big.Int).Mul(priceBumpPercent, x)
-	threshold = threshold.Div(threshold, oneHundred)
+	threshold.Div(threshold, oneHundred)
+	// Guarantee to add at least 1 wei. Edge-case during near-zero fee conditions.
+	if threshold.Cmp(x) == 0 {
+		threshold.Add(threshold, big.NewInt(1))
+	}
 	return threshold
 }
 

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -839,6 +839,14 @@ func TestIncreaseGasPrice(t *testing.T) {
 		run  func(t *testing.T)
 	}{
 		{
+			name: "bump at least 1",
+			run: func(t *testing.T) {
+				tx, newTx := doGasPriceIncrease(t, 1, 3, 1, 1)
+				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
+				require.True(t, newTx.GasTipCap().Cmp(tx.GasTipCap()) > 0, "new tx tip must be larger")
+			},
+		},
+		{
 			name: "enforces min bump",
 			run: func(t *testing.T) {
 				tx, newTx := doGasPriceIncrease(t, 100, 1000, 101, 460)


### PR DESCRIPTION
**Description**

Fixes an edge-case during near-zero network fee conditions.

**Tests**

Added test that failed before change.

**Additional context**

The lack of this causes the txmgr to not properly bump very low fees. E.g. 2 wei + 10% is still 2 wei, rounded, so no bump would happen.

