### PR TITLE
op-e2e: Skip TestOutputCannonStepWithLargePreimage until we can fix the flakiness

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -212,6 +212,9 @@ func TestOutputCannonDefendStep(t *testing.T) {
 }
 
 func TestOutputCannonStepWithLargePreimage(t *testing.T) {
+	// TODO(client-pod#525): Investigate and fix flakiness
+	t.Skip("Skipping until the flakiness can be resolved")
+
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Description**

Skip TestOutputCannonStepWithLargePreimage until we can fix the flakiness. The batcher seems to be able to create a transaction below the minimum large preimage size sometimes. 

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/525
