### PR TITLE
op-service/sources: Always validate number of receipts when fetching receipts

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -327,6 +327,8 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 		if err := validateReceipts(block, info.ReceiptHash(), txHashes, receipts); err != nil {
 			return info, nil, fmt.Errorf("invalid receipts: %w", err)
 		}
+	} else if len(txHashes) != len(receipts) {
+		return info, nil, fmt.Errorf("unexpected number of receipts, expected: %d, got: %d", len(txHashes), len(receipts))
 	}
 
 	return info, receipts, nil


### PR DESCRIPTION

**Description**

Always validate number of receipts when fetching receipts even if we're trusting the rpc source. This is a cheap sanity check.

**Tests**

Extended `validateReceipts` test with a few more cases.

**Additional context**

Should catch rpc problems where fewer receipts are fetched, but no other error occurs.

