### PR TITLE
export rpcBlock

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -187,7 +187,7 @@ func (n numberID) CheckID(id eth.BlockID) error {
 }
 
 func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID) (eth.BlockInfo, error) {
-	var header *rpcHeader
+	var header *RPCHeader
 	err := s.client.CallContext(ctx, &header, method, id.Arg(), false) // headers are just blocks without txs
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (s *EthClient) headerCall(ctx context.Context, method string, id rpcBlockID
 }
 
 func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID) (eth.BlockInfo, types.Transactions, error) {
-	var block *rpcBlock
+	var block *RPCBlock
 	err := s.client.CallContext(ctx, &block, method, id.Arg(), true)
 	if err != nil {
 		return nil, nil, err
@@ -228,7 +228,7 @@ func (s *EthClient) blockCall(ctx context.Context, method string, id rpcBlockID)
 }
 
 func (s *EthClient) payloadCall(ctx context.Context, method string, id rpcBlockID) (*eth.ExecutionPayloadEnvelope, error) {
-	var block *rpcBlock
+	var block *RPCBlock
 	err := s.client.CallContext(ctx, &block, method, id.Arg(), true)
 	if err != nil {
 		return nil, err

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -235,7 +235,7 @@ func testEthClient_validateReceipts(t *testing.T, test validateReceiptsTest) {
 		receipts = mut(receipts)
 	}
 
-	mrpc.On("CallContext", ctx, mock.AnythingOfType("**sources.rpcBlock"),
+	mrpc.On("CallContext", ctx, mock.AnythingOfType("**sources.RPCBlock"),
 		"eth_getBlockByHash", []any{block.Hash, true}).
 		Run(func(args mock.Arguments) {
 			*(args[1].(**RPCBlock)) = block

--- a/op-service/sources/eth_client_test.go
+++ b/op-service/sources/eth_client_test.go
@@ -62,7 +62,7 @@ func randHash() (out common.Hash) {
 	return out
 }
 
-func randHeader() (*types.Header, *rpcHeader) {
+func randHeader() (*types.Header, *RPCHeader) {
 	hdr := &types.Header{
 		ParentHash:  randHash(),
 		UncleHash:   randHash(),
@@ -81,7 +81,7 @@ func randHeader() (*types.Header, *rpcHeader) {
 		Nonce:       types.BlockNonce{},
 		BaseFee:     big.NewInt(100),
 	}
-	rhdr := &rpcHeader{
+	rhdr := &RPCHeader{
 		ParentHash:  hdr.ParentHash,
 		UncleHash:   hdr.UncleHash,
 		Coinbase:    hdr.Coinbase,
@@ -108,9 +108,9 @@ func TestEthClient_InfoByHash(t *testing.T) {
 	_, rhdr := randHeader()
 	expectedInfo, _ := rhdr.Info(true, false)
 	ctx := context.Background()
-	m.On("CallContext", ctx, new(*rpcHeader),
+	m.On("CallContext", ctx, new(*RPCHeader),
 		"eth_getBlockByHash", []any{rhdr.Hash, false}).Run(func(args mock.Arguments) {
-		*args[1].(**rpcHeader) = rhdr
+		*args[1].(**RPCHeader) = rhdr
 	}).Return([]error{nil})
 	s, err := NewEthClient(m, nil, nil, testEthClientConfig)
 	require.NoError(t, err)
@@ -131,9 +131,9 @@ func TestEthClient_InfoByNumber(t *testing.T) {
 	expectedInfo, _ := rhdr.Info(true, false)
 	n := rhdr.Number
 	ctx := context.Background()
-	m.On("CallContext", ctx, new(*rpcHeader),
+	m.On("CallContext", ctx, new(*RPCHeader),
 		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
-		*args[1].(**rpcHeader) = rhdr
+		*args[1].(**RPCHeader) = rhdr
 	}).Return([]error{nil})
 	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
 	require.NoError(t, err)
@@ -150,9 +150,9 @@ func TestEthClient_WrongInfoByNumber(t *testing.T) {
 	rhdr2.Number += 1
 	n := rhdr.Number
 	ctx := context.Background()
-	m.On("CallContext", ctx, new(*rpcHeader),
+	m.On("CallContext", ctx, new(*RPCHeader),
 		"eth_getBlockByNumber", []any{n.String(), false}).Run(func(args mock.Arguments) {
-		*args[1].(**rpcHeader) = &rhdr2
+		*args[1].(**RPCHeader) = &rhdr2
 	}).Return([]error{nil})
 	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
 	require.NoError(t, err)
@@ -169,9 +169,9 @@ func TestEthClient_WrongInfoByHash(t *testing.T) {
 	rhdr2.Hash = rhdr2.computeBlockHash()
 	k := rhdr.Hash
 	ctx := context.Background()
-	m.On("CallContext", ctx, new(*rpcHeader),
+	m.On("CallContext", ctx, new(*RPCHeader),
 		"eth_getBlockByHash", []any{k, false}).Run(func(args mock.Arguments) {
-		*args[1].(**rpcHeader) = &rhdr2
+		*args[1].(**RPCHeader) = &rhdr2
 	}).Return([]error{nil})
 	s, err := NewL1Client(m, nil, nil, L1ClientDefaultConfig(&rollup.Config{SeqWindowSize: 10}, true, RPCKindStandard))
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func testEthClient_validateReceipts(t *testing.T, test validateReceiptsTest) {
 	mrpc.On("CallContext", ctx, mock.AnythingOfType("**sources.rpcBlock"),
 		"eth_getBlockByHash", []any{block.Hash, true}).
 		Run(func(args mock.Arguments) {
-			*(args[1].(**rpcBlock)) = block
+			*(args[1].(**RPCBlock)) = block
 		}).
 		Return([]error{nil}).Once()
 

--- a/op-service/sources/receipts_basic_test.go
+++ b/op-service/sources/receipts_basic_test.go
@@ -130,7 +130,7 @@ func TestBasicRPCReceiptsFetcher_Concurrency(t *testing.T) {
 	require.Less(finalNumCalls, numFetchers, "Some IterativeBatchCalls should have been shared.")
 }
 
-func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers int, receipts types.Receipts, block *rpcBlock) {
+func runConcurrentFetchingTest(t *testing.T, rp ReceiptsProvider, numFetchers int, receipts types.Receipts, block *RPCBlock) {
 	require := require.New(t)
 	txHashes := receiptTxHashes(receipts)
 

--- a/op-service/sources/receipts_test.go
+++ b/op-service/sources/receipts_test.go
@@ -27,9 +27,9 @@ type ethBackend struct {
 	*mock.Mock
 }
 
-func (b *ethBackend) GetBlockByHash(id common.Hash, fullTxs bool) (*rpcBlock, error) {
+func (b *ethBackend) GetBlockByHash(id common.Hash, fullTxs bool) (*RPCBlock, error) {
 	out := b.Mock.MethodCalled("eth_getBlockByHash", id, fullTxs)
-	return out[0].(*rpcBlock), nil
+	return out[0].(*RPCBlock), nil
 }
 
 func (b *ethBackend) GetTransactionReceipt(txHash common.Hash) (*types.Receipt, error) {
@@ -98,7 +98,7 @@ type ReceiptsTestCase struct {
 	name         string
 	providerKind RPCProviderKind
 	staticMethod bool
-	setup        func(t *testing.T) (*rpcBlock, []ReceiptsRequest)
+	setup        func(t *testing.T) (*RPCBlock, []ReceiptsRequest)
 }
 
 func (tc *ReceiptsTestCase) Run(t *testing.T) {
@@ -185,10 +185,10 @@ func (tc *ReceiptsTestCase) Run(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
-func randomRpcBlockAndReceipts(rng *rand.Rand, txCount uint64) (*rpcBlock, []*types.Receipt) {
+func randomRpcBlockAndReceipts(rng *rand.Rand, txCount uint64) (*RPCBlock, []*types.Receipt) {
 	block, receipts := testutils.RandomBlock(rng, txCount)
-	return &rpcBlock{
-		rpcHeader: rpcHeader{
+	return &RPCBlock{
+		RPCHeader: RPCHeader{
 			ParentHash:  block.ParentHash(),
 			UncleHash:   block.UncleHash(),
 			Coinbase:    block.Coinbase(),
@@ -214,8 +214,8 @@ func randomRpcBlockAndReceipts(rng *rand.Rand, txCount uint64) (*rpcBlock, []*ty
 func TestEthClient_FetchReceipts(t *testing.T) {
 	// Helper to quickly define the test case requests scenario:
 	// each method fails to fetch the receipts, except the last
-	fallbackCase := func(txCount uint64, methods ...ReceiptsFetchingMethod) func(t *testing.T) (*rpcBlock, []ReceiptsRequest) {
-		return func(t *testing.T) (*rpcBlock, []ReceiptsRequest) {
+	fallbackCase := func(txCount uint64, methods ...ReceiptsFetchingMethod) func(t *testing.T) (*RPCBlock, []ReceiptsRequest) {
+		return func(t *testing.T) (*RPCBlock, []ReceiptsRequest) {
 			block, receipts := randomRpcBlockAndReceipts(rand.New(rand.NewSource(123)), txCount)
 			// zero out the data we don't want to verify
 			for _, r := range receipts {

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -98,7 +98,7 @@ func (h headerInfo) HeaderRLP() ([]byte, error) {
 	return rlp.EncodeToBytes(h.Header)
 }
 
-type rpcHeader struct {
+type RPCHeader struct {
 	ParentHash  common.Hash      `json:"parentHash"`
 	UncleHash   common.Hash      `json:"sha3Uncles"`
 	Coinbase    common.Address   `json:"miner"`
@@ -136,7 +136,7 @@ type rpcHeader struct {
 
 // checkPostMerge checks that the block header meets all criteria to be a valid ExecutionPayloadHeader,
 // see EIP-3675 (block header changes) and EIP-4399 (mixHash usage for prev-randao)
-func (hdr *rpcHeader) checkPostMerge() error {
+func (hdr *RPCHeader) checkPostMerge() error {
 	// TODO: the genesis block has a non-zero difficulty number value.
 	// Either this block needs to change, or we special case it. This is not valid w.r.t. EIP-3675.
 	if hdr.Number != 0 && (*big.Int)(&hdr.Difficulty).Cmp(common.Big0) != 0 {
@@ -157,12 +157,12 @@ func (hdr *rpcHeader) checkPostMerge() error {
 	return nil
 }
 
-func (hdr *rpcHeader) computeBlockHash() common.Hash {
+func (hdr *RPCHeader) computeBlockHash() common.Hash {
 	gethHeader := hdr.createGethHeader()
 	return gethHeader.Hash()
 }
 
-func (hdr *rpcHeader) createGethHeader() *types.Header {
+func (hdr *RPCHeader) createGethHeader() *types.Header {
 	return &types.Header{
 		ParentHash:      hdr.ParentHash,
 		UncleHash:       hdr.UncleHash,
@@ -188,7 +188,7 @@ func (hdr *rpcHeader) createGethHeader() *types.Header {
 	}
 }
 
-func (hdr *rpcHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, error) {
+func (hdr *RPCHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, error) {
 	if mustBePostMerge {
 		if err := hdr.checkPostMerge(); err != nil {
 			return nil, err
@@ -202,22 +202,20 @@ func (hdr *rpcHeader) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo
 	return &headerInfo{hdr.Hash, hdr.createGethHeader()}, nil
 }
 
-func (hdr *rpcHeader) BlockID() eth.BlockID {
+func (hdr *RPCHeader) BlockID() eth.BlockID {
 	return eth.BlockID{
 		Hash:   hdr.Hash,
 		Number: uint64(hdr.Number),
 	}
 }
 
-type RPCBlock rpcBlock
-
-type rpcBlock struct {
-	rpcHeader
+type RPCBlock struct {
+	RPCHeader
 	Transactions []*types.Transaction `json:"transactions"`
 	Withdrawals  *types.Withdrawals   `json:"withdrawals,omitempty"`
 }
 
-func (block *rpcBlock) verify() error {
+func (block *RPCBlock) verify() error {
 	if computed := block.computeBlockHash(); computed != block.Hash {
 		return fmt.Errorf("failed to verify block hash: computed %s but RPC said %s", computed, block.Hash)
 	}
@@ -249,7 +247,7 @@ func (block *rpcBlock) verify() error {
 	return nil
 }
 
-func (block *rpcBlock) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, types.Transactions, error) {
+func (block *RPCBlock) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInfo, types.Transactions, error) {
 	if mustBePostMerge {
 		if err := block.checkPostMerge(); err != nil {
 			return nil, nil, err
@@ -262,7 +260,7 @@ func (block *rpcBlock) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInf
 	}
 
 	// verify the header data
-	info, err := block.rpcHeader.Info(trustCache, mustBePostMerge)
+	info, err := block.RPCHeader.Info(trustCache, mustBePostMerge)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to verify block from RPC: %w", err)
 	}
@@ -270,7 +268,7 @@ func (block *rpcBlock) Info(trustCache bool, mustBePostMerge bool) (eth.BlockInf
 	return info, block.Transactions, nil
 }
 
-func (block *rpcBlock) ExecutionPayloadEnvelope(trustCache bool) (*eth.ExecutionPayloadEnvelope, error) {
+func (block *RPCBlock) ExecutionPayloadEnvelope(trustCache bool) (*eth.ExecutionPayloadEnvelope, error) {
 	if err := block.checkPostMerge(); err != nil {
 		return nil, err
 	}

--- a/op-service/sources/types.go
+++ b/op-service/sources/types.go
@@ -209,6 +209,8 @@ func (hdr *rpcHeader) BlockID() eth.BlockID {
 	}
 }
 
+type RPCBlock rpcBlock
+
 type rpcBlock struct {
 	rpcHeader
 	Transactions []*types.Transaction `json:"transactions"`

--- a/op-service/sources/types_test.go
+++ b/op-service/sources/types_test.go
@@ -42,7 +42,7 @@ func TestBlockHeaderJSON(t *testing.T) {
 		var metadata testMetadata
 		readJsonTestdata(t, "testdata/data/headers/"+entry.Name(), &metadata)
 		t.Run(metadata.Name, func(t *testing.T) {
-			var header rpcHeader
+			var header RPCHeader
 			readJsonTestdata(t, "testdata/data/headers/"+strings.Replace(entry.Name(), "_metadata.json", "_data.json", 1), &header)
 
 			h := header.computeBlockHash()
@@ -67,7 +67,7 @@ func TestBlockJSON(t *testing.T) {
 		var metadata testMetadata
 		readJsonTestdata(t, "testdata/data/blocks/"+entry.Name(), &metadata)
 		t.Run(metadata.Name, func(t *testing.T) {
-			var block rpcBlock
+			var block RPCBlock
 			readJsonTestdata(t, "testdata/data/blocks/"+strings.Replace(entry.Name(), "_metadata.json", "_data.json", 1), &block)
 
 			err := block.verify()
@@ -106,7 +106,7 @@ func TestBlockToExecutionPayloadIncludesEcotoneProperties(t *testing.T) {
 		BlobGasUsed:      &zero,
 		ParentBeaconRoot: &common.Hash{},
 	}
-	rhdr := rpcHeader{
+	rhdr := RPCHeader{
 		ParentBeaconRoot: hdr.ParentBeaconRoot,
 		ParentHash:       hdr.ParentHash,
 		WithdrawalsRoot:  hdr.WithdrawalsHash,
@@ -130,8 +130,8 @@ func TestBlockToExecutionPayloadIncludesEcotoneProperties(t *testing.T) {
 		ExcessBlobGas:    (*hexutil.Uint64)(hdr.ExcessBlobGas),
 	}
 
-	block := rpcBlock{
-		rpcHeader:    rhdr,
+	block := RPCBlock{
+		RPCHeader:    rhdr,
 		Transactions: types.Transactions{},
 		Withdrawals:  &types.Withdrawals{},
 	}


### PR DESCRIPTION
Did you know, if you don't like that Mac quits your apps when you hit Command+Q, you can fix that by overloading that command with an accessibility option? I use `invert colors` which scares me, but not as badly as quitting my apps suddenly.

This renames `rpcBlock` as `RPCBlock` in sources. I need to pull blocks in a batch, and so I need to reference this data type. In doing this change in my feature branch first (through an alias instead of full rename), I was able to do a batchRPC call with what appears to be all fields. Attaching a sample below:


```
 (*sources.RPCBlock)(0x14000561600)({
  rpcHeader: (sources.rpcHeader) {
   ParentHash: (common.Hash) (len=32 cap=32) 1000000,
      IsSystemTransaction: (bool) false,
      Data: ([]uint8) (len=260 cap=260) {
       00000000  01 5d 8e b9 00 00 00 00  00 00 00 00 00 00 00 00  |.]..............|
       00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       00000020  01 22 f5 29 00 00 00 00  00 00 00 00 00 00 00 00  |.".)............|
       00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       00000040  65 af 79 7f 00 00 00 00  00 00 00 00 00 00 00 00  |e.y.............|
       00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 02  |................|
       00000060  ac a4 41 46 da 21 da cd  0f 01 0a 94 cf 8a 84 d2  |..AF.!..........|
       00000070  2e 94 05 71 7a 87 df e6  b0 33 4f 5d 19 21 17 7d  |...qz....3O].!.}|
       00000080  0e 58 0f 14 00 00 00 00  00 00 00 00 00 00 00 00  |.X..............|
       00000090  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000a0  00 00 00 02 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000b0  68 87 24 66 68 a3 b8 7f  54 de b3 b9 4b a4 7a 6f  |h.$fh...T...K.zo|
       000000c0  63 f3 29 85 00 00 00 00  00 00 00 00 00 00 00 00  |c.).............|
       000000d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000e0  00 00 00 bc 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       00000100  00 0a 6f e0                                       |..o.|
      }
     },
     EffectiveNonce: (uint64) 9964955
    }),
    time: (time.Time) 0xecc3a974c4639199f00ca305fbeca4f7b80069fcbfc8fe6def1fac3d4152ac3d,
   UncleHash: (common.Hash) (len=32 cap=32) 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347,
   Coinbase: (common.Address) (len=20 cap=20) 2024-01-29 21:06:10.601756 -0600 CST m=+1.019884501,
    hash: (atomic.Value) {
     v: (interface {}) <nil>
    },
    size: (atomic.Value) {
     0x4200000000000000000000000000000000000011,
   Root: v: (interface {}) <nil>
    },
    from: (atomic.Value) {
     v: (interface {}) <nil>
    },
    rollupCostData: ((common.Hash) (len=32 cap=32) 0x8ddaa3cd0acb5ff39c4fbaa2569270a35db955f5bbec6c1ab40fce8debe0d36e,
   TxHash: (common.Hash) (len=32 cap=32) 0x19e5521a032ac5bc070a9d007b4ab87a45cb157de80e7d1b45b1a8938e6fb1a0,
   ReceiptHash: (common.Hash) (len=32 cap=32) atomic.Value) {
     v: (interface {}) <nil>
    }
0xae230bbd7d7d515e59a2bf9bbf00e7e632f81a6fa4c736c8dc79d6e630c76c11,
   Bloom: (eth.Bytes256) (len=256 cap=256) 0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
   Difficulty: (hexutil.Big) 0x0,
   Number: (hexutil.Uint64) 0x6ddd031,
   GasLimit: (hexutil.Uint64)   }),
   (*types.Transaction)(0x1400035f880)({
    inner: (*types.DynamicFeeTx)(0x140006be300)({
     ChainID: (*big.Int)(0x14000699060)(10),
     Nonce: (uint64) 17,
     GasTipCap:  0x1c9c380,
   GasUsed: (hexutil.Uint64) 0xfa0d,
   Time: (hexutil.Uint64) 0x65af7a1b,
   Extra: (hexutil.Bytes) 0x,
   MixDigest: (common.Hash) (len=32 cap=32) 0xfd2e96a3acb6954ff8228311cd86d838a6e61ef7d47584fcfe007296bc79d076,
   Nonce: (types.BlockNonce) (len=8 cap=8) {
    00000000  00 00 00 00 00 00 00 00                           |........|
   },
   BaseFee: (*hexutil.Big)(0x140007b0c80)(0x3058f1),
   WithdrawalsRoot: (*common.Hash)(0x140001f33e0)((len=32 cap=32) 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421),
   BlobGasUsed: (*hexutil.Uint64)(<nil>),
   ExcessBlobGas: (*hexutil.Uint64)(<nil>),
   ParentBeaconRoot: (*common.Hash)(<nil>),
   Hash: (common.Hash) (len=32 cap=32) 0x0115f65fa0f94b493b2fc0ed73f205c501dc1163fdc39b227e05fec76bb1d28f
  },
  Transactions: ([]*types.Transaction) (len=1 (*big.Int)(0x140006990c0)(1145199),
     GasFeeCap: (*big.Int)(0x140006990a0)(33011809),
     cap=1) Gas: (uint64) 206777,
     To: (*common.Address)(0x140001630e0)((len=20 cap=20) 0x296F55F8Fb28E498B858d0BcDA06D955B2Cb3f97),
     Value: (*big.Int)(0x14000699140)({
   (*types.Transaction)(0x14000352380)({
    inner: (*types.depositTxWithNonce)(0x140007a1200)({
     DepositTx: (types.DepositTx) {
      SourceHash: (common.Hash) (len=32 cap=32) 0xf760a8ad1a818564587f89ff05da8d6cdb866bc1ccc65d31d950fb2049f0a967,
      From: (common.Address) (len=138326480935341),
     Data: ([]uint8) (len=324 cap=324) {
20 cap=20) 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001,
      To: (*common.Address)(0x1400079e738)((len=20 cap=20) 0x4200000000000000000000000000000000000015),
      Mint: (*big.Int)(0x140007b0cc0)(      00000000  2e 15 23 8c 00 00 00 00  00 00 00 00 00 00 00 00  |..#.............|
      00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000020  00 00 00 6d 00 00 00 00  00 00 00 00 00 00 00 00  |...m............|
      00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000040  00 00 00 a0 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000050  00 00 00 00 00 00 00 00  00 00 00 53 97 3c 3d 24  |...........S.<=$|
      00000060  c2 5a a8 01 00 00 00 00  00 00 00 00 00 00 00 00  |.Z..............|
      00000070  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000080  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000090  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      000000a0  00 00 00 e0 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      000000b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      000000c0  00 00 00 14 0e da 95 fb  67 cd 5f d0 38 81 e2 b4  |........g._.8...|
      000000d0  79 13 b5 b4 9b fa 61 2f  00 00 00 00 00 00 00 00  |y.....a/........|
      000000e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      000000f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000100  00 00 00 22 00 01 00 00  00 00 00 00 00 00 00 00  |..."............|
      00000110  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000120  00 00 00 01 4c 08 00 00  00 00 00 00 00 00 00 00  |....L...........|
      00000130  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
      00000140  00 00 00 00                                       |....|
     },
     AccessList: (types.AccessList) {
     }0),
      Value: (*big.Int)(0x140007b0d40)(0),
      Gas: (uint64) 1000000,
      IsSystemTransaction: (bool) false,
      Data: ([]uint8) (len=260 cap=260) {
,
     V: (*big.Int)(0x14000699160)(0),
     R: (*big.Int)(0x140006990e0)(50440375328558334173452966943729044975211047817181622559562642228339091465650),
     S: (*big.Int)(0x14000699100)(39422552849751636032568127909597868588585725902924037826390885136673068427696)
    }),
    time: (time.Time) 2024-01-29 21:06:10.601768 -0600 CST m=+1.019896210,
    hash: (atomic.Value) {
     v: (interface {}) <nil>
    },
    size       00000000  01 5d 8e b9 00 00 00 00  00 00 00 00 00 00 00 00  |.]..............|
       00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       00000020  01 22 f5 2e 00 00 00 00  00 00 00 00 00 00 00 00  |."..............|
       00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       00000040  65 af 79 c7 00 00 00 00  00 00 00 00 00 00 00 00  |e.y.............|
       00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 02  |................|
       00000060  7c d5 8e 85 37 1c ef 35  d3 f4 ef 7a 93 76 c9 38  ||...7..5...z.v.8|
       00000070  74 8a 46 16 32 0c a5 c4  69 ab 2d 31 24 5c 1b 0c  |t.F.2...i.-1$\..|
       00000080  0e 64 02 c9 00 00 00 00  00 00 00 00 00 00 00 00  |.d..............|
       00000090  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000a0  00 00 00 01 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000b0  68 87 24 66 68 a3 b8 7f  54 de b3 b9 4b a4 7a 6f  |h.$fh...T...K.zo|
       000000c0  63 f3 29 85 00 00 00 00  00 00 00 00 00 00 00 00  |c.).............|
       000000d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000e0  00 00 00 bc 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       000000f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
       00000100  00 0a 6f e0                                       |..o.|
      }
     },
     EffectiveNonce: (uint64) 9964985
    }),
    time: (time.Time) : (atomic.Value) {
     v: (interface {}) <nil>
2024-01-29 21:06:10.617859 -0600 CST m=+1.035987126,
    hash: (atomic.Value) {
     v: (interface {}) <nil>
    },
    size    },
    from: (atomic.Value) {
     v: (interface {}) <nil>
    },
    : (atomic.Value) {
     v: (interface {}) <nil>
    },
    rollupCostData: (atomic.Value) {
     v: (interface {}) <nil>
    }
   }),
   (from: (atomic.Value) {
     *types.Transaction)(0x1400035f8f0)({
    inner: (*types.DynamicFeeTx)(0x140006be380)({
     ChainID: (*big.Int)(0x140006991a0)(10),
     Nonce: (uint64) 70,
     v: (interface {}) <nil>
    },
    rollupCostData: (atomic.Value) {
     v: (interface {}) <nil>
    }
   })
  },
  GasTipCap: (*big.Int)(0x14000699200)(1100000),
     GasFeeCap: (*big.Int)Withdrawals: (*types.Withdrawals)(0x140005b90f8)((0x140006991e0)(5000000000),
     Gas: (uint64) 24228,
     To: ({
  })
 })
}
*common.Address)(0x14000163110)((len=20 cap=20) 0x0a88BC5c32b684D467b43C06D9e0899EfEAF59Df),
     Value: (*big.Int)(0x14000699280)(230000000009023),
     Data: ([]uint8) (len=62 cap=62) {
      00000000  64 61 74 61 3a 2c 7b 22  70 22 3a 22 6c 61 79 65  |data:,{"p":"laye|
      00000010  72 32 2d 32 30 22 2c 22  6f 70 22 3a 22 63 6c 61  |r2-20","op":"cla|
      00000020  69 6d 22 2c 22 74 69 63  6b 22 3a 22 24 4c 32 22  |im","tick":"$L2"|
      00000030  2c 22 61 6d 74 22 3a 22  31 30 30 30 22 7d        |,"amt":"1000"}|
     },
     AccessList: (types.AccessList) {
     },
     V: (*big.Int)(0x140006992a0)(0),
     R: (*big.Int)(0x14000699220)(101596725415687331201126926330312113064485597732289656850520501456539649624726),
     S: (*big.Int)(0x14000699240)(5651726231327341011538498308574222638830422791176112882576335870362504131110)
    }),
    time: (time.Time) 2024-01-29 21:06:10.601778 -0600 CST m=+1.019906043,
    hash: (atomic.Value) {
     v: (interface {}) <nil>
    },
    size: (atomic.Value) {
     v: (interface {}) <nil>
    },
    from: (atomic.Value) {
     v: (interface {}) <nil>
    },
    rollupCostData: (atomic.Value) {
     v: (interface {}) <nil>
    }
   })
  },
  Withdrawals: (*types.Withdrawals)(0x140005ff200)({
  })
 })
}
```