### PR TITLE
contracts-bedrock: hacky patch for CI failures

### DIFF
--- a/packages/contracts-bedrock/.gas-snapshot
+++ b/packages/contracts-bedrock/.gas-snapshot
@@ -8,4 +8,4 @@ GasBenchMark_L1StandardBridge_Finalize:test_finalizeETHWithdrawal_benchmark() (g
 GasBenchMark_L2OutputOracle:test_proposeL2Output_benchmark() (gas: 86629)
 GasBenchMark_OptimismPortal:test_depositTransaction_benchmark() (gas: 68450)
 GasBenchMark_OptimismPortal:test_depositTransaction_benchmark_1() (gas: 68899)
-GasBenchMark_OptimismPortal:test_proveWithdrawalTransaction_benchmark() (gas: 153501)
+GasBenchMark_OptimismPortal:test_proveWithdrawalTransaction_benchmark() (gas: 153493)

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -146,6 +146,12 @@ contract Setup {
             args[2] = string.concat(vm.projectRoot(), "/scripts/generate-l2-genesis.sh");
             vm.ffi(args);
         }
+
+        // Prevent race condition where the genesis.json file is not yet created
+        while (vm.isFile(allocsPath) == false) {
+            vm.sleep(1);
+        }
+
         vm.loadAllocs(allocsPath);
 
         // Set the governance token's owner to be the final system owner


### PR DESCRIPTION
**Description**

CI is consistently failing due to the L2 genesis generation happening
out of process using ffi. Ideally the genesis state could be ran a
single time once outside of the process ahead of time but the problem
with this approach is that the deployer nonce is not correct and the
L1 contract addresses in practice end up not matching the addresses
that are injected into the L2 genesis state. There are a few solutions
to this problem, one is deploying the proxies with create2 and another
is to ensure that the deployer does not deploy additional contracts
in the test case setup that are not deployed in the L1 genesis gen
setup so that we are guaranteed that the contracts have the same
addresses.

This is a hacky patch to attempt to fix the issue where it will wait
if the allocs file doesn't exist. Something with the process running in
parallel causes the file to not exist. The downside of this fix is that
CI may hang silently forever if the file is lost for some reason.

Another solution would be to return the JSON to solidity and then write
it to a temp file. This isn't ideal but could work in the short term.
We are working on a rewrite of the L2 genesis generation in solidity
that will fix this issue along with many other devex issues in the
monorepo.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

