### PR TITLE
feat(ops): Reproducible Prestate Build With Output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,15 @@ jobs:
               $DOCKER_OUTPUT_DESTINATION \
               <<parameters.docker_name>>
 
+            # Create the easily reproducible absolute prestate
+            DOCKER_BUILDKIT=1 \
+            DOCKER_OUTPUT_DESTINATION="" \
+            docker buildx bake \
+            --set op-program-mips.output=. \
+            --progress plain \
+            -f docker-bake.hcl \
+            op-program-mips
+
           no_output_timeout: 45m
       - when:
           condition: "<<parameters.publish>>"

--- a/op-program/Dockerfile.mips
+++ b/op-program/Dockerfile.mips
@@ -1,6 +1,15 @@
 ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
 FROM $OP_STACK_GO_BUILDER as builder
 
-COPY --from=builder /usr/local/bin/op-program /usr/local/bin/op-program
+COPY --from=builder /usr/local/bin/cannon /usr/local/bin/cannon
+COPY --from=builder /usr/local/bin/op-program-client.elf /usr/local/bin/op-program-client.elf
+COPY --from=builder /usr/local/bin/meta.json /usr/local/bin/meta.json
 
-CMD ["op-program"]
+RUN cannon load-elf --path /usr/local/bin/op-program-client.elf --out /usr/local/bin/prestate.json --meta /usr/local/bin/meta.json
+
+
+CMD ["cannon"]
+
+	./cannon/bin/
+	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate.json --meta op-program/bin/meta.json --proof-fmt 'op-program/bin/%d.json' --output ""
+	mv op-program/bin/0.json op-program/bin/prestate-proof.json

--- a/op-program/Dockerfile.mips
+++ b/op-program/Dockerfile.mips
@@ -1,15 +1,18 @@
 ARG OP_STACK_GO_BUILDER=us-docker.pkg.dev/oplabs-tools-artifacts/images/op-stack-go:latest
 FROM $OP_STACK_GO_BUILDER as builder
 
-COPY --from=builder /usr/local/bin/cannon /usr/local/bin/cannon
-COPY --from=builder /usr/local/bin/op-program-client.elf /usr/local/bin/op-program-client.elf
-COPY --from=builder /usr/local/bin/meta.json /usr/local/bin/meta.json
+# Run the op-program-client.elf binary directly through cannon's load-elf subcommand.
+RUN cannon load-elf --path /usr/local/bin/op-program-client.elf --out /usr/local/bin/prestate.json --meta ""
 
-RUN cannon load-elf --path /usr/local/bin/op-program-client.elf --out /usr/local/bin/prestate.json --meta /usr/local/bin/meta.json
+# Generate the prestate proof.
+RUN cannon run --proof-at '=0' --stop-at '=1' --input /usr/local/bin/prestate.json --meta "" --proof-fmt '/usr/local/bin/%d.json' --output ""
+RUN mv /usr/local/bin/0.json /usr/local/bin/prestate-proof.json
 
-
-CMD ["cannon"]
-
-	./cannon/bin/
-	./cannon/bin/cannon run --proof-at '=0' --stop-at '=1' --input op-program/bin/prestate.json --meta op-program/bin/meta.json --proof-fmt 'op-program/bin/%d.json' --output ""
-	mv op-program/bin/0.json op-program/bin/prestate-proof.json
+# Export the prestate.json file to the specified output location.
+# The output location can be overridden by setting the target's output.
+# e.g. `docker buildx bake --set op-program-mips.output=.`
+# Additionally, writing files to host requires buildkit to be enabled.
+# e.g. `BUILDKIT=1 docker build ...`
+FROM scratch AS export-stage
+COPY --from=builder /usr/local/bin/prestate.json .
+COPY --from=builder /usr/local/bin/prestate-proof.json .

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -75,6 +75,7 @@ FROM alpine:3.18
 
 COPY --from=builder /app/cannon/bin/cannon /usr/local/bin/
 COPY --from=builder /app/op-program/bin/op-program /usr/local/bin/
+COPY --from=builder /app/op-program/bin/op-program-client.elf /usr/local/bin/
 
 COPY --from=builder /app/op-heartbeat/bin/op-heartbeat /usr/local/bin/
 COPY --from=builder /app/op-wheel/bin/op-wheel /usr/local/bin/

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -49,9 +49,10 @@ ARG TARGETOS TARGETARCH
 
 RUN --mount=type=cache,target=/root/.cache/go-build cd cannon && make cannon  \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$CANNON_VERSION"
-# note: we only build the host, that's all the user needs. No Go MIPS cross-build in docker
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-host  \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
+RUN --mount=type=cache,target=/root/.cache/go-build cd op-program && make op-program-client-mips  \
+    GOOS=linux GOARCH=mips GOMIPS=softfloat GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_PROGRAM_VERSION"
 
 RUN --mount=type=cache,target=/root/.cache/go-build cd op-heartbeat && make op-heartbeat  \
     GOOS=$TARGETOS GOARCH=$TARGETARCH GITCOMMIT=$GIT_COMMIT GITDATE=$GIT_DATE VERSION="$OP_HEARTBEAT_VERSION"


### PR DESCRIPTION
**Description**

Makes the op-program absolute prestate run through cannon's `load-elf` subcommand reproducible through a mips32 be architecture docker container. The added ci command outputs `prestate.json` and `prestate-proof.json` files as defined in the op-program's new `Dockerfile.mips` dockerfile.

**Metadata**

Progresses https://github.com/ethereum-optimism/client-pod/issues/442