### PR TITLE
chore(ci): Weekly Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/ops-bedrock"
     schedule:
-      interval: "weekly"
+      interval: "daily"
       day: "tuesday"
       time: "14:30"
       timezone: "America/New_York"
@@ -40,7 +40,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
       day: "tuesday"
       time: "14:30"
       timezone: "America/New_York"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
       time: "14:30"
       timezone: "America/New_York"
     open-pull-requests-limit: 10
-    prefix: "dependabot(docker): "
+    commit-message:
+      prefix: "dependabot(docker): "
     labels:
       - "M-dependabot"
 
@@ -20,7 +21,8 @@ updates:
       time: "14:30"
       timezone: "America/New_York"
     open-pull-requests-limit: 10
-    prefix: "dependabot(actions): "
+    commit-message:
+      prefix: "dependabot(actions): "
     labels:
       - "M-dependabot"
 
@@ -33,7 +35,8 @@ updates:
       timezone: "America/New_York"
     open-pull-requests-limit: 10
     versioning-strategy: "auto"
-    prefix: "dependabot(npm): "
+    commit-message:
+      prefix: "dependabot(npm): "
     labels:
       - "M-dependabot"
 
@@ -45,6 +48,7 @@ updates:
       time: "14:30"
       timezone: "America/New_York"
     open-pull-requests-limit: 10
-    prefix: "dependabot(gomod): "
+    commit-message:
+      prefix: "dependabot(gomod): "
     labels:
       - "M-dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,50 @@
 version: 2
 updates:
-  - package-ecosystem: docker
+  - package-ecosystem: "docker"
     directory: "/ops-bedrock"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - M-dependabot
-
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - M-dependabot
-
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "16:30"
+      interval: "weekly"
+      day: "tuesday"
+      time: "14:30"
       timezone: "America/New_York"
     open-pull-requests-limit: 10
-    versioning-strategy: auto
+    prefix: "dependabot(docker): "
     labels:
-      - M-dependabot
+      - "M-dependabot"
 
-  - package-ecosystem: gomod
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+      day: "tuesday"
+      time: "14:30"
+      timezone: "America/New_York"
     open-pull-requests-limit: 10
+    prefix: "dependabot(actions): "
     labels:
-      - M-dependabot
+      - "M-dependabot"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "14:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    versioning-strategy: "auto"
+    prefix: "dependabot(npm): "
+    labels:
+      - "M-dependabot"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "14:30"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    prefix: "dependabot(gomod): "
+    labels:
+      - "M-dependabot"


### PR DESCRIPTION
**Description**

Dependabot has been very noisy, often with the same dependencies seeing patch changes on a daily basis.

This PR modifies dependabot to run weekly as opposed to daily.
