### PR TITLE
Update deployed bytecode comparison for preinstall `create2deployer`

### DIFF
--- a/op-bindings/bindgen/remote_handlers.go
+++ b/op-bindings/bindgen/remote_handlers.go
@@ -69,14 +69,14 @@ func (generator *BindGenGeneratorRemote) create2DeployerHandler(contractMetadata
 		return err
 	}
 
-	// We're expecting the bytecode for Create2Deployer to not match the deployment on OP,
-	// because we're predeploying a modified version of Create2Deployer that has not yet been
-	// deployed to OP.
+	// We're expecting the initialization bytecode for Create2Deployer to not match the init code on OP,
+	// because the deployment on OP has been overwritten by the Canyon hardfork, and the init code
+	// Etherscan returns for the OP deployment is from the initial outdated deployment.
 	// For context: https://github.com/ethereum-optimism/op-geth/pull/126
 	if err := generator.CompareInitBytecodeWithOp(contractMetadata, false); err != nil {
 		return fmt.Errorf("%s: %w", contractMetadata.Name, err)
 	}
-	if err := generator.CompareDeployedBytecodeWithOp(contractMetadata, false); err != nil {
+	if err := generator.CompareDeployedBytecodeWithOp(contractMetadata, true); err != nil {
 		return fmt.Errorf("%s: %w", contractMetadata.Name, err)
 	}
 


### PR DESCRIPTION
The deployed bytecode for `create2deployer` has been modified via the Canyon hardfork. This PR updates the bytecode comparison between ETH and OP mainnets

Previously we were comparing the new implementation of `create2deployer` (`0xF496...` deployed on ETH) against the existing implementation (`0x13b0` deployed on OP/ETH), and were asserting that they were different. Now that canyon is active, the `0x13b0` implementation on OP has been overwritten to match `0xF496`

For additional context: https://github.com/ethereum-optimism/op-geth/pull/126