### PR TITLE
contracts-bedrock: attempt to fix flake

### DIFF
--- a/packages/contracts-bedrock/invariant-docs/CrossDomainMessenger.md
+++ b/packages/contracts-bedrock/invariant-docs/CrossDomainMessenger.md
@@ -1,14 +1,14 @@
 # `CrossDomainMessenger` Invariants
 
 ## A call to `relayMessage` should succeed if at least the minimum gas limit can be supplied to the target context, there is enough gas to complete execution of `relayMessage` after the target context's execution is finished, and the target context did not revert.
-**Test:** [`CrossDomainMessenger.t.sol#L137`](../test/invariants/CrossDomainMessenger.t.sol#L137)
+**Test:** [`CrossDomainMessenger.t.sol#L144`](../test/invariants/CrossDomainMessenger.t.sol#L144)
 
 There are two minimum gas limits here: 
 - The outer min gas limit is for the call from the `OptimismPortal` to the `L1CrossDomainMessenger`,  and it can be retrieved by calling the xdm's `baseGas` function with the `message` and inner limit. 
 - The inner min gas limit is for the call from the `L1CrossDomainMessenger` to the target contract. 
 
 ## A call to `relayMessage` should assign the message hash to the `failedMessages` mapping if not enough gas is supplied to forward `minGasLimit` to the target context or if there is not enough gas to complete execution of `relayMessage` after the target context's execution is finished.
-**Test:** [`CrossDomainMessenger.t.sol#L170`](../test/invariants/CrossDomainMessenger.t.sol#L170)
+**Test:** [`CrossDomainMessenger.t.sol#L177`](../test/invariants/CrossDomainMessenger.t.sol#L177)
 
 There are two minimum gas limits here: 
 - The outer min gas limit is for the call from the `OptimismPortal` to the `L1CrossDomainMessenger`,  and it can be retrieved by calling the xdm's `baseGas` function with the `message` and inner limit. 

--- a/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
@@ -108,6 +108,13 @@ contract XDM_MinGasLimits is Bridge_Initializer {
         // Don't allow the estimation address to be the sender
         excludeSender(Constants.ESTIMATION_ADDRESS);
 
+        // Don't allow the predeploys to be the senders
+        uint160 prefix = uint160(0x420) << 148;
+        for (uint256 i = 0; i < 2048; i++) {
+            address addr = address(prefix | uint160(i));
+            excludeContract(addr);
+        }
+
         // Target the actor's `relay` function
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = actor.relay.selector;


### PR DESCRIPTION
**Description**

The xdm invariant tests are failing, attempt to fix through
ensuring that proxies are ignored.

Example result of a failing test:

```
Failing tests:
Encountered 1 failing test in test/invariants/CrossDomainMessenger.t.sol:XDM_MinGasLimits_Reverts
[FAIL. Reason: <empty revert data>]
[Sequence]
sender=0x420000000000000000000000000000000000078C addr=[test/invariants/CrossDomainMessenger.t.sol:RelayActor]0x22b24e3bBa3087f537d2E35f8E2F1E9a257eAa98 calldata=relay(uint8,uint8,bytes) args=[97, 74, 0x0000000000000000000000000000000000000000000000000000000000001e4c]
sender=0x0000000000000000000000000000000000002f8D addr=0x420000000000000000000000000000000000078C calldata=0x4f1ef28600000000000000000000000000000000000000000000000000000000000025f800000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000180e args=[]
sender=0x00000000000000000000000000000000000010e4 addr=[test/invariants/CrossDomainMessenger.t.sol:RelayActor]0x22b24e3bBa3087f537d2E35f8E2F1E9a257eAa98 calldata=relay(uint8,uint8,bytes) args=[254, 3, 0x08daedb9c7ea07d62e421fe926b7d73f04b73c8fd120be847e937abf2659f31e4137dabd04c355a93fd71b78050a02f12e1ab7d353]
sender=0x0000000000000000000000000000000000001533 addr=0x420000000000000000000000000000000000078C calldata=0x4f1ef2860000000000000000000000002dfbf40ac423099dff1d47cbf2198311a132084b00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000020c32e06324e64ab299df2856f5d081a93b30c98764b1fac5213339a070c13a0a4 args=[]
sender=0x0000000000000000000000000000000018160Ddc addr=[test/invariants/CrossDomainMessenger.t.sol:RelayActor]0x22b24e3bBa3087f537d2E35f8E2F1E9a257eAa98 calldata=relay(uint8,uint8,bytes) args=[10, 12, 0x1998c6d2b9539a719f8393a7bd3a90611f940901e3f2ddc44866d450f60a21b99391b804ea77473a42c7e869123cb61c2f137f3f9116568a4709a86615d0617555]
sender=0x6F77000000000000000000000000000000000001 addr=[test/invariants/CrossDomainMessenger.t.sol:RelayActor]0x22b24e3bBa3087f537d2E35f8E2F1E9a257eAa98 calldata=relay(uint8,uint8,bytes) args=[1, 0, 0x3ce36e01a862e656ef6d7e534c604f7371751d22722f7d27382b5bc92b1b926dacb6fe80]
sender=0x3D7Ebc40AF7092E3F1C81F2e996cbA5Cae2090d7 addr=0x420000000000000000000000000000000000078C calldata=0x8f283970000000000000000000000000f0cc4c31297072a46cdf740fbfaf9d6d35017c06 args=[]
sender=0xB80194025AeE4A9126B156619C8943372b72dA2b addr=[test/invariants/CrossDomainMessenger.t.sol:RelayActor]0x22b24e3bBa3087f537d2E35f8E2F1E9a257eAa98 calldata=relay(uint8,uint8,bytes) args=[0, 1, 0xeca8d0fabc96e0c64ec9faed41e05a5a0cb6ebb9de5c5f]
 invariant_minGasLimits() (runs: 256, calls: 8168, reverts: 2278)

Encountered a total of 1 failing tests, 879 tests succeeded
```

I believe the issue is `addr=0x420000000000000000000000000000000000078C` - A predeploy is set to
`addr`. Not sure if this will 100% fix the issue but first attempt.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

