### PR TITLE
op-e2e: Try to make TestELSync more stable

### DIFF
--- a/op-e2e/actions/l2_engine.go
+++ b/op-e2e/actions/l2_engine.go
@@ -142,6 +142,10 @@ func (s *L2Engine) AddPeers(peers ...*enode.Node) {
 	}
 }
 
+func (s *L2Engine) PeerCount() int {
+	return s.node.Server().PeerCount()
+}
+
 func (s *L2Engine) EthClient() *ethclient.Client {
 	cl := s.node.Attach()
 	return ethclient.NewClient(cl)

--- a/op-program/client/l2/engineapi/l2_engine_api.go
+++ b/op-program/client/l2/engineapi/l2_engine_api.go
@@ -350,7 +350,7 @@ func (ea *L2EngineAPI) forkchoiceUpdated(ctx context.Context, state *eth.Forkcho
 			return STATUS_SYNCING, nil
 		}
 
-		ea.log.Info("Forkchoice requested sync to new head", "number", header.Number, "hash", header.Hash())
+		ea.log.Info("Forkchoice requested sync to new head", "number", header.Number(), "hash", header.Hash())
 		if err := ea.downloader.BeaconSync(downloader.SnapSync, header.Header(), nil); err != nil {
 			return STATUS_SYNCING, err
 		}


### PR DESCRIPTION
**Description**

This moves the op-geth peering step to later in the lifecycle of the TestELSync test. EL sync requires op-geth to be peered & the op-geth peering loop takes a while so by moving the peering step back until op-geth is more likely to be ready we can increase the reliability.

This also ensure that the sequencer and verifier are peered to better isolate the root cause.


**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/541
