### PR TITLE
feat(op-dispute-mon): Forecast Metrics and Enhanced Testing

### DIFF
--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,7 +15,7 @@ import (
 )
 
 var (
-	failedForecaseLog     = "Failed to forecast game"
+	failedForecastLog     = "Failed to forecast game"
 	expectedInProgressLog = "Game is not in progress, skipping forecast"
 	unexpectedResultLog   = "Forecasting unexpected game result"
 	expectedResultLog     = "Forecasting expected game result"
@@ -24,19 +25,19 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	t.Parallel()
 
 	t.Run("NoGames", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
 		forecast.Forecast(context.Background(), []types.GameMetadata{})
 		require.Equal(t, 0, creator.calls)
 		require.Equal(t, 0, creator.caller.calls)
 		require.Equal(t, 0, creator.caller.claimsCalls)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 	})
 
 	t.Run("ContractCreationFails", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
 		creator.err = errors.New("boom")
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
@@ -44,7 +45,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 		require.Equal(t, 0, creator.caller.claimsCalls)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		l := logs.FindLog(levelFilter, messageFilter)
 		require.NotNil(t, l)
 		err := l.AttrValue("err")
@@ -53,16 +54,17 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("MetadataFetchFails", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
 		creator.caller.err = errors.New("boom")
+		creator.caller.rootClaim = []common.Hash{mockRootClaim}
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 0, creator.caller.claimsCalls)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		l := logs.FindLog(levelFilter, messageFilter)
 		require.NotNil(t, l)
 		err := l.AttrValue("err")
@@ -71,16 +73,17 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("ClaimsFetchFails", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
 		creator.caller.claimsErr = errors.New("boom")
+		creator.caller.rootClaim = []common.Hash{mockRootClaim}
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 1, creator.caller.claimsCalls)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		l := logs.FindLog(levelFilter, messageFilter)
 		require.NotNil(t, l)
 		err := l.AttrValue("err")
@@ -89,15 +92,18 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("RollupFetchFails", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
 		rollup.err = errors.New("boom")
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1]}
+		creator.caller.rootClaim = []common.Hash{mockRootClaim}
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 1, creator.caller.claimsCalls)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		l := logs.FindLog(levelFilter, messageFilter)
 		require.NotNil(t, l)
 		err := l.AttrValue("err")
@@ -106,9 +112,9 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("ChallengerWonGameSkipped", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusChallengerWon}
-		creator.caller.claims = createDeepClaimList()[:1]
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller.status = []types.GameStatus{types.GameStatusChallengerWon}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1]}
 		expectedGame := types.GameMetadata{}
 		forecast.Forecast(context.Background(), []types.GameMetadata{expectedGame})
 		require.Equal(t, 1, creator.calls)
@@ -116,7 +122,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 		require.Equal(t, 0, creator.caller.claimsCalls)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -127,9 +133,9 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("DefenderWonGameSkipped", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusDefenderWon}
-		creator.caller.claims = createDeepClaimList()[:1]
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller.status = []types.GameStatus{types.GameStatusDefenderWon}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1]}
 		expectedGame := types.GameMetadata{}
 		forecast.Forecast(context.Background(), []types.GameMetadata{expectedGame})
 		require.Equal(t, 1, creator.calls)
@@ -137,7 +143,7 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 		require.Equal(t, 0, creator.caller.claimsCalls)
 		require.Equal(t, 0, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -148,16 +154,16 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("SingleGame", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
-		creator.caller.claims = createDeepClaimList()[:1]
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1]}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 1, creator.caller.claimsCalls)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -165,16 +171,17 @@ func TestForecast_Forecast_BasicTests(t *testing.T) {
 	})
 
 	t.Run("MultipleGames", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller.claims = createDeepClaimList()[:1]
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress, types.GameStatusInProgress, types.GameStatusInProgress}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1], createDeepClaimList()[:1], createDeepClaimList()[:1]}
+		creator.caller.rootClaim = []common.Hash{{}, {}, {}}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}, {}, {}})
 		require.Equal(t, 3, creator.calls)
 		require.Equal(t, 3, creator.caller.calls)
 		require.Equal(t, 3, creator.caller.claimsCalls)
 		require.Equal(t, 3, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -186,40 +193,16 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 	t.Parallel()
 
 	t.Run("AgreeDefenderWins", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
-		creator.caller.claims = createDeepClaimList()[:1]
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1]}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 1, creator.caller.claimsCalls)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
-		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
-		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
-		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
-		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
-		levelFilter = testlog.NewLevelFilter(log.LevelWarn)
-		messageFilter = testlog.NewMessageFilter(unexpectedResultLog)
-		l := logs.FindLog(levelFilter, messageFilter)
-		require.NotNil(t, l)
-		require.Equal(t, common.Hash{}, l.AttrValue("rootClaim"))
-		require.Equal(t, mockRootClaim, l.AttrValue("expected"))
-		require.Equal(t, types.GameStatusDefenderWon, l.AttrValue("status"))
-	})
-
-	t.Run("AgreeChallengerWins", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
-		creator.caller.claims = createDeepClaimList()[:2]
-		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
-		require.Equal(t, 1, creator.calls)
-		require.Equal(t, 1, creator.caller.calls)
-		require.Equal(t, 1, creator.caller.claimsCalls)
-		require.Equal(t, 1, rollup.calls)
-		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -228,23 +211,48 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 		messageFilter = testlog.NewMessageFilter(expectedResultLog)
 		l := logs.FindLog(levelFilter, messageFilter)
 		require.NotNil(t, l)
-		require.Equal(t, common.Hash{}, l.AttrValue("rootClaim"))
+		require.Equal(t, mockRootClaim, l.AttrValue("rootClaim"))
 		require.Equal(t, mockRootClaim, l.AttrValue("expected"))
-		require.Equal(t, types.GameStatusChallengerWon, l.AttrValue("status"))
+		require.Equal(t, types.GameStatusDefenderWon, l.AttrValue("status"))
 	})
 
-	t.Run("DisagreeChallengerWins", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
-		creator.caller.rootClaim = common.Hash{}
-		creator.caller.claims = createDeepClaimList()[:2]
+	t.Run("AgreeChallengerWins", func(t *testing.T) {
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller.status = []types.GameStatus{types.GameStatusInProgress}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:2]}
+		creator.caller.rootClaim = []common.Hash{mockRootClaim}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 1, creator.caller.claimsCalls)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
+		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
+		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
+		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
+		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
+		levelFilter = testlog.NewLevelFilter(log.LevelWarn)
+		messageFilter = testlog.NewMessageFilter(unexpectedResultLog)
+		l := logs.FindLog(levelFilter, messageFilter)
+		require.NotNil(t, l)
+		require.Equal(t, mockRootClaim, l.AttrValue("rootClaim"))
+		require.Equal(t, mockRootClaim, l.AttrValue("expected"))
+		require.Equal(t, types.GameStatusChallengerWon, l.AttrValue("status"))
+	})
+
+	t.Run("DisagreeChallengerWins", func(t *testing.T) {
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller = &mockGameCaller{status: []types.GameStatus{types.GameStatusInProgress}}
+		creator.caller.rootClaim = []common.Hash{{}}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:2]}
+		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
+		require.Equal(t, 1, creator.calls)
+		require.Equal(t, 1, creator.caller.calls)
+		require.Equal(t, 1, creator.caller.claimsCalls)
+		require.Equal(t, 1, rollup.calls)
+		levelFilter := testlog.NewLevelFilter(log.LevelError)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -259,17 +267,17 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 	})
 
 	t.Run("DisagreeDefenderWins", func(t *testing.T) {
-		forecast, creator, rollup, logs := setupForecastTest(t)
-		creator.caller = &mockGameCaller{status: types.GameStatusInProgress}
-		creator.caller.rootClaim = common.Hash{}
-		creator.caller.claims = createDeepClaimList()[:1]
+		forecast, _, creator, rollup, logs := setupForecastTest(t)
+		creator.caller = &mockGameCaller{status: []types.GameStatus{types.GameStatusInProgress}}
+		creator.caller.rootClaim = []common.Hash{{}}
+		creator.caller.claims = [][]faultTypes.Claim{createDeepClaimList()[:1]}
 		forecast.Forecast(context.Background(), []types.GameMetadata{{}})
 		require.Equal(t, 1, creator.calls)
 		require.Equal(t, 1, creator.caller.calls)
 		require.Equal(t, 1, creator.caller.claimsCalls)
 		require.Equal(t, 1, rollup.calls)
 		levelFilter := testlog.NewLevelFilter(log.LevelError)
-		messageFilter := testlog.NewMessageFilter(failedForecaseLog)
+		messageFilter := testlog.NewMessageFilter(failedForecastLog)
 		require.Nil(t, logs.FindLog(levelFilter, messageFilter))
 		levelFilter = testlog.NewLevelFilter(log.LevelDebug)
 		messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
@@ -284,10 +292,75 @@ func TestForecast_Forecast_EndLogs(t *testing.T) {
 	})
 }
 
-func setupForecastTest(t *testing.T) (*forecast, *mockGameCallerCreator, *stubOutputValidator, *testlog.CapturingHandler) {
+func TestForecast_Forecast_MultipleGames(t *testing.T) {
+	forecast, _, creator, rollup, logs := setupForecastTest(t)
+	creator.caller.status = []types.GameStatus{
+		types.GameStatusChallengerWon,
+		types.GameStatusInProgress,
+		types.GameStatusInProgress,
+		types.GameStatusDefenderWon,
+		types.GameStatusInProgress,
+		types.GameStatusInProgress,
+		types.GameStatusDefenderWon,
+		types.GameStatusChallengerWon,
+		types.GameStatusChallengerWon,
+	}
+	creator.caller.claims = [][]faultTypes.Claim{
+		createDeepClaimList()[:1],
+		createDeepClaimList()[:2],
+		createDeepClaimList()[:2],
+		createDeepClaimList()[:1],
+	}
+	creator.caller.rootClaim = []common.Hash{
+		{},
+		{},
+		mockRootClaim,
+		{},
+		{},
+		mockRootClaim,
+		{},
+		{},
+		{},
+	}
+	games := make([]types.GameMetadata, 9)
+	forecast.Forecast(context.Background(), games)
+	require.Equal(t, 9, creator.calls)
+	require.Equal(t, 9, creator.caller.calls)
+	require.Equal(t, 4, creator.caller.claimsCalls)
+	require.Equal(t, 4, rollup.calls)
+	levelFilter := testlog.NewLevelFilter(log.LevelError)
+	messageFilter := testlog.NewMessageFilter(failedForecastLog)
+	require.Nil(t, logs.FindLog(levelFilter, messageFilter))
+	levelFilter = testlog.NewLevelFilter(log.LevelDebug)
+	messageFilter = testlog.NewMessageFilter(expectedInProgressLog)
+	require.Len(t, logs.FindLogs(levelFilter, messageFilter), 5)
+}
+
+func setupForecastTest(t *testing.T) (*forecast, *mockForecastMetrics, *mockGameCallerCreator, *stubOutputValidator, *testlog.CapturingHandler) {
 	logger, capturedLogs := testlog.CaptureLogger(t, log.LvlDebug)
 	validator := &stubOutputValidator{}
-	caller := &mockGameCaller{rootClaim: mockRootClaim}
+	caller := &mockGameCaller{rootClaim: []common.Hash{mockRootClaim}}
 	creator := &mockGameCallerCreator{caller: caller}
-	return newForecast(logger, creator, validator), creator, validator, capturedLogs
+	metrics := &mockForecastMetrics{}
+	return newForecast(logger, metrics, creator, validator), metrics, creator, validator, capturedLogs
+}
+
+type mockForecastMetrics struct {
+	agreeDefenderAhead      int
+	disagreeDefenderAhead   int
+	agreeChallengerAhead    int
+	disagreeChallengerAhead int
+}
+
+func (m *mockForecastMetrics) RecordGameAgreement(status string, count int) {
+	switch status {
+	case "agree_defender_ahead":
+		m.agreeDefenderAhead = count
+	case "disagree_defender_ahead":
+		m.disagreeDefenderAhead = count
+	case "agree_challenger_ahead":
+		m.agreeChallengerAhead = count
+	case "disagree_challenger_ahead":
+		m.disagreeChallengerAhead = count
+	}
 }

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -79,11 +79,14 @@ func (s *Service) initFromConfig(ctx context.Context, cfg *config.Config) error 
 	if err := s.initOutputRollupClient(ctx, cfg); err != nil {
 		return fmt.Errorf("failed to init rollup client: %w", err)
 	}
-	s.initOutputValidator()
-	s.initGameCallerCreator()
+
+	s.initOutputValidator()   // Must be called before initForecast
+	s.initGameCallerCreator() // Must be called before initForecast
+
 	s.initForecast(cfg)
 	s.initDetector()
-	s.initMonitor(ctx, cfg)
+
+	s.initMonitor(ctx, cfg) // Monitor must be initialized last
 
 	s.metrics.RecordInfo(version.SimpleWithMeta)
 	s.metrics.RecordUp()
@@ -100,7 +103,7 @@ func (s *Service) initGameCallerCreator() {
 }
 
 func (s *Service) initForecast(cfg *config.Config) {
-	s.forecast = newForecast(s.logger, s.game, s.validator)
+	s.forecast = newForecast(s.logger, s.metrics, s.game, s.validator)
 }
 
 func (s *Service) initDetector() {

--- a/op-dispute-mon/mon/types.go
+++ b/op-dispute-mon/mon/types.go
@@ -19,6 +19,13 @@ func (s *statusBatch) Add(status types.GameStatus) {
 	}
 }
 
+type forecastBatch struct {
+	AgreeDefenderAhead      int
+	DisagreeDefenderAhead   int
+	AgreeChallengerAhead    int
+	DisagreeChallengerAhead int
+}
+
 type detectionBatch struct {
 	inProgress             int
 	agreeDefenderWins      int


### PR DESCRIPTION
**Description**

Adds metrics to the `forecast` component of the `op-dispute-mon` service.

Enhances and adds extensive testing for forecasting.

**Tests**

Forecasting is now tested with multiple games, log assertions, and component calls.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/536
