### PR TITLE
op-e2e: Reduce flakiness in p2p tests

### DIFF
--- a/op-e2e/tx_helper.go
+++ b/op-e2e/tx_helper.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
@@ -112,13 +114,13 @@ func SendL2Tx(t *testing.T, cfg SystemConfig, l2Client *ethclient.Client, privKe
 	err := l2Client.SendTransaction(ctx, tx)
 	require.NoError(t, err, "Sending L2 tx")
 
-	receipt, err := geth.WaitForTransaction(tx.Hash(), l2Client, 10*time.Duration(cfg.DeployConfig.L2BlockTime)*time.Second)
+	receipt, err := wait.ForReceiptOK(ctx, l2Client, tx.Hash())
 	require.NoError(t, err, "Waiting for L2 tx")
 	require.Equal(t, opts.ExpectedStatus, receipt.Status, "TX should have expected status")
 
 	for i, client := range opts.VerifyClients {
 		t.Logf("Waiting for tx %v on verification client %d", tx.Hash(), i)
-		receiptVerif, err := geth.WaitForTransaction(tx.Hash(), client, 10*time.Duration(cfg.DeployConfig.L2BlockTime)*time.Second)
+		receiptVerif, err := wait.ForReceiptOK(ctx, client, tx.Hash())
 		require.NoErrorf(t, err, "Waiting for L2 tx on verification client %d", i)
 		require.Equalf(t, receipt, receiptVerif, "Receipts should be the same on sequencer and verification client %d", i)
 	}


### PR DESCRIPTION
P2P tests were flaking sometimes due to the checks asserting that everything received was published. `require.ElementsMatch` requires that lists be equal, sans duplicates. Sometimes, however, messages would get sent multiple times/not be picked up in time for the assertions leading to errors like this following:

```
listA:
([]string) (len=29) {
 ... elided
 (string) (len=68) "0xd770621d3b0a196087ace7efcb0a8a61b353736526f6095946c714ec134b1648:1",
 (string) (len=69) "0x71a364bf88d4e7e049cfe1635e95c31c9d93435b03a4d20c8863637fc0eb319f:28",
 (string) (len=68) "0xd770621d3b0a196087ace7efcb0a8a61b353736526f6095946c714ec134b1648:1"
}

listB:
([]string) (len=29) {
 (string) (len=68) "0xd770621d3b0a196087ace7efcb0a8a61b353736526f6095946c714ec134b1648:1",
 ... elided
 (string) (len=69) "0xf84acde28fb7b630f9e5d91bddc7c2d4d2e1f4ce29a7d1a4551fee9ac828b10f:29"
}

extra elements in list A:
([]interface {}) (len=1) {
 (string) (len=68) "0xd770621d3b0a196087ace7efcb0a8a61b353736526f6095946c714ec134b1648:1"
}

extra elements in list B:
([]interface {}) (len=1) {
 (string) (len=69) "0xf84acde28fb7b630f9e5d91bddc7c2d4d2e1f4ce29a7d1a4551fee9ac828b10f:29"
}
```

This PR refactors to use `require.Subset` which handles this case while still asserting that everything received was in fact published.
