### PR TITLE
Add op-contracts to tag service

### DIFF
--- a/.github/workflows/tag-service.yml
+++ b/.github/workflows/tag-service.yml
@@ -29,6 +29,7 @@ on:
           - op-ufm
           - proxyd
           - ufm-metamask
+          - op-contracts
       prerelease:
         description: Increment major/minor/patch as prerelease?
         required: false

--- a/ops/tag-service/tag-service.py
+++ b/ops/tag-service/tag-service.py
@@ -21,6 +21,7 @@ MIN_VERSIONS = {
     'proxyd': '3.16.0',
     'op-heartbeat': '0.1.0',
     'ufm-metamask': '0.1.0',
+    'op-contracts': '1.0.0',
 }
 
 VALID_BUMPS = ('major', 'minor', 'patch', 'prerelease', 'finalize-prerelease')


### PR DESCRIPTION
**Description**

A small PR to add a new `op-contracts` prefix to the release tags.
