### PR TITLE
op-program: Don't verify KZG commitments for blobs inside the VM

### DIFF
--- a/op-program/client/l1/oracle.go
+++ b/op-program/client/l1/oracle.go
@@ -1,7 +1,6 @@
 package l1
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -112,11 +111,6 @@ func (p *PreimageOracle) GetBlob(ref eth.L1BlockRef, blobHash eth.IndexedBlobHas
 		fieldElement := p.oracle.Get(preimage.BlobKey(crypto.Keccak256(fieldElemKey)))
 
 		copy(blob[i<<5:(i+1)<<5], fieldElement[:])
-	}
-
-	blobCommitment, err := blob.ComputeKZGCommitment()
-	if err != nil || !bytes.Equal(blobCommitment[:], commitment[:]) {
-		panic(fmt.Errorf("invalid blob commitment: %w", err))
 	}
 
 	return &blob


### PR DESCRIPTION
**Description**

Don't recompute the blob kzg commitment to validate it in the preimage oracle client. The verification is running inside the VM which increases execution time significantly. The data coming from the preimage oracle is trusted because the oracle verifies it so the client doesn't need to repeat that verification.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/548
