### PR TITLE
chore: Add warning if npm token is not set in changeset workflow

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -29,6 +29,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Verify NPM Token is valid
+        run: npm whoami
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish snapshots
         uses: seek-oss/changesets-snapshot@v0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,22 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Check if NPM_TOKEN is set
+        id: check_token
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "NPM_TOKEN is not set. Is it set it in your repository secrets?"
+            exit 1
+          fi
+        shell: bash
+
       - name: Set deployment token
         run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify NPM Token is valid
+        run: npm whoami
 
       # Makes a pr to publish the changesets that when
       # merged will publish to npm


### PR DESCRIPTION
chnageset publishing is failing and it's not clear if npm token is set. This pr adds a step to the workflow to validate that the npm token exists

This is useful to merge generally because without this you get a really confusing error message (404 instead of 401) but I will be testing this in a workflow_dispatch before it merges
