### PR TITLE
ci: Use default circleci image for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder:v0.42.0
   base_image:
     type: string
-    default: ubuntu-2204:2022.07.1
+    default: default
 
 orbs:
   go: circleci/go@1.8.0


### PR DESCRIPTION
The current image is deprecated and will no longer be [available](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177) by EOY.

It appears that even images from last year including `ubuntu-2204:2023.07.2` are being removed. So migrating builds to use whatever `default` image circleci provides ensures that the image is always available. This is also what circleci recommends. We'll have to be cognizant of potential breakage as circleci updates the default image every 3 months.