### PR TITLE
contracts: Rename OptimismPortal2 to L1ToL2MessagePasser

### DIFF
--- a/packages/contracts-bedrock/scripts/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/ChainAssertions.sol
@@ -13,7 +13,7 @@ import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
 import { ProtocolVersion, ProtocolVersions } from "src/L1/ProtocolVersions.sol";
 import { SuperchainConfig } from "src/L1/SuperchainConfig.sol";
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";
-import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { L1ToL2MessagePasser } from "src/L1/L1ToL2MessagePasser.sol";
 import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
 import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
@@ -54,7 +54,7 @@ library ChainAssertions {
         checkOptimismMintableERC20Factory({ _contracts: _prox, _isProxy: true });
         checkL1ERC721Bridge({ _contracts: _prox, _isProxy: true });
         checkOptimismPortal({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
-        checkOptimismPortal2({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
+        checkL1ToL2MessagePasser({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
         checkProtocolVersions({ _contracts: _prox, _cfg: _cfg, _isProxy: true });
     }
 
@@ -293,8 +293,8 @@ library ChainAssertions {
         }
     }
 
-    /// @notice Asserts the OptimismPortal2 is setup correctly
-    function checkOptimismPortal2(
+    /// @notice Asserts the L1ToL2MessagePasser is setup correctly
+    function checkL1ToL2MessagePasser(
         Types.ContractSet memory _contracts,
         DeployConfig _cfg,
         bool _isProxy
@@ -302,9 +302,9 @@ library ChainAssertions {
         internal
         view
     {
-        console.log("Running chain assertions on the OptimismPortal2");
+        console.log("Running chain assertions on the L1ToL2MessagePasser");
 
-        OptimismPortal2 portal = OptimismPortal2(payable(_contracts.OptimismPortal2));
+        L1ToL2MessagePasser portal = L1ToL2MessagePasser(payable(_contracts.L1ToL2MessagePasser));
 
         // Check that the contract is initialized
         assertSlotValueIsOne({ _contractAddress: address(portal), _slot: 0, _offset: 0 });

--- a/packages/contracts-bedrock/scripts/Types.sol
+++ b/packages/contracts-bedrock/scripts/Types.sol
@@ -10,7 +10,7 @@ library Types {
         address DisputeGameFactory;
         address OptimismMintableERC20Factory;
         address OptimismPortal;
-        address OptimismPortal2;
+        address L1ToL2MessagePasser;
         address SystemConfig;
         address L1ERC721Bridge;
         address ProtocolVersions;

--- a/packages/contracts-bedrock/snapshots/abi/L1ToL2MessagePasser.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1ToL2MessagePasser.json
@@ -1,0 +1,630 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_proofMaturityDelaySeconds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_disputeGameFinalityDelaySeconds",
+        "type": "uint256"
+      },
+      {
+        "internalType": "GameType",
+        "name": "_initialRespectedGameType",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  },
+  {
+    "inputs": [],
+    "name": "GUARDIAN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "SYSTEM_CONFIG",
+    "outputs": [
+      {
+        "internalType": "contract SystemConfig",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "_disputeGame",
+        "type": "address"
+      }
+    ],
+    "name": "blacklistDisputeGame",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_withdrawalHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "checkWithdrawal",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_withdrawalHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "deleteProvenWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_gasLimit",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isCreation",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "depositTransaction",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "disputeGameBlacklist",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disputeGameFactory",
+    "outputs": [
+      {
+        "internalType": "contract DisputeGameFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disputeGameFinalityDelaySeconds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "donateETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      }
+    ],
+    "name": "finalizeWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "finalizedWithdrawals",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "guardian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract DisputeGameFactory",
+        "name": "_disputeGameFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "contract SystemConfig",
+        "name": "_systemConfig",
+        "type": "address"
+      },
+      {
+        "internalType": "contract SuperchainConfig",
+        "name": "_superchainConfig",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l2Sender",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "_byteCount",
+        "type": "uint64"
+      }
+    ],
+    "name": "minimumGasLimit",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "params",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "prevBaseFee",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "prevBoughtGas",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "prevBlockNum",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proofMaturityDelaySeconds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasLimit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Types.WithdrawalTransaction",
+        "name": "_tx",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_disputeGameIndex",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "version",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "stateRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagePasserStorageRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "latestBlockhash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct Types.OutputRootProof",
+        "name": "_outputRootProof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_withdrawalProof",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "proveWithdrawalTransaction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "provenWithdrawals",
+    "outputs": [
+      {
+        "internalType": "contract IDisputeGame",
+        "name": "disputeGameProxy",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "respectedGameType",
+    "outputs": [
+      {
+        "internalType": "GameType",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sauron",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "GameType",
+        "name": "_gameType",
+        "type": "uint32"
+      }
+    ],
+    "name": "setRespectedGameType",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "superchainConfig",
+    "outputs": [
+      {
+        "internalType": "contract SuperchainConfig",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "systemConfig",
+    "outputs": [
+      {
+        "internalType": "contract SystemConfig",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "opaqueData",
+        "type": "bytes"
+      }
+    ],
+    "name": "TransactionDeposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "name": "WithdrawalFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "withdrawalHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "WithdrawalProven",
+    "type": "event"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1ToL2MessagePasser.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1ToL2MessagePasser.json
@@ -1,0 +1,107 @@
+[
+  {
+    "bytes": "1",
+    "label": "_initialized",
+    "offset": 0,
+    "slot": "0",
+    "type": "uint8"
+  },
+  {
+    "bytes": "1",
+    "label": "_initializing",
+    "offset": 1,
+    "slot": "0",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "label": "params",
+    "offset": 0,
+    "slot": "1",
+    "type": "struct ResourceMetering.ResourceParams"
+  },
+  {
+    "bytes": "1536",
+    "label": "__gap",
+    "offset": 0,
+    "slot": "2",
+    "type": "uint256[48]"
+  },
+  {
+    "bytes": "20",
+    "label": "l2Sender",
+    "offset": 0,
+    "slot": "50",
+    "type": "address"
+  },
+  {
+    "bytes": "32",
+    "label": "finalizedWithdrawals",
+    "offset": 0,
+    "slot": "51",
+    "type": "mapping(bytes32 => bool)"
+  },
+  {
+    "bytes": "32",
+    "label": "spacer_52_0_32",
+    "offset": 0,
+    "slot": "52",
+    "type": "bytes32"
+  },
+  {
+    "bytes": "1",
+    "label": "spacer_53_0_1",
+    "offset": 0,
+    "slot": "53",
+    "type": "bool"
+  },
+  {
+    "bytes": "20",
+    "label": "superchainConfig",
+    "offset": 1,
+    "slot": "53",
+    "type": "contract SuperchainConfig"
+  },
+  {
+    "bytes": "20",
+    "label": "spacer_54_0_20",
+    "offset": 0,
+    "slot": "54",
+    "type": "address"
+  },
+  {
+    "bytes": "20",
+    "label": "systemConfig",
+    "offset": 0,
+    "slot": "55",
+    "type": "contract SystemConfig"
+  },
+  {
+    "bytes": "20",
+    "label": "disputeGameFactory",
+    "offset": 0,
+    "slot": "56",
+    "type": "contract DisputeGameFactory"
+  },
+  {
+    "bytes": "32",
+    "label": "provenWithdrawals",
+    "offset": 0,
+    "slot": "57",
+    "type": "mapping(bytes32 => struct L1ToL2MessagePasser.ProvenWithdrawal)"
+  },
+  {
+    "bytes": "32",
+    "label": "disputeGameBlacklist",
+    "offset": 0,
+    "slot": "58",
+    "type": "mapping(contract IDisputeGame => bool)"
+  },
+  {
+    "bytes": "4",
+    "label": "respectedGameType",
+    "offset": 0,
+    "slot": "59",
+    "type": "GameType"
+  }
+]

--- a/packages/contracts-bedrock/test/Specs.t.sol
+++ b/packages/contracts-bedrock/test/Specs.t.sol
@@ -6,7 +6,7 @@ import { Executables } from "scripts/Executables.sol";
 import { console2 as console } from "forge-std/console2.sol";
 import { ProtocolVersions } from "src/L1/ProtocolVersions.sol";
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";
-import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { L1ToL2MessagePasser } from "src/L1/L1ToL2MessagePasser.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
 
 /// @title Specification_Test
@@ -224,38 +224,42 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OptimismPortal", _sel: _getSel("systemConfig()") });
         _addSpec({ _name: "OptimismPortal", _sel: _getSel("version()") });
 
-        // OptimismPortal2
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("GUARDIAN()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("SYSTEM_CONFIG()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("depositTransaction(address,uint256,uint64,bool,bytes)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("donateETH()") });
+        // L1ToL2MessagePasser
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("GUARDIAN()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("SYSTEM_CONFIG()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("depositTransaction(address,uint256,uint64,bool,bytes)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("donateETH()") });
         _addSpec({
-            _name: "OptimismPortal2",
-            _sel: OptimismPortal2.finalizeWithdrawalTransaction.selector,
+            _name: "L1ToL2MessagePasser",
+            _sel: L1ToL2MessagePasser.finalizeWithdrawalTransaction.selector,
             _pausable: true
         });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("finalizedWithdrawals(bytes32)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("guardian()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("sauron()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("initialize(address,address,address)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("l2Sender()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("minimumGasLimit(uint64)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("params()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("paused()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: OptimismPortal2.proveWithdrawalTransaction.selector, _pausable: true });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("provenWithdrawals(bytes32)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("superchainConfig()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("systemConfig()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("version()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("disputeGameFactory()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("disputeGameBlacklist(address)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("respectedGameType()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("blacklistDisputeGame(address)"), _auth: Role.SAURON });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("deleteProvenWithdrawal(bytes32)"), _auth: Role.SAURON });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("setRespectedGameType(uint32)"), _auth: Role.SAURON });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("checkWithdrawal(bytes32)") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("proofMaturityDelaySeconds()") });
-        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("disputeGameFinalityDelaySeconds()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("finalizedWithdrawals(bytes32)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("guardian()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("sauron()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("initialize(address,address,address)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("l2Sender()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("minimumGasLimit(uint64)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("params()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("paused()") });
+        _addSpec({
+            _name: "L1ToL2MessagePasser",
+            _sel: L1ToL2MessagePasser.proveWithdrawalTransaction.selector,
+            _pausable: true
+        });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("provenWithdrawals(bytes32)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("superchainConfig()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("systemConfig()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("version()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("disputeGameFactory()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("disputeGameBlacklist(address)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("respectedGameType()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("blacklistDisputeGame(address)"), _auth: Role.SAURON });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("deleteProvenWithdrawal(bytes32)"), _auth: Role.SAURON });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("setRespectedGameType(uint32)"), _auth: Role.SAURON });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("checkWithdrawal(bytes32)") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("proofMaturityDelaySeconds()") });
+        _addSpec({ _name: "L1ToL2MessagePasser", _sel: _getSel("disputeGameFinalityDelaySeconds()") });
 
         // ProtocolVersions
         _addSpec({ _name: "ProtocolVersions", _sel: _getSel("RECOMMENDED_SLOT()") });

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -18,7 +18,7 @@ import { LegacyERC20ETH } from "src/legacy/LegacyERC20ETH.sol";
 import { StandardBridge } from "src/universal/StandardBridge.sol";
 import { FeeVault } from "src/universal/FeeVault.sol";
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";
-import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { L1ToL2MessagePasser } from "src/L1/L1ToL2MessagePasser.sol";
 import { DisputeGameFactory } from "src/dispute/DisputeGameFactory.sol";
 import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 import { DeployConfig } from "scripts/DeployConfig.s.sol";
@@ -48,7 +48,7 @@ contract Setup {
     Deploy internal constant deploy = Deploy(address(uint160(uint256(keccak256(abi.encode("optimism.deploy"))))));
 
     OptimismPortal optimismPortal;
-    OptimismPortal2 optimismPortal2;
+    L1ToL2MessagePasser l1ToL2MessagePasser;
     DisputeGameFactory disputeGameFactory;
     L2OutputOracle l2OutputOracle;
     SystemConfig systemConfig;
@@ -99,7 +99,7 @@ contract Setup {
         deploy.run();
 
         optimismPortal = OptimismPortal(deploy.mustGetAddress("OptimismPortalProxy"));
-        optimismPortal2 = OptimismPortal2(deploy.mustGetAddress("OptimismPortalProxy"));
+        l1ToL2MessagePasser = L1ToL2MessagePasser(deploy.mustGetAddress("OptimismPortalProxy"));
         disputeGameFactory = DisputeGameFactory(deploy.mustGetAddress("DisputeGameFactoryProxy"));
         l2OutputOracle = L2OutputOracle(deploy.mustGetAddress("L2OutputOracleProxy"));
         systemConfig = SystemConfig(deploy.mustGetAddress("SystemConfigProxy"));

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -108,14 +108,14 @@ contract Initializer_Test is Bridge_Initializer {
                 initializedSlotVal: deploy.loadInitializedSlot("OptimismPortal")
             })
         );
-        // OptimismPortal2Impl
+        // L1ToL2MessagePasserImpl
         contracts.push(
             InitializeableContract({
-                target: deploy.mustGetAddress("OptimismPortal2"),
+                target: deploy.mustGetAddress("L1ToL2MessagePasser"),
                 initCalldata: abi.encodeCall(
-                    optimismPortal2.initialize, (disputeGameFactory, systemConfig, superchainConfig)
+                    l1ToL2MessagePasser.initialize, (disputeGameFactory, systemConfig, superchainConfig)
                     ),
-                initializedSlotVal: deploy.loadInitializedSlot("OptimismPortal2")
+                initializedSlotVal: deploy.loadInitializedSlot("L1ToL2MessagePasser")
             })
         );
         // OptimismPortalProxy
@@ -297,7 +297,8 @@ contract Initializer_Test is Bridge_Initializer {
     ///         3. The `initialize()` function of each contract cannot be called more than once.
     function test_cannotReinitialize_succeeds() public {
         // Ensure that all L1, L2 `Initializable` contracts are accounted for, in addition to
-        // OptimismMintableERC20FactoryImpl, OptimismMintableERC20FactoryProxy, OptimismPortal2, DisputeGameFactoryImpl
+        // OptimismMintableERC20FactoryImpl, OptimismMintableERC20FactoryProxy, L1ToL2MessagePasser,
+        // DisputeGameFactoryImpl
         // and DisputeGameFactoryProxy
         assertEq(_getNumInitializable() + 3, contracts.length);
 


### PR DESCRIPTION
**Description**

This is controversial, so I'm just opening in draft for now to progress the conversation and see if I've missed any CI checks.
