### PR TITLE
fix(op-challenger): Large Preimage Unique Identifier Construction

### DIFF
--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -102,9 +102,6 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 // newUUID generates a new unique identifier for the preimage by hashing the
 // concatenated preimage data, preimage offset, and sender address.
 func (p *LargePreimageUploader) newUUID(data *types.PreimageOracleData) *big.Int {
-	if data == nil {
-		return big.NewInt(0)
-	}
 	sender := p.txMgr.From()
 	offset := make([]byte, 4)
 	binary.LittleEndian.PutUint32(offset, data.OracleOffset)

--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -3,7 +3,7 @@ package preimages
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/matrix"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -81,13 +82,8 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 		}
 	}
 
-	// TODO(client-pod#473): The UUID must be deterministic so the challenger can resume uploads.
-	uuid, err := p.newUUID()
-	if err != nil {
-		return fmt.Errorf("failed to generate UUID: %w", err)
-	}
-
-	err = p.initLargePreimage(ctx, uuid, data.OracleOffset, uint32(len(data.OracleData)))
+	uuid := p.newUUID(data)
+	err := p.initLargePreimage(ctx, uuid, data.OracleOffset, uint32(len(data.OracleData)))
 	if err != nil {
 		return fmt.Errorf("failed to initialize large preimage with uuid: %s: %w", uuid, err)
 	}
@@ -103,10 +99,19 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 	return errNotSupported
 }
 
-func (p *LargePreimageUploader) newUUID() (*big.Int, error) {
-	max := new(big.Int)
-	max.Exp(big.NewInt(2), big.NewInt(130), nil).Sub(max, big.NewInt(1))
-	return rand.Int(rand.Reader, max)
+// newUUID generates a new unique identifier for the preimage by hashing the
+// concatenated preimage data, preimage offset, and sender address.
+func (p *LargePreimageUploader) newUUID(data *types.PreimageOracleData) *big.Int {
+	if data == nil {
+		return big.NewInt(0)
+	}
+	sender := p.txMgr.From()
+	offset := make([]byte, 4)
+	binary.LittleEndian.PutUint32(offset, data.OracleOffset)
+	concatenated := append(data.OracleData, offset...)
+	concatenated = append(concatenated, sender.Bytes()...)
+	hash := crypto.Keccak256Hash(concatenated)
+	return hash.Big()
 }
 
 // initLargePreimage initializes the large preimage proposal.

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -25,12 +25,7 @@ func TestLargePreimageUploader_NewUUID(t *testing.T) {
 		expectedUUID *big.Int
 	}{
 		{
-			name:         "nil data",
-			data:         nil,
-			expectedUUID: big.NewInt(0),
-		},
-		{
-			name:         "empty data",
+			name:         "EmptyOracleData",
 			data:         &types.PreimageOracleData{},
 			expectedUUID: new(big.Int).SetBytes(common.Hex2Bytes("827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd")),
 		},

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -18,6 +18,57 @@ import (
 
 var mockAddLeavesError = errors.New("mock add leaves error")
 
+func TestLargePreimageUploader_NewUUID(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         *types.PreimageOracleData
+		expectedUUID *big.Int
+	}{
+		{
+			name:         "nil data",
+			data:         nil,
+			expectedUUID: big.NewInt(0),
+		},
+		{
+			name:         "empty data",
+			data:         &types.PreimageOracleData{},
+			expectedUUID: new(big.Int).SetBytes(common.Hex2Bytes("827b659bbda2a0bdecce2c91b8b68462545758f3eba2dbefef18e0daf84f5ccd")),
+		},
+		{
+			name: "OracleDataAndOffset_Control",
+			data: &types.PreimageOracleData{
+				OracleData:   []byte{1, 2, 3},
+				OracleOffset: 0x010203,
+			},
+			expectedUUID: new(big.Int).SetBytes(common.Hex2Bytes("641e230bcf3ade8c71b7e591d210184cdb190e853f61ba59a1411c3b7aca9890")),
+		},
+		{
+			name: "OracleDataAndOffset_DifferentOffset",
+			data: &types.PreimageOracleData{
+				OracleData:   []byte{1, 2, 3},
+				OracleOffset: 0x010204,
+			},
+			expectedUUID: new(big.Int).SetBytes(common.Hex2Bytes("aec56de44401325420e5793f72b777e3e547778de7d8344004b31be086a3136d")),
+		},
+		{
+			name: "OracleDataAndOffset_DifferentData",
+			data: &types.PreimageOracleData{
+				OracleData:   []byte{1, 2, 3, 4},
+				OracleOffset: 0x010203,
+			},
+			expectedUUID: new(big.Int).SetBytes(common.Hex2Bytes("ca38aa17d56805cf26376a050c2c7b15b6be4e709bc422a1c679fe21aa6aa8c7")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			oracle, _, _ := newTestLargePreimageUploader(t)
+			uuid := oracle.newUUID(test.data)
+			require.Equal(t, test.expectedUUID, uuid)
+		})
+	}
+}
+
 func TestLargePreimageUploader_UploadPreimage(t *testing.T) {
 	t.Run("InitFails", func(t *testing.T) {
 		oracle, _, contract := newTestLargePreimageUploader(t)


### PR DESCRIPTION
**Description**

Updates the `op-challenger`'s large preimage uploader component to generate a valid unique identifier for preimages.

The UUID is constructed by taking the hash of the byte-concatenated preimage data, preimage part offset, and txmgr sender address.

**Tests**

Unit tests around the `LargePreimageUploader.newUUID(...)` method with output assertions to prevent erroneous changes.
i.e. if the `newUUID` is updated for some reason, these tests will likely fail and will need to be updated.

**Metadata**

Necessary for https://github.com/ethereum-optimism/client-pod/issues/473 to ensure UUIDs are deterministic.
