### PR TITLE
fix(op-bindings): `forge clean`

### DIFF
--- a/op-bindings/Makefile
+++ b/op-bindings/Makefile
@@ -18,6 +18,7 @@ version:
 
 compile:
 	cd $(contracts-dir) && \
+		forge clean && \
 		pnpm build
 
 bindings: bindgen-local


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/ethereum-optimism/optimism/pull/8992, there is still non-determinism in the bindings during partial compilation. Requires a `forge clean` before generating again.
