### PR TITLE
ci-builder: install jq earlier

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-  apt-get install -y curl build-essential git clang lld curl
+  apt-get install -y curl build-essential git clang lld curl jq
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh && \
   chmod +x ./rustup.sh && \


### PR DESCRIPTION
**Description**

The foundry install script uses `jq` so we must install `jq` as early
as possible in `ci-builder` to ensure that its always present.

Follow up to https://github.com/ethereum-optimism/optimism/pull/9042
which fixes the broken build from https://github.com/ethereum-optimism/optimism/pull/8920.

I don't think that #8920 broke the fix in this commit so perhaps the
build was broken longer than we thought? Either way, we need new forge
version in CI that was introduced in https://github.com/ethereum-optimism/optimism/pull/9038
so we need a successful build of `ci-builder`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Example failed build: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/40990/workflows/7a644dc2-310e-49c9-88eb-fd4d790e0c68/jobs/1825774
