### PR TITLE
op-challenger: Add support for permissioned games

### DIFF
--- a/op-challenger/cmd/main_test.go
+++ b/op-challenger/cmd/main_test.go
@@ -115,8 +115,10 @@ func TestMultipleTraceTypes(t *testing.T) {
 		// Add extra trace types (cannon is already specified)
 		args = append(args,
 			"--trace-type", config.TraceTypeAlphabet.String())
+		args = append(args,
+			"--trace-type", config.TraceTypePermissioned.String())
 		cfg := configForArgs(t, args)
-		require.Equal(t, []config.TraceType{config.TraceTypeCannon, config.TraceTypeAlphabet}, cfg.TraceTypes)
+		require.Equal(t, []config.TraceType{config.TraceTypeCannon, config.TraceTypeAlphabet, config.TraceTypePermissioned}, cfg.TraceTypes)
 	})
 	t.Run("WithSomeOptions", func(t *testing.T) {
 		argsMap := requiredArgs(config.TraceTypeCannon)
@@ -241,59 +243,174 @@ func TestPollInterval(t *testing.T) {
 	})
 }
 
-func TestCannonBin(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-bin"))
-	})
+func TestCannonRequiredArgs(t *testing.T) {
+	for _, traceType := range []config.TraceType{config.TraceTypeCannon, config.TraceTypePermissioned} {
+		traceType := traceType
+		t.Run(fmt.Sprintf("TestCannonBin-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-bin"))
+			})
 
-	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag cannon-bin is required", addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-bin"))
-	})
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag cannon-bin is required", addRequiredArgsExcept(traceType, "--cannon-bin"))
+			})
 
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-bin", "--cannon-bin=./cannon"))
-		require.Equal(t, "./cannon", cfg.CannonBin)
-	})
-}
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-bin", "--cannon-bin=./cannon"))
+				require.Equal(t, "./cannon", cfg.CannonBin)
+			})
+		})
 
-func TestCannonServer(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-server"))
-	})
+		t.Run(fmt.Sprintf("TestCannonServer-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-server"))
+			})
 
-	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag cannon-server is required", addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-server"))
-	})
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag cannon-server is required", addRequiredArgsExcept(traceType, "--cannon-server"))
+			})
 
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-server", "--cannon-server=./op-program"))
-		require.Equal(t, "./op-program", cfg.CannonServer)
-	})
-}
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-server", "--cannon-server=./op-program"))
+				require.Equal(t, "./op-program", cfg.CannonServer)
+			})
+		})
 
-func TestCannonAbsolutePrestate(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-prestate"))
-	})
+		t.Run(fmt.Sprintf("TestCannonAbsolutePrestate-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-prestate"))
+			})
 
-	t.Run("Required", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag cannon-prestate is required", addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-prestate"))
-	})
+			t.Run("Required", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag cannon-prestate is required", addRequiredArgsExcept(traceType, "--cannon-prestate"))
+			})
 
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-prestate", "--cannon-prestate=./pre.json"))
-		require.Equal(t, "./pre.json", cfg.CannonAbsolutePreState)
-	})
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-prestate", "--cannon-prestate=./pre.json"))
+				require.Equal(t, "./pre.json", cfg.CannonAbsolutePreState)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-l2"))
+			})
+
+			t.Run("RequiredForCannonTrace", func(t *testing.T) {
+				verifyArgsInvalid(t, "flag cannon-l2 is required", addRequiredArgsExcept(traceType, "--cannon-l2"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgs(traceType))
+				require.Equal(t, cannonL2, cfg.CannonL2)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonSnapshotFreq-%v", traceType), func(t *testing.T) {
+			t.Run("UsesDefault", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgs(traceType))
+				require.Equal(t, config.DefaultCannonSnapshotFreq, cfg.CannonSnapshotFreq)
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgs(traceType, "--cannon-snapshot-freq=1234"))
+				require.Equal(t, uint(1234), cfg.CannonSnapshotFreq)
+			})
+
+			t.Run("Invalid", func(t *testing.T) {
+				verifyArgsInvalid(t, "invalid value \"abc\" for flag -cannon-snapshot-freq",
+					addRequiredArgs(traceType, "--cannon-snapshot-freq=abc"))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonInfoFreq-%v", traceType), func(t *testing.T) {
+			t.Run("UsesDefault", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgs(traceType))
+				require.Equal(t, config.DefaultCannonInfoFreq, cfg.CannonInfoFreq)
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgs(traceType, "--cannon-info-freq=1234"))
+				require.Equal(t, uint(1234), cfg.CannonInfoFreq)
+			})
+
+			t.Run("Invalid", func(t *testing.T) {
+				verifyArgsInvalid(t, "invalid value \"abc\" for flag -cannon-info-freq",
+					addRequiredArgs(traceType, "--cannon-info-freq=abc"))
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestRequireEitherCannonNetworkOrRollupAndGenesis-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag cannon-network or cannon-rollup-config and cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--cannon-network"))
+			verifyArgsInvalid(
+				t,
+				"flag cannon-network or cannon-rollup-config and cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-rollup-config=rollup.json"))
+			verifyArgsInvalid(
+				t,
+				"flag cannon-network or cannon-rollup-config and cannon-l2-genesis is required",
+				addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-l2-genesis=gensis.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(
+				t,
+				"flag cannon-network can not be used with cannon-rollup-config and cannon-l2-genesis",
+				addRequiredArgsExcept(traceType, "--cannon-network",
+					"--cannon-network", cannonNetwork, "--cannon-rollup-config=rollup.json"))
+		})
+
+		t.Run(fmt.Sprintf("TestCannonNetwork-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-network"))
+			})
+
+			t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network",
+					"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-network", otherCannonNetwork))
+				require.Equal(t, otherCannonNetwork, cfg.CannonNetwork)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonRollupConfig-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-rollup-config"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				require.Equal(t, "rollup.json", cfg.CannonRollupConfigPath)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2Genesis-%v", traceType), func(t *testing.T) {
+			t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
+				configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-l2-genesis"))
+			})
+
+			t.Run("Valid", func(t *testing.T) {
+				cfg := configForArgs(t, addRequiredArgsExcept(traceType, "--cannon-network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
+				require.Equal(t, "genesis.json", cfg.CannonL2GenesisPath)
+			})
+		})
+	}
 }
 
 func TestDataDir(t *testing.T) {
-	t.Run("RequiredForAlphabetTrace", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag datadir is required", addRequiredArgsExcept(config.TraceTypeAlphabet, "--datadir"))
-	})
+	for _, traceType := range config.TraceTypes {
+		traceType := traceType
 
-	t.Run("RequiredForCannonTrace", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag datadir is required", addRequiredArgsExcept(config.TraceTypeCannon, "--datadir"))
-	})
+		t.Run(fmt.Sprintf("RequiredFor-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(t, "flag datadir is required", addRequiredArgsExcept(traceType, "--datadir"))
+		})
+	}
 
 	t.Run("Valid", func(t *testing.T) {
 		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--datadir", "--datadir=/foo/bar/cannon"))
@@ -302,66 +419,17 @@ func TestDataDir(t *testing.T) {
 }
 
 func TestRollupRpc(t *testing.T) {
-	t.Run("RequiredForAlphabetTrace", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept(config.TraceTypeAlphabet, "--rollup-rpc"))
-	})
+	for _, traceType := range config.TraceTypes {
+		traceType := traceType
 
-	t.Run("RequiredForCannonTrace", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept(config.TraceTypeCannon, "--rollup-rpc"))
-	})
+		t.Run(fmt.Sprintf("RequiredFor-%v", traceType), func(t *testing.T) {
+			verifyArgsInvalid(t, "flag rollup-rpc is required", addRequiredArgsExcept(traceType, "--rollup-rpc"))
+		})
+	}
 
 	t.Run("Valid", func(t *testing.T) {
 		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeCannon))
 		require.Equal(t, rollupRpc, cfg.RollupRpc)
-	})
-}
-
-func TestCannonL2(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-l2"))
-	})
-
-	t.Run("RequiredForCannonTrace", func(t *testing.T) {
-		verifyArgsInvalid(t, "flag cannon-l2 is required", addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-l2"))
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeCannon))
-		require.Equal(t, cannonL2, cfg.CannonL2)
-	})
-}
-
-func TestCannonSnapshotFreq(t *testing.T) {
-	t.Run("UsesDefault", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeCannon))
-		require.Equal(t, config.DefaultCannonSnapshotFreq, cfg.CannonSnapshotFreq)
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeCannon, "--cannon-snapshot-freq=1234"))
-		require.Equal(t, uint(1234), cfg.CannonSnapshotFreq)
-	})
-
-	t.Run("Invalid", func(t *testing.T) {
-		verifyArgsInvalid(t, "invalid value \"abc\" for flag -cannon-snapshot-freq",
-			addRequiredArgs(config.TraceTypeCannon, "--cannon-snapshot-freq=abc"))
-	})
-}
-
-func TestCannonInfoFreq(t *testing.T) {
-	t.Run("UsesDefault", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeCannon))
-		require.Equal(t, config.DefaultCannonInfoFreq, cfg.CannonInfoFreq)
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeCannon, "--cannon-info-freq=1234"))
-		require.Equal(t, uint(1234), cfg.CannonInfoFreq)
-	})
-
-	t.Run("Invalid", func(t *testing.T) {
-		verifyArgsInvalid(t, "invalid value \"abc\" for flag -cannon-info-freq",
-			addRequiredArgs(config.TraceTypeCannon, "--cannon-info-freq=abc"))
 	})
 }
 
@@ -379,67 +447,6 @@ func TestGameWindow(t *testing.T) {
 	t.Run("ParsesDefault", func(t *testing.T) {
 		cfg := configForArgs(t, addRequiredArgs(config.TraceTypeAlphabet, "--game-window=264h"))
 		require.Equal(t, config.DefaultGameWindow, cfg.GameWindow)
-	})
-}
-
-func TestRequireEitherCannonNetworkOrRollupAndGenesis(t *testing.T) {
-	verifyArgsInvalid(
-		t,
-		"flag cannon-network or cannon-rollup-config and cannon-l2-genesis is required",
-		addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network"))
-	verifyArgsInvalid(
-		t,
-		"flag cannon-network or cannon-rollup-config and cannon-l2-genesis is required",
-		addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network", "--cannon-rollup-config=rollup.json"))
-	verifyArgsInvalid(
-		t,
-		"flag cannon-network or cannon-rollup-config and cannon-l2-genesis is required",
-		addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network", "--cannon-l2-genesis=gensis.json"))
-}
-
-func TestMustNotSpecifyNetworkAndRollup(t *testing.T) {
-	verifyArgsInvalid(
-		t,
-		"flag cannon-network can not be used with cannon-rollup-config and cannon-l2-genesis",
-		addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network",
-			"--cannon-network", cannonNetwork, "--cannon-rollup-config=rollup.json"))
-}
-
-func TestCannonNetwork(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-network"))
-	})
-
-	t.Run("NotRequiredWhenRollupAndGenesIsSpecified", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network",
-			"--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network", "--cannon-network", otherCannonNetwork))
-		require.Equal(t, otherCannonNetwork, cfg.CannonNetwork)
-	})
-}
-
-func TestCannonRollupConfig(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-rollup-config"))
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-		require.Equal(t, "rollup.json", cfg.CannonRollupConfigPath)
-	})
-}
-
-func TestCannonL2Genesis(t *testing.T) {
-	t.Run("NotRequiredForAlphabetTrace", func(t *testing.T) {
-		configForArgs(t, addRequiredArgsExcept(config.TraceTypeAlphabet, "--cannon-l2-genesis"))
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg := configForArgs(t, addRequiredArgsExcept(config.TraceTypeCannon, "--cannon-network", "--cannon-rollup-config=rollup.json", "--cannon-l2-genesis=genesis.json"))
-		require.Equal(t, "genesis.json", cfg.CannonL2GenesisPath)
 	})
 }
 
@@ -513,7 +520,7 @@ func requiredArgs(traceType config.TraceType) map[string]string {
 		"--datadir":              datadir,
 	}
 	switch traceType {
-	case config.TraceTypeCannon:
+	case config.TraceTypeCannon, config.TraceTypePermissioned:
 		addRequiredCannonArgs(args)
 	case config.TraceTypeAlphabet:
 		addRequiredOutputArgs(args)

--- a/op-challenger/config/config.go
+++ b/op-challenger/config/config.go
@@ -39,23 +39,12 @@ var (
 type TraceType string
 
 const (
-	TraceTypeAlphabet TraceType = "alphabet"
-	TraceTypeCannon   TraceType = "cannon"
-
-	// Mainnet games
-	CannonFaultGameID = 0
-
-	// Devnet games
-	AlphabetFaultGameID = 255
+	TraceTypeAlphabet     TraceType = "alphabet"
+	TraceTypeCannon       TraceType = "cannon"
+	TraceTypePermissioned TraceType = "permissioned"
 )
 
-var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon}
-
-// GameIdToString maps game IDs to their string representation.
-var GameIdToString = map[uint8]string{
-	CannonFaultGameID:   "Cannon",
-	AlphabetFaultGameID: "Alphabet",
-}
+var TraceTypes = []TraceType{TraceTypeAlphabet, TraceTypeCannon, TraceTypePermissioned}
 
 func (t TraceType) String() string {
 	return string(t)
@@ -189,7 +178,7 @@ func (c Config) Check() error {
 	if c.MaxConcurrency == 0 {
 		return ErrMaxConcurrencyZero
 	}
-	if c.TraceTypeEnabled(TraceTypeCannon) {
+	if c.TraceTypeEnabled(TraceTypeCannon) || c.TraceTypeEnabled(TraceTypePermissioned) {
 		if c.CannonBin == "" {
 			return ErrMissingCannonBin
 		}

--- a/op-challenger/config/config_test.go
+++ b/op-challenger/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -23,9 +24,11 @@ var (
 	validRollupRpc             = "http://localhost:8555"
 )
 
+var cannonTraceTypes = []TraceType{TraceTypeCannon, TraceTypePermissioned}
+
 func validConfig(traceType TraceType) Config {
 	cfg := NewConfig(validGameFactoryAddress, validL1EthRpc, validL1BeaconUrl, validDatadir, traceType)
-	if traceType == TraceTypeCannon {
+	if traceType == TraceTypeCannon || traceType == TraceTypePermissioned {
 		cfg.CannonBin = validCannonBin
 		cfg.CannonServer = validCannonOpProgramBin
 		cfg.CannonAbsolutePreState = validCannonAbsolutPreState
@@ -79,22 +82,88 @@ func TestGameAllowlistNotRequired(t *testing.T) {
 	require.NoError(t, config.Check())
 }
 
-func TestCannonBinRequired(t *testing.T) {
-	config := validConfig(TraceTypeCannon)
-	config.CannonBin = ""
-	require.ErrorIs(t, config.Check(), ErrMissingCannonBin)
-}
+func TestCannonRequiredArgs(t *testing.T) {
+	for _, traceType := range cannonTraceTypes {
+		traceType := traceType
 
-func TestCannonServerRequired(t *testing.T) {
-	config := validConfig(TraceTypeCannon)
-	config.CannonServer = ""
-	require.ErrorIs(t, config.Check(), ErrMissingCannonServer)
-}
+		t.Run(fmt.Sprintf("TestCannonBinRequired-%v", traceType), func(t *testing.T) {
+			config := validConfig(traceType)
+			config.CannonBin = ""
+			require.ErrorIs(t, config.Check(), ErrMissingCannonBin)
+		})
 
-func TestCannonAbsolutePreStateRequired(t *testing.T) {
-	config := validConfig(TraceTypeCannon)
-	config.CannonAbsolutePreState = ""
-	require.ErrorIs(t, config.Check(), ErrMissingCannonAbsolutePreState)
+		t.Run(fmt.Sprintf("TestCannonServerRequired-%v", traceType), func(t *testing.T) {
+			config := validConfig(traceType)
+			config.CannonServer = ""
+			require.ErrorIs(t, config.Check(), ErrMissingCannonServer)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonAbsolutePreStateRequired-%v", traceType), func(t *testing.T) {
+			config := validConfig(traceType)
+			config.CannonAbsolutePreState = ""
+			require.ErrorIs(t, config.Check(), ErrMissingCannonAbsolutePreState)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonL2Required-%v", traceType), func(t *testing.T) {
+			config := validConfig(traceType)
+			config.CannonL2 = ""
+			require.ErrorIs(t, config.Check(), ErrMissingCannonL2)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonSnapshotFreq-%v", traceType), func(t *testing.T) {
+			t.Run("MustNotBeZero", func(t *testing.T) {
+				cfg := validConfig(traceType)
+				cfg.CannonSnapshotFreq = 0
+				require.ErrorIs(t, cfg.Check(), ErrMissingCannonSnapshotFreq)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonInfoFreq-%v", traceType), func(t *testing.T) {
+			t.Run("MustNotBeZero", func(t *testing.T) {
+				cfg := validConfig(traceType)
+				cfg.CannonInfoFreq = 0
+				require.ErrorIs(t, cfg.Check(), ErrMissingCannonInfoFreq)
+			})
+		})
+
+		t.Run(fmt.Sprintf("TestCannonNetworkOrRollupConfigRequired-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.CannonNetwork = ""
+			cfg.CannonRollupConfigPath = ""
+			cfg.CannonL2GenesisPath = "genesis.json"
+			require.ErrorIs(t, cfg.Check(), ErrMissingCannonRollupConfig)
+		})
+
+		t.Run(fmt.Sprintf("TestCannonNetworkOrL2GenesisRequired-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.CannonNetwork = ""
+			cfg.CannonRollupConfigPath = "foo.json"
+			cfg.CannonL2GenesisPath = ""
+			require.ErrorIs(t, cfg.Check(), ErrMissingCannonL2Genesis)
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndRollup-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.CannonNetwork = validCannonNetwork
+			cfg.CannonRollupConfigPath = "foo.json"
+			cfg.CannonL2GenesisPath = ""
+			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkAndRollupConfig)
+		})
+
+		t.Run(fmt.Sprintf("TestMustNotSpecifyNetworkAndL2Genesis-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.CannonNetwork = validCannonNetwork
+			cfg.CannonRollupConfigPath = ""
+			cfg.CannonL2GenesisPath = "foo.json"
+			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkAndL2Genesis)
+		})
+
+		t.Run(fmt.Sprintf("TestNetworkMustBeValid-%v", traceType), func(t *testing.T) {
+			cfg := validConfig(traceType)
+			cfg.CannonNetwork = "unknown"
+			require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
+		})
+	}
 }
 
 func TestDatadirRequired(t *testing.T) {
@@ -123,76 +192,15 @@ func TestHttpPollInterval(t *testing.T) {
 	})
 }
 
-func TestRollupRpcRequired_Cannon(t *testing.T) {
-	config := validConfig(TraceTypeCannon)
-	config.RollupRpc = ""
-	require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
-}
-
-func TestRollupRpcRequired_Alphabet(t *testing.T) {
-	config := validConfig(TraceTypeAlphabet)
-	config.RollupRpc = ""
-	require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
-}
-
-func TestCannonL2Required(t *testing.T) {
-	config := validConfig(TraceTypeCannon)
-	config.CannonL2 = ""
-	require.ErrorIs(t, config.Check(), ErrMissingCannonL2)
-}
-
-func TestCannonSnapshotFreq(t *testing.T) {
-	t.Run("MustNotBeZero", func(t *testing.T) {
-		cfg := validConfig(TraceTypeCannon)
-		cfg.CannonSnapshotFreq = 0
-		require.ErrorIs(t, cfg.Check(), ErrMissingCannonSnapshotFreq)
-	})
-}
-
-func TestCannonInfoFreq(t *testing.T) {
-	t.Run("MustNotBeZero", func(t *testing.T) {
-		cfg := validConfig(TraceTypeCannon)
-		cfg.CannonInfoFreq = 0
-		require.ErrorIs(t, cfg.Check(), ErrMissingCannonInfoFreq)
-	})
-}
-
-func TestCannonNetworkOrRollupConfigRequired(t *testing.T) {
-	cfg := validConfig(TraceTypeCannon)
-	cfg.CannonNetwork = ""
-	cfg.CannonRollupConfigPath = ""
-	cfg.CannonL2GenesisPath = "genesis.json"
-	require.ErrorIs(t, cfg.Check(), ErrMissingCannonRollupConfig)
-}
-
-func TestCannonNetworkOrL2GenesisRequired(t *testing.T) {
-	cfg := validConfig(TraceTypeCannon)
-	cfg.CannonNetwork = ""
-	cfg.CannonRollupConfigPath = "foo.json"
-	cfg.CannonL2GenesisPath = ""
-	require.ErrorIs(t, cfg.Check(), ErrMissingCannonL2Genesis)
-}
-
-func TestMustNotSpecifyNetworkAndRollup(t *testing.T) {
-	cfg := validConfig(TraceTypeCannon)
-	cfg.CannonNetwork = validCannonNetwork
-	cfg.CannonRollupConfigPath = "foo.json"
-	cfg.CannonL2GenesisPath = ""
-	require.ErrorIs(t, cfg.Check(), ErrCannonNetworkAndRollupConfig)
-}
-
-func TestMustNotSpecifyNetworkAndL2Genesis(t *testing.T) {
-	cfg := validConfig(TraceTypeCannon)
-	cfg.CannonNetwork = validCannonNetwork
-	cfg.CannonRollupConfigPath = ""
-	cfg.CannonL2GenesisPath = "foo.json"
-	require.ErrorIs(t, cfg.Check(), ErrCannonNetworkAndL2Genesis)
-}
-
-func TestNetworkMustBeValid(t *testing.T) {
-	cfg := validConfig(TraceTypeCannon)
-	cfg.CannonNetwork = "unknown"
-	require.ErrorIs(t, cfg.Check(), ErrCannonNetworkUnknown)
+func TestRollupRpcRequired(t *testing.T) {
+	for _, traceType := range TraceTypes {
+		traceType := traceType
+		t.Run(traceType.String(), func(t *testing.T) {
+			config := validConfig(traceType)
+			config.RollupRpc = ""
+			require.ErrorIs(t, config.Check(), ErrMissingRollupRpc)
+		})
+	}
 }
 
 func TestRequireConfigForMultipleTraceTypes(t *testing.T) {

--- a/op-challenger/flags/flags.go
+++ b/op-challenger/flags/flags.go
@@ -223,7 +223,7 @@ func CheckRequired(ctx *cli.Context, traceTypes []config.TraceType) error {
 	}
 	for _, traceType := range traceTypes {
 		switch traceType {
-		case config.TraceTypeCannon:
+		case config.TraceTypeCannon, config.TraceTypePermissioned:
 			if err := CheckCannonFlags(ctx); err != nil {
 				return err
 			}

--- a/op-challenger/game/fault/register.go
+++ b/op-challenger/game/fault/register.go
@@ -41,7 +41,7 @@ func RegisterGameTypes(
 ) (CloseFunc, error) {
 	var closer CloseFunc
 	var l2Client *ethclient.Client
-	if cfg.TraceTypeEnabled(config.TraceTypeCannon) {
+	if cfg.TraceTypeEnabled(config.TraceTypeCannon) || cfg.TraceTypeEnabled(config.TraceTypePermissioned) {
 		l2, err := ethclient.DialContext(ctx, cfg.CannonL2)
 		if err != nil {
 			return nil, fmt.Errorf("dial l2 client %v: %w", cfg.CannonL2, err)
@@ -50,8 +50,13 @@ func RegisterGameTypes(
 		closer = l2Client.Close
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeCannon) {
-		if err := registerCannon(registry, ctx, cl, logger, m, cfg, rollupClient, txSender, gameFactory, caller, l2Client); err != nil {
+		if err := registerCannon(faultTypes.CannonGameType, registry, ctx, cl, logger, m, cfg, rollupClient, txSender, gameFactory, caller, l2Client); err != nil {
 			return nil, fmt.Errorf("failed to register cannon game type: %w", err)
+		}
+	}
+	if cfg.TraceTypeEnabled(config.TraceTypePermissioned) {
+		if err := registerCannon(faultTypes.PermissionedGameType, registry, ctx, cl, logger, m, cfg, rollupClient, txSender, gameFactory, caller, l2Client); err != nil {
+			return nil, fmt.Errorf("failed to register permissioned cannon game type: %w", err)
 		}
 	}
 	if cfg.TraceTypeEnabled(config.TraceTypeAlphabet) {
@@ -128,6 +133,7 @@ func createOracle(ctx context.Context, gameFactory *contracts.DisputeGameFactory
 }
 
 func registerCannon(
+	gameType uint32,
 	registry Registry,
 	ctx context.Context,
 	cl faultTypes.ClockReader,
@@ -165,15 +171,15 @@ func registerCannon(
 		genesisValidator := NewPrestateValidator("output root", contract.GetGenesisOutputRoot, prestateProvider)
 		return NewGamePlayer(ctx, cl, logger, m, dir, game.Proxy, txSender, contract, []Validator{prestateValidator, genesisValidator}, creator)
 	}
-	oracle, err := createOracle(ctx, gameFactory, caller, faultTypes.CannonGameType)
+	oracle, err := createOracle(ctx, gameFactory, caller, gameType)
 	if err != nil {
 		return err
 	}
-	registry.RegisterGameType(faultTypes.CannonGameType, playerCreator, oracle)
+	registry.RegisterGameType(gameType, playerCreator, oracle)
 
 	contractCreator := func(game types.GameMetadata) (claims.BondContract, error) {
 		return contracts.NewFaultDisputeGameContract(game.Proxy, caller)
 	}
-	registry.RegisterBondContract(faultTypes.CannonGameType, contractCreator)
+	registry.RegisterBondContract(gameType, contractCreator)
 	return nil
 }

--- a/op-challenger/game/fault/types/types.go
+++ b/op-challenger/game/fault/types/types.go
@@ -19,8 +19,9 @@ var (
 )
 
 const (
-	CannonGameType   uint32 = 0
-	AlphabetGameType uint32 = 255
+	CannonGameType       uint32 = 0
+	PermissionedGameType uint32 = 1
+	AlphabetGameType     uint32 = 255
 )
 
 type ClockReader interface {


### PR DESCRIPTION
**Description**

Adds support for the permissioned trace type to challenger.  It is not enabled by default but can be enabled at the same time as cannon traces.

**Tests**

Updated unit tests.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/564
