### PR TITLE
feat(specs): adds L2 output root proposal section to the glossary

### DIFF
--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -4,7 +4,6 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Glossary](#glossary)
 - [General Terms](#general-terms)
   - [Layer 1 (L1)](#layer-1-l1)
   - [Layer 2 (L2)](#layer-2-l2)

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -42,6 +42,8 @@
   - [Batcher](#batcher)
   - [Batcher Transaction](#batcher-transaction)
   - [Channel Timeout](#channel-timeout)
+- [L2 Output Root Proposals](#l2-output-root-proposals)
+  - [Proposer](#proposer)
 - [L2 Chain Derivation](#l2-chain-derivation)
   - [L2 Derivation Inputs](#l2-derivation-inputs)
   - [System Configuration](#system-configuration)
@@ -497,6 +499,18 @@ The purpose of channel timeouts is dual:
 [reset-channel-buffer]: derivation.md#resetting-channel-buffering
 
 > **TODO** specify `CHANNEL_TIMEOUT`
+
+------------------------------------------------------------------------------------------------------------------------
+
+# L2 Output Root Proposals
+
+[l2-output-root-proposals]: glossary.md#l2-output-root-proposals
+
+## Proposer
+
+[proposer]: glossary.md#proposer
+
+The proposer's role is to construct and submit output roots, which are commitments to the L2's state, to the L2OutputOracle contract on L1 (the settlement layer). To do this, the proposer periodically queries the rollup node for the latest output root derived from the latest finalized L1 block. It then takes the output root and submits it to the L2OutputOracle contract on the settlement layer (L1).
 
 ------------------------------------------------------------------------------------------------------------------------
 

--- a/specs/glossary.md
+++ b/specs/glossary.md
@@ -4,6 +4,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
+- [Glossary](#glossary)
 - [General Terms](#general-terms)
   - [Layer 1 (L1)](#layer-1-l1)
   - [Layer 2 (L2)](#layer-2-l2)
@@ -510,7 +511,10 @@ The purpose of channel timeouts is dual:
 
 [proposer]: glossary.md#proposer
 
-The proposer's role is to construct and submit output roots, which are commitments to the L2's state, to the L2OutputOracle contract on L1 (the settlement layer). To do this, the proposer periodically queries the rollup node for the latest output root derived from the latest finalized L1 block. It then takes the output root and submits it to the L2OutputOracle contract on the settlement layer (L1).
+The proposer's role is to construct and submit output roots, which are commitments to the L2's state, to the
+L2OutputOracle contract on L1 (the settlement layer). To do this, the proposer periodically queries the rollup node for
+the latest output root derived from the latest finalized L1 block. It then takes the output root and submits it to the
+L2OutputOracle contract on the settlement layer (L1).
 
 ------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a L2 Output Root Proposal section and the Proposer to the glossary. I got the description from the proposals spec file.

**Tests**

n/a 

**Additional context**

 I noticed this was missing in the docs and its probably because its not listed here in the specs.

**Metadata**

- Fixes #[Link to Issue]
