### PR TITLE
feat(op-dispute-mon): Extractor Wiring

### DIFF
--- a/op-dispute-mon/mon/detector.go
+++ b/op-dispute-mon/mon/detector.go
@@ -2,7 +2,6 @@ package mon
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/extract"
@@ -41,19 +40,12 @@ func newDetector(logger log.Logger, metrics DetectorMetrics, creator GameCallerC
 	}
 }
 
-func (d *detector) Detect(ctx context.Context, games []types.GameMetadata) {
+func (d *detector) Detect(ctx context.Context, games []monTypes.EnrichedGameData) {
 	statBatch := monTypes.StatusBatch{}
 	detectBatch := monTypes.DetectionBatch{}
 	for _, game := range games {
-		// Fetch the game metadata to ensure the game status is recorded
-		// regardless of whether the game agreement is checked.
-		l2BlockNum, rootClaim, status, err := d.fetchGameMetadata(ctx, game)
-		if err != nil {
-			d.logger.Error("Failed to fetch game metadata", "err", err)
-			continue
-		}
-		statBatch.Add(status)
-		processed, err := d.checkAgreement(ctx, game.Proxy, l2BlockNum, rootClaim, status)
+		statBatch.Add(game.Status)
+		processed, err := d.checkAgreement(ctx, game.Proxy, game.L2BlockNumber, game.RootClaim, game.Status)
 		if err != nil {
 			d.logger.Error("Failed to process game", "err", err)
 			continue
@@ -71,18 +63,6 @@ func (d *detector) recordBatch(batch monTypes.DetectionBatch) {
 	d.metrics.RecordGameAgreement("disagree_defender_wins", batch.DisagreeDefenderWins)
 	d.metrics.RecordGameAgreement("agree_challenger_wins", batch.AgreeChallengerWins)
 	d.metrics.RecordGameAgreement("disagree_challenger_wins", batch.DisagreeChallengerWins)
-}
-
-func (d *detector) fetchGameMetadata(ctx context.Context, game types.GameMetadata) (uint64, common.Hash, types.GameStatus, error) {
-	loader, err := d.creator.CreateContract(game)
-	if err != nil {
-		return 0, common.Hash{}, 0, fmt.Errorf("failed to create contract: %w", err)
-	}
-	blockNum, rootClaim, status, err := loader.GetGameMetadata(ctx)
-	if err != nil {
-		return 0, common.Hash{}, 0, fmt.Errorf("failed to fetch game metadata: %w", err)
-	}
-	return blockNum, rootClaim, status, nil
 }
 
 func (d *detector) checkAgreement(ctx context.Context, addr common.Address, blockNum uint64, rootClaim common.Hash, status types.GameStatus) (monTypes.DetectionBatch, error) {


### PR DESCRIPTION
**Description**

Wires up the extractor.

This is needed to fetch the game claims concisely and provide them to the downstream resolution status and resolution max delay components as well as the detection component.

**Tests**

Tests are updated to use the extractor.

**Metadata**

Required for https://github.com/ethereum-optimism/client-pod/issues/537
