### PR TITLE
op-e2e: Move TestOutputCannonStepWithPreimage to executor 0

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -217,10 +217,9 @@ func TestOutputCannonDefendStep(t *testing.T) {
 }
 
 func TestOutputCannonStepWithPreimage(t *testing.T) {
-	executor := uint64(1) // Different executor to the other tests to help balance things better
-
+	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(outputCannonTestExecutor))
 	testPreimageStep := func(t *testing.T, preloadPreimage bool) {
-		op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(executor))
+		op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(outputCannonTestExecutor))
 
 		ctx := context.Background()
 		sys, l1Client := startFaultDisputeSystem(t)


### PR DESCRIPTION
**Description**

op-e2e: Move TestOutputCannonStepWithPreimage to executor and ensure it can run in parallel with other tests properly.
