### PR TITLE
op-node: fix parent-beacon-block-root comparison check [Ecotone]

### DIFF
--- a/op-node/rollup/derive/engine_consolidate.go
+++ b/op-node/rollup/derive/engine_consolidate.go
@@ -47,8 +47,25 @@ func AttributesMatchBlock(rollupCfg *rollup.Config, attrs *eth.PayloadAttributes
 	if withdrawalErr := checkWithdrawalsMatch(attrs.Withdrawals, block.Withdrawals); withdrawalErr != nil {
 		return withdrawalErr
 	}
-	if envelope.ParentBeaconBlockRoot != attrs.ParentBeaconBlockRoot {
-		return fmt.Errorf("parent beacon block root does not match. expected %v. got: %v", attrs.ParentBeaconBlockRoot, envelope.ParentBeaconBlockRoot)
+	if err := checkParentBeaconBlockRootMatch(attrs.ParentBeaconBlockRoot, envelope.ParentBeaconBlockRoot); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkParentBeaconBlockRootMatch(attrRoot, blockRoot *common.Hash) error {
+	if blockRoot == nil {
+		if attrRoot != nil {
+			return fmt.Errorf("expected non-nil parent beacon block root %s but got nil", *attrRoot)
+		}
+	} else {
+		if attrRoot == nil {
+			return fmt.Errorf("expected nil parent beacon block root but got non-nil %s", *blockRoot)
+		} else {
+			if *blockRoot != *attrRoot {
+				return fmt.Errorf("parent beacon block root does not match. expected %s. got: %s", *attrRoot, *blockRoot)
+			}
+		}
 	}
 	return nil
 }

--- a/op-node/rollup/derive/engine_consolidate.go
+++ b/op-node/rollup/derive/engine_consolidate.go
@@ -61,10 +61,8 @@ func checkParentBeaconBlockRootMatch(attrRoot, blockRoot *common.Hash) error {
 	} else {
 		if attrRoot == nil {
 			return fmt.Errorf("expected nil parent beacon block root but got non-nil %s", *blockRoot)
-		} else {
-			if *blockRoot != *attrRoot {
-				return fmt.Errorf("parent beacon block root does not match. expected %s. got: %s", *attrRoot, *blockRoot)
-			}
+		} else if *blockRoot != *attrRoot {
+			return fmt.Errorf("parent beacon block root does not match. expected %s. got: %s", *attrRoot, *blockRoot)
 		}
 	}
 	return nil

--- a/op-node/rollup/derive/engine_consolidate_test.go
+++ b/op-node/rollup/derive/engine_consolidate_test.go
@@ -71,6 +71,26 @@ func ecotoneNoParentBeaconBlockRoot() args {
 	return args
 }
 
+func ecotoneUnexpectedParentBeaconBlockRoot() args {
+	args := ecotoneArgs()
+	args.attrs.ParentBeaconBlockRoot = nil
+	return args
+}
+
+func ecotoneMismatchParentBeaconBlockRoot() args {
+	args := ecotoneArgs()
+	h := common.HexToHash("0xabc")
+	args.attrs.ParentBeaconBlockRoot = &h
+	return args
+}
+
+func ecotoneMismatchParentBeaconBlockRootPtr() args {
+	args := ecotoneArgs()
+	cpy := *args.attrs.ParentBeaconBlockRoot
+	args.attrs.ParentBeaconBlockRoot = &cpy
+	return args
+}
+
 func mismatchedParentHashArgs() args {
 	args := ecotoneArgs()
 	args.parentHash = common.HexToHash("0xabc")
@@ -129,6 +149,18 @@ func TestAttributesMatch(t *testing.T) {
 		{
 			shouldMatch: false,
 			args:        ecotoneNoParentBeaconBlockRoot(),
+		},
+		{
+			shouldMatch: false,
+			args:        ecotoneUnexpectedParentBeaconBlockRoot(),
+		},
+		{
+			shouldMatch: false,
+			args:        ecotoneMismatchParentBeaconBlockRoot(),
+		},
+		{
+			shouldMatch: true,
+			args:        ecotoneMismatchParentBeaconBlockRootPtr(),
 		},
 		{
 			shouldMatch: false,

--- a/op-node/rollup/derive/engine_consolidate_test.go
+++ b/op-node/rollup/derive/engine_consolidate_test.go
@@ -91,6 +91,13 @@ func ecotoneMismatchParentBeaconBlockRootPtr() args {
 	return args
 }
 
+func ecotoneNilParentBeaconBlockRoots() args {
+	args := ecotoneArgs()
+	args.attrs.ParentBeaconBlockRoot = nil
+	args.envelope.ParentBeaconBlockRoot = nil
+	return args
+}
+
 func mismatchedParentHashArgs() args {
 	args := ecotoneArgs()
 	args.parentHash = common.HexToHash("0xabc")
@@ -161,6 +168,10 @@ func TestAttributesMatch(t *testing.T) {
 		{
 			shouldMatch: true,
 			args:        ecotoneMismatchParentBeaconBlockRootPtr(),
+		},
+		{
+			shouldMatch: true,
+			args:        ecotoneNilParentBeaconBlockRoots(),
 		},
 		{
 			shouldMatch: false,


### PR DESCRIPTION
**Description**

The Ecotone block attribute comparison was consolidating by pointer comparison. Two equal hashes could have the same value, yet incorrectly fail to consolidate. This fixes that.

**Tests**

Handle the nil and non-nil cases, and the pointer-difference case.

