### PR TITLE
contracts-bedrock: omit build-info

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -24,6 +24,7 @@ remappings = [
 ]
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
+build_info_path = 'artifacts/build-info'
 
 # Test / Script Runner Settings
 ffi = true

--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -24,8 +24,6 @@ remappings = [
 ]
 extra_output = ['devdoc', 'userdoc', 'metadata', 'storageLayout']
 bytecode_hash = 'none'
-build_info = true
-build_info_path = 'artifacts/build-info'
 
 # Test / Script Runner Settings
 ffi = true


### PR DESCRIPTION
**Description**

The `build-info` was required by the legacy hh deploy workflow.
It is no longer required and will save a lot of disk i/o by turning
off. `slither` uses build-info but it will clean and pass the cli
flag to `forge` directly. We do not need to create the build info
on each build. This should speed up foundry build times but not
by a huge amount.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

