### PR TITLE
[op-conductor] Disable flaky sequencer failover test 

### DIFF
--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -1,3 +1,4 @@
+//nolint:all
 package op_e2e
 
 import (

--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -1,4 +1,3 @@
-//nolint:all
 package op_e2e
 
 import (

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -1,3 +1,4 @@
+//nolint:all
 package op_e2e
 
 import (
@@ -8,7 +9,7 @@ import (
 
 // [Category: Initial Setup]
 // In this test, we test that we can successfully setup a working cluster.
-func TestSequencerFailover_SetupCluster(t *testing.T) {
+func xTestSequencerFailover_SetupCluster(t *testing.T) {
 	sys, conductors := setupSequencerFailoverTest(t)
 	defer sys.Close()
 

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -9,7 +9,7 @@ import (
 // [Category: Initial Setup]
 // In this test, we test that we can successfully setup a working cluster.
 func TestSequencerFailover_SetupCluster(t *testing.T) {
-	t.Skip("temporarily disable for now")
+	t.Skip("temporarily disable due to flakiness for now")
 	sys, conductors := setupSequencerFailoverTest(t)
 	defer sys.Close()
 

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -1,4 +1,3 @@
-//nolint:all
 package op_e2e
 
 import (
@@ -9,7 +8,8 @@ import (
 
 // [Category: Initial Setup]
 // In this test, we test that we can successfully setup a working cluster.
-func xTestSequencerFailover_SetupCluster(t *testing.T) {
+func TestSequencerFailover_SetupCluster(t *testing.T) {
+	t.Skip("temporarily disable for now")
 	sys, conductors := setupSequencerFailoverTest(t)
 	defer sys.Close()
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Disable flaky sequencer failover test for now to save CI time / retries.
