### PR TITLE
op-node: Follow convention for pending safe metric

### DIFF
--- a/op-node/rollup/derive/engine_queue.go
+++ b/op-node/rollup/derive/engine_queue.go
@@ -411,7 +411,7 @@ func (eq *EngineQueue) logSyncProgress(reason string) {
 		"reason", reason,
 		"l2_finalized", eq.ec.Finalized(),
 		"l2_safe", eq.ec.SafeL2Head(),
-		"l2_safe_pending", eq.ec.PendingSafeL2Head(),
+		"l2_pending_safe", eq.ec.PendingSafeL2Head(),
 		"l2_unsafe", eq.ec.UnsafeL2Head(),
 		"l2_time", eq.ec.UnsafeL2Head().Time,
 		"l1_derived", eq.origin,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

PendingSafeL2Head metrics are stored with the name `l2_pending_safe`. This PR makes logging also follow the name, removing ambiguity. Noticed while searching `l2_pending_safe` and `l2_safe_pending` in original codebase.


