### PR TITLE
fix(sdk): bug in L1 gas cost estimation

### DIFF
--- a/.changeset/mean-otters-sleep.md
+++ b/.changeset/mean-otters-sleep.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Fixes a bug in l1 gas cost estimation.

--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -72,12 +72,10 @@ export const estimateL1Gas = async (
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1GasUsed(
     serialize({
-      data: tx.data,
-      to: tx.to,
-      gasPrice: tx.gasPrice,
-      type: tx.type,
-      gasLimit: tx.gasLimit,
-      nonce: await getNonceForTx(l2Provider, tx),
+      ...tx,
+      nonce: tx.nonce
+        ? BigNumber.from(tx.nonce).toNumber()
+        : await getNonceForTx(l2Provider, tx),
     })
   )
 }
@@ -96,12 +94,10 @@ export const estimateL1GasCost = async (
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1Fee(
     serialize({
-      data: tx.data,
-      to: tx.to,
-      gasPrice: tx.gasPrice,
-      type: tx.type,
-      gasLimit: tx.gasLimit,
-      nonce: await getNonceForTx(l2Provider, tx),
+      ...tx,
+      nonce: tx.nonce
+        ? BigNumber.from(tx.nonce).toNumber()
+        : await getNonceForTx(l2Provider, tx),
     })
   )
 }


### PR DESCRIPTION
Fixes a bug in L1 gas cost estimation where not all properties from the input transaction were being used. This meant that certain properties like access lists or transaction value weren't included in the calculation. Resulting estimates were wrong.
