### PR TITLE
op-signer: update client to support Blob tx signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.13.5 => github.com/ethereum-optimism/op-geth v1.101305.2-rc.2.0.20240123201117-bfa8ffc685e0
+replace github.com/ethereum/go-ethereum v1.13.5 => github.com/ethereum-optimism/op-geth v1.101305.3-rc.1.0.20240124221225-5c6f10d449ab
 
 //replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain-registry/superchain
 //replace github.com/ethereum/go-ethereum v1.13.5 => ../go-ethereum

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101305.2-rc.2.0.20240123201117-bfa8ffc685e0 h1:Cu3e2Pgn0rBTzr7FjLbUBsJRq2RcVWDPf9tTp6dBZtY=
-github.com/ethereum-optimism/op-geth v1.101305.2-rc.2.0.20240123201117-bfa8ffc685e0/go.mod h1:/0cPafbmmt3JR0yiuoBJWTRCx8briXUd/mtXr+GJ3Zw=
+github.com/ethereum-optimism/op-geth v1.101305.3-rc.1.0.20240124221225-5c6f10d449ab h1:SpoQiEG5mteZnaPCo5Pm5QrberdODUefwLjdAtL9LAE=
+github.com/ethereum-optimism/op-geth v1.101305.3-rc.1.0.20240124221225-5c6f10d449ab/go.mod h1:/0cPafbmmt3JR0yiuoBJWTRCx8briXUd/mtXr+GJ3Zw=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240123193359-a5fc767e225a h1:mWIRpGyrAlWHUznUHKgAJUafkNGfO7VmeLjilhVhB80=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240123193359-a5fc767e225a/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -389,6 +389,7 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txDat
 }
 
 func (l *BatchSubmitter) blobTxCandidate(data []byte) (*txmgr.TxCandidate, error) {
+	l.Log.Info("building Blob transaction candidate", "size", len(data))
 	var b eth.Blob
 	if err := b.FromData(data); err != nil {
 		return nil, fmt.Errorf("data could not be converted to blob: %w", err)
@@ -400,6 +401,7 @@ func (l *BatchSubmitter) blobTxCandidate(data []byte) (*txmgr.TxCandidate, error
 }
 
 func (l *BatchSubmitter) calldataTxCandidate(data []byte) *txmgr.TxCandidate {
+	l.Log.Info("building Calldata transaction candidate", "size", len(data))
 	return &txmgr.TxCandidate{
 		To:     &l.RollupConfig.BatchInboxAddress,
 		TxData: data,

--- a/op-service/signer/transaction_args.go
+++ b/op-service/signer/transaction_args.go
@@ -15,7 +15,7 @@ import (
 
 // TransactionArgs represents the arguments to construct a new transaction
 // or a message call.
-// Geth has an internal version of this, but this internal version does not support blob transactions, nor is exported.
+// Geth has an internal version of this, but this is not exported, and only supported in v1.13.11 and forward.
 // This signing API format is based on the legacy personal-account signing RPC of ethereum.
 type TransactionArgs struct {
 	From                 *common.Address `json:"from"`
@@ -38,7 +38,7 @@ type TransactionArgs struct {
 
 	// Custom extension for EIP-4844 support
 	BlobVersionedHashes []common.Hash `json:"blobVersionedHashes,omitempty"`
-	BlobFeeCap          *hexutil.Big  `json:"blobFeeCap,omitempty"`
+	BlobFeeCap          *hexutil.Big  `json:"maxFeePerBlobGas,omitempty"`
 }
 
 // NewTransactionArgsFromTransaction creates a TransactionArgs struct from an EIP-1559 or EIP-4844 transaction

--- a/op-service/signer/transaction_args.go
+++ b/op-service/signer/transaction_args.go
@@ -1,7 +1,12 @@
 package signer
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"math/big"
+
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -10,6 +15,8 @@ import (
 
 // TransactionArgs represents the arguments to construct a new transaction
 // or a message call.
+// Geth has an internal version of this, but this internal version does not support blob transactions, nor is exported.
+// This signing API format is based on the legacy personal-account signing RPC of ethereum.
 type TransactionArgs struct {
 	From                 *common.Address `json:"from"`
 	To                   *common.Address `json:"to"`
@@ -28,16 +35,20 @@ type TransactionArgs struct {
 
 	AccessList *types.AccessList `json:"accessList,omitempty"`
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+
+	// Custom extension for EIP-4844 support
+	BlobVersionedHashes []common.Hash `json:"blobVersionedHashes,omitempty"`
+	BlobFeeCap          *hexutil.Big  `json:"blobFeeCap,omitempty"`
 }
 
-// NewTransactionArgsFromTransaction creates a TransactionArgs struct from an EIP-1559 transaction
-func NewTransactionArgsFromTransaction(chainId *big.Int, from common.Address, tx *types.Transaction) *TransactionArgs {
+// NewTransactionArgsFromTransaction creates a TransactionArgs struct from an EIP-1559 or EIP-4844 transaction
+func NewTransactionArgsFromTransaction(chainId *big.Int, from *common.Address, tx *types.Transaction) *TransactionArgs {
 	data := hexutil.Bytes(tx.Data())
 	nonce := hexutil.Uint64(tx.Nonce())
 	gas := hexutil.Uint64(tx.Gas())
 	accesses := tx.AccessList()
 	args := &TransactionArgs{
-		From:                 &from,
+		From:                 from,
 		Input:                &data,
 		Nonce:                &nonce,
 		Value:                (*hexutil.Big)(tx.Value()),
@@ -47,6 +58,8 @@ func NewTransactionArgsFromTransaction(chainId *big.Int, from common.Address, tx
 		MaxFeePerGas:         (*hexutil.Big)(tx.GasFeeCap()),
 		MaxPriorityFeePerGas: (*hexutil.Big)(tx.GasTipCap()),
 		AccessList:           &accesses,
+		BlobVersionedHashes:  tx.BlobHashes(),
+		BlobFeeCap:           (*hexutil.Big)(tx.BlobGasFeeCap()),
 	}
 	return args
 }
@@ -62,23 +75,106 @@ func (args *TransactionArgs) data() []byte {
 	return nil
 }
 
-// ToTransaction converts the arguments to a transaction.
-func (args *TransactionArgs) ToTransaction() *types.Transaction {
+func (args *TransactionArgs) Check() error {
+	if args.Gas == nil {
+		return errors.New("gas not specified")
+	}
+	if args.GasPrice != nil {
+		return errors.New("only accepts maxFeePerGas/maxPriorityFeePerGas params")
+	}
+	if args.MaxFeePerGas == nil || args.MaxPriorityFeePerGas == nil {
+		return errors.New("missing maxFeePerGas or maxPriorityFeePerGas")
+	}
+	// Both EIP-1559 fee parameters are now set; sanity check them.
+	if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
+		return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)
+	}
+	if args.Nonce == nil {
+		return errors.New("nonce not specified")
+	}
+	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
+		return errors.New(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
+	}
+	if args.To == nil && len(args.data()) == 0 {
+		return errors.New("contract creation without any data provided")
+	}
+	if args.ChainID == nil {
+		return errors.New("chain id not specified")
+	}
+	if args.Value == nil {
+		args.Value = new(hexutil.Big)
+	}
+	if args.AccessList == nil {
+		args.AccessList = &types.AccessList{}
+	}
+	if args.BlobVersionedHashes != nil {
+		if len(args.BlobVersionedHashes) == 0 {
+			return errors.New("non-null blob versioned hashes should not be empty")
+		}
+		if args.BlobFeeCap == nil {
+			return errors.New("when including blobs a blob-fee-cap is required")
+		}
+	} else {
+		if args.BlobFeeCap != nil {
+			return errors.New("unexpected blob-fee-cap, transaction does not include blobs")
+		}
+	}
+	return nil
+}
+
+// ToTransactionData converts the arguments to transaction content-data. Warning: this excludes blob data.
+func (args *TransactionArgs) ToTransactionData() (types.TxData, error) {
 	var data types.TxData
 	al := types.AccessList{}
 	if args.AccessList != nil {
 		al = *args.AccessList
 	}
-	data = &types.DynamicFeeTx{
-		To:         args.To,
-		ChainID:    (*big.Int)(args.ChainID),
-		Nonce:      uint64(*args.Nonce),
-		Gas:        uint64(*args.Gas),
-		GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
-		GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
-		Value:      (*big.Int)(args.Value),
-		Data:       args.data(),
-		AccessList: al,
+	if len(args.BlobVersionedHashes) > 0 {
+		chainID, overflow := uint256.FromBig((*big.Int)(args.ChainID))
+		if overflow {
+			return nil, fmt.Errorf("chainID %s too large for blob tx", args.ChainID)
+		}
+		maxFeePerGas, overflow := uint256.FromBig((*big.Int)(args.MaxFeePerGas))
+		if overflow {
+			return nil, fmt.Errorf("maxFeePerGas %s too large for blob tx", args.MaxFeePerGas)
+		}
+		maxPriorityFeePerGas, overflow := uint256.FromBig((*big.Int)(args.MaxPriorityFeePerGas))
+		if overflow {
+			return nil, fmt.Errorf("maxPriorityFeePerGas %s too large for blob tx", args.MaxPriorityFeePerGas)
+		}
+		value, overflow := uint256.FromBig((*big.Int)(args.Value))
+		if overflow {
+			return nil, fmt.Errorf("value %s too large for blob tx", args.Value)
+		}
+		blobFeeCap, overflow := uint256.FromBig((*big.Int)(args.BlobFeeCap))
+		if overflow {
+			return nil, fmt.Errorf("blobFeeCap %s too large for blob tx", args.BlobFeeCap)
+		}
+		data = &types.BlobTx{
+			ChainID:    chainID,
+			Nonce:      uint64(*args.Nonce),
+			GasTipCap:  maxPriorityFeePerGas,
+			GasFeeCap:  maxFeePerGas,
+			Gas:        uint64(*args.Gas),
+			To:         *args.To,
+			Value:      value,
+			Data:       args.data(),
+			AccessList: al,
+			BlobFeeCap: blobFeeCap,
+			BlobHashes: args.BlobVersionedHashes,
+		}
+	} else {
+		data = &types.DynamicFeeTx{
+			ChainID:    (*big.Int)(args.ChainID),
+			Nonce:      uint64(*args.Nonce),
+			GasTipCap:  (*big.Int)(args.MaxPriorityFeePerGas),
+			GasFeeCap:  (*big.Int)(args.MaxFeePerGas),
+			Gas:        uint64(*args.Gas),
+			To:         args.To,
+			Value:      (*big.Int)(args.Value),
+			Data:       args.data(),
+			AccessList: al,
+		}
 	}
-	return types.NewTx(data)
+	return data, nil
 }

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -245,6 +245,7 @@ func (m *SimpleTxManager) send(ctx context.Context, candidate TxCandidate) (*typ
 // NOTE: If the [TxCandidate.GasLimit] is non-zero, it will be used as the transaction's gas.
 // NOTE: Otherwise, the [SimpleTxManager] will query the specified backend for an estimate.
 func (m *SimpleTxManager) craftTx(ctx context.Context, candidate TxCandidate) (*types.Transaction, error) {
+	m.l.Debug("crafting Transaction", "blobs", len(candidate.Blobs), "calldata_size", len(candidate.TxData))
 	gasTipCap, baseFee, blobBaseFee, err := m.suggestGasPriceCaps(ctx)
 	if err != nil {
 		m.metr.RPCError()


### PR DESCRIPTION
**Description**

Updates the op-signer client to forward the new EIP-4844 blob attributes. When signing a blob tx with a remote signer, preserve the blobs sidecar locally, but don't forward the full sidecar to the remote.

This also moves the arg-validation into the client package, to avoid the arg-checks not matching the actual args.

Also add some additional logging to the batcher / tx-manager, to confirm we are signing blob-transactions.

**Tests**

Code is covered in the op-signer server-side PR.

