### PR TITLE
ci: Publish op-dispute-mon docker on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1775,6 +1775,21 @@ workflows:
           context:
             - oplabs-gcr-release
       - docker-build:
+          name: op-dispute-mon-docker-release
+          filters:
+            tags:
+              only: /^op-dispute-mon\/v.*/
+            branches:
+              ignore: /.*/
+          docker_name: op-dispute-mon
+          docker_tags: <<pipeline.git.revision>>
+          requires: ['op-stack-go-docker-build-release']
+          platforms: "linux/amd64,linux/arm64"
+          publish: true
+          release: true
+          context:
+            - oplabs-gcr-release
+      - docker-build:
           name: op-conductor-docker-release
           filters:
             tags:

--- a/cannon/example/claim/go.mod
+++ b/cannon/example/claim/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.1
 require github.com/ethereum-optimism/optimism v0.0.0
 
 require (
-	golang.org/x/crypto v0.18.0 // indirect
+	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 )
 

--- a/cannon/example/claim/go.sum
+++ b/cannon/example/claim/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
-golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
+golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
**Description**

Add missed job to publish dispute-mon docker images when a tag is created.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/539
