### PR TITLE
ci: bump ci-builder to 0.40.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.38.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.39.0
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.39.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.39.0-rc.1
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.35.0
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.38.0
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.39.1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.40.0
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   ci_builder_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.39.0-rc.1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.39.1
   base_image:
     type: string
     default: ubuntu-2204:2022.07.1


### PR DESCRIPTION
**Description**

Bumps to the latest ci-builder. This contains the new release
of foundry that contains the `vm.dumpState` cheatcode. This is
required for https://github.com/ethereum-optimism/optimism/pull/9091
to pass which fixes flakes in CI.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

