### PR TITLE
[op-conductor] improve start sequencer logic

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -597,7 +597,7 @@ func (oc *OpConductor) startSequencer() error {
 		if !strings.Contains(err.Error(), driver.ErrSequencerAlreadyStarted.Error()) {
 			return errors.Wrap(err, "failed to start sequencer")
 		} else {
-			oc.log.Warn("sequencer already started", "err", err)
+			oc.log.Warn("sequencer already started.", "err", err)
 		}
 	}
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -596,7 +596,7 @@ func (oc *OpConductor) startSequencer() error {
 	if err = oc.ctrl.StartSequencer(ctx, unsafeInCons.ExecutionPayload.BlockHash); err != nil {
 		// cannot directly compare using Errors.Is because the error is returned from an JSON RPC server which lost its type.
 		if !strings.Contains(err.Error(), driver.ErrSequencerAlreadyStarted.Error()) {
-			return errors.Wrap(err, "failed to start sequencer")
+			return fmt.Errorf("failed to start sequencer: %w", err)
 		} else {
 			oc.log.Warn("sequencer already started.", "err", err)
 		}

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -594,6 +594,7 @@ func (oc *OpConductor) startSequencer() error {
 	}
 
 	if err = oc.ctrl.StartSequencer(ctx, unsafeInCons.ExecutionPayload.BlockHash); err != nil {
+		// cannot directly compare using Errors.Is because the error is returned from an JSON RPC server which lost its type.
 		if !strings.Contains(err.Error(), driver.ErrSequencerAlreadyStarted.Error()) {
 			return errors.Wrap(err, "failed to start sequencer")
 		} else {

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -21,6 +21,8 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
 
+var ErrSequencerAlreadyStarted = errors.New("sequencer already running")
+
 // Deprecated: use eth.SyncStatus instead.
 type SyncStatus = eth.SyncStatus
 
@@ -408,7 +410,7 @@ func (s *Driver) eventLoop() {
 		case resp := <-s.startSequencer:
 			unsafeHead := s.engineController.UnsafeL2Head().Hash
 			if !s.driverConfig.SequencerStopped {
-				resp.err <- errors.New("sequencer already running")
+				resp.err <- ErrSequencerAlreadyStarted
 			} else if !bytes.Equal(unsafeHead[:], resp.hash[:]) {
 				resp.err <- fmt.Errorf("block hash does not match: head %s, received %s", unsafeHead.String(), resp.hash.String())
 			} else {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Improve start sequencer logic to handle sequencer already started situation.

**Tests**

Will be added later in e2e tests.

**Metadata**

- https://github.com/ethereum-optimism/protocol-quest/issues/44
