### PR TITLE
fix(op-challenger): Fetch PreimageOracle Large Preimage Threshold

### DIFF
--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -29,6 +29,7 @@ const (
 	methodProposalBlocksLen         = "proposalBlocksLen"
 	methodProposalBlocks            = "proposalBlocks"
 	methodPreimagePartOk            = "preimagePartOk"
+	methodMinProposalSize           = "minProposalSize"
 )
 
 var (
@@ -132,6 +133,15 @@ func abiEncodeStateMatrix(stateMatrix *matrix.StateMatrix) bindings.LibKeccakSta
 		stateSlice[i/8] = new(big.Int).SetBytes(packedState[i : i+8]).Uint64()
 	}
 	return bindings.LibKeccakStateMatrix{State: *stateSlice}
+}
+
+// MinLargePreimageSize returns the minimum size of a large preimage.
+func (c *PreimageOracleContract) MinLargePreimageSize(ctx context.Context) (uint64, error) {
+	result, err := c.multiCaller.SingleCall(ctx, batching.BlockLatest, c.contract.Call(methodMinProposalSize))
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch min lpp size bytes: %w", err)
+	}
+	return result.GetBigInt(0).Uint64(), nil
 }
 
 func (c *PreimageOracleContract) GetActivePreimages(ctx context.Context, blockHash common.Hash) ([]keccakTypes.LargePreimageMetaData, error) {

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -88,9 +88,13 @@ func NewGamePlayer(
 	if err != nil {
 		return nil, fmt.Errorf("failed to load oracle: %w", err)
 	}
+	minLargePreimageSize, err := oracle.MinLargePreimageSize(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load min large preimage size: %w", err)
+	}
 	direct := preimages.NewDirectPreimageUploader(logger, txMgr, loader)
 	large := preimages.NewLargePreimageUploader(logger, txMgr, oracle)
-	uploader := preimages.NewSplitPreimageUploader(direct, large)
+	uploader := preimages.NewSplitPreimageUploader(direct, large, minLargePreimageSize)
 
 	responder, err := responder.NewFaultResponder(logger, txMgr, loader, uploader, oracle)
 	if err != nil {

--- a/op-challenger/game/fault/preimages/split.go
+++ b/op-challenger/game/fault/preimages/split.go
@@ -8,31 +8,26 @@ import (
 
 var _ PreimageUploader = (*SplitPreimageUploader)(nil)
 
-// PREIMAGE_SIZE_THRESHOLD is the size threshold for determining whether a preimage
-// should be uploaded directly or through the large preimage uploader.
-// TODO(client-pod#467): determine the correct size threshold to toggle between
-//
-//	the direct and large preimage uploaders.
-const PREIMAGE_SIZE_THRESHOLD = 136 * 128
-
 // SplitPreimageUploader routes preimage uploads to the appropriate uploader
 // based on the size of the preimage.
 type SplitPreimageUploader struct {
-	directUploader PreimageUploader
-	largeUploader  PreimageUploader
+	largePreimageSizeThreshold uint64
+	directUploader             PreimageUploader
+	largeUploader              PreimageUploader
 }
 
-func NewSplitPreimageUploader(directUploader PreimageUploader, largeUploader PreimageUploader) *SplitPreimageUploader {
-	return &SplitPreimageUploader{directUploader, largeUploader}
+func NewSplitPreimageUploader(directUploader PreimageUploader, largeUploader PreimageUploader, minLargePreimageSize uint64) *SplitPreimageUploader {
+	return &SplitPreimageUploader{minLargePreimageSize, directUploader, largeUploader}
 }
 
 func (s *SplitPreimageUploader) UploadPreimage(ctx context.Context, parent uint64, data *types.PreimageOracleData) error {
 	if data == nil {
 		return ErrNilPreimageData
 	}
-	if len(data.OracleData) > PREIMAGE_SIZE_THRESHOLD {
-		return s.largeUploader.UploadPreimage(ctx, parent, data)
-	} else {
+	// Always route local preimage uploads to the direct uploader.
+	if uint64(len(data.OracleData)) < s.largePreimageSizeThreshold || data.IsLocal {
 		return s.directUploader.UploadPreimage(ctx, parent, data)
+	} else {
+		return s.largeUploader.UploadPreimage(ctx, parent, data)
 	}
 }

--- a/op-challenger/game/fault/preimages/split_test.go
+++ b/op-challenger/game/fault/preimages/split_test.go
@@ -8,25 +8,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var mockLargePreimageSizeThreshold = uint64(100)
+
 func TestSplitPreimageUploader_UploadPreimage(t *testing.T) {
 	t.Run("DirectUploadSucceeds", func(t *testing.T) {
-		oracle, direct, large := newTestSplitPreimageUploader(t)
+		oracle, direct, large := newTestSplitPreimageUploader(t, mockLargePreimageSizeThreshold)
 		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{})
 		require.NoError(t, err)
 		require.Equal(t, 1, direct.updates)
 		require.Equal(t, 0, large.updates)
 	})
 
+	t.Run("LocalDataUploadSucceeds", func(t *testing.T) {
+		oracle, direct, large := newTestSplitPreimageUploader(t, mockLargePreimageSizeThreshold)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{IsLocal: true})
+		require.NoError(t, err)
+		require.Equal(t, 1, direct.updates)
+		require.Equal(t, 0, large.updates)
+	})
+
+	t.Run("MaxSizeDirectUploadSucceeds", func(t *testing.T) {
+		oracle, direct, large := newTestSplitPreimageUploader(t, mockLargePreimageSizeThreshold)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{OracleData: make([]byte, mockLargePreimageSizeThreshold-1)})
+		require.NoError(t, err)
+		require.Equal(t, 1, direct.updates)
+		require.Equal(t, 0, large.updates)
+	})
+
 	t.Run("LargeUploadSucceeds", func(t *testing.T) {
-		oracle, direct, large := newTestSplitPreimageUploader(t)
-		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{OracleData: make([]byte, PREIMAGE_SIZE_THRESHOLD+1)})
+		oracle, direct, large := newTestSplitPreimageUploader(t, mockLargePreimageSizeThreshold)
+		err := oracle.UploadPreimage(context.Background(), 0, &types.PreimageOracleData{OracleData: make([]byte, mockLargePreimageSizeThreshold)})
 		require.NoError(t, err)
 		require.Equal(t, 1, large.updates)
 		require.Equal(t, 0, direct.updates)
 	})
 
 	t.Run("NilPreimageOracleData", func(t *testing.T) {
-		oracle, _, _ := newTestSplitPreimageUploader(t)
+		oracle, _, _ := newTestSplitPreimageUploader(t, mockLargePreimageSizeThreshold)
 		err := oracle.UploadPreimage(context.Background(), 0, nil)
 		require.ErrorIs(t, err, ErrNilPreimageData)
 	})
@@ -45,8 +63,8 @@ func (s *mockPreimageUploader) UploadPreimage(ctx context.Context, parent uint64
 	return nil
 }
 
-func newTestSplitPreimageUploader(t *testing.T) (*SplitPreimageUploader, *mockPreimageUploader, *mockPreimageUploader) {
+func newTestSplitPreimageUploader(t *testing.T, threshold uint64) (*SplitPreimageUploader, *mockPreimageUploader, *mockPreimageUploader) {
 	direct := &mockPreimageUploader{}
 	large := &mockPreimageUploader{}
-	return NewSplitPreimageUploader(direct, large), direct, large
+	return NewSplitPreimageUploader(direct, large, threshold), direct, large
 }


### PR DESCRIPTION
**Description**

This PR updates the `op-challenger` to query the `PreimageOracle` contract for the minimum large preimage size in bytes (the [`MIN_LPP_SIZE_BYTES`](https://github.com/ethereum-optimism/optimism/blob/aa28bcfd1004d55c1d71b1b405c25dabfc12eb8c/packages/contracts-bedrock/src/cannon/PreimageOracle.sol#L22) state variable) which represents a conservative threshold for routing preimage uploads.

The minimum large preimage size is queried during construction of the game player and passed into the `SplitPreimageUploader` to use as its threshold. The `PreimageOracle` and its bindings are also updated in this pr to change the visibility of the `MIN_LPP_SIZE_BYTES` state variable from `internal` to `public`.

**Tests**

Split preimage uploader tests are updated to pass a mock threshold.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/467
