### PR TITLE
op-node: Disable xor requirement on Network and rollup.config flags

### DIFF
--- a/op-service/flags/flags.go
+++ b/op-service/flags/flags.go
@@ -55,10 +55,11 @@ func CLIRollupConfigFlag(envPrefix string) cli.Flag {
 // This checks flags that are exclusive & required. Specifically for each
 // set of flags, exactly one flag must be set.
 var requiredXorFlags = [][]string{
-	{
-		RollupConfigFlagName,
-		NetworkFlagName,
-	},
+	// TODO(client-pod#391): Re-enable this check at a later point
+	// {
+	// 	RollupConfigFlagName,
+	// 	NetworkFlagName,
+	// },
 }
 
 func CheckRequiredXor(ctx *cli.Context) error {


### PR DESCRIPTION
**Description**

Disable the xor check.
