### PR TITLE
feat(op-challenger): Split Preimage Uploader

### DIFF
--- a/op-challenger/game/fault/preimages/direct.go
+++ b/op-challenger/game/fault/preimages/direct.go
@@ -12,8 +12,6 @@ import (
 
 var _ PreimageUploader = (*DirectPreimageUploader)(nil)
 
-var ErrNilPreimageData = fmt.Errorf("cannot upload nil preimage data")
-
 // DirectPreimageUploader uploads the provided [types.PreimageOracleData]
 // directly to the PreimageOracle contract in a single transaction.
 type DirectPreimageUploader struct {

--- a/op-challenger/game/fault/preimages/split.go
+++ b/op-challenger/game/fault/preimages/split.go
@@ -1,0 +1,38 @@
+package preimages
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+)
+
+var _ PreimageUploader = (*SplitPreimageUploader)(nil)
+
+// PREIMAGE_SIZE_THRESHOLD is the size threshold for determining whether a preimage
+// should be uploaded directly or through the large preimage uploader.
+// TODO(client-pod#467): determine the correct size threshold to toggle between
+//
+//	the direct and large preimage uploaders.
+const PREIMAGE_SIZE_THRESHOLD = 136 * 128
+
+// SplitPreimageUploader routes preimage uploads to the appropriate uploader
+// based on the size of the preimage.
+type SplitPreimageUploader struct {
+	directUploader PreimageUploader
+	largeUploader  PreimageUploader
+}
+
+func NewSplitPreimageUploader(directUploader PreimageUploader, largeUploader PreimageUploader) *SplitPreimageUploader {
+	return &SplitPreimageUploader{directUploader, largeUploader}
+}
+
+func (s *SplitPreimageUploader) UploadPreimage(ctx context.Context, parent uint64, data *types.PreimageOracleData) error {
+	if data == nil {
+		return ErrNilPreimageData
+	}
+	if len(data.OracleData) > PREIMAGE_SIZE_THRESHOLD {
+		return s.largeUploader.UploadPreimage(ctx, parent, data)
+	} else {
+		return s.directUploader.UploadPreimage(ctx, parent, data)
+	}
+}

--- a/op-challenger/game/fault/preimages/split_test.go
+++ b/op-challenger/game/fault/preimages/split_test.go
@@ -1,0 +1,52 @@
+package preimages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPreimageUploader_UploadPreimage(t *testing.T) {
+	t.Run("DirectUploadSucceeds", func(t *testing.T) {
+		oracle, direct, large := newTestSplitPreimageUploader(t)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
+		require.NoError(t, err)
+		require.Equal(t, 1, direct.updates)
+		require.Equal(t, 0, large.updates)
+	})
+
+	t.Run("LargeUploadSucceeds", func(t *testing.T) {
+		oracle, direct, large := newTestSplitPreimageUploader(t)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{OracleData: make([]byte, PREIMAGE_SIZE_THRESHOLD+1)})
+		require.NoError(t, err)
+		require.Equal(t, 1, large.updates)
+		require.Equal(t, 0, direct.updates)
+	})
+
+	t.Run("NilPreimageOracleData", func(t *testing.T) {
+		oracle, _, _ := newTestSplitPreimageUploader(t)
+		err := oracle.UploadPreimage(context.Background(), 0, nil)
+		require.ErrorIs(t, err, ErrNilPreimageData)
+	})
+}
+
+type mockPreimageUploader struct {
+	updates     int
+	uploadFails bool
+}
+
+func (s *mockPreimageUploader) UploadPreimage(ctx context.Context, parent uint64, data *types.PreimageOracleData) error {
+	s.updates++
+	if s.uploadFails {
+		return mockUpdateOracleTxError
+	}
+	return nil
+}
+
+func newTestSplitPreimageUploader(t *testing.T) (*SplitPreimageUploader, *mockPreimageUploader, *mockPreimageUploader) {
+	direct := &mockPreimageUploader{}
+	large := &mockPreimageUploader{}
+	return NewSplitPreimageUploader(direct, large), direct, large
+}

--- a/op-challenger/game/fault/preimages/types.go
+++ b/op-challenger/game/fault/preimages/types.go
@@ -2,10 +2,13 @@ package preimages
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 )
+
+var ErrNilPreimageData = fmt.Errorf("cannot upload nil preimage data")
 
 // PreimageUploader is responsible for posting preimages.
 type PreimageUploader interface {


### PR DESCRIPTION
**Description**

Implements the split preimage uploader, toggling between the `DirectPreimageUploader` and `LargePreimageUploader` depending upon the preimage oracle data size.

The threshold is currently hardcoded to a naive `32`, which will certainly need to change in this or a follow-on pr.

**Tests**

Unit tests around the dispatching of preimage upload calls on `SplitPreimageUploader.UploadPreimage`.

**Metadata**

Story 3/3 of https://github.com/ethereum-optimism/client-pod/issues/471.

_Note: a final stacked pr will close this ticket out by wiring up the split preimage uploader as an argument to the responder component._
