### PR TITLE
ci/add shellcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ orbs:
   go: circleci/go@1.8.0
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@4.10.1
+  shellcheck: circleci/shellcheck@3.2.0
 commands:
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
@@ -1608,6 +1609,12 @@ workflows:
       - cannon-go-lint-and-test
       - cannon-build-test-vectors
       - kontrol-tests
+      - shellcheck/check:
+          # We don't need the `exclude` key as the orb detects the `.shellcheckrc`
+          dir: .
+          ignore-dirs:
+            ./packages/contracts-bedrock/lib
+
   release:
     when:
       not:

--- a/op-chain-ops/cmd/check-delta/aggregate-channels.sh
+++ b/op-chain-ops/cmd/check-delta/aggregate-channels.sh
@@ -33,6 +33,7 @@ singular_batch_count=0
 
 channels_with_invalid_batches=()
 
+# shellcheck disable=SC2016
 batch_type_counter_jq_script='reduce .batch_types[] as $batch_type (
     {"span_batch_count": 0, "singular_batch_count": 0};
     if $batch_type == 1 then
@@ -50,7 +51,7 @@ for file in "$directory_path"/*.json; do
         continue
     fi
     # check channels are ready
-    if [ $(jq -r ".is_ready" "$file") == "false" ] ; then
+    if [ "$(jq -r ".is_ready" "$file")" == "false" ] ; then
         # not ready channel have no batches so invalid_batches field is always false
         ((not_ready_channel_count++))
         not_ready_channels+=("$file")
@@ -59,12 +60,13 @@ for file in "$directory_path"/*.json; do
         ((ready_channel_count++))
     fi
     # check channels contain invalid batches
-    if [ $(jq -r ".invalid_batches" "$file") == "true" ] ; then
+    if [ "$(jq -r ".invalid_batches" "$file")" == "true" ] ; then
         channels_with_invalid_batches+=("$file")
     fi
     # count singular batch count and span batch count
     jq_result=$(jq "$batch_type_counter_jq_script" "$file")
-    read span_batch_count_per_channel singular_batch_count_per_channel <<< $jq_result
+    # shellcheck disable=SC2162
+    read span_batch_count_per_channel singular_batch_count_per_channel <<< "$jq_result"
     span_batch_count=$((span_batch_count+span_batch_count_per_channel))
     singular_batch_count=$((singular_batch_count+singular_batch_count_per_channel))
 done

--- a/ops/scripts/geth-version-checker.sh
+++ b/ops/scripts/geth-version-checker.sh
@@ -7,7 +7,7 @@ MONOREPO_DIR=$(cd "$SCRIPTS_DIR/../../" && pwd)
 GETH_VERSION="v$(geth version | grep '^Version:' | awk '{print $2}')"
 
 # Read the version from the versions file
-EXPECTED_GETH_VERSION=$(jq -r .geth < $MONOREPO_DIR/versions.json)
+EXPECTED_GETH_VERSION=$(jq -r .geth < "$MONOREPO_DIR"/versions.json)
 
 # Check if EXPECTED_GETH_VERSION contains a '-'. If not, append '-stable'.
 if [[ $EXPECTED_GETH_VERSION != *-* ]]; then

--- a/ops/scripts/install-foundry.sh
+++ b/ops/scripts/install-foundry.sh
@@ -6,7 +6,7 @@ SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 MONOREPO_DIR=$(cd "$SCRIPTS_DIR/../../" && pwd)
 
 # Grab the foundry commit hash.
-SHA=$(jq -r .foundry < $MONOREPO_DIR/versions.json)
+SHA=$(jq -r .foundry < "$MONOREPO_DIR"/versions.json)
 
 # Check if there is a nightly tag corresponding to the commit hash
 TAG="nightly-$SHA"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:ts:check": "npx nx run-many --target=lint:ts:check",
     "lint:check": "npx nx run-many --target=lint:check",
     "lint:fix": "npx nx run-many --target=lint:fix",
+    "lint:shellcheck": "find . -type f -name '*.sh' -not -path '*/node_modules/*' -not -path './packages/contracts-bedrock/lib/*' -not -path './.husky/_/husky.sh' -exec sh -c 'echo \"Checking $1\"; shellcheck \"$1\"' _ {} \\;",
     "preinstall": "npx only-allow pnpm",
     "ready": "pnpm lint && pnpm test",
     "prepare": "husky install",

--- a/packages/contracts-bedrock/scripts/print-addresses.sh
+++ b/packages/contracts-bedrock/scripts/print-addresses.sh
@@ -42,6 +42,7 @@ for file in "$DIR"/*.json; do
     filename=$(basename "$file" .json)
 
     # If SDK mode is on and the filename is not in the list, skip it
+    # shellcheck disable=SC2199,SC2076
     if $SDK_MODE && [[ ! " ${SDK_FILES[@]} " =~ " ${filename} " ]]; then
         continue
     fi


### PR DESCRIPTION
Following PRs #8487 and #8594, this PR:
1. Fixes additional shellcheck issues since those PRs
2. Adds shellcheck into CI 

I've tested the CI job locally with the CircleCI CLI by running `circleci local execute shellcheck/check`. However, this requires docker which devs may not want to run to lint their shell scripts, so I added a `lint:shellcheck` job to the root `package.json` that provides the same functionality.

I'm going to leave comments on this PR with comments/questions around any of the specific shellcheck fixes that were made.