### PR TITLE
chore: Remove Legacy Devnet Deploy Makefile Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,6 @@ devnet-up: pre-devnet
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=.
 .PHONY: devnet-up
 
-# alias for devnet-up
-devnet-up-deploy: devnet-up
-
 devnet-test: pre-devnet
 	PYTHONPATH=./bedrock-devnet $(PYTHON) ./bedrock-devnet/main.py --monorepo-dir=. --test
 .PHONY: devnet-test

--- a/bedrock-devnet/README.md
+++ b/bedrock-devnet/README.md
@@ -2,4 +2,4 @@
 
 This is a utility for running a local Bedrock devnet. It is designed to replace the legacy Bash-based devnet runner as part of a progressive migration away from Bash automation.
 
-The easiest way to invoke this script is to run `make devnet-up-deploy` from the root of this repository. Otherwise, to use this script run `python3 main.py --monorepo-dir=<path to the monorepo>`. You may need to set `PYTHONPATH` to this directory if you are invoking the script from somewhere other than `bedrock-devnet`.
+The easiest way to invoke this script is to run `make devnet-up` from the root of this repository. Otherwise, to use this script run `python3 main.py --monorepo-dir=<path to the monorepo>`. You may need to set `PYTHONPATH` to this directory if you are invoking the script from somewhere other than `bedrock-devnet`.


### PR DESCRIPTION
**Description**

Micro PR to remove the `devnet-up-deploy` top-level makefile target since it is a legacy target and has just aliased `devnet-up` for a while.
