### PR TITLE
refactor: move op-preimage tests to separate package

### DIFF
--- a/op-preimage/filepoller_test.go
+++ b/op-preimage/filepoller_test.go
@@ -1,18 +1,20 @@
-package preimage
+package preimage_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestFilePoller_Read(t *testing.T) {
-	chanA, chanB, err := CreateBidirectionalChannel()
+	chanA, chanB, err := preimage.CreateBidirectionalChannel()
 	require.NoError(t, err)
 	ctx := context.Background()
-	chanAPoller := NewFilePoller(ctx, chanA, time.Millisecond*100)
+	chanAPoller := preimage.NewFilePoller(ctx, chanA, time.Millisecond*100)
 
 	go func() {
 		_, _ = chanB.Write([]byte("hello"))
@@ -26,10 +28,10 @@ func TestFilePoller_Read(t *testing.T) {
 }
 
 func TestFilePoller_Write(t *testing.T) {
-	chanA, chanB, err := CreateBidirectionalChannel()
+	chanA, chanB, err := preimage.CreateBidirectionalChannel()
 	require.NoError(t, err)
 	ctx := context.Background()
-	chanAPoller := NewFilePoller(ctx, chanA, time.Millisecond*100)
+	chanAPoller := preimage.NewFilePoller(ctx, chanA, time.Millisecond*100)
 
 	bufch := make(chan []byte, 1)
 	go func() {
@@ -53,10 +55,10 @@ func TestFilePoller_Write(t *testing.T) {
 }
 
 func TestFilePoller_ReadCancel(t *testing.T) {
-	chanA, chanB, err := CreateBidirectionalChannel()
+	chanA, chanB, err := preimage.CreateBidirectionalChannel()
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
-	chanAPoller := NewFilePoller(ctx, chanA, time.Millisecond*100)
+	chanAPoller := preimage.NewFilePoller(ctx, chanA, time.Millisecond*100)
 
 	go func() {
 		_, _ = chanB.Write([]byte("hello"))
@@ -69,10 +71,10 @@ func TestFilePoller_ReadCancel(t *testing.T) {
 }
 
 func TestFilePoller_WriteCancel(t *testing.T) {
-	chanA, chanB, err := CreateBidirectionalChannel()
+	chanA, chanB, err := preimage.CreateBidirectionalChannel()
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
-	chanAPoller := NewFilePoller(ctx, chanA, time.Millisecond*100)
+	chanAPoller := preimage.NewFilePoller(ctx, chanA, time.Millisecond*100)
 
 	go func() {
 		var buf [5]byte

--- a/op-preimage/hints_test.go
+++ b/op-preimage/hints_test.go
@@ -1,4 +1,4 @@
-package preimage
+package preimage_test
 
 import (
 	"bytes"
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +29,7 @@ func TestHints(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-			hw := NewHintWriter(a)
+			hw := preimage.NewHintWriter(a)
 			for _, h := range hints {
 				hw.Hint(rawHint(h))
 			}
@@ -37,7 +39,7 @@ func TestHints(t *testing.T) {
 		got := make(chan string, len(hints))
 		go func() {
 			defer wg.Done()
-			hr := NewHintReader(b)
+			hr := preimage.NewHintReader(b)
 			for i := 0; i < len(hints); i++ {
 				err := hr.NextHint(func(hint string) error {
 					got <- hint
@@ -81,10 +83,10 @@ func TestHints(t *testing.T) {
 	})
 	t.Run("unexpected EOF", func(t *testing.T) {
 		var buf bytes.Buffer
-		hw := NewHintWriter(&buf)
+		hw := preimage.NewHintWriter(&buf)
 		hw.Hint(rawHint("hello"))
 		_, _ = buf.Read(make([]byte, 1)) // read one byte so it falls short, see if it's detected
-		hr := NewHintReader(&buf)
+		hr := preimage.NewHintReader(&buf)
 		err := hr.NextHint(func(hint string) error { return nil })
 		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
@@ -94,14 +96,14 @@ func TestHints(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-			hw := NewHintWriter(a)
+			hw := preimage.NewHintWriter(a)
 			hw.Hint(rawHint("one"))
 			hw.Hint(rawHint("two"))
 			wg.Done()
 		}()
 		go func() {
 			defer wg.Done()
-			hr := NewHintReader(b)
+			hr := preimage.NewHintReader(b)
 			cbErr := errors.New("fail")
 			err := hr.NextHint(func(hint string) error { return cbErr })
 			require.ErrorIs(t, err, cbErr)

--- a/op-preimage/oracle_test.go
+++ b/op-preimage/oracle_test.go
@@ -1,4 +1,4 @@
-package preimage
+package preimage_test
 
 import (
 	"bytes"
@@ -7,6 +7,8 @@ import (
 	"io"
 	"sync"
 	"testing"
+
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 
 	"github.com/stretchr/testify/require"
 )
@@ -25,21 +27,21 @@ func bidirectionalPipe() (a, b io.ReadWriter) {
 func TestOracle(t *testing.T) {
 	testPreimage := func(preimages ...[]byte) {
 		a, b := bidirectionalPipe()
-		cl := NewOracleClient(a)
-		srv := NewOracleServer(b)
+		cl := preimage.NewOracleClient(a)
+		srv := preimage.NewOracleServer(b)
 
 		preimageByHash := make(map[[32]byte][]byte)
 		for _, p := range preimages {
-			k := Keccak256Key(Keccak256(p))
+			k := preimage.Keccak256Key(preimage.Keccak256(p))
 			preimageByHash[k.PreimageKey()] = p
 		}
 		for _, p := range preimages {
-			k := Keccak256Key(Keccak256(p))
+			k := preimage.Keccak256Key(preimage.Keccak256(p))
 
 			var wg sync.WaitGroup
 			wg.Add(2)
 
-			go func(k Key, p []byte) {
+			go func(k preimage.Key, p []byte) {
 				result := cl.Get(k)
 				wg.Done()
 				expected := preimageByHash[k.PreimageKey()]

--- a/op-preimage/verifier_test.go
+++ b/op-preimage/verifier_test.go
@@ -62,7 +62,7 @@ func TestWithVerification(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		//test := test
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			source := preimage.WithVerification(func(key [32]byte) ([]byte, error) {
 				return test.data, test.err

--- a/op-preimage/verifier_test.go
+++ b/op-preimage/verifier_test.go
@@ -1,20 +1,22 @@
-package preimage
+package preimage_test
 
 import (
 	"errors"
 	"testing"
+
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestWithVerification(t *testing.T) {
 	validData := []byte{1, 2, 3, 4, 5, 6}
-	keccak256Key := Keccak256Key(Keccak256(validData))
+	keccak256Key := preimage.Keccak256Key(preimage.Keccak256(validData))
 	anError := errors.New("boom")
 
 	tests := []struct {
 		name         string
-		key          Key
+		key          preimage.Key
 		data         []byte
 		err          error
 		expectedErr  error
@@ -22,7 +24,7 @@ func TestWithVerification(t *testing.T) {
 	}{
 		{
 			name:         "LocalKey NoVerification",
-			key:          LocalIndexKey(1),
+			key:          preimage.LocalIndexKey(1),
 			data:         []byte{4, 3, 5, 7, 3},
 			expectedData: []byte{4, 3, 5, 7, 3},
 		},
@@ -43,26 +45,26 @@ func TestWithVerification(t *testing.T) {
 			name:        "Keccak256 InvalidData",
 			key:         keccak256Key,
 			data:        []byte{6, 7, 8},
-			expectedErr: ErrIncorrectData,
+			expectedErr: preimage.ErrIncorrectData,
 		},
 		{
 			name:        "EmptyData",
 			key:         keccak256Key,
 			data:        []byte{},
-			expectedErr: ErrIncorrectData,
+			expectedErr: preimage.ErrIncorrectData,
 		},
 		{
 			name:        "UnknownKey",
 			key:         invalidKey([32]byte{0xaa}),
 			data:        []byte{},
-			expectedErr: ErrUnsupportedKeyType,
+			expectedErr: preimage.ErrUnsupportedKeyType,
 		},
 	}
 
 	for _, test := range tests {
-		test := test
+		//test := test
 		t.Run(test.name, func(t *testing.T) {
-			source := WithVerification(func(key [32]byte) ([]byte, error) {
+			source := preimage.WithVerification(func(key [32]byte) ([]byte, error) {
 				return test.data, test.err
 			})
 			actual, err := source(test.key.PreimageKey())


### PR DESCRIPTION
**Description**

Go tests may exist in the same folder as the code they're testing but in a separate `_test` package.

Separating test code into its own `_test` package is good practice, as it forces the test to test only the public interfaces of the code under test rather than depend on non-public package-internal implementation details.

I applied this technique to op-preimage, but it really applies to everything in the repo. In the interests of creating a narrowly-scoped PR and not over-investing until I get buy-in on this refactoring, I limited changes to just the op-preimage folder.

**Tests**

N/A

**Additional context**

N/A

**Metadata**

- Reference: https://pkg.go.dev/testing
- Reference: https://github.com/golang/go/issues/25223
