### PR TITLE
contracts-bedrock: Predeploys assertion update

### DIFF
--- a/packages/contracts-bedrock/test/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/Predeploys.t.sol
@@ -26,7 +26,7 @@ contract PredeploysTest is CommonTest {
             ) {
                 continue;
             }
-            assertTrue(EIP1967Helper.getAdmin(addr) == Predeploys.PROXY_ADMIN, "Admin mismatch");
+            assertEq(EIP1967Helper.getAdmin(addr), Predeploys.PROXY_ADMIN, "Admin mismatch");
         }
     }
 }


### PR DESCRIPTION
**Description**

We want to delete `check-l2` to reduce the overhead of contributing
to the solidity code. We are nearly there, we just need to ensure
that the same checks in `check-l2` exist in the predeploys spec
and the rest of the individual unit tests since now the unit
tests run against the output of the genesis generation script.

This change makes it more clear when there is a bug because it
shows the expected vs the actual value with `assertEq` instead
of `assertTrue` that just shows it was not true.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

