### PR TITLE
feat(indexer): reorg-delete command

### DIFF
--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -33,7 +33,7 @@ var (
 	}
 	ReorgFlag = &cli.Uint64Flag{
 		Name:     "l1-height",
-		Aliases:  []string{"h", "height"},
+		Aliases:  []string{"height"},
 		Usage:    "the lowest l1 height that has been reorg'd. All L1 data and derived L2 blocks starting from this height will be deleted",
 		Required: true,
 	}
@@ -148,7 +148,8 @@ func newCli(GitCommit string, GitDate string) *cli.App {
 				Action:      runMigrations,
 			},
 			{
-				Name:        "reorg",
+				Name:        "reorg-delete",
+				Aliases:     []string{"reorg"},
 				Flags:       append(flags, ReorgFlag),
 				Description: "Deletes data that has been reorg'ed out of the canonical L1 chain",
 				Action:      runReorgDeletion,

--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -32,9 +32,10 @@ var (
 		EnvVars: []string{"INDEXER_MIGRATIONS_DIR"},
 	}
 	ReorgFlag = &cli.Uint64Flag{
-		Name:     "l1-height",
-		Aliases:  []string{"height"},
-		Usage:    "the lowest l1 height that has been reorg'd. All L1 data and derived L2 blocks starting from this height will be deleted",
+		Name:    "l1-height",
+		Aliases: []string{"height"},
+		Usage: `the lowest l1 height that has been reorg'd. All L1 data and derived L2 state will be deleted. Since not all L1 blocks are
+		indexed, this will find the maximum indexed height <= the marker, which may result in slightly more deleted state.`,
 		Required: true,
 	}
 )

--- a/indexer/cmd/indexer/cli.go
+++ b/indexer/cmd/indexer/cli.go
@@ -106,7 +106,7 @@ func runReorgDeletion(ctx *cli.Context) error {
 	fromL1Height := ctx.Uint64(ReorgFlag.Name)
 
 	log := oplog.NewLogger(oplog.AppOut(ctx), oplog.ReadCLIConfig(ctx)).New("role", "reorg-deletion")
-	oplog.SetGlobalLogHandler(log.GetHandler())
+	oplog.SetGlobalLogHandler(log.Handler())
 	cfg, err := config.LoadConfig(log, ctx.String(ConfigFlag.Name))
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)

--- a/indexer/database/blocks.go
+++ b/indexer/database/blocks.go
@@ -179,7 +179,9 @@ func (db *blocksDB) L2LatestBlockHeader() (*L2BlockHeader, error) {
 // Reorgs
 
 func (db *blocksDB) DeleteReorgedState(fromL1Height *big.Int) error {
-	l1Header, err := db.L1BlockHeaderWithFilter(BlockHeader{Number: fromL1Height})
+	l1Header, err := db.L1BlockHeaderWithScope(func(db *gorm.DB) *gorm.DB {
+		return db.Where("number <= ?", fromL1Height).Order("number DESC").Limit(1)
+	})
 	if err != nil {
 		log.Error("unable to find L1 header associated with height", "err", err, "height", fromL1Height)
 		return err

--- a/indexer/database/mocks.go
+++ b/indexer/database/mocks.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"gorm.io/gorm"
 
@@ -78,8 +76,8 @@ func (m *MockBlocksDB) StoreL2BlockHeaders(headers []L2BlockHeader) error {
 	return args.Error(1)
 }
 
-func (m *MockBlocksDB) DeleteReorgedState(fromL1Height *big.Int) error {
-	args := m.Called(fromL1Height)
+func (m *MockBlocksDB) DeleteReorgedState(timestamp uint64) error {
+	args := m.Called(timestamp)
 	return args.Error(1)
 }
 

--- a/indexer/database/mocks.go
+++ b/indexer/database/mocks.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"gorm.io/gorm"
 
@@ -73,6 +75,11 @@ func (m *MockBlocksDB) StoreL1BlockHeaders(headers []L1BlockHeader) error {
 
 func (m *MockBlocksDB) StoreL2BlockHeaders(headers []L2BlockHeader) error {
 	args := m.Called(headers)
+	return args.Error(1)
+}
+
+func (m *MockBlocksDB) DeleteReorgedState(fromL1Height *big.Int) error {
+	args := m.Called(fromL1Height)
 	return args.Error(1)
 }
 

--- a/indexer/e2e_tests/reorg_e2e_test.go
+++ b/indexer/e2e_tests/reorg_e2e_test.go
@@ -72,7 +72,7 @@ func TestE2EReorgDeletion(t *testing.T) {
 	depositBlock, err := testSuite.DB.Blocks.L1BlockHeaderWithFilter(database.BlockHeader{Number: depositReceipt.BlockNumber})
 	require.NoError(t, err)
 	require.NoError(t, testSuite.Indexer.Stop(context.Background()))
-	require.NoError(t, testSuite.DB.Blocks.DeleteReorgedState(depositReceipt.BlockNumber))
+	require.NoError(t, testSuite.DB.Blocks.DeleteReorgedState(deposits.Deposits[0].L1BridgeDeposit.Tx.Timestamp))
 
 	// L1 & L2 block state deleted appropriately
 	latestL1Header, err := testSuite.DB.Blocks.L2LatestBlockHeader()

--- a/indexer/e2e_tests/reorg_e2e_test.go
+++ b/indexer/e2e_tests/reorg_e2e_test.go
@@ -1,0 +1,92 @@
+package e2e_tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/indexer/database"
+	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2EReorgDeletion(t *testing.T) {
+	testSuite := createE2ETestSuite(t)
+
+	// Conduct an L1 Deposit/Withdrawal through the standard bridge
+	// which touches the CDM and root bridge contracts. Thus we'll e2e
+	// test that the deletes appropriately cascades to all tables
+
+	l1StandardBridge, err := bindings.NewL1StandardBridge(testSuite.OpCfg.L1Deployments.L1StandardBridgeProxy, testSuite.L1Client)
+	require.NoError(t, err)
+	l2StandardBridge, err := bindings.NewL2StandardBridge(predeploys.L2StandardBridgeAddr, testSuite.L2Client)
+	require.NoError(t, err)
+
+	aliceAddr := testSuite.OpCfg.Secrets.Addresses().Alice
+
+	l1Opts, err := bind.NewKeyedTransactorWithChainID(testSuite.OpCfg.Secrets.Alice, testSuite.OpCfg.L1ChainIDBig())
+	require.NoError(t, err)
+	l2Opts, err := bind.NewKeyedTransactorWithChainID(testSuite.OpCfg.Secrets.Alice, testSuite.OpCfg.L2ChainIDBig())
+	require.NoError(t, err)
+
+	l1Opts.Value = big.NewInt(params.Ether)
+	l2Opts.Value = big.NewInt(params.Ether)
+
+	// wait for an L1 block (depends on an emitted event -- L2OO) to get indexed as a reference point prior to deletion
+	require.NoError(t, wait.For(context.Background(), 500*time.Millisecond, func() (bool, error) {
+		latestL1Header, err := testSuite.DB.Blocks.L1LatestBlockHeader()
+		return latestL1Header != nil, err
+	}))
+
+	depositTx, err := l1StandardBridge.DepositETH(l1Opts, 200_000, []byte{byte(1)})
+	require.NoError(t, err)
+	depositReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L1Client, depositTx.Hash())
+	require.NoError(t, err)
+	require.NoError(t, wait.For(context.Background(), 500*time.Millisecond, func() (bool, error) {
+		l1Header := testSuite.Indexer.BridgeProcessor.LastL1Header
+		return l1Header != nil && l1Header.Number.Uint64() >= depositReceipt.BlockNumber.Uint64(), nil
+	}))
+	deposits, err := testSuite.DB.BridgeTransfers.L1BridgeDepositsByAddress(aliceAddr, "", 1)
+	require.NoError(t, err)
+	require.Len(t, deposits.Deposits, 1)
+
+	withdrawTx, err := l2StandardBridge.Withdraw(l2Opts, predeploys.LegacyERC20ETHAddr, l2Opts.Value, 200_000, []byte{byte(1)})
+	require.NoError(t, err)
+	withdrawReceipt, err := wait.ForReceiptOK(context.Background(), testSuite.L2Client, withdrawTx.Hash())
+	require.NoError(t, err)
+	require.NoError(t, wait.For(context.Background(), 500*time.Millisecond, func() (bool, error) {
+		l2Header := testSuite.Indexer.BridgeProcessor.LastL2Header
+		return l2Header != nil && l2Header.Number.Uint64() >= withdrawReceipt.BlockNumber.Uint64(), nil
+	}))
+	withdrawals, err := testSuite.DB.BridgeTransfers.L2BridgeWithdrawalsByAddress(aliceAddr, "", 1)
+	require.NoError(t, err)
+	require.Len(t, withdrawals.Withdrawals, 1)
+
+	// Stop the indexer and reorg out L1 state from the deposit transaction
+	// and implicitly the derived L2 state where the withdrawal was initiated
+	depositBlock, err := testSuite.DB.Blocks.L1BlockHeaderWithFilter(database.BlockHeader{Number: depositReceipt.BlockNumber})
+	require.NoError(t, err)
+	require.NoError(t, testSuite.Indexer.Stop(context.Background()))
+	require.NoError(t, testSuite.DB.Blocks.DeleteReorgedState(depositReceipt.BlockNumber))
+
+	// L1 & L2 block state deleted appropriately
+	latestL1Header, err := testSuite.DB.Blocks.L2LatestBlockHeader()
+	require.NoError(t, err)
+	require.True(t, latestL1Header.Timestamp < depositBlock.Timestamp)
+	latestL2Header, err := testSuite.DB.Blocks.L2LatestBlockHeader()
+	require.NoError(t, err)
+	require.True(t, latestL2Header.Timestamp < depositBlock.Timestamp)
+
+	// Deposits/Withdrawals deletes cascade appropriately from log deletion
+	deposits, err = testSuite.DB.BridgeTransfers.L1BridgeDepositsByAddress(aliceAddr, "", 1)
+	require.NoError(t, err)
+	require.Len(t, deposits.Deposits, 0)
+	withdrawals, err = testSuite.DB.BridgeTransfers.L2BridgeWithdrawalsByAddress(aliceAddr, "", 1)
+	require.NoError(t, err)
+	require.Len(t, withdrawals.Withdrawals, 0)
+}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -80,7 +80,7 @@ func (ix *Indexer) Start(ctx context.Context) error {
 }
 
 func (ix *Indexer) Stop(ctx context.Context) error {
-	if ix.stopped.Load() == true {
+	if ix.stopped.Load() {
 		return nil
 	}
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -80,6 +80,10 @@ func (ix *Indexer) Start(ctx context.Context) error {
 }
 
 func (ix *Indexer) Stop(ctx context.Context) error {
+	if ix.stopped.Load() == true {
+		return nil
+	}
+
 	var result error
 
 	if ix.L1ETL != nil {
@@ -128,9 +132,7 @@ func (ix *Indexer) Stop(ctx context.Context) error {
 	}
 
 	ix.stopped.Store(true)
-
 	ix.log.Info("indexer stopped")
-
 	return result
 }
 

--- a/indexer/ops/docs/troubleshooting.md
+++ b/indexer/ops/docs/troubleshooting.md
@@ -18,7 +18,7 @@ This document provides a set of troubleshooting steps for common failure scenari
 Header traversal is a client abstraction that allows the indexer to sequentially traverse the chain via batches of blocks. The following are some common failure modes and how to resolve them:
 1. `the HeaderTraversal and provider have diverged in state`
 This error occurs when the indexer is operating on a different block state than the node. This is typically caused by network reorgs and is the result of `l1-confirmation-depth` or `l2-confirmation-depth` values being set too low. To resolve this issue, 
-    * Delete L1/L2 blocks in the database back to a last known valid height
+    * Delete blocks in the database back to a last known valid L1 height. See the `reorg-delete` command available in the cli that'll appropriately conduct the deletions.
     * Increase confirmation depth values
     * Restart the indexer
 


### PR DESCRIPTION
If the chain reorgs and the confirmation depths weren't appopriately set, the operator needs to manually
delete L1/L2 blocks to the last valid state.

Rather than requiring the operator to manually execute sql queries that's error prone, lets provide a
command that automates this by providing the last valid L1 height
