### PR TITLE
log: Fix DynamicLogHandler to also capture derived handlers

### DIFF
--- a/op-service/log/dynamic.go
+++ b/op-service/log/dynamic.go
@@ -12,28 +12,42 @@ type LvlSetter interface {
 
 // DynamicLogHandler allow runtime-configuration of the log handler.
 type DynamicLogHandler struct {
-	slog.Handler // embedded, to expose any extra methods the underlying handler might provide
-	minLvl       slog.Level
+	h      slog.Handler
+	minLvl *slog.Level // shared with derived dynamic handlers
 }
 
 func NewDynamicLogHandler(lvl slog.Level, h slog.Handler) *DynamicLogHandler {
 	return &DynamicLogHandler{
-		Handler: h,
-		minLvl:  lvl,
+		h:      h,
+		minLvl: &lvl,
 	}
 }
 
 func (d *DynamicLogHandler) SetLogLevel(lvl slog.Level) {
-	d.minLvl = lvl
+	*d.minLvl = lvl
 }
 
 func (d *DynamicLogHandler) Handle(ctx context.Context, r slog.Record) error {
-	if r.Level < d.minLvl { // higher log level values are more critical
+	if r.Level < *d.minLvl { // higher log level values are more critical
 		return nil
 	}
-	return d.Handler.Handle(ctx, r) // process the log
+	return d.h.Handle(ctx, r) // process the log
 }
 
 func (d *DynamicLogHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
-	return (lvl >= d.minLvl) && d.Handler.Enabled(ctx, lvl)
+	return (lvl >= *d.minLvl) && d.h.Enabled(ctx, lvl)
+}
+
+func (d *DynamicLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &DynamicLogHandler{
+		h:      d.h.WithAttrs(attrs),
+		minLvl: d.minLvl,
+	}
+}
+
+func (d *DynamicLogHandler) WithGroup(name string) slog.Handler {
+	return &DynamicLogHandler{
+		h:      d.h.WithGroup(name),
+		minLvl: d.minLvl,
+	}
 }


### PR DESCRIPTION
**Description**

Fixes the `DynamicLogHandler` to also take effect on derived log handlers from `WithAttrs` and `WithGroup`.

**Tests**

Added a test that a derived logger is affected by the dynamic levels set on the original dynamic handler.

**Additional context**

Fixes a bug where derived loggers from `logger.With(...)` don't have the same log levels set as the original logger, if that logger used a dynamic log handler.

