### PR TITLE
fix(op-challenger): Update Alphabet Trace Provider with Starting L2 Block Number

### DIFF
--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -3,6 +3,7 @@ package fault
 import (
 	"context"
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace"
@@ -57,7 +58,7 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 	responder.callResolveErr = errors.New("game is not resolvable")
 	responder.callResolveClaimErr = errors.New("claim is not resolvable")
 	depth := types.Depth(4)
-	claimBuilder := test.NewClaimBuilder(t, depth, alphabet.NewTraceProvider("abcdefg", depth))
+	claimBuilder := test.NewClaimBuilder(t, depth, alphabet.NewTraceProvider(big.NewInt(0), depth))
 
 	claimLoader.claims = []types.Claim{
 		claimBuilder.CreateRootClaim(true),
@@ -74,7 +75,7 @@ func setupTestAgent(t *testing.T) (*Agent, *stubClaimLoader, *stubResponder) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	claimLoader := &stubClaimLoader{}
 	depth := types.Depth(4)
-	provider := alphabet.NewTraceProvider("abcd", depth)
+	provider := alphabet.NewTraceProvider(big.NewInt(0), depth)
 	responder := &stubResponder{}
 	agent := NewAgent(metrics.NoopMetrics, claimLoader, depth, trace.NewSimpleTraceAccessor(provider), responder, logger)
 	return agent, claimLoader, responder

--- a/op-challenger/game/fault/solver/game_solver_test.go
+++ b/op-challenger/game/fault/solver/game_solver_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"context"
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	faulttest "github.com/ethereum-optimism/optimism/op-challenger/game/fault/test"
@@ -14,7 +15,8 @@ import (
 
 func TestCalculateNextActions(t *testing.T) {
 	maxDepth := types.Depth(4)
-	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, maxDepth)
+	startingL2BlockNumber := big.NewInt(0)
+	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, startingL2BlockNumber, maxDepth)
 
 	tests := []struct {
 		name             string

--- a/op-challenger/game/fault/solver/solver_test.go
+++ b/op-challenger/game/fault/solver/solver_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestAttemptStep(t *testing.T) {
 	maxDepth := types.Depth(3)
-	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, maxDepth)
+	startingL2BlockNumber := big.NewInt(0)
+	claimBuilder := faulttest.NewAlphabetClaimBuilder(t, startingL2BlockNumber, maxDepth)
 
 	// Last accessible leaf is the second last trace index
 	// The root node is used for the last trace index and can only be attacked.

--- a/op-challenger/game/fault/test/alphabet.go
+++ b/op-challenger/game/fault/test/alphabet.go
@@ -2,22 +2,23 @@ package test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 )
 
-func NewAlphabetWithProofProvider(t *testing.T, maxDepth types.Depth, oracleError error) *alphabetWithProofProvider {
+func NewAlphabetWithProofProvider(t *testing.T, startingL2BlockNumber *big.Int, maxDepth types.Depth, oracleError error) *alphabetWithProofProvider {
 	return &alphabetWithProofProvider{
-		alphabet.NewTraceProvider("abcdefghijklmnopqrstuvwxyz", maxDepth),
+		alphabet.NewTraceProvider(startingL2BlockNumber, maxDepth),
 		maxDepth,
 		oracleError,
 	}
 }
 
-func NewAlphabetClaimBuilder(t *testing.T, maxDepth types.Depth) *ClaimBuilder {
-	alphabetProvider := NewAlphabetWithProofProvider(t, maxDepth, nil)
+func NewAlphabetClaimBuilder(t *testing.T, startingL2BlockNumber *big.Int, maxDepth types.Depth) *ClaimBuilder {
+	alphabetProvider := NewAlphabetWithProofProvider(t, startingL2BlockNumber, maxDepth, nil)
 	return NewClaimBuilder(t, maxDepth, alphabetProvider)
 }
 

--- a/op-challenger/game/fault/trace/access_test.go
+++ b/op-challenger/game/fault/trace/access_test.go
@@ -15,8 +15,8 @@ import (
 func TestAccessor_UsesSelector(t *testing.T) {
 	ctx := context.Background()
 	depth := types.Depth(4)
-	provider1 := test.NewAlphabetWithProofProvider(t, depth, nil)
-	provider2 := alphabet.NewTraceProvider("qrstuv", depth)
+	provider1 := test.NewAlphabetWithProofProvider(t, big.NewInt(0), depth, nil)
+	provider2 := alphabet.NewTraceProvider(big.NewInt(0), depth)
 	claim := types.Claim{}
 	game := types.NewGameState([]types.Claim{claim}, depth)
 	pos1 := types.NewPositionFromGIndex(big.NewInt(4))

--- a/op-challenger/game/fault/trace/alphabet/prestate.go
+++ b/op-challenger/game/fault/trace/alphabet/prestate.go
@@ -2,6 +2,7 @@ package alphabet
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -10,7 +11,7 @@ import (
 )
 
 var absolutePrestate = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
-var absolutePrestateHash = common.HexToHash("0000000000000000000000000000000000000000000000000000000000000060")
+var absolutePrestateInt = new(big.Int).SetBytes(absolutePrestate)
 
 var _ types.PrestateProvider = (*AlphabetPrestateProvider)(nil)
 

--- a/op-challenger/game/fault/trace/alphabet/prestate.go
+++ b/op-challenger/game/fault/trace/alphabet/prestate.go
@@ -10,6 +10,7 @@ import (
 )
 
 var absolutePrestate = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")
+var absolutePrestateHash = common.HexToHash("0000000000000000000000000000000000000000000000000000000000000060")
 
 var _ types.PrestateProvider = (*AlphabetPrestateProvider)(nil)
 

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -49,7 +49,7 @@ func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, pos types.Posi
 	if posIndex.Cmp(common.Big0) == 0 {
 		return absolutePrestate, []byte{}, preimageData, nil
 	}
-    // We want the pre-state which is the value prior to the one requested
+	// We want the pre-state which is the value prior to the one requested
 	prestateTraceIndex := posIndex.Sub(posIndex, big.NewInt(1))
 	if prestateTraceIndex.Cmp(new(big.Int).SetUint64(ap.maxLen)) >= 0 {
 		return nil, nil, nil, fmt.Errorf("%w depth: %v index: %v max: %v", ErrIndexTooLarge, ap.depth, posIndex, ap.maxLen)

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -1,6 +1,7 @@
 package alphabet
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -41,24 +42,38 @@ func NewTraceProvider(startingBlockNumber *big.Int, depth types.Depth) *Alphabet
 	}
 }
 
-func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, i types.Position) ([]byte, []byte, *types.PreimageOracleData, error) {
-	traceIndex := i.TraceIndex(ap.depth)
+func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, pos types.Position) ([]byte, []byte, *types.PreimageOracleData, error) {
+	posIndex := pos.TraceIndex(ap.depth)
 	key := preimage.LocalIndexKey(L2ClaimBlockNumberLocalIndex).PreimageKey()
 	preimageData := types.NewPreimageOracleData(key[:], ap.startingBlockNumber.Bytes(), 0)
-	if traceIndex.Cmp(common.Big0) == 0 {
+	if posIndex.Cmp(common.Big0) == 0 {
 		return absolutePrestate, []byte{}, preimageData, nil
 	}
-	// We want the pre-state which is the value prior to the one requested
-	prestateTraceIndex := traceIndex.Sub(traceIndex, big.NewInt(1))
-	// The index cannot be larger than the maximum index as computed by the depth.
-	if prestateTraceIndex.Cmp(big.NewInt(int64(ap.maxLen))) >= 0 {
-		return nil, nil, nil, fmt.Errorf("%w traceIndex: %v max: %v pos: %v", ErrIndexTooLarge, prestateTraceIndex, ap.maxLen, i)
+    // We want the pre-state which is the value prior to the one requested
+	prestateTraceIndex := posIndex.Sub(posIndex, big.NewInt(1))
+	if prestateTraceIndex.Cmp(new(big.Int).SetUint64(ap.maxLen)) >= 0 {
+		return nil, nil, nil, fmt.Errorf("%w depth: %v index: %v max: %v", ErrIndexTooLarge, ap.depth, posIndex, ap.maxLen)
 	}
-	initialTraceIndex := new(big.Int).Lsh(ap.startingBlockNumber, 4)
-	initialClaim := new(big.Int).Add(absolutePrestateInt, initialTraceIndex)
-	newTraceIndex := new(big.Int).Add(initialTraceIndex, prestateTraceIndex)
-	newClaim := new(big.Int).Add(initialClaim, prestateTraceIndex)
-	return BuildAlphabetPreimage(newTraceIndex, newClaim), []byte{}, preimageData, nil
+	claim := BuildAlphabetPreimage(big.NewInt(0), absolutePrestateInt)
+	for i := big.NewInt(0); i.Cmp(posIndex) < 0; i = i.Add(i, big.NewInt(1)) {
+		claim = ap.step(claim)
+	}
+	return claim, []byte{}, preimageData, nil
+}
+
+// step accepts the trace index and claim and returns the stepped trace index and claim.
+func (ap *AlphabetTraceProvider) step(stateData []byte) []byte {
+	// Decode the stateData into the trace index and claim
+	traceIndex := new(big.Int).SetBytes(stateData[:32])
+	claim := stateData[32:]
+	if bytes.Equal(claim, absolutePrestate) {
+		initTraceIndex := new(big.Int).Lsh(ap.startingBlockNumber, 4)
+		initClaim := new(big.Int).Add(absolutePrestateInt, initTraceIndex)
+		return BuildAlphabetPreimage(initTraceIndex, initClaim)
+	}
+	stepTraceIndex := new(big.Int).Add(traceIndex, big.NewInt(1))
+	stepClaim := new(big.Int).Add(new(big.Int).SetBytes(claim), big.NewInt(1))
+	return BuildAlphabetPreimage(stepTraceIndex, stepClaim)
 }
 
 // Get returns the claim value at the given index in the trace.

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -78,7 +78,7 @@ func (ap *AlphabetTraceProvider) Get(ctx context.Context, i types.Position) (com
 
 // BuildAlphabetPreimage constructs the claim bytes for the index and claim.
 func BuildAlphabetPreimage(i *big.Int, blockNumber *big.Int) []byte {
-	return append(i.FillBytes(make([]byte, 32)), blockNumber.Bytes()...)
+	return append(i.FillBytes(make([]byte, 32)), blockNumber.FillBytes(make([]byte, 32))...)
 }
 
 func alphabetStateHash(state []byte) common.Hash {

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -54,7 +54,7 @@ func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, i types.Positi
 	if prestateTraceIndex.Cmp(big.NewInt(int64(ap.maxLen))) >= 0 {
 		return nil, nil, nil, fmt.Errorf("%w traceIndex: %v max: %v pos: %v", ErrIndexTooLarge, prestateTraceIndex, ap.maxLen, i)
 	}
-	claim := new(big.Int).Add(absolutePrestateHash.Big(), prestateTraceIndex)
+	claim := new(big.Int).Add(absolutePrestateInt, prestateTraceIndex)
 	return BuildAlphabetPreimage(prestateTraceIndex, claim), []byte{}, preimageData, nil
 }
 

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -54,8 +54,11 @@ func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, i types.Positi
 	if prestateTraceIndex.Cmp(big.NewInt(int64(ap.maxLen))) >= 0 {
 		return nil, nil, nil, fmt.Errorf("%w traceIndex: %v max: %v pos: %v", ErrIndexTooLarge, prestateTraceIndex, ap.maxLen, i)
 	}
-	claim := new(big.Int).Add(absolutePrestateInt, prestateTraceIndex)
-	return BuildAlphabetPreimage(prestateTraceIndex, claim), []byte{}, preimageData, nil
+	initialTraceIndex := new(big.Int).Lsh(ap.startingBlockNumber, 4)
+	initialClaim := new(big.Int).Add(absolutePrestateInt, initialTraceIndex)
+	newTraceIndex := new(big.Int).Add(initialTraceIndex, prestateTraceIndex)
+	newClaim := new(big.Int).Add(initialClaim, prestateTraceIndex)
+	return BuildAlphabetPreimage(newTraceIndex, newClaim), []byte{}, preimageData, nil
 }
 
 // Get returns the claim value at the given index in the trace.

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -87,7 +87,7 @@ func TestGet_Succeeds(t *testing.T) {
 	pos := types.NewPosition(depth, big.NewInt(0))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
-	expected := alphabetClaim(big.NewInt(0), absolutePrestateHash.Big())
+	expected := alphabetClaim(big.NewInt(0), absolutePrestateInt)
 	require.Equal(t, expected, claim)
 }
 

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -31,15 +31,15 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	}{
 		{
 			types.NewPosition(depth, big.NewInt(7)),
-			alphabetClaim(big.NewInt(7), big.NewInt(7)),
+			alphabetClaim(big.NewInt(7), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(7))),
 		},
 		{
 			types.NewPosition(depth, big.NewInt(3)),
-			alphabetClaim(big.NewInt(3), big.NewInt(3)),
+			alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(3))),
 		},
 		{
 			types.NewPosition(depth, big.NewInt(5)),
-			alphabetClaim(big.NewInt(5), big.NewInt(5)),
+			alphabetClaim(big.NewInt(5), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(5))),
 		},
 	}
 
@@ -57,7 +57,7 @@ func TestGetStepData_Succeeds(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
 	ap := NewTraceProvider(startingL2BlockNumber, depth)
-	expected := BuildAlphabetPreimage(big.NewInt(0), big.NewInt(0))
+	expected := BuildAlphabetPreimage(big.NewInt(0), absolutePrestateHash.Big())
 	pos := types.NewPosition(depth, big.NewInt(1))
 	retrieved, proof, data, err := ap.GetStepData(context.Background(), pos)
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestGet_Succeeds(t *testing.T) {
 	pos := types.NewPosition(depth, big.NewInt(0))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
-	expected := alphabetClaim(big.NewInt(0), big.NewInt(0))
+	expected := alphabetClaim(big.NewInt(0), absolutePrestateHash.Big())
 	require.Equal(t, expected, claim)
 }
 
@@ -120,6 +120,6 @@ func TestGet_Extends(t *testing.T) {
 	pos := types.NewPosition(depth, big.NewInt(3))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
-	expected := alphabetClaim(big.NewInt(3), big.NewInt(3))
+	expected := alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(3)))
 	require.Equal(t, expected, claim)
 }

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -22,6 +22,8 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	// Create a new alphabet provider.
 	depth := types.Depth(3)
 	startingL2BlockNumber := big.NewInt(1)
+	sbn := new(big.Int).Lsh(startingL2BlockNumber, 4)
+	startingTraceIndex := new(big.Int).Add(absolutePrestateInt, sbn)
 	canonicalProvider := NewTraceProvider(startingL2BlockNumber, depth)
 
 	// Build a list of traces.
@@ -31,15 +33,15 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	}{
 		{
 			types.NewPosition(depth, big.NewInt(7)),
-			alphabetClaim(big.NewInt(7), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(7))),
+			alphabetClaim(new(big.Int).Add(sbn, big.NewInt(7)), new(big.Int).Add(startingTraceIndex, big.NewInt(7))),
 		},
 		{
 			types.NewPosition(depth, big.NewInt(3)),
-			alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(3))),
+			alphabetClaim(new(big.Int).Add(sbn, big.NewInt(3)), new(big.Int).Add(startingTraceIndex, big.NewInt(3))),
 		},
 		{
 			types.NewPosition(depth, big.NewInt(5)),
-			alphabetClaim(big.NewInt(5), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(5))),
+			alphabetClaim(new(big.Int).Add(sbn, big.NewInt(5)), new(big.Int).Add(startingTraceIndex, big.NewInt(5))),
 		},
 	}
 
@@ -56,8 +58,10 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 func TestGetStepData_Succeeds(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
+	sbn := new(big.Int).Lsh(startingL2BlockNumber, 4)
+	startingTraceIndex := new(big.Int).Add(absolutePrestateInt, sbn)
 	ap := NewTraceProvider(startingL2BlockNumber, depth)
-	expected := BuildAlphabetPreimage(big.NewInt(0), absolutePrestateHash.Big())
+	expected := BuildAlphabetPreimage(sbn, startingTraceIndex)
 	pos := types.NewPosition(depth, big.NewInt(1))
 	retrieved, proof, data, err := ap.GetStepData(context.Background(), pos)
 	require.NoError(t, err)
@@ -83,11 +87,13 @@ func TestGetStepData_TooLargeIndex_Fails(t *testing.T) {
 func TestGet_Succeeds(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
+	sbn := new(big.Int).Lsh(startingL2BlockNumber, 4)
+	startingTraceIndex := new(big.Int).Add(absolutePrestateInt, sbn)
 	ap := NewTraceProvider(startingL2BlockNumber, depth)
 	pos := types.NewPosition(depth, big.NewInt(0))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
-	expected := alphabetClaim(big.NewInt(0), absolutePrestateInt)
+	expected := alphabetClaim(sbn, startingTraceIndex)
 	require.Equal(t, expected, claim)
 }
 
@@ -116,10 +122,12 @@ func TestGet_DepthTooLarge(t *testing.T) {
 func TestGet_Extends(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
+	sbn := new(big.Int).Lsh(startingL2BlockNumber, 4)
+	startingTraceIndex := new(big.Int).Add(absolutePrestateInt, sbn)
 	ap := NewTraceProvider(startingL2BlockNumber, depth)
 	pos := types.NewPosition(depth, big.NewInt(3))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
-	expected := alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(3)))
+	expected := alphabetClaim(new(big.Int).Add(sbn, big.NewInt(3)), new(big.Int).Add(startingTraceIndex, big.NewInt(3)))
 	require.Equal(t, expected, claim)
 }

--- a/op-challenger/game/fault/trace/outputs/output_alphabet.go
+++ b/op-challenger/game/fault/trace/outputs/output_alphabet.go
@@ -24,7 +24,7 @@ func NewOutputAlphabetTraceAccessor(
 ) (*trace.Accessor, error) {
 	outputProvider := NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, splitDepth, prestateBlock, poststateBlock)
 	alphabetCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
-		provider := alphabet.NewTraceProvider(localContext.Hex(), depth)
+		provider := alphabet.NewTraceProvider(agreed.L2BlockNumber, depth)
 		return provider, nil
 	}
 	cache := NewProviderCache(m, "output_alphabet_provider", alphabetCreator)

--- a/op-challenger/game/fault/trace/outputs/provider_cache_test.go
+++ b/op-challenger/game/fault/trace/outputs/provider_cache_test.go
@@ -26,7 +26,7 @@ func TestProviderCache(t *testing.T) {
 	depth := types.Depth(6)
 	var createdProvider types.TraceProvider
 	creator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
-		createdProvider = alphabet.NewTraceProvider("abcdef", depth)
+		createdProvider = alphabet.NewTraceProvider(big.NewInt(0), depth)
 		return createdProvider, nil
 	}
 	localContext1 := common.Hash{0xdd}

--- a/op-challenger/game/fault/trace/split/split_test.go
+++ b/op-challenger/game/fault/trace/split/split_test.go
@@ -303,17 +303,17 @@ func asBottomTraceProvider(t *testing.T, actual types.TraceProvider) *bottomTrac
 }
 
 func setupAlphabetSplitSelector(t *testing.T) (*alphabet.AlphabetTraceProvider, trace.ProviderSelector, *test.GameBuilder) {
-	top := alphabet.NewTraceProvider("abcdef", splitDepth)
+	top := alphabet.NewTraceProvider(big.NewInt(0), splitDepth)
 	bottomCreator := func(ctx context.Context, depth types.Depth, pre types.Claim, post types.Claim) (types.TraceProvider, error) {
 		return &bottomTraceProvider{
 			pre:                   pre,
 			post:                  post,
-			AlphabetTraceProvider: alphabet.NewTraceProvider(post.Value.Hex(), depth),
+			AlphabetTraceProvider: alphabet.NewTraceProvider(big.NewInt(0), depth),
 		}, nil
 	}
 	selector := NewSplitProviderSelector(top, splitDepth, bottomCreator)
 
-	claimBuilder := test.NewAlphabetClaimBuilder(t, gameDepth)
+	claimBuilder := test.NewAlphabetClaimBuilder(t, big.NewInt(0), gameDepth)
 	gameBuilder := claimBuilder.GameBuilder(true)
 	return top, selector, gameBuilder
 }

--- a/op-challenger/game/fault/trace/translate_test.go
+++ b/op-challenger/game/fault/trace/translate_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTranslate(t *testing.T) {
-	orig := alphabet.NewTraceProvider("abcdefghij", 4)
+	orig := alphabet.NewTraceProvider(big.NewInt(0), 4)
 	translated := Translate(orig, 3)
 	// All nodes on the first translated layer, map to GIndex 1
 	for i := int64(8); i <= 15; i++ {
@@ -50,7 +50,7 @@ func requireSameValue(t *testing.T, a types.TraceProvider, aGIdx int64, b types.
 }
 
 func TestTranslate_AbsolutePreStateCommitment(t *testing.T) {
-	orig := alphabet.NewTraceProvider("abcdefghij", 4)
+	orig := alphabet.NewTraceProvider(big.NewInt(0), 4)
 	translated := Translate(orig, 3)
 	origValue, err := orig.AbsolutePreStateCommitment(context.Background())
 	require.NoError(t, err)

--- a/op-e2e/e2eutils/disputegame/alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/alphabet_helper.go
@@ -2,6 +2,7 @@ package disputegame
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -31,7 +32,7 @@ func (g *AlphabetGameHelper) CreateHonestActor(alphabetTrace string, depth types
 		t:            g.t,
 		require:      g.require,
 		game:         &g.FaultGameHelper,
-		correctTrace: alphabet.NewTraceProvider(alphabetTrace, depth),
+		correctTrace: alphabet.NewTraceProvider(big.NewInt(0), depth),
 	}
 }
 

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutputAlphabetGame(t *testing.T) {
+func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -67,7 +67,7 @@ func TestOutputAlphabetGame(t *testing.T) {
 	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 }
 
-func TestOutputAlphabetGameWithValidOutputRoot(t *testing.T) {
+func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
@@ -14,8 +13,6 @@ import (
 )
 
 func TestOutputAlphabetGame(t *testing.T) {
-	// TODO(client-pod#43) Fix alphabet trace provider and re-enable.
-	t.Skip("client-pod#43: AlphabetTraceProvider not using the new alphabet vm spec")
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -27,35 +24,42 @@ func TestOutputAlphabetGame(t *testing.T) {
 
 	opts := challenger.WithPrivKey(sys.Cfg.Secrets.Alice)
 	game.StartChallenger(ctx, "sequencer", "Challenger", opts)
-
 	game.LogGameData(ctx)
+
 	// Challenger should post an output root to counter claims down to the leaf level of the top game
-	splitDepth := game.SplitDepth(ctx)
-	for i := int64(1); types.Depth(i) < splitDepth; i += 2 {
-		game.WaitForCorrectOutputRoot(ctx, i)
-		game.Attack(ctx, i, common.Hash{0xaa})
-		game.LogGameData(ctx)
+	claim := game.RootClaim(ctx)
+	for claim.IsOutputRoot(ctx) && !claim.IsOutputRootLeaf(ctx) {
+		if claim.AgreesWithOutputRoot() {
+			// If the latest claim agrees with the output root, expect the honest challenger to counter it
+			claim = claim.WaitForCounterClaim(ctx)
+			game.LogGameData(ctx)
+			claim.RequireCorrectOutputRoot(ctx)
+		} else {
+			// Otherwise we should counter
+			claim = claim.Attack(ctx, common.Hash{0xaa})
+			game.LogGameData(ctx)
+		}
 	}
 
-	// Wait for the challenger to post the first claim in the alphabet trace
-	game.WaitForClaimAtDepth(ctx, splitDepth+1)
+	// Wait for the challenger to post the first claim in the cannon trace
+	claim = claim.WaitForCounterClaim(ctx)
 	game.LogGameData(ctx)
 
-	game.Attack(ctx, int64(splitDepth)+1, common.Hash{0x00, 0xcc})
-	gameDepth := game.MaxDepth(ctx)
-	for i := splitDepth + 3; i < gameDepth; i += 2 {
-		// Wait for challenger to respond
-		game.WaitForClaimAtDepth(ctx, types.Depth(i))
-		game.LogGameData(ctx)
-
-		// Respond to push the game down to the max depth
-		game.Defend(ctx, int64(i), common.Hash{0x00, 0xdd})
-		game.LogGameData(ctx)
+	// Attack the root of the cannon trace subgame
+	claim = claim.Attack(ctx, common.Hash{0x00, 0xcc})
+	for !claim.IsMaxDepth(ctx) {
+		if claim.AgreesWithOutputRoot() {
+			// If the latest claim supports the output root, wait for the honest challenger to respond
+			claim = claim.WaitForCounterClaim(ctx)
+			game.LogGameData(ctx)
+		} else {
+			// Otherwise we need to counter the honest claim
+			claim = claim.Defend(ctx, common.Hash{0x00, 0xdd})
+			game.LogGameData(ctx)
+		}
 	}
-	game.LogGameData(ctx)
-
 	// Challenger should be able to call step and counter the leaf claim.
-	game.WaitForClaimAtMaxDepth(ctx, true)
+	claim.WaitForCountered(ctx)
 	game.LogGameData(ctx)
 
 	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
@@ -64,8 +68,6 @@ func TestOutputAlphabetGame(t *testing.T) {
 }
 
 func TestOutputAlphabetGameWithValidOutputRoot(t *testing.T) {
-	// TODO(client-pod#43) Fix alphabet trace provider and re-enable.
-	t.Skip("client-pod#43: AlphabetTraceProvider not using the new alphabet vm spec")
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -82,17 +84,14 @@ func TestOutputAlphabetGameWithValidOutputRoot(t *testing.T) {
 	opts := challenger.WithPrivKey(sys.Cfg.Secrets.Alice)
 	game.StartChallenger(ctx, "sequencer", "Challenger", opts)
 
+	claim = claim.WaitForCounterClaim(ctx)
+	game.LogGameData(ctx)
 	for !claim.IsMaxDepth(ctx) {
-		claim = claim.WaitForCounterClaim(ctx)
-		game.LogGameData(ctx)
 		// Dishonest actor always attacks with the correct trace
 		claim = correctTrace.AttackClaim(ctx, claim)
+		claim = claim.WaitForCounterClaim(ctx)
+		game.LogGameData(ctx)
 	}
-	game.LogGameData(ctx)
-
-	// Challenger should be able to call step and counter the leaf claim.
-	game.WaitForClaimAtMaxDepth(ctx, true)
-	game.LogGameData(ctx)
 
 	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
 	require.NoError(t, wait.ForNextBlock(ctx, l1Client))


### PR DESCRIPTION
**Description**

Fixes up the alphabet trace provider to use the starting l2 block number rather than the canonical alphabet trace string.

This is a follow-on to #8798.

**Metadata**

Makes progress on https://github.com/ethereum-optimism/client-pod/issues/403