### PR TITLE
op-challenger: Load proposed large preimages

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -190,19 +190,11 @@ func (f *FaultDisputeGameContract) GetClaim(ctx context.Context, idx uint64) (ty
 }
 
 func (f *FaultDisputeGameContract) GetAllClaims(ctx context.Context) ([]types.Claim, error) {
-	count, err := f.GetClaimCount(ctx)
+	results, err := batching.ReadArray(ctx, f.multiCaller, batching.BlockLatest, f.contract.Call(methodClaimCount), func(i *big.Int) *batching.ContractCall {
+		return f.contract.Call(methodClaim, i)
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to load claim count: %w", err)
-	}
-
-	calls := make([]*batching.ContractCall, count)
-	for i := uint64(0); i < count; i++ {
-		calls[i] = f.contract.Call(methodClaim, new(big.Int).SetUint64(i))
-	}
-
-	results, err := f.multiCaller.Call(ctx, batching.BlockLatest, calls...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch claim data: %w", err)
+		return nil, fmt.Errorf("failed to load claims: %w", err)
 	}
 
 	var claims []types.Claim

--- a/op-challenger/game/fault/contracts/oracle_test.go
+++ b/op-challenger/game/fault/contracts/oracle_test.go
@@ -1,12 +1,14 @@
 package contracts
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/matrix"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
 	"github.com/ethereum/go-ethereum/common"
@@ -102,6 +104,52 @@ func TestPreimageOracleContract_Squeeze(t *testing.T) {
 	tx, err := oracle.Squeeze(claimant, uuid, stateMatrix, preState, preStateProof, postState, postStateProof)
 	require.NoError(t, err)
 	stubRpc.VerifyTxCandidate(tx)
+}
+
+func TestGetActivePreimages(t *testing.T) {
+	stubRpc, oracle := setupPreimageOracleTest(t)
+	blockHash := common.Hash{0xaa}
+	stubRpc.SetResponse(
+		oracleAddr,
+		methodProposalCount,
+		batching.BlockByHash(blockHash),
+		[]interface{}{},
+		[]interface{}{big.NewInt(3)})
+
+	preimage1 := gameTypes.LargePreimageMetaData{
+		Claimant: common.Address{0xaa},
+		UUID:     big.NewInt(1111),
+	}
+	preimage2 := gameTypes.LargePreimageMetaData{
+		Claimant: common.Address{0xbb},
+		UUID:     big.NewInt(2222),
+	}
+	preimage3 := gameTypes.LargePreimageMetaData{
+		Claimant: common.Address{0xcc},
+		UUID:     big.NewInt(3333),
+	}
+	expectGetProposals(stubRpc, batching.BlockByHash(blockHash), preimage1, preimage2, preimage3)
+	preimages, err := oracle.GetActivePreimages(context.Background(), blockHash)
+	require.NoError(t, err)
+	require.Equal(t, []gameTypes.LargePreimageMetaData{preimage1, preimage2, preimage3}, preimages)
+}
+
+func expectGetProposals(stubRpc *batchingTest.AbiBasedRpc, block batching.Block, proposals ...gameTypes.LargePreimageMetaData) {
+	for i, proposal := range proposals {
+		expectGetProposal(stubRpc, block, int64(i), proposal)
+	}
+}
+
+func expectGetProposal(stubRpc *batchingTest.AbiBasedRpc, block batching.Block, idx int64, proposal gameTypes.LargePreimageMetaData) {
+	stubRpc.SetResponse(
+		oracleAddr,
+		methodProposals,
+		block,
+		[]interface{}{big.NewInt(idx)},
+		[]interface{}{
+			proposal.Claimant,
+			proposal.UUID,
+		})
 }
 
 func setupPreimageOracleTest(t *testing.T) (*batchingTest.AbiBasedRpc, *PreimageOracleContract) {

--- a/op-challenger/game/keccak/scheduler.go
+++ b/op-challenger/game/keccak/scheduler.go
@@ -1,0 +1,76 @@
+package keccak
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type LargePreimageScheduler struct {
+	log     log.Logger
+	ch      chan common.Hash
+	oracles []types.LargePreimageOracle
+	cancel  func()
+	wg      sync.WaitGroup
+}
+
+func NewLargePreimageScheduler(logger log.Logger, oracles []types.LargePreimageOracle) *LargePreimageScheduler {
+	return &LargePreimageScheduler{
+		log:     logger,
+		ch:      make(chan common.Hash, 1),
+		oracles: oracles,
+	}
+}
+
+func (s *LargePreimageScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+func (s *LargePreimageScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *LargePreimageScheduler) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case blockHash := <-s.ch:
+			if err := s.verifyPreimages(ctx, blockHash); err != nil {
+				s.log.Error("Failed to verify large preimages", "err", err)
+			}
+		}
+	}
+}
+
+func (s *LargePreimageScheduler) Schedule(blockHash common.Hash, _ uint64) error {
+	select {
+	case s.ch <- blockHash:
+	default:
+		// Already busy processing, skip this update
+	}
+	return nil
+}
+
+func (s *LargePreimageScheduler) verifyPreimages(ctx context.Context, blockHash common.Hash) error {
+	for _, oracle := range s.oracles {
+		if err := s.verifyOraclePreimages(ctx, oracle, blockHash); err != nil {
+			s.log.Error("Failed to verify preimages in oracle %v: %w", oracle.Addr(), err)
+		}
+	}
+	return nil
+}
+
+func (s *LargePreimageScheduler) verifyOraclePreimages(ctx context.Context, oracle types.LargePreimageOracle, blockHash common.Hash) error {
+	_, err := oracle.GetActivePreimages(ctx, blockHash)
+	return err
+}

--- a/op-challenger/game/keccak/scheduler_test.go
+++ b/op-challenger/game/keccak/scheduler_test.go
@@ -1,0 +1,51 @@
+package keccak
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleNextCheck(t *testing.T) {
+	ctx := context.Background()
+	logger := testlog.Logger(t, log.LvlInfo)
+	oracle := &stubOracle{}
+	scheduler := NewLargePreimageScheduler(logger, []types.LargePreimageOracle{oracle})
+	scheduler.Start(ctx)
+	defer scheduler.Close()
+	err := scheduler.Schedule(common.Hash{0xaa}, 3)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return oracle.GetPreimagesCount() == 1
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+type stubOracle struct {
+	m                 sync.Mutex
+	addr              common.Address
+	getPreimagesCount int
+}
+
+func (s *stubOracle) Addr() common.Address {
+	return s.addr
+}
+
+func (s *stubOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]types.LargePreimageMetaData, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.getPreimagesCount++
+	return nil, nil
+}
+
+func (s *stubOracle) GetPreimagesCount() int {
+	s.m.Lock()
+	defer s.m.Unlock()
+	return s.getPreimagesCount
+}

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
@@ -60,4 +61,8 @@ type stubPreimageOracle common.Address
 
 func (s stubPreimageOracle) Addr() common.Address {
 	return common.Address(s)
+}
+
+func (s stubPreimageOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]types.LargePreimageMetaData, error) {
+	return nil, nil
 }

--- a/op-challenger/game/types/types.go
+++ b/op-challenger/game/types/types.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -42,6 +44,12 @@ type GameMetadata struct {
 	Proxy     common.Address
 }
 
+type LargePreimageMetaData struct {
+	Claimant common.Address
+	UUID     *big.Int
+}
+
 type LargePreimageOracle interface {
 	Addr() common.Address
+	GetActivePreimages(ctx context.Context, blockHash common.Hash) ([]LargePreimageMetaData, error)
 }

--- a/op-service/sources/batching/arrays.go
+++ b/op-service/sources/batching/arrays.go
@@ -1,0 +1,28 @@
+package batching
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+)
+
+// ReadArray uses batch calls to load all entries from an array.
+// countCall is used to retrieve the current array length, then getCall is used to create calls for each element
+// which are sent in a batch call.
+// The returned *CallResult slice, contains a result for each entry in the array, in the same order as in the contract.
+func ReadArray(ctx context.Context, caller *MultiCaller, block Block, countCall *ContractCall, getCall func(i *big.Int) *ContractCall) ([]*CallResult, error) {
+	result, err := caller.SingleCall(ctx, block, countCall)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load array length: %w", err)
+	}
+	count := result.GetBigInt(0).Uint64()
+	calls := make([]*ContractCall, count)
+	for i := uint64(0); i < count; i++ {
+		calls[i] = getCall(new(big.Int).SetUint64(i))
+	}
+	results, err := caller.Call(ctx, block, calls...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch array data: %w", err)
+	}
+	return results, nil
+}


### PR DESCRIPTION
**Description**

Introduces the infrastructure for monitoring large pre-image proposals, up to loading the list of in-progress games from the contract. Actual content of the preimages is not yet loaded or checked.

Also introduces a utility method `ReadArray` to make it easy to use batch calls to read all entries in a solidity array.

**Tests**

Added unit tests

**Metadata**

- Provides most of https://github.com/ethereum-optimism/client-pod/issues/478
