### PR TITLE
EIP4844 L1 Smart Contract Updates

### DIFF
--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -17,12 +17,14 @@ contract SystemConfig is OwnableUpgradeable, ISemver {
     /// @custom:value GAS_CONFIG           Represents an update to txn fee config on L2.
     /// @custom:value GAS_LIMIT            Represents an update to gas limit on L2.
     /// @custom:value UNSAFE_BLOCK_SIGNER  Represents an update to the signer key for unsafe
+    /// @custom:value FEE_SCALARS_ECOTONE  Represents an update to fee scalars on L2 after ecotone.
     ///                                    block distrubution.
     enum UpdateType {
         BATCHER,
         GAS_CONFIG,
         GAS_LIMIT,
-        UNSAFE_BLOCK_SIGNER
+        UNSAFE_BLOCK_SIGNER,
+        FEE_SCALARS_ECOTONE
     }
 
     /// @notice Version identifier, used for upgrades.
@@ -52,6 +54,12 @@ contract SystemConfig is OwnableUpgradeable, ISemver {
     /// @notice L2 block gas limit.
     uint64 public gasLimit;
 
+    /// @notice The scalar value applied to the L1 base fee portion of the blob-capable L1 cost func
+	uint32 public basefeeScalar;
+
+    /// @notice The scalar value applied to the L1 blob base fee portion of the blob-capable L1 cost func
+	uint32 public blobBasefeeScalar;
+
     /// @notice The configuration for the deposit fee market.
     ///         Used by the OptimismPortal to meter the cost of buying L2 gas on L1.
     ///         Set as internal with a getter so that the struct is returned instead of a tuple.
@@ -64,8 +72,8 @@ contract SystemConfig is OwnableUpgradeable, ISemver {
     event ConfigUpdate(uint256 indexed version, UpdateType indexed updateType, bytes data);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.11.0
-    string public constant version = "1.11.0";
+    /// @custom:semver 1.12.0
+    string public constant version = "1.12.0";
 
     /// @notice Constructs the SystemConfig contract. Cannot set
     ///         the owner to `address(0)` due to the Ownable contract's
@@ -124,6 +132,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver {
         // These are set in ascending order of their UpdateTypes.
         _setBatcherHash(_batcherHash);
         _setGasConfig({ _overhead: _overhead, _scalar: _scalar });
+        _setFeeScalarsEcotone({ _basefeeScalar: _scalar, _blobBasefeeScalar: 0 });
         _setGasLimit(_gasLimit);
         _setUnsafeBlockSigner(_unsafeBlockSigner);
         _setResourceConfig(_config);
@@ -195,6 +204,24 @@ contract SystemConfig is OwnableUpgradeable, ISemver {
 
         bytes memory data = abi.encode(_overhead, _scalar);
         emit ConfigUpdate(VERSION, UpdateType.GAS_CONFIG, data);
+    }
+
+    /// @notice Updates fee scalars. Can only be called by the owner. Introduced in Ecotone.
+    /// @param _basefeeScalar New basefeeScalar value.
+    /// @param _blobBasefeeScalar New blobBasefeeScalar value.
+    function setFeeScalarsEcotone(uint32 _basefeeScalar, uint32 _blobBasefeeScalar) external onlyOwner {
+        _setFeeScalarsEcotone(_basefeeScalar, _blobBasefeeScalar);
+    }
+
+    /// @notice Internal function for updating the fee scalars.
+    /// @param _basefeeScalar New basefeeScalar value.
+    /// @param _blobBasefeeScalar New blobBasefeeScalar value.
+    function _setFeeScalarsEcotone(uint32 _basefeeScalar, uint32 _blobBasefeeScalar) internal {
+        basefeeScalar = _basefeeScalar;
+        blobBasefeeScalar = _blobBasefeeScalar;
+
+        bytes memory data = abi.encode(_basefeeScalar, _blobBasefeeScalar);
+        emit ConfigUpdate(VERSION, UpdateType.FEE_SCALARS_ECOTONE, data);
     }
 
     /// @notice Updates the L2 gas limit. Can only be called by the owner.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Splitting out L1 contract changes in a separate PR since they're fully separate from the L2 contract changes in #8712 . 
Adds new scalars to the SystemConfig contract 

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
