### PR TITLE
specs: 4844 blob encoding v2

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -518,7 +518,7 @@ To save computational overhead, only `254` bits per field element are used for r
 `127` bytes of application-layer rollup data is encoded at a time, into 4 adjacent field elements of the blob:
 
 ```python
-# read(N): read N bytes from the application-layer rollup-data.
+# read(N): read the next N bytes from the application-layer rollup-data. The next read starts where the last stopped.
 # write(V): append V (one or more bytes) to the raw blob.
 bytes tailA = read(31)
 byte x = read(1)


### PR DESCRIPTION
**Description**

This reduces the amount of data that has to be buffered while reading/writing from 128 bytes down to just 32 bytes.

- This still allows the rollup-data prefix (anything in first 31 bytes) to be read from the first field-element.
- This splits the 6-bit values differently, so there's less to buffer.
- This approach allows us to read 31 bytes, read 1 byte, write 32, and continue with a buffer of 1 byte. Without dynamically shifting every byte, this is the fastest we can have.

