### PR TITLE
[op-conductor] rpc api / client / backend

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -20,6 +20,7 @@ import (
 	opp2p "github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	opclient "github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 )
 
@@ -293,6 +294,46 @@ func (oc *OpConductor) Resume(ctx context.Context) error {
 // Paused returns true if OpConductor is paused.
 func (oc *OpConductor) Paused() bool {
 	return oc.paused.Load()
+}
+
+// Leader returns true if OpConductor is the leader.
+func (oc *OpConductor) Leader(_ context.Context) bool {
+	return oc.cons.Leader()
+}
+
+// LeaderWithID returns the current leader's server ID and address.
+func (oc *OpConductor) LeaderWithID(_ context.Context) (string, string) {
+	return oc.cons.LeaderWithID()
+}
+
+// AddServerAsVoter adds a server as a voter to the cluster.
+func (oc *OpConductor) AddServerAsVoter(_ context.Context, id string, addr string) error {
+	return oc.cons.AddVoter(id, addr)
+}
+
+// AddServerAsNonvoter adds a server as a non-voter to the cluster. non-voter will not participate in leader election.
+func (oc *OpConductor) AddServerAsNonvoter(_ context.Context, id string, addr string) error {
+	return oc.cons.AddNonVoter(id, addr)
+}
+
+// RemoveServer removes a server from the cluster.
+func (oc *OpConductor) RemoveServer(_ context.Context, id string) error {
+	return oc.cons.RemoveServer(id)
+}
+
+// TransferLeader transfers leadership to another server.
+func (oc *OpConductor) TransferLeader(_ context.Context) error {
+	return oc.cons.TransferLeader()
+}
+
+// TransferLeaderToServer transfers leadership to a specific server.
+func (oc *OpConductor) TransferLeaderToServer(_ context.Context, id string, addr string) error {
+	return oc.cons.TransferLeaderTo(id, addr)
+}
+
+// CommitUnsafePayload commits a unsafe payload (lastest head) to the cluster FSM.
+func (oc *OpConductor) CommitUnsafePayload(_ context.Context, payload *eth.ExecutionPayload) error {
+	return oc.cons.CommitUnsafePayload(payload)
 }
 
 func (oc *OpConductor) loop() {

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -193,11 +193,6 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 		Version:   oc.version,
 		Service:   api,
 	})
-
-	oc.log.Info("starting JSON-RPC server")
-	if err := server.Start(); err != nil {
-		return errors.Wrap(err, "failed to start JSON-RPC server")
-	}
 	oc.rpcServer = server
 	return nil
 }
@@ -250,6 +245,11 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 
 	if err := oc.hmon.Start(); err != nil {
 		return errors.Wrap(err, "failed to start health monitor")
+	}
+
+	oc.log.Info("starting JSON-RPC server")
+	if err := oc.rpcServer.Start(); err != nil {
+		return errors.Wrap(err, "failed to start JSON-RPC server")
 	}
 
 	oc.shutdownCtx, oc.shutdownCancel = context.WithCancel(ctx)

--- a/op-conductor/conductor/service_test.go
+++ b/op-conductor/conductor/service_test.go
@@ -275,7 +275,7 @@ func (s *OpConductorTestSuite) TestScenario2() {
 func (s *OpConductorTestSuite) TestScenario3() {
 	s.enableSynchronization()
 
-	mockPayload := eth.ExecutionPayload{
+	mockPayload := &eth.ExecutionPayload{
 		BlockNumber: 1,
 		Timestamp:   hexutil.Uint64(time.Now().Unix()),
 		BlockHash:   [32]byte{1, 2, 3},
@@ -311,7 +311,7 @@ func (s *OpConductorTestSuite) TestScenario4() {
 
 	// unsafe in consensus is 1 block ahead of unsafe in sequencer, we try to post the unsafe payload to sequencer and return error to allow retry
 	// this is normal because the latest unsafe (in consensus) might not arrive at sequencer through p2p yet
-	mockPayload := eth.ExecutionPayload{
+	mockPayload := &eth.ExecutionPayload{
 		BlockNumber: 2,
 		Timestamp:   hexutil.Uint64(time.Now().Unix()),
 		BlockHash:   [32]byte{1, 2, 3},

--- a/op-conductor/consensus/iface.go
+++ b/op-conductor/consensus/iface.go
@@ -20,6 +20,8 @@ type Consensus interface {
 	LeaderCh() <-chan bool
 	// Leader returns if it is the leader of the cluster.
 	Leader() bool
+	// LeaderWithID returns the leader's server ID and address.
+	LeaderWithID() (string, string)
 	// ServerID returns the server ID of the consensus.
 	ServerID() string
 	// TransferLeader triggers leadership transfer to another member in the cluster.
@@ -28,9 +30,9 @@ type Consensus interface {
 	TransferLeaderTo(id, addr string) error
 
 	// CommitPayload commits latest unsafe payload to the FSM.
-	CommitUnsafePayload(payload eth.ExecutionPayload) error
+	CommitUnsafePayload(payload *eth.ExecutionPayload) error
 	// LatestUnsafeBlock returns the latest unsafe payload from FSM.
-	LatestUnsafePayload() eth.ExecutionPayload
+	LatestUnsafePayload() *eth.ExecutionPayload
 
 	// Shutdown shuts down the consensus protocol client.
 	Shutdown() error

--- a/op-conductor/consensus/mocks/Consensus.go
+++ b/op-conductor/consensus/mocks/Consensus.go
@@ -107,11 +107,11 @@ func (_c *Consensus_AddVoter_Call) RunAndReturn(run func(string, string) error) 
 }
 
 // CommitUnsafePayload provides a mock function with given fields: payload
-func (_m *Consensus) CommitUnsafePayload(payload eth.ExecutionPayload) error {
+func (_m *Consensus) CommitUnsafePayload(payload *eth.ExecutionPayload) error {
 	ret := _m.Called(payload)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(eth.ExecutionPayload) error); ok {
+	if rf, ok := ret.Get(0).(func(*eth.ExecutionPayload) error); ok {
 		r0 = rf(payload)
 	} else {
 		r0 = ret.Error(0)
@@ -126,14 +126,14 @@ type Consensus_CommitUnsafePayload_Call struct {
 }
 
 // CommitUnsafePayload is a helper method to define mock.On call
-//   - payload eth.ExecutionPayload
+//   - payload *eth.ExecutionPayload
 func (_e *Consensus_Expecter) CommitUnsafePayload(payload interface{}) *Consensus_CommitUnsafePayload_Call {
 	return &Consensus_CommitUnsafePayload_Call{Call: _e.mock.On("CommitUnsafePayload", payload)}
 }
 
-func (_c *Consensus_CommitUnsafePayload_Call) Run(run func(payload eth.ExecutionPayload)) *Consensus_CommitUnsafePayload_Call {
+func (_c *Consensus_CommitUnsafePayload_Call) Run(run func(payload *eth.ExecutionPayload)) *Consensus_CommitUnsafePayload_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(eth.ExecutionPayload))
+		run(args[0].(*eth.ExecutionPayload))
 	})
 	return _c
 }
@@ -143,7 +143,7 @@ func (_c *Consensus_CommitUnsafePayload_Call) Return(_a0 error) *Consensus_Commi
 	return _c
 }
 
-func (_c *Consensus_CommitUnsafePayload_Call) RunAndReturn(run func(eth.ExecutionPayload) error) *Consensus_CommitUnsafePayload_Call {
+func (_c *Consensus_CommitUnsafePayload_Call) RunAndReturn(run func(*eth.ExecutionPayload) error) *Consensus_CommitUnsafePayload_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -191,14 +191,16 @@ func (_c *Consensus_DemoteVoter_Call) RunAndReturn(run func(string) error) *Cons
 }
 
 // LatestUnsafePayload provides a mock function with given fields:
-func (_m *Consensus) LatestUnsafePayload() eth.ExecutionPayload {
+func (_m *Consensus) LatestUnsafePayload() *eth.ExecutionPayload {
 	ret := _m.Called()
 
-	var r0 eth.ExecutionPayload
-	if rf, ok := ret.Get(0).(func() eth.ExecutionPayload); ok {
+	var r0 *eth.ExecutionPayload
+	if rf, ok := ret.Get(0).(func() *eth.ExecutionPayload); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(eth.ExecutionPayload)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*eth.ExecutionPayload)
+		}
 	}
 
 	return r0
@@ -221,12 +223,12 @@ func (_c *Consensus_LatestUnsafePayload_Call) Run(run func()) *Consensus_LatestU
 	return _c
 }
 
-func (_c *Consensus_LatestUnsafePayload_Call) Return(_a0 eth.ExecutionPayload) *Consensus_LatestUnsafePayload_Call {
+func (_c *Consensus_LatestUnsafePayload_Call) Return(_a0 *eth.ExecutionPayload) *Consensus_LatestUnsafePayload_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Consensus_LatestUnsafePayload_Call) RunAndReturn(run func() eth.ExecutionPayload) *Consensus_LatestUnsafePayload_Call {
+func (_c *Consensus_LatestUnsafePayload_Call) RunAndReturn(run func() *eth.ExecutionPayload) *Consensus_LatestUnsafePayload_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -311,6 +313,57 @@ func (_c *Consensus_LeaderCh_Call) Return(_a0 <-chan bool) *Consensus_LeaderCh_C
 }
 
 func (_c *Consensus_LeaderCh_Call) RunAndReturn(run func() <-chan bool) *Consensus_LeaderCh_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// LeaderWithID provides a mock function with given fields:
+func (_m *Consensus) LeaderWithID() (string, string) {
+	ret := _m.Called()
+
+	var r0 string
+	var r1 string
+	if rf, ok := ret.Get(0).(func() (string, string)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func() string); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
+}
+
+// Consensus_LeaderWithID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LeaderWithID'
+type Consensus_LeaderWithID_Call struct {
+	*mock.Call
+}
+
+// LeaderWithID is a helper method to define mock.On call
+func (_e *Consensus_Expecter) LeaderWithID() *Consensus_LeaderWithID_Call {
+	return &Consensus_LeaderWithID_Call{Call: _e.mock.On("LeaderWithID")}
+}
+
+func (_c *Consensus_LeaderWithID_Call) Run(run func()) *Consensus_LeaderWithID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Consensus_LeaderWithID_Call) Return(_a0 string, _a1 string) *Consensus_LeaderWithID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Consensus_LeaderWithID_Call) RunAndReturn(run func() (string, string)) *Consensus_LeaderWithID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -144,6 +144,12 @@ func (rc *RaftConsensus) Leader() bool {
 	return id == rc.serverID
 }
 
+// LeaderWithID implements Consensus, it returns the leader's server ID and address.
+func (rc *RaftConsensus) LeaderWithID() (string, string) {
+	addr, id := rc.r.LeaderWithID()
+	return string(id), string(addr)
+}
+
 // LeaderCh implements Consensus, it returns a channel that will be notified when leadership status changes (true = leader, false = follower).
 func (rc *RaftConsensus) LeaderCh() <-chan bool {
 	return rc.r.LeaderCh()
@@ -196,7 +202,7 @@ func (rc *RaftConsensus) Shutdown() error {
 }
 
 // CommitUnsafePayload implements Consensus, it commits latest unsafe payload to the cluster FSM.
-func (rc *RaftConsensus) CommitUnsafePayload(payload eth.ExecutionPayload) error {
+func (rc *RaftConsensus) CommitUnsafePayload(payload *eth.ExecutionPayload) error {
 	blockVersion := eth.BlockV1
 	if rc.rollupCfg.IsCanyon(uint64(payload.Timestamp)) {
 		blockVersion = eth.BlockV2
@@ -204,7 +210,7 @@ func (rc *RaftConsensus) CommitUnsafePayload(payload eth.ExecutionPayload) error
 
 	data := unsafeHeadData{
 		version: blockVersion,
-		payload: payload,
+		payload: *payload,
 	}
 
 	var buf bytes.Buffer
@@ -221,6 +227,7 @@ func (rc *RaftConsensus) CommitUnsafePayload(payload eth.ExecutionPayload) error
 }
 
 // LatestUnsafePayload implements Consensus, it returns the latest unsafe payload from FSM.
-func (rc *RaftConsensus) LatestUnsafePayload() eth.ExecutionPayload {
-	return rc.unsafeTracker.UnsafeHead()
+func (rc *RaftConsensus) LatestUnsafePayload() *eth.ExecutionPayload {
+	payload := rc.unsafeTracker.UnsafeHead()
+	return &payload
 }

--- a/op-conductor/consensus/raft_test.go
+++ b/op-conductor/consensus/raft_test.go
@@ -36,7 +36,7 @@ func TestCommitAndRead(t *testing.T) {
 	<-cons.LeaderCh()
 
 	// eth.BlockV1
-	payload := eth.ExecutionPayload{
+	payload := &eth.ExecutionPayload{
 		BlockNumber:  1,
 		Timestamp:    hexutil.Uint64(now - 20),
 		Transactions: []eth.Data{},
@@ -50,7 +50,7 @@ func TestCommitAndRead(t *testing.T) {
 	require.Equal(t, payload, unsafeHead)
 
 	// eth.BlockV2
-	payload = eth.ExecutionPayload{
+	payload = &eth.ExecutionPayload{
 		BlockNumber:  2,
 		Timestamp:    hexutil.Uint64(time.Now().Unix()),
 		Transactions: []eth.Data{},

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -6,20 +6,23 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
+type ServerInfo struct {
+	ID   string `json:"id"`
+	Addr string `json:"addr"`
+}
+
 // API defines the interface for the op-conductor API.
 type API interface {
 	// Pause pauses op-conductor.
 	Pause(ctx context.Context) error
 	// Resume resumes op-conductor.
 	Resume(ctx context.Context) error
-	// Stop stops op-conductor.
-	Stop(ctx context.Context) error
 
 	// Consensus related APIs
 	// Leader returns true if the server is the leader.
-	Leader(ctx context.Context) bool
-	// LeaderWithID returns the current leader's server ID and address.
-	LeaderWithID(ctx context.Context) (string, string)
+	Leader(ctx context.Context) (bool, error)
+	// LeaderWithID returns the current leader's server info.
+	LeaderWithID(ctx context.Context) (*ServerInfo, error)
 	// AddServerAsVoter adds a server as a voter to the cluster.
 	AddServerAsVoter(ctx context.Context, id string, addr string) error
 	// AddServerAsNonvoter adds a server as a non-voter to the cluster. non-voter will not participate in leader election.
@@ -33,7 +36,7 @@ type API interface {
 
 	// APIs called by op-node
 	// Active returns true if op-conductor is active.
-	Active(ctx context.Context) bool
+	Active(ctx context.Context) (bool, error)
 	// CommitUnsafePayload commits a unsafe payload (lastest head) to the consensus layer.
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error
 }

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -1,0 +1,45 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// ServerID is the ID of the server, e.g. "SequencerA"
+type ServerID string
+
+// ServerAddr is the address of the server, e.g. "8.8.8.8:50050", "dns:50050"
+type ServerAddr string
+
+// API defines the interface for the op-conductor API.
+type API interface {
+	// Pause pauses op-conductor.
+	Pause(ctx context.Context) error
+	// Resume resumes op-conductor.
+	Resume(ctx context.Context) error
+	// Stop stops op-conductor.
+	Stop(ctx context.Context) error
+
+	// Consensus related APIs
+	// IsLeader returns true if the server is the leader.
+	IsLeader(ctx context.Context) bool
+	// LeaderWithID returns the current leader address and ID of the cluster.
+	LeaderWithID(ctx context.Context) (ServerAddr, ServerID)
+	// AddServerAsVoter adds a server as a voter to the cluster.
+	AddServerAsVoter(ctx context.Context, id ServerID, addr ServerAddr) error
+	// AddServerAsNonvoter adds a server as a non-voter to the cluster. non-voter will not participate in leader election.
+	AddServerAsNonvoter(ctx context.Context, id ServerID, addr ServerAddr) error
+	// RemoveServer removes a server from the cluster.
+	RemoveServer(ctx context.Context, id ServerID) error
+	// TransferLeader transfers leadership to another server.
+	TransferLeader(ctx context.Context) error
+	// TransferLeaderToServer transfers leadership to a specific server.
+	TransferLeaderToServer(ctx context.Context, id ServerID, addr ServerAddr) error
+
+	// APIs called by op-node
+	// Active returns true if op-conductor is active (not paused).
+	Active(ctx context.Context) (bool, error)
+	// CommitUnsafePayload commits a unsafe payload (lastest head) to the consensus layer.
+	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error
+}

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -6,12 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// ServerID is the ID of the server, e.g. "SequencerA"
-type ServerID string
-
-// ServerAddr is the address of the server, e.g. "8.8.8.8:50050", "dns:50050"
-type ServerAddr string
-
 // API defines the interface for the op-conductor API.
 type API interface {
 	// Pause pauses op-conductor.
@@ -22,24 +16,24 @@ type API interface {
 	Stop(ctx context.Context) error
 
 	// Consensus related APIs
-	// IsLeader returns true if the server is the leader.
-	IsLeader(ctx context.Context) bool
-	// LeaderWithID returns the current leader address and ID of the cluster.
-	LeaderWithID(ctx context.Context) (ServerAddr, ServerID)
+	// Leader returns true if the server is the leader.
+	Leader(ctx context.Context) bool
+	// LeaderWithID returns the current leader's server ID and address.
+	LeaderWithID(ctx context.Context) (string, string)
 	// AddServerAsVoter adds a server as a voter to the cluster.
-	AddServerAsVoter(ctx context.Context, id ServerID, addr ServerAddr) error
+	AddServerAsVoter(ctx context.Context, id string, addr string) error
 	// AddServerAsNonvoter adds a server as a non-voter to the cluster. non-voter will not participate in leader election.
-	AddServerAsNonvoter(ctx context.Context, id ServerID, addr ServerAddr) error
+	AddServerAsNonvoter(ctx context.Context, id string, addr string) error
 	// RemoveServer removes a server from the cluster.
-	RemoveServer(ctx context.Context, id ServerID) error
+	RemoveServer(ctx context.Context, id string) error
 	// TransferLeader transfers leadership to another server.
 	TransferLeader(ctx context.Context) error
 	// TransferLeaderToServer transfers leadership to a specific server.
-	TransferLeaderToServer(ctx context.Context, id ServerID, addr ServerAddr) error
+	TransferLeaderToServer(ctx context.Context, id string, addr string) error
 
 	// APIs called by op-node
-	// Active returns true if op-conductor is active (not paused).
-	Active(ctx context.Context) (bool, error)
+	// Active returns true if op-conductor is active.
+	Active(ctx context.Context) bool
 	// CommitUnsafePayload commits a unsafe payload (lastest head) to the consensus layer.
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error
 }

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -5,20 +5,35 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+type conductor interface {
+	Pause(ctx context.Context) error
+	Resume(ctx context.Context) error
+	Paused() bool
+	Stopped() bool
+
+	Leader(ctx context.Context) bool
+	LeaderWithID(ctx context.Context) (string, string)
+	AddServerAsVoter(ctx context.Context, id string, addr string) error
+	AddServerAsNonvoter(ctx context.Context, id string, addr string) error
+	RemoveServer(ctx context.Context, id string) error
+	TransferLeader(ctx context.Context) error
+	TransferLeaderToServer(ctx context.Context, id string, addr string) error
+	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error
+}
 
 // APIBackend is the backend implementation of the API.
 type APIBackend struct {
 	log log.Logger
-	con *conductor.OpConductor
+	con conductor
 
 	// TODO (https://github.com/ethereum-optimism/protocol-quest/issues/45) Add metrics tracer here
 }
 
 // NewAPIBackend creates a new APIBackend instance.
-func NewAPIBackend(log log.Logger, con *conductor.OpConductor) *APIBackend {
+func NewAPIBackend(log log.Logger, con conductor) *APIBackend {
 	return &APIBackend{
 		log: log,
 		con: con,

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -25,11 +25,11 @@ type conductor interface {
 }
 
 // APIBackend is the backend implementation of the API.
+// TODO: (https://github.com/ethereum-optimism/protocol-quest/issues/45) Add metrics tracer here.
+// TODO: (https://github.com/ethereum-optimism/protocol-quest/issues/44) add tests after e2e setup.
 type APIBackend struct {
 	log log.Logger
 	con conductor
-
-	// TODO (https://github.com/ethereum-optimism/protocol-quest/issues/45) Add metrics tracer here
 }
 
 // NewAPIBackend creates a new APIBackend instance.

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -28,8 +28,8 @@ func NewAPIBackend(log log.Logger, con *conductor.OpConductor) *APIBackend {
 var _ API = (*APIBackend)(nil)
 
 // Active implements API.
-func (api *APIBackend) Active(_ context.Context) bool {
-	return !api.con.Stopped() && !api.con.Paused()
+func (api *APIBackend) Active(_ context.Context) (bool, error) {
+	return !api.con.Stopped() && !api.con.Paused(), nil
 }
 
 // AddServerAsNonvoter implements API.
@@ -48,13 +48,17 @@ func (api *APIBackend) CommitUnsafePayload(ctx context.Context, payload *eth.Exe
 }
 
 // Leader implements API, returns true if current conductor is leader of the cluster.
-func (api *APIBackend) Leader(ctx context.Context) bool {
-	return api.con.Leader(ctx)
+func (api *APIBackend) Leader(ctx context.Context) (bool, error) {
+	return api.con.Leader(ctx), nil
 }
 
 // LeaderWithID implements API, returns the leader's server ID and address (not necessarily the current conductor).
-func (api *APIBackend) LeaderWithID(ctx context.Context) (string, string) {
-	return api.con.LeaderWithID(ctx)
+func (api *APIBackend) LeaderWithID(ctx context.Context) (*ServerInfo, error) {
+	id, addr := api.con.LeaderWithID(ctx)
+	return &ServerInfo{
+		ID:   id,
+		Addr: addr,
+	}, nil
 }
 
 // Pause implements API.
@@ -70,11 +74,6 @@ func (api *APIBackend) RemoveServer(ctx context.Context, id string) error {
 // Resume implements API.
 func (api *APIBackend) Resume(ctx context.Context) error {
 	return api.con.Resume(ctx)
-}
-
-// Stop implements API.
-func (api *APIBackend) Stop(ctx context.Context) error {
-	return api.con.Stop(ctx)
 }
 
 // TransferLeader implements API.

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -1,0 +1,88 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+var RPCNamespace = "conductor"
+
+// APIClient provides a client for calling API methods.
+type APIClient struct {
+	c *rpc.Client
+}
+
+var _ API = (*APIClient)(nil)
+
+// NewAPIClient creates a new APIClient instance.
+func NewAPIClient(c *rpc.Client) *APIClient {
+	return &APIClient{c: c}
+}
+
+func prefixRPC(method string) string {
+	return RPCNamespace + "_" + method
+}
+
+// Active implements API.
+func (c *APIClient) Active(ctx context.Context) (bool, error) {
+	var active bool
+	err := c.c.CallContext(ctx, &active, prefixRPC("active"))
+	return active, err
+}
+
+// AddServerAsNonvoter implements API.
+func (c *APIClient) AddServerAsNonvoter(ctx context.Context, id string, addr string) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("addServerAsNonvoter"), id, addr)
+}
+
+// AddServerAsVoter implements API.
+func (c *APIClient) AddServerAsVoter(ctx context.Context, id string, addr string) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("addServerAsVoter"), id, addr)
+}
+
+// CommitUnsafePayload implements API.
+func (c *APIClient) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("commitUnsafePayload"), payload)
+}
+
+// Leader implements API.
+func (c *APIClient) Leader(ctx context.Context) (bool, error) {
+	var leader bool
+	err := c.c.CallContext(ctx, &leader, prefixRPC("leader"))
+	return leader, err
+}
+
+// LeaderWithID implements API.
+func (c *APIClient) LeaderWithID(ctx context.Context) (*ServerInfo, error) {
+	var info *ServerInfo
+	err := c.c.CallContext(ctx, &info, prefixRPC("leaderWithID"))
+	return info, err
+}
+
+// Pause implements API.
+func (c *APIClient) Pause(ctx context.Context) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("pause"))
+}
+
+// RemoveServer implements API.
+func (c *APIClient) RemoveServer(ctx context.Context, id string) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("removeServer"), id)
+}
+
+// Resume implements API.
+func (c *APIClient) Resume(ctx context.Context) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("resume"))
+}
+
+// TransferLeader implements API.
+func (c *APIClient) TransferLeader(ctx context.Context) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("transferLeader"))
+}
+
+// TransferLeaderToServer implements API.
+func (c *APIClient) TransferLeaderToServer(ctx context.Context, id string, addr string) error {
+	return c.c.CallContext(ctx, nil, prefixRPC("transferLeaderToServer"), id, addr)
+}

--- a/op-conductor/rpc/server.go
+++ b/op-conductor/rpc/server.go
@@ -1,0 +1,88 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/conductor"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// APIBackend is the backend implementation of the API.
+type APIBackend struct {
+	log log.Logger
+	con *conductor.OpConductor
+
+	// TODO (https://github.com/ethereum-optimism/protocol-quest/issues/45) Add metrics tracer here
+}
+
+// NewAPIBackend creates a new APIBackend instance.
+func NewAPIBackend(log log.Logger, con *conductor.OpConductor) *APIBackend {
+	return &APIBackend{
+		log: log,
+		con: con,
+	}
+}
+
+var _ API = (*APIBackend)(nil)
+
+// Active implements API.
+func (api *APIBackend) Active(_ context.Context) bool {
+	return !api.con.Stopped() && !api.con.Paused()
+}
+
+// AddServerAsNonvoter implements API.
+func (api *APIBackend) AddServerAsNonvoter(ctx context.Context, id string, addr string) error {
+	return api.con.AddServerAsNonvoter(ctx, id, addr)
+}
+
+// AddServerAsVoter implements API.
+func (api *APIBackend) AddServerAsVoter(ctx context.Context, id string, addr string) error {
+	return api.con.AddServerAsVoter(ctx, id, addr)
+}
+
+// CommitUnsafePayload implements API.
+func (api *APIBackend) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayload) error {
+	return api.con.CommitUnsafePayload(ctx, payload)
+}
+
+// Leader implements API, returns true if current conductor is leader of the cluster.
+func (api *APIBackend) Leader(ctx context.Context) bool {
+	return api.con.Leader(ctx)
+}
+
+// LeaderWithID implements API, returns the leader's server ID and address (not necessarily the current conductor).
+func (api *APIBackend) LeaderWithID(ctx context.Context) (string, string) {
+	return api.con.LeaderWithID(ctx)
+}
+
+// Pause implements API.
+func (api *APIBackend) Pause(ctx context.Context) error {
+	return api.con.Pause(ctx)
+}
+
+// RemoveServer implements API.
+func (api *APIBackend) RemoveServer(ctx context.Context, id string) error {
+	return api.con.RemoveServer(ctx, id)
+}
+
+// Resume implements API.
+func (api *APIBackend) Resume(ctx context.Context) error {
+	return api.con.Resume(ctx)
+}
+
+// Stop implements API.
+func (api *APIBackend) Stop(ctx context.Context) error {
+	return api.con.Stop(ctx)
+}
+
+// TransferLeader implements API.
+func (api *APIBackend) TransferLeader(ctx context.Context) error {
+	return api.con.TransferLeader(ctx)
+}
+
+// TransferLeaderToServer implements API.
+func (api *APIBackend) TransferLeaderToServer(ctx context.Context, id string, addr string) error {
+	return api.con.TransferLeaderToServer(ctx, id, addr)
+}


### PR DESCRIPTION
**Description**

* Defined op-conductor rpc API and implemented client & api backend
* Added rpc server initialization in op-conductor

**Tests**

* Currently no tests. Will add tests once e2e are setup (we need e2e tests to fully test API's functionality)
* Also all the functions here are mainly wrappers to the underlying op-conductor logic which will be tested later in e2e as well.

**Metadata**

- https://github.com/ethereum-optimism/protocol-quest/issues/44
