### PR TITLE
Use engine API that matches hardfork version

### DIFF
--- a/op-e2e/actions/l2_engine_test.go
+++ b/op-e2e/actions/l2_engine_test.go
@@ -154,7 +154,7 @@ func TestL2EngineAPIBlockBuilding(gt *testing.T) {
 			engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
 		}
 
-		envelope, err := l2Cl.GetPayload(t.Ctx(), *fcRes.PayloadID)
+		envelope, err := l2Cl.GetPayload(t.Ctx(), eth.PayloadInfo{ID: *fcRes.PayloadID, Timestamp: uint64(nextBlockTime)})
 		payload := envelope.ExecutionPayload
 		require.NoError(t, err)
 		require.Equal(t, parent.Hash(), payload.ParentHash, "block builds on parent block")

--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -146,7 +146,7 @@ func (d *OpGeth) AddL2Block(ctx context.Context, txs ...*types.Transaction) (*et
 		return nil, err
 	}
 
-	envelope, err := d.l2Engine.GetPayload(ctx, *res.PayloadID)
+	envelope, err := d.l2Engine.GetPayload(ctx, eth.PayloadInfo{ID: *res.PayloadID, Timestamp: uint64(attrs.Timestamp)})
 	payload := envelope.ExecutionPayload
 
 	if err != nil {

--- a/op-e2e/op_geth_test.go
+++ b/op-e2e/op_geth_test.go
@@ -196,7 +196,7 @@ func TestGethOnlyPendingBlockIsLatest(t *testing.T) {
 	time.Sleep(time.Second * 4) // conservatively wait 4 seconds, CI might lag during block building.
 
 	// retrieve the block
-	envelope, err := opGeth.l2Engine.GetPayload(ctx, *res.PayloadID)
+	envelope, err := opGeth.l2Engine.GetPayload(ctx, eth.PayloadInfo{ID: *res.PayloadID, Timestamp: uint64(attrs.Timestamp)})
 	require.NoError(t, err)
 
 	payload := envelope.ExecutionPayload

--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -38,7 +38,7 @@ var _ EngineControl = (*EngineController)(nil)
 var _ LocalEngineControl = (*EngineController)(nil)
 
 type ExecEngine interface {
-	GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error)
+	GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
@@ -63,7 +63,7 @@ type EngineController struct {
 
 	// Building State
 	buildingOnto eth.L2BlockRef
-	buildingID   eth.PayloadID
+	buildingInfo eth.PayloadInfo
 	buildingSafe bool
 	safeAttrs    *AttributesWithParent
 }
@@ -104,7 +104,7 @@ func (e *EngineController) Finalized() eth.L2BlockRef {
 }
 
 func (e *EngineController) BuildingPayload() (eth.L2BlockRef, eth.PayloadID, bool) {
-	return e.buildingOnto, e.buildingID, e.buildingSafe
+	return e.buildingOnto, e.buildingInfo.ID, e.buildingSafe
 }
 
 func (e *EngineController) IsEngineSyncing() bool {
@@ -146,8 +146,8 @@ func (e *EngineController) StartPayload(ctx context.Context, parent eth.L2BlockR
 	if e.IsEngineSyncing() {
 		return BlockInsertTemporaryErr, fmt.Errorf("engine is in progess of p2p sync")
 	}
-	if e.buildingID != (eth.PayloadID{}) {
-		e.log.Warn("did not finish previous block building, starting new building now", "prev_onto", e.buildingOnto, "prev_payload_id", e.buildingID, "new_onto", parent)
+	if e.buildingInfo != (eth.PayloadInfo{}) {
+		e.log.Warn("did not finish previous block building, starting new building now", "prev_onto", e.buildingOnto, "prev_payload_id", e.buildingInfo.ID, "new_onto", parent)
 		// TODO(8841): maybe worth it to force-cancel the old payload ID here.
 	}
 	fc := eth.ForkchoiceState{
@@ -161,7 +161,7 @@ func (e *EngineController) StartPayload(ctx context.Context, parent eth.L2BlockR
 		return errTyp, err
 	}
 
-	e.buildingID = id
+	e.buildingInfo = eth.PayloadInfo{ID: id, Timestamp: uint64(attrs.attributes.Timestamp)}
 	e.buildingSafe = updateSafe
 	e.buildingOnto = parent
 	if updateSafe {
@@ -172,7 +172,7 @@ func (e *EngineController) StartPayload(ctx context.Context, parent eth.L2BlockR
 }
 
 func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.AsyncGossiper, sequencerConductor conductor.SequencerConductor) (out *eth.ExecutionPayloadEnvelope, errTyp BlockInsertionErrType, err error) {
-	if e.buildingID == (eth.PayloadID{}) {
+	if e.buildingInfo == (eth.PayloadInfo{}) {
 		return nil, BlockInsertPrestateErr, fmt.Errorf("cannot complete payload building: not currently building a payload")
 	}
 	if e.buildingOnto.Hash != e.unsafeHead.Hash { // E.g. when safe-attributes consolidation fails, it will drop the existing work.
@@ -185,9 +185,9 @@ func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.Asy
 	}
 	// Update the safe head if the payload is built with the last attributes in the batch.
 	updateSafe := e.buildingSafe && e.safeAttrs != nil && e.safeAttrs.isLastInSpan
-	envelope, errTyp, err := confirmPayload(ctx, e.log, e.engine, fc, e.buildingID, updateSafe, agossip, sequencerConductor)
+	envelope, errTyp, err := confirmPayload(ctx, e.log, e.engine, fc, e.buildingInfo, updateSafe, agossip, sequencerConductor)
 	if err != nil {
-		return nil, errTyp, fmt.Errorf("failed to complete building on top of L2 chain %s, id: %s, error (%d): %w", e.buildingOnto, e.buildingID, errTyp, err)
+		return nil, errTyp, fmt.Errorf("failed to complete building on top of L2 chain %s, id: %s, error (%d): %w", e.buildingOnto, e.buildingInfo.ID, errTyp, err)
 	}
 	ref, err := PayloadToBlockRef(e.rollupCfg, envelope.ExecutionPayload)
 	if err != nil {
@@ -211,14 +211,14 @@ func (e *EngineController) ConfirmPayload(ctx context.Context, agossip async.Asy
 }
 
 func (e *EngineController) CancelPayload(ctx context.Context, force bool) error {
-	if e.buildingID == (eth.PayloadID{}) { // only cancel if there is something to cancel.
+	if e.buildingInfo == (eth.PayloadInfo{}) { // only cancel if there is something to cancel.
 		return nil
 	}
 	// the building job gets wrapped up as soon as the payload is retrieved, there's no explicit cancel in the Engine API
-	e.log.Error("cancelling old block sealing job", "payload", e.buildingID)
-	_, err := e.engine.GetPayload(ctx, e.buildingID)
+	e.log.Error("cancelling old block sealing job", "payload", e.buildingInfo.ID)
+	_, err := e.engine.GetPayload(ctx, e.buildingInfo)
 	if err != nil {
-		e.log.Error("failed to cancel block building job", "payload", e.buildingID, "err", err)
+		e.log.Error("failed to cancel block building job", "payload", e.buildingInfo.ID, "err", err)
 		if !force {
 			return err
 		}
@@ -228,7 +228,7 @@ func (e *EngineController) CancelPayload(ctx context.Context, force bool) error 
 }
 
 func (e *EngineController) resetBuildingState() {
-	e.buildingID = eth.PayloadID{}
+	e.buildingInfo = eth.PayloadInfo{}
 	e.buildingOnto = eth.L2BlockRef{}
 	e.buildingSafe = false
 	e.safeAttrs = nil

--- a/op-node/rollup/derive/engine_update.go
+++ b/op-node/rollup/derive/engine_update.go
@@ -124,7 +124,7 @@ func confirmPayload(
 	log log.Logger,
 	eng ExecEngine,
 	fc eth.ForkchoiceState,
-	id eth.PayloadID,
+	payloadInfo eth.PayloadInfo,
 	updateSafe bool,
 	agossip async.AsyncGossiper,
 	sequencerConductor conductor.SequencerConductor,
@@ -140,7 +140,7 @@ func confirmPayload(
 			"parent", envelope.ExecutionPayload.ParentHash,
 			"txs", len(envelope.ExecutionPayload.Transactions))
 	} else {
-		envelope, err = eng.GetPayload(ctx, id)
+		envelope, err = eng.GetPayload(ctx, payloadInfo)
 	}
 	if err != nil {
 		// even if it is an input-error (unknown payload ID), it is temporary, since we will re-attempt the full payload building, not just the retrieval of the payload.

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -354,11 +354,12 @@ func (c *Config) IsInterop(timestamp uint64) bool {
 }
 
 // ForkchoiceUpdatedVersion returns the EngineAPIMethod suitable for the chain hard fork version.
-func (c *Config) ForkchoiceUpdatedVersion(timestamp uint64) eth.EngineAPIMethod {
-	if c.IsEcotone(timestamp) {
+func (c *Config) ForkchoiceUpdatedVersion(attr *eth.PayloadAttributes) eth.EngineAPIMethod {
+	ts := uint64(attr.Timestamp)
+	if c.IsEcotone(ts) {
 		// Cancun
 		return eth.FCUV3
-	} else if c.IsCanyon(timestamp) {
+	} else if c.IsCanyon(ts) {
 		// Shanghai
 		return eth.FCUV2
 	} else {

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -355,6 +355,10 @@ func (c *Config) IsInterop(timestamp uint64) bool {
 
 // ForkchoiceUpdatedVersion returns the EngineAPIMethod suitable for the chain hard fork version.
 func (c *Config) ForkchoiceUpdatedVersion(attr *eth.PayloadAttributes) eth.EngineAPIMethod {
+	if attr == nil {
+		// Don't begin payload build process.
+		return eth.FCUV3
+	}
 	ts := uint64(attr.Timestamp)
 	if c.IsEcotone(ts) {
 		// Cancun

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -353,38 +353,38 @@ func (c *Config) IsInterop(timestamp uint64) bool {
 	return c.InteropTime != nil && timestamp >= *c.InteropTime
 }
 
-// ForkchoiceUpdatedVersion returns the EngineAPIVersion suitable for the chain hard fork version.
-func (c *Config) ForkchoiceUpdatedVersion(timestamp uint64) EngineAPIVersion {
+// ForkchoiceUpdatedVersion returns the EngineAPIMethod suitable for the chain hard fork version.
+func (c *Config) ForkchoiceUpdatedVersion(timestamp uint64) eth.EngineAPIMethod {
 	if c.IsEcotone(timestamp) {
 		// Cancun
-		return EngineAPIV3
+		return eth.FCUV3
 	} else if c.IsCanyon(timestamp) {
 		// Shanghai
-		return EngineAPIV2
+		return eth.FCUV2
 	} else {
 		// According to Ethereum engine API spec, we can use fcuV2 here,
 		// but upstream Geth v1.13.11 does not accept V2 before Shanghai.
-		return EngineAPIV1
+		return eth.FCUV1
 	}
 }
 
-// NewPayloadVersion returns the EngineAPIVersion suitable for the chain hard fork version.
-func (c *Config) NewPayloadVersion(timestamp uint64) EngineAPIVersion {
+// NewPayloadVersion returns the EngineAPIMethod suitable for the chain hard fork version.
+func (c *Config) NewPayloadVersion(timestamp uint64) eth.EngineAPIMethod {
 	if c.IsEcotone(timestamp) {
 		// Cancun
-		return EngineAPIV3
+		return eth.NewPayloadV3
 	} else {
-		return EngineAPIV2
+		return eth.NewPayloadV2
 	}
 }
 
-// GetPayloadVersion returns the EngineAPIVersion suitable for the chain hard fork version.
-func (c *Config) GetPayloadVersion(timestamp uint64) EngineAPIVersion {
+// GetPayloadVersion returns the EngineAPIMethod suitable for the chain hard fork version.
+func (c *Config) GetPayloadVersion(timestamp uint64) eth.EngineAPIMethod {
 	if c.IsEcotone(timestamp) {
 		// Cancun
-		return EngineAPIV3
+		return eth.GetPayloadV3
 	} else {
-		return EngineAPIV2
+		return eth.GetPayloadV2
 	}
 }
 
@@ -468,11 +468,3 @@ func fmtTime(v uint64) string {
 }
 
 type Epoch uint64
-
-type EngineAPIVersion string
-
-const (
-	EngineAPIV1 EngineAPIVersion = "V1"
-	EngineAPIV2 EngineAPIVersion = "V2"
-	EngineAPIV3 EngineAPIVersion = "V3"
-)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -353,6 +353,41 @@ func (c *Config) IsInterop(timestamp uint64) bool {
 	return c.InteropTime != nil && timestamp >= *c.InteropTime
 }
 
+// ForkchoiceUpdatedVersion returns the EngineAPIVersion suitable for the chain hard fork version.
+func (c *Config) ForkchoiceUpdatedVersion(timestamp uint64) EngineAPIVersion {
+	if c.IsEcotone(timestamp) {
+		// Cancun
+		return EngineAPIV3
+	} else if c.IsCanyon(timestamp) {
+		// Shanghai
+		return EngineAPIV2
+	} else {
+		// According to Ethereum engine API spec, we can use fcuV2 here,
+		// but upstream Geth v1.13.11 does not accept V2 before Shanghai.
+		return EngineAPIV1
+	}
+}
+
+// NewPayloadVersion returns the EngineAPIVersion suitable for the chain hard fork version.
+func (c *Config) NewPayloadVersion(timestamp uint64) EngineAPIVersion {
+	if c.IsEcotone(timestamp) {
+		// Cancun
+		return EngineAPIV3
+	} else {
+		return EngineAPIV2
+	}
+}
+
+// GetPayloadVersion returns the EngineAPIVersion suitable for the chain hard fork version.
+func (c *Config) GetPayloadVersion(timestamp uint64) EngineAPIVersion {
+	if c.IsEcotone(timestamp) {
+		// Cancun
+		return EngineAPIV3
+	} else {
+		return EngineAPIV2
+	}
+}
+
 // Description outputs a banner describing the important parts of rollup configuration in a human-readable form.
 // Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain with if not unknown.
 // The config should be config.Check()-ed before creating a description.
@@ -433,3 +468,11 @@ func fmtTime(v uint64) string {
 }
 
 type Epoch uint64
+
+type EngineAPIVersion string
+
+const (
+	EngineAPIV1 EngineAPIVersion = "V1"
+	EngineAPIV2 EngineAPIVersion = "V2"
+	EngineAPIV3 EngineAPIVersion = "V3"
+)

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -67,7 +67,7 @@ func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 
 func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	if attr != nil {
-		switch o.rollupCfg.ForkchoiceUpdatedVersion(uint64(attr.Timestamp)) {
+		switch o.rollupCfg.ForkchoiceUpdatedVersion(attr) {
 		case eth.FCUV3:
 			return o.api.ForkchoiceUpdatedV3(ctx, state, attr)
 		case eth.FCUV2:

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -54,7 +54,7 @@ func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 	var res *eth.ExecutionPayloadEnvelope
 	var err error
 	switch o.rollupCfg.GetPayloadVersion(payloadInfo.Timestamp) {
-	case rollup.EngineAPIV3:
+	case eth.GetPayloadV3:
 		res, err = o.api.GetPayloadV3(ctx, payloadInfo.ID)
 	default:
 		res, err = o.api.GetPayloadV2(ctx, payloadInfo.ID)
@@ -68,9 +68,9 @@ func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
 	if attr != nil {
 		switch o.rollupCfg.ForkchoiceUpdatedVersion(uint64(attr.Timestamp)) {
-		case rollup.EngineAPIV3:
+		case eth.FCUV3:
 			return o.api.ForkchoiceUpdatedV3(ctx, state, attr)
-		case rollup.EngineAPIV2:
+		case eth.FCUV2:
 			return o.api.ForkchoiceUpdatedV2(ctx, state, attr)
 		default:
 			return o.api.ForkchoiceUpdatedV1(ctx, state, attr)
@@ -81,7 +81,7 @@ func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.Forkchoi
 
 func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
 	switch o.rollupCfg.GetPayloadVersion(uint64(payload.Timestamp)) {
-	case rollup.EngineAPIV3:
+	case eth.NewPayloadV3:
 		return o.api.NewPayloadV3(ctx, payload, []common.Hash{}, parentBeaconBlockRoot)
 	default:
 		return o.api.NewPayloadV2(ctx, payload)

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -68,19 +68,16 @@ func (o *OracleEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadIn
 }
 
 func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error) {
-	if attr != nil {
-		switch method := o.rollupCfg.ForkchoiceUpdatedVersion(attr); method {
-		case eth.FCUV3:
-			return o.api.ForkchoiceUpdatedV3(ctx, state, attr)
-		case eth.FCUV2:
-			return o.api.ForkchoiceUpdatedV2(ctx, state, attr)
-		case eth.FCUV1:
-			return o.api.ForkchoiceUpdatedV1(ctx, state, attr)
-		default:
-			return nil, fmt.Errorf("unsupported ForkchoiceUpdated version: %s", method)
-		}
+	switch method := o.rollupCfg.ForkchoiceUpdatedVersion(attr); method {
+	case eth.FCUV3:
+		return o.api.ForkchoiceUpdatedV3(ctx, state, attr)
+	case eth.FCUV2:
+		return o.api.ForkchoiceUpdatedV2(ctx, state, attr)
+	case eth.FCUV1:
+		return o.api.ForkchoiceUpdatedV1(ctx, state, attr)
+	default:
+		return nil, fmt.Errorf("unsupported ForkchoiceUpdated version: %s", method)
 	}
-	return o.api.ForkchoiceUpdatedV3(ctx, state, attr)
 }
 
 func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {

--- a/op-program/client/l2/engine.go
+++ b/op-program/client/l2/engine.go
@@ -80,7 +80,7 @@ func (o *OracleEngine) ForkchoiceUpdate(ctx context.Context, state *eth.Forkchoi
 }
 
 func (o *OracleEngine) NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error) {
-	switch o.rollupCfg.GetPayloadVersion(uint64(payload.Timestamp)) {
+	switch o.rollupCfg.NewPayloadVersion(uint64(payload.Timestamp)) {
 	case eth.NewPayloadV3:
 		return o.api.NewPayloadV3(ctx, payload, []common.Hash{}, parentBeaconBlockRoot)
 	default:

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -153,6 +153,10 @@ type Uint256Quantity = uint256.Int
 type Data = hexutil.Bytes
 
 type PayloadID = engine.PayloadID
+type PayloadInfo struct {
+	ID        PayloadID
+	Timestamp uint64
+}
 
 type ExecutionPayloadEnvelope struct {
 	ParentBeaconBlockRoot *common.Hash      `json:"parentBeaconBlockRoot,omitempty"`

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -458,3 +458,17 @@ func (v *Uint64String) UnmarshalText(b []byte) error {
 	*v = Uint64String(n)
 	return nil
 }
+
+type EngineAPIMethod string
+
+const (
+	FCUV1 EngineAPIMethod = "engine_forkchoiceUpdatedV1"
+	FCUV2 EngineAPIMethod = "engine_forkchoiceUpdatedV2"
+	FCUV3 EngineAPIMethod = "engine_forkchoiceUpdatedV3"
+
+	NewPayloadV2 EngineAPIMethod = "engine_newPayloadV2"
+	NewPayloadV3 EngineAPIMethod = "engine_newPayloadV3"
+
+	GetPayloadV2 EngineAPIMethod = "engine_getPayloadV2"
+	GetPayloadV3 EngineAPIMethod = "engine_getPayloadV3"
+)

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -102,8 +102,10 @@ func (s *EngineClient) NewPayload(ctx context.Context, payload *eth.ExecutionPay
 	switch method := s.rollupCfg.NewPayloadVersion(uint64(payload.Timestamp)); method {
 	case eth.NewPayloadV3:
 		err = s.client.CallContext(execCtx, &result, string(method), payload, []common.Hash{}, parentBeaconBlockRoot)
-	default:
+	case eth.NewPayloadV2:
 		err = s.client.CallContext(execCtx, &result, string(method), payload)
+	default:
+		return nil, fmt.Errorf("unsupported NewPayload version: %s", method)
 	}
 
 	e.Trace("Received payload execution result", "status", result.Status, "latestValidHash", result.LatestValidHash, "message", result.ValidationError)

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -60,7 +60,7 @@ func (s *EngineClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceS
 	var result eth.ForkchoiceUpdatedResult
 	method := eth.FCUV3
 	if attributes != nil {
-		method = s.rollupCfg.ForkchoiceUpdatedVersion(uint64(attributes.Timestamp))
+		method = s.rollupCfg.ForkchoiceUpdatedVersion(attributes)
 	}
 	err := s.client.CallContext(fcCtx, &result, string(method), fc, attributes)
 	if err == nil {

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -58,10 +58,7 @@ func (s *EngineClient) ForkchoiceUpdate(ctx context.Context, fc *eth.ForkchoiceS
 	fcCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	var result eth.ForkchoiceUpdatedResult
-	method := eth.FCUV3
-	if attributes != nil {
-		method = s.rollupCfg.ForkchoiceUpdatedVersion(attributes)
-	}
+	method := s.rollupCfg.ForkchoiceUpdatedVersion(attributes)
 	err := s.client.CallContext(fcCtx, &result, string(method), fc, attributes)
 	if err == nil {
 		tlog.Trace("Shared forkchoice-updated signal")

--- a/op-service/testutils/mock_engine.go
+++ b/op-service/testutils/mock_engine.go
@@ -12,8 +12,8 @@ type MockEngine struct {
 	MockL2Client
 }
 
-func (m *MockEngine) GetPayload(ctx context.Context, payloadId eth.PayloadID) (*eth.ExecutionPayloadEnvelope, error) {
-	out := m.Mock.Called(payloadId)
+func (m *MockEngine) GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	out := m.Mock.Called(payloadInfo.ID)
 	return out.Get(0).(*eth.ExecutionPayloadEnvelope), out.Error(1)
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

[Ethereun Cancun engine API spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#methods) specifies that `newPayloadV3`, `forkchoiceUpdatedV3` and `getPayloadV3` must return `Unsupported fork` error if they are called before Cancun.

Erigon followed the specs, and Geth also merged PRs that check hardfork version in engine APIs last week. (https://github.com/ethereum/go-ethereum/pull/28230, https://github.com/ethereum/go-ethereum/pull/28246)

But the current version of op-geth does not merge upstream fix, so it always accepts V3 APIs from op-node.

I think we should adhere to the L1 engine API specs - merge upstream Geth PRs to op-geth, fix op-node and update exec-engine specs.

This PR is the draft of op-node fix.

**Tests**
CI will verify that every change does not affect anything. And I have manually tested the fix works with op-erigon (drop V3 API before Cancun)

