### PR TITLE
ci: delete dead step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1069,9 +1069,6 @@ jobs:
             source $HOME/.bashrc
             forge --version
       - run:
-          name: install geth
-          command: make install-geth
-      - run:
           name: Install NVM
           command: |
             curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash


### PR DESCRIPTION
**Description**

Generating the allocs no longer relies on `geth` so we do not need to
install `geth` as part of bringing up the devnet. We also generate the
allocs once and then persist them to the CI workspace. This will save
~1-1.5 minutes per CI run by no longer installing `geth` as part of
the devnet.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

