### PR TITLE
contracts-bedrock: delete strict deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
           working_directory: packages/contracts-bedrock
       - run:
           name: run tests
-          command: STRICT_DEPLOYMENT=false pnpm test
+          command: pnpm test
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
@@ -402,6 +402,9 @@ jobs:
           command: pnpm install:ci
       # Note: this step needs to come first because one of the later steps modifies the cache & forces a contracts rebuild
       - run:
+          name: forge version
+          command: forge --version
+      - run:
           name: semver lock
           command: |
             pnpm semver-lock
@@ -419,8 +422,7 @@ jobs:
       - run:
           name: gas snapshot
           command: |
-            forge --version
-            STRICT_DEPLOYMENT=false pnpm gas-snapshot --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
+            pnpm gas-snapshot --check || echo "export GAS_SNAPSHOT_STATUS=1" >> "$BASH_ENV"
           environment:
             FOUNDRY_PROFILE: ci
           working_directory: packages/contracts-bedrock
@@ -440,12 +442,12 @@ jobs:
           name: check statuses
           command: |
             if [[ "$LINT_STATUS" -ne 0 ]]; then
-              FAILED=1
               echo "Linting failed, see job output for details."
+              FAILED=1
             fi
             if [[ "$GAS_SNAPSHOT_STATUS" -ne 0 ]]; then
-              FAILED=1
               echo "Gas snapshot failed, see job output for details."
+              FAILED=1
             fi
             if [[ "$SEMVER_LOCK_STATUS" -ne 0 ]]; then
               echo "Semver lock failed, see job output for details."

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -59,17 +59,6 @@ abstract contract Artifacts {
         try vm.createDir(deploymentsDir, true) { } catch (bytes memory) { }
 
         uint256 chainId = vm.envOr("CHAIN_ID", block.chainid);
-        string memory chainIdPath = string.concat(deploymentsDir, string("/.chainId"));
-        try vm.readFile(chainIdPath) returns (string memory localChainId) {
-            if (vm.envOr("STRICT_DEPLOYMENT", true)) {
-                require(
-                    vm.parseUint(localChainId) == chainId,
-                    string.concat("Misconfigured networks: ", localChainId, " != ", vm.toString(chainId))
-                );
-            }
-        } catch {
-            vm.writeFile(chainIdPath, vm.toString(chainId));
-        }
         console.log("Connected to network with chainid %s", chainId);
 
         // Load addresses from a JSON file if the CONTRACT_ADDRESSES_PATH environment variable


### PR DESCRIPTION
**Description**

There was previously a concept in the deploy script that
would check a `.chainId` file on disk against the remote chainid.
This check became problematic because of the parallel nature of
foundry tests that caused it to attempt to read/write the same
file to disk many times in parallel and then it caused a lot
of flakes around the file not existing. Remove this feature
from the deploy script to reduce the complexity of it. We need
less complexity and rely on instead simulations and assertions
for correctness. The assertions can expect a particular chainid
instead of using the local filesystem. This also ties into
the migration of the deployment artifacts away from being in
`contracts-bedrock` and instead towards the superchain registry.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

