### PR TITLE
op-e2e: Re-enable large preimage e2e test

### DIFF
--- a/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
+++ b/op-e2e/e2eutils/disputegame/preimage/preimage_helper.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const MinPreimageSize = 18000
+const MinPreimageSize = 10000
 
 type Helper struct {
 	t              *testing.T
@@ -65,6 +65,14 @@ func WithReplacedCommitment(idx uint64, value common.Hash) InputModifier {
 			return
 		}
 		input.Commitments[idx-startBlock] = value
+	}
+}
+
+func WithLastCommitment(value common.Hash) InputModifier {
+	return func(startBlock uint64, input *types.InputData) {
+		if input.Finalize {
+			input.Commitments[len(input.Commitments)-1] = value
+		}
 	}
 }
 

--- a/op-e2e/faultproofs/challenge_preimage_test.go
+++ b/op-e2e/faultproofs/challenge_preimage_test.go
@@ -60,7 +60,7 @@ func TestChallengeLargePreimages_ChallengeLast(t *testing.T) {
 		challenger.WithPrivKey(sys.Cfg.Secrets.Mallory))
 	preimageHelper := disputeGameFactory.PreimageHelper(ctx)
 	ident := preimageHelper.UploadLargePreimage(ctx, preimage.MinPreimageSize,
-		preimage.WithReplacedCommitment(132, common.Hash{0xaa}))
+		preimage.WithLastCommitment(common.Hash{0xaa}))
 
 	require.NotEqual(t, ident.Claimant, common.Address{})
 

--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -10,6 +10,7 @@ import (
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/challenger"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/disputegame/preimage"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -254,7 +255,7 @@ func TestOutputCannonStepWithLargePreimage(t *testing.T) {
 	// execution game. We then move to challenge it to induce a large preimage load.
 	sender := sys.Cfg.Secrets.Addresses().Alice
 	preimageLoadCheck := game.CreateStepLargePreimageLoadCheck(ctx, sender)
-	game.ChallengeToPreimageLoad(ctx, outputRootClaim, sys.Cfg.Secrets.Alice, cannon.PreimageLargerThan(18_000), preimageLoadCheck, false)
+	game.ChallengeToPreimageLoad(ctx, outputRootClaim, sys.Cfg.Secrets.Alice, cannon.PreimageLargerThan(preimage.MinPreimageSize), preimageLoadCheck, false)
 	// The above method already verified the image was uploaded and step called successfully
 	// So we don't waste time resolving the game - that's tested elsewhere.
 }

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -12,9 +12,11 @@ type faultDisputeConfigOpts func(cfg *op_e2e.SystemConfig)
 
 func withLargeBatches() faultDisputeConfigOpts {
 	return func(cfg *op_e2e.SystemConfig) {
+		maxTxDataSize := uint64(131072) // As per the Ethereum spec.
 		// Allow the batcher to produce really huge calldata transactions.
-		cfg.BatcherTargetL1TxSizeBytes = 130072 // A bit under the max tx size as per Ethereum spec
-		cfg.BatcherMaxL1TxSizeBytes = 130072
+		// Make the max deliberately bigger than the target but still with some padding below the actual limit
+		cfg.BatcherTargetL1TxSizeBytes = maxTxDataSize - 5000
+		cfg.BatcherMaxL1TxSizeBytes = maxTxDataSize - 1000
 	}
 }
 

--- a/packages/contracts-bedrock/deploy-config/devnetL1-template.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-template.json
@@ -55,7 +55,7 @@
   "faultGameGenesisBlock": 0,
   "faultGameGenesisOutputRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "faultGameSplitDepth": 14,
-  "preimageOracleMinProposalSize": 18000,
+  "preimageOracleMinProposalSize": 10000,
   "preimageOracleChallengePeriod": 120,
   "preimageOracleCancunActivationTimestamp": 0
 }


### PR DESCRIPTION
**Description**

* Reduce the min size for large preimages in devnet to make it easier to reach the limit.
* Provide a buffer between target and max batch size to avoid the batcher splitting the large tx across multiple smaller frames.

**Tests**

Ran the test locally repeatedly for a few hours with no issues.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/525
