### PR TITLE
contracts-bedrock: sepolia deploy config start block

### DIFF
--- a/packages/contracts-bedrock/deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia.json
@@ -39,7 +39,7 @@
   "eip1559Denominator": 50,
   "eip1559Elasticity": 6,
   "l2GenesisRegolithTimeOffset": "0x0",
-  "systemConfigStartBlock": 0,
+  "systemConfigStartBlock": 4071248,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000004000000000000000000000001",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000004000000000000000000000001",
   "faultGameAbsolutePrestate": "0x037bbcc23684afbb7f608024369242c5cdea261a4f63981387efb7cd81763536",


### PR DESCRIPTION
**Description**

Updates the `systemConfigStartBlock` in the deploy config
to be the correct value. This should be the first time that
the system config proxy was initialized on sepolia.

The system config proxy is `0x034edD2A225f7f429A63E0f1D2084B9E0A93b538`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

