### PR TITLE
ctb: add slither-report.json to gitignore

### DIFF
--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -6,6 +6,7 @@ broadcast
 kout-deployment
 kout-proofs
 test/kontrol/logs
+slither-report.json
 
 # Metrics
 coverage.out

--- a/packages/contracts-bedrock/package.json
+++ b/packages/contracts-bedrock/package.json
@@ -40,7 +40,7 @@
     "preinstall": "npx only-allow pnpm",
     "pre-pr:no-build": "pnpm gas-snapshot:no-build && pnpm snapshots && pnpm semver-lock && pnpm autogen:invariant-docs && pnpm lint && pnpm bindings:go:no-build",
     "pre-pr": "pnpm clean && pnpm build:go-ffi && pnpm build && pnpm pre-pr:no-build",
-    "pre-pr:full": "pnpm test && pnpm slither && pnpm validate-deploy-configs && pnpm validate-spacers && pnpm pre-pr",
+    "pre-pr:full": "pnpm test && pnpm validate-deploy-configs && pnpm validate-spacers && pnpm pre-pr",
     "lint:ts:check": "eslint . --max-warnings=0",
     "lint:forge-tests:check": "npx tsx scripts/forge-test-names.ts",
     "lint:contracts:check": "pnpm lint:fix && git diff --exit-code",


### PR DESCRIPTION
slither-report.json is no longer used in CI. 
We also remove slither build from `pnpm pre-pr`. Though for now, we'll leave the commands in package.json.