### PR TITLE
contracts-bedrock: cleanup libraries

### DIFF
--- a/packages/contracts-bedrock/src/libraries/Arithmetic.sol
+++ b/packages/contracts-bedrock/src/libraries/Arithmetic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { SignedMath } from "@openzeppelin/contracts/utils/math/SignedMath.sol";
 import { FixedPointMathLib } from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";

--- a/packages/contracts-bedrock/src/libraries/Burn.sol
+++ b/packages/contracts-bedrock/src/libraries/Burn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 /// @title Burn
 /// @notice Utilities for burning stuff.

--- a/packages/contracts-bedrock/src/libraries/Burn.sol
+++ b/packages/contracts-bedrock/src/libraries/Burn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.15;
 
 /// @title Burn
 /// @notice Utilities for burning stuff.

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ResourceMetering } from "../L1/ResourceMetering.sol";
+import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 
 /// @title Constants
 /// @notice Constants is a library for storing constants. Simple! Don't put everything in here, just

--- a/packages/contracts-bedrock/src/libraries/DisputeErrors.sol
+++ b/packages/contracts-bedrock/src/libraries/DisputeErrors.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import "./DisputeTypes.sol";
+import "src/libraries/DisputeTypes.sol";
 
 ////////////////////////////////////////////////////////////////
 //                `DisputeGameFactory` Errors                 //

--- a/packages/contracts-bedrock/src/libraries/Encoding.sol
+++ b/packages/contracts-bedrock/src/libraries/Encoding.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Types } from "./Types.sol";
-import { Hashing } from "./Hashing.sol";
-import { RLPWriter } from "./rlp/RLPWriter.sol";
+import { Types } from "src/libraries/Types.sol";
+import { Hashing } from "src/libraries/Hashing.sol";
+import { RLPWriter } from "src/libraries/rlp/RLPWriter.sol";
 
 /// @title Encoding
 /// @notice Encoding handles Optimism's various different encoding schemes.

--- a/packages/contracts-bedrock/src/libraries/Hashing.sol
+++ b/packages/contracts-bedrock/src/libraries/Hashing.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Types } from "./Types.sol";
-import { Encoding } from "./Encoding.sol";
+import { Types } from "src/libraries/Types.sol";
+import { Encoding } from "src/libraries/Encoding.sol";
 
 /// @title Hashing
 /// @notice Hashing handles Optimism's various different hashing schemes.


### PR DESCRIPTION
**Description**

Updates the pragma in libraries to be more permissive, making it less
complex to import the libraries into different codebases. The actual
implementations enforce a particular version, so it is safe to allow
the libs to have permissive versioning contrainsts. Also update the
code to use the absolute path for imports relative from the project
root. Using this import pattern is the standard for the codebase.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

