### PR TITLE
fix: defer cancel on publishTx

### DIFF
--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -483,8 +483,8 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 		}
 
 		cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
-		err := m.backend.SendTransaction(cCtx, tx)
 		defer cancel()
+		err := m.backend.SendTransaction(cCtx, tx)
 		sendState.ProcessSendError(err)
 
 		if err == nil {

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -484,7 +484,7 @@ func (m *SimpleTxManager) publishTx(ctx context.Context, tx *types.Transaction, 
 
 		cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
 		err := m.backend.SendTransaction(cCtx, tx)
-		cancel()
+		defer cancel()
 		sendState.ProcessSendError(err)
 
 		if err == nil {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

cancel() should be deferred unless it's intended. Worth taking a look.

Before

```go
		cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
		err := m.backend.SendTransaction(cCtx, tx)
		cancel()
		sendState.ProcessSendError(err)
```

After

```go
		cCtx, cancel := context.WithTimeout(ctx, m.cfg.NetworkTimeout)
		err := m.backend.SendTransaction(cCtx, tx)
		defer cancel()
		sendState.ProcessSendError(err)
```
