### PR TITLE
op-challenger: Remove TODO.

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -244,7 +244,6 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 				// Attack everything but oddly using the correct hash.
 				// Except the root of the cannon game must have an invalid VM status code.
 				if claim.IsOutputRootLeaf(ctx) {
-					// TODO(client-pod#262): Verify that an attack with a valid status code is rejected
 					return claim.Attack(ctx, common.Hash{0x01})
 				}
 				return correctTrace.AttackClaim(ctx, claim)


### PR DESCRIPTION
**Description**

Remove TODO about checking that the vm status code has to be right.  This is better tested by contract unit tests since the expected code now varies depending on the place in the game.