### PR TITLE
op-dispute-mon: Fix order of initing components

### DIFF
--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -92,6 +92,7 @@ func (d *detector) Detect(ctx context.Context, games []types.GameMetadata) {
 	}
 	d.metrics.RecordGamesStatus(statBatch.inProgress, statBatch.defenderWon, statBatch.challengerWon)
 	d.recordBatch(detectBatch)
+	d.logger.Info("Completed updating games", "count", len(games))
 }
 
 func (d *detector) recordBatch(batch detectionBatch) {

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -77,8 +77,8 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
-	s.initDetector()
 	s.initMetadataCreator()
+	s.initDetector()
 	s.initMonitor(ctx, cfg)
 
 	s.metrics.RecordInfo(version.SimpleWithMeta)
@@ -180,10 +180,10 @@ func (s *Service) initMonitor(ctx context.Context, cfg *config.Config) {
 }
 
 func (s *Service) Start(ctx context.Context) error {
-	s.logger.Info("starting scheduler")
-	s.logger.Info("starting monitoring")
+	s.logger.Info("Starting scheduler")
+	s.logger.Info("Starting monitoring")
 	s.monitor.StartMonitoring()
-	s.logger.Info("dispute monitor game service start completed")
+	s.logger.Info("Dispute monitor game service start completed")
 	return nil
 }
 
@@ -192,7 +192,7 @@ func (s *Service) Stopped() bool {
 }
 
 func (s *Service) Stop(ctx context.Context) error {
-	s.logger.Info("stopping dispute mon service")
+	s.logger.Info("Stopping dispute mon service")
 
 	var result error
 	if s.pprofService != nil {


### PR DESCRIPTION
**Description**

Avoids a nil pointer reference.
Use capitals at the start of log messages.
Log when games have been updated to confirm that the app is doing something.
