### PR TITLE
Expected Foundry checks and install script updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "release:version": "changeset version && pnpm install --lockfile-only",
     "install:foundry": "curl -L https://foundry.paradigm.xyz | bash && pnpm update:foundry",
     "update:foundry": "bash ./ops/scripts/install-foundry.sh",
+    "check:foundry": "bash ./packages/contracts-bedrock/scripts/verify-foundry-install.sh",
     "install:kontrol": "curl -L https://kframework.org/install | bash && pnpm update:kontrol",
     "update:kontrol": "kup install kontrol --version v$(jq -r .kontrol < versions.json)",
     "install:abigen": "go install github.com/ethereum/go-ethereum/cmd/abigen@$(jq -r .abigen < versions.json)",

--- a/packages/contracts-bedrock/scripts/getting-started/versions.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/versions.sh
@@ -14,23 +14,37 @@ version() {
   fi
 }
 
+versionFoundry() {
+  local string="$1"
+  local version_regex='forge ([0-9]+\.[0-9]+\.[0-9]+)'
+  local commit_hash_regex='\(([a-fA-F0-9]+)'
+  local full_regex="${version_regex} ${commit_hash_regex}"
+
+  if [[ $string =~ $full_regex ]]; then
+    echo "${BASH_REMATCH[1]} (${BASH_REMATCH[2]})"
+  else
+    echo "No version, commit hash, and timestamp found."
+  fi
+}
+
+
 # Grab versions
 ver_git=$(version "$(git --version)")
 ver_go=$(version "$(go version)")
 ver_node=$(version "$(node --version)")
 ver_pnpm=$(version "$(pnpm --version)")
-ver_foundry=$(version "$(forge --version)")
+ver_foundry=$(versionFoundry "$(forge --version)")
 ver_make=$(version "$(make --version)")
 ver_jq=$(version "$(jq --version)")
 ver_direnv=$(version "$(direnv --version)")
 
 # Print versions
-echo "Dependency | Minimum | Actual"
-echo "git          2         $ver_git"
-echo "go           1.21      $ver_go"
-echo "node         20        $ver_node"
-echo "pnpm         8         $ver_pnpm"
-echo "foundry      0.2.0     $ver_foundry"
-echo "make         3         $ver_make"
-echo "jq           1.6       $ver_jq"
-echo "direnv       2         $ver_direnv"
+echo "Dependency | Minimum         | Actual"
+echo "git          2                $ver_git"
+echo "go           1.21             $ver_go"
+echo "node         20               $ver_node"
+echo "pnpm         8                $ver_pnpm"
+echo "foundry      0.2.0 (a5efe4f)  $ver_foundry"
+echo "make         3                $ver_make"
+echo "jq           1.6              $ver_jq"
+echo "direnv       2                $ver_direnv"

--- a/packages/contracts-bedrock/scripts/verify-foundry-install.sh
+++ b/packages/contracts-bedrock/scripts/verify-foundry-install.sh
@@ -1,11 +1,38 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+CONTRACTS_BASE=$(dirname "$SCRIPT_DIR")
+MONOREPO_BASE=$(dirname "$(dirname "$CONTRACTS_BASE")")
+VERSIONS_FILE="${MONOREPO_BASE}/versions.json"
+
 if ! command -v forge &> /dev/null
 then
   # shellcheck disable=SC2006
-  echo "Is Foundry not installed? Consider installing via `curl -L https://foundry.paradigm.xyz | bash` and then running `foundryup` on a new terminal. For more context, check the installation instructions in the book: https://book.getfoundry.sh/getting-started/installation.html."
+  echo "Is Foundry not installed? Consider installing via pnpm install:foundry" >&2
   exit 1
 fi
 
-VERSION=$(forge --version)
-echo "Using foundry version: $VERSION"
+# Check VERSIONS_FILE has expected foundry property
+if ! jq -e '.foundry' "$VERSIONS_FILE" &> /dev/null; then
+  echo "'foundry' is missing from $VERSIONS_FILE" >&2
+  exit 1
+fi
+
+# Extract the expected foundry version from versions.json
+EXPECTED_VERSION=$(jq -r '.foundry' "$VERSIONS_FILE" | cut -c 1-7)
+if [ -z "$EXPECTED_VERSION" ]; then
+  echo "Unable to extract Foundry version from $VERSIONS_FILE" >&2
+  exit 1
+fi
+
+# Extract the installed forge version
+INSTALLED_VERSION=$(forge --version | grep -o '[a-f0-9]\{7\}' | head -n 1)
+
+# Compare the installed timestamp with the expected timestamp
+if [ "$INSTALLED_VERSION" = "$EXPECTED_VERSION" ]; then
+  echo "Foundry version matches the expected version."
+else
+  echo "Mismatch between installed Foundry version ($INSTALLED_VERSION) and expected version ($EXPECTED_VERSION)."
+  echo "Your version of Foundry may either not be up to date, or it could be a later version."
+  echo "Running pnpm update:foundry will install the expected version."
+fi

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
   "abigen": "v1.10.25",
-  "foundry": "84d98427e17370ff08ec34f00e3c7e539753a760",
+  "foundry": "a5efe4f8f425e2f6fb35b0e298f0f46acce11dad",
   "geth": "v1.13.4",
   "nvm": "v20.9.0",
   "slither": "0.10.0",


### PR DESCRIPTION
The `make devnet-allocs` cmd and the refactored L2 genesis generation script (#9292) need one of the recently published nightly versions of Foundry. This PR:

- Updates the expected Foundry version commit hash in `versions.json` to: `a5efe4f8f425e2f6fb35b0e298f0f46acce11dad` (latest release as of `(2024-02-08T00:16:00.244105000Z)`)
- Updates the `verify-foundry-install.sh` script to check if the installed Forge version matches what's specified in `versions.json`
- Updates `versions.sh` script to output expected commit hash and timestamp for Forge version
- Adds `check:foundry` pnpm cmd to root `package.json` to execute `verify-foundry-install.sh`

[Additional context](https://github.com/ethereum-optimism/optimism/pull/9292#discussion_r1479166511) on why this was done