### PR TITLE
chore: Challenger Script Touchups

### DIFF
--- a/op-challenger/README.md
+++ b/op-challenger/README.md
@@ -33,7 +33,7 @@ From the top level of the repository run:
 
 ```shell
 make devnet-clean
-make cannon-prestate op-challenger
+make op-challenger
 make devnet-up
 ```
 

--- a/op-challenger/scripts/alphabet/init_game.sh
+++ b/op-challenger/scripts/alphabet/init_game.sh
@@ -11,7 +11,6 @@ make
 
 cd "$MONOREPO_DIR"
 make devnet-clean
-make cannon-prestate
 make devnet-up
 
 DEVNET_SPONSOR="ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"

--- a/op-challenger/scripts/create_game.sh
+++ b/op-challenger/scripts/create_game.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CHALLENGER_DIR="${SOURCE_DIR%/*}"
 
-# ./create_game.sh <rpc-addr> <dispute-game-factory-addr> <cast signing args>
+# ./create_game.sh <rpc-addr> <dispute-game-factory-addr> <root-claim> <cast signing args>
 RPC=${1:?Must specify RPC address}
 FACTORY_ADDR=${2:?Must specify factory address}
 ROOT_CLAIM=${3:?Must specify root claim}


### PR DESCRIPTION
**Description**

Touches up challenger scripts. Since the `devnet-up` target references `pre-devnet`, it implicitly creates the cannon-prestate so we don't need to additionally create the prestate if it already exists, speeding up game initialization.
