### PR TITLE
op-dispute-mon: Fix unexpected game status logging.

### DIFF
--- a/op-service/testlog/capturing.go
+++ b/op-service/testlog/capturing.go
@@ -65,6 +65,16 @@ func (c *CapturingHandler) FindLog(lvl slog.Level, msg string) *HelperRecord {
 	return nil
 }
 
+func (c *CapturingHandler) FindLogsWithLevel(lvl slog.Level) []*HelperRecord {
+	var logs []*HelperRecord
+	for _, record := range *c.Logs {
+		if record.Level == lvl {
+			logs = append(logs, &HelperRecord{record})
+		}
+	}
+	return logs
+}
+
 func (c *CapturingHandler) FindLogContaining(msg string) (*HelperRecord, bool) {
 	for _, record := range *c.Logs {
 		if strings.Contains(record.Message, msg) {


### PR DESCRIPTION
**Description**

It was previously logging an error that an invalid output root was correctly challenged. Also switched to using the same log message for all invalid outcomes so its easier to search for.

**Tests**

Added tests for the log output.

