### PR TITLE
cannon: Support stopping at specific types of preimages not just local or keccak

### DIFF
--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -252,10 +252,14 @@ type preimageOpts []string
 
 type PreimageOpt func() preimageOpts
 
-func FirstGlobalPreimageLoad() PreimageOpt {
+func FirstPreimageLoadOfType(preimageType string) PreimageOpt {
 	return func() preimageOpts {
-		return []string{"--stop-at-preimage-type", "global"}
+		return []string{"--stop-at-preimage-type", preimageType}
 	}
+}
+
+func FirstKeccakPreimageLoad() PreimageOpt {
+	return FirstPreimageLoadOfType("keccak")
 }
 
 func PreimageLargerThan(size int) PreimageOpt {

--- a/op-e2e/e2eutils/disputegame/output_cannon_helper.go
+++ b/op-e2e/e2eutils/disputegame/output_cannon_helper.go
@@ -209,6 +209,7 @@ func (g *OutputCannonGameHelper) ChallengeToPreimageLoad(ctx context.Context, ou
 
 	// Now the preimage is available wait for the step call to succeed.
 	leafClaim.WaitForCountered(ctx)
+	g.LogGameData(ctx)
 }
 
 func (g *OutputCannonGameHelper) createCannonTraceProvider(ctx context.Context, l2Node string, outputRootClaim *ClaimHelper, options ...challenger.Option) *cannon.CannonTraceProviderForTest {


### PR DESCRIPTION
**Description**

Updates cannon to support stopping a preimages of a specific type, rather than just local or keccak.  This will allow testing uploads of sha256 or blob data (once challenger supports running with Ecotone active).

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/548
