### PR TITLE
op-service/txmgr: Fix tx logging

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -149,7 +149,7 @@ func (m *SimpleTxManager) txLogger(tx *types.Transaction, logGas bool) log.Logge
 	if logGas {
 		fields = append(fields, "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap(), "gasLimit", tx.Gas())
 	}
-	return m.l.New(fields)
+	return m.l.New(fields...)
 }
 
 // TxCandidate is a transaction candidate that can be submitted to ask the


### PR DESCRIPTION

**Description**

Forgot to expand the variadic parameter...

Current logs show errors like
```
t=2024-01-06T11:38:02+0000 lvl=info msg="Transaction receipt not found"       service=batcher LOG15_ERROR=[]interface {} is not a string key LOG15_ERROR="Normalized odd number of arguments by adding nil" err="context canceled"
```


