### PR TITLE
interop(op-node) config

### DIFF
--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -563,6 +563,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	for name, rollupCfg := range cfg.Nodes {
 		configureL1(rollupCfg, sys.EthInstances["l1"])
 		configureL2(rollupCfg, sys.EthInstances[name], cfg.JWTSecret)
+		configureInterop(rollupCfg)
 	}
 
 	// Geth Clients
@@ -858,6 +859,11 @@ func configureL1(rollupNodeCfg *rollupNode.Config, l1Node EthInstance) {
 		HttpPollInterval: time.Millisecond * 100,
 		MaxConcurrency:   10,
 	}
+}
+
+// disable for now
+func configureInterop(rollupNodeCfg *rollupNode.Config) {
+	rollupNodeCfg.InteropL2s = &rollupNode.InteropEndpointsConfig{}
 }
 
 type WSOrHTTPEndpoint interface {

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -83,8 +83,9 @@ type Metrics struct {
 
 	metrics.RPCMetrics
 
-	L1SourceCache *metrics.CacheMetrics
-	L2SourceCache *metrics.CacheMetrics
+	L1SourceCache        *metrics.CacheMetrics
+	L2SourceCache        *metrics.CacheMetrics
+	InteropL2SourceCache *metrics.CacheMetrics
 
 	DerivationIdle prometheus.Gauge
 
@@ -180,8 +181,9 @@ func NewMetrics(procName string) *Metrics {
 
 		RPCMetrics: metrics.MakeRPCMetrics(ns, factory),
 
-		L1SourceCache: metrics.NewCacheMetrics(factory, ns, "l1_source_cache", "L1 Source cache"),
-		L2SourceCache: metrics.NewCacheMetrics(factory, ns, "l2_source_cache", "L2 Source cache"),
+		L1SourceCache:        metrics.NewCacheMetrics(factory, ns, "l1_source_cache", "L1 Source cache"),
+		L2SourceCache:        metrics.NewCacheMetrics(factory, ns, "l2_source_cache", "L2 Source cache"),
+		InteropL2SourceCache: metrics.NewCacheMetrics(factory, ns, "interop_l2_source_cache", "Interop L2 Source cache"),
 
 		DerivationIdle: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Config struct {
-	L1 L1EndpointSetup
-	L2 L2EndpointSetup
+	L1         L1EndpointSetup
+	L2         L2EndpointSetup
+	InteropL2s InteropEndpointsSetup
 
 	Beacon L1BeaconEndpointSetup
 
@@ -122,6 +123,9 @@ func (cfg *Config) LoadPersisted(log log.Logger) error {
 func (cfg *Config) Check() error {
 	if err := cfg.L1.Check(); err != nil {
 		return fmt.Errorf("l2 endpoint config error: %w", err)
+	}
+	if err := cfg.InteropL2s.Check(); err != nil {
+		return fmt.Errorf("interop endpoint config error: %w", err)
 	}
 	if err := cfg.L2.Check(); err != nil {
 		return fmt.Errorf("l2 endpoint config error: %w", err)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -57,6 +57,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	}
 
 	l1Endpoint := NewL1EndpointConfig(ctx)
+	interopEndpoints := NewInteropEndpointsConfig(ctx)
 
 	l2Endpoint, err := NewL2EndpointConfig(ctx, log)
 	if err != nil {
@@ -74,10 +75,11 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 	}
 
 	cfg := &node.Config{
-		L1:     l1Endpoint,
-		L2:     l2Endpoint,
-		Rollup: *rollupConfig,
-		Driver: *driverConfig,
+		L1:         l1Endpoint,
+		L2:         l2Endpoint,
+		InteropL2s: interopEndpoints,
+		Rollup:     *rollupConfig,
+		Driver:     *driverConfig,
 		RPC: node.RPCConfig{
 			ListenAddr:  ctx.String(flags.RPCListenAddr.Name),
 			ListenPort:  ctx.Int(flags.RPCListenPort.Name),
@@ -158,6 +160,13 @@ func NewL2EndpointConfig(ctx *cli.Context, log log.Logger) (*node.L2EndpointConf
 		L2EngineAddr:      l2Addr,
 		L2EngineJWTSecret: secret,
 	}, nil
+}
+
+func NewInteropEndpointsConfig(ctx *cli.Context) *node.InteropEndpointsConfig {
+	// define flags
+	return &node.InteropEndpointsConfig{
+		ChainCfgs: map[uint64]node.L1EndpointConfig{},
+	}
 }
 
 func NewConfigPersistence(ctx *cli.Context) node.ConfigPersistence {


### PR DESCRIPTION
This is the start of configuration for interop. Primarily setting up
remote L2 peers which apart of the interop set.

We leverage the `L1Client`, `eth.L1BlockRef`, and `L1EndpointSetup`, as we want
to treat this peer like any ETH remote. The infra around the `L2Client` and
`L2EndpointSetup` focuses on the local L2 instance. We'll likely want to refactor
some of this tooling such that we have client libraries that are agnostic to
the L1/L2. `sources.EthClient` moves in this direction but there are some holes.
