### PR TITLE
feat(op-challenger): Bond Claiming

### DIFF
--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -90,7 +90,7 @@ const (
 	// DefaultGameWindow is the default maximum time duration in the past
 	// that the challenger will look for games to progress.
 	// The default value is 11 days, which is a 4 day resolution buffer
-	// plus the 7 day game finalization window.
+	// and bond claiming buffer plus the 7 day game finalization window.
 	DefaultGameWindow   = time.Duration(11 * 24 * time.Hour)
 	DefaultMaxPendingTx = 10
 )

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -131,8 +131,9 @@ var (
 		Value:   config.DefaultCannonInfoFreq,
 	}
 	GameWindowFlag = &cli.DurationFlag{
-		Name:    "game-window",
-		Usage:   "The time window which the challenger will look for games to progress.",
+		Name: "game-window",
+		Usage: "The time window which the challenger will look for games to progress and claim bonds. " +
+			"This should include a buffer for the challenger to claim bonds for games outside the maximum game duration.",
 		EnvVars: prefixEnvVars("GAME_WINDOW"),
 		Value:   config.DefaultGameWindow,
 	}

--- a/op-challenger/game/fault/claims/claimer.go
+++ b/op-challenger/game/fault/claims/claimer.go
@@ -1,0 +1,85 @@
+package claims
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var _ BondClaimer = (*claimer)(nil)
+
+type BondClaimer interface {
+	ClaimBonds(ctx context.Context, games []types.GameMetadata) error
+}
+
+type BondClaimMetrics interface {
+	RecordBondClaimed(amount uint64)
+}
+
+type BondContract interface {
+	GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error)
+	ClaimCredit(receipient common.Address) (txmgr.TxCandidate, error)
+}
+
+type claimer struct {
+	logger  log.Logger
+	metrics BondClaimMetrics
+
+	caller   *batching.MultiCaller
+	txSender types.TxSender
+}
+
+func NewBondClaimer(l log.Logger, m BondClaimMetrics, c *batching.MultiCaller, txSender types.TxSender) *claimer {
+	return &claimer{
+		logger:   l,
+		metrics:  m,
+		caller:   c,
+		txSender: txSender,
+	}
+}
+
+func (c *claimer) ClaimBonds(ctx context.Context, games []types.GameMetadata) (err error) {
+	for _, game := range games {
+		err = errors.Join(err, c.claimBond(ctx, game.Proxy))
+	}
+	return err
+}
+
+func (c *claimer) claimBond(ctx context.Context, gameAddr common.Address) error {
+	c.logger.Debug("attempting to claim bonds for", "game", gameAddr)
+
+	contract, err := contracts.NewFaultDisputeGameContract(gameAddr, c.caller)
+	if err != nil {
+		return fmt.Errorf("failed to create contract: %w", err)
+	}
+
+	credit, err := contract.GetCredit(ctx, c.txSender.From())
+	if err != nil {
+		return fmt.Errorf("failed to get credit: %w", err)
+	}
+
+	if credit.Cmp(big.NewInt(0)) == 0 {
+		c.logger.Debug("no credit to claim", "game", gameAddr)
+		return nil
+	}
+
+	candidate, err := contract.ClaimCredit(c.txSender.From())
+	if err != nil {
+		return fmt.Errorf("failed to create credit claim tx: %w", err)
+	}
+
+	if _, err = c.txSender.SendAndWait("claim credit", candidate); err != nil {
+		return fmt.Errorf("failed to claim credit: %w", err)
+	}
+
+	c.metrics.RecordBondClaimed(credit.Uint64())
+	return nil
+}

--- a/op-challenger/game/fault/claims/claimer_test.go
+++ b/op-challenger/game/fault/claims/claimer_test.go
@@ -1,0 +1,108 @@
+package claims
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	methodCredit       = "credit"
+	mockTxMgrSendError = errors.New("mock tx mgr send error")
+)
+
+func TestClaimer_ClaimBonds(t *testing.T) {
+	t.Run("MultipleBondClaimsSucceed", func(t *testing.T) {
+		gameAddr := common.HexToAddress("0x1234")
+		c, m, rpc, txSender := newTestClaimer(t, gameAddr)
+		rpc.SetResponse(gameAddr, methodCredit, batching.BlockLatest, []interface{}{txSender.From()}, []interface{}{big.NewInt(1)})
+		err := c.ClaimBonds(context.Background(), []types.GameMetadata{{Proxy: gameAddr}, {Proxy: gameAddr}, {Proxy: gameAddr}})
+		require.NoError(t, err)
+		require.Equal(t, 3, txSender.sends)
+		require.Equal(t, 3, m.RecordBondClaimedCalls)
+	})
+
+	t.Run("BondClaimSucceeds", func(t *testing.T) {
+		gameAddr := common.HexToAddress("0x1234")
+		c, m, rpc, txSender := newTestClaimer(t, gameAddr)
+		rpc.SetResponse(gameAddr, methodCredit, batching.BlockLatest, []interface{}{txSender.From()}, []interface{}{big.NewInt(1)})
+		err := c.ClaimBonds(context.Background(), []types.GameMetadata{{Proxy: gameAddr}})
+		require.NoError(t, err)
+		require.Equal(t, 1, txSender.sends)
+		require.Equal(t, 1, m.RecordBondClaimedCalls)
+	})
+
+	t.Run("BondClaimFails", func(t *testing.T) {
+		gameAddr := common.HexToAddress("0x1234")
+		c, m, rpc, txSender := newTestClaimer(t, gameAddr)
+		txSender.sendFails = true
+		rpc.SetResponse(gameAddr, methodCredit, batching.BlockLatest, []interface{}{txSender.From()}, []interface{}{big.NewInt(1)})
+		err := c.ClaimBonds(context.Background(), []types.GameMetadata{{Proxy: gameAddr}})
+		require.ErrorIs(t, err, mockTxMgrSendError)
+		require.Equal(t, 1, txSender.sends)
+		require.Equal(t, 0, m.RecordBondClaimedCalls)
+	})
+
+	t.Run("ZeroCreditReturnsNil", func(t *testing.T) {
+		gameAddr := common.HexToAddress("0x1234")
+		c, m, rpc, txSender := newTestClaimer(t, gameAddr)
+		rpc.SetResponse(gameAddr, methodCredit, batching.BlockLatest, []interface{}{txSender.From()}, []interface{}{big.NewInt(0)})
+		err := c.ClaimBonds(context.Background(), []types.GameMetadata{{Proxy: gameAddr}})
+		require.NoError(t, err)
+		require.Equal(t, 0, txSender.sends)
+		require.Equal(t, 0, m.RecordBondClaimedCalls)
+	})
+}
+
+func newTestClaimer(t *testing.T, gameAddr common.Address) (*claimer, *mockClaimMetrics, *batchingTest.AbiBasedRpc, *mockTxSender) {
+	logger := testlog.Logger(t, log.LvlDebug)
+	m := &mockClaimMetrics{}
+	txSender := &mockTxSender{}
+	fdgAbi, err := bindings.FaultDisputeGameMetaData.GetAbi()
+	require.NoError(t, err)
+	stubRpc := batchingTest.NewAbiBasedRpc(t, gameAddr, fdgAbi)
+	caller := batching.NewMultiCaller(stubRpc, 100)
+	c := NewBondClaimer(logger, m, caller, txSender)
+	return c, m, stubRpc, txSender
+}
+
+type mockClaimMetrics struct {
+	RecordBondClaimedCalls int
+}
+
+func (m *mockClaimMetrics) RecordBondClaimed(amount uint64) {
+	m.RecordBondClaimedCalls++
+}
+
+type mockTxSender struct {
+	sends      int
+	sendFails  bool
+	statusFail bool
+}
+
+func (s *mockTxSender) From() common.Address {
+	return common.HexToAddress("0x33333")
+}
+
+func (s *mockTxSender) SendAndWait(_ string, _ ...txmgr.TxCandidate) ([]*ethtypes.Receipt, error) {
+	s.sends++
+	if s.sendFails {
+		return nil, mockTxMgrSendError
+	}
+	if s.statusFail {
+		return []*ethtypes.Receipt{{Status: ethtypes.ReceiptStatusFailed}}, nil
+	}
+	return []*ethtypes.Receipt{{Status: ethtypes.ReceiptStatusSuccessful}}, nil
+}

--- a/op-challenger/game/fault/claims/scheduler.go
+++ b/op-challenger/game/fault/claims/scheduler.go
@@ -1,0 +1,66 @@
+package claims
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type BondClaimerScheduler struct {
+	log     log.Logger
+	ch      chan schedulerMessage
+	claimer BondClaimer
+	cancel  func()
+	wg      sync.WaitGroup
+}
+
+type schedulerMessage struct {
+	blockNumber uint64
+	games       []types.GameMetadata
+}
+
+func NewBondClaimerScheduler(logger log.Logger, claimer BondClaimer) *BondClaimerScheduler {
+	return &BondClaimerScheduler{
+		log:     logger,
+		ch:      make(chan schedulerMessage, 1),
+		claimer: claimer,
+	}
+}
+
+func (s *BondClaimerScheduler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+func (s *BondClaimerScheduler) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *BondClaimerScheduler) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-s.ch:
+			if err := s.claimer.ClaimBonds(ctx, msg.games); err != nil {
+				s.log.Error("Failed to claim bonds", "blockNumber", msg.blockNumber, "err", err)
+			}
+		}
+	}
+}
+
+func (s *BondClaimerScheduler) Schedule(blockNumber uint64, games []types.GameMetadata) error {
+	select {
+	case s.ch <- schedulerMessage{blockNumber, games}:
+	default:
+		s.log.Trace("Skipping game bond claim while claiming in progress")
+	}
+	return nil
+}

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -33,6 +33,8 @@ var (
 	methodSplitDepth         = "splitDepth"
 	methodL2BlockNumber      = "l2BlockNumber"
 	methodRequiredBond       = "getRequiredBond"
+	methodClaimCredit        = "claimCredit"
+	methodCredit             = "credit"
 )
 
 type FaultDisputeGameContract struct {
@@ -90,6 +92,19 @@ func (c *FaultDisputeGameContract) GetSplitDepth(ctx context.Context) (types.Dep
 		return 0, fmt.Errorf("failed to retrieve split depth: %w", err)
 	}
 	return types.Depth(splitDepth.GetBigInt(0).Uint64()), nil
+}
+
+func (c *FaultDisputeGameContract) GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error) {
+	credit, err := c.multiCaller.SingleCall(ctx, batching.BlockLatest, c.contract.Call(methodCredit, receipient))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve credit: %w", err)
+	}
+	return credit.GetBigInt(0), nil
+}
+
+func (f *FaultDisputeGameContract) ClaimCredit(recipient common.Address) (txmgr.TxCandidate, error) {
+	call := f.contract.Call(methodClaimCredit, recipient)
+	return call.ToTxCandidate()
 }
 
 func (c *FaultDisputeGameContract) GetRequiredBond(ctx context.Context, position types.Position) (*big.Int, error) {

--- a/op-challenger/game/fault/responder/responder.go
+++ b/op-challenger/game/fault/responder/responder.go
@@ -23,6 +23,8 @@ type GameContract interface {
 	DefendTx(parentContractIndex uint64, pivot common.Hash) (txmgr.TxCandidate, error)
 	StepTx(claimIdx uint64, isAttack bool, stateData []byte, proof []byte) (txmgr.TxCandidate, error)
 	GetRequiredBond(ctx context.Context, position types.Position) (*big.Int, error)
+	GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error)
+	ClaimCredit(receipient common.Address) (txmgr.TxCandidate, error)
 }
 
 type Oracle interface {
@@ -31,8 +33,7 @@ type Oracle interface {
 
 // FaultResponder implements the [Responder] interface to send onchain transactions.
 type FaultResponder struct {
-	log log.Logger
-
+	log      log.Logger
 	sender   gameTypes.TxSender
 	contract GameContract
 	uploader preimages.PreimageUploader

--- a/op-challenger/game/fault/responder/responder_test.go
+++ b/op-challenger/game/fault/responder/responder_test.go
@@ -411,3 +411,11 @@ func (m *mockContract) UpdateOracleTx(_ context.Context, claimIdx uint64, data *
 func (m *mockContract) GetRequiredBond(_ context.Context, position types.Position) (*big.Int, error) {
 	return big.NewInt(5), nil
 }
+
+func (m *mockContract) GetCredit(_ context.Context, _ common.Address) (*big.Int, error) {
+	return big.NewInt(5), nil
+}
+
+func (m *mockContract) ClaimCredit(_ common.Address) (txmgr.TxCandidate, error) {
+	return txmgr.TxCandidate{TxData: ([]byte)("claimCredit")}, nil
+}

--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -120,6 +120,9 @@ func (m *gameMonitor) progressGames(ctx context.Context, blockHash common.Hash, 
 	if err != nil {
 		return fmt.Errorf("failed to load games: %w", err)
 	}
+	if err := m.claimer.Schedule(blockNumber, games); err != nil {
+		return fmt.Errorf("failed to schedule bond claims: %w", err)
+	}
 	var gamesToPlay []types.GameMetadata
 	for _, game := range games {
 		if !m.allowedGame(game.Proxy) {
@@ -127,9 +130,6 @@ func (m *gameMonitor) progressGames(ctx context.Context, blockHash common.Hash, 
 			continue
 		}
 		gamesToPlay = append(gamesToPlay, game)
-	}
-	if err := m.claimer.Schedule(blockNumber, gamesToPlay); err != nil {
-		return fmt.Errorf("failed to schedule bond claims: %w", err)
 	}
 	if err := m.scheduler.Schedule(gamesToPlay, blockNumber); errors.Is(err, scheduler.ErrBusy) {
 		m.logger.Info("Scheduler still busy with previous update")

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/claims"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/loader"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/registry"
@@ -48,6 +49,8 @@ type Service struct {
 	txSender *sender.TxSender
 
 	loader *loader.GameLoader
+
+	claimer *claims.BondClaimerScheduler
 
 	factoryContract *contracts.DisputeGameFactoryContract
 	registry        *registry.GameTypeRegistry
@@ -104,6 +107,9 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	}
 	if err := s.initGameLoader(); err != nil {
 		return fmt.Errorf("failed to init game loader: %w", err)
+	}
+	if err := s.initBondClaimer(cfg); err != nil {
+		return fmt.Errorf("failed to init bond claimer: %w", err)
 	}
 	if err := s.registerGameTypes(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to register game types: %w", err)
@@ -201,6 +207,13 @@ func (s *Service) initGameLoader() error {
 	return nil
 }
 
+func (s *Service) initBondClaimer(cfg *config.Config) error {
+	caller := batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize)
+	claimer := claims.NewBondClaimer(s.logger, s.metrics, caller, s.txSender)
+	s.claimer = claims.NewBondClaimerScheduler(s.logger, claimer)
+	return nil
+}
+
 func (s *Service) initRollupClient(ctx context.Context, cfg *config.Config) error {
 	if cfg.RollupRpc == "" {
 		return nil
@@ -240,7 +253,7 @@ func (s *Service) initLargePreimages() error {
 }
 
 func (s *Service) initMonitor(cfg *config.Config) {
-	s.monitor = newGameMonitor(s.logger, s.cl, s.loader, s.sched, s.preimages, cfg.GameWindow, s.l1Client.BlockNumber, cfg.GameAllowlist, s.pollClient)
+	s.monitor = newGameMonitor(s.logger, s.cl, s.loader, s.sched, s.preimages, cfg.GameWindow, s.claimer, s.l1Client.BlockNumber, cfg.GameAllowlist, s.pollClient)
 }
 
 func (s *Service) Start(ctx context.Context) error {

--- a/op-challenger/game/service.go
+++ b/op-challenger/game/service.go
@@ -50,7 +50,7 @@ type Service struct {
 
 	loader *loader.GameLoader
 
-	claimer *claims.BondClaimerScheduler
+	claimer *claims.BondClaimScheduler
 
 	factoryContract *contracts.DisputeGameFactoryContract
 	registry        *registry.GameTypeRegistry
@@ -108,8 +108,8 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initGameLoader(); err != nil {
 		return fmt.Errorf("failed to init game loader: %w", err)
 	}
-	if err := s.initBondClaimer(cfg); err != nil {
-		return fmt.Errorf("failed to init bond claimer: %w", err)
+	if err := s.initBondClaims(cfg); err != nil {
+		return fmt.Errorf("failed to init bond claiming: %w", err)
 	}
 	if err := s.registerGameTypes(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to register game types: %w", err)
@@ -207,10 +207,10 @@ func (s *Service) initGameLoader() error {
 	return nil
 }
 
-func (s *Service) initBondClaimer(cfg *config.Config) error {
+func (s *Service) initBondClaims(cfg *config.Config) error {
 	caller := batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize)
 	claimer := claims.NewBondClaimer(s.logger, s.metrics, caller, s.txSender)
-	s.claimer = claims.NewBondClaimerScheduler(s.logger, claimer)
+	s.claimer = claims.NewBondClaimScheduler(s.logger, s.metrics, claimer)
 	return nil
 }
 

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -34,6 +34,8 @@ type Metricer interface {
 	RecordGameMove()
 	RecordCannonExecutionTime(t float64)
 
+	RecordBondClaimed(amount uint64)
+
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 
 	RecordGameUpdateScheduled()
@@ -61,6 +63,7 @@ type Metrics struct {
 	up   prometheus.Gauge
 
 	executors prometheus.GaugeVec
+	bonds     prometheus.Counter
 
 	highestActedL1Block prometheus.Gauge
 
@@ -129,6 +132,11 @@ func NewMetrics() *Metrics {
 				[]float64{1.0, 10.0},
 				prometheus.ExponentialBuckets(30.0, 2.0, 14)...),
 		}),
+		bonds: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "bonds",
+			Help:      "Number of bonds claimed by the challenge agent",
+		}),
 		trackedGames: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Name:      "tracked_games",
@@ -183,6 +191,10 @@ func (m *Metrics) RecordGameMove() {
 
 func (m *Metrics) RecordGameStep() {
 	m.steps.Add(1)
+}
+
+func (m *Metrics) RecordBondClaimed(amount uint64) {
+	m.bonds.Add(float64(amount))
 }
 
 func (m *Metrics) RecordCannonExecutionTime(t float64) {

--- a/op-challenger/metrics/metrics.go
+++ b/op-challenger/metrics/metrics.go
@@ -34,6 +34,7 @@ type Metricer interface {
 	RecordGameMove()
 	RecordCannonExecutionTime(t float64)
 
+	RecordBondClaimFailed()
 	RecordBondClaimed(amount uint64)
 
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
@@ -63,7 +64,9 @@ type Metrics struct {
 	up   prometheus.Gauge
 
 	executors prometheus.GaugeVec
-	bonds     prometheus.Counter
+
+	bondClaimFailures prometheus.Counter
+	bondsClaimed      prometheus.Counter
 
 	highestActedL1Block prometheus.Gauge
 
@@ -132,7 +135,12 @@ func NewMetrics() *Metrics {
 				[]float64{1.0, 10.0},
 				prometheus.ExponentialBuckets(30.0, 2.0, 14)...),
 		}),
-		bonds: factory.NewCounter(prometheus.CounterOpts{
+		bondClaimFailures: factory.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "claim_failures",
+			Help:      "Number of bond claims that failed",
+		}),
+		bondsClaimed: factory.NewCounter(prometheus.CounterOpts{
 			Namespace: Namespace,
 			Name:      "bonds",
 			Help:      "Number of bonds claimed by the challenge agent",
@@ -193,8 +201,12 @@ func (m *Metrics) RecordGameStep() {
 	m.steps.Add(1)
 }
 
+func (m *Metrics) RecordBondClaimFailed() {
+	m.bondClaimFailures.Add(1)
+}
+
 func (m *Metrics) RecordBondClaimed(amount uint64) {
-	m.bonds.Add(float64(amount))
+	m.bondsClaimed.Add(float64(amount))
 }
 
 func (m *Metrics) RecordCannonExecutionTime(t float64) {

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -28,6 +28,7 @@ func (*NoopMetricsImpl) RecordGameStep() {}
 
 func (*NoopMetricsImpl) RecordActedL1Block(_ uint64) {}
 
+func (*NoopMetricsImpl) RecordBondClaimFailed()   {}
 func (*NoopMetricsImpl) RecordBondClaimed(uint64) {}
 
 func (*NoopMetricsImpl) RecordCannonExecutionTime(t float64) {}

--- a/op-challenger/metrics/noop.go
+++ b/op-challenger/metrics/noop.go
@@ -28,6 +28,8 @@ func (*NoopMetricsImpl) RecordGameStep() {}
 
 func (*NoopMetricsImpl) RecordActedL1Block(_ uint64) {}
 
+func (*NoopMetricsImpl) RecordBondClaimed(uint64) {}
+
 func (*NoopMetricsImpl) RecordCannonExecutionTime(t float64) {}
 
 func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}


### PR DESCRIPTION
**Description**

Implements bond claiming in the `op-challenger`. A new `BondClaimer` is introduced in the `fault` package that handles the claiming contract calls.

When the `Responder` component fetches a list of games to progress, it adds (technically subtracts) a "bond buffer" from the minimum game timestamp.
It then splits the games into a list of games to progress, which are just the games that are not any older than the minimum timestamp, and a list of games to attempt to claim bonds.
The list of games to attempt to claim bonds is the full fetched list of games starting at the minimum timestamp less the bond buffer.

The addition of a bond buffer as a solution to which games to attempt to claim bonds from is a compromise.
On one hand, it will become overwhelming for the challenger to try to claim bonds on all games.
On the other hand, we cannot just claim bonds for games younger than the minimum game timestamp in case the challenger goes offline for a period of time.

If the challenger _does_ go offline, the bond buffer is a neat solution since it can be configured via a cli flag.
So when the challenger is started up again, one can simply increase the bond buffer argument such that it covers the amount of time the challenger was offline.
This way no claimable bonds are missed by the challenger.

Additionally, I've added bond claiming metrics so we can gauge
a) How much eth is posted as bonds in games that are currently active.
b) How much eth the challenger has claimed as bonds.

**Tests**

Unit tests around the `BondClaimer`.

Unit tests around the bond buffer logic and games splicing in the `Responder` component.
