### PR TITLE
Add batch submission policy that uses Blob transactions

### DIFF
--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -209,6 +209,7 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		"l1Head", l1Head,
 		"blocks_pending", len(s.blocks),
 		"batch_type", s.cfg.BatchType,
+		"max_frame_size", s.cfg.MaxFrameSize,
 	)
 	s.metr.RecordChannelOpened(pc.ID(), len(s.blocks))
 

--- a/op-batcher/batcher/config.go
+++ b/op-batcher/batcher/config.go
@@ -57,6 +57,10 @@ type CLIConfig struct {
 
 	BatchType uint
 
+	// DataAvailabilityType is one of the values defined in op-batcher/flags/flags.go and dictates
+	// the data availability type to use for poting batches, e.g. blobs vs calldata.
+	DataAvailabilityType string
+
 	TxMgrConfig      txmgr.CLIConfig
 	LogConfig        oplog.CLIConfig
 	MetricsConfig    opmetrics.CLIConfig
@@ -87,7 +91,12 @@ func (c *CLIConfig) Check() error {
 	if c.BatchType > 1 {
 		return fmt.Errorf("unknown batch type: %v", c.BatchType)
 	}
-
+	switch c.DataAvailabilityType {
+	case flags.CalldataType:
+	case flags.BlobsType:
+	default:
+		return fmt.Errorf("unknown data availability type: %v", c.DataAvailabilityType)
+	}
 	if err := c.MetricsConfig.Check(); err != nil {
 		return err
 	}
@@ -119,6 +128,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		MaxL1TxSize:            ctx.Uint64(flags.MaxL1TxSizeBytesFlag.Name),
 		Stopped:                ctx.Bool(flags.StoppedFlag.Name),
 		BatchType:              ctx.Uint(flags.BatchTypeFlag.Name),
+		DataAvailabilityType:   ctx.String(flags.DataAvailabilityTypeFlag.Name),
 		TxMgrConfig:            txmgr.ReadCLIConfig(ctx),
 		LogConfig:              oplog.ReadCLIConfig(ctx),
 		MetricsConfig:          opmetrics.ReadCLIConfig(ctx),

--- a/op-batcher/batcher/config_test.go
+++ b/op-batcher/batcher/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/pprof"
@@ -25,6 +26,7 @@ func validBatcherConfig() batcher.CLIConfig {
 		MaxL1TxSize:            10,
 		Stopped:                false,
 		BatchType:              0,
+		DataAvailabilityType:   flags.CalldataType,
 		TxMgrConfig:            txmgr.NewCLIConfig("fake", txmgr.DefaultBatcherFlagValues),
 		LogConfig:              log.DefaultCLIConfig(),
 		MetricsConfig:          metrics.DefaultCLIConfig(),
@@ -79,6 +81,11 @@ func TestBatcherConfig(t *testing.T) {
 			name:      "invalid batch type far",
 			override:  func(c *batcher.CLIConfig) { c.BatchType = 100 },
 			errString: "unknown batch type: 100",
+		},
+		{
+			name:      "invalid batch submission policy",
+			override:  func(c *batcher.CLIConfig) { c.DataAvailabilityType = "foo" },
+			errString: "unknown data availability type: foo",
 		},
 	}
 

--- a/op-batcher/flags/flags.go
+++ b/op-batcher/flags/flags.go
@@ -21,6 +21,12 @@ func prefixEnvVars(name string) []string {
 	return opservice.PrefixEnvVar(EnvVarPrefix, name)
 }
 
+const (
+	// data availability types
+	CalldataType = "calldata"
+	BlobsType    = "blobs"
+)
+
 var (
 	// Required flags
 	L1EthRpcFlag = &cli.StringFlag{
@@ -82,6 +88,12 @@ var (
 		Value:   0,
 		EnvVars: prefixEnvVars("BATCH_TYPE"),
 	}
+	DataAvailabilityTypeFlag = &cli.StringFlag{
+		Name:    "data-availability-type",
+		Usage:   "The data availability type to use for submitting batches to the L1, e.g. blobs or calldata.",
+		Value:   CalldataType,
+		EnvVars: prefixEnvVars("DATA_AVAILABILITY_TYPE"),
+	}
 	// Legacy Flags
 	SequencerHDPathFlag = txmgr.SequencerHDPathFlag
 )
@@ -101,6 +113,7 @@ var optionalFlags = []cli.Flag{
 	StoppedFlag,
 	SequencerHDPathFlag,
 	BatchTypeFlag,
+	DataAvailabilityTypeFlag,
 }
 
 func init() {

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -40,6 +40,7 @@ import (
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	"github.com/ethereum-optimism/optimism/op-batcher/compressor"
+	batcherFlags "github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-e2e/config"
@@ -774,8 +775,9 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 			Level:  log.LvlInfo,
 			Format: oplog.FormatText,
 		},
-		Stopped:   sys.Cfg.DisableBatcher, // Batch submitter may be enabled later
-		BatchType: batchType,
+		Stopped:              sys.Cfg.DisableBatcher, // Batch submitter may be enabled later
+		BatchType:            batchType,
+		DataAvailabilityType: batcherFlags.CalldataType,
 	}
 	// Batch Submitter
 	batcher, err := bss.BatcherServiceFromCLIConfig(context.Background(), "0.0.1", batcherCLIConfig, sys.Cfg.Loggers["batcher"])

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -295,7 +295,7 @@ func (n *OpNode) initRuntimeConfig(ctx context.Context, cfg *Config) error {
 
 func (n *OpNode) initL1BeaconAPI(ctx context.Context, cfg *Config) error {
 	if cfg.Beacon == nil {
-		n.log.Error("No beacon endpoint configured. Configuration is mandatory for the Ecotone upgrade")
+		n.log.Warn("No beacon endpoint configured. Configuration is mandatory for the Ecotone upgrade")
 		return nil
 	}
 	httpClient, err := cfg.Beacon.Setup(ctx, n.log)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Once Dencun / 4844 is activated on the L1, we wish to allow batches to be posted using Blob transactions. This PR adds a batcher configuration option to trigger submitting batches using blobs instead of calldata.

**Tests**

This is primarily a configuration change and will be ultimately be tested via e2e tests in a subsequent PR.
