### PR TITLE
Revert "Finish conductor rpc e2e tests (#8929)"

### DIFF
--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -405,7 +405,7 @@ func (oc *OpConductor) Leader(_ context.Context) bool {
 }
 
 // LeaderWithID returns the current leader's server ID and address.
-func (oc *OpConductor) LeaderWithID(_ context.Context) *consensus.ServerInfo {
+func (oc *OpConductor) LeaderWithID(_ context.Context) (string, string) {
 	return oc.cons.LeaderWithID()
 }
 
@@ -442,16 +442,6 @@ func (oc *OpConductor) CommitUnsafePayload(_ context.Context, payload *eth.Execu
 // SequencerHealthy returns true if sequencer is healthy.
 func (oc *OpConductor) SequencerHealthy(_ context.Context) bool {
 	return oc.healthy.Load()
-}
-
-// ClusterMembership returns current cluster's membership information.
-func (oc *OpConductor) ClusterMembership(_ context.Context) ([]*consensus.ServerInfo, error) {
-	return oc.cons.ClusterMembership()
-}
-
-// LatestUnsafePayload returns the latest unsafe payload envelope from FSM.
-func (oc *OpConductor) LatestUnsafePayload(_ context.Context) *eth.ExecutionPayloadEnvelope {
-	return oc.cons.LatestUnsafePayload()
 }
 
 func (oc *OpConductor) loop() {

--- a/op-conductor/consensus/iface.go
+++ b/op-conductor/consensus/iface.go
@@ -4,34 +4,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// ServerSuffrage determines whether a Server in a Configuration gets a vote.
-type ServerSuffrage int
-
-const (
-	// Voter is a server whose vote is counted in elections.
-	Voter ServerSuffrage = iota
-	// Nonvoter is a server that receives log entries but is not considered for
-	// elections or commitment purposes.
-	Nonvoter
-)
-
-func (s ServerSuffrage) String() string {
-	switch s {
-	case Voter:
-		return "Voter"
-	case Nonvoter:
-		return "Nonvoter"
-	}
-	return "ServerSuffrage"
-}
-
-// ServerInfo defines the server information.
-type ServerInfo struct {
-	ID       string         `json:"id"`
-	Addr     string         `json:"addr"`
-	Suffrage ServerSuffrage `json:"suffrage"`
-}
-
 // Consensus defines the consensus interface for leadership election.
 //
 //go:generate mockery --name Consensus --output mocks/ --with-expecter=true
@@ -49,15 +21,13 @@ type Consensus interface {
 	// Leader returns if it is the leader of the cluster.
 	Leader() bool
 	// LeaderWithID returns the leader's server ID and address.
-	LeaderWithID() *ServerInfo
+	LeaderWithID() (string, string)
 	// ServerID returns the server ID of the consensus.
 	ServerID() string
 	// TransferLeader triggers leadership transfer to another member in the cluster.
 	TransferLeader() error
 	// TransferLeaderTo triggers leadership transfer to a specific member in the cluster.
 	TransferLeaderTo(id, addr string) error
-	// ClusterMembership returns the current cluster membership configuration.
-	ClusterMembership() ([]*ServerInfo, error)
 
 	// CommitPayload commits latest unsafe payload to the FSM.
 	CommitUnsafePayload(payload *eth.ExecutionPayloadEnvelope) error

--- a/op-conductor/consensus/mocks/Consensus.go
+++ b/op-conductor/consensus/mocks/Consensus.go
@@ -3,9 +3,7 @@
 package mocks
 
 import (
-	consensus "github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	eth "github.com/ethereum-optimism/optimism/op-service/eth"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -112,63 +110,6 @@ func (_c *Consensus_AddVoter_Call) Return(_a0 error) *Consensus_AddVoter_Call {
 }
 
 func (_c *Consensus_AddVoter_Call) RunAndReturn(run func(string, string) error) *Consensus_AddVoter_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ClusterMembership provides a mock function with given fields:
-func (_m *Consensus) ClusterMembership() ([]*consensus.ServerInfo, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ClusterMembership")
-	}
-
-	var r0 []*consensus.ServerInfo
-	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]*consensus.ServerInfo, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() []*consensus.ServerInfo); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*consensus.ServerInfo)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Consensus_ClusterMembership_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClusterMembership'
-type Consensus_ClusterMembership_Call struct {
-	*mock.Call
-}
-
-// ClusterMembership is a helper method to define mock.On call
-func (_e *Consensus_Expecter) ClusterMembership() *Consensus_ClusterMembership_Call {
-	return &Consensus_ClusterMembership_Call{Call: _e.mock.On("ClusterMembership")}
-}
-
-func (_c *Consensus_ClusterMembership_Call) Run(run func()) *Consensus_ClusterMembership_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *Consensus_ClusterMembership_Call) Return(_a0 []*consensus.ServerInfo, _a1 error) *Consensus_ClusterMembership_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Consensus_ClusterMembership_Call) RunAndReturn(run func() ([]*consensus.ServerInfo, error)) *Consensus_ClusterMembership_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -405,23 +346,31 @@ func (_c *Consensus_LeaderCh_Call) RunAndReturn(run func() <-chan bool) *Consens
 }
 
 // LeaderWithID provides a mock function with given fields:
-func (_m *Consensus) LeaderWithID() *consensus.ServerInfo {
+func (_m *Consensus) LeaderWithID() (string, string) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for LeaderWithID")
 	}
 
-	var r0 *consensus.ServerInfo
-	if rf, ok := ret.Get(0).(func() *consensus.ServerInfo); ok {
+	var r0 string
+	var r1 string
+	if rf, ok := ret.Get(0).(func() (string, string)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*consensus.ServerInfo)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func() string); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
 }
 
 // Consensus_LeaderWithID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LeaderWithID'
@@ -441,12 +390,12 @@ func (_c *Consensus_LeaderWithID_Call) Run(run func()) *Consensus_LeaderWithID_C
 	return _c
 }
 
-func (_c *Consensus_LeaderWithID_Call) Return(_a0 *consensus.ServerInfo) *Consensus_LeaderWithID_Call {
-	_c.Call.Return(_a0)
+func (_c *Consensus_LeaderWithID_Call) Return(_a0 string, _a1 string) *Consensus_LeaderWithID_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Consensus_LeaderWithID_Call) RunAndReturn(run func() *consensus.ServerInfo) *Consensus_LeaderWithID_Call {
+func (_c *Consensus_LeaderWithID_Call) RunAndReturn(run func() (string, string)) *Consensus_LeaderWithID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/op-conductor/consensus/raft.go
+++ b/op-conductor/consensus/raft.go
@@ -145,13 +145,9 @@ func (rc *RaftConsensus) Leader() bool {
 }
 
 // LeaderWithID implements Consensus, it returns the leader's server ID and address.
-func (rc *RaftConsensus) LeaderWithID() *ServerInfo {
+func (rc *RaftConsensus) LeaderWithID() (string, string) {
 	addr, id := rc.r.LeaderWithID()
-	return &ServerInfo{
-		ID:       string(id),
-		Addr:     string(addr),
-		Suffrage: Voter, // leader will always be Voter
-	}
+	return string(id), string(addr)
 }
 
 // LeaderCh implements Consensus, it returns a channel that will be notified when leadership status changes (true = leader, false = follower).
@@ -224,22 +220,4 @@ func (rc *RaftConsensus) CommitUnsafePayload(payload *eth.ExecutionPayloadEnvelo
 func (rc *RaftConsensus) LatestUnsafePayload() *eth.ExecutionPayloadEnvelope {
 	payload := rc.unsafeTracker.UnsafeHead()
 	return payload
-}
-
-// ClusterMembership implements Consensus, it returns the current cluster membership configuration.
-func (rc *RaftConsensus) ClusterMembership() ([]*ServerInfo, error) {
-	var future raft.ConfigurationFuture
-	if future = rc.r.GetConfiguration(); future.Error() != nil {
-		return nil, future.Error()
-	}
-
-	var servers []*ServerInfo
-	for _, srv := range future.Configuration().Servers {
-		servers = append(servers, &ServerInfo{
-			ID:       string(srv.ID),
-			Addr:     string(srv.Address),
-			Suffrage: ServerSuffrage(srv.Suffrage),
-		})
-	}
-	return servers, nil
 }

--- a/op-conductor/rpc/api.go
+++ b/op-conductor/rpc/api.go
@@ -6,12 +6,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var ErrNotLeader = errors.New("refusing to proxy request to non-leader sequencer")
+
+type ServerInfo struct {
+	ID   string `json:"id"`
+	Addr string `json:"addr"`
+}
 
 // API defines the interface for the op-conductor API.
 type API interface {
@@ -26,7 +30,7 @@ type API interface {
 	// Leader returns true if the server is the leader.
 	Leader(ctx context.Context) (bool, error)
 	// LeaderWithID returns the current leader's server info.
-	LeaderWithID(ctx context.Context) (*consensus.ServerInfo, error)
+	LeaderWithID(ctx context.Context) (*ServerInfo, error)
 	// AddServerAsVoter adds a server as a voter to the cluster.
 	AddServerAsVoter(ctx context.Context, id string, addr string) error
 	// AddServerAsNonvoter adds a server as a non-voter to the cluster. non-voter will not participate in leader election.
@@ -37,8 +41,6 @@ type API interface {
 	TransferLeader(ctx context.Context) error
 	// TransferLeaderToServer transfers leadership to a specific server.
 	TransferLeaderToServer(ctx context.Context, id string, addr string) error
-	// ClusterMembership returns the current cluster membership configuration.
-	ClusterMembership(ctx context.Context) ([]*consensus.ServerInfo, error)
 
 	// APIs called by op-node
 	// Active returns true if op-conductor is active.

--- a/op-conductor/rpc/backend.go
+++ b/op-conductor/rpc/backend.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -17,14 +16,13 @@ type conductor interface {
 	SequencerHealthy(ctx context.Context) bool
 
 	Leader(ctx context.Context) bool
-	LeaderWithID(ctx context.Context) *consensus.ServerInfo
+	LeaderWithID(ctx context.Context) (string, string)
 	AddServerAsVoter(ctx context.Context, id string, addr string) error
 	AddServerAsNonvoter(ctx context.Context, id string, addr string) error
 	RemoveServer(ctx context.Context, id string) error
 	TransferLeader(ctx context.Context) error
 	TransferLeaderToServer(ctx context.Context, id string, addr string) error
 	CommitUnsafePayload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error
-	ClusterMembership(ctx context.Context) ([]*consensus.ServerInfo, error)
 }
 
 // APIBackend is the backend implementation of the API.
@@ -71,8 +69,12 @@ func (api *APIBackend) Leader(ctx context.Context) (bool, error) {
 }
 
 // LeaderWithID implements API, returns the leader's server ID and address (not necessarily the current conductor).
-func (api *APIBackend) LeaderWithID(ctx context.Context) (*consensus.ServerInfo, error) {
-	return api.con.LeaderWithID(ctx), nil
+func (api *APIBackend) LeaderWithID(ctx context.Context) (*ServerInfo, error) {
+	id, addr := api.con.LeaderWithID(ctx)
+	return &ServerInfo{
+		ID:   id,
+		Addr: addr,
+	}, nil
 }
 
 // Pause implements API.
@@ -90,14 +92,12 @@ func (api *APIBackend) Resume(ctx context.Context) error {
 	return api.con.Resume(ctx)
 }
 
-// TransferLeader implements API. With Raft implementation, a successful call does not mean that leadership transfer is complete
-// It just means that leadership transfer is in progress (current leader has initiated a new leader election round and stepped down as leader)
+// TransferLeader implements API.
 func (api *APIBackend) TransferLeader(ctx context.Context) error {
 	return api.con.TransferLeader(ctx)
 }
 
-// TransferLeaderToServer implements API. With Raft implementation, a successful call does not mean that leadership transfer is complete
-// It just means that leadership transfer is in progress (current leader has initiated a new leader election round and stepped down as leader)
+// TransferLeaderToServer implements API.
 func (api *APIBackend) TransferLeaderToServer(ctx context.Context, id string, addr string) error {
 	return api.con.TransferLeaderToServer(ctx, id, addr)
 }
@@ -105,9 +105,4 @@ func (api *APIBackend) TransferLeaderToServer(ctx context.Context, id string, ad
 // SequencerHealthy implements API.
 func (api *APIBackend) SequencerHealthy(ctx context.Context) (bool, error) {
 	return api.con.SequencerHealthy(ctx), nil
-}
-
-// ClusterMembership implements API.
-func (api *APIBackend) ClusterMembership(ctx context.Context) ([]*consensus.ServerInfo, error) {
-	return api.con.ClusterMembership(ctx)
 }

--- a/op-conductor/rpc/client.go
+++ b/op-conductor/rpc/client.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -62,8 +61,8 @@ func (c *APIClient) Leader(ctx context.Context) (bool, error) {
 }
 
 // LeaderWithID implements API.
-func (c *APIClient) LeaderWithID(ctx context.Context) (*consensus.ServerInfo, error) {
-	var info *consensus.ServerInfo
+func (c *APIClient) LeaderWithID(ctx context.Context) (*ServerInfo, error) {
+	var info *ServerInfo
 	err := c.c.CallContext(ctx, &info, prefixRPC("leaderWithID"))
 	return info, err
 }
@@ -98,11 +97,4 @@ func (c *APIClient) SequencerHealthy(ctx context.Context) (bool, error) {
 	var healthy bool
 	err := c.c.CallContext(ctx, &healthy, prefixRPC("sequencerHealthy"))
 	return healthy, err
-}
-
-// ClusterMembership implements API.
-func (c *APIClient) ClusterMembership(ctx context.Context) ([]*consensus.ServerInfo, error) {
-	var info []*consensus.ServerInfo
-	err := c.c.CallContext(ctx, &info, prefixRPC("clusterMembership"))
-	return info, err
 }

--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -299,44 +299,24 @@ func sequencerCfg(rpcPort int) *rollupNode.Config {
 	}
 }
 
-func waitFor(t *testing.T, duration time.Duration, condition func() bool) error {
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
+func waitForLeadershipChange(t *testing.T, c *conductor, leader bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if condition() {
+			isLeader, err := c.client.Leader(ctx)
+			if err != nil {
+				return err
+			}
+			if isLeader == leader {
 				return nil
 			}
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-}
-
-func waitForLeadershipChange(t *testing.T, c *conductor, leader bool) error {
-	condiction := func() bool {
-		isLeader, err := c.client.Leader(context.Background())
-		if err != nil {
-			return false
-		}
-		return isLeader == leader
-	}
-
-	return waitFor(t, 10*time.Second, condiction)
-}
-
-func waitForSequencerStatusChange(t *testing.T, rollupClient *sources.RollupClient, active bool) error {
-	condiction := func() bool {
-		isActive, err := rollupClient.SequencerActive(context.Background())
-		if err != nil {
-			return false
-		}
-		return isActive == active
-	}
-
-	return waitFor(t, 5*time.Second, condiction)
 }
 
 func leader(t *testing.T, ctx context.Context, con *conductor) bool {
@@ -386,15 +366,6 @@ func findAvailablePort(t *testing.T) int {
 func findLeader(t *testing.T, conductors map[string]*conductor) (string, *conductor) {
 	for id, con := range conductors {
 		if leader(t, context.Background(), con) {
-			return id, con
-		}
-	}
-	return "", nil
-}
-
-func findFollower(t *testing.T, conductors map[string]*conductor) (string, *conductor) {
-	for id, con := range conductors {
-		if !leader(t, context.Background(), con) {
 			return id, con
 		}
 	}

--- a/op-e2e/sequencer_failover_test.go
+++ b/op-e2e/sequencer_failover_test.go
@@ -1,13 +1,9 @@
 package op_e2e
 
 import (
-	"context"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 )
 
 // [Category: Initial Setup]
@@ -20,125 +16,4 @@ func TestSequencerFailover_SetupCluster(t *testing.T) {
 	for _, con := range conductors {
 		require.NotNil(t, con, "Expected conductor to be non-nil")
 	}
-}
-
-// [Category: conductor rpc]
-// In this test, we test all rpcs exposed by conductor.
-func TestSequencerFailover_ConductorRPC(t *testing.T) {
-	ctx := context.Background()
-	sys, conductors := setupSequencerFailoverTest(t)
-	defer sys.Close()
-
-	// SequencerHealthy, Leader, AddServerAsVoter are used in setup already.
-
-	// Test ClusterMembership
-	t.Log("Testing ClusterMembership")
-	c1 := conductors[Sequencer1Name]
-	c2 := conductors[Sequencer2Name]
-	c3 := conductors[Sequencer3Name]
-	membership, err := c1.client.ClusterMembership(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(membership), "Expected 3 members in cluster")
-	ids := make([]string, 0)
-	for _, member := range membership {
-		ids = append(ids, member.ID)
-		require.Equal(t, consensus.Voter, member.Suffrage, "Expected all members to be voters")
-	}
-	sort.Strings(ids)
-	require.Equal(t, []string{Sequencer1Name, Sequencer2Name, Sequencer3Name}, ids, "Expected all sequencers to be in cluster")
-
-	// Test Active & Pause & Resume
-	t.Log("Testing Active & Pause & Resume")
-	active, err := c1.client.Active(ctx)
-	require.NoError(t, err)
-	require.True(t, active, "Expected conductor to be active")
-
-	err = c1.client.Pause(ctx)
-	require.NoError(t, err)
-	active, err = c1.client.Active(ctx)
-	require.NoError(t, err)
-	require.False(t, active, "Expected conductor to be paused")
-
-	err = c1.client.Resume(ctx)
-	require.NoError(t, err)
-	active, err = c1.client.Active(ctx)
-	require.NoError(t, err)
-	require.True(t, active, "Expected conductor to be active")
-
-	// Test LeaderWithID
-	t.Log("Testing LeaderWithID")
-	leader1, err := c1.client.LeaderWithID(ctx)
-	require.NoError(t, err)
-	leader2, err := c2.client.LeaderWithID(ctx)
-	require.NoError(t, err)
-	leader3, err := c3.client.LeaderWithID(ctx)
-	require.NoError(t, err)
-	require.Equal(t, leader1.ID, leader2.ID, "Expected leader ID to be the same")
-	require.Equal(t, leader1.ID, leader3.ID, "Expected leader ID to be the same")
-
-	// Test TransferLeader & TransferLeaderToServer
-	t.Log("Testing TransferLeader")
-	lid, leader := findLeader(t, conductors)
-	err = leader.client.TransferLeader(ctx)
-	require.NoError(t, err, "Expected leader to transfer leadership")
-	require.NoError(t, waitForLeadershipChange(t, leader, false))
-	newLeader, err := leader.client.LeaderWithID(ctx)
-	require.NoError(t, err)
-	isLeader, err := leader.client.Leader(ctx)
-	require.NoError(t, err)
-	require.False(t, isLeader, "Expected leader to transfer leadership")
-	require.NotEqual(t, lid, newLeader.ID, "Expected leader to change")
-	require.NoError(t, waitForSequencerStatusChange(t, sys.RollupClient(newLeader.ID), true))
-
-	// old leader now became follower, we're trying to transfer leadership directly back to it.
-	t.Log("Testing TransferLeaderToServer")
-	fid, follower := lid, leader
-	_, leader = findLeader(t, conductors)
-	err = leader.client.TransferLeaderToServer(ctx, fid, follower.ConsensusEndpoint())
-	require.NoError(t, err, "Expected leader to transfer leadership to follower")
-	require.NoError(t, waitForLeadershipChange(t, follower, true))
-	require.NoError(t, waitForSequencerStatusChange(t, sys.RollupClient(fid), true))
-	leader = follower
-
-	// Test AddServerAsNonvoter, do not start a new sequencer just for this purpose, use Sequencer3's rpc to start conductor.
-	// This is fine as this mainly tests conductor's ability to add itself into the raft consensus cluster as a nonvoter.
-	t.Log("Testing AddServerAsNonvoter")
-	nonvoter := setupConductor(
-		t, VerifierName, t.TempDir(),
-		sys.RollupEndpoint(Sequencer3Name),
-		sys.NodeEndpoint(Sequencer3Name),
-		findAvailablePort(t),
-		false,
-		*sys.RollupConfig,
-	)
-
-	err = leader.client.AddServerAsNonvoter(ctx, VerifierName, nonvoter.ConsensusEndpoint())
-	require.NoError(t, err, "Expected leader to add non-voter")
-	membership, err = leader.client.ClusterMembership(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 4, len(membership), "Expected 4 members in cluster")
-	require.Equal(t, consensus.Nonvoter, membership[3].Suffrage, "Expected last member to be non-voter")
-
-	t.Log("Testing RemoveServer")
-	lid, leader = findLeader(t, conductors)
-	fid, follower = findFollower(t, conductors)
-	err = follower.client.RemoveServer(ctx, lid)
-	require.ErrorContains(t, err, "node is not the leader", "Expected follower to fail to remove leader")
-	membership, err = c1.client.ClusterMembership(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 4, len(membership), "Expected 4 members in cluster")
-
-	err = leader.client.RemoveServer(ctx, VerifierName)
-	require.NoError(t, err, "Expected leader to remove non-voter")
-	membership, err = c1.client.ClusterMembership(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(membership), "Expected 2 members in cluster after removal")
-	require.NotContains(t, membership, VerifierName, "Expected follower to be removed from cluster")
-
-	err = leader.client.RemoveServer(ctx, fid)
-	require.NoError(t, err, "Expected leader to remove follower")
-	membership, err = c1.client.ClusterMembership(ctx)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(membership), "Expected 2 members in cluster after removal")
-	require.NotContains(t, membership, fid, "Expected follower to be removed from cluster")
 }


### PR DESCRIPTION
**Description**

This reverts commit 8beb1d76e6984553b87de1db06b8a471d7eeb9a0.

The new test added is causing regular panics in CI:

```
--- FAIL: TestSequencerFailover_ConductorRPC (16.80s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x19a88ee]

goroutine 4686 [running]:
testing.tRunner.func1.2({0x1d15f20, 0x38d5cd0})
	/usr/local/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1548 +0x397
panic({0x1d15f20?, 0x38d5cd0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/ethereum-optimism/optimism/op-node/node.(*OpNode).HTTPEndpoint(0x1ceb720?)
	/root/project/op-node/node/node.go:695 +0xe
github.com/ethereum-optimism/optimism/op-e2e.(*System).RollupEndpoint(...)
	/root/project/op-e2e/setup.go:301
github.com/ethereum-optimism/optimism/op-e2e.(*System).RollupClient(0xc00df12000, {0x0, 0x0})
	/root/project/op-e2e/setup.go:310 +0x145
github.com/ethereum-optimism/optimism/op-e2e.TestSequencerFailover_ConductorRPC(0xc000cccb60)
	/root/project/op-e2e/sequencer_failover_test.go:91 +0xc65
testing.tRunner(0xc000cccb60, 0x266a6e0)
	/usr/local/go/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1648 +0x3ad
exit status 2
```
https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/43284/workflows/71c863d4-8784-4114-96d3-e0f81cc43f31/jobs/1922749/tests
