### PR TITLE
op-e2e: Skip TestOutputCannonStepWithKZGPointEvaluation

### DIFF
--- a/op-e2e/faultproofs/output_cannon_test.go
+++ b/op-e2e/faultproofs/output_cannon_test.go
@@ -295,6 +295,8 @@ func TestOutputCannonStepWithPreimage(t *testing.T) {
 }
 
 func TestOutputCannonStepWithKZGPointEvaluation(t *testing.T) {
+	t.Skip("TODO: Fix flaky test")
+
 	testPreimageStep := func(t *testing.T, preloadPreimage bool) {
 		op_e2e.InitParallel(t, op_e2e.UsesCannon)
 


### PR DESCRIPTION
This will be fixed and re-enabled soon.