### PR TITLE
chore(CODEOWNERS): Require op-dispute-mon PRs with go-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 /op-bootnode    @ethereum-optimism/go-reviewers
 /op-chain-ops   @ethereum-optimism/go-reviewers
 /op-challenger  @ethereum-optimism/go-reviewers
+/op-dispute-mon  @ethereum-optimism/go-reviewers
 /op-e2e         @ethereum-optimism/go-reviewers
 /op-heartbeat   @ethereum-optimism/go-reviewers
 /op-node        @ethereum-optimism/go-reviewers


### PR DESCRIPTION
**Description**

Adds the `op-dispute-mon` package to the `.github/CODEOWNERS` file so a `go-reviewers` review is now required for PRs to be merged.
