### PR TITLE
op-bootnode: Enable P2P RPC Server

### DIFF
--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	opnode "github.com/ethereum-optimism/optimism/op-node"
 	"github.com/ethereum-optimism/optimism/op-node/metrics"
@@ -20,6 +21,7 @@ import (
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/opio"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
 type gossipNoop struct{}
@@ -72,6 +74,29 @@ func Main(cliCtx *cli.Context) error {
 	if p2pNode.Dv5Udp() == nil {
 		return fmt.Errorf("uninitialized discovery service")
 	}
+
+	rpcCfg := oprpc.ReadCLIConfig(cliCtx)
+	if err := rpcCfg.Check(); err != nil {
+		return fmt.Errorf("failed to validate RPC config")
+	}
+	rpcServer := oprpc.NewServer(rpcCfg.ListenAddr, rpcCfg.ListenPort, "", oprpc.WithLogger(logger))
+	if rpcCfg.EnableAdmin {
+		logger.Info("Admin RPC enabled but does nothing for the bootnode")
+	}
+	rpcServer.AddAPI(rpc.API{
+		Namespace:     p2p.NamespaceRPC,
+		Version:       "",
+		Service:       p2p.NewP2PAPIBackend(p2pNode, logger, m),
+		Authenticated: false,
+	})
+	if err := rpcServer.Start(); err != nil {
+		return fmt.Errorf("failed to start the RPC server")
+	}
+	defer func() {
+		if err := rpcServer.Stop(); err != nil {
+			log.Error("failed to stop RPC server", "err", err)
+		}
+	}()
 
 	go p2pNode.DiscoveryProcess(ctx, logger, config, p2pConfig.TargetPeers())
 

--- a/op-bootnode/flags/flags.go
+++ b/op-bootnode/flags/flags.go
@@ -7,6 +7,7 @@ import (
 	opflags "github.com/ethereum-optimism/optimism/op-service/flags"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 )
 
 const envVarPrefix = "OP_BOOTNODE"
@@ -20,4 +21,5 @@ func init() {
 	Flags = append(Flags, flags.P2PFlags(envVarPrefix)...)
 	Flags = append(Flags, opmetrics.CLIFlags(envVarPrefix)...)
 	Flags = append(Flags, oplog.CLIFlags(envVarPrefix)...)
+	Flags = append(Flags, oprpc.CLIFlags(envVarPrefix)...)
 }


### PR DESCRIPTION
**Description**

Adds the P2P RPC Server to the bootnodes. This enables getting good debug data off of the bootnodes.
