### PR TITLE
op-challenger: Trigger verification of completed preimages

### DIFF
--- a/op-challenger/game/keccak/verifier.go
+++ b/op-challenger/game/keccak/verifier.go
@@ -1,0 +1,22 @@
+package keccak
+
+import (
+	"context"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type PreimageVerifier struct {
+	log log.Logger
+}
+
+func NewPreimageVerifier(logger log.Logger) *PreimageVerifier {
+	return &PreimageVerifier{
+		log: logger,
+	}
+}
+
+func (v *PreimageVerifier) Verify(ctx context.Context, oracle types.LargePreimageOracle, preimage types.LargePreimageMetaData) {
+	// No verification currently performed.
+}

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -225,7 +225,8 @@ func (s *Service) initScheduler(cfg *config.Config) error {
 }
 
 func (s *Service) initLargePreimages() error {
-	s.preimages = keccak.NewLargePreimageScheduler(s.logger, s.registry.Oracles())
+	verifier := keccak.NewPreimageVerifier(s.logger)
+	s.preimages = keccak.NewLargePreimageScheduler(s.logger, s.registry.Oracles(), verifier)
 	return nil
 }
 

--- a/op-challenger/game/types/types.go
+++ b/op-challenger/game/types/types.go
@@ -62,6 +62,12 @@ type LargePreimageMetaData struct {
 	Countered       bool
 }
 
+// ShouldVerify returns true if the preimage upload is complete and has not yet been countered.
+// Note that the challenge period for the preimage may have expired but the image not yet been finalized.
+func (m LargePreimageMetaData) ShouldVerify() bool {
+	return m.Timestamp > 0 && !m.Countered
+}
+
 type LargePreimageOracle interface {
 	Addr() common.Address
 	GetActivePreimages(ctx context.Context, blockHash common.Hash) ([]LargePreimageMetaData, error)


### PR DESCRIPTION
**Description**

The preimage scheduler now checks the metadata to determine if the preimage is worth verifying and if it is, passes it off to the verifier.  Currently verification is a no-op - it will be progressed as part of https://github.com/ethereum-optimism/client-pod/issues/479

**Tests**

Updated unit tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/478
