### PR TITLE
Tag Tool

### DIFF
--- a/ops/tag-service/README.md
+++ b/ops/tag-service/README.md
@@ -15,7 +15,7 @@ It accepts:
 
 Tag Tool is meant to be run locally, and *does not* perform any write operations. Instead, it prints the git commands to console for the operator to use.
 
-Additionally, a special service name "full" is available, which will bump versions for `op-node`, `op-batcher` and `op-proposer` from the highest semver amongst them.
+Additionally, a special service name "op-stack" is available, which will bump versions for `op-node`, `op-batcher` and `op-proposer` from the highest semver amongst them.
 
 To run Tag Tool locally, the only dependency is `pip install semver`
 

--- a/ops/tag-service/README.md
+++ b/ops/tag-service/README.md
@@ -1,0 +1,21 @@
+# Tag Service
+Tag Service is a Github action which builds new tags and applies them to services in the monorepo.
+It accepts:
+* Service name
+* Bump Amount [major, minor, patch]
+* Prerelease and Finalize-Prerelease (to add/remove `rc` versions)
+
+It can be triggered from the Github Actions panel in the monorepo
+
+# Tag Tool
+Tag Tool is a minimal rewrite of the Tag Service to let operators prepare and commit tags from commandline
+It accepts:
+* Service name
+* Bump Amount [major, minor, patch, prerelease, finalize-prerelease]
+
+Tag Tool is meant to be run locally, and *does not* perform any write operations. Instead, it prints the git commands to console for the operator to use.
+
+Additionally, a special service name "full" is available, which will bump versions for `op-node`, `op-batcher` and `op-proposer` from the highest semver amongst them.
+
+To run Tag Tool locally, the only dependency is `pip install semver`
+

--- a/ops/tag-service/tag-tool.py
+++ b/ops/tag-service/tag-tool.py
@@ -18,7 +18,8 @@ SERVICES  = [
     'op-heartbeat',
     'ufm-metamask',
     'op-contracts',
-    'full', # special case for tagging op-node, op-batcher, and op-proposer together
+    'test',
+    'op-stack', # special case for tagging op-node, op-batcher, and op-proposer together
 ]
 VERSION_PATTERN = '^{service}/v\\d+\\.\\d+\\.\\d+(-rc\\.\\d+)?$'
 GIT_TAG_COMMAND = 'git tag -a {tag} -m "{message}"'
@@ -41,10 +42,10 @@ def new_tag(service, version, bump):
 
 def latest_version(service):
     # Get the list of tags from the git repository.
-    tags = subprocess.run(['git', 'tag', '--list'], capture_output=True, check=True) \
+    tags = subprocess.run(['git', 'tag', '--list', f'{service}/v*'], capture_output=True, check=True) \
         .stdout.decode('utf-8').splitlines()
     # Filter out tags that don't match the service name, and tags for prerelease versions.
-    svc_versions = sorted([t.replace(f'{service}/v', '') for t in tags if re.match(VERSION_PATTERN.format(service=service), t)])
+    svc_versions = sorted([t.replace(f'{service}/v', '') for t in tags])
     if len(svc_versions) == 0:
         raise Exception(f'No tags found for service: {service}')
     return svc_versions[-1]
@@ -66,7 +67,7 @@ def main():
 
     service = args.service
 
-    if service == 'full':
+    if service == 'op-stack':
       latest = latest_among_services(['op-node', 'op-batcher', 'op-proposer'])
     else:
       latest = latest_version(service)
@@ -77,13 +78,13 @@ def main():
     print(f'new tag: {bumped}')
     print('run the following commands to create the new tag:\n')
     # special case for tagging op-node, op-batcher, and op-proposer together. All three would share the same semver
-    if args.service == 'full':
-        print(GIT_TAG_COMMAND.format(tag=bumped.replace('full', 'op-node'), message=args.message))
-        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('full', 'op-node')))
-        print(GIT_TAG_COMMAND.format(tag=bumped.replace('full', 'op-batcher'), message=args.message))
-        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('full', 'op-batcher')))
-        print(GIT_TAG_COMMAND.format(tag=bumped.replace('full', 'op-proposer'), message=args.message))
-        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('full', 'op-proposer')))
+    if args.service == 'op-stack':
+        print(GIT_TAG_COMMAND.format(tag=bumped.replace('op-stack', 'op-node'), message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('op-stack', 'op-node')))
+        print(GIT_TAG_COMMAND.format(tag=bumped.replace('op-stack', 'op-batcher'), message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('op-stack', 'op-batcher')))
+        print(GIT_TAG_COMMAND.format(tag=bumped.replace('op-stack', 'op-proposer'), message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('op-stack', 'op-proposer')))
     else:
         print(GIT_TAG_COMMAND.format(tag=bumped, message=args.message))
         print(GIT_PUSH_COMMAND.format(tag=bumped))

--- a/ops/tag-service/tag-tool.py
+++ b/ops/tag-service/tag-tool.py
@@ -1,0 +1,93 @@
+import argparse
+import subprocess
+import re
+import semver
+
+SERVICES  = [
+    'ci-builder',
+    'ci-builder-rust',
+    'chain-mon',
+    'indexer',
+    'op-node',
+    'op-batcher',
+    'op-challenger',
+    'op-dispute-mon',
+    'op-proposer',
+    'op-ufm',
+    'proxyd',
+    'op-heartbeat',
+    'ufm-metamask',
+    'op-contracts',
+    'full', # special case for tagging op-node, op-batcher, and op-proposer together
+]
+VERSION_PATTERN = '^{service}/v\\d+\\.\\d+\\.\\d+(-rc\\.\\d+)?$'
+GIT_TAG_COMMAND = 'git tag -a {tag} -m "{message}"'
+GIT_PUSH_COMMAND = 'git push origin {tag}'
+
+def new_tag(service, version, bump):
+    if bump == 'major':
+        bumped = version.bump_major()
+    elif bump == 'minor':
+        bumped = version.bump_minor()
+    elif bump == 'patch':
+        bumped = version.bump_patch()
+    elif bump == 'prerelease':
+        bumped = version.bump_prerelease()
+    elif bump == 'finalize-prerelease':
+        bumped = version.finalize_version()
+    else:
+        raise Exception('Invalid bump type: {}'.format(bump))
+    return f'{service}/v{bumped}'
+
+def latest_version(service):
+    # Get the list of tags from the git repository.
+    tags = subprocess.run(['git', 'tag', '--list'], capture_output=True, check=True) \
+        .stdout.decode('utf-8').splitlines()
+    # Filter out tags that don't match the service name, and tags for prerelease versions.
+    svc_versions = sorted([t.replace(f'{service}/v', '') for t in tags if re.match(VERSION_PATTERN.format(service=service), t)])
+    if len(svc_versions) == 0:
+        raise Exception(f'No tags found for service: {service}')
+    return svc_versions[-1]
+
+def latest_among_services(services):
+    latest = '0.0.0'
+    for service in services:
+        candidate = latest_version(service)
+        if semver.compare(candidate, latest) > 0:
+            latest = candidate
+    return latest
+
+def main():
+    parser = argparse.ArgumentParser(description='Create a new git tag for a service')
+    parser.add_argument('--service', type=str, help='The name of the Service')
+    parser.add_argument('--bump', type=str, help='The type of bump to apply to the version number')
+    parser.add_argument('--message', type=str, help='Message to include in git tag', default='[tag-tool-release]')
+    args = parser.parse_args()
+
+    service = args.service
+
+    if service == 'full':
+      latest = latest_among_services(['op-node', 'op-batcher', 'op-proposer'])
+    else:
+      latest = latest_version(service)
+
+    bumped = new_tag(service, semver.VersionInfo.parse(latest), args.bump)
+
+    print(f'latest tag: {latest}')
+    print(f'new tag: {bumped}')
+    print('run the following commands to create the new tag:\n')
+    # special case for tagging op-node, op-batcher, and op-proposer together. All three would share the same semver
+    if args.service == 'full':
+        print(GIT_TAG_COMMAND.format(tag=bumped.replace('full', 'op-node'), message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('full', 'op-node')))
+        print(GIT_TAG_COMMAND.format(tag=bumped.replace('full', 'op-batcher'), message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('full', 'op-batcher')))
+        print(GIT_TAG_COMMAND.format(tag=bumped.replace('full', 'op-proposer'), message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped.replace('full', 'op-proposer')))
+    else:
+        print(GIT_TAG_COMMAND.format(tag=bumped, message=args.message))
+        print(GIT_PUSH_COMMAND.format(tag=bumped))
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
# What
Offers a new tool for generating tags for service releases in the monorepo

# Why
`tag-service` exists and is usable as a Github action to easily bump versions of services. However, tag service does not allow any insight into the known latest version, nor does it display what the new versions of services *will be*. This was leading operators to prefer CLI based tag updates.

`tag-tool` is meant as a guard-rail to prevent errors during manual CLI tagging, while allowing the operator the insight and flexibility to manage the tags.

# How
Tag Tool copies most implementation details from Tag Service, but strips it down a bit. Tag Tool *ONLY* prints the tag commands to screen for the operator to use. It also prints the latest version it found

# Additional Goodies
* README.md now exists for the tag-service folder
* Tag Tool supports `--service full`, which will select the highest semver amongst [op-node, op-batcher, op-proposer], and will emit tagging commands to upgrade all three to a shared version.

# Example

```
> $ python3 tag-service/tag-tool.py --service full --bump major                                                                                                                                                                                      
latest tag: 1.5.1-rc.2
new tag: full/v2.0.0
run the following commands to create the new tag:

git tag -a op-node/v2.0.0 -m "[tag-tool-release]"
git push origin op-node/v2.0.0
git tag -a op-batcher/v2.0.0 -m "[tag-tool-release]"
git push origin op-batcher/v2.0.0
git tag -a op-proposer/v2.0.0 -m "[tag-tool-release]"
git push origin op-proposer/v2.0.0
```

Fixes https://github.com/ethereum-optimism/client-pod/issues/571