### PR TITLE
op-conductor: fixes a few configuration bugs

### DIFF
--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -109,6 +109,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 	return &Config{
 		ConsensusAddr:  ctx.String(flags.ConsensusAddr.Name),
 		ConsensusPort:  ctx.Int(flags.ConsensusPort.Name),
+		RaftBootstrap:  ctx.Bool(flags.RaftBootstrap.Name),
 		RaftServerID:   ctx.String(flags.RaftServerID.Name),
 		RaftStorageDir: ctx.String(flags.RaftStorageDir.Name),
 		NodeRPC:        ctx.String(flags.NodeRPC.Name),

--- a/op-conductor/flags/flags.go
+++ b/op-conductor/flags/flags.go
@@ -28,6 +28,12 @@ var (
 		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "CONSENSUS_PORT"),
 		Value:   50050,
 	}
+	RaftBootstrap = &cli.BoolFlag{
+		Name:    "raft.bootstrap",
+		Usage:   "If this node should bootstrap a new raft cluster",
+		EnvVars: opservice.PrefixEnvVar(EnvVarPrefix, "RAFT_BOOTSTRAP"),
+		Value:   false,
+	}
 	RaftServerID = &cli.StringFlag{
 		Name:    "raft.server.id",
 		Usage:   "Unique ID for this server used by raft consensus",
@@ -90,6 +96,7 @@ var requiredFlags = []cli.Flag{
 	NodeRPC,
 	ExecutionRPC,
 	HealthCheckInterval,
+	HealthCheckUnsafeInterval,
 	HealthCheckSafeInterval,
 	HealthCheckMinPeerCount,
 }
@@ -97,6 +104,7 @@ var requiredFlags = []cli.Flag{
 var optionalFlags = []cli.Flag{
 	Paused,
 	RPCEnableProxy,
+	RaftBootstrap,
 }
 
 func init() {


### PR DESCRIPTION
**Description**

* Adds missing HealthcheckUnsafeInterval flag requirement
* Adds missing RaftBootstrap flag