### PR TITLE
specs: clarify blobbasefee opcode semantics on L2

### DIFF
--- a/specs/exec-engine.md
+++ b/specs/exec-engine.md
@@ -367,6 +367,10 @@ EIP-4844 is disabled as following:
 - Block-building code does not select EIP-4844 transactions.
 - An L2 block state-transition with EIP-4844 transactions is invalid.
 
+The [BLOBBASEFEE opcode](https://eips.ethereum.org/EIPS/eip-7516) is present but its semantics are
+altered because there are no blobs processed by L2. The opcode will always push a value of 1 onto
+the stack.
+
 ## Ecotone: Beacon Block Root
 
 [EIP-4788] introduces a "beacon block root" into the execution-layer block-header and EVM.

--- a/specs/superchain-upgrades.md
+++ b/specs/superchain-upgrades.md
@@ -325,6 +325,7 @@ Dencun Upgrade:
   - [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethereum.org/EIPS/eip-5656)
   - [EIP-6780: SELFDESTRUCT only in same transaction](https://eips.ethereum.org/EIPS/eip-6780)
   - [EIP-7516: BLOBBASEFEE opcode](https://eips.ethereum.org/EIPS/eip-7516)
+    - [BLOBBASEFEE always pushes 1 onto the stack](./exec-engine.md#ecotone-disable-blob-transactions)
 - Deneb (Consensus Layer): *not applicable to L2*
   - [EIP-7044: Perpetually Valid Signed Voluntary Exits](https://eips.ethereum.org/EIPS/eip-7044)
   - [EIP-7045: Increase Max Attestation Inclusion Slot](https://eips.ethereum.org/EIPS/eip-7045)


### PR DESCRIPTION
**Description**

Since L2 disables blob txs, there is no market for blobspace on L2. The blobbasefee will not change based on supply and demand, it will always push 1 onto the stack.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

