### PR TITLE
chore: replacing link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 There are plenty of ways to contribute, in particular we appreciate support in the following areas:
 
 - Reporting issues. For security issues see [Security policy](https://github.com/ethereum-optimism/.github/blob/master/SECURITY.md).
-- Fixing and responding to existing issues. You can start off with those tagged ["good first issue"](https://github.com/ethereum-optimism/optimism/contribute) which are meant as introductory issues for external contributors.
+- Fixing and responding to existing issues. You can start off with those tagged ["good first issue"](https://github.com/ethereum-optimism/optimism/labels/D-good-first-issue) which are meant as introductory issues for external contributors.
 - Improving the [community site](https://community.optimism.io/), [documentation](https://github.com/ethereum-optimism/community-hub) and [tutorials](https://github.com/ethereum-optimism/optimism-tutorial).
 - Become an "Optimizer" and answer questions in the [Optimism Discord](https://discord.optimism.io).
 - Get involved in the protocol design process by proposing changes or new features or write parts of the spec yourself in the [specs subdirectory](./specs/).


### PR DESCRIPTION
Previous link was https://github.com/ethereum-optimism/optimism/contribute, which is empty.
Replaced it with the list of issues labelled "D-good-first-issue".

That is all, doesn't require testing or changelog entry. Figured it would be quicker to open a quick PR like that than opening an issue and asking someone to correct it.

Have a nice evening and good etf day.

edit : it appears it is not etf day. lol.
