### PR TITLE
chore(op-e2e): Remove Unused Mover

### DIFF
--- a/op-e2e/e2eutils/disputegame/game_helper.go
+++ b/op-e2e/e2eutils/disputegame/game_helper.go
@@ -246,7 +246,7 @@ func (g *FaultGameHelper) WaitForInactivity(ctx context.Context, numInactiveBloc
 // DefendRootClaim uses the supplied Mover to perform moves in an attempt to defend the root claim.
 // It is assumed that the output root being disputed is valid and that an honest op-challenger is already running.
 // When the game has reached the maximum depth it waits for the honest challenger to counter the leaf claim with step.
-func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove Mover) {
+func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove func(parentClaimIdx int64)) {
 	maxDepth := g.MaxDepth(ctx)
 	for claimCount := int64(1); claimCount < maxDepth; {
 		g.LogGameData(ctx)
@@ -268,7 +268,7 @@ func (g *FaultGameHelper) DefendRootClaim(ctx context.Context, performMove Mover
 // It is assumed that the output root being disputed is invalid and that an honest op-challenger is already running.
 // When the game has reached the maximum depth it calls the Stepper to attempt to counter the leaf claim.
 // Since the output root is invalid, it should not be possible for the Stepper to call step successfully.
-func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove Mover, attemptStep Stepper) {
+func (g *FaultGameHelper) ChallengeRootClaim(ctx context.Context, performMove func(parentClaimIdx int64), attemptStep Stepper) {
 	maxDepth := g.MaxDepth(ctx)
 	for claimCount := int64(1); claimCount < maxDepth; {
 		g.LogGameData(ctx)

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -328,9 +328,6 @@ func (g *OutputGameHelper) WaitForInactivity(ctx context.Context, numInactiveBlo
 	}
 }
 
-// Mover is a function that either attacks or defends the claim at parentClaimIdx
-type Mover func(parent *ClaimHelper) *ClaimHelper
-
 // Stepper is a function that attempts to perform a step against the claim at parentClaimIdx
 type Stepper func(parentClaimIdx int64)
 

--- a/op-e2e/e2eutils/disputegame/output_game_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_game_helper.go
@@ -208,11 +208,12 @@ func (g *OutputGameHelper) GetClaimValue(ctx context.Context, claimIdx int64) co
 
 func (g *OutputGameHelper) getAllClaims(ctx context.Context) []ContractClaim {
 	count := g.getClaimCount(ctx)
-	var claims []ContractClaim
+	claims := make([]ContractClaim, 0, count)
 	for i := int64(0); i < count; i++ {
 		claims = append(claims, g.getClaim(ctx, i))
 	}
 	return claims
+}
 }
 
 // getClaim retrieves the claim data for a specific index.

--- a/op-e2e/e2eutils/disputegame/output_honest_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_honest_helper.go
@@ -18,6 +18,16 @@ type OutputHonestHelper struct {
 	correctTrace types.TraceAccessor
 }
 
+func (h *OutputHonestHelper) AttackClaim(ctx context.Context, claim *ClaimHelper) *ClaimHelper {
+	h.Attack(ctx, claim.index)
+	return claim.WaitForCounterClaim(ctx)
+}
+
+func (h *OutputHonestHelper) DefendClaim(ctx context.Context, claim *ClaimHelper) *ClaimHelper {
+	h.Defend(ctx, claim.index)
+	return claim.WaitForCounterClaim(ctx)
+}
+
 func (h *OutputHonestHelper) Attack(ctx context.Context, claimIdx int64) {
 	// Ensure the claim exists
 	h.game.WaitForClaimCount(ctx, claimIdx+1)


### PR DESCRIPTION
**Description**

Small follow-on pr to remove the unused `Mover` type alias that was inlined in #8743.
