### PR TITLE
dispute-mon: Disagree with output roots that are not found by the local node

### DIFF
--- a/op-dispute-mon/mon/validator.go
+++ b/op-dispute-mon/mon/validator.go
@@ -3,6 +3,7 @@ package mon
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -27,6 +28,11 @@ func newOutputValidator(client OutputRollupClient) *outputValidator {
 func (o *outputValidator) CheckRootAgreement(ctx context.Context, blockNum uint64, rootClaim common.Hash) (bool, common.Hash, error) {
 	output, err := o.client.OutputAtBlock(ctx, blockNum)
 	if err != nil {
+		// string match as the error comes from the remote server so we can't use Errors.Is sadly.
+		if strings.Contains(err.Error(), "not found") {
+			// Output root doesn't exist, so we must disagree with it.
+			return false, common.Hash{}, nil
+		}
 		return false, common.Hash{}, fmt.Errorf("failed to get output at block: %w", err)
 	}
 	expected := common.Hash(output.OutputRoot)

--- a/op-dispute-mon/mon/validator_test.go
+++ b/op-dispute-mon/mon/validator_test.go
@@ -41,6 +41,16 @@ func TestDetector_CheckRootAgreement(t *testing.T) {
 		require.Equal(t, mockRootClaim, fetched)
 		require.True(t, agree)
 	})
+
+	t.Run("OutputNotFound", func(t *testing.T) {
+		validator, rollup := setupOutputValidatorTest(t)
+		// This crazy error is what we actually get back from the API
+		rollup.err = errors.New("failed to get L2 block ref with sync status: failed to determine L2BlockRef of height 42984924, could not get payload: not found")
+		agree, fetched, err := validator.CheckRootAgreement(context.Background(), 42984924, mockRootClaim)
+		require.NoError(t, err)
+		require.Equal(t, common.Hash{}, fetched)
+		require.False(t, agree)
+	})
 }
 
 func setupOutputValidatorTest(t *testing.T) (*outputValidator, *stubRollupClient) {


### PR DESCRIPTION
**Description**

When the local node does not have an output root, treat it as invalid rather than failing checks with an error.

**Tests**

Added unit test.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/555
