### PR TITLE
fix(CI): S-Exempt-Stale Status Label Support

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-issue-label: 'S-stale'
-          exempt-pr-labels: exempt-stale
+          exempt-pr-labels: 'S-exempt-stale'
           days-before-issue-stale: 999
           days-before-pr-stale: 14
           days-before-close: 5


### PR DESCRIPTION
**Description**

Previously, we had `exempt-stale` as a label that could be used to tell the [stale github action](https://github.com/actions/stale) not to consider a pr when running the stale check.

This label doesn't exist, so I added a new https://github.com/ethereum-optimism/optimism/labels/S-exempt-stale label that more closely matches our label ergonomics and updated the github action in this pr to use that new label.

**Motivation**

So that @protolambda doesn't need to remove the https://github.com/ethereum-optimism/optimism/labels/Stale label every two weeks https://github.com/ethereum-optimism/optimism/pull/7281 :smile:
