### PR TITLE
chore: Husky Pre-commit Hook Install for ts-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build-ts: submodules
 		. $$NVM_DIR/nvm.sh && nvm use; \
 	fi
 	pnpm install:ci
+	pnpm prepare
 	pnpm build
 .PHONY: build-ts
 


### PR DESCRIPTION
**Description**

Nuking the monorepo will remove husky hooks in `.husky/*`.

When re-building the monorepo, hooks are then not installed and commits will then error due to husky.

This pr adds the lightweight `pnpm prepare` command to the top-level `build-ts` Makefile target so husky hooks are installed when the monorepo is built.
