### PR TITLE
txmgr,op-batcher: Improve logging & metrics

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -241,7 +241,7 @@ func (s *channelManager) processBlocks() error {
 		} else if err != nil {
 			return fmt.Errorf("adding block[%d] to channel builder: %w", i, err)
 		}
-		s.log.Debug("Added block to channel", "id", s.currentChannel.ID(), "block", block)
+		s.log.Debug("Added block to channel", "id", s.currentChannel.ID(), "block", eth.ToBlockID(block))
 
 		blocksAdded += 1
 		latestL2ref = l2BlockRefFromBlockAndL1Info(block, l1info)
@@ -359,7 +359,7 @@ func (s *channelManager) Close() error {
 	// Any pending state can be proactively cleared if there are no submitted transactions
 	for _, ch := range s.channelQueue {
 		if ch.NoneSubmitted() {
-			s.log.Info("Channel has no past or pending submission - dropping", "id", ch.ID(), "")
+			s.log.Info("Channel has no past or pending submission - dropping", "id", ch.ID())
 			s.removePendingChannel(ch)
 		} else {
 			s.log.Info("Channel is in-flight and will need to be submitted after close", "id", ch.ID(), "confirmed", len(ch.confirmedTransactions), "pending", len(ch.pendingTransactions))

--- a/op-service/eth/id.go
+++ b/op-service/eth/id.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type BlockID struct {
@@ -19,6 +20,14 @@ func (id BlockID) String() string {
 // output during logging.
 func (id BlockID) TerminalString() string {
 	return fmt.Sprintf("%s:%d", id.Hash.TerminalString(), id.Number)
+}
+
+func ReceiptBlockID(r *types.Receipt) BlockID {
+	return BlockID{Number: r.BlockNumber.Uint64(), Hash: r.BlockHash}
+}
+
+func HeaderBlockID(h *types.Header) BlockID {
+	return BlockID{Number: h.Number.Uint64(), Hash: h.Hash()}
 }
 
 type L2BlockRef struct {

--- a/op-service/txmgr/metrics/noop.go
+++ b/op-service/txmgr/metrics/noop.go
@@ -1,6 +1,10 @@
 package metrics
 
-import "github.com/ethereum/go-ethereum/core/types"
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
 
 type NoopTxMetrics struct{}
 
@@ -10,4 +14,6 @@ func (*NoopTxMetrics) RecordGasBumpCount(int)            {}
 func (*NoopTxMetrics) RecordTxConfirmationLatency(int64) {}
 func (*NoopTxMetrics) TxConfirmed(*types.Receipt)        {}
 func (*NoopTxMetrics) TxPublished(string)                {}
+func (*NoopTxMetrics) RecordBasefee(*big.Int)            {}
+func (*NoopTxMetrics) RecordTipCap(*big.Int)             {}
 func (*NoopTxMetrics) RPCError()                         {}

--- a/op-service/txmgr/queue.go
+++ b/op-service/txmgr/queue.go
@@ -10,7 +10,7 @@ import (
 )
 
 type TxReceipt[T any] struct {
-	// ID can be used to identify unique tx receipts within the recept channel
+	// ID can be used to identify unique tx receipts within the receipt channel
 	ID T
 	// Receipt result from the transaction send
 	Receipt *types.Receipt
@@ -28,6 +28,8 @@ type Queue[T any] struct {
 }
 
 // NewQueue creates a new transaction sending Queue, with the following parameters:
+//   - ctx: runtime context of the queue. If canceled, all ongoing send processes are canceled.
+//   - txMgt: transaction managre to use for transaction sending
 //   - maxPending: max number of pending txs at once (0 == no limit)
 func NewQueue[T any](ctx context.Context, txMgr TxManager, maxPending uint64) *Queue[T] {
 	if maxPending > math.MaxInt {


### PR DESCRIPTION
- Standardize field names
- Add more fields to tx logging
- Add metrics for basefee and tip cap. Whenever we sample a basefee or suggested tip cap, we record these.
    - Note that the implementation was changed such that when waiting for confirmation, the chain head is always fetched, so that changes in the basefee can be recorded. This should help debugging transactions that are not getting included during basefee hikes.
- Log frame id and transaction hash together. This helps debugging transactions for a specific channel. 
    - In a follow-up, this will be further improved.
- Fix the `Queue` test to do assertions in the main testing goroutine, and remove a goroutine leak

Fixes https://github.com/ethereum-optimism/client-pod/issues/145
