### PR TITLE
chore(op-dispute-mon): Extraction Package

### DIFF
--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/extract"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,7 +17,7 @@ type OutputValidator interface {
 }
 
 type GameCallerCreator interface {
-	CreateContract(game types.GameMetadata) (GameCaller, error)
+	CreateContract(game types.GameMetadata) (extract.GameCaller, error)
 }
 
 type DetectorMetrics interface {

--- a/op-dispute-mon/mon/detector_test.go
+++ b/op-dispute-mon/mon/detector_test.go
@@ -7,6 +7,7 @@ import (
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/extract"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -266,7 +267,7 @@ type mockGameCallerCreator struct {
 	caller *mockGameCaller
 }
 
-func (m *mockGameCallerCreator) CreateContract(game types.GameMetadata) (GameCaller, error) {
+func (m *mockGameCallerCreator) CreateContract(game types.GameMetadata) (extract.GameCaller, error) {
 	m.calls++
 	if m.err != nil {
 		return nil, m.err

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -1,4 +1,4 @@
-package mon
+package extract
 
 import (
 	"context"
@@ -20,19 +20,19 @@ type GameCaller interface {
 	GetAllClaims(ctx context.Context) ([]faultTypes.Claim, error)
 }
 
-type gameCallerCreator struct {
+type GameCallerCreator struct {
 	cache  *caching.LRUCache[common.Address, *contracts.FaultDisputeGameContract]
 	caller *batching.MultiCaller
 }
 
-func NewGameCallerCreator(m caching.Metrics, caller *batching.MultiCaller) *gameCallerCreator {
-	return &gameCallerCreator{
+func NewGameCallerCreator(m caching.Metrics, caller *batching.MultiCaller) *GameCallerCreator {
+	return &GameCallerCreator{
 		caller: caller,
 		cache:  caching.NewLRUCache[common.Address, *contracts.FaultDisputeGameContract](m, metricsLabel, 100),
 	}
 }
 
-func (g *gameCallerCreator) CreateContract(game types.GameMetadata) (GameCaller, error) {
+func (g *GameCallerCreator) CreateContract(game types.GameMetadata) (GameCaller, error) {
 	if fdg, ok := g.cache.Get(game.Proxy); ok {
 		return fdg, nil
 	}

--- a/op-dispute-mon/mon/extract/caller_test.go
+++ b/op-dispute-mon/mon/extract/caller_test.go
@@ -1,4 +1,4 @@
-package mon
+package extract
 
 import (
 	"fmt"

--- a/op-dispute-mon/mon/service.go
+++ b/op-dispute-mon/mon/service.go
@@ -11,11 +11,12 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
-
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/config"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/extract"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/version"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/httputil"
@@ -35,7 +36,7 @@ type Service struct {
 	cl clock.Clock
 
 	forecast     *forecast
-	game         *gameCallerCreator
+	game         *extract.GameCallerCreator
 	rollupClient *sources.RollupClient
 	detector     *detector
 	validator    *outputValidator
@@ -99,7 +100,7 @@ func (s *Service) initOutputValidator() {
 }
 
 func (s *Service) initGameCallerCreator() {
-	s.game = NewGameCallerCreator(s.metrics, batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize))
+	s.game = extract.NewGameCallerCreator(s.metrics, batching.NewMultiCaller(s.l1Client.Client(), batching.DefaultBatchSize))
 }
 
 func (s *Service) initForecast(cfg *config.Config) {


### PR DESCRIPTION
**Description**

Moves the `GameCaller` and its associated creator into a new `extract` package that sets up the dispute monitor for an ETL pattern refactor.
