### PR TITLE
ci: Refactor dependencies to reduce runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -809,6 +809,10 @@ jobs:
         description: Number of parallel test runs
         type: integer
         default: 6
+      notify:
+        description: Whether to notify on failure
+        type: boolean
+        default: false
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
     resource_class: xlarge
@@ -863,6 +867,10 @@ jobs:
           when: always
       - store_test_results:
           path: /tmp/test-results
+      - when:
+          condition: "<<parameters.notify>>"
+          steps:
+            - notify-failures-on-develop
 
   go-lint-test-build:
     parameters:
@@ -1031,6 +1039,8 @@ jobs:
           name: Install Geth
           command: |
             wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.13.4-3f907d6a.tar.gz
+            # geth only provides md5 sums sadly
+            echo 'c2e3d38372cb8081ed01591246a7556f geth-alltools-linux-amd64-1.13.4-3f907d6a.tar.gz' | md5sum -c -
             tar -xzvf geth-alltools-linux-amd64-1.13.4-3f907d6a.tar.gz
             sudo cp geth-alltools-linux-amd64-1.13.4-3f907d6a/* /usr/local/bin
       - run:
@@ -1848,9 +1858,9 @@ workflows:
           context:
             - slack
 
-  scheduled-fpp:
+  develop-fault-proofs:
     when:
-      equal: [ build_four_hours, <<pipeline.schedule.name>> ]
+      equal: [ "develop", <<pipeline.git.branch>> ]
     jobs:
       - go-mod-download
       - cannon-prestate:
@@ -1869,9 +1879,12 @@ workflows:
           module: op-e2e
           target: test-cannon
           parallelism: 4
+          notify: true
           requires:
             - pnpm-monorepo
             - cannon-prestate
+          context:
+            - slack
 
   scheduled-kontrol-tests:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1858,6 +1858,15 @@ workflows:
           context:
             - slack
 
+  scheduled-fpp:
+    when:
+      equal: [ build_four_hours, <<pipeline.schedule.name>> ]
+    jobs:
+      - fpp-verify:
+          context:
+            - slack
+            - oplabs-fpp-nodes
+
   develop-fault-proofs:
     when:
       equal: [ "develop", <<pipeline.git.branch>> ]
@@ -1870,10 +1879,6 @@ workflows:
           name: pnpm-monorepo
           requires:
             - go-mod-download
-      - fpp-verify:
-          context:
-            - slack
-            - oplabs-fpp-nodes
       - go-e2e-test:
           name: op-e2e-cannon-tests
           module: op-e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
             gcloud auth login --brief --cred-file "<< parameters.gcp_cred_config_file_path >>"
             # Configure ADC
             echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a "$BASH_ENV"
+
   check-changed:
     description: "Conditionally halts a step if certain modules change"
     parameters:
@@ -73,6 +74,7 @@ commands:
             cd ops/check-changed
             pip3 install -r requirements.txt
             python3 main.py "<<parameters.patterns>>"
+
   notify-failures-on-develop:
     description: "Notify Slack"
     parameters:
@@ -138,14 +140,18 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Check L1 geth version"
+          command: ./ops/scripts/geth-version-checker.sh || (echo "geth version is wrong, update ci-builder"; false)
+      - run:
           name: git submodules
           command: make submodules
-      - check-changed:
-          patterns: op-chain-ops,packages/,op-node
       - restore_cache:
           name: Restore PNPM Package Cache
           keys:
             - pnpm-packages-v2-{{ checksum "pnpm-lock.yaml" }}
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
       # Fetch node_modules into the pnpm store
       # This will cache node_modules based on pnpm-lock so other steps can instantly install them with `pnpm install --prefer-offline`
       # --prefer-offline installs node_modules instantly by just reading from cache if it exists rather than fetching from network
@@ -171,6 +177,9 @@ jobs:
           environment:
             FOUNDRY_PROFILE: ci
           command: pnpm build
+      - run:
+          name: Generate allocs
+          command: make devnet-allocs
       - persist_to_workspace:
           root: "."
           paths:
@@ -180,6 +189,10 @@ jobs:
             - "packages/contracts-bedrock/forge-artifacts"
             - "packages/contracts-bedrock/tsconfig.tsbuildinfo"
             - "packages/contracts-bedrock/tsconfig.build.tsbuildinfo"
+            - ".devnet/allocs-l1.json"
+            - ".devnet/addresses.json"
+            - "packages/contracts-bedrock/deploy-config/devnetL1.json"
+            - "packages/contracts-bedrock/deployments/devnetL1"
 
   docker-build:
     environment:
@@ -241,13 +254,6 @@ jobs:
               - "<<parameters.release>>"
           steps:
             - gcp-oidc-authenticate
-      # Below is CircleCI recommended way of specifying nameservers on an Ubuntu box:
-      # https://support.circleci.com/hc/en-us/articles/7323511028251-How-to-set-custom-DNS-on-Ubuntu-based-images-using-netplan
-      - run: sudo sed -i '13 i \ \ \ \ \ \ \ \ \ \ \ \ nameservers:' /etc/netplan/50-cloud-init.yaml
-      - run: sudo sed -i '14 i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ addresses:' /etc/netplan/50-cloud-init.yaml
-      - run: sudo sed -i "s/addresses:/ addresses":" [8.8.8.8, 8.8.4.4] /g" /etc/netplan/50-cloud-init.yaml
-      - run: cat /etc/netplan/50-cloud-init.yaml
-      - run: sudo netplan apply
       - run:
           name: Build
           command: |
@@ -819,6 +825,12 @@ jobs:
       - run:
           name: prep results dir
           command: mkdir -p /tmp/test-results
+      - restore_cache:
+          name: Restore Go modules cache
+          key: gomod-{{ checksum "go.sum" }}
+      - restore_cache:
+          name: Restore Go build cache
+          key: golang-build-cache
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -1016,6 +1028,12 @@ jobs:
             export PATH=$PATH:/usr/local/go/bin
             go version
       - run:
+          name: Install Geth
+          command: |
+            wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.13.4-3f907d6a.tar.gz
+            tar -xzvf geth-alltools-linux-amd64-1.13.4-3f907d6a.tar.gz
+            sudo cp geth-alltools-linux-amd64-1.13.4-3f907d6a/* /usr/local/bin
+      - run:
           name: foundryup
           command: |
             curl -L https://foundry.paradigm.xyz | bash
@@ -1042,44 +1060,31 @@ jobs:
       - run:
           name: git submodules
           command: make submodules
-      - run:
-          name: Install and build
-          command: |
-            pnpm install:ci && pnpm build
       - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Load cannon pre-state
-          command: |
-            mkdir -p op-program/bin
-            cp /tmp/workspace/op-program/bin/prestate.json op-program/bin/prestate.json
-            cp /tmp/workspace/op-program/bin/meta.json op-program/bin/meta.json
-            cp /tmp/workspace/op-program/bin/prestate-proof.json op-program/bin/prestate-proof.json
-      - run:
-          name: Load devnet-allocs
-          command: |
-            mkdir -p .devnet
-            cp /tmp/workspace/.devnet/allocs-l1.json .devnet/allocs-l1.json
-            cp /tmp/workspace/.devnet/addresses.json .devnet/addresses.json
-            cp /tmp/workspace/packages/contracts-bedrock/deploy-config/devnetL1.json packages/contracts-bedrock/deploy-config/devnetL1.json
-            cp -r /tmp/workspace/packages/contracts-bedrock/deployments/devnetL1 packages/contracts-bedrock/deployments/devnetL1
+          at: "."
       - run:
           name: Load and tag docker images
           command: |
             IMAGE_BASE_PREFIX="us-docker.pkg.dev/oplabs-tools-artifacts/images"
             # Load from previous docker-build job
-            docker load < "/tmp/workspace/op-stack-go.tar"
-            docker load < "/tmp/workspace/op-node.tar"
-            docker load < "/tmp/workspace/op-proposer.tar"
-            docker load < "/tmp/workspace/op-batcher.tar"
+            docker load < "./op-stack-go.tar"
+            docker load < "./op-node.tar"
+            docker load < "./op-proposer.tar"
+            docker load < "./op-batcher.tar"
             # rename to the tags that the docker-compose of the devnet expects
             docker tag "$IMAGE_BASE_PREFIX/op-stack-go:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-stack-go:devnet"
             docker tag "$IMAGE_BASE_PREFIX/op-node:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-node:devnet"
             docker tag "$IMAGE_BASE_PREFIX/op-proposer:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-proposer:devnet"
             docker tag "$IMAGE_BASE_PREFIX/op-batcher:<<pipeline.git.revision>>" "$IMAGE_BASE_PREFIX/op-batcher:devnet"
       - run:
+          name: pnpm i
+          command: |
+            pnpm i && pnpm build
+      - run:
           name: Bring up the stack
-          command: make devnet-up
+          command: |
+            # Specify like this to avoid a forced rebuild of the contracts + devnet L1
+            PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=.
       - run:
           name: Test the stack
           command: make devnet-test
@@ -1184,6 +1189,16 @@ jobs:
       - run:
           command: go mod download
           name: Download Go module dependencies
+      - run:
+          name: "Go mod tidy"
+          command: make mod-tidy && git diff --exit-code
+      - run:
+          name: run Go linter
+          command: |
+            # Identify how many cores it defaults to
+            golangci-lint --help | grep concurrency
+            make lint-go
+          working_directory: .
       - save_cache:
           key: << parameters.key >>-{{ checksum "<< parameters.file >>" }}
           name: Save Go modules cache
@@ -1243,7 +1258,10 @@ jobs:
 
   bedrock-go-tests:  # just a helper, that depends on all the actual test jobs
     docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
+      # Use a smaller base image to avoid pulling the huge ci-builder
+      # image which is not needed for this job and sometimes misses
+      # the cache.
+      - image: cimg/base:2024.01
     resource_class: medium
     steps:
       - run: echo Done
@@ -1349,7 +1367,8 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - pnpm-monorepo
+      - pnpm-monorepo:
+          name: pnpm-monorepo
       - js-lint-test:
           name: common-ts-tests
           coverage_flag: common-ts-tests
@@ -1409,131 +1428,118 @@ workflows:
           binary_name: proxyd
           working_directory: proxyd
       - indexer-tests
-      - l1-geth-version-check
       - semgrep-scan
       - go-mod-download
-      - go-mod-tidy:
-          requires: ["go-mod-download"]
-      - devnet-allocs:  # devnet-allocs uses op-node genesis sub-command
-          requires:
-            - "go-mod-tidy"
-            - l1-geth-version-check
-      - go-lint: # we combine most of the go-lint work for two reasons: (1) warm up the Go build cache, (2) reduce sum of lint time
-          name: op-stack-go-lint
-          requires: [ "go-mod-tidy" ]
       - fuzz-golang:
           name: op-challenger-fuzz
           package_name: op-challenger
           on_changes: op-challenger
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - fuzz-golang:
           name: op-node-fuzz
           package_name: op-node
           on_changes: op-node
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - fuzz-golang:
           name: op-service-fuzz
           package_name: op-service
           on_changes: op-service
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - fuzz-golang:
           name: op-chain-ops-fuzz
           package_name: op-chain-ops
           on_changes: op-chain-ops,op-bindings
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - fuzz-golang:
           name: cannon-fuzz
           package_name: cannon
           on_changes: cannon,packages/contracts-bedrock/src/cannon
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-heartbeat-tests
           module: op-heartbeat
-          requires: [ "op-stack-go-lint" ]
+          requires: [ "go-mod-download" ]
       - go-test:
           name: op-batcher-tests
           module: op-batcher
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-bindings-tests
           module: op-bindings
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-chain-ops-tests
           module: op-chain-ops
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-node-tests
           module: op-node
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-proposer-tests
           module: op-proposer
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-challenger-tests
           module: op-challenger
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-conductor-tests
           module: op-conductor
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-program-tests
           module: op-program
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - go-test:
           name: op-service-tests
           module: op-service
-          requires: ["op-stack-go-lint"]
+          requires: ["go-mod-download"]
       - op-service-rethdb-tests:
           requires:
-            - op-stack-go-lint
+            - go-mod-download
       - go-e2e-test:
           name: op-e2e-HTTP-tests
           module: op-e2e
           target: test-http
           parallelism: 4
           requires:
-            - op-stack-go-lint
-            - devnet-allocs
+            - go-mod-download
+            - pnpm-monorepo
       - go-e2e-test:
           name: op-e2e-action-tests
           module: op-e2e
           target: test-actions
           parallelism: 1
           requires:
-            - op-stack-go-lint
-            - devnet-allocs
+            - go-mod-download
+            - pnpm-monorepo
       - go-e2e-test:
-          name: op-e2e-cannon-tests
+          name: op-e2e-fault-proof-tests
           module: op-e2e
-          target: test-cannon
-          parallelism: 8
+          target: test-fault-proofs
+          parallelism: 4
           requires:
-            - op-stack-go-lint
-            - devnet-allocs
+            - pnpm-monorepo
             - cannon-prestate
       - go-e2e-test:
           name: op-e2e-ext-geth-tests
           module: op-e2e
           target: test-external-geth
           requires:
-            - op-stack-go-lint
-            - devnet-allocs
-            - l1-geth-version-check
+            - go-mod-download
+            - pnpm-monorepo
       - op-program-compat:
           requires:
             - op-program-tests
       - bedrock-go-tests:
           requires:
             - go-mod-download
-            - go-mod-tidy
             - cannon-build-test-vectors
             - cannon-go-lint-and-test
             - check-generated-mocks-op-node
             - check-generated-mocks-op-service
-            - op-stack-go-lint
+            - go-mod-download
             - op-batcher-tests
             - op-bindings-tests
             - op-chain-ops-tests
@@ -1546,7 +1552,7 @@ workflows:
             - op-program-compat
             - op-service-tests
             - op-e2e-HTTP-tests
-            - op-e2e-cannon-tests
+            - op-e2e-fault-proof-tests
             - op-e2e-action-tests
             - op-e2e-ext-geth-tests
             - op-service-rethdb-tests
@@ -1598,14 +1604,14 @@ workflows:
           requires: ['op-stack-go-docker-build']
           save_image_tag: <<pipeline.git.revision>> # for devnet later
       - cannon-prestate:
-          requires: ["op-stack-go-lint"]
+          requires:
+            - go-mod-download
       - devnet:
           requires:
-            - op-node-docker-build
+            - pnpm-monorepo
             - op-batcher-docker-build
             - op-proposer-docker-build
-            - l1-geth-version-check
-            - devnet-allocs
+            - op-node-docker-build
             - cannon-prestate
       - docker-build:
           name: indexer-docker-build
@@ -1846,10 +1852,26 @@ workflows:
     when:
       equal: [ build_four_hours, <<pipeline.schedule.name>> ]
     jobs:
+      - go-mod-download
+      - cannon-prestate:
+          requires:
+            - go-mod-download
+      - pnpm-monorepo:
+          name: pnpm-monorepo
+          requires:
+            - go-mod-download
       - fpp-verify:
           context:
             - slack
             - oplabs-fpp-nodes
+      - go-e2e-test:
+          name: op-e2e-cannon-tests
+          module: op-e2e
+          target: test-cannon
+          parallelism: 4
+          requires:
+            - pnpm-monorepo
+            - cannon-prestate
 
   scheduled-kontrol-tests:
     when:

--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -29,6 +29,11 @@ test-http: pre-test
 
 test-cannon: pre-test
 	OP_E2E_CANNON_ENABLED=true $(go_test) $(go_test_flags) ./faultproofs
+.PHONY: test-cannon
+
+test-fault-proofs: pre-test
+	$(go_test) $(go_test_flags) ./faultproofs
+.PHONY: test-faultproofs
 
 cannon-prestate:
 	make -C .. cannon-prestate

--- a/op-e2e/actions/action.go
+++ b/op-e2e/actions/action.go
@@ -2,25 +2,11 @@ package actions
 
 import (
 	"context"
-	"os"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 )
-
-var enableParallelTesting bool = true
-
-func init() {
-	if os.Getenv("OP_E2E_DISABLE_PARALLEL") == "true" {
-		enableParallelTesting = false
-	}
-}
-
-func parallel(t e2eutils.TestingBase) {
-	t.Helper()
-	if enableParallelTesting {
-		t.Parallel()
-	}
-}
 
 // Testing is an interface to Go-like testing,
 // extended with a context getter for the test runner to shut down individual actions without interrupting the test,
@@ -69,7 +55,8 @@ type StatefulTesting interface {
 // NewDefaultTesting returns a new testing obj, and enables parallel test execution.
 // Returns an interface, we're likely changing the behavior here as we build more action tests.
 func NewDefaultTesting(tb e2eutils.TestingBase) StatefulTesting {
-	parallel(tb)
+	op_e2e.InitParallel(tb)
+
 	return &defaultTesting{
 		TestingBase: tb,
 		ctx:         context.Background(),

--- a/op-e2e/faultproofs/multi_test.go
+++ b/op-e2e/faultproofs/multi_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMultipleGameTypes(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(0))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, _ := startFaultDisputeSystem(t)

--- a/op-e2e/faultproofs/output_alphabet_test.go
+++ b/op-e2e/faultproofs/output_alphabet_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
+	op_e2e.InitParallel(t)
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
@@ -71,7 +71,7 @@ func TestOutputAlphabetGame_ChallengerWins(t *testing.T) {
 }
 
 func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
+	op_e2e.InitParallel(t)
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
@@ -102,7 +102,7 @@ func TestOutputAlphabetGame_ValidOutputRoot(t *testing.T) {
 }
 
 func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
+	op_e2e.InitParallel(t)
 
 	testCase := func(t *testing.T, isRootCorrect bool) {
 		ctx := context.Background()
@@ -159,11 +159,11 @@ func TestChallengerCompleteExhaustiveDisputeGame(t *testing.T) {
 	}
 
 	t.Run("RootCorrect", func(t *testing.T) {
-		op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
+		op_e2e.InitParallel(t)
 		testCase(t, true)
 	})
 	t.Run("RootIncorrect", func(t *testing.T) {
-		op_e2e.InitParallel(t, op_e2e.UseExecutor(1))
+		op_e2e.InitParallel(t)
 		testCase(t, false)
 	})
 }

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestOutputCannonGame(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(0))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
@@ -72,7 +72,7 @@ func TestOutputCannonGame(t *testing.T) {
 
 func TestOutputCannon_ChallengeAllZeroClaim(t *testing.T) {
 	// The dishonest actor always posts claims with all zeros.
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(1))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
 	t.Cleanup(sys.Close)
@@ -109,7 +109,7 @@ func TestOutputCannon_PublishCannonRootClaim(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(fmt.Sprintf("Dispute_%v", test.disputeL2BlockNumber), func(t *testing.T) {
-			op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(2))
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 			ctx := context.Background()
 			sys, _ := startFaultDisputeSystem(t)
@@ -139,7 +139,7 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(3))
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 			ctx := context.Background()
 			sys, l1Client := startFaultDisputeSystem(t)
@@ -176,7 +176,7 @@ func TestOutputCannonDisputeGame(t *testing.T) {
 }
 
 func TestOutputCannonDefendStep(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(4))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -212,7 +212,7 @@ func TestOutputCannonDefendStep(t *testing.T) {
 }
 
 func TestOutputCannonStepWithLargePreimage(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(0))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, _ := startFaultDisputeSystem(t, withLargeBatches())
@@ -258,7 +258,7 @@ func TestOutputCannonStepWithLargePreimage(t *testing.T) {
 
 func TestOutputCannonStepWithPreimage(t *testing.T) {
 	testPreimageStep := func(t *testing.T, preloadPreimage bool) {
-		op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(5))
+		op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 		ctx := context.Background()
 		sys, l1Client := startFaultDisputeSystem(t)
@@ -315,9 +315,6 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 		// performStep is called once the maximum game depth is reached. It should perform a step to counter the
 		// claim at parentClaimIdx. Since the proposed output root is invalid, the step call should always revert.
 		performStep func(ctx context.Context, game *disputegame.OutputCannonGameHelper, correctTrace *disputegame.OutputHonestHelper, parentClaimIdx int64)
-
-		// executor to run the task on
-		executor uint64
 	}{
 		{
 			name: "AttackWithCorrectTrace",
@@ -330,7 +327,6 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 				return correctTrace.AttackClaim(ctx, claim)
 			},
 			performStep: honestStepsFail,
-			executor:    6,
 		},
 		{
 			name: "DefendWithCorrectTrace",
@@ -349,14 +345,13 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 				return correctTrace.DefendClaim(ctx, claim)
 			},
 			performStep: honestStepsFail,
-			executor:    7,
 		},
 	}
 
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(test.executor))
+			op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 			ctx := context.Background()
 			sys, l1Client := startFaultDisputeSystem(t)
@@ -390,7 +385,7 @@ func TestOutputCannonProposedOutputRootValid(t *testing.T) {
 }
 
 func TestOutputCannonPoisonedPostState(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(1))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -454,7 +449,7 @@ func TestOutputCannonPoisonedPostState(t *testing.T) {
 }
 
 func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(2))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -504,7 +499,7 @@ func TestDisputeOutputRootBeyondProposedBlock_ValidOutputRoot(t *testing.T) {
 }
 
 func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(3))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)
@@ -555,7 +550,7 @@ func TestDisputeOutputRootBeyondProposedBlock_InvalidOutputRoot(t *testing.T) {
 }
 
 func TestDisputeOutputRoot_ChangeClaimedOutputRoot(t *testing.T) {
-	op_e2e.InitParallel(t, op_e2e.UsesCannon, op_e2e.UseExecutor(4))
+	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()
 	sys, l1Client := startFaultDisputeSystem(t)

--- a/op-e2e/helper.go
+++ b/op-e2e/helper.go
@@ -4,7 +4,8 @@ import (
 	"crypto/md5"
 	"os"
 	"strconv"
-	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
 )
 
 var enableParallelTesting bool = os.Getenv("OP_E2E_DISABLE_PARALLEL") != "true"
@@ -13,7 +14,7 @@ type testopts struct {
 	executor uint64
 }
 
-func InitParallel(t *testing.T, args ...func(t *testing.T, opts *testopts)) {
+func InitParallel(t e2eutils.TestingBase, args ...func(t e2eutils.TestingBase, opts *testopts)) {
 	t.Helper()
 	if enableParallelTesting {
 		t.Parallel()
@@ -32,7 +33,7 @@ func InitParallel(t *testing.T, args ...func(t *testing.T, opts *testopts)) {
 	checkExecutor(t, info, opts.executor)
 }
 
-func UsesCannon(t *testing.T, opts *testopts) {
+func UsesCannon(t e2eutils.TestingBase, opts *testopts) {
 	if os.Getenv("OP_E2E_CANNON_ENABLED") == "false" {
 		t.Skip("Skipping cannon test")
 	}
@@ -44,8 +45,8 @@ func UsesCannon(t *testing.T, opts *testopts) {
 // InitParallel(t, UseExecutor(1))
 // Any tests assigned to an executor greater than the number available automatically use the last executor.
 // Executor indexes start from 0
-func UseExecutor(assignedIdx uint64) func(t *testing.T, opts *testopts) {
-	return func(t *testing.T, opts *testopts) {
+func UseExecutor(assignedIdx uint64) func(t e2eutils.TestingBase, opts *testopts) {
+	return func(t e2eutils.TestingBase, opts *testopts) {
 		opts.executor = assignedIdx
 	}
 }
@@ -56,7 +57,7 @@ type executorInfo struct {
 	splitInUse bool
 }
 
-func getExecutorInfo(t *testing.T) executorInfo {
+func getExecutorInfo(t e2eutils.TestingBase) executorInfo {
 	var info executorInfo
 	envTotal := os.Getenv("CIRCLE_NODE_TOTAL")
 	envIdx := os.Getenv("CIRCLE_NODE_INDEX")
@@ -81,7 +82,7 @@ func getExecutorInfo(t *testing.T) executorInfo {
 	return info
 }
 
-func checkExecutor(t *testing.T, info executorInfo, assignedIdx uint64) {
+func checkExecutor(t e2eutils.TestingBase, info executorInfo, assignedIdx uint64) {
 	if !info.splitInUse {
 		t.Logf("Test splitting not in use.")
 		return


### PR DESCRIPTION
This PR makes the following changes in order to reduce CI runtime:

1. Move the long-running Cannon E2E tests into a scheduled job. This reduces E2E runtime by 8 minutes.
2. Updates the `devnet` task to leverage the contract artifacts and cannon pre-state created in order jobs. This job was also updated to use a Geth binary rather than compiling it from source. This reduces devnet runtime by 5 minutes.
3. Removes intermediate linting, allocs, and geth version check jobs by putting them all in `pnpm-monorepo`. `pnpm-monorepo` already builds the contracts, devnet allocs, and checks the Geth version in parallel so splitting these jobs out actually makes things slower due to CCI image download/environment spin-up overhead. The `pnpm-monorepo` job now plugs into a bunch of downstream jobs.
4. Refactors the action tests to take advantage of multiple test executors.
5. Swaps the `bedrock-go-tests` image to a simple CCI base image to reduce runtime (this job alone was taking ~1min due to spin up overhead).
6. Puts linting in `go-mod-download` to avoid spin-up overhead.

In sum, this PR reduces overall CI runtime from 22 minutes to ~13.