### PR TITLE
op-node: fix p2p deserialization for ecotone

### DIFF
--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -655,7 +655,9 @@ func (s *SyncClient) doRequest(ctx context.Context, id peer.ID, expectedBlockNum
 
 func (s *SyncClient) readExecutionPayload(data []byte, expectedTime uint64) (*eth.ExecutionPayloadEnvelope, error) {
 	blockVersion := eth.BlockV1
-	if s.cfg.IsCanyon(expectedTime) {
+	if s.cfg.IsEcotone(expectedTime) {
+		blockVersion = eth.BlockV3
+	} else if s.cfg.IsCanyon(expectedTime) {
 		blockVersion = eth.BlockV2
 	}
 


### PR DESCRIPTION
**Description**

Seems like ecotone updates are not caught in the p2p req/res
sync codepath? Might be a few other places that need updates
too.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

