### PR TITLE
Add `jq` to monorepo dependencies in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ You'll need the following:
 * [Docker Compose](https://docs.docker.com/compose/install/)
 * [Go](https://go.dev/dl/)
 * [Foundry](https://getfoundry.sh)
+* [jq](https://jqlang.github.io/jq/)
 * [go-ethereum](https://github.com/ethereum/go-ethereum)
 
 ### Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ To build all of the [TypeScript packages](./packages), run:
 
 ```bash
 pnpm clean
+pnpm install
 pnpm build
 ```
 
@@ -142,6 +143,7 @@ Finally, **if you're running into weird problems and nothing seems to be working
 ```bash
 cd optimism
 pnpm clean
+pnpm install
 pnpm build
 cd ops
 docker compose down -v


### PR DESCRIPTION
**Description**
Edits to CONTRIBUTING.md:
1. `jq` is an implicit dependency of the monorepo, without which the smart contract tests will fail to run:
https://github.com/ethereum-optimism/optimism/blob/ee8e6bbf77e9a5c43870ed470f3e389094efc3d6/packages/contracts-bedrock/scripts/SemverLock.s.sol#L38
2. `pnpm clean` removes `node_modules`:
https://github.com/ethereum-optimism/optimism/blob/23dd85a41d7c2e029da87861716572916d325d40/package.json#L12
so `pnpm install` should be run before trying `pnpm build`. 

**Tests**

I tried to run `pnpm test` as per existing instructions without `jq` installed and got lots of output such as:
```
FAIL. Reason: setup failed: the path ProtocolVersions.sol/ProtocolVersions.json is not allowed to be accessed for read operations
```
Installing `jq` fixed the problem.


**Additional context**

These are just minor tweaks I discovered as a newcomer to the repo.

**Metadata**

- Fixes #[Link to Issue]
