### PR TITLE
fix(indexer): flaky indexer e2e tests for funded withdrawals

### DIFF
--- a/indexer/e2e_tests/bridge_messages_e2e_test.go
+++ b/indexer/e2e_tests/bridge_messages_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum-optimism/optimism/op-node/withdrawals"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/stretchr/testify/require"
@@ -114,7 +115,12 @@ func TestE2EBridgeL2CrossDomainMessenger(t *testing.T) {
 	l1Opts.Value = l2Opts.Value
 	depositTx, err := optimismPortal.Receive(l1Opts)
 	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	require.NoError(t, err)
+	depositInfo, err := e2etest_utils.ParseDepositInfo(depositReceipt)
+	require.NoError(t, err)
+	depositL2TxHash := types.NewTx(depositInfo.DepositTx).Hash()
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.L2Client, depositL2TxHash)
 	require.NoError(t, err)
 
 	// (1) Send the Message

--- a/indexer/e2e_tests/bridge_transactions_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transactions_e2e_test.go
@@ -94,7 +94,12 @@ func TestE2EBridgeTransactionsL2ToL1MessagePasserWithdrawal(t *testing.T) {
 	l1Opts.Value = l2Opts.Value
 	depositTx, err := optimismPortal.Receive(l1Opts)
 	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	require.NoError(t, err)
+	depositInfo, err := e2etest_utils.ParseDepositInfo(depositReceipt)
+	require.NoError(t, err)
+	depositL2TxHash := types.NewTx(depositInfo.DepositTx).Hash()
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.L2Client, depositL2TxHash)
 	require.NoError(t, err)
 
 	withdrawTx, err := l2ToL1MessagePasser.InitiateWithdrawal(l2Opts, aliceAddr, big.NewInt(100_000), calldata)

--- a/indexer/e2e_tests/bridge_transfers_e2e_test.go
+++ b/indexer/e2e_tests/bridge_transfers_e2e_test.go
@@ -240,7 +240,12 @@ func TestE2EBridgeTransfersStandardBridgeETHWithdrawal(t *testing.T) {
 	l1Opts.Value = l2Opts.Value
 	depositTx, err := optimismPortal.Receive(l1Opts)
 	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	require.NoError(t, err)
+	depositInfo, err := e2etest_utils.ParseDepositInfo(depositReceipt)
+	require.NoError(t, err)
+	depositL2TxHash := types.NewTx(depositInfo.DepositTx).Hash()
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.L2Client, depositL2TxHash)
 	require.NoError(t, err)
 
 	// (1) Test Withdrawal Initiation
@@ -324,7 +329,12 @@ func TestE2EBridgeTransfersL2ToL1MessagePasserETHReceive(t *testing.T) {
 	l1Opts.Value = l2Opts.Value
 	depositTx, err := optimismPortal.Receive(l1Opts)
 	require.NoError(t, err)
-	_, err = wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	require.NoError(t, err)
+	depositInfo, err := e2etest_utils.ParseDepositInfo(depositReceipt)
+	require.NoError(t, err)
+	depositL2TxHash := types.NewTx(depositInfo.DepositTx).Hash()
+	_, err = wait.ForReceiptOK(context.Background(), testSuite.L2Client, depositL2TxHash)
 	require.NoError(t, err)
 
 	// (1) Test Withdrawal Initiation
@@ -510,6 +520,11 @@ func TestClientBridgeFunctions(t *testing.T) {
 		depositTx, err := optimismPortal.Receive(l1Opts)
 		require.NoError(t, err)
 		depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+		require.NoError(t, err)
+		depositInfo, err := e2etest_utils.ParseDepositInfo(depositReceipt)
+		require.NoError(t, err)
+		depositL2TxHash := types.NewTx(depositInfo.DepositTx).Hash()
+		_, err = wait.ForReceiptOK(context.Background(), testSuite.L2Client, depositL2TxHash)
 		require.NoError(t, err)
 
 		mintSum = new(big.Int).Add(mintSum, depositTx.Value())

--- a/indexer/e2e_tests/setup.go
+++ b/indexer/e2e_tests/setup.go
@@ -53,6 +53,9 @@ type E2ETestSuite struct {
 }
 
 func init() {
+	// Disable the global logger. Ideally we'd like to dump geth
+	// logs per-test but that's possible when running tests in
+	// parallel as the root logger is shared.
 	log.Root().SetHandler(log.DiscardHandler())
 }
 
@@ -69,8 +72,6 @@ func createE2ETestSuite(t *testing.T) E2ETestSuite {
 	// Bump up the block times to try minimize resource
 	// contention when parallel devnets are running
 	opCfg := op_e2e.DefaultSystemConfig(t)
-	opCfg.DeployConfig.L1BlockTime = 6
-	opCfg.DeployConfig.L2BlockTime = 2
 
 	// Unless specified, omit logs emitted by the various components
 	if len(os.Getenv("ENABLE_ROLLUP_LOGS")) == 0 {


### PR DESCRIPTION
This should close #8677.

For indexer e2e tests that fund withdrawals through deposits on L1,
there is a race between the withdrawals and included deposit on L2
as the deposit tx will increment the account's tx nonce.

By waiting for deposit inclusion on L2, the nonce used for the
withdrawal should be correct

Odd the flakiness only showed when the tests were run in parallel! Likely
due to delays in deposit inclusion that didn't happen when run individually
