### PR TITLE
Bumps @eth-optimism/contracts-bedrock

### DIFF
--- a/.changeset/rotten-dots-destroy.md
+++ b/.changeset/rotten-dots-destroy.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/contracts-bedrock': patch
+---
+
+Bumps version so fpac contracts exist for SDK to consume


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Bumps `@eth-optimism/contracts-bedrock` so fpac contracts exist for the SDK on lookup.

When I pull in the latest SDK version on the develop branch it's resolving to [0.16.2](https://www.npmjs.com/package/@eth-optimism/contracts-bedrock/v/0.16.2) this is 4 months old and doesn't have the `DisputeGameFactory` & `OptimismPortal2` json in it.

Results in anything that consumes the SDK to crash on startup

```
Uncaught TypeError: Failed to resolve module specifier "@eth-optimism/contracts-bedrock/forge-artifacts/DisputeGameFactory.sol/DisputeGameFactory.json". Relative references must start with either "/", "./", or "../".
```

The code for the above errors is happening over [here](https://github.com/ethereum-optimism/optimism/blob/5b34a86c1a9912616823677ccf8ed3b726089805/packages/sdk/src/utils/contracts.ts#L17-L18)