### PR TITLE
non-zero scalar padding as MaxUint32 baseFeeScalar instead of error

### DIFF
--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -3,7 +3,9 @@ package eth
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -22,6 +24,10 @@ const (
 	UnknownPayload           ErrorCode = -32001 // Payload does not exist / is not available.
 	InvalidForkchoiceState   ErrorCode = -38002 // Forkchoice state is invalid / inconsistent.
 	InvalidPayloadAttributes ErrorCode = -38003 // Payload attributes are invalid / inconsistent.
+)
+
+var (
+	ErrBedrockScalarPaddingNotEmpty = errors.New("version 0 scalar value has non-empty padding")
 )
 
 // InputError distinguishes an user-input error from regular rpc errors,
@@ -335,6 +341,11 @@ const (
 
 func (sysCfg *SystemConfig) EcotoneScalars() (blobBaseFeeScalar, baseFeeScalar uint32, err error) {
 	if err := CheckEcotoneL1SystemConfigScalar(sysCfg.Scalar); err != nil {
+		if errors.Is(err, ErrBedrockScalarPaddingNotEmpty) {
+			// L2 spec mandates we set baseFeeScalar to MaxUint32 if there are non-zero bytes in
+			// the padding area.
+			return 0, math.MaxUint32, nil
+		}
 		return 0, 0, err
 	}
 	switch sysCfg.Scalar[0] {
@@ -355,7 +366,7 @@ func CheckEcotoneL1SystemConfigScalar(scalar [32]byte) error {
 	switch versionByte {
 	case L1ScalarBedrock:
 		if ([27]byte)(scalar[1:28]) != ([27]byte{}) { // check padding
-			return fmt.Errorf("invalid version 0 scalar padding: %x", scalar[1:28])
+			return ErrBedrockScalarPaddingNotEmpty
 		}
 		return nil
 	case L1ScalarEcotone:

--- a/op-service/eth/types_test.go
+++ b/op-service/eth/types_test.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,9 +30,10 @@ type scalarTest struct {
 
 func TestEcotoneScalars(t *testing.T) {
 	testCases := []scalarTest{
-		{"invalid v0 scalar", Bytes32{0: 0, 27: 1, 31: 2}, true, 0, 0},
+		{"dirty padding v0 scalar", Bytes32{0: 0, 27: 1, 31: 2}, false, 0, math.MaxUint32},
+		{"dirty padding v0 scalar v2", Bytes32{0: 0, 1: 1, 31: 2}, false, 0, math.MaxUint32},
 		{"valid v0 scalar", Bytes32{0: 0, 27: 0, 31: 2}, false, 0, 2},
-		{"invalid v1 scalar", Bytes32{0: 0, 7: 1, 31: 2}, true, 0, 0},
+		{"invalid v1 scalar", Bytes32{0: 1, 7: 1, 31: 2}, true, 0, 0},
 		{"valid v1 scalar with 0 blob scalar", Bytes32{0: 1, 27: 0, 31: 2}, false, 0, 2},
 		{"valid v1 scalar with non-0 blob scalar", Bytes32{0: 1, 27: 123, 31: 2}, false, 123, 2},
 		{"valid v1 scalar with non-0 blob scalar and 0 scalar", Bytes32{0: 1, 27: 123, 31: 0}, false, 123, 0},

--- a/specs/system_config.md
+++ b/specs/system_config.md
@@ -61,9 +61,10 @@ The `scalar` is encoded as big-endian `uint256`, interpreted as `bytes32`, and c
 - `0`: scalar-version byte
 - `[1, 32)`: depending scalar-version:
   - Scalar-version `0`:
-    - `[1, 28)`: padding, must be zero.
+    - `[1, 28)`: padding, should be zero.
     - `[28, 32)`: big-endian `uint32`, encoding the L1-fee `baseFeeScalar`
     - This version implies the L1-fee `blobBaseFeeScalar` is set to 0.
+    - In the event there are non-zero bytes in the padding area, `baseFeeScalar` must be set to MaxUint32.
     - This version is compatible with the pre-Ecotone `scalar` value (assuming a `uint32` range).
   - Scalar-version `1`:
     - `[1, 24)`: padding, must be zero.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change spec/handling of non-zero padding in version 0 Ecotone scalar to result in baseFeeScalar=MaxUint32 instead of error. This allows for graceful handling of pre-Ecotone scalar settings out of uint32 range.
