### PR TITLE
op-e2e: Increase timeout for e2e tests

### DIFF
--- a/op-e2e/Makefile
+++ b/op-e2e/Makefile
@@ -2,7 +2,7 @@
 ifdef JUNIT_FILE
 	go_test = OP_TESTLOG_DISABLE_COLOR=true OP_E2E_DISABLE_PARALLEL=false gotestsum --format=standard-verbose --junitfile=$(JUNIT_FILE) -- -failfast
   # Note: -parallel must be set to match the number of cores in the resource class
-	go_test_flags = -timeout=40m -parallel=8
+	go_test_flags = -timeout=60m -parallel=8
 else
 	go_test = go test
 	go_test_flags = -v


### PR DESCRIPTION
**Description**

The fault proof tests aren't being load balanced particularly well so an executor sometimes takes more than 40m to run. Until we can come up with a better way to load balance them, increase the timeout to prevent flakes.
