### PR TITLE
4844: Add missing consolidation properties

### DIFF
--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -875,14 +875,17 @@ safe head.
 
 The following fields of the derived L2 payload attributes are checked for equality with the L2 block:
 
-- `parent_hash`
-- `timestamp`
-- `randao`
-- `fee_recipient`
-- `transactions_list` (first length, then equality of each of the encoded transactions, including deposits)
-- `gas_limit`
-- `withdrawals` (first presence, then length, then equality of each of the encoded withdrawals)
-- `parent_beacon_block_root`
+- Bedrock, Canyon, Delta, Ecotone Blocks
+  - `parent_hash`
+  - `timestamp`
+  - `randao`
+  - `fee_recipient`
+  - `transactions_list` (first length, then equality of each of the encoded transactions, including deposits)
+  - `gas_limit`
+- Canyon, Delta, Ecotone Blocks
+  - `withdrawals` (first presence, then length, then equality of each of the encoded withdrawals)
+- Ecotone Blocks
+  - `parent_beacon_block_root`
 
 If consolidation succeeds, the forkchoice change will synchronize as described in the section above.
 

--- a/specs/derivation.md
+++ b/specs/derivation.md
@@ -880,6 +880,9 @@ The following fields of the derived L2 payload attributes are checked for equali
 - `randao`
 - `fee_recipient`
 - `transactions_list` (first length, then equality of each of the encoded transactions, including deposits)
+- `gas_limit`
+- `withdrawals` (first presence, then length, then equality of each of the encoded withdrawals)
+- `parent_beacon_block_root`
 
 If consolidation succeeds, the forkchoice change will synchronize as described in the section above.
 


### PR DESCRIPTION
**Description**

The specification for which fields to check between the L2 Block and L2 Payload is incomplete. We also check for the following fields:

* [Gas Limit](https://github.com/ethereum-optimism/optimism/blob/dencun/op-node/rollup/derive/engine_consolidate.go#L41-L46) checking was added as part of Bedrock
* [Withdrawals](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/engine_consolidate.go#L45-L47) checking was added as part of Canyon
* [Parent Beacon Block Root](https://github.com/ethereum-optimism/optimism/blob/dencun/op-node/rollup/derive/engine_consolidate.go#L50-L52) is being added as part of Ecotone.
