### PR TITLE
op-node: adds conductor commit hook for current leader sequencer

### DIFF
--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -43,6 +43,11 @@ func (c *APIClient) AddServerAsVoter(ctx context.Context, id string, addr string
 	return c.c.CallContext(ctx, nil, prefixRPC("addServerAsVoter"), id, addr)
 }
 
+// Close closes the underlying RPC client.
+func (c *APIClient) Close() {
+	c.c.Close()
+}
+
 // CommitUnsafePayload implements API.
 func (c *APIClient) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
 	return c.c.CallContext(ctx, nil, prefixRPC("commitUnsafePayload"), payload)

--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -108,7 +109,7 @@ func (s *L2Sequencer) ActL2EndBlock(t Testing) {
 	}
 	s.l2Building = false
 
-	_, err := s.sequencer.CompleteBuildingBlock(t.Ctx(), async.NoOpGossiper{})
+	_, err := s.sequencer.CompleteBuildingBlock(t.Ctx(), async.NoOpGossiper{}, &conductor.NoOpConductor{})
 	// TODO: there may be legitimate temporary errors here, if we mock engine API RPC-failure.
 	// For advanced tests we can catch those and print a warning instead.
 	require.NoError(t, err)

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -256,6 +256,24 @@ var (
 		EnvVars: prefixEnvVars("L2_BACKUP_UNSAFE_SYNC_RPC_TRUST_RPC"),
 		Hidden:  true,
 	}
+	ConductorEnabledFlag = &cli.BoolFlag{
+		Name:    "conductor.enabled",
+		Usage:   "Enable the conductor service",
+		EnvVars: prefixEnvVars("CONDUCTOR_ENABLED"),
+		Value:   false,
+	}
+	ConductorRpcFlag = &cli.StringFlag{
+		Name:    "conductor.rpc",
+		Usage:   "Conductor service rpc endpoint",
+		EnvVars: prefixEnvVars("CONDUCTOR_RPC"),
+		Value:   "http://127.0.0.1:8547",
+	}
+	ConductorRpcTimeoutFlag = &cli.DurationFlag{
+		Name:    "conductor.rpc-timeout",
+		Usage:   "Conductor service rpc timeout",
+		EnvVars: prefixEnvVars("CONDUCTOR_RPC_TIMEOUT"),
+		Value:   time.Second * 1,
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -295,6 +313,9 @@ var optionalFlags = []cli.Flag{
 	RollupHalt,
 	RollupLoadProtocolVersions,
 	L1RethDBPath,
+	ConductorEnabledFlag,
+	ConductorRpcFlag,
+	ConductorRpcTimeoutFlag,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/conductor.go
+++ b/op-node/node/conductor.go
@@ -1,0 +1,87 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/retry"
+	"github.com/ethereum/go-ethereum/log"
+
+	conductorRpc "github.com/ethereum-optimism/optimism/op-conductor/rpc"
+)
+
+// ConductorClient is a client for the op-conductor RPC service.
+type ConductorClient struct {
+	cfg       *Config
+	metrics   *metrics.Metrics
+	log       log.Logger
+	apiClient *conductorRpc.APIClient
+}
+
+var _ conductor.SequencerConductor = &ConductorClient{}
+
+// NewConductorClient returns a new conductor client for the op-conductor RPC service.
+func NewConductorClient(cfg *Config, log log.Logger, metrics *metrics.Metrics) *ConductorClient {
+	return &ConductorClient{cfg: cfg, metrics: metrics, log: log}
+}
+
+// Initialize initializes the conductor client.
+func (c *ConductorClient) initialize() error {
+	if c.apiClient != nil {
+		return nil
+	}
+	conductorRpcClient, err := dial.DialRPCClientWithTimeout(context.Background(), time.Minute*1, c.log, c.cfg.ConductorRpc)
+	if err != nil {
+		return fmt.Errorf("failed to dial conductor RPC: %w", err)
+	}
+	c.apiClient = conductorRpc.NewAPIClient(conductorRpcClient)
+	return nil
+}
+
+// Leader returns true if this node is the leader sequencer.
+func (c *ConductorClient) Leader(ctx context.Context) (bool, error) {
+	if err := c.initialize(); err != nil {
+		return false, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.ConductorRpcTimeout)
+	defer cancel()
+
+	isLeader, err := retry.Do(ctx, 2, retry.Fixed(50*time.Millisecond), func() (bool, error) {
+		record := c.metrics.RecordRPCClientRequest("conductor_leader")
+		result, err := c.apiClient.Leader(ctx)
+		record(err)
+		return result, err
+	})
+	return isLeader, err
+}
+
+// CommitUnsafePayload commits an unsafe payload to the conductor log.
+func (c *ConductorClient) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	if err := c.initialize(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.ConductorRpcTimeout)
+	defer cancel()
+
+	// extra bool return value is required for the generic, can be ignored.
+	_, err := retry.Do(ctx, 2, retry.Fixed(50*time.Millisecond), func() (bool, error) {
+		record := c.metrics.RecordRPCClientRequest("conductor_commitUnsafePayload")
+		err := c.apiClient.CommitUnsafePayload(ctx, payload)
+		record(err)
+		return true, err
+	})
+	return err
+}
+
+func (c *ConductorClient) Close() {
+	if c.apiClient == nil {
+		return
+	}
+	c.apiClient.Close()
+	c.apiClient = nil
+}

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -64,6 +64,11 @@ type Config struct {
 
 	// [OPTIONAL] The reth DB path to read receipts from
 	RethDBPath string
+
+	// Conductor is used to determine this node is the leader sequencer.
+	ConductorEnabled    bool
+	ConductorRpc        string
+	ConductorRpcTimeout time.Duration
 }
 
 type RPCConfig struct {
@@ -150,6 +155,14 @@ func (cfg *Config) Check() error {
 	}
 	if !(cfg.RollupHalt == "" || cfg.RollupHalt == "major" || cfg.RollupHalt == "minor" || cfg.RollupHalt == "patch") {
 		return fmt.Errorf("invalid rollup halting option: %q", cfg.RollupHalt)
+	}
+	if cfg.ConductorEnabled {
+		if state, _ := cfg.ConfigPersistence.SequencerState(); state != StateUnset {
+			return fmt.Errorf("config persistence must be disabled when conductor is enabled")
+		}
+		if !cfg.Driver.SequencerEnabled {
+			return fmt.Errorf("sequencer must be enabled when conductor is enabled")
+		}
 	}
 	return nil
 }

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/heartbeat"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-node/version"
@@ -367,7 +368,11 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config, snapshotLog log.Logger
 		return err
 	}
 
-	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n.beacon, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, &cfg.Sync)
+	var sequencerConductor conductor.SequencerConductor = &conductor.NoOpConductor{}
+	if cfg.ConductorEnabled {
+		sequencerConductor = NewConductorClient(cfg, n.log, n.metrics)
+	}
+	n.l2Driver = driver.NewDriver(&cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source, n.beacon, n, n, n.log, snapshotLog, n.metrics, cfg.ConfigPersistence, &cfg.Sync, sequencerConductor)
 
 	return nil
 }

--- a/op-node/rollup/conductor/conductor.go
+++ b/op-node/rollup/conductor/conductor.go
@@ -1,0 +1,31 @@
+package conductor
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// SequencerConductor is an interface for the driver to communicate with the sequencer conductor.
+// It is used to determine if the current node is the active sequencer, and to commit unsafe payloads to the conductor log.
+type SequencerConductor interface {
+	Leader(ctx context.Context) (bool, error)
+	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+	Close()
+}
+
+// NoOpConductor is a no-op conductor that assumes this node is the leader sequencer.
+type NoOpConductor struct{}
+
+// Leader returns true if this node is the leader sequencer. NoOpConductor always returns true.
+func (c *NoOpConductor) Leader(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+// CommitUnsafePayload commits an unsafe payload to the conductor log.
+func (c *NoOpConductor) CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	return nil
+}
+
+// Close closes the conductor client.
+func (c *NoOpConductor) Close() {}

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -170,7 +171,7 @@ func (e *EngineController) StartPayload(ctx context.Context, parent eth.L2BlockR
 	return BlockInsertOK, nil
 }
 
-func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
+func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
 	if e.buildingID == (eth.PayloadID{}) {
 		return nil, BlockInsertPrestateErr, fmt.Errorf("cannot complete payload building: not currently building a payload")
 	}
@@ -184,7 +185,7 @@ func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.Asy
 	}
 	// Update the safe head if the payload is built with the last attributes in the batch.
 	updateSafe := e.buildingSafe && e.safeAttrs != nil && e.safeAttrs.isLastInSpan
-	envelope, errTyp, err := confirmPayload(ctx, e.log, e.engine, fc, e.buildingID, updateSafe, agossip)
+	envelope, errTyp, err := confirmPayload(ctx, e.log, e.engine, fc, e.buildingID, updateSafe, agossip, sequencerConductor)
 	if err != nil {
 		return nil, errTyp, fmt.Errorf("failed to complete building on top of L2 chain %s, id: %s, error (%d): %w", e.buildingOnto, e.buildingID, errTyp, err)
 	}

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -68,7 +69,7 @@ type EngineControl interface {
 	// If updateSafe, the resulting block will be marked as a safe block.
 	StartPayload(ctx context.Context, parent eth.L2BlockRef, attrs *AttributesWithParent, updateSafe bool) (errType BlockInsertionErrType, err error)
 	// ConfirmPayload requests the engine to complete the current block. If no block is being built, or if it fails, an error is returned.
-	ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error)
+	ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error)
 	// CancelPayload requests the engine to stop building the current block without making it canonical.
 	// This is optional, as the engine expires building jobs that are left uncompleted, but can still save resources.
 	CancelPayload(ctx context.Context, force bool) error
@@ -537,7 +538,7 @@ func (eq *EngineQueue) forceNextSafeAttributes(ctx context.Context) error {
 	lastInSpan := eq.safeAttributes.isLastInSpan
 	errType, err := eq.StartPayload(ctx, eq.ec.PendingSafeL2Head(), eq.safeAttributes, true)
 	if err == nil {
-		_, errType, err = eq.ec.ConfirmPayload(ctx, async.NoOpGossiper{})
+		_, errType, err = eq.ec.ConfirmPayload(ctx, async.NoOpGossiper{}, &conductor.NoOpConductor{})
 	}
 	if err != nil {
 		switch errType {
@@ -590,8 +591,8 @@ func (eq *EngineQueue) StartPayload(ctx context.Context, parent eth.L2BlockRef, 
 	return eq.ec.StartPayload(ctx, parent, attrs, updateSafe)
 }
 
-func (eq *EngineQueue) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
-	return eq.ec.ConfirmPayload(ctx, agossip)
+func (eq *EngineQueue) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
+	return eq.ec.ConfirmPayload(ctx, agossip, sequencerConductor)
 }
 
 func (eq *EngineQueue) CancelPayload(ctx context.Context, force bool) error {

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -1003,7 +1004,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	eng.ExpectForkchoiceUpdate(postFc, nil, postFcRes, nil)
 
 	// Now complete the job, as external user of the engine
-	_, _, err = eq.ConfirmPayload(context.Background(), async.NoOpGossiper{})
+	_, _, err = eq.ConfirmPayload(context.Background(), async.NoOpGossiper{}, &conductor.NoOpConductor{})
 	require.NoError(t, err)
 	require.Equal(t, refA1, ec.SafeL2Head(), "safe head should have changed")
 

--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -126,6 +127,7 @@ func confirmPayload(
 	id eth.PayloadID,
 	updateSafe bool,
 	agossip async.AsyncGossiper,
+	sequencerConductor conductor.SequencerConductor,
 ) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
 	var envelope *eth.ExecutionPayloadEnvelope
 	// if the payload is available from the async gossiper, it means it was not yet imported, so we reuse it
@@ -147,6 +149,9 @@ func confirmPayload(
 	payload := envelope.ExecutionPayload
 	if err := sanityCheckPayload(payload); err != nil {
 		return nil, BlockInsertPayloadErr, err
+	}
+	if err := sequencerConductor.CommitUnsafePayload(ctx, envelope); err != nil {
+		return nil, BlockInsertTemporaryErr, fmt.Errorf("failed to commit unsafe payload to conductor: %w", err)
 	}
 	// begin gossiping as soon as possible
 	// agossip.Clear() will be called later if an non-temporary error is found, or if the payload is successfully inserted

--- a/op-node/rollup/driver/metered_engine.go
+++ b/op-node/rollup/driver/metered_engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -61,10 +62,10 @@ func (m *MeteredEngine) StartPayload(ctx context.Context, parent eth.L2BlockRef,
 	return errType, err
 }
 
-func (m *MeteredEngine) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
+func (m *MeteredEngine) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
 	sealingStart := time.Now()
 	// Actually execute the block and add it to the head of the chain.
-	payload, errType, err := m.inner.ConfirmPayload(ctx, agossip)
+	payload, errType, err := m.inner.ConfirmPayload(ctx, agossip, sequencerConductor)
 	if err != nil {
 		m.metrics.RecordSequencingError()
 		return payload, errType, err

--- a/op-node/rollup/driver/sequencer_test.go
+++ b/op-node/rollup/driver/sequencer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -74,7 +75,7 @@ func (m *FakeEngineControl) StartPayload(ctx context.Context, parent eth.L2Block
 	return derive.BlockInsertOK, nil
 }
 
-func (m *FakeEngineControl) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
+func (m *FakeEngineControl) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
 	if m.err != nil {
 		return nil, m.errTyp, m.err
 	}
@@ -345,7 +346,7 @@ func TestSequencerChaosMonkey(t *testing.T) {
 		default:
 			// no error
 		}
-		payload, err := seq.RunNextSequencerAction(context.Background(), async.NoOpGossiper{})
+		payload, err := seq.RunNextSequencerAction(context.Background(), async.NoOpGossiper{}, &conductor.NoOpConductor{})
 		// RunNextSequencerAction passes ErrReset & ErrCritical through.
 		// Only suppress ErrReset, not ErrCritical
 		if !errors.Is(err, derive.ErrReset) {

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -103,10 +103,19 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		Sync:              *syncConfig,
 		RollupHalt:        haltOption,
 		RethDBPath:        ctx.String(flags.L1RethDBPath.Name),
+
+		ConductorEnabled:    ctx.Bool(flags.ConductorEnabledFlag.Name),
+		ConductorRpc:        ctx.String(flags.ConductorRpcFlag.Name),
+		ConductorRpcTimeout: ctx.Duration(flags.ConductorRpcTimeoutFlag.Name),
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {
 		return nil, fmt.Errorf("failed to load driver config: %w", err)
+	}
+
+	// conductor controls the sequencer state
+	if cfg.ConductorEnabled {
+		cfg.Driver.SequencerStopped = true
 	}
 
 	if err := cfg.Check(); err != nil {

--- a/op-service/dial/dial.go
+++ b/op-service/dial/dial.go
@@ -47,6 +47,15 @@ func DialRollupClientWithTimeout(ctx context.Context, timeout time.Duration, log
 	return sources.NewRollupClient(client.NewBaseRPCClient(rpcCl)), nil
 }
 
+// DialRPCClientWithTimeout attempts to dial the RPC provider using the provided URL.
+// If the dial doesn't complete within timeout seconds, this method will return an error.
+func DialRPCClientWithTimeout(ctx context.Context, timeout time.Duration, log log.Logger, url string) (*rpc.Client, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return dialRPCClientWithBackoff(ctx, log, url)
+}
+
 // Dials a JSON-RPC endpoint repeatedly, with a backoff, until a client connection is established. Auth is optional.
 func dialRPCClientWithBackoff(ctx context.Context, log log.Logger, addr string) (*rpc.Client, error) {
 	bOff := retry.Fixed(defaultRetryTime)


### PR DESCRIPTION
**Description**

Adds an op-conductor rpc hook to op-node driver that is used to determine if the node is the leader sequencer or not and commit the unsafe payload to the conductor cluster FSM, before publishing unsafe data via p2p. The FSM state acts as the canonical latest unsafe head which can be used as start point for leadership changes. This commit must happen before publishing so that if the leader fails over, we don't have any ambiguity on which block to start sequencing from on the new leader. The commit will fail if the calling sequencer is not the leader.

This feature is enabled by new set of configurations, and when left disabled doesn't change any existing behaviours.  

**Tests**

The client is quite simple and the existing driver has no unit test fixture. Will be adding e2e tests for these conductor calls in a future PR.

**Additional context**

https://docs.google.com/document/d/1n3TtOi3Y2hUCBkRZqds-eKjQHEu7-n5sHinL8xI-rVE

**Metadata**

- ethereum-optimism/protocol-quest/issues/44