### PR TITLE
fix: typo on cache_test eth_call

### DIFF
--- a/proxyd/cache_test.go
+++ b/proxyd/cache_test.go
@@ -183,7 +183,7 @@ func TestRPCCacheUnsupportedMethod(t *testing.T) {
 			name: "eth_call",
 			req: &RPCReq{
 				JSONRPC: "2.0",
-				Method:  "eth_gasPrice",
+				Method:  "eth_call",
 				ID:      ID,
 			},
 		},


### PR DESCRIPTION
**Description**

The method being called in `cache_test.go` for `eth_call` was `eth_gasPrice`. This PR fixes it
