### PR TITLE
Add overloads with default values for _addSpec

### DIFF
--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -56,218 +56,80 @@ contract Specification_Test is CommonTest {
         super.setUp();
 
         // DelayedVetoable
-        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("delay()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("initiator()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("queuedAt(bytes32)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("target()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("vetoer()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("delay()") });
+        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("initiator()") });
+        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("queuedAt(bytes32)") });
+        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("target()") });
+        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("version()") });
+        _addSpec({ _name: "DelayedVetoable", _sel: _getSel("vetoer()") });
 
         // L1CrossDomainMessenger
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("MESSAGE_VERSION()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("MIN_GAS_CALLDATA_OVERHEAD()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("OTHER_MESSENGER()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("PORTAL()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("RELAY_CALL_OVERHEAD()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("RELAY_CONSTANT_OVERHEAD()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("RELAY_GAS_CHECK_BUFFER()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("RELAY_RESERVED_GAS()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("baseGas(bytes,uint32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("failedMessages(bytes32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("initialize(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("messageNonce()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("paused()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("portal()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("MESSAGE_VERSION()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("MIN_GAS_CALLDATA_OVERHEAD()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("OTHER_MESSENGER()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("PORTAL()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("RELAY_CALL_OVERHEAD()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("RELAY_CONSTANT_OVERHEAD()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("RELAY_GAS_CHECK_BUFFER()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("RELAY_RESERVED_GAS()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("baseGas(bytes,uint32)") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("failedMessages(bytes32)") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("initialize(address)") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("messageNonce()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("paused()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("portal()") });
         _addSpec({
             _name: "L1CrossDomainMessenger",
             _sel: _getSel("relayMessage(uint256,address,address,uint256,uint256,bytes)"),
-            _auth: Role.NOAUTH,
             _pausable: true
         });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("sendMessage(address,bytes,uint32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("successfulMessages(bytes32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("superchainConfig()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L1CrossDomainMessenger",
-            _sel: _getSel("xDomainMessageSender()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("sendMessage(address,bytes,uint32)") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("successfulMessages(bytes32)") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("version()") });
+        _addSpec({ _name: "L1CrossDomainMessenger", _sel: _getSel("xDomainMessageSender()") });
 
         // L1ERC721Bridge
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("MESSENGER()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("OTHER_BRIDGE()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("MESSENGER()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("OTHER_BRIDGE()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("bridgeERC721(address,address,uint256,uint32,bytes)") });
         _addSpec({
             _name: "L1ERC721Bridge",
-            _sel: _getSel("bridgeERC721(address,address,uint256,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
+            _sel: _getSel("bridgeERC721To(address,address,address,uint256,uint32,bytes)")
         });
-        _addSpec({
-            _name: "L1ERC721Bridge",
-            _sel: _getSel("bridgeERC721To(address,address,address,uint256,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1ERC721Bridge",
-            _sel: _getSel("deposits(address,address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("deposits(address,address,uint256)") });
         _addSpec({
             _name: "L1ERC721Bridge",
             _sel: _getSel("finalizeBridgeERC721(address,address,address,address,uint256,bytes)"),
-            _auth: Role.NOAUTH,
             _pausable: true
         });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("messenger()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("otherBridge()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("superchainConfig()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("paused()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("initialize(address)"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("messenger()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("otherBridge()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("version()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("paused()") });
+        _addSpec({ _name: "L1ERC721Bridge", _sel: _getSel("initialize(address)") });
 
         // L1StandardBridge
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("MESSENGER()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("OTHER_BRIDGE()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("MESSENGER()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("OTHER_BRIDGE()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("bridgeERC20(address,address,uint256,uint32,bytes)") });
         _addSpec({
             _name: "L1StandardBridge",
-            _sel: _getSel("bridgeERC20(address,address,uint256,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
+            _sel: _getSel("bridgeERC20To(address,address,address,uint256,uint32,bytes)")
         });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("bridgeETH(uint32,bytes)") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("bridgeETHTo(address,uint32,bytes)") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("depositERC20(address,address,uint256,uint32,bytes)") });
         _addSpec({
             _name: "L1StandardBridge",
-            _sel: _getSel("bridgeERC20To(address,address,address,uint256,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
+            _sel: _getSel("depositERC20To(address,address,address,uint256,uint32,bytes)")
         });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("bridgeETH(uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("bridgeETHTo(address,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("depositERC20(address,address,uint256,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("depositERC20To(address,address,address,uint256,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("depositETH(uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("depositETHTo(address,uint32,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("deposits(address,address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("depositETH(uint32,bytes)") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("depositETHTo(address,uint32,bytes)") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("deposits(address,address)") });
         _addSpec({
             _name: "L1StandardBridge",
             _sel: _getSel("finalizeBridgeERC20(address,address,address,address,uint256,bytes)"),
@@ -292,500 +154,208 @@ contract Specification_Test is CommonTest {
             _auth: Role.MESSENGER,
             _pausable: true
         });
-        _addSpec({
-            _name: "L1StandardBridge",
-            _sel: _getSel("initialize(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("l2TokenBridge()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("messenger()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("otherBridge()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("paused()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("superchainConfig()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("initialize(address)") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("l2TokenBridge()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("messenger()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("otherBridge()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("paused()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "L1StandardBridge", _sel: _getSel("version()") });
 
         // L2OutputOracle
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("CHALLENGER()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("FINALIZATION_PERIOD_SECONDS()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("L2_BLOCK_TIME()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("PROPOSER()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("SUBMISSION_INTERVAL()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("challenger()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("computeL2Timestamp(uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("deleteL2Outputs(uint256)"),
-            _auth: Role.CHALLENGER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("finalizationPeriodSeconds()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("getL2Output(uint256)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("getL2OutputAfter(uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("getL2OutputIndexAfter(uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("initialize(uint256,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("l2BlockTime()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("latestBlockNumber()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("latestOutputIndex()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("nextBlockNumber()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("nextOutputIndex()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("CHALLENGER()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("FINALIZATION_PERIOD_SECONDS()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("L2_BLOCK_TIME()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("PROPOSER()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("SUBMISSION_INTERVAL()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("challenger()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("computeL2Timestamp(uint256)") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("deleteL2Outputs(uint256)"), _auth: Role.CHALLENGER });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("finalizationPeriodSeconds()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("getL2Output(uint256)") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("getL2OutputAfter(uint256)") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("getL2OutputIndexAfter(uint256)") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("initialize(uint256,uint256)") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("l2BlockTime()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("latestBlockNumber()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("latestOutputIndex()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("nextBlockNumber()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("nextOutputIndex()") });
         _addSpec({
             _name: "L2OutputOracle",
             _sel: _getSel("proposeL2Output(bytes32,uint256,bytes32,uint256)"),
-            _auth: Role.PROPOSER,
-            _pausable: false
+            _auth: Role.PROPOSER
         });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("proposer()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "L2OutputOracle",
-            _sel: _getSel("startingBlockNumber()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("startingTimestamp()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("submissionInterval()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("proposer()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("startingBlockNumber()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("startingTimestamp()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("submissionInterval()") });
+        _addSpec({ _name: "L2OutputOracle", _sel: _getSel("version()") });
 
         // OptimismPortal
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("GUARDIAN()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("L2_ORACLE()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("SYSTEM_CONFIG()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "OptimismPortal",
-            _sel: _getSel("depositTransaction(address,uint256,uint64,bool,bytes)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("donateETH()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("GUARDIAN()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("L2_ORACLE()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("SYSTEM_CONFIG()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("depositTransaction(address,uint256,uint64,bool,bytes)") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("donateETH()") });
         _addSpec({
             _name: "OptimismPortal",
             _sel: OptimismPortal.finalizeWithdrawalTransaction.selector,
-            _auth: Role.NOAUTH,
             _pausable: true
         });
-        _addSpec({
-            _name: "OptimismPortal",
-            _sel: _getSel("finalizedWithdrawals(bytes32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("guardian()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("initialize(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "OptimismPortal",
-            _sel: _getSel("isOutputFinalized(uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("l2Oracle()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("l2Sender()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "OptimismPortal",
-            _sel: _getSel("minimumGasLimit(uint64)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("params()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("paused()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "OptimismPortal",
-            _sel: OptimismPortal.proveWithdrawalTransaction.selector,
-            _auth: Role.NOAUTH,
-            _pausable: true
-        });
-        _addSpec({
-            _name: "OptimismPortal",
-            _sel: _getSel("provenWithdrawals(bytes32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("superchainConfig()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("systemConfig()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "OptimismPortal", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("finalizedWithdrawals(bytes32)") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("guardian()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("initialize(address)") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("isOutputFinalized(uint256)") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("l2Oracle()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("l2Sender()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("minimumGasLimit(uint64)") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("params()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("paused()") });
+        _addSpec({ _name: "OptimismPortal", _sel: OptimismPortal.proveWithdrawalTransaction.selector, _pausable: true });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("provenWithdrawals(bytes32)") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("systemConfig()") });
+        _addSpec({ _name: "OptimismPortal", _sel: _getSel("version()") });
 
         // ProtocolVersions
-        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("RECOMMENDED_SLOT()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("REQUIRED_SLOT()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("VERSION()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "ProtocolVersions",
-            _sel: ProtocolVersions.initialize.selector,
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("owner()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "ProtocolVersions",
-            _sel: ProtocolVersions.recommended.selector,
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "ProtocolVersions",
-            _sel: _getSel("renounceOwnership()"),
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "ProtocolVersions",
-            _sel: ProtocolVersions.required.selector,
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("RECOMMENDED_SLOT()") });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("REQUIRED_SLOT()") });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("VERSION()") });
+        _addSpec({ _name: "ProtocolVersions", _sel: ProtocolVersions.initialize.selector });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("owner()") });
+        _addSpec({ _name: "ProtocolVersions", _sel: ProtocolVersions.recommended.selector });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("renounceOwnership()"), _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "ProtocolVersions", _sel: ProtocolVersions.required.selector });
         _addSpec({
             _name: "ProtocolVersions",
             _sel: ProtocolVersions.setRequired.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
+            _auth: Role.SYSTEMCONFIGOWNER
         });
         _addSpec({
             _name: "ProtocolVersions",
             _sel: ProtocolVersions.setRecommended.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
+            _auth: Role.SYSTEMCONFIGOWNER
         });
-        _addSpec({
-            _name: "ProtocolVersions",
-            _sel: _getSel("transferOwnership(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("transferOwnership(address)") });
+        _addSpec({ _name: "ProtocolVersions", _sel: _getSel("version()") });
 
         // ResourceMetering
-        _addSpec({ _name: "ResourceMetering", _sel: _getSel("params()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "ResourceMetering", _sel: _getSel("params()") });
 
         // SuperchainConfig
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("GUARDIAN_SLOT()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("PAUSED_SLOT()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("guardian()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "SuperchainConfig",
-            _sel: _getSel("initialize(address,bool)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("pause(string)"), _auth: Role.GUARDIAN, _pausable: false });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("paused()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("unpause()"), _auth: Role.GUARDIAN, _pausable: false });
-        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("GUARDIAN_SLOT()") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("PAUSED_SLOT()") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("guardian()") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("initialize(address,bool)") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("pause(string)"), _auth: Role.GUARDIAN });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("paused()") });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("unpause()"), _auth: Role.GUARDIAN });
+        _addSpec({ _name: "SuperchainConfig", _sel: _getSel("version()") });
 
         // SystemConfig
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: _getSel("UNSAFE_BLOCK_SIGNER_SLOT()"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("VERSION()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("batcherHash()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("gasLimit()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.initialize.selector, _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.minimumGasLimit.selector,
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("overhead()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("owner()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: _getSel("renounceOwnership()"),
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.resourceConfig.selector,
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("scalar()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.setBatcherHash.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.setGasConfig.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.setGasLimit.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.setResourceConfig.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("UNSAFE_BLOCK_SIGNER_SLOT()") });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("VERSION()") });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("batcherHash()") });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("gasLimit()") });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.initialize.selector });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.minimumGasLimit.selector });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("overhead()") });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("owner()") });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("renounceOwnership()"), _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.resourceConfig.selector });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("scalar()") });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.setBatcherHash.selector, _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.setGasConfig.selector, _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.setGasLimit.selector, _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.setResourceConfig.selector, _auth: Role.SYSTEMCONFIGOWNER });
         _addSpec({
             _name: "SystemConfig",
             _sel: SystemConfig.setUnsafeBlockSigner.selector,
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
+            _auth: Role.SYSTEMCONFIGOWNER
         });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: _getSel("transferOwnership(address)"),
-            _auth: Role.SYSTEMCONFIGOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "SystemConfig",
-            _sel: SystemConfig.unsafeBlockSigner.selector,
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "SystemConfig", _sel: _getSel("version()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("transferOwnership(address)"), _auth: Role.SYSTEMCONFIGOWNER });
+        _addSpec({ _name: "SystemConfig", _sel: SystemConfig.unsafeBlockSigner.selector });
+        _addSpec({ _name: "SystemConfig", _sel: _getSel("version()") });
 
         // ProxyAdmin
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("addressManager()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("addressManager()") });
         _addSpec({
             _name: "ProxyAdmin",
             _sel: _getSel("changeProxyAdmin(address,address)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
+            _auth: Role.L1PROXYADMINOWNER
         });
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("getProxyAdmin(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("getProxyImplementation(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("implementationName(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("isUpgrading()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("owner()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("proxyType(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("renounceOwnership()"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("setAddress(string,address)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("setAddressManager(address)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
-        });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("getProxyAdmin(address)") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("getProxyImplementation(address)") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("implementationName(address)") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("isUpgrading()") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("owner()") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("proxyType(address)") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("renounceOwnership()"), _auth: Role.L1PROXYADMINOWNER });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("setAddress(string,address)"), _auth: Role.L1PROXYADMINOWNER });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("setAddressManager(address)"), _auth: Role.L1PROXYADMINOWNER });
         _addSpec({
             _name: "ProxyAdmin",
             _sel: _getSel("setImplementationName(address,string)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
+            _auth: Role.L1PROXYADMINOWNER
         });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("setProxyType(address,uint8)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
-        });
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("setUpgrading(bool)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "ProxyAdmin",
-            _sel: _getSel("transferOwnership(address)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
-        });
-        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("upgrade(address,address)"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("setProxyType(address,uint8)"), _auth: Role.L1PROXYADMINOWNER });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("setUpgrading(bool)") });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("transferOwnership(address)"), _auth: Role.L1PROXYADMINOWNER });
+        _addSpec({ _name: "ProxyAdmin", _sel: _getSel("upgrade(address,address)") });
         _addSpec({
             _name: "ProxyAdmin",
             _sel: _getSel("upgradeAndCall(address,address,bytes)"),
-            _auth: Role.L1PROXYADMINOWNER,
-            _pausable: false
+            _auth: Role.L1PROXYADMINOWNER
         });
 
         // GovernanceToken
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("DOMAIN_SEPARATOR()"), _auth: Role.NOAUTH, _pausable: false });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("DOMAIN_SEPARATOR()") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("allowance(address,address)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("approve(address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("balanceOf(address)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("burn(uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("burnFrom(address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("checkpoints(address,uint32)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("decimals()") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("decreaseAllowance(address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("delegate(address)") });
         _addSpec({
             _name: "GovernanceToken",
-            _sel: _getSel("allowance(address,address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
+            _sel: _getSel("delegateBySig(address,uint256,uint256,uint8,bytes32,bytes32)")
         });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("delegates(address)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("getPastTotalSupply(uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("getPastVotes(address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("getVotes(address)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("increaseAllowance(address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("mint(address,uint256)"), _auth: Role.GOVERNANCETOKENOWNER });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("name()") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("nonces(address)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("numCheckpoints(address)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("owner()") });
         _addSpec({
             _name: "GovernanceToken",
-            _sel: _getSel("approve(address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
+            _sel: _getSel("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)")
         });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("balanceOf(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("burn(uint256)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("burnFrom(address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("checkpoints(address,uint32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("decimals()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("decreaseAllowance(address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("delegate(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("delegateBySig(address,uint256,uint256,uint8,bytes32,bytes32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("delegates(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("getPastTotalSupply(uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("getPastVotes(address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("getVotes(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("increaseAllowance(address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("mint(address,uint256)"),
-            _auth: Role.GOVERNANCETOKENOWNER,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("name()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("nonces(address)"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("numCheckpoints(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("owner()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("renounceOwnership()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("symbol()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "GovernanceToken", _sel: _getSel("totalSupply()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("transfer(address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("transferFrom(address,address,uint256)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "GovernanceToken",
-            _sel: _getSel("transferOwnership(address)"),
-            _auth: Role.NOAUTH,
-            _pausable: false
-        });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("renounceOwnership()") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("symbol()") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("totalSupply()") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("transfer(address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("transferFrom(address,address,uint256)") });
+        _addSpec({ _name: "GovernanceToken", _sel: _getSel("transferOwnership(address)") });
 
         // MintManager
-        _addSpec({ _name: "MintManager", _sel: _getSel("DENOMINATOR()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "MintManager", _sel: _getSel("MINT_CAP()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "MintManager", _sel: _getSel("MINT_PERIOD()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "MintManager", _sel: _getSel("governanceToken()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "MintManager",
-            _sel: _getSel("mint(address,uint256)"),
-            _auth: Role.MINTMANAGEROWNER,
-            _pausable: false
-        });
-        _addSpec({ _name: "MintManager", _sel: _getSel("mintPermittedAfter()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({ _name: "MintManager", _sel: _getSel("owner()"), _auth: Role.NOAUTH, _pausable: false });
-        _addSpec({
-            _name: "MintManager",
-            _sel: _getSel("renounceOwnership()"),
-            _auth: Role.MINTMANAGEROWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "MintManager",
-            _sel: _getSel("transferOwnership(address)"),
-            _auth: Role.MINTMANAGEROWNER,
-            _pausable: false
-        });
-        _addSpec({
-            _name: "MintManager",
-            _sel: _getSel("upgrade(address)"),
-            _auth: Role.MINTMANAGEROWNER,
-            _pausable: false
-        });
+        _addSpec({ _name: "MintManager", _sel: _getSel("DENOMINATOR()") });
+        _addSpec({ _name: "MintManager", _sel: _getSel("MINT_CAP()") });
+        _addSpec({ _name: "MintManager", _sel: _getSel("MINT_PERIOD()") });
+        _addSpec({ _name: "MintManager", _sel: _getSel("governanceToken()") });
+        _addSpec({ _name: "MintManager", _sel: _getSel("mint(address,uint256)"), _auth: Role.MINTMANAGEROWNER });
+        _addSpec({ _name: "MintManager", _sel: _getSel("mintPermittedAfter()") });
+        _addSpec({ _name: "MintManager", _sel: _getSel("owner()") });
+        _addSpec({ _name: "MintManager", _sel: _getSel("renounceOwnership()"), _auth: Role.MINTMANAGEROWNER });
+        _addSpec({ _name: "MintManager", _sel: _getSel("transferOwnership(address)"), _auth: Role.MINTMANAGEROWNER });
+        _addSpec({ _name: "MintManager", _sel: _getSel("upgrade(address)"), _auth: Role.MINTMANAGEROWNER });
     }
 
     /// @dev Computes the selector from a function signature.
@@ -797,6 +367,21 @@ contract Specification_Test is CommonTest {
     function _addSpec(string memory _name, bytes4 _sel, Role _auth, bool _pausable) internal {
         specs[_name][_sel] = Spec({ name: _name, sel: _sel, auth: _auth, pausable: _pausable });
         numEntries[_name]++;
+    }
+
+    /// @dev Adds a spec for a function with no auth.
+    function _addSpec(string memory _name, bytes4 _sel, bool _pausable) internal {
+        _addSpec({ _name: _name, _sel: _sel, _auth: Role.NOAUTH, _pausable: _pausable });
+    }
+
+    /// @dev Adds a spec for a function with no pausability.
+    function _addSpec(string memory _name, bytes4 _sel, Role _auth) internal {
+        _addSpec({ _name: _name, _sel: _sel, _auth: _auth, _pausable: false });
+    }
+
+    /// @dev Adds a spec for a function with no auth and no pausability.
+    function _addSpec(string memory _name, bytes4 _sel) internal {
+        _addSpec({ _name: _name, _sel: _sel, _auth: Role.NOAUTH, _pausable: false });
     }
 
     /// @notice Ensures that there's an auth spec for every L1 contract function.


### PR DESCRIPTION
Tradesoff some additional complexity by defining several variations of `_addSpec`, but this gets us a much more readable file IMO.

The downside is that if we add more properties, we increase the possible number of default values we need to accept.