### PR TITLE
chore(ci): Run `kontrol-tests` on a scheduled job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1330,16 +1330,6 @@ jobs:
     steps:
       - checkout
       - run:
-          # This is a workaround for how check-changed doesn't work in
-          # the merge queue. By running this check the kontrol tests will
-          # run on PR builds and on develop, but not the merge queue.
-          name: Ensure PR/develop
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" != "develop" ]; then
-              echo "Not a PR or develop branch, skipping kontrol tests"
-              circleci step halt
-            fi
-      - run:
           name: Checkout Submodule
           command: make submodules
       - check-changed:
@@ -1352,6 +1342,7 @@ jobs:
           working_directory: ./packages/contracts-bedrock
       - store_artifacts:
           path: ./packages/contracts-bedrock/kontrol-results_latest.tar.gz
+      - notify-failures-on-develop
 
 workflows:
   main:
@@ -1620,7 +1611,6 @@ workflows:
       - check-generated-mocks-op-service
       - cannon-go-lint-and-test
       - cannon-build-test-vectors
-      - kontrol-tests
       - shellcheck/check:
           name: shell-check
           # We don't need the `exclude` key as the orb detects the `.shellcheckrc`
@@ -1852,6 +1842,14 @@ workflows:
           context:
             - slack
             - oplabs-fpp-nodes
+
+  scheduled-kontrol-tests:
+    when:
+      equal: [ build_six_hours, <<pipeline.schedule.name>> ]
+    jobs:
+      - kontrol-tests:
+          context:
+            - slack
 
   scheduled-docker-publish:
     when:


### PR DESCRIPTION
## Overview

Runs `kontrol-tests` on a scheduled job at a 6 hour interval rather than on every PR / `develop` merge that doesn't pass the check changed script. These tests take a huge amount of time to run.
