### PR TITLE
deps: update foundry

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "71d8ea5923571f33c7aab9ee6e0d1f9a348bd6be",
+  "foundry": "9e2830d7f0566e0d00b1104eeaedd5032a4e556e",
   "geth": "v1.13.4",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
**Description**

Updates foundry to the commit `9e2830d7f0566e0d00b1104eeaedd5032a4e556e`.
Includes the `vm.dumpState` cheatcode implemented in https://github.com/foundry-rs/foundry/pull/6827.
This will unblock the migration of the genesis generation to solidity to
improve the devex of the L2 contracts and allow us to delete a lot of
custom Go code as well as reduce flakes in CI due to not being able to
find the `genesis.json`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

