### PR TITLE
chore(op-dispute-mon): Output Validation Refactor

### DIFF
--- a/op-dispute-mon/mon/detector_test.go
+++ b/op-dispute-mon/mon/detector_test.go
@@ -6,15 +6,10 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
-)
-
-var (
-	mockRootClaim = common.HexToHash("0x10")
 )
 
 func TestDetector_Detect(t *testing.T) {
@@ -213,53 +208,25 @@ func TestDetector_CheckAgreement_Succeeds(t *testing.T) {
 	}
 }
 
-func TestDetector_CheckRootAgreement(t *testing.T) {
-	t.Parallel()
-
-	t.Run("OutputFetchFails", func(t *testing.T) {
-		detector, _, _, rollup := setupDetectorTest(t)
-		rollup.err = errors.New("boom")
-		agree, fetched, err := detector.checkRootAgreement(context.Background(), 0, mockRootClaim)
-		require.ErrorIs(t, err, rollup.err)
-		require.Equal(t, common.Hash{}, fetched)
-		require.False(t, agree)
-	})
-
-	t.Run("OutputMismatch", func(t *testing.T) {
-		detector, _, _, _ := setupDetectorTest(t)
-		agree, fetched, err := detector.checkRootAgreement(context.Background(), 0, common.Hash{})
-		require.NoError(t, err)
-		require.Equal(t, mockRootClaim, fetched)
-		require.False(t, agree)
-	})
-
-	t.Run("OutputMatches", func(t *testing.T) {
-		detector, _, _, _ := setupDetectorTest(t)
-		agree, fetched, err := detector.checkRootAgreement(context.Background(), 0, mockRootClaim)
-		require.NoError(t, err)
-		require.Equal(t, mockRootClaim, fetched)
-		require.True(t, agree)
-	})
-}
-
-func setupDetectorTest(t *testing.T) (*detector, *mockDetectorMetricer, *mockMetadataCreator, *stubRollupClient) {
+func setupDetectorTest(t *testing.T) (*detector, *mockDetectorMetricer, *mockMetadataCreator, *stubOutputValidator) {
 	logger := testlog.Logger(t, log.LvlDebug)
 	metrics := &mockDetectorMetricer{}
 	loader := &mockMetadataLoader{}
 	creator := &mockMetadataCreator{loader: loader}
-	rollupClient := &stubRollupClient{}
-	detector := newDetector(logger, metrics, creator, rollupClient)
-	return detector, metrics, creator, rollupClient
+	validator := &stubOutputValidator{}
+	detector := newDetector(logger, metrics, creator, validator)
+	return detector, metrics, creator, validator
 }
 
-type stubRollupClient struct {
-	blockNum uint64
-	err      error
+type stubOutputValidator struct {
+	err error
 }
 
-func (s *stubRollupClient) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error) {
-	s.blockNum = blockNum
-	return &eth.OutputResponse{OutputRoot: eth.Bytes32(mockRootClaim)}, s.err
+func (s *stubOutputValidator) CheckRootAgreement(ctx context.Context, blockNum uint64, rootClaim common.Hash) (bool, common.Hash, error) {
+	if s.err != nil {
+		return false, common.Hash{}, s.err
+	}
+	return rootClaim == mockRootClaim, mockRootClaim, nil
 }
 
 type mockMetadataCreator struct {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -37,6 +37,7 @@ type Service struct {
 	metadata     *metadataCreator
 	rollupClient *sources.RollupClient
 	detector     *detector
+	validator    *outputValidator
 
 	l1Client *ethclient.Client
 
@@ -77,6 +78,7 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
+	s.initOutputValidator()
 	s.initDetector()
 	s.initMetadataCreator()
 	s.initMonitor(ctx, cfg)
@@ -87,8 +89,12 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	return nil
 }
 
+func (s *Service) initOutputValidator() {
+	s.validator = newOutputValidator(s.rollupClient)
+}
+
 func (s *Service) initDetector() {
-	s.detector = newDetector(s.logger, s.metrics, s.metadata, s.rollupClient)
+	s.detector = newDetector(s.logger, s.metrics, s.metadata, s.validator)
 }
 
 func (s *Service) initOutputRollupClient(ctx context.Context, cfg *config.Config) error {

--- a/op-dispute-mon/mon/validator.go
+++ b/op-dispute-mon/mon/validator.go
@@ -1,0 +1,34 @@
+package mon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+type OutputRollupClient interface {
+	OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error)
+}
+
+type outputValidator struct {
+	client OutputRollupClient
+}
+
+func newOutputValidator(client OutputRollupClient) *outputValidator {
+	return &outputValidator{
+		client: client,
+	}
+}
+
+// CheckRootAgreement validates the specified root claim against the output at the given block number.
+func (o *outputValidator) CheckRootAgreement(ctx context.Context, blockNum uint64, rootClaim common.Hash) (bool, common.Hash, error) {
+	output, err := o.client.OutputAtBlock(ctx, blockNum)
+	if err != nil {
+		return false, common.Hash{}, fmt.Errorf("failed to get output at block: %w", err)
+	}
+	expected := common.Hash(output.OutputRoot)
+	return rootClaim == expected, expected, nil
+}

--- a/op-dispute-mon/mon/validator_test.go
+++ b/op-dispute-mon/mon/validator_test.go
@@ -1,0 +1,60 @@
+package mon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockRootClaim = common.HexToHash("0x10")
+)
+
+func TestDetector_CheckRootAgreement(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OutputFetchFails", func(t *testing.T) {
+		validator, rollup := setupOutputValidatorTest(t)
+		rollup.err = errors.New("boom")
+		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 0, mockRootClaim)
+		require.ErrorIs(t, err, rollup.err)
+		require.Equal(t, common.Hash{}, fetched)
+		require.False(t, agree)
+	})
+
+	t.Run("OutputMismatch", func(t *testing.T) {
+		validator, _ := setupOutputValidatorTest(t)
+		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 0, common.Hash{})
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, fetched)
+		require.False(t, agree)
+	})
+
+	t.Run("OutputMatches", func(t *testing.T) {
+		validator, _ := setupOutputValidatorTest(t)
+		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 0, mockRootClaim)
+		require.NoError(t, err)
+		require.Equal(t, mockRootClaim, fetched)
+		require.True(t, agree)
+	})
+}
+
+func setupOutputValidatorTest(t *testing.T) (*outputValidator, *stubRollupClient) {
+	client := &stubRollupClient{}
+	validator := newOutputValidator(client)
+	return validator, client
+}
+
+type stubRollupClient struct {
+	blockNum uint64
+	err      error
+}
+
+func (s *stubRollupClient) OutputAtBlock(ctx context.Context, blockNum uint64) (*eth.OutputResponse, error) {
+	s.blockNum = blockNum
+	return &eth.OutputResponse{OutputRoot: eth.Bytes32(mockRootClaim)}, s.err
+}


### PR DESCRIPTION
**Description**

Small PR to refactor Output Root validation out of the `detector` component so it may be re-used by the `forecast` component introduced in https://github.com/ethereum-optimism/optimism/pull/9449.

**Tests**

Tests around the `checkRootAgreement` method of `detector` component are now moved to the de-coupled `validator_test` source.
