### PR TITLE
op-preimage: Update verification for sha256 and blobs

### DIFF
--- a/op-preimage/verifier.go
+++ b/op-preimage/verifier.go
@@ -1,6 +1,7 @@
 package preimage
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"slices"
@@ -27,6 +28,15 @@ func WithVerification(source PreimageGetter) PreimageGetter {
 			if !slices.Equal(hash[1:], key[1:]) {
 				return nil, fmt.Errorf("%w for key %v, hash: %v data: %x", ErrIncorrectData, key, hash, data)
 			}
+			return data, nil
+		case Sha256KeyType:
+			hash := sha256.Sum256(data)
+			if !slices.Equal(hash[1:], key[1:]) {
+				return nil, fmt.Errorf("%w for key %v, hash: %v data: %x", ErrIncorrectData, key, hash, data)
+			}
+			return data, nil
+		case BlobKeyType:
+			// Can't verify an individual field element without having a kzg proof
 			return data, nil
 		default:
 			return nil, fmt.Errorf("%w: %v", ErrUnsupportedKeyType, key[0])

--- a/op-preimage/verifier_test.go
+++ b/op-preimage/verifier_test.go
@@ -1,7 +1,10 @@
 package preimage
 
 import (
+	"crypto/sha256"
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,16 +13,20 @@ import (
 func TestWithVerification(t *testing.T) {
 	validData := []byte{1, 2, 3, 4, 5, 6}
 	keccak256Key := Keccak256Key(Keccak256(validData))
+	sha256Key := Sha256Key(sha256.Sum256(validData))
 	anError := errors.New("boom")
 
-	tests := []struct {
+	validKeys := []Key{keccak256Key, sha256Key}
+
+	type testData struct {
 		name         string
 		key          Key
 		data         []byte
 		err          error
 		expectedErr  error
 		expectedData []byte
-	}{
+	}
+	tests := []testData{
 		{
 			name:         "LocalKey NoVerification",
 			key:          LocalIndexKey(1),
@@ -27,29 +34,10 @@ func TestWithVerification(t *testing.T) {
 			expectedData: []byte{4, 3, 5, 7, 3},
 		},
 		{
-			name:         "Keccak256 Valid",
-			key:          keccak256Key,
-			data:         validData,
-			expectedData: validData,
-		},
-		{
-			name:        "Keccak256 Error",
-			key:         keccak256Key,
-			data:        validData,
-			err:         anError,
-			expectedErr: anError,
-		},
-		{
-			name:        "Keccak256 InvalidData",
-			key:         keccak256Key,
-			data:        []byte{6, 7, 8},
-			expectedErr: ErrIncorrectData,
-		},
-		{
-			name:        "EmptyData",
-			key:         keccak256Key,
-			data:        []byte{},
-			expectedErr: ErrIncorrectData,
+			name:         "BlobKey NoVerification",
+			key:          BlobKey([32]byte{1, 2, 3, 4}),
+			data:         []byte{4, 3, 5, 7, 3},
+			expectedData: []byte{4, 3, 5, 7, 3},
 		},
 		{
 			name:        "UnknownKey",
@@ -57,6 +45,36 @@ func TestWithVerification(t *testing.T) {
 			data:        []byte{},
 			expectedErr: ErrUnsupportedKeyType,
 		},
+	}
+
+	for _, key := range validKeys {
+		name := reflect.TypeOf(key).Name()
+		tests = append(tests,
+			testData{
+				name:         fmt.Sprintf("%v-Valid", name),
+				key:          key,
+				data:         validData,
+				expectedData: validData,
+			},
+			testData{
+				name:        fmt.Sprintf("%v-Error", name),
+				key:         key,
+				data:        validData,
+				err:         anError,
+				expectedErr: anError,
+			},
+			testData{
+				name:        fmt.Sprintf("%v-InvalidData", name),
+				key:         key,
+				data:        []byte{6, 7, 8},
+				expectedErr: ErrIncorrectData,
+			},
+			testData{
+				name:        fmt.Sprintf("%v-EmptyData", name),
+				key:         key,
+				data:        []byte{},
+				expectedErr: ErrIncorrectData,
+			})
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Description**

Updates the preimage verifier to support sha256 and blob data types.

**Tests**

Updated unit tests.


**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/548
