### PR TITLE
MemoryStateDB mutex fix

### DIFF
--- a/op-chain-ops/state/memory_db.go
+++ b/op-chain-ops/state/memory_db.go
@@ -179,8 +179,8 @@ func (db *MemoryStateDB) SetCode(addr common.Address, code []byte) {
 }
 
 func (db *MemoryStateDB) GetCodeSize(addr common.Address) int {
-	db.rw.Lock()
-	defer db.rw.Unlock()
+	db.rw.RLock()
+	defer db.rw.RUnlock()
 
 	account, ok := db.genesis.Alloc[addr]
 	if !ok {
@@ -232,6 +232,9 @@ func (db *MemoryStateDB) SetState(addr common.Address, key, value common.Hash) {
 }
 
 func (db *MemoryStateDB) DeleteState(addr common.Address, key common.Hash) {
+	db.rw.Lock()
+	defer db.rw.Unlock()
+
 	account, ok := db.genesis.Alloc[addr]
 	if !ok {
 		panic(fmt.Sprintf("%s not in state", addr))


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR fixes two issues in `op-chain-ops/state/memory_db.go`:
- Changes the use of the `sync.RWMutex` `MemoryStateDB.rw` in `(*MemoryStateDB) GetCodeSize` from a read/write lock to a read-only lock. This is okay to do since there no data being written here.
- Adds a lock to `(*MemoryStateDB) DeleteState()` since none was present. This is needed as data writes in race conditions can corrupt memory in Go.