### PR TITLE
ci: Only run Kontrol tests on PRs or develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1329,6 +1329,16 @@ jobs:
     steps:
       - checkout
       - run:
+          # This is a workaround for how check-changed doesn't work in
+          # the merge queue. By running this check the kontrol tests will
+          # run on PR builds and on develop, but not the merge queue.
+          name: Ensure PR/develop
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" != "develop" ]; then
+              echo "Not a PR or develop branch, skipping kontrol tests"
+              circleci step halt
+            fi
+      - run:
           name: Checkout Submodule
           command: make submodules
       - check-changed:


### PR DESCRIPTION
Adds a check to prevent long-running Kontrol tests from running in the merge queue. They will still run on PRs and on `develop`. This helps get around a limitation in check-changed that causes all tests to be run on PRs in the merge queue.
