### PR TITLE
4844: Fix nil pointer in p2p sync for Ecotone blocks

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -625,7 +625,7 @@ func (s *SyncClient) doRequest(ctx context.Context, id peer.ID, expectedBlockNum
 		return fmt.Errorf("failed to read response: %w", err)
 	}
 
-	var envelope *eth.ExecutionPayloadEnvelope
+	envelope := &eth.ExecutionPayloadEnvelope{}
 
 	if version == 0 {
 		expectedBlockTime := s.cfg.TimestampForBlock(expectedBlockNum)


### PR DESCRIPTION
**Description**

Found a nil pointer bug when decoding Ecotone blocks sent via p2p. Fixed & updated the sync tests to check the Ecotone flow.

**Tests**

Added a test for p2p req/resp sync of Ecotone blocks.
