### PR TITLE
op-e2e: Don't double peer

### DIFF
--- a/op-e2e/actions/sync_test.go
+++ b/op-e2e/actions/sync_test.go
@@ -187,7 +187,6 @@ func TestELSync(gt *testing.T) {
 	}
 
 	// Wait longer to peer. This tests flakes or takes a long time when the op-geth instances are not able to peer.
-	seqEng.AddPeers(verEng.Enode())
 	verEng.AddPeers(seqEng.Enode())
 
 	// Insert it on the verifier
@@ -201,7 +200,7 @@ func TestELSync(gt *testing.T) {
 		func() bool {
 			return seqEng.PeerCount() > 0 && verEng.PeerCount() > 0
 		},
-		60*time.Second, 1500*time.Millisecond,
+		120*time.Second, 1500*time.Millisecond,
 		"Sequencer & Verifier must peer with each other for snap sync to work",
 	)
 


### PR DESCRIPTION
**Description**

This does a one-way peer from the verifier to the sequencer instead of having both peer with each other. Locally this seemed to be more reliable than the two nodes both dialing each other.

This also bumps the peering timeout.


**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/5
