### PR TITLE
op-challenger: Avoid loading already existing global preimages

### DIFF
--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -92,7 +92,7 @@ func NewGamePlayer(
 	large := preimages.NewLargePreimageUploader(logger, txMgr, oracle)
 	uploader := preimages.NewSplitPreimageUploader(direct, large)
 
-	responder, err := responder.NewFaultResponder(logger, txMgr, loader, uploader)
+	responder, err := responder.NewFaultResponder(logger, txMgr, loader, uploader, oracle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the responder: %w", err)
 	}

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -22,12 +22,13 @@ var (
 	mockPreimageUploadErr = errors.New("mock preimage upload error")
 	mockSendError         = errors.New("mock send error")
 	mockCallError         = errors.New("mock call error")
+	mockOracleExistsError = errors.New("mock oracle exists error")
 )
 
 // TestCallResolve tests the [Responder.CallResolve].
 func TestCallResolve(t *testing.T) {
 	t.Run("SendFails", func(t *testing.T) {
-		responder, _, contract, _ := newTestFaultResponder(t)
+		responder, _, contract, _, _ := newTestFaultResponder(t)
 		contract.callFails = true
 		status, err := responder.CallResolve(context.Background())
 		require.ErrorIs(t, err, mockCallError)
@@ -36,7 +37,7 @@ func TestCallResolve(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		responder, _, contract, _ := newTestFaultResponder(t)
+		responder, _, contract, _, _ := newTestFaultResponder(t)
 		status, err := responder.CallResolve(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, gameTypes.GameStatusInProgress, status)
@@ -47,7 +48,7 @@ func TestCallResolve(t *testing.T) {
 // TestResolve tests the [Responder.Resolve] method.
 func TestResolve(t *testing.T) {
 	t.Run("SendFails", func(t *testing.T) {
-		responder, mockTxMgr, _, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		mockTxMgr.sendFails = true
 		err := responder.Resolve(context.Background())
 		require.ErrorIs(t, err, mockSendError)
@@ -55,7 +56,7 @@ func TestResolve(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		responder, mockTxMgr, _, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		err := responder.Resolve(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, 1, mockTxMgr.sends)
@@ -64,7 +65,7 @@ func TestResolve(t *testing.T) {
 
 func TestCallResolveClaim(t *testing.T) {
 	t.Run("SendFails", func(t *testing.T) {
-		responder, _, contract, _ := newTestFaultResponder(t)
+		responder, _, contract, _, _ := newTestFaultResponder(t)
 		contract.callFails = true
 		err := responder.CallResolveClaim(context.Background(), 0)
 		require.ErrorIs(t, err, mockCallError)
@@ -72,7 +73,7 @@ func TestCallResolveClaim(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		responder, _, contract, _ := newTestFaultResponder(t)
+		responder, _, contract, _, _ := newTestFaultResponder(t)
 		err := responder.CallResolveClaim(context.Background(), 0)
 		require.NoError(t, err)
 		require.Equal(t, 1, contract.calls)
@@ -81,7 +82,7 @@ func TestCallResolveClaim(t *testing.T) {
 
 func TestResolveClaim(t *testing.T) {
 	t.Run("SendFails", func(t *testing.T) {
-		responder, mockTxMgr, _, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		mockTxMgr.sendFails = true
 		err := responder.ResolveClaim(context.Background(), 0)
 		require.ErrorIs(t, err, mockSendError)
@@ -89,7 +90,7 @@ func TestResolveClaim(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		responder, mockTxMgr, _, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		err := responder.ResolveClaim(context.Background(), 0)
 		require.NoError(t, err)
 		require.Equal(t, 1, mockTxMgr.sends)
@@ -99,7 +100,7 @@ func TestResolveClaim(t *testing.T) {
 // TestRespond tests the [Responder.Respond] method.
 func TestPerformAction(t *testing.T) {
 	t.Run("send fails", func(t *testing.T) {
-		responder, mockTxMgr, _, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		mockTxMgr.sendFails = true
 		err := responder.PerformAction(context.Background(), types.Action{
 			Type:      types.ActionTypeMove,
@@ -112,7 +113,7 @@ func TestPerformAction(t *testing.T) {
 	})
 
 	t.Run("sends response", func(t *testing.T) {
-		responder, mockTxMgr, _, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, _, _, _ := newTestFaultResponder(t)
 		err := responder.PerformAction(context.Background(), types.Action{
 			Type:      types.ActionTypeMove,
 			ParentIdx: 123,
@@ -124,7 +125,7 @@ func TestPerformAction(t *testing.T) {
 	})
 
 	t.Run("attack", func(t *testing.T) {
-		responder, mockTxMgr, contract, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, contract, _, _ := newTestFaultResponder(t)
 		action := types.Action{
 			Type:      types.ActionTypeMove,
 			ParentIdx: 123,
@@ -140,7 +141,7 @@ func TestPerformAction(t *testing.T) {
 	})
 
 	t.Run("defend", func(t *testing.T) {
-		responder, mockTxMgr, contract, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, contract, _, _ := newTestFaultResponder(t)
 		action := types.Action{
 			Type:      types.ActionTypeMove,
 			ParentIdx: 123,
@@ -156,7 +157,7 @@ func TestPerformAction(t *testing.T) {
 	})
 
 	t.Run("step", func(t *testing.T) {
-		responder, mockTxMgr, contract, _ := newTestFaultResponder(t)
+		responder, mockTxMgr, contract, _, _ := newTestFaultResponder(t)
 		action := types.Action{
 			Type:      types.ActionTypeStep,
 			ParentIdx: 123,
@@ -172,8 +173,8 @@ func TestPerformAction(t *testing.T) {
 		require.Equal(t, ([]byte)("step"), mockTxMgr.sent[0].TxData)
 	})
 
-	t.Run("stepWithOracleData", func(t *testing.T) {
-		responder, mockTxMgr, contract, uploader := newTestFaultResponder(t)
+	t.Run("stepWithLocalOracleData", func(t *testing.T) {
+		responder, mockTxMgr, contract, uploader, oracle := newTestFaultResponder(t)
 		action := types.Action{
 			Type:      types.ActionTypeStep,
 			ParentIdx: 123,
@@ -191,10 +192,33 @@ func TestPerformAction(t *testing.T) {
 		require.Nil(t, contract.updateOracleArgs) // mock uploader returns nil
 		require.Equal(t, ([]byte)("step"), mockTxMgr.sent[0].TxData)
 		require.Equal(t, 1, uploader.updates)
+		require.Equal(t, 0, oracle.existCalls)
+	})
+
+	t.Run("stepWithGlobalOracleData", func(t *testing.T) {
+		responder, mockTxMgr, contract, uploader, oracle := newTestFaultResponder(t)
+		action := types.Action{
+			Type:      types.ActionTypeStep,
+			ParentIdx: 123,
+			IsAttack:  true,
+			PreState:  []byte{1, 2, 3},
+			ProofData: []byte{4, 5, 6},
+			OracleData: &types.PreimageOracleData{
+				IsLocal: false,
+			},
+		}
+		err := responder.PerformAction(context.Background(), action)
+		require.NoError(t, err)
+
+		require.Len(t, mockTxMgr.sent, 1)
+		require.Nil(t, contract.updateOracleArgs) // mock uploader returns nil
+		require.Equal(t, ([]byte)("step"), mockTxMgr.sent[0].TxData)
+		require.Equal(t, 1, uploader.updates)
+		require.Equal(t, 1, oracle.existCalls)
 	})
 
 	t.Run("stepWithOracleDataAndUploadFails", func(t *testing.T) {
-		responder, mockTxMgr, contract, uploader := newTestFaultResponder(t)
+		responder, mockTxMgr, contract, uploader, _ := newTestFaultResponder(t)
 		uploader.uploadFails = true
 		action := types.Action{
 			Type:      types.ActionTypeStep,
@@ -212,16 +236,59 @@ func TestPerformAction(t *testing.T) {
 		require.Nil(t, contract.updateOracleArgs) // mock uploader returns nil
 		require.Equal(t, 1, uploader.updates)
 	})
+
+	t.Run("stepWithOracleDataAndGlobalPreimageAlreadyExists", func(t *testing.T) {
+		responder, mockTxMgr, contract, uploader, oracle := newTestFaultResponder(t)
+		oracle.existsResult = true
+		action := types.Action{
+			Type:      types.ActionTypeStep,
+			ParentIdx: 123,
+			IsAttack:  true,
+			PreState:  []byte{1, 2, 3},
+			ProofData: []byte{4, 5, 6},
+			OracleData: &types.PreimageOracleData{
+				IsLocal: false,
+			},
+		}
+		err := responder.PerformAction(context.Background(), action)
+		require.Nil(t, err)
+		require.Len(t, mockTxMgr.sent, 1)
+		require.Nil(t, contract.updateOracleArgs) // mock uploader returns nil
+		require.Equal(t, 0, uploader.updates)
+		require.Equal(t, 1, oracle.existCalls)
+	})
+
+	t.Run("stepWithOracleDataAndGlobalPreimageExistsFails", func(t *testing.T) {
+		responder, mockTxMgr, contract, uploader, oracle := newTestFaultResponder(t)
+		oracle.existsFails = true
+		action := types.Action{
+			Type:      types.ActionTypeStep,
+			ParentIdx: 123,
+			IsAttack:  true,
+			PreState:  []byte{1, 2, 3},
+			ProofData: []byte{4, 5, 6},
+			OracleData: &types.PreimageOracleData{
+				IsLocal: false,
+			},
+		}
+		err := responder.PerformAction(context.Background(), action)
+		require.ErrorIs(t, err, mockOracleExistsError)
+		require.Len(t, mockTxMgr.sent, 0)
+		require.Nil(t, contract.updateOracleArgs) // mock uploader returns nil
+		require.Equal(t, 0, uploader.updates)
+		require.Equal(t, 1, oracle.existCalls)
+	})
 }
 
-func newTestFaultResponder(t *testing.T) (*FaultResponder, *mockTxManager, *mockContract, *mockPreimageUploader) {
+func newTestFaultResponder(t *testing.T) (*FaultResponder, *mockTxManager, *mockContract, *mockPreimageUploader, *mockOracle) {
 	log := testlog.Logger(t, log.LvlError)
 	mockTxMgr := &mockTxManager{}
 	contract := &mockContract{}
 	uploader := &mockPreimageUploader{}
-	responder, err := NewFaultResponder(log, mockTxMgr, contract, uploader)
+	oracle := &mockOracle{}
+	responder, err := NewFaultResponder(log, mockTxMgr, contract, uploader, oracle)
 	require.NoError(t, err)
-	return responder, mockTxMgr, contract, uploader
+	return responder, mockTxMgr, contract, uploader, oracle
 }
 
 type mockPreimageUploader struct {
@@ -235,6 +302,20 @@ func (m *mockPreimageUploader) UploadPreimage(ctx context.Context, parent uint64
 		return mockPreimageUploadErr
 	}
 	return nil
+}
+
+type mockOracle struct {
+	existCalls   int
+	existsResult bool
+	existsFails  bool
+}
+
+func (m *mockOracle) GlobalDataExists(ctx context.Context, data *types.PreimageOracleData) (bool, error) {
+	m.existCalls++
+	if m.existsFails {
+		return false, mockOracleExistsError
+	}
+	return m.existsResult, nil
 }
 
 type mockTxManager struct {

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -232,6 +232,8 @@ func TestOutputCannonStepWithPreimage(t *testing.T) {
 		outputRootClaim := game.DisputeLastBlock(ctx)
 		game.LogGameData(ctx)
 
+		game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+
 		// Wait for the honest challenger to dispute the outputRootClaim. This creates a root of an execution game that we challenge by coercing
 		// a step at a preimage trace index.
 		outputRootClaim = outputRootClaim.WaitForCounterClaim(ctx)

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -218,33 +218,41 @@ func TestOutputCannonDefendStep(t *testing.T) {
 
 func TestOutputCannonStepWithPreimage(t *testing.T) {
 	executor := uint64(1) // Different executor to the other tests to help balance things better
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(executor))
 
-	ctx := context.Background()
-	sys, l1Client := startFaultDisputeSystem(t)
-	t.Cleanup(sys.Close)
+	testPreimageStep := func(t *testing.T, preloadPreimage bool) {
+		op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(executor))
 
-	disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
-	game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
-	require.NotNil(t, game)
-	outputRootClaim := game.DisputeLastBlock(ctx)
-	game.LogGameData(ctx)
+		ctx := context.Background()
+		sys, l1Client := startFaultDisputeSystem(t)
+		t.Cleanup(sys.Close)
 
-	game.StartChallenger(ctx, "sequencer", "Challenger", challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
+		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
+		game := disputeGameFactory.StartOutputCannonGame(ctx, "sequencer", 1, common.Hash{0x01, 0xaa})
+		require.NotNil(t, game)
+		outputRootClaim := game.DisputeLastBlock(ctx)
+		game.LogGameData(ctx)
 
-	// Wait for the honest challenger to dispute the outputRootClaim. This creates a root of an execution game that we challenge by coercing
-	// a step at a preimage trace index.
-	outputRootClaim = outputRootClaim.WaitForCounterClaim(ctx)
+		// Wait for the honest challenger to dispute the outputRootClaim. This creates a root of an execution game that we challenge by coercing
+		// a step at a preimage trace index.
+		outputRootClaim = outputRootClaim.WaitForCounterClaim(ctx)
 
-	// Now the honest challenger is positioned as the defender of the execution game
-	// We then move to challenge it to induce a preimage load
-	game.ChallengeToFirstGlobalPreimageLoad(ctx, outputRootClaim, sys.Cfg.Secrets.Alice)
+		// Now the honest challenger is positioned as the defender of the execution game
+		// We then move to challenge it to induce a preimage load
+		game.ChallengeToFirstGlobalPreimageLoad(ctx, outputRootClaim, sys.Cfg.Secrets.Alice, preloadPreimage)
 
-	sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
-	require.NoError(t, wait.ForNextBlock(ctx, l1Client))
-	game.WaitForInactivity(ctx, 10, true)
-	game.LogGameData(ctx)
-	require.EqualValues(t, disputegame.StatusChallengerWins, game.Status(ctx))
+		sys.TimeTravelClock.AdvanceTime(game.GameDuration(ctx))
+		require.NoError(t, wait.ForNextBlock(ctx, l1Client))
+		game.WaitForInactivity(ctx, 10, true)
+		game.LogGameData(ctx)
+		require.EqualValues(t, disputegame.StatusChallengerWins, game.Status(ctx))
+	}
+
+	t.Run("non-existing preimage", func(t *testing.T) {
+		testPreimageStep(t, false)
+	})
+	t.Run("preimage already exists", func(t *testing.T) {
+		testPreimageStep(t, true)
+	})
 }
 
 func TestOutputCannonProposedOutputRootValid(t *testing.T) {


### PR DESCRIPTION
Patch contains the following changes to the op-challenger:

- Global preimage data are not uploaded if they're already in the preimage oracle to save gas.
- Local preimages will continue to always be loaded. The only scenario where a local key needs to be loaded multiple times if when a step move failed such that the leaf claim isn't countered. We assume this doesn't happen to honest challengers. So for avoid the complexity of localizing keys in the `fault.Responder`, we always load local keys.

## Testing

- `fault.Responder` tests for pre-existing preimages.
- e2e test asserting that the challenger works correctly when stepping on states that already have its preimage loaded onto the oracle.

fixes https://github.com/ethereum-optimism/client-pod/issues/476