### PR TITLE
fix(op-dispute-mon): Fix noBond Size

### DIFF
--- a/op-dispute-mon/mon/bonds/bonds.go
+++ b/op-dispute-mon/mon/bonds/bonds.go
@@ -8,11 +8,10 @@ import (
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/holiman/uint256"
 	"golang.org/x/exp/maps"
 )
 
-var noBond = new(uint256.Int).Sub(uint256.NewInt(0), uint256.NewInt(1)).ToBig()
+var noBond = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
 
 type BondContract interface {
 	GetCredits(ctx context.Context, block batching.Block, recipients ...common.Address) ([]*big.Int, error)

--- a/op-dispute-mon/mon/bonds/bonds_test.go
+++ b/op-dispute-mon/mon/bonds/bonds_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMaxValue(t *testing.T) {
-	require.Equal(t, noBond.String(), "115792089237316195423570985008687907853269984665640564039457584007913129639935")
+	require.Equal(t, noBond.String(), "340282366920938463463374607431768211455")
 }
 
 func TestCalculateRequiredCollateral(t *testing.T) {
@@ -41,8 +41,8 @@ func TestCalculateRequiredCollateral(t *testing.T) {
 	}
 	contract := &stubBondContract{
 		credits: map[common.Address]*big.Int{
-			common.Address{0x01}: big.NewInt(3),
-			common.Address{0x03}: big.NewInt(8),
+			{0x01}: big.NewInt(3),
+			{0x03}: big.NewInt(8),
 		},
 	}
 	collateral, err := CalculateRequiredCollateral(context.Background(), contract, common.Hash{0xab}, claims)


### PR DESCRIPTION
**Description**

Small fix for https://github.com/ethereum-optimism/optimism/pull/9460 to use the correct `type(uint128).max` as the `noBond` amount as opposed to `uint256`. Removes a dependency as well which is nice.