### PR TITLE
4844: Fix Dencun e2e tests

### DIFF
--- a/op-e2e/actions/dencun_fork_test.go
+++ b/op-e2e/actions/dencun_fork_test.go
@@ -160,6 +160,7 @@ func TestDencunL2ForkAtGenesis(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	offset := hexutil.Uint64(0)
+	dp.DeployConfig.L2GenesisRegolithTimeOffset = &offset
 	dp.DeployConfig.L1CancunTimeOffset = &offset
 	dp.DeployConfig.L2GenesisCanyonTimeOffset = &offset
 	dp.DeployConfig.L2GenesisDeltaTimeOffset = &offset
@@ -202,6 +203,7 @@ func TestDencunBlobTxRPC(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	offset := hexutil.Uint64(0)
+	dp.DeployConfig.L2GenesisRegolithTimeOffset = &offset
 	dp.DeployConfig.L2GenesisCanyonTimeOffset = &offset
 	dp.DeployConfig.L2GenesisDeltaTimeOffset = &offset
 	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &offset
@@ -220,6 +222,7 @@ func TestDencunBlobTxInTxPool(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	offset := hexutil.Uint64(0)
+	dp.DeployConfig.L2GenesisRegolithTimeOffset = &offset
 	dp.DeployConfig.L2GenesisCanyonTimeOffset = &offset
 	dp.DeployConfig.L2GenesisDeltaTimeOffset = &offset
 	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &offset
@@ -237,6 +240,7 @@ func TestDencunBlobTxInclusion(gt *testing.T) {
 	t := NewDefaultTesting(gt)
 	dp := e2eutils.MakeDeployParams(t, defaultRollupTestParams)
 	offset := hexutil.Uint64(0)
+	dp.DeployConfig.L2GenesisRegolithTimeOffset = &offset
 	dp.DeployConfig.L2GenesisCanyonTimeOffset = &offset
 	dp.DeployConfig.L2GenesisDeltaTimeOffset = &offset
 	dp.DeployConfig.L2GenesisEcotoneTimeOffset = &offset

--- a/op-e2e/actions/l2_verifier_test.go
+++ b/op-e2e/actions/l2_verifier_test.go
@@ -17,7 +17,8 @@ func setupVerifier(t Testing, sd *e2eutils.SetupData, log log.Logger, l1F derive
 	jwtPath := e2eutils.WriteDefaultJWT(t)
 	engine := NewL2Engine(t, log, sd.L2Cfg, sd.RollupCfg.Genesis.L1, jwtPath)
 	engCl := engine.EngineClient(t, sd.RollupCfg)
-	verifier := NewL2Verifier(t, log, l1F, engCl, sd.RollupCfg, syncCfg)
+	mockBlobFetcher := &emptyL1BlobsFetcher{t: t}
+	verifier := NewL2Verifier(t, log, l1F, mockBlobFetcher, engCl, sd.RollupCfg, syncCfg)
 	return engine, verifier
 }
 


### PR DESCRIPTION
**Description**

Currently we [pass `nil` for the `L1BlobFetcher`](https://github.com/ethereum-optimism/optimism/blob/23dd85a41d7c2e029da87861716572916d325d40/op-e2e/actions/l2_verifier.go#L62), which causes [this error](https://github.com/ethereum-optimism/optimism/blob/23dd85a41d7c2e029da87861716572916d325d40/op-node/rollup/derive/data_source.go#L51) to occur for post-Ecotone blocks which results in `ActL2PipelineFull` never returning as the pipeline is never set to idle (due to it being an supported error).

This PR passes makes the following changes:

* Provide a no-op mock for fetching blobs
  *  Should never be called as the actions tests have their own [batcher](https://github.com/ethereum-optimism/optimism/blob/23dd85a41d7c2e029da87861716572916d325d40/op-e2e/actions/l2_batcher.go#L81) which only supports calldata.
* Fail the tests if there's an unexpected error

