### PR TITLE
contracts: typo fix on repo name (registry not ops)

### DIFF
--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -72,7 +72,7 @@ abstract contract Artifacts {
 
     /// @notice Populates the addresses to be used in a script based on a JSON file.
     ///         The format of the JSON file is the same that it output by this script
-    ///         as well as the JSON files that contain addresses in the `superchain-ops`
+    ///         as well as the JSON files that contain addresses in the `superchain-registry`
     ///         repo. The JSON key is the name of the contract and the value is an address.
     function _loadAddresses(string memory _path) internal {
         string[] memory commands = new string[](3);


### PR DESCRIPTION
**Description**

It's easy to confuse superchain-ops and superchain-registry