### PR TITLE
fix(sdk): bug with unsupported fields

### DIFF
--- a/.changeset/silly-jokes-shake.md
+++ b/.changeset/silly-jokes-shake.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/sdk': patch
+---
+
+Fixes a bug in the SDK that would fail if unsupported fields were provided.

--- a/packages/sdk/src/l2-provider.ts
+++ b/packages/sdk/src/l2-provider.ts
@@ -72,7 +72,16 @@ export const estimateL1Gas = async (
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1GasUsed(
     serialize({
-      ...tx,
+      to: tx.to,
+      gasLimit: tx.gasLimit,
+      gasPrice: tx.gasPrice,
+      maxFeePerGas: tx.maxFeePerGas,
+      maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+      data: tx.data,
+      value: tx.value,
+      chainId: tx.chainId,
+      type: tx.type,
+      accessList: tx.accessList,
       nonce: tx.nonce
         ? BigNumber.from(tx.nonce).toNumber()
         : await getNonceForTx(l2Provider, tx),
@@ -94,7 +103,16 @@ export const estimateL1GasCost = async (
   const gpo = connectGasPriceOracle(l2Provider)
   return gpo.getL1Fee(
     serialize({
-      ...tx,
+      to: tx.to,
+      gasLimit: tx.gasLimit,
+      gasPrice: tx.gasPrice,
+      maxFeePerGas: tx.maxFeePerGas,
+      maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+      data: tx.data,
+      value: tx.value,
+      chainId: tx.chainId,
+      type: tx.type,
+      accessList: tx.accessList,
       nonce: tx.nonce
         ? BigNumber.from(tx.nonce).toNumber()
         : await getNonceForTx(l2Provider, tx),


### PR DESCRIPTION
Fixes a bug that was introduced in a recent fix. The input type (TransactionRequest) sometimes has fields that are not supported by the UnsignedTransaction type. This fix explicitly uses the fields of the UnsignedTransaction type to resolve this issue.

Fixes #8890 