### PR TITLE
ci: update kontrol schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1867,7 +1867,7 @@ workflows:
 
   scheduled-kontrol-tests:
     when:
-      equal: [ build_six_hours, <<pipeline.schedule.name>> ]
+      equal: [ build_four_hours, <<pipeline.schedule.name>> ]
     jobs:
       - kontrol-tests:
           context:


### PR DESCRIPTION
PR https://github.com/ethereum-optimism/optimism/pull/9301 moved kontrol to a scheduled job to run every 6 hours. However I did not see it running in CI, which seems to be because we don't have a `build_six_hours` trigger. We do have a `build_four_hours` trigger, so this PR switches to using that instead of creating a new trigger.