### PR TITLE
Ecotone: process Ecotone upgrade transactions during L2 Genesis generation

### DIFF
--- a/op-chain-ops/genesis/helpers.go
+++ b/op-chain-ops/genesis/helpers.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -107,19 +106,4 @@ func newHexBig(in uint64) *hexutil.Big {
 	b := new(big.Int).SetUint64(in)
 	hb := hexutil.Big(*b)
 	return &hb
-}
-
-func maybeSetupEcotone4788(config *DeployConfig, db *state.MemoryStateDB) (*state.MemoryStateDB, error) {
-	genesis := db.Genesis()
-
-	ecotoneTime := config.EcotoneTime(genesis.Timestamp)
-
-	if ecotoneTime != nil && *ecotoneTime <= genesis.Timestamp {
-		err := setup4788Contract(db)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return db, nil
 }

--- a/op-chain-ops/genesis/layer_two.go
+++ b/op-chain-ops/genesis/layer_two.go
@@ -13,7 +13,9 @@ import (
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/deployer"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/immutables"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/squash"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -112,10 +114,25 @@ func BuildL2Genesis(config *DeployConfig, l1StartBlock *types.Block) (*core.Gene
 		}
 	}
 
-	db, err = maybeSetupEcotone4788(config, db)
-	if err != nil {
-		return nil, err
+	if err := PerformUpgradeTxs(db); err != nil {
+		return nil, fmt.Errorf("failed to perform upgrade txs: %w", err)
 	}
 
 	return db.Genesis(), nil
+}
+
+func PerformUpgradeTxs(db *state.MemoryStateDB) error {
+	// Only the Ecotone upgrade is performed with upgrade-txs.
+	if !db.Genesis().Config.IsEcotone(db.Genesis().Timestamp) {
+		return nil
+	}
+	sim := squash.NewSimulator(db)
+	ecotone, err := derive.EcotoneNetworkUpgradeTransactions()
+	if err != nil {
+		return fmt.Errorf("failed to build ecotone upgrade txs: %w", err)
+	}
+	if err := sim.AddUpgradeTxs(ecotone); err != nil {
+		return fmt.Errorf("failed to apply ecotone upgrade txs: %w", err)
+	}
+	return nil
 }

--- a/op-chain-ops/genesis/setters.go
+++ b/op-chain-ops/genesis/setters.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
-	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/immutables"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -88,13 +87,5 @@ func setupPredeploy(db vm.StateDB, deployResults immutables.DeploymentResults, s
 		}
 	}
 
-	return nil
-}
-
-// setup4788Contract creates the EIP-4788 beacon-block-roots contract, part of the Ecotone upgrade.
-func setup4788Contract(db vm.StateDB) error {
-	db.CreateAccount(predeploys.EIP4788ContractAddr)
-	db.SetCode(predeploys.EIP4788ContractAddr, predeploys.EIP4788ContractCode)
-	db.SetNonce(predeploys.EIP4788ContractAddr, 1) // After contract deployment, the resulting contract has nonce=1, see EIP-158
 	return nil
 }

--- a/op-chain-ops/squash/sim.go
+++ b/op-chain-ops/squash/sim.go
@@ -1,0 +1,199 @@
+package squash
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
+)
+
+type staticChain struct {
+	startTime uint64
+	blockTime uint64
+}
+
+func (d *staticChain) Engine() consensus.Engine {
+	return ethash.NewFullFaker()
+}
+
+func (d *staticChain) GetHeader(h common.Hash, n uint64) *types.Header {
+	parentHash := common.Hash{0: 0xff}
+	binary.BigEndian.PutUint64(parentHash[1:], n-1)
+	return &types.Header{
+		ParentHash:      parentHash,
+		UncleHash:       types.EmptyUncleHash,
+		Coinbase:        common.Address{},
+		Root:            common.Hash{},
+		TxHash:          types.EmptyTxsHash,
+		ReceiptHash:     types.EmptyReceiptsHash,
+		Bloom:           types.Bloom{},
+		Difficulty:      big.NewInt(0),
+		Number:          new(big.Int).SetUint64(n),
+		GasLimit:        30_000_000,
+		GasUsed:         0,
+		Time:            d.startTime + n*d.blockTime,
+		Extra:           nil,
+		MixDigest:       common.Hash{},
+		Nonce:           types.BlockNonce{},
+		BaseFee:         big.NewInt(7),
+		WithdrawalsHash: &types.EmptyWithdrawalsHash,
+	}
+}
+
+type simState struct {
+	*state.MemoryStateDB
+	snapshotIndex int
+
+	tempAccessList map[common.Address]map[common.Hash]struct{}
+}
+
+func (db *simState) AddressInAccessList(addr common.Address) bool {
+	_, ok := db.tempAccessList[addr]
+	return ok
+}
+
+func (db *simState) AddLog(log *types.Log) {
+	// no-op
+}
+
+func (db *simState) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	// return the latest state, instead of the pre-tx state.
+	acc, ok := db.Genesis().Alloc[addr]
+	if !ok {
+		return common.Hash{}
+	}
+	return acc.Storage[hash]
+}
+
+func (db *simState) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	// things like the fee-vault-address get marked as warm
+	m, ok := db.tempAccessList[addr]
+	if !ok {
+		m = make(map[common.Hash]struct{})
+		db.tempAccessList[addr] = m
+	}
+	m[slot] = struct{}{}
+}
+
+func (db *simState) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	m, addressOk := db.tempAccessList[addr]
+	if !addressOk {
+		return false, false
+	}
+	_, slotOk = m[slot]
+	return true, slotOk
+}
+
+func (db *simState) GetRefund() uint64 {
+	return 0
+}
+
+func (db *simState) AddAddressToAccessList(addr common.Address) {
+	if _, ok := db.tempAccessList[addr]; !ok {
+		db.tempAccessList[addr] = make(map[common.Hash]struct{})
+	}
+}
+
+func (db *simState) RevertToSnapshot(int) {
+	panic("RevertToSnapshot not supported")
+}
+
+func (db *simState) Snapshot() int {
+	db.snapshotIndex += 1
+	return db.snapshotIndex
+}
+
+// SquashSim wraps an op-chain-ops MemporyStateDB,
+// and applies EVM-messages as if they all exist in the same infinite EVM block.
+// The result is squashing all the EVM execution changes into the state.
+type SquashSim struct {
+	chainConfig *params.ChainConfig
+	state       *simState
+	evm         *vm.EVM
+	signer      types.Signer
+}
+
+// AddMessage processes a message on top of the chain-state that is squashed into a genesis state allocation.
+func (sim *SquashSim) AddMessage(msg *core.Message) (res *core.ExecutionResult, err error) {
+	defer func() {
+		if rErr := recover(); rErr != nil {
+			err = fmt.Errorf("critical error: %v", rErr)
+		}
+	}()
+
+	// reset access-list
+	sim.state.tempAccessList = make(map[common.Address]map[common.Hash]struct{})
+
+	gp := new(core.GasPool)
+	gp.AddGas(30_000_000)
+
+	rules := sim.evm.ChainConfig().Rules(sim.evm.Context.BlockNumber, true, sim.evm.Context.Time)
+	sim.evm.StateDB.Prepare(rules, msg.From, predeploys.SequencerFeeVaultAddr, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
+	if !sim.state.Exist(msg.From) {
+		sim.state.CreateAccount(msg.From)
+	}
+	return core.ApplyMessage(sim.evm, msg, gp)
+}
+
+func (sim *SquashSim) BlockContext() *vm.BlockContext {
+	return &sim.evm.Context
+}
+
+// AddUpgradeTxs traverses a list of encoded deposit transactions.
+// These transactions should match what would be included in the live system upgrade.
+// The resulting state changes are squashed together, such that the final state can then be used as genesis state.
+func (sim *SquashSim) AddUpgradeTxs(txs []hexutil.Bytes) error {
+	for i, otx := range txs {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(otx); err != nil {
+			return fmt.Errorf("failed to decode upgrade tx %d: %w", i, err)
+		}
+		msg, err := core.TransactionToMessage(&tx, sim.signer, sim.BlockContext().BaseFee)
+		if err != nil {
+			return fmt.Errorf("failed to turn upgrade tx %d into message: %w", i, err)
+		}
+		if !msg.IsDepositTx {
+			return fmt.Errorf("upgrade tx %d is not a depost", i)
+		}
+		if res, err := sim.AddMessage(msg); err != nil {
+			return fmt.Errorf("invalid upgrade tx %d, EVM invocation failed: %w", i, err)
+		} else {
+			if res.Err != nil {
+				return fmt.Errorf("failed to successfully execute upgrade tx %d: %w", i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func NewSimulator(db *state.MemoryStateDB) *SquashSim {
+	offsetBlocks := uint64(0)
+	genesisTime := uint64(17_000_000)
+	blockTime := uint64(2)
+	bc := &staticChain{startTime: genesisTime, blockTime: blockTime}
+	header := bc.GetHeader(common.Hash{}, genesisTime+offsetBlocks)
+	chainCfg := db.Genesis().Config
+	blockContext := core.NewEVMBlockContext(header, bc, nil, chainCfg, db)
+	vmCfg := vm.Config{}
+	signer := types.LatestSigner(db.Genesis().Config)
+	simDB := &simState{MemoryStateDB: db}
+	env := vm.NewEVM(blockContext, vm.TxContext{}, simDB, chainCfg, vmCfg)
+
+	return &SquashSim{
+		chainConfig: chainCfg,
+		state:       simDB,
+		evm:         env,
+		signer:      signer,
+	}
+}

--- a/op-chain-ops/squash/sim.go
+++ b/op-chain-ops/squash/sim.go
@@ -53,10 +53,11 @@ func (d *staticChain) GetHeader(h common.Hash, n uint64) *types.Header {
 
 type simState struct {
 	*state.MemoryStateDB
-	snapshotIndex int
-
+	snapshotIndex  int
 	tempAccessList map[common.Address]map[common.Hash]struct{}
 }
+
+var _ vm.StateDB = (*simState)(nil)
 
 func (db *simState) AddressInAccessList(addr common.Address) bool {
 	_, ok := db.tempAccessList[addr]

--- a/op-e2e/system_test.go
+++ b/op-e2e/system_test.go
@@ -1067,7 +1067,7 @@ func (sga *stateGetterAdapter) GetState(addr common.Address, key common.Hash) co
 }
 
 // TestFees checks that L1/L2 fees are handled.
-func TestL1Fees(t *testing.T) {
+func TestFees(t *testing.T) {
 	InitParallel(t)
 
 	t.Run("pre-regolith", func(t *testing.T) {
@@ -1078,10 +1078,9 @@ func TestL1Fees(t *testing.T) {
 		cfg.DeployConfig.L2GenesisCanyonTimeOffset = nil
 		cfg.DeployConfig.L2GenesisDeltaTimeOffset = nil
 		cfg.DeployConfig.L2GenesisEcotoneTimeOffset = nil
-		testL1Fees(t, cfg)
+		testFees(t, cfg)
 	})
 	t.Run("regolith", func(t *testing.T) {
-		t.Skip("getL1GasUsed in GPO does not support Regolith, it returns the Bedrock L1 cost, incl 68*16 gas overhead")
 		cfg := DefaultSystemConfig(t)
 		cfg.DeployConfig.L1GenesisBlockBaseFeePerGas = (*hexutil.Big)(big.NewInt(7))
 
@@ -1089,10 +1088,9 @@ func TestL1Fees(t *testing.T) {
 		cfg.DeployConfig.L2GenesisCanyonTimeOffset = nil
 		cfg.DeployConfig.L2GenesisDeltaTimeOffset = nil
 		cfg.DeployConfig.L2GenesisEcotoneTimeOffset = nil
-		testL1Fees(t, cfg)
+		testFees(t, cfg)
 	})
 	t.Run("ecotone", func(t *testing.T) {
-		t.Skip("when activating Ecotone at Genesis we do not yet call setEcotone() on GPO")
 		cfg := DefaultSystemConfig(t)
 		cfg.DeployConfig.L1GenesisBlockBaseFeePerGas = (*hexutil.Big)(big.NewInt(7))
 
@@ -1100,11 +1098,11 @@ func TestL1Fees(t *testing.T) {
 		cfg.DeployConfig.L2GenesisCanyonTimeOffset = new(hexutil.Uint64)
 		cfg.DeployConfig.L2GenesisDeltaTimeOffset = new(hexutil.Uint64)
 		cfg.DeployConfig.L2GenesisEcotoneTimeOffset = new(hexutil.Uint64)
-		testL1Fees(t, cfg)
+		testFees(t, cfg)
 	})
 }
 
-func testL1Fees(t *testing.T, cfg SystemConfig) {
+func testFees(t *testing.T, cfg SystemConfig) {
 
 	sys, err := cfg.Start(t)
 	require.Nil(t, err, "Error starting up system")
@@ -1135,16 +1133,25 @@ func testL1Fees(t *testing.T, cfg SystemConfig) {
 	gpoContract, err := bindings.NewGasPriceOracle(predeploys.GasPriceOracleAddr, l2Seq)
 	require.Nil(t, err)
 
-	overhead, err := gpoContract.Overhead(&bind.CallOpts{})
-	require.Nil(t, err, "reading gpo overhead")
+	if !sys.RollupConfig.IsEcotone(sys.L2GenesisCfg.Timestamp) {
+		overhead, err := gpoContract.Overhead(&bind.CallOpts{})
+		require.Nil(t, err, "reading gpo overhead")
+		require.Equal(t, overhead.Uint64(), cfg.DeployConfig.GasPriceOracleOverhead, "wrong gpo overhead")
+
+		scalar, err := gpoContract.Scalar(&bind.CallOpts{})
+		require.Nil(t, err, "reading gpo scalar")
+		require.Equal(t, scalar.Uint64(), cfg.DeployConfig.GasPriceOracleScalar, "wrong gpo scalar")
+	} else {
+		_, err := gpoContract.Overhead(&bind.CallOpts{})
+		require.ErrorContains(t, err, "deprecated")
+		_, err = gpoContract.Scalar(&bind.CallOpts{})
+		require.ErrorContains(t, err, "deprecated")
+	}
+
 	decimals, err := gpoContract.Decimals(&bind.CallOpts{})
 	require.Nil(t, err, "reading gpo decimals")
-	scalar, err := gpoContract.Scalar(&bind.CallOpts{})
-	require.Nil(t, err, "reading gpo scalar")
 
-	require.Equal(t, overhead.Uint64(), cfg.DeployConfig.GasPriceOracleOverhead, "wrong gpo overhead")
 	require.Equal(t, decimals.Uint64(), uint64(6), "wrong gpo decimals")
-	require.Equal(t, scalar.Uint64(), cfg.DeployConfig.GasPriceOracleScalar, "wrong gpo scalar")
 
 	// BaseFee Recipient
 	baseFeeRecipientStartBalance, err := l2Seq.BalanceAt(context.Background(), predeploys.BaseFeeVaultAddr, big.NewInt(rpc.EarliestBlockNumber.Int64()))
@@ -1227,17 +1234,32 @@ func testL1Fees(t *testing.T, cfg SystemConfig) {
 	l1Fee := l1CostFn(tx.RollupCostData(), header.Time)
 	require.Equalf(t, l1Fee, l1FeeRecipientDiff, "L1 fee mismatch: start balance %v, end balance %v", l1FeeRecipientStartBalance, l1FeeRecipientEndBalance)
 
+	gpoEcotone, err := gpoContract.IsEcotone(nil)
+	require.NoError(t, err)
+	require.Equal(t, sys.RollupConfig.IsEcotone(header.Time), gpoEcotone, "GPO and chain must have same ecotone view")
+
 	gpoL1Fee, err := gpoContract.GetL1Fee(&bind.CallOpts{}, bytes)
 	require.Nil(t, err)
-	require.Equal(t, l1Fee, gpoL1Fee, "GPO reports L1 fee mismatch")
+
+	adjustedGPOFee := gpoL1Fee
+	if sys.RollupConfig.IsRegolith(header.Time) {
+		// if post-regolith, adjust the GPO fee by removing the overhead it adds because of signature data
+		artificialGPOOverhead := big.NewInt(68 * 16) // it adds 68 bytes to cover signature and RLP data
+		l1BaseFee := big.NewInt(7)                   // we assume the L1 basefee is the minimum, 7
+		// in our case we already include that, so we subtract it, to do a 1:1 comparison
+		adjustedGPOFee = new(big.Int).Sub(gpoL1Fee, new(big.Int).Mul(artificialGPOOverhead, l1BaseFee))
+	}
+	require.Equal(t, l1Fee, adjustedGPOFee, "GPO reports L1 fee mismatch")
 
 	require.Equal(t, receipt.L1Fee, l1Fee, "l1 fee in receipt is correct")
-	require.Equal(t,
-		new(big.Float).Mul(
-			new(big.Float).SetInt(l1Header.BaseFee),
-			new(big.Float).Mul(new(big.Float).SetInt(receipt.L1GasUsed), receipt.FeeScalar),
-		),
-		new(big.Float).SetInt(receipt.L1Fee), "fee field in receipt matches gas used times scalar times base fee")
+	if !sys.RollupConfig.IsEcotone(header.Time) { // FeeScalar receipt attribute is removed as of Ecotone
+		require.Equal(t,
+			new(big.Float).Mul(
+				new(big.Float).SetInt(l1Header.BaseFee),
+				new(big.Float).Mul(new(big.Float).SetInt(receipt.L1GasUsed), receipt.FeeScalar),
+			),
+			new(big.Float).SetInt(receipt.L1Fee), "fee field in receipt matches gas used times scalar times base fee")
+	}
 
 	// Calculate total fee
 	baseFeeRecipientDiff.Add(baseFeeRecipientDiff, coinbaseDiff)


### PR DESCRIPTION
**Description**

Include the upgrade txs inclusion in genesis construction, using a new EVM sim util that can process transactions on top of our genesis memory DB we use in op-chain-ops. And rename the test back to its original name, since it covers L2 fees too.

Depends on https://github.com/ethereum-optimism/optimism/pull/8981

**Tests**

Fix the most legacy fees test to cover Regolith and Ecotone fees. The GPO fee comparison is fixed now, to handle the +68 bytes difference in GPO post-regolith.

**Metadata**

Fix https://github.com/ethereum-optimism/protocol-quest/issues/61
