### PR TITLE
fix(op-challenger): Bond Claim Scheduler Tests

### DIFF
--- a/op-challenger/game/fault/claims/scheduler_test.go
+++ b/op-challenger/game/fault/claims/scheduler_test.go
@@ -1,0 +1,98 @@
+package claims
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+var mockClaimError = errors.New("mock claim error")
+
+func TestBondClaimScheduler_Schedule(t *testing.T) {
+	tests := []struct {
+		name                string
+		claimErr            error
+		games               []types.GameMetadata
+		expectedMetricCalls int
+		expectedClaimCalls  int
+	}{
+		{
+			name:                "SingleGame_Succeeds",
+			games:               []types.GameMetadata{{}},
+			expectedMetricCalls: 0,
+			expectedClaimCalls:  1,
+		},
+		{
+			name:                "SingleGame_Fails",
+			claimErr:            mockClaimError,
+			games:               []types.GameMetadata{{}},
+			expectedMetricCalls: 1,
+			expectedClaimCalls:  1,
+		},
+		{
+			name:                "MultipleGames_Succeed",
+			games:               []types.GameMetadata{{}, {}, {}},
+			expectedMetricCalls: 0,
+			expectedClaimCalls:  1,
+		},
+		{
+			name:                "MultipleGames_Fails",
+			claimErr:            mockClaimError,
+			games:               []types.GameMetadata{{}, {}, {}},
+			expectedMetricCalls: 1,
+			expectedClaimCalls:  1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheduler, metrics, claimer := setupTestBondClaimScheduler(t)
+			claimer.claimErr = test.claimErr
+			scheduler.Start(ctx)
+			defer scheduler.Close()
+
+			err := scheduler.Schedule(1, test.games)
+			require.NoError(t, err)
+			require.Eventually(t, func() bool {
+				return claimer.claimCalls == test.expectedClaimCalls
+			}, 10*time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool {
+				return metrics.failedCalls == test.expectedMetricCalls
+			}, 10*time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
+func setupTestBondClaimScheduler(t *testing.T) (*BondClaimScheduler, *stubMetrics, *stubClaimer) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	metrics := &stubMetrics{}
+	claimer := &stubClaimer{}
+	scheduler := NewBondClaimScheduler(logger, metrics, claimer)
+	return scheduler, metrics, claimer
+}
+
+type stubMetrics struct {
+	failedCalls int
+}
+
+func (s *stubMetrics) RecordBondClaimFailed() {
+	s.failedCalls++
+}
+
+type stubClaimer struct {
+	claimCalls int
+	claimErr   error
+}
+
+func (s *stubClaimer) ClaimBonds(ctx context.Context, games []types.GameMetadata) error {
+	s.claimCalls++
+	return s.claimErr
+}


### PR DESCRIPTION
**Description**

Adds forgotten testing for the `op-challenger` bond claim scheduler.

Follows convention set by the large preimage scheduler testing.

This is a precursor to refactoring out the scheduler into a reusable component as specified in https://github.com/ethereum-optimism/client-pod/issues/522
