### PR TITLE
chore: Remove AgreeWithProposedOutput Flag References

### DIFF
--- a/docs/fault-proof-alpha/run-challenger.md
+++ b/docs/fault-proof-alpha/run-challenger.md
@@ -40,7 +40,6 @@ make op-challenger op-program cannon
   --trace-type cannon \
   --l1-eth-rpc <L1_URL> \
   --game-factory-address <DISPUTE_GAME_FACTORY_ADDRESS> \
-  --agree-with-proposed-output=true \
   --datadir temp/challenger-goerli \
   --cannon-network goerli \
   --cannon-bin ./cannon/bin/cannon \

--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -44,7 +44,6 @@ DISPUTE_GAME_FACTORY=$(jq -r .DisputeGameFactoryProxy .devnet/addresses.json)
   --trace-type cannon \
   --l1-eth-rpc http://localhost:8545 \
   --game-factory-address $DISPUTE_GAME_FACTORY \
-  --agree-with-proposed-output=true \
   --datadir temp/challenger-data \
   --cannon-rollup-config .devnet/rollup.json  \
   --cannon-l2-genesis .devnet/genesis-l2.json \

--- a/op-challenger/scripts/alphabet/charlie.sh
+++ b/op-challenger/scripts/alphabet/charlie.sh
@@ -35,5 +35,4 @@ cleanup(){
   --private-key "$CHARLIE_KEY" \
   --num-confirmations 1 \
   --metrics.enabled --metrics.port=7304 \
-  --pprof.enabled --pprof.port=6064 \
-  --agree-with-proposed-output=true
+  --pprof.enabled --pprof.port=6064

--- a/op-challenger/scripts/alphabet/mallory.sh
+++ b/op-challenger/scripts/alphabet/mallory.sh
@@ -35,5 +35,4 @@ cleanup(){
   --private-key "$MALLORY_KEY" \
   --num-confirmations 1 \
   --metrics.enabled --metrics.port=7305 \
-  --pprof.enabled --pprof.port=6065 \
-  --agree-with-proposed-output=false
+  --pprof.enabled --pprof.port=6065


### PR DESCRIPTION
**Description**

Removes script and documentation references to the `--agree-with-proposed-output` flag removed in #8338.

Small PR to keep challenger docs and references up-to-date.
