### PR TITLE
op-e2e: Add FundedAccount so parallel tests can share a single system

### DIFF
--- a/op-e2e/e2eutils/accounts/helper.go
+++ b/op-e2e/e2eutils/accounts/helper.go
@@ -1,0 +1,33 @@
+package accounts
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type Account struct {
+	PrivKey      *ecdsa.PrivateKey
+	Addr         common.Address
+	TransactOpts *bind.TransactOpts
+}
+
+func NewAccount(chainID *big.Int) (*Account, error) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate ecdsa key: %w", err)
+	}
+	opts, err := bind.NewKeyedTransactorWithChainID(key, chainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transactor: %w", err)
+	}
+	return &Account{
+		PrivKey:      key,
+		Addr:         crypto.PubkeyToAddress(key.PublicKey),
+		TransactOpts: opts,
+	}, nil
+}

--- a/op-e2e/e2eutils/challenger/helper.go
+++ b/op-e2e/e2eutils/challenger/helper.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/accounts"
 	"github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/stretchr/testify/require"
 
@@ -26,6 +27,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
+
+type System interface {
+	FundedAccount(t *testing.T, ctx context.Context, node string) *accounts.Account
+}
 
 type Helper struct {
 	log     log.Logger
@@ -52,6 +57,13 @@ func WithGameAddress(addr common.Address) Option {
 func WithPrivKey(key *ecdsa.PrivateKey) Option {
 	return func(c *config.Config) {
 		c.TxMgrConfig.PrivateKey = e2eutils.EncodePrivKeyToString(key)
+	}
+}
+
+func WithNewAccount(t *testing.T, ctx context.Context, system System) Option {
+	return func(c *config.Config) {
+		acct := system.FundedAccount(t, ctx, "l1")
+		c.TxMgrConfig.PrivateKey = e2eutils.EncodePrivKeyToString(acct.PrivKey)
 	}
 }
 

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -104,11 +104,11 @@ func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
 
-	testCase := func(t *testing.T, isRootCorrect bool) {
-		ctx := context.Background()
-		sys, l1Client := startFaultDisputeSystem(t)
-		t.Cleanup(sys.Close)
+	ctx := context.Background()
+	sys, l1Client := startFaultDisputeSystem(t)
+	t.Cleanup(sys.Close)
 
+	testCase := func(t *testing.T, isRootCorrect bool) {
 		disputeGameFactory := disputegame.NewFactoryHelper(t, ctx, sys)
 		var game *disputegame.OutputAlphabetGameHelper
 		if isRootCorrect {
@@ -123,7 +123,7 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 		// Start honest challenger
 		game.StartChallenger(ctx, "sequencer", "Challenger",
 			challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
-			challenger.WithPrivKey(sys.Cfg.Secrets.Alice),
+			challenger.WithNewAccount(t, ctx, sys),
 			// Ensures the challenger responds to all claims before test timeout
 			challenger.WithPollInterval(time.Millisecond*400),
 		)


### PR DESCRIPTION
**Description**

Add a `System.FundedAccount` method that creates a new, unique private key and transfers funds to it.  This allows multiple tests to run in parallel against the same System without getting nonce conflicts.
