### PR TITLE
fix(op-challenger): Encapsulate Job Instantiation

### DIFF
--- a/op-challenger/game/scheduler/coordinator.go
+++ b/op-challenger/game/scheduler/coordinator.go
@@ -143,7 +143,7 @@ func (c *coordinator) createJob(ctx context.Context, game types.GameMetadata, bl
 		c.logger.Debug("Not rescheduling resolved game", "game", game.Proxy, "status", state.status)
 		return nil, nil
 	}
-	return &job{block: blockNumber, addr: game.Proxy, player: state.player, status: state.status}, nil
+	return newJob(blockNumber, game.Proxy, state.player, state.status), nil
 }
 
 func (c *coordinator) enqueueJob(ctx context.Context, j job) error {

--- a/op-challenger/game/scheduler/types.go
+++ b/op-challenger/game/scheduler/types.go
@@ -25,3 +25,12 @@ type job struct {
 	player GamePlayer
 	status types.GameStatus
 }
+
+func newJob(block uint64, addr common.Address, player GamePlayer, status types.GameStatus) *job {
+	return &job{
+		block:  block,
+		addr:   addr,
+		player: player,
+		status: status,
+	}
+}


### PR DESCRIPTION
**Description**

MicoPR that encapsulates job instantiation. Providing an explicit constructor avoids leaking the internals of the `job` struct.
This is useful because if you added a field to the `job` struct in the future, it would be difficult, and error-prone to find all explicit
instantiations and add the new field. By providing a local constructor, adding the field to the constructor is in the immediate context.
