### PR TITLE
fix(op-e2e): Dynamic MinProposalSize Loading

### DIFF
--- a/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
+++ b/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
@@ -25,8 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const MinPreimageSize = 18000
-
 type Helper struct {
 	t              *testing.T
 	require        *require.Assertions
@@ -66,6 +64,12 @@ func WithReplacedCommitment(idx uint64, value common.Hash) InputModifier {
 		}
 		input.Commitments[idx-startBlock] = value
 	}
+}
+
+func (h *Helper) MinPreimageSize() int {
+	minProposalSize, err := h.oracleBindings.MinProposalSize(&bind.CallOpts{})
+	require.NoError(h.t, err)
+	return int(minProposalSize.Uint64())
 }
 
 // UploadLargePreimage inits the preimage upload and uploads the leaves, starting the challenge period.

--- a/op-e2e/faultproofs/challenge_preimage_test.go
+++ b/op-e2e/faultproofs/challenge_preimage_test.go
@@ -25,7 +25,8 @@ func TestChallengeLargePreimages_ChallengeFirst(t *testing.T) {
 		challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Alice))
 	preimageHelper := disputeGameFactory.PreimageHelper(ctx)
-	ident := preimageHelper.UploadLargePreimage(ctx, preimage.MinPreimageSize,
+	minPreimageSize := preimageHelper.MinPreimageSize()
+	ident := preimageHelper.UploadLargePreimage(ctx, minPreimageSize,
 		preimage.WithReplacedCommitment(0, common.Hash{0xaa}))
 
 	require.NotEqual(t, ident.Claimant, common.Address{})
@@ -45,7 +46,8 @@ func TestChallengeLargePreimages_ChallengeMiddle(t *testing.T) {
 		challenger.WithAlphabet(sys.RollupEndpoint("sequencer")),
 		challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 	preimageHelper := disputeGameFactory.PreimageHelper(ctx)
-	ident := preimageHelper.UploadLargePreimage(ctx, preimage.MinPreimageSize,
+	minPreimageSize := preimageHelper.MinPreimageSize()
+	ident := preimageHelper.UploadLargePreimage(ctx, minPreimageSize,
 		preimage.WithReplacedCommitment(10, common.Hash{0xaa}))
 
 	require.NotEqual(t, ident.Claimant, common.Address{})


### PR DESCRIPTION
**Description**

Updates the large preimage `op-e2e` tests to dynamically load the min proposal side through the oracle contract instead of hardcoding the value in a deeply nested test file.