### PR TITLE
chore(ctb): Increase invariant runs to 256 in CI

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -57,6 +57,10 @@ ignore = ['src/vendor/WETH9.sol']
 deny_warnings = true
 fuzz = { runs = 512 }
 
+[profile.ci.invariant]
+runs = 256
+depth = 32
+
 ################################################################
 #                         PROFILE: LITE                        #
 ################################################################


### PR DESCRIPTION
## Overview

Increases the default number of invariant runs in the `ci` profile of `contracts-bedrock`.
