### PR TITLE
op-challenger: Wire fetcher into preimage validator

### DIFF
--- a/op-challenger/game/keccak/fetcher/fetcher_test.go
+++ b/op-challenger/game/keccak/fetcher/fetcher_test.go
@@ -283,15 +283,15 @@ func (s *stubL1Source) ChainID(_ context.Context) (*big.Int, error) {
 	return chainID, nil
 }
 
-func (s *stubL1Source) TxsByNumber(_ context.Context, number uint64) (types.Transactions, error) {
-	txs, ok := s.txs[number]
+func (s *stubL1Source) BlockByNumber(_ context.Context, number *big.Int) (*types.Block, error) {
+	txs, ok := s.txs[number.Uint64()]
 	if !ok {
 		return nil, errors.New("not found")
 	}
-	return txs, nil
+	return (&types.Block{}).WithBody(txs, nil), nil
 }
 
-func (s *stubL1Source) FetchReceipt(_ context.Context, txHash common.Hash) (*types.Receipt, error) {
+func (s *stubL1Source) TransactionReceipt(_ context.Context, txHash common.Hash) (*types.Receipt, error) {
 	rcptStatus, ok := s.rcptStatus[txHash]
 	if !ok {
 		rcptStatus = types.ReceiptStatusSuccessful

--- a/op-challenger/game/keccak/scheduler.go
+++ b/op-challenger/game/keccak/scheduler.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Verifier interface {
-	Verify(ctx context.Context, oracle keccakTypes.LargePreimageOracle, preimage keccakTypes.LargePreimageMetaData)
+	Verify(ctx context.Context, blockHash common.Hash, oracle keccakTypes.LargePreimageOracle, preimage keccakTypes.LargePreimageMetaData) error
 }
 
 type LargePreimageScheduler struct {
@@ -80,7 +80,9 @@ func (s *LargePreimageScheduler) verifyOraclePreimages(ctx context.Context, orac
 	preimages, err := oracle.GetActivePreimages(ctx, blockHash)
 	for _, preimage := range preimages {
 		if preimage.ShouldVerify() {
-			s.verifier.Verify(ctx, oracle, preimage)
+			if err := s.verifier.Verify(ctx, blockHash, oracle, preimage); err != nil {
+				s.log.Error("Failed to verify large preimage", "oracle", oracle.Addr(), "claimant", preimage.Claimant, "uuid", preimage.UUID, "err", err)
+			}
 		}
 	}
 	return err

--- a/op-challenger/game/keccak/scheduler_test.go
+++ b/op-challenger/game/keccak/scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -64,6 +65,14 @@ type stubOracle struct {
 	images            []keccakTypes.LargePreimageMetaData
 }
 
+func (s *stubOracle) GetInputDataBlocks(_ context.Context, _ batching.Block, _ keccakTypes.LargePreimageIdent) ([]uint64, error) {
+	panic("not supported")
+}
+
+func (s *stubOracle) DecodeInputData(_ []byte) (*big.Int, keccakTypes.InputData, error) {
+	panic("not supported")
+}
+
 func (s *stubOracle) Addr() common.Address {
 	return s.addr
 }
@@ -86,10 +95,11 @@ type stubVerifier struct {
 	verified []keccakTypes.LargePreimageMetaData
 }
 
-func (s *stubVerifier) Verify(_ context.Context, _ keccakTypes.LargePreimageOracle, image keccakTypes.LargePreimageMetaData) {
+func (s *stubVerifier) Verify(_ context.Context, _ common.Hash, _ keccakTypes.LargePreimageOracle, image keccakTypes.LargePreimageMetaData) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.verified = append(s.verified, image)
+	return nil
 }
 
 func (s *stubVerifier) Verified() []keccakTypes.LargePreimageMetaData {

--- a/op-challenger/game/keccak/types/types.go
+++ b/op-challenger/game/keccak/types/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -59,4 +60,6 @@ func (m LargePreimageMetaData) ShouldVerify() bool {
 type LargePreimageOracle interface {
 	Addr() common.Address
 	GetActivePreimages(ctx context.Context, blockHash common.Hash) ([]LargePreimageMetaData, error)
+	GetInputDataBlocks(ctx context.Context, block batching.Block, ident LargePreimageIdent) ([]uint64, error)
+	DecodeInputData(data []byte) (*big.Int, InputData, error)
 }

--- a/op-challenger/game/keccak/verifier.go
+++ b/op-challenger/game/keccak/verifier.go
@@ -2,21 +2,34 @@ package keccak
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/fetcher"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type PreimageVerifier struct {
-	log log.Logger
+type Fetcher interface {
+	FetchInputs(ctx context.Context, blockHash common.Hash, oracle fetcher.Oracle, ident keccakTypes.LargePreimageIdent) ([]keccakTypes.InputData, error)
 }
 
-func NewPreimageVerifier(logger log.Logger) *PreimageVerifier {
+type PreimageVerifier struct {
+	log     log.Logger
+	fetcher Fetcher
+}
+
+func NewPreimageVerifier(logger log.Logger, fetcher Fetcher) *PreimageVerifier {
 	return &PreimageVerifier{
-		log: logger,
+		log:     logger,
+		fetcher: fetcher,
 	}
 }
 
-func (v *PreimageVerifier) Verify(ctx context.Context, oracle keccakTypes.LargePreimageOracle, preimage keccakTypes.LargePreimageMetaData) {
-	// No verification currently performed.
+func (v *PreimageVerifier) Verify(ctx context.Context, blockHash common.Hash, oracle keccakTypes.LargePreimageOracle, preimage keccakTypes.LargePreimageMetaData) error {
+	_, err := v.fetcher.FetchInputs(ctx, blockHash, oracle, preimage.LargePreimageIdent)
+	if err != nil {
+		return fmt.Errorf("failed to fetch leaves: %w", err)
+	}
+	return nil
 }

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -2,12 +2,14 @@ package registry
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +61,14 @@ func TestDeduplicateOracles(t *testing.T) {
 }
 
 type stubPreimageOracle common.Address
+
+func (s stubPreimageOracle) GetInputDataBlocks(_ context.Context, _ batching.Block, _ keccakTypes.LargePreimageIdent) ([]uint64, error) {
+	panic("not supported")
+}
+
+func (s stubPreimageOracle) DecodeInputData(_ []byte) (*big.Int, keccakTypes.InputData, error) {
+	panic("not supported")
+}
 
 func (s stubPreimageOracle) Addr() common.Address {
 	return common.Address(s)

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/fetcher"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
@@ -225,7 +226,8 @@ func (s *Service) initScheduler(cfg *config.Config) error {
 }
 
 func (s *Service) initLargePreimages() error {
-	verifier := keccak.NewPreimageVerifier(s.logger)
+	fetcher := fetcher.NewPreimageFetcher(s.logger, s.l1Client)
+	verifier := keccak.NewPreimageVerifier(s.logger, fetcher)
 	s.preimages = keccak.NewLargePreimageScheduler(s.logger, s.registry.Oracles(), verifier)
 	return nil
 }


### PR DESCRIPTION
**Description**

Wires the fetcher into the verifier.  Moves `Leaf` and `LeafSize` from `contracts` package to the game `types` package to avoid import cycles.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/9122

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/479
