### PR TITLE
fix(bootnode): disable req/response sync on bootnode p2p

### DIFF
--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -37,7 +37,7 @@ func (g *gossipConfig) P2PSequencerAddress() common.Address {
 type l2Chain struct{}
 
 func (l *l2Chain) PayloadByNumber(_ context.Context, _ uint64) (*eth.ExecutionPayloadEnvelope, error) {
-	return nil, nil
+	return nil, errors.New("P2P req/resp is not supported in bootnodes")
 }
 
 func Main(cliCtx *cli.Context) error {
@@ -59,6 +59,10 @@ func Main(cliCtx *cli.Context) error {
 	p2pConfig, err := p2pcli.NewConfig(cliCtx, config)
 	if err != nil {
 		return fmt.Errorf("failed to load p2p config: %w", err)
+	}
+	if p2pConfig.EnableReqRespSync {
+		logger.Warn("req-resp sync is enabled, bootnode does not support this feature")
+		p2pConfig.EnableReqRespSync = false
 	}
 
 	p2pNode, err := p2p.NewNodeP2P(ctx, config, logger, p2pConfig, &gossipNoop{}, &l2Chain{}, &gossipConfig{}, m, false)


### PR DESCRIPTION
**Description**

We noticed a lot of panics in our production bootnode logs due to nil pointer errors. This happens due to following:

1. When request/response sync is enabled it would [setup a client & server for the request response flow](https://github.com/ethereum-optimism/optimism/blob/8beb1d76e6984553b87de1db06b8a471d7eeb9a0/op-node/p2p/node.go#L108-L132) 
2. The server would receive a sync request, and then use the stubbed l2 client to lookup the [payload by number](https://github.com/ethereum-optimism/optimism/blob/705db877a211826e3cdb35eedb0b22c9275ab539/op-node/p2p/sync.go#L817)
3. This will return a nil error and then attempt to [write the nil payload](https://github.com/ethereum-optimism/optimism/blob/705db877a211826e3cdb35eedb0b22c9275ab539/op-node/p2p/sync.go#L831).

This PR forces request/response to be disabled -- as the bootnode doesn't support it (and logs a warning if this is not the case). It also updates the stub `PayloadByNumber` method to return an unsupported error to ensure that if it's used anywhere else, the caller will receive an error vs. panicing.