### PR TITLE
op-challenger: Fix metrics

### DIFF
--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -45,6 +45,9 @@ type Metricer interface {
 	DecIdleExecutors()
 }
 
+// Metrics implementation must implement RegistryMetricer to allow the metrics server to work.
+var _ opmetrics.RegistryMetricer = (*Metrics)(nil)
+
 type Metrics struct {
 	ns       string
 	registry *prometheus.Registry
@@ -68,6 +71,10 @@ type Metrics struct {
 
 	trackedGames  prometheus.GaugeVec
 	inflightGames prometheus.Gauge
+}
+
+func (m *Metrics) Registry() *prometheus.Registry {
+	return m.registry
 }
 
 var _ Metricer = (*Metrics)(nil)

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -133,6 +134,11 @@ func NewChallengerConfig(t *testing.T, l1Endpoint string, options ...Option) *co
 	if cfg.MaxConcurrency > 4 {
 		// Limit concurrency to something more reasonable when there are also multiple tests executing in parallel
 		cfg.MaxConcurrency = 4
+	}
+	cfg.MetricsConfig = metrics.CLIConfig{
+		Enabled:    true,
+		ListenAddr: "127.0.0.1",
+		ListenPort: 0, // Find any available port (avoids conflicts)
 	}
 	for _, option := range options {
 		option(&cfg)


### PR DESCRIPTION
**Description**

Add missing method to challenger metrics to fix failure on startup:

```
failed to init challenger game service: failed to init metrics server: metrics were enabled, but metricer *metrics.Metrics does not expose registry for metrics-server
```

**Tests**

Enabled metrics for challenger in e2e tests.
