### PR TITLE
Emit histogram for blob size

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -372,6 +372,7 @@ func (l *BatchSubmitter) sendTransaction(txdata txData, queue *txmgr.Queue[txDat
 			// or configuration issue.
 			return fmt.Errorf("could not create blob tx candidate: %w", err)
 		}
+		l.Metr.RecordBlobUsedBytes(len(data))
 	} else {
 		candidate = l.calldataTxCandidate(data)
 	}

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -189,6 +189,7 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "blob_used_bytes",
 			Help:      "Blob size in bytes being submitted.",
+			Buckets:   prometheus.LinearBuckets(0.0, eth.MaxBlobDataSize/13, 13),
 		}),
 
 		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -46,6 +46,8 @@ type Metricer interface {
 	RecordBatchTxSuccess()
 	RecordBatchTxFailed()
 
+	RecordBlobUsedBytes(num int)
+
 	Document() []opmetrics.DocumentedMetric
 }
 
@@ -79,6 +81,8 @@ type Metrics struct {
 	channelOutputBytesTotal prometheus.Counter
 
 	batcherTxEvs opmetrics.EventVec
+
+	blobUsedBytes prometheus.Gauge
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -180,6 +184,11 @@ func NewMetrics(procName string) *Metrics {
 			Namespace: ns,
 			Name:      "output_bytes_total",
 			Help:      "Total number of compressed output bytes from a channel.",
+		}),
+		blobUsedBytes: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "blob_used_bytes",
+			Help:      "Blob size in bytes being submitted.",
 		}),
 
 		batcherTxEvs: opmetrics.NewEventVec(factory, ns, "", "batcher_tx", "BatcherTx", []string{"stage"}),
@@ -302,6 +311,10 @@ func (m *Metrics) RecordBatchTxSuccess() {
 
 func (m *Metrics) RecordBatchTxFailed() {
 	m.batcherTxEvs.Record(TxStageFailed)
+}
+
+func (m *Metrics) RecordBlobUsedBytes(num int) {
+	m.blobUsedBytes.Set(float64(num))
 }
 
 // estimateBatchSize estimates the size of the batch

--- a/op-batcher/metrics/metrics.go
+++ b/op-batcher/metrics/metrics.go
@@ -82,7 +82,7 @@ type Metrics struct {
 
 	batcherTxEvs opmetrics.EventVec
 
-	blobUsedBytes prometheus.Gauge
+	blobUsedBytes prometheus.Histogram
 }
 
 var _ Metricer = (*Metrics)(nil)
@@ -185,7 +185,7 @@ func NewMetrics(procName string) *Metrics {
 			Name:      "output_bytes_total",
 			Help:      "Total number of compressed output bytes from a channel.",
 		}),
-		blobUsedBytes: factory.NewGauge(prometheus.GaugeOpts{
+		blobUsedBytes: factory.NewHistogram(prometheus.HistogramOpts{
 			Namespace: ns,
 			Name:      "blob_used_bytes",
 			Help:      "Blob size in bytes being submitted.",
@@ -314,7 +314,7 @@ func (m *Metrics) RecordBatchTxFailed() {
 }
 
 func (m *Metrics) RecordBlobUsedBytes(num int) {
-	m.blobUsedBytes.Set(float64(num))
+	m.blobUsedBytes.Observe(float64(num))
 }
 
 // estimateBatchSize estimates the size of the batch

--- a/op-batcher/metrics/noop.go
+++ b/op-batcher/metrics/noop.go
@@ -42,6 +42,7 @@ func (*noopMetrics) RecordChannelTimedOut(derive.ChannelID)       {}
 func (*noopMetrics) RecordBatchTxSubmitted() {}
 func (*noopMetrics) RecordBatchTxSuccess()   {}
 func (*noopMetrics) RecordBatchTxFailed()    {}
+func (*noopMetrics) RecordBlobUsedBytes(int) {}
 func (*noopMetrics) StartBalanceMetrics(log.Logger, *ethclient.Client, common.Address) io.Closer {
 	return nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Track used bytes of blobs posted to L1 from the batcher. Using the size non-encoded bytes of the data input, rather than tracking the size of encoded bytes and exposing via new method to eth.Blob

**Tests**

Tests were unaffected by this change, only a new metric was added

**Additional context**

Please share if you prefer to track and expose size of encoded data from eth.Blob

**Metadata**

- Fixes #[Link to Issue]
