### PR TITLE
op-node: Initialize EngineController inside the Driver

### DIFF
--- a/op-e2e/actions/l2_sequencer.go
+++ b/op-e2e/actions/l2_sequencer.go
@@ -49,7 +49,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, c
 	}
 	return &L2Sequencer{
 		L2Verifier:              *ver,
-		sequencer:               driver.NewSequencer(log, cfg, ver.derivation, attrBuilder, l1OriginSelector, metrics.NoopMetrics),
+		sequencer:               driver.NewSequencer(log, cfg, ver.engine, attrBuilder, l1OriginSelector, metrics.NoopMetrics),
 		mockL1OriginSelector:    l1OriginSelector,
 		failL2GossipUnsafeBlock: nil,
 	}
@@ -104,7 +104,7 @@ func (s *L2Sequencer) ActL2EndBlock(t Testing) {
 
 // ActL2KeepL1Origin makes the sequencer use the current L1 origin, even if the next origin is available.
 func (s *L2Sequencer) ActL2KeepL1Origin(t Testing) {
-	parent := s.derivation.UnsafeL2Head()
+	parent := s.engine.UnsafeL2Head()
 	// force old origin, for testing purposes
 	oldOrigin, err := s.l1.L1BlockRefByHash(t.Ctx(), parent.L1Origin.Hash)
 	require.NoError(t, err, "failed to get current origin: %s", parent.L1Origin)
@@ -113,7 +113,7 @@ func (s *L2Sequencer) ActL2KeepL1Origin(t Testing) {
 
 // ActBuildToL1Head builds empty blocks until (incl.) the L1 head becomes the L2 origin
 func (s *L2Sequencer) ActBuildToL1Head(t Testing) {
-	for s.derivation.UnsafeL2Head().L1Origin.Number < s.l1State.L1Head().Number {
+	for s.engine.UnsafeL2Head().L1Origin.Number < s.l1State.L1Head().Number {
 		s.ActL2PipelineFull(t)
 		s.ActL2StartBlock(t)
 		s.ActL2EndBlock(t)
@@ -122,7 +122,7 @@ func (s *L2Sequencer) ActBuildToL1Head(t Testing) {
 
 // ActBuildToL1HeadUnsafe builds empty blocks until (incl.) the L1 head becomes the L1 origin of the L2 head
 func (s *L2Sequencer) ActBuildToL1HeadUnsafe(t Testing) {
-	for s.derivation.UnsafeL2Head().L1Origin.Number < s.l1State.L1Head().Number {
+	for s.engine.UnsafeL2Head().L1Origin.Number < s.l1State.L1Head().Number {
 		// Note: the derivation pipeline does not run, we are just sequencing a block on top of the existing L2 chain.
 		s.ActL2StartBlock(t)
 		s.ActL2EndBlock(t)
@@ -133,7 +133,7 @@ func (s *L2Sequencer) ActBuildToL1HeadUnsafe(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 	for {
 		s.ActL2PipelineFull(t)
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.derivation.UnsafeL2Head())
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.l1State.L1Head().Number {
 			break
@@ -147,7 +147,7 @@ func (s *L2Sequencer) ActBuildToL1HeadExcl(t Testing) {
 func (s *L2Sequencer) ActBuildToL1HeadExclUnsafe(t Testing) {
 	for {
 		// Note: the derivation pipeline does not run, we are just sequencing a block on top of the existing L2 chain.
-		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.derivation.UnsafeL2Head())
+		nextOrigin, err := s.mockL1OriginSelector.FindL1Origin(t.Ctx(), s.engine.UnsafeL2Head())
 		require.NoError(t, err)
 		if nextOrigin.Number >= s.l1State.L1Head().Number {
 			break

--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -33,6 +33,7 @@ type L2Verifier struct {
 	}
 
 	// L2 rollup
+	engine     *derive.EngineController
 	derivation *derive.DerivationPipeline
 
 	l1      derive.L1Fetcher
@@ -59,12 +60,14 @@ type L2API interface {
 
 func NewL2Verifier(t Testing, log log.Logger, l1 derive.L1Fetcher, eng L2API, cfg *rollup.Config, syncCfg *sync.Config) *L2Verifier {
 	metrics := &testutils.TestDerivationMetrics{}
-	pipeline := derive.NewDerivationPipeline(log, cfg, l1, nil, eng, metrics, syncCfg)
+	engine := derive.NewEngineController(eng, log, metrics, cfg, syncCfg.SyncMode)
+	pipeline := derive.NewDerivationPipeline(log, cfg, l1, nil, eng, engine, metrics, syncCfg)
 	pipeline.Reset()
 
 	rollupNode := &L2Verifier{
 		log:            log,
 		eng:            eng,
+		engine:         engine,
 		derivation:     pipeline,
 		l1:             l1,
 		l1State:        driver.NewL1State(log, metrics),
@@ -132,19 +135,19 @@ func (s *l2VerifierBackend) OnUnsafeL2Payload(ctx context.Context, payload *eth.
 }
 
 func (s *L2Verifier) L2Finalized() eth.L2BlockRef {
-	return s.derivation.Finalized()
+	return s.engine.Finalized()
 }
 
 func (s *L2Verifier) L2Safe() eth.L2BlockRef {
-	return s.derivation.SafeL2Head()
+	return s.engine.SafeL2Head()
 }
 
 func (s *L2Verifier) L2PendingSafe() eth.L2BlockRef {
-	return s.derivation.PendingSafeL2Head()
+	return s.engine.PendingSafeL2Head()
 }
 
 func (s *L2Verifier) L2Unsafe() eth.L2BlockRef {
-	return s.derivation.UnsafeL2Head()
+	return s.engine.UnsafeL2Head()
 }
 
 func (s *L2Verifier) SyncStatus() *eth.SyncStatus {
@@ -158,7 +161,6 @@ func (s *L2Verifier) SyncStatus() *eth.SyncStatus {
 		SafeL2:             s.L2Safe(),
 		FinalizedL2:        s.L2Finalized(),
 		PendingSafeL2:      s.L2PendingSafe(),
-		UnsafeL2SyncTarget: s.derivation.UnsafeL2SyncTarget(),
 	}
 }
 

--- a/op-e2e/actions/reorg_test.go
+++ b/op-e2e/actions/reorg_test.go
@@ -833,11 +833,11 @@ func SyncAfterReorg(gt *testing.T, deltaTimeOffset *hexutil.Uint64) {
 	miner.ActL1SetFeeRecipient(common.Address{'A', 0})
 	miner.ActEmptyBlock(t)
 	sequencer.ActL1HeadSignal(t)
-	for sequencer.derivation.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
+	for sequencer.engine.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
 		// build L2 blocks until the L1 origin is the current L1 head(A0)
 		sequencer.ActL2PipelineFull(t)
 		sequencer.ActL2StartBlock(t)
-		if sequencer.derivation.UnsafeL2Head().Number == 11 {
+		if sequencer.engine.UnsafeL2Head().Number == 11 {
 			// include a user tx at L2 block #12 to make a state transition
 			alice.L2.ActResetTxOpts(t)
 			alice.L2.ActSetTxToAddr(&dp.Addresses.Bob)(t)

--- a/op-e2e/actions/span_batch_test.go
+++ b/op-e2e/actions/span_batch_test.go
@@ -509,7 +509,7 @@ func TestSpanBatchLowThroughputChain(gt *testing.T) {
 	totalTxCount := 0
 	// Make 600 L2 blocks (L1BlockTime / L2BlockTime * 50) including 1~3 txs
 	for i := 0; i < 50; i++ {
-		for sequencer.derivation.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
+		for sequencer.engine.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
 			sequencer.ActL2StartBlock(t)
 			// fill the block with random number of L2 txs
 			for j := 0; j < rand.Intn(3); j++ {
@@ -646,7 +646,7 @@ func TestBatchEquivalence(gt *testing.T) {
 	sequencer.ActL2PipelineFull(t)
 	totalTxCount := 0
 	// Build random blocks
-	for sequencer.derivation.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
+	for sequencer.engine.UnsafeL2Head().L1Origin.Number < sequencer.l1State.L1Head().Number {
 		sequencer.ActL2StartBlock(t)
 		// fill the block with random number of L2 txs
 		for j := 0; j < rand.Intn(3); j++ {

--- a/op-node/node/server_test.go
+++ b/op-node/node/server_test.go
@@ -161,7 +161,6 @@ func randomSyncStatus(rng *rand.Rand) *eth.SyncStatus {
 		SafeL2:             testutils.RandomL2BlockRef(rng),
 		FinalizedL2:        testutils.RandomL2BlockRef(rng),
 		PendingSafeL2:      testutils.RandomL2BlockRef(rng),
-		UnsafeL2SyncTarget: testutils.RandomL2BlockRef(rng),
 	}
 }
 

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -32,7 +32,7 @@ type EngineController struct {
 
 	// Block Head State
 	unsafeHead      eth.L2BlockRef
-	pendingSafeHead eth.L2BlockRef
+	pendingSafeHead eth.L2BlockRef // L2 block processed from the middle of a span batch, but not marked as the safe block yet.
 	safeHead        eth.L2BlockRef
 	finalizedHead   eth.L2BlockRef
 	needFCUCall     bool
@@ -165,7 +165,6 @@ func (e *EngineController) ConfirmPayload(ctx context.Context) (out *eth.Executi
 	e.unsafeHead = ref
 
 	e.metrics.RecordL2Ref("l2_unsafe", ref)
-	e.metrics.RecordL2Ref("l2_engineSyncTarget", ref)
 	if e.buildingSafe {
 		e.metrics.RecordL2Ref("l2_pending_safe", ref)
 		e.pendingSafeHead = ref

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -32,33 +32,19 @@ type L1Fetcher interface {
 	L1TransactionFetcher
 }
 
-// ResettableEngineControl wraps EngineControl with reset-functionality,
-// which handles reorgs like the derivation pipeline:
-// by determining the last valid block references to continue from.
-type ResettableEngineControl interface {
-	EngineControl
-	Reset()
-}
-
 type ResettableStage interface {
 	// Reset resets a pull stage. `base` refers to the L1 Block Reference to reset to, with corresponding configuration.
 	Reset(ctx context.Context, base eth.L1BlockRef, baseCfg eth.SystemConfig) error
 }
 
 type EngineQueueStage interface {
-	EngineControl
-
+	LowestQueuedUnsafeBlock() eth.L2BlockRef
 	FinalizedL1() eth.L1BlockRef
-	Finalized() eth.L2BlockRef
-	UnsafeL2Head() eth.L2BlockRef
-	SafeL2Head() eth.L2BlockRef
-	PendingSafeL2Head() eth.L2BlockRef
 	Origin() eth.L1BlockRef
 	SystemConfig() eth.SystemConfig
 
 	Finalize(l1Origin eth.L1BlockRef)
 	AddUnsafePayload(payload *eth.ExecutionPayload)
-	UnsafeL2SyncTarget() eth.L2BlockRef
 	Step(context.Context) error
 }
 
@@ -81,7 +67,8 @@ type DerivationPipeline struct {
 }
 
 // NewDerivationPipeline creates a derivation pipeline, which should be reset before use.
-func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher, engine Engine, metrics Metrics, syncCfg *sync.Config) *DerivationPipeline {
+
+func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher, l2Source L2Source, engine LocalEngineControl, metrics Metrics, syncCfg *sync.Config) *DerivationPipeline {
 
 	// Pull stages
 	l1Traversal := NewL1Traversal(log, rollupCfg, l1Fetcher)
@@ -90,12 +77,12 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, rollupCfg, frameQueue, l1Fetcher, metrics)
 	chInReader := NewChannelInReader(rollupCfg, log, bank, metrics)
-	batchQueue := NewBatchQueue(log, rollupCfg, chInReader, engine)
-	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1Fetcher, engine)
+	batchQueue := NewBatchQueue(log, rollupCfg, chInReader, l2Source)
+	attrBuilder := NewFetchingAttributesBuilder(rollupCfg, l1Fetcher, l2Source)
 	attributesQueue := NewAttributesQueue(log, rollupCfg, attrBuilder, batchQueue)
 
 	// Step stages
-	eng := NewEngineQueue(log, rollupCfg, engine, metrics, attributesQueue, l1Fetcher, syncCfg)
+	eng := NewEngineQueue(log, rollupCfg, l2Source, engine, metrics, attributesQueue, l1Fetcher, syncCfg)
 
 	// Reset from engine queue then up from L1 Traversal. The stages do not talk to each other during
 	// the reset, but after the engine queue, this is the order in which the stages could talk to each other.
@@ -140,47 +127,15 @@ func (dp *DerivationPipeline) FinalizedL1() eth.L1BlockRef {
 	return dp.eng.FinalizedL1()
 }
 
-func (dp *DerivationPipeline) Finalized() eth.L2BlockRef {
-	return dp.eng.Finalized()
-}
-
-func (dp *DerivationPipeline) SafeL2Head() eth.L2BlockRef {
-	return dp.eng.SafeL2Head()
-}
-
-func (dp *DerivationPipeline) PendingSafeL2Head() eth.L2BlockRef {
-	return dp.eng.PendingSafeL2Head()
-}
-
-// UnsafeL2Head returns the head of the L2 chain that we are deriving for, this may be past what we derived from L1
-func (dp *DerivationPipeline) UnsafeL2Head() eth.L2BlockRef {
-	return dp.eng.UnsafeL2Head()
-}
-
-func (dp *DerivationPipeline) StartPayload(ctx context.Context, parent eth.L2BlockRef, attrs *AttributesWithParent, updateSafe bool) (errType BlockInsertionErrType, err error) {
-	return dp.eng.StartPayload(ctx, parent, attrs, updateSafe)
-}
-
-func (dp *DerivationPipeline) ConfirmPayload(ctx context.Context) (out *eth.ExecutionPayload, errTyp BlockInsertionErrType, err error) {
-	return dp.eng.ConfirmPayload(ctx)
-}
-
-func (dp *DerivationPipeline) CancelPayload(ctx context.Context, force bool) error {
-	return dp.eng.CancelPayload(ctx, force)
-}
-
-func (dp *DerivationPipeline) BuildingPayload() (onto eth.L2BlockRef, id eth.PayloadID, safe bool) {
-	return dp.eng.BuildingPayload()
-}
-
 // AddUnsafePayload schedules an execution payload to be processed, ahead of deriving it from L1
 func (dp *DerivationPipeline) AddUnsafePayload(payload *eth.ExecutionPayload) {
 	dp.eng.AddUnsafePayload(payload)
 }
 
-// UnsafeL2SyncTarget retrieves the first queued-up L2 unsafe payload, or a zeroed reference if there is none.
-func (dp *DerivationPipeline) UnsafeL2SyncTarget() eth.L2BlockRef {
-	return dp.eng.UnsafeL2SyncTarget()
+// LowestQueuedUnsafeBlock returns the lowest queued unsafe block. If the gap is filled from the unsafe head
+// to this block, the EngineQueue will be able to apply the queued payloads.
+func (dp *DerivationPipeline) LowestQueuedUnsafeBlock() eth.L2BlockRef {
+	return dp.eng.LowestQueuedUnsafeBlock()
 }
 
 // Step tries to progress the buffer.

--- a/op-node/rollup/driver/metered_engine.go
+++ b/op-node/rollup/driver/metered_engine.go
@@ -21,7 +21,7 @@ type EngineMetrics interface {
 
 // MeteredEngine wraps an EngineControl and adds metrics such as block building time diff and sealing time
 type MeteredEngine struct {
-	inner derive.ResettableEngineControl
+	inner derive.EngineControl
 
 	cfg     *rollup.Config
 	metrics EngineMetrics
@@ -30,10 +30,7 @@ type MeteredEngine struct {
 	buildingStartTime time.Time
 }
 
-// MeteredEngine implements derive.ResettableEngineControl
-var _ derive.ResettableEngineControl = (*MeteredEngine)(nil)
-
-func NewMeteredEngine(cfg *rollup.Config, inner derive.ResettableEngineControl, metrics EngineMetrics, log log.Logger) *MeteredEngine {
+func NewMeteredEngine(cfg *rollup.Config, inner derive.EngineControl, metrics EngineMetrics, log log.Logger) *MeteredEngine {
 	return &MeteredEngine{
 		inner:   inner,
 		cfg:     cfg,
@@ -92,8 +89,4 @@ func (m *MeteredEngine) CancelPayload(ctx context.Context, force bool) error {
 
 func (m *MeteredEngine) BuildingPayload() (onto eth.L2BlockRef, id eth.PayloadID, safe bool) {
 	return m.inner.BuildingPayload()
-}
-
-func (m *MeteredEngine) Reset() {
-	m.inner.Reset()
 }

--- a/op-program/client/driver/driver.go
+++ b/op-program/client/driver/driver.go
@@ -20,6 +20,9 @@ var (
 
 type Derivation interface {
 	Step(ctx context.Context) error
+}
+
+type EngineState interface {
 	SafeL2Head() eth.L2BlockRef
 }
 
@@ -31,16 +34,19 @@ type L2Source interface {
 type Driver struct {
 	logger         log.Logger
 	pipeline       Derivation
+	engine         EngineState
 	l2OutputRoot   func(uint64) (eth.Bytes32, error)
 	targetBlockNum uint64
 }
 
 func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher, l2Source L2Source, targetBlockNum uint64) *Driver {
-	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, nil, l2Source, metrics.NoopMetrics, &sync.Config{})
+	engine := derive.NewEngineController(l2Source, logger, metrics.NoopMetrics, cfg, sync.CLSync)
+	pipeline := derive.NewDerivationPipeline(logger, cfg, l1Source, nil, l2Source, engine, metrics.NoopMetrics, &sync.Config{})
 	pipeline.Reset()
 	return &Driver{
 		logger:         logger,
 		pipeline:       pipeline,
+		engine:         engine,
 		l2OutputRoot:   l2Source.L2OutputRoot,
 		targetBlockNum: targetBlockNum,
 	}
@@ -52,10 +58,10 @@ func NewDriver(logger log.Logger, cfg *rollup.Config, l1Source derive.L1Fetcher,
 // Returns a non-EOF error if the derivation failed
 func (d *Driver) Step(ctx context.Context) error {
 	if err := d.pipeline.Step(ctx); errors.Is(err, io.EOF) {
-		d.logger.Info("Derivation complete: reached L1 head", "head", d.pipeline.SafeL2Head())
+		d.logger.Info("Derivation complete: reached L1 head", "head", d.engine.SafeL2Head())
 		return io.EOF
 	} else if errors.Is(err, derive.NotEnoughData) {
-		head := d.pipeline.SafeL2Head()
+		head := d.engine.SafeL2Head()
 		if head.Number >= d.targetBlockNum {
 			d.logger.Info("Derivation complete: reached L2 block", "head", head)
 			return io.EOF
@@ -74,7 +80,7 @@ func (d *Driver) Step(ctx context.Context) error {
 }
 
 func (d *Driver) SafeHead() eth.L2BlockRef {
-	return d.pipeline.SafeL2Head()
+	return d.engine.SafeL2Head()
 }
 
 func (d *Driver) ValidateClaim(l2ClaimBlockNum uint64, claimedOutputRoot eth.Bytes32) error {

--- a/op-program/client/driver/driver_test.go
+++ b/op-program/client/driver/driver_test.go
@@ -109,6 +109,7 @@ func createDriverWithNextBlock(t *testing.T, derivationResult error, nextBlockNu
 	return &Driver{
 		logger:         testlog.Logger(t, log.LvlDebug),
 		pipeline:       derivation,
+		engine:         derivation,
 		targetBlockNum: 1_000_000,
 	}
 }

--- a/op-service/eth/sync_status.go
+++ b/op-service/eth/sync_status.go
@@ -34,7 +34,4 @@ type SyncStatus struct {
 	FinalizedL2 L2BlockRef `json:"finalized_l2"`
 	// PendingSafeL2 points to the L2 block processed from the batch, but not consolidated to the safe block yet.
 	PendingSafeL2 L2BlockRef `json:"pending_safe_l2"`
-	// UnsafeL2SyncTarget points to the first unprocessed unsafe L2 block.
-	// It may be zeroed if there is no targeted block.
-	UnsafeL2SyncTarget L2BlockRef `json:"queued_unsafe_l2"`
 }


### PR DESCRIPTION
**Description**

This moves the EngineController up to be able to use it without having to intialize the Derivation Pipeline.

**Tests**

No tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/448
