### PR TITLE
refactor: replace single-use named structs with anonymous structs

### DIFF
--- a/cannon/mipsevm/evm_test.go
+++ b/cannon/mipsevm/evm_test.go
@@ -223,13 +223,12 @@ func TestEVMSingleStep(t *testing.T) {
 	var tracer vm.EVMLogger
 	//tracer = SourceMapTracer(t, contracts, addrs)
 
-	type testInput struct {
+	cases := []struct {
 		name   string
 		pc     uint32
 		nextPC uint32
 		insn   uint32
-	}
-	cases := []testInput{
+	}{
 		{"j MSB set target", 0, 4, 0x0A_00_00_02},                         // j 0x02_00_00_02
 		{"j non-zero PC region", 0x10000000, 0x10000004, 0x08_00_00_02},   // j 0x2
 		{"jal MSB set target", 0, 4, 0x0E_00_00_02},                       // jal 0x02_00_00_02
@@ -264,12 +263,11 @@ func TestEVMFault(t *testing.T) {
 	env, evmState := NewEVMEnv(contracts, addrs)
 	env.Config.Tracer = tracer
 
-	type testInput struct {
+	cases := []struct {
 		name   string
 		nextPC uint32
 		insn   uint32
-	}
-	cases := []testInput{
+	}{
 		{"illegal instruction", 0, 0xFF_FF_FF_FF},
 		{"branch in delay-slot", 8, 0x11_02_00_03},
 		{"jump in delay-slot", 8, 0x0c_00_00_0c},

--- a/op-batcher/compressor/ratio_compressor_test.go
+++ b/op-batcher/compressor/ratio_compressor_test.go
@@ -16,13 +16,12 @@ func TestInputThreshold(t *testing.T) {
 		TargetNumFrames  int
 		ApproxComprRatio float64
 	}
-	type test struct {
-		input     testInput
-		assertion func(uint64)
-	}
 
 	// Construct test cases that test the boundary conditions
-	tests := []test{
+	tests := []struct {
+		input     testInput
+		assertion func(uint64)
+	}{
 		{
 			input: testInput{
 				TargetFrameSize:  1,

--- a/op-batcher/compressor/shadow_compressor_test.go
+++ b/op-batcher/compressor/shadow_compressor_test.go
@@ -25,16 +25,14 @@ func randomBytes(t *testing.T, length int) []byte {
 }
 
 func TestShadowCompressor(t *testing.T) {
-	type test struct {
+	tests := []struct {
 		name            string
 		targetFrameSize uint64
 		targetNumFrames int
 		data            [][]byte
 		errs            []error
 		fullErr         error
-	}
-
-	tests := []test{{
+	}{{
 		name:            "no data",
 		targetFrameSize: 1,
 		targetNumFrames: 1,

--- a/op-bindings/ast/canonicalize_test.go
+++ b/op-bindings/ast/canonicalize_test.go
@@ -10,11 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type astIDTest struct {
-	In  *solc.StorageLayout `json:"in"`
-	Out *solc.StorageLayout `json:"out"`
-}
-
 func TestCanonicalize(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -42,7 +37,10 @@ func TestCanonicalize(t *testing.T) {
 			f, err := os.Open(path.Join("testdata", tt.filename))
 			require.NoError(t, err)
 			dec := json.NewDecoder(f)
-			var testData astIDTest
+			var testData struct {
+				In  *solc.StorageLayout `json:"in"`
+				Out *solc.StorageLayout `json:"out"`
+			}
 			require.NoError(t, dec.Decode(&testData))
 			require.NoError(t, f.Close())
 

--- a/op-challenger/game/fault/types/position_test.go
+++ b/op-challenger/game/fault/types/position_test.go
@@ -39,7 +39,7 @@ func TestBigMSB(t *testing.T) {
 	}
 }
 
-type testNodeInfo struct {
+var treeNodes = []struct {
 	GIndex       *big.Int
 	Depth        int
 	MaxDepth     int
@@ -47,9 +47,7 @@ type testNodeInfo struct {
 	TraceIndex   *big.Int
 	AttackGIndex *big.Int // 0 indicates attack is not possible from this node
 	DefendGIndex *big.Int // 0 indicates defend is not possible from this node
-}
-
-var treeNodes = []testNodeInfo{
+}{
 	{GIndex: bi(1), Depth: 0, MaxDepth: 4, IndexAtDepth: bi(0), TraceIndex: bi(15), AttackGIndex: bi(2)},
 
 	{GIndex: bi(2), Depth: 1, MaxDepth: 4, IndexAtDepth: bi(0), TraceIndex: bi(7), AttackGIndex: bi(4), DefendGIndex: bi(6)},

--- a/op-service/txmgr/queue_test.go
+++ b/op-service/txmgr/queue_test.go
@@ -38,15 +38,6 @@ type testTx struct {
 	sendErr bool // error to return from send for this tx
 }
 
-type testCase struct {
-	name   string        // name of the test
-	max    uint64        // max concurrency of the queue
-	calls  []queueCall   // calls to the queue
-	txs    []testTx      // txs to generate from the factory (and potentially error in send)
-	nonces []uint64      // expected sent tx nonces after all calls are made
-	total  time.Duration // approx. total time it should take to complete all queue calls
-}
-
 type mockBackendWithNonce struct {
 	mockBackend
 }
@@ -65,7 +56,14 @@ func (b *mockBackendWithNonce) NonceAt(ctx context.Context, account common.Addre
 }
 
 func TestSend(t *testing.T) {
-	testCases := []testCase{
+	testCases := []struct {
+		name   string        // name of the test
+		max    uint64        // max concurrency of the queue
+		calls  []queueCall   // calls to the queue
+		txs    []testTx      // txs to generate from the factory (and potentially error in send)
+		nonces []uint64      // expected sent tx nonces after all calls are made
+		total  time.Duration // approx. total time it should take to complete all queue calls
+	}{
 		{
 			name: "success",
 			max:  5,


### PR DESCRIPTION
**Description**

I noticed that several tests declared named structs and only used the type in one place. That's a good opportunity for Go's anonymous structs, so I replaced the single-use types with anonymous structs.

Anonymous structs result in more succinct code and stronger cohesion between the struct definition and its usage.

**Tests**

This is a pure, non-functional refactoring, so additional tests are not necessary.

**Additional context**

N/A

**Metadata**

N/A
