### PR TITLE
op-chain-ops: create tool to determine which contract versions are deployed for each chain

### DIFF
--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -1,3 +1,6 @@
+op-version-check:
+	go build -o ./bin/op-version-check ./cmd/op-version-check/main.go
+
 test:
 	go test ./...
 

--- a/op-chain-ops/README.md
+++ b/op-chain-ops/README.md
@@ -1,3 +1,52 @@
 # op-chain-ops
 
 This package contains utilities for working with chain state.
+
+## op-version-check
+
+A CLI tool for determining which contract versions are deployed for
+chains in a superchain. It will output a JSON file that contains a
+list of each chain's versions. It is assumed that the implementations
+that are being checked have already been deployed and their contract
+addresses exist inside of the `superchain-registry` repository. It is
+also assumed that the semantic version file in the `superchain-registry`
+has been updated. The tool will output the semantic versioning to
+determine which contract versions are deployed.
+
+### Configuration
+
+#### L1 RPC URL
+
+The L1 RPC URL is used to determine which superchain to target. All
+L2s that are not based on top of the L1 chain that corresponds to the
+L1 RPC URL are filtered out from being checked. It also is used to
+double check that the data in the `superchain-registry` is correct.
+
+#### Chain IDs
+
+A list of L2 chain IDs can be passed that will be used to filter which
+L2 chains will have their versions checked. Omitting this argument will
+result in all chains in the superchain being considered.
+
+#### Deploy Config
+
+The path to the `deploy-config` directory in the contracts package.
+Since multiple L2 networks may be considered in the check, the `deploy-config`
+directory must be passed and then the particular deploy config files will
+be read out of the directory as needed.
+
+#### Outfile
+
+The file that the versions should be written to. If omitted, the file
+will be written to stdout
+
+#### Usage
+
+It can be built and run using the [Makefile](./Makefile) `op-version-check`
+target. Run `make op-version-check` to create a binary in [./bin/op-version-check](./bin/op-version-check)
+that can be executed, optionally providing the `--l1-rpc-url`, `--chain-ids`,
+`--superchain-target`, and `--outfile` flags.
+
+```sh
+./bin/op-version-check
+```

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -80,7 +80,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	superchainName := ctx.String("superchain-target")
 	if superchainName == "" {
-		superchainName, err = toSuperchainName(l1ChainID.Uint64())
+		superchainName, err = upgrades.ToSuperchainName(l1ChainID.Uint64())
 		if err != nil {
 			return err
 		}
@@ -240,19 +240,4 @@ func toDeployConfigName(cfg *superchain.ChainConfig) (string, error) {
 		return "zora-goerli", nil
 	}
 	return "", fmt.Errorf("unsupported chain name %s", cfg.Name)
-}
-
-// toSuperchainName turns a base layer chain id into a superchain
-// network name.
-func toSuperchainName(chainID uint64) (string, error) {
-	if chainID == 1 {
-		return "mainnet", nil
-	}
-	if chainID == 5 {
-		return "goerli", nil
-	}
-	if chainID == 11155111 {
-		return "sepolia", nil
-	}
-	return "", fmt.Errorf("unsupported chain ID %d", chainID)
 }

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/safe"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 
-	op_node_genesis "github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
@@ -203,7 +203,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	// Write the batch to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
-		if err := op_node_genesis.WriteJSONFile(outfile, batch); err != nil {
+		if err := jsonutil.WriteJSON(outfile, batch); err != nil {
 			return err
 		}
 	} else {

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/safe"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
 
+	op_node_genesis "github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
@@ -202,7 +203,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	// Write the batch to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
-		if err := writeJSON(outfile, batch); err != nil {
+		if err := op_node_genesis.WriteJSONFile(outfile, batch); err != nil {
 			return err
 		}
 	} else {
@@ -254,16 +255,4 @@ func toSuperchainName(chainID uint64) (string, error) {
 		return "sepolia", nil
 	}
 	return "", fmt.Errorf("unsupported chain ID %d", chainID)
-}
-
-func writeJSON(outfile string, input interface{}) error {
-	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	return enc.Encode(input)
 }

--- a/op-chain-ops/cmd/op-version-check/README.md
+++ b/op-chain-ops/cmd/op-version-check/README.md
@@ -35,3 +35,14 @@ be read out of the directory as needed.
 
 The file that the versions should be written to. If omitted, the file
 will be written to stdout.
+
+#### Usage
+
+It can be built and run using the [Makefile](./Makefile) `op-version-check`
+target. Run `make op-version-check` to create a binary in [./bin/op-version-check](./bin/op-version-check)
+that can be executed, optionally providing the `--l1-rpc-url`, `--chain-ids`,
+`--superchain-target`, and `--outfile` flags.
+
+```sh
+./bin/op-version-check
+```

--- a/op-chain-ops/cmd/op-version-check/README.md
+++ b/op-chain-ops/cmd/op-version-check/README.md
@@ -1,0 +1,37 @@
+# op-version-check
+
+A CLI tool for determining which contract versions are deployed for
+chains in a superchain. It will output a JSON file that contains a
+list of each chain's versions. It is assumed that the implementations
+that are being checked have already been deployed and their contract
+addresses exist inside of the `superchain-registry` repository. It is
+also assumed that the semantic version file in the `superchain-registry`
+has been updated. The tool will use output the semantic versioning to
+determine which contract versions are deployed.
+
+### Configuration
+
+#### L1 RPC URL
+
+The L1 RPC URL is used to determine which superchain to target. All
+L2s that are not based on top of the L1 chain that corresponds to the
+L1 RPC URL are filtered out from being checked. It also is used to
+double check that the data in the `superchain-registry` is correct.
+
+#### Chain IDs
+
+A list of L2 chain IDs can be passed that will be used to filter which
+L2 chains will have their versions checked. Omitting this argument will
+result in all chains in the superchain being considered.
+
+#### Deploy Config
+
+The path to the `deploy-config` directory in the contracts package.
+Since multiple L2 networks may be considered in the check, the `deploy-config`
+directory must be passed and then the particular deploy config files will
+be read out of the directory as needed.
+
+#### Outfile
+
+The file that the versions should be written to. If omitted, the file
+will be written to stdout.

--- a/op-chain-ops/cmd/op-version-check/README.md
+++ b/op-chain-ops/cmd/op-version-check/README.md
@@ -34,12 +34,12 @@ be read out of the directory as needed.
 #### Outfile
 
 The file that the versions should be written to. If omitted, the file
-will be written to stdout.
+will be written to stdout
 
 #### Usage
 
-It can be built and run using the [Makefile](./Makefile) `op-version-check`
-target. Run `make op-version-check` to create a binary in [./bin/op-version-check](./bin/op-version-check)
+It can be built and run using the [Makefile](../../Makefile) `op-version-check`
+target. Run `make op-version-check` to create a binary in [../../bin/op-version-check](../../bin/op-version-check)
 that can be executed, optionally providing the `--l1-rpc-url`, `--chain-ids`,
 `--superchain-target`, and `--outfile` flags.
 

--- a/op-chain-ops/cmd/op-version-check/README.md
+++ b/op-chain-ops/cmd/op-version-check/README.md
@@ -6,7 +6,7 @@ list of each chain's versions. It is assumed that the implementations
 that are being checked have already been deployed and their contract
 addresses exist inside of the `superchain-registry` repository. It is
 also assumed that the semantic version file in the `superchain-registry`
-has been updated. The tool will use output the semantic versioning to
+has been updated. The tool will output the semantic versioning to
 determine which contract versions are deployed.
 
 ### Configuration

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/mattn/go-isatty"
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/safe"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+)
+
+func main() {
+	log.Root().SetHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(isatty.IsTerminal(os.Stderr.Fd()))))
+
+	app := &cli.App{
+		Name:  "op-upgrade",
+		Usage: "Build transactions useful for upgrading the Superchain",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "l1-rpc-url",
+				Value:   "http://127.0.0.1:8545",
+				Usage:   "L1 RPC URL, the chain ID will be used to determine the superchain",
+				EnvVars: []string{"L1_RPC_URL"},
+			},
+			&cli.Uint64SliceFlag{
+				Name:  "chain-ids",
+				Usage: "L2 Chain IDs corresponding to chains to upgrade. Corresponds to all chains if empty",
+			},
+			&cli.StringFlag{
+				Name:    "superchain-target",
+				Usage:   "The name of the superchain to upgrade",
+				EnvVars: []string{"SUPERCHAIN_TARGET"},
+			},
+			&cli.PathFlag{
+				Name:     "deploy-config",
+				Usage:    "The path to the deploy config file",
+				Required: true,
+				EnvVars:  []string{"DEPLOY_CONFIG"},
+			},
+			&cli.PathFlag{
+				Name:    "outfile",
+				Usage:   "The file to write the output to. If not specified, output is written to stdout",
+				EnvVars: []string{"OUTFILE"},
+			},
+		},
+		Action: entrypoint,
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Crit("error op-upgrade", "err", err)
+	}
+}
+
+// entrypoint contains the main logic of the script
+func entrypoint(ctx *cli.Context) error {
+	client, err := ethclient.Dial(ctx.String("l1-rpc-url"))
+	if err != nil {
+		return err
+	}
+
+	// Fetch the L1 chain ID to determine the superchain name
+	l1ChainID, err := client.ChainID(ctx.Context)
+	if err != nil {
+		return err
+	}
+
+	superchainName := ctx.String("superchain-target")
+	if superchainName == "" {
+		superchainName, err = toSuperchainName(l1ChainID.Uint64())
+		if err != nil {
+			return err
+		}
+	}
+
+	chainIDs := ctx.Uint64Slice("chain-ids")
+	deployConfig := ctx.Path("deploy-config")
+
+	// If no chain IDs are specified, upgrade all chains
+	if len(chainIDs) == 0 {
+		chainIDs = maps.Keys(superchain.OPChains)
+	}
+	slices.Sort(chainIDs)
+
+	targets := make([]*superchain.ChainConfig, 0)
+	for _, chainConfig := range superchain.OPChains {
+		if chainConfig.Superchain == superchainName && slices.Contains(chainIDs, chainConfig.ChainID) {
+			targets = append(targets, chainConfig)
+		}
+	}
+
+	slices.SortFunc(targets, func(i, j *superchain.ChainConfig) int {
+		return int(i.ChainID) - int(j.ChainID)
+	})
+
+	// Create a batch of transactions
+	batch := safe.Batch{}
+
+	for _, chainConfig := range targets {
+		name, _ := toDeployConfigName(chainConfig)
+		config, err := genesis.NewDeployConfigWithNetwork(name, deployConfig)
+		if err != nil {
+			log.Warn("Cannot find deploy config for network", "name", chainConfig.Name, "deploy-config-name", name, "path", deployConfig, "err", err)
+		}
+
+		if config != nil {
+			log.Info("Checking deploy config validity", "name", chainConfig.Name)
+			if err := config.Check(); err != nil {
+				return fmt.Errorf("error checking deploy config: %w", err)
+			}
+		}
+
+		clients, err := clients.NewClients(ctx.String("l1-rpc-url"), chainConfig.PublicRPC)
+		if err != nil {
+			return fmt.Errorf("cannot create RPC clients: %w", err)
+		}
+		// The L1Client is required
+		if clients.L1Client == nil {
+			return errors.New("Cannot create L1 client")
+		}
+
+		l1ChainID, err := clients.L1Client.ChainID(ctx.Context)
+		if err != nil {
+			return fmt.Errorf("cannot fetch L1 chain ID: %w", err)
+		}
+
+		// The L2Client is not required, but double check the chain id matches if possible
+		if clients.L2Client != nil {
+			l2ChainID, err := clients.L2Client.ChainID(ctx.Context)
+			if err != nil {
+				return fmt.Errorf("cannot fetch L2 chain ID: %w", err)
+			}
+			if chainConfig.ChainID != l2ChainID.Uint64() {
+				return fmt.Errorf("Mismatched chain IDs: %d != %d", chainConfig.ChainID, l2ChainID)
+			}
+		}
+
+		log.Info(chainConfig.Name, "l1-chain-id", l1ChainID, "l2-chain-id", chainConfig.ChainID)
+
+		log.Info("Detecting on chain contracts")
+		// Tracking the individual addresses can be deprecated once the system is upgraded
+		// to the new contracts where the system config has a reference to each address.
+		addresses, ok := superchain.Addresses[chainConfig.ChainID]
+		if !ok {
+			return fmt.Errorf("no addresses for chain ID %d", chainConfig.ChainID)
+		}
+		versions, err := upgrades.GetContractVersions(ctx.Context, addresses, chainConfig, clients.L1Client)
+		if err != nil {
+			return fmt.Errorf("error getting contract versions: %w", err)
+		}
+
+		log.Info("L1CrossDomainMessenger", "version", versions.L1CrossDomainMessenger, "address", addresses.L1CrossDomainMessengerProxy)
+		log.Info("L1ERC721Bridge", "version", versions.L1ERC721Bridge, "address", addresses.L1ERC721BridgeProxy)
+		log.Info("L1StandardBridge", "version", versions.L1StandardBridge, "address", addresses.L1StandardBridgeProxy)
+		log.Info("L2OutputOracle", "version", versions.L2OutputOracle, "address", addresses.L2OutputOracleProxy)
+		log.Info("OptimismMintableERC20Factory", "version", versions.OptimismMintableERC20Factory, "address", addresses.OptimismMintableERC20FactoryProxy)
+		log.Info("OptimismPortal", "version", versions.OptimismPortal, "address", addresses.OptimismPortalProxy)
+		log.Info("SystemConfig", "version", versions.SystemConfig, "address", chainConfig.SystemConfigAddr)
+
+		implementations, ok := superchain.Implementations[l1ChainID.Uint64()]
+		if !ok {
+			return fmt.Errorf("no implementations for chain ID %d", l1ChainID.Uint64())
+		}
+
+		list, err := implementations.Resolve(superchain.SuperchainSemver)
+		if err != nil {
+			return err
+		}
+
+		log.Info("Upgrading to the following versions")
+		log.Info("L1CrossDomainMessenger", "version", list.L1CrossDomainMessenger.Version, "address", list.L1CrossDomainMessenger.Address)
+		log.Info("L1ERC721Bridge", "version", list.L1ERC721Bridge.Version, "address", list.L1ERC721Bridge.Address)
+		log.Info("L1StandardBridge", "version", list.L1StandardBridge.Version, "address", list.L1StandardBridge.Address)
+		log.Info("L2OutputOracle", "version", list.L2OutputOracle.Version, "address", list.L2OutputOracle.Address)
+		log.Info("OptimismMintableERC20Factory", "version", list.OptimismMintableERC20Factory.Version, "address", list.OptimismMintableERC20Factory.Address)
+		log.Info("OptimismPortal", "version", list.OptimismPortal.Version, "address", list.OptimismPortal.Address)
+		log.Info("SystemConfig", "version", list.SystemConfig.Version, "address", list.SystemConfig.Address)
+
+		// Ensure that the superchain registry information is correct by checking the
+		// actual versions based on what the registry says is true.
+		if err := upgrades.CheckL1(ctx.Context, &list, clients.L1Client); err != nil {
+			return fmt.Errorf("error checking L1: %w", err)
+		}
+
+		// Build the batch
+		if err := upgrades.L1(&batch, list, *addresses, config, chainConfig, clients.L1Client); err != nil {
+			return err
+		}
+	}
+
+	// Write the batch to disk or stdout
+	if outfile := ctx.Path("outfile"); outfile != "" {
+		if err := writeJSON(outfile, batch); err != nil {
+			return err
+		}
+	} else {
+		data, err := json.MarshalIndent(batch, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+	}
+	return nil
+}
+
+// toDeployConfigName is a temporary function that maps the chain config names
+// to deploy config names. This should be able to be removed in the future
+// with a canonical naming scheme. If an empty string is returned, then
+// it means that the chain is not supported yet.
+func toDeployConfigName(cfg *superchain.ChainConfig) (string, error) {
+	if cfg.Name == "OP-Sepolia" {
+		return "sepolia", nil
+	}
+	if cfg.Name == "OP-Goerli" {
+		return "goerli", nil
+	}
+	if cfg.Name == "PGN" {
+		return "pgn", nil
+	}
+	if cfg.Name == "Zora" {
+		return "zora", nil
+	}
+	if cfg.Name == "OP-Mainnet" {
+		return "mainnet", nil
+	}
+	if cfg.Name == "Zora Goerli" {
+		return "zora-goerli", nil
+	}
+	return "", fmt.Errorf("unsupported chain name %s", cfg.Name)
+}
+
+// toSuperchainName turns a base layer chain id into a superchain
+// network name.
+func toSuperchainName(chainID uint64) (string, error) {
+	if chainID == 1 {
+		return "mainnet", nil
+	}
+	if chainID == 5 {
+		return "goerli", nil
+	}
+	if chainID == 11155111 {
+		return "sepolia", nil
+	}
+	return "", fmt.Errorf("unsupported chain ID %d", chainID)
+}
+
+func writeJSON(outfile string, input interface{}) error {
+	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(input)
+}

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -111,7 +111,7 @@ func entrypoint(ctx *cli.Context) error {
 		}
 		// The L1Client is required
 		if clients.L1Client == nil {
-			return errors.New("Cannot create L1 client")
+			return errors.New("cannot create L1 client")
 		}
 
 		l1ChainID, err := clients.L1Client.ChainID(ctx.Context)
@@ -126,7 +126,7 @@ func entrypoint(ctx *cli.Context) error {
 				return fmt.Errorf("cannot fetch L2 chain ID: %w", err)
 			}
 			if chainConfig.ChainID != l2ChainID.Uint64() {
-				return fmt.Errorf("Mismatched chain IDs: %d != %d", chainConfig.ChainID, l2ChainID)
+				return fmt.Errorf("mismatched chain IDs: %d != %d", chainConfig.ChainID, l2ChainID)
 			}
 		}
 

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -16,8 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
-
-	op_node_genesis "github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
+	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
@@ -170,7 +169,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	// Write contract versions to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
-		if err := op_node_genesis.WriteJSONFile(outfile, output); err != nil {
+		if err := jsonutil.WriteJSON(outfile, output); err != nil {
 			return err
 		}
 	} else {

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -163,32 +163,6 @@ func entrypoint(ctx *cli.Context) error {
 	return nil
 }
 
-// toDeployConfigName is a temporary function that maps the chain config names
-// to deploy config names. This should be able to be removed in the future
-// with a canonical naming scheme. If an empty string is returned, then
-// it means that the chain is not supported yet.
-func toDeployConfigName(cfg *superchain.ChainConfig) (string, error) {
-	if cfg.Name == "OP-Sepolia" {
-		return "sepolia", nil
-	}
-	if cfg.Name == "OP-Goerli" {
-		return "goerli", nil
-	}
-	if cfg.Name == "PGN" {
-		return "pgn", nil
-	}
-	if cfg.Name == "Zora" {
-		return "zora", nil
-	}
-	if cfg.Name == "OP-Mainnet" {
-		return "mainnet", nil
-	}
-	if cfg.Name == "Zora Goerli" {
-		return "zora-goerli", nil
-	}
-	return "", fmt.Errorf("unsupported chain name %s", cfg.Name)
-}
-
 // toSuperchainName turns a base layer chain id into a superchain
 // network name.
 func toSuperchainName(chainID uint64) (string, error) {

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -2,14 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"slices"
 
-	"golang.org/x/exp/maps"
-
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
@@ -38,20 +33,15 @@ func main() {
 		Name:  "op-version-check",
 		Usage: "Determine which contract versions are deployed for chains in a superchain",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "l1-rpc-url",
-				Value:   "http://127.0.0.1:8545",
-				Usage:   "L1 RPC URL, the chain ID will be used to determine the superchain",
+			&cli.StringSliceFlag{
+				Name:    "l1-rpc-urls",
+				Usage:   "L1 RPC URLs, the chain ID will be used to determine the superchain",
 				EnvVars: []string{"L1_RPC_URL"},
 			},
-			&cli.Uint64SliceFlag{
-				Name:  "chain-ids",
-				Usage: "L2 Chain IDs corresponding to chains to check versions for. Corresponds to all chains if empty",
-			},
-			&cli.StringFlag{
-				Name:    "superchain-target",
-				Usage:   "The name of the superchain",
-				EnvVars: []string{"SUPERCHAIN_TARGET"},
+			&cli.StringSliceFlag{
+				Name:    "l2-rpc-urls",
+				Usage:   "L2 RPC URLs, corresponding to chains to check versions for. Corresponds to all chains if empty",
+				EnvVars: []string{"L1_RPC_URL"},
 			},
 			&cli.PathFlag{
 				Name:    "outfile",
@@ -69,104 +59,82 @@ func main() {
 
 // entrypoint contains the main logic of the script
 func entrypoint(ctx *cli.Context) error {
-	client, err := ethclient.Dial(ctx.String("l1-rpc-url"))
-	if err != nil {
-		return err
-	}
-
-	// Fetch the L1 chain ID to determine the superchain name
-	l1ChainID, err := client.ChainID(ctx.Context)
-	if err != nil {
-		return err
-	}
-
-	superchainName := ctx.String("superchain-target")
-	if superchainName == "" {
-		superchainName, err = upgrades.ToSuperchainName(l1ChainID.Uint64())
-		if err != nil {
-			return err
-		}
-	}
-
-	chainIDs := ctx.Uint64Slice("chain-ids")
-
-	// If no chain IDs are specified, check all chains
-	if len(chainIDs) == 0 {
-		chainIDs = maps.Keys(superchain.OPChains)
-	}
-	slices.Sort(chainIDs)
-
-	targets := make([]*superchain.ChainConfig, 0)
-	for _, chainConfig := range superchain.OPChains {
-		if chainConfig.Superchain == superchainName && slices.Contains(chainIDs, chainConfig.ChainID) {
-			targets = append(targets, chainConfig)
-		} else {
-			log.Info("Skipping chain", "superchain", chainConfig.Superchain, "chainID", chainConfig.ChainID)
-		}
-	}
-
-	slices.SortFunc(targets, func(i, j *superchain.ChainConfig) int {
-		return int(i.ChainID) - int(j.ChainID)
-	})
+	l1RPCURLs := ctx.StringSlice("l1-rpc-urls")
+	l2RPCURLs := ctx.StringSlice("l2-rpc-urls")
 
 	output := []ChainVersionCheck{}
 
-	for _, chainConfig := range targets {
-		clients, err := clients.NewClients(ctx.String("l1-rpc-url"), chainConfig.PublicRPC)
-		if err != nil {
-			return fmt.Errorf("cannot create RPC clients: %w", err)
+	if len(l2RPCURLs) == 0 {
+		for _, chainConfig := range superchain.OPChains {
+			l2RPCURLs = append(l2RPCURLs, chainConfig.PublicRPC)
 		}
-		// The L1Client is required
-		if clients.L1Client == nil {
-			return errors.New("cannot create L1 client")
-		}
-
-		l1ChainID, err := clients.L1Client.ChainID(ctx.Context)
-		if err != nil {
-			return fmt.Errorf("cannot fetch L1 chain ID: %w", err)
-		}
-
-		// The L2Client is not required, but double check the chain id matches if possible
-		if clients.L2Client != nil {
-			l2ChainID, err := clients.L2Client.ChainID(ctx.Context)
-			if err != nil {
-				return fmt.Errorf("cannot fetch L2 chain ID: %w", err)
-			}
-			if chainConfig.ChainID != l2ChainID.Uint64() {
-				return fmt.Errorf("mismatched chain IDs: %d != %d", chainConfig.ChainID, l2ChainID)
-			}
-		}
-
-		log.Info(chainConfig.Name, "l1-chain-id", l1ChainID, "l2-chain-id", chainConfig.ChainID)
-
-		log.Info("Detecting on chain contracts")
-		// Tracking the individual addresses can be deprecated once the system is upgraded
-		// to the new contracts where the system config has a reference to each address.
-		addresses, ok := superchain.Addresses[chainConfig.ChainID]
-		if !ok {
-			return fmt.Errorf("no addresses for chain ID %d", chainConfig.ChainID)
-		}
-
-		versions, err := upgrades.GetContractVersions(ctx.Context, addresses, chainConfig, clients.L1Client)
-		if err != nil {
-			return fmt.Errorf("error getting contract versions: %w", err)
-		}
-
-		contracts := make(map[string]Contract)
-
-		contracts["AddressManager"] = Contract{Version: "null", Address: addresses.AddressManager}
-		contracts["L1CrossDomainMessenger"] = Contract{Version: versions.L1CrossDomainMessenger, Address: addresses.L1CrossDomainMessengerProxy}
-		contracts["L1ERC721Bridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1ERC721BridgeProxy}
-		contracts["L1StandardBridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1StandardBridgeProxy}
-		contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
-		contracts["OptimismMintableERC20Factory"] = Contract{Version: versions.OptimismMintableERC20Factory, Address: addresses.OptimismMintableERC20FactoryProxy}
-		contracts["OptimismPortal"] = Contract{Version: versions.OptimismPortal, Address: addresses.OptimismPortalProxy}
-		contracts["SystemConfig"] = Contract{Version: versions.SystemConfig, Address: chainConfig.SystemConfigAddr}
-		contracts["ProxyAdmin"] = Contract{Version: "null", Address: addresses.ProxyAdmin}
-
-		output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: chainConfig.ChainID, Contracts: contracts})
 	}
 
+	for _, l1RPCURL := range l1RPCURLs {
+		for _, l2RPCURL := range l2RPCURLs {
+			clients, err := clients.NewClients(l1RPCURL, l2RPCURL)
+			if err != nil {
+				log.Warn("cannot create RPC clients", "err", err)
+				continue
+			}
+
+			// The L1Client is required
+			if clients.L1Client == nil {
+				log.Warn("cannot create L1 client")
+				continue
+			}
+
+			l1ChainID, err := clients.L1Client.ChainID(ctx.Context)
+			if err != nil {
+				log.Warn("cannot fetch L1 chain ID", "err", err)
+				continue
+			}
+
+			// The L2Client is not required, but double check the chain id matches if possible
+			if clients.L2Client == nil {
+				log.Warn("cannot create L2 client")
+				continue
+			}
+
+			l2ChainID, err := clients.L2Client.ChainID(ctx.Context)
+			if err != nil {
+				log.Warn("cannot fetch L2 chain ID", "err", err)
+				continue
+			}
+
+			chainConfig := superchain.OPChains[l2ChainID.Uint64()]
+
+			log.Info(chainConfig.Name, "l1-chain-id", l1ChainID, "l2-chain-id", chainConfig.ChainID)
+
+			log.Info("Detecting on chain contracts")
+			// Tracking the individual addresses can be deprecated once the system is upgraded
+			// to the new contracts where the system config has a reference to each address.
+			addresses, ok := superchain.Addresses[chainConfig.ChainID]
+			if !ok {
+				return fmt.Errorf("no addresses for chain ID %d", chainConfig.ChainID)
+			}
+			versions, err := upgrades.GetContractVersions(ctx.Context, addresses, chainConfig, clients.L1Client)
+			if err != nil {
+				//return fmt.Errorf("error getting contract versions: %w", err)
+				log.Warn("error getting contract versions", "err", err)
+				continue
+			}
+
+			contracts := make(map[string]Contract)
+
+			contracts["AddressManager"] = Contract{Version: "null", Address: addresses.AddressManager}
+			contracts["L1CrossDomainMessenger"] = Contract{Version: versions.L1CrossDomainMessenger, Address: addresses.L1CrossDomainMessengerProxy}
+			contracts["L1ERC721Bridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1ERC721BridgeProxy}
+			contracts["L1StandardBridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1StandardBridgeProxy}
+			contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
+			contracts["OptimismMintableERC20Factory"] = Contract{Version: versions.OptimismMintableERC20Factory, Address: addresses.OptimismMintableERC20FactoryProxy}
+			contracts["OptimismPortal"] = Contract{Version: versions.OptimismPortal, Address: addresses.OptimismPortalProxy}
+			contracts["SystemConfig"] = Contract{Version: versions.SystemConfig, Address: chainConfig.SystemConfigAddr}
+			contracts["ProxyAdmin"] = Contract{Version: "null", Address: addresses.ProxyAdmin}
+
+			output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: chainConfig.ChainID, Contracts: contracts})
+		}
+	}
 	// Write contract versions to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
 		if err := jsonutil.WriteJSON(outfile, output); err != nil {

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -78,7 +78,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	superchainName := ctx.String("superchain-target")
 	if superchainName == "" {
-		superchainName, err = toSuperchainName(l1ChainID.Uint64())
+		superchainName, err = upgrades.ToSuperchainName(l1ChainID.Uint64())
 		if err != nil {
 			return err
 		}
@@ -163,19 +163,4 @@ func entrypoint(ctx *cli.Context) error {
 		fmt.Println(string(data))
 	}
 	return nil
-}
-
-// toSuperchainName turns a base layer chain id into a superchain
-// network name.
-func toSuperchainName(chainID uint64) (string, error) {
-	if chainID == 1 {
-		return "mainnet", nil
-	}
-	if chainID == 5 {
-		return "goerli", nil
-	}
-	if chainID == 11155111 {
-		return "sepolia", nil
-	}
-	return "", fmt.Errorf("unsupported chain ID %d", chainID)
 }

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -104,6 +104,8 @@ func entrypoint(ctx *cli.Context) error {
 		return int(i.ChainID) - int(j.ChainID)
 	})
 
+	versions := superchain.ContractVersions{}
+
 	for _, chainConfig := range targets {
 		name, _ := toDeployConfigName(chainConfig)
 		config, err := genesis.NewDeployConfigWithNetwork(name, deployConfig)
@@ -152,7 +154,7 @@ func entrypoint(ctx *cli.Context) error {
 		if !ok {
 			return fmt.Errorf("no addresses for chain ID %d", chainConfig.ChainID)
 		}
-		versions, err := upgrades.GetContractVersions(ctx.Context, addresses, chainConfig, clients.L1Client)
+		versions, err = upgrades.GetContractVersions(ctx.Context, addresses, chainConfig, clients.L1Client)
 		if err != nil {
 			return fmt.Errorf("error getting contract versions: %w", err)
 		}
@@ -166,13 +168,13 @@ func entrypoint(ctx *cli.Context) error {
 		log.Info("SystemConfig", "version", versions.SystemConfig, "address", chainConfig.SystemConfigAddr)
 	}
 
-	// Write the batch to disk or stdout
+	// Write contract versions to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
-		if err := writeJSON(outfile, ""); err != nil {
+		if err := writeJSON(outfile, versions); err != nil {
 			return err
 		}
 	} else {
-		data, err := json.MarshalIndent("", "", "  ")
+		data, err := json.MarshalIndent(versions, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
 
+	"github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
@@ -92,6 +93,7 @@ func entrypoint(ctx *cli.Context) error {
 	slices.Sort(chainIDs)
 
 	targets := make([]*superchain.ChainConfig, 0)
+	// TODO: Need some logging here if a chain ID is filtered out for whatever reason.
 	for _, chainConfig := range superchain.OPChains {
 		if chainConfig.Superchain == superchainName && slices.Contains(chainIDs, chainConfig.ChainID) {
 			targets = append(targets, chainConfig)
@@ -150,7 +152,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	// Write contract versions to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
-		if err := writeJSON(outfile, output); err != nil {
+		if err := genesis.WriteJSONFile(outfile, output); err != nil {
 			return err
 		}
 	} else {
@@ -176,16 +178,4 @@ func toSuperchainName(chainID uint64) (string, error) {
 		return "sepolia", nil
 	}
 	return "", fmt.Errorf("unsupported chain ID %d", chainID)
-}
-
-func writeJSON(outfile string, input interface{}) error {
-	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	return enc.Encode(input)
 }

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -21,10 +21,15 @@ import (
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
+type Contract struct {
+	Version string             `yaml:"version"`
+	Address superchain.Address `yaml:"address"`
+}
+
 type ChainVersionCheck struct {
-	Name             string                      `yaml:"name"`
-	ChainID          uint64                      `yaml:"chain_id"`
-	ContractVersions superchain.ContractVersions `yaml:"contract_versions"`
+	Name      string              `yaml:"name"`
+	ChainID   uint64              `yaml:"chain_id"`
+	Contracts map[string]Contract `yaml:"contracts"`
 }
 
 func main() {
@@ -147,7 +152,19 @@ func entrypoint(ctx *cli.Context) error {
 			return fmt.Errorf("error getting contract versions: %w", err)
 		}
 
-		output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: chainConfig.ChainID, ContractVersions: versions})
+		contracts := make(map[string]Contract)
+
+		contracts["AddressManager"] = Contract{Version: "null", Address: addresses.AddressManager}
+		contracts["L1CrossDomainMessenger"] = Contract{Version: versions.L1CrossDomainMessenger, Address: addresses.L1CrossDomainMessengerProxy}
+		contracts["L1ERC721Bridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1ERC721BridgeProxy}
+		contracts["L1StandardBridge"] = Contract{Version: versions.L1ERC721Bridge, Address: addresses.L1StandardBridgeProxy}
+		contracts["L2OutputOracle"] = Contract{Version: versions.L2OutputOracle, Address: addresses.L2OutputOracleProxy}
+		contracts["OptimismMintableERC20Factory"] = Contract{Version: versions.OptimismMintableERC20Factory, Address: addresses.OptimismMintableERC20FactoryProxy}
+		contracts["OptimismPortal"] = Contract{Version: versions.OptimismPortal, Address: addresses.OptimismPortalProxy}
+		contracts["SystemConfig"] = Contract{Version: versions.SystemConfig, Address: chainConfig.SystemConfigAddr}
+		contracts["ProxyAdmin"] = Contract{Version: "null", Address: addresses.ProxyAdmin}
+
+		output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: chainConfig.ChainID, Contracts: contracts})
 	}
 
 	// Write contract versions to disk or stdout

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -31,8 +31,8 @@ func main() {
 	log.Root().SetHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(isatty.IsTerminal(os.Stderr.Fd()))))
 
 	app := &cli.App{
-		Name:  "op-upgrade",
-		Usage: "Build transactions useful for upgrading the Superchain",
+		Name:  "op-version-check",
+		Usage: "Determine which contract versions are deployed for chains in a superchain",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "l1-rpc-url",
@@ -42,16 +42,16 @@ func main() {
 			},
 			&cli.Uint64SliceFlag{
 				Name:  "chain-ids",
-				Usage: "L2 Chain IDs corresponding to chains to upgrade. Corresponds to all chains if empty",
+				Usage: "L2 Chain IDs corresponding to chains to check versions for. Corresponds to all chains if empty",
 			},
 			&cli.StringFlag{
 				Name:    "superchain-target",
-				Usage:   "The name of the superchain to upgrade",
+				Usage:   "The name of the superchain",
 				EnvVars: []string{"SUPERCHAIN_TARGET"},
 			},
 			&cli.PathFlag{
 				Name:     "deploy-config",
-				Usage:    "The path to the deploy config file",
+				Usage:    "The path to the deploy config directory",
 				Required: true,
 				EnvVars:  []string{"DEPLOY_CONFIG"},
 			},
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		log.Crit("error op-upgrade", "err", err)
+		log.Crit("error op-version-check", "err", err)
 	}
 }
 
@@ -93,7 +93,7 @@ func entrypoint(ctx *cli.Context) error {
 	chainIDs := ctx.Uint64Slice("chain-ids")
 	deployConfig := ctx.Path("deploy-config")
 
-	// If no chain IDs are specified, upgrade all chains
+	// If no chain IDs are specified, check all chains
 	if len(chainIDs) == 0 {
 		chainIDs = maps.Keys(superchain.OPChains)
 	}

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -144,6 +144,7 @@ func entrypoint(ctx *cli.Context) error {
 
 			output = append(output, ChainVersionCheck{Name: chainConfig.Name, ChainID: l2ChainID, Contracts: contracts})
 
+			log.Info("Successfully processed contract versions", "chain", chainConfig.Name, "l1-chain-id", l1ChainID, "l2-chain-id", l2ChainID)
 			break
 		}
 	}

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
 
-	"github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
+	op_node_genesis "github.com/ethereum-optimism/optimism/op-node/cmd/genesis"
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 )
 
@@ -152,7 +152,7 @@ func entrypoint(ctx *cli.Context) error {
 
 	// Write contract versions to disk or stdout
 	if outfile := ctx.Path("outfile"); outfile != "" {
-		if err := genesis.WriteJSONFile(outfile, output); err != nil {
+		if err := op_node_genesis.WriteJSONFile(outfile, output); err != nil {
 			return err
 		}
 	} else {

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -98,10 +98,11 @@ func entrypoint(ctx *cli.Context) error {
 	slices.Sort(chainIDs)
 
 	targets := make([]*superchain.ChainConfig, 0)
-	// TODO: Need some logging here if a chain ID is filtered out for whatever reason.
 	for _, chainConfig := range superchain.OPChains {
 		if chainConfig.Superchain == superchainName && slices.Contains(chainIDs, chainConfig.ChainID) {
 			targets = append(targets, chainConfig)
+		} else {
+			log.Info("Skipping chain", "superchain", chainConfig.Superchain, "chainID", chainConfig.ChainID)
 		}
 	}
 

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/clients"
-	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/upgrades"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
@@ -48,12 +47,6 @@ func main() {
 				Name:    "superchain-target",
 				Usage:   "The name of the superchain",
 				EnvVars: []string{"SUPERCHAIN_TARGET"},
-			},
-			&cli.PathFlag{
-				Name:     "deploy-config",
-				Usage:    "The path to the deploy config directory",
-				Required: true,
-				EnvVars:  []string{"DEPLOY_CONFIG"},
 			},
 			&cli.PathFlag{
 				Name:    "outfile",
@@ -91,7 +84,6 @@ func entrypoint(ctx *cli.Context) error {
 	}
 
 	chainIDs := ctx.Uint64Slice("chain-ids")
-	deployConfig := ctx.Path("deploy-config")
 
 	// If no chain IDs are specified, check all chains
 	if len(chainIDs) == 0 {
@@ -113,19 +105,6 @@ func entrypoint(ctx *cli.Context) error {
 	output := []ChainVersionCheck{}
 
 	for _, chainConfig := range targets {
-		name, _ := toDeployConfigName(chainConfig)
-		config, err := genesis.NewDeployConfigWithNetwork(name, deployConfig)
-		if err != nil {
-			log.Warn("Cannot find deploy config for network", "name", chainConfig.Name, "deploy-config-name", name, "path", deployConfig, "err", err)
-		}
-
-		if config != nil {
-			log.Info("Checking deploy config validity", "name", chainConfig.Name)
-			if err := config.Check(); err != nil {
-				return fmt.Errorf("error checking deploy config: %w", err)
-			}
-		}
-
 		clients, err := clients.NewClients(ctx.String("l1-rpc-url"), chainConfig.PublicRPC)
 		if err != nil {
 			return fmt.Errorf("cannot create RPC clients: %w", err)

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -122,3 +122,17 @@ func cmpVersion(v1, v2 string) bool {
 	}
 	return v1 == v2
 }
+
+// ToSuperchainName turns a base layer chain id into a superchain network name.
+func ToSuperchainName(chainID uint64) (string, error) {
+	if chainID == 1 {
+		return "mainnet", nil
+	}
+	if chainID == 5 {
+		return "goerli", nil
+	}
+	if chainID == 11155111 {
+		return "sepolia", nil
+	}
+	return "", fmt.Errorf("unsupported chain ID %d", chainID)
+}

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -126,7 +126,7 @@ var Subcommands = cli.Commands{
 				return err
 			}
 
-			return WriteJSONFile(ctx.String("outfile.l1"), l1Genesis)
+			return writeJSONFile(ctx.String("outfile.l1"), l1Genesis)
 		},
 	},
 	{
@@ -249,17 +249,17 @@ var Subcommands = cli.Commands{
 				return fmt.Errorf("generated rollup config does not pass validation: %w", err)
 			}
 
-			if err := WriteJSONFile(ctx.String("outfile.l2"), l2Genesis); err != nil {
+			if err := writeJSONFile(ctx.String("outfile.l2"), l2Genesis); err != nil {
 				return err
 			}
-			return WriteJSONFile(ctx.String("outfile.rollup"), rollupConfig)
+			return writeJSONFile(ctx.String("outfile.rollup"), rollupConfig)
 		},
 	},
 }
 
-// WriteJSONFile will write a JSON file to disk at the given path
+// writeJSONFile will write a JSON file to disk at the given path
 // containing the JSON serialized input value.
-func WriteJSONFile(outfile string, input any) error {
+func writeJSONFile(outfile string, input any) error {
 	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -126,7 +126,7 @@ var Subcommands = cli.Commands{
 				return err
 			}
 
-			return writeJSONFile(ctx.String("outfile.l1"), l1Genesis)
+			return WriteJSONFile(ctx.String("outfile.l1"), l1Genesis)
 		},
 	},
 	{
@@ -249,17 +249,17 @@ var Subcommands = cli.Commands{
 				return fmt.Errorf("generated rollup config does not pass validation: %w", err)
 			}
 
-			if err := writeJSONFile(ctx.String("outfile.l2"), l2Genesis); err != nil {
+			if err := WriteJSONFile(ctx.String("outfile.l2"), l2Genesis); err != nil {
 				return err
 			}
-			return writeJSONFile(ctx.String("outfile.rollup"), rollupConfig)
+			return WriteJSONFile(ctx.String("outfile.rollup"), rollupConfig)
 		},
 	},
 }
 
-// writeJSONFile will write a JSON file to disk at the given path
+// WriteJSONFile will write a JSON file to disk at the given path
 // containing the JSON serialized input value.
-func writeJSONFile(outfile string, input any) error {
+func WriteJSONFile(outfile string, input any) error {
 	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err

--- a/op-service/jsonutil/write.go
+++ b/op-service/jsonutil/write.go
@@ -1,0 +1,18 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func WriteJSON(outfile string, input interface{}) error {
+	f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(input)
+}


### PR DESCRIPTION
Addressing https://github.com/ethereum-optimism/client-pod/issues/405 as part of https://github.com/ethereum-optimism/client-pod/issues/411.

Sample output only passing a Goerli RPC for the `--l1-rpc-url` flag:
```
INFO [01-05|11:41:27.654] OP-Goerli                                l1-chain-id=5 l2-chain-id=420
INFO [01-05|11:41:27.654] Detecting on chain contracts 
INFO [01-05|11:41:29.288] Base Goerli                              l1-chain-id=5 l2-chain-id=84531
INFO [01-05|11:41:29.289] Detecting on chain contracts 
[
  {
    "Name": "OP-Goerli",
    "ChainID": 420,
    "ContractVersions": {
      "L1CrossDomainMessenger": "1.7.0",
      "L1ERC721Bridge": "1.4.0",
      "L1StandardBridge": "1.4.0",
      "L2OutputOracle": "1.6.0",
      "OptimismMintableERC20Factory": "1.6.0",
      "OptimismPortal": "1.10.0",
      "SystemConfig": "1.10.0"
    }
  },
  {
    "Name": "Base Goerli",
    "ChainID": 84531,
    "ContractVersions": {
      "L1CrossDomainMessenger": "1.4.0",
      "L1ERC721Bridge": "1.1.1",
      "L1StandardBridge": "1.1.0",
      "L2OutputOracle": "1.3.0",
      "OptimismMintableERC20Factory": "1.1.0",
      "OptimismPortal": "1.6.0",
      "SystemConfig": "1.3.0"
    }
  }
]
```

Similar to `op-upgrade`, the output file can be specified by a flag. If none is passed, the file is written to stdout (as in the sample output above).