### PR TITLE
chore(op-service): MinGameTimestamp Clock Arithmetic Refactor

### DIFF
--- a/op-challenger/game/monitor.go
+++ b/op-challenger/game/monitor.go
@@ -28,6 +28,7 @@ type gameSource interface {
 type RWClock interface {
 	SetTime(uint64)
 	Now() time.Time
+	Add(time.Duration) time.Time
 }
 
 type gameScheduler interface {
@@ -108,15 +109,7 @@ func (m *gameMonitor) allowedGame(game common.Address) bool {
 }
 
 func (m *gameMonitor) minGameTimestamp() uint64 {
-	if m.gameWindow.Seconds() == 0 {
-		return 0
-	}
-	// time: "To compute t-d for a duration d, use t.Add(-d)."
-	// https://pkg.go.dev/time#Time.Sub
-	if m.clock.Now().Unix() > int64(m.gameWindow.Seconds()) {
-		return uint64(m.clock.Now().Add(-m.gameWindow).Unix())
-	}
-	return 0
+	return uint64(m.clock.Add(-m.gameWindow).Unix())
 }
 
 func (m *gameMonitor) progressGames(ctx context.Context, blockHash common.Hash, blockNumber uint64) error {

--- a/op-dispute-mon/mon/monitor.go
+++ b/op-dispute-mon/mon/monitor.go
@@ -61,15 +61,7 @@ func newGameMonitor(
 }
 
 func (m *gameMonitor) minGameTimestamp() uint64 {
-	if m.gameWindow.Seconds() == 0 {
-		return 0
-	}
-	// time: "To compute t-d for a duration d, use t.Add(-d)."
-	// https://pkg.go.dev/time#Time.Sub
-	if m.clock.Now().Unix() > int64(m.gameWindow.Seconds()) {
-		return uint64(m.clock.Now().Add(-m.gameWindow).Unix())
-	}
-	return 0
+	return uint64(m.clock.Add(-m.gameWindow).Unix())
 }
 
 func (m *gameMonitor) monitorGames() error {

--- a/op-dispute-mon/mon/monitor_test.go
+++ b/op-dispute-mon/mon/monitor_test.go
@@ -25,6 +25,7 @@ func TestMonitor_MinGameTimestamp(t *testing.T) {
 	t.Run("ZeroGameWindow", func(t *testing.T) {
 		monitor, _, _ := setupMonitorTest(t)
 		monitor.gameWindow = time.Duration(0)
+		monitor.clock = clock.NewDeterministicClock(time.Unix(0, 0))
 		require.Equal(t, monitor.minGameTimestamp(), uint64(0))
 	})
 

--- a/op-service/clock/clock.go
+++ b/op-service/clock/clock.go
@@ -3,6 +3,7 @@ package clock
 
 import (
 	"context"
+	"math"
 	"time"
 )
 
@@ -12,6 +13,10 @@ import (
 type Clock interface {
 	// Now provides the current local time. Equivalent to time.Now
 	Now() time.Time
+
+	// Add returns the time t+d. Equivalent to time.Now().Add(d)
+	// If d is negative, the duration is safely subtracted from t.
+	Add(d time.Duration) time.Time
 
 	// Since returns the time elapsed since t. It is shorthand for time.Now().Sub(t).
 	Since(time.Time) time.Duration
@@ -90,6 +95,14 @@ func (s systemClock) Since(t time.Time) time.Duration {
 
 func (s systemClock) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
+}
+
+func (s systemClock) Add(d time.Duration) time.Time {
+	now := s.Now()
+	if d < 0 && math.Abs(d.Seconds()) > float64(now.Unix()) {
+		return time.Unix(0, 0)
+	}
+	return now.Add(d)
 }
 
 type SystemTicker struct {

--- a/op-service/clock/clock_test.go
+++ b/op-service/clock/clock_test.go
@@ -30,3 +30,33 @@ func TestSystemClock_SleepCtx(t *testing.T) {
 		require.Greater(t, end.Sub(start), 5*time.Millisecond, "should sleep at least a bit")
 	})
 }
+
+func TestSystemClock_Add(t *testing.T) {
+	t.Run("PositiveDuration", func(t *testing.T) {
+		now := time.Now()
+		d := 5 * time.Minute
+		expected := now.Add(d)
+		actual := SystemClock.Add(d)
+		require.WithinDuration(t, expected, actual, time.Second)
+	})
+
+	t.Run("NegativeDuration", func(t *testing.T) {
+		now := time.Now()
+		d := -5 * time.Minute
+		expected := now.Add(d)
+		actual := SystemClock.Add(d)
+		require.WithinDuration(t, expected, actual, time.Second)
+	})
+
+	t.Run("NegativeDurationSinceUnix", func(t *testing.T) {
+		d := -SystemClock.Since(time.Unix(0, 0))
+		actual := SystemClock.Add(d)
+		require.Equal(t, time.Unix(0, 0), actual)
+	})
+
+	t.Run("NegativeDurationTooLarge", func(t *testing.T) {
+		d := -2 * SystemClock.Since(time.Unix(0, 0))
+		actual := SystemClock.Add(d)
+		require.Equal(t, time.Unix(0, 0), actual)
+	})
+}

--- a/op-service/clock/deterministic.go
+++ b/op-service/clock/deterministic.go
@@ -2,6 +2,7 @@ package clock
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 )
@@ -155,6 +156,16 @@ func (s *DeterministicClock) After(d time.Duration) <-chan time.Time {
 		s.addPending(&task{ch: ch, due: s.now.Add(d)})
 	}
 	return ch
+}
+
+func (s *DeterministicClock) Add(d time.Duration) time.Time {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	now := s.now
+	if d < 0 && math.Abs(d.Seconds()) > float64(now.Unix()) {
+		return time.Unix(0, 0)
+	}
+	return now.Add(d)
 }
 
 func (s *DeterministicClock) AfterFunc(d time.Duration, f func()) Timer {

--- a/op-service/clock/deterministic_test.go
+++ b/op-service/clock/deterministic_test.go
@@ -64,6 +64,36 @@ func TestAfter(t *testing.T) {
 	})
 }
 
+func TestAdd(t *testing.T) {
+	t.Run("PositiveDuration", func(t *testing.T) {
+		clock := NewDeterministicClock(time.UnixMilli(1000))
+		clock.AdvanceTime(10 * time.Minute)
+		d := 5 * time.Minute
+		require.Equal(t, clock.Now().Add(d), clock.Add(d))
+	})
+
+	t.Run("NegativeDuration", func(t *testing.T) {
+		clock := NewDeterministicClock(time.UnixMilli(1000))
+		clock.AdvanceTime(10 * time.Minute)
+		d := -5 * time.Minute
+		require.Equal(t, clock.Now().Add(d), clock.Add(d))
+	})
+
+	t.Run("NegativeDurationSinceUnix", func(t *testing.T) {
+		clock := NewDeterministicClock(time.UnixMilli(1000))
+		clock.AdvanceTime(10 * time.Minute)
+		d := -clock.Since(time.Unix(0, 0))
+		require.Equal(t, time.Unix(0, 0), clock.Add(d))
+	})
+
+	t.Run("NegativeDurationTooLarge", func(t *testing.T) {
+		clock := NewDeterministicClock(time.UnixMilli(1000))
+		clock.AdvanceTime(10 * time.Minute)
+		d := -2 * clock.Since(time.Unix(0, 0))
+		require.Equal(t, time.Unix(0, 0), clock.Add(d))
+	})
+}
+
 func TestAfterFunc(t *testing.T) {
 	t.Run("ZeroExecutesImmediately", func(t *testing.T) {
 		clock := NewDeterministicClock(time.UnixMilli(1000))

--- a/op-service/clock/simple.go
+++ b/op-service/clock/simple.go
@@ -1,6 +1,7 @@
 package clock
 
 import (
+	"math"
 	"sync/atomic"
 	"time"
 )
@@ -13,10 +14,18 @@ func NewSimpleClock() *SimpleClock {
 	return &SimpleClock{}
 }
 
-func (c *SimpleClock) SetTime(u uint64) {
-	c.unix.Store(u)
+func (s *SimpleClock) Add(d time.Duration) time.Time {
+	now := s.Now()
+	if d < 0 && math.Abs(d.Seconds()) > float64(now.Unix()) {
+		return time.Unix(0, 0)
+	}
+	return now.Add(d)
 }
 
-func (c *SimpleClock) Now() time.Time {
-	return time.Unix(int64(c.unix.Load()), 0)
+func (s *SimpleClock) SetTime(u uint64) {
+	s.unix.Store(u)
+}
+
+func (s *SimpleClock) Now() time.Time {
+	return time.Unix(int64(s.unix.Load()), 0)
 }

--- a/op-service/clock/simple_test.go
+++ b/op-service/clock/simple_test.go
@@ -50,3 +50,40 @@ func TestSimpleClock_SetTime(t *testing.T) {
 		})
 	}
 }
+
+func TestSimpleClock_Add(t *testing.T) {
+	t.Run("PositiveDuration", func(t *testing.T) {
+		c := NewSimpleClock()
+		now := c.Now()
+		d := 5 * time.Minute
+		expected := now.Add(d)
+		actual := c.Add(d)
+		require.WithinDuration(t, expected, actual, time.Second)
+	})
+
+	t.Run("NegativeDuration", func(t *testing.T) {
+		c := NewSimpleClock()
+		c.SetTime(uint64(10 * time.Minute))
+		now := c.Now()
+		d := -5 * time.Minute
+		expected := now.Add(d)
+		actual := c.Add(d)
+		require.WithinDuration(t, expected, actual, time.Second)
+	})
+
+	t.Run("NegativeDurationSinceUnix", func(t *testing.T) {
+		c := NewSimpleClock()
+		c.SetTime(5)
+		d := -1 * time.Duration(5*time.Second)
+		actual := c.Add(d)
+		require.Equal(t, time.Unix(0, 0), actual)
+	})
+
+	t.Run("NegativeDurationTooLarge", func(t *testing.T) {
+		c := NewSimpleClock()
+		c.SetTime(5)
+		d := -2 * time.Duration(5*time.Second)
+		actual := c.Add(d)
+		require.Equal(t, time.Unix(0, 0), actual)
+	})
+}


### PR DESCRIPTION
**Description**

The game monitor for the `op-challenger` and `op-dispute-mon` contained duplicate `minGameTimestamp` clock arithmetic logic that
contains logic specific to the `time` dependency.

This PR refactors that arithmetic out into the upstream `op-service/clock` package so that it is properly unit tested and abstracted
away from downstream Clock usage.

**Tests**

Added `Add(d time.Duration) time.Time` unit tests for implementations in various clocks.

**Metadata**

Further challenger cleaning for the dispute monitor hook it up milestone.
