### PR TITLE
fix(config): add preimageOracle MinProposalSize and ChallengePeriod for config.sh

### DIFF
--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -95,7 +95,10 @@ config=$(cat << EOL
   "faultGameMaxDuration": 1200,
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
-  "faultGameSplitDepth": 14
+  "faultGameSplitDepth": 14,
+
+  "preimageOracleMinProposalSize": 1800000,
+  "preimageOracleChallengePeriod": 86400
 }
 EOL
 )


### PR DESCRIPTION
**Description**

add preimageOracleMinProposalSize and preimageOracleChallengePeriod in packages/contracts-bedrock/scripts/DeployConfig.s.sol file
https://github.com/ethereum-optimism/optimism/blob/db28a833d03e3b9da6f17320179d04b7df1c72ae/packages/contracts-bedrock/scripts/DeployConfig.s.sol#L119-L120

but the corresponding file `config.sh` has not been updated.
