### PR TITLE
op-node: Still EL sync if the transition block is finalized

### DIFF
--- a/op-node/rollup/derive/engine_controller.go
+++ b/op-node/rollup/derive/engine_controller.go
@@ -298,7 +298,8 @@ func (e *EngineController) InsertUnsafePayload(ctx context.Context, envelope *et
 	// Check if there is a finalized head once when doing EL sync. If so, transition to CL sync
 	if e.syncStatus == syncStatusWillStartEL {
 		b, err := e.engine.L2BlockRefByLabel(ctx, eth.Finalized)
-		if errors.Is(err, ethereum.NotFound) {
+		isTransitionBlock := e.rollupCfg.Genesis.L2.Number != 0 && b.Hash == e.rollupCfg.Genesis.L2.Hash
+		if errors.Is(err, ethereum.NotFound) || isTransitionBlock {
 			e.syncStatus = syncStatusStartedEL
 			e.log.Info("Starting EL sync")
 			e.elStart = e.clock.Now()


### PR DESCRIPTION
**Description**

Skip going from EL sync to CL on chains where the start finalized block is the bedrock transition block. This enables block by block archive sync.

**Tests**

Manually tested.

**Metadata**

- Fixes https://github.com/ethereum-optimism/protocol-quest/issues/87