### PR TITLE
op-node: Gossip Before Import

### DIFF
--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
@@ -107,7 +108,7 @@ func (s *L2Sequencer) ActL2EndBlock(t Testing) {
 	}
 	s.l2Building = false
 
-	_, err := s.sequencer.CompleteBuildingBlock(t.Ctx())
+	_, err := s.sequencer.CompleteBuildingBlock(t.Ctx(), async.NoOpGossiper{})
 	// TODO: there may be legitimate temporary errors here, if we mock engine API RPC-failure.
 	// For advanced tests we can catch those and print a warning instead.
 	require.NoError(t, err)

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -1,0 +1,161 @@
+package async
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type AsyncGossiper interface {
+	Gossip(payload *eth.ExecutionPayloadEnvelope)
+	Get() *eth.ExecutionPayloadEnvelope
+	Clear()
+	Stop()
+	Start()
+}
+
+// SimpleAsyncGossiper is a component that stores and gossips a single payload at a time
+// it uses a separate goroutine to handle gossiping the payload asynchronously
+// the payload can be accessed by the Get function to be reused when the payload was gossiped but not inserted
+// exposed functions are synchronous, and block until the async routine is able to start handling the request
+type SimpleAsyncGossiper struct {
+	running atomic.Bool
+	// channel to add new payloads to gossip
+	set chan *eth.ExecutionPayloadEnvelope
+	// channel to request getting the currently gossiping payload
+	get chan chan *eth.ExecutionPayloadEnvelope
+	// channel to request clearing the currently gossiping payload
+	clear chan struct{}
+	// channel to request stopping the handling loop
+	stop chan struct{}
+
+	currentPayload *eth.ExecutionPayloadEnvelope
+	ctx            context.Context
+	net            Network
+	log            log.Logger
+	metrics        Metrics
+}
+
+// To avoid import cycles, we define a new Network interface here
+// this interface is compatable with driver.Network
+type Network interface {
+	PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
+}
+
+// To avoid import cycles, we define a new Metrics interface here
+// this interface is compatable with driver.Metrics
+type Metrics interface {
+	RecordPublishingError()
+}
+
+func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics Metrics) *SimpleAsyncGossiper {
+	return &SimpleAsyncGossiper{
+		running: atomic.Bool{},
+		set:     make(chan *eth.ExecutionPayloadEnvelope),
+		get:     make(chan chan *eth.ExecutionPayloadEnvelope),
+		clear:   make(chan struct{}),
+		stop:    make(chan struct{}),
+
+		currentPayload: nil,
+		net:            net,
+		ctx:            ctx,
+		log:            log,
+		metrics:        metrics,
+	}
+}
+
+// Gossip is a synchronous function to store and gossip a payload
+// it blocks until the payload can be taken by the async routine
+func (p *SimpleAsyncGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {
+	p.set <- payload
+}
+
+// Get is a synchronous function to get the currently held payload
+// it blocks until the async routine is able to return the payload
+func (p *SimpleAsyncGossiper) Get() *eth.ExecutionPayloadEnvelope {
+	c := make(chan *eth.ExecutionPayloadEnvelope)
+	p.get <- c
+	return <-c
+}
+
+// Clear is a synchronous function to clear the currently gossiping payload
+// it blocks until the signal to clear is picked up by the async routine
+func (p *SimpleAsyncGossiper) Clear() {
+	p.clear <- struct{}{}
+}
+
+// Stop is a synchronous function to stop the async routine
+// it blocks until the async routine accepts the signal
+func (p *SimpleAsyncGossiper) Stop() {
+	p.stop <- struct{}{}
+}
+
+// Start starts the AsyncGossiper's gossiping loop on a separate goroutine
+// each behavior of the loop is handled by a select case on a channel, plus an internal handler function call
+func (p *SimpleAsyncGossiper) Start() {
+	// if the gossiping is already running, return
+	if p.running.Load() {
+		return
+	}
+	p.running.Store(true)
+	// else, start the handling loop
+	go func() {
+		defer p.running.Store(false)
+		for {
+			select {
+			// new payloads to be gossiped are found in the `set` channel
+			case payload := <-p.set:
+				p.gossip(p.ctx, payload)
+			// requests to get the current payload are found in the `get` channel
+			case c := <-p.get:
+				p.getPayload(c)
+			// requests to clear the current payload are found in the `clear` channel
+			case <-p.clear:
+				p.clearPayload()
+			// if the context is done, return
+			case <-p.stop:
+				return
+			}
+		}
+	}()
+}
+
+// gossip is the internal handler function for gossiping the current payload
+// and storing the payload in the async AsyncGossiper's state
+// it is called by the Start loop when a new payload is set
+// the payload is only stored if the publish is successful
+func (p *SimpleAsyncGossiper) gossip(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) {
+	if err := p.net.PublishL2Payload(ctx, payload); err == nil {
+		p.currentPayload = payload
+	} else {
+		p.log.Warn("failed to publish newly created block",
+			"id", payload.ExecutionPayload.ID(),
+			"hash", payload.ExecutionPayload.BlockHash,
+			"err", err)
+		p.metrics.RecordPublishingError()
+	}
+}
+
+// getPayload is the internal handler function for getting the current payload
+// c is the channel the caller expects to receive the payload on
+func (p *SimpleAsyncGossiper) getPayload(c chan *eth.ExecutionPayloadEnvelope) {
+	c <- p.currentPayload
+}
+
+// clearPayload is the internal handler function for clearing the current payload
+func (p *SimpleAsyncGossiper) clearPayload() {
+	p.currentPayload = nil
+}
+
+// NoOpGossiper is a no-op implementation of AsyncGossiper
+// it serves as a placeholder for when the AsyncGossiper is not needed
+type NoOpGossiper struct{}
+
+func (NoOpGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {}
+func (NoOpGossiper) Get() *eth.ExecutionPayloadEnvelope           { return nil }
+func (NoOpGossiper) Clear()                                       {}
+func (NoOpGossiper) Stop()                                        {}
+func (NoOpGossiper) Start()                                       {}

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -1,0 +1,149 @@
+package async
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type mockNetwork struct {
+	reqs []*eth.ExecutionPayloadEnvelope
+}
+
+func (m *mockNetwork) PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	m.reqs = append(m.reqs, payload)
+	return nil
+}
+
+type mockMetrics struct{}
+
+func (m *mockMetrics) RecordPublishingError() {}
+
+// TestAsyncGossiper tests the AsyncGossiper component
+// because the component is small and simple, it is tested as a whole
+// this test starts, runs, clears and stops the AsyncGossiper
+// because the AsyncGossiper is run in an async component, it is tested with eventually
+func TestAsyncGossiper(t *testing.T) {
+	m := &mockNetwork{}
+	// Create a new instance of AsyncGossiper
+	p := NewAsyncGossiper(context.Background(), m, log.New(), &mockMetrics{})
+
+	// Start the AsyncGossiper
+	p.Start()
+
+	// Test that the AsyncGossiper is running within a short duration
+	require.Eventually(t, func() bool {
+		return p.running.Load()
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// send a payload
+	payload := &eth.ExecutionPayload{
+		BlockNumber: hexutil.Uint64(1),
+	}
+	envelope := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: payload,
+	}
+	p.Gossip(envelope)
+	require.Eventually(t, func() bool {
+		// Test that the gossiper has content at all
+		return p.Get() == envelope &&
+			// Test that the payload has been sent to the (mock) network
+			m.reqs[0] == envelope
+	}, 10*time.Second, 10*time.Millisecond)
+
+	p.Clear()
+	require.Eventually(t, func() bool {
+		// Test that the gossiper has no payload
+		return p.Get() == nil
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Stop the AsyncGossiper
+	p.Stop()
+
+	// Test that the AsyncGossiper stops within a short duration
+	require.Eventually(t, func() bool {
+		return !p.running.Load()
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+// TestAsyncGossiperLoop confirms that when called repeatedly, the AsyncGossiper holds the latest payload
+// and sends all payloads to the network
+func TestAsyncGossiperLoop(t *testing.T) {
+	m := &mockNetwork{}
+	// Create a new instance of AsyncGossiper
+	p := NewAsyncGossiper(context.Background(), m, log.New(), &mockMetrics{})
+
+	// Start the AsyncGossiper
+	p.Start()
+
+	// Test that the AsyncGossiper is running within a short duration
+	require.Eventually(t, func() bool {
+		return p.running.Load()
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// send multiple payloads
+	for i := 0; i < 10; i++ {
+		payload := &eth.ExecutionPayload{
+			BlockNumber: hexutil.Uint64(i),
+		}
+		envelope := &eth.ExecutionPayloadEnvelope{
+			ExecutionPayload: payload,
+		}
+		p.Gossip(envelope)
+		require.Eventually(t, func() bool {
+			// Test that the gossiper has content at all
+			return p.Get() == envelope &&
+				// Test that the payload has been sent to the (mock) network
+				m.reqs[len(m.reqs)-1] == envelope
+		}, 10*time.Second, 10*time.Millisecond)
+	}
+	require.Equal(t, 10, len(m.reqs))
+	// Stop the AsyncGossiper
+	p.Stop()
+	// Test that the AsyncGossiper stops within a short duration
+	require.Eventually(t, func() bool {
+		return !p.running.Load()
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+// failingNetwork is a mock network that always fails to publish
+type failingNetwork struct{}
+
+func (f *failingNetwork) PublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	return errors.New("failed to publish")
+}
+
+// TestAsyncGossiperFailToPublish tests that the AsyncGossiper clears the stored payload if the network fails
+func TestAsyncGossiperFailToPublish(t *testing.T) {
+	m := &failingNetwork{}
+	// Create a new instance of AsyncGossiper
+	p := NewAsyncGossiper(context.Background(), m, log.New(), &mockMetrics{})
+
+	// Start the AsyncGossiper
+	p.Start()
+
+	// send a payload
+	payload := &eth.ExecutionPayload{
+		BlockNumber: hexutil.Uint64(1),
+	}
+	envelope := &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: payload,
+	}
+	p.Gossip(envelope)
+	// Rather than expect the payload to become available, we should never see it, due to the publish failure
+	require.Never(t, func() bool {
+		return p.Get() == envelope
+	}, 10*time.Second, 10*time.Millisecond)
+	// Stop the AsyncGossiper
+	p.Stop()
+	// Test that the AsyncGossiper stops within a short duration
+	require.Eventually(t, func() bool {
+		return !p.running.Load()
+	}, 10*time.Second, 10*time.Millisecond)
+}

--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -67,7 +68,7 @@ type EngineControl interface {
 	// If updateSafe, the resulting block will be marked as a safe block.
 	StartPayload(ctx context.Context, parent eth.L2BlockRef, attrs *AttributesWithParent, updateSafe bool) (errType BlockInsertionErrType, err error)
 	// ConfirmPayload requests the engine to complete the current block. If no block is being built, or if it fails, an error is returned.
-	ConfirmPayload(ctx context.Context) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error)
+	ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error)
 	// CancelPayload requests the engine to stop building the current block without making it canonical.
 	// This is optional, as the engine expires building jobs that are left uncompleted, but can still save resources.
 	CancelPayload(ctx context.Context, force bool) error
@@ -536,7 +537,7 @@ func (eq *EngineQueue) forceNextSafeAttributes(ctx context.Context) error {
 	lastInSpan := eq.safeAttributes.isLastInSpan
 	errType, err := eq.StartPayload(ctx, eq.ec.PendingSafeL2Head(), eq.safeAttributes, true)
 	if err == nil {
-		_, errType, err = eq.ec.ConfirmPayload(ctx)
+		_, errType, err = eq.ec.ConfirmPayload(ctx, async.NoOpGossiper{})
 	}
 	if err != nil {
 		switch errType {
@@ -589,8 +590,8 @@ func (eq *EngineQueue) StartPayload(ctx context.Context, parent eth.L2BlockRef, 
 	return eq.ec.StartPayload(ctx, parent, attrs, updateSafe)
 }
 
-func (eq *EngineQueue) ConfirmPayload(ctx context.Context) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
-	return eq.ec.ConfirmPayload(ctx)
+func (eq *EngineQueue) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
+	return eq.ec.ConfirmPayload(ctx, agossip)
 }
 
 func (eq *EngineQueue) CancelPayload(ctx context.Context, force bool) error {

--- a/op-node/rollup/derive/engine_queue_test.go
+++ b/op-node/rollup/derive/engine_queue_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -1002,7 +1003,7 @@ func TestBlockBuildingRace(t *testing.T) {
 	eng.ExpectForkchoiceUpdate(postFc, nil, postFcRes, nil)
 
 	// Now complete the job, as external user of the engine
-	_, _, err = eq.ConfirmPayload(context.Background())
+	_, _, err = eq.ConfirmPayload(context.Background(), async.NoOpGossiper{})
 	require.NoError(t, err)
 	require.Equal(t, refA1, ec.SafeL2Head(), "safe head should have changed")
 

--- a/op-node/rollup/driver/metered_engine.go
+++ b/op-node/rollup/driver/metered_engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -60,10 +61,10 @@ func (m *MeteredEngine) StartPayload(ctx context.Context, parent eth.L2BlockRef,
 	return errType, err
 }
 
-func (m *MeteredEngine) ConfirmPayload(ctx context.Context) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
+func (m *MeteredEngine) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
 	sealingStart := time.Now()
 	// Actually execute the block and add it to the head of the chain.
-	payload, errType, err := m.inner.ConfirmPayload(ctx)
+	payload, errType, err := m.inner.ConfirmPayload(ctx, agossip)
 	if err != nil {
 		m.metrics.RecordSequencingError()
 		return payload, errType, err

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -113,8 +114,8 @@ func (d *Sequencer) StartBuildingBlock(ctx context.Context) error {
 // CompleteBuildingBlock takes the current block that is being built, and asks the engine to complete the building, seal the block, and persist it as canonical.
 // Warning: the safe and finalized L2 blocks as viewed during the initiation of the block building are reused for completion of the block building.
 // The Execution engine should not change the safe and finalized blocks between start and completion of block building.
-func (d *Sequencer) CompleteBuildingBlock(ctx context.Context) (*eth.ExecutionPayloadEnvelope, error) {
-	envelope, errTyp, err := d.engine.ConfirmPayload(ctx)
+func (d *Sequencer) CompleteBuildingBlock(ctx context.Context, agossip async.AsyncGossiper) (*eth.ExecutionPayloadEnvelope, error) {
+	envelope, errTyp, err := d.engine.ConfirmPayload(ctx, agossip)
 	if err != nil {
 		return nil, fmt.Errorf("failed to complete building block: error (%d): %w", errTyp, err)
 	}
@@ -203,15 +204,16 @@ func (d *Sequencer) BuildingOnto() eth.L2BlockRef {
 // If the derivation pipeline does force a conflicting block, then an ongoing sequencer task might still finish,
 // but the derivation can continue to reset until the chain is correct.
 // If the engine is currently building safe blocks, then that building is not interrupted, and sequencing is delayed.
-func (d *Sequencer) RunNextSequencerAction(ctx context.Context) (*eth.ExecutionPayloadEnvelope, error) {
-	if onto, buildingID, safe := d.engine.BuildingPayload(); buildingID != (eth.PayloadID{}) {
+func (d *Sequencer) RunNextSequencerAction(ctx context.Context, agossip async.AsyncGossiper) (*eth.ExecutionPayloadEnvelope, error) {
+	// if the engine returns a non-empty payload, OR if the async gossiper already has a payload, we can CompleteBuildingBlock
+	if onto, buildingID, safe := d.engine.BuildingPayload(); buildingID != (eth.PayloadID{}) || agossip.Get() != nil {
 		if safe {
 			d.log.Warn("avoiding sequencing to not interrupt safe-head changes", "onto", onto, "onto_time", onto.Time)
 			// approximates the worst-case time it takes to build a block, to reattempt sequencing after.
 			d.nextAction = d.timeNow().Add(time.Second * time.Duration(d.rollupCfg.BlockTime))
 			return nil, nil
 		}
-		envelope, err := d.CompleteBuildingBlock(ctx)
+		envelope, err := d.CompleteBuildingBlock(ctx, agossip)
 		if err != nil {
 			if errors.Is(err, derive.ErrCritical) {
 				return nil, err // bubble up critical errors.

--- a/op-node/rollup/driver/sequencer_test.go
+++ b/op-node/rollup/driver/sequencer_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
@@ -73,7 +74,7 @@ func (m *FakeEngineControl) StartPayload(ctx context.Context, parent eth.L2Block
 	return derive.BlockInsertOK, nil
 }
 
-func (m *FakeEngineControl) ConfirmPayload(ctx context.Context) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
+func (m *FakeEngineControl) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper) (out *eth.ExecutionPayloadEnvelope, errTyp derive.BlockInsertionErrType, err error) {
 	if m.err != nil {
 		return nil, m.errTyp, m.err
 	}
@@ -344,7 +345,7 @@ func TestSequencerChaosMonkey(t *testing.T) {
 		default:
 			// no error
 		}
-		payload, err := seq.RunNextSequencerAction(context.Background())
+		payload, err := seq.RunNextSequencerAction(context.Background(), async.NoOpGossiper{})
 		// RunNextSequencerAction passes ErrReset & ErrCritical through.
 		// Only suppress ErrReset, not ErrCritical
 		if !errors.Is(err, derive.ErrReset) {


### PR DESCRIPTION
# What
Adds "Async Gossiper" component to the derivation pipeline, and wires it into the state loop and related interfaces.

# Why
There is interest in gossiping earlier in the derivation pipeline. Currently, the flow is:
* Engine Controller receives a block
* Engine Controller reinserts that block
* State Loop Continues
* Block is gossiped

We would like to insert the gossiping of the block between the receiving and reinserting of the block to avoid waiting any longer than needed before gossiping.

# How
A new component has been written and added to the Driver. This component, the AsyncGossiper, is an asynchronous worker with a synchronized interface for Gossiping. The Driver passes this component down through the layers, and is used during the internal `confirmPayload` work.

It also stores and can return the most recently gossiped payload. This feature allows for the derivation pipeline to reuse a payload which was created during `confirmPayload`, if the insertion failed. This is done because we want to avoid regenerating a new block at the same height if we've already begun gossiping this one. As the component is passed down through the layers, it is used by `RunNextSequencerAction` to decide if there's already a usable block, and by `confirmPayload` to potentially get a cached block instead of asking the engine to rebuild one.

When the `confirmPayload` function is able to reinsert the payload, it calls `Clear` on this component, which wipes out the stored payload. This is because the AsyncGossiper only needs to know about the payload from the time it exists, to the time it has been inserted, and any re-attempts that may live in between those two points.

# Testing
* unit test was added demonstrating the basic functionality of the component
* unit test was added demonstrating that repeated calls to the component work
* unit test was added demonstrating that if the publishing fails, the payload is not saved

# Notes, Nuance, Concerns
* Adding this component created a lot of interface changes. That may indicate that it's integrated suboptimally, but because it's used in multiple locations in the pipeline, having it owned by the Driver and passed down made the most sense to me.
* Code paths which don't need or use an AsyncGossiper supply `nil` as needed. There's a `nil` check prior to use which should guard against NPEs
* The component lives in its own package `rollout/async` due to import cycle issues.
* This PR may need to rebase or refactor onto changes being actively made by @trianglesphere and changes related to the development of EIP4844