### PR TITLE
fpac-deploy: Adds some new config options to the sepolia deploy config and use reproducible build

### DIFF
--- a/packages/contracts-bedrock/deploy-config/sepolia.json
+++ b/packages/contracts-bedrock/deploy-config/sepolia.json
@@ -42,7 +42,7 @@
   "systemConfigStartBlock": 4071248,
   "requiredProtocolVersion": "0x0000000000000000000000000000000000000004000000000000000000000001",
   "recommendedProtocolVersion": "0x0000000000000000000000000000000000000004000000000000000000000001",
-  "faultGameAbsolutePrestate": "0x037bbcc23684afbb7f608024369242c5cdea261a4f63981387efb7cd81763536",
+  "faultGameAbsolutePrestate": "0x03e1255457128b9afd9acf93239c1d477bdff88624901f9ca8fe0783b756dbe0",
   "faultGameMaxDepth": 73,
   "faultGameMaxDuration": 86400,
   "faultGameGenesisBlock": 0,
@@ -50,5 +50,9 @@
   "faultGameSplitDepth": 32,
   "preimageOracleMinProposalSize": 1800000,
   "preimageOracleChallengePeriod": 86400,
-  "preimageOracleCancunActivationTimestamp": 1706655072
+  "preimageOracleCancunActivationTimestamp": 1706655072,
+  "proofMaturityDelaySeconds": 12,
+  "disputeGameFinalityDelaySeconds": 6,
+  "respectedGameType": 0,
+  "useFaultProofs": false
 }

--- a/packages/contracts-bedrock/scripts/fpac/Makefile
+++ b/packages/contracts-bedrock/scripts/fpac/Makefile
@@ -10,7 +10,7 @@ help: # Show help for each of the Makefile recipes.
 
 .PHONY: cannon-prestate
 cannon-prestate: # Generate the cannon prestate, and tar the `op-program` + `cannon` binaries + prestate data used to generate it.
-	cd $(monorepo_root) && make cannon-prestate
+	cd $(monorepo_root) && make reproducible-prestate
 	@mkdir -p prestate-artifacts
 	@cp -r $(monorepo_root)/cannon/bin/** prestate-artifacts/
 	@cp -r $(monorepo_root)/op-program/bin/** prestate-artifacts/


### PR DESCRIPTION
**Description**

The fpac deploy script now includes the new config options that have been added as part of hook it up.  It also uses the reproducible-prestate build target so we should get the same prestate when rebuilding.
