### PR TITLE
fix(multisig-mon): bool conversion

### DIFF
--- a/packages/chain-mon/src/multisig-mon/service.ts
+++ b/packages/chain-mon/src/multisig-mon/service.ts
@@ -134,7 +134,7 @@ export class MultisigMonService extends BaseServiceV2<
 
       this.metrics.pausedState.set(
         { address: account.optimismPortalAddress, nickname: account.nickname },
-        parseInt(paused.toString(), 10)
+        paused ? 1 : 0
       )
     } catch (err) {
       this.logger.error(`got unexpected RPC error`, {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

There is a small type conversion bug which assumes `paused` is an int wrapped in a string. It is actually already a bool, so just need to convert to 0/1.

**Tests**

Tested locally on devnet.
