### PR TITLE
contracts-bedrock: Initializable test leftover log

### DIFF
--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -162,7 +162,6 @@ contract Initializer_Test is Bridge_Initializer {
             assembly {
                 size := extcodesize(target)
             }
-            console.log(size);
             // Assert that the contract is already initialized.
             assertEq(_contract.initializedSlotVal, 1);
 


### PR DESCRIPTION
**Description**

Deletes a leftover log from the `Initializable` test.
This is just some routine code cleanup as logs should not be left
unless they are necessary.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
