### PR TITLE
fix: ci-builder

### DIFF
--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -1,6 +1,6 @@
 # Copy docker buildx in order to generate the absolute prestate
 # in the CI pipeline for reproducible fault proof builds
-FROM docker as buildx
+FROM --platform=linux/amd64 docker as buildx
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 RUN docker buildx version
 
@@ -33,8 +33,6 @@ RUN source $HOME/.profile && ./install-foundry.sh
 RUN strip /root/.foundry/bin/forge && \
   strip /root/.foundry/bin/cast && \
   strip /root/.foundry/bin/anvil
-
-FROM --platform=linux/amd64 ghcr.io/crytic/echidna/echidna:v2.0.4 as echidna-test
 
 FROM --platform=linux/amd64 debian:bullseye-slim as go-build
 
@@ -87,8 +85,6 @@ COPY --from=rust-build /root/.foundry/bin/forge /usr/local/bin/forge
 COPY --from=rust-build /root/.foundry/bin/cast /usr/local/bin/cast
 COPY --from=rust-build /root/.foundry/bin/anvil /usr/local/bin/anvil
 
-COPY --from=echidna-test /usr/local/bin/echidna-test /usr/local/bin/echidna-test
-
 COPY .nvmrc .nvmrc
 COPY ./versions.json ./versions.json
 
@@ -96,7 +92,7 @@ ENV NODE_MAJOR=20
 
 RUN /bin/sh -c set -eux; \
   apt-get update; \
-  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential pkg-config libssl-dev clang libclang-dev ca-certificates jq gnupg binutils-mips-linux-gnu python3 python3-pip; \
+  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential pkg-config libssl-dev clang lld libclang-dev ca-certificates jq gnupg binutils-mips-linux-gnu python3 python3-pip; \
   mkdir -p /etc/apt/keyrings; \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -94,22 +94,15 @@ COPY ./versions.json ./versions.json
 
 ENV NODE_MAJOR=20
 
-# note: python3 package in apt is python 3.9, while base image already has python 3.11
 RUN /bin/sh -c set -eux; \
   apt-get update; \
-  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential pkg-config libssl-dev clang libclang-dev ca-certificates jq gnupg binutils-mips-linux-gnu libffi-dev zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libreadline-dev wget; \
+  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential pkg-config libssl-dev clang libclang-dev ca-certificates jq gnupg binutils-mips-linux-gnu python3 python3-pip; \
   mkdir -p /etc/apt/keyrings; \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
   curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \
   chmod a+r /etc/apt/keyrings/docker.gpg; \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null; \
-  wget -P /tmp https://www.python.org/ftp/python/3.12.1/Python-3.12.1.tgz; \
-  tar -xzvf /tmp/Python-3.12.1.tgz -C /tmp; \
-  cd /tmp/Python-3.12.1 && ./configure --enable-optimizations; \
-  make -C /tmp/Python-3.12.1 -j `nproc`; \
-  ln -s /usr/local/bin/python3.12 /usr/local/bin/python3; \
-  ln -s /usr/local/bin/python3.12 /usr/local/bin/python; \
   apt-get update; \
   apt-get install -y nodejs docker-ce-cli; \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt; \

--- a/ops/docker/ci-builder/Dockerfile
+++ b/ops/docker/ci-builder/Dockerfile
@@ -58,7 +58,7 @@ RUN go install gotest.tools/gotestsum@latest
 RUN go install github.com/vektra/mockery/v2@v2.28.1
 RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 
-FROM --platform=linux/amd64 python:3.11.4-slim-bullseye
+FROM --platform=linux/amd64 debian:bullseye-slim
 
 ENV GOPATH=/go
 ENV PATH=/usr/local/go/bin:$GOPATH/bin:$PATH
@@ -97,13 +97,19 @@ ENV NODE_MAJOR=20
 # note: python3 package in apt is python 3.9, while base image already has python 3.11
 RUN /bin/sh -c set -eux; \
   apt-get update; \
-  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential pkg-config libssl-dev clang libclang-dev ca-certificates jq gnupg binutils-mips-linux-gnu; \
+  apt-get install -y --no-install-recommends bash curl openssh-client git build-essential pkg-config libssl-dev clang libclang-dev ca-certificates jq gnupg binutils-mips-linux-gnu libffi-dev zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libreadline-dev wget; \
   mkdir -p /etc/apt/keyrings; \
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
   curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \
   chmod a+r /etc/apt/keyrings/docker.gpg; \
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null; \
+  wget -P /tmp https://www.python.org/ftp/python/3.12.1/Python-3.12.1.tgz; \
+  tar -xzvf /tmp/Python-3.12.1.tgz -C /tmp; \
+  cd /tmp/Python-3.12.1 && ./configure --enable-optimizations; \
+  make -C /tmp/Python-3.12.1 -j `nproc`; \
+  ln -s /usr/local/bin/python3.12 /usr/local/bin/python3; \
+  ln -s /usr/local/bin/python3.12 /usr/local/bin/python; \
   apt-get update; \
   apt-get install -y nodejs docker-ce-cli; \
   ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt; \


### PR DESCRIPTION
ci-builder: attempt fix

**Description**

Ensure that the docker images used in `ci-builder` are more standard.
Instead of using a python image as the final image, use the same
image that is used for building to ensure that the versions of the
standard libraries are the same across them.

This is an attempted fix of an "illegal instruction" error when running
foundry in CI. I believe it is an issue with `solc`.

We can safely install python using apt because slither will work with
the version of python that is on apt, we don't need the latest version
of python3

Also ensure that the same deps are present in the build container as the image that runs and remove echnida because it isn't necessary anymore

- ci-builder: build python from source
- ci-builder: simplify install

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


