### PR TITLE
op-e2e: Convert output_cannon tests to use claim helper

### DIFF
--- a/op-e2e/e2eutils/disputegame/claim_helper.go
+++ b/op-e2e/e2eutils/disputegame/claim_helper.go
@@ -3,6 +3,7 @@ package disputegame
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -35,6 +36,10 @@ func (c *ClaimHelper) AgreesWithOutputRoot() bool {
 	return c.position.Depth()%2 == 0
 }
 
+func (c *ClaimHelper) IsRootClaim() bool {
+	return c.position.IsRootPosition()
+}
+
 func (c *ClaimHelper) IsOutputRoot(ctx context.Context) bool {
 	splitDepth := c.game.SplitDepth(ctx)
 	return int64(c.position.Depth()) <= splitDepth
@@ -45,16 +50,25 @@ func (c *ClaimHelper) IsOutputRootLeaf(ctx context.Context) bool {
 	return int64(c.position.Depth()) == splitDepth
 }
 
+func (c *ClaimHelper) IsBottomGameRoot(ctx context.Context) bool {
+	splitDepth := c.game.SplitDepth(ctx)
+	return int64(c.position.Depth()) == splitDepth+1
+}
+
 func (c *ClaimHelper) IsMaxDepth(ctx context.Context) bool {
 	maxDepth := c.game.MaxDepth(ctx)
 	return int64(c.position.Depth()) == maxDepth
 }
 
+func (c *ClaimHelper) Depth() int64 {
+	return int64(c.position.Depth())
+}
+
 // WaitForCounterClaim waits for the claim to be countered by another claim being posted.
 // It returns a helper for the claim that countered this one.
-func (c *ClaimHelper) WaitForCounterClaim(ctx context.Context) *ClaimHelper {
-	counterIdx, counterClaim := c.game.waitForClaim(ctx, fmt.Sprintf("failed to find claim with parent idx %v", c.index), func(claim ContractClaim) bool {
-		return int64(claim.ParentIndex) == c.index
+func (c *ClaimHelper) WaitForCounterClaim(ctx context.Context, ignoreClaims ...*ClaimHelper) *ClaimHelper {
+	counterIdx, counterClaim := c.game.waitForClaim(ctx, fmt.Sprintf("failed to find claim with parent idx %v", c.index), func(claimIdx int64, claim ContractClaim) bool {
+		return int64(claim.ParentIndex) == c.index && !containsClaim(claimIdx, ignoreClaims)
 	})
 	return newClaimHelper(c.game, counterIdx, counterClaim)
 }
@@ -91,4 +105,24 @@ func (c *ClaimHelper) Defend(ctx context.Context, value common.Hash) *ClaimHelpe
 
 func (c *ClaimHelper) RequireDifferentClaimValue(other *ClaimHelper) {
 	c.require.NotEqual(c.claim, other.claim, "should have posted different claims")
+}
+
+func (c *ClaimHelper) RequireOnlyCounteredBy(ctx context.Context, expected ...*ClaimHelper) {
+	claims := c.game.getAllClaims(ctx)
+	for idx, claim := range claims {
+		if int64(claim.ParentIndex) != c.index {
+			// Doesn't counter this claim, so ignore
+			continue
+		}
+		if !containsClaim(int64(idx), expected) {
+			// Found a countering claim not in the expected list. Fail.
+			c.require.FailNowf("Found unexpected countering claim", "Parent claim index: %v Game state:\n%v", c.index, c.game.gameData(ctx))
+		}
+	}
+}
+
+func containsClaim(claimIdx int64, haystack []*ClaimHelper) bool {
+	return slices.ContainsFunc(haystack, func(candidate *ClaimHelper) bool {
+		return candidate.index == claimIdx
+	})
 }

--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -246,7 +246,7 @@ func (g *FaultGameHelper) WaitForInactivity(ctx context.Context, numInactiveBloc
 // DefendRootClaim uses the supplied Mover to perform moves in an attempt to defend the root claim.
 // It is assumed that the output root being disputed is valid and that an honest op-challenger is already running.
 // When the game has reached the maximum depth it waits for the honest challenger to counter the leaf claim with step.
-func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove Mover) {
+func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove func(parentClaimIdx int64)) {
 	maxDepth := g.MaxDepth(ctx)
 	for claimCount := int64(1); claimCount < maxDepth; {
 		g.LogGameData(ctx)
@@ -268,7 +268,7 @@ func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove Mover
 // It is assumed that the output root being disputed is invalid and that an honest op-challenger is already running.
 // When the game has reached the maximum depth it calls the Stepper to attempt to counter the leaf claim.
 // Since the output root is invalid, it should not be possible for the Stepper to call step successfully.
-func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mover, attemptStep Stepper) {
+func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove func(parentClaimIdx int64), attemptStep Stepper) {
 	maxDepth := g.MaxDepth(ctx)
 	for claimCount := int64(1); claimCount < maxDepth; {
 		g.LogGameData(ctx)

--- a/op-e2e/e2eutils/disputegame/output_honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_honest_helper.go
@@ -18,6 +18,16 @@ type OutputHonestHelper struct {
 	correctTrace types.TraceAccessor
 }
 
+func (h *OutputHonestHelper) AttackClaim(ctx context.Context, claim *ClaimHelper) *ClaimHelper {
+	h.Attack(ctx, claim.index)
+	return claim.WaitForCounterClaim(ctx)
+}
+
+func (h *OutputHonestHelper) DefendClaim(ctx context.Context, claim *ClaimHelper) *ClaimHelper {
+	h.Defend(ctx, claim.index)
+	return claim.WaitForCounterClaim(ctx)
+}
+
 func (h *OutputHonestHelper) Attack(ctx context.Context, claimIdx int64) {
 	// Ensure the claim exists
 	h.game.WaitForClaimCount(ctx, claimIdx+1)


### PR DESCRIPTION
**Description**

Converts the output_cannon tests over to using the claim helper.
