### PR TITLE
Add Missing Predeploys to L2 Genesis Script

### DIFF
--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -39,8 +39,10 @@ contract DeployConfig is Script {
     address public proxyAdminOwner;
     address public baseFeeVaultRecipient;
     uint256 public baseFeeVaultMinimumWithdrawalAmount;
+    uint256 public baseFeeVaultWithdrawalNetwork;
     address public l1FeeVaultRecipient;
     uint256 public l1FeeVaultMinimumWithdrawalAmount;
+    uint256 public l1FeeVaultWithdrawalNetwork;
     address public sequencerFeeVaultRecipient;
     uint256 public sequencerFeeVaultMinimumWithdrawalAmount;
     uint256 public sequencerFeeVaultWithdrawalNetwork;
@@ -101,8 +103,10 @@ contract DeployConfig is Script {
         proxyAdminOwner = stdJson.readAddress(_json, "$.proxyAdminOwner");
         baseFeeVaultRecipient = stdJson.readAddress(_json, "$.baseFeeVaultRecipient");
         baseFeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.baseFeeVaultMinimumWithdrawalAmount");
+        baseFeeVaultWithdrawalNetwork = stdJson.readUint(_json, "$.baseFeeVaultWithdrawalNetwork");
         l1FeeVaultRecipient = stdJson.readAddress(_json, "$.l1FeeVaultRecipient");
         l1FeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.l1FeeVaultMinimumWithdrawalAmount");
+        l1FeeVaultWithdrawalNetwork = stdJson.readUint(_json, "$.l1FeeVaultWithdrawalNetwork");
         sequencerFeeVaultRecipient = stdJson.readAddress(_json, "$.sequencerFeeVaultRecipient");
         sequencerFeeVaultMinimumWithdrawalAmount = stdJson.readUint(_json, "$.sequencerFeeVaultMinimumWithdrawalAmount");
         sequencerFeeVaultWithdrawalNetwork = stdJson.readUint(_json, "$.sequencerFeeVaultWithdrawalNetwork");


### PR DESCRIPTION
Some predeploys were missing from #9292:

- L2ToL1MessagePasser
- L2ERC721Bridge
- OptimismMintableERC721Factory
- DeployerWhitelist
- BaseFeeVault
- L1FeeVault
- SchemaRegistry

EAS is also missing, but the contract requires solc verion `0.8.19` while some of the other contracts require `0.8.15`. Because EAS has some `immutable`s, we need to deploy this contract in order to obtain the runtime bytecode to be `vm.etch`ed to the predeploy proxy address. I'm not sure how to solve for this, we _could_ hardcode the runtime bytecode within L2 genesis script since the `immutable` values are [hardcoded](https://github.com/ethereum-optimism/optimism/blob/8fb5be5f76e1c1d4b7338c5d7736e45774060e81/packages/contracts-bedrock/src/EAS/EAS.sol#L87)