### PR TITLE
fix(op-challenger): Globalized Alphabet TraceProvider Stepdata Position

### DIFF
--- a/op-challenger/game/fault/agent_test.go
+++ b/op-challenger/game/fault/agent_test.go
@@ -58,7 +58,7 @@ func TestLoadClaimsWhenGameNotResolvable(t *testing.T) {
 	responder.callResolveErr = errors.New("game is not resolvable")
 	responder.callResolveClaimErr = errors.New("claim is not resolvable")
 	depth := types.Depth(4)
-	claimBuilder := test.NewClaimBuilder(t, depth, alphabet.NewTraceProvider(big.NewInt(0), depth))
+	claimBuilder := test.NewClaimBuilder(t, depth, alphabet.NewTraceProvider(big.NewInt(0), depth, depth))
 
 	claimLoader.claims = []types.Claim{
 		claimBuilder.CreateRootClaim(true),
@@ -75,7 +75,7 @@ func setupTestAgent(t *testing.T) (*Agent, *stubClaimLoader, *stubResponder) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	claimLoader := &stubClaimLoader{}
 	depth := types.Depth(4)
-	provider := alphabet.NewTraceProvider(big.NewInt(0), depth)
+	provider := alphabet.NewTraceProvider(big.NewInt(0), depth, depth)
 	responder := &stubResponder{}
 	agent := NewAgent(metrics.NoopMetrics, claimLoader, depth, trace.NewSimpleTraceAccessor(provider), responder, logger)
 	return agent, claimLoader, responder

--- a/op-challenger/game/fault/test/alphabet.go
+++ b/op-challenger/game/fault/test/alphabet.go
@@ -11,7 +11,7 @@ import (
 
 func NewAlphabetWithProofProvider(t *testing.T, startingL2BlockNumber *big.Int, maxDepth types.Depth, oracleError error) *alphabetWithProofProvider {
 	return &alphabetWithProofProvider{
-		alphabet.NewTraceProvider(startingL2BlockNumber, maxDepth),
+		alphabet.NewTraceProvider(startingL2BlockNumber, maxDepth, maxDepth),
 		maxDepth,
 		oracleError,
 	}

--- a/op-challenger/game/fault/trace/access_test.go
+++ b/op-challenger/game/fault/trace/access_test.go
@@ -16,7 +16,7 @@ func TestAccessor_UsesSelector(t *testing.T) {
 	ctx := context.Background()
 	depth := types.Depth(4)
 	provider1 := test.NewAlphabetWithProofProvider(t, big.NewInt(0), depth, nil)
-	provider2 := alphabet.NewTraceProvider(big.NewInt(0), depth)
+	provider2 := alphabet.NewTraceProvider(big.NewInt(0), depth, depth)
 	claim := types.Claim{}
 	game := types.NewGameState([]types.Claim{claim}, depth)
 	pos1 := types.NewPositionFromGIndex(big.NewInt(4))

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -22,7 +22,7 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	// Create a new alphabet provider.
 	depth := types.Depth(3)
 	startingL2BlockNumber := big.NewInt(1)
-	canonicalProvider := NewTraceProvider(startingL2BlockNumber, depth)
+	canonicalProvider := NewTraceProvider(startingL2BlockNumber, depth, depth)
 
 	// Build a list of traces.
 	traces := []struct {
@@ -56,7 +56,7 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 func TestGetStepData_Succeeds(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
-	ap := NewTraceProvider(startingL2BlockNumber, depth)
+	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
 	expected := BuildAlphabetPreimage(big.NewInt(0), absolutePrestateHash.Big())
 	pos := types.NewPosition(depth, big.NewInt(1))
 	retrieved, proof, data, err := ap.GetStepData(context.Background(), pos)
@@ -73,7 +73,7 @@ func TestGetStepData_Succeeds(t *testing.T) {
 func TestGetStepData_TooLargeIndex_Fails(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
-	ap := NewTraceProvider(startingL2BlockNumber, depth)
+	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
 	pos := types.NewPosition(depth, big.NewInt(5))
 	_, _, _, err := ap.GetStepData(context.Background(), pos)
 	require.ErrorIs(t, err, ErrIndexTooLarge)
@@ -83,7 +83,7 @@ func TestGetStepData_TooLargeIndex_Fails(t *testing.T) {
 func TestGet_Succeeds(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
-	ap := NewTraceProvider(startingL2BlockNumber, depth)
+	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
 	pos := types.NewPosition(depth, big.NewInt(0))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestGet_Succeeds(t *testing.T) {
 func TestGet_IndexTooLarge(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
-	ap := NewTraceProvider(startingL2BlockNumber, depth)
+	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
 	pos := types.NewPosition(depth, big.NewInt(4))
 	_, err := ap.Get(context.Background(), pos)
 	require.ErrorIs(t, err, ErrIndexTooLarge)
@@ -105,7 +105,7 @@ func TestGet_IndexTooLarge(t *testing.T) {
 func TestGet_DepthTooLarge(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
-	ap := NewTraceProvider(startingL2BlockNumber, depth)
+	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
 	pos := types.NewPosition(depth+1, big.NewInt(0))
 	_, err := ap.Get(context.Background(), pos)
 	require.ErrorIs(t, err, ErrIndexTooLarge)
@@ -116,7 +116,7 @@ func TestGet_DepthTooLarge(t *testing.T) {
 func TestGet_Extends(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
-	ap := NewTraceProvider(startingL2BlockNumber, depth)
+	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
 	pos := types.NewPosition(depth, big.NewInt(3))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -17,7 +17,6 @@ func alphabetClaim(index *big.Int, claim *big.Int) common.Hash {
 	return alphabetStateHash(BuildAlphabetPreimage(index, claim))
 }
 
-// TestAlphabetProvider_Get_ClaimsByTraceIndex tests the [fault.AlphabetProvider] Get function.
 func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	// Create a new alphabet provider.
 	depth := types.Depth(3)
@@ -31,15 +30,15 @@ func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	}{
 		{
 			types.NewPosition(depth, big.NewInt(7)),
-			alphabetClaim(big.NewInt(7), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(7))),
+			alphabetClaim(big.NewInt(7), new(big.Int).Add(absolutePrestateInt, big.NewInt(7))),
 		},
 		{
 			types.NewPosition(depth, big.NewInt(3)),
-			alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(3))),
+			alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateInt, big.NewInt(3))),
 		},
 		{
 			types.NewPosition(depth, big.NewInt(5)),
-			alphabetClaim(big.NewInt(5), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(5))),
+			alphabetClaim(big.NewInt(5), new(big.Int).Add(absolutePrestateInt, big.NewInt(5))),
 		},
 	}
 
@@ -57,7 +56,7 @@ func TestGetStepData_Succeeds(t *testing.T) {
 	depth := types.Depth(2)
 	startingL2BlockNumber := big.NewInt(1)
 	ap := NewTraceProvider(startingL2BlockNumber, depth, depth)
-	expected := BuildAlphabetPreimage(big.NewInt(0), absolutePrestateHash.Big())
+	expected := BuildAlphabetPreimage(big.NewInt(0), absolutePrestateInt)
 	pos := types.NewPosition(depth, big.NewInt(1))
 	retrieved, proof, data, err := ap.GetStepData(context.Background(), pos)
 	require.NoError(t, err)
@@ -120,6 +119,6 @@ func TestGet_Extends(t *testing.T) {
 	pos := types.NewPosition(depth, big.NewInt(3))
 	claim, err := ap.Get(context.Background(), pos)
 	require.NoError(t, err)
-	expected := alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateHash.Big(), big.NewInt(3)))
+	expected := alphabetClaim(big.NewInt(3), new(big.Int).Add(absolutePrestateInt, big.NewInt(3)))
 	require.Equal(t, expected, claim)
 }

--- a/op-challenger/game/fault/trace/outputs/output_alphabet.go
+++ b/op-challenger/game/fault/trace/outputs/output_alphabet.go
@@ -24,7 +24,7 @@ func NewOutputAlphabetTraceAccessor(
 ) (*trace.Accessor, error) {
 	outputProvider := NewTraceProviderFromInputs(logger, prestateProvider, rollupClient, splitDepth, prestateBlock, poststateBlock)
 	alphabetCreator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
-		provider := alphabet.NewTraceProvider(agreed.L2BlockNumber, depth)
+		provider := alphabet.NewTraceProvider(agreed.L2BlockNumber, depth, depth+splitDepth+1)
 		return provider, nil
 	}
 	cache := NewProviderCache(m, "output_alphabet_provider", alphabetCreator)

--- a/op-challenger/game/fault/trace/outputs/provider_cache_test.go
+++ b/op-challenger/game/fault/trace/outputs/provider_cache_test.go
@@ -26,7 +26,7 @@ func TestProviderCache(t *testing.T) {
 	depth := types.Depth(6)
 	var createdProvider types.TraceProvider
 	creator := func(ctx context.Context, localContext common.Hash, depth types.Depth, agreed contracts.Proposal, claimed contracts.Proposal) (types.TraceProvider, error) {
-		createdProvider = alphabet.NewTraceProvider(big.NewInt(0), depth)
+		createdProvider = alphabet.NewTraceProvider(big.NewInt(0), depth, depth)
 		return createdProvider, nil
 	}
 	localContext1 := common.Hash{0xdd}

--- a/op-challenger/game/fault/trace/split/split_test.go
+++ b/op-challenger/game/fault/trace/split/split_test.go
@@ -303,12 +303,12 @@ func asBottomTraceProvider(t *testing.T, actual types.TraceProvider) *bottomTrac
 }
 
 func setupAlphabetSplitSelector(t *testing.T) (*alphabet.AlphabetTraceProvider, trace.ProviderSelector, *test.GameBuilder) {
-	top := alphabet.NewTraceProvider(big.NewInt(0), splitDepth)
+	top := alphabet.NewTraceProvider(big.NewInt(0), splitDepth, splitDepth)
 	bottomCreator := func(ctx context.Context, depth types.Depth, pre types.Claim, post types.Claim) (types.TraceProvider, error) {
 		return &bottomTraceProvider{
 			pre:                   pre,
 			post:                  post,
-			AlphabetTraceProvider: alphabet.NewTraceProvider(big.NewInt(0), depth),
+			AlphabetTraceProvider: alphabet.NewTraceProvider(big.NewInt(0), depth, depth),
 		}, nil
 	}
 	selector := NewSplitProviderSelector(top, splitDepth, bottomCreator)

--- a/op-challenger/game/fault/trace/translate.go
+++ b/op-challenger/game/fault/trace/translate.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/alphabet"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -35,6 +36,11 @@ func (p *TranslatingProvider) Get(ctx context.Context, pos types.Position) (comm
 }
 
 func (p *TranslatingProvider) GetStepData(ctx context.Context, pos types.Position) (prestate []byte, proofData []byte, preimageData *types.PreimageOracleData, err error) {
+	// If the trace provider is the alphabet provider, do not make the position relative
+	// as the alphabet provider does not support relative positions.
+	if _, ok := p.provider.(*alphabet.AlphabetTraceProvider); ok {
+		return p.provider.GetStepData(ctx, pos)
+	}
 	relativePos, err := pos.RelativeToAncestorAtDepth(p.rootDepth)
 	if err != nil {
 		return nil, nil, nil, err

--- a/op-challenger/game/fault/trace/translate_test.go
+++ b/op-challenger/game/fault/trace/translate_test.go
@@ -11,16 +11,19 @@ import (
 )
 
 func TestTranslate(t *testing.T) {
-	orig := alphabet.NewTraceProvider(big.NewInt(0), 4)
+	orig := alphabet.NewTraceProvider(big.NewInt(0), 4, 4)
 	translated := Translate(orig, 3)
 	// All nodes on the first translated layer, map to GIndex 1
 	for i := int64(8); i <= 15; i++ {
 		requireSameValue(t, orig, 1, translated, i)
+		requireOriginalValue(t, orig, 1, translated)
 	}
 	// Nodes on the second translated layer map to GIndex 2 and 3 alternately
 	for i := int64(16); i <= 31; i += 2 {
 		requireSameValue(t, orig, 2, translated, i)
 		requireSameValue(t, orig, 3, translated, i+1)
+		requireOriginalValue(t, orig, 2, translated)
+		requireOriginalValue(t, orig, 3, translated)
 	}
 	// Nodes on the third translated layer map to GIndex 4, 5, 6 and 7
 	for i := int64(32); i <= 61; i += 4 {
@@ -28,6 +31,10 @@ func TestTranslate(t *testing.T) {
 		requireSameValue(t, orig, 5, translated, i+1)
 		requireSameValue(t, orig, 6, translated, i+2)
 		requireSameValue(t, orig, 7, translated, i+3)
+		requireOriginalValue(t, orig, 4, translated)
+		requireOriginalValue(t, orig, 5, translated)
+		requireOriginalValue(t, orig, 6, translated)
+		requireOriginalValue(t, orig, 7, translated)
 	}
 }
 
@@ -38,11 +45,13 @@ func requireSameValue(t *testing.T, a types.TraceProvider, aGIdx int64, b types.
 	bValue, err := b.Get(context.Background(), types.NewPositionFromGIndex(big.NewInt(bGIdx)))
 	require.NoError(t, err)
 	require.Equal(t, aValue, bValue)
+}
 
-	// Check GetStepData returns the same results
+func requireOriginalValue(t *testing.T, a types.TraceProvider, aGIdx int64, b types.TraceProvider) {
+	// Check GetStepData returns the globalized position results
 	aPrestate, aProofData, aPreimageData, err := a.GetStepData(context.Background(), types.NewPositionFromGIndex(big.NewInt(aGIdx)))
 	require.NoError(t, err)
-	bPrestate, bProofData, bPreimageData, err := b.GetStepData(context.Background(), types.NewPositionFromGIndex(big.NewInt(bGIdx)))
+	bPrestate, bProofData, bPreimageData, err := b.GetStepData(context.Background(), types.NewPositionFromGIndex(big.NewInt(aGIdx)))
 	require.NoError(t, err)
 	require.Equal(t, aPrestate, bPrestate)
 	require.Equal(t, aProofData, bProofData)
@@ -50,7 +59,7 @@ func requireSameValue(t *testing.T, a types.TraceProvider, aGIdx int64, b types.
 }
 
 func TestTranslate_AbsolutePreStateCommitment(t *testing.T) {
-	orig := alphabet.NewTraceProvider(big.NewInt(0), 4)
+	orig := alphabet.NewTraceProvider(big.NewInt(0), 4, 4)
 	translated := Translate(orig, 3)
 	origValue, err := orig.AbsolutePreStateCommitment(context.Background())
 	require.NoError(t, err)

--- a/op-e2e/e2eutils/disputegame/alphabet_helper.go
+++ b/op-e2e/e2eutils/disputegame/alphabet_helper.go
@@ -32,7 +32,7 @@ func (g *AlphabetGameHelper) CreateHonestActor(alphabetTrace string, depth types
 		t:            g.t,
 		require:      g.require,
 		game:         &g.FaultGameHelper,
-		correctTrace: alphabet.NewTraceProvider(big.NewInt(0), depth),
+		correctTrace: alphabet.NewTraceProvider(big.NewInt(0), depth, depth),
 	}
 }
 

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutputAlphabetGame(t *testing.T) {
+func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -67,7 +67,7 @@ func TestOutputAlphabetGame(t *testing.T) {
 	game.WaitForGameStatus(ctx, disputegame.StatusChallengerWins)
 }
 
-func TestOutputAlphabetGameWithValidOutputRoot(t *testing.T) {
+func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)


### PR DESCRIPTION
**Description**

Spike to globalize the Position passed into the Alphabet TraceProvider's Stepdata call via the split trace provider.