### PR TITLE
op-e2e: Fix flaky large preimage test

### DIFF
--- a/op-e2e/e2eutils/batcher/batcher.go
+++ b/op-e2e/e2eutils/batcher/batcher.go
@@ -1,0 +1,56 @@
+package batcher
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+type Helper struct {
+	t         *testing.T
+	privKey   *ecdsa.PrivateKey
+	rollupCfg *rollup.Config
+	l1Client  *ethclient.Client
+}
+
+func NewHelper(t *testing.T, privKey *ecdsa.PrivateKey, rollupCfg *rollup.Config, l1Client *ethclient.Client) *Helper {
+	return &Helper{
+		t:         t,
+		privKey:   privKey,
+		rollupCfg: rollupCfg,
+		l1Client:  l1Client,
+	}
+}
+
+func (h *Helper) SendLargeInvalidBatch(ctx context.Context) {
+	nonce, err := h.l1Client.PendingNonceAt(ctx, crypto.PubkeyToAddress(h.privKey.PublicKey))
+	require.NoError(h.t, err, "Should get next batcher nonce")
+
+	maxTxDataSize := 131072 // As per the Ethereum spec.
+	data := testutils.RandomData(rand.New(rand.NewSource(9849248)), maxTxDataSize-200)
+	tx := gethTypes.MustSignNewTx(h.privKey, h.rollupCfg.L1Signer(), &gethTypes.DynamicFeeTx{
+		ChainID:   h.rollupCfg.L1ChainID,
+		Nonce:     nonce,
+		GasTipCap: big.NewInt(1 * params.GWei),
+		GasFeeCap: big.NewInt(10 * params.GWei),
+		Gas:       5_000_000,
+		To:        &h.rollupCfg.BatchInboxAddress,
+		Value:     big.NewInt(0),
+		Data:      data,
+	})
+	err = h.l1Client.SendTransaction(ctx, tx)
+	require.NoError(h.t, err, "Should send large batch transaction")
+	_, err = wait.ForReceiptOK(ctx, h.l1Client, tx.Hash())
+	require.NoError(h.t, err, "Tx should be ok")
+}

--- a/op-e2e/e2eutils/wait/blocks.go
+++ b/op-e2e/e2eutils/wait/blocks.go
@@ -84,11 +84,11 @@ func ForUnsafeBlock(ctx context.Context, rollupCl *sources.RollupClient, n uint6
 	return err
 }
 
-func ForNextSafeBlock(ctx context.Context, client BlockCaller) error {
+func ForNextSafeBlock(ctx context.Context, client BlockCaller) (*types.Block, error) {
 	safeBlockNumber := big.NewInt(rpc.SafeBlockNumber.Int64())
 	current, err := client.BlockByNumber(ctx, safeBlockNumber)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Long timeout so we don't have to care what the block time is. If the test passes this will complete early anyway.
@@ -97,14 +97,14 @@ func ForNextSafeBlock(ctx context.Context, client BlockCaller) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		default:
 			next, err := client.BlockByNumber(ctx, safeBlockNumber)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if next.NumberU64() > current.NumberU64() {
-				return nil
+				return next, nil
 			}
 			time.Sleep(500 * time.Millisecond)
 		}

--- a/op-e2e/faultproofs/util.go
+++ b/op-e2e/faultproofs/util.go
@@ -10,13 +10,9 @@ import (
 
 type faultDisputeConfigOpts func(cfg *op_e2e.SystemConfig)
 
-func withLargeBatches() faultDisputeConfigOpts {
+func withBatcherStopped() faultDisputeConfigOpts {
 	return func(cfg *op_e2e.SystemConfig) {
-		maxTxDataSize := uint64(131072) // As per the Ethereum spec.
-		// Allow the batcher to produce really huge calldata transactions.
-		// Make the max deliberately bigger than the target but still with some padding below the actual limit
-		cfg.BatcherTargetL1TxSizeBytes = maxTxDataSize - 5000
-		cfg.BatcherMaxL1TxSizeBytes = maxTxDataSize - 1000
+		cfg.DisableBatcher = true
 	}
 }
 

--- a/op-e2e/sequencer_failover_setup.go
+++ b/op-e2e/sequencer_failover_setup.go
@@ -115,8 +115,10 @@ func setupSequencerFailoverTest(t *testing.T) (*System, map[string]*conductor) {
 	// weirdly, batcher does not submit a batch until unsafe block 9.
 	// It became normal after that and submits a batch every L1 block (2s) per configuration.
 	// Since our health monitor checks on safe head progression, wait for batcher to become normal before proceeding.
-	require.NoError(t, wait.ForNextSafeBlock(ctx, sys.Clients[Sequencer1Name]))
-	require.NoError(t, wait.ForNextSafeBlock(ctx, sys.Clients[Sequencer1Name]))
+	_, err = wait.ForNextSafeBlock(ctx, sys.Clients[Sequencer1Name])
+	require.NoError(t, err)
+	_, err = wait.ForNextSafeBlock(ctx, sys.Clients[Sequencer1Name])
+	require.NoError(t, err)
 
 	// make sure conductor reports all sequencers as healthy, this means they're syncing correctly.
 	require.Eventually(t, func() bool {

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/batcher"
 	ds "github.com/ipfs/go-datastore"
 	dsSync "github.com/ipfs/go-datastore/sync"
 	ic "github.com/libp2p/go-libp2p/core/crypto"
@@ -851,6 +852,10 @@ func (sys *System) newMockNetPeer() (host.Host, error) {
 		return nil, err
 	}
 	return sys.Mocknet.AddPeerWithPeerstore(p, eps)
+}
+
+func (sys *System) BatcherHelper() *batcher.Helper {
+	return batcher.NewHelper(sys.t, sys.Cfg.Secrets.Batcher, sys.RollupConfig, sys.NodeClient("l1"))
 }
 
 func UseHTTP() bool {

--- a/op-e2e/tx_helper.go
+++ b/op-e2e/tx_helper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"math/big"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
-	"github.com/ethereum-optimism/optimism/op-service/testutils"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -79,17 +77,6 @@ func defaultDepositTxOpts(opts *bind.TransactOpts) *DepositTxOpts {
 		Data:           nil,
 		ExpectedStatus: types.ReceiptStatusSuccessful,
 	}
-}
-
-// SendLargeL2Tx creates and sends a transaction with a large amount of txdata.
-func SendLargeL2Tx(t *testing.T, cfg SystemConfig, l2Client *ethclient.Client, privKey *ecdsa.PrivateKey, applyTxOpts TxOptsFn) *types.Receipt {
-	maxTxDataSize := 131072                                                          // As per the Ethereum spec.
-	data := testutils.RandomData(rand.New(rand.NewSource(12342)), maxTxDataSize-200) // Leave some buffer
-	return SendL2Tx(t, cfg, l2Client, privKey, func(opts *TxOpts) {
-		opts.Data = data
-		opts.Gas = uint64(2_200_000) // Lots but less than the block limit
-		applyTxOpts(opts)
-	})
 }
 
 // SendL2Tx creates and sends a transaction.


### PR DESCRIPTION
**Description**

Take the batcher out of the equation and manually send a very large batch transaction.
