### PR TITLE
script to compute gas config scalar after Ecotone upgrade

### DIFF
--- a/op-chain-ops/Makefile
+++ b/op-chain-ops/Makefile
@@ -1,6 +1,9 @@
 op-version-check:
 	go build -o ./bin/op-version-check ./cmd/op-version-check/main.go
 
+ecotone-scalar:
+	go build -o ./bin/ecotone-scalar ./cmd/ecotone-scalar/main.go
+
 test:
 	go test ./...
 

--- a/op-chain-ops/cmd/ecotone-scalar/README.md
+++ b/op-chain-ops/cmd/ecotone-scalar/README.md
@@ -1,0 +1,17 @@
+# ecotone-scalar
+
+A CLI tool for computing the value of `scalar` to use after the Ecotone upgrade in a call to
+setGasConfig(scalar, overhead) of the L1 SystemConfig contract. After the Ecotone upgrade, the
+overhead parameter is ignored, and the scalar parameter encodes a versioned bytes32 that allows
+configuring the base fee scalar and blob base fee scalars separately.
+
+#### Usage
+
+Build and run using the [Makefile](../../Makefile) `ecotone-scalar` target. Run `make
+ecotone-scalar` to create a binary in [../../bin/ecotone-scalar](../../bin/ecotone-scalar) that can
+be executed, providing the `--scalar` and `--blob-scalar` flags to specify the base bee scalar and
+blob base fee parameters respectively, for example:
+
+```sh
+./bin/ecotone-scalar --scalar=100 --blob-scalar=680000
+```

--- a/op-chain-ops/cmd/ecotone-scalar/main.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"math"
+	"math/big"
+	"os"
+)
+
+func main() {
+	var scalar, blobScalar uint
+	flag.UintVar(&scalar, "scalar", 0, "base fee scalar value for the gas config (uint32)")
+	flag.UintVar(&blobScalar, "blob-scalar", 0, "blob base fee scalar value for the gas config (uint32)")
+	flag.Parse()
+
+	if scalar > math.MaxUint32 {
+		fmt.Fprintln(flag.CommandLine.Output(), "scalar out of uint32 range")
+		flag.Usage()
+		os.Exit(2)
+	}
+	if blobScalar > math.MaxUint32 {
+		fmt.Fprintln(flag.CommandLine.Output(), "blob-scalar out of uint32 range")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	var n [32]byte
+	n[0] = 1 // version
+	binary.BigEndian.PutUint32(n[32-4:], uint32(scalar))
+	binary.BigEndian.PutUint32(n[32-8:], uint32(blobScalar))
+	i := new(big.Int).SetBytes(n[:])
+
+	fmt.Println("# base fee scalar     :", scalar)
+	fmt.Println("# blob base fee scalar:", blobScalar)
+	fmt.Printf("# v1 binary encoding  : %x\n", n[:])
+	fmt.Println("# uint value for the 'scalar' parameter in SystemConfig.setGasConfig():")
+	fmt.Println(i)
+}

--- a/op-chain-ops/cmd/ecotone-scalar/main.go
+++ b/op-chain-ops/cmd/ecotone-scalar/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	fmt.Println("# base fee scalar     :", scalar)
 	fmt.Println("# blob base fee scalar:", blobScalar)
-	fmt.Printf("# v1 binary encoding  : %x\n", n[:])
+	fmt.Printf("# v1 hex encoding  : 0x%x\n", n[:])
 	fmt.Println("# uint value for the 'scalar' parameter in SystemConfig.setGasConfig():")
 	fmt.Println(i)
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

A CLI tool for computing the value of `scalar` to use after the Ecotone upgrade in a call to
setGasConfig(scalar, overhead) of the L1 SystemConfig contract. After the Ecotone upgrade, the
overhead parameter is ignored, and the scalar parameter encodes a versioned bytes32 that allows
configuring the base fee scalar and blob base fee scalars separately.

Addresses: https://github.com/ethereum-optimism/protocol-quest/issues/108
