### PR TITLE
doc(ctb): LPP Merkle Tree clarifying comment

### DIFF
--- a/packages/contracts-bedrock/slither-report.json
+++ b/packages/contracts-bedrock/slither-report.json
@@ -1096,10 +1096,10 @@
     "impact": "Medium",
     "confidence": "Medium",
     "check": "uninitialized-local",
-    "description": "PreimageOracle.challengeFirstLPP(address,uint256,PreimageOracle.Leaf,bytes32[]).stateMatrix (src/cannon/PreimageOracle.sol#444) is a local variable never initialized\n",
+    "description": "PreimageOracle.challengeFirstLPP(address,uint256,PreimageOracle.Leaf,bytes32[]).stateMatrix (src/cannon/PreimageOracle.sol#446) is a local variable never initialized\n",
     "type": "variable",
     "name": "stateMatrix",
-    "start": 20524,
+    "start": 20750,
     "length": 40,
     "filename_relative": "src/cannon/PreimageOracle.sol"
   },

--- a/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
+++ b/packages/contracts-bedrock/src/cannon/PreimageOracle.sol
@@ -366,7 +366,9 @@ contract PreimageOracle is IPreimageOracle {
             }
         }
 
-        // Do not allow for posting preimages larger than the merkle tree can support.
+        // Do not allow for posting preimages larger than the merkle tree can support. The incremental merkle tree
+        // algorithm only supports 2**height - 1 leaves, the right most leaf must always be kept empty.
+        // Reference: https://daejunpark.github.io/papers/deposit.pdf - Page 10, Section 5.1.
         if (blocksProcessed > MAX_LEAF_COUNT) revert TreeSizeOverflow();
 
         // Update the proposal metadata to include the number of blocks processed and total bytes processed.


### PR DESCRIPTION
## Overview

Adds a clarifying comment with respect to the max number of leaves in the large preimage proposal merkle tree that links to @daejunpark's paper on the formal verification of the Beacon chain deposit contract, which uses the same incremental merkle tree algorithm that we do.
