### PR TITLE
feat(op-challenger): Generic Scheduler Refactor

### DIFF
--- a/op-challenger/game/keccak/scheduler_test.go
+++ b/op-challenger/game/keccak/scheduler_test.go
@@ -53,7 +53,7 @@ func TestScheduleNextCheck(t *testing.T) {
 	scheduler := NewLargePreimageScheduler(logger, cl, []keccakTypes.LargePreimageOracle{oracle}, challenger)
 	scheduler.Start(ctx)
 	defer scheduler.Close()
-	err := scheduler.Schedule(common.Hash{0xaa}, 3)
+	err := scheduler.Schedule(common.Hash{0xaa})
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return oracle.GetPreimagesCount() == 1

--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -35,7 +35,7 @@ type gameScheduler interface {
 }
 
 type preimageScheduler interface {
-	Schedule(blockHash common.Hash, blockNumber uint64) error
+	Schedule(blockHash common.Hash) error
 }
 
 type claimer interface {
@@ -148,7 +148,7 @@ func (m *gameMonitor) onNewL1Head(ctx context.Context, sig eth.L1BlockRef) {
 	if err := m.progressGames(ctx, sig.Hash, sig.Number); err != nil {
 		m.logger.Error("Failed to progress games", "err", err)
 	}
-	if err := m.preimages.Schedule(sig.Hash, sig.Number); err != nil {
+	if err := m.preimages.Schedule(sig.Hash); err != nil {
 		m.logger.Error("Failed to validate large preimages", "err", err)
 	}
 }

--- a/op-challenger/game/monitor_test.go
+++ b/op-challenger/game/monitor_test.go
@@ -310,7 +310,7 @@ type stubPreimageScheduler struct {
 	scheduleCount int
 }
 
-func (s *stubPreimageScheduler) Schedule(_ common.Hash, _ uint64) error {
+func (s *stubPreimageScheduler) Schedule(_ common.Hash) error {
 	s.Lock()
 	defer s.Unlock()
 	s.scheduleCount++

--- a/op-service/sync/scheduler.go
+++ b/op-service/sync/scheduler.go
@@ -1,0 +1,78 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrChannelFull is returned when the scheduler's processing channel is full
+// and a new item cannot be scheduled.
+var ErrChannelFull = errors.New("channel full")
+
+// SchedulerRunner is a function that processes items received by the [Scheduler].
+type SchedulerRunner[T any] func(ctx context.Context, item T)
+
+// Scheduler processes generic [T any] items using a provided runner function.
+// Processing may be buffered with the [NewSchedulerFromBufferSize] constructor.
+type Scheduler[T any] struct {
+	receiver chan T
+	runner   SchedulerRunner[T]
+	cancel   func()
+	wg       sync.WaitGroup
+}
+
+func NewSchedulerFromBufferSize[T any](runner SchedulerRunner[T], bufferSize int) *Scheduler[T] {
+	return &Scheduler[T]{
+		receiver: make(chan T, bufferSize),
+		runner:   runner,
+	}
+}
+
+// Start starts the scheduler.
+func (s *Scheduler[T]) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.run(ctx)
+}
+
+// Close stops the scheduler and waits for all in-flight processing to finish.
+func (s *Scheduler[T]) Close() error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}
+
+// Drain drains the scheduler's processing channel.
+func (s *Scheduler[T]) Drain() {
+	for {
+		select {
+		case <-s.receiver:
+		default:
+			return
+		}
+	}
+}
+
+func (s *Scheduler[T]) run(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case item := <-s.receiver:
+			s.runner(ctx, item)
+		}
+	}
+}
+
+// Schedule sends an item to the scheduler for processing.
+func (s *Scheduler[T]) Schedule(item T) error {
+	select {
+	case s.receiver <- item:
+	default:
+		return ErrChannelFull
+	}
+	return nil
+}

--- a/op-service/sync/scheduler_test.go
+++ b/op-service/sync/scheduler_test.go
@@ -1,0 +1,79 @@
+package sync
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduler(t *testing.T) {
+	t.Run("ImmediateShutdown", func(t *testing.T) {
+		runner := func(ctx context.Context, item int) {}
+		s := NewSchedulerFromBufferSize(runner, 1)
+		s.Start(context.Background())
+		err := s.Close()
+		require.NoError(t, err)
+	})
+
+	t.Run("Drain", func(t *testing.T) {
+		runnerCalls := uint64(0)
+		runner := func(ctx context.Context, item int) {
+			atomic.AddUint64(&runnerCalls, 1)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+		}
+		s := NewSchedulerFromBufferSize(runner, 10)
+		s.Start(context.Background())
+		for i := 0; i < 10; i++ {
+			err := s.Schedule(1)
+			require.NoError(t, err)
+		}
+		require.Eventually(t, func() bool {
+			return atomic.LoadUint64(&runnerCalls) > 0
+		}, 10*time.Second, 10*time.Millisecond)
+		require.Equal(t, 9, len(s.receiver))
+		s.Drain()
+		require.Equal(t, 0, len(s.receiver))
+		s.Close()
+		require.Equal(t, 0, len(s.receiver))
+	})
+
+	t.Run("ScheduleMessage", func(t *testing.T) {
+		runnerCalls := 0
+		runner := func(ctx context.Context, item int) {
+			runnerCalls++
+		}
+		s := NewSchedulerFromBufferSize(runner, 1)
+		s.Start(context.Background())
+		err := s.Schedule(1)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			return runnerCalls > 0
+		}, 10*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("ScheduleMessageBufferFull", func(t *testing.T) {
+		runnerCalls := 0
+		runner := func(ctx context.Context, item int) {
+			runnerCalls++
+		}
+		s := NewSchedulerFromBufferSize(runner, 1)
+		s.Start(context.Background())
+		err := s.Schedule(1)
+		require.NoError(t, err)
+		err = s.Schedule(2)
+		require.Error(t, err)
+		require.Eventually(t, func() bool {
+			return runnerCalls > 0
+		}, 10*time.Second, 10*time.Millisecond)
+	})
+}

--- a/op-service/sync/scheduler_test.go
+++ b/op-service/sync/scheduler_test.go
@@ -47,6 +47,14 @@ func TestScheduler(t *testing.T) {
 		require.Equal(t, 0, len(s.receiver))
 	})
 
+	t.Run("ZeroBuffer", func(t *testing.T) {
+		runner := func(ctx context.Context, item int) {}
+		s := NewSchedulerFromBufferSize(runner, 0)
+		s.Start(context.Background())
+		err := s.Schedule(1)
+		require.ErrorIs(t, err, ErrChannelFull)
+	})
+
 	t.Run("ScheduleMessage", func(t *testing.T) {
 		runnerCalls := 0
 		runner := func(ctx context.Context, item int) {


### PR DESCRIPTION
**Description**

Refactors scaffold scheduler logic into a generic `op-service` component.

Ideally, this component can be extended to support wiring into the top-level coordinator-scheduler architecture.

For now, it is hooked up in the Bond Claiming Scheduler and the Large Preimage Challenging Scheduler.

**Tests**

Tests around the `op-service/sync/Scheduler`.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/522
