### PR TITLE
txmgr: Add min basefee and tip cap parameters to enforce fee minima

### DIFF
--- a/op-service/eth/ether.go
+++ b/op-service/eth/ether.go
@@ -1,0 +1,29 @@
+package eth
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func GweiToWei(gwei float64) (*big.Int, error) {
+	if math.IsNaN(gwei) || math.IsInf(gwei, 0) {
+		return nil, fmt.Errorf("invalid gwei value: %v", gwei)
+	}
+
+	// convert float GWei value into integer Wei value
+	wei, _ := new(big.Float).Mul(
+		big.NewFloat(gwei),
+		big.NewFloat(params.GWei)).
+		Int(nil)
+
+	if wei.Cmp(abi.MaxUint256) == 1 {
+		return nil, errors.New("gwei value larger than max uint256")
+	}
+
+	return wei, nil
+}

--- a/op-service/eth/ether_test.go
+++ b/op-service/eth/ether_test.go
@@ -1,0 +1,71 @@
+package eth
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGweiToWei(t *testing.T) {
+	maxUint256p1, _ := new(big.Int).Add(abi.MaxUint256, big.NewInt(1)).Float64()
+	for _, tt := range []struct {
+		desc string
+		gwei float64
+		wei  *big.Int
+		err  bool
+	}{
+		{
+			desc: "zero",
+			gwei: 0,
+			wei:  new(big.Int),
+		},
+		{
+			desc: "one-wei",
+			gwei: 0.000000001,
+			wei:  big.NewInt(1),
+		},
+		{
+			desc: "one-gwei",
+			gwei: 1.0,
+			wei:  big.NewInt(1e9),
+		},
+		{
+			desc: "one-ether",
+			gwei: 1e9,
+			wei:  big.NewInt(1e18),
+		},
+		{
+			desc: "err-pos-inf",
+			gwei: math.Inf(1),
+			err:  true,
+		},
+		{
+			desc: "err-neg-inf",
+			gwei: math.Inf(-1),
+			err:  true,
+		},
+		{
+			desc: "err-nan",
+			gwei: math.NaN(),
+			err:  true,
+		},
+		{
+			desc: "err-too-large",
+			gwei: maxUint256p1,
+			err:  true,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			wei, err := GweiToWei(tt.gwei)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wei, wei)
+			}
+		})
+	}
+}

--- a/op-service/txmgr/txmgr_test.go
+++ b/op-service/txmgr/txmgr_test.go
@@ -871,7 +871,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 			},
 		},
 		{
-			name: "enforces min bump on only tip incrase",
+			name: "enforces min bump on only tip increase",
 			run: func(t *testing.T) {
 				tx, newTx := doGasPriceIncrease(t, 100, 1000, 101, 440)
 				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
@@ -879,7 +879,7 @@ func TestIncreaseGasPrice(t *testing.T) {
 			},
 		},
 		{
-			name: "enforces min bump on only basefee incrase",
+			name: "enforces min bump on only basefee increase",
 			run: func(t *testing.T) {
 				tx, newTx := doGasPriceIncrease(t, 100, 1000, 99, 460)
 				require.True(t, newTx.GasFeeCap().Cmp(tx.GasFeeCap()) > 0, "new tx fee cap must be larger")
@@ -1052,4 +1052,71 @@ func TestNonceReset(t *testing.T) {
 
 	// internal nonce tracking should be reset every 3rd tx
 	require.Equal(t, []uint64{0, 0, 1, 2, 0, 1, 2, 0}, nonces)
+}
+
+func TestMinFees(t *testing.T) {
+	for _, tt := range []struct {
+		desc             string
+		minBasefee       *big.Int
+		minTipCap        *big.Int
+		expectMinBasefee bool
+		expectMinTipCap  bool
+	}{
+		{
+			desc: "no-mins",
+		},
+		{
+			desc:             "high-min-basefee",
+			minBasefee:       big.NewInt(10_000_000),
+			expectMinBasefee: true,
+		},
+		{
+			desc:            "high-min-tipcap",
+			minTipCap:       big.NewInt(1_000_000),
+			expectMinTipCap: true,
+		},
+		{
+			desc:             "high-mins",
+			minBasefee:       big.NewInt(10_000_000),
+			minTipCap:        big.NewInt(1_000_000),
+			expectMinBasefee: true,
+			expectMinTipCap:  true,
+		},
+		{
+			desc:       "low-min-basefee",
+			minBasefee: big.NewInt(1),
+		},
+		{
+			desc:      "low-min-tipcap",
+			minTipCap: big.NewInt(1),
+		},
+		{
+			desc:       "low-mins",
+			minBasefee: big.NewInt(1),
+			minTipCap:  big.NewInt(1),
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			require := require.New(t)
+			conf := configWithNumConfs(1)
+			conf.MinBasefee = tt.minBasefee
+			conf.MinTipCap = tt.minTipCap
+			h := newTestHarnessWithConfig(t, conf)
+
+			tip, basefee, err := h.mgr.suggestGasPriceCaps(context.TODO())
+			require.NoError(err)
+
+			if tt.expectMinBasefee {
+				require.Equal(tt.minBasefee, basefee, "expect suggested basefee to equal MinBasefee")
+			} else {
+				require.Equal(h.gasPricer.baseBaseFee, basefee, "expect suggested basefee to equal mock basefee")
+			}
+
+			if tt.expectMinTipCap {
+				require.Equal(tt.minTipCap, tip, "expect suggested tip to equal MinTipCap")
+			} else {
+				require.Equal(h.gasPricer.baseGasTipFee, tip, "expect suggested tip to equal mock tip")
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds two new parameters to the transaction manager that specify a min basefee and tip cap to use when performing fee estimations.

Default is off, so no minima are enforced. This is primarily helpful for low-fee testnets.

**Tests**

Test added for all combinations of the parameters.

**Additional context**

This allows for dealing with super-low fee testnets, where sudden fee "spikes" will keep transactions from being included, even though the absolute fees are still very low.

