### PR TITLE
fix(op-challenger): Squeeze Large Preimages Post Challenge Period

### DIFF
--- a/op-challenger/challenger.go
+++ b/op-challenger/challenger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 )
 
 // Main is the programmatic entry-point for running op-challenger with a given configuration.
@@ -15,6 +16,6 @@ func Main(ctx context.Context, logger log.Logger, cfg *config.Config) (cliapp.Li
 	if err := cfg.Check(); err != nil {
 		return nil, err
 	}
-	srv, err := game.NewService(ctx, logger, cfg)
+	srv, err := game.NewService(ctx, clock.SystemClock, logger, cfg)
 	return srv, err
 }

--- a/op-challenger/game/fault/contracts/oracle_test.go
+++ b/op-challenger/game/fault/contracts/oracle_test.go
@@ -37,6 +37,28 @@ func TestPreimageOracleContract_LoadKeccak256(t *testing.T) {
 	stubRpc.VerifyTxCandidate(tx)
 }
 
+func TestPreimageOracleContract_ChallengePeriod(t *testing.T) {
+	stubRpc, oracle := setupPreimageOracleTest(t)
+	stubRpc.SetResponse(oracleAddr, methodChallengePeriod, batching.BlockLatest,
+		[]interface{}{},
+		[]interface{}{big.NewInt(123)},
+	)
+	challengePeriod, err := oracle.ChallengePeriod(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(123), challengePeriod)
+}
+
+func TestPreimageOracleContract_MinLargePreimageSize(t *testing.T) {
+	stubRpc, oracle := setupPreimageOracleTest(t)
+	stubRpc.SetResponse(oracleAddr, methodMinProposalSize, batching.BlockLatest,
+		[]interface{}{},
+		[]interface{}{big.NewInt(123)},
+	)
+	minProposalSize, err := oracle.MinLargePreimageSize(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(123), minProposalSize)
+}
+
 func TestPreimageOracleContract_PreimageDataExists(t *testing.T) {
 	t.Run("exists", func(t *testing.T) {
 		stubRpc, oracle := setupPreimageOracleTest(t)

--- a/op-challenger/game/fault/player.go
+++ b/op-challenger/game/fault/player.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -43,6 +44,7 @@ type resourceCreator func(ctx context.Context, logger log.Logger, gameDepth type
 
 func NewGamePlayer(
 	ctx context.Context,
+	cl clock.Clock,
 	logger log.Logger,
 	m metrics.Metricer,
 	dir string,
@@ -93,7 +95,7 @@ func NewGamePlayer(
 		return nil, fmt.Errorf("failed to load min large preimage size: %w", err)
 	}
 	direct := preimages.NewDirectPreimageUploader(logger, txSender, loader)
-	large := preimages.NewLargePreimageUploader(logger, txSender, oracle)
+	large := preimages.NewLargePreimageUploader(logger, cl, txSender, oracle)
 	uploader := preimages.NewSplitPreimageUploader(direct, large, minLargePreimageSize)
 	responder, err := responder.NewFaultResponder(logger, txSender, loader, uploader, oracle)
 	if err != nil {

--- a/op-challenger/game/fault/preimages/types.go
+++ b/op-challenger/game/fault/preimages/types.go
@@ -29,4 +29,5 @@ type PreimageOracleContract interface {
 	Squeeze(claimant common.Address, uuid *big.Int, stateMatrix *matrix.StateMatrix, preState keccakTypes.Leaf, preStateProof merkle.Proof, postState keccakTypes.Leaf, postStateProof merkle.Proof) (txmgr.TxCandidate, error)
 	CallSqueeze(ctx context.Context, claimant common.Address, uuid *big.Int, stateMatrix *matrix.StateMatrix, preState keccakTypes.Leaf, preStateProof merkle.Proof, postState keccakTypes.Leaf, postStateProof merkle.Proof) error
 	GetProposalMetadata(ctx context.Context, block batching.Block, idents ...keccakTypes.LargePreimageIdent) ([]keccakTypes.LargePreimageMetaData, error)
+	ChallengePeriod(ctx context.Context) (uint64, error)
 }

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -94,7 +94,10 @@ func (r *FaultResponder) PerformAction(ctx context.Context, action types.Action)
 		// Always upload local preimages
 		if !preimageExists {
 			err := r.uploader.UploadPreimage(ctx, uint64(action.ParentIdx), action.OracleData)
-			if err != nil {
+			if err == preimages.ErrChallengePeriodNotOver {
+				r.log.Debug("Large Preimage Squeeze failed, challenge period not over")
+				return nil
+			} else if err != nil {
 				return fmt.Errorf("failed to upload preimage: %w", err)
 			}
 		}


### PR DESCRIPTION
**Description**

Updates the `op-challenger` to only perform the squeeze for large preimages after the challenge preiod has elapsed.

**Tests**

Adds unit tests against the `LargePreimageUploader.UploadPreimage` method to test squeeze is **not** called if the challenge period has not elapsed. Verifies that once the challenge period has elapsed, squeeze can then be called.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/474
