### PR TITLE
op-challenger: Switch Leaf.Index to uint64 instead of big.Int

### DIFF
--- a/op-challenger/game/fault/contracts/oracle.go
+++ b/op-challenger/game/fault/contracts/oracle.go
@@ -50,7 +50,7 @@ type PreimageOracleContract struct {
 func toPreimageOracleLeaf(l keccakTypes.Leaf) bindings.PreimageOracleLeaf {
 	return bindings.PreimageOracleLeaf{
 		Input:           l.Input[:],
-		Index:           l.Index,
+		Index:           new(big.Int).SetUint64(l.Index),
 		StateCommitment: l.StateCommitment,
 	}
 }

--- a/op-challenger/game/fault/contracts/oracle_test.go
+++ b/op-challenger/game/fault/contracts/oracle_test.go
@@ -138,13 +138,13 @@ func TestPreimageOracleContract_Squeeze(t *testing.T) {
 	stateMatrix := matrix.NewStateMatrix()
 	preState := keccakTypes.Leaf{
 		Input:           [keccakTypes.BlockSize]byte{0x12},
-		Index:           big.NewInt(123),
+		Index:           123,
 		StateCommitment: common.Hash{0x34},
 	}
 	preStateProof := merkle.Proof{{0x34}}
 	postState := keccakTypes.Leaf{
 		Input:           [keccakTypes.BlockSize]byte{0x34},
-		Index:           big.NewInt(456),
+		Index:           456,
 		StateCommitment: common.Hash{0x56},
 	}
 	postStateProof := merkle.Proof{{0x56}}
@@ -507,7 +507,7 @@ func TestChallenge_First(t *testing.T) {
 		Prestate:    keccakTypes.Leaf{},
 		Poststate: keccakTypes.Leaf{
 			Input:           [136]byte{5, 4, 3, 2, 1},
-			Index:           big.NewInt(0),
+			Index:           0,
 			StateCommitment: common.Hash{0xbb},
 		},
 		PoststateProof: merkle.Proof{common.Hash{0x01}, common.Hash{0x02}},
@@ -517,7 +517,7 @@ func TestChallenge_First(t *testing.T) {
 			ident.Claimant, ident.UUID,
 			bindings.PreimageOracleLeaf{
 				Input:           challenge.Poststate.Input[:],
-				Index:           challenge.Poststate.Index,
+				Index:           new(big.Int).SetUint64(challenge.Poststate.Index),
 				StateCommitment: challenge.Poststate.StateCommitment,
 			},
 			challenge.PoststateProof,
@@ -539,13 +539,13 @@ func TestChallenge_NotFirst(t *testing.T) {
 		StateMatrix: bytes.Repeat([]byte{1, 2, 3, 4, 5, 6, 7, 8}, 25),
 		Prestate: keccakTypes.Leaf{
 			Input:           [136]byte{9, 8, 7, 6, 5},
-			Index:           big.NewInt(3),
+			Index:           3,
 			StateCommitment: common.Hash{0xcc},
 		},
 		PrestateProof: merkle.Proof{common.Hash{0x01}, common.Hash{0x02}},
 		Poststate: keccakTypes.Leaf{
 			Input:           [136]byte{5, 4, 3, 2, 1},
-			Index:           big.NewInt(4),
+			Index:           4,
 			StateCommitment: common.Hash{0xbb},
 		},
 		PoststateProof: merkle.Proof{common.Hash{0x03}, common.Hash{0x04}},
@@ -556,13 +556,13 @@ func TestChallenge_NotFirst(t *testing.T) {
 			abiEncodePackedState(challenge.StateMatrix),
 			bindings.PreimageOracleLeaf{
 				Input:           challenge.Prestate.Input[:],
-				Index:           challenge.Prestate.Index,
+				Index:           new(big.Int).SetUint64(challenge.Prestate.Index),
 				StateCommitment: challenge.Prestate.StateCommitment,
 			},
 			challenge.PrestateProof,
 			bindings.PreimageOracleLeaf{
 				Input:           challenge.Poststate.Input[:],
-				Index:           challenge.Poststate.Index,
+				Index:           new(big.Int).SetUint64(challenge.Poststate.Index),
 				StateCommitment: challenge.Poststate.StateCommitment,
 			},
 			challenge.PoststateProof,

--- a/op-challenger/game/fault/preimages/large_test.go
+++ b/op-challenger/game/fault/preimages/large_test.go
@@ -206,12 +206,12 @@ func TestLargePreimageUploader_UploadPreimage_Succeeds(t *testing.T) {
 			addCalls: 1,
 			prestateLeaf: keccakTypes.Leaf{
 				Input:           *fullLeaf,
-				Index:           big.NewInt(0),
+				Index:           0,
 				StateCommitment: common.HexToHash("9788a3b3bc36c482525b5890767be37130c997917bceca6e91a6c93359a4d1c6"),
 			},
 			poststateLeaf: keccakTypes.Leaf{
 				Input:           [keccakTypes.BlockSize]byte{},
-				Index:           big.NewInt(1),
+				Index:           1,
 				StateCommitment: common.HexToHash("78358b902b7774b314bcffdf0948746f18d6044086e76e3924d585dca3486c7d"),
 			},
 		},
@@ -221,12 +221,12 @@ func TestLargePreimageUploader_UploadPreimage_Succeeds(t *testing.T) {
 			addCalls: 1,
 			prestateLeaf: keccakTypes.Leaf{
 				Input:           *fullLeaf,
-				Index:           big.NewInt(2),
+				Index:           2,
 				StateCommitment: common.HexToHash("e3deed8ab6f8bbcf3d4fe825d74f703b3f2fc2f5b0afaa2574926fcfd0d4c895"),
 			},
 			poststateLeaf: keccakTypes.Leaf{
 				Input:           [keccakTypes.BlockSize]byte{},
-				Index:           big.NewInt(3),
+				Index:           3,
 				StateCommitment: common.HexToHash("79115eeab1ff2eccf5baf3ea2dda13bc79c548ce906bdd16433a23089c679df2"),
 			},
 		},
@@ -236,12 +236,12 @@ func TestLargePreimageUploader_UploadPreimage_Succeeds(t *testing.T) {
 			addCalls: 1,
 			prestateLeaf: keccakTypes.Leaf{
 				Input:           *fullLeaf,
-				Index:           big.NewInt(1),
+				Index:           1,
 				StateCommitment: common.HexToHash("b5ea400e375b2c1ce348f3cc4ad5b6ad28e1b36759ddd2aba155f0b1d476b015"),
 			},
 			poststateLeaf: keccakTypes.Leaf{
 				Input:           [keccakTypes.BlockSize]byte{byte(9)},
-				Index:           big.NewInt(2),
+				Index:           2,
 				StateCommitment: common.HexToHash("fa87e115dc4786e699bf80cc75d13ac1e2db0708c1418fc8cbc9800d17b5811a"),
 			},
 		},
@@ -251,12 +251,12 @@ func TestLargePreimageUploader_UploadPreimage_Succeeds(t *testing.T) {
 			addCalls: 2,
 			prestateLeaf: keccakTypes.Leaf{
 				Input:           *fullLeaf,
-				Index:           big.NewInt(301),
+				Index:           301,
 				StateCommitment: common.HexToHash("4e9c55542478939feca4ff55ee98fbc632bb65a784a55b94536644bc87298ca4"),
 			},
 			poststateLeaf: keccakTypes.Leaf{
 				Input:           [keccakTypes.BlockSize]byte{},
-				Index:           big.NewInt(302),
+				Index:           302,
 				StateCommitment: common.HexToHash("775020bfcaa93700263d040a4eeec3c8c3cf09e178457d04044594beaaf5e20b"),
 			},
 		},

--- a/op-challenger/game/keccak/matrix/matrix_test.go
+++ b/op-challenger/game/keccak/matrix/matrix_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"math/rand"
 	"testing"
 
@@ -291,7 +290,7 @@ func TestVerifyPreimage(t *testing.T) {
 		for i, commitment := range commitments {
 			leaf := types.Leaf{
 				Input:           leafData(i),
-				Index:           big.NewInt(int64(i)),
+				Index:           uint64(i),
 				StateCommitment: commitment,
 			}
 			m.AddLeaf(leaf.Hash())
@@ -312,14 +311,14 @@ func TestVerifyPreimage(t *testing.T) {
 			StateMatrix: s.PackState(),
 			Prestate: types.Leaf{
 				Input:           prestateLeaf,
-				Index:           big.NewInt(int64(invalidIdx - 1)),
+				Index:           uint64(invalidIdx - 1),
 				StateCommitment: commitments[invalidIdx-1],
 			},
 			PrestateProof: fullMerkle.ProofAtIndex(uint64(invalidIdx - 1)),
 
 			Poststate: types.Leaf{
 				Input:           poststateLeaf,
-				Index:           big.NewInt(int64(invalidIdx)),
+				Index:           uint64(invalidIdx),
 				StateCommitment: commitments[invalidIdx],
 			},
 			PoststateProof: fullMerkle.ProofAtIndex(uint64(invalidIdx)),
@@ -353,7 +352,7 @@ func TestVerifyPreimage(t *testing.T) {
 					Prestate:    types.Leaf{},
 					Poststate: types.Leaf{
 						Input:           poststateLeaf,
-						Index:           big.NewInt(int64(0)),
+						Index:           0,
 						StateCommitment: common.Hash{0xaa},
 					},
 					PoststateProof: merkleTree(incorrectFirstCommitment).ProofAtIndex(0),

--- a/op-challenger/game/keccak/types/types.go
+++ b/op-challenger/game/keccak/types/types.go
@@ -18,16 +18,9 @@ type Leaf struct {
 	// Input is the data absorbed for the block, exactly 136 bytes
 	Input [BlockSize]byte
 	// Index of the block in the absorption process
-	Index *big.Int
+	Index uint64
 	// StateCommitment is the hash of the internal state after absorbing the input.
 	StateCommitment common.Hash
-}
-
-func (l Leaf) IndexUint64() uint64 {
-	if l.Index == nil {
-		return 0
-	}
-	return l.Index.Uint64()
 }
 
 // Hash returns the hash of the leaf data. That is the
@@ -35,13 +28,7 @@ func (l Leaf) IndexUint64() uint64 {
 func (l Leaf) Hash() common.Hash {
 	concatted := make([]byte, 0, 136+32+32)
 	concatted = append(concatted, l.Input[:]...)
-	var indexBytes []byte
-	if l.Index != nil {
-		indexBytes = l.Index.Bytes()
-	} else {
-		indexBytes = big.NewInt(0).Bytes()
-	}
-	concatted = append(concatted, indexBytes...)
+	concatted = append(concatted, new(big.Int).SetUint64(l.Index).Bytes()...)
 	concatted = append(concatted, l.StateCommitment.Bytes()...)
 	return crypto.Keccak256Hash(concatted)
 }


### PR DESCRIPTION
**Description**

Change `Leaf.Index` from `big.Int` to `uint64` so the default `types.Leaf{}` doesn't risk nil pointer references. Also simplifies working with the index.  This is safe because the maximum number of leaves that can be added is `2^16-1` or the Binary Merkle Tree overflows.

**Additional context**

Builds on https://github.com/ethereum-optimism/optimism/pull/9228

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/480
