### PR TITLE
op-program: Retry offline FPP execution during verify-goerli when flakes are detected

### DIFF
--- a/op-preimage/oracle.go
+++ b/op-preimage/oracle.go
@@ -19,6 +19,8 @@ func NewOracleClient(rw io.ReadWriter) *OracleClient {
 
 var _ Oracle = (*OracleClient)(nil)
 
+var ErrPreimageRead = fmt.Errorf("pre-image length read error")
+
 func (o *OracleClient) Get(key Key) []byte {
 	h := key.PreimageKey()
 	if _, err := o.rw.Write(h[:]); err != nil {
@@ -27,7 +29,7 @@ func (o *OracleClient) Get(key Key) []byte {
 
 	var length uint64
 	if err := binary.Read(o.rw, binary.BigEndian, &length); err != nil {
-		panic(fmt.Errorf("failed to read pre-image length of key %s (%T) from pre-image oracle: %w", key, key, err))
+		panic(fmt.Errorf("%s: key %s (%T) from pre-image oracle: %w", ErrPreimageRead.Error(), key, key, err))
 	}
 	payload := make([]byte, length)
 	if _, err := io.ReadFull(o.rw, payload); err != nil {


### PR DESCRIPTION
FPP runs outside of Cannon are not deterministic. This non-determinism can induce different sets of pre-images to be loaded across runs. The pre-images loaded are not used directly during derivation, but rather are used as a side effect. Depending on the order state is accessed in op-geth (which isn't nonrandom when iterating maps in Go), different pre-images are loaded during each run.

When an offline FPP program is executed as a child process, it will access state in a different order each time. One of these order of state accesses will "correctly" use the same pre-images that were pre-loaded by the online FPP run. So the fix is to retry offline execution whenever we observe that a pre-image is unavailable.

fixes https://github.com/ethereum-optimism/client-pod/issues/348