### PR TITLE
feat(ops + op-program): Reproducible MIPS Absolute Prestate Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,12 @@ jobs:
 
             # Create the easily reproducible absolute prestate
             # todo(client-pod#442): validate the prestate hash?
-            make cannon-prestate
+            DOCKER_OUTPUT_DESTINATION="" \
+            docker buildx bake \
+            --set op-program-mips.output=op-program/bin/ \
+            --progress plain \
+            -f docker-bake.hcl \
+            op-program-mips
 
           no_output_timeout: 45m
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,13 +294,8 @@ jobs:
               <<parameters.docker_name>>
 
             # Create the easily reproducible absolute prestate
-            DOCKER_BUILDKIT=1 \
-            DOCKER_OUTPUT_DESTINATION="" \
-            docker buildx bake \
-            --set op-program-mips.output=. \
-            --progress plain \
-            -f docker-bake.hcl \
-            op-program-mips
+            # todo(client-pod#442): validate the prestate hash?
+            make cannon-prestate
 
           no_output_timeout: 45m
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,15 @@ jobs:
               $DOCKER_OUTPUT_DESTINATION \
               <<parameters.docker_name>>
 
+            # Create the easily reproducible absolute prestate
+            DOCKER_BUILDKIT=1 \
+            DOCKER_OUTPUT_DESTINATION="" \
+            docker buildx bake \
+            --set op-program-mips.output=. \
+            --progress plain \
+            -f docker-bake.hcl \
+            op-program-mips
+
           no_output_timeout: 45m
       - when:
           condition: "<<parameters.publish>>"

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ cannon:
 .PHONY: cannon
 
 cannon-prestate: op-program cannon
+	if ! docker buildx inspect | grep -m 1 'Name' | awk  '{print $$2}' | grep -q 'buildx-build'; then \
+		echo "Creating buildx-build builder"; \
+		DOCKER_BUILDKIT=1 docker buildx create --driver=docker-container --name=buildx-build --bootstrap --use; \
+	fi
 	DOCKER_BUILDKIT=1 DOCKER_OUTPUT_DESTINATION="" docker buildx bake --set op-program-mips.output=op-program/bin/ --progress plain -f docker-bake.hcl op-program-mips
 .PHONY: cannon-prestate
 

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,15 @@ cannon:
 	make -C ./cannon cannon
 .PHONY: cannon
 
-cannon-prestate: op-program cannon
+cannon-prestate:
+	DOCKER_BUILDKIT=1 DOCKER_OUTPUT_DESTINATION="" docker buildx bake --set op-program-mips.output=op-program/bin/ --progress plain -f docker-bake.hcl op-program-mips
+.PHONY: cannon-prestate
+
+cannon-prestate-local: op-program cannon
 	./cannon/bin/cannon load-elf --path op-program/bin/op-program-client.elf --out op-program/bin/prestate.json --meta op-program/bin/meta.json
 	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate.json --meta op-program/bin/meta.json --proof-fmt 'op-program/bin/%d.json' --output ""
 	mv op-program/bin/0.json op-program/bin/prestate-proof.json
-.PHONY: cannon-prestate
+.PHONY: cannon-prestate-local
 
 mod-tidy:
 	# Below GOPRIVATE line allows mod-tidy to be run immediately after

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ cannon:
 	make -C ./cannon cannon
 .PHONY: cannon
 
-cannon-prestate:
+cannon-prestate: op-program cannon
 	DOCKER_BUILDKIT=1 DOCKER_OUTPUT_DESTINATION="" docker buildx bake --set op-program-mips.output=op-program/bin/ --progress plain -f docker-bake.hcl op-program-mips
 .PHONY: cannon-prestate
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -132,6 +132,19 @@ target "op-program" {
   tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-program:${tag}"]
 }
 
+target "op-program-mips" {
+  dockerfile = "Dockerfile.mips"
+  context = "./op-program"
+  args = {
+    OP_STACK_GO_BUILDER = "op-stack-go"
+  }
+  contexts = {
+    op-stack-go: "target:op-stack-go"
+  }
+  platforms = ["linux/mips32be"]
+  tags = [for tag in split(",", IMAGE_TAGS) : "${REGISTRY}/${REPOSITORY}/op-program-mips:${tag}"]
+}
+
 target "op-ufm" {
   dockerfile = "./op-ufm/Dockerfile"
   context = "./"

--- a/op-program/Dockerfile.mips
+++ b/op-program/Dockerfile.mips
@@ -1,0 +1,18 @@
+ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
+FROM $OP_STACK_GO_BUILDER as builder
+
+# Run the op-program-client.elf binary directly through cannon's load-elf subcommand.
+RUN cannon load-elf --path /usr/local/bin/op-program-client.elf --out /usr/local/bin/prestate.json --meta ""
+
+# Generate the prestate proof.
+RUN cannon run --proof-at '=0' --stop-at '=1' --input /usr/local/bin/prestate.json --meta "" --proof-fmt '/usr/local/bin/%d.json' --output ""
+RUN mv /usr/local/bin/0.json /usr/local/bin/prestate-proof.json
+
+# Export the prestate.json file to the specified output location.
+# The output location can be overridden by setting the target's output.
+# e.g. `docker buildx bake --set op-program-mips.output=.`
+# Additionally, writing files to host requires buildkit to be enabled.
+# e.g. `BUILDKIT=1 docker build ...`
+FROM scratch AS export-stage
+COPY --from=builder /usr/local/bin/prestate.json .
+COPY --from=builder /usr/local/bin/prestate-proof.json .

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -49,9 +49,10 @@ ARG TARGETOS TARGETARCH
 
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
-# note: we only build the host, that's all the user needs. No Go MIPS cross-build in docker
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-host  \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-client-mips  \
+    GOOS=linux GOARCH=mips GOMIPS=softfloat GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
 
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-heartbeat && make op-heartbeat  \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_HEARTBEAT_VERSION"
@@ -74,6 +75,7 @@ FROM alpine:3.18
 
 COPY --from=builder /app/cannon/bin/cannon /usr/local/bin/
 COPY --from=builder /app/op-program/bin/op-program /usr/local/bin/
+COPY --from=builder /app/op-program/bin/op-program-client.elf /usr/local/bin/
 
 COPY --from=builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin/
 COPY --from=builder /app/op-wheel/bin/op-wheel /usr/local/bin/


### PR DESCRIPTION
**Description**

Adds an `op-program-mips` target to `docker-bake.hcl` that will be used to build the absolute prestate.

https://github.com/ethereum-optimism/optimism/pull/8901 made the op-program absolute prestate run through cannon's `load-elf` subcommand reproducible through a mips32 be architecture docker container. The added ci command outputs `prestate.json` and `prestate-proof.json` files as defined in the op-program's new `Dockerfile.mips` dockerfile.

**Metadata**

Advances https://github.com/ethereum-optimism/client-pod/issues/442