### PR TITLE
contracts-bedrock: bump forge-std 1fd874f0efdb711cb6807c4f4a000ed2805dc809

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -115,7 +115,7 @@ contract Deploy is Deployer {
     /// @notice The create2 salt used for deployment of the contract implementations.
     ///         Using this helps to reduce config across networks as the implementation
     ///         addresses will be the same across networks when deployed with create2.
-    function _implSalt() internal returns (bytes32) {
+    function _implSalt() internal view returns (bytes32) {
         return keccak256(bytes(vm.envOr("IMPL_SALT", string("ethers phoenix"))));
     }
 

--- a/packages/contracts-bedrock/scripts/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/Deployer.sol
@@ -624,7 +624,7 @@ abstract contract Deployer is Script {
 
     /// @notice The context of the deployment is used to namespace the artifacts.
     ///         An unknown context will use the chainid as the context name.
-    function _getDeploymentContext() private returns (string memory) {
+    function _getDeploymentContext() private view returns (string memory) {
         string memory context = vm.envOr("DEPLOYMENT_CONTEXT", string(""));
         if (bytes(context).length > 0) {
             return context;


### PR DESCRIPTION
**Description**

Bumps `forge-std` to the latest commit that includes the `vm.dumpState`
cheatcode.

- https://github.com/foundry-rs/forge-std/pull/499
- https://github.com/foundry-rs/foundry/pull/6827

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->
