### PR TITLE
fix(indexer): L1/L2 independent resyncing

### DIFF
--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -144,7 +144,7 @@ CREATE TABLE IF NOT EXISTS l1_bridge_messages(
     nonce                   UINT256 NOT NULL UNIQUE,
     transaction_source_hash VARCHAR NOT NULL UNIQUE REFERENCES l1_transaction_deposits(source_hash) ON DELETE CASCADE,
 
-    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
+    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE,
     relayed_message_event_guid VARCHAR UNIQUE REFERENCES l2_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
 
     -- sent message
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS l2_bridge_messages(
     nonce                       UINT256 NOT NULL UNIQUE,
     transaction_withdrawal_hash VARCHAR NOT NULL UNIQUE REFERENCES l2_transaction_withdrawals(withdrawal_hash) ON DELETE CASCADE,
 
-    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l2_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
+    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l2_contract_events(guid) ON DELETE CASCADE,
     relayed_message_event_guid VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
 
     -- sent message

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -120,8 +120,8 @@ CREATE TABLE IF NOT EXISTS l2_transaction_withdrawals (
     initiated_l2_event_guid VARCHAR NOT NULL UNIQUE REFERENCES l2_contract_events(guid) ON DELETE CASCADE,
 
     -- Multistep (bedrock) process of a withdrawal
-    proven_l1_event_guid    VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE,
-    finalized_l1_event_guid VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE,
+    proven_l1_event_guid    VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
+    finalized_l1_event_guid VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
     succeeded               BOOLEAN,
 
     -- transaction data
@@ -144,8 +144,8 @@ CREATE TABLE IF NOT EXISTS l1_bridge_messages(
     nonce                   UINT256 NOT NULL UNIQUE,
     transaction_source_hash VARCHAR NOT NULL UNIQUE REFERENCES l1_transaction_deposits(source_hash) ON DELETE CASCADE,
 
-    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE,
-    relayed_message_event_guid VARCHAR UNIQUE REFERENCES l2_contract_events(guid) ON DELETE CASCADE,
+    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
+    relayed_message_event_guid VARCHAR UNIQUE REFERENCES l2_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
 
     -- sent message
     from_address VARCHAR NOT NULL,
@@ -166,8 +166,8 @@ CREATE TABLE IF NOT EXISTS l2_bridge_messages(
     nonce                       UINT256 NOT NULL UNIQUE,
     transaction_withdrawal_hash VARCHAR NOT NULL UNIQUE REFERENCES l2_transaction_withdrawals(withdrawal_hash) ON DELETE CASCADE,
 
-    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l2_contract_events(guid) ON DELETE CASCADE,
-    relayed_message_event_guid VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE CASCADE,
+    sent_message_event_guid    VARCHAR NOT NULL UNIQUE REFERENCES l2_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
+    relayed_message_event_guid VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
 
     -- sent message
     from_address VARCHAR NOT NULL,

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -182,7 +182,7 @@ func (b *BridgeProcessor) onL2Data(latestL2Header *types.Header) (errs error) {
 		}
 
 		// Finalized L2 Events (on L1)
-		if b.LastFinalizedL1Header == nil || b.LastFinalizedL1Header.Timestamp < latestL2Header.Time {
+		if b.LastL2Header != nil && (b.LastFinalizedL1Header == nil || b.LastFinalizedL1Header.Timestamp < latestL2Header.Time) {
 			if err := b.processFinalizedL1Events(latestL2Header); err != nil {
 				errs = errors.Join(errs, fmt.Errorf("failed processing finalized l1 events: %w", err))
 			}


### PR DESCRIPTION
If the operator chooses to resync, they should be able to resync either L1 or L2 without having
to wipe the entire database.

To support this, we need to slightly alter our foreign key constraints. For example if all L2 data
is wiped and not L1, the L1 finalization event markers on the L2 tables should be set to NULL and
not have the delete cascaded

In order to migrate an already created database here's the command to run. Didn't bother trying to
do this idempotently via the migrations sql file since it's non-trivial to identify what constraints
are currently set
``` sql
ALTER TABLE l2_transaction_withdrawals
    DROP CONSTRAINT l2_transaction_withdrawals_proven_l1_event_guid_fkey,
    DROP CONSTRAINT l2_transaction_withdrawals_finalized_l1_event_guid_fkey,
    ADD CONSTRAINT l2_transaction_withdrawals_proven_l1_event_guid_fkey FOREIGN KEY (proven_l1_event_guid) REFERENCES l1_contract_events(guid)
        ON DELETE SET NULL ON UPDATE CASCADE,
    ADD CONSTRAINT l2_transaction_withdrawals_finalized_l1_event_guid_fkey FOREIGN KEY (finalized_l1_event_guid) REFERENCES l1_contract_events(guid)
        ON DELETE SET NULL ON UPDATE CASCADE;

ALTER TABLE l1_bridge_messages
    DROP CONSTRAINT l1_bridge_messages_relayed_message_event_guid_fkey,
    ADD CONSTRAINT l1_bridge_messages_relayed_message_event_guid_fkey FOREIGN KEY (relayed_message_event_guid) REFERENCES l2_contract_events(guid)
        ON DELETE SET NULL ON UPDATE CASCADE;

ALTER TABLE l2_bridge_messages
    DROP CONSTRAINT l2_bridge_messages_relayed_message_event_guid_fkey,
    ADD CONSTRAINT l2_bridge_messages_relayed_message_event_guid_fkey FOREIGN KEY (relayed_message_event_guid) REFERENCES l1_contract_events(guid)
        ON DELETE SET NULL ON UPDATE CASCADE;
```
