### PR TITLE
op-dispute-mon: Add function to calculate required collateral

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -116,12 +116,28 @@ func (c *FaultDisputeGameContract) GetSplitDepth(ctx context.Context) (types.Dep
 	return types.Depth(splitDepth.GetBigInt(0).Uint64()), nil
 }
 
-func (c *FaultDisputeGameContract) GetCredit(ctx context.Context, receipient common.Address) (*big.Int, error) {
-	credit, err := c.multiCaller.SingleCall(ctx, batching.BlockLatest, c.contract.Call(methodCredit, receipient))
+func (c *FaultDisputeGameContract) GetCredit(ctx context.Context, recipient common.Address) (*big.Int, error) {
+	if credits, err := c.GetCredits(ctx, batching.BlockLatest, recipient); err != nil {
+		return nil, err
+	} else {
+		return credits[0], nil
+	}
+}
+
+func (c *FaultDisputeGameContract) GetCredits(ctx context.Context, block batching.Block, recipients ...common.Address) ([]*big.Int, error) {
+	calls := make([]*batching.ContractCall, 0, len(recipients))
+	for _, recipient := range recipients {
+		calls = append(calls, c.contract.Call(methodCredit, recipient))
+	}
+	results, err := c.multiCaller.Call(ctx, block, calls...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve credit: %w", err)
 	}
-	return credit.GetBigInt(0), nil
+	credits := make([]*big.Int, 0, len(recipients))
+	for _, result := range results {
+		credits = append(credits, result.GetBigInt(0))
+	}
+	return credits, nil
 }
 
 func (f *FaultDisputeGameContract) ClaimCredit(recipient common.Address) (txmgr.TxCandidate, error) {

--- a/op-dispute-mon/mon/bonds/bonds.go
+++ b/op-dispute-mon/mon/bonds/bonds.go
@@ -8,11 +8,10 @@ import (
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
 	"golang.org/x/exp/maps"
 )
 
-var noBond = new(uint256.Int).Sub(uint256.NewInt(0), uint256.NewInt(1)).ToBig()
+var noBond = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
 
 type BondContract interface {
 	GetCredits(ctx context.Context, block batching.Block, recipients ...common.Address) ([]*big.Int, error)

--- a/op-dispute-mon/mon/bonds/bonds.go
+++ b/op-dispute-mon/mon/bonds/bonds.go
@@ -1,0 +1,45 @@
+package bonds
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+	"golang.org/x/exp/maps"
+)
+
+var noBond = new(uint256.Int).Sub(uint256.NewInt(0), uint256.NewInt(1)).ToBig()
+
+type BondContract interface {
+	GetCredits(ctx context.Context, block batching.Block, recipients ...common.Address) ([]*big.Int, error)
+}
+
+// CalculateRequiredCollateral determines the minimum balance required for a fault dispute game contract in order
+// to pay the outstanding bonds and credits.
+// It returns the sum of unpaid bonds from claims, plus the sum of allocated but unclaimed credits.
+func CalculateRequiredCollateral(ctx context.Context, contract BondContract, blockHash common.Hash, claims []faultTypes.Claim) (*big.Int, error) {
+	unpaidBonds := big.NewInt(0)
+	recipients := make(map[common.Address]bool)
+	for _, claim := range claims {
+		if noBond.Cmp(claim.Bond) != 0 {
+			unpaidBonds = new(big.Int).Add(unpaidBonds, claim.Bond)
+		}
+		recipients[claim.Claimant] = true
+		if claim.CounteredBy != (common.Address{}) {
+			recipients[claim.CounteredBy] = true
+		}
+	}
+
+	credits, err := contract.GetCredits(ctx, batching.BlockByHash(blockHash), maps.Keys(recipients)...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load credits: %w", err)
+	}
+	for _, credit := range credits {
+		unpaidBonds = new(big.Int).Add(unpaidBonds, credit)
+	}
+	return unpaidBonds, nil
+}

--- a/op-dispute-mon/mon/bonds/bonds_test.go
+++ b/op-dispute-mon/mon/bonds/bonds_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMaxValue(t *testing.T) {
-	require.Equal(t, noBond.String(), "115792089237316195423570985008687907853269984665640564039457584007913129639935")
+	require.Equal(t, noBond.String(), "340282366920938463463374607431768211455")
 }
 
 func TestCalculateRequiredCollateral(t *testing.T) {
@@ -41,8 +41,8 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 	}
 	contract := &stubBondContract{
 		credits: map[common.Address]*big.Int{
-			common.Address{0x01}: big.NewInt(3),
-			common.Address{0x03}: big.NewInt(8),
+			{0x01}: big.NewInt(3),
+			{0x03}: big.NewInt(8),
 		},
 	}
 	collateral, err := CalculateRequiredCollateral(context.Background(), contract, common.Hash{0xab}, claims)

--- a/op-dispute-mon/mon/bonds/bonds_test.go
+++ b/op-dispute-mon/mon/bonds/bonds_test.go
@@ -1,0 +1,67 @@
+package bonds
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxValue(t *testing.T) {
+	require.Equal(t, noBond.String(), "115792089237316195423570985008687907853269984665640564039457584007913129639935")
+}
+
+func TestCalculateRequiredCollateral(t *testing.T) {
+	claims := []types.Claim{
+		{
+			ClaimData: types.ClaimData{
+				Bond: noBond,
+			},
+			Claimant:    common.Address{0x01},
+			CounteredBy: common.Address{0x02},
+		},
+		{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(5),
+			},
+			Claimant:    common.Address{0x03},
+			CounteredBy: common.Address{},
+		},
+		{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(7),
+			},
+			Claimant:    common.Address{0x03},
+			CounteredBy: common.Address{},
+		},
+	}
+	contract := &stubBondContract{
+		credits: map[common.Address]*big.Int{
+			common.Address{0x01}: big.NewInt(3),
+			common.Address{0x03}: big.NewInt(8),
+		},
+	}
+	collateral, err := CalculateRequiredCollateral(context.Background(), contract, common.Hash{0xab}, claims)
+	require.NoError(t, err)
+	require.Equal(t, collateral.Int64(), int64(5+7+3+8))
+}
+
+type stubBondContract struct {
+	credits map[common.Address]*big.Int
+}
+
+func (s *stubBondContract) GetCredits(_ context.Context, _ batching.Block, recipients ...common.Address) ([]*big.Int, error) {
+	results := make([]*big.Int, len(recipients))
+	for i, recipient := range recipients {
+		credit, ok := s.credits[recipient]
+		if !ok {
+			credit = big.NewInt(0)
+		}
+		results[i] = credit
+	}
+	return results, nil
+}


### PR DESCRIPTION
**Description**

Adds a function that given the claims for a dispute game calculates the required collateral to cover all outstanding payments. It calculates this by summing up the unpaid `bond` amounts from each claim, plus looking up the allocated but unclaimed credits. Unclaimed credits are loaded by collecting all `Claimant` and `CounteredBy` addresses in the claims and checking for any unclaimed credits via a new batch method.

This depends on the invariant that no bonds should be paid to anyone who isn't either a `Claimant` or `CounteredBy` address in the game's claims. This holds because bonds are payments are either:
1. Paid to the user who calls `step` against a leaf claim. This user is recorded as the `CounteredBy` which can't be changed.
2. Paid to the `Claimant` of the left most uncountered child claim
3. Paid to the `Claimant` of the claim itself if it is ultimately found to be uncountered.

Hence, the `Claimant` and `CounteredBy` fields are sufficient to identify the owners of all credits.

**Tests**

Added unit tests.

**Additional context**

Haven't hooked this up as that may interfere with Andrea's work, just doing the isolated business logic to work through how to calculate the value.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/538
