### PR TITLE
specs, op-node: Handle early ecotone edge-case

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -126,8 +126,8 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 	var parentBeaconRoot *common.Hash
 	if ba.rollupCfg.IsEcotone(nextL2Time) {
 		parentBeaconRoot = l1Info.ParentBeaconRoot()
-		if parentBeaconRoot == nil {
-			return nil, NewCriticalError(fmt.Errorf("cannot build Ecotone (L2 Dencun) block without L1 Dencun info, at L2 timestamp %d", nextL2Time))
+		if parentBeaconRoot == nil { // default to zero hash if there is no beacon-block-root available
+			parentBeaconRoot = new(common.Hash)
 		}
 	}
 

--- a/specs/exec-engine.md
+++ b/specs/exec-engine.md
@@ -278,8 +278,9 @@ PayloadAttributesV3: {
 The requirements of this object are the same as extended [`PayloadAttributesV2`][#extended-payloadattributesv2] with
 the addition of `parentBeaconBlockRoot` which is the parent beacon block root from the L1 origin block of the L2 block.
 
-`parentBeaconBlockRoot` must be nil for Bedrock/Canyon/Delta payloads, but must be set to the L1
-origin `parentBeaconBlockRoot`.
+The `parentBeaconBlockRoot` must be nil for Bedrock/Canyon/Delta payloads.
+Starting at Ecotone, the `parentBeaconBlockRoot` must be set to the L1 origin `parentBeaconBlockRoot`,
+or a zero `bytes32` if the Dencun functionality with `parentBeaconBlockRoot` is not active on L1.
 
 ### `engine_newPayloadV2`
 


### PR DESCRIPTION
**Description**

This is very unlikely, but an edge-case still worth testing: if we activate Ecotone before L1 activates Dencun, then we must be able to sequence blocks.

We already handle the blob-basefee dependency (being set to 1, since excess-gas would be 0, and EIP-4844 defines it that way), but didn't handle the parent-beacon-block root dependency. 

The specs are updated to reflect this case with Ecotone, and it tidies up the related wording a bit.

**Tests**

op-e2e action test that shows we can sequence a block with Ecotone, before Dencun on L1.


