### PR TITLE
op-e2e: Actually re-enable large preimage e2e test

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -213,9 +213,6 @@ func TestOutputCannonDefendStep(t *testing.T) {
 }
 
 func TestOutputCannonStepWithLargePreimage(t *testing.T) {
-	// TODO(client-pod#525): Investigate and fix flakiness
-	t.Skip("Skipping until the flakiness can be resolved")
-
 	op_e2e.InitParallel(t, op_e2e.UsesCannon)
 
 	ctx := context.Background()


### PR DESCRIPTION
**Description**

The disable and fix PRs wound up merging cleanly and leaving it disabled.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/525
