### PR TITLE
[txmgr] Ensure that fee is increased by at least 10%

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -30,6 +30,7 @@ const (
 var (
 	priceBumpPercent = big.NewInt(100 + priceBump)
 	oneHundred       = big.NewInt(100)
+	ninetyNine       = big.NewInt(99)
 )
 
 // TxManager is an interface that allows callers to reliably publish txs,
@@ -603,15 +604,12 @@ func (m *SimpleTxManager) checkLimits(tip, basefee, bumpedTip, bumpedFee *big.In
 	return nil
 }
 
-// calcThresholdValue returns x * priceBumpPercent / 100
+// calcThresholdValue returns ceil(x * priceBumpPercent / 100)
 // It guarantees that x is increased by at least 1
 func calcThresholdValue(x *big.Int) *big.Int {
 	threshold := new(big.Int).Mul(priceBumpPercent, x)
+	threshold.Add(threshold, ninetyNine)
 	threshold.Div(threshold, oneHundred)
-	// Guarantee to add at least 1 wei. Edge-case during near-zero fee conditions.
-	if threshold.Cmp(x) == 0 {
-		threshold.Add(threshold, big.NewInt(1))
-	}
 	return threshold
 }
 

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -907,15 +907,15 @@ func TestIncreaseGasPrice(t *testing.T) {
 func TestIncreaseGasPriceLimits(t *testing.T) {
 	t.Run("no-threshold", func(t *testing.T) {
 		testIncreaseGasPriceLimit(t, gasPriceLimitTest{
-			expTipCap: 36,
-			expFeeCap: 493, // just below 5*100
+			expTipCap: 46,
+			expFeeCap: 354, // just below 5*100
 		})
 	})
 	t.Run("with-threshold", func(t *testing.T) {
 		testIncreaseGasPriceLimit(t, gasPriceLimitTest{
 			thr:       big.NewInt(params.GWei),
-			expTipCap: 61_265_017,
-			expFeeCap: 957_582_949, // just below 1 gwei
+			expTipCap: 131_326_987,
+			expFeeCap: 933_286_308, // just below 1 gwei
 		})
 	})
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

#8713 fixed a `txmgr` bug where if the fees were < 10, the fee would not be bumped at all.

This PR ensures we conform to the spec a little more, guaranteeing that we bump the fee by at least 10%.

For example, the current implementation will bump `11` to `12`, which is not technically 10% more (because we do `floor(fee * 1.1)`. This PR switches to use `ceil(fee * 1.1)`.

**Tests**

Updated tests.

**Additional context**

go-ethereum currently rounds down internally, so this would not affect L1s running geth.