### PR TITLE
feat(op-challenger): Resume Large Preimage Uploads

### DIFF
--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -150,12 +150,15 @@ func (c *PreimageOracleContract) GetActivePreimages(ctx context.Context, blockHa
 		idents = append(idents, c.decodePreimageIdent(result))
 	}
 
-	// Fetch the metadata for each preimage
+	return c.GetProposalMetadata(ctx, block, idents...)
+}
+
+func (c *PreimageOracleContract) GetProposalMetadata(ctx context.Context, block batching.Block, idents ...gameTypes.LargePreimageIdent) ([]gameTypes.LargePreimageMetaData, error) {
 	var calls []*batching.ContractCall
 	for _, ident := range idents {
 		calls = append(calls, c.contract.Call(methodProposalMetadata, ident.Claimant, ident.UUID))
 	}
-	results, err = c.multiCaller.Call(ctx, block, calls...)
+	results, err := c.multiCaller.Call(ctx, block, calls...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load proposal metadata: %w", err)
 	}
@@ -172,7 +175,6 @@ func (c *PreimageOracleContract) GetActivePreimages(ctx context.Context, blockHa
 			Countered:          meta.countered(),
 		})
 	}
-
 	return proposals, nil
 }
 

--- a/op-challenger/game/fault/preimages/direct_test.go
+++ b/op-challenger/game/fault/preimages/direct_test.go
@@ -112,7 +112,7 @@ func (s *mockTxMgr) Send(_ context.Context, _ txmgr.TxCandidate) (*ethtypes.Rece
 	if s.statusFail {
 		return &ethtypes.Receipt{Status: ethtypes.ReceiptStatusFailed}, nil
 	}
-	return &ethtypes.Receipt{}, nil
+	return &ethtypes.Receipt{Status: ethtypes.ReceiptStatusSuccessful}, nil
 }
 
 func (s *mockTxMgr) BlockNumber(_ context.Context) (uint64, error) { return 0, nil }

--- a/op-challenger/game/fault/preimages/types.go
+++ b/op-challenger/game/fault/preimages/types.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/matrix"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -25,4 +27,5 @@ type PreimageOracleContract interface {
 	InitLargePreimage(uuid *big.Int, partOffset uint32, claimedSize uint32) (txmgr.TxCandidate, error)
 	AddLeaves(uuid *big.Int, input []byte, commitments [][32]byte, finalize bool) (txmgr.TxCandidate, error)
 	Squeeze(claimant common.Address, uuid *big.Int, stateMatrix *matrix.StateMatrix, preState contracts.Leaf, preStateProof contracts.MerkleProof, postState contracts.Leaf, postStateProof contracts.MerkleProof) (txmgr.TxCandidate, error)
+	GetProposalMetadata(ctx context.Context, block batching.Block, idents ...gameTypes.LargePreimageIdent) ([]gameTypes.LargePreimageMetaData, error)
 }


### PR DESCRIPTION
**Description**

Resumes large preimage uploads by fetching proposal metadata for the (now) deterministic preimage oracle UUID.

Initialized is only called if the part offset or claimed size are unset for the given metadata.

Add calls are constructed for chunks that are not already uploaded based on the proposal metadata `BytesProcessed` field as fetched from the contract.

**Tests**

Unit tests surrounding the `LargePreimageUploader.UploadPreimage` for various states of preimage uploads (none, initialized, partial, full).

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/473
