### PR TITLE
op-e2e: Fix index in fakebeacon blob responses

### DIFF
--- a/op-e2e/e2eutils/fakebeacon/blobs.go
+++ b/op-e2e/e2eutils/fakebeacon/blobs.go
@@ -113,7 +113,7 @@ func (f *FakeBeacon) Start(addr string) error {
 				return
 			}
 			sidecars[i] = &eth.APIBlobSidecar{
-				Index:         eth.Uint64String(i),
+				Index:         eth.Uint64String(ix),
 				KZGCommitment: eth.Bytes48(bundle.Commitments[ix]),
 				KZGProof:      eth.Bytes48(bundle.Proofs[ix]),
 				SignedBlockHeader: eth.SignedBeaconBlockHeader{

--- a/op-service/sources/l1_beacon_client.go
+++ b/op-service/sources/l1_beacon_client.go
@@ -140,7 +140,7 @@ func (cl *L1BeaconClient) GetBlobSidecars(ctx context.Context, ref eth.L1BlockRe
 	}
 
 	if len(hashes) != len(apiscs) {
-		return nil, fmt.Errorf("expected %v sidecars but got %v", len(hashes), len(resp.Data))
+		return nil, fmt.Errorf("expected %v sidecars but got %v", len(hashes), len(apiscs))
 	}
 
 	bscs := make([]*eth.BlobSidecar, 0, len(hashes))


### PR DESCRIPTION
**Description**

The fake beacon API was starting the blob indices it returned from 0 even if it had filtered the blobs.  So when filtering to retrieve only blob 1 it was returned with blob 0 which then failed the client's validation.

Also fixed the error message in the client validation so it doesn't say "expected 1 sidecars but got 1 sidecars).