### PR TITLE
op-chain-ops: remove post process step

### DIFF
--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -1,7 +1,6 @@
 package genesis
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -44,7 +44,7 @@ func init() {
 // all of the state required for an Optimism network to function.
 // It is expected that the dump contains all of the required state to bootstrap
 // the L1 chain.
-func BuildL1DeveloperGenesis(config *DeployConfig, dump *gstate.Dump, l1Deployments *L1Deployments, postProcess bool) (*core.Genesis, error) {
+func BuildL1DeveloperGenesis(config *DeployConfig, dump *gstate.Dump, l1Deployments *L1Deployments) (*core.Genesis, error) {
 	log.Info("Building developer L1 genesis block")
 	genesis, err := NewL1Genesis(config)
 	if err != nil {

--- a/op-chain-ops/genesis/layer_one.go
+++ b/op-chain-ops/genesis/layer_one.go
@@ -79,49 +79,7 @@ func BuildL1DeveloperGenesis(config *DeployConfig, dump *gstate.Dump, l1Deployme
 				memDB.SetState(address, key, common.HexToHash(value))
 			}
 		}
-
-		// This should only be used if we are expecting Optimism specific state to be set
-		if postProcess {
-			if err := PostProcessL1DeveloperGenesis(memDB, l1Deployments); err != nil {
-				return nil, fmt.Errorf("failed to post process L1 developer genesis: %w", err)
-			}
-		}
 	}
 
 	return memDB.Genesis(), nil
-}
-
-// PostProcessL1DeveloperGenesis will apply post processing to the L1 genesis
-// state. This is required to handle edge cases in the genesis generation.
-// `block.number` is used during deployment and without specifically setting
-// the value to 0, it will cause underflow reverts for deposits in testing.
-func PostProcessL1DeveloperGenesis(stateDB *state.MemoryStateDB, deployments *L1Deployments) error {
-	log.Info("Post processing state")
-
-	if stateDB == nil {
-		return errors.New("cannot post process nil stateDB")
-	}
-	if deployments == nil {
-		return errors.New("cannot post process dump with nil deployments")
-	}
-
-	if !stateDB.Exist(deployments.OptimismPortalProxy) {
-		return fmt.Errorf("portal proxy doesn't exist at %s", deployments.OptimismPortalProxy)
-	}
-
-	layout, err := bindings.GetStorageLayout("OptimismPortal")
-	if err != nil {
-		return errors.New("failed to get storage layout for OptimismPortal")
-	}
-
-	entry, err := layout.GetStorageLayoutEntry("params")
-	if err != nil {
-		return errors.New("failed to get storage layout entry for OptimismPortal.params")
-	}
-	slot := common.BigToHash(big.NewInt(int64(entry.Slot)))
-
-	stateDB.SetState(deployments.OptimismPortalProxy, slot, common.Hash{})
-	log.Info("Post process update", "address", deployments.OptimismPortalProxy, "slot", slot.Hex(), "value", common.Hash{}.Hex())
-
-	return nil
 }

--- a/op-chain-ops/genesis/layer_one_test.go
+++ b/op-chain-ops/genesis/layer_one_test.go
@@ -43,7 +43,7 @@ func TestBuildL1DeveloperGenesis(t *testing.T) {
 	deployments, err := NewL1Deployments("testdata/deploy.json")
 	require.NoError(t, err)
 
-	genesis, err := BuildL1DeveloperGenesis(config, dump, nil, false)
+	genesis, err := BuildL1DeveloperGenesis(config, dump, nil)
 	require.NoError(t, err)
 
 	sim := backends.NewSimulatedBackend(

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -105,7 +105,7 @@ func Setup(t require.TestingT, deployParams *DeployParams, alloc *AllocParams) *
 	l1Deployments := config.L1Deployments.Copy()
 	require.NoError(t, l1Deployments.Check())
 
-	l1Genesis, err := genesis.BuildL1DeveloperGenesis(deployConf, config.L1Allocs, l1Deployments, true)
+	l1Genesis, err := genesis.BuildL1DeveloperGenesis(deployConf, config.L1Allocs, l1Deployments)
 	require.NoError(t, err, "failed to create l1 genesis")
 	if alloc.PrefundTestUsers {
 		for _, addr := range deployParams.Addresses.All() {

--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -54,7 +54,7 @@ type OpGeth struct {
 func NewOpGeth(t *testing.T, ctx context.Context, cfg *SystemConfig) (*OpGeth, error) {
 	logger := testlog.Logger(t, log.LvlCrit)
 
-	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig, config.L1Allocs, config.L1Deployments, true)
+	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig, config.L1Allocs, config.L1Deployments)
 	require.Nil(t, err)
 	l1Block := l1Genesis.ToBlock()
 

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -434,7 +434,7 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 		return nil, err
 	}
 
-	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig, config.L1Allocs, config.L1Deployments, true)
+	l1Genesis, err := genesis.BuildL1DeveloperGenesis(cfg.DeployConfig, config.L1Allocs, config.L1Deployments)
 	if err != nil {
 		return nil, err
 	}

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -121,7 +121,7 @@ var Subcommands = cli.Commands{
 				}
 			}
 
-			l1Genesis, err := genesis.BuildL1DeveloperGenesis(config, dump, deployments, true)
+			l1Genesis, err := genesis.BuildL1DeveloperGenesis(config, dump, deployments)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description**

Now the the L1 genesis is generated by foundry, there should be
no need to post process the L1 genesis state. Transactions would
fail because of the resource metering values in the optimism portal
contract being set as part of the genesis setup. The setup was
originally created when Go code was used to generate the L1 genesis.



<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

