### PR TITLE
interop(op-node): interop msg queue & sequencer inclusion

### DIFF
--- a/op-e2e/actions/interop_test.go
+++ b/op-e2e/actions/interop_test.go
@@ -82,4 +82,8 @@ func TestL2InteropSequencer(gt *testing.T) {
 	unconsumed, err := inbox.UnconsumedMessages(nil, common.HexToHash("0xabc"))
 	require.NoError(t, err)
 	require.True(t, unconsumed)
+
+	mintedEth, err := cl.BalanceAt(t.Ctx(), predeploys.CrossL2InboxAddr, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), mintedEth.Uint64())
 }

--- a/op-e2e/actions/interop_test.go
+++ b/op-e2e/actions/interop_test.go
@@ -1,20 +1,23 @@
 package actions
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
 
-func TestL2Interop(gt *testing.T) {
+func TestL2InteropSetup(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	interopAtGenesis := hexutil.Uint64(0)
@@ -22,15 +25,9 @@ func TestL2Interop(gt *testing.T) {
 
 	sd := e2eutils.Setup(t, dp, defaultAlloc)
 	log := testlog.Logger(t, log.LvlDebug)
-	_, engine, sequencer := setupSequencerTest(t, sd, log)
+	_, engine, _ := setupSequencerTest(t, sd, log)
+
 	cl := engine.EthClient()
-	sequencer.ActL2PipelineFull(t)
-
-	sequencer.ActL2StartBlock(t)
-	sequencer.ActL2EndBlock(t)
-
-	head := engine.l2Chain.CurrentBlock()
-	require.Less(t, uint64(0), head.Number.Uint64())
 
 	inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, cl)
 	require.NoError(t, err)
@@ -53,6 +50,36 @@ func TestL2Interop(gt *testing.T) {
 	messenger, err := sb.MESSENGER(nil)
 	require.NoError(t, err)
 	require.Equal(t, predeploys.InteropL2CrossDomainMessengerAddr, messenger, "Interop SB Messenger contract misconfigured")
+}
 
-	// This test can be extended with batch-submission, and replication by a verifier
+func TestL2InteropSequencer(gt *testing.T) {
+	t := NewDefaultTesting(gt)
+	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
+	interopAtGenesis := hexutil.Uint64(0)
+	dp.DeployConfig.L2GenesisInteropTimeOffset = &interopAtGenesis
+
+	sd := e2eutils.Setup(t, dp, defaultAlloc)
+	log := testlog.Logger(t, log.LvlDebug)
+	_, engine, sequencer := setupSequencerTest(t, sd, log)
+	_ = engine.EthClient()
+	sequencer.ActL2PipelineFull(t)
+
+	// Make an interop messages available
+	sequencer.mockInteropMsgQueue.nextMessages = append(sequencer.mockInteropMsgQueue.nextMessages, derive.InteropMessages{
+		SourceInfo: derive.InteropMessageSourceInfo{RemoteChain: common.HexToHash("0x1"), ToBlockNumber: big.NewInt(1)},
+		Messages:   []derive.InteropMessage{{MessageRoot: common.HexToHash("0xabc"), Value: big.NewInt(10)}},
+	})
+
+	sequencer.ActL2StartBlock(t)
+	sequencer.ActL2EndBlock(t)
+	require.Less(t, uint64(0), engine.l2Chain.CurrentBlock().Number.Uint64())
+
+	// check inbox state
+	cl := engine.EthClient()
+	inbox, err := bindings.NewCrossL2Inbox(predeploys.CrossL2InboxAddr, cl)
+	require.NoError(t, err)
+
+	unconsumed, err := inbox.UnconsumedMessages(nil, common.HexToHash("0xabc"))
+	require.NoError(t, err)
+	require.True(t, unconsumed)
 }

--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -28,9 +28,11 @@ func (m *MockL1OriginSelector) FindL1Origin(ctx context.Context, l2Head eth.L2Bl
 	return m.actual.FindL1Origin(ctx, l2Head)
 }
 
-type MockInteropMessageQueue struct{}
+type MockInteropMessageQueue struct {
+	nextMessages []derive.InteropMessages // a new set of messages to include
+}
 
-func (t *MockInteropMessageQueue) NewMessages() []derive.InteropMessages { return nil }
+func (t *MockInteropMessageQueue) NewMessages() []derive.InteropMessages { return t.nextMessages }
 
 // L2Sequencer is an actor that functions like a rollup node,
 // without the full P2P/API/Node stack, but just the derivation state, and simplified driver with sequencing ability.
@@ -42,6 +44,7 @@ type L2Sequencer struct {
 	failL2GossipUnsafeBlock error // mock error
 
 	mockL1OriginSelector *MockL1OriginSelector
+	mockInteropMsgQueue  *MockInteropMessageQueue
 }
 
 func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, cfg *rollup.Config, seqConfDepth uint64) *L2Sequencer {
@@ -54,6 +57,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, c
 		L2Verifier:              *ver,
 		sequencer:               driver.NewSequencer(log, cfg, ver.derivation, attrBuilder, l1OriginSelector, interopMsgQueue, metrics.NoopMetrics),
 		mockL1OriginSelector:    l1OriginSelector,
+		mockInteropMsgQueue:     interopMsgQueue,
 		failL2GossipUnsafeBlock: nil,
 	}
 }

--- a/op-node/rollup/derive/interop_msg.go
+++ b/op-node/rollup/derive/interop_msg.go
@@ -1,0 +1,151 @@
+package derive
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	OutboxMessagePassedABI     = "MessagePassed(uint256,address,address,bytes32,uint256,uint256,bytes,bytes32)"
+	OutboxMessagePassedABIHash = crypto.Keccak256Hash([]byte(OutboxMessagePassedABI))
+
+	// TODO
+	CrossL2InboxAddr          = predeploys.CrossL2InboxAddr
+	CrossL2InboxDepositorAddr = common.Address{byte(1)}
+	CrossL2InboxFuncSignature = "deliverMessages((bytes32,bytes32,uint256,bytes32[])[])"
+	CrossL2InboxFuncBytes4    = crypto.Keccak256([]byte(CrossL2InboxFuncSignature))[:4]
+)
+
+type InteropMessage struct {
+	Nonce *big.Int
+
+	SourceChain common.Hash
+	TargetChain common.Hash
+
+	From common.Address
+	To   common.Address
+
+	Value    *big.Int
+	GasLimit *big.Int
+
+	Data hexutil.Bytes
+
+	MessageRoot common.Hash
+}
+
+type InteropMessageSourceInfo struct {
+	RemoteChain common.Hash
+
+	FromBlockNumber *big.Int
+	ToBlockNumber   *big.Int
+}
+
+type InteropMessages struct {
+	SourceInfo InteropMessageSourceInfo
+	Messages   []InteropMessage
+}
+
+func UnmarshalInteropMessageLog(remoteChain common.Hash, ev *types.Log) (*InteropMessage, error) {
+	if len(ev.Topics) != 4 {
+		return nil, fmt.Errorf("expected 4 event topics for outbox message event. got %d", len(ev.Topics))
+	}
+	if ev.Topics[0] != OutboxMessagePassedABIHash {
+		return nil, fmt.Errorf("invalid message event selector: %s, expected: %s", ev.Topics[0], OutboxMessagePassedABIHash)
+	}
+
+	// indexed fields
+	nonce := new(big.Int).SetBytes(ev.Topics[1][:])
+	from := common.BytesToAddress(ev.Topics[2][12:])
+	to := common.BytesToAddress(ev.Topics[3][12:])
+
+	// TODO: dont rely on bindings as & manually marshal/unmarshal structs
+	var outboxMessagePassed bindings.CrossL2OutboxMessagePassed
+	abi, err := bindings.CrossL2OutboxMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	if err := abi.UnpackIntoInterface(&outboxMessagePassed, "MessagePassed", ev.Data); err != nil {
+		return nil, err
+	}
+
+	msg := InteropMessage{
+		Nonce: nonce,
+		From:  from,
+		To:    to,
+
+		SourceChain: remoteChain,
+		TargetChain: outboxMessagePassed.TargetChain,
+		Value:       outboxMessagePassed.Value,
+		GasLimit:    outboxMessagePassed.GasLimit,
+		Data:        outboxMessagePassed.Data,
+		MessageRoot: outboxMessagePassed.MessageRoot,
+	}
+
+	return &msg, nil
+}
+
+// InteropMessagesDeposit will marshal the supplied batch of incoming interop messages
+// into a system deposit transaction. When constructng this batch, the outbox of each
+// remote chain should have been filtered to only include messages targeted for the local
+// chain.
+func InteropMessagesDeposit(interopMsgs []InteropMessages) (*types.DepositTx, error) {
+	// TODO: dont rely on bindings & manually marshal/unmarshal structs
+	abi, err := bindings.CrossL2InboxMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: derive from the remote source info. Since the calldata includes the
+	// latest remote block number, the transaction hash will be unique anyways
+	sourceHash := common.Hash{}
+
+	type inboxMessage struct {
+		Chain        common.Hash
+		Output       common.Hash
+		BlockNumber  *big.Int
+		MessageRoots []common.Hash
+	}
+
+	inboxMessages := make([]inboxMessage, len(interopMsgs))
+
+	mint := big.NewInt(0)
+	for i, chainMsgs := range interopMsgs {
+		msgRoots := make([]common.Hash, len(chainMsgs.Messages))
+		for j, msg := range chainMsgs.Messages {
+			msgRoots[j] = msg.MessageRoot // verify message root
+			mint = mint.Add(mint, msg.Value)
+		}
+
+		inboxMessages[i] = inboxMessage{
+			Chain:        chainMsgs.SourceInfo.RemoteChain,
+			BlockNumber:  chainMsgs.SourceInfo.ToBlockNumber,
+			MessageRoots: msgRoots,
+			// TODO: output information
+		}
+	}
+
+	// encode function call
+	deliverMsgsFn := abi.Methods["deliverMessages"]
+	data, err := deliverMsgsFn.Inputs.Pack(inboxMessages)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.DepositTx{
+		SourceHash:          sourceHash,
+		From:                CrossL2InboxDepositorAddr,
+		To:                  &CrossL2InboxAddr,
+		Mint:                mint,
+		Value:               mint,
+		Gas:                 RegolithSystemTxGas,
+		IsSystemTransaction: false,
+		Data:                data,
+	}, nil
+}

--- a/op-node/rollup/derive/interop_msg.go
+++ b/op-node/rollup/derive/interop_msg.go
@@ -16,11 +16,11 @@ var (
 	OutboxMessagePassedABI     = "MessagePassed(uint256,address,address,bytes32,uint256,uint256,bytes,bytes32)"
 	OutboxMessagePassedABIHash = crypto.Keccak256Hash([]byte(OutboxMessagePassedABI))
 
-	// TODO
 	CrossL2InboxAddr          = predeploys.CrossL2InboxAddr
-	CrossL2InboxDepositorAddr = common.Address{byte(1)}
 	CrossL2InboxFuncSignature = "deliverMessages((bytes32,bytes32,uint256,bytes32[])[])"
 	CrossL2InboxFuncBytes4    = crypto.Keccak256([]byte(CrossL2InboxFuncSignature))[:4]
+
+	CrossL2InboxDepositerAddress = common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0002")
 )
 
 type InteropMessage struct {
@@ -140,7 +140,7 @@ func InteropMessagesDeposit(interopMsgs []InteropMessages) (*types.DepositTx, er
 
 	return &types.DepositTx{
 		SourceHash:          sourceHash,
-		From:                CrossL2InboxDepositorAddr,
+		From:                CrossL2InboxDepositerAddress,
 		To:                  &CrossL2InboxAddr,
 		Mint:                mint,
 		Value:               mint,

--- a/op-node/rollup/derive/interop_msg_test.go
+++ b/op-node/rollup/derive/interop_msg_test.go
@@ -1,0 +1,48 @@
+package derive
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInteropMessageDeposit(t *testing.T) {
+	interopMsgs := []InteropMessages{
+		{
+			SourceInfo: InteropMessageSourceInfo{ToBlockNumber: big.NewInt(1)},
+			Messages:   []InteropMessage{{Value: big.NewInt(1), GasLimit: big.NewInt(0), Data: []byte{}, MessageRoot: common.Hash{byte('a')}}},
+		},
+		{
+			SourceInfo: InteropMessageSourceInfo{ToBlockNumber: big.NewInt(1)},
+			Messages:   []InteropMessage{{Value: big.NewInt(1), GasLimit: big.NewInt(0), Data: []byte{}, MessageRoot: common.Hash{byte('b')}}},
+		},
+	}
+
+	deposit, err := InteropMessagesDeposit(interopMsgs)
+	require.NoError(t, err)
+	require.Equal(t, CrossL2InboxDepositorAddr, deposit.From)
+	require.Equal(t, CrossL2InboxAddr, *deposit.To)
+	require.Equal(t, uint64(2), deposit.Mint.Uint64())
+	require.Equal(t, uint64(2), deposit.Value.Uint64())
+	require.Equal(t, uint64(RegolithSystemTxGas), deposit.Gas)
+
+	abi, err := bindings.CrossL2InboxMetaData.GetAbi()
+	require.NoError(t, err)
+
+	inputs, err := abi.Methods["deliverMessages"].Inputs.Unpack(deposit.Data)
+	require.NoError(t, err)
+
+	// easiest way to convert anonymous interface is to marshal/unmarshal into json
+	bytes, err := json.Marshal(inputs[0])
+	require.NoError(t, err)
+
+	var inboxMsgs []bindings.InboxMessages
+	require.NoError(t, json.Unmarshal(bytes, &inboxMsgs))
+	require.Len(t, inboxMsgs, 2)
+	require.Equal(t, common.Hash{byte('a')}, common.Hash(inboxMsgs[0].MessageRoots[0]))
+	require.Equal(t, common.Hash{byte('b')}, common.Hash(inboxMsgs[1].MessageRoots[0]))
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -52,6 +52,11 @@ type L2Chain interface {
 	L2BlockRefByNumber(ctx context.Context, num uint64) (eth.L2BlockRef, error)
 }
 
+type Interop interface {
+	HandleNewFinalizedBlock(chain uint64, finalized eth.L1BlockRef) error
+	NewMessages() []derive.InteropMessages
+}
+
 type DerivationPipeline interface {
 	Reset()
 	Step(ctx context.Context) error
@@ -117,7 +122,7 @@ type SequencerStateListener interface {
 }
 
 // NewDriver composes an events handler that tracks L1 state, triggers L2 derivation, and optionally sequences new L2 blocks.
-func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, l1Blobs derive.L1BlobsFetcher, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics, sequencerStateListener SequencerStateListener, syncCfg *sync.Config) *Driver {
+func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, l1Blobs derive.L1BlobsFetcher, interop Interop, altSync AltSync, network Network, log log.Logger, snapshotLog log.Logger, metrics Metrics, sequencerStateListener SequencerStateListener, syncCfg *sync.Config) *Driver {
 	l1 = NewMeteredL1Fetcher(l1, metrics)
 	l1State := NewL1State(log, metrics)
 	sequencerConfDepth := NewConfDepth(driverCfg.SequencerConfDepth, l1State.L1Head, l1)
@@ -127,32 +132,33 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, l1
 	attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 	engine := derivationPipeline
 	meteredEngine := NewMeteredEngine(cfg, engine, metrics, log)
-	sequencer := NewSequencer(log, cfg, meteredEngine, attrBuilder, findL1Origin, metrics)
+	sequencer := NewSequencer(log, cfg, meteredEngine, attrBuilder, findL1Origin, interop, metrics)
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 	return &Driver{
-		l1State:          l1State,
-		derivation:       derivationPipeline,
-		stateReq:         make(chan chan struct{}),
-		forceReset:       make(chan chan struct{}, 10),
-		startSequencer:   make(chan hashAndErrorChannel, 10),
-		stopSequencer:    make(chan chan hashAndError, 10),
-		sequencerActive:  make(chan chan bool, 10),
-		sequencerNotifs:  sequencerStateListener,
-		config:           cfg,
-		driverConfig:     driverCfg,
-		driverCtx:        driverCtx,
-		driverCancel:     driverCancel,
-		log:              log,
-		snapshotLog:      snapshotLog,
-		l1:               l1,
-		l2:               l2,
-		sequencer:        sequencer,
-		network:          network,
-		metrics:          metrics,
-		l1HeadSig:        make(chan eth.L1BlockRef, 10),
-		l1SafeSig:        make(chan eth.L1BlockRef, 10),
-		l1FinalizedSig:   make(chan eth.L1BlockRef, 10),
-		unsafeL2Payloads: make(chan *eth.ExecutionPayload, 10),
-		altSync:          altSync,
+		l1State:                l1State,
+		derivation:             derivationPipeline,
+		stateReq:               make(chan chan struct{}),
+		forceReset:             make(chan chan struct{}, 10),
+		startSequencer:         make(chan hashAndErrorChannel, 10),
+		stopSequencer:          make(chan chan hashAndError, 10),
+		sequencerActive:        make(chan chan bool, 10),
+		sequencerNotifs:        sequencerStateListener,
+		config:                 cfg,
+		driverConfig:           driverCfg,
+		driverCtx:              driverCtx,
+		driverCancel:           driverCancel,
+		log:                    log,
+		snapshotLog:            snapshotLog,
+		l1:                     l1,
+		l2:                     l2,
+		sequencer:              sequencer,
+		network:                network,
+		metrics:                metrics,
+		l1HeadSig:              make(chan eth.L1BlockRef, 10),
+		l1SafeSig:              make(chan eth.L1BlockRef, 10),
+		l1FinalizedSig:         make(chan eth.L1BlockRef, 10),
+		interopFinalizedUpdate: make(chan finalizedHeadAndChain, 10),
+		unsafeL2Payloads:       make(chan *eth.ExecutionPayload, 10),
+		altSync:                altSync,
 	}
 }

--- a/op-node/rollup/driver/interop_msg_fetcher.go
+++ b/op-node/rollup/driver/interop_msg_fetcher.go
@@ -1,0 +1,155 @@
+package driver
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const DefaultMessagesBuffer = 10
+
+// InteropMessageFetcher watches for remote changes in finalized
+// state and buffers interop messages intended for this chain.
+// Whenever possible, messages are flushed into the provided sink.
+//
+// TODOs:
+//
+//  1. Accept or compute starting heights for the remote.
+//     - Starting height when interop relationship has already been
+//     established as well as already bridged messages
+//     - This needs to timed with the InteropHardFork marker as well
+//     as the L1 heights of when the interop relationship was established
+//
+//  2. Establish what happens in errors state w.r.t to derivation (liveness)
+//
+// Questions:
+//
+//  1. Should finalized L1Origin be kept consistent between local/remote for consistency
+//
+//  2. Should the remote be processed on a per-block basis or block-range
+type InteropMessageFetcher struct {
+	log log.Logger
+
+	localChain  common.Hash
+	remoteChain common.Hash
+
+	// TODO: we should probably utilize `source.EthClient` however, that fetches
+	// all receipts per block and we're only interested in the Outbox and dont want
+	// to unneccesarily cause cashing of uninteresting receipts.
+	clnt client.RPC
+
+	// New messages are buffered in the background and
+	// flushed into the provided sink when possible
+	buffer chan derive.InteropMessages
+	sink   chan<- derive.InteropMessages
+
+	finalized chan eth.L1BlockRef
+}
+
+func NewInteropMessageFetcher(log log.Logger, localChain, remoteChain common.Hash, clnt client.RPC, sink chan<- derive.InteropMessages) *InteropMessageFetcher {
+	log = log.New("module", "interop_fetcher", "remote_chain_id", remoteChain)
+	f := &InteropMessageFetcher{
+		log:         log,
+		localChain:  localChain,
+		remoteChain: remoteChain,
+		clnt:        clnt,
+		finalized:   make(chan eth.L1BlockRef, 5),
+
+		sink:   sink,
+		buffer: make(chan derive.InteropMessages, DefaultMessagesBuffer),
+	}
+
+	go f.pollMessages()
+	go f.flushMessages()
+	return f
+}
+
+func (f *InteropMessageFetcher) HandleNewFinalizedBlock(finalized eth.L1BlockRef) error {
+	select {
+	case f.finalized <- finalized:
+	default:
+		// we dont want to block if the fetcher is already busy processing prior updates.
+		// Since this channel is buffered, the fetcher should already be aware of additional
+		// work that needs to be processed prior so we'll just skip over this update
+		f.log.Warn("unable to handle finalized update", "hash", finalized.Hash, "number", finalized.Number)
+
+		// TODO: maybe at some point we need to signal upwards a problem with an interop peer
+	}
+
+	return nil
+}
+
+func (f *InteropMessageFetcher) flushMessages() {
+	for newMsgs := range f.buffer {
+		f.log.Info("flushing messages", "size", len(newMsgs.Messages))
+		f.sink <- newMsgs
+	}
+}
+
+func (f *InteropMessageFetcher) pollMessages() {
+	lastFinalized := eth.L1BlockRef{}
+
+	// After each finalization event, there's a range of
+	// blocks for which the outbox needs to be checked.
+	for finalized := range f.finalized {
+		var fromBlockNumber, toBlockNumber uint64 = 0, finalized.Number
+		if (lastFinalized != eth.L1BlockRef{}) {
+			fromBlockNumber = lastFinalized.Number + 1
+		}
+
+		// Query for new messages. (to be replaced with the specific interop rpc)
+
+		var logs []types.Log
+		filterArgs := map[string]interface{}{}
+		filterArgs["addresses"] = []common.Address{predeploys.CrossL2OutboxAddr}
+		filterArgs["topics"] = []common.Hash{derive.OutboxMessagePassedABIHash}
+		filterArgs["fromBlock"] = hexutil.EncodeUint64(fromBlockNumber)
+		filterArgs["toBlock"] = hexutil.EncodeUint64(toBlockNumber)
+
+		err := f.clnt.CallContext(context.Background(), &logs, "eth_getLogs", filterArgs)
+		if err != nil {
+			f.log.Error("unable to fetch for logs", "err", err)
+			continue
+		}
+
+		newMessages := make([]derive.InteropMessage, 0, len(logs))
+		for _, log := range logs {
+			msg, err := derive.UnmarshalInteropMessageLog(f.remoteChain, &log)
+			if err != nil {
+				f.log.Error("unable to process outbox messages", "err", err)
+				panic(err) // fix
+			}
+			if msg.TargetChain != f.localChain {
+				f.log.Debug("skipping message for a different chain", "nonce", msg.Nonce)
+				continue
+			}
+
+			newMessages = append(newMessages, *msg)
+		}
+
+		if len(newMessages) == 0 {
+			f.log.Debug("no messages for this chain in the outbox")
+			continue
+		}
+
+		f.buffer <- derive.InteropMessages{
+			Messages: newMessages,
+			SourceInfo: derive.InteropMessageSourceInfo{
+				RemoteChain:     f.remoteChain,
+				FromBlockNumber: big.NewInt(int64(fromBlockNumber)),
+				ToBlockNumber:   big.NewInt(int64(toBlockNumber)),
+			},
+		}
+
+		lastFinalized = finalized
+	}
+}

--- a/op-node/rollup/driver/interop_msg_fetcher_test.go
+++ b/op-node/rollup/driver/interop_msg_fetcher_test.go
@@ -1,0 +1,116 @@
+package driver
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func rpcOnLogs(rpc *testutils.MockRPCClient, logs []types.Log) *mock.Call {
+	return rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getLogs", mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			*args.Get(1).(*[]types.Log) = logs
+		})
+}
+
+func encodeMessages(blockNumber uint64, messages []bindings.CrossL2OutboxMessagePassed) []types.Log {
+	outboxAbi, _ := bindings.CrossL2OutboxMetaData.GetAbi()
+	msgPassedArgs := outboxAbi.Events["MessagePassed"].Inputs.NonIndexed()
+
+	logs := make([]types.Log, len(messages))
+	for i, msg := range messages {
+		logData, _ := msgPassedArgs.Pack(msg.TargetChain, msg.Value, msg.GasLimit, msg.Data, msg.MessageRoot)
+		logs[i] = types.Log{
+			Topics: []common.Hash{
+				outboxAbi.Events["MessagePassed"].ID,
+				common.BigToHash(msg.Nonce),
+				common.BytesToHash(msg.From[:]),
+				common.BytesToHash(msg.To[:]),
+			},
+			Data:        logData,
+			BlockNumber: blockNumber,
+		}
+	}
+	return logs
+}
+
+func TestInteropMessageFetcherFlushesMessages(t *testing.T) {
+	log := testlog.Logger(t, log.LvlDebug)
+	localChain, remoteChain := common.BigToHash(big.NewInt(990)), common.BigToHash(big.NewInt(991))
+
+	// ignore the poller
+	rpc := &testutils.MockRPCClient{}
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything).Return(nil)
+
+	msgsSink := make(chan derive.InteropMessages)
+	f := NewInteropMessageFetcher(log, localChain, remoteChain, rpc, msgsSink)
+
+	// single message available in block 5
+	rpcOnLogs(rpc, encodeMessages(5, []bindings.CrossL2OutboxMessagePassed{
+		{Nonce: big.NewInt(1), TargetChain: localChain, Value: big.NewInt(0), GasLimit: big.NewInt(0)},
+	}))
+
+	// finalization update
+	f.finalized <- eth.L1BlockRef{Number: 10}
+
+	// message gets dumped into the sink
+	m := <-msgsSink
+	require.Equal(t, 1, len(m.Messages))
+	require.Equal(t, uint64(0), m.SourceInfo.FromBlockNumber.Uint64())
+	require.Equal(t, uint64(10), m.SourceInfo.ToBlockNumber.Uint64())
+}
+
+func TestInteropMessageFetcherMessageBuffer(t *testing.T) {
+	log := testlog.Logger(t, log.LvlDebug)
+	localChain, remoteChain := common.BigToHash(big.NewInt(990)), common.BigToHash(big.NewInt(991))
+
+	// ignore the poller
+	rpc := &testutils.MockRPCClient{}
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything).Return(nil)
+
+	msgsSink := make(chan derive.InteropMessages)
+	f := NewInteropMessageFetcher(log, localChain, remoteChain, rpc, msgsSink)
+
+	// single message in block 5
+	rpcOnLogs(rpc, encodeMessages(5, []bindings.CrossL2OutboxMessagePassed{
+		{Nonce: big.NewInt(1), TargetChain: localChain, Value: big.NewInt(0), GasLimit: big.NewInt(0)},
+	})).Times(1)
+
+	// finalization update causing a read (immediately available in the sink)
+	f.finalized <- eth.L1BlockRef{Number: 10}
+
+	// another message in block 15
+	rpcOnLogs(rpc, encodeMessages(15, []bindings.CrossL2OutboxMessagePassed{
+		{Nonce: big.NewInt(2), TargetChain: localChain, Value: big.NewInt(0), GasLimit: big.NewInt(0)},
+	}))
+
+	// finalization update causing a read (placed in the buffer)
+	f.finalized <- eth.L1BlockRef{Number: 20}
+	wait.For(context.Background(), 100*time.Millisecond, func() (bool, error) { return len(f.buffer) == 1, nil })
+
+	// both messages can be read through the sink
+	firstMsg := <-msgsSink
+	require.Equal(t, 1, len(firstMsg.Messages))
+	require.Equal(t, uint64(0), firstMsg.SourceInfo.FromBlockNumber.Uint64())
+	require.Equal(t, uint64(10), firstMsg.SourceInfo.ToBlockNumber.Uint64())
+	secondMsg := <-msgsSink
+	require.Equal(t, 1, len(secondMsg.Messages))
+	require.Equal(t, uint64(11), secondMsg.SourceInfo.FromBlockNumber.Uint64())
+	require.Equal(t, uint64(20), secondMsg.SourceInfo.ToBlockNumber.Uint64())
+}

--- a/op-node/rollup/driver/interop_msg_queue.go
+++ b/op-node/rollup/driver/interop_msg_queue.go
@@ -1,0 +1,100 @@
+package driver
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type interopMessages struct {
+	derive.InteropMessages
+	read chan<- interface{}
+}
+
+// InteropMessageQueue returns the next set of interop
+// message to include per chain.
+//
+// TODOs:
+//  1. Establish a priority queue for incoming messages.
+//     All messages per chains cannot be consumed at once
+//     and should instead be ordered & limited by gas.
+type InteropMessageQueue struct {
+	log log.Logger
+	mu  sync.Mutex
+
+	newMsgs     []interopMessages
+	msgFetchers map[uint64]*InteropMessageFetcher
+}
+
+func NewInteropMessageQueue(log log.Logger, localChainId *big.Int, remoteChains map[uint64]client.RPC) *InteropMessageQueue {
+	q := InteropMessageQueue{
+		log: log.New("module", "interop_msg_queue"),
+
+		newMsgs:     nil,
+		msgFetchers: map[uint64]*InteropMessageFetcher{},
+	}
+
+	localChain := common.BigToHash(localChainId)
+
+	for chainId, rpc := range remoteChains {
+		q.log.Info("initializing remote", "chain_id", chainId)
+		remoteChain := common.BigToHash(big.NewInt(int64(chainId)))
+
+		msgsSink := make(chan derive.InteropMessages)
+		go q.onNewMessages(msgsSink)
+		q.msgFetchers[chainId] = NewInteropMessageFetcher(log, localChain, remoteChain, rpc, msgsSink)
+	}
+
+	return &q
+}
+
+func (q *InteropMessageQueue) HandleNewFinalizedBlock(chain uint64, finalized eth.L1BlockRef) error {
+	f, ok := q.msgFetchers[chain]
+	if !ok {
+		return fmt.Errorf("interop rpc not found for peer chain: %d", chain)
+	}
+
+	return f.HandleNewFinalizedBlock(finalized)
+}
+
+// NewMessages will return the next set of available messages per chain
+func (q *InteropMessageQueue) NewMessages() []derive.InteropMessages {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.newMsgs) == 0 {
+		return nil
+	}
+
+	result := make([]derive.InteropMessages, len(q.newMsgs))
+	for i, msgs := range q.newMsgs {
+		result[i] = msgs.InteropMessages
+		msgs.read <- struct{}{}
+	}
+
+	q.newMsgs = nil
+	return result
+}
+
+func (q *InteropMessageQueue) onNewMessages(msgs <-chan derive.InteropMessages) {
+	for newMsgs := range msgs {
+		read := make(chan interface{}, 1)
+		item := interopMessages{
+			InteropMessages: newMsgs,
+			read:            read,
+		}
+
+		q.mu.Lock()
+		q.newMsgs = append(q.newMsgs, item)
+		q.mu.Unlock()
+
+		// only move on once the item has been consumed
+		<-read
+	}
+}

--- a/op-node/rollup/driver/interop_msg_queue_test.go
+++ b/op-node/rollup/driver/interop_msg_queue_test.go
@@ -1,0 +1,49 @@
+package driver
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func TestInteropMessageQueue(t *testing.T) {
+	log := testlog.Logger(t, log.LvlDebug)
+	localChainId := big.NewInt(990)
+
+	// ignore all rpcs
+	rpc := &testutils.MockRPCClient{}
+	rpc.On("CallContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	remoteRpcs := map[uint64]client.RPC{991: rpc, 992: rpc}
+	q, err := NewInteropMessageQueue(log, localChainId, remoteRpcs)
+	require.NoError(t, err)
+
+	// Two Batches Ready in 991. T=1, T= 2
+	q.msgFetchers[991].buffer <- derive.InteropMessages{}
+	q.msgFetchers[991].buffer <- derive.InteropMessages{}
+
+	// One Batch Ready for 992. T = 0
+	q.msgFetchers[992].buffer <- derive.InteropMessages{}
+
+	// Queue will fill up with one item per chain
+	wait.For(context.Background(), 100*time.Millisecond, func() (bool, error) { return len(q.newMsgs) == 2, nil })
+	msgs := q.NewMessages()
+	require.Len(t, msgs, 2)
+
+	// Second batch in 991 flushed to the queue
+	wait.For(context.Background(), 100*time.Millisecond, func() (bool, error) { return len(q.newMsgs) == 1, nil })
+	msgs = q.NewMessages()
+	require.Len(t, msgs, 1)
+}

--- a/op-node/rollup/driver/sequencer_test.go
+++ b/op-node/rollup/driver/sequencer_test.go
@@ -147,6 +147,12 @@ func (fn testOriginSelectorFn) FindL1Origin(ctx context.Context, l2Head eth.L2Bl
 
 var _ L1OriginSelectorIface = (testOriginSelectorFn)(nil)
 
+type testInteropMessageQueue struct{}
+
+func (t *testInteropMessageQueue) NewMessages() []derive.InteropMessages { return nil }
+
+var _ InteropMessageQueueIface = (*testInteropMessageQueue)(nil)
+
 // TestSequencerChaosMonkey runs the sequencer in a mocked adversarial environment with
 // repeated random errors in dependencies and poor clock timing.
 // At the end the health of the chain is checked to show that the sequencer kept the chain in shape.
@@ -302,7 +308,9 @@ func TestSequencerChaosMonkey(t *testing.T) {
 		}
 	})
 
-	seq := NewSequencer(log, cfg, engControl, attrBuilder, originSelector, metrics.NoopMetrics)
+	interopMsgQueue := &testInteropMessageQueue{}
+
+	seq := NewSequencer(log, cfg, engControl, attrBuilder, originSelector, interopMsgQueue, metrics.NoopMetrics)
 	seq.timeNow = clockFn
 
 	// try to build 1000 blocks, with 5x as many planning attempts, to handle errors and clock problems

--- a/op-service/testutils/mock_rpc_client.go
+++ b/op-service/testutils/mock_rpc_client.go
@@ -1,0 +1,37 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-service/client"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ client.RPC = &MockRPCClient{}
+
+type MockRPCClient struct {
+	mock.Mock
+}
+
+func (m *MockRPCClient) Close() {
+	m.Mock.Called()
+}
+
+func (m *MockRPCClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
+	out := m.Called(ctx, result, method, args)
+	return out.Error(0)
+}
+
+func (m *MockRPCClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	out := m.Called(ctx, b)
+	return out.Error(0)
+}
+
+func (m *MockRPCClient) EthSubscribe(ctx context.Context, channel any, args ...any) (ethereum.Subscription, error) {
+	out := m.Called(ctx, channel, args)
+	return out.Get(0).(ethereum.Subscription), out.Error(1)
+}


### PR DESCRIPTION
WIP of ethereum-optimism/interop#53 & ethereum-optimism/interop#54

Part of the sequencer pipeline, we'll need a watcher of
remote state that can buffer and feed new interop messages

This PR creates a quick scaffold of a interop message fetcher
and message queue that serves new messages to consumed
per chain

Currently ignored/unhandled for now (priority is to unblock batcher/verifier code)
- Order messages by time & limit consumed messages by total gas
- Defined behavior for error states (liveness issues with the remote)
- Startup code that identifies the starting heights for each peer
