### PR TITLE
op-node: delete dead hh artifact reading code

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/hardhat"
 	"github.com/ethereum-optimism/optimism/op-bindings/predeploys"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/immutables"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/state"
@@ -458,52 +457,6 @@ func (d *DeployConfig) SetDeployments(deployments *L1Deployments) {
 	d.OptimismPortalProxy = deployments.OptimismPortalProxy
 }
 
-// GetDeployedAddresses will get the deployed addresses of deployed L1 contracts
-// required for the L2 genesis creation.
-func (d *DeployConfig) GetDeployedAddresses(hh *hardhat.Hardhat) error {
-	if d.L1StandardBridgeProxy == (common.Address{}) {
-		l1StandardBridgeProxyDeployment, err := hh.GetDeployment("L1StandardBridgeProxy")
-		if err != nil {
-			return fmt.Errorf("cannot find L1StandardBridgeProxy artifact: %w", err)
-		}
-		d.L1StandardBridgeProxy = l1StandardBridgeProxyDeployment.Address
-	}
-
-	if d.L1CrossDomainMessengerProxy == (common.Address{}) {
-		l1CrossDomainMessengerProxyDeployment, err := hh.GetDeployment("L1CrossDomainMessengerProxy")
-		if err != nil {
-			return fmt.Errorf("cannot find L1CrossDomainMessengerProxy artifact: %w", err)
-		}
-		d.L1CrossDomainMessengerProxy = l1CrossDomainMessengerProxyDeployment.Address
-	}
-
-	if d.L1ERC721BridgeProxy == (common.Address{}) {
-		l1ERC721BridgeProxyDeployment, err := hh.GetDeployment("L1ERC721BridgeProxy")
-		if err != nil {
-			return fmt.Errorf("cannot find L1ERC721BridgeProxy artifact: %w", err)
-		}
-		d.L1ERC721BridgeProxy = l1ERC721BridgeProxyDeployment.Address
-	}
-
-	if d.SystemConfigProxy == (common.Address{}) {
-		systemConfigProxyDeployment, err := hh.GetDeployment("SystemConfigProxy")
-		if err != nil {
-			return fmt.Errorf("cannot find SystemConfigProxy artifact: %w", err)
-		}
-		d.SystemConfigProxy = systemConfigProxyDeployment.Address
-	}
-
-	if d.OptimismPortalProxy == (common.Address{}) {
-		optimismPortalProxyDeployment, err := hh.GetDeployment("OptimismPortalProxy")
-		if err != nil {
-			return fmt.Errorf("cannot find OptimismPortalProxy artifact: %w", err)
-		}
-		d.OptimismPortalProxy = optimismPortalProxyDeployment.Address
-	}
-
-	return nil
-}
-
 func (d *DeployConfig) GovernanceEnabled() bool {
 	return d.EnableGovernance
 }
@@ -885,8 +838,7 @@ func NewL2ImmutableConfig(config *DeployConfig, block *types.Block) (*immutables
 	return &cfg, nil
 }
 
-// NewL2StorageConfig will create a StorageConfig given an instance of a
-// Hardhat and a DeployConfig.
+// NewL2StorageConfig will create a StorageConfig given an instance of a DeployConfig and genesis block.
 func NewL2StorageConfig(config *DeployConfig, block *types.Block) (state.StorageConfig, error) {
 	storage := make(state.StorageConfig)
 

--- a/op-node/cmd/genesis/cmd.go
+++ b/op-node/cmd/genesis/cmd.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path/filepath"
 
 	"github.com/urfave/cli/v2"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum-optimism/optimism/op-bindings/hardhat"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-service/jsonutil"
 )
@@ -37,13 +35,10 @@ var (
 		Usage:    "Path to deploy config file",
 		Required: true,
 	}
-	deploymentDirFlag = &cli.PathFlag{
-		Name:  "deployment-dir",
-		Usage: "Path to network deployment directory. Cannot be used with --l1-deployments",
-	}
 	l1DeploymentsFlag = &cli.PathFlag{
-		Name:  "l1-deployments",
-		Usage: "Path to L1 deployments JSON file. Cannot be used with --deployment-dir",
+		Name:     "l1-deployments",
+		Usage:    "Path to L1 deployments JSON file as in superchain-registry",
+		Required: true,
 	}
 	outfileL2Flag = &cli.PathFlag{
 		Name:  "outfile.l2",
@@ -74,7 +69,6 @@ var (
 		l1RPCFlag,
 		l1StartingBlockFlag,
 		deployConfigFlag,
-		deploymentDirFlag,
 		l1DeploymentsFlag,
 		outfileL2Flag,
 		outfileRollupFlag,
@@ -147,16 +141,7 @@ var Subcommands = cli.Commands{
 				return err
 			}
 
-			deployDir := ctx.Path("deployment-dir")
 			l1Deployments := ctx.Path("l1-deployments")
-
-			if deployDir != "" && l1Deployments != "" {
-				return errors.New("cannot specify both --deployment-dir and --l1-deployments")
-			}
-			if deployDir == "" && l1Deployments == "" {
-				return errors.New("must specify either --deployment-dir or --l1-deployments")
-			}
-
 			l1StartBlockPath := ctx.Path("l1-starting-block")
 			l1RPC := ctx.String("l1-rpc")
 
@@ -167,27 +152,11 @@ var Subcommands = cli.Commands{
 				return errors.New("cannot specify both --l1-starting-block and --l1-rpc")
 			}
 
-			if deployDir != "" {
-				log.Info("Deployment directory", "path", deployDir)
-				depPath, network := filepath.Split(deployDir)
-				hh, err := hardhat.New(network, nil, []string{depPath})
-				if err != nil {
-					return err
-				}
-
-				// Read the appropriate deployment addresses from disk
-				if err := config.GetDeployedAddresses(hh); err != nil {
-					return err
-				}
+			deployments, err := genesis.NewL1Deployments(l1Deployments)
+			if err != nil {
+				return fmt.Errorf("cannot read L1 deployments at %s: %w", l1Deployments, err)
 			}
-
-			if l1Deployments != "" {
-				deployments, err := genesis.NewL1Deployments(l1Deployments)
-				if err != nil {
-					return fmt.Errorf("cannot read L1 deployments at %s: %w", l1Deployments, err)
-				}
-				config.SetDeployments(deployments)
-			}
+			config.SetDeployments(deployments)
 
 			var l1StartBlock *types.Block
 			if l1StartBlockPath != "" {


### PR DESCRIPTION
**Description**

The config option for using `superchain-registry` style config
has been around for awhile and has been used by the devnet for
awhile. We have deprecated the usage of hh deploy style artifacts
as part of the repo and have deleted them and the code that
generates them. This PR removes the functionality of reading
hh deploy style artifacts from disk to create the L2 genesis
in `op-node`. This deletes dead code to simplify things.

Larger refactors are coming to this code path as it will wrap
forge in the future since the forge script is what will be
used to build the L2 genesis. This will ensure backwards compatibility.
Right now since the Go code builds the L2 genesis, the L2 genesis
is tied to releases of `op-node`. Once we move to foundry, then
the L2 contracts will be on their own release schedule specific
to the contracts and not the `op-node`.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

