### PR TITLE
change nonce to uint from bytes to fix panic in json unmarshal

### DIFF
--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -719,7 +719,7 @@ type ForgeDump gstate.Dump
 func (d *ForgeDump) UnmarshalJSON(b []byte) error {
 	type forgeDumpAccount struct {
 		Balance     string                 `json:"balance"`
-		Nonce       hexutil.Uint64         `json:"nonce"`
+		Nonce       uint64                 `json:"nonce"`
 		Root        hexutil.Bytes          `json:"root"`
 		CodeHash    hexutil.Bytes          `json:"codeHash"`
 		Code        hexutil.Bytes          `json:"code,omitempty"`


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

running tests in /e2e-utils/  is currently panicing (for me) without this change.
