### PR TITLE
bindgen: fix build

### DIFF
--- a/indexer/config/devnet.go
+++ b/indexer/config/devnet.go
@@ -3,10 +3,11 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 )
 
 var DevnetPresetId = 901
@@ -17,7 +18,7 @@ func DevnetPreset() (*Preset, error) {
 		return nil, err
 	}
 
-	root, err := findMonorepoRoot(cwd)
+	root, err := op_service.FindMonorepoRoot(cwd)
 	if err != nil {
 		return nil, err
 	}
@@ -41,26 +42,4 @@ func DevnetPreset() (*Preset, error) {
 		Name:        "Local Devnet",
 		ChainConfig: ChainConfig{Preset: DevnetPresetId, L1Contracts: l1Contracts},
 	}, nil
-}
-
-// findMonorepoRoot will recursively search upwards for a go.mod file.
-// This depends on the structure of the monorepo having a go.mod file at the root.
-func findMonorepoRoot(startDir string) (string, error) {
-	dir, err := filepath.Abs(startDir)
-	if err != nil {
-		return "", err
-	}
-	for {
-		modulePath := filepath.Join(dir, "go.mod")
-		if _, err := os.Stat(modulePath); err == nil {
-			return dir, nil
-		}
-		parentDir := filepath.Dir(dir)
-		// Check if we reached the filesystem root
-		if parentDir == dir {
-			break
-		}
-		dir = parentDir
-	}
-	return "", fmt.Errorf("monorepo root not found")
 }

--- a/op-bindings/bindgen/main.go
+++ b/op-bindings/bindgen/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/etherscan"
-	"github.com/ethereum-optimism/optimism/op-e2e/config"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -134,7 +134,7 @@ func parseConfigBase(logger log.Logger, c *cli.Context) (bindGenGeneratorBase, e
 		return bindGenGeneratorBase{}, err
 	}
 
-	monoRepoPath, err := config.FindMonorepoRoot(cwd)
+	monoRepoPath, err := op_service.FindMonorepoRoot(cwd)
 	if err != nil {
 		return bindGenGeneratorBase{}, err
 	}

--- a/op-e2e/config/init.go
+++ b/op-e2e/config/init.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/external"
+	op_service "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 )
 
@@ -49,7 +50,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	root, err := FindMonorepoRoot(cwd)
+	root, err := op_service.FindMonorepoRoot(cwd)
 	if err != nil {
 		panic(err)
 	}
@@ -157,26 +158,4 @@ func allExist(filenames ...string) error {
 		}
 	}
 	return nil
-}
-
-// FindMonorepoRoot will recursively search upwards for a go.mod file.
-// This depends on the structure of the monorepo having a go.mod file at the root.
-func FindMonorepoRoot(startDir string) (string, error) {
-	dir, err := filepath.Abs(startDir)
-	if err != nil {
-		return "", err
-	}
-	for {
-		modulePath := filepath.Join(dir, "go.mod")
-		if _, err := os.Stat(modulePath); err == nil {
-			return dir, nil
-		}
-		parentDir := filepath.Dir(dir)
-		// Check if we reached the filesystem root
-		if parentDir == dir {
-			break
-		}
-		dir = parentDir
-	}
-	return "", fmt.Errorf("monorepo root not found")
 }

--- a/op-service/util.go
+++ b/op-service/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"syscall"
@@ -118,4 +119,26 @@ func CloseAction(fn func(ctx context.Context, shutdown <-chan struct{}) error) e
 		cancel()
 		return err
 	}
+}
+
+// FindMonorepoRoot will recursively search upwards for a go.mod file.
+// This depends on the structure of the monorepo having a go.mod file at the root.
+func FindMonorepoRoot(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", err
+	}
+	for {
+		modulePath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(modulePath); err == nil {
+			return dir, nil
+		}
+		parentDir := filepath.Dir(dir)
+		// Check if we reached the filesystem root
+		if parentDir == dir {
+			break
+		}
+		dir = parentDir
+	}
+	return "", fmt.Errorf("monorepo root not found")
 }


### PR DESCRIPTION
**Description**

The bindgen command was causing a panic without this change. We should
not be coupling bindgen to op-e2e. There is no reason to trigger the
init function inside of op-e2e when running bindgen. This commit
dedupes the `FindMonoRepoRoot` function by putting it into a common
location where it can be consumed. Now bindgen no longer depends on
op-e2e. The op-e2e package is for tests, not defining library functions
that are used elsewhere in the repo.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
