### PR TITLE
chore: use string labels for severity levels

### DIFF
--- a/packages/common-ts/src/common/logger.ts
+++ b/packages/common-ts/src/common/logger.ts
@@ -35,6 +35,12 @@ export class Logger {
 
       level: options.level || 'debug',
 
+      formatters: {
+        level: (label: string) => {
+          return { level: label.toUpperCase() };
+        },
+      },
+
       // Remove pid and hostname considering production runs inside docker
       base: null,
     }

--- a/packages/common-ts/src/common/logger.ts
+++ b/packages/common-ts/src/common/logger.ts
@@ -37,7 +37,7 @@ export class Logger {
 
       formatters: {
         level: (label: string) => {
-          return { level: label.toUpperCase() };
+          return { level: label.toUpperCase() }
         },
       },
 


### PR DESCRIPTION
**Description**
chore: use string labels for severity levels

**Tests**
None

**Additional context**

https://betterstack.com/community/guides/logging/how-to-install-setup-and-use-pino-to-log-node-js-applications/


