### PR TITLE
fix(ci-builder): Copy Docker Buildx in Final Build Stage

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -1,6 +1,6 @@
 # Copy docker buildx in order to generate the absolute prestate
 # in the CI pipeline for reproducible fault proof builds
-FROM docker
+FROM docker as buildx
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 RUN docker buildx version
 
@@ -133,6 +133,9 @@ RUN echo "downloading and verifying Codecov uploader" && \
   cp codecov /usr/local/bin/codecov && \
   chmod +x /usr/local/bin/codecov  && \
   rm codecov
+
+# Copy docker buildx
+COPY --from=buildx /usr/libexec/docker/cli-plugins/docker-buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 # within docker use bash
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
**Description**

https://github.com/ethereum-optimism/optimism/pull/8913 previously attempted to add docker `buildx` support to the `ci-builder` for reproducible builds of binaries using docker as an architecture box.
Since the `COPY` command was executed in an isolated build stage of the `ci-builder`'s dockerfile, it was never copied into the _last_ build stage that contains the `ci-builder` bash command.

This PR fixes this by copying over buildx support in the final build stage of the `ci-builder`.

**Proof of Buildx Support**

<img width="991" alt="Screenshot 2024-01-10 at 1 19 25 PM" src="https://github.com/ethereum-optimism/optimism/assets/21288394/39c5c118-7af8-4541-940e-dcb4e1374f08">