### PR TITLE
op-challenger: Fix uploading blob preimages

### DIFF
--- a/op-challenger/game/fault/trace/cannon/provider.go
+++ b/op-challenger/game/fault/trace/cannon/provider.go
@@ -273,11 +273,12 @@ func PreimageLargerThan(size int) PreimageOpt {
 
 func NewTraceProviderForTest(logger log.Logger, m CannonMetricer, cfg *config.Config, localInputs LocalGameInputs, dir string, gameDepth types.Depth) *CannonTraceProviderForTest {
 	p := &CannonTraceProvider{
-		logger:    logger,
-		dir:       dir,
-		prestate:  cfg.CannonAbsolutePreState,
-		generator: NewExecutor(logger, m, cfg, localInputs),
-		gameDepth: gameDepth,
+		logger:         logger,
+		dir:            dir,
+		prestate:       cfg.CannonAbsolutePreState,
+		generator:      NewExecutor(logger, m, cfg, localInputs),
+		gameDepth:      gameDepth,
+		preimageLoader: newPreimageLoader(kvstore.NewDiskKV(preimageDir(dir)).Get),
 	}
 	return &CannonTraceProviderForTest{p}
 }


### PR DESCRIPTION
**Description**

Fix publishing of blob preimages. The proof is computed by specified the blob and desired field element and returns the polynomial claim that needs to be posted to the preimage oracle.  When you combine this PR, #9439 and #9432 an e2e test that request uploading blob data actually passes (will put that up as a PR next).

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/548
