### PR TITLE
feat(op-dispute-mon): Max Claim Resolution Delay Metrics

### DIFF
--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -80,25 +80,27 @@ func (c *FaultDisputeGameContract) GetBlockRange(ctx context.Context) (prestateB
 	return
 }
 
-// GetGameMetadata returns the game's L2 block number, root claim, and status.
-func (c *FaultDisputeGameContract) GetGameMetadata(ctx context.Context) (uint64, common.Hash, gameTypes.GameStatus, error) {
+// GetGameMetadata returns the game's L2 block number, root claim, status, and game duration.
+func (c *FaultDisputeGameContract) GetGameMetadata(ctx context.Context) (uint64, common.Hash, gameTypes.GameStatus, uint64, error) {
 	results, err := c.multiCaller.Call(ctx, batching.BlockLatest,
 		c.contract.Call(methodL2BlockNumber),
 		c.contract.Call(methodRootClaim),
-		c.contract.Call(methodStatus))
+		c.contract.Call(methodStatus),
+		c.contract.Call(methodGameDuration))
 	if err != nil {
-		return 0, common.Hash{}, 0, fmt.Errorf("failed to retrieve game metadata: %w", err)
+		return 0, common.Hash{}, 0, 0, fmt.Errorf("failed to retrieve game metadata: %w", err)
 	}
-	if len(results) != 3 {
-		return 0, common.Hash{}, 0, fmt.Errorf("expected 3 results but got %v", len(results))
+	if len(results) != 4 {
+		return 0, common.Hash{}, 0, 0, fmt.Errorf("expected 3 results but got %v", len(results))
 	}
 	l2BlockNumber := results[0].GetBigInt(0).Uint64()
 	rootClaim := results[1].GetHash(0)
+	duration := results[3].GetUint64(0)
 	status, err := gameTypes.GameStatusFromUint8(results[2].GetUint8(0))
 	if err != nil {
-		return 0, common.Hash{}, 0, fmt.Errorf("failed to convert game status: %w", err)
+		return 0, common.Hash{}, 0, 0, fmt.Errorf("failed to convert game status: %w", err)
 	}
-	return l2BlockNumber, rootClaim, status, nil
+	return l2BlockNumber, rootClaim, status, duration, nil
 }
 
 func (c *FaultDisputeGameContract) GetGenesisOutputRoot(ctx context.Context) (common.Hash, error) {

--- a/op-challenger/game/fault/contracts/faultdisputegame_test.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame_test.go
@@ -319,16 +319,19 @@ func TestGetSplitDepth(t *testing.T) {
 func TestGetGameMetadata(t *testing.T) {
 	stubRpc, contract := setupFaultDisputeGameTest(t)
 	expectedL2BlockNumber := uint64(123)
+	expectedGameDuration := uint64(456)
 	expectedRootClaim := common.Hash{0x01, 0x02}
 	expectedStatus := types.GameStatusChallengerWon
 	stubRpc.SetResponse(fdgAddr, methodL2BlockNumber, batching.BlockLatest, nil, []interface{}{new(big.Int).SetUint64(expectedL2BlockNumber)})
 	stubRpc.SetResponse(fdgAddr, methodRootClaim, batching.BlockLatest, nil, []interface{}{expectedRootClaim})
 	stubRpc.SetResponse(fdgAddr, methodStatus, batching.BlockLatest, nil, []interface{}{expectedStatus})
-	l2BlockNumber, rootClaim, status, err := contract.GetGameMetadata(context.Background())
+	stubRpc.SetResponse(fdgAddr, methodGameDuration, batching.BlockLatest, nil, []interface{}{expectedGameDuration})
+	l2BlockNumber, rootClaim, status, duration, err := contract.GetGameMetadata(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, expectedL2BlockNumber, l2BlockNumber)
 	require.Equal(t, expectedRootClaim, rootClaim)
 	require.Equal(t, expectedStatus, status)
+	require.Equal(t, expectedGameDuration, duration)
 }
 
 func TestGetGenesisOutputRoot(t *testing.T) {

--- a/op-dispute-mon/metrics/metrics.go
+++ b/op-dispute-mon/metrics/metrics.go
@@ -36,6 +36,8 @@ type Metricer interface {
 	RecordInfo(version string)
 	RecordUp()
 
+	RecordClaimResolutionDelayMax(delay float64)
+
 	RecordGamesStatus(inProgress, defenderWon, challengerWon int)
 	RecordGameAgreement(status GameAgreementStatus, count int)
 
@@ -54,6 +56,8 @@ type Metrics struct {
 
 	info prometheus.GaugeVec
 	up   prometheus.Gauge
+
+	claimResolutionDelayMax prometheus.Gauge
 
 	trackedGames   prometheus.GaugeVec
 	gamesAgreement prometheus.GaugeVec
@@ -87,6 +91,11 @@ func NewMetrics() *Metrics {
 			Namespace: Namespace,
 			Name:      "up",
 			Help:      "1 if the op-challenger has finished starting up",
+		}),
+		claimResolutionDelayMax: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "claim_resolution_delay_max",
+			Help:      "Maximum claim resolution delay in seconds",
 		}),
 		trackedGames: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: Namespace,
@@ -130,6 +139,10 @@ func (m *Metrics) RecordInfo(version string) {
 func (m *Metrics) RecordUp() {
 	prometheus.MustRegister()
 	m.up.Set(1)
+}
+
+func (m *Metrics) RecordClaimResolutionDelayMax(delay float64) {
+	m.claimResolutionDelayMax.Set(delay)
 }
 
 func (m *Metrics) Document() []opmetrics.DocumentedMetric {

--- a/op-dispute-mon/metrics/noop.go
+++ b/op-dispute-mon/metrics/noop.go
@@ -10,5 +10,7 @@ func (*NoopMetricsImpl) RecordUp()                 {}
 func (*NoopMetricsImpl) CacheAdd(_ string, _ int, _ bool) {}
 func (*NoopMetricsImpl) CacheGet(_ string, _ bool)        {}
 
+func (*NoopMetricsImpl) RecordClaimResolutionDelayMax(delay float64) {}
+
 func (*NoopMetricsImpl) RecordGamesStatus(inProgress, defenderWon, challengerWon int) {}
 func (*NoopMetricsImpl) RecordGameAgreement(status GameAgreementStatus, count int)    {}

--- a/op-dispute-mon/mon/bonds/bonds.go
+++ b/op-dispute-mon/mon/bonds/bonds.go
@@ -6,12 +6,11 @@ import (
 	"math/big"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/exp/maps"
 )
-
-var noBond = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
 
 type BondContract interface {
 	GetCredits(ctx context.Context, block batching.Block, recipients ...common.Address) ([]*big.Int, error)
@@ -24,7 +23,7 @@ func CalculateRequiredCollateral(ctx context.Context, contract BondContract, blo
 	unpaidBonds := big.NewInt(0)
 	recipients := make(map[common.Address]bool)
 	for _, claim := range claims {
-		if noBond.Cmp(claim.Bond) != 0 {
+		if monTypes.ResolvedBondAmount.Cmp(claim.Bond) != 0 {
 			unpaidBonds = new(big.Int).Add(unpaidBonds, claim.Bond)
 		}
 		recipients[claim.Claimant] = true

--- a/op-dispute-mon/mon/bonds/bonds_test.go
+++ b/op-dispute-mon/mon/bonds/bonds_test.go
@@ -6,20 +6,17 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMaxValue(t *testing.T) {
-	require.Equal(t, noBond.String(), "340282366920938463463374607431768211455")
-}
-
 func TestCalculateRequiredCollateral(t *testing.T) {
 	claims := []types.Claim{
 		{
 			ClaimData: types.ClaimData{
-				Bond: noBond,
+				Bond: monTypes.ResolvedBondAmount,
 			},
 			Claimant:    common.Address{0x01},
 			CounteredBy: common.Address{0x02},

--- a/op-dispute-mon/mon/extract/caller.go
+++ b/op-dispute-mon/mon/extract/caller.go
@@ -16,8 +16,8 @@ import (
 const metricsLabel = "game_caller_creator"
 
 type GameCaller interface {
-	GetGameMetadata(context.Context) (uint64, common.Hash, types.GameStatus, error)
-	GetAllClaims(ctx context.Context) ([]faultTypes.Claim, error)
+	GetGameMetadata(context.Context) (uint64, common.Hash, types.GameStatus, uint64, error)
+	GetAllClaims(context.Context) ([]faultTypes.Claim, error)
 }
 
 type GameCallerCreator struct {

--- a/op-dispute-mon/mon/extract/extractor.go
+++ b/op-dispute-mon/mon/extract/extractor.go
@@ -44,7 +44,7 @@ func (e *Extractor) enrichGames(ctx context.Context, games []gameTypes.GameMetad
 			e.logger.Error("failed to create game caller", "err", err)
 			continue
 		}
-		l2BlockNum, rootClaim, status, err := caller.GetGameMetadata(ctx)
+		l2BlockNum, rootClaim, status, duration, err := caller.GetGameMetadata(ctx)
 		if err != nil {
 			e.logger.Error("failed to fetch game metadata", "err", err)
 			continue
@@ -59,6 +59,7 @@ func (e *Extractor) enrichGames(ctx context.Context, games []gameTypes.GameMetad
 			L2BlockNumber: l2BlockNum,
 			RootClaim:     rootClaim,
 			Status:        status,
+			Duration:      duration,
 			Claims:        claims,
 		})
 	}

--- a/op-dispute-mon/mon/forecast.go
+++ b/op-dispute-mon/mon/forecast.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/metrics"
+	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/resolution"
 	"github.com/ethereum-optimism/optimism/op-dispute-mon/mon/transform"
 	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
 
@@ -21,6 +22,7 @@ var (
 )
 
 type ForecastMetrics interface {
+	RecordClaimResolutionDelayMax(delay float64)
 	RecordGameAgreement(status metrics.GameAgreementStatus, count int)
 }
 
@@ -65,7 +67,7 @@ func (f *forecast) forecastGame(ctx context.Context, game *monTypes.EnrichedGame
 	tree := transform.CreateBidirectionalTree(game.Claims)
 
 	// Compute the resolution status of the game.
-	status := Resolve(tree)
+	status := resolution.Resolve(tree)
 
 	// Check the root agreement.
 	agreement, expected, err := f.validator.CheckRootAgreement(ctx, game.L2BlockNumber, game.RootClaim)

--- a/op-dispute-mon/mon/forecast_test.go
+++ b/op-dispute-mon/mon/forecast_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 	"testing"
 
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -267,6 +269,7 @@ type mockForecastMetrics struct {
 	disagreeDefenderAhead   int
 	agreeChallengerAhead    int
 	disagreeChallengerAhead int
+	claimResolutionDelayMax float64
 }
 
 func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementStatus, count int) {
@@ -279,5 +282,40 @@ func (m *mockForecastMetrics) RecordGameAgreement(status metrics.GameAgreementSt
 		m.agreeChallengerAhead = count
 	case metrics.DisagreeChallengerAhead:
 		m.disagreeChallengerAhead = count
+	}
+}
+
+func (m *mockForecastMetrics) RecordClaimResolutionDelayMax(delay float64) {
+	m.claimResolutionDelayMax = delay
+}
+
+func createDeepClaimList() []faultTypes.Claim {
+	return []faultTypes.Claim{
+		{
+			ClaimData: faultTypes.ClaimData{
+				Position: faultTypes.NewPosition(0, big.NewInt(0)),
+			},
+			ContractIndex:       0,
+			CounteredBy:         common.HexToAddress("0x222222"),
+			ParentContractIndex: math.MaxInt64,
+			Claimant:            common.HexToAddress("0x111111"),
+		},
+		{
+			ClaimData: faultTypes.ClaimData{
+				Position: faultTypes.NewPosition(1, big.NewInt(0)),
+			},
+			CounteredBy:         common.HexToAddress("0x111111"),
+			ContractIndex:       1,
+			ParentContractIndex: 0,
+			Claimant:            common.HexToAddress("0x222222"),
+		},
+		{
+			ClaimData: faultTypes.ClaimData{
+				Position: faultTypes.NewPosition(2, big.NewInt(0)),
+			},
+			ContractIndex:       2,
+			ParentContractIndex: 1,
+			Claimant:            common.HexToAddress("0x111111"),
+		},
 	}
 }

--- a/op-dispute-mon/mon/resolution/delay.go
+++ b/op-dispute-mon/mon/resolution/delay.go
@@ -1,0 +1,52 @@
+package resolution
+
+import (
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+)
+
+type DelayMetrics interface {
+	RecordClaimResolutionDelayMax(delay float64)
+}
+
+type DelayCalculator struct {
+	metrics DelayMetrics
+	clock   clock.Clock
+}
+
+func NewDelayCalculator(metrics DelayMetrics, clock clock.Clock) *DelayCalculator {
+	return &DelayCalculator{
+		metrics: metrics,
+		clock:   clock,
+	}
+}
+
+func (d *DelayCalculator) RecordClaimResolutionDelayMax(games []*monTypes.EnrichedGameData) {
+	var maxDelay uint64 = 0
+	for _, game := range games {
+		maxDelay = max(d.getMaxResolutionDelay(game), maxDelay)
+	}
+	d.metrics.RecordClaimResolutionDelayMax(float64(maxDelay))
+}
+
+func (d *DelayCalculator) getMaxResolutionDelay(game *monTypes.EnrichedGameData) uint64 {
+	var maxDelay uint64 = 0
+	for _, claim := range game.Claims {
+		maxDelay = max(d.getOverflowTime(game.Duration, &claim), maxDelay)
+	}
+	return maxDelay
+}
+
+func (d *DelayCalculator) getOverflowTime(maxGameDuration uint64, claim *types.Claim) uint64 {
+	// If the bond amount is the max uint128 value, the claim is resolved.
+	if monTypes.ResolvedBondAmount.Cmp(claim.ClaimData.Bond) == 0 {
+		return 0
+	}
+	maxChessTime := maxGameDuration / 2
+	accumulatedTime := uint64(claim.ChessTime(d.clock.Now()))
+	if accumulatedTime < maxChessTime {
+		return 0
+	}
+	return accumulatedTime - maxChessTime
+}

--- a/op-dispute-mon/mon/resolution/delay_test.go
+++ b/op-dispute-mon/mon/resolution/delay_test.go
@@ -1,0 +1,181 @@
+package resolution
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
+	monTypes "github.com/ethereum-optimism/optimism/op-dispute-mon/mon/types"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	maxGameDuration = uint64(960)
+	frozen          = time.Unix(int64(time.Hour.Seconds()), 0)
+)
+
+func TestDelayCalculator_getOverflowTime(t *testing.T) {
+	t.Run("NoClock", func(t *testing.T) {
+		d, metrics, _ := setupDelayCalculatorTest(t)
+		claim := &types.Claim{
+			ClaimData: types.ClaimData{
+				Bond: monTypes.ResolvedBondAmount,
+			},
+		}
+		delay := d.getOverflowTime(maxGameDuration, claim)
+		require.Equal(t, uint64(0), delay)
+		require.Equal(t, 0, metrics.calls)
+	})
+
+	t.Run("RemainingTime", func(t *testing.T) {
+		d, metrics, cl := setupDelayCalculatorTest(t)
+		duration := uint64(3 * 60)
+		timestamp := uint64(cl.Now().Add(-time.Minute).Unix())
+		claim := &types.Claim{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(5),
+			},
+			Clock: types.NewClock(duration, timestamp),
+		}
+		delay := d.getOverflowTime(maxGameDuration, claim)
+		require.Equal(t, uint64(0), delay)
+		require.Equal(t, 0, metrics.calls)
+	})
+
+	t.Run("OverflowTime", func(t *testing.T) {
+		d, metrics, cl := setupDelayCalculatorTest(t)
+		duration := maxGameDuration / 2
+		timestamp := uint64(cl.Now().Add(4 * -time.Minute).Unix())
+		claim := &types.Claim{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(5),
+			},
+			Clock: types.NewClock(duration, timestamp),
+		}
+		delay := d.getOverflowTime(maxGameDuration, claim)
+		require.Equal(t, uint64(240), delay)
+		require.Equal(t, 0, metrics.calls)
+	})
+}
+
+func TestDelayCalculator_getMaxResolutionDelay(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims []types.Claim
+		want   uint64
+	}{
+		{"NoClaims", []types.Claim{}, 0},
+		{"SingleClaim", createClaimList()[:1], 180},
+		{"MultipleClaims", createClaimList()[:2], 300},
+		{"ClaimsWithMaxUint128", createClaimList(), 300},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			d, metrics, _ := setupDelayCalculatorTest(t)
+			game := &monTypes.EnrichedGameData{
+				Claims:   test.claims,
+				Duration: maxGameDuration,
+			}
+			got := d.getMaxResolutionDelay(game)
+			require.Equal(t, 0, metrics.calls)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestDelayCalculator_RecordClaimResolutionDelayMax(t *testing.T) {
+	tests := []struct {
+		name  string
+		games []*monTypes.EnrichedGameData
+		want  float64
+	}{
+		{"NoGames", createGameWithClaimsList()[:0], 0},
+		{"SingleGame", createGameWithClaimsList()[:1], 180},
+		{"MultipleGames", createGameWithClaimsList()[:2], 300},
+		{"ClaimsWithMaxUint128", createGameWithClaimsList(), 300},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			d, metrics, _ := setupDelayCalculatorTest(t)
+			d.RecordClaimResolutionDelayMax(test.games)
+			require.Equal(t, 1, metrics.calls)
+			require.Equal(t, test.want, metrics.maxDelay)
+		})
+	}
+}
+
+func setupDelayCalculatorTest(t *testing.T) (*DelayCalculator, *mockDelayMetrics, *clock.DeterministicClock) {
+	metrics := &mockDelayMetrics{}
+	cl := clock.NewDeterministicClock(frozen)
+	return NewDelayCalculator(metrics, cl), metrics, cl
+}
+
+func createGameWithClaimsList() []*monTypes.EnrichedGameData {
+	return []*monTypes.EnrichedGameData{
+		{
+			Claims:   createClaimList()[:1],
+			Duration: maxGameDuration,
+		},
+		{
+			Claims:   createClaimList()[:2],
+			Duration: maxGameDuration,
+		},
+		{
+			Claims:   createClaimList(),
+			Duration: maxGameDuration,
+		},
+	}
+}
+
+func createClaimList() []types.Claim {
+	newClock := func(multiplier int) *types.Clock {
+		duration := maxGameDuration / 2
+		timestamp := uint64(frozen.Add(-time.Minute * time.Duration(multiplier)).Unix())
+		return types.NewClock(duration, timestamp)
+	}
+	return []types.Claim{
+		{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(5),
+			},
+			Clock: newClock(3),
+		},
+		{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(10),
+			},
+			Clock: newClock(5),
+		},
+		{
+			ClaimData: types.ClaimData{
+				Bond: big.NewInt(100),
+			},
+			Clock: newClock(2),
+		},
+		{
+			// This claim should be skipped because it's resolved.
+			ClaimData: types.ClaimData{
+				Bond: monTypes.ResolvedBondAmount,
+			},
+			Clock: newClock(10),
+		},
+	}
+}
+
+type mockDelayMetrics struct {
+	calls    int
+	maxDelay float64
+}
+
+func (m *mockDelayMetrics) RecordClaimResolutionDelayMax(delay float64) {
+	m.calls++
+	if delay > m.maxDelay {
+		m.maxDelay = delay
+	}
+}

--- a/op-dispute-mon/mon/resolution/resolver.go
+++ b/op-dispute-mon/mon/resolution/resolver.go
@@ -1,4 +1,4 @@
-package mon
+package resolution
 
 import (
 	"github.com/ethereum/go-ethereum/common"

--- a/op-dispute-mon/mon/resolution/resolver_test.go
+++ b/op-dispute-mon/mon/resolution/resolver_test.go
@@ -1,4 +1,4 @@
-package mon
+package resolution
 
 import (
 	"math"

--- a/op-dispute-mon/mon/types/types.go
+++ b/op-dispute-mon/mon/types/types.go
@@ -1,16 +1,22 @@
 package types
 
 import (
+	"math/big"
+
 	faultTypes "github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+// ResolvedBondAmount is the uint128 value where a bond is considered claimed.
+var ResolvedBondAmount = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
 
 type EnrichedGameData struct {
 	types.GameMetadata
 	L2BlockNumber uint64
 	RootClaim     common.Hash
 	Status        types.GameStatus
+	Duration      uint64
 	Claims        []faultTypes.Claim
 }
 

--- a/op-dispute-mon/mon/types/types_test.go
+++ b/op-dispute-mon/mon/types/types_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMaxValue(t *testing.T) {
+	require.Equal(t, ResolvedBondAmount.String(), "340282366920938463463374607431768211455")
+}
+
 func TestStatusBatch_Add(t *testing.T) {
 	statusExpectations := []struct {
 		status types.GameStatus


### PR DESCRIPTION
**Description**

Introduces a `delay` component in the `resolution` package to calculate the resolution delay.

This is stacked ontop of the extractor wiring so claims are not fetched in multiple places for each game, but instead are "extracted" through the ETL pattern.

**Tests**

Surrounding the `DelayCalculator` component.

**Metadata**

Fixes https://github.com/ethereum-optimism/client-pod/issues/537.
