### PR TITLE
chore(contracts-bedrock): print error message if generate-l2-genesis.sh fails

### DIFF
--- a/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
+++ b/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
@@ -69,10 +69,10 @@ if mkdir -- "$LOCKDIR" > /dev/null 2>&1; then
       --l1-deployments "$DEPLOY_ARTIFACT" \
       --l1-starting-block "$L1_STARTING_BLOCK_PATH" \
       --outfile.l2 "$OUTFILE_L2" \
-      --outfile.rollup "$OUTFILE_ROLLUP" 2>$tempfile; then
-      cat $tempfile >&2
+      --outfile.rollup "$OUTFILE_ROLLUP" 2>"$tempfile"; then
+      cat "$tempfile" >&2
     fi
-    rm $tempfile
+    rm "$tempfile"
   fi
 else
   # Wait up to 5 minutes for the lock to be released

--- a/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
+++ b/packages/contracts-bedrock/scripts/generate-l2-genesis.sh
@@ -63,12 +63,16 @@ if mkdir -- "$LOCKDIR" > /dev/null 2>&1; then
   fi
 
   if [ ! -f "$OUTFILE_L2" ]; then
-    go run "$OP_NODE" genesis l2 \
+    tempfile=$(mktemp)
+    if ! go run "$OP_NODE" genesis l2 \
       --deploy-config "$CONTRACTS_DIR/deploy-config/hardhat.json" \
       --l1-deployments "$DEPLOY_ARTIFACT" \
       --l1-starting-block "$L1_STARTING_BLOCK_PATH" \
       --outfile.l2 "$OUTFILE_L2" \
-      --outfile.rollup "$OUTFILE_ROLLUP" > /dev/null 2>&1
+      --outfile.rollup "$OUTFILE_ROLLUP" 2>$tempfile; then
+      cat $tempfile >&2
+    fi
+    rm $tempfile
   fi
 else
   # Wait up to 5 minutes for the lock to be released


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

I was stuck on `Setup.sol` stalling without output, until 3h later it errored with `EvmError: OutOfGas` and finally revealed where it was stuck - on waiting for `contracts-bedrock/.testdata/genesis.json`. The reason this file was not generated was because the `go run "$OP_NODE" genesis l2` command in `generate-l2-genesis.sh` failed silently. This change makes the error message print if the command fails, while still muting the output if everything runs smoothly.