### PR TITLE
nx: cleanup config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -81,6 +81,5 @@
       "dependsOn": ["^build", "build:contracts"],
       "outputs": ["{projectRoot}/dist"]
     }
-  },
-  "$schema": "./node_modules/nx/schemas/nx-schema.json"
+  }
 }


### PR DESCRIPTION
**Description**

The `schema` field is defined twice, delete the second time that
it is defined.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

