### PR TITLE
`op-chain-ops`:  invert lookup from chainID to superchain

### DIFF
--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -79,11 +79,13 @@ func entrypoint(ctx *cli.Context) error {
 	}
 
 	superchainName := ctx.String("superchain-target")
-	if superchainName == "" {
-		superchainName, err = upgrades.ToSuperchainName(l1ChainID.Uint64())
-		if err != nil {
-			return err
-		}
+	declaredChainID, err := upgrades.SuperChainID(superchainName)
+	if err != nil {
+		return err
+	}
+	if declaredChainID != l1ChainID.Uint64() {
+		return fmt.Errorf("superchain %s has chainID %d, but the l1-rpc-url returned a chainId of %d",
+			superchainName, declaredChainID, l1ChainID.Uint64())
 	}
 
 	chainIDs := ctx.Uint64Slice("chain-ids")

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -79,7 +79,12 @@ func entrypoint(ctx *cli.Context) error {
 	}
 
 	superchainName := ctx.String("superchain-target")
-	declaredChainID := superchain.Superchains[superchainName].Config.L1.ChainID
+	sc, ok := superchain.Superchains[superchainName]
+	if !ok {
+		return fmt.Errorf("superchain name %s not registered", superchainName)
+	}
+
+	declaredChainID := sc.Config.L1.ChainID
 
 	if declaredChainID != l1ChainID.Uint64() {
 		return fmt.Errorf("superchain %s has chainID %d, but the l1-rpc-url returned a chainId of %d",

--- a/op-chain-ops/cmd/op-upgrade/main.go
+++ b/op-chain-ops/cmd/op-upgrade/main.go
@@ -79,10 +79,8 @@ func entrypoint(ctx *cli.Context) error {
 	}
 
 	superchainName := ctx.String("superchain-target")
-	declaredChainID, err := upgrades.SuperChainID(superchainName)
-	if err != nil {
-		return err
-	}
+	declaredChainID := superchain.Superchains[superchainName].Config.L1.ChainID
+
 	if declaredChainID != l1ChainID.Uint64() {
 		return fmt.Errorf("superchain %s has chainID %d, but the l1-rpc-url returned a chainId of %d",
 			superchainName, declaredChainID, l1ChainID.Uint64())

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -105,12 +105,9 @@ func entrypoint(ctx *cli.Context) error {
 				return fmt.Errorf("cannot fetch L1 chain ID: %w", err)
 			}
 
-			superchainName, err := upgrades.ToSuperchainName(l1ChainID.Uint64())
-			if err != nil {
-				return fmt.Errorf("error getting superchain name: %w", err)
-			}
+			declaredL1ChainID, err := upgrades.SuperChainID((chainConfig.Superchain))
 
-			if superchainName != chainConfig.Superchain {
+			if l1ChainID.Uint64() != declaredL1ChainID || err != nil {
 				// L2 corresponds to a different superchain than L1, skip
 				log.Info("Ignoring L1/L2", "l1-chain-id", l1ChainID, "l2-chain-id", l2ChainID)
 				continue

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -106,8 +106,11 @@ func entrypoint(ctx *cli.Context) error {
 			}
 
 			declaredL1ChainID, err := upgrades.SuperChainID((chainConfig.Superchain))
+			if err != nil {
+				return err
+			}
 
-			if l1ChainID.Uint64() != declaredL1ChainID || err != nil {
+			if l1ChainID.Uint64() != declaredL1ChainID {
 				// L2 corresponds to a different superchain than L1, skip
 				log.Info("Ignoring L1/L2", "l1-chain-id", l1ChainID, "l2-chain-id", l2ChainID)
 				continue

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -105,7 +105,12 @@ func entrypoint(ctx *cli.Context) error {
 				return fmt.Errorf("cannot fetch L1 chain ID: %w", err)
 			}
 
-			declaredL1ChainID := superchain.Superchains[chainConfig.Superchain].Config.L1.ChainID
+			sc, ok := superchain.Superchains[chainConfig.Superchain]
+			if !ok {
+				return fmt.Errorf("superchain name %s not registered", chainConfig.Superchain)
+			}
+
+			declaredL1ChainID := sc.Config.L1.ChainID
 
 			if l1ChainID.Uint64() != declaredL1ChainID {
 				// L2 corresponds to a different superchain than L1, skip

--- a/op-chain-ops/cmd/op-version-check/main.go
+++ b/op-chain-ops/cmd/op-version-check/main.go
@@ -105,10 +105,7 @@ func entrypoint(ctx *cli.Context) error {
 				return fmt.Errorf("cannot fetch L1 chain ID: %w", err)
 			}
 
-			declaredL1ChainID, err := upgrades.SuperChainID((chainConfig.Superchain))
-			if err != nil {
-				return err
-			}
+			declaredL1ChainID := superchain.Superchains[chainConfig.Superchain].Config.L1.ChainID
 
 			if l1ChainID.Uint64() != declaredL1ChainID {
 				// L2 corresponds to a different superchain than L1, skip

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -123,16 +123,17 @@ func cmpVersion(v1, v2 string) bool {
 	return v1 == v2
 }
 
-// ToSuperchainName turns a base layer chain id into a superchain network name.
-func ToSuperchainName(chainID uint64) (string, error) {
-	if chainID == 1 {
-		return "mainnet", nil
+// SuperChainID returns the chain ID for the supplied superchain name, or an error
+// if no such superchain is known.
+func SuperChainID(superchain string) (uint64, error) {
+	switch superchain {
+	case "mainnet":
+		return 1, nil
+	case "goerli":
+	case "goerli-dev-0":
+		return 5, nil
+	case "sepolia":
+		return 11155111, nil
 	}
-	if chainID == 5 {
-		return "goerli", nil
-	}
-	if chainID == 11155111 {
-		return "sepolia", nil
-	}
-	return "", fmt.Errorf("unsupported chain ID %d", chainID)
+	return 0, fmt.Errorf("unkown superchain %s", superchain)
 }

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -135,5 +135,5 @@ func SuperChainID(superchain string) (uint64, error) {
 	case "sepolia":
 		return 11155111, nil
 	}
-	return 0, fmt.Errorf("unkown superchain %s", superchain)
+	return 0, fmt.Errorf("unknown superchain %s", superchain)
 }

--- a/op-chain-ops/upgrades/check.go
+++ b/op-chain-ops/upgrades/check.go
@@ -122,18 +122,3 @@ func cmpVersion(v1, v2 string) bool {
 	}
 	return v1 == v2
 }
-
-// SuperChainID returns the chain ID for the supplied superchain name, or an error
-// if no such superchain is known.
-func SuperChainID(superchain string) (uint64, error) {
-	switch superchain {
-	case "mainnet":
-		return 1, nil
-	case "goerli":
-	case "goerli-dev-0":
-		return 5, nil
-	case "sepolia":
-		return 11155111, nil
-	}
-	return 0, fmt.Errorf("unknown superchain %s", superchain)
-}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Replaces `ToSuperchainName(chainID uint64) (string, error)` utility with `SuperChainID(superchain string) (uint64, error)` and makes follow-on changes.

**Tests**
I manually verified that this fixes #9209

**Additional context**

There can be (and are) more than one superchain with a given id. Conversely, each superchain will have exactly one id.


**Metadata**

- Fixes #9202
