### PR TITLE
fix(op-proposer): Handle context closing on error

### DIFF
--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -77,15 +77,19 @@ type L2OutputSubmitter struct {
 }
 
 // NewL2OutputSubmitter creates a new L2 Output Submitter
-func NewL2OutputSubmitter(setup DriverSetup) (*L2OutputSubmitter, error) {
+func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil || recover() != nil {
+			cancel()
+		}
+	}()
 
 	if setup.Cfg.L2OutputOracleAddr != nil {
 		return newL2OOSubmitter(ctx, cancel, setup)
 	} else if setup.Cfg.DisputeGameFactoryAddr != nil {
 		return newDGFSubmitter(ctx, cancel, setup)
 	} else {
-		cancel()
 		return nil, errors.New("neither the `L2OutputOracle` nor `DisputeGameFactory` addresses were provided")
 	}
 }

--- a/op-proposer/proposer/driver.go
+++ b/op-proposer/proposer/driver.go
@@ -79,6 +79,9 @@ type L2OutputSubmitter struct {
 // NewL2OutputSubmitter creates a new L2 Output Submitter
 func NewL2OutputSubmitter(setup DriverSetup) (_ *L2OutputSubmitter, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	// The above context is long-lived, and passed to the `L2OutputSubmitter` instance. This context is closed by
+	// `StopL2OutputSubmitting`, but if this function returns an error or panics, we want to ensure that the context
+	// doesn't leak.
 	defer func() {
 		if err != nil || recover() != nil {
 			cancel()


### PR DESCRIPTION
## Overview

Fixes a potential context leak in the `op-proposer`, pointed out by @sebastianst in https://github.com/ethereum-optimism/optimism/pull/8689#discussion_r1440320760
