### PR TITLE
specs: specify Ecotone SystemConfig scalar data and upgrade behavior

### DIFF
--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -303,7 +303,7 @@ The pre-Ecotone values are migrated over 1:1. The new Ecotone attributes are set
 - The `baseFeeScalar` is set to the pre-Ecotone `scalar` value.
 - The `blobBaseFeeScalar` is set to 0.
 - The pre-Ecotone `overhead` attribute is dropped.
-- The `blobBaseFee` represents the L1 blob basefee of the L1 origin block.
+- The `blobBaseFee` represents the L1 blob base fee of the L1 origin block.
   Or `0` if the L1 block does not support blobs.
 
 ## Special Accounts on L2
@@ -342,6 +342,8 @@ The predeploy stores the following values:
 - System configurables tied to the L1 block, see [System configuration specification](./system_config.md):
   - `batcherHash` (`bytes32`): A versioned commitment to the batch-submitter(s) currently operating.
   - `overhead` (`uint256`): The L1 fee overhead to apply to L1 cost computation of transactions in this L2 block.
+    The `overhead` value is dropped as it is no longer used in the
+    [Ecotone L1 fee formula](./exec-engine.md#ecotone-l1-cost-fee-changes-eip-4844-da).
   - `scalar` (`uint256`): The L1 fee scalar to apply to L1 cost computation of transactions in this L2 block.
 - With the Ecotone upgrade, the predeploy additionally stores:
   - `blobBaseFee` (`uint256`)

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -298,13 +298,16 @@ deposit transaction.
 
 In the first L2 block after the Ecotone activation block, the Ecotone L1 attributes are first used.
 
-The pre-Ecotone values are migrated over 1:1. The new Ecotone attributes are set as following:
+The pre-Ecotone values are migrated over 1:1.
+Blocks after the Ecotone activation block contain all pre-Ecotone values 1:1,
+and also set the following new attributes:
 
 - The `baseFeeScalar` is set to the pre-Ecotone `scalar` value.
-- The `blobBaseFeeScalar` is set to 0.
+- The `blobBaseFeeScalar` is set to `0`.
 - The pre-Ecotone `overhead` attribute is dropped.
-- The `blobBaseFee` represents the L1 blob base fee of the L1 origin block.
-  Or `0` if the L1 block does not support blobs.
+- The `blobBaseFee` is set to the L1 blob base fee of the L1 origin block.
+  Or `1` if the L1 block does not support blobs.
+  The `1` value is derived from the EIP-4844 `MIN_BLOB_GASPRICE`.
 
 ## Special Accounts on L2
 

--- a/specs/deposits.md
+++ b/specs/deposits.md
@@ -31,8 +31,8 @@ with the authorization and validation conditions on L2.
 - [Deposit Receipt](#deposit-receipt)
 - [L1 Attributes Deposited Transaction](#l1-attributes-deposited-transaction)
   - [L1 Attributes Deposited Transaction Calldata](#l1-attributes-deposited-transaction-calldata)
-    - [Bedrock, Canyon, Delta](#bedrock-canyon-delta)
-    - [Ecotone](#ecotone)
+    - [L1 Attributes - Bedrock, Canyon, Delta](#l1-attributes---bedrock-canyon-delta)
+    - [L1 Attributes - Ecotone](#l1-attributes---ecotone)
 - [Special Accounts on L2](#special-accounts-on-l2)
   - [L1 Attributes Depositor Account](#l1-attributes-depositor-account)
   - [L1 Attributes Predeployed Contract](#l1-attributes-predeployed-contract)
@@ -258,13 +258,13 @@ This system-initiated transaction for L1 attributes is not charged any ETH for i
 
 ### L1 Attributes Deposited Transaction Calldata
 
-#### Bedrock, Canyon, Delta
+#### L1 Attributes - Bedrock, Canyon, Delta
 
 The `data` field of the L1 attributes deposited transaction is an [ABI][ABI] encoded call to the
 `setL1BlockValues()` function with correct values associated with the corresponding L1 block
 (cf.  [reference implementation][l1-attr-ref-implem]).
 
-#### Ecotone
+#### L1 Attributes - Ecotone
 
 On the Ecotone activation block, and if Ecotone is not activated at Genesis,
 the L1 Attributes Transaction includes a call to `setL1BlockValues()`
@@ -295,6 +295,16 @@ The overall calldata layout is as follows:
 Total calldata length MUST be exactly 164 bytes, implying the sixth and final segment is only
 partially filled. This helps to slow database growth as every L2 block includes a L1 Attributes
 deposit transaction.
+
+In the first L2 block after the Ecotone activation block, the Ecotone L1 attributes are first used.
+
+The pre-Ecotone values are migrated over 1:1. The new Ecotone attributes are set as following:
+
+- The `baseFeeScalar` is set to the pre-Ecotone `scalar` value.
+- The `blobBaseFeeScalar` is set to 0.
+- The pre-Ecotone `overhead` attribute is dropped.
+- The `blobBaseFee` represents the L1 blob basefee of the L1 origin block.
+  Or `0` if the L1 block does not support blobs.
 
 ## Special Accounts on L2
 

--- a/specs/system_config.md
+++ b/specs/system_config.md
@@ -7,8 +7,8 @@
 - [System config contents (version 0)](#system-config-contents-version-0)
   - [`batcherHash` (`bytes32`)](#batcherhash-bytes32)
   - [Scalars](#scalars)
-    - [`overhead`,`scalar` (`uint256,uint256`)](#overheadscalar-uint256uint256)
-    - [`l1BasefeeScalar`,`l1BlobBasefeeScalar` (`uint32,uint32`)](#l1basefeescalarl1blobbasefeescalar-uint32uint32)
+    - [Pre-Ecotone `scalar`, `overhead` (`uint256,uint256`)](#pre-ecotone-scalar-overhead-uint256uint256)
+    - [Ecotone `scalar`, `overhead` (`uint256,uint256`) change](#ecotone-scalar-overhead-uint256uint256-change)
   - [`gasLimit` (`uint64`)](#gaslimit-uint64)
   - [`unsafeBlockSigner` (`address`)](#unsafeblocksigner-address)
 - [Writing the system config](#writing-the-system-config)
@@ -39,20 +39,49 @@ The L1 fee parameters, also known as Gas Price Oracle (GPO) parameters, are used
 data fee applied to an L2 transaction.  The specific parameters used depend on the upgrades that
 are active.
 
-#### `overhead`,`scalar` (`uint256,uint256`)
+Fee parameter updates are signaled to L2 through the `GAS_CONFIG` log-event of the `SystemConfig`.
 
-Prior to the Ecotone upgrade, `overhead` and `scalar` are consulted and passed to the L2 via L1
-attribute info.
+#### Pre-Ecotone `scalar`, `overhead` (`uint256,uint256`)
 
-#### `l1BasefeeScalar`,`l1BlobBasefeeScalar` (`uint32,uint32`)
+The `overhead` and `scalar` are consulted and passed to the L2 via L1 attribute info.
 
-After the Ecotone upgrade, `l1BasefeeScalar` and `l1BlobBasefeeScalar` are passed to the L2
-instead.
+The values are interpreted as big-endian `uint256`.
 
-The only exception is for chains that have genesis prior to Ecotone and go through the Ecotone
-transition. For these chains, the very first Ecotone block will pass the older
-parameters. Thereafter and up until a type `4` log event is processed, `l1BasefeeScalar` passed to
-the L2 *must* be set to the value of `scalar`, or MaxUint32 if `scalar` is outside 32-bit range.
+#### Ecotone `scalar`, `overhead` (`uint256,uint256`) change
+
+After Ecotone activation, the `scalar` attribute encodes additional scalar information, in a versioned encoding scheme.
+
+After Ecotone activation, the `overhead` value is ignored: it does not affect the L2 state-transition output.
+
+The `scalar` is encoded as big-endian `uint256`. This `bytes32` is decoded as following:
+
+*Byte ranges are indicated with `[` (inclusive) and `)` (exclusive).
+
+- `0`: scalar-version byte
+- `[1, 32)`: depending scalar-version:
+  - Scalar-version `0`:
+    - `[1, 28)`: padding, must be zero.
+    - `[28, 32)`: big-endian `uint32`, encoding the L1-fee `baseFeeScalar`
+    - This version implies the L1-fee `blobBaseFeeScalar` is set to 0.
+    - This version is compatible with the pre-Ecotone `scalar` value (assuming a `uint32` range).
+  - Scalar-version `1`:
+    - `[1, 24)`: padding, must be zero.
+    - `[24, 28)`: big-endian `uint32`, encoding the `blobBaseFeeScalar`
+    - `[28, 32)`: big-endian `uint32`, encoding the `baseFeeScalar`
+    - This version is meant to configure the EIP-4844 blob fee component, once DA utilizes blob fees.
+  - Other scalar-version values: unrecognized.
+    OP-Stack forks are recommended to utilize the `>= 128` scalar-version range and document their `scalar` encoding.
+
+Invalid and unrecognized scalar event-data should be ignored,
+and the last valid configuration should continue to be utilized.
+
+The `baseFeeScalar` and `blobBaseFeeScalar` are incorporated into the L2 through the
+[Ecotone L1 attributes deposit transaction calldata](./deposits.md#l1-attributes---ecotone).
+
+Future upgrades of the `SystemConfig` contract may provide additional typed getters/setters
+for the versioned scalar information.
+
+In Ecotone the existing `setGasConfig` function, and `scalar` and `overhead` getters, continue to function.
 
 ### `gasLimit` (`uint64`)
 

--- a/specs/system_config.md
+++ b/specs/system_config.md
@@ -49,9 +49,10 @@ The values are interpreted as big-endian `uint256`.
 
 #### Ecotone `scalar`, `overhead` (`uint256,uint256`) change
 
-After Ecotone activation, the `scalar` attribute encodes additional scalar information, in a versioned encoding scheme.
+After Ecotone activation:
 
-After Ecotone activation, the `overhead` value is ignored: it does not affect the L2 state-transition output.
+- The `scalar` attribute encodes additional scalar information, in a versioned encoding scheme.
+- The `overhead` value is ignored: it does not affect the L2 state-transition output.
 
 The `scalar` is encoded as big-endian `uint256`. This `bytes32` is decoded as following:
 
@@ -82,6 +83,15 @@ Future upgrades of the `SystemConfig` contract may provide additional typed gett
 for the versioned scalar information.
 
 In Ecotone the existing `setGasConfig` function, and `scalar` and `overhead` getters, continue to function.
+
+When the batch-submitter utilizes EIP-4844 blob data for data-availability
+it can adjust the scalars to accurately price the resources:
+
+- `baseFeeScalar` to correspond to share of a user-transaction (per byte)
+  in the total Blob data that is introduced by the data-transaction of the batch-submitter.
+- `blobBaseFeeScalar` to correspond to the share of the user-transaction (per byte)
+  in the total regular L1 EVM gas usage consumed by the data-transaction of the batch-submitter.
+  For regular data-transactions this is the fixed intrinsic gas cost of the L1 transaction.
 
 ### `gasLimit` (`uint64`)
 

--- a/specs/system_config.md
+++ b/specs/system_config.md
@@ -54,7 +54,7 @@ After Ecotone activation:
 - The `scalar` attribute encodes additional scalar information, in a versioned encoding scheme.
 - The `overhead` value is ignored: it does not affect the L2 state-transition output.
 
-The `scalar` is encoded as big-endian `uint256`. This `bytes32` is decoded as following:
+The `scalar` is encoded as big-endian `uint256`, interpreted as `bytes32`, and composed as following:
 
 *Byte ranges are indicated with `[` (inclusive) and `)` (exclusive).
 

--- a/specs/system_config.md
+++ b/specs/system_config.md
@@ -69,7 +69,7 @@ The `scalar` is encoded as big-endian `uint256`, interpreted as `bytes32`, and c
     - `[1, 24)`: padding, must be zero.
     - `[24, 28)`: big-endian `uint32`, encoding the `blobBaseFeeScalar`
     - `[28, 32)`: big-endian `uint32`, encoding the `baseFeeScalar`
-    - This version is meant to configure the EIP-4844 blob fee component, once DA utilizes blob fees.
+    - This version is meant to configure the EIP-4844 blob fee component, once blobs are used for data-availability.
   - Other scalar-version values: unrecognized.
     OP-Stack forks are recommended to utilize the `>= 128` scalar-version range and document their `scalar` encoding.
 


### PR DESCRIPTION
**Description**

Specify how the systemconfig scalar is interpreted in Ecotone, and how it translates to the L1 info attributes.

This decouples the MCP and 4844 projects by not requiring `SystemConfig` changes for Ecotone. 