### PR TITLE
op-challenger: Load and decode preimage metadata

### DIFF
--- a/op-challenger/game/types/types.go
+++ b/op-challenger/game/types/types.go
@@ -44,9 +44,22 @@ type GameMetadata struct {
 	Proxy     common.Address
 }
 
-type LargePreimageMetaData struct {
+type LargePreimageIdent struct {
 	Claimant common.Address
 	UUID     *big.Int
+}
+
+type LargePreimageMetaData struct {
+	LargePreimageIdent
+
+	// Timestamp is the time at which the proposal first became fully available.
+	// 0 when not all data is available yet
+	Timestamp       uint64
+	PartOffset      uint32
+	ClaimedSize     uint32
+	BlocksProcessed uint32
+	BytesProcessed  uint32
+	Countered       bool
 }
 
 type LargePreimageOracle interface {

--- a/op-service/sources/batching/call.go
+++ b/op-service/sources/batching/call.go
@@ -133,3 +133,7 @@ func (c *CallResult) GetBigInt(i int) *big.Int {
 func (c *CallResult) GetStruct(i int, target interface{}) {
 	abi.ConvertType(c.out[i], target)
 }
+
+func (c *CallResult) GetBytes32(i int) [32]byte {
+	return *abi.ConvertType(c.out[i], new([32]byte)).(*[32]byte)
+}

--- a/op-service/sources/batching/call_test.go
+++ b/op-service/sources/batching/call_test.go
@@ -149,6 +149,13 @@ func TestCallResult_GetValues(t *testing.T) {
 			expected: ([32]byte)(common.Hash{0xaa, 0xbb, 0xcc}),
 		},
 		{
+			name: "GetBytes32",
+			getter: func(result *CallResult, i int) interface{} {
+				return result.GetBytes32(i)
+			},
+			expected: [32]byte{0xaa, 0xbb, 0xcc},
+		},
+		{
 			name: "GetBigInt",
 			getter: func(result *CallResult, i int) interface{} {
 				return result.GetBigInt(i)


### PR DESCRIPTION
**Description**

Update oracle contract bindings to be able to load and decode proposed preimage metadata. This will allow filtering down to just preimages that can be challenged.

**Tests**

Added unit tests.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/478
