### PR TITLE
chore: Remove lint Makefile .PHONY

### DIFF
--- a/op-challenger/Makefile
+++ b/op-challenger/Makefile
@@ -32,7 +32,6 @@ alphabet-actors:
 	clean \
 	op-challenger \
 	test \
-	lint \
 	visualize \
 	alphabet \
 	alphabet-actors


### PR DESCRIPTION
**Description**

Miniscule pr to remove the Makefile `lint` .PHONY.
