### PR TITLE
imp(packages): delete duplicated key l2GenesisRegolithTimeOffset in config.sh

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -81,7 +81,6 @@ config=$(cat << EOL
   "eip1559DenominatorCanyon": 250,
   "eip1559Elasticity": 6,
 
-  "l2GenesisRegolithTimeOffset": "0x0",
   "l2GenesisDeltaTimeOffset": null,
   "l2GenesisCanyonTimeOffset": "0x0",
 


### PR DESCRIPTION
**Description**

delete duplicated key `l2GenesisRegolithTimeOffset` in optimism/packages/contracts-bedrock/scripts/getting-started/config.sh