### PR TITLE
op-node: Expose method to load rollup config without a CLI context

### DIFF
--- a/op-bootnode/bootnode/entrypoint.go
+++ b/op-bootnode/bootnode/entrypoint.go
@@ -50,7 +50,7 @@ func Main(cliCtx *cli.Context) error {
 	m := metrics.NewMetrics("default")
 	ctx := context.Background()
 
-	config, err := opnode.NewRollupConfig(logger, cliCtx)
+	config, err := opnode.NewRollupConfigFromCLI(logger, cliCtx)
 	if err != nil {
 		return err
 	}

--- a/op-conductor/conductor/config.go
+++ b/op-conductor/conductor/config.go
@@ -101,7 +101,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*Config, error) {
 		return nil, errors.Wrap(err, "missing required flags")
 	}
 
-	rollupCfg, err := opnode.NewRollupConfig(log, ctx)
+	rollupCfg, err := opnode.NewRollupConfigFromCLI(log, ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load rollup config")
 	}

--- a/op-node/cmd/networks/cmd.go
+++ b/op-node/cmd/networks/cmd.go
@@ -29,7 +29,7 @@ var Subcommands = []*cli.Command{
 				return errors.New("must specify a network name")
 			}
 
-			rCfg, err := opnode.NewRollupConfig(logger, ctx)
+			rCfg, err := opnode.NewRollupConfigFromCLI(logger, ctx)
 			if err != nil {
 				return err
 			}

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -33,7 +33,7 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		return nil, err
 	}
 
-	rollupConfig, err := NewRollupConfig(log, ctx)
+	rollupConfig, err := NewRollupConfigFromCLI(log, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -196,12 +196,21 @@ func NewDriverConfig(ctx *cli.Context) *driver.Config {
 	}
 }
 
-func NewRollupConfig(log log.Logger, ctx *cli.Context) (*rollup.Config, error) {
+func NewRollupConfigFromCLI(log log.Logger, ctx *cli.Context) (*rollup.Config, error) {
 	network := ctx.String(opflags.NetworkFlagName)
 	rollupConfigPath := ctx.String(opflags.RollupConfigFlagName)
 	if ctx.Bool(flags.BetaExtraNetworks.Name) {
 		log.Warn("The beta.extra-networks flag is deprecated and can be omitted safely.")
 	}
+	rollupConfig, err := NewRollupConfig(log, network, rollupConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	applyOverrides(ctx, rollupConfig)
+	return rollupConfig, nil
+}
+
+func NewRollupConfig(log log.Logger, network string, rollupConfigPath string) (*rollup.Config, error) {
 	if network != "" {
 		if rollupConfigPath != "" {
 			log.Error(`Cannot configure network and rollup-config at the same time.
@@ -213,7 +222,6 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 		if err != nil {
 			return nil, err
 		}
-		applyOverrides(ctx, rollupConfig)
 		return rollupConfig, nil
 	}
 
@@ -227,7 +235,6 @@ Conflicting configuration is deprecated, and will stop the op-node from starting
 	if err := json.NewDecoder(file).Decode(&rollupConfig); err != nil {
 		return nil, fmt.Errorf("failed to decode rollup config: %w", err)
 	}
-	applyOverrides(ctx, &rollupConfig)
 	return &rollupConfig, nil
 }
 

--- a/op-program/host/config/config.go
+++ b/op-program/host/config/config.go
@@ -46,7 +46,6 @@ type Config struct {
 	L1RPCKind   sources.RPCProviderKind
 
 	// L2Head is the l2 block hash contained in the L2 Output referenced by the L2OutputRoot
-	// TODO(inphi): This can be made optional with hardcoded rollup configs and output oracle addresses by searching the oracle for the l2 output root
 	L2Head common.Hash
 	// L2OutputRoot is the agreed L2 output root to start derivation from
 	L2OutputRoot common.Hash
@@ -138,7 +137,7 @@ func NewConfigFromCLI(log log.Logger, ctx *cli.Context) (*Config, error) {
 	if err := flags.CheckRequired(ctx); err != nil {
 		return nil, err
 	}
-	rollupCfg, err := opnode.NewRollupConfig(log, ctx)
+	rollupCfg, err := opnode.NewRollupConfigFromCLI(log, ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description**

Expose a method to load a rollup config by passing in the network and rollup path values rather than having to pull them from the CLI context.  Will enable op-challenger to load the rollup config as part of verifying output roots even though it uses different arg names (deliberately).  Overrides are deliberately not applied in this version as they can't be passed in and op-program doesn't support them anyway.

**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/416
