### PR TITLE
ci-builder: fix build

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -38,7 +38,7 @@ FROM --platform=linux/amd64 ghcr.io/crytic/echidna/echidna:v2.0.4 as echidna-tes
 
 FROM --platform=linux/amd64 debian:bullseye-slim as go-build
 
-RUN apt-get update && apt-get install -y curl ca-certificates
+RUN apt-get update && apt-get install -y curl ca-certificates jq
 
 ENV GO_VERSION=1.21.1
 


### PR DESCRIPTION
**Description**

Was broken with https://github.com/ethereum-optimism/optimism/pull/8920
due to the new `jq` dependency not being present in the builder image.
Fix by installing `jq` in the builder image.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
