### PR TITLE
contracts-bedrock: exclude the ffi contract from invariant calls

### DIFF
--- a/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/invariants/CrossDomainMessenger.t.sol
@@ -107,6 +107,7 @@ contract XDM_MinGasLimits is Bridge_Initializer {
 
         // Don't allow the estimation address to be the sender
         excludeSender(Constants.ESTIMATION_ADDRESS);
+        excludeContract(address(ffi));
 
         // Don't allow the predeploys to be the senders
         uint160 prefix = uint160(0x420) << 148;

--- a/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
+++ b/packages/contracts-bedrock/test/invariants/L2OutputOracle.t.sol
@@ -40,6 +40,7 @@ contract L2OutputOracle_MonotonicBlockNumIncrease_Invariant is CommonTest {
 
         // Set the target contract to the proposer actor.
         targetContract(address(actor));
+        excludeContract(address(ffi));
 
         // Set the target selector for `proposeL2Output`
         // `proposeL2Output` is the only function we care about, as it is the only function

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal.t.sol
@@ -136,6 +136,7 @@ contract OptimismPortal_Deposit_Invariant is CommonTest {
         actor = new OptimismPortal_Depositor(vm, optimismPortal);
 
         targetContract(address(actor));
+        excludeContract(address(ffi));
 
         bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = actor.depositTransactionCompletes.selector;


### PR DESCRIPTION
**Description**

We do not want to call the `FFIInterface` contract as part of the
invariant tests because it will create malformed inputs and cause
unrelated invariant tests to fail. Ideally we create a wrapper
around `CommonTest` that is `CommonInvariant` and exclude all
addresses there. That can be done in a follow up PR.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

