### PR TITLE
op-challenger: Support posting sha256 preimages

### DIFF
--- a/op-challenger/game/fault/contracts/oracle_test.go
+++ b/op-challenger/game/fault/contracts/oracle_test.go
@@ -11,24 +11,46 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/keccak/merkle"
 	keccakTypes "github.com/ethereum-optimism/optimism/op-challenger/game/keccak/types"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPreimageOracleContract_LoadKeccak256(t *testing.T) {
-	stubRpc, oracle := setupPreimageOracleTest(t)
+func TestPreimageOracleContract_AddGlobalDataTx(t *testing.T) {
+	t.Run("UnknownType", func(t *testing.T) {
+		_, oracle := setupPreimageOracleTest(t)
+		data := types.NewPreimageOracleData(common.Hash{0xcc}.Bytes(), make([]byte, 20), uint32(545))
+		_, err := oracle.AddGlobalDataTx(data)
+		require.ErrorIs(t, err, ErrUnsupportedKeyType)
+	})
 
-	data := types.NewPreimageOracleData(common.Hash{0xcc}.Bytes(), make([]byte, 20), 545)
-	stubRpc.SetResponse(oracleAddr, methodLoadKeccak256PreimagePart, batching.BlockLatest, []interface{}{
-		new(big.Int).SetUint64(uint64(data.OracleOffset)),
-		data.GetPreimageWithoutSize(),
-	}, nil)
+	t.Run("Keccak256", func(t *testing.T) {
+		stubRpc, oracle := setupPreimageOracleTest(t)
+		data := types.NewPreimageOracleData(common.Hash{byte(preimage.Keccak256KeyType), 0xcc}.Bytes(), make([]byte, 20), uint32(545))
+		stubRpc.SetResponse(oracleAddr, methodLoadKeccak256PreimagePart, batching.BlockLatest, []interface{}{
+			new(big.Int).SetUint64(uint64(data.OracleOffset)),
+			data.GetPreimageWithoutSize(),
+		}, nil)
 
-	tx, err := oracle.AddGlobalDataTx(data)
-	require.NoError(t, err)
-	stubRpc.VerifyTxCandidate(tx)
+		tx, err := oracle.AddGlobalDataTx(data)
+		require.NoError(t, err)
+		stubRpc.VerifyTxCandidate(tx)
+	})
+
+	t.Run("Sha256", func(t *testing.T) {
+		stubRpc, oracle := setupPreimageOracleTest(t)
+		data := types.NewPreimageOracleData(common.Hash{byte(preimage.Sha256KeyType), 0xcc}.Bytes(), make([]byte, 20), uint32(545))
+		stubRpc.SetResponse(oracleAddr, methodLoadSha256PreimagePart, batching.BlockLatest, []interface{}{
+			new(big.Int).SetUint64(uint64(data.OracleOffset)),
+			data.GetPreimageWithoutSize(),
+		}, nil)
+
+		tx, err := oracle.AddGlobalDataTx(data)
+		require.NoError(t, err)
+		stubRpc.VerifyTxCandidate(tx)
+	})
 }
 
 func TestPreimageOracleContract_ChallengePeriod(t *testing.T) {

--- a/op-challenger/game/fault/contracts/vm_test.go
+++ b/op-challenger/game/fault/contracts/vm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
 	"github.com/ethereum/go-ethereum/common"
@@ -24,7 +25,7 @@ func TestVMContract_Oracle(t *testing.T) {
 
 	oracleContract, err := vmContract.Oracle(context.Background())
 	require.NoError(t, err)
-	tx, err := oracleContract.AddGlobalDataTx(types.NewPreimageOracleData(common.Hash{}.Bytes(), make([]byte, 20), 0))
+	tx, err := oracleContract.AddGlobalDataTx(types.NewPreimageOracleData(common.Hash{byte(preimage.Keccak256KeyType)}.Bytes(), make([]byte, 20), 0))
 	require.NoError(t, err)
 	// This test doesn't care about all the tx details, we just want to confirm the contract binding is using the
 	// correct address

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"time"
 
+	preimage "github.com/ethereum-optimism/optimism/op-preimage"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -48,7 +49,7 @@ func (p *PreimageOracleData) GetPreimageWithSize() []byte {
 // NewPreimageOracleData creates a new [PreimageOracleData] instance.
 func NewPreimageOracleData(key []byte, data []byte, offset uint32) *PreimageOracleData {
 	return &PreimageOracleData{
-		IsLocal:      len(key) > 0 && key[0] == byte(1),
+		IsLocal:      len(key) > 0 && key[0] == byte(preimage.LocalKeyType),
 		OracleKey:    key,
 		oracleData:   data,
 		OracleOffset: offset,

--- a/op-preimage/iface.go
+++ b/op-preimage/iface.go
@@ -34,7 +34,7 @@ const (
 	LocalKeyType KeyType = 1
 	// Keccak256KeyType is for keccak256 pre-images, for any global shared pre-images.
 	Keccak256KeyType KeyType = 2
-	// GlobalGenericKeyType is a reseved key type for generic global data.
+	// GlobalGenericKeyType is a reserved key type for generic global data.
 	GlobalGenericKeyType KeyType = 3
 	// Sha256KeyType is for sha256 pre-images, for any global shared pre-images.
 	Sha256KeyType KeyType = 4


### PR DESCRIPTION
**Description**

Add support for posting sha256 preimages to op-challenger.

**Tests**

Updated unit tests.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/548
