### PR TITLE
ci: Add better name for shellcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1622,6 +1622,7 @@ workflows:
       - cannon-build-test-vectors
       - kontrol-tests
       - shellcheck/check:
+          name: shell-check
           # We don't need the `exclude` key as the orb detects the `.shellcheckrc`
           dir: .
           ignore-dirs:


### PR DESCRIPTION
**Description**

Add a name to shellcheck so it doesn't just appear as `check`.