### PR TITLE
crr(indexer): clearer etl metrics

### DIFF
--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -161,11 +161,6 @@ func (l1Etl *L1ETL) handleBatch(batch *ETLBatch) error {
 		}
 	}
 
-	if len(l1BlockHeaders) == 0 {
-		batch.Logger.Info("no l1 blocks with logs in batch")
-		return nil
-	}
-
 	l1ContractEvents := make([]database.L1ContractEvent, len(batch.Logs))
 	for i := range batch.Logs {
 		timestamp := batch.HeaderMap[batch.Logs[i].BlockHash].Time
@@ -176,6 +171,10 @@ func (l1Etl *L1ETL) handleBatch(batch *ETLBatch) error {
 	// Continually try to persist this batch. If it fails after 10 attempts, we simply error out
 	retryStrategy := &retry.ExponentialStrategy{Min: 1000, Max: 20_000, MaxJitter: 250}
 	if _, err := retry.Do[interface{}](l1Etl.resourceCtx, 10, retryStrategy, func() (interface{}, error) {
+		if len(l1BlockHeaders) == 0 {
+			return nil, nil // skip
+		}
+
 		if err := l1Etl.db.Transaction(func(tx *database.DB) error {
 			if err := tx.Blocks.StoreL1BlockHeaders(l1BlockHeaders); err != nil {
 				return err
@@ -190,19 +189,23 @@ func (l1Etl *L1ETL) handleBatch(batch *ETLBatch) error {
 			return nil, fmt.Errorf("unable to persist batch: %w", err)
 		}
 
-		// Since not every L1 block is indexed, we still want our metrics to cover L1 blocks
-		// that have been observed so that a false stall alert isn't triggered on low activity
-		l1Etl.ETL.metrics.RecordIndexedHeaders(len(l1BlockHeaders))
-		l1Etl.ETL.metrics.RecordEtlLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
-
 		// a-ok!
 		return nil, nil
 	}); err != nil {
 		return err
 	}
 
-	batch.Logger.Info("indexed batch")
+	if len(l1BlockHeaders) == 0 {
+		batch.Logger.Info("skipped batch. no logs found")
+	} else {
+		batch.Logger.Info("indexed batch")
+	}
+
+	// Since not every L1 block is indexed, we still want our metrics to cover L1 blocks
+	// that have been observed so that a false stall alert isn't triggered on low activity
 	l1Etl.LatestHeader = &batch.Headers[len(batch.Headers)-1]
+	l1Etl.ETL.metrics.RecordIndexedHeaders(len(l1BlockHeaders))
+	l1Etl.ETL.metrics.RecordEtlLatestHeight(l1Etl.LatestHeader.Number)
 
 	// Notify Listeners
 	l1Etl.mu.Lock()

--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -191,9 +191,9 @@ func (l1Etl *L1ETL) handleBatch(batch *ETLBatch) error {
 		}
 
 		// Since not every L1 block is indexed, we still want our metrics to cover L1 blocks
-		// that have been observed so that a false stall alart isn't triggered on low activity
+		// that have been observed so that a false stall alert isn't triggered on low activity
 		l1Etl.ETL.metrics.RecordIndexedHeaders(len(l1BlockHeaders))
-		l1Etl.ETL.metrics.RecordIndexedLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
+		l1Etl.ETL.metrics.RecordEtlLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
 
 		// a-ok!
 		return nil, nil

--- a/indexer/etl/l1_etl.go
+++ b/indexer/etl/l1_etl.go
@@ -190,8 +190,10 @@ func (l1Etl *L1ETL) handleBatch(batch *ETLBatch) error {
 			return nil, fmt.Errorf("unable to persist batch: %w", err)
 		}
 
+		// Since not every L1 block is indexed, we still want our metrics to cover L1 blocks
+		// that have been observed so that a false stall alart isn't triggered on low activity
 		l1Etl.ETL.metrics.RecordIndexedHeaders(len(l1BlockHeaders))
-		l1Etl.ETL.metrics.RecordIndexedLatestHeight(l1BlockHeaders[len(l1BlockHeaders)-1].Number)
+		l1Etl.ETL.metrics.RecordIndexedLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
 
 		// a-ok!
 		return nil, nil

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -170,7 +170,7 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 
 		// All L2 blocks are indexed so len(batch.Headers) == len(l2BlockHeaders)
 		l2Etl.ETL.metrics.RecordIndexedHeaders(len(l2BlockHeaders))
-		l2Etl.ETL.metrics.RecordIndexedLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
+		l2Etl.ETL.metrics.RecordEtlLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
 
 		// a-ok!
 		return nil, nil

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -168,8 +168,9 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 			return nil, err
 		}
 
+		// All L2 blocks are indexed so len(batch.Headers) == len(l2BlockHeaders)
 		l2Etl.ETL.metrics.RecordIndexedHeaders(len(l2BlockHeaders))
-		l2Etl.ETL.metrics.RecordIndexedLatestHeight(l2BlockHeaders[len(l2BlockHeaders)-1].Number)
+		l2Etl.ETL.metrics.RecordIndexedLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
 
 		// a-ok!
 		return nil, nil

--- a/indexer/etl/l2_etl.go
+++ b/indexer/etl/l2_etl.go
@@ -168,10 +168,6 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 			return nil, err
 		}
 
-		// All L2 blocks are indexed so len(batch.Headers) == len(l2BlockHeaders)
-		l2Etl.ETL.metrics.RecordIndexedHeaders(len(l2BlockHeaders))
-		l2Etl.ETL.metrics.RecordEtlLatestHeight(batch.Headers[len(batch.Headers)-1].Number)
-
 		// a-ok!
 		return nil, nil
 	}); err != nil {
@@ -179,7 +175,11 @@ func (l2Etl *L2ETL) handleBatch(batch *ETLBatch) error {
 	}
 
 	batch.Logger.Info("indexed batch")
+
+	// All L2 blocks are indexed so len(batch.Headers) == len(l2BlockHeaders)
 	l2Etl.LatestHeader = &batch.Headers[len(batch.Headers)-1]
+	l2Etl.ETL.metrics.RecordIndexedHeaders(len(l2BlockHeaders))
+	l2Etl.ETL.metrics.RecordEtlLatestHeight(l2Etl.LatestHeader.Number)
 
 	// Notify Listeners
 	l2Etl.mu.Lock()

--- a/indexer/etl/metrics.go
+++ b/indexer/etl/metrics.go
@@ -64,7 +64,7 @@ func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
 			Name:      "indexed_height",
-			Help:      "the latest block height indexed into the database",
+			Help:      "the latest block height processed by the etl",
 		}),
 		indexedHeaders: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,

--- a/indexer/etl/metrics.go
+++ b/indexer/etl/metrics.go
@@ -16,8 +16,7 @@ type Metricer interface {
 	RecordInterval() (done func(err error))
 	RecordLatestHeight(height *big.Int)
 
-	// Indexed Batches
-	RecordIndexedLatestHeight(height *big.Int)
+	RecordEtlLatestHeight(height *big.Int)
 	RecordIndexedHeaders(size int)
 	RecordIndexedLog(contractAddress common.Address)
 }
@@ -28,9 +27,9 @@ type etlMetrics struct {
 	intervalFailures prometheus.Counter
 	latestHeight     prometheus.Gauge
 
-	indexedLatestHeight prometheus.Gauge
-	indexedHeaders      prometheus.Counter
-	indexedLogs         *prometheus.CounterVec
+	etlLatestHeight prometheus.Gauge
+	indexedHeaders  prometheus.Counter
+	indexedLogs     *prometheus.CounterVec
 }
 
 func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
@@ -60,11 +59,11 @@ func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
 			Name:      "latest_height",
 			Help:      "the latest height reported by the connected client",
 		}),
-		indexedLatestHeight: factory.NewGauge(prometheus.GaugeOpts{
+		etlLatestHeight: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
-			Name:      "indexed_height",
-			Help:      "the latest block height processed by the etl",
+			Name:      "etl_height",
+			Help:      "the latest block height after a processing interval by the etl",
 		}),
 		indexedHeaders: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
@@ -98,8 +97,8 @@ func (m *etlMetrics) RecordLatestHeight(height *big.Int) {
 	m.latestHeight.Set(float64(height.Uint64()))
 }
 
-func (m *etlMetrics) RecordIndexedLatestHeight(height *big.Int) {
-	m.indexedLatestHeight.Set(float64(height.Uint64()))
+func (m *etlMetrics) RecordEtlLatestHeight(height *big.Int) {
+	m.etlLatestHeight.Set(float64(height.Uint64()))
 }
 
 func (m *etlMetrics) RecordIndexedHeaders(size int) {

--- a/indexer/etl/metrics.go
+++ b/indexer/etl/metrics.go
@@ -62,7 +62,7 @@ func NewMetrics(registry *prometheus.Registry, subsystem string) Metricer {
 		etlLatestHeight: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: MetricsNamespace,
 			Subsystem: subsystem,
-			Name:      "etl_height",
+			Name:      "indexed_height",
 			Help:      "the latest block height after a processing interval by the etl",
 		}),
 		indexedHeaders: factory.NewCounter(prometheus.CounterOpts{

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -286,8 +286,8 @@ func (b *BridgeProcessor) processFinalizedL1Events() error {
 		lastFinalizedL1BlockNumber = b.LastFinalizedL1Header.Number
 	}
 
-	// Latest unfinalized L1 state bounded by `blockLimit` blocks that have had L2 bridge events indexed. Since L1 data
-	// is indexed independently of L2, there may not be new L1 state to finalized
+	// Latest unfinalized L1 state bounded by `blockLimit` blocks that have had L2 bridge events
+	// indexed. Since L1 data is indexed independently, there may not be new L1 state to finalized
 	latestL1HeaderScope := func(db *gorm.DB) *gorm.DB {
 		newQuery := db.Session(&gorm.Session{NewDB: true}) // fresh subquery
 		headers := newQuery.Model(database.L1BlockHeader{}).Where("number > ? AND timestamp <= ?", lastFinalizedL1BlockNumber, b.LastL2Header.Timestamp)
@@ -340,8 +340,8 @@ func (b *BridgeProcessor) processFinalizedL2Events() error {
 		lastFinalizedL2BlockNumber = b.LastFinalizedL2Header.Number
 	}
 
-	// Latest unfinalized L2 state bounded by `blockLimit` blocks that have had L1 bridge events indexed. Since L2 data
-	// is indexed independently of L1, there may not be new L2 state to finalized
+	// Latest unfinalized L2 state bounded by `blockLimit` blocks that have had L1 bridge events
+	// indexed. Since L2 data is indexed independently, there may not be new L2 state to finalized
 	latestL2HeaderScope := func(db *gorm.DB) *gorm.DB {
 		newQuery := db.Session(&gorm.Session{NewDB: true}) // fresh subquery
 		headers := newQuery.Model(database.L2BlockHeader{}).Where("number > ? AND timestamp <= ?", lastFinalizedL2BlockNumber, b.LastL1Header.Timestamp)

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -132,8 +132,9 @@ func (b *BridgeProcessor) onL1Data() error {
 	}
 
 	// `LastFinalizedL2Header` and `LastL1Header` are mutated by the same routine and can
-	// safely be read without needing any sync primitives
-	if b.LastFinalizedL2Header == nil || b.LastFinalizedL2Header.Timestamp < b.LastL1Header.Timestamp {
+	// safely be read without needing any sync primitives. Not every L1 block is indexed
+	// so check against a false interval on start.
+	if b.LastL1Header != nil && (b.LastFinalizedL2Header == nil || b.LastFinalizedL2Header.Timestamp < b.LastL1Header.Timestamp) {
 		if err := b.processFinalizedL2Events(); err != nil {
 			b.log.Error("failed to process finalized L2 events", "err", err)
 			errs = errors.Join(errs, err)

--- a/indexer/processors/bridge.go
+++ b/indexer/processors/bridge.go
@@ -179,7 +179,7 @@ func (b *BridgeProcessor) processInitiatedL1Events() error {
 	}
 
 	// Latest unobserved L1 state bounded by `blockLimits` blocks. Since
-	// not every L1 block is indexed, we may have nothign to process.
+	// not every L1 block is indexed, we may have nothing to process.
 	latestL1HeaderScope := func(db *gorm.DB) *gorm.DB {
 		newQuery := db.Session(&gorm.Session{NewDB: true}) // fresh subquery
 		headers := newQuery.Model(database.L1BlockHeader{}).Where("number > ?", lastL1BlockNumber)
@@ -288,7 +288,7 @@ func (b *BridgeProcessor) processFinalizedL1Events() error {
 	}
 
 	// Latest unfinalized L1 state bounded by `blockLimit` blocks that have had L2 bridge events
-	// indexed. Since L1 data is indexed independently, there may not be new L1 state to finalized
+	// indexed. Since L1 data is indexed independently, there may not be new L1 state to finalize
 	latestL1HeaderScope := func(db *gorm.DB) *gorm.DB {
 		newQuery := db.Session(&gorm.Session{NewDB: true}) // fresh subquery
 		headers := newQuery.Model(database.L1BlockHeader{}).Where("number > ? AND timestamp <= ?", lastFinalizedL1BlockNumber, b.LastL2Header.Timestamp)
@@ -342,7 +342,7 @@ func (b *BridgeProcessor) processFinalizedL2Events() error {
 	}
 
 	// Latest unfinalized L2 state bounded by `blockLimit` blocks that have had L1 bridge events
-	// indexed. Since L2 data is indexed independently, there may not be new L2 state to finalized
+	// indexed. Since L2 data is indexed independently, there may not be new L2 state to finalize
 	latestL2HeaderScope := func(db *gorm.DB) *gorm.DB {
 		newQuery := db.Session(&gorm.Session{NewDB: true}) // fresh subquery
 		headers := newQuery.Model(database.L2BlockHeader{}).Where("number > ? AND timestamp <= ?", lastFinalizedL2BlockNumber, b.LastL1Header.Timestamp)


### PR DESCRIPTION
L1 ETL metrics are only updated when there is a block with logs to index.

Even if there's no data, we should mark the latest traversed height as
indexed. Even when there's no L1 data, we still allow the bridge `onL1Data`
to run since there may be new L2 state to finalize. The extra SQL query
as a result is cheap enough to just do
