### PR TITLE
deps: latest foundry

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "2335dea2e0d938d769a2b87947e79e02484a8c5a",
+  "foundry": "84d98427e17370ff08ec34f00e3c7e539753a760",
   "geth": "v1.13.4",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
**Description**

Updates foundry to the latest nightly release.

https://github.com/foundry-rs/foundry/releases/tag/nightly-84d98427e17370ff08ec34f00e3c7e539753a760

It includes https://github.com/foundry-rs/foundry/pull/6986 which will
help to make L2 genesis generation much more simple.

Reminder that we must always do releases of `ci-builder` using a nightly
foundry release that has not yet been pruned from github. When building
from source in `ci-builder`, there are issues at runtime. When
downloading the binary from github, there are no issues.

Will follow up with a release of `ci-builder` and then update the
version of `ci-builder` used in CI.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

