### PR TITLE
op-challenger: Register the oracle used by each game type

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -118,15 +118,19 @@ func (f *FaultDisputeGameContract) addLocalDataTx(claimIdx uint64, data *types.P
 }
 
 func (f *FaultDisputeGameContract) addGlobalDataTx(ctx context.Context, data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
-	vm, err := f.vm(ctx)
-	if err != nil {
-		return txmgr.TxCandidate{}, err
-	}
-	oracle, err := vm.Oracle(ctx)
+	oracle, err := f.GetOracle(ctx)
 	if err != nil {
 		return txmgr.TxCandidate{}, err
 	}
 	return oracle.AddGlobalDataTx(data)
+}
+
+func (f *FaultDisputeGameContract) GetOracle(ctx context.Context) (*PreimageOracleContract, error) {
+	vm, err := f.vm(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return vm.Oracle(ctx)
 }
 
 func (f *FaultDisputeGameContract) GetGameDuration(ctx context.Context) (uint64, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -105,6 +105,16 @@ func TestSimpleGetters(t *testing.T) {
 	}
 }
 
+func TestGetOracleAddr(t *testing.T) {
+	stubRpc, game := setupFaultDisputeGameTest(t)
+	stubRpc.SetResponse(fdgAddr, methodVM, batching.BlockLatest, nil, []interface{}{vmAddr})
+	stubRpc.SetResponse(vmAddr, methodOracle, batching.BlockLatest, nil, []interface{}{oracleAddr})
+
+	actual, err := game.GetOracle(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, oracleAddr, actual.Addr())
+}
+
 func TestGetClaim(t *testing.T) {
 	stubRpc, game := setupFaultDisputeGameTest(t)
 	idx := big.NewInt(2)

--- a/op-challenger/game/fault/contracts/gamefactory.go
+++ b/op-challenger/game/fault/contracts/gamefactory.go
@@ -14,6 +14,7 @@ import (
 const (
 	methodGameCount   = "gameCount"
 	methodGameAtIndex = "gameAtIndex"
+	methodGameImpls   = "gameImpls"
 )
 
 type DisputeGameFactoryContract struct {
@@ -46,6 +47,14 @@ func (f *DisputeGameFactoryContract) GetGame(ctx context.Context, idx uint64, bl
 		return types.GameMetadata{}, fmt.Errorf("failed to load game %v: %w", idx, err)
 	}
 	return f.decodeGame(result), nil
+}
+
+func (f *DisputeGameFactoryContract) GetGameImpl(ctx context.Context, gameType uint8) (common.Address, error) {
+	result, err := f.multiCaller.SingleCall(ctx, batching.BlockLatest, f.contract.Call(methodGameImpls, gameType))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to load game impl for type %v: %w", gameType, err)
+	}
+	return result.GetAddress(0), nil
 }
 
 func (f *DisputeGameFactoryContract) decodeGame(result *batching.CallResult) types.GameMetadata {

--- a/op-challenger/game/fault/contracts/gamefactory_test.go
+++ b/op-challenger/game/fault/contracts/gamefactory_test.go
@@ -78,6 +78,21 @@ func TestLoadGame(t *testing.T) {
 	}
 }
 
+func TestGetGameImpl(t *testing.T) {
+	stubRpc, factory := setupDisputeGameFactoryTest(t)
+	gameType := uint8(3)
+	gameImplAddr := common.Address{0xaa}
+	stubRpc.SetResponse(
+		factoryAddr,
+		"gameImpls",
+		batching.BlockLatest,
+		[]interface{}{gameType},
+		[]interface{}{gameImplAddr})
+	actual, err := factory.GetGameImpl(context.Background(), gameType)
+	require.NoError(t, err)
+	require.Equal(t, gameImplAddr, actual)
+}
+
 func expectGetGame(stubRpc *batchingTest.AbiBasedRpc, idx int, blockHash common.Hash, game types.GameMetadata) {
 	stubRpc.SetResponse(
 		factoryAddr,

--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -17,6 +17,7 @@ const (
 
 // PreimageOracleContract is a binding that works with contracts implementing the IPreimageOracle interface
 type PreimageOracleContract struct {
+	addr        common.Address
 	multiCaller *batching.MultiCaller
 	contract    *batching.BoundContract
 }
@@ -28,12 +29,17 @@ func NewPreimageOracleContract(addr common.Address, caller *batching.MultiCaller
 	}
 
 	return &PreimageOracleContract{
+		addr:        addr,
 		multiCaller: caller,
 		contract:    batching.NewBoundContract(mipsAbi, addr),
 	}, nil
 }
 
-func (c PreimageOracleContract) AddGlobalDataTx(data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
+func (c *PreimageOracleContract) Addr() common.Address {
+	return c.addr
+}
+
+func (c *PreimageOracleContract) AddGlobalDataTx(data *types.PreimageOracleData) (txmgr.TxCandidate, error) {
 	call := c.contract.Call(methodLoadKeccak256PreimagePart, new(big.Int).SetUint64(uint64(data.OracleOffset)), data.GetPreimageWithoutSize())
 	return call.ToTxCandidate()
 }

--- a/op-challenger/game/registry/registry.go
+++ b/op-challenger/game/registry/registry.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/common"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -13,22 +15,29 @@ var (
 )
 
 type GameTypeRegistry struct {
-	types map[uint8]scheduler.PlayerCreator
+	types   map[uint8]scheduler.PlayerCreator
+	oracles map[common.Address]types.LargePreimageOracle
 }
 
 func NewGameTypeRegistry() *GameTypeRegistry {
 	return &GameTypeRegistry{
-		types: make(map[uint8]scheduler.PlayerCreator),
+		types:   make(map[uint8]scheduler.PlayerCreator),
+		oracles: make(map[common.Address]types.LargePreimageOracle),
 	}
 }
 
 // RegisterGameType registers a scheduler.PlayerCreator to use for a specific game type.
 // Panics if the same game type is registered multiple times, since this indicates a significant programmer error.
-func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.PlayerCreator) {
+func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.PlayerCreator, oracle types.LargePreimageOracle) {
 	if _, ok := r.types[gameType]; ok {
 		panic(fmt.Errorf("duplicate creator registered for game type: %v", gameType))
 	}
 	r.types[gameType] = creator
+	if oracle != nil {
+		// It's ok to have two game types use the same oracle contract.
+		// We add them to a map deliberately to deduplicate them.
+		r.oracles[oracle.Addr()] = oracle
+	}
 }
 
 // CreatePlayer creates a new game player for the given game, using the specified directory for persisting data.
@@ -38,4 +47,8 @@ func (r *GameTypeRegistry) CreatePlayer(game types.GameMetadata, dir string) (sc
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedGameType, game.GameType)
 	}
 	return creator(game, dir)
+}
+
+func (r *GameTypeRegistry) Oracles() []types.LargePreimageOracle {
+	return maps.Values(r.oracles)
 }

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ func TestKnownGameType(t *testing.T) {
 	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		return expectedPlayer, nil
 	}
-	registry.RegisterGameType(0, creator)
+	registry.RegisterGameType(0, creator, nil)
 	player, err := registry.CreatePlayer(types.GameMetadata{GameType: 0}, "")
 	require.NoError(t, err)
 	require.Same(t, expectedPlayer, player)
@@ -33,8 +34,30 @@ func TestPanicsOnDuplicateGameType(t *testing.T) {
 	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
 		return nil, nil
 	}
-	registry.RegisterGameType(0, creator)
+	registry.RegisterGameType(0, creator, nil)
 	require.Panics(t, func() {
-		registry.RegisterGameType(0, creator)
+		registry.RegisterGameType(0, creator, nil)
 	})
+}
+
+func TestDeduplicateOracles(t *testing.T) {
+	registry := NewGameTypeRegistry()
+	creator := func(game types.GameMetadata, dir string) (scheduler.GamePlayer, error) {
+		return nil, nil
+	}
+	oracleA := stubPreimageOracle{0xaa}
+	oracleB := stubPreimageOracle{0xbb}
+	registry.RegisterGameType(0, creator, oracleA)
+	registry.RegisterGameType(1, creator, oracleB)
+	registry.RegisterGameType(2, creator, oracleB)
+	oracles := registry.Oracles()
+	require.Len(t, oracles, 2)
+	require.Contains(t, oracles, oracleA)
+	require.Contains(t, oracles, oracleB)
+}
+
+type stubPreimageOracle common.Address
+
+func (s stubPreimageOracle) Addr() common.Address {
+	return common.Address(s)
 }

--- a/op-challenger/game/types/types.go
+++ b/op-challenger/game/types/types.go
@@ -41,3 +41,7 @@ type GameMetadata struct {
 	Timestamp uint64
 	Proxy     common.Address
 }
+
+type LargePreimageOracle interface {
+	Addr() common.Address
+}


### PR DESCRIPTION
**Description**

Registers the preimage oracle from each supported game type in the game type registry. This is prep work for being able to monitor the preimage oracle for large preimages that need to be validated and potentially challenged.

Typically each game type will use the same preimage oracle contract, but theoretically they could use separate ones so we need to handle that possibility.  The oracles are deduplicated so we won't wind up monitoring the same one multiple times.

**Tests**

Added tests for the registry and added contract bindings.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/478
