### PR TITLE
reject blobs with extraneous data

### DIFF
--- a/op-service/Makefile
+++ b/op-service/Makefile
@@ -11,6 +11,7 @@ fuzz:
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzExecutionPayloadMarshalUnmarshalV3 ./eth
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzOBP01 ./eth
 	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzEncodeDecodeBlob ./eth
+	go test -run NOTAREALTEST -v -fuzztime 10s -fuzz FuzzDetectNonBijectivity ./eth
 
 .PHONY: \
 	test \


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Enforce that different blob input should never decode to the same output by rejecting blobs with extraneous data.

**Tests**

Fuzz & unit tests to catch non-bijectivity.

