### PR TITLE
feat(ci): `NO_GO_DEPS` option for `check-changed`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,15 @@ commands:
       patterns:
         type: string
         description: "Comma-separated list of dependencies"
+      no_go_deps:
+        type: string
+        default: ""
+        description: "If set, does not trigger on `go.mod` / `go.sum` changes."
     steps:
       - run:
           name: "Check for changes"
+          environment:
+            CHECK_CHANGED_NO_GO_DEPS: "<<parameters.no_go_deps>>"
           command: |
             cd ops/check-changed
             pip3 install -r requirements.txt
@@ -1345,6 +1351,7 @@ jobs:
           name: Checkout Submodule
           command: make submodules
       - check-changed:
+          no_go_deps: "true"
           patterns: contracts-bedrock/test/kontrol,contracts-bedrock/src/L1/OptimismPortal\.sol,contracts-bedrock/src/L1/L1CrossDomainMessenger\.sol,contracts-bedrock/src/L1/L1ERC721Bridge\.sol,contracts-bedrock/src/L1/L1StandardBridge\.sol,contracts-bedrock/src/L1/ResourceMetering\.sol,contracts-bedrock/src/universal/StandardBridge\.sol,contracts-bedrock/src/universal/ERC721Bridge\.sol,contracts-bedrock/src/universal/CrossDomainMessenger\.sol
       - setup_remote_docker:
           docker_layer_caching: true

--- a/ops/check-changed/main.py
+++ b/ops/check-changed/main.py
@@ -12,13 +12,15 @@ REBUILD_ALL_PATTERNS = [
     r'^\.github/\.*',
     r'^package\.json',
     r'ops/check-changed/.*',
-    r'^go\.mod',
-    r'^go\.sum',
-    r'ops/check-changed/.*'
 ]
 with open("../../nx.json") as file:
     nx_json_data = json.load(file)
 REBUILD_ALL_PATTERNS += nx_json_data["implicitDependencies"].keys()
+
+GO_PATTERNS = [
+    r'^go\.mod',
+    r'^go\.sum',
+]
 
 WHITELISTED_BRANCHES = {
     'master',
@@ -55,8 +57,10 @@ log = logging.getLogger(__name__)
 
 
 def main():
-    patterns = sys.argv[1].split(',')
-    patterns = patterns + REBUILD_ALL_PATTERNS
+    patterns = sys.argv[1].split(',') + REBUILD_ALL_PATTERNS
+    no_go_deps = os.getenv('CHECK_CHANGED_NO_GO_DEPS')
+    if no_go_deps is None:
+        patterns = patterns + GO_PATTERNS
 
     fp = os.path.realpath(__file__)
     monorepo_path = os.path.realpath(os.path.join(fp, '..', '..'))


### PR DESCRIPTION
## Overview

Adds an option to the `check-changed` script to not trigger on `go.mod` / `go.sum` changes if the `CHECK_CHANGED_NO_GO_DEPS` environment variable is set.
