### PR TITLE
feat(op-challenger): Large Preimage Uploader InitLPP Call Support

### DIFF
--- a/op-challenger/game/fault/preimages/direct_test.go
+++ b/op-challenger/game/fault/preimages/direct_test.go
@@ -17,6 +17,7 @@ import (
 var (
 	mockUpdateOracleTxError = errors.New("mock update oracle tx error")
 	mockTxMgrSendError      = errors.New("mock tx mgr send error")
+	mockInitLPPError        = errors.New("mock init LPP error")
 )
 
 func TestDirectPreimageUploader_UploadPreimage(t *testing.T) {
@@ -25,7 +26,7 @@ func TestDirectPreimageUploader_UploadPreimage(t *testing.T) {
 		contract.updateFails = true
 		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
 		require.ErrorIs(t, err, mockUpdateOracleTxError)
-		require.Equal(t, 1, contract.updates)
+		require.Equal(t, 1, contract.updateCalls)
 		require.Equal(t, 0, txMgr.sends) // verify that the tx was not sent
 	})
 
@@ -34,7 +35,7 @@ func TestDirectPreimageUploader_UploadPreimage(t *testing.T) {
 		txMgr.sendFails = true
 		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
 		require.ErrorIs(t, err, mockTxMgrSendError)
-		require.Equal(t, 1, contract.updates)
+		require.Equal(t, 1, contract.updateCalls)
 		require.Equal(t, 1, txMgr.sends)
 	})
 
@@ -48,7 +49,7 @@ func TestDirectPreimageUploader_UploadPreimage(t *testing.T) {
 		oracle, _, contract := newTestDirectPreimageUploader(t)
 		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
 		require.NoError(t, err)
-		require.Equal(t, 1, contract.updates)
+		require.Equal(t, 1, contract.updateCalls)
 	})
 }
 
@@ -85,12 +86,12 @@ func newTestDirectPreimageUploader(t *testing.T) (*DirectPreimageUploader, *mock
 }
 
 type mockPreimageGameContract struct {
-	updates     int
+	updateCalls int
 	updateFails bool
 }
 
 func (s *mockPreimageGameContract) UpdateOracleTx(_ context.Context, _ uint64, _ *types.PreimageOracleData) (txmgr.TxCandidate, error) {
-	s.updates++
+	s.updateCalls++
 	if s.updateFails {
 		return txmgr.TxCandidate{}, mockUpdateOracleTxError
 	}

--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -3,6 +3,7 @@ package preimages
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -11,6 +12,8 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
+
+var errNotSupported = errors.New("not supported")
 
 var _ PreimageUploader = (*LargePreimageUploader)(nil)
 
@@ -35,6 +38,8 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 	// todo(proofs#467): split up the preimage into chunks and submit the preimages
 	//                   and state commitments to the preimage oracle contract using
 	//                   `PreimageOracle.addLeavesLPP` (`_finalize` = false).
+
+	// TODO(client-pod#473): The UUID must be deterministic so the challenger can resume uploads.
 	uuid, err := p.newUUID()
 	if err != nil {
 		return fmt.Errorf("failed to generate UUID: %w", err)
@@ -43,9 +48,11 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 	if err != nil {
 		return fmt.Errorf("failed to initialize large preimage with uuid: %s: %w", uuid, err)
 	}
+
 	// todo(proofs#467): track the challenge period starting once the full preimage is posted.
 	// todo(proofs#467): once the challenge period is over, call `squeezeLPP` on the preimage oracle contract.
-	return nil
+
+	return errNotSupported
 }
 
 func (p *LargePreimageUploader) newUUID() (*big.Int, error) {

--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -3,9 +3,12 @@ package preimages
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -37,4 +40,32 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 	// todo(proofs#467): track the challenge period starting once the full preimage is posted.
 	// todo(proofs#467): once the challenge period is over, call `squeezeLPP` on the preimage oracle contract.
 	return errNotSupported
+}
+
+// initLargePreimage initializes the large preimage proposal.
+// This method *must* be called before adding any leaves.
+func (p *LargePreimageUploader) initLargePreimage(ctx context.Context, uuid *big.Int, partOffset uint32, claimedSize uint32) error {
+	candidate, err := p.contract.InitLargePreimage(uuid, partOffset, claimedSize)
+	if err != nil {
+		return fmt.Errorf("failed to create pre-image oracle tx: %w", err)
+	}
+	if err := p.sendTxAndWait(ctx, candidate); err != nil {
+		return fmt.Errorf("failed to populate pre-image oracle: %w", err)
+	}
+	return nil
+}
+
+// sendTxAndWait sends a transaction through the [txmgr] and waits for a receipt.
+// This sets the tx GasLimit to 0, performing gas estimation online through the [txmgr].
+func (p *LargePreimageUploader) sendTxAndWait(ctx context.Context, candidate txmgr.TxCandidate) error {
+	receipt, err := p.txMgr.Send(ctx, candidate)
+	if err != nil {
+		return err
+	}
+	if receipt.Status == ethtypes.ReceiptStatusFailed {
+		p.log.Error("LargePreimageUploader tx successfully published but reverted", "tx_hash", receipt.TxHash)
+	} else {
+		p.log.Debug("LargePreimageUploader tx successfully published", "tx_hash", receipt.TxHash)
+	}
+	return nil
 }

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -27,8 +27,9 @@ func TestLargePreimageUploader_UploadPreimage(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		oracle, _, contract := newTestLargePreimageUploader(t)
 		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
-		require.NoError(t, err)
 		require.Equal(t, 1, contract.initCalls)
+		// TODO(proofs#467): fix this to not error. See LargePreimageUploader.UploadPreimage.
+		require.ErrorIs(t, err, errNotSupported)
 	})
 }
 

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -16,26 +16,17 @@ import (
 )
 
 func TestLargePreimageUploader_UploadPreimage(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		oracle, _, _ := newTestLargePreimageUploader(t)
-		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
-		// TODO(proofs#467): fix this to not error. See LargePreimageUploader.UploadPreimage.
-		require.ErrorIs(t, err, errNotSupported)
-	})
-}
-
-func TestLargePreimageUploader_InitLargePreimage(t *testing.T) {
 	t.Run("InitFails", func(t *testing.T) {
 		oracle, _, contract := newTestLargePreimageUploader(t)
 		contract.initFails = true
-		err := oracle.initLargePreimage(context.Background(), nil, 0, 0)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
 		require.ErrorIs(t, err, mockInitLPPError)
 		require.Equal(t, 1, contract.initCalls)
 	})
 
 	t.Run("Success", func(t *testing.T) {
 		oracle, _, contract := newTestLargePreimageUploader(t)
-		err := oracle.initLargePreimage(context.Background(), nil, 0, 0)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
 		require.NoError(t, err)
 		require.Equal(t, 1, contract.initCalls)
 	})


### PR DESCRIPTION
**Description**

Adds support to the `op-challenger` `LargePreimageUploader` component to construct and sent an `initLPP` transaction to the `PreimageOracle` contract using the intermediary Fault Dispute Game contract helpers.

**Tests**

Unit tests around `LargePreimageUploader.initLPP`.

**Metadata**

Makes progress on https://github.com/ethereum-optimism/client-pod/issues/472