### PR TITLE
feat(op-challenger): Large Preimage Uploader

### DIFF
--- a/op-challenger/game/fault/preimages/direct.go
+++ b/op-challenger/game/fault/preimages/direct.go
@@ -14,10 +14,6 @@ var _ PreimageUploader = (*DirectPreimageUploader)(nil)
 
 var ErrNilPreimageData = fmt.Errorf("cannot upload nil preimage data")
 
-type PreimageOracleContract interface {
-	UpdateOracleTx(ctx context.Context, claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error)
-}
-
 // DirectPreimageUploader uploads the provided [types.PreimageOracleData]
 // directly to the PreimageOracle contract in a single transaction.
 type DirectPreimageUploader struct {

--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -1,0 +1,40 @@
+package preimages
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var _ PreimageUploader = (*LargePreimageUploader)(nil)
+
+var errNotSupported = errors.New("not supported")
+
+// LargePreimageUploader handles uploading large preimages by
+// streaming the merkleized preimage to the PreimageOracle contract,
+// tightly packed across multiple transactions.
+type LargePreimageUploader struct {
+	log log.Logger
+
+	txMgr    txmgr.TxManager
+	contract PreimageOracleContract
+}
+
+func NewLargePreimageUploader(logger log.Logger, txMgr txmgr.TxManager, contract PreimageOracleContract) *LargePreimageUploader {
+	return &LargePreimageUploader{logger, txMgr, contract}
+}
+
+func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint64, data *types.PreimageOracleData) error {
+	// todo(proofs#467): generate the full preimage
+	// todo(proofs#467): run the preimage through the keccak permutation, hashing
+	//                   the intermediate state matrix after each block is applied.
+	// todo(proofs#467): split up the preimage into chunks and submit the preimages
+	//                   and state commitments to the preimage oracle contract using
+	//                   `PreimageOracle.addLeavesLPP` (`_finalize` = false).
+	// todo(proofs#467): track the challenge period starting once the full preimage is posted.
+	// todo(proofs#467): once the challenge period is over, call `squeezeLPP` on the preimage oracle contract.
+	return errNotSupported
+}

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -1,0 +1,27 @@
+package preimages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLargePreimageUploader_UploadPreimage(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		oracle, _, _ := newTestLargePreimageUploader(t)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
+		// todo(proofs#467): fix this to not error. See LargePreimageUploader.UploadPreimage.
+		require.ErrorIs(t, err, errNotSupported)
+	})
+}
+
+func newTestLargePreimageUploader(t *testing.T) (*LargePreimageUploader, *mockTxMgr, *mockPreimageOracleContract) {
+	logger := testlog.Logger(t, log.LvlError)
+	txMgr := &mockTxMgr{}
+	contract := &mockPreimageOracleContract{}
+	return NewLargePreimageUploader(logger, txMgr, contract), txMgr, contract
+}

--- a/op-challenger/game/fault/preimages/types.go
+++ b/op-challenger/game/fault/preimages/types.go
@@ -4,10 +4,16 @@ import (
 	"context"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
 
 // PreimageUploader is responsible for posting preimages.
 type PreimageUploader interface {
 	// UploadPreimage uploads the provided preimage.
 	UploadPreimage(ctx context.Context, claimIdx uint64, data *types.PreimageOracleData) error
+}
+
+// PreimageOracleContract is the interface for interacting with the PreimageOracle contract.
+type PreimageOracleContract interface {
+	UpdateOracleTx(ctx context.Context, claimIdx uint64, data *types.PreimageOracleData) (txmgr.TxCandidate, error)
 }


### PR DESCRIPTION
**Description**

Implements a stubbed out `LargePreimageUploader` that will be used by the `op-challenger`'s responder component to handle uploading large preimages to the preimage oracle contract.

Currently, this component errors with an unsupported message so progress can be made later on and/or stacked ontop of this stack group.

**Tests**

Unit tests around the `LargePreimageUploader.UploadPreimage` method currently assert an error is bubbled up.

**Metadata**

Story 2/3 of https://github.com/ethereum-optimism/client-pod/issues/471
