### PR TITLE
Fix typo in `op-version-check` tool

### DIFF
--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -38,12 +38,12 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:    "l1-rpc-urls",
 				Usage:   "L1 RPC URLs, the chain ID will be used to determine the superchain",
-				EnvVars: []string{"L1_RPC_URL"},
+				EnvVars: []string{"L1_RPC_URLS"},
 			},
 			&cli.StringSliceFlag{
 				Name:    "l2-rpc-urls",
 				Usage:   "L2 RPC URLs, corresponding to chains to check versions for. Corresponds to all chains if empty",
-				EnvVars: []string{"L2_RPC_URL"},
+				EnvVars: []string{"L2_RPC_URLS"},
 			},
 			&cli.PathFlag{
 				Name:    "outfile",

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -43,7 +43,7 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:    "l2-rpc-urls",
 				Usage:   "L2 RPC URLs, corresponding to chains to check versions for. Corresponds to all chains if empty",
-				EnvVars: []string{"L1_RPC_URL"},
+				EnvVars: []string{"L2_RPC_URL"},
 			},
 			&cli.PathFlag{
 				Name:    "outfile",


### PR DESCRIPTION
**Description**

Simple typo fix.

**Tests**

Trying to run the tool with environment variables results in a panic. 
To reproduce, run `make op-version-check` from the `op-chain-ops` directory. Then: 

```
> L1_RPC_URL=https://ethereum-mainnet-rpc.allthatnode.com ./bin/op-version-check
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x10157e4b0]

goroutine 1 [running]:
main.entrypoint(0x140000bc500)
	/Users/georgeknee/code/ethereum-optimism/optimism/op-chain-ops/cmd/op-version-check/main.go:93 +0x290
github.com/urfave/cli/v2.(*Command).Run(0x14000202580, 0x140000bc500, {0x140001ae050, 0x1, 0x1})
	/Users/georgeknee/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/command.go:279 +0x754
github.com/urfave/cli/v2.(*App).RunContext(0x1400031cc00, {0x101c0d7c0?, 0x10222fee0}, {0x140001ae050, 0x1, 0x1})
	/Users/georgeknee/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/app.go:337 +0x534
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/georgeknee/go/pkg/mod/github.com/urfave/cli/v2@v2.27.1/app.go:311
main.main()
	/Users/georgeknee/code/ethereum-optimism/optimism/op-chain-ops/cmd/op-version-check/main.go:57 +0x4cc
```

With the fix (and rebuilding) the tool starts to work:
```
> L1_RPC_URLS=https://ethereum-mainnet-rpc.allthatnode.com ./bin/op-version-check
INFO [01-22|13:27:07.614] Mode                                     l1-chain-id=1 l2-chain-id=34443
INFO [01-22|13:27:07.614] Detecting on chain contracts
INFO [01-22|13:27:07.999] Successfully processed contract versions chain=Mode l1-chain-id=1 l2-chain-id=34443
INFO [01-22|13:27:08.042] OP-Mainnet                               l1-chain-id=1 l2-chain-id=10
INFO [01-22|13:27:08.042] Detecting on chain contracts
INFO [01-22|13:27:08.475] Successfully processed contract versions chain=OP-Mainnet l1-chain-id=1 l2-chain-id=10
INFO [01-22|13:27:08.754] Orderly Network                          l1-chain-id=1 l2-chain-id=291
INFO [01-22|13:27:08.754] Detecting on chain contracts
CRIT [01-22|13:27:08.820] error op-version-check                   err="error getting contract versions: L1CrossDomainMessenger: 0xc76543A64666d9a073FaEF4e75F651c88e7DBC08: 429 Too Many Requests: {\"error\": \"too many requests, we recommend you to use free api key\",\"id\":2, \"project\": \"11307768e6d77951256a33cc9abd40851f6f5ce8\"}"
```