### PR TITLE
[op-conductor] change health monitor to return error instead of bool

### DIFF
--- a/op-conductor/health/mocks/HealthMonitor.go
+++ b/op-conductor/health/mocks/HealthMonitor.go
@@ -108,19 +108,19 @@ func (_c *HealthMonitor_Stop_Call) RunAndReturn(run func() error) *HealthMonitor
 }
 
 // Subscribe provides a mock function with given fields:
-func (_m *HealthMonitor) Subscribe() <-chan bool {
+func (_m *HealthMonitor) Subscribe() <-chan error {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Subscribe")
 	}
 
-	var r0 <-chan bool
-	if rf, ok := ret.Get(0).(func() <-chan bool); ok {
+	var r0 <-chan error
+	if rf, ok := ret.Get(0).(func() <-chan error); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(<-chan bool)
+			r0 = ret.Get(0).(<-chan error)
 		}
 	}
 
@@ -144,12 +144,12 @@ func (_c *HealthMonitor_Subscribe_Call) Run(run func()) *HealthMonitor_Subscribe
 	return _c
 }
 
-func (_c *HealthMonitor_Subscribe_Call) Return(_a0 <-chan bool) *HealthMonitor_Subscribe_Call {
+func (_c *HealthMonitor_Subscribe_Call) Return(_a0 <-chan error) *HealthMonitor_Subscribe_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *HealthMonitor_Subscribe_Call) RunAndReturn(run func() <-chan bool) *HealthMonitor_Subscribe_Call {
+func (_c *HealthMonitor_Subscribe_Call) RunAndReturn(run func() <-chan error) *HealthMonitor_Subscribe_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/op-conductor/health/monitor_test.go
+++ b/op-conductor/health/monitor_test.go
@@ -80,7 +80,7 @@ func (s *HealthMonitorTestSuite) TestUnhealthyLowPeerCount() {
 
 	healthUpdateCh := s.monitor.Subscribe()
 	healthy := <-healthUpdateCh
-	s.False(healthy)
+	s.NotNil(healthy)
 }
 
 func (s *HealthMonitorTestSuite) TestUnhealthyUnsafeHeadNotProgressing() {
@@ -108,9 +108,9 @@ func (s *HealthMonitorTestSuite) TestUnhealthyUnsafeHeadNotProgressing() {
 	for i := 0; i < 3; i++ {
 		healthy := <-healthUpdateCh
 		if i < 2 {
-			s.True(healthy)
+			s.Nil(healthy)
 		} else {
-			s.False(healthy)
+			s.NotNil(healthy)
 		}
 	}
 }
@@ -143,9 +143,9 @@ func (s *HealthMonitorTestSuite) TestUnhealthySafeHeadNotProgressing() {
 	for i := 0; i < 6; i++ {
 		healthy := <-healthUpdateCh
 		if i < 5 {
-			s.True(healthy)
+			s.Nil(healthy)
 		} else {
-			s.False(healthy)
+			s.NotNil(healthy)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change health monitor to return error instead of bool, this way it could provide more granular information to help with decisions about whether to transfer leadership or not.

**Tests**

Existing tests already covered.

**Metadata**

- https://github.com/ethereum-optimism/protocol-quest/issues/114, addresses edge case scenario 1
