### PR TITLE
fix(ops): TODO Checker Script Case Sensitivity

### DIFF
--- a/ops/scripts/todo-checker.sh
+++ b/ops/scripts/todo-checker.sh
@@ -50,7 +50,7 @@ for arg in "$@"; do
 done
 
 # Use ripgrep to search for the pattern in all files within the repo
-todos=$(rg -o --with-filename -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
+todos=$(rg -o --with-filename -i -n -g '!ops/scripts/todo-checker.sh' 'TODO\(([^)]+)\): [^,;]*')
 
 # Check each TODO comment in the repo
 IFS=$'\n' # Set Internal Field Separator to newline for iteration


### PR DESCRIPTION
**Description**

There is a minor bug in the todo issue checker script which is run in ci where the [ripgrep](https://github.com/BurntSushi/ripgrep) search for inline code comments with the `TODO(org/repo#num)`.

The current search is **case sensitive** so only comments where the `TODO` is capitalized are found.

This pr updates the search to be **case insensitive** by simply tacking on the `-i` flag to the `rg` command in the script h/t @clabby.
