### PR TITLE
op-node: Execution Layer Sync

### DIFF
--- a/op-e2e/actions/l2_verifier.go
+++ b/op-e2e/actions/l2_verifier.go
@@ -254,3 +254,13 @@ func (s *L2Verifier) ActL2UnsafeGossipReceive(payload *eth.ExecutionPayloadEnvel
 		s.derivation.AddUnsafePayload(payload)
 	}
 }
+
+// ActL2InsertUnsafePayload creates an action that can insert an unsafe execution payload
+func (s *L2Verifier) ActL2InsertUnsafePayload(payload *eth.ExecutionPayloadEnvelope) Action {
+	return func(t Testing) {
+		ref, err := derive.PayloadToBlockRef(s.rollupCfg, payload.ExecutionPayload)
+		require.NoError(t, err)
+		err = s.engine.InsertUnsafePayload(t.Ctx(), payload, ref)
+		require.NoError(t, err)
+	}
+}

--- a/op-e2e/actions/l2_verifier_test.go
+++ b/op-e2e/actions/l2_verifier_test.go
@@ -15,7 +15,7 @@ import (
 
 func setupVerifier(t Testing, sd *e2eutils.SetupData, log log.Logger, l1F derive.L1Fetcher, syncCfg *sync.Config) (*L2Engine, *L2Verifier) {
 	jwtPath := e2eutils.WriteDefaultJWT(t)
-	engine := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath)
+	engine := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath, EngineWithP2P())
 	engCl := engine.EngineClient(t, sd.RollupCfg)
 	mockBlobFetcher := &emptyL1BlobsFetcher{t: t}
 	verifier := NewL2Verifier(t, log, l1F, mockBlobFetcher, engCl, sd.RollupCfg, syncCfg)

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -218,6 +218,7 @@ func TestSystemE2E(t *testing.T) {
 
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")
+	runE2ESystemTest(t, sys)
 	defer sys.Close()
 }
 

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -409,7 +409,8 @@ func (n *OpNode) initPProf(cfg *Config) error {
 
 func (n *OpNode) initP2P(ctx context.Context, cfg *Config) error {
 	if cfg.P2P != nil {
-		p2pNode, err := p2p.NewNodeP2P(n.resourcesCtx, &cfg.Rollup, n.log, cfg.P2P, n, n.l2Source, n.runCfg, n.metrics, cfg.Sync.SyncMode == sync.ELSync)
+		// TODO(protocol-quest/97): Use EL Sync instead of CL Alt sync for fetching missing blocks in the payload queue.
+		p2pNode, err := p2p.NewNodeP2P(n.resourcesCtx, &cfg.Rollup, n.log, cfg.P2P, n, n.l2Source, n.runCfg, n.metrics, false)
 		if err != nil || p2pNode == nil {
 			return err
 		}

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -4,13 +4,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+)
+
+type syncStatusEnum int
+
+const (
+	syncStatusCL syncStatusEnum = iota
+	// We transition between the 4 EL states linearly. We spend the majority of the time in the second & fourth.
+	// We only want to EL sync if there is no finalized block & once we finish EL sync we need to mark the last block
+	// as finalized so we can switch to consolidation
+	// TODO(protocol-quest/91): We can restart EL sync & still consolidate if there finalized blocks on the execution client if the
+	// execution client is running in archive mode. In some cases we may want to switch back from CL to EL sync, but that is complicated.
+	syncStatusWillStartEL               // First if we are directed to EL sync, check that nothing has been finalized yet
+	syncStatusStartedEL                 // Perform our EL sync
+	syncStatusFinishedELButNotFinalized // EL sync is done, but we need to mark the final sync block as finalized
+	syncStatusFinishedEL                // EL sync is done & we should be performing consolidation
 )
 
 var errNoFCUNeeded = errors.New("no FCU call was needed")
@@ -22,14 +39,17 @@ type ExecEngine interface {
 	GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
+	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
 }
 
 type EngineController struct {
-	engine    ExecEngine // Underlying execution engine RPC
-	log       log.Logger
-	metrics   Metrics
-	syncMode  sync.Mode
-	rollupCfg *rollup.Config
+	engine     ExecEngine // Underlying execution engine RPC
+	log        log.Logger
+	metrics    Metrics
+	syncMode   sync.Mode
+	syncStatus syncStatusEnum
+	rollupCfg  *rollup.Config
+	elStart    time.Time
 
 	// Block Head State
 	unsafeHead      eth.L2BlockRef
@@ -46,11 +66,18 @@ type EngineController struct {
 }
 
 func NewEngineController(engine ExecEngine, log log.Logger, metrics Metrics, rollupCfg *rollup.Config, syncMode sync.Mode) *EngineController {
+	syncStatus := syncStatusCL
+	if syncMode == sync.ELSync {
+		syncStatus = syncStatusWillStartEL
+	}
+
 	return &EngineController{
-		engine:    engine,
-		log:       log,
-		metrics:   metrics,
-		rollupCfg: rollupCfg,
+		engine:     engine,
+		log:        log,
+		metrics:    metrics,
+		rollupCfg:  rollupCfg,
+		syncMode:   syncMode,
+		syncStatus: syncStatus,
 	}
 }
 
@@ -77,7 +104,7 @@ func (e *EngineController) BuildingPayload() (eth.L2BlockRef, eth.PayloadID, boo
 }
 
 func (e *EngineController) IsEngineSyncing() bool {
-	return false
+	return e.syncStatus == syncStatusWillStartEL || e.syncStatus == syncStatusStartedEL || e.syncStatus == syncStatusFinishedELButNotFinalized
 }
 
 // Setters
@@ -209,6 +236,9 @@ func (e *EngineController) resetBuildingState() {
 // It returns true if the status is acceptable.
 func (e *EngineController) checkNewPayloadStatus(status eth.ExecutePayloadStatus) bool {
 	if e.syncMode == sync.ELSync {
+		if status == eth.ExecutionValid && e.syncStatus == syncStatusStartedEL {
+			e.syncStatus = syncStatusFinishedELButNotFinalized
+		}
 		// Allow SYNCING and ACCEPTED if engine EL sync is enabled
 		return status == eth.ExecutionValid || status == eth.ExecutionSyncing || status == eth.ExecutionAccepted
 	}
@@ -219,6 +249,9 @@ func (e *EngineController) checkNewPayloadStatus(status eth.ExecutePayloadStatus
 // It returns true if the status is acceptable.
 func (e *EngineController) checkForkchoiceUpdatedStatus(status eth.ExecutePayloadStatus) bool {
 	if e.syncMode == sync.ELSync {
+		if status == eth.ExecutionValid && e.syncStatus == syncStatusStartedEL {
+			e.syncStatus = syncStatusFinishedELButNotFinalized
+		}
 		// Allow SYNCING if engine P2P sync is enabled
 		return status == eth.ExecutionValid || status == eth.ExecutionSyncing
 	}
@@ -258,6 +291,22 @@ func (e *EngineController) TryUpdateEngine(ctx context.Context) error {
 }
 
 func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef) error {
+	// Check if there is a finalized head once when doing EL sync. If so, transition to CL sync
+	if e.syncStatus == syncStatusWillStartEL {
+		b, err := e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
+		if errors.Is(err, ethereum.NotFound) {
+			e.syncStatus = syncStatusStartedEL
+			e.log.Info("Starting EL sync")
+			e.elStart = time.Now()
+		} else if err == nil {
+			e.syncStatus = syncStatusFinishedEL
+			e.log.Info("Skipping EL sync and going straight to CL sync because there is a finalized block", "id", b.ID())
+			return nil
+		} else {
+			return NewTemporaryError(fmt.Errorf("failed to fetch finalized head: %w", err))
+		}
+	}
+	// Insert the payload & then call FCU
 	status, err := e.engine.NewPayload(ctx, envelope.ExecutionPayload, envelope.ParentBeaconBlockRoot)
 	if err != nil {
 		return NewTemporaryError(fmt.Errorf("failed to update insert payload: %w", err))
@@ -273,6 +322,12 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		HeadBlockHash:      envelope.ExecutionPayload.BlockHash,
 		SafeBlockHash:      e.safeHead.Hash,
 		FinalizedBlockHash: e.finalizedHead.Hash,
+	}
+	if e.syncStatus == syncStatusFinishedELButNotFinalized {
+		fc.SafeBlockHash = envelope.ExecutionPayload.BlockHash
+		fc.FinalizedBlockHash = envelope.ExecutionPayload.BlockHash
+		e.SetSafeHead(ref)
+		e.SetFinalizedHead(ref)
 	}
 	fcRes, err := e.engine.ForkchoiceUpdate(ctx, &fc, nil)
 	if err != nil {
@@ -293,8 +348,13 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 		return NewTemporaryError(fmt.Errorf("cannot prepare unsafe chain for new payload: new - %v; parent: %v; err: %w",
 			payload.ID(), payload.ParentID(), eth.ForkchoiceUpdateErr(fcRes.PayloadStatus)))
 	}
-	e.unsafeHead = ref
+	e.SetUnsafeHead(ref)
 	e.needFCUCall = false
+
+	if e.syncStatus == syncStatusFinishedELButNotFinalized {
+		e.log.Info("Finished EL sync", "sync_duration", time.Since(e.elStart))
+		e.syncStatus = syncStatusFinishedEL
+	}
 
 	return nil
 }
@@ -302,14 +362,4 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 // ResetBuildingState implements LocalEngineControl.
 func (e *EngineController) ResetBuildingState() {
 	e.resetBuildingState()
-}
-
-// ForkchoiceUpdate implements LocalEngineControl.
-func (e *EngineController) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	return e.engine.ForkchoiceUpdate(ctx, state, attr)
-}
-
-// NewPayload implements LocalEngineControl.
-func (e *EngineController) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
-	return e.engine.NewPayload(ctx, payload, parentBeaconBlockRoot)
 }

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -137,6 +137,7 @@ func NewDriver(driverCfg *Config, cfg *rollup.Config, l2 L2Chain, l1 L1Chain, l1
 		sequencerActive:  make(chan chan bool, 10),
 		sequencerNotifs:  sequencerStateListener,
 		config:           cfg,
+		syncCfg:          syncCfg,
 		driverConfig:     driverCfg,
 		driverCtx:        driverCtx,
 		driverCancel:     driverCancel,

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -26,7 +26,7 @@ type OracleEngine struct {
 }
 
 func NewOracleEngine(rollupCfg *rollup.Config, logger log.Logger, backend engineapi.EngineBackend) *OracleEngine {
-	engineAPI := engineapi.NewL2EngineAPI(logger, backend)
+	engineAPI := engineapi.NewL2EngineAPI(logger, backend, nil)
 	return &OracleEngine{
 		api:       engineAPI,
 		backend:   backend,

--- a/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
+++ b/op-program/client/l2/engineapi/test/l2_engine_api_tests.go
@@ -320,7 +320,7 @@ func newTestHelper(t *testing.T, createBackend func(t *testing.T) engineapi.Engi
 	logger := testlog.Logger(t, log.LvlDebug)
 	ctx := context.Background()
 	backend := createBackend(t)
-	api := engineapi.NewL2EngineAPI(logger, backend)
+	api := engineapi.NewL2EngineAPI(logger, backend, nil)
 	test := &testHelper{
 		t:       t,
 		ctx:     ctx,

--- a/op-service/clock/clock.go
+++ b/op-service/clock/clock.go
@@ -13,6 +13,9 @@ type Clock interface {
 	// Now provides the current local time. Equivalent to time.Now
 	Now() time.Time
 
+	// Since returns the time elapsed since t. It is shorthand for time.Now().Sub(t).
+	Since(time.Time) time.Duration
+
 	// After waits for the duration to elapse and then sends the current time on the returned channel.
 	// It is equivalent to time.After
 	After(d time.Duration) <-chan time.Time
@@ -79,6 +82,10 @@ type systemClock struct {
 
 func (s systemClock) Now() time.Time {
 	return time.Now()
+}
+
+func (s systemClock) Since(t time.Time) time.Duration {
+	return time.Since(t)
 }
 
 func (s systemClock) After(d time.Duration) <-chan time.Time {

--- a/op-service/clock/deterministic.go
+++ b/op-service/clock/deterministic.go
@@ -138,6 +138,12 @@ func (s *DeterministicClock) Now() time.Time {
 	return s.now
 }
 
+func (s *DeterministicClock) Since(t time.Time) time.Duration {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.now.Sub(t)
+}
+
 func (s *DeterministicClock) After(d time.Duration) <-chan time.Time {
 	s.lock.Lock()
 	defer s.lock.Unlock()


### PR DESCRIPTION
**Description**

This passes unsafe payloads directly the EngineController for immediate
insertion when Execution Layer sync is active. This tells the execution
client to sync to that target. Once the EL sync is complete, the last
unsafe payload is marked as safe. This is required when doing snap sync
because the EL does not have the pre-state required to do the engine
consolidation until the sync is complete.

**Tests**

I've manually tested this code & also have added an action test.


**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/377
- Fixes https://github.com/ethereum-optimism/optimism/issues/8308
