### PR TITLE
update op-geth to latest version with fixed BaseFee naming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.5 => github.com/ethereum-optimism/op-geth v1.101305.1-rc.1.0.20240109215805-a79bde2c0f4f
+replace github.com/ethereum/go-ethereum v1.13.5 => github.com/ethereum-optimism/op-geth v1.101305.2-rc.2
 
 //replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain-registry/superchain
 //replace github.com/ethereum/go-ethereum v1.13.5 => ../go-ethereum

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101305.1-rc.1.0.20240109215805-a79bde2c0f4f h1:W8oHHUpk3d1h5MLEC9vPQ2oiC9m2NdGHcCbbra9VqHc=
-github.com/ethereum-optimism/op-geth v1.101305.1-rc.1.0.20240109215805-a79bde2c0f4f/go.mod h1:HGpRaQiUONEEfsL/hq9/jg8YnR9TCHCPqjmaPoFBhto=
+github.com/ethereum-optimism/op-geth v1.101305.2-rc.2 h1:UQVo1JKEjZ80JdrL4meey1KhHmdbT/l6kmc8SzIbp3s=
+github.com/ethereum-optimism/op-geth v1.101305.2-rc.2/go.mod h1:HGpRaQiUONEEfsL/hq9/jg8YnR9TCHCPqjmaPoFBhto=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753 h1:DL667cfM6peU8H9Ut/uu9h9Bd4gQCcJrjq+yYsfYwjk=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=

--- a/op-bindings/predeploys/addresses_test.go
+++ b/op-bindings/predeploys/addresses_test.go
@@ -50,11 +50,11 @@ func TestL1BlockSlots(t *testing.T) {
 
 	require.Equal(t, types.OverheadSlot, overHeadSlot)
 	require.Equal(t, types.ScalarSlot, scalarSlot)
-	require.Equal(t, types.L1BasefeeSlot, l1BaseFeeSlot)
+	require.Equal(t, types.L1BaseFeeSlot, l1BaseFeeSlot)
 	// new in Ecotone
-	require.Equal(t, types.L1BlobBasefeeSlot, blobBaseFeeSlot)
+	require.Equal(t, types.L1BlobBaseFeeSlot, blobBaseFeeSlot)
 	require.Equal(t, types.L1FeeScalarsSlot, l1BaseFeeScalarSlot)
 	require.Equal(t, types.L1FeeScalarsSlot, l1BlobBaseFeeScalarSlot)
-	require.Equal(t, uint(types.BasefeeScalarSlotOffset), l1BaseFeeScalarOffset)
-	require.Equal(t, uint(types.BlobBasefeeScalarSlotOffset), l1BlobBaseFeeScalarOffset)
+	require.Equal(t, uint(types.BaseFeeScalarSlotOffset), l1BaseFeeScalarOffset)
+	require.Equal(t, uint(types.BlobBaseFeeScalarSlotOffset), l1BlobBaseFeeScalarOffset)
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates geth to v1.101305.2-rc.2 to continue with Ecotone work.