### PR TITLE
op-challenger: Fix cli args for subcommands

### DIFF
--- a/op-challenger/cmd/create_game.go
+++ b/op-challenger/cmd/create_game.go
@@ -63,16 +63,16 @@ func CreateGame(ctx *cli.Context) error {
 	return nil
 }
 
-var createGameFlags = []cli.Flag{
-	flags.L1EthRpcFlag,
-	flags.FactoryAddressFlag,
-	OutputRootFlag,
-	L2BlockNumFlag,
-}
-
-func init() {
-	createGameFlags = append(createGameFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
-	createGameFlags = append(createGameFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
+func createGameFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		flags.L1EthRpcFlag,
+		flags.FactoryAddressFlag,
+		OutputRootFlag,
+		L2BlockNumFlag,
+	}
+	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
+	return cliFlags
 }
 
 var CreateGameCommand = &cli.Command{
@@ -80,6 +80,6 @@ var CreateGameCommand = &cli.Command{
 	Usage:       "Creates a dispute game via the factory",
 	Description: "Creates a dispute game via the factory",
 	Action:      CreateGame,
-	Flags:       createGameFlags,
+	Flags:       createGameFlags(),
 	Hidden:      true,
 }

--- a/op-challenger/cmd/list_claims.go
+++ b/op-challenger/cmd/list_claims.go
@@ -83,13 +83,13 @@ func listClaims(ctx context.Context, game *contracts.FaultDisputeGameContract) e
 	return nil
 }
 
-var listClaimsFlags = []cli.Flag{
-	flags.L1EthRpcFlag,
-	GameAddressFlag,
-}
-
-func init() {
-	listClaimsFlags = append(listClaimsFlags, oplog.CLIFlags("OP_CHALLENGER")...)
+func listClaimsFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		flags.L1EthRpcFlag,
+		GameAddressFlag,
+	}
+	cliFlags = append(cliFlags, oplog.CLIFlags("OP_CHALLENGER")...)
+	return cliFlags
 }
 
 var ListClaimsCommand = &cli.Command{
@@ -97,6 +97,6 @@ var ListClaimsCommand = &cli.Command{
 	Usage:       "List the claims in a dispute game",
 	Description: "Lists the claims in a dispute game",
 	Action:      ListClaims,
-	Flags:       listClaimsFlags,
+	Flags:       listClaimsFlags(),
 	Hidden:      true,
 }

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -100,13 +100,13 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 	return nil
 }
 
-var listGamesFlags = []cli.Flag{
-	flags.L1EthRpcFlag,
-	flags.FactoryAddressFlag,
-}
-
-func init() {
-	listGamesFlags = append(listGamesFlags, oplog.CLIFlags("OP_CHALLENGER")...)
+func listGamesFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		flags.L1EthRpcFlag,
+		flags.FactoryAddressFlag,
+	}
+	cliFlags = append(cliFlags, oplog.CLIFlags("OP_CHALLENGER")...)
+	return cliFlags
 }
 
 var ListGamesCommand = &cli.Command{
@@ -114,6 +114,6 @@ var ListGamesCommand = &cli.Command{
 	Usage:       "List the games created by a dispute game factory",
 	Description: "Lists the games created by a dispute game factory",
 	Action:      ListGames,
-	Flags:       listGamesFlags,
+	Flags:       listGamesFlags(),
 	Hidden:      true,
 }

--- a/op-challenger/cmd/main.go
+++ b/op-challenger/cmd/main.go
@@ -48,6 +48,9 @@ func run(ctx context.Context, args []string, action ConfiguredLifecycle) error {
 	app.Commands = []*cli.Command{
 		ListGamesCommand,
 		ListClaimsCommand,
+		CreateGameCommand,
+		MoveCommand,
+		ResolveCommand,
 	}
 	app.Action = cliapp.LifecycleCmd(func(ctx *cli.Context, close context.CancelCauseFunc) (cliapp.Lifecycle, error) {
 		logger, err := setupLogging(ctx)

--- a/op-challenger/cmd/move.go
+++ b/op-challenger/cmd/move.go
@@ -75,18 +75,18 @@ func Move(ctx *cli.Context) error {
 	return nil
 }
 
-var moveFlags = []cli.Flag{
-	flags.L1EthRpcFlag,
-	GameAddressFlag,
-	AttackFlag,
-	DefendFlag,
-	ParentIndexFlag,
-	ClaimFlag,
-}
-
-func init() {
-	moveFlags = append(moveFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
-	moveFlags = append(moveFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
+func moveFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		flags.L1EthRpcFlag,
+		GameAddressFlag,
+		AttackFlag,
+		DefendFlag,
+		ParentIndexFlag,
+		ClaimFlag,
+	}
+	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
+	return cliFlags
 }
 
 var MoveCommand = &cli.Command{
@@ -94,6 +94,6 @@ var MoveCommand = &cli.Command{
 	Usage:       "Creates and sends a move transaction to the dispute game",
 	Description: "Creates and sends a move transaction to the dispute game",
 	Action:      Move,
-	Flags:       moveFlags,
+	Flags:       moveFlags(),
 	Hidden:      true,
 }

--- a/op-challenger/cmd/resolve.go
+++ b/op-challenger/cmd/resolve.go
@@ -32,14 +32,14 @@ func Resolve(ctx *cli.Context) error {
 	return nil
 }
 
-var resolveFlags = []cli.Flag{
-	flags.L1EthRpcFlag,
-	GameAddressFlag,
-}
-
-func init() {
-	resolveFlags = append(resolveFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
-	resolveFlags = append(resolveFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
+func resolveFlags() []cli.Flag {
+	cliFlags := []cli.Flag{
+		flags.L1EthRpcFlag,
+		GameAddressFlag,
+	}
+	cliFlags = append(cliFlags, txmgr.CLIFlagsWithDefaults(flags.EnvVarPrefix, txmgr.DefaultChallengerFlagValues)...)
+	cliFlags = append(cliFlags, oplog.CLIFlags(flags.EnvVarPrefix)...)
+	return cliFlags
 }
 
 var ResolveCommand = &cli.Command{
@@ -47,6 +47,6 @@ var ResolveCommand = &cli.Command{
 	Usage:       "Resolves the specified dispute game if possible",
 	Description: "Resolves the specified dispute game if possible",
 	Action:      Resolve,
-	Flags:       resolveFlags,
+	Flags:       resolveFlags(),
 	Hidden:      true,
 }


### PR DESCRIPTION
**Description**

The additional flags from logging and txmgr weren't being picked up. e.g.:

```
./bin/op-challenger create-game --help
NAME:
   op-challenger create-game - Creates a dispute game via the factory

USAGE:
   op-challenger create-game [command options] [arguments...]

DESCRIPTION:
   Creates a dispute game via the factory

OPTIONS:

          --l1-eth-rpc value                                                     ($OP_CHALLENGER_L1_ETH_RPC)
                HTTP provider URL for L1.

          --game-factory-address value                                           ($OP_CHALLENGER_GAME_FACTORY_ADDRESS)
                Address of the fault game factory contract.

          --output-root value                                                    ($OP_CHALLENGER_OUTPUT_ROOT)
                The output root for the fault dispute game.

          --l2-block-num value                                                   ($OP_CHALLENGER_L2_BLOCK_NUM)
                The l2 block number for the game.

          --help, -h                          (default: false)
                show help
```
