### PR TITLE
op-proposer: Unhide dispute game flags

### DIFF
--- a/op-proposer/flags/flags.go
+++ b/op-proposer/flags/flags.go
@@ -51,23 +51,20 @@ var (
 		EnvVars: prefixEnvVars("ALLOW_NON_FINALIZED"),
 	}
 	DisputeGameFactoryAddressFlag = &cli.StringFlag{
-		Name:    "dgf-address",
+		Name:    "game-factory-address",
 		Usage:   "Address of the DisputeGameFactory contract",
-		EnvVars: prefixEnvVars("DGF_ADDRESS"),
-		Hidden:  true,
+		EnvVars: prefixEnvVars("GAME_FACTORY_ADDRESS"),
 	}
 	ProposalIntervalFlag = &cli.DurationFlag{
 		Name:    "proposal-interval",
-		Usage:   "Interval between submitting L2 output proposals when the DGFAddress is set",
+		Usage:   "Interval between submitting L2 output proposals when the dispute game factory address is set",
 		EnvVars: prefixEnvVars("PROPOSAL_INTERVAL"),
-		Hidden:  true,
 	}
 	DisputeGameTypeFlag = &cli.UintFlag{
-		Name:    "dg-type",
+		Name:    "game-type",
 		Usage:   "Dispute game type to create via the configured DisputeGameFactory",
 		Value:   0,
-		EnvVars: prefixEnvVars("DG_TYPE"),
-		Hidden:  true,
+		EnvVars: prefixEnvVars("GAME_TYPE"),
 	}
 	ActiveSequencerCheckDurationFlag = &cli.DurationFlag{
 		Name:    "active-sequencer-check-duration",


### PR DESCRIPTION
**Description**

Unhide the dispute game related op-proposer flags.  We originally hid them to keep them unsupported but they're stable enough to be unhidden now in preparation for shipping.