### PR TITLE
contracts-bedrock: add initialized var checks in ChainAssertions

### DIFF
--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -23,6 +23,8 @@ import { ISystemConfigV0 } from "scripts/interfaces/ISystemConfigV0.sol";
 import { console2 as console } from "forge-std/console2.sol";
 
 library ChainAssertions {
+    Vm internal constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
     /// @notice Asserts the correctness of an L1 deployment. This function expects that all contracts
     ///         within the `prox` ContractSet are proxies that have been setup and initialized.
     function postDeployAssertions(
@@ -386,5 +388,11 @@ library ChainAssertions {
 
         require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
         require(superchainConfig.paused() == _isPaused);
+    }
+
+    /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.
+    function assertSlotIsOne(address contractAddress, uint256 slot, uint256 offset) internal view {
+        bytes32 slotVal = vm.load(contractAddress, bytes32(slot));
+        require(uint8((uint256(slotVal) >> (offset * 8)) & 0xFF) == uint8(1), "Value not 1");
     }
 }

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -371,6 +371,6 @@ library ChainAssertions {
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.
     function assertSlotValueIsOne(address _contractAddress, uint256 _slot, uint256 _offset) internal view {
         bytes32 slotVal = vm.load(_contractAddress, bytes32(_slot));
-        require(uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offet not 1");
+        require(uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offset not 1");
     }
 }

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -63,7 +63,7 @@ library ChainAssertions {
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(config), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(config), _slot: 0, _offset: 0 });
 
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
 
@@ -125,7 +125,7 @@ library ChainAssertions {
         L1CrossDomainMessenger messenger = L1CrossDomainMessenger(_contracts.L1CrossDomainMessenger);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(messenger), slot: 0, offset: 20 });
+        assertSlotIsOne({ _contractAddress: address(messenger), _slot: 0, _offset: 20 });
 
         require(address(messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
         require(address(messenger.otherMessenger()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
@@ -149,7 +149,7 @@ library ChainAssertions {
         L1StandardBridge bridge = L1StandardBridge(payable(_contracts.L1StandardBridge));
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(bridge), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(bridge), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(address(bridge.MESSENGER()) == _contracts.L1CrossDomainMessenger);
@@ -180,7 +180,7 @@ library ChainAssertions {
         L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(oracle), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(oracle), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(oracle.SUBMISSION_INTERVAL() == _cfg.l2OutputOracleSubmissionInterval());
@@ -217,7 +217,7 @@ library ChainAssertions {
         OptimismMintableERC20Factory factory = OptimismMintableERC20Factory(_contracts.OptimismMintableERC20Factory);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(factory), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(factory), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(factory.BRIDGE() == _contracts.L1StandardBridge);
@@ -234,7 +234,7 @@ library ChainAssertions {
         L1ERC721Bridge bridge = L1ERC721Bridge(_contracts.L1ERC721Bridge);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(bridge), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(bridge), _slot: 0, _offset: 0 });
 
         require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE);
         require(address(bridge.otherBridge()) == Predeploys.L2_ERC721_BRIDGE);
@@ -257,7 +257,7 @@ library ChainAssertions {
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(portal), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });
 
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
@@ -298,7 +298,7 @@ library ChainAssertions {
         OptimismPortal2 portal = OptimismPortal2(payable(_contracts.OptimismPortal2));
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(portal), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });
 
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
@@ -336,7 +336,7 @@ library ChainAssertions {
         ProtocolVersions versions = ProtocolVersions(_contracts.ProtocolVersions);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(versions), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(versions), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(versions.owner() == _cfg.finalSystemOwner());
@@ -362,15 +362,15 @@ library ChainAssertions {
         SuperchainConfig superchainConfig = SuperchainConfig(_contracts.SuperchainConfig);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ contractAddress: address(superchainConfig), slot: 0, offset: 0 });
+        assertSlotIsOne({ _contractAddress: address(superchainConfig), _slot: 0, _offset: 0 });
 
         require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
         require(superchainConfig.paused() == _isPaused);
     }
 
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.
-    function assertSlotIsOne(address contractAddress, uint256 slot, uint256 offset) internal view {
-        bytes32 slotVal = vm.load(contractAddress, bytes32(slot));
-        require(uint8((uint256(slotVal) >> (offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offet not 1");
+    function assertSlotIsOne(address _contractAddress, uint256 _slot, uint256 _offset) internal view {
+        bytes32 slotVal = vm.load(_contractAddress, bytes32(_slot));
+        require(uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offet not 1");
     }
 }

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -60,6 +60,9 @@ library ChainAssertions {
         console.log("Running chain assertions on the SystemConfig");
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
+        bytes32 initialized = vm.load(address(config), bytes32(0));
+        require(initialized != 0);
+
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
 
         if (_isProxy) {
@@ -119,6 +122,9 @@ library ChainAssertions {
         console.log("Running chain assertions on the L1CrossDomainMessenger");
         L1CrossDomainMessenger messenger = L1CrossDomainMessenger(_contracts.L1CrossDomainMessenger);
 
+        bytes32 initialized = vm.load(address(messenger), bytes32(0));
+        require(initialized != 0);
+
         require(address(messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
         require(address(messenger.otherMessenger()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
 
@@ -139,6 +145,9 @@ library ChainAssertions {
     function checkL1StandardBridge(Types.ContractSet memory _contracts, bool _isProxy) internal view {
         console.log("Running chain assertions on the L1StandardBridge");
         L1StandardBridge bridge = L1StandardBridge(payable(_contracts.L1StandardBridge));
+
+        bytes32 initialized = vm.load(address(bridge), bytes32(0));
+        require(initialized != 0);
 
         if (_isProxy) {
             require(address(bridge.MESSENGER()) == _contracts.L1CrossDomainMessenger);
@@ -167,6 +176,9 @@ library ChainAssertions {
     {
         console.log("Running chain assertions on the L2OutputOracle");
         L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
+
+        bytes32 initialized = vm.load(address(oracle), bytes32(0));
+        require(initialized != 0);
 
         if (_isProxy) {
             require(oracle.SUBMISSION_INTERVAL() == _cfg.l2OutputOracleSubmissionInterval());
@@ -202,6 +214,9 @@ library ChainAssertions {
         console.log("Running chain assertions on the OptimismMintableERC20Factory");
         OptimismMintableERC20Factory factory = OptimismMintableERC20Factory(_contracts.OptimismMintableERC20Factory);
 
+        bytes32 initialized = vm.load(address(factory), bytes32(0));
+        require(initialized != 0);
+
         if (_isProxy) {
             require(factory.BRIDGE() == _contracts.L1StandardBridge);
             require(factory.bridge() == _contracts.L1StandardBridge);
@@ -215,6 +230,9 @@ library ChainAssertions {
     function checkL1ERC721Bridge(Types.ContractSet memory _contracts, bool _isProxy) internal view {
         console.log("Running chain assertions on the L1ERC721Bridge");
         L1ERC721Bridge bridge = L1ERC721Bridge(_contracts.L1ERC721Bridge);
+
+        bytes32 initialized = vm.load(address(bridge), bytes32(0));
+        require(initialized != 0);
 
         require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE);
         require(address(bridge.otherBridge()) == Predeploys.L2_ERC721_BRIDGE);
@@ -233,8 +251,10 @@ library ChainAssertions {
     /// @notice Asserts the OptimismPortal is setup correctly
     function checkOptimismPortal(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
         console.log("Running chain assertions on the OptimismPortal");
-
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
+
+        bytes32 initialized = vm.load(address(portal), bytes32(0));
+        require(initialized != 0);
 
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
@@ -308,6 +328,10 @@ library ChainAssertions {
     {
         console.log("Running chain assertions on the ProtocolVersions");
         ProtocolVersions versions = ProtocolVersions(_contracts.ProtocolVersions);
+
+        bytes32 initialized = vm.load(address(versions), bytes32(0));
+        require(initialized != 0);
+
         if (_isProxy) {
             require(versions.owner() == _cfg.finalSystemOwner());
             require(ProtocolVersion.unwrap(versions.required()) == _cfg.requiredProtocolVersion());
@@ -330,6 +354,10 @@ library ChainAssertions {
     {
         console.log("Running chain assertions on the SuperchainConfig");
         SuperchainConfig superchainConfig = SuperchainConfig(_contracts.SuperchainConfig);
+
+        bytes32 initialized = vm.load(address(superchainConfig), bytes32(0));
+        require(initialized != 0);
+
         require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
         require(superchainConfig.paused() == _isPaused);
     }

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -371,6 +371,6 @@ library ChainAssertions {
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.
     function assertSlotIsOne(address contractAddress, uint256 slot, uint256 offset) internal view {
         bytes32 slotVal = vm.load(contractAddress, bytes32(slot));
-        require(uint8((uint256(slotVal) >> (offset * 8)) & 0xFF) == uint8(1), "Value not 1");
+        require(uint8((uint256(slotVal) >> (offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offet not 1");
     }
 }

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -53,6 +53,7 @@ library ChainAssertions {
         checkOptimismMintableERC20Factory({ _contracts: _prox, _isProxy: true });
         checkL1ERC721Bridge({ _contracts: _prox, _isProxy: true });
         checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkOptimismPortal2({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
         checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
     }
 
@@ -252,6 +253,7 @@ library ChainAssertions {
     /// @notice Asserts the OptimismPortal is setup correctly
     function checkOptimismPortal(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
         console.log("Running chain assertions on the OptimismPortal");
+
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
 
         // Check that the contract is initialized

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -63,7 +63,7 @@ library ChainAssertions {
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(config), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(config), _slot: 0, _offset: 0 });
 
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
 
@@ -125,7 +125,7 @@ library ChainAssertions {
         L1CrossDomainMessenger messenger = L1CrossDomainMessenger(_contracts.L1CrossDomainMessenger);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(messenger), _slot: 0, _offset: 20 });
+        assertSlotValueIsOne({ _contractAddress: address(messenger), _slot: 0, _offset: 20 });
 
         require(address(messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
         require(address(messenger.otherMessenger()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
@@ -149,7 +149,7 @@ library ChainAssertions {
         L1StandardBridge bridge = L1StandardBridge(payable(_contracts.L1StandardBridge));
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(bridge), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(bridge), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(address(bridge.MESSENGER()) == _contracts.L1CrossDomainMessenger);
@@ -180,7 +180,7 @@ library ChainAssertions {
         L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(oracle), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(oracle), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(oracle.SUBMISSION_INTERVAL() == _cfg.l2OutputOracleSubmissionInterval());
@@ -217,7 +217,7 @@ library ChainAssertions {
         OptimismMintableERC20Factory factory = OptimismMintableERC20Factory(_contracts.OptimismMintableERC20Factory);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(factory), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(factory), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(factory.BRIDGE() == _contracts.L1StandardBridge);
@@ -234,7 +234,7 @@ library ChainAssertions {
         L1ERC721Bridge bridge = L1ERC721Bridge(_contracts.L1ERC721Bridge);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(bridge), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(bridge), _slot: 0, _offset: 0 });
 
         require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE);
         require(address(bridge.otherBridge()) == Predeploys.L2_ERC721_BRIDGE);
@@ -257,7 +257,7 @@ library ChainAssertions {
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });
 
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
@@ -298,7 +298,7 @@ library ChainAssertions {
         OptimismPortal2 portal = OptimismPortal2(payable(_contracts.OptimismPortal2));
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });
 
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
@@ -336,7 +336,7 @@ library ChainAssertions {
         ProtocolVersions versions = ProtocolVersions(_contracts.ProtocolVersions);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(versions), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(versions), _slot: 0, _offset: 0 });
 
         if (_isProxy) {
             require(versions.owner() == _cfg.finalSystemOwner());
@@ -362,14 +362,14 @@ library ChainAssertions {
         SuperchainConfig superchainConfig = SuperchainConfig(_contracts.SuperchainConfig);
 
         // Check that the contract is initialized
-        assertSlotIsOne({ _contractAddress: address(superchainConfig), _slot: 0, _offset: 0 });
+        assertSlotValueIsOne({ _contractAddress: address(superchainConfig), _slot: 0, _offset: 0 });
 
         require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
         require(superchainConfig.paused() == _isPaused);
     }
 
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.
-    function assertSlotIsOne(address _contractAddress, uint256 _slot, uint256 _offset) internal view {
+    function assertSlotValueIsOne(address _contractAddress, uint256 _slot, uint256 _offset) internal view {
         bytes32 slotVal = vm.load(_contractAddress, bytes32(_slot));
         require(uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offet not 1");
     }

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -41,32 +41,23 @@ library ChainAssertions {
         ResourceMetering.ResourceConfig memory dflt = Constants.DEFAULT_RESOURCE_CONFIG();
         require(keccak256(abi.encode(rcfg)) == keccak256(abi.encode(dflt)));
 
-        checkSystemConfig({ _contracts: _prox, _cfg: _cfg, _vm: _vm, _isProxy: true });
+        checkSystemConfig({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
         checkL1CrossDomainMessenger({ _contracts: _prox, _vm: _vm, _isProxy: true });
-        checkL1StandardBridge({ _contracts: _prox, _vm: _vm, _isProxy: true });
+        checkL1StandardBridge({ _contracts: _prox, _isProxy: true });
         checkL2OutputOracle({
             _contracts: _prox,
             _cfg: _cfg,
             _l2OutputOracleStartingTimestamp: _l2OutputOracleStartingTimestamp,
-            _vm: _vm,
             _isProxy: true
         });
-        checkOptimismMintableERC20Factory({ _contracts: _prox, _vm: _vm, _isProxy: true });
-        checkL1ERC721Bridge({ _contracts: _prox, _vm: _vm, _isProxy: true });
-        checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _vm: _vm, _isProxy: true });
-        checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _vm: _vm, _isProxy: true });
+        checkOptimismMintableERC20Factory({ _contracts: _prox, _isProxy: true });
+        checkL1ERC721Bridge({ _contracts: _prox, _isProxy: true });
+        checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
     }
 
     /// @notice Asserts that the SystemConfig is setup correctly
-    function checkSystemConfig(
-        Types.ContractSet memory _contracts,
-        DeployConfig _cfg,
-        Vm _vm,
-        bool _isProxy
-    )
-        internal
-        view
-    {
+    function checkSystemConfig(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
         console.log("Running chain assertions on the SystemConfig");
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
@@ -152,7 +143,7 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the L1StandardBridge is setup correctly
-    function checkL1StandardBridge(Types.ContractSet memory _contracts, Vm _vm, bool _isProxy) internal view {
+    function checkL1StandardBridge(Types.ContractSet memory _contracts, bool _isProxy) internal view {
         console.log("Running chain assertions on the L1StandardBridge");
         L1StandardBridge bridge = L1StandardBridge(payable(_contracts.L1StandardBridge));
 
@@ -179,7 +170,6 @@ library ChainAssertions {
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
         uint256 _l2OutputOracleStartingTimestamp,
-        Vm _vm,
         bool _isProxy
     )
         internal
@@ -221,14 +211,7 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the OptimismMintableERC20Factory is setup correctly
-    function checkOptimismMintableERC20Factory(
-        Types.ContractSet memory _contracts,
-        Vm _vm,
-        bool _isProxy
-    )
-        internal
-        view
-    {
+    function checkOptimismMintableERC20Factory(Types.ContractSet memory _contracts, bool _isProxy) internal view {
         console.log("Running chain assertions on the OptimismMintableERC20Factory");
         OptimismMintableERC20Factory factory = OptimismMintableERC20Factory(_contracts.OptimismMintableERC20Factory);
 
@@ -245,7 +228,7 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the L1ERC721Bridge is setup correctly
-    function checkL1ERC721Bridge(Types.ContractSet memory _contracts, Vm _vm, bool _isProxy) internal view {
+    function checkL1ERC721Bridge(Types.ContractSet memory _contracts, bool _isProxy) internal view {
         console.log("Running chain assertions on the L1ERC721Bridge");
         L1ERC721Bridge bridge = L1ERC721Bridge(_contracts.L1ERC721Bridge);
 
@@ -267,15 +250,7 @@ library ChainAssertions {
     }
 
     /// @notice Asserts the OptimismPortal is setup correctly
-    function checkOptimismPortal(
-        Types.ContractSet memory _contracts,
-        DeployConfig _cfg,
-        Vm _vm,
-        bool _isProxy
-    )
-        internal
-        view
-    {
+    function checkOptimismPortal(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
         console.log("Running chain assertions on the OptimismPortal");
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
 
@@ -350,7 +325,6 @@ library ChainAssertions {
     function checkProtocolVersions(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
-        Vm _vm,
         bool _isProxy
     )
         internal
@@ -377,7 +351,6 @@ library ChainAssertions {
     function checkSuperchainConfig(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
-        Vm _vm,
         bool _isPaused
     )
         internal

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -39,28 +39,36 @@ library ChainAssertions {
         ResourceMetering.ResourceConfig memory dflt = Constants.DEFAULT_RESOURCE_CONFIG();
         require(keccak256(abi.encode(rcfg)) == keccak256(abi.encode(dflt)));
 
-        checkSystemConfig({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkSystemConfig({ _contracts: _prox, _cfg: _cfg, _vm: _vm, _isProxy: true });
         checkL1CrossDomainMessenger({ _contracts: _prox, _vm: _vm, _isProxy: true });
-        checkL1StandardBridge({ _contracts: _prox, _isProxy: true });
+        checkL1StandardBridge({ _contracts: _prox, _vm: _vm, _isProxy: true });
         checkL2OutputOracle({
             _contracts: _prox,
             _cfg: _cfg,
             _l2OutputOracleStartingTimestamp: _l2OutputOracleStartingTimestamp,
+            _vm: _vm,
             _isProxy: true
         });
-        checkOptimismMintableERC20Factory({ _contracts: _prox, _isProxy: true });
-        checkL1ERC721Bridge({ _contracts: _prox, _isProxy: true });
-        checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
-        checkOptimismPortal2({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
-        checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkOptimismMintableERC20Factory({ _contracts: _prox, _vm: _vm, _isProxy: true });
+        checkL1ERC721Bridge({ _contracts: _prox, _vm: _vm, _isProxy: true });
+        checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _vm: _vm, _isProxy: true });
+        checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _vm: _vm, _isProxy: true });
     }
 
     /// @notice Asserts that the SystemConfig is setup correctly
-    function checkSystemConfig(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
+    function checkSystemConfig(
+        Types.ContractSet memory _contracts,
+        DeployConfig _cfg,
+        Vm _vm,
+        bool _isProxy
+    )
+        internal
+        view
+    {
         console.log("Running chain assertions on the SystemConfig");
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
-        bytes32 initialized = vm.load(address(config), bytes32(0));
+        bytes32 initialized = _vm.load(address(config), bytes32(0));
         require(initialized != 0);
 
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
@@ -122,7 +130,7 @@ library ChainAssertions {
         console.log("Running chain assertions on the L1CrossDomainMessenger");
         L1CrossDomainMessenger messenger = L1CrossDomainMessenger(_contracts.L1CrossDomainMessenger);
 
-        bytes32 initialized = vm.load(address(messenger), bytes32(0));
+        bytes32 initialized = _vm.load(address(messenger), bytes32(0));
         require(initialized != 0);
 
         require(address(messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
@@ -142,11 +150,11 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the L1StandardBridge is setup correctly
-    function checkL1StandardBridge(Types.ContractSet memory _contracts, bool _isProxy) internal view {
+    function checkL1StandardBridge(Types.ContractSet memory _contracts, Vm _vm, bool _isProxy) internal view {
         console.log("Running chain assertions on the L1StandardBridge");
         L1StandardBridge bridge = L1StandardBridge(payable(_contracts.L1StandardBridge));
 
-        bytes32 initialized = vm.load(address(bridge), bytes32(0));
+        bytes32 initialized = _vm.load(address(bridge), bytes32(0));
         require(initialized != 0);
 
         if (_isProxy) {
@@ -169,6 +177,7 @@ library ChainAssertions {
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
         uint256 _l2OutputOracleStartingTimestamp,
+        Vm _vm,
         bool _isProxy
     )
         internal
@@ -177,7 +186,7 @@ library ChainAssertions {
         console.log("Running chain assertions on the L2OutputOracle");
         L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
 
-        bytes32 initialized = vm.load(address(oracle), bytes32(0));
+        bytes32 initialized = _vm.load(address(oracle), bytes32(0));
         require(initialized != 0);
 
         if (_isProxy) {
@@ -210,11 +219,18 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the OptimismMintableERC20Factory is setup correctly
-    function checkOptimismMintableERC20Factory(Types.ContractSet memory _contracts, bool _isProxy) internal view {
+    function checkOptimismMintableERC20Factory(
+        Types.ContractSet memory _contracts,
+        Vm _vm,
+        bool _isProxy
+    )
+        internal
+        view
+    {
         console.log("Running chain assertions on the OptimismMintableERC20Factory");
         OptimismMintableERC20Factory factory = OptimismMintableERC20Factory(_contracts.OptimismMintableERC20Factory);
 
-        bytes32 initialized = vm.load(address(factory), bytes32(0));
+        bytes32 initialized = _vm.load(address(factory), bytes32(0));
         require(initialized != 0);
 
         if (_isProxy) {
@@ -227,11 +243,11 @@ library ChainAssertions {
     }
 
     /// @notice Asserts that the L1ERC721Bridge is setup correctly
-    function checkL1ERC721Bridge(Types.ContractSet memory _contracts, bool _isProxy) internal view {
+    function checkL1ERC721Bridge(Types.ContractSet memory _contracts, Vm _vm, bool _isProxy) internal view {
         console.log("Running chain assertions on the L1ERC721Bridge");
         L1ERC721Bridge bridge = L1ERC721Bridge(_contracts.L1ERC721Bridge);
 
-        bytes32 initialized = vm.load(address(bridge), bytes32(0));
+        bytes32 initialized = _vm.load(address(bridge), bytes32(0));
         require(initialized != 0);
 
         require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE);
@@ -249,11 +265,19 @@ library ChainAssertions {
     }
 
     /// @notice Asserts the OptimismPortal is setup correctly
-    function checkOptimismPortal(Types.ContractSet memory _contracts, DeployConfig _cfg, bool _isProxy) internal view {
+    function checkOptimismPortal(
+        Types.ContractSet memory _contracts,
+        DeployConfig _cfg,
+        Vm _vm,
+        bool _isProxy
+    )
+        internal
+        view
+    {
         console.log("Running chain assertions on the OptimismPortal");
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
 
-        bytes32 initialized = vm.load(address(portal), bytes32(0));
+        bytes32 initialized = _vm.load(address(portal), bytes32(0));
         require(initialized != 0);
 
         address guardian = _cfg.superchainConfigGuardian();
@@ -321,6 +345,7 @@ library ChainAssertions {
     function checkProtocolVersions(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
+        Vm _vm,
         bool _isProxy
     )
         internal
@@ -329,7 +354,7 @@ library ChainAssertions {
         console.log("Running chain assertions on the ProtocolVersions");
         ProtocolVersions versions = ProtocolVersions(_contracts.ProtocolVersions);
 
-        bytes32 initialized = vm.load(address(versions), bytes32(0));
+        bytes32 initialized = _vm.load(address(versions), bytes32(0));
         require(initialized != 0);
 
         if (_isProxy) {
@@ -347,6 +372,7 @@ library ChainAssertions {
     function checkSuperchainConfig(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
+        Vm _vm,
         bool _isPaused
     )
         internal
@@ -355,7 +381,7 @@ library ChainAssertions {
         console.log("Running chain assertions on the SuperchainConfig");
         SuperchainConfig superchainConfig = SuperchainConfig(_contracts.SuperchainConfig);
 
-        bytes32 initialized = vm.load(address(superchainConfig), bytes32(0));
+        bytes32 initialized = _vm.load(address(superchainConfig), bytes32(0));
         require(initialized != 0);
 
         require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -70,8 +70,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the SystemConfig");
         SystemConfig config = SystemConfig(_contracts.SystemConfig);
 
-        bytes32 initialized = _vm.load(address(config), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(config), slot: 0, offset: 0 });
 
         ResourceMetering.ResourceConfig memory resourceConfig = config.resourceConfig();
 
@@ -132,8 +132,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the L1CrossDomainMessenger");
         L1CrossDomainMessenger messenger = L1CrossDomainMessenger(_contracts.L1CrossDomainMessenger);
 
-        bytes32 initialized = _vm.load(address(messenger), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(messenger), slot: 0, offset: 20 });
 
         require(address(messenger.OTHER_MESSENGER()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
         require(address(messenger.otherMessenger()) == Predeploys.L2_CROSS_DOMAIN_MESSENGER);
@@ -156,8 +156,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the L1StandardBridge");
         L1StandardBridge bridge = L1StandardBridge(payable(_contracts.L1StandardBridge));
 
-        bytes32 initialized = _vm.load(address(bridge), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(bridge), slot: 0, offset: 0 });
 
         if (_isProxy) {
             require(address(bridge.MESSENGER()) == _contracts.L1CrossDomainMessenger);
@@ -188,8 +188,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the L2OutputOracle");
         L2OutputOracle oracle = L2OutputOracle(_contracts.L2OutputOracle);
 
-        bytes32 initialized = _vm.load(address(oracle), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(oracle), slot: 0, offset: 0 });
 
         if (_isProxy) {
             require(oracle.SUBMISSION_INTERVAL() == _cfg.l2OutputOracleSubmissionInterval());
@@ -232,8 +232,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the OptimismMintableERC20Factory");
         OptimismMintableERC20Factory factory = OptimismMintableERC20Factory(_contracts.OptimismMintableERC20Factory);
 
-        bytes32 initialized = _vm.load(address(factory), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(factory), slot: 0, offset: 0 });
 
         if (_isProxy) {
             require(factory.BRIDGE() == _contracts.L1StandardBridge);
@@ -249,8 +249,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the L1ERC721Bridge");
         L1ERC721Bridge bridge = L1ERC721Bridge(_contracts.L1ERC721Bridge);
 
-        bytes32 initialized = _vm.load(address(bridge), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(bridge), slot: 0, offset: 0 });
 
         require(address(bridge.OTHER_BRIDGE()) == Predeploys.L2_ERC721_BRIDGE);
         require(address(bridge.otherBridge()) == Predeploys.L2_ERC721_BRIDGE);
@@ -279,8 +279,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the OptimismPortal");
         OptimismPortal portal = OptimismPortal(payable(_contracts.OptimismPortal));
 
-        bytes32 initialized = _vm.load(address(portal), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(portal), slot: 0, offset: 0 });
 
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
@@ -320,6 +320,9 @@ library ChainAssertions {
 
         OptimismPortal2 portal = OptimismPortal2(payable(_contracts.OptimismPortal2));
 
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(portal), slot: 0, offset: 0 });
+
         address guardian = _cfg.superchainConfigGuardian();
         if (guardian.code.length == 0) {
             console.log("Guardian has no code: %s", guardian);
@@ -356,8 +359,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the ProtocolVersions");
         ProtocolVersions versions = ProtocolVersions(_contracts.ProtocolVersions);
 
-        bytes32 initialized = _vm.load(address(versions), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(versions), slot: 0, offset: 0 });
 
         if (_isProxy) {
             require(versions.owner() == _cfg.finalSystemOwner());
@@ -383,8 +386,8 @@ library ChainAssertions {
         console.log("Running chain assertions on the SuperchainConfig");
         SuperchainConfig superchainConfig = SuperchainConfig(_contracts.SuperchainConfig);
 
-        bytes32 initialized = _vm.load(address(superchainConfig), bytes32(0));
-        require(initialized != 0);
+        // Check that the contract is initialized
+        assertSlotIsOne({ contractAddress: address(superchainConfig), slot: 0, offset: 0 });
 
         require(superchainConfig.guardian() == _cfg.superchainConfigGuardian());
         require(superchainConfig.paused() == _isPaused);

--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -371,6 +371,9 @@ library ChainAssertions {
     /// @dev Asserts that for a given contract the value of a storage slot at an offset is 1.
     function assertSlotValueIsOne(address _contractAddress, uint256 _slot, uint256 _offset) internal view {
         bytes32 slotVal = vm.load(_contractAddress, bytes32(_slot));
-        require(uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF) == uint8(1), "Contract's slot value at offset not 1");
+        require(
+            uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF) == uint8(1),
+            "Storage value is not 1 at the given slot and offset"
+        );
     }
 }

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -548,7 +548,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.OptimismPortal = address(portal);
-        ChainAssertions.checkOptimismPortal({ _contracts: contracts, _cfg: cfg, _vm: vm, _isProxy: false });
+        ChainAssertions.checkOptimismPortal({ _contracts: contracts, _cfg: cfg, _isProxy: false });
 
         require(loadInitializedSlot("OptimismPortal") == 1, "OptimismPortal is not initialized");
 
@@ -602,7 +602,6 @@ contract Deploy is Deployer {
             _contracts: contracts,
             _cfg: cfg,
             _l2OutputOracleStartingTimestamp: 0,
-            _vm: vm,
             _isProxy: false
         });
 
@@ -624,7 +623,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.OptimismMintableERC20Factory = address(factory);
-        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: contracts, _vm: vm, _isProxy: false });
+        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: contracts, _isProxy: false });
 
         addr_ = address(factory);
     }
@@ -653,7 +652,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.ProtocolVersions = address(versions);
-        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _vm: vm, _isProxy: false });
+        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: false });
 
         require(loadInitializedSlot("ProtocolVersions") == 1, "ProtocolVersions is not initialized");
 
@@ -697,7 +696,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.SystemConfig = address(config);
-        ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _vm: vm, _isProxy: false });
+        ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _isProxy: false });
 
         require(loadInitializedSlot("SystemConfig") == 1, "SystemConfig is not initialized");
 
@@ -718,7 +717,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.L1StandardBridge = address(bridge);
-        ChainAssertions.checkL1StandardBridge({ _contracts: contracts, _vm: vm, _isProxy: false });
+        ChainAssertions.checkL1StandardBridge({ _contracts: contracts, _isProxy: false });
 
         addr_ = address(bridge);
     }
@@ -737,7 +736,7 @@ contract Deploy is Deployer {
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.L1ERC721Bridge = address(bridge);
 
-        ChainAssertions.checkL1ERC721Bridge({ _contracts: contracts, _vm: vm, _isProxy: false });
+        ChainAssertions.checkL1ERC721Bridge({ _contracts: contracts, _isProxy: false });
 
         addr_ = address(bridge);
     }
@@ -770,7 +769,7 @@ contract Deploy is Deployer {
             _innerCallData: abi.encodeCall(SuperchainConfig.initialize, (cfg.superchainConfigGuardian(), false))
         });
 
-        ChainAssertions.checkSuperchainConfig({ _contracts: _proxiesUnstrict(), _cfg: cfg, _vm: vm, _isPaused: false });
+        ChainAssertions.checkSuperchainConfig({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isPaused: false });
     }
 
     /// @notice Initialize the DisputeGameFactory
@@ -829,7 +828,7 @@ contract Deploy is Deployer {
         string memory version = config.version();
         console.log("SystemConfig version: %s", version);
 
-        ChainAssertions.checkSystemConfig({ _contracts: _proxies(), _cfg: cfg, _vm: vm, _isProxy: true });
+        ChainAssertions.checkSystemConfig({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
 
         require(loadInitializedSlot("SystemConfigProxy") == 1, "SystemConfigProxy is not initialized");
     }
@@ -864,7 +863,7 @@ contract Deploy is Deployer {
         string memory version = L1StandardBridge(payable(l1StandardBridgeProxy)).version();
         console.log("L1StandardBridge version: %s", version);
 
-        ChainAssertions.checkL1StandardBridge({ _contracts: _proxies(), _vm: vm, _isProxy: true });
+        ChainAssertions.checkL1StandardBridge({ _contracts: _proxies(), _isProxy: true });
     }
 
     /// @notice Initialize the L1ERC721Bridge
@@ -888,7 +887,7 @@ contract Deploy is Deployer {
         string memory version = bridge.version();
         console.log("L1ERC721Bridge version: %s", version);
 
-        ChainAssertions.checkL1ERC721Bridge({ _contracts: _proxies(), _vm: vm, _isProxy: true });
+        ChainAssertions.checkL1ERC721Bridge({ _contracts: _proxies(), _isProxy: true });
     }
 
     /// @notice Ininitialize the OptimismMintableERC20Factory
@@ -908,7 +907,7 @@ contract Deploy is Deployer {
         string memory version = factory.version();
         console.log("OptimismMintableERC20Factory version: %s", version);
 
-        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: _proxies(), _vm: vm, _isProxy: true });
+        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: _proxies(), _isProxy: true });
     }
 
     /// @notice initializeL1CrossDomainMessenger
@@ -993,7 +992,6 @@ contract Deploy is Deployer {
             _contracts: _proxies(),
             _cfg: cfg,
             _l2OutputOracleStartingTimestamp: cfg.l2OutputOracleStartingTimestamp(),
-            _vm: vm,
             _isProxy: true
         });
 
@@ -1026,7 +1024,7 @@ contract Deploy is Deployer {
         string memory version = portal.version();
         console.log("OptimismPortal version: %s", version);
 
-        ChainAssertions.checkOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _vm: vm, _isProxy: true });
+        ChainAssertions.checkOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
 
         require(loadInitializedSlot("OptimismPortalProxy") == 1, "OptimismPortalProxy is not initialized");
     }
@@ -1088,7 +1086,7 @@ contract Deploy is Deployer {
         string memory version = versions.version();
         console.log("ProtocolVersions version: %s", version);
 
-        ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _vm: vm, _isProxy: true });
+        ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isProxy: true });
 
         require(loadInitializedSlot("ProtocolVersionsProxy") == 1, "ProtocolVersionsProxy is not initialized");
     }

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -548,7 +548,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.OptimismPortal = address(portal);
-        ChainAssertions.checkOptimismPortal({ _contracts: contracts, _cfg: cfg, _isProxy: false });
+        ChainAssertions.checkOptimismPortal({ _contracts: contracts, _cfg: cfg, _vm: vm, _isProxy: false });
 
         require(loadInitializedSlot("OptimismPortal") == 1, "OptimismPortal is not initialized");
 
@@ -602,6 +602,7 @@ contract Deploy is Deployer {
             _contracts: contracts,
             _cfg: cfg,
             _l2OutputOracleStartingTimestamp: 0,
+            _vm: vm,
             _isProxy: false
         });
 
@@ -623,7 +624,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.OptimismMintableERC20Factory = address(factory);
-        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: contracts, _isProxy: false });
+        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: contracts, _vm: vm, _isProxy: false });
 
         addr_ = address(factory);
     }
@@ -652,7 +653,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.ProtocolVersions = address(versions);
-        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: false });
+        ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _vm: vm, _isProxy: false });
 
         require(loadInitializedSlot("ProtocolVersions") == 1, "ProtocolVersions is not initialized");
 
@@ -696,7 +697,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.SystemConfig = address(config);
-        ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _isProxy: false });
+        ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _vm: vm, _isProxy: false });
 
         require(loadInitializedSlot("SystemConfig") == 1, "SystemConfig is not initialized");
 
@@ -717,7 +718,7 @@ contract Deploy is Deployer {
         // are always proxies.
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.L1StandardBridge = address(bridge);
-        ChainAssertions.checkL1StandardBridge({ _contracts: contracts, _isProxy: false });
+        ChainAssertions.checkL1StandardBridge({ _contracts: contracts, _vm: vm, _isProxy: false });
 
         addr_ = address(bridge);
     }
@@ -736,7 +737,7 @@ contract Deploy is Deployer {
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.L1ERC721Bridge = address(bridge);
 
-        ChainAssertions.checkL1ERC721Bridge({ _contracts: contracts, _isProxy: false });
+        ChainAssertions.checkL1ERC721Bridge({ _contracts: contracts, _vm: vm, _isProxy: false });
 
         addr_ = address(bridge);
     }
@@ -769,7 +770,7 @@ contract Deploy is Deployer {
             _innerCallData: abi.encodeCall(SuperchainConfig.initialize, (cfg.superchainConfigGuardian(), false))
         });
 
-        ChainAssertions.checkSuperchainConfig({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isPaused: false });
+        ChainAssertions.checkSuperchainConfig({ _contracts: _proxiesUnstrict(), _cfg: cfg, _vm: vm, _isPaused: false });
     }
 
     /// @notice Initialize the DisputeGameFactory
@@ -828,7 +829,7 @@ contract Deploy is Deployer {
         string memory version = config.version();
         console.log("SystemConfig version: %s", version);
 
-        ChainAssertions.checkSystemConfig({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
+        ChainAssertions.checkSystemConfig({ _contracts: _proxies(), _cfg: cfg, _vm: vm, _isProxy: true });
 
         require(loadInitializedSlot("SystemConfigProxy") == 1, "SystemConfigProxy is not initialized");
     }
@@ -863,7 +864,7 @@ contract Deploy is Deployer {
         string memory version = L1StandardBridge(payable(l1StandardBridgeProxy)).version();
         console.log("L1StandardBridge version: %s", version);
 
-        ChainAssertions.checkL1StandardBridge({ _contracts: _proxies(), _isProxy: true });
+        ChainAssertions.checkL1StandardBridge({ _contracts: _proxies(), _vm: vm, _isProxy: true });
     }
 
     /// @notice Initialize the L1ERC721Bridge
@@ -887,7 +888,7 @@ contract Deploy is Deployer {
         string memory version = bridge.version();
         console.log("L1ERC721Bridge version: %s", version);
 
-        ChainAssertions.checkL1ERC721Bridge({ _contracts: _proxies(), _isProxy: true });
+        ChainAssertions.checkL1ERC721Bridge({ _contracts: _proxies(), _vm: vm, _isProxy: true });
     }
 
     /// @notice Ininitialize the OptimismMintableERC20Factory
@@ -907,7 +908,7 @@ contract Deploy is Deployer {
         string memory version = factory.version();
         console.log("OptimismMintableERC20Factory version: %s", version);
 
-        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: _proxies(), _isProxy: true });
+        ChainAssertions.checkOptimismMintableERC20Factory({ _contracts: _proxies(), _vm: vm, _isProxy: true });
     }
 
     /// @notice initializeL1CrossDomainMessenger
@@ -992,6 +993,7 @@ contract Deploy is Deployer {
             _contracts: _proxies(),
             _cfg: cfg,
             _l2OutputOracleStartingTimestamp: cfg.l2OutputOracleStartingTimestamp(),
+            _vm: vm,
             _isProxy: true
         });
 
@@ -1024,7 +1026,7 @@ contract Deploy is Deployer {
         string memory version = portal.version();
         console.log("OptimismPortal version: %s", version);
 
-        ChainAssertions.checkOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
+        ChainAssertions.checkOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _vm: vm, _isProxy: true });
 
         require(loadInitializedSlot("OptimismPortalProxy") == 1, "OptimismPortalProxy is not initialized");
     }
@@ -1086,7 +1088,7 @@ contract Deploy is Deployer {
         string memory version = versions.version();
         console.log("ProtocolVersions version: %s", version);
 
-        ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isProxy: true });
+        ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _vm: vm, _isProxy: true });
 
         require(loadInitializedSlot("ProtocolVersionsProxy") == 1, "ProtocolVersionsProxy is not initialized");
     }

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -529,8 +529,6 @@ contract Deploy is Deployer {
         contracts.L1CrossDomainMessenger = address(messenger);
         ChainAssertions.checkL1CrossDomainMessenger({ _contracts: contracts, _vm: vm, _isProxy: false });
 
-        require(loadInitializedSlot("L1CrossDomainMessenger") == 1, "L1CrossDomainMessenger is not initialized");
-
         addr_ = address(messenger);
     }
 
@@ -549,8 +547,6 @@ contract Deploy is Deployer {
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.OptimismPortal = address(portal);
         ChainAssertions.checkOptimismPortal({ _contracts: contracts, _cfg: cfg, _isProxy: false });
-
-        require(loadInitializedSlot("OptimismPortal") == 1, "OptimismPortal is not initialized");
 
         addr_ = address(portal);
     }
@@ -580,8 +576,6 @@ contract Deploy is Deployer {
         contracts.OptimismPortal2 = address(portal);
         ChainAssertions.checkOptimismPortal2({ _contracts: contracts, _cfg: cfg, _isProxy: false });
 
-        require(loadInitializedSlot("OptimismPortal2") == 1, "OptimismPortal2 is not initialized");
-
         addr_ = address(portal);
     }
 
@@ -604,8 +598,6 @@ contract Deploy is Deployer {
             _l2OutputOracleStartingTimestamp: 0,
             _isProxy: false
         });
-
-        require(loadInitializedSlot("L2OutputOracle") == 1, "L2OutputOracle is not initialized");
 
         addr_ = address(oracle);
     }
@@ -654,8 +646,6 @@ contract Deploy is Deployer {
         contracts.ProtocolVersions = address(versions);
         ChainAssertions.checkProtocolVersions({ _contracts: contracts, _cfg: cfg, _isProxy: false });
 
-        require(loadInitializedSlot("ProtocolVersions") == 1, "ProtocolVersions is not initialized");
-
         addr_ = address(versions);
     }
 
@@ -697,8 +687,6 @@ contract Deploy is Deployer {
         Types.ContractSet memory contracts = _proxiesUnstrict();
         contracts.SystemConfig = address(config);
         ChainAssertions.checkSystemConfig({ _contracts: contracts, _cfg: cfg, _isProxy: false });
-
-        require(loadInitializedSlot("SystemConfig") == 1, "SystemConfig is not initialized");
 
         addr_ = address(config);
     }
@@ -829,8 +817,6 @@ contract Deploy is Deployer {
         console.log("SystemConfig version: %s", version);
 
         ChainAssertions.checkSystemConfig({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
-
-        require(loadInitializedSlot("SystemConfigProxy") == 1, "SystemConfigProxy is not initialized");
     }
 
     /// @notice Initialize the L1StandardBridge
@@ -955,10 +941,6 @@ contract Deploy is Deployer {
         console.log("L1CrossDomainMessenger version: %s", version);
 
         ChainAssertions.checkL1CrossDomainMessenger({ _contracts: _proxies(), _vm: vm, _isProxy: true });
-
-        require(
-            loadInitializedSlot("L1CrossDomainMessengerProxy") == 1, "L1CrossDomainMessengerProxy is not initialized"
-        );
     }
 
     /// @notice Initialize the L2OutputOracle
@@ -994,8 +976,6 @@ contract Deploy is Deployer {
             _l2OutputOracleStartingTimestamp: cfg.l2OutputOracleStartingTimestamp(),
             _isProxy: true
         });
-
-        require(loadInitializedSlot("L2OutputOracleProxy") == 1, "L2OutputOracleProxy is not initialized");
     }
 
     /// @notice Initialize the OptimismPortal
@@ -1025,8 +1005,6 @@ contract Deploy is Deployer {
         console.log("OptimismPortal version: %s", version);
 
         ChainAssertions.checkOptimismPortal({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
-
-        require(loadInitializedSlot("OptimismPortalProxy") == 1, "OptimismPortalProxy is not initialized");
     }
 
     /// @notice Initialize the OptimismPortal2
@@ -1056,8 +1034,6 @@ contract Deploy is Deployer {
         console.log("OptimismPortal2 version: %s", version);
 
         ChainAssertions.checkOptimismPortal2({ _contracts: _proxies(), _cfg: cfg, _isProxy: true });
-
-        require(loadInitializedSlot("OptimismPortalProxy") == 1, "OptimismPortalProxy is not initialized");
     }
 
     function initializeProtocolVersions() public broadcast {
@@ -1087,8 +1063,6 @@ contract Deploy is Deployer {
         console.log("ProtocolVersions version: %s", version);
 
         ChainAssertions.checkProtocolVersions({ _contracts: _proxiesUnstrict(), _cfg: cfg, _isProxy: true });
-
-        require(loadInitializedSlot("ProtocolVersionsProxy") == 1, "ProtocolVersionsProxy is not initialized");
     }
 
     /// @notice Transfer ownership of the DisputeGameFactory contract to the final system owner

--- a/packages/contracts-bedrock/snapshots/state-diff/Kontrol-Deploy.json
+++ b/packages/contracts-bedrock/snapshots/state-diff/Kontrol-Deploy.json
@@ -10881,32 +10881,6 @@
       "value": 0
     },
     {
-      "accessor": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
-      "account": "0xBb2180ebd78ce97360503434eD37fcf4a1Df61c3",
-      "chainInfo": {
-        "chainId": 31337,
-        "forkId": 0
-      },
-      "data": "0xbf40fac10000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a4f564d5f4c3143726f7373446f6d61696e4d657373656e676572000000000000",
-      "deployedCode": "0x",
-      "initialized": true,
-      "kind": "StaticCall",
-      "newBalance": 0,
-      "oldBalance": 0,
-      "reverted": false,
-      "storageAccesses": [
-        {
-          "account": "0xBb2180ebd78ce97360503434eD37fcf4a1Df61c3",
-          "isWrite": false,
-          "newValue": "0x00000000000000000000000071fa82ea96672797954c28032b337aa40aafc99f",
-          "previousValue": "0x00000000000000000000000071fa82ea96672797954c28032b337aa40aafc99f",
-          "reverted": false,
-          "slot": "0x515216935740e67dfdda5cf8e248ea32b3277787818ab59153061ac875c9385e"
-        }
-      ],
-      "value": 0
-    },
-    {
       "accessor": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
       "account": "0x7109709ECfa91a80626fF3989D68f67F5b1DD12D",
       "chainInfo": {


### PR DESCRIPTION
Add checks to the ChainAssertions lib that directly read (`vm.load()`) the `initialized` boolean value and ensure its set to `true`.