### PR TITLE
op-service: Fix incorrect error message in multicall

### DIFF
--- a/op-service/sources/batching/multicall.go
+++ b/op-service/sources/batching/multicall.go
@@ -67,7 +67,7 @@ func (m *MultiCaller) Call(ctx context.Context, block Block, calls ...*ContractC
 		if err := fetcher.Fetch(ctx); err == io.EOF {
 			break
 		} else if err != nil {
-			return nil, fmt.Errorf("failed to fetch claims: %w", err)
+			return nil, fmt.Errorf("failed to fetch batch: %w", err)
 		}
 	}
 	results, err := fetcher.Result()


### PR DESCRIPTION
**Description**

Fix the error message in MultiCaller since it's not just used for fetching claims.
