### PR TITLE
op-challenger: Separate concepts of InputData and Leaf

### DIFF
--- a/op-challenger/game/fault/preimages/large.go
+++ b/op-challenger/game/fault/preimages/large.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/matrix"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -23,23 +23,13 @@ var errNotSupported = errors.New("not supported")
 
 var _ PreimageUploader = (*LargePreimageUploader)(nil)
 
-// MaxLeafsPerChunk is the maximum number of leafs per chunk.
-const MaxLeafsPerChunk = 300
+// MaxBlocksPerChunk is the maximum number of keccak blocks per chunk.
+const MaxBlocksPerChunk = 300
 
 // MaxChunkSize is the maximum size of a preimage chunk in bytes.
 // Notice, the max chunk size must be a multiple of the leaf size.
 // The max chunk size is roughly 0.04MB to avoid memory expansion.
-const MaxChunkSize = MaxLeafsPerChunk * matrix.LeafSize
-
-// Chunk is a contigous segment of preimage data.
-type Chunk struct {
-	// Input is the preimage data.
-	Input []byte
-	// Commitments are the keccak commitments for each leaf in the chunk.
-	Commitments [][32]byte
-	// Finalize indicates whether the chunk is the final chunk.
-	Finalize bool
-}
+const MaxChunkSize = MaxBlocksPerChunk * keccakTypes.BlockSize
 
 // LargePreimageUploader handles uploading large preimages by
 // streaming the merkleized preimage to the PreimageOracle contract,
@@ -56,7 +46,7 @@ func NewLargePreimageUploader(logger log.Logger, txMgr txmgr.TxManager, contract
 }
 
 func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint64, data *types.PreimageOracleData) error {
-	chunks, err := p.splitChunks(data)
+	calls, err := p.splitCalls(data)
 	if err != nil {
 		return fmt.Errorf("failed to split preimage into chunks for data with oracle offset %d: %w", data.OracleOffset, err)
 	}
@@ -64,7 +54,7 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 	uuid := p.newUUID(data)
 
 	// Fetch the current metadata for this preimage data, if it exists.
-	ident := gameTypes.LargePreimageIdent{Claimant: p.txMgr.From(), UUID: uuid}
+	ident := keccakTypes.LargePreimageIdent{Claimant: p.txMgr.From(), UUID: uuid}
 	metadata, err := p.contract.GetProposalMetadata(ctx, batching.BlockLatest, ident)
 	if err != nil {
 		return fmt.Errorf("failed to get pre-image oracle metadata: %w", err)
@@ -81,14 +71,14 @@ func (p *LargePreimageUploader) UploadPreimage(ctx context.Context, parent uint6
 	// Filter out any chunks that have already been uploaded to the Preimage Oracle.
 	if len(metadata) > 0 {
 		numSkip := metadata[0].BytesProcessed / MaxChunkSize
-		chunks = chunks[numSkip:]
+		calls = calls[numSkip:]
 		// If the timestamp is non-zero, the preimage has been finalized.
 		if metadata[0].Timestamp != 0 {
-			chunks = chunks[len(chunks):]
+			calls = calls[len(calls):]
 		}
 	}
 
-	err = p.addLargePreimageLeafs(ctx, uuid, chunks)
+	err = p.addLargePreimageData(ctx, uuid, calls)
 	if err != nil {
 		return fmt.Errorf("failed to add leaves to large preimage with uuid: %s: %w", uuid, err)
 	}
@@ -112,34 +102,22 @@ func (p *LargePreimageUploader) newUUID(data *types.PreimageOracleData) *big.Int
 }
 
 // splitChunks splits the preimage data into chunks of size [MaxChunkSize] (except the last chunk).
-func (p *LargePreimageUploader) splitChunks(data *types.PreimageOracleData) ([]Chunk, error) {
+func (p *LargePreimageUploader) splitCalls(data *types.PreimageOracleData) ([]keccakTypes.InputData, error) {
+	// Split the preimage data into chunks of size [MaxChunkSize] (except the last chunk).
 	stateMatrix := matrix.NewStateMatrix()
-	chunk := make([]byte, 0, MaxChunkSize)
-	chunks := []Chunk{}
-	commitments := make([][32]byte, 0, MaxLeafsPerChunk)
+	var calls []keccakTypes.InputData
 	in := bytes.NewReader(data.OracleData)
-	for i := 0; ; i++ {
-		// Absorb the next preimage chunk leaf and run the keccak permutation.
-		leaf, err := stateMatrix.AbsorbNextLeaf(in)
-		chunk = append(chunk, leaf...)
-		commitments = append(commitments, stateMatrix.StateCommitment())
-		// SAFETY: the last leaf will always return an [io.EOF] error from [AbsorbNextLeaf].
+	for {
+		call, err := stateMatrix.AbsorbUpTo(in, MaxChunkSize)
 		if errors.Is(err, io.EOF) {
-			chunks = append(chunks, Chunk{chunk, commitments[:], true})
+			calls = append(calls, call)
 			break
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to absorb data: %w", err)
 		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to absorb leaf: %w", err)
-		}
-
-		// Only create a call if the chunk is full.
-		if len(chunk) >= MaxChunkSize {
-			chunks = append(chunks, Chunk{chunk, commitments[:], false})
-			chunk = make([]byte, 0, MaxChunkSize)
-			commitments = make([][32]byte, 0, MaxLeafsPerChunk)
-		}
+		calls = append(calls, call)
 	}
-	return chunks, nil
+	return calls, nil
 }
 
 // initLargePreimage initializes the large preimage proposal.
@@ -155,10 +133,10 @@ func (p *LargePreimageUploader) initLargePreimage(ctx context.Context, uuid *big
 	return nil
 }
 
-// addLargePreimageLeafs adds leafs to the large preimage proposal.
+// addLargePreimageData adds data to the large preimage proposal.
 // This method **must** be called after calling [initLargePreimage].
 // SAFETY: submits transactions in a [Queue] for latency while preserving submission order.
-func (p *LargePreimageUploader) addLargePreimageLeafs(ctx context.Context, uuid *big.Int, chunks []Chunk) error {
+func (p *LargePreimageUploader) addLargePreimageData(ctx context.Context, uuid *big.Int, chunks []keccakTypes.InputData) error {
 	queue := txmgr.NewQueue[int](ctx, p.txMgr, 10)
 	receiptChs := make([]chan txmgr.TxReceipt[int], len(chunks))
 	for i, chunk := range chunks {

--- a/op-challenger/game/fault/preimages/types.go
+++ b/op-challenger/game/fault/preimages/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/matrix"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
@@ -25,7 +25,7 @@ type PreimageUploader interface {
 // PreimageOracleContract is the interface for interacting with the PreimageOracle contract.
 type PreimageOracleContract interface {
 	InitLargePreimage(uuid *big.Int, partOffset uint32, claimedSize uint32) (txmgr.TxCandidate, error)
-	AddLeaves(uuid *big.Int, input []byte, commitments [][32]byte, finalize bool) (txmgr.TxCandidate, error)
-	Squeeze(claimant common.Address, uuid *big.Int, stateMatrix *matrix.StateMatrix, preState contracts.Leaf, preStateProof contracts.MerkleProof, postState contracts.Leaf, postStateProof contracts.MerkleProof) (txmgr.TxCandidate, error)
-	GetProposalMetadata(ctx context.Context, block batching.Block, idents ...gameTypes.LargePreimageIdent) ([]gameTypes.LargePreimageMetaData, error)
+	AddLeaves(uuid *big.Int, input []byte, commitments []common.Hash, finalize bool) (txmgr.TxCandidate, error)
+	Squeeze(claimant common.Address, uuid *big.Int, stateMatrix *matrix.StateMatrix, preState keccakTypes.Leaf, preStateProof contracts.MerkleProof, postState keccakTypes.Leaf, postStateProof contracts.MerkleProof) (txmgr.TxCandidate, error)
+	GetProposalMetadata(ctx context.Context, block batching.Block, idents ...keccakTypes.LargePreimageIdent) ([]keccakTypes.LargePreimageMetaData, error)
 }

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/cannon"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/outputs"
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
@@ -26,7 +27,7 @@ var (
 type CloseFunc func()
 
 type Registry interface {
-	RegisterGameType(gameType uint8, creator scheduler.PlayerCreator, oracle types.LargePreimageOracle)
+	RegisterGameType(gameType uint8, creator scheduler.PlayerCreator, oracle keccakTypes.LargePreimageOracle)
 }
 
 func RegisterGameTypes(

--- a/op-challenger/game/keccak/scheduler.go
+++ b/op-challenger/game/keccak/scheduler.go
@@ -4,25 +4,25 @@ import (
 	"context"
 	"sync"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 type Verifier interface {
-	Verify(ctx context.Context, oracle types.LargePreimageOracle, preimage types.LargePreimageMetaData)
+	Verify(ctx context.Context, oracle keccakTypes.LargePreimageOracle, preimage keccakTypes.LargePreimageMetaData)
 }
 
 type LargePreimageScheduler struct {
 	log      log.Logger
 	ch       chan common.Hash
-	oracles  []types.LargePreimageOracle
+	oracles  []keccakTypes.LargePreimageOracle
 	verifier Verifier
 	cancel   func()
 	wg       sync.WaitGroup
 }
 
-func NewLargePreimageScheduler(logger log.Logger, oracles []types.LargePreimageOracle, verifier Verifier) *LargePreimageScheduler {
+func NewLargePreimageScheduler(logger log.Logger, oracles []keccakTypes.LargePreimageOracle, verifier Verifier) *LargePreimageScheduler {
 	return &LargePreimageScheduler{
 		log:      logger,
 		ch:       make(chan common.Hash, 1),
@@ -76,7 +76,7 @@ func (s *LargePreimageScheduler) verifyPreimages(ctx context.Context, blockHash 
 	return nil
 }
 
-func (s *LargePreimageScheduler) verifyOraclePreimages(ctx context.Context, oracle types.LargePreimageOracle, blockHash common.Hash) error {
+func (s *LargePreimageScheduler) verifyOraclePreimages(ctx context.Context, oracle keccakTypes.LargePreimageOracle, blockHash common.Hash) error {
 	preimages, err := oracle.GetActivePreimages(ctx, blockHash)
 	for _, preimage := range preimages {
 		if preimage.ShouldVerify() {

--- a/op-challenger/game/keccak/scheduler_test.go
+++ b/op-challenger/game/keccak/scheduler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -17,32 +17,32 @@ import (
 func TestScheduleNextCheck(t *testing.T) {
 	ctx := context.Background()
 	logger := testlog.Logger(t, log.LvlInfo)
-	preimage1 := types.LargePreimageMetaData{ // Incomplete so won't be verified
-		LargePreimageIdent: types.LargePreimageIdent{
+	preimage1 := keccakTypes.LargePreimageMetaData{ // Incomplete so won't be verified
+		LargePreimageIdent: keccakTypes.LargePreimageIdent{
 			Claimant: common.Address{0xab},
 			UUID:     big.NewInt(111),
 		},
 	}
-	preimage2 := types.LargePreimageMetaData{ // Already countered so won't be verified
-		LargePreimageIdent: types.LargePreimageIdent{
+	preimage2 := keccakTypes.LargePreimageMetaData{ // Already countered so won't be verified
+		LargePreimageIdent: keccakTypes.LargePreimageIdent{
 			Claimant: common.Address{0xab},
 			UUID:     big.NewInt(222),
 		},
 		Timestamp: 1234,
 		Countered: true,
 	}
-	preimage3 := types.LargePreimageMetaData{
-		LargePreimageIdent: types.LargePreimageIdent{
+	preimage3 := keccakTypes.LargePreimageMetaData{
+		LargePreimageIdent: keccakTypes.LargePreimageIdent{
 			Claimant: common.Address{0xdd},
 			UUID:     big.NewInt(333),
 		},
 		Timestamp: 1234,
 	}
 	oracle := &stubOracle{
-		images: []types.LargePreimageMetaData{preimage1, preimage2, preimage3},
+		images: []keccakTypes.LargePreimageMetaData{preimage1, preimage2, preimage3},
 	}
 	verifier := &stubVerifier{}
-	scheduler := NewLargePreimageScheduler(logger, []types.LargePreimageOracle{oracle}, verifier)
+	scheduler := NewLargePreimageScheduler(logger, []keccakTypes.LargePreimageOracle{oracle}, verifier)
 	scheduler.Start(ctx)
 	defer scheduler.Close()
 	err := scheduler.Schedule(common.Hash{0xaa}, 3)
@@ -61,14 +61,14 @@ type stubOracle struct {
 	m                 sync.Mutex
 	addr              common.Address
 	getPreimagesCount int
-	images            []types.LargePreimageMetaData
+	images            []keccakTypes.LargePreimageMetaData
 }
 
 func (s *stubOracle) Addr() common.Address {
 	return s.addr
 }
 
-func (s *stubOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]types.LargePreimageMetaData, error) {
+func (s *stubOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]keccakTypes.LargePreimageMetaData, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.getPreimagesCount++
@@ -83,19 +83,19 @@ func (s *stubOracle) GetPreimagesCount() int {
 
 type stubVerifier struct {
 	m        sync.Mutex
-	verified []types.LargePreimageMetaData
+	verified []keccakTypes.LargePreimageMetaData
 }
 
-func (s *stubVerifier) Verify(_ context.Context, _ types.LargePreimageOracle, image types.LargePreimageMetaData) {
+func (s *stubVerifier) Verify(_ context.Context, _ keccakTypes.LargePreimageOracle, image keccakTypes.LargePreimageMetaData) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.verified = append(s.verified, image)
 }
 
-func (s *stubVerifier) Verified() []types.LargePreimageMetaData {
+func (s *stubVerifier) Verified() []keccakTypes.LargePreimageMetaData {
 	s.m.Lock()
 	defer s.m.Unlock()
-	v := make([]types.LargePreimageMetaData, len(s.verified))
+	v := make([]keccakTypes.LargePreimageMetaData, len(s.verified))
 	copy(v, s.verified)
 	return v
 }

--- a/op-challenger/game/keccak/types/types.go
+++ b/op-challenger/game/keccak/types/types.go
@@ -1,0 +1,62 @@
+package types
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// BlockSize is the size in bytes required for leaf data.
+const BlockSize = 136
+
+// Leaf is the keccak state matrix added to the large preimage merkle tree.
+type Leaf struct {
+	// Input is the data absorbed for the block, exactly 136 bytes
+	Input [BlockSize]byte
+	// Index of the block in the absorption process
+	Index *big.Int
+	// StateCommitment is the hash of the internal state after absorbing the input.
+	StateCommitment common.Hash
+}
+
+// InputData is a contiguous segment of preimage data.
+type InputData struct {
+	// Input is the preimage data.
+	// When Finalize is false, len(Input) must equal len(Commitments)*BlockSize
+	// When Finalize is true, len(Input) must be between len(Commitments - 1)*BlockSize and len(Commitments)*BlockSize
+	Input []byte
+	// Commitments are the keccak commitments for each leaf in the chunk.
+	Commitments []common.Hash
+	// Finalize indicates whether the chunk is the final chunk.
+	Finalize bool
+}
+
+type LargePreimageIdent struct {
+	Claimant common.Address
+	UUID     *big.Int
+}
+
+type LargePreimageMetaData struct {
+	LargePreimageIdent
+
+	// Timestamp is the time at which the proposal first became fully available.
+	// 0 when not all data is available yet
+	Timestamp       uint64
+	PartOffset      uint32
+	ClaimedSize     uint32
+	BlocksProcessed uint32
+	BytesProcessed  uint32
+	Countered       bool
+}
+
+// ShouldVerify returns true if the preimage upload is complete and has not yet been countered.
+// Note that the challenge period for the preimage may have expired but the image not yet been finalized.
+func (m LargePreimageMetaData) ShouldVerify() bool {
+	return m.Timestamp > 0 && !m.Countered
+}
+
+type LargePreimageOracle interface {
+	Addr() common.Address
+	GetActivePreimages(ctx context.Context, blockHash common.Hash) ([]LargePreimageMetaData, error)
+}

--- a/op-challenger/game/keccak/verifier.go
+++ b/op-challenger/game/keccak/verifier.go
@@ -3,7 +3,7 @@ package keccak
 import (
 	"context"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -17,6 +17,6 @@ func NewPreimageVerifier(logger log.Logger) *PreimageVerifier {
 	}
 }
 
-func (v *PreimageVerifier) Verify(ctx context.Context, oracle types.LargePreimageOracle, preimage types.LargePreimageMetaData) {
+func (v *PreimageVerifier) Verify(ctx context.Context, oracle keccakTypes.LargePreimageOracle, preimage keccakTypes.LargePreimageMetaData) {
 	// No verification currently performed.
 }

--- a/op-challenger/game/registry/registry.go
+++ b/op-challenger/game/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,19 +17,19 @@ var (
 
 type GameTypeRegistry struct {
 	types   map[uint8]scheduler.PlayerCreator
-	oracles map[common.Address]types.LargePreimageOracle
+	oracles map[common.Address]keccakTypes.LargePreimageOracle
 }
 
 func NewGameTypeRegistry() *GameTypeRegistry {
 	return &GameTypeRegistry{
 		types:   make(map[uint8]scheduler.PlayerCreator),
-		oracles: make(map[common.Address]types.LargePreimageOracle),
+		oracles: make(map[common.Address]keccakTypes.LargePreimageOracle),
 	}
 }
 
 // RegisterGameType registers a scheduler.PlayerCreator to use for a specific game type.
 // Panics if the same game type is registered multiple times, since this indicates a significant programmer error.
-func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.PlayerCreator, oracle types.LargePreimageOracle) {
+func (r *GameTypeRegistry) RegisterGameType(gameType uint8, creator scheduler.PlayerCreator, oracle keccakTypes.LargePreimageOracle) {
 	if _, ok := r.types[gameType]; ok {
 		panic(fmt.Errorf("duplicate creator registered for game type: %v", gameType))
 	}
@@ -49,6 +50,6 @@ func (r *GameTypeRegistry) CreatePlayer(game types.GameMetadata, dir string) (sc
 	return creator(game, dir)
 }
 
-func (r *GameTypeRegistry) Oracles() []types.LargePreimageOracle {
+func (r *GameTypeRegistry) Oracles() []keccakTypes.LargePreimageOracle {
 	return maps.Values(r.oracles)
 }

--- a/op-challenger/game/registry/registry_test.go
+++ b/op-challenger/game/registry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/scheduler/test"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
@@ -63,6 +64,6 @@ func (s stubPreimageOracle) Addr() common.Address {
 	return common.Address(s)
 }
 
-func (s stubPreimageOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]types.LargePreimageMetaData, error) {
+func (s stubPreimageOracle) GetActivePreimages(_ context.Context, _ common.Hash) ([]keccakTypes.LargePreimageMetaData, error) {
 	return nil, nil
 }

--- a/op-challenger/game/types/types.go
+++ b/op-challenger/game/types/types.go
@@ -1,9 +1,7 @@
 package types
 
 import (
-	"context"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -42,33 +40,4 @@ type GameMetadata struct {
 	GameType  uint8
 	Timestamp uint64
 	Proxy     common.Address
-}
-
-type LargePreimageIdent struct {
-	Claimant common.Address
-	UUID     *big.Int
-}
-
-type LargePreimageMetaData struct {
-	LargePreimageIdent
-
-	// Timestamp is the time at which the proposal first became fully available.
-	// 0 when not all data is available yet
-	Timestamp       uint64
-	PartOffset      uint32
-	ClaimedSize     uint32
-	BlocksProcessed uint32
-	BytesProcessed  uint32
-	Countered       bool
-}
-
-// ShouldVerify returns true if the preimage upload is complete and has not yet been countered.
-// Note that the challenge period for the preimage may have expired but the image not yet been finalized.
-func (m LargePreimageMetaData) ShouldVerify() bool {
-	return m.Timestamp > 0 && !m.Countered
-}
-
-type LargePreimageOracle interface {
-	Addr() common.Address
-	GetActivePreimages(ctx context.Context, blockHash common.Hash) ([]LargePreimageMetaData, error)
 }


### PR DESCRIPTION
**Description**

We actually wind up with three related but distinct concepts:

* `Leaf` - exactly 136 bytes of data including keccak padding for the last leaf, with an index and state comment. This is the value that's hashed and added to the merkle tree
* `InputData` - variable sized data, with one or more state commitments and a `Finalize` flag. This matches the data provided to `addLeavesLPP` contract method. The data length must be equal to `len(StateCommitments)*136` except if `Finalize` is true, in which case the last leaf worth of data may not be complete.  Does not include keccak padding.
* `LeafInput` - currently entirely hidden within `StateMatrix`. This is the input data for a single leaf without keccak padding. All but the last `LeafInput` are 136 bytes long.

All these types are in a new `keccak/types` package which creates a bit more noise in the changes but since the names were changing we may as well start grouping the code together better.