### PR TITLE
fix(op-challenger): Flatten Alphabet Trace Provider Step Loop

### DIFF
--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -1,7 +1,6 @@
 package alphabet
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -43,38 +42,22 @@ func NewTraceProvider(startingBlockNumber *big.Int, depth types.Depth) *Alphabet
 }
 
 func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, pos types.Position) ([]byte, []byte, *types.PreimageOracleData, error) {
-	posIndex := pos.TraceIndex(ap.depth)
+	traceIndex := pos.TraceIndex(ap.depth)
 	key := preimage.LocalIndexKey(L2ClaimBlockNumberLocalIndex).PreimageKey()
 	preimageData := types.NewPreimageOracleData(key[:], ap.startingBlockNumber.Bytes(), 0)
-	if posIndex.Cmp(common.Big0) == 0 {
+	if traceIndex.Cmp(common.Big0) == 0 {
 		return absolutePrestate, []byte{}, preimageData, nil
 	}
 	// We want the pre-state which is the value prior to the one requested
-	prestateTraceIndex := new(big.Int).Sub(posIndex, big.NewInt(1))
+	prestateTraceIndex := new(big.Int).Sub(traceIndex, big.NewInt(1))
 	if prestateTraceIndex.Cmp(new(big.Int).SetUint64(ap.maxLen)) >= 0 {
-		return nil, nil, nil, fmt.Errorf("%w depth: %v index: %v max: %v", ErrIndexTooLarge, ap.depth, posIndex, ap.maxLen)
+		return nil, nil, nil, fmt.Errorf("%w depth: %v index: %v max: %v", ErrIndexTooLarge, ap.depth, traceIndex, ap.maxLen)
 	}
-	// First step expands the absolute preimage to its full form. Weird but it's how AlphabetVM works.
-	claim := ap.step(absolutePrestate)
-	for i := big.NewInt(0); i.Cmp(prestateTraceIndex) <= 0; i = i.Add(i, big.NewInt(1)) {
-		claim = ap.step(claim)
-	}
-	return claim, []byte{}, preimageData, nil
-}
-
-// step accepts the trace index and claim and returns the stepped trace index and claim.
-func (ap *AlphabetTraceProvider) step(stateData []byte) []byte {
-	// Decode the stateData into the trace index and claim
-	traceIndex := new(big.Int).SetBytes(stateData[:32])
-	claim := stateData[32:]
-	if bytes.Equal(stateData, absolutePrestate) {
-		initTraceIndex := new(big.Int).Lsh(ap.startingBlockNumber, 4)
-		initClaim := new(big.Int).Add(absolutePrestateInt, initTraceIndex)
-		return BuildAlphabetPreimage(initTraceIndex, initClaim)
-	}
-	stepTraceIndex := new(big.Int).Add(traceIndex, big.NewInt(1))
-	stepClaim := new(big.Int).Add(new(big.Int).SetBytes(claim), big.NewInt(1))
-	return BuildAlphabetPreimage(stepTraceIndex, stepClaim)
+	initialTraceIndex := new(big.Int).Lsh(ap.startingBlockNumber, 4)
+	initialClaim := new(big.Int).Add(absolutePrestateInt, initialTraceIndex)
+	newTraceIndex := new(big.Int).Add(initialTraceIndex, traceIndex)
+	newClaim := new(big.Int).Add(initialClaim, traceIndex)
+	return BuildAlphabetPreimage(newTraceIndex, newClaim), []byte{}, preimageData, nil
 }
 
 // Get returns the claim value at the given index in the trace.

--- a/op-challenger/game/fault/trace/alphabet/provider.go
+++ b/op-challenger/game/fault/trace/alphabet/provider.go
@@ -48,9 +48,7 @@ func (ap *AlphabetTraceProvider) GetStepData(ctx context.Context, pos types.Posi
 	if traceIndex.Cmp(common.Big0) == 0 {
 		return absolutePrestate, []byte{}, preimageData, nil
 	}
-	// We want the pre-state which is the value prior to the one requested
-	prestateTraceIndex := new(big.Int).Sub(traceIndex, big.NewInt(1))
-	if prestateTraceIndex.Cmp(new(big.Int).SetUint64(ap.maxLen)) >= 0 {
+	if traceIndex.Cmp(new(big.Int).SetUint64(ap.maxLen)) > 0 {
 		return nil, nil, nil, fmt.Errorf("%w depth: %v index: %v max: %v", ErrIndexTooLarge, ap.depth, traceIndex, ap.maxLen)
 	}
 	initialTraceIndex := new(big.Int).Lsh(ap.startingBlockNumber, 4)

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -44,6 +44,25 @@ func TestAlphabetProvider_Prestate(t *testing.T) {
 	}
 }
 
+func TestAlphabetProvider_GetStepData_MaxLen(t *testing.T) {
+	depth := types.Depth(4)
+	startingL2BlockNumber := big.NewInt(2)
+	ap := NewTraceProvider(startingL2BlockNumber, depth)
+
+	// Step data for the max position is allowed
+	maxLen := int64(1 << depth)
+	maxPos := types.NewPosition(4, big.NewInt(maxLen))
+	result, _, _, err := ap.GetStepData(context.Background(), maxPos)
+	require.NoError(t, err)
+	expected := "00000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000090"
+	require.Equal(t, expected, common.Bytes2Hex(result))
+
+	// Cannot step on a position greater than the max.
+	oobPos := types.NewPosition(4, big.NewInt(int64(1<<depth)+1))
+	_, _, _, err = ap.GetStepData(context.Background(), oobPos)
+	require.ErrorIs(t, err, ErrIndexTooLarge)
+}
+
 // TestAlphabetProvider_Get_ClaimsByTraceIndex tests the Get function.
 func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	// Create a new alphabet provider.

--- a/op-challenger/game/fault/trace/alphabet/provider_test.go
+++ b/op-challenger/game/fault/trace/alphabet/provider_test.go
@@ -44,7 +44,7 @@ func TestAlphabetProvider_Prestate(t *testing.T) {
 	}
 }
 
-// TestAlphabetProvider_Get_ClaimsByTraceIndex tests the [fault.AlphabetProvider] Get function.
+// TestAlphabetProvider_Get_ClaimsByTraceIndex tests the Get function.
 func TestAlphabetProvider_Get_ClaimsByTraceIndex(t *testing.T) {
 	// Create a new alphabet provider.
 	depth := types.Depth(3)


### PR DESCRIPTION
**Description**

In https://github.com/ethereum-optimism/optimism/pull/8812, the alphabet trace provider `GetStepData` method was
updated to work for FPAC by porting the step function nearly verbatim to go code, an iterative method for computing
the data to pass to the step call. This is suboptimal and requires theta(n) iterations every `GetStepData` function
call where `n` is the trace index of the leaf position in the bottom subgame. As the depth of the subgame grows,
this becomes increasingly expensive, amortized.

This PR updates the `GetStepData` method to compute the step data (or `stateData` in solidity) by calculating the
final step trace index and claim inline using the specified position's trace index, removing the need for the
`step` loop.

This also now closes https://github.com/ethereum-optimism/client-pod/issues/403 as specified in the additional
[comment](https://github.com/ethereum-optimism/client-pod/issues/403#issuecomment-1877914495).

**Tests**

Covered by existing Alphabet Trace Provider unit tests.
Step unit tests are removed since the method is deleted.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/403
