### PR TITLE
[op-conductor] admin api - PostUnsafePayload

### DIFF
--- a/op-conductor/client/sequencer.go
+++ b/op-conductor/client/sequencer.go
@@ -14,6 +14,7 @@ type SequencerControl interface {
 	StartSequencer(ctx context.Context, hash common.Hash) error
 	StopSequencer(ctx context.Context) (common.Hash, error)
 	LatestUnsafeBlock(ctx context.Context) (eth.BlockInfo, error)
+	PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error
 }
 
 // NewSequencerControl creates a new SequencerControl instance.
@@ -44,4 +45,9 @@ func (s *sequencerController) StartSequencer(ctx context.Context, hash common.Ha
 // StopSequencer implements SequencerControl.
 func (s *sequencerController) StopSequencer(ctx context.Context) (common.Hash, error) {
 	return s.node.StopSequencer(ctx)
+}
+
+// PostUnsafePayload implements SequencerControl.
+func (s *sequencerController) PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	return s.node.PostUnsafePayload(ctx, payload)
 }

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -127,6 +127,10 @@ func (s *l2VerifierBackend) SequencerActive(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
+func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	return nil
+}
+
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
 	return s.derivation.Finalized()
 }

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -30,6 +30,7 @@ type driverClient interface {
 	StartSequencer(ctx context.Context, blockHash common.Hash) error
 	StopSequencer(context.Context) (common.Hash, error)
 	SequencerActive(context.Context) (bool, error)
+	OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayload) error
 }
 
 type adminAPI struct {
@@ -66,6 +67,20 @@ func (n *adminAPI) SequencerActive(ctx context.Context) (bool, error) {
 	recordDur := n.M.RecordRPCServerRequest("admin_sequencerActive")
 	defer recordDur()
 	return n.dr.SequencerActive(ctx)
+}
+
+// PostUnsafePayload is a special API that allows posting an unsafe payload to the L2 derivation pipeline.
+// It should only be used by op-conductor for sequencer failover scenarios.
+func (n *adminAPI) PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	recordDur := n.M.RecordRPCServerRequest("admin_postUnsafePayload")
+	defer recordDur()
+
+	if actual, ok := payload.CheckBlockHash(); !ok {
+		log.Error("payload has bad block hash", "bad_hash", payload.BlockHash.String(), "actual", actual.String())
+		return fmt.Errorf("payload has bad block hash: %s, actual block hash is: %s", payload.BlockHash.String(), actual.String())
+	}
+
+	return n.dr.OnUnsafeL2Payload(ctx, payload)
 }
 
 type nodeAPI struct {

--- a/op-node/node/api.go
+++ b/op-node/node/api.go
@@ -69,7 +69,7 @@ func (n *adminAPI) SequencerActive(ctx context.Context) (bool, error) {
 	return n.dr.SequencerActive(ctx)
 }
 
-// PostUnsafePayload is a special API that allows posting an unsafe payload to the L2 derivation pipeline.
+// PostUnsafePayload is a special API that allow posting an unsafe payload to the L2 derivation pipeline.
 // It should only be used by op-conductor for sequencer failover scenarios.
 func (n *adminAPI) PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error {
 	recordDur := n.M.RecordRPCServerRequest("admin_postUnsafePayload")

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -229,4 +228,8 @@ func (c *mockDriverClient) StopSequencer(ctx context.Context) (common.Hash, erro
 
 func (c *mockDriverClient) SequencerActive(ctx context.Context) (bool, error) {
 	return c.Mock.MethodCalled("SequencerActive").Get(0).(bool), nil
+}
+
+func (c *mockDriverClient) OnUnsafeL2Payload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	return c.Mock.MethodCalled("OnUnsafeL2Payload").Get(0).(error)
 }

--- a/op-service/sources/rollupclient.go
+++ b/op-service/sources/rollupclient.go
@@ -60,6 +60,10 @@ func (r *RollupClient) SequencerActive(ctx context.Context) (bool, error) {
 	return result, err
 }
 
+func (r *RollupClient) PostUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	return r.rpc.CallContext(ctx, nil, "admin_postUnsafePayload", payload)
+}
+
 func (r *RollupClient) SetLogLevel(ctx context.Context, lvl log.Lvl) error {
 	return r.rpc.CallContext(ctx, nil, "admin_setLogLevel", lvl.String())
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds an admin API `PostUnsafePayload` to allow `op-conductor` to be able to post unsafe payload to `op-node` to allow it to have the latest unsafe payload and be able to take over as active sequencer.

An alternative approach of using p2p is discussed and less-desired due to the implementation complexity.

**Tests**

No tests added because it's simply function calls into existing well tested code.

**Metadata**

- https://github.com/ethereum-optimism/protocol-quest/issues/45
