### PR TITLE
chore(ci): Bump ci-builder Minor Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.34.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1

--- a/packages/contracts-bedrock/semver-lock.json
+++ b/packages/contracts-bedrock/semver-lock.json
@@ -37,7 +37,7 @@
   },
   "src/L1/SuperchainConfig.sol": {
     "initCodeHash": "0xa71c67640d6a25c750fef910a5fe85776ebb7bb18c677bb1b9b95c2f3f561b0c",
-    "sourceCodeHash": "0xfe22a85a76e6dca67a24202742374a23135354f3ce135f58ad8c06adf56a1d1c"
+    "sourceCodeHash": "0xd6a894e371c2c7182b5960c507491f81c3775dda0efedd29475f7c30ca07b004"
   },
   "src/L1/SystemConfig.sol": {
     "initCodeHash": "0x7662ba203d662cf433b3e44b85fdd6f4d5b39d77eb88156200d15b6bc8f15bc4",

--- a/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SuperchainConfig.sol
@@ -11,7 +11,9 @@ import { Storage } from "src/libraries/Storage.sol";
 contract SuperchainConfig is Initializable, ISemver {
     /// @notice Enum representing different types of updates.
     /// @custom:value GUARDIAN            Represents an update to the guardian.
-    enum UpdateType { GUARDIAN }
+    enum UpdateType {
+        GUARDIAN
+    }
 
     /// @notice Whether or not the Superchain is paused.
     bytes32 public constant PAUSED_SLOT = bytes32(uint256(keccak256("superchainConfig.paused")) - 1);

--- a/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
+++ b/packages/contracts-bedrock/src/libraries/DisputeTypes.sol
@@ -80,9 +80,8 @@ type GameType is uint8;
 type VMStatus is uint8;
 
 /// @notice The current status of the dispute game.
-enum GameStatus
-// The game is currently in progress, and has not been resolved.
-{
+enum GameStatus {
+    // The game is currently in progress, and has not been resolved.
     IN_PROGRESS,
     // The game has concluded, and the `rootClaim` was challenged successfully.
     CHALLENGER_WINS,

--- a/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
@@ -323,10 +323,12 @@ contract LivenessModule_RemoveOwnersFuzz_Test is LivenessModule_TestInit {
 
     /// @dev Options for handling the event that the number of owners remaining is less than minOwners
     enum ShutDownBehavior {
-        Correct, // Correctly removes the owners and transfers to the shutDown owner
-        DoesNotTransferToFallbackOwner, // Removes all but one owner, and does not transfer to the shutDown owner
-        DoesNotRemoveAllOwners // Leaves more than one owner when below minOwners
-
+        // Correctly removes the owners and transfers to the shutDown owner
+        Correct,
+        // Removes all but one owner, and does not transfer to the shutDown owner
+        DoesNotTransferToFallbackOwner,
+        // Leaves more than one owner when below minOwners
+        DoesNotRemoveAllOwners
     }
 
     /// @dev This contract inherits the storage layout from the LivenessModule_TestInit contract, but we

--- a/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/Safe/LivenessModule.t.sol
@@ -326,6 +326,7 @@ contract LivenessModule_RemoveOwnersFuzz_Test is LivenessModule_TestInit {
         Correct, // Correctly removes the owners and transfers to the shutDown owner
         DoesNotTransferToFallbackOwner, // Removes all but one owner, and does not transfer to the shutDown owner
         DoesNotRemoveAllOwners // Leaves more than one owner when below minOwners
+
     }
 
     /// @dev This contract inherits the storage layout from the LivenessModule_TestInit contract, but we


### PR DESCRIPTION
**Description**

Bumps the minor version of `ci-builder` from `0.34.0` to `0.35.0`.

This minor release includes docker `buildx` in the `ci-builder` to allow ci to build docker images.
Adding docker buildx support to ci directly allows for building the fault proof absolute prestate in an easily reproducible way.
