### PR TITLE
op-node/rollup: Add delta time override for oplabs sepolia devnet 0

### DIFF
--- a/op-node/rollup/superchain.go
+++ b/op-node/rollup/superchain.go
@@ -15,17 +15,19 @@ import (
 var OPStackSupport = params.ProtocolVersionV0{Build: [8]byte{}, Major: 6, Minor: 0, Patch: 0, PreRelease: 1}.Encode()
 
 const (
-	opMainnet   = 10
-	opGoerli    = 420
-	opSepolia   = 11155420
+	opMainnet = 10
+	opGoerli  = 420
+	opSepolia = 11155420
+
+	labsGoerliDevnet   = 997
+	labsGoerliChaosnet = 888
+	labsSepoliaDevnet0 = 11155421
+
 	baseGoerli  = 84531
 	baseMainnet = 8453
-	pgnMainnet  = 424
-	pgnSepolia  = 58008
-	zoraGoerli  = 999
-	zoraMainnet = 7777777
-	labsDevnet  = 997
-	chaosnet    = 888
+
+	pgnMainnet = 424
+	pgnSepolia = 58008
 )
 
 // LoadOPStackRollupConfig loads the rollup configuration of the requested chain ID from the superchain-registry.
@@ -68,10 +70,18 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		regolithTime = 1683219600
 	case opGoerli:
 		regolithTime = 1679079600
-	case labsDevnet:
+	case labsGoerliDevnet:
 		regolithTime = 1677984480
-	case chaosnet:
+	case labsGoerliChaosnet:
 		regolithTime = 1692156862
+	}
+
+	deltaTime := superChain.Config.DeltaTime
+	// OP Labs Sepolia devnet 0 activated delta at genesis, slightly earlier than
+	// Base Sepolia devnet 0 on the same superchain.
+	switch chainID {
+	case labsSepoliaDevnet0:
+		deltaTime = new(uint64)
 	}
 
 	cfg := &Config{
@@ -99,7 +109,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 		L2ChainID:              new(big.Int).SetUint64(chConfig.ChainID),
 		RegolithTime:           &regolithTime,
 		CanyonTime:             superChain.Config.CanyonTime,
-		DeltaTime:              superChain.Config.DeltaTime,
+		DeltaTime:              deltaTime,
 		EcotoneTime:            superChain.Config.EcotoneTime,
 		FjordTime:              superChain.Config.FjordTime,
 		BatchInboxAddress:      common.Address(chConfig.BatchInboxAddr),
@@ -109,7 +119,7 @@ func LoadOPStackRollupConfig(chainID uint64) (*Config, error) {
 	if superChain.Config.ProtocolVersionsAddr != nil { // Set optional protocol versions address
 		cfg.ProtocolVersionsAddress = common.Address(*superChain.Config.ProtocolVersionsAddr)
 	}
-	if chainID == labsDevnet || chainID == chaosnet {
+	if chainID == labsGoerliDevnet || chainID == labsGoerliChaosnet {
 		cfg.ChannelTimeout = 120
 		cfg.MaxSequencerDrift = 1200
 	}


### PR DESCRIPTION
**Description**

Adds an exception for Lab's `sepolia-dev-0` devnet to activate delta at genesis.

**Tests**

Will do manual testing.

**Additional context**

Labs' `sepolia-dev-0` devnet chain activated delta at genesis. Base activated slightly (~a day) later.


