### PR TITLE
op-service/sources: Always validate receipts when fetching them

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -323,12 +323,8 @@ func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (e
 		return nil, nil, err
 	}
 
-	if !s.trustRPC {
-		if err := validateReceipts(block, info.ReceiptHash(), txHashes, receipts); err != nil {
-			return info, nil, fmt.Errorf("invalid receipts: %w", err)
-		}
-	} else if len(txHashes) != len(receipts) {
-		return info, nil, fmt.Errorf("unexpected number of receipts, expected: %d, got: %d", len(txHashes), len(receipts))
+	if err := validateReceipts(block, info.ReceiptHash(), txHashes, receipts); err != nil {
+		return info, nil, fmt.Errorf("invalid receipts: %w", err)
 	}
 
 	return info, receipts, nil


### PR DESCRIPTION
**Description**

Revert the change in receipts validation behavior from https://github.com/ethereum-optimism/optimism/pull/8130 to always validate receipts again when fetching them. 

**Tests**

Adapted validation tests to test both cases, with and without trusting the rpc.

**Additional context**

Receipts from L1 rpcs are just too often corrupted to ever skip validation. We've probably seen a few derivation errors where nodes stopped because they were running with `trustRpc` enabled.

A different issue to investigate is how a truncated list of receipts made it through `FetchReceipts` with a `nil` error in the first place.


