### PR TITLE
fix(op-node): Concrete Span Batch Error Type

### DIFF
--- a/op-node/rollup/derive/error.go
+++ b/op-node/rollup/derive/error.go
@@ -5,6 +5,17 @@ import (
 	"fmt"
 )
 
+var (
+	ErrTypedTxTooShort = errors.New("typed transaction data too short")
+
+	// NotEnoughData implies that the function currently does not have enough data to progress
+	// but if it is retried enough times, it will eventually return a real value or io.EOF
+	NotEnoughData = errors.New("not enough data")
+
+	// EngineELSyncing implies that the execution engine is currently in progress of syncing.
+	EngineELSyncing = errors.New("engine is performing EL sync")
+)
+
 // Level is the severity level of the error.
 type Level uint
 
@@ -92,10 +103,3 @@ func NewCriticalError(err error) error {
 var ErrTemporary = NewTemporaryError(nil)
 var ErrReset = NewResetError(nil)
 var ErrCritical = NewCriticalError(nil)
-
-// NotEnoughData implies that the function currently does not have enough data to progress
-// but if it is retried enough times, it will eventually return a real value or io.EOF
-var NotEnoughData = errors.New("not enough data")
-
-// EngineELSyncing implies that the execution engine is currently in progress of syncing.
-var EngineELSyncing = errors.New("engine is performing EL sync")

--- a/op-node/rollup/derive/error.go
+++ b/op-node/rollup/derive/error.go
@@ -14,6 +14,12 @@ var (
 
 	// EngineELSyncing implies that the execution engine is currently in progress of syncing.
 	EngineELSyncing = errors.New("engine is performing EL sync")
+
+	// Sentinel errors, use these to get the severity of errors by calling
+	// errors.Is(err, ErrTemporary) for example.
+	ErrTemporary = NewTemporaryError(nil)
+	ErrReset     = NewResetError(nil)
+	ErrCritical  = NewCriticalError(nil)
 )
 
 // Level is the severity level of the error.
@@ -97,9 +103,3 @@ func NewResetError(err error) error {
 func NewCriticalError(err error) error {
 	return NewError(err, LevelCritical)
 }
-
-// Sentinel errors, use these to get the severity of errors by calling
-// errors.Is(err, ErrTemporary) for example.
-var ErrTemporary = NewTemporaryError(nil)
-var ErrReset = NewResetError(nil)
-var ErrCritical = NewCriticalError(nil)

--- a/op-node/rollup/derive/span_batch_tx.go
+++ b/op-node/rollup/derive/span_batch_tx.go
@@ -2,7 +2,6 @@ package derive
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -77,7 +76,7 @@ func (tx *spanBatchTx) setDecoded(inner spanBatchTxData, size uint64) {
 // decodeTyped decodes a typed transaction from the canonical format.
 func (tx *spanBatchTx) decodeTyped(b []byte) (spanBatchTxData, error) {
 	if len(b) <= 1 {
-		return nil, errors.New("typed transaction too short")
+		return nil, fmt.Errorf("failed to decode span batch: %w", ErrTypedTxTooShort)
 	}
 	switch b[0] {
 	case types.AccessListTxType:

--- a/op-node/rollup/derive/span_batch_tx_test.go
+++ b/op-node/rollup/derive/span_batch_tx_test.go
@@ -96,6 +96,7 @@ func TestSpanBatchTxRoundTrip(t *testing.T) {
 type spanBatchDummyTxData struct{}
 
 func (txData *spanBatchDummyTxData) txType() byte { return types.DepositTxType }
+
 func TestSpanBatchTxInvalidTxType(t *testing.T) {
 	// span batch never contain deposit tx
 	depositTx := types.NewTx(&types.DepositTx{})
@@ -111,7 +112,7 @@ func TestSpanBatchTxInvalidTxType(t *testing.T) {
 func TestSpanBatchTxDecodeInvalid(t *testing.T) {
 	var sbtx spanBatchTx
 	_, err := sbtx.decodeTyped([]byte{})
-	require.EqualError(t, err, "typed transaction too short")
+	require.ErrorIs(t, err, ErrTypedTxTooShort)
 
 	tx := types.NewTx(&types.LegacyTx{})
 	txEncoded, err := tx.MarshalBinary()


### PR DESCRIPTION
**Description**

Moves the too short tx data error into a concrete type with associated test fix.

**Metadata**

Advances #8388
