### PR TITLE
contracts-bedrock: fix invariant flakes

### DIFF
--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -26,6 +26,11 @@ contract CommonTest is Test, Setup, Events {
         vm.etch(address(ffi), vm.getDeployedCode("FFIInterface.sol:FFIInterface"));
         vm.label(address(ffi), "FFIInterface");
 
+        // Exclude contracts for the invariant tests
+        excludeContract(address(ffi));
+        excludeContract(address(deploy));
+        excludeContract(address(deploy.cfg()));
+
         // Make sure the base fee is non zero
         vm.fee(1 gwei);
 


### PR DESCRIPTION
**Description**

Replaces https://github.com/ethereum-optimism/optimism/pull/9089

We do not want to call the `FFIInterface` or other test contracts as part of the
invariant tests because it will create malformed inputs and cause
unrelated invariant tests to fail.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

