### PR TITLE
Rename superChain.Config var from EclipseTime to EcotoneTime 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231211205419-ff2e152c624f
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240110213637-8dbdcf965b5f
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.11

--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -100,7 +100,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		RegolithTime:           &regolithTime,
 		CanyonTime:             superChain.Config.CanyonTime,
 		DeltaTime:              superChain.Config.DeltaTime,
-		EcotoneTime:            superChain.Config.EclipseTime,
+		EcotoneTime:            superChain.Config.EcotoneTime,
 		FjordTime:              superChain.Config.FjordTime,
 		BatchInboxAddress:      common.Address(chConfig.BatchInboxAddr),
 		DepositContractAddress: depositContractAddress,


### PR DESCRIPTION
**Description**

Fixes an incompatibility between the `op-node` and `superchain-registry`. 

**Tests**

I have not added any, however this could presumably be caught with a simple smoke test?