### PR TITLE
feat(ops): Wire Dispute Monitor into the Tag Service

### DIFF
--- a/.github/workflows/tag-service.yml
+++ b/.github/workflows/tag-service.yml
@@ -27,6 +27,7 @@ on:
           - op-batcher
           - op-proposer
           - op-challenger
+          - op-dispute-mon
           - op-ufm
           - proxyd
           - ufm-metamask

--- a/ops/tag-service/tag-service.py
+++ b/ops/tag-service/tag-service.py
@@ -17,6 +17,7 @@ MIN_VERSIONS = {
     'op-node': '0.10.14',
     'op-batcher': '0.10.14',
     'op-challenger': '0.0.4',
+    'op-dispute-mon': '0.0.0',
     'op-proposer': '0.10.14',
     'op-ufm': '0.1.0',
     'proxyd': '3.16.0',


### PR DESCRIPTION
**Description**

Wires up the new `op-dispute-mon` into the `tag-service`.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/532
