### PR TITLE
feat(indexer) re-proving withdrawals

### DIFF
--- a/indexer/database/bridge_transactions.go
+++ b/indexer/database/bridge_transactions.go
@@ -188,10 +188,11 @@ func (db *bridgeTransactionsDB) MarkL2TransactionWithdrawalProvenEvent(withdrawa
 
 	if withdrawal.ProvenL1EventGUID != nil && withdrawal.ProvenL1EventGUID.ID() == provenL1EventGuid.ID() {
 		return nil
-	} else if withdrawal.ProvenL1EventGUID != nil {
-		return fmt.Errorf("proven withdrawal %s re-proven with a different event %s", withdrawalHash, provenL1EventGuid)
 	}
 
+	// Withdrawals can be re-proven in the event that the claim they were proven against was successfully
+	// challenged. Rather than track each individual dispute game, we allow the proven event to simply be
+	// overwritten.
 	withdrawal.ProvenL1EventGUID = &provenL1EventGuid
 	result := db.gorm.Save(&withdrawal)
 	return result.Error

--- a/indexer/migrations/20230523_create_schema.sql
+++ b/indexer/migrations/20230523_create_schema.sql
@@ -119,7 +119,10 @@ CREATE TABLE IF NOT EXISTS l2_transaction_withdrawals (
     nonce                   UINT256 NOT NULL UNIQUE,
     initiated_l2_event_guid VARCHAR NOT NULL UNIQUE REFERENCES l2_contract_events(guid) ON DELETE CASCADE,
 
-    -- Multistep (bedrock) process of a withdrawal
+    -- Multistep (bedrock) process of a withdrawal. With permissionless-output proposals, `proven_l1_event_guid`
+    -- should be treated as the last known proven event. It may be the case (rare) that the proven state of this
+    -- withdrawal was invalidated via a fault proof. This case is considered "rare" a malicious outputs are
+    -- disincentivezed via the posted bond.
     proven_l1_event_guid    VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
     finalized_l1_event_guid VARCHAR UNIQUE REFERENCES l1_contract_events(guid) ON DELETE SET NULL ON UPDATE CASCADE,
     succeeded               BOOLEAN,

--- a/indexer/processors/bridge/l1_bridge_processor.go
+++ b/indexer/processors/bridge/l1_bridge_processor.go
@@ -170,6 +170,10 @@ func L1ProcessFinalizedBridgeEvents(log log.Logger, db *database.DB, metrics L1M
 			return fmt.Errorf("missing indexed withdrawal! tx_hash = %s", provenWithdrawal.Event.TransactionHash)
 		}
 
+		if withdrawal.ProvenL1EventGUID != nil && withdrawal.ProvenL1EventGUID.ID() != provenWithdrawals[i].Event.GUID.ID() {
+			log.Info("detected re-proven withdrawal", "tx_hash", provenWithdrawal.Event.TransactionHash.String())
+		}
+
 		if err := db.BridgeTransactions.MarkL2TransactionWithdrawalProvenEvent(provenWithdrawal.WithdrawalHash, provenWithdrawals[i].Event.GUID); err != nil {
 			return fmt.Errorf("failed to mark withdrawal as proven. tx_hash = %s: %w", provenWithdrawal.Event.TransactionHash, err)
 		}


### PR DESCRIPTION
Although rare, withdrawals may need to be reproven if the output it was proven
against was invalidated. This is considered rare as this behavior is disincentivized
with bonds in FPAC.

It would be a good amount of complexity for the indexer to track every single dispute
game so we simply allow the `proven_event_guid` marker on the withdrawal to be overwritten
if seen again. The caller of the bridge api should handle this edge case on its own for now.
We can re-evaluate the indexer tracking this if this edge case becomes common
